### PR TITLE
API for querying network clients from GS

### DIFF
--- a/projects/openttd_vs100.vcxproj
+++ b/projects/openttd_vs100.vcxproj
@@ -1010,6 +1010,8 @@
     <ClInclude Include="..\src\script\api\script_cargo.hpp" />
     <ClInclude Include="..\src\script\api\script_cargolist.hpp" />
     <ClInclude Include="..\src\script\api\script_cargomonitor.hpp" />
+    <ClInclude Include="..\src\script\api\script_client.hpp" />
+    <ClInclude Include="..\src\script\api\script_clientlist.hpp" />
     <ClInclude Include="..\src\script\api\script_company.hpp" />
     <ClInclude Include="..\src\script\api\script_companymode.hpp" />
     <ClInclude Include="..\src\script\api\script_controller.hpp" />
@@ -1075,6 +1077,8 @@
     <ClCompile Include="..\src\script\api\script_cargo.cpp" />
     <ClCompile Include="..\src\script\api\script_cargolist.cpp" />
     <ClCompile Include="..\src\script\api\script_cargomonitor.cpp" />
+    <ClCompile Include="..\src\script\api\script_client.cpp" />
+    <ClCompile Include="..\src\script\api\script_clientlist.cpp" />
     <ClCompile Include="..\src\script\api\script_company.cpp" />
     <ClCompile Include="..\src\script\api\script_companymode.cpp" />
     <ClCompile Include="..\src\script\api\script_controller.cpp" />

--- a/projects/openttd_vs100.vcxproj.filters
+++ b/projects/openttd_vs100.vcxproj.filters
@@ -2223,6 +2223,12 @@
     <ClInclude Include="..\src\script\api\script_cargomonitor.hpp">
       <Filter>Script API</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\script\api\script_client.hpp">
+      <Filter>Script API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\script\api\script_clientlist.hpp">
+      <Filter>Script API</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\script\api\script_company.hpp">
       <Filter>Script API</Filter>
     </ClInclude>
@@ -2416,6 +2422,12 @@
       <Filter>Script API Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\src\script\api\script_cargomonitor.cpp">
+      <Filter>Script API Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\script\api\script_client.cpp">
+      <Filter>Script API Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\script\api\script_clientlist.cpp">
       <Filter>Script API Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\src\script\api\script_company.cpp">

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -1031,6 +1031,8 @@
     <ClInclude Include="..\src\script\api\script_cargo.hpp" />
     <ClInclude Include="..\src\script\api\script_cargolist.hpp" />
     <ClInclude Include="..\src\script\api\script_cargomonitor.hpp" />
+    <ClInclude Include="..\src\script\api\script_client.hpp" />
+    <ClInclude Include="..\src\script\api\script_clientlist.hpp" />
     <ClInclude Include="..\src\script\api\script_company.hpp" />
     <ClInclude Include="..\src\script\api\script_companymode.hpp" />
     <ClInclude Include="..\src\script\api\script_controller.hpp" />
@@ -1096,6 +1098,8 @@
     <ClCompile Include="..\src\script\api\script_cargo.cpp" />
     <ClCompile Include="..\src\script\api\script_cargolist.cpp" />
     <ClCompile Include="..\src\script\api\script_cargomonitor.cpp" />
+    <ClCompile Include="..\src\script\api\script_client.cpp" />
+    <ClCompile Include="..\src\script\api\script_clientlist.cpp" />
     <ClCompile Include="..\src\script\api\script_company.cpp" />
     <ClCompile Include="..\src\script\api\script_companymode.cpp" />
     <ClCompile Include="..\src\script\api\script_controller.cpp" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -2223,6 +2223,12 @@
     <ClInclude Include="..\src\script\api\script_cargomonitor.hpp">
       <Filter>Script API</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\script\api\script_client.hpp">
+      <Filter>Script API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\script\api\script_clientlist.hpp">
+      <Filter>Script API</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\script\api\script_company.hpp">
       <Filter>Script API</Filter>
     </ClInclude>
@@ -2416,6 +2422,12 @@
       <Filter>Script API Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\src\script\api\script_cargomonitor.cpp">
+      <Filter>Script API Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\script\api\script_client.cpp">
+      <Filter>Script API Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\script\api\script_clientlist.cpp">
       <Filter>Script API Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\src\script\api\script_company.cpp">

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -1031,6 +1031,8 @@
     <ClInclude Include="..\src\script\api\script_cargo.hpp" />
     <ClInclude Include="..\src\script\api\script_cargolist.hpp" />
     <ClInclude Include="..\src\script\api\script_cargomonitor.hpp" />
+    <ClInclude Include="..\src\script\api\script_client.hpp" />
+    <ClInclude Include="..\src\script\api\script_clientlist.hpp" />
     <ClInclude Include="..\src\script\api\script_company.hpp" />
     <ClInclude Include="..\src\script\api\script_companymode.hpp" />
     <ClInclude Include="..\src\script\api\script_controller.hpp" />
