### PR TITLE
 Remove: NO_DEBUG_MESSAGES was only read and setting it broke compilation

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -100,8 +100,6 @@ char *DumpDebugFacilityNames(char *buf, char *last)
 	return buf;
 }
 
-#if !defined(NO_DEBUG_MESSAGES)
-
 /**
  * Internal function for outputting the debug line.
  * @param dbg Debug category.
@@ -168,7 +166,6 @@ void CDECL debug(const char *dbg, const char *format, ...)
 
 	debug_print(dbg, buf);
 }
-#endif /* NO_DEBUG_MESSAGES */
 
 /**
  * Set debugging levels by parsing the text in \a s.

--- a/src/debug.h
+++ b/src/debug.h
@@ -28,37 +28,33 @@
  * 6.. - extremely detailed spamming
  */
 
-#ifdef NO_DEBUG_MESSAGES
-	#define DEBUG(name, level, ...) { }
-#else /* NO_DEBUG_MESSAGES */
-	/**
-	 * Output a line of debugging information.
-	 * @param name Category
-	 * @param level Debugging level, higher levels means more detailed information.
-	 */
-	#define DEBUG(name, level, ...) if ((level) == 0 || _debug_ ## name ## _level >= (level)) debug(#name, __VA_ARGS__)
+/**
+ * Output a line of debugging information.
+ * @param name Category
+ * @param level Debugging level, higher levels means more detailed information.
+ */
+#define DEBUG(name, level, ...) if ((level) == 0 || _debug_ ## name ## _level >= (level)) debug(#name, __VA_ARGS__)
 
-	extern int _debug_driver_level;
-	extern int _debug_grf_level;
-	extern int _debug_map_level;
-	extern int _debug_misc_level;
-	extern int _debug_net_level;
-	extern int _debug_sprite_level;
-	extern int _debug_oldloader_level;
-	extern int _debug_npf_level;
-	extern int _debug_yapf_level;
-	extern int _debug_freetype_level;
-	extern int _debug_script_level;
-	extern int _debug_sl_level;
-	extern int _debug_gamelog_level;
-	extern int _debug_desync_level;
-	extern int _debug_console_level;
+extern int _debug_driver_level;
+extern int _debug_grf_level;
+extern int _debug_map_level;
+extern int _debug_misc_level;
+extern int _debug_net_level;
+extern int _debug_sprite_level;
+extern int _debug_oldloader_level;
+extern int _debug_npf_level;
+extern int _debug_yapf_level;
+extern int _debug_freetype_level;
+extern int _debug_script_level;
+extern int _debug_sl_level;
+extern int _debug_gamelog_level;
+extern int _debug_desync_level;
+extern int _debug_console_level;
 #ifdef RANDOM_DEBUG
-	extern int _debug_random_level;
+extern int _debug_random_level;
 #endif
 
-	void CDECL debug(const char *dbg, const char *format, ...) WARN_FORMAT(2, 3);
-#endif /* NO_DEBUG_MESSAGES */
+void CDECL debug(const char *dbg, const char *format, ...) WARN_FORMAT(2, 3);
 
 char *DumpDebugFacilityNames(char *buf, char *last);
 void SetDebugString(const char *s);

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -99,7 +99,6 @@ const char *MusicDriver_DMusic::Start(const char * const *parm)
 
 	int port = GetDriverParamInt(parm, "port", -1);
 
-#ifndef NO_DEBUG_MESSAGES
 	if (_debug_driver_level > 0) {
 		/* Print all valid output ports. */
 		char desc[DMUS_MAX_DESCRIPTION];
@@ -116,7 +115,6 @@ const char *MusicDriver_DMusic::Start(const char * const *parm)
 			}
 		}
 	}
-#endif
 
 	IDirectMusicPort *music_port = NULL; // NULL means 'use default port'.
 

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -275,7 +275,6 @@ static uint NPFReservedTrackCost(AyStarNode *current)
  */
 static void NPFMarkTile(TileIndex tile)
 {
-#ifndef NO_DEBUG_MESSAGES
 	if (_debug_npf_level < 1 || _networking) return;
 	switch (GetTileType(tile)) {
 		case MP_RAILWAY:
@@ -296,7 +295,6 @@ static void NPFMarkTile(TileIndex tile)
 		default:
 			break;
 	}
-#endif
 }
 
 static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *parent)

--- a/src/pathfinder/yapf/yapf_base.hpp
+++ b/src/pathfinder/yapf/yapf_base.hpp
@@ -122,10 +122,8 @@ public:
 	{
 		m_veh = v;
 
-#ifndef NO_DEBUG_MESSAGES
 		CPerformanceTimer perf;
 		perf.Start();
-#endif /* !NO_DEBUG_MESSAGES */
 
 		Yapf().PfSetStartupNodes();
 		bool bDestFound = true;
@@ -154,7 +152,6 @@ public:
 
 		bDestFound &= (m_pBestDestNode != NULL);
 
-#ifndef NO_DEBUG_MESSAGES
 		perf.Stop();
 		if (_debug_yapf_level >= 2) {
 			int t = perf.Get(1000000);
@@ -174,7 +171,6 @@ public:
 				);
 			}
 		}
-#endif /* !NO_DEBUG_MESSAGES */
 		return bDestFound;
 	}
 

--- a/src/thread/thread_morphos.cpp
+++ b/src/thread/thread_morphos.cpp
@@ -50,14 +50,10 @@ struct OTTDThreadStartupMessage {
  *  Default OpenTTD STDIO/ERR debug output is not very useful for this, so we
  *  utilize serial/ramdebug instead.
  */
-#ifndef NO_DEBUG_MESSAGES
 void KPutStr(CONST_STRPTR format)
 {
 	RawDoFmt(format, NULL, (void (*)())RAWFMTFUNC_SERIAL, NULL);
 }
-#else
-#define KPutStr(x)
-#endif
 
 
 /**


### PR DESCRIPTION
Given any speed issue cannot be attributed to checking for _debug_NNN_level, removing this is a safe action

This fixes #6652.