### PR TITLE
Allow scripts to check for river tiles #5377

### DIFF
--- a/bin/ai/regression/tst_regression/main.nut
+++ b/bin/ai/regression/tst_regression/main.nut
@@ -552,6 +552,7 @@ function Regression::Prices()
 	print("  BT_CLEAR_ROCKY:  " + AITile.GetBuildCost(AITile.BT_CLEAR_ROCKY));
 	print("  BT_CLEAR_FIELDS: " + AITile.GetBuildCost(AITile.BT_CLEAR_FIELDS));
 	print("  BT_CLEAR_HOUSE:  " + AITile.GetBuildCost(AITile.BT_CLEAR_HOUSE));
+	print("  BT_CLEAR_RIVER:  " + AITile.GetBuildCost(AITile.BT_CLEAR_RIVER));
 }
 
 function cost_callback(old_path, new_tile, new_direction, self) { if (old_path == null) return 0; return old_path.GetCost() + 1; }

--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -7323,6 +7323,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   BT_CLEAR_ROCKY:  150
   BT_CLEAR_FIELDS: 375
   BT_CLEAR_HOUSE:  1200
+  BT_CLEAR_RIVER:  7500
 
 --Rail--
     IsRailTile():                  false

--- a/src/script/api/ai/ai_tile.hpp.sq
+++ b/src/script/api/ai/ai_tile.hpp.sq
@@ -84,6 +84,7 @@ void SQAITile_Register(Squirrel *engine)
 	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsBuildable,                "IsBuildable",                2, ".i");
 	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsBuildableRectangle,       "IsBuildableRectangle",       4, ".iii");
 	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsWaterTile,                "IsWaterTile",                2, ".i");
+	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsRiverTile,                "IsRiverTile",                2, ".i");
 	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsCoastTile,                "IsCoastTile",                2, ".i");
 	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsStationTile,              "IsStationTile",              2, ".i");
 	SQAITile.DefSQStaticMethod(engine, &ScriptTile::IsSteepSlope,               "IsSteepSlope",               2, ".i");

--- a/src/script/api/ai/ai_tile.hpp.sq
+++ b/src/script/api/ai/ai_tile.hpp.sq
@@ -66,6 +66,7 @@ void SQAITile_Register(Squirrel *engine)
 	SQAITile.DefSQConst(engine, ScriptTile::BT_CLEAR_ROCKY,              "BT_CLEAR_ROCKY");
 	SQAITile.DefSQConst(engine, ScriptTile::BT_CLEAR_FIELDS,             "BT_CLEAR_FIELDS");
 	SQAITile.DefSQConst(engine, ScriptTile::BT_CLEAR_HOUSE,              "BT_CLEAR_HOUSE");
+	SQAITile.DefSQConst(engine, ScriptTile::BT_CLEAR_RIVER,              "BT_CLEAR_RIVER");
 	SQAITile.DefSQConst(engine, ScriptTile::TERRAIN_NORMAL,              "TERRAIN_NORMAL");
 	SQAITile.DefSQConst(engine, ScriptTile::TERRAIN_DESERT,              "TERRAIN_DESERT");
 	SQAITile.DefSQConst(engine, ScriptTile::TERRAIN_RAINFOREST,          "TERRAIN_RAINFOREST");

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -18,6 +18,8 @@
  * \b 1.9.0
  *
  * 1.9.0 is not yet released. The following changes are not set in stone yet.
+ * API additions:
+ * \li GSTile::IsRiverTile
  *
  * \b 1.8.0
  *

--- a/src/script/api/game/game_tile.hpp.sq
+++ b/src/script/api/game/game_tile.hpp.sq
@@ -84,6 +84,7 @@ void SQGSTile_Register(Squirrel *engine)
 	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsBuildable,                "IsBuildable",                2, ".i");
 	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsBuildableRectangle,       "IsBuildableRectangle",       4, ".iii");
 	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsWaterTile,                "IsWaterTile",                2, ".i");