@@ -1096,6 +1098,8 @@
     <ClCompile Include="..\src\script\api\script_cargo.cpp" />
     <ClCompile Include="..\src\script\api\script_cargolist.cpp" />
     <ClCompile Include="..\src\script\api\script_cargomonitor.cpp" />
+    <ClCompile Include="..\src\script\api\script_client.cpp" />
+    <ClCompile Include="..\src\script\api\script_clientlist.cpp" />
     <ClCompile Include="..\src\script\api\script_company.cpp" />
     <ClCompile Include="..\src\script\api\script_companymode.cpp" />
     <ClCompile Include="..\src\script\api\script_controller.cpp" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -2223,6 +2223,12 @@
     <ClInclude Include="..\src\script\api\script_cargomonitor.hpp">
       <Filter>Script API</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\script\api\script_client.hpp">
+      <Filter>Script API</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\script\api\script_clientlist.hpp">
+      <Filter>Script API</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\script\api\script_company.hpp">
       <Filter>Script API</Filter>
     </ClInclude>
@@ -2416,6 +2422,12 @@
       <Filter>Script API Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\src\script\api\script_cargomonitor.cpp">
+      <Filter>Script API Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\script\api\script_client.cpp">
+      <Filter>Script API Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\script\api\script_clientlist.cpp">
       <Filter>Script API Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\src\script\api\script_company.cpp">

--- a/projects/openttd_vs80.vcproj
+++ b/projects/openttd_vs80.vcproj
@@ -3327,6 +3327,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\..\src\script\api\script_client.hpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\script\api\script_clientlist.hpp"
+				>
+			</File>
+			<File
 				RelativePath=".\..\src\script\api\script_company.hpp"
 				>
 			</File>
@@ -3588,6 +3596,14 @@
 			</File>
 			<File
 				RelativePath=".\..\src\script\api\script_cargomonitor.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\script\api\script_client.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\script\api\script_clientlist.cpp"
 				>
 			</File>
 			<File

--- a/projects/openttd_vs90.vcproj
+++ b/projects/openttd_vs90.vcproj
@@ -3324,6 +3324,14 @@
 				>
 			</File>
 			<File
+				RelativePath=".\..\src\script\api\script_client.hpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\script\api\script_clientlist.hpp"
+				>
+			</File>
+			<File
 				RelativePath=".\..\src\script\api\script_company.hpp"
 				>
 			</File>
@@ -3585,6 +3593,14 @@
 			</File>
 			<File
 				RelativePath=".\..\src\script\api\script_cargomonitor.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\script\api\script_client.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\script\api\script_clientlist.cpp"
 				>
 			</File>
 			<File

--- a/source.list
+++ b/source.list
@@ -782,6 +782,8 @@ script/api/script_bridgelist.hpp
 script/api/script_cargo.hpp
 script/api/script_cargolist.hpp
 script/api/script_cargomonitor.hpp
+script/api/script_client.hpp
+script/api/script_clientlist.hpp
 script/api/script_company.hpp
 script/api/script_companymode.hpp
 script/api/script_controller.hpp
@@ -849,6 +851,8 @@ script/api/script_bridgelist.cpp
 script/api/script_cargo.cpp
 script/api/script_cargolist.cpp
 script/api/script_cargomonitor.cpp
+script/api/script_client.cpp
+script/api/script_clientlist.cpp
 script/api/script_company.cpp
 script/api/script_companymode.cpp
 script/api/script_controller.cpp

--- a/src/game/game_instance.cpp
+++ b/src/game/game_instance.cpp
@@ -34,6 +34,8 @@
 #include "../script/api/game/game_cargo.hpp.sq"
 #include "../script/api/game/game_cargolist.hpp.sq"
 #include "../script/api/game/game_cargomonitor.hpp.sq"
+#include "../script/api/game/game_client.hpp.sq"
+#include "../script/api/game/game_clientlist.hpp.sq"
 #include "../script/api/game/game_company.hpp.sq"
 #include "../script/api/game/game_companymode.hpp.sq"
 #include "../script/api/game/game_controller.hpp.sq"
@@ -122,6 +124,9 @@ void GameInstance::RegisterAPI()
 	SQGSCargoList_IndustryProducing_Register(this->engine);
 	SQGSCargoList_StationAccepting_Register(this->engine);
 	SQGSCargoMonitor_Register(this->engine);
+	SQGSClient_Register(this->engine);
+	SQGSClientList_Register(this->engine);
+	SQGSClientList_Company_Register(this->engine);
 	SQGSCompany_Register(this->engine);
 	SQGSCompanyMode_Register(this->engine);
 	SQGSDate_Register(this->engine);

