### PR TITLE
TTD DOS music loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,21 +224,20 @@ have to copy the data files from the CD-ROM into the baseset/ directory. It
 does not matter whether you copy them from the DOS or Windows version of
 Transport Tycoon Deluxe. The Windows install can optionally copy these files.
 You need to copy the following files:
-
-- sample.cat
-- trg1r.grf or TRG1.GRF
-- trgcr.grf or TRGC.GRF
-- trghr.grf or TRGH.GRF
-- trgir.grf or TRGI.GRF
-- trgtr.grf or TRGT.GRF
+ - sample.cat
+ - trg1r.grf or TRG1.GRF
+ - trgcr.grf or TRGC.GRF
+ - trghr.grf or TRGH.GRF
+ - trgir.grf or TRGI.GRF
+ - trgtr.grf or TRGT.GRF
 
 #### 4.1.3) Original Transport Tycoon Deluxe music
 
-If you want the Transport Tycoon Deluxe music, copy the files from the gm/
-folder from the Windows version of Transport Tycoon Deluxe to the baseset
-folder in your OpenTTD folder (also explained in the following sections).
-The music from the DOS version as well as the original Transport Tycoon does
-not work.
+If you want the Transport Tycoon Deluxe music, copy the appropriate files from
+the original game into the baseset folder.
+ - TTD for Windows: All files in the gm/ folder (gm_tt00.gm up to gm_tt21.gm)
+ - TTD for DOS: The GM.CAT file
+ - Transport Tycoon Original: The GM.CAT file, but rename it to GM-TTO.CAT
 
 #### 4.1.4) AIs
 

--- a/bin/baseset/orig_dos.obm
+++ b/bin/baseset/orig_dos.obm
@@ -1,0 +1,76 @@
+; $Id$
+;
+; This represents the original music as on the Transport
+; Tycoon Deluxe for DOS CD.
+;
+[metadata]
+name              = original_dos
+shortname         = TTDD
+version           = 1
+description       = Original Transport Tycoon Deluxe DOS edition music.
+
+[files]
+theme = gm.cat
+old_0 = gm.cat
+old_1 = gm.cat
+old_2 = gm.cat
+old_3 = gm.cat
+old_4 = gm.cat
+old_5 = gm.cat
+old_6 = gm.cat
+old_7 = gm.cat
+old_8 =
+old_9 =
+new_0 = gm.cat
+new_1 = gm.cat
+new_2 = gm.cat
+new_3 = gm.cat
+new_4 = gm.cat
+new_5 = gm.cat
+new_6 = gm.cat
+new_7 =
+new_8 =
+new_9 =
+ezy_0 = gm.cat
+ezy_1 = gm.cat
+ezy_2 = gm.cat
+ezy_3 = gm.cat
+ezy_4 = gm.cat
+ezy_5 = gm.cat
+ezy_6 =
+ezy_7 =
+ezy_8 =
+ezy_9 =
+
+[md5s]
+gm.cat = 7a29d2d0c4f7d2e03091ffa9b2bdfffb
+
+[catindex]
+theme = 0
+old_0 = 1
+old_1 = 8
+old_2 = 2
+old_3 = 9
+old_4 = 14
+old_5 = 15
+old_6 = 19
+old_7 = 13
+new_0 = 6
+new_1 = 11
+new_2 = 10
+new_3 = 17
+new_4 = 21
+new_5 = 18
+new_6 = 5
+ezy_0 = 12
+ezy_1 = 7
+ezy_2 = 16
+ezy_3 = 3
+ezy_4 = 20
+ezy_5 = 4
+
+[names]
+; Names get read from the CAT file
+
+[origin]
+default      = You can find it on your Transport Tycoon Deluxe CD-ROM.

--- a/bin/baseset/orig_tto.obm
+++ b/bin/baseset/orig_tto.obm
@@ -1,0 +1,71 @@
+; $Id$
+;
+; This represents the original music as on the Transport
+; Tycoon (with World Editor) for DOS CD.
+;
+[metadata]
+name              = original_tto
+shortname         = TTOD
+version           = 1
+description       = Original Transport Tycoon (Original/World Editor) music.
+
+[files]
+theme = gm-tto.cat
+old_0 = gm-tto.cat
+old_1 = gm-tto.cat
+old_2 = gm-tto.cat
+old_3 = gm-tto.cat
+old_4 = gm-tto.cat
+old_5 = gm-tto.cat
+old_6 = gm-tto.cat
+old_7 = gm-tto.cat
+old_8 =
+old_9 =
+new_0 = gm-tto.cat
+new_1 = gm-tto.cat
+new_2 = gm-tto.cat
+new_3 = gm-tto.cat
+new_4 = gm-tto.cat
+new_5 = gm-tto.cat
+new_6 = gm-tto.cat
+new_7 = gm-tto.cat
+new_8 =
+new_9 =
+ezy_0 =
+ezy_1 =
+ezy_2 =
+ezy_3 =
+ezy_4 =
+ezy_5 =
+ezy_6 =
+ezy_7 =
+ezy_8 =
+ezy_9 =
+
+[catindex]
+theme = 0
+old_0 = 1
+old_1 = 6
+old_2 = 2
+old_3 = 7
+old_4 = 11
+old_5 = 12
+old_6 = 15
+old_7 = 10
+new_0 = 4
+new_1 = 5
+new_2 = 9
+new_3 = 8
+new_4 = 13
+new_5 = 16
+new_6 = 14
+new_7 = 3
+
+[md5s]
+gm-tto.cat = 26e85ff84b0063aa5da05dd4698fc76e
+
+[names]
+; Names get read from the CAT file
+
+[origin]
+default      = You can find it on your Transport Tycoon CD-ROM.