+	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsRiverTile,                "IsRiverTile",                2, ".i");
 	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsCoastTile,                "IsCoastTile",                2, ".i");
 	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsStationTile,              "IsStationTile",              2, ".i");
 	SQGSTile.DefSQStaticMethod(engine, &ScriptTile::IsSteepSlope,               "IsSteepSlope",               2, ".i");

--- a/src/script/api/game/game_tile.hpp.sq
+++ b/src/script/api/game/game_tile.hpp.sq
@@ -66,6 +66,7 @@ void SQGSTile_Register(Squirrel *engine)
 	SQGSTile.DefSQConst(engine, ScriptTile::BT_CLEAR_ROCKY,              "BT_CLEAR_ROCKY");
 	SQGSTile.DefSQConst(engine, ScriptTile::BT_CLEAR_FIELDS,             "BT_CLEAR_FIELDS");
 	SQGSTile.DefSQConst(engine, ScriptTile::BT_CLEAR_HOUSE,              "BT_CLEAR_HOUSE");
+	SQGSTile.DefSQConst(engine, ScriptTile::BT_CLEAR_RIVER,              "BT_CLEAR_RIVER");
 	SQGSTile.DefSQConst(engine, ScriptTile::TERRAIN_NORMAL,              "TERRAIN_NORMAL");
 	SQGSTile.DefSQConst(engine, ScriptTile::TERRAIN_DESERT,              "TERRAIN_DESERT");
 	SQGSTile.DefSQConst(engine, ScriptTile::TERRAIN_RAINFOREST,          "TERRAIN_RAINFOREST");

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -25,6 +25,7 @@
  * \li GSViewport::ScrollEveryoneTo
  * \li GSViewport::ScrollCompanyClientsTo
  * \li GSViewport::ScrollClientTo
+ * \li GSTile::IsRiverTile
  *
  * \b 1.8.0
  *

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -67,6 +67,13 @@
 	return ::IsTileType(tile, MP_WATER) && !::IsCoast(tile);
 }
 
+/* static */ bool ScriptTile::IsRiverTile(TileIndex tile)
+{
+	if (!::IsValidTile(tile)) return false;
+
+	return ::IsTileType(tile, MP_WATER) && ::IsRiver(tile);
+}
+
 /* static */ bool ScriptTile::IsCoastTile(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return false;

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -325,6 +325,7 @@
 		case BT_CLEAR_ROCKY:  return ::GetPrice(PR_CLEAR_ROCKS, 1, NULL);
 		case BT_CLEAR_FIELDS: return ::GetPrice(PR_CLEAR_FIELDS, 1, NULL);
 		case BT_CLEAR_HOUSE:  return ::GetPrice(PR_CLEAR_HOUSE, 1, NULL);
+		case BT_CLEAR_RIVER:  return ::GetPrice(PR_CLEAR_WATER, 1, NULL);
 		default: return -1;
 	}
 }

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -166,6 +166,14 @@ public:
 	static bool IsWaterTile(TileIndex tile);
 
 	/**
+	 * Checks whether the given tile is actually a river tile.
+	 * @param tile The tile to check on.
+	 * @pre ScriptMap::IsValidTile(tile).
+	 * @return True if and only if the tile is a river tile.
+	 */
+	static bool IsRiverTile(TileIndex tile);
+
+	/**
 	 * Checks whether the given tile is actually a coast tile.
 	 * @param tile The tile to check.
 	 * @pre ScriptMap::IsValidTile(tile).

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -118,6 +118,7 @@ public:
 		BT_CLEAR_ROCKY,  ///< Clear a tile with rocks
 		BT_CLEAR_FIELDS, ///< Clear a tile with farm fields
 		BT_CLEAR_HOUSE,  ///< Clear a tile with a house
+		BT_CLEAR_RIVER,  ///< Clear a tile with a river
 	};
 
 	/**


### PR DESCRIPTION
Adds these two methods for AIs and Game Scripts
* ScriptTile::IsRiverTile(tile): Checks if a tile is a river
* ScriptTile::GetBuildCost(ScriptTile.BT_CLEAR_RIVER): Provides the cost to demolish a river tile.

Based on FlySpray patch by krinn (#5377)