--- a/src/script/api/ai/ai_company.hpp.sq
+++ b/src/script/api/ai/ai_company.hpp.sq
@@ -21,15 +21,16 @@ void SQAICompany_Register(Squirrel *engine)
 	SQAICompany.PreRegister(engine);
 	SQAICompany.AddConstructor<void (ScriptCompany::*)(), 1>(engine, "x");
 
-	SQAICompany.DefSQConst(engine, ScriptCompany::CURRENT_QUARTER,  "CURRENT_QUARTER");
-	SQAICompany.DefSQConst(engine, ScriptCompany::EARLIEST_QUARTER, "EARLIEST_QUARTER");
-	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_FIRST,    "COMPANY_FIRST");
-	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_LAST,     "COMPANY_LAST");
-	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_INVALID,  "COMPANY_INVALID");
-	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_SELF,     "COMPANY_SELF");
-	SQAICompany.DefSQConst(engine, ScriptCompany::GENDER_MALE,      "GENDER_MALE");
-	SQAICompany.DefSQConst(engine, ScriptCompany::GENDER_FEMALE,    "GENDER_FEMALE");
-	SQAICompany.DefSQConst(engine, ScriptCompany::GENDER_INVALID,   "GENDER_INVALID");
+	SQAICompany.DefSQConst(engine, ScriptCompany::CURRENT_QUARTER,   "CURRENT_QUARTER");
+	SQAICompany.DefSQConst(engine, ScriptCompany::EARLIEST_QUARTER,  "EARLIEST_QUARTER");
+	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_FIRST,     "COMPANY_FIRST");
+	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_LAST,      "COMPANY_LAST");
+	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_INVALID,   "COMPANY_INVALID");
+	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_SELF,      "COMPANY_SELF");
+	SQAICompany.DefSQConst(engine, ScriptCompany::COMPANY_SPECTATOR, "COMPANY_SPECTATOR");
+	SQAICompany.DefSQConst(engine, ScriptCompany::GENDER_MALE,       "GENDER_MALE");
+	SQAICompany.DefSQConst(engine, ScriptCompany::GENDER_FEMALE,     "GENDER_FEMALE");
+	SQAICompany.DefSQConst(engine, ScriptCompany::GENDER_INVALID,    "GENDER_INVALID");
 
 	SQAICompany.DefSQStaticMethod(engine, &ScriptCompany::ResolveCompanyID,              "ResolveCompanyID",              2, ".i");
 	SQAICompany.DefSQStaticMethod(engine, &ScriptCompany::IsMine,                        "IsMine",                        2, ".i");

--- a/src/script/api/game/game_client.hpp.sq
+++ b/src/script/api/game/game_client.hpp.sq
@@ -1,0 +1,34 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE IS AUTO-GENERATED; PLEASE DO NOT ALTER MANUALLY */
+
+#include "../script_client.hpp"
+#include "../template/template_client.hpp.sq"
+
+
+template <> const char *GetClassName<ScriptClient, ST_GS>() { return "GSClient"; }
+
+void SQGSClient_Register(Squirrel *engine)
+{
+	DefSQClass<ScriptClient, ST_GS> SQGSClient("GSClient");
+	SQGSClient.PreRegister(engine);
+	SQGSClient.AddConstructor<void (ScriptClient::*)(), 1>(engine, "x");
+
+	SQGSClient.DefSQConst(engine, ScriptClient::CLIENT_INVALID, "CLIENT_INVALID");
+	SQGSClient.DefSQConst(engine, ScriptClient::CLIENT_SERVER,  "CLIENT_SERVER");
+	SQGSClient.DefSQConst(engine, ScriptClient::CLIENT_FIRST,   "CLIENT_FIRST");
+
+	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::ResolveClientID, "ResolveClientID", 2, ".i");
+	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetName,         "GetName",         2, ".i");
+	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetCompany,      "GetCompany",      2, ".i");
+	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetJoinedDate,   "GetJoinedDate",   2, ".i");
+
+	SQGSClient.PostRegister(engine);
+}

--- a/src/script/api/game/game_client.hpp.sq
+++ b/src/script/api/game/game_client.hpp.sq
@@ -28,7 +28,7 @@ void SQGSClient_Register(Squirrel *engine)
 	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::ResolveClientID, "ResolveClientID", 2, ".i");
 	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetName,         "GetName",         2, ".i");
 	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetCompany,      "GetCompany",      2, ".i");
-	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetJoinedDate,   "GetJoinedDate",   2, ".i");
+	SQGSClient.DefSQStaticMethod(engine, &ScriptClient::GetJoinDate,     "GetJoinDate",     2, ".i");
 
 	SQGSClient.PostRegister(engine);
 }

