### PR TITLE
Fix some template-related warnings with clang

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -219,6 +219,11 @@ public:
 	static bool HasSet(const ContentInfo *ci, bool md5sum);
 };
 
+template <class Tbase_set> /* static */ const char *BaseMedia<Tbase_set>::ini_set;
+template <class Tbase_set> /* static */ const Tbase_set *BaseMedia<Tbase_set>::used_set;
+template <class Tbase_set> /* static */ Tbase_set *BaseMedia<Tbase_set>::available_sets;
+template <class Tbase_set> /* static */ Tbase_set *BaseMedia<Tbase_set>::duplicate_sets;
+
 /**
  * Check whether there's a base set matching some information.
  * @param ci The content info to compare it to.

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -17,11 +17,6 @@
 #include "ini_type.h"
 #include "string_func.h"
 
-template <class Tbase_set> /* static */ const char *BaseMedia<Tbase_set>::ini_set;
-template <class Tbase_set> /* static */ const Tbase_set *BaseMedia<Tbase_set>::used_set;
-template <class Tbase_set> /* static */ Tbase_set *BaseMedia<Tbase_set>::available_sets;
-template <class Tbase_set> /* static */ Tbase_set *BaseMedia<Tbase_set>::duplicate_sets;
-
 /**
  * Try to read a single piece of metadata and return false if it doesn't exist.
  * @param name the name of the item to fetch.

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -35,9 +35,6 @@
 StationPool _station_pool("Station");
 INSTANTIATE_POOL_METHODS(Station)
 
-typedef StationIDStack::SmallStackPool StationIDStackPool;
-template<> StationIDStackPool StationIDStack::_pool = StationIDStackPool();
-
 BaseStation::~BaseStation()
 {
 	free(this->name);


### PR DESCRIPTION
Clang seems more picky about whether static members of objects are instantiated or not.

BaseMedia's warnings are resolved by just moving them to a different file, SmallStack's warning is resolved by changing it to a singleton method instead of a static member. There was an internet provided solution to SmallStack that didn't involve changing its type, but that caused different issues with GCC