--- a/docs/Readme_Windows_MSVC.txt
+++ b/docs/Readme_Windows_MSVC.txt
@@ -1,27 +1,24 @@
 Compiling OpenTTD using Microsoft Visual C++
-Last updated: 2010-01-03
+Last updated: 2018-03-21
 --------------------------------------------
 PLEASE READ THE ENTIRE DOCUMENT BEFORE DOING ANY ACTUAL CHANGES!!
 
 
 SUPPORTED MSVC COMPILERS
 ------------------------
-OpenTTD includes projects for MSVC 2005.NET and MSVC 2008.NET. Both will
-compile out of the box, providing you have the required libraries/headers;
-which ones, see below. There is no support for VS6 or MSVC 2002, or
-MSVC 2003.NET. You are therefore strongly encouraged to either upgrade to
-MSVC 2008 Express (free) or use GCC.
+OpenTTD includes projects for Microsoft Visual Studio 2005 and later.
+This is the earliest compiler supported, Visual C++ 2003, Visual C++ 6.0,
+or earlier, will not compile OpenTTD.
+You can download the free Visual Studio Community Edition from Microsoft.
 
 
 1) REQUIRED FILES
 -----------------
 You might already have some of the files already installed, so check before
-downloading; mostly because the DirectX SDK and Platform SDK are about
-500MB each.
+downloading; mostly because the Platform SDK is about 500MB.
 Download the following files:
 
 	* openttd-useful.zip (http://binaries.openttd.org/extra/openttd-useful/)
-	* DirectX 8.1 SDK (http://neuron.tuke.sk/~mizanin/eng/Dx81sdk-include-lib.rar) (or alternatively the latest DirectX SDK from Microsoft)
 	* MS Windows Platform SDK (http://www.microsoft.com/downloads/details.aspx?FamilyId=A55B6B43-E24F-4EA3-A93E-40C0EC4F68E5&displaylang=en)
 	* afxres.h (http://www-d0.fnal.gov/d0dist/dist/packages/d0ve/devel/windows/AFXRES.H)
 
@@ -81,12 +78,16 @@ See section 4.1 of README.md for the required 3rdparty files and how to install 
 
 4) COMPILING
 ------------
-Open trunk/openttd_vs[89]0.sln
+Open the appropriate "sln" (Solution) file for your version of Visual Studio:
+ - VS 2005: projects/openttd_vs80.sln
+ - VS 2008: projects/openttd_vs90.sln
+ - VS 2010: projects/openttd_vs100.sln
+ - VS 2015: projects/openttd_vs140.sln
 Set the build mode to 'Release' in
 Build > Configuration manager > Active solution configuration > select "Release"
 Compile...
 
-If everything works well the binary should be in trunk/objs/Win[32|64]/Release/openttd.exe
+If everything works well the binary should be in objs/Win[32|64]/Release/openttd.exe
 
 
 5) EDITING, CHANGING SOURCE CODE

--- a/docs/obm_format.txt
+++ b/docs/obm_format.txt
@@ -45,12 +45,15 @@ description.en_US = howdie
 ; The file names are case sensitive.
 ; You can have empty file names; in that case no song will be loaded
 ; for that 'entry'.
+; If you want to load music from the MPS DOS music driver "cat" format,
+; specify just the name of the .cat file the song is located in, then
+; fill out the "catindex" section.
 [files]
 ; The theme song for OpenTTD
 theme = THEME_SONG.GM
 ; The songs in the 'old style' category
-old_0 =
-old_1 =
+old_0 = GM.CAT
+old_1 = GM.CAT
 old_2 =
 old_3 =
 old_4 =
@@ -86,8 +89,16 @@ ezy_9 =
 ; Note that the list of files is case sensitive. Each file listed in the
 ; files section must be listed here with it's song name, otherwise you
 ; will get a lot of warnings when starting OpenTTD.
+; You don't need to fill this out for "cat" format music, the song names
+; are loaded directly from the file in that case.
 [names]
 THEME_SONG.GM = Tycoon DELUXE Theme
+
+; If you are loading music from the DOS version "cat" format, specify
+; which index into the file the song has.
+[catindex]
+old_0 = 1
+old_1 = 3
 
 ; The md5s section lists the MD5 checksum for the files that replace them.
 ; Note that the list of files is case sensitive. Each file listed in the
@@ -95,6 +106,13 @@ THEME_SONG.GM = Tycoon DELUXE Theme
 ; will get a lot of warnings when starting OpenTTD.
 [md5s]
 THEME_SONG.GM = 45cfec1b9d8c7a0ad45e755833cbf221
+
+; If a song needs to have parts of the start or end cut off to avoid long
+; silences, you can specify MIDI tick codes for start:end of the actual
+; music part for each file here.
+; Not all music drivers might support this feature.
+[timingtrim]
+THEME_SONG.GM = 768:53760
 
 ; The origin section provides the possibility to put and extra line into
 ; the warning that a file is missing/corrupt. This can be used to tell

--- a/media/baseset/orig_dos.obm
+++ b/media/baseset/orig_dos.obm
@@ -1,0 +1,76 @@
+; $Id$
+;
+; This represents the original music as on the Transport
+; Tycoon Deluxe for DOS CD.
+;
+[metadata]
+name              = original_dos
+shortname         = TTDD
+version           = 1
+!! description STR_BASEMUSIC_DOS_DESCRIPTION
+
+[files]
+theme = gm.cat
+old_0 = gm.cat
+old_1 = gm.cat
+old_2 = gm.cat
+old_3 = gm.cat
+old_4 = gm.cat
+old_5 = gm.cat
+old_6 = gm.cat
+old_7 = gm.cat
+old_8 =
+old_9 =
+new_0 = gm.cat
+new_1 = gm.cat
+new_2 = gm.cat
+new_3 = gm.cat
+new_4 = gm.cat
+new_5 = gm.cat
+new_6 = gm.cat
+new_7 =
+new_8 =
+new_9 =
+ezy_0 = gm.cat
+ezy_1 = gm.cat
+ezy_2 = gm.cat
+ezy_3 = gm.cat
+ezy_4 = gm.cat
+ezy_5 = gm.cat
+ezy_6 =
+ezy_7 =
+ezy_8 =
+ezy_9 =
+
+[md5s]
+gm.cat = 7a29d2d0c4f7d2e03091ffa9b2bdfffb
+
+[catindex]
+theme = 0
+old_0 = 1
+old_1 = 8
+old_2 = 2
+old_3 = 9
+old_4 = 14
+old_5 = 15
+old_6 = 19
+old_7 = 13
+new_0 = 6
+new_1 = 11
+new_2 = 10
+new_3 = 17
+new_4 = 21
+new_5 = 18
+new_6 = 5
+ezy_0 = 12
+ezy_1 = 7
+ezy_2 = 16
+ezy_3 = 3
+ezy_4 = 20
+ezy_5 = 4
+
+[names]
+; Names get read from the CAT file
+
+[origin]
+default      = You can find it on your Transport Tycoon Deluxe CD-ROM.

--- a/media/baseset/orig_tto.obm
+++ b/media/baseset/orig_tto.obm
@@ -1,0 +1,71 @@
+; $Id$
+;
+; This represents the original music as on the Transport
+; Tycoon (with World Editor) for DOS CD.
+;
+[metadata]
+name              = original_tto
+shortname         = TTOD
+version           = 1
+!! description STR_BASEMUSIC_TTO_DESCRIPTION
+
+[files]
+theme = gm-tto.cat
+old_0 = gm-tto.cat
+old_1 = gm-tto.cat
+old_2 = gm-tto.cat
+old_3 = gm-tto.cat
+old_4 = gm-tto.cat
+old_5 = gm-tto.cat
+old_6 = gm-tto.cat
+old_7 = gm-tto.cat
+old_8 =
+old_9 =
+new_0 = gm-tto.cat
+new_1 = gm-tto.cat
+new_2 = gm-tto.cat
+new_3 = gm-tto.cat
+new_4 = gm-tto.cat
+new_5 = gm-tto.cat
+new_6 = gm-tto.cat
+new_7 = gm-tto.cat
+new_8 =
+new_9 =
+ezy_0 =
+ezy_1 =
+ezy_2 =
+ezy_3 =
+ezy_4 =
+ezy_5 =
+ezy_6 =
+ezy_7 =
+ezy_8 =
+ezy_9 =
+
+[catindex]
+theme = 0
+old_0 = 1
+old_1 = 6
+old_2 = 2
+old_3 = 7
+old_4 = 11
+old_5 = 12
+old_6 = 15
+old_7 = 10
+new_0 = 4
+new_1 = 5
+new_2 = 9
+new_3 = 8
+new_4 = 13
+new_5 = 16
+new_6 = 14
+new_7 = 3
+
+[md5s]
+gm-tto.cat = 26e85ff84b0063aa5da05dd4698fc76e
+
+[names]
+; Names get read from the CAT file
+
+[origin]
+default      = You can find it on your Transport Tycoon CD-ROM.

--- a/os/windows/installer/install.nsi
+++ b/os/windows/installer/install.nsi
@@ -304,6 +304,7 @@ Section /o "Copy data from Transport Tycoon Deluxe CD-ROM" Section2
 	; Let's copy the files with size approximation
 	SetOutPath "$INSTDIR\baseset"
 	CopyFiles "$CDDRIVE\gm\*.gm" "$INSTDIR\baseset\" 1028
+	CopyFiles "$CDDRIVE\gm.cat" "$INSTDIR\baseset\gm.cat" 415
 	CopyFiles "$CDDRIVE\sample.cat" "$INSTDIR\baseset\sample.cat" 1566
 	; Copy Windows files
 	CopyFiles "$CDDRIVE\trg1r.grf" "$INSTDIR\baseset\trg1r.grf" 2365
@@ -426,6 +427,8 @@ Section "Uninstall"
 	Delete "$INSTDIR\baseset\trgt.grf"
 	Delete "$INSTDIR\baseset\trgc.grf"
 	Delete "$INSTDIR\baseset\trgi.grf"
+	Delete "$INSTDIR\baseset\gm.cat"
+	Delete "$INSTDIR\baseset\gm-tto.cat"
 	Delete "$INSTDIR\baseset\*.gm"
 
 	Delete "$INSTDIR\data\sample.cat"
@@ -467,8 +470,10 @@ Section "Uninstall"
 
 	; Base sets for music
 	Delete "$INSTDIR\gm\orig_win.obm"
+	Delete "$INSTDIR\gm\orig_dos.obm"
 	Delete "$INSTDIR\gm\no_music.obm"
 	Delete "$INSTDIR\baseset\orig_win.obm"
+	Delete "$INSTDIR\baseset\orig_dos.obm"
 	Delete "$INSTDIR\baseset\no_music.obm"
 
 	; Remove remaining directories

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -285,11 +285,23 @@ static const uint NUM_SONGS_AVAILABLE = 1 + NUM_SONG_CLASSES * NUM_SONGS_CLASS;
 /** Maximum number of songs in the (custom) playlist */
 static const uint NUM_SONGS_PLAYLIST  = 32;
 
+enum MusicTrackType {
+	MTT_STANDARDMIDI, ///< Standard MIDI file
+};
+
+/** Metadata about a music track. */
+struct MusicSongInfo {
+	char songname[32];       ///< name of song displayed in UI
+	byte tracknr;            ///< track number of song displayed in UI
+	const char *filename;    ///< file on disk containing song (when used in MusicSet class, this pointer is owned by MD5File object for the file)
+	MusicTrackType filetype; ///< decoder required for song file
+};
+
 /** All data of a music set. */
 struct MusicSet : BaseSet<MusicSet, NUM_SONGS_AVAILABLE, false> {
-	/** The name of the different songs. */
-	char song_name[NUM_SONGS_AVAILABLE][32];
-	byte track_nr[NUM_SONGS_AVAILABLE];
+	/** Data about individual songs in set. */
+	MusicSongInfo songinfo[NUM_SONGS_AVAILABLE];
+	/** Number of valid songs in set. */
 	byte num_available;
 
 	bool FillSetDetails(struct IniFile *ini, const char *path, const char *full_filename);

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -285,8 +285,13 @@ static const uint NUM_SONGS_AVAILABLE = 1 + NUM_SONG_CLASSES * NUM_SONGS_CLASS;
 /** Maximum number of songs in the (custom) playlist */
 static const uint NUM_SONGS_PLAYLIST  = 32;
 
+/* Functions to read DOS music CAT files, similar to but not quite the same as sound effect CAT files */
+char *GetMusicCatEntryName(const char *filename, size_t entrynum);
+byte *GetMusicCatEntryData(const char *filename, size_t entrynum, size_t &entrylen);
+
 enum MusicTrackType {
 	MTT_STANDARDMIDI, ///< Standard MIDI file
+	MTT_MPSMIDI,      ///< MPS GM driver MIDI format (contained in a CAT file)
 };
 
 /** Metadata about a music track. */
@@ -295,6 +300,7 @@ struct MusicSongInfo {
 	byte tracknr;            ///< track number of song displayed in UI
 	const char *filename;    ///< file on disk containing song (when used in MusicSet class, this pointer is owned by MD5File object for the file)
 	MusicTrackType filetype; ///< decoder required for song file
+	int cat_index;           ///< entry index in CAT file, for filetype==MTT_MPSMIDI
 };
 
 /** All data of a music set. */

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -532,7 +532,7 @@ FILE *FioFOpenFile(const char *filename, const char *mode, Subdirectory subdir, 
  * Create a directory with the given name
  * @param name the new name of the directory
  */
-static void FioCreateDirectory(const char *name)
+void FioCreateDirectory(const char *name)
 {
 	/* Ignore directory creation errors; they'll surface later on, and most
 	 * of the time they are 'directory already exists' errors anyhow. */

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -55,6 +55,7 @@ char *FioGetFullPath(char *buf, const char *last, Searchpath sp, Subdirectory su
 char *FioFindFullPath(char *buf, const char *last, Subdirectory subdir, const char *filename);
 char *FioAppendDirectory(char *buf, const char *last, Searchpath sp, Subdirectory subdir);
 char *FioGetDirectory(char *buf, const char *last, Subdirectory subdir);
+void FioCreateDirectory(const char *name);
 
 const char *FiosGetScreenshotDir();
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4486,6 +4486,8 @@ STR_BASESOUNDS_DOS_DESCRIPTION                                  :Original Transp
 STR_BASESOUNDS_WIN_DESCRIPTION                                  :Original Transport Tycoon Deluxe Windows edition sounds.
 STR_BASESOUNDS_NONE_DESCRIPTION                                 :A sound pack without any sounds.
 STR_BASEMUSIC_WIN_DESCRIPTION                                   :Original Transport Tycoon Deluxe Windows edition music.
+STR_BASEMUSIC_DOS_DESCRIPTION                                   :Original Transport Tycoon Deluxe DOS edition music.
+STR_BASEMUSIC_TTO_DESCRIPTION                                   :Original Transport Tycoon (Original/World Editor) DOS edition music.
 STR_BASEMUSIC_NONE_DESCRIPTION                                  :A music pack without actual music.
 
 ##id 0x2000

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -66,12 +66,15 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 	if (ret) {
 		this->num_available = 0;
 		IniGroup *names = ini->GetGroup("names");
-		for (uint i = 0, j = 1; i < lengthof(this->song_name); i++) {
+		for (uint i = 0, j = 1; i < lengthof(this->songinfo); i++) {
 			const char *filename = this->files[i].filename;
 			if (names == NULL || StrEmpty(filename)) {
-				this->song_name[i][0] = '\0';
+				this->songinfo[i].songname[0] = '\0';
 				continue;
 			}
+
+			this->songinfo[i].filename = filename; // non-owned pointer
+			this->songinfo[i].filetype = MTT_STANDARDMIDI;
 
 			IniItem *item = NULL;
 			/* As we possibly add a path to the filename and we compare
@@ -91,8 +94,8 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 				return false;
 			}
 
-			strecpy(this->song_name[i], item->value, lastof(this->song_name[i]));
-			this->track_nr[i] = j++;
+			strecpy(this->songinfo[i].songname, item->value, lastof(this->songinfo[i].songname));
+			this->songinfo[i].tracknr = j++;
 			this->num_available++;
 		}
 	}

--- a/src/music/allegro_m.cpp
+++ b/src/music/allegro_m.cpp
@@ -58,10 +58,12 @@ void MusicDriver_Allegro::Stop()
 	if (--_allegro_instance_count == 0) allegro_exit();
 }
 
-void MusicDriver_Allegro::PlaySong(const char *filename)
+void MusicDriver_Allegro::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	if (_midi != NULL) destroy_midi(_midi);
-	_midi = load_midi(filename);
+	_midi = load_midi(song.filename);
 	play_midi(_midi, false);
 }
 

--- a/src/music/allegro_m.cpp
+++ b/src/music/allegro_m.cpp
@@ -14,6 +14,7 @@
 #include "../stdafx.h"
 #include "../debug.h"
 #include "allegro_m.h"
+#include "midifile.hpp"
 #include <allegro.h>
 
 #include "../safeguards.h"
@@ -60,11 +61,15 @@ void MusicDriver_Allegro::Stop()
 
 void MusicDriver_Allegro::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
+	std::string filename = MidiFile::GetSMFFile(song);
 
 	if (_midi != NULL) destroy_midi(_midi);
-	_midi = load_midi(song.filename);
-	play_midi(_midi, false);
+	if (!filename.empty()) {
+		_midi = load_midi(filename.c_str());
+		play_midi(_midi, false);
+	} else {
+		_midi = NULL;
+	}
 }
 
 void MusicDriver_Allegro::StopSong()

--- a/src/music/allegro_m.h
+++ b/src/music/allegro_m.h
@@ -21,7 +21,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/bemidi.cpp
+++ b/src/music/bemidi.cpp
@@ -12,6 +12,7 @@
 #include "../stdafx.h"
 #include "../openttd.h"
 #include "bemidi.h"
+#include "../base_media_base.h"
 
 /* BeOS System Includes */
 #include <MidiSynthFile.h>
@@ -34,11 +35,13 @@ void MusicDriver_BeMidi::Stop()
 	midiSynthFile.UnloadFile();
 }
 
-void MusicDriver_BeMidi::PlaySong(const char *filename)
+void MusicDriver_BeMidi::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	this->Stop();
 	entry_ref midiRef;
-	get_ref_for_path(filename, &midiRef);
+	get_ref_for_path(song.filename, &midiRef);
 	midiSynthFile.LoadFile(&midiRef);
 	midiSynthFile.Start();
 }

--- a/src/music/bemidi.cpp
+++ b/src/music/bemidi.cpp
@@ -13,6 +13,7 @@
 #include "../openttd.h"
 #include "bemidi.h"
 #include "../base_media_base.h"
+#include "midifile.hpp"
 
 /* BeOS System Includes */
 #include <MidiSynthFile.h>
@@ -37,13 +38,15 @@ void MusicDriver_BeMidi::Stop()
 
 void MusicDriver_BeMidi::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
+	std::string filename = MidiFile::GetSMFFile(song);
 
 	this->Stop();
-	entry_ref midiRef;
-	get_ref_for_path(song.filename, &midiRef);
-	midiSynthFile.LoadFile(&midiRef);
-	midiSynthFile.Start();
+	if (!filename.empty()) {
+		entry_ref midiRef;
+		get_ref_for_path(filename.c_str(), &midiRef);
+		midiSynthFile.LoadFile(&midiRef);
+		midiSynthFile.Start();
+	}
 }
 
 void MusicDriver_BeMidi::StopSong()

--- a/src/music/bemidi.h
+++ b/src/music/bemidi.h
@@ -21,7 +21,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -18,6 +18,7 @@
 #include "../stdafx.h"
 #include "../os/macosx/macos.h"
 #include "cocoa_m.h"
+#include "midifile.hpp"
 #include "../debug.h"
 #include "../base_media_base.h"
 
@@ -142,13 +143,13 @@ void MusicDriver_Cocoa::Stop()
 /**
  * Starts playing a new song.
  *
- * @param filename Path to a MIDI file.
+ * @param song Description of music to load and play
  */
 void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
+	std::string filename = MidiFile::GetSMFFile(song);
 
-	DEBUG(driver, 2, "cocoa_m: trying to play '%s'", filename);
+	DEBUG(driver, 2, "cocoa_m: trying to play '%s'", filename.c_str());
 
 	this->StopSong();
 	if (_sequence != NULL) {
@@ -156,12 +157,14 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 		_sequence = NULL;
 	}
 
+	if (filename.empty()) return;
+
 	if (NewMusicSequence(&_sequence) != noErr) {
 		DEBUG(driver, 0, "cocoa_m: Failed to create music sequence");
 		return;
 	}
 
-	const char *os_file = OTTD2FS(song.filename);
+	const char *os_file = OTTD2FS(filename.c_str());
 	CFURLRef url = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file, strlen(os_file), false);
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
@@ -221,7 +224,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	if (MusicPlayerStart(_player) != noErr) return;
 	_playing = true;
 
-	DEBUG(driver, 3, "cocoa_m: playing '%s'", filename);
+	DEBUG(driver, 3, "cocoa_m: playing '%s'", filename.c_str());
 }
 
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -19,6 +19,7 @@
 #include "../os/macosx/macos.h"
 #include "cocoa_m.h"
 #include "../debug.h"
+#include "../base_media_base.h"
 
 #define Rect        OTTDRect
 #define Point       OTTDPoint
@@ -143,8 +144,10 @@ void MusicDriver_Cocoa::Stop()
  *
  * @param filename Path to a MIDI file.
  */
-void MusicDriver_Cocoa::PlaySong(const char *filename)
+void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	DEBUG(driver, 2, "cocoa_m: trying to play '%s'", filename);
 
 	this->StopSong();
@@ -158,7 +161,7 @@ void MusicDriver_Cocoa::PlaySong(const char *filename)
 		return;
 	}
 
-	const char *os_file = OTTD2FS(filename);
+	const char *os_file = OTTD2FS(song.filename);
 	CFURLRef url = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file, strlen(os_file), false);
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)

--- a/src/music/cocoa_m.h
+++ b/src/music/cocoa_m.h
@@ -20,7 +20,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -1228,11 +1228,10 @@ void MusicDriver_DMusic::Stop()
 
 void MusicDriver_DMusic::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
-
 	ThreadMutexLocker lock(_thread_mutex);
 
-	_playback.next_file.LoadFile(song.filename);
+	if (!_playback.next_file.LoadSong(song)) return;
+
 	_playback.next_segment.start = 0;
 	_playback.next_segment.end = 0;
 	_playback.next_segment.loop = false;

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -21,6 +21,7 @@
 #include "../core/mem_func.hpp"
 #include "../thread/thread.h"
 #include "../fileio_func.h"
+#include "../base_media_base.h"
 #include "dmusic.h"
 #include "midifile.hpp"
 #include "midi.h"
@@ -1225,11 +1226,13 @@ void MusicDriver_DMusic::Stop()
 }
 
 
