### PR TITLE
List recent news messages in crashlog output

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -27,6 +27,7 @@
 #include "network/network.h"
 #include "language.h"
 #include "fontcache.h"
+#include "news_gui.h"
 
 #include "ai/ai_info.hpp"
 #include "game/game.hpp"
@@ -309,6 +310,27 @@ char *CrashLog::LogGamelog(char *buffer, const char *last) const
 }
 
 /**
+ * Writes any recent news messages to the buffer.
+ * @param buffer The begin where to write at.
+ * @param last   The last position in the buffer to write to.
+ * @return the position of the \c '\0' character after the buffer.
+ */
+char *CrashLog::LogRecentNews(char *buffer, const char *last) const
+{
+	buffer += seprintf(buffer, last, "Recent news messages:\n");
+
+	for (NewsItem *news = _oldest_news; news != NULL; news = news->next) {
+		YearMonthDay ymd;
+		ConvertDateToYMD(news->date, &ymd);
+		buffer += seprintf(buffer, last, "(%i-%02i-%02i) StringID: %u, Type: %u, Ref1: %u, %u, Ref2: %u, %u\n",
+		                   ymd.year, ymd.month + 1, ymd.day, news->string_id, news->type,
+		                   news->reftype1, news->ref1, news->reftype2, news->ref2);
+	}
+	buffer += seprintf(buffer, last, "\n");
+	return buffer;
+}
+
+/**
  * Fill the crash log buffer with all data of a crash log.
  * @param buffer The begin where to write at.
  * @param last   The last position in the buffer to write to.
@@ -334,6 +356,7 @@ char *CrashLog::FillCrashLog(char *buffer, const char *last) const
 	buffer = this->LogLibraries(buffer, last);
 	buffer = this->LogModules(buffer, last);
 	buffer = this->LogGamelog(buffer, last);
+	buffer = this->LogRecentNews(buffer, last);
 
 	buffer += seprintf(buffer, last, "*** End of OpenTTD Crash Report ***\n");
 	return buffer;

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -85,6 +85,7 @@ protected:
 	char *LogConfiguration(char *buffer, const char *last) const;
 	char *LogLibraries(char *buffer, const char *last) const;
 	char *LogGamelog(char *buffer, const char *last) const;
+	char *LogRecentNews(char *buffer, const char *list) const;
 
 public:
 	/** Stub destructor to silence some compilers. */

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -42,10 +42,10 @@
 
 const NewsItem *_statusbar_news_item = NULL;
 
-static uint MIN_NEWS_AMOUNT = 30;           ///< preferred minimum amount of news messages
-static uint _total_news = 0;                ///< current number of news items
-static NewsItem *_oldest_news = NULL;       ///< head of news items queue
-static NewsItem *_latest_news = NULL;       ///< tail of news items queue
+static uint MIN_NEWS_AMOUNT = 30;      ///< preferred minimum amount of news messages
+static uint _total_news = 0;           ///< current number of news items
+NewsItem *_oldest_news = NULL;         ///< head of news items queue
+static NewsItem *_latest_news = NULL;  ///< tail of news items queue
 
 /**
  * Forced news item.

--- a/src/news_gui.h
+++ b/src/news_gui.h
@@ -12,7 +12,11 @@
 #ifndef NEWS_GUI_H
 #define NEWS_GUI_H
 
+#include "news_type.h"
+
 void ShowLastNewsMessage();
 void ShowMessageHistory();
+
+extern NewsItem *_oldest_news;
 
 #endif /* NEWS_GUI_H */


### PR DESCRIPTION
As per todo list. A very-much cut down version of a patch I made 5 years ago in #5722 with further comments applied to it.

Output looks approximately like:
![](https://i.imgur.com/1BDOEUQ.png)

Closes #5722.