### PR TITLE
Fix e614357: Ask the compiler who it is, instead of using symlinks

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1202,10 +1202,6 @@ check_params() {
 	fi
 }
 
-if [ -z `which realpath 2>/dev/null` ]; then
-	realpath() { readlink -f -- "$@"; }
-fi
-
 make_compiler_cflags() {
 	# Params:
 	# $1 - compiler
@@ -1214,17 +1210,17 @@ make_compiler_cflags() {
 	# $4 - name of the ldflags variable
 	# $5 - name of the features variable
 
-	# Resolve symlinks, if your OS even does them
-	compiler="`realpath \`which $1\``"
+	# Get the compiler to tell us who it is
+	compiler="`$1 --version | head -n1 | cut -d' ' -f1`"
 
 	eval eval "flags=\\\$$2"
 	eval eval "cxxflags=\\\$$3"
 	eval eval "ldflags=\\\$$4"
 	eval eval "features=\\\$$5"
 
-	if [ `basename $compiler | cut -c 1-3` = "icc" ]; then
+	if [ "$compiler" = "icc" ]; then
 		# Enable some things only for certain ICC versions
-		cc_version=`$compiler -dumpversion | cut -c 1-4 | sed s@\\\.@@g`
+		cc_version=`$1 -dumpversion | cut -c 1-4 | sed s@\\\.@@g`
 
 		flags="$flags -rdynamic"
 		ldflags="$ldflags -rdynamic"
@@ -1302,16 +1298,16 @@ make_compiler_cflags() {
 		fi
 
 		if [ "$enable_lto" != "0" ]; then
-			has_ipo=`$compiler -help ipo | grep '\-ipo'`
+			has_ipo=`$1 -help ipo | grep '\-ipo'`
 			if [ -n "$has_ipo" ]; then
 				# Use IPO (only if we see IPO exists and is requested)
 				flags="$flags -ipo"
 				features="$features lto"
 			fi
 		fi
-	elif [ `basename $compiler | grep 'clang'` ]; then
+	elif [ "$compiler" = "clang" ]; then
 		# Enable some things only for certain clang versions
-		cc_version="`$compiler -v 2>&1 | head -n 1 | sed s@[^0-9]@@g | cut -c 1-2`"
+		cc_version="`$1 -v 2>&1 | head -n 1 | sed s@[^0-9]@@g | cut -c 1-2`"
 
 		# aliasing rules are not held in openttd code
 		flags="$flags -fno-strict-aliasing"
@@ -1366,11 +1362,13 @@ make_compiler_cflags() {
 
 		# rdynamic is used to get useful stack traces from crash reports.
 		ldflags="$ldflags -rdynamic"
+
+	# Assume gcc, since it just uses argv[0] in its --version output
 	else
 		# Enable some things only for certain GCC versions
 		# cc_version = major_version * 100 + minor_version
 		# For example: "3.3" -> 303, "4.9.2" -> 409, "6" -> 600, "23.5" -> 2305
-		cc_version=`$compiler -dumpversion | $awk -F . '{printf "%d%02d", $1, $2}'`
+		cc_version=`$1 -dumpversion | $awk -F . '{printf "%d%02d", $1, $2}'`
 
 		if [ $cc_version -lt 303 ]; then
 			log 1 "configure: error: gcc older than 3.3 can't compile OpenTTD because of its poor template support"
@@ -1452,7 +1450,7 @@ make_compiler_cflags() {
 
 		if [ "$enable_lto" != "0" ]; then
 			# GCC 4.5 outputs '%{flto}', GCC 4.6 outputs '%{flto*}'
-			has_lto=`$compiler -dumpspecs | grep '\%{flto'`
+			has_lto=`$1 -dumpspecs | grep '\%{flto'`
 			if [ -n "$has_lto" ]; then
 				# Use LTO only if we see LTO exists and is requested
 				if [ $cc_version -lt 406 ]; then
@@ -1465,7 +1463,7 @@ make_compiler_cflags() {
 			fi
 		fi
 
-		has_rdynamic=`$compiler -dumpspecs | grep rdynamic`
+		has_rdynamic=`$1 -dumpspecs | grep rdynamic`
 		if [ -n "$has_rdynamic" ]; then
 			# rdynamic is used to get useful stack traces from crash reports.
 			flags="$flags -rdynamic"


### PR DESCRIPTION
In the case that ccache binaries are in PATH, and come before actual compilers.

Fixes #6723 