-void MusicDriver_DMusic::PlaySong(const char *filename)
+void MusicDriver_DMusic::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	ThreadMutexLocker lock(_thread_mutex);
 
-	_playback.next_file.LoadFile(filename);
+	_playback.next_file.LoadFile(song.filename);
 	_playback.next_segment.start = 0;
 	_playback.next_segment.end = 0;
 	_playback.next_segment.loop = false;

--- a/src/music/dmusic.h
+++ b/src/music/dmusic.h
@@ -23,7 +23,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -17,6 +17,7 @@
 #include "../video/video_driver.hpp"
 #include "../gfx_func.h"
 #include "extmidi.h"
+#include "../base_media_base.h"
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -83,9 +84,11 @@ void MusicDriver_ExtMidi::Stop()
 	this->DoStop();
 }
 
-void MusicDriver_ExtMidi::PlaySong(const char *filename)
+void MusicDriver_ExtMidi::PlaySong(const MusicSongInfo &song)
 {
-	strecpy(this->song, filename, lastof(this->song));
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
+	strecpy(this->song, song.filename, lastof(this->song));
 	this->DoStop();
 }
 

--- a/src/music/extmidi.cpp
+++ b/src/music/extmidi.cpp
@@ -18,6 +18,7 @@
 #include "../gfx_func.h"
 #include "extmidi.h"
 #include "../base_media_base.h"