--- a/src/script/api/game/game_clientlist.hpp.sq
+++ b/src/script/api/game/game_clientlist.hpp.sq
@@ -1,0 +1,37 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE IS AUTO-GENERATED; PLEASE DO NOT ALTER MANUALLY */
+
+#include "../script_clientlist.hpp"
+#include "../template/template_clientlist.hpp.sq"
+
+
+template <> const char *GetClassName<ScriptClientList, ST_GS>() { return "GSClientList"; }
+
+void SQGSClientList_Register(Squirrel *engine)
+{
+	DefSQClass<ScriptClientList, ST_GS> SQGSClientList("GSClientList");
+	SQGSClientList.PreRegister(engine, "GSList");
+	SQGSClientList.AddConstructor<void (ScriptClientList::*)(), 1>(engine, "x");
+
+	SQGSClientList.PostRegister(engine);
+}
+
+
+template <> const char *GetClassName<ScriptClientList_Company, ST_GS>() { return "GSClientList_Company"; }
+
+void SQGSClientList_Company_Register(Squirrel *engine)
+{
+	DefSQClass<ScriptClientList_Company, ST_GS> SQGSClientList_Company("GSClientList_Company");
+	SQGSClientList_Company.PreRegister(engine, "GSList");
+	SQGSClientList_Company.AddConstructor<void (ScriptClientList_Company::*)(ScriptCompany::CompanyID company), 2>(engine, "xi");
+
+	SQGSClientList_Company.PostRegister(engine);
+}

--- a/src/script/api/game/game_company.hpp.sq
+++ b/src/script/api/game/game_company.hpp.sq
@@ -27,6 +27,7 @@ void SQGSCompany_Register(Squirrel *engine)
 	SQGSCompany.DefSQConst(engine, ScriptCompany::COMPANY_LAST,          "COMPANY_LAST");
 	SQGSCompany.DefSQConst(engine, ScriptCompany::COMPANY_INVALID,       "COMPANY_INVALID");
 	SQGSCompany.DefSQConst(engine, ScriptCompany::COMPANY_SELF,          "COMPANY_SELF");
+	SQGSCompany.DefSQConst(engine, ScriptCompany::COMPANY_SPECTATOR,     "COMPANY_SPECTATOR");
 	SQGSCompany.DefSQConst(engine, ScriptCompany::GENDER_MALE,           "GENDER_MALE");
 	SQGSCompany.DefSQConst(engine, ScriptCompany::GENDER_FEMALE,         "GENDER_FEMALE");
 	SQGSCompany.DefSQConst(engine, ScriptCompany::GENDER_INVALID,        "GENDER_INVALID");

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -18,10 +18,16 @@
  * \b 1.9.0
  *
  * 1.9.0 is not yet released. The following changes are not set in stone yet.
+ * \li GSClientList
+ * \li GSClientList_Company
+ * \li GSClient::ResolveClientID
+ * \li GSClient::GetName
+ * \li GSClient::GetCompany
+ * \li GSClient::GetJoinedDate
  *
  * \b 1.8.0
  *
- * 1.8.0 is not yet released. The following changes are not set in stone yet.
+ * No changes
  *
  * \b 1.7.0 - 1.7.2
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -23,7 +23,7 @@
  * \li GSClient::ResolveClientID
  * \li GSClient::GetName
  * \li GSClient::GetCompany
- * \li GSClient::GetJoinedDate
+ * \li GSClient::GetJoinDate
  *
  * \b 1.8.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -18,12 +18,10 @@
  * \b 1.9.0
  *
  * 1.9.0 is not yet released. The following changes are not set in stone yet.
+ * API additions:
+ * \li GSClient
  * \li GSClientList
  * \li GSClientList_Company
- * \li GSClient::ResolveClientID
- * \li GSClient::GetName
- * \li GSClient::GetCompany
- * \li GSClient::GetJoinDate
  *
  * \b 1.8.0
  *

--- a/src/script/api/script_client.cpp
+++ b/src/script/api/script_client.cpp
@@ -62,7 +62,7 @@ static NetworkClientInfo *FindClientInfo(ScriptClient::ClientID client)
 #endif
 }
 
