### PR TITLE
Decouple windows update from game update.

### DIFF
--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -77,6 +77,7 @@ void HandleCtrlChanged();
 void HandleMouseEvents();
 void CSleep(int milliseconds);
 void UpdateWindows();
+void DrawWindows();
 
 void DrawMouseCursor();
 void ScreenSizeChanged();

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -528,14 +528,11 @@ void VideoDriver_Allegro::MainLoop()
 
 			UpdateWindows();
 			CheckPaletteAnim();
-			DrawSurfaceToScreen();
 		} else {
 			CSleep(1);
-			NetworkDrawChatMessage();
-			DrawMouseCursor();
-			DrawSurfaceToScreen();
 		}
 		DrawWindows();
+		DrawSurfaceToScreen();
 	}
 }
 

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -526,6 +526,7 @@ void VideoDriver_Allegro::MainLoop()
 
 			GameLoop();
 
+			UpdateWindows();
 			CheckPaletteAnim();
 			DrawSurfaceToScreen();
 		} else {
@@ -534,7 +535,7 @@ void VideoDriver_Allegro::MainLoop()
 			DrawMouseCursor();
 			DrawSurfaceToScreen();
 		}
-		UpdateWindows();
+		DrawWindows();
 	}
 }
 

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -526,7 +526,6 @@ void VideoDriver_Allegro::MainLoop()
 
 			GameLoop();
 
-			UpdateWindows();
 			CheckPaletteAnim();
 			DrawSurfaceToScreen();
 		} else {
@@ -535,6 +534,7 @@ void VideoDriver_Allegro::MainLoop()
 			DrawMouseCursor();
 			DrawSurfaceToScreen();
 		}
+		UpdateWindows();
 	}
 }
 

--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -698,6 +698,7 @@ void QZ_GameLoop()
 			DrawMouseCursor();
 			_cocoa_subdriver->Draw();
 		}
+		DrawWindows();
 	}
 
 #ifdef _DEBUG

--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -685,7 +685,6 @@ void QZ_GameLoop()
 
 			UpdateWindows();
 			QZ_CheckPaletteAnim();
-			_cocoa_subdriver->Draw();
 		} else {
 #ifdef _DEBUG
 			uint32 st0 = GetTick();
@@ -694,11 +693,9 @@ void QZ_GameLoop()
 #ifdef _DEBUG
 			st += GetTick() - st0;
 #endif
-			NetworkDrawChatMessage();
-			DrawMouseCursor();
-			_cocoa_subdriver->Draw();
 		}
 		DrawWindows();
+		_cocoa_subdriver->Draw();
 	}
 
 #ifdef _DEBUG

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -754,7 +754,6 @@ void VideoDriver_SDL::MainLoop()
 
 			if (_draw_mutex != NULL) _draw_mutex->BeginCritical();
 
-			UpdateWindows();
 			_local_palette = _cur_palette;
 		} else {
 			/* Release the thread while sleeping */
@@ -765,6 +764,8 @@ void VideoDriver_SDL::MainLoop()
 			NetworkDrawChatMessage();
 			DrawMouseCursor();
 		}
+
+		UpdateWindows();
 
 		/* End of the critical part. */
 		if (_draw_mutex != NULL && !HasModalProgress()) {

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -761,9 +761,6 @@ void VideoDriver_SDL::MainLoop()
 			if (_draw_mutex != NULL) _draw_mutex->EndCritical();
 			CSleep(1);
 			if (_draw_mutex != NULL) _draw_mutex->BeginCritical();
-
-			NetworkDrawChatMessage();
-			DrawMouseCursor();
 		}
 
 		DrawWindows();

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -754,6 +754,7 @@ void VideoDriver_SDL::MainLoop()
 
 			if (_draw_mutex != NULL) _draw_mutex->BeginCritical();
 
+			UpdateWindows();
 			_local_palette = _cur_palette;
 		} else {
 			/* Release the thread while sleeping */
@@ -765,7 +766,7 @@ void VideoDriver_SDL::MainLoop()
 			DrawMouseCursor();
 		}
 
-		UpdateWindows();
+		DrawWindows();
 
 		/* End of the critical part. */
 		if (_draw_mutex != NULL && !HasModalProgress()) {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1308,7 +1308,6 @@ void VideoDriver_Win32::MainLoop()
 
 			if (_force_full_redraw) MarkWholeScreenDirty();
 
-			UpdateWindows();
 			CheckPaletteAnim();
 		} else {
 #if !defined(WINCE)
@@ -1324,6 +1323,8 @@ void VideoDriver_Win32::MainLoop()
 			NetworkDrawChatMessage();
 			DrawMouseCursor();
 		}
+
+		UpdateWindows();
 	}
 
 	if (_draw_threaded) {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1308,6 +1308,7 @@ void VideoDriver_Win32::MainLoop()
 
 			if (_force_full_redraw) MarkWholeScreenDirty();
 
+			UpdateWindows();
 			CheckPaletteAnim();
 		} else {
 #if !defined(WINCE)
@@ -1324,7 +1325,7 @@ void VideoDriver_Win32::MainLoop()
 			DrawMouseCursor();
 		}
 