+#include "midifile.hpp"
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -86,10 +87,11 @@ void MusicDriver_ExtMidi::Stop()
 
 void MusicDriver_ExtMidi::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
-
-	strecpy(this->song, song.filename, lastof(this->song));
-	this->DoStop();
+	std::string filename = MidiFile::GetSMFFile(song);
+	if (!filename.empty()) {
+		strecpy(this->song, filename.c_str(), lastof(this->song));
+		this->DoStop();
+	}
 }
 
 void MusicDriver_ExtMidi::StopSong()

--- a/src/music/extmidi.h
+++ b/src/music/extmidi.h
@@ -28,7 +28,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/libtimidity.cpp
+++ b/src/music/libtimidity.cpp
@@ -14,6 +14,7 @@
 #include "../sound_type.h"
 #include "../debug.h"
 #include "libtimidity.h"
+#include "midifile.hpp"
 #include "../base_media_base.h"
 #include <fcntl.h>
 #include <sys/types.h>
@@ -76,11 +77,12 @@ void MusicDriver_LibTimidity::Stop()
 
 void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
+	std::string filename = MidiFile::GetSMFFile(song);
 
 	this->StopSong();
+	if (filename.empty()) return;
 
-	_midi.stream = mid_istream_open_file(song.filename);
+	_midi.stream = mid_istream_open_file(filename.c_str());
 	if (_midi.stream == NULL) {
 		DEBUG(driver, 0, "Could not open music file");
 		return;

--- a/src/music/libtimidity.cpp
+++ b/src/music/libtimidity.cpp
@@ -14,6 +14,7 @@
 #include "../sound_type.h"
 #include "../debug.h"
 #include "libtimidity.h"
+#include "../base_media_base.h"
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -73,11 +74,13 @@ void MusicDriver_LibTimidity::Stop()
 	mid_exit();
 }
 