-/* static */ ScriptDate::Date ScriptClient::GetJoinedDate(ScriptClient::ClientID client)
+/* static */ ScriptDate::Date ScriptClient::GetJoinDate(ScriptClient::ClientID client)
 {
 #ifdef ENABLE_NETWORK
 	NetworkClientInfo *ci = FindClientInfo(client);

--- a/src/script/api/script_client.cpp
+++ b/src/script/api/script_client.cpp
@@ -17,6 +17,12 @@
 #include "../../safeguards.h"
 
 #ifdef ENABLE_NETWORK
+/**
+ * Finds NetworkClientInfo given client-identifier,
+ *  is used by other methods to resolve client-identifier.
+ * @param client The client to get info structure for
+ * @return A pointer to corresponding CI struct or NULL when not found.
+ */
 static NetworkClientInfo *FindClientInfo(ScriptClient::ClientID client)
 {
 	if (client == ScriptClient::CLIENT_INVALID) return NULL;

--- a/src/script/api/script_client.cpp
+++ b/src/script/api/script_client.cpp
@@ -16,38 +16,53 @@
 
 #include "../../safeguards.h"
 
-/* static */ NetworkClientInfo *ScriptClient::FindClientInfo(ScriptClient::ClientID client)
+#ifdef ENABLE_NETWORK
+static NetworkClientInfo *FindClientInfo(ScriptClient::ClientID client)
 {
-	if (client == CLIENT_INVALID) return NULL;
+	if (client == ScriptClient::CLIENT_INVALID) return NULL;
 	if (!_networking) return NULL;
 	return NetworkClientInfo::GetByClientID((::ClientID)client);
 }
+#endif
 
 /* static */ ScriptClient::ClientID ScriptClient::ResolveClientID(ScriptClient::ClientID client)
 {
-	return (FindClientInfo(client) == NULL ? client : CLIENT_INVALID);
+#ifdef ENABLE_NETWORK
+	return (FindClientInfo(client) == NULL ? ScriptClient::CLIENT_INVALID : client);
+#else
+	return CLIENT_INVALID;
+#endif
 }
 
 /* static */ char *ScriptClient::GetName(ScriptClient::ClientID client)
 {
+#ifdef ENABLE_NETWORK
 	NetworkClientInfo *ci = FindClientInfo(client);
 	if (ci == NULL) return NULL;
-
 	return stredup(ci->client_name);
+#else
+	return NULL;
+#endif
 }
 
 /* static */ ScriptCompany::CompanyID ScriptClient::GetCompany(ScriptClient::ClientID client)
 {
+#ifdef ENABLE_NETWORK
 	NetworkClientInfo *ci = FindClientInfo(client);
 	if (ci == NULL) return ScriptCompany::COMPANY_INVALID;
-
 	return (ScriptCompany::CompanyID)ci->client_playas;
+#else
+	return ScriptCompany::COMPANY_INVALID;
+#endif
 }
 
 /* static */ ScriptDate::Date ScriptClient::GetJoinedDate(ScriptClient::ClientID client)
 {
+#ifdef ENABLE_NETWORK
 	NetworkClientInfo *ci = FindClientInfo(client);
 	if (ci == NULL) return ScriptDate::DATE_INVALID;
-
 	return (ScriptDate::Date)ci->join_date;
+#else
+	return ScriptDate::DATE_INVALID;
+#endif
 }

--- a/src/script/api/script_client.cpp
+++ b/src/script/api/script_client.cpp
@@ -1,0 +1,53 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_client.cpp Implementation of ScriptClient. */
+
+#include "../../stdafx.h"
+#include "script_client.hpp"
+#include "../../network/network.h"
+#include "../../network/network_base.h"
+
+#include "../../safeguards.h"
+
+/* static */ NetworkClientInfo *ScriptClient::FindClientInfo(ScriptClient::ClientID client)
+{
+	if (client == CLIENT_INVALID) return NULL;
+	if (!_networking) return NULL;
+	return NetworkClientInfo::GetByClientID((::ClientID)client);
+}
+
+/* static */ ScriptClient::ClientID ScriptClient::ResolveClientID(ScriptClient::ClientID client)
+{
+	return (FindClientInfo(client) == NULL ? client : CLIENT_INVALID);
+}
+
+/* static */ char *ScriptClient::GetName(ScriptClient::ClientID client)
+{
+	NetworkClientInfo *ci = FindClientInfo(client);
+	if (ci == NULL) return NULL;
+
+	return stredup(ci->client_name);
+}
+
+/* static */ ScriptCompany::CompanyID ScriptClient::GetCompany(ScriptClient::ClientID client)
+{
+	NetworkClientInfo *ci = FindClientInfo(client);
+	if (ci == NULL) return ScriptCompany::COMPANY_INVALID;
+
+	return (ScriptCompany::CompanyID)ci->client_playas;
+}
+
+/* static */ ScriptDate::Date ScriptClient::GetJoinedDate(ScriptClient::ClientID client)
+{
+	NetworkClientInfo *ci = FindClientInfo(client);
+	if (ci == NULL) return ScriptDate::DATE_INVALID;
+
+	return (ScriptDate::Date)ci->join_date;
+}

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -53,7 +53,7 @@ public:
 	 * Get the company in which the given client is playing.
 	 * @param client The client to get company for.
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
-	 * @return The company in which client is playing.
+	 * @return The company in which client is playing or COMPANY_SPECTATOR.
 	 */
 	static ScriptCompany::CompanyID GetCompany(ClientID client);
 

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -58,10 +58,10 @@ public:
 	static ScriptCompany::CompanyID GetCompany(ClientID client);
 
 	/**
-	* Get the game date when the given client has joined.
-	* @param client The client to get joining date for.
-	* @pre ResolveClientID(client) != CLIENT_INVALID.
-	* @return The date when client has joined.
+	 * Get the game date when the given client has joined.
+	 * @param client The client to get joining date for.
+	 * @pre ResolveClientID(client) != CLIENT_INVALID.
+	 * @return The date when client has joined.
 	 */
 	static ScriptDate::Date GetJoinedDate(ClientID client);
 };

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -64,15 +64,6 @@ public:
 	* @return The date when client has joined.
 	 */
 	static ScriptDate::Date GetJoinedDate(ClientID client);
-
-protected:
-	/**
-	* Finds NetworkClientInfo given client-identifier,
-	   is used by other methods to resolve client-identifier.
-	* @param client The client to get info structure for.
-	* @return A pointer to corresponding CI struct or NULL when not found.
-	 */
-	 static NetworkClientInfo *FindClientInfo(ClientID client);
 };
 
 

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -27,9 +27,9 @@ public:
 
 	/** Different constants related to ClientID. */
 	enum ClientID {
-		CLIENT_INVALID = 0,  ///< c1
-		CLIENT_SERVER  = 1,  ///< c2
-		CLIENT_FIRST   = 2,  ///< c3
+		CLIENT_INVALID = 0,  ///< Client is not part of anything
+		CLIENT_SERVER  = 1,  ///< Servers always have this ID
+		CLIENT_FIRST   = 2,  ///< The first client ID
 	};
 
 	/**

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -1,0 +1,79 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_client.hpp Everything to query a network client's information */
+
+#ifndef SCRIPT_CLIENT_HPP
+#define SCRIPT_CLIENT_HPP
+
+#include "script_text.hpp"
+#include "script_date.hpp"
+#include "script_company.hpp"
+#include "../../network/network_type.h"
+
+/**
+ * Class that handles all client related functions.
+ *
+ * @api game
+ */
+class ScriptClient : public ScriptObject {
+public:
+
+	/** Different constants related to ClientID. */
+	enum ClientID {
+		CLIENT_INVALID = 0,  ///< c1
+		CLIENT_SERVER  = 1,  ///< c2
+		CLIENT_FIRST   = 2,  ///< c3
+	};
+
+	/**
+	 * Resolves the given client id to the correct index for the client.
+	 *  If the client with the given id does not exist it will
+	 *  return CLIENT_INVALID.
+	 * @param client The client id to resolve.
+	 * @return The resolved client id.
+	 */
+	static ClientID ResolveClientID(ClientID client);
+
+	/**
+	 * Get the name of the given client.
+	 * @param client The client to get the name for.
+	 * @pre ResolveClientID(client) != CLIENT_INVALID.
+	 * @return The name of the given client.
+	 */
+	static char *GetName(ClientID client);
+
+	/**
+	 * Get the company in which the given client is playing.
+	 * @param client The client to get company for.
+	 * @pre ResolveClientID(client) != CLIENT_INVALID.
+	 * @return The company in which client is playing.
+	 */
+	static ScriptCompany::CompanyID GetCompany(ClientID client);
+
+	/**
+	* Get the game date when the given client has joined.
+	* @param client The client to get joining date for.
+	* @pre ResolveClientID(client) != CLIENT_INVALID.
+	* @return The date when client has joined.
+	 */
+	static ScriptDate::Date GetJoinedDate(ClientID client);
+
+protected:
+	/**
+	* Finds NetworkClientInfo given client-identifier,
+	   is used by other methods to resolve client-identifier.
+	* @param client The client to get info structure for.
+	* @return A pointer to corresponding CI struct or NULL when not found.
+	 */
+	 static NetworkClientInfo *FindClientInfo(ClientID client);
+};
+
+
+#endif /* SCRIPT_CLIENT_HPP */

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -63,7 +63,7 @@ public:
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
 	 * @return The date when client has joined.
 	 */
