### PR TITLE
Change: [OSX] Disable macOS Sierra's automatic tab feature

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -214,6 +214,12 @@ static void setupApplication()
 	}
 #endif
 
+	/* Disable the system-wide tab feature as we only have one window. */
+	if ([ NSWindow respondsToSelector:@selector(setAllowsAutomaticWindowTabbing:) ]) {
+		/* We use nil instead of NO as withObject requires an id. */
+		[ NSWindow performSelector:@selector(setAllowsAutomaticWindowTabbing:) withObject:nil];
+	}
+
 	/* Become the front process, important when start from the command line. */
 	[ [ NSApplication sharedApplication ] activateIgnoringOtherApps:YES ];
 


### PR DESCRIPTION
Since Sierra, macOS adds tab support to any application that has windows and creates some additional items in the window menu. Since OpenTTD has only one window it has no use, so it makes sense to disable the feature.