### PR TITLE
Use native Win32 function for mouse tracking if present

### DIFF
--- a/projects/openttd_vs100.vcxproj
+++ b/projects/openttd_vs100.vcxproj
@@ -146,7 +146,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -192,7 +192,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -251,7 +251,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -299,7 +299,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/projects/openttd_vs100.vcxproj.in
+++ b/projects/openttd_vs100.vcxproj.in
@@ -146,7 +146,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -192,7 +192,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -251,7 +251,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -299,7 +299,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>dpi_aware.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>dpi_aware.manifest;os_versions.manifest</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -152,6 +152,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -202,6 +203,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -264,6 +266,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -316,6 +319,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>

--- a/projects/openttd_vs140.vcxproj.in
+++ b/projects/openttd_vs140.vcxproj.in
@@ -152,6 +152,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -202,6 +203,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -264,6 +266,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -316,6 +319,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -152,6 +152,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -202,6 +203,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -264,6 +266,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -316,6 +319,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>

--- a/projects/openttd_vs141.vcxproj.in
+++ b/projects/openttd_vs141.vcxproj.in
@@ -152,6 +152,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -202,6 +203,7 @@
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -264,6 +266,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
@@ -316,6 +319,7 @@
       <MinimumRequiredVersion>5.02</MinimumRequiredVersion>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>os_versions.manifest</AdditionalManifestFiles>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>

--- a/projects/os_versions.manifest
+++ b/projects/os_versions.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" >
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--This Id value indicates the application supports Windows Vista functionality -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!--This Id value indicates the application supports Windows 7 functionality-->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--This Id value indicates the application supports Windows 8 functionality-->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--This Id value indicates the application supports Windows 8.1 functionality-->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--This Id value indicates the application supports Windows 10 functionality-->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+	</application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Non-ancient Windows versions have a built-in mouse tracking functions. Use it in case MS ever cooks up new stuff that breaks our simple emulation.