### PR TITLE
Add: Include basic .editorconfig file to help enforce tab style #6699

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,cpp,h,hpp}]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,4 @@ trim_trailing_whitespace = true
 
 [*.{c,cpp,h,hpp}]
 indent_style = tab
+charset = utf-8


### PR DESCRIPTION
As per http://editorconfig.org/, add a .editorconfig file to help coax editors into doing the right thing by default. :)

Duplicate of PR 6699 since that one seems to have broken github...