### PR TITLE
Feature: GS methods to scroll viewport for players

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -167,6 +167,7 @@ CommandProc CmdSetStoryPageDate;
 CommandProc CmdShowStoryPage;
 CommandProc CmdRemoveStoryPage;
 CommandProc CmdRemoveStoryPageElement;
+CommandProc CmdScrollViewport;
 
 CommandProc CmdLevelLand;
 
@@ -322,6 +323,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdShowStoryPage,                          CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_SHOW_STORY_PAGE
 	DEF_CMD(CmdRemoveStoryPage,                        CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_REMOVE_STORY_PAGE
 	DEF_CMD(CmdRemoveStoryPageElement,                 CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_REMOVE_STORY_ELEMENT_PAGE
+	DEF_CMD(CmdScrollViewport,                         CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_SCROLL_VIEWPORT
 
 	DEF_CMD(CmdLevelLand, CMD_ALL_TILES | CMD_NO_TEST | CMD_AUTO, CMDT_LANDSCAPE_CONSTRUCTION), // CMD_LEVEL_LAND; test run might clear tiles multiple times, in execution that only happens once
 

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -293,6 +293,8 @@ enum Commands {
 	CMD_SHOW_STORY_PAGE,              ///< show a story page
 	CMD_REMOVE_STORY_PAGE,            ///< remove a story page
 	CMD_REMOVE_STORY_PAGE_ELEMENT,    ///< remove a story page element
+	CMD_SCROLL_VIEWPORT,              ///< scroll main viewport of players
+
 	CMD_LEVEL_LAND,                   ///< level land
 
 	CMD_BUILD_LOCK,                   ///< build a lock

--- a/src/script/api/game/game_viewport.hpp.sq
+++ b/src/script/api/game/game_viewport.hpp.sq
@@ -21,7 +21,10 @@ void SQGSViewport_Register(Squirrel *engine)
 	SQGSViewport.PreRegister(engine);
 	SQGSViewport.AddConstructor<void (ScriptViewport::*)(), 1>(engine, "x");
 
-	SQGSViewport.DefSQStaticMethod(engine, &ScriptViewport::ScrollTo, "ScrollTo", 2, ".i");
+	SQGSViewport.DefSQStaticMethod(engine, &ScriptViewport::ScrollTo,               "ScrollTo",               2, ".i");
+	SQGSViewport.DefSQStaticMethod(engine, &ScriptViewport::ScrollEveryoneTo,       "ScrollEveryoneTo",       2, ".i");
+	SQGSViewport.DefSQStaticMethod(engine, &ScriptViewport::ScrollCompanyClientsTo, "ScrollCompanyClientsTo", 3, ".ii");
+	SQGSViewport.DefSQStaticMethod(engine, &ScriptViewport::ScrollClientTo,         "ScrollClientTo",         3, ".ii");
 
 	SQGSViewport.PostRegister(engine);
 }

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -22,6 +22,9 @@
  * \li GSClient
  * \li GSClientList
  * \li GSClientList_Company
+ * \li GSViewport::ScrollEveryoneTo
+ * \li GSViewport::ScrollCompanyClientsTo
+ * \li GSViewport::ScrollClientTo
  *
  * \b 1.8.0
  *

--- a/src/script/api/script_viewport.cpp
+++ b/src/script/api/script_viewport.cpp
@@ -10,9 +10,11 @@
 /** @file script_viewport.cpp Implementation of ScriptViewport. */
 
 #include "../../stdafx.h"
+#include "script_error.hpp"
 #include "script_viewport.hpp"
 #include "script_game.hpp"
 #include "script_map.hpp"
+#include "../script_instance.hpp"
 #include "../../viewport_func.h"
 
 #include "../../safeguards.h"
@@ -23,4 +25,35 @@
 	if (!ScriptMap::IsValidTile(tile)) return;
 
 	ScrollMainWindowToTile(tile);
+}
+
+/* static */ bool ScriptViewport::ScrollEveryoneTo(TileIndex tile)
+{
+	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
+
+	return ScriptObject::DoCommand(tile, VST_EVERYONE, 0, CMD_SCROLL_VIEWPORT);
+}
+
+/* static */ bool ScriptViewport::ScrollCompanyClientsTo(ScriptCompany::CompanyID company, TileIndex tile)
+{
+	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
+
+	company = ScriptCompany::ResolveCompanyID(company);
+	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
+
+	return ScriptObject::DoCommand(tile, VST_COMPANY, company, CMD_SCROLL_VIEWPORT);
+}
+
+/* static */ bool ScriptViewport::ScrollClientTo(ScriptClient::ClientID client, TileIndex tile)
+{
+	EnforcePrecondition(false, ScriptGame::IsMultiplayer());
+	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
+
+	client = ScriptClient::ResolveClientID(client);
+	EnforcePrecondition(false, client != ScriptClient::CLIENT_INVALID);
+
+	return ScriptObject::DoCommand(tile, VST_CLIENT, client, CMD_SCROLL_VIEWPORT);
 }

--- a/src/script/api/script_viewport.hpp
+++ b/src/script/api/script_viewport.hpp
@@ -13,6 +13,8 @@
 #define SCRIPT_VIEWPORT_HPP
 
 #include "script_object.hpp"
+#include "script_client.hpp"
+#include "script_company.hpp"
 
 /**
  * Class that manipulates the user's viewport.
@@ -28,6 +30,38 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 */
 	static void ScrollTo(TileIndex tile);
+
+	/**
+	 * Scroll the viewport of all players to the given tile,
+	 *  where the tile will be in the center of the screen.
+	 * @param tile The tile to put in the center of the screen.
+	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
+	 * @pre ScriptMap::IsValidTile(tile)
+	 */
+	static bool ScrollEveryoneTo(TileIndex tile);
+
+	/**
+	 * Scroll the viewports of all players in the company to the given tile,
+	 *  where the tile will be in the center of the screen.
+	 * @param company The company which players to scroll the viewport of.
+	 * @param tile The tile to put in the center of the screen.
+	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
+	 * @pre ScriptMap::IsValidTile(tile)
+	 * @pre ResolveCompanyID(company) != COMPANY_INVALID
+	 */
+	static bool ScrollCompanyClientsTo(ScriptCompany::CompanyID company, TileIndex tile);
+
+	/**
+	 * Scroll the viewport of the client to the given tile,
+	 *  where the tile will be in the center of the screen.
+	 * @param client The client to scroll the viewport of.
+	 * @param tile The tile to put in the center of the screen.
+	 * @pre ScriptGame::IsMultiplayer()
+	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
+	 * @pre ScriptMap::IsValidTile(tile)
+	 * @pre ResolveClientID(client) != CLIENT_INVALID
+	 */
+	static bool ScrollClientTo(ScriptClient::ClientID client, TileIndex tile);
 };
 
 #endif /* SCRIPT_ADMIN_HPP */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3267,7 +3267,7 @@ CommandCost CmdScrollViewport(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 {
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 	ViewportScrollTarget target = (ViewportScrollTarget)p1;
-	switch(target) {
+	switch (target) {
 		case VST_EVERYONE:
 			break;
 		case VST_COMPANY:
@@ -3276,14 +3276,17 @@ CommandCost CmdScrollViewport(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 		case VST_CLIENT:
 #ifdef ENABLE_NETWORK
 			if (_network_own_client_id != (ClientID)p2) return CommandCost();
+			break;
 #else
 			return CommandCost();
 #endif
-			break;
 		default:
 			return CMD_ERROR;
 	}
 
-	if (flags & DC_EXEC) ScrollMainWindowToTile(tile);
+	if (flags & DC_EXEC) {
+		ResetObjectToPlace();
+		ScrollMainWindowToTile(tile);
+	}
 	return CommandCost();
 }

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -84,6 +84,9 @@
 #include "linkgraph/linkgraph_gui.h"
 #include "viewport_sprite_sorter.h"
 #include "bridge_map.h"
+#include "company_base.h"
+#include "command_func.h"
+#include "network/network_func.h"
 
 #include <map>
 
@@ -3249,4 +3252,38 @@ void InitializeSpriteSorter()
 		}
 	}
 	assert(_vp_sprite_sorter != NULL);
