### PR TITLE
Codechange #6729: mute bogus  GCC 7 warning

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1971,12 +1971,12 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 					if (length == 0 || number == 0) break;
 
 					if (length > statspec->lengths) {
+						byte diff_length = length - statspec->lengths;
 						statspec->platforms = ReallocT(statspec->platforms, length);
-						memset(statspec->platforms + statspec->lengths, 0, length - statspec->lengths);
+						memset(statspec->platforms + statspec->lengths, 0, diff_length);
 
 						statspec->layouts = ReallocT(statspec->layouts, length);
-						memset(statspec->layouts + statspec->lengths, 0,
-						       (length - statspec->lengths) * sizeof(*statspec->layouts));
+						memset(statspec->layouts + statspec->lengths, 0, diff_length * sizeof(*statspec->layouts));
 
 						statspec->lengths = length;
 					}


### PR DESCRIPTION
We do a memset of (byte - byte), which strictly seen ranges from -254 .. 255, for which GCC warns.
But just before this memset is an if() which says the first byte has to be bigger than the second.
So this is a bogus warning.