### PR TITLE
Change: Refactor window ticks into game ticks and realtime events.

### DIFF
--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -521,6 +521,7 @@
     <ClInclude Include="..\src\group_gui.h" />
     <ClInclude Include="..\src\group_type.h" />
     <ClInclude Include="..\src\gui.h" />
+    <ClInclude Include="..\src\guitimer_func.h" />
     <ClInclude Include="..\src\heightmap.h" />
     <ClInclude Include="..\src\highscore.h" />
     <ClInclude Include="..\src\hotkeys.h" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -651,6 +651,9 @@
     <ClInclude Include="..\src\gui.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\guitimer_func.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\heightmap.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -521,6 +521,7 @@
     <ClInclude Include="..\src\group_gui.h" />
     <ClInclude Include="..\src\group_type.h" />
     <ClInclude Include="..\src\gui.h" />
+    <ClInclude Include="..\src\guitimer_func.h" />
     <ClInclude Include="..\src\heightmap.h" />
     <ClInclude Include="..\src\highscore.h" />
     <ClInclude Include="..\src\hotkeys.h" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -651,6 +651,9 @@
     <ClInclude Include="..\src\gui.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\guitimer_func.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\heightmap.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/source.list
+++ b/source.list
@@ -210,6 +210,7 @@ group.h
 group_gui.h
 group_type.h
 gui.h
