### PR TITLE
[OSX] Improved pinch to zoom behaviour

### DIFF
--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -439,7 +439,7 @@ struct MainWindow : Window
 
 	virtual void OnMouseWheel(int wheel)
 	{
-		if (_settings_client.gui.scrollwheel_scrolling == 0) {
+		if (_settings_client.gui.scrollwheel_scrolling != 2) {
 			ZoomInOrOutToCursorWindow(wheel < 0, this);
 		}
 	}

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1559,7 +1559,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 
 /* virtual */ void SmallMapWindow::OnMouseWheel(int wheel)
 {
-	if (_settings_client.gui.scrollwheel_scrolling == 0) {
+	if (_settings_client.gui.scrollwheel_scrolling != 2) {
 		const NWidgetBase *wid = this->GetWidget<NWidgetBase>(WID_SM_MAP);
 		int cursor_x = _cursor.pos.x - this->left - wid->pos_x;
 		int cursor_y = _cursor.pos.y - this->top  - wid->pos_y;

--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -587,12 +587,12 @@ static bool QZ_PollEvent()
 
 			while (_current_magnification >= 1.0f) {
 				_current_magnification -= 1.0f;
-				_cursor.wheel++;
+				_cursor.wheel--;
 				HandleMouseEvents();
 			}
 			while (_current_magnification <= -1.0f) {
 				_current_magnification += 1.0f;
-				_cursor.wheel--;
+				_cursor.wheel++;
 				HandleMouseEvents();
 			}
 			break;

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -138,7 +138,7 @@ public:
 
 	virtual void OnMouseWheel(int wheel)
 	{
-		if (_settings_client.gui.scrollwheel_scrolling == 0) {
+		if (_settings_client.gui.scrollwheel_scrolling != 2) {
 			ZoomInOrOutToCursorWindow(wheel < 0, this);
 		}
 	}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2858,8 +2858,8 @@ static void MouseLoop(MouseClick click, int mousewheel)
 	if (vp != NULL && (_game_mode == GM_MENU || HasModalProgress())) return;
 
 	if (mousewheel != 0) {
-		/* Send mousewheel event to window */
-		w->OnMouseWheel(mousewheel);
+		/* Send mousewheel event to window, unless we're scrolling a viewport or the map */
+		if (!scrollwheel_scrolling || (vp == NULL && w->window_class != WC_SMALLMAP)) w->OnMouseWheel(mousewheel);
 
 		/* Dispatch a MouseWheelEvent for widgets if it is not a viewport */
 		if (vp == NULL) DispatchMouseWheelEvent(w, w->nested_root->GetWidgetFromPos(x - w->left, y - w->top), mousewheel);


### PR DESCRIPTION
Improved the pinch to zoom behaviour on Macs with a trackpad:
- Reverse pinch to zoom to match the normal macOS behaviour: pinching out zooms in and pinching in zooms out
- Keep pinch to zoom working when setting the scroll-wheel to scroll the map rather than zoom. This is super useful because it allows users to use the trackpad both for scrolling and zooming. Note: disabling the scroll-wheel functionality entirely will still disable pinch to zoom.