### PR TITLE
Fix: VS projects language file ordering

### DIFF
--- a/projects/generate
+++ b/projects/generate
@@ -192,7 +192,7 @@ load_main_data() {
 
 load_lang_data() {
 	RES=""
-	for i in `ls $1`
+	for i in `ls $1 | sort -d`
 	do
 		i=`basename $i | sed s~.txt$~~g`
 		if [ "$i" == "english" ]


### PR DESCRIPTION
Sort the language source filenames before adding them into the MS VS project files. On some systems, the spanish.txt/spanish_MX.txt files switch order compared to other systems, by sorting them the ordering should be kept consistent.