-		UpdateWindows();
+		DrawWindows();
 	}
 
 	if (_draw_threaded) {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1320,9 +1320,6 @@ void VideoDriver_Win32::MainLoop()
 			if (_draw_threaded) _draw_mutex->EndCritical();
 			Sleep(1);
 			if (_draw_threaded) _draw_mutex->BeginCritical();
-
-			NetworkDrawChatMessage();
-			DrawMouseCursor();
 		}
 
 		DrawWindows();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3061,8 +3061,8 @@ void InputLoop()
 	HandleAutoscroll();
 }
 
-#define TICK_15_INTERVAL (15 * MILLISECONDS_PER_TICK)
-#define TICK_100_INTERVAL (100 * MILLISECONDS_PER_TICK)
+static const uint TICK_15_INTERVAL = 15 * MILLISECONDS_PER_TICK;
+static const uint TICK_100_INTERVAL = 100 * MILLISECONDS_PER_TICK;
 
 /**
  * Update the continuously changing contents of the windows, such as the viewports
@@ -3071,7 +3071,7 @@ void UpdateWindows()
 {
 	Window *w;
 
-	static int next_highlight_time = _realtime_tick + TICK_15_INTERVAL;
+	static uint32 next_highlight_time = _realtime_tick + TICK_15_INTERVAL;
 	if (_realtime_tick >= next_highlight_time)
 	{
 		next_highlight_time = _realtime_tick + TICK_15_INTERVAL;
@@ -3082,12 +3082,17 @@ void UpdateWindows()
 		w->ProcessScheduledInvalidations();
 		w->ProcessHighlightedInvalidations();
 	}
+}
+
+void DrawWindows()
+{
+	Window *w;
 
 	/* Skip the actual drawing on dedicated servers without screen.
 	 * But still empty the invalidation queues above. */
 	if (_network_dedicated) return;
 
-	static int we4_next_time = _realtime_tick + TICK_100_INTERVAL;
+	static uint32 we4_next_time = _realtime_tick + TICK_100_INTERVAL;
 	if (_realtime_tick >= we4_next_time) {
 		FOR_ALL_WINDOWS_FROM_FRONT(w) {
 			w->OnHundredthTick();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3088,10 +3088,6 @@ void DrawWindows()
 {
 	Window *w;
 
-	/* Skip the actual drawing on dedicated servers without screen.
-	 * But still empty the invalidation queues above. */
-	if (_network_dedicated) return;
-
 	static uint32 we4_next_time = _realtime_tick + TICK_100_INTERVAL;
 	if (_realtime_tick >= we4_next_time) {
 		FOR_ALL_WINDOWS_FROM_FRONT(w) {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3061,6 +3061,9 @@ void InputLoop()
 	HandleAutoscroll();
 }
 
+#define TICK_15_INTERVAL (15 * MILLISECONDS_PER_TICK)
+#define TICK_100_INTERVAL (100 * MILLISECONDS_PER_TICK)
+
 /**
  * Update the continuously changing contents of the windows, such as the viewports
  */
@@ -3068,9 +3071,10 @@ void UpdateWindows()
 {
 	Window *w;
 
-	static int highlight_timer = 1;
-	if (--highlight_timer == 0) {
-		highlight_timer = 15;
+	static int next_highlight_time = _realtime_tick + TICK_15_INTERVAL;
+	if (_realtime_tick >= next_highlight_time)
+	{
+		next_highlight_time = _realtime_tick + TICK_15_INTERVAL;
 		_window_highlight_colour = !_window_highlight_colour;
 	}
 
@@ -3083,16 +3087,13 @@ void UpdateWindows()
 	 * But still empty the invalidation queues above. */
 	if (_network_dedicated) return;
 
-	static int we4_timer = 0;
-	int t = we4_timer + 1;
-
-	if (t >= 100) {
+	static int we4_next_time = _realtime_tick + TICK_100_INTERVAL;
+	if (_realtime_tick >= we4_next_time) {
 		FOR_ALL_WINDOWS_FROM_FRONT(w) {
 			w->OnHundredthTick();
 		}
-		t = 0;
+		we4_next_time = _realtime_tick + TICK_100_INTERVAL;
 	}
-	we4_timer = t;
 
 	FOR_ALL_WINDOWS_FROM_FRONT(w) {
 		if ((w->flags & WF_WHITE_BORDER) && --w->white_border_timer == 0) {


### PR DESCRIPTION
This will allow the window to update each time the frame is rendered giving it a smooth experience, currently it is locked towards the 30hz.

Comparison:
Before: https://share.epic-domain.com/2018-04-22_20-15-35.webm
After: https://share.epic-domain.com/2018-04-22_20-13-06.webm

This shouldn't affect any logic since every input is still handled within the fixed time loop.