+}
+
+/**
+ * Scroll players main viewport.
+ * @param tile tile to center viewport on
+ * @param flags type of operation
+ * @param p1 ViewportScrollTarget of scroll target
+ * @param p2 company or client id depending on the target
+ * @param text unused
+ * @return the cost of this operation or an error
+ */
+CommandCost CmdScrollViewport(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+{
+	if (_current_company != OWNER_DEITY) return CMD_ERROR;
+	ViewportScrollTarget target = (ViewportScrollTarget)p1;
+	switch(target) {
+		case VST_EVERYONE:
+			break;
+		case VST_COMPANY:
+			if (_local_company != (CompanyID)p2) return CommandCost();
+			break;
+		case VST_CLIENT:
+#ifdef ENABLE_NETWORK
+			if (_network_own_client_id != (ClientID)p2) return CommandCost();
+#else
+			return CommandCost();
+#endif
+			break;
+		default:
+			return CMD_ERROR;
+	}
+
+	if (flags & DC_EXEC) ScrollMainWindowToTile(tile);
+	return CommandCost();
 }

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -123,4 +123,14 @@ enum ViewportDragDropSelectionProcess {
 	DDSP_REMOVE_TRUCKSTOP,     ///< Road stop removal (trucks)
 };
 
+
+/**
+ * Target of the viewport scrolling GS method
+ */
+enum ViewportScrollTarget {
+	VST_EVERYONE, ///< All players
+	VST_COMPANY,  ///< All players in specific company
+	VST_CLIENT,   ///< Single player
+};
+
 #endif /* VIEWPORT_TYPE_H */


### PR DESCRIPTION
Adds 3 new methods to scroll viewport for players to GSViewport:

 - *ScrollEveryoneTo* - scrolls all active players. E.g. when game ends in CB scroll eveyone to winner's town.
 - *ScrollCompanyClientsTo* - scrolls all players in specific company (#6422). E.g. when company claims a town in CB.
 - *ScrollClientTo* - scroll single client. E.g. when client joins company in CB scroll him to claimed town.

Simple GS for testing: [testscroll.tar.gz](https://github.com/OpenTTD/OpenTTD/files/1935970/testscroll.tar.gz)
