### PR TITLE
Fix #6090: And svn r27822. Run scripts for widgets.

### DIFF
--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -551,6 +551,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_GL_DELETE_GROUP,                       "WID_GL_DELETE_GROUP");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_GL_RENAME_GROUP,                       "WID_GL_RENAME_GROUP");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_GL_REPLACE_PROTECTION,                 "WID_GL_REPLACE_PROTECTION");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_GL_INFO,                               "WID_GL_INFO");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_H_BACKGROUND,                          "WID_H_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_DPI_MATRIX_WIDGET,                     "WID_DPI_MATRIX_WIDGET");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_DPI_SCROLLBAR,                         "WID_DPI_SCROLLBAR");
@@ -626,9 +627,11 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TF_BACKGROUND,                         "WID_TF_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TF_VSCROLLBAR,                         "WID_TF_VSCROLLBAR");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TF_HSCROLLBAR,                         "WID_TF_HSCROLLBAR");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_CAPTION,                           "WID_MTS_CAPTION");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_LIST_LEFT,                         "WID_MTS_LIST_LEFT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_PLAYLIST,                          "WID_MTS_PLAYLIST");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_LIST_RIGHT,                        "WID_MTS_LIST_RIGHT");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_MUSICSET,                          "WID_MTS_MUSICSET");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_ALL,                               "WID_MTS_ALL");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_OLD,                               "WID_MTS_OLD");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MTS_NEW,                               "WID_MTS_NEW");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1439,6 +1439,7 @@ public:
 		WID_GL_DELETE_GROUP                          = ::WID_GL_DELETE_GROUP,                          ///< Delete group button.
 		WID_GL_RENAME_GROUP                          = ::WID_GL_RENAME_GROUP,                          ///< Rename group button.
 		WID_GL_REPLACE_PROTECTION                    = ::WID_GL_REPLACE_PROTECTION,                    ///< Replace protection button.
+		WID_GL_INFO                                  = ::WID_GL_INFO,                                  ///< Group info.
 	};
 
 	/* automatically generated from ../../widgets/highscore_widget.h */
@@ -1581,9 +1582,11 @@ public:
 	/* automatically generated from ../../widgets/music_widget.h */
 	/** Widgets of the #MusicTrackSelectionWindow class. */
 	enum MusicTrackSelectionWidgets {
+		WID_MTS_CAPTION                              = ::WID_MTS_CAPTION,                              ///< Window caption.
 		WID_MTS_LIST_LEFT                            = ::WID_MTS_LIST_LEFT,                            ///< Left button.
 		WID_MTS_PLAYLIST                             = ::WID_MTS_PLAYLIST,                             ///< Playlist.
 		WID_MTS_LIST_RIGHT                           = ::WID_MTS_LIST_RIGHT,                           ///< Right button.
+		WID_MTS_MUSICSET                             = ::WID_MTS_MUSICSET,                             ///< Music set selection.
 		WID_MTS_ALL                                  = ::WID_MTS_ALL,                                  ///< All button.
 		WID_MTS_OLD                                  = ::WID_MTS_OLD,                                  ///< Old button.
 		WID_MTS_NEW                                  = ::WID_MTS_NEW,                                  ///< New button.


### PR DESCRIPTION
In (svn r27822) and the commit that added "Feature #6090: Change music set during gameplay", the api scripts ./generate_widget.sh and ./squirrel_export.sh weren't executed.