### PR TITLE
Increase readability of track and pathfinding code

### DIFF
--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -73,7 +73,8 @@ struct CFollowTrackT
 
 	inline void Init(Owner o, RailTypes railtype_override, CPerformanceTimer *pPerf)
 	{
-		assert((!IsRoadTT() || m_veh != NULL) && (!IsRailTT() || railtype_override != INVALID_RAILTYPES));
+		assert(!IsRoadTT() || m_veh != NULL);
+		assert(!IsRailTT() || railtype_override != INVALID_RAILTYPES);
 		m_veh_owner = o;
 		m_pPerf = pPerf;
 		/* don't worry, all is inlined so compiler should remove unnecessary initializations */

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -240,7 +240,7 @@ protected:
 		} else {
 			m_new_td_bits = TrackStatusToTrackdirBits(GetTileTrackStatus(m_new_tile, TT(), IsRoadTT() ? RoadVehicle::From(m_veh)->compatible_roadtypes : 0));
 
-			if (IsTram() && m_new_td_bits == 0) {
+			if (IsTram() && m_new_td_bits == TRACKDIR_BIT_NONE) {
 				/* GetTileTrackStatus() returns 0 for single tram bits.
 				 * As we cannot change it there (easily) without breaking something, change it here */
 				switch (GetSingleTramBit(m_new_tile)) {

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -228,8 +228,6 @@ protected:
 			m_is_station = true;
 		} else if (IsRoadTT() && IsRoadStopTile(m_new_tile)) {
 			m_is_station = true;
-		} else {
-			m_is_station = false;
 		}
 	}
 

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -807,7 +807,7 @@ static TrackdirBits GetDriveableTrackdirBits(TileIndex dst_tile, Trackdir src_tr
 {
 	TrackdirBits trackdirbits = TrackStatusToTrackdirBits(GetTileTrackStatus(dst_tile, type, subtype));
 
-	if (trackdirbits == 0 && type == TRANSPORT_ROAD && HasBit(subtype, ROADTYPE_TRAM)) {
+	if (trackdirbits == TRACKDIR_BIT_NONE && type == TRANSPORT_ROAD && HasBit(subtype, ROADTYPE_TRAM)) {
 		/* GetTileTrackStatus() returns 0 for single tram bits.
 		 * As we cannot change it there (easily) without breaking something, change it here */
 		switch (GetSingleTramBit(dst_tile)) {
@@ -900,7 +900,7 @@ static void NPFFollowTrack(AyStar *aystar, OpenListNode *current)
 
 		trackdirbits = GetDriveableTrackdirBits(dst_tile, src_trackdir, type, subtype);
 
-		if (trackdirbits == 0) {
+		if (trackdirbits == TRACKDIR_BIT_NONE) {
 			/* We cannot enter the next tile. Road vehicles can reverse, others reach dead end */
 			if (type != TRANSPORT_ROAD || HasBit(subtype, ROADTYPE_TRAM)) return;
 
@@ -924,7 +924,7 @@ static void NPFFollowTrack(AyStar *aystar, OpenListNode *current)
 
 	/* Enumerate possible track */
 	uint i = 0;
-	while (trackdirbits != 0) {
+	while (trackdirbits != TRACKDIR_BIT_NONE) {
 		Trackdir dst_trackdir = RemoveFirstTrackdir(&trackdirbits);
 		DEBUG(npf, 5, "Expanded into trackdir: %d, remaining trackdirs: 0x%X", dst_trackdir, trackdirbits);
 

--- a/src/pathfinder/opf/opf_ship.cpp
+++ b/src/pathfinder/opf/opf_ship.cpp
@@ -206,7 +206,7 @@ Track OPFShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir, 
 	TrackBits rev_tracks = TrackStatusToTrackBits(GetTileTrackStatus(tile2, TRANSPORT_WATER, 0)) &
 			DiagdirReachesTracks(rev_enterdir);
 
-	if ((rev_tracks & TrackToTrackBits(cur_track) != TRACK_BIT_NONE) {
+	if (HasTrack(rev_tracks, cur_track)) {
 		rev_dist = FindShipTrack(v, tile2, rev_enterdir, TrackToTrackBits(cur_track), tile, &track);
 		if (rev_dist != UINT_MAX) rev_dist++; // penalty for reversing
 	}

--- a/src/pathfinder/yapf/yapf_common.hpp
+++ b/src/pathfinder/yapf/yapf_common.hpp
@@ -142,8 +142,7 @@ public:
 	/** Called by YAPF to detect if node ends in the desired destination */
 	inline bool PfDetectDestination(Node &n)
 	{
-		bool bDest = (n.m_key.m_tile == m_destTile) && ((m_destTrackdirs & TrackdirToTrackdirBits(n.GetTrackdir())) != TRACKDIR_BIT_NONE);
-		return bDest;
+		return (n.m_key.m_tile == m_destTile) && ((m_destTrackdirs & TrackdirToTrackdirBits(n.GetTrackdir())) != TRACKDIR_BIT_NONE);
 	}
 
 	/**

--- a/src/pathfinder/yapf/yapf_common.hpp
+++ b/src/pathfinder/yapf/yapf_common.hpp
@@ -142,7 +142,7 @@ public:
 	/** Called by YAPF to detect if node ends in the desired destination */
 	inline bool PfDetectDestination(Node &n)
 	{
-		return (n.m_key.m_tile == m_destTile) && ((m_destTrackdirs & TrackdirToTrackdirBits(n.GetTrackdir())) != TRACKDIR_BIT_NONE);
+		return (n.m_key.m_tile == m_destTile) && HasTrackdir(m_destTrackdirs, n.GetTrackdir());
 	}
 
 	/**

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -104,7 +104,7 @@ public:
 		assert(IsValidTrackdir(td2));
 		int cost = 0;
 		if (TrackFollower::Allow90degTurns()
-				&& ((TrackdirToTrackdirBits(td2) & (TrackdirBits)TrackdirCrossesTrackdirs(td1)) != 0)) {
+				&& ((TrackdirToTrackdirBits(td2) & TrackdirCrossesTrackdirs(td1)) != TRACKDIR_BIT_NONE)) {
 			/* 90-deg curve penalty */
 			cost += Yapf().PfGetSettings().rail_curve90_penalty;
 		} else if (td2 != NextTrackdir(td1)) {

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -104,7 +104,7 @@ public:
 		assert(IsValidTrackdir(td2));
 		int cost = 0;
 		if (TrackFollower::Allow90degTurns()
-				&& ((TrackdirToTrackdirBits(td2) & TrackdirCrossesTrackdirs(td1)) != TRACKDIR_BIT_NONE)) {
+				&& HasTrackdir(TrackdirCrossesTrackdirs(td1), td2)) {
 			/* 90-deg curve penalty */
 			cost += Yapf().PfGetSettings().rail_curve90_penalty;
 		} else if (td2 != NextTrackdir(td1)) {
@@ -280,7 +280,7 @@ public:
 	{
 		assert(!n.flags_u.flags_s.m_targed_seen);
 		assert(tf->m_new_tile == n.m_key.m_tile);
-		assert((TrackdirToTrackdirBits(n.m_key.m_td) & tf->m_new_td_bits) != TRACKDIR_BIT_NONE);
+		assert((HasTrackdir(tf->m_new_td_bits, n.m_key.m_td)));
 
 		CPerfStart perf_cost(Yapf().m_perf_cost);
 

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -166,16 +166,13 @@ public:
 	/** Called by YAPF to detect if node ends in the desired destination */
 	inline bool PfDetectDestination(TileIndex tile, Trackdir td)
 	{
-		bool bDest;
 		if (m_dest_station_id != INVALID_STATION) {
-			bDest = HasStationTileRail(tile)
+			return HasStationTileRail(tile)
 				&& (GetStationIndex(tile) == m_dest_station_id)
 				&& (GetRailStationTrack(tile) == TrackdirToTrack(td));
-		} else {
-			bDest = (tile == m_destTile)
-				&& ((m_destTrackdirs & TrackdirToTrackdirBits(td)) != TRACKDIR_BIT_NONE);
 		}
-		return bDest;
+
+		return (tile == m_destTile) && ((m_destTrackdirs & TrackdirToTrackdirBits(td)) != TRACKDIR_BIT_NONE);
 	}
 
 	/**

--- a/src/pathfinder/yapf/yapf_destrail.hpp
+++ b/src/pathfinder/yapf/yapf_destrail.hpp
@@ -172,7 +172,7 @@ public:
 				&& (GetRailStationTrack(tile) == TrackdirToTrack(td));
 		}
 
-		return (tile == m_destTile) && ((m_destTrackdirs & TrackdirToTrackdirBits(td)) != TRACKDIR_BIT_NONE);
+		return (tile == m_destTile) && HasTrackdir(m_destTrackdirs, td);
 	}
 
 	/**

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -260,7 +260,7 @@ public:
 				(m_non_artic || IsDriveThroughStopTile(tile));
 		}
 
-		return tile == m_destTile && ((m_destTrackdirs & TrackdirToTrackdirBits(trackdir)) != TRACKDIR_BIT_NONE);
+		return tile == m_destTile && HasTrackdir(m_destTrackdirs, trackdir);
 	}
 
 	/**
@@ -420,7 +420,7 @@ public:
 		/* set origin (tile, trackdir) */
 		TileIndex src_tile = v->tile;
 		Trackdir src_td = v->GetVehicleTrackdir();
-		if ((TrackStatusToTrackdirBits(GetTileTrackStatus(src_tile, TRANSPORT_ROAD, v->compatible_roadtypes)) & TrackdirToTrackdirBits(src_td)) == 0) {
+		if (!HasTrackdir(TrackStatusToTrackdirBits(GetTileTrackStatus(src_tile, TRANSPORT_ROAD, v->compatible_roadtypes)), src_td)) {
 			/* sometimes the roadveh is not on the road (it resides on non-existing track)
 			 * how should we handle that situation? */
 			return false;
@@ -503,7 +503,7 @@ FindDepotData YapfRoadVehicleFindNearestDepot(const RoadVehicle *v, int max_dist
 {
 	TileIndex tile = v->tile;
 	Trackdir trackdir = v->GetVehicleTrackdir();
-	if ((TrackStatusToTrackdirBits(GetTileTrackStatus(tile, TRANSPORT_ROAD, v->compatible_roadtypes)) & TrackdirToTrackdirBits(trackdir)) == 0) {
+	if (!HasTrackdir(TrackStatusToTrackdirBits(GetTileTrackStatus(tile, TRANSPORT_ROAD, v->compatible_roadtypes)), trackdir)) {
 		return FindDepotData();
 	}
 

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -185,8 +185,7 @@ public:
 	/** Called by YAPF to detect if node ends in the desired destination */
 	inline bool PfDetectDestination(Node &n)
 	{
-		bool bDest = IsRoadDepotTile(n.m_segment_last_tile);
-		return bDest;
+		return IsRoadDepotTile(n.m_segment_last_tile);
 	}
 
 	inline bool PfDetectDestinationTile(TileIndex tile, Trackdir trackdir)

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -65,7 +65,7 @@ public:
 
 			/* use vehicle's current direction if that's possible, otherwise use first usable one. */
 			Trackdir veh_dir = v->GetVehicleTrackdir();
-			return ((trackdirs & TrackdirToTrackdirBits(veh_dir)) != 0) ? veh_dir : (Trackdir)FindFirstBit2x64(trackdirs);
+			return (HasTrackdir(trackdirs, veh_dir)) ? veh_dir : (Trackdir)FindFirstBit2x64(trackdirs);
 		}
 
 		/* move back to the old tile/trackdir (where ship is coming from) */

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -81,7 +81,7 @@ void SetRailStationPlatformReservation(TileIndex start, DiagDirection dir, bool 
  */
 bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 {
-	assert((GetTileTrackStatus(tile, TRANSPORT_RAIL, 0) & TrackToTrackBits(t)) != 0);
+	assert(HasTrack(TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_RAIL, 0)), t));
 
 	if (_settings_client.gui.show_track_reservation) {
 		/* show the reserved rail if needed */
@@ -142,7 +142,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
  */
 void UnreserveRailTrack(TileIndex tile, Track t)
 {
-	assert((GetTileTrackStatus(tile, TRANSPORT_RAIL, 0) & TrackToTrackBits(t)) != 0);
+	assert(HasTrack(TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_RAIL, 0)), t));
 
 	if (_settings_client.gui.show_track_reservation) {
 		if (IsBridgeTile(tile)) {

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -332,6 +332,28 @@ static inline TrackdirBits TrackBitsToTrackdirBits(TrackBits bits)
 }
 
 /**
+ * Checks whether a TrackBits has a given Track.
+ * @param tracks The track bits.
+ * @param track The track to check.
+ */
+static inline bool HasTrack(TrackBits tracks, Track track)
+{
+	assert(IsValidTrack(track));
+	return HasBit(tracks, track);
+}
+
+/**
+ * Checks whether a TrackdirBits has a given Trackdir.
+ * @param trackdirs The trackdir bits.
+ * @param trackdir The trackdir to check.
+ */
+static inline bool HasTrackdir(TrackdirBits trackdirs, Trackdir trackdir)
+{
+	assert(IsValidTrackdir(trackdir));
+	return HasBit(trackdirs, trackdir);
+}
+
+/**
  * Returns the present-trackdir-information of a TrackStatus.
  *
  * @param ts The TrackStatus returned by GetTileTrackStatus()

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -61,7 +61,7 @@ static inline bool IsValidTrackdirForRoadVehicle(Trackdir trackdir)
  */
 static inline bool IsValidTrackdir(Trackdir trackdir)
 {
-	return (1 << trackdir & TRACKDIR_BIT_MASK) != 0;
+	return (1 << trackdir & TRACKDIR_BIT_MASK) != TRACKDIR_BIT_NONE;
 }
 
 /**


### PR DESCRIPTION
This pull request contains mostly changes that may look unnecessary. Feel free to reject them. Anyway, having worked with those lines of code, the easier to read them, the better.

Maybe the most significant internal change is checking the presence of a track(dir) just looking the corresponding bit, instead of making and "&" and a comparison (not a great improvement, but it helps in understanding and simplifying what the code does).

I have doubts about the last commit ( 8be3c3e8ef4cdd290d582d5f14a5e722ed9280ed ). The first line is replaced by the second one:

`-	assert((GetTileTrackStatus(tile, TRANSPORT_RAIL, 0) & TrackToTrackBits(t)) != 0);`
`+	assert(HasTrack(TrackStatusToTrackBits(GetTileTrackStatus(tile, TRANSPORT_RAIL, 0)), t));`

Yet, given how that TrackStatus is obtained, it would suffice with this one:

`+	assert(HasTrack((TrackBits)GetTileTrackStatus(tile, TRANSPORT_RAIL, 0)), t);`

This is due to the way TrackStatuses are calculated right now. As that could change in the (...far...far...) future, I decided on adding the TrackStatusToTrackBits conversion to the assert. I have no strong opinion about any of the two options though.