-	static ScriptDate::Date GetJoinedDate(ClientID client);
+	static ScriptDate::Date GetJoinDate(ClientID client);
 };
 
 

--- a/src/script/api/script_clientlist.cpp
+++ b/src/script/api/script_clientlist.cpp
@@ -1,0 +1,38 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_clientlist.cpp Implementation of ScriptClientList and friends. */
+
+#include "../../stdafx.h"
+#include "script_clientlist.hpp"
+#include "../../network/network.h"
+#include "../../network/network_base.h"
+
+#include "../../safeguards.h"
+
+ScriptClientList::ScriptClientList()
+{
+	if (!_networking) return;
+	NetworkClientInfo *ci;
+	FOR_ALL_CLIENT_INFOS(ci) {
+		this->AddItem(ci->client_id);
+	}
+}
+
+ScriptClientList_Company::ScriptClientList_Company(ScriptCompany::CompanyID company)
+{
+	if (!_networking) return;
+	CompanyID c = (CompanyID)company;
+	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+
+	NetworkClientInfo *ci;
+	FOR_ALL_CLIENT_INFOS(ci) {
+		if (ci->client_playas == c) this->AddItem(ci->client_id);
+	}
+}

--- a/src/script/api/script_clientlist.cpp
+++ b/src/script/api/script_clientlist.cpp
@@ -10,6 +10,7 @@
 /** @file script_clientlist.cpp Implementation of ScriptClientList and friends. */
 
 #include "../../stdafx.h"
