### PR TITLE
Add {NORMAL_FONT} and {MONO_FONT} control codes to GS strings

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -596,10 +596,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, const char *&str, 
 			state.SetColour((TextColour)(c - SCC_BLUE));
 		} else if (c == SCC_PREVIOUS_COLOUR) { // Revert to the previous colour.
 			state.SetPreviousColour();
-		} else if (c == SCC_TINYFONT) {
-			state.SetFontSize(FS_SMALL);
-		} else if (c == SCC_BIGFONT) {
-			state.SetFontSize(FS_LARGE);
+		} else if (c >= SCC_NORMALFONT && c <= SCC_MONOFONT) {
+			state.SetFontSize((FontSize)(c - SCC_NORMALFONT));
 		} else {
 			/* Filter out text direction characters that shouldn't be drawn, and
 			 * will not be handled in the fallback non ICU case because they are

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -596,8 +596,8 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, const char *&str, 
 			state.SetColour((TextColour)(c - SCC_BLUE));
 		} else if (c == SCC_PREVIOUS_COLOUR) { // Revert to the previous colour.
 			state.SetPreviousColour();
-		} else if (c >= SCC_NORMALFONT && c <= SCC_MONOFONT) {
-			state.SetFontSize((FontSize)(c - SCC_NORMALFONT));
+		} else if (c >= SCC_FIRST_FONT && c <= SCC_LAST_FONT) {
+			state.SetFontSize((FontSize)(c - SCC_FIRST_FONT));
 		} else {
 			/* Filter out text direction characters that shouldn't be drawn, and
 			 * will not be handled in the fallback non ICU case because they are

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2014,9 +2014,8 @@ bool MissingGlyphSearcher::FindMissingGlyphs(const char **str)
 		FontSize size = this->DefaultSize();
 		if (str != NULL) *str = text;
 		for (WChar c = Utf8Consume(&text); c != '\0'; c = Utf8Consume(&text)) {
-
-			if (c >= SCC_NORMALFONT && c <= SCC_MONOFONT) {
-				size = (FontSize)(c - SCC_NORMALFONT);
+			if (c >= SCC_FIRST_FONT && c <= SCC_LAST_FONT) {
+				size = (FontSize)(c - SCC_FIRST_FONT);
 			} else if (!IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END) && IsPrintable(c) && !IsTextDirectionChar(c) && c != '?' && GetGlyph(size, c) == question_mark[size]) {
 				/* The character is printable, but not in the normal font. This is the case we were testing for. */
 				return true;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2014,10 +2014,9 @@ bool MissingGlyphSearcher::FindMissingGlyphs(const char **str)
 		FontSize size = this->DefaultSize();
 		if (str != NULL) *str = text;
 		for (WChar c = Utf8Consume(&text); c != '\0'; c = Utf8Consume(&text)) {
-			if (c == SCC_TINYFONT) {
-				size = FS_SMALL;
-			} else if (c == SCC_BIGFONT) {
-				size = FS_LARGE;
+
+			if (c >= SCC_NORMALFONT && c <= SCC_MONOFONT) {
+				size = (FontSize)(c - SCC_NORMALFONT);
 			} else if (!IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END) && IsPrintable(c) && !IsTextDirectionChar(c) && c != '?' && GetGlyph(size, c) == question_mark[size]) {
 				/* The character is printable, but not in the normal font. This is the case we were testing for. */
 				return true;

--- a/src/table/control_codes.h
+++ b/src/table/control_codes.h
@@ -27,8 +27,10 @@ enum StringControlCode {
 	SCC_ENCODED = SCC_CONTROL_START,
 
 	/* Display control codes */
-	SCC_TINYFONT,  ///< Switch to small font
-	SCC_BIGFONT,   ///< Switch to large font
+	SCC_NORMALFONT, ///< Switch to normal size font
+	SCC_TINYFONT,   ///< Switch to small font
+	SCC_BIGFONT,    ///< Switch to large font
+	SCC_MONOFONT,   ///< Switch to monospaced font
 
 	/* Formatting control codes */
 	SCC_REVISION,

--- a/src/table/control_codes.h
+++ b/src/table/control_codes.h
@@ -26,11 +26,13 @@ enum StringControlCode {
 	/* This must be the first entry. It's encoded in strings that are saved. */
 	SCC_ENCODED = SCC_CONTROL_START,
 
-	/* Display control codes */
-	SCC_NORMALFONT, ///< Switch to normal size font
+	/* Font selection codes, must be in same order as FontSize enum */
+	SCC_FIRST_FONT,
+	SCC_NORMALFONT = SCC_FIRST_FONT, ///< Switch to normal size font
 	SCC_TINYFONT,   ///< Switch to small font
 	SCC_BIGFONT,    ///< Switch to large font
 	SCC_MONOFONT,   ///< Switch to monospaced font
+	SCC_LAST_FONT = SCC_MONOFONT,
 
 	/* Formatting control codes */
 	SCC_REVISION,

--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -37,8 +37,10 @@ extern void EmitGender(Buffer *buffer, char *buf, int value);
 
 static const CmdStruct _cmd_structs[] = {
 	/* Font size */
+	{"NORMAL_FONT",       EmitSingleChar, SCC_NORMALFONT,         0, -1, C_NONE},
 	{"TINY_FONT",         EmitSingleChar, SCC_TINYFONT,           0, -1, C_NONE},
 	{"BIG_FONT",          EmitSingleChar, SCC_BIGFONT,            0, -1, C_NONE},
+	{"MONO_FONT",         EmitSingleChar, SCC_MONOFONT,           0, -1, C_NONE},
 
 	/* Colours */
 	{"BLUE",              EmitSingleChar, SCC_BLUE,               0, -1, C_DONTCOUNT},


### PR DESCRIPTION
PR for issue #6465 

Having mono font will be very useful for text alignment (e.g. tables)
And not having normal font code sometimes prevents usage of big/small font as there is no way to go back.