+guitimer_func.h
 heightmap.h
 highscore.h
 hotkeys.h

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -543,7 +543,7 @@ public:
 		this->SelectFirstAvailableAirport(false);
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
 		CheckRedrawStationCoverage(this);
 	}

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -451,7 +451,7 @@ public:
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
 		CheckRedrawStationCoverage(this);
 	}

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1474,8 +1474,6 @@ struct PerformanceRatingDetailWindow : Window {
 
 	virtual void OnGameTick()
 	{
-		if (_pause_mode != PM_UNPAUSED) return;
-
 		/* Update the company score every 5 days */
 		if (--this->timeout == 0) {
 			this->UpdateCompanyStats();

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -539,7 +539,7 @@ public:
 		if (widget == WID_CV_KEY_BUTTON) ShowGraphLegend();
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		this->UpdateStatistics(false);
 	}
@@ -998,9 +998,9 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
-		/* Override default OnTick */
+		/* Override default OnGameTick */
 	}
 
 	/**
@@ -1239,7 +1239,7 @@ public:
 	}
 
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		if (this->companies.NeedResort()) {
 			this->SetDirty();
@@ -1472,7 +1472,7 @@ struct PerformanceRatingDetailWindow : Window {
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		if (_pause_mode != PM_UNPAUSED) return;
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -860,7 +860,6 @@ public:
 
 	virtual void OnGameTick()
 	{
-		if (_pause_mode != PM_UNPAUSED) return;
 		if (this->groups.NeedResort() || this->vehicles.NeedResort()) {
 			this->SetDirty();
 		}

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -858,7 +858,7 @@ public:
 		this->SetDirty();
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		if (_pause_mode != PM_UNPAUSED) return;
 		if (this->groups.NeedResort() || this->vehicles.NeedResort()) {

--- a/src/guitimer_func.h
+++ b/src/guitimer_func.h
@@ -1,0 +1,65 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file guitimer_func.h GUI Timers. */
+
+#ifndef GUITIMER_FUNC_H
+#define GUITIMER_FUNC_H
+
+class GUITimer
+{
+protected:
+	uint timer;
+	uint interval;
+
+public:
+	GUITimer() : timer(0), interval(0) { }
+	explicit GUITimer(uint interval) : timer(0), interval(interval) { }
+
+	inline bool HasElapsed() const
+	{
+		return this->interval == 0;
+	}
+
+	inline void SetInterval(uint interval)
+	{
+		this->timer = 0;
+		this->interval = interval;
+	}
+
+	/**
+	 * Count how many times the interval has elapsed.
+	 * Use to ensure a specific amount of events happen within a timeframe, e.g. for animation.
+	 * @param delta Time since last test.
+	 * @return Number of times the interval has elapsed.
+	 */
+	inline uint CountElapsed(uint delta)
+	{
+		if (this->interval == 0) return 0;
+		uint count = delta / this->interval;
+		if (this->timer + (delta % this->interval) >= this->interval) count++;
+		this->timer = (this->timer + delta) % this->interval;
+		return count;
+	}
+
+	/**
+	 * Test if a timer has elapsed.
+	 * Use to ensure an event happens only once within a timeframe, e.g. for window updates.
+	 * @param delta Time since last test.
+	 * @return True iff the timer has elapsed.
+	 */
+	inline bool Elapsed(uint delta)
+	{
+		if (this->CountElapsed(delta) == 0) return false;
+		this->SetInterval(0);
+		return true;
+	}
+};
+
+#endif /* GUITIMER_FUNC_H */

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -647,7 +647,7 @@ public:
 		if (success && !_settings_client.gui.persistent_buildingtools) ResetObjectToPlace();
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		if (_pause_mode != PM_UNPAUSED) return;
 		if (!this->timer_enabled) return;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -649,7 +649,6 @@ public:
 
 	virtual void OnGameTick()
 	{
-		if (_pause_mode != PM_UNPAUSED) return;
 		if (!this->timer_enabled) return;
 		if (--this->callback_timer == 0) {
 			/* We have just passed another day.

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -235,10 +235,11 @@ enum {
 
 struct MainWindow : Window
 {
-	uint refresh;
+	int refresh;
 
-	static const uint LINKGRAPH_REFRESH_PERIOD = 0xff;
-	static const uint LINKGRAPH_DELAY = 0xf;
+	/* Refresh times in milliseconds */
+	static const uint LINKGRAPH_REFRESH_PERIOD = 7650;
+	static const uint LINKGRAPH_DELAY = 450;
 
 	MainWindow(WindowDesc *desc) : Window(desc)
 	{
@@ -253,9 +254,9 @@ struct MainWindow : Window
 		this->refresh = LINKGRAPH_DELAY;
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (--this->refresh > 0) return;
+		if (!TimerElapsed(this->refresh, delta_ms)) return;
 
 		this->refresh = LINKGRAPH_REFRESH_PERIOD;
 

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -32,6 +32,7 @@
 #include "linkgraph/linkgraph_gui.h"
 #include "tilehighlight_func.h"
 #include "hotkeys.h"
+#include "guitimer_func.h"
 
 #include "saveload/saveload.h"
 
@@ -235,7 +236,7 @@ enum {
 
 struct MainWindow : Window
 {
-	int refresh;
+	GUITimer refresh;
 
 	/* Refresh times in milliseconds */
 	static const uint LINKGRAPH_REFRESH_PERIOD = 7650;
@@ -251,14 +252,14 @@ struct MainWindow : Window
 		nvp->InitializeViewport(this, TileXY(32, 32), ZOOM_LVL_VIEWPORT);
 
 		this->viewport->overlay = new LinkGraphOverlay(this, WID_M_VIEWPORT, 0, 0, 3);
-		this->refresh = LINKGRAPH_DELAY;
+		this->refresh.SetInterval(LINKGRAPH_DELAY);
 	}
 
 	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (!TimerElapsed(this->refresh, delta_ms)) return;
+		if (!this->refresh.Elapsed(delta_ms)) return;
 
-		this->refresh = LINKGRAPH_REFRESH_PERIOD;
+		this->refresh.SetInterval(LINKGRAPH_REFRESH_PERIOD);
 
 		if (this->viewport->overlay->GetCargoMask() == 0 ||
 				this->viewport->overlay->GetCompanyMask() == 0) {
@@ -435,7 +436,7 @@ struct MainWindow : Window
 		this->viewport->scrollpos_y += ScaleByZoom(delta.y, this->viewport->zoom);
 		this->viewport->dest_scrollpos_x = this->viewport->scrollpos_x;
 		this->viewport->dest_scrollpos_y = this->viewport->scrollpos_y;
-		this->refresh = LINKGRAPH_DELAY;
+		this->refresh.SetInterval(LINKGRAPH_DELAY);
 	}
 
 	virtual void OnMouseWheel(int wheel)
@@ -450,7 +451,7 @@ struct MainWindow : Window
 		if (this->viewport != NULL) {
 			NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_M_VIEWPORT);
 			nvp->UpdateViewportCoordinates(this);
-			this->refresh = LINKGRAPH_DELAY;
+			this->refresh.SetInterval(LINKGRAPH_DELAY);
 		}
 	}
 

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -26,6 +26,7 @@
 #include "core/geometry_func.hpp"
 #include "newgrf_debug.h"
 #include "zoom_func.h"
+#include "guitimer_func.h"
 
 #include "widgets/misc_widget.h"
 
@@ -458,13 +459,14 @@ struct AboutWindow : public Window {
 	static const int num_visible_lines = 19; ///< The number of lines visible simultaneously
 
 	static const uint TIMER_INTERVAL = 150;  ///< Scrolling interval in ms
-	uint timer;
+	GUITimer timer;
 
 	AboutWindow() : Window(&_about_desc)
 	{
 		this->InitNested(WN_GAME_OPTIONS_ABOUT);
 
 		this->text_position = this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y + this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->current_y;
+		this->timer.SetInterval(TIMER_INTERVAL);
 	}
 
 	virtual void SetStringParameters(int widget) const
@@ -505,7 +507,7 @@ struct AboutWindow : public Window {
 
 	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		uint count = CountIntervalElapsed(this->timer, delta_ms, TIMER_INTERVAL);
+		uint count = this->timer.CountElapsed(delta_ms);
 		if (count > 0) {
 			this->text_position -= count;
 			/* If the last text has scrolled start a new from the start */

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -454,15 +454,16 @@ static const char * const _credits[] = {
 
 struct AboutWindow : public Window {
 	int text_position;                       ///< The top of the scrolling text
-	byte counter;                            ///< Used to scroll the text every 5 ticks
 	int line_height;                         ///< The height of a single line
 	static const int num_visible_lines = 19; ///< The number of lines visible simultaneously
+
+	static const uint TIMER_INTERVAL = 150;  ///< Scrolling interval in ms
+	uint timer;
 
 	AboutWindow() : Window(&_about_desc)
 	{
 		this->InitNested(WN_GAME_OPTIONS_ABOUT);
 
-		this->counter = 5;
 		this->text_position = this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y + this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->current_y;
 	}
 
@@ -502,11 +503,11 @@ struct AboutWindow : public Window {
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (--this->counter == 0) {
-			this->counter = 5;
-			this->text_position--;
+		uint count = CountIntervalElapsed(this->timer, delta_ms, TIMER_INTERVAL);
+		if (count > 0) {
+			this->text_position -= count;
 			/* If the last text has scrolled start a new from the start */
 			if (this->text_position < (int)(this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y - lengthof(_credits) * this->line_height)) {
 				this->text_position = this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->pos_y + this->GetWidget<NWidgetBase>(WID_A_SCROLLING_TEXT)->current_y;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -403,7 +403,7 @@ struct NewGRFParametersWindow : public Window {
 						par_info->SetValue(this->grf_config, val);
 
 						this->clicked_button = num;
-						this->timeout = 5;
+						this->timeout = 150;
 					}
 				} else if (par_info->type == PTYPE_UINT_ENUM && !par_info->complete_labels && click_count >= 2) {
 					/* Display a query box so users can enter a custom value. */
@@ -483,9 +483,9 @@ struct NewGRFParametersWindow : public Window {
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (--this->timeout == 0) {
+		if (TimerElapsed(this->timeout, delta_ms)) {
 			this->clicked_button = UINT_MAX;
 			this->SetDirty();
 		}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -30,6 +30,7 @@
 #include "textfile_gui.h"
 #include "tilehighlight_func.h"
 #include "fios.h"
+#include "guitimer_func.h"
 
 #include "widgets/newgrf_widget.h"
 #include "widgets/misc_widget.h"
@@ -150,7 +151,7 @@ struct NewGRFParametersWindow : public Window {
 	bool clicked_increase; ///< True if the increase button was clicked, false for the decrease button.
 	bool clicked_dropdown; ///< Whether the dropdown is open.
 	bool closing_dropdown; ///< True, if the dropdown list is currently closing.
-	int timeout;           ///< How long before we unpress the last-pressed button?
+	GUITimer timeout;      ///< How long before we unpress the last-pressed button?
 	uint clicked_row;      ///< The selected parameter
 	int line_height;       ///< Height of a row in the matrix widget.
 	Scrollbar *vscroll;
@@ -162,7 +163,6 @@ struct NewGRFParametersWindow : public Window {
 		clicked_button(UINT_MAX),
 		clicked_dropdown(false),
 		closing_dropdown(false),
-		timeout(0),
 		clicked_row(UINT_MAX),
 		editable(editable)
 	{
@@ -403,7 +403,7 @@ struct NewGRFParametersWindow : public Window {
 						par_info->SetValue(this->grf_config, val);
 
 						this->clicked_button = num;
-						this->timeout = 150;
+						this->timeout.SetInterval(150);
 					}
 				} else if (par_info->type == PTYPE_UINT_ENUM && !par_info->complete_labels && click_count >= 2) {
 					/* Display a query box so users can enter a custom value. */
@@ -485,7 +485,7 @@ struct NewGRFParametersWindow : public Window {
 
 	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (TimerElapsed(this->timeout, delta_ms)) {
+		if (timeout.Elapsed(delta_ms)) {
 			this->clicked_button = UINT_MAX;
 			this->SetDirty();
 		}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -260,11 +260,13 @@ struct NewsWindow : Window {
 	uint16 chat_height;   ///< Height of the chat window.
 	uint16 status_height; ///< Height of the status bar window
 	const NewsItem *ni;   ///< News item to display.
-	static uint duration; ///< Remaining time for showing current news message (may only be accessed while a news item is displayed).
+	static int duration;  ///< Remaining time for showing the current news message (may only be access while a news item is displayed).
+
+	uint timer;
 
 	NewsWindow(WindowDesc *desc, const NewsItem *ni) : Window(desc), ni(ni)
 	{
-		NewsWindow::duration = 555;
+		NewsWindow::duration = 16650;
 		const Window *w = FindWindowByClass(WC_SEND_NETWORK_MSG);
 		this->chat_height = (w != NULL) ? w->height : 0;
 		this->status_height = FindWindowById(WC_STATUS_BAR, 0)->height;
@@ -485,11 +487,18 @@ struct NewsWindow : Window {
 		this->SetWindowTop(newtop);
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		/* Scroll up newsmessages from the bottom in steps of 4 pixels */
-		int newtop = max(this->top - 4, _screen.height - this->height - this->status_height - this->chat_height);
-		this->SetWindowTop(newtop);
+		int count = CountIntervalElapsed(this->timer, delta_ms, 15);
+		if (count > 0) {
+			/* Scroll up newsmessages from the bottom */
+			int newtop = max(this->top - 2 * count, _screen.height - this->height - this->status_height - this->chat_height);
+			this->SetWindowTop(newtop);
+		}
+
+		/* Decrement the news timer. We don't need to action an elapsed event here,
+		 * so no need to use TimerElapsed(). */
+		if (NewsWindow::duration > 0) NewsWindow::duration -= delta_ms;
 	}
 
 private:
@@ -536,7 +545,7 @@ private:
 	}
 };
 
-/* static */ uint NewsWindow::duration = 0; // Instance creation.
+/* static */ int NewsWindow::duration = 0; // Instance creation.
 
 
 /** Open up an own newspaper window for the news item */
@@ -588,11 +597,8 @@ static bool ReadyForNextItem()
 	 * Check if the status bar message is still being displayed? */
 	if (IsNewsTickerShown()) return false;
 
-	/* Newspaper message, decrement duration counter */
-	if (NewsWindow::duration != 0) NewsWindow::duration--;
-
 	/* neither newsticker nor newspaper are running */
-	return (NewsWindow::duration == 0 || FindWindowById(WC_NEWS_WINDOW, 0) == NULL);
+	return (NewsWindow::duration <= 0 || FindWindowById(WC_NEWS_WINDOW, 0) == NULL);
 }
 
 /** Move to the next news item */

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -33,6 +33,7 @@
 #include "command_func.h"
 #include "company_base.h"
 #include "settings_internal.h"
+#include "guitimer_func.h"
 
 #include "widgets/news_widget.h"
 
@@ -262,7 +263,7 @@ struct NewsWindow : Window {
 	const NewsItem *ni;   ///< News item to display.
 	static int duration;  ///< Remaining time for showing the current news message (may only be access while a news item is displayed).
 
-	uint timer;
+	GUITimer timer;
 
 	NewsWindow(WindowDesc *desc, const NewsItem *ni) : Window(desc), ni(ni)
 	{
@@ -272,6 +273,8 @@ struct NewsWindow : Window {
 		this->status_height = FindWindowById(WC_STATUS_BAR, 0)->height;
 
 		this->flags |= WF_DISABLE_VP_SCROLL;
+
+		this->timer.SetInterval(15);
 
 		this->CreateNestedTree();
 
@@ -489,7 +492,7 @@ struct NewsWindow : Window {
 
 	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		int count = CountIntervalElapsed(this->timer, delta_ms, 15);
+		int count = this->timer.CountElapsed(delta_ms);
 		if (count > 0) {
 			/* Scroll up newsmessages from the bottom */
 			int newtop = max(this->top - 2 * count, _screen.height - this->height - this->status_height - this->chat_height);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1487,8 +1487,6 @@ void GameLoop()
 
 	if (!_pause_mode && HasBit(_display_opt, DO_FULL_ANIMATION)) DoPaletteAnimations();
 
-	if (!_pause_mode || _game_mode == GM_EDITOR || _settings_game.construction.command_pause_level > CMDPL_NO_CONSTRUCTION) MoveAllTextEffects();
-
 	InputLoop();
 
 	SoundDriver::GetInstance()->MainLoop();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1465,10 +1465,6 @@ void GameLoop()
 	IncreaseSpriteLRU();
 	InteractiveRandom();
 
-	extern int _caret_timer;
-	_caret_timer += 3;
-	CursorTick();
-
 #ifdef ENABLE_NETWORK
 	/* Check for UDP stuff */
 	if (_network_available) NetworkBackgroundLoop();
@@ -1484,13 +1480,6 @@ void GameLoop()
 		}
 		/* Singleplayer */
 		StateGameLoop();
-	}
-
-	/* Check chat messages roughly once a second. */
-	static uint check_message = 0;
-	if (++check_message > 1000 / MILLISECONDS_PER_TICK) {
-		check_message = 0;
-		NetworkChatMessageLoop();
 	}
 #else
 	StateGameLoop();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -76,7 +76,7 @@ void IncreaseDate();
 void DoPaletteAnimations();
 void MusicLoop();
 void ResetMusic();
-void CallWindowTickEvent();
+void CallWindowGameTickEvent();
 bool HandleBootstrap();
 
 extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
@@ -1355,7 +1355,6 @@ void StateGameLoop()
 #ifndef DEBUG_DUMP_COMMANDS
 		Game::GameLoop();
 #endif
-		CallWindowTickEvent();
 		return;
 	}
 
@@ -1373,7 +1372,7 @@ void StateGameLoop()
 		BasePersistentStorageArray::SwitchMode(PSM_LEAVE_GAMELOOP);
 		UpdateLandscapingLimits();
 
-		CallWindowTickEvent();
+		CallWindowGameTickEvent();
 		NewsLoop();
 	} else {
 		if (_debug_desync_level > 2 && _date_fract == 0 && (_date & 0x1F) == 0) {
@@ -1403,7 +1402,7 @@ void StateGameLoop()
 #endif
 		UpdateLandscapingLimits();
 
-		CallWindowTickEvent();
+		CallWindowGameTickEvent();
 		NewsLoop();
 		cur_company.Restore();
 	}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1368,7 +1368,7 @@ public:
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
 		CheckRedrawStationCoverage(this);
 	}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1053,7 +1053,7 @@ struct BuildRoadStationWindow : public PickerWindowBase {
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
 		CheckRedrawStationCoverage(this);
 	}

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -23,6 +23,7 @@
 #include "sound_func.h"
 #include "window_func.h"
 #include "company_base.h"
+#include "guitimer_func.h"
 
 #include "smallmap_gui.h"
 
@@ -1055,7 +1056,7 @@ void SmallMapWindow::SetupWidgetData()
 	this->GetWidget<NWidgetStacked>(WID_SM_SELECT_BUTTONS)->SetDisplayedPlane(plane);
 }
 
-SmallMapWindow::SmallMapWindow(WindowDesc *desc, int window_number) : Window(desc), refresh(FORCE_REFRESH_PERIOD)
+SmallMapWindow::SmallMapWindow(WindowDesc *desc, int window_number) : Window(desc), refresh(GUITimer(FORCE_REFRESH_PERIOD))
 {
 	_smallmap_industry_highlight = INVALID_INDUSTRYTYPE;
 	this->overlay = new LinkGraphOverlay(this, WID_SM_MAP, 0, this->GetOverlayCompanyMask(), 1);
@@ -1390,7 +1391,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 	}
 	if (new_highlight != _smallmap_industry_highlight) {
 		_smallmap_industry_highlight = new_highlight;
-		this->refresh = _smallmap_industry_highlight != INVALID_INDUSTRYTYPE ? BLINK_PERIOD : FORCE_REFRESH_PERIOD;
+		this->refresh.SetInterval(_smallmap_industry_highlight != INVALID_INDUSTRYTYPE ? BLINK_PERIOD : FORCE_REFRESH_PERIOD);
 		_smallmap_industry_highlight_state = true;
 		this->SetDirty();
 	}
@@ -1573,7 +1574,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 /* virtual */ void SmallMapWindow::OnRealtimeTick(uint delta_ms)
 {
 	/* Update the window every now and then */
-	if (!TimerElapsed(this->refresh, delta_ms)) return;
+	if (!this->refresh.Elapsed(delta_ms)) return;
 
 	if (this->map_type == SMT_LINKSTATS) {
 		uint32 company_mask = this->GetOverlayCompanyMask();
@@ -1585,7 +1586,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 	}
 	_smallmap_industry_highlight_state = !_smallmap_industry_highlight_state;
 
-	this->refresh = _smallmap_industry_highlight != INVALID_INDUSTRYTYPE ? BLINK_PERIOD : FORCE_REFRESH_PERIOD;
+	this->refresh.SetInterval(_smallmap_industry_highlight != INVALID_INDUSTRYTYPE ? BLINK_PERIOD : FORCE_REFRESH_PERIOD);
 	this->SetDirty();
 }
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1570,10 +1570,10 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 	}
 }
 
-/* virtual */ void SmallMapWindow::OnTick()
+/* virtual */ void SmallMapWindow::OnRealtimeTick(uint delta_ms)
 {
 	/* Update the window every now and then */
-	if (--this->refresh != 0) return;
+	if (!TimerElapsed(this->refresh, delta_ms)) return;
 
 	if (this->map_type == SMT_LINKSTATS) {
 		uint32 company_mask = this->GetOverlayCompanyMask();

--- a/src/smallmap_gui.h
+++ b/src/smallmap_gui.h
@@ -19,6 +19,7 @@
 #include "blitter/factory.hpp"
 #include "linkgraph/linkgraph_gui.h"
 #include "widgets/smallmap_widget.h"
+#include "guitimer_func.h"
 
 /* set up the cargos to be displayed in the smallmap's route legend */
 void BuildLinkStatsLegend();
@@ -79,7 +80,7 @@ protected:
 	int32 subscroll; ///< Number of pixels (0..3) between the right end of the base tile and the pixel at the top-left corner of the smallmap display.
 	int zoom;        ///< Zoom level. Bigger number means more zoom-out (further away).
 
-	int refresh;     ///< Refresh timer, in millseconds.
+	GUITimer refresh; ///< Refresh timer.
 	LinkGraphOverlay *overlay;
 
 	static void BreakIndustryChainLink();

--- a/src/smallmap_gui.h
+++ b/src/smallmap_gui.h
@@ -67,8 +67,8 @@ protected:
 
 	static const uint LEGEND_BLOB_WIDTH = 8;              ///< Width of the coloured blob in front of a line text in the #WID_SM_LEGEND widget.
 	static const uint INDUSTRY_MIN_NUMBER_OF_COLUMNS = 2; ///< Minimal number of columns in the #WID_SM_LEGEND widget for the #SMT_INDUSTRY legend.
-	static const uint FORCE_REFRESH_PERIOD = 0x1F; ///< map is redrawn after that many ticks
-	static const uint BLINK_PERIOD         = 0x0F; ///< highlight blinking interval
+	static const uint FORCE_REFRESH_PERIOD = 930; ///< map is redrawn after that many milliseconds.
+	static const uint BLINK_PERIOD         = 450; ///< highlight blinking interval in milliseconds.
 
 	uint min_number_of_columns;    ///< Minimal number of columns in legends.
 	uint min_number_of_fixed_rows; ///< Minimal number of rows in the legends for the fixed layouts only (all except #SMT_INDUSTRY).
@@ -79,7 +79,7 @@ protected:
 	int32 subscroll; ///< Number of pixels (0..3) between the right end of the base tile and the pixel at the top-left corner of the smallmap display.
 	int zoom;        ///< Zoom level. Bigger number means more zoom-out (further away).
 
-	uint8 refresh;   ///< Refresh counter, zeroed every FORCE_REFRESH_PERIOD ticks.
+	int refresh;     ///< Refresh timer, in millseconds.
 	LinkGraphOverlay *overlay;
 
 	static void BreakIndustryChainLink();
@@ -187,7 +187,7 @@ public:
 	virtual void OnInvalidateData(int data = 0, bool gui_scope = true);
 	virtual bool OnRightClick(Point pt, int widget);
 	virtual void OnMouseWheel(int wheel);
-	virtual void OnTick();
+	virtual void OnRealtimeTick(uint delta_ms);
 	virtual void OnScroll(Point delta);
 	virtual void OnMouseOver(Point pt, int widget);
 };

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -623,7 +623,6 @@ public:
 
 	virtual void OnGameTick()
 	{
-		if (_pause_mode != PM_UNPAUSED) return;
 		if (this->stations.NeedResort()) {
 			DEBUG(misc, 3, "Periodic rebuild station list company %d", this->window_number);
 			this->SetDirty();

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -621,7 +621,7 @@ public:
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		if (_pause_mode != PM_UNPAUSED) return;
 		if (this->stations.NeedResort()) {
@@ -2312,7 +2312,7 @@ struct SelectStationWindow : Window {
 		DeleteWindowById(WC_SELECT_STATION, 0);
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
 		if (_thd.dirty & 2) {
 			_thd.dirty &= ~2;

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -16,7 +16,7 @@
 #include "core/smallvec_type.hpp"
 #include "viewport_func.h"
 #include "settings_type.h"
-#include "window_func.h"
+#include "guitimer_func.h"
 
 #include "safeguards.h"
 
@@ -85,8 +85,8 @@ void RemoveTextEffect(TextEffectID te_id)
 
 void MoveAllTextEffects(uint delta_ms)
 {
-	static uint texteffecttimer = 0;
-	uint count = CountIntervalElapsed(texteffecttimer, delta_ms, MILLISECONDS_PER_TICK);
+	static GUITimer texteffecttimer = GUITimer(MILLISECONDS_PER_TICK);
+	uint count = texteffecttimer.CountElapsed(delta_ms);
 	if (count == 0) return;
 
 	const TextEffect *end = _text_effects.End();

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -16,6 +16,7 @@
 #include "core/smallvec_type.hpp"
 #include "viewport_func.h"
 #include "settings_type.h"
+#include "window_func.h"
 
 #include "safeguards.h"
 
@@ -82,20 +83,25 @@ void RemoveTextEffect(TextEffectID te_id)
 	_text_effects[te_id].Reset();
 }
 
-void MoveAllTextEffects()
+void MoveAllTextEffects(uint delta_ms)
 {
+	static uint texteffecttimer = 0;
+	uint count = CountIntervalElapsed(texteffecttimer, delta_ms, MILLISECONDS_PER_TICK);
+	if (count == 0) return;
+
 	const TextEffect *end = _text_effects.End();
 	for (TextEffect *te = _text_effects.Begin(); te != end; te++) {
 		if (te->string_id == INVALID_STRING_ID) continue;
 		if (te->mode != TE_RISING) continue;
 
-		if (te->duration-- == 0) {
+		if (te->duration < count) {
 			te->Reset();
 			continue;
 		}
 
 		te->MarkDirty(ZOOM_LVL_OUT_8X);
-		te->top -= ZOOM_LVL_BASE;
+		te->duration -= count;
+		te->top -= count * ZOOM_LVL_BASE;
 		te->MarkDirty(ZOOM_LVL_OUT_8X);
 	}
 }

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -28,7 +28,7 @@ enum TextEffectMode {
 
 typedef uint16 TextEffectID;
 
-void MoveAllTextEffects();
+void MoveAllTextEffects(uint delta_ms);
 TextEffectID AddTextEffect(StringID msg, int x, int y, uint8 duration, TextEffectMode mode);
 void InitTextEffects();
 void DrawTextEffects(DrawPixelInfo *dpi);

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1978,6 +1978,8 @@ enum MainToolbarHotkeys {
 
 /** Main toolbar. */
 struct MainToolbarWindow : Window {
+	int timer;
+
 	MainToolbarWindow(WindowDesc *desc) : Window(desc)
 	{
 		this->InitNested(0);
@@ -1988,6 +1990,8 @@ struct MainToolbarWindow : Window {
 		this->SetWidgetDisabledState(WID_TN_FAST_FORWARD, _networking); // if networking, disable fast-forward button
 		PositionMainToolbar(this);
 		DoZoomInOutWindow(ZOOM_NONE, this);
+
+		this->timer = MILLISECONDS_PER_TICK;
 	}
 
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height)
@@ -2092,8 +2096,11 @@ struct MainToolbarWindow : Window {
 		_last_started_action = CBF_NONE;
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
+		if (!TimerElapsed(this->timer, delta_ms)) return;
+		this->timer = MILLISECONDS_PER_TICK;
+
 		if (this->IsWidgetLowered(WID_TN_PAUSE) != !!_pause_mode) {
 			this->ToggleWidgetLoweredState(WID_TN_PAUSE);
 			this->SetWidgetDirty(WID_TN_PAUSE);
@@ -2310,6 +2317,8 @@ enum MainToolbarEditorHotkeys {
 };
 
 struct ScenarioEditorToolbarWindow : Window {
+	int timer;
+
 	ScenarioEditorToolbarWindow(WindowDesc *desc) : Window(desc)
 	{
 		this->InitNested(0);
@@ -2318,6 +2327,8 @@ struct ScenarioEditorToolbarWindow : Window {
 		CLRBITS(this->flags, WF_WHITE_BORDER);
 		PositionMainToolbar(this);
 		DoZoomInOutWindow(ZOOM_NONE, this);
+
+		this->timer = MILLISECONDS_PER_TICK;
 	}
 
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height)
@@ -2445,8 +2456,11 @@ struct ScenarioEditorToolbarWindow : Window {
 		this->SetWidgetDirty(WID_TE_DATE_FORWARD);
 	}
 
-	virtual void OnTick()
+	virtual void OnRealtimeTick(uint delta_ms)
 	{
+		if (!TimerElapsed(this->timer, delta_ms)) return;
+		this->timer = MILLISECONDS_PER_TICK;
+
 		if (this->IsWidgetLowered(WID_TE_PAUSE) != !!_pause_mode) {
 			this->ToggleWidgetLoweredState(WID_TE_PAUSE);
 			this->SetDirty();

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -48,6 +48,7 @@
 #include "story_base.h"
 #include "toolbar_gui.h"
 #include "framerate_type.h"
+#include "guitimer_func.h"
 
 #include "widgets/toolbar_widget.h"
 
@@ -1978,7 +1979,7 @@ enum MainToolbarHotkeys {
 
 /** Main toolbar. */
 struct MainToolbarWindow : Window {
-	int timer;
+	GUITimer timer;
 
 	MainToolbarWindow(WindowDesc *desc) : Window(desc)
 	{
@@ -1991,7 +1992,7 @@ struct MainToolbarWindow : Window {
 		PositionMainToolbar(this);
 		DoZoomInOutWindow(ZOOM_NONE, this);
 
-		this->timer = MILLISECONDS_PER_TICK;
+		this->timer.SetInterval(MILLISECONDS_PER_TICK);
 	}
 
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height)
@@ -2098,8 +2099,8 @@ struct MainToolbarWindow : Window {
 
 	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (!TimerElapsed(this->timer, delta_ms)) return;
-		this->timer = MILLISECONDS_PER_TICK;
+		if (!this->timer.Elapsed(delta_ms)) return;
+		this->timer.SetInterval(MILLISECONDS_PER_TICK);
 
 		if (this->IsWidgetLowered(WID_TN_PAUSE) != !!_pause_mode) {
 			this->ToggleWidgetLoweredState(WID_TN_PAUSE);
@@ -2317,7 +2318,7 @@ enum MainToolbarEditorHotkeys {
 };
 
 struct ScenarioEditorToolbarWindow : Window {
-	int timer;
+	GUITimer timer;
 
 	ScenarioEditorToolbarWindow(WindowDesc *desc) : Window(desc)
 	{
@@ -2328,7 +2329,7 @@ struct ScenarioEditorToolbarWindow : Window {
 		PositionMainToolbar(this);
 		DoZoomInOutWindow(ZOOM_NONE, this);
 
-		this->timer = MILLISECONDS_PER_TICK;
+		this->timer.SetInterval(MILLISECONDS_PER_TICK);
 	}
 
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height)
@@ -2458,8 +2459,8 @@ struct ScenarioEditorToolbarWindow : Window {
 
 	virtual void OnRealtimeTick(uint delta_ms)
 	{
-		if (!TimerElapsed(this->timer, delta_ms)) return;
-		this->timer = MILLISECONDS_PER_TICK;
+		if (!this->timer.Elapsed(delta_ms)) return;
+		this->timer.SetInterval(MILLISECONDS_PER_TICK);
 
 		if (this->IsWidgetLowered(WID_TE_PAUSE) != !!_pause_mode) {
 			this->ToggleWidgetLoweredState(WID_TE_PAUSE);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1676,7 +1676,7 @@ public:
 		this->SetDirty();
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		if (_pause_mode != PM_UNPAUSED) return;
 		if (this->vehicles.NeedResort()) {
@@ -2733,7 +2733,7 @@ public:
 		}
 	}
 
-	virtual void OnTick()
+	virtual void OnGameTick()
 	{
 		const Vehicle *v = Vehicle::Get(this->window_number);
 		bool veh_stopped = v->IsStoppedInDepot();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1678,7 +1678,6 @@ public:
 
 	virtual void OnGameTick()
 	{
-		if (_pause_mode != PM_UNPAUSED) return;
 		if (this->vehicles.NeedResort()) {
 			StationID station = (this->vli.type == VL_STATION_LIST) ? this->vli.index : INVALID_STATION;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3156,9 +3156,9 @@ void UpdateWindows()
 				w->SetDirty();
 			}
 		}
-
-		DrawDirtyBlocks();
 	}
+
+	DrawDirtyBlocks();
 
 	FOR_ALL_WINDOWS_FROM_BACK(w) {
 		/* Update viewport only if window is not shaded. */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3126,6 +3126,8 @@ void UpdateWindows()
 		_window_highlight_colour = !_window_highlight_colour;
 	}
 
+	if (!_pause_mode || _game_mode == GM_EDITOR || _settings_game.construction.command_pause_level > CMDPL_NO_CONSTRUCTION) MoveAllTextEffects(delta_ms);
+
 	FOR_ALL_WINDOWS_FROM_FRONT(w) {
 		w->ProcessScheduledInvalidations();
 		w->ProcessHighlightedInvalidations();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3075,12 +3075,31 @@ void InputLoop()
 }
 
 /**
+ * Dispatch OnRealtimeTick event over all windows
+ */
+void CallWindowRealtimeTickEvent(uint delta_ms)
+{
+	Window *w;
+	FOR_ALL_WINDOWS_FROM_FRONT(w) {
+		w->OnRealtimeTick(delta_ms);
+	}
+}
+
+/**
  * Update the continuously changing contents of the windows, such as the viewports
  */
 void UpdateWindows()
 {
+	static uint32 last_realtime_tick = _realtime_tick;
+	uint delta_ms = _realtime_tick - last_realtime_tick;
+	last_realtime_tick = _realtime_tick;
+
+	if (delta_ms == 0) return;
+
 	PerformanceMeasurer framerate(PFE_DRAWING);
 	PerformanceAccumulator::Reset(PFE_DRAWWORLD);
+
+	CallWindowRealtimeTickEvent(delta_ms);
 
 	Window *w;
 
@@ -3263,13 +3282,13 @@ void InvalidateWindowClassesData(WindowClass cls, int data, bool gui_scope)
 }
 
 /**
- * Dispatch WE_TICK event over all windows
+ * Dispatch OnTick event over all windows
  */
-void CallWindowTickEvent()
+void CallWindowGameTickEvent()
 {
 	Window *w;
 	FOR_ALL_WINDOWS_FROM_FRONT(w) {
-		w->OnTick();
+		w->OnGameTick();
 	}
 }
 

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -56,36 +56,4 @@ void DeleteWindowByClass(WindowClass cls);
 bool EditBoxInGlobalFocus();
 Point GetCaretPosition();
 
-/**
- * Count how many times the interval has elapsed, and update the timer.
- * Use to ensure a specific amount of events happen within a timeframe, e.g. for animation.
- * The timer value does not need to be initialised.
- * @param timer Timer to test. Value will be increased.
- * @param delta Time since last test.
- * @param interval Timing interval.
- * @return Number of times the interval has elapsed.
- */
-static inline uint CountIntervalElapsed(uint &timer, uint delta, uint interval)
-{
-	uint count = delta / interval;
-	if (timer + (delta % interval) >= interval) count++;
-	timer = (timer + delta) % interval;
-	return count;
-}
-
-/**
- * Test if a timer has elapsed, and update the timer.
- * Use to ensure an event happens only once within a timeframe, e.g. for window updates.
- * The timer value must be initialised in order for the timer to elapsed.
- * @param timer Timer to test. Value will be decreased.
- * @param delta Time since last test.
- * @return True iff the timer has elapsed.
- */
-static inline bool TimerElapsed(int &timer, uint delta)
-{
-	if (timer <= 0) return false;
-	timer -= delta;
-	return timer <= 0;
-}
-
 #endif /* WINDOW_FUNC_H */

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -56,4 +56,36 @@ void DeleteWindowByClass(WindowClass cls);
 bool EditBoxInGlobalFocus();
 Point GetCaretPosition();
 
+/**
+ * Count how many times the interval has elapsed, and update the timer.
+ * Use to ensure a specific amount of events happen within a timeframe, e.g. for animation.
+ * The timer value does not need to be initialised.
+ * @param timer Timer to test. Value will be increased.
+ * @param delta Time since last test.
+ * @param interval Timing interval.
+ * @return Number of times the interval has elapsed.
+ */
+static inline uint CountIntervalElapsed(uint &timer, uint delta, uint interval)
+{
+	uint count = delta / interval;
+	if (timer + (delta % interval) >= interval) count++;
+	timer = (timer + delta) % interval;
+	return count;
+}
+
+/**
+ * Test if a timer has elapsed, and update the timer.
+ * Use to ensure an event happens only once within a timeframe, e.g. for window updates.
+ * The timer value must be initialised in order for the timer to elapsed.
+ * @param timer Timer to test. Value will be decreased.
+ * @param delta Time since last test.
+ * @return True iff the timer has elapsed.
+ */
+static inline bool TimerElapsed(int &timer, uint delta)
+{
+	if (timer <= 0) return false;
+	timer -= delta;
+	return timer <= 0;
+}
+
 #endif /* WINDOW_FUNC_H */

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -678,12 +678,17 @@ public:
 	/**
 	 * Called once per (game) tick.
 	 */
-	virtual void OnTick() {}
+	virtual void OnGameTick() {}
 
 	/**
 	 * Called once every 100 (game) ticks.
 	 */
 	virtual void OnHundredthTick() {}
+
+	/**
+	 * Called periodically.
+	 */
+	virtual void OnRealtimeTick(uint delta_ms) {}
 
 	/**
 	 * Called when this window's timeout has been reached.


### PR DESCRIPTION
These changes uncouple GUI timing (used for e.g. animations, debouncing, refresh intervals) from game timing. This change is most visible when using fast-forward, although it is also noticeable on very slow savegames as well.

Timing intervals have been multiplied by 30 to convert from game ticks to milliseconds. Note that although MILLISECONDS_PER_TICK is 30, in reality I often see 30, 31 or 32ms per game tick, so some animations may differ very slightly.

These changes may need additional refactoring due to feature creep.