-void MusicDriver_LibTimidity::PlaySong(const char *filename)
+void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	this->StopSong();
 
-	_midi.stream = mid_istream_open_file(filename);
+	_midi.stream = mid_istream_open_file(song.filename);
 	if (_midi.stream == NULL) {
 		DEBUG(driver, 0, "Could not open music file");
 		return;

--- a/src/music/libtimidity.h
+++ b/src/music/libtimidity.h
@@ -21,7 +21,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -36,10 +36,15 @@ struct MidiFile {
 	std::vector<TempoChange> tempos; ///< list of tempo changes in file
 	uint16 tickdiv;                  ///< ticks per quarter note
 
+	MidiFile();
+	~MidiFile();
+
 	bool LoadFile(const char *filename);
 	bool LoadMpsData(const byte *data, size_t length);
 	bool LoadSong(const MusicSongInfo &song);
 	void MoveFrom(MidiFile &other);
+
+	bool WriteSMF(const char *filename);
 
 	static bool ReadSMFHeader(const char *filename, SMFHeader &header);
 	static bool ReadSMFHeader(FILE *file, SMFHeader &header);

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -17,6 +17,8 @@
 #include "midi.h"
 #include <vector>
 
+struct MusicSongInfo;
+
 struct MidiFile {
 	struct DataBlock {
 		uint32 ticktime;           ///< tick number since start of file this block should be triggered at
@@ -35,6 +37,8 @@ struct MidiFile {
 	uint16 tickdiv;                  ///< ticks per quarter note
 
 	bool LoadFile(const char *filename);
+	bool LoadMpsData(const byte *data, size_t length);
+	bool LoadSong(const MusicSongInfo &song);
 	void MoveFrom(MidiFile &other);
 
 	static bool ReadSMFHeader(const char *filename, SMFHeader &header);

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -16,6 +16,7 @@
 #include "../core/smallvec_type.hpp"
 #include "midi.h"
 #include <vector>
+#include <string>
 
 struct MusicSongInfo;
 
@@ -46,6 +47,7 @@ struct MidiFile {
 
 	bool WriteSMF(const char *filename);
 
+	static std::string GetSMFFile(const MusicSongInfo &song);
 	static bool ReadSMFHeader(const char *filename, SMFHeader &header);
 	static bool ReadSMFHeader(FILE *file, SMFHeader &header);
 };

--- a/src/music/music_driver.hpp
+++ b/src/music/music_driver.hpp
@@ -14,6 +14,8 @@
 
 #include "../driver.h"
 
+struct MusicSongInfo;
+
 /** Driver for all music playback. */
 class MusicDriver : public Driver {
 public:
@@ -21,7 +23,7 @@ public:
 	 * Play a particular song.
 	 * @param filename The name of file with the song to play.
 	 */
-	virtual void PlaySong(const char *filename) = 0;
+	virtual void PlaySong(const MusicSongInfo &song) = 0;
 
 	/**
 	 * Stop playing the current song.

--- a/src/music/null_m.h
+++ b/src/music/null_m.h
@@ -21,7 +21,7 @@ public:
 
 	/* virtual */ void Stop() { }
 
-	/* virtual */ void PlaySong(const char *filename) { }
+	/* virtual */ void PlaySong(const MusicSongInfo &song) { }
 
 	/* virtual */ void StopSong() { }
 

--- a/src/music/os2_m.cpp
+++ b/src/music/os2_m.cpp
@@ -12,6 +12,7 @@
 #include "../stdafx.h"
 #include "../openttd.h"
 #include "os2_m.h"
+#include "midifile.hpp"
 #include "../base_media_base.h"
 
 #define INCL_DOS
@@ -52,11 +53,12 @@ static FMusicDriver_OS2 iFMusicDriver_OS2;
 
 void MusicDriver_OS2::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
+	std::string filename = MidiFile::GetSMFFile(song);
 
 	MidiSendCommand("close all");
+	if (filename.empty()) return;
 
-	if (MidiSendCommand("open %s type sequencer alias song", song.filename) != 0) {
+	if (MidiSendCommand("open %s type sequencer alias song", filename.c_str()) != 0) {
 		return;
 	}
 

--- a/src/music/os2_m.cpp
+++ b/src/music/os2_m.cpp
@@ -12,6 +12,7 @@
 #include "../stdafx.h"
 #include "../openttd.h"
 #include "os2_m.h"
+#include "../base_media_base.h"
 
 #define INCL_DOS
 #define INCL_OS2MM
@@ -49,11 +50,13 @@ static long CDECL MidiSendCommand(const char *cmd, ...)
 /** OS/2's music player's factory. */
 static FMusicDriver_OS2 iFMusicDriver_OS2;
 
-void MusicDriver_OS2::PlaySong(const char *filename)
+void MusicDriver_OS2::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	MidiSendCommand("close all");
 
-	if (MidiSendCommand("open %s type sequencer alias song", filename) != 0) {
+	if (MidiSendCommand("open %s type sequencer alias song", song.filename) != 0) {
 		return;
 	}
 

--- a/src/music/os2_m.h
+++ b/src/music/os2_m.h
@@ -21,7 +21,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/qtmidi.cpp
+++ b/src/music/qtmidi.cpp
@@ -31,6 +31,7 @@
 #include "../stdafx.h"
 #include "qtmidi.h"
 #include "../debug.h"
+#include "../base_media_base.h"
 
 #define Rect  OTTDRect
 #define Point OTTDPoint
@@ -258,8 +259,9 @@ void MusicDriver_QtMidi::Stop()
  *
  * @param filename Path to a MIDI file.
  */
-void MusicDriver_QtMidi::PlaySong(const char *filename)
+void MusicDriver_QtMidi::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
 	if (!_quicktime_started) return;
 
 	DEBUG(driver, 2, "qtmidi: trying to play '%s'", filename);
@@ -276,7 +278,7 @@ void MusicDriver_QtMidi::PlaySong(const char *filename)
 			FALLTHROUGH;
 
 		case QT_STATE_IDLE:
-			LoadMovieForMIDIFile(filename, &_quicktime_movie);
+			LoadMovieForMIDIFile(song.filename, &_quicktime_movie);
 			SetMovieVolume(_quicktime_movie, VOLUME);
 			StartMovie(_quicktime_movie);
 			_quicktime_state = QT_STATE_PLAY;

--- a/src/music/qtmidi.cpp
+++ b/src/music/qtmidi.cpp
@@ -30,6 +30,7 @@
 
 #include "../stdafx.h"
 #include "qtmidi.h"
+#include "midifile.hpp"
 #include "../debug.h"
 #include "../base_media_base.h"
 
@@ -261,10 +262,12 @@ void MusicDriver_QtMidi::Stop()
  */
 void MusicDriver_QtMidi::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
 	if (!_quicktime_started) return;
 
-	DEBUG(driver, 2, "qtmidi: trying to play '%s'", filename);
+	std::string filename = MidiFile::GetSMFFile(song);
+	if (filename.empty()) return;
+
+	DEBUG(driver, 2, "qtmidi: trying to play '%s'", filename.c_str());
 	switch (_quicktime_state) {
 		case QT_STATE_PLAY:
 			StopSong();
@@ -278,12 +281,12 @@ void MusicDriver_QtMidi::PlaySong(const MusicSongInfo &song)
 			FALLTHROUGH;
 
 		case QT_STATE_IDLE:
-			LoadMovieForMIDIFile(song.filename, &_quicktime_movie);
+			LoadMovieForMIDIFile(filename.c_str(), &_quicktime_movie);
 			SetMovieVolume(_quicktime_movie, VOLUME);
 			StartMovie(_quicktime_movie);
 			_quicktime_state = QT_STATE_PLAY;
 	}
-	DEBUG(driver, 3, "qtmidi: playing '%s'", filename);
+	DEBUG(driver, 3, "qtmidi: playing '%s'", filename.c_str());
 }
 
 

--- a/src/music/qtmidi.h
+++ b/src/music/qtmidi.h
@@ -20,7 +20,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -307,12 +307,14 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 
 void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 {
-	if (song.filetype != MTT_STANDARDMIDI) return;
-
 	DEBUG(driver, 2, "Win32-MIDI: PlaySong: entry");
 	EnterCriticalSection(&_midi.lock);
 
-	_midi.next_file.LoadFile(song.filename);
+	if (!_midi.next_file.LoadSong(song)) {
+		LeaveCriticalSection(&_midi.lock);
+		return;
+	}
+
 	_midi.next_segment.start = 0;
 	_midi.next_segment.end = 0;
 	_midi.next_segment.loop = false;

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -18,6 +18,7 @@
 #include "../debug.h"
 #include "midifile.hpp"
 #include "midi.h"
+#include "../base_media_base.h"
 
 #include "../safeguards.h"
 
@@ -304,12 +305,14 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 	}
 }
 
-void MusicDriver_Win32::PlaySong(const char *filename)
+void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 {
+	if (song.filetype != MTT_STANDARDMIDI) return;
+
 	DEBUG(driver, 2, "Win32-MIDI: PlaySong: entry");
 	EnterCriticalSection(&_midi.lock);
 
-	_midi.next_file.LoadFile(filename);
+	_midi.next_file.LoadFile(song.filename);
 	_midi.next_segment.start = 0;
 	_midi.next_segment.end = 0;
 	_midi.next_segment.loop = false;

--- a/src/music/win32_m.h
+++ b/src/music/win32_m.h
@@ -21,7 +21,7 @@ public:
 
 	/* virtual */ void Stop();
 
-	/* virtual */ void PlaySong(const char *filename);
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
 
 	/* virtual */ void StopSong();
 

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -42,7 +42,7 @@
  */
 static const char *GetSongName(int index)
 {
-	return BaseMusic::GetUsedSet()->song_name[index];
+	return BaseMusic::GetUsedSet()->songinfo[index].songname;
 }
 
 /**
@@ -52,7 +52,7 @@ static const char *GetSongName(int index)
  */
 static int GetTrackNumber(int index)
 {
-	return BaseMusic::GetUsedSet()->track_nr[index];
+	return BaseMusic::GetUsedSet()->songinfo[index].tracknr;
 }
 
 /** The currently played song */
@@ -186,10 +186,12 @@ static void MusicVolumeChanged(byte new_vol)
 static void DoPlaySong()
 {
 	char filename[MAX_PATH];
-	if (FioFindFullPath(filename, lastof(filename), BASESET_DIR, BaseMusic::GetUsedSet()->files[_music_wnd_cursong - 1].filename) == NULL) {
-		FioFindFullPath(filename, lastof(filename), OLD_GM_DIR, BaseMusic::GetUsedSet()->files[_music_wnd_cursong - 1].filename);
+	MusicSongInfo songinfo = BaseMusic::GetUsedSet()->songinfo[_music_wnd_cursong - 1]; // copy
+	if (FioFindFullPath(filename, lastof(filename), BASESET_DIR, songinfo.filename) == NULL) {
+		FioFindFullPath(filename, lastof(filename), OLD_GM_DIR, songinfo.filename);
 	}
-	MusicDriver::GetInstance()->PlaySong(filename);
+	songinfo.filename = filename; // non-owned pointer
+	MusicDriver::GetInstance()->PlaySong(songinfo);
 	SetWindowDirty(WC_MUSIC_WINDOW, 0);
 }
 


### PR DESCRIPTION
Decoder for TTD DOS version music (also TTO DOS music), and loading of it in all existing music drivers.

Only the DMusic and Win32 drivers are tested but they both work as intended. All changes to other drivers follow the pattern of the DMusic driver changes and "should" work as well.

The changes to the Windows installer are untested, but simple enough that they should "obviously" work.

Will conflict with #6774 (Remove DMusic).