### PR TITLE
Codechange: [OSX] MacOS/MacPorts don't have realpath, ./configure fails

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1202,6 +1202,10 @@ check_params() {
 	fi
 }
 
+if ! which realpath; then
+	realpath() { readlink -f -- "$@"; }
+fi
+
 make_compiler_cflags() {
 	# Params:
 	# $1 - compiler
@@ -1211,11 +1215,7 @@ make_compiler_cflags() {
 	# $5 - name of the features variable
 
 	# Resolve symlinks, if your OS even does them
-	if [ "$os" = "MINGW" ] || [ "$os" = "CYGWIN" ] || [ "$os" = "DOS" ]; then
-		compiler="$1"
-	else
-		compiler="`realpath \`which $1\``"
-	fi
+	compiler="`realpath \`which $1\``"
 
 	eval eval "flags=\\\$$2"
 	eval eval "cxxflags=\\\$$3"


### PR DESCRIPTION
Second try at #6708.
MacOS doesn't originally have `realpath`, which is used some lines below.
This led to a failed `./configure`.