### PR TITLE
Don't automatically deactivate the vehicle clone tool after cloning a vehicle

### DIFF
--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -908,7 +908,15 @@ struct DepotWindow : Window {
 	 */
 	virtual bool OnVehicleSelect(const Vehicle *v)
 	{
-		DoCommandP(this->window_number, v->index, _ctrl_pressed ? 1 : 0, CMD_CLONE_VEHICLE | CMD_MSG(STR_ERROR_CAN_T_BUY_TRAIN + v->type), CcCloneVehicle);
+		if (_ctrl_pressed) {
+			/* Share-clone, do not open new viewport, and keep tool active */
+			DoCommandP(this->window_number, v->index, 1, CMD_CLONE_VEHICLE | CMD_MSG(STR_ERROR_CAN_T_BUY_TRAIN + v->type), NULL);
+		} else {
+			/* Copy-clone, open viewport for new vehicle, and deselect the tool (assume player wants to changs things on new vehicle) */
+			if (DoCommandP(this->window_number, v->index, 0, CMD_CLONE_VEHICLE | CMD_MSG(STR_ERROR_CAN_T_BUY_TRAIN + v->type), CcCloneVehicle)) {
+				ResetObjectToPlace();
+			}
+		}
 
 		return true;
 	}

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -908,9 +908,8 @@ struct DepotWindow : Window {
 	 */
 	virtual bool OnVehicleSelect(const Vehicle *v)
 	{
-		if (DoCommandP(this->window_number, v->index, _ctrl_pressed ? 1 : 0, CMD_CLONE_VEHICLE | CMD_MSG(STR_ERROR_CAN_T_BUY_TRAIN + v->type), CcCloneVehicle)) {
-			ResetObjectToPlace();
-		}
+		DoCommandP(this->window_number, v->index, _ctrl_pressed ? 1 : 0, CMD_CLONE_VEHICLE | CMD_MSG(STR_ERROR_CAN_T_BUY_TRAIN + v->type), CcCloneVehicle);
+
 		return true;
 	}
 


### PR DESCRIPTION
Changed the vehicle clone tool to remain active after cloning a vehicle instead of resetting the cursor (and disabling the clone tool).

This behaviour is more similar to the other tools (e.g. adding orders, building, etc.) and allows you to clone a vehicle multiple times without having to click the clone button again for each one.