+#include "script_company.hpp"
 #include "script_clientlist.hpp"
 #include "../../network/network.h"
 #include "../../network/network_base.h"
@@ -31,8 +32,14 @@ ScriptClientList_Company::ScriptClientList_Company(ScriptCompany::CompanyID comp
 {
 #ifdef ENABLE_NETWORK
 	if (!_networking) return;
-	CompanyID c = (CompanyID)company;
-	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
+	CompanyID c;
+	if (company == ScriptCompany::COMPANY_SPECTATOR) {
+		c = ::COMPANY_SPECTATOR;
+	} else {
+		company = ScriptCompany::ResolveCompanyID(company);
+		if (company == ScriptCompany::COMPANY_INVALID) return;
+		c = (CompanyID)company;
+	}
 
 	NetworkClientInfo *ci;
 	FOR_ALL_CLIENT_INFOS(ci) {

--- a/src/script/api/script_clientlist.cpp
+++ b/src/script/api/script_clientlist.cpp
@@ -18,15 +18,18 @@
 
 ScriptClientList::ScriptClientList()
 {
+#ifdef ENABLE_NETWORK
 	if (!_networking) return;
 	NetworkClientInfo *ci;
 	FOR_ALL_CLIENT_INFOS(ci) {
 		this->AddItem(ci->client_id);
 	}
+#endif
 }
 
 ScriptClientList_Company::ScriptClientList_Company(ScriptCompany::CompanyID company)
 {
+#ifdef ENABLE_NETWORK
 	if (!_networking) return;
 	CompanyID c = (CompanyID)company;
 	if (company == ScriptCompany::COMPANY_INVALID) c = INVALID_COMPANY;
@@ -35,4 +38,5 @@ ScriptClientList_Company::ScriptClientList_Company(ScriptCompany::CompanyID comp
 	FOR_ALL_CLIENT_INFOS(ci) {
 		if (ci->client_playas == c) this->AddItem(ci->client_id);
 	}
+#endif
 }

--- a/src/script/api/script_clientlist.hpp
+++ b/src/script/api/script_clientlist.hpp
@@ -1,0 +1,42 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_clientlist.hpp List all the TODO. */
+
+#ifndef SCRIPT_CLIENTLIST_HPP
+#define SCRIPT_CLIENTLIST_HPP
+
+#include "script_list.hpp"
+#include "script_company.hpp"
+
+
+/**
+ * Creates a list of clients that are currently in game.
+ * @api game
+ * @ingroup ScriptList
+ */
+class ScriptClientList : public ScriptList {
+public:
+	ScriptClientList();
+};
+
+/**
+ * Creates a list of clients that are playing in the company.
+ * @api game
+ * @ingroup ScriptList
+ */
+class ScriptClientList_Company : public ScriptList {
+public:
+	/**
+	 * @param company_id The company to list clients for.
+	 */
+	 ScriptClientList_Company(ScriptCompany::CompanyID company);
+};
+
+#endif /* SCRIPT_CIENTLIST_HPP */

--- a/src/script/api/script_clientlist.hpp
+++ b/src/script/api/script_clientlist.hpp
@@ -36,7 +36,7 @@ public:
 	/**
 	 * @param company_id The company to list clients for.
 	 */
-	 ScriptClientList_Company(ScriptCompany::CompanyID company);
+	ScriptClientList_Company(ScriptCompany::CompanyID company);
 };
 
 #endif /* SCRIPT_CIENTLIST_HPP */

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -30,12 +30,13 @@ public:
 	/** Different constants related to CompanyID. */
 	enum CompanyID {
 		/* Note: these values represent part of the in-game Owner enum */
-		COMPANY_FIRST   = ::COMPANY_FIRST,   ///< The first available company.
-		COMPANY_LAST    = ::MAX_COMPANIES,   ///< The last available company.
+		COMPANY_FIRST     = ::COMPANY_FIRST,   ///< The first available company.
+		COMPANY_LAST      = ::MAX_COMPANIES,   ///< The last available company.
 
 		/* Custom added value, only valid for this API */
-		COMPANY_INVALID = -1,                ///< An invalid company.
-		COMPANY_SELF    = 254,               ///< Constant that gets resolved to the correct company index for your company.
+		COMPANY_INVALID   = -1,                ///< An invalid company.
+		COMPANY_SELF      = 254,               ///< Constant that gets resolved to the correct company index for your company.
+		COMPANY_SPECTATOR = 255,               ///< Constant indicating that player is spectating (gets resolved to COMPANY_INVALID)
 	};
 
 	/** Possible genders for company presidents. */

--- a/src/script/api/template/template_client.hpp.sq
+++ b/src/script/api/template/template_client.hpp.sq
@@ -1,0 +1,25 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE IS AUTO-GENERATED; PLEASE DO NOT ALTER MANUALLY */
+
+#include "../script_client.hpp"
+
+namespace SQConvert {
+	/* Allow enums to be used as Squirrel parameters */
+	template <> inline ScriptClient::ClientID GetParam(ForceType<ScriptClient::ClientID>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQInteger tmp; sq_getinteger(vm, index, &tmp); return (ScriptClient::ClientID)tmp; }
+	template <> inline int Return<ScriptClient::ClientID>(HSQUIRRELVM vm, ScriptClient::ClientID res) { sq_pushinteger(vm, (int32)res); return 1; }
+
+	/* Allow ScriptClient to be used as Squirrel parameter */
+	template <> inline ScriptClient *GetParam(ForceType<ScriptClient *>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return  (ScriptClient *)instance; }
+	template <> inline ScriptClient &GetParam(ForceType<ScriptClient &>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return *(ScriptClient *)instance; }
+	template <> inline const ScriptClient *GetParam(ForceType<const ScriptClient *>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return  (ScriptClient *)instance; }
+	template <> inline const ScriptClient &GetParam(ForceType<const ScriptClient &>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return *(ScriptClient *)instance; }
+	template <> inline int Return<ScriptClient *>(HSQUIRRELVM vm, ScriptClient *res) { if (res == NULL) { sq_pushnull(vm); return 1; } res->AddRef(); Squirrel::CreateClassInstanceVM(vm, "Client", res, NULL, DefSQDestructorCallback<ScriptClient>, true); return 1; }
+} // namespace SQConvert

--- a/src/script/api/template/template_clientlist.hpp.sq
+++ b/src/script/api/template/template_clientlist.hpp.sq
@@ -1,0 +1,30 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* THIS FILE IS AUTO-GENERATED; PLEASE DO NOT ALTER MANUALLY */
+
+#include "../script_clientlist.hpp"
+
+namespace SQConvert {
+	/* Allow ScriptClientList to be used as Squirrel parameter */
+	template <> inline ScriptClientList *GetParam(ForceType<ScriptClientList *>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return  (ScriptClientList *)instance; }
+	template <> inline ScriptClientList &GetParam(ForceType<ScriptClientList &>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return *(ScriptClientList *)instance; }
+	template <> inline const ScriptClientList *GetParam(ForceType<const ScriptClientList *>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return  (ScriptClientList *)instance; }
+	template <> inline const ScriptClientList &GetParam(ForceType<const ScriptClientList &>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return *(ScriptClientList *)instance; }
+	template <> inline int Return<ScriptClientList *>(HSQUIRRELVM vm, ScriptClientList *res) { if (res == NULL) { sq_pushnull(vm); return 1; } res->AddRef(); Squirrel::CreateClassInstanceVM(vm, "ClientList", res, NULL, DefSQDestructorCallback<ScriptClientList>, true); return 1; }
+} // namespace SQConvert
+
+namespace SQConvert {
+	/* Allow ScriptClientList_Company to be used as Squirrel parameter */
+	template <> inline ScriptClientList_Company *GetParam(ForceType<ScriptClientList_Company *>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return  (ScriptClientList_Company *)instance; }
+	template <> inline ScriptClientList_Company &GetParam(ForceType<ScriptClientList_Company &>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return *(ScriptClientList_Company *)instance; }
+	template <> inline const ScriptClientList_Company *GetParam(ForceType<const ScriptClientList_Company *>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return  (ScriptClientList_Company *)instance; }
+	template <> inline const ScriptClientList_Company &GetParam(ForceType<const ScriptClientList_Company &>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQUserPointer instance; sq_getinstanceup(vm, index, &instance, 0); return *(ScriptClientList_Company *)instance; }
+	template <> inline int Return<ScriptClientList_Company *>(HSQUIRRELVM vm, ScriptClientList_Company *res) { if (res == NULL) { sq_pushnull(vm); return 1; } res->AddRef(); Squirrel::CreateClassInstanceVM(vm, "ClientList_Company", res, NULL, DefSQDestructorCallback<ScriptClientList_Company>, true); return 1; }
+} // namespace SQConvert


### PR DESCRIPTION
PR for #6459 

Adds GSClient namespace with ResolveClientID, GetName, GetCompany, GetJoinedDate
Also GSClientList, GSClientList_Company

Probably doesn't have much use on its own, but is a necessary prerequisite to allow methods that work with clients. Two obvious patches that I'll do once it's settled are:
- Method to send messages to a single client (similar to GSGoal.Question)
- Method to scroll client's viewport (like #6422)

Simple testing GS(updated version) that prints this client info to GS log:
[testclients.tar.gz](https://github.com/OpenTTD/OpenTTD/files/1921453/testclients.tar.gz)



