### PR TITLE
Fix warnings with GCC8

### DIFF
--- a/src/3rdparty/squirrel/squirrel/squtils.h
+++ b/src/3rdparty/squirrel/squirrel/squtils.h
@@ -90,7 +90,7 @@ public:
 	{
 		_vals[idx].~T();
 		if(idx < (_size - 1)) {
-			memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - (size_t)idx - 1));
+			memmove(static_cast<void *>(&_vals[idx]), &_vals[idx+1], sizeof(T) * (_size - (size_t)idx - 1));
 		}
 		_size--;
 	}

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -378,8 +378,7 @@ bool SQVM::StartCall(SQClosure *closure,SQInteger target,SQInteger args,SQIntege
 	}
 
 	if (!tailcall) {
-		CallInfo lc;
-		memset(&lc, 0, sizeof(lc));
+		CallInfo lc = {};
 		lc._generator = NULL;
 		lc._etraps = 0;
 		lc._prevstkbase = (SQInt32) ( stackbase - _stackbase );
@@ -1159,8 +1158,7 @@ bool SQVM::CallNative(SQNativeClosure *nclosure,SQInteger nargs,SQInteger stackb
 	SQInteger oldtop = _top;
 	SQInteger oldstackbase = _stackbase;
 	_top = stackbase + nargs;
-	CallInfo lci;
-	memset(&lci, 0, sizeof(lci));
+	CallInfo lci = {};
 	lci._closure = nclosure;
 	lci._generator = NULL;
 	lci._etraps = 0;

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -40,8 +40,6 @@
 template <class T, size_t Tnum_files, bool Tsearch_in_tars>
 bool BaseSet<T, Tnum_files, Tsearch_in_tars>::FillSetDetails(IniFile *ini, const char *path, const char *full_filename, bool allow_empty_filename)
 {
-	memset(this, 0, sizeof(*this));
-
 	IniGroup *metadata = ini->GetGroup("metadata");
 	IniItem *item;
 

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -361,7 +361,7 @@ void Blitter_32bppAnim::CopyFromBuffer(void *video, const void *src, int width, 
 		Colour *dst_pal = dst;
 		uint16 *anim_pal = anim_line;
 
-		memcpy(dst, usrc, width * sizeof(uint32));
+		memcpy(static_cast<void *>(dst), usrc, width * sizeof(uint32));
 		usrc += width;
 		dst += _screen.pitch;
 		/* Copy back the anim-buffer */

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -96,7 +96,13 @@ struct CompanyProperties {
 	CompanyEconomyEntry old_economy[MAX_HISTORY_QUARTERS]; ///< Economic data of the company of the last #MAX_HISTORY_QUARTERS quarters.
 	byte num_valid_stat_ent;                               ///< Number of valid statistical entries in #old_economy.
 
-	CompanyProperties() : name(NULL), president_name(NULL) {}
+	// TODO: Change some of these member variables to use relevant INVALID_xxx constants
+	CompanyProperties()
+		: name_2(0), name_1(0), name(NULL), president_name_1(0), president_name_2(0), president_name(NULL),
+		  face(0), money(0), money_fraction(0), current_loan(0), colour(0), block_preview(0),
+		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0),
+		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
+		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false) {}
 
 	~CompanyProperties()
 	{

--- a/src/core/alloc_func.hpp
+++ b/src/core/alloc_func.hpp
@@ -125,7 +125,7 @@ static inline T *ReallocT(T *t_ptr, size_t num_elements)
 	/* Ensure the size does not overflow. */
 	CheckAllocationConstraints<T>(num_elements);
 
-	t_ptr = (T*)realloc(t_ptr, num_elements * sizeof(T));
+	t_ptr = (T*)realloc(static_cast<void *>(t_ptr), num_elements * sizeof(T));
 	if (t_ptr == NULL) ReallocError(num_elements * sizeof(T));
 	return t_ptr;
 }

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -696,9 +696,10 @@ static void CompaniesGenStatistics()
 	if (!HasBit(1 << 0 | 1 << 3 | 1 << 6 | 1 << 9, _cur_month)) return;
 
 	FOR_ALL_COMPANIES(c) {
-		memmove(&c->old_economy[1], &c->old_economy[0], sizeof(c->old_economy) - sizeof(c->old_economy[0]));
+		/* Drop the oldest history off the end */
+		std::copy_backward(c->old_economy, c->old_economy + MAX_HISTORY_QUARTERS - 1, c->old_economy + MAX_HISTORY_QUARTERS);
 		c->old_economy[0] = c->cur_economy;
-		memset(&c->cur_economy, 0, sizeof(c->cur_economy));
+		c->cur_economy = {};
 
 		if (c->num_valid_stat_ent != MAX_HISTORY_QUARTERS) c->num_valid_stat_ent++;
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1080,8 +1080,7 @@ static uint River_Hash(uint tile, uint dir)
  */
 static void BuildRiver(TileIndex begin, TileIndex end)
 {
-	AyStar finder;
-	MemSetT(&finder, 0);
+	AyStar finder = {};
 	finder.CalculateG = River_CalculateG;
 	finder.CalculateH = River_CalculateH;
 	finder.GetNeighbours = River_GetNeighbours;

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -96,7 +96,9 @@ uint ObjectSpec::Index() const
 void ResetObjects()
 {
 	/* Clean the pool. */
-	MemSetT(_object_specs, 0, lengthof(_object_specs));
+	for (uint16 i = 0; i < NUM_OBJECTS; i++) {
+		_object_specs[i] = {};
+	}
 
 	/* And add our originals. */
 	MemCpyT(_object_specs, _original_objects, lengthof(_original_objects));

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -497,7 +497,6 @@ static void Check_PLYR()
 	int index;
 	while ((index = SlIterateArray()) != -1) {
 		CompanyProperties *cprops = new CompanyProperties();
-		memset(cprops, 0, sizeof(*cprops));
 		SaveLoad_PLYR_common(NULL, cprops);
 
 		/* We do not load old custom names */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -436,7 +436,7 @@ typedef SaveLoad SaveLoadGlobVarList;
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
  */
-#define SLEG_STR(variable, type) SLEG_CONDSTR(variable, type, lengthof(variable), 0, SL_MAX_VERSION)
+#define SLEG_STR(variable, type) SLEG_CONDSTR(variable, type, sizeof(variable), 0, SL_MAX_VERSION)
 
 /**
  * Storage of a global list in every savegame version.

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -74,7 +74,7 @@ static size_t ConvertLandscape(const char *value);
 	SDTG_GENERAL(name, SDT_INTLIST, SL_ARR, type, flags, guiflags, var, length, def, 0, 0, 0, NULL, str, strhelp, strval, proc, from, to, cat)
 
 #define SDTG_STR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, lengthof(var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, from, to, cat)
+	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, from, to, cat)
 
 #define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat)\
 	SDTG_GENERAL(name, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat)
@@ -102,7 +102,7 @@ static size_t ConvertLandscape(const char *value);
 	SDT_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, NULL, from, to, cat)
 
 #define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, NULL, from, to, cat)
+	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, NULL, from, to, cat)
 
 #define SDT_CHR(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
 	SDT_GENERAL(#var, SDT_STRING, SL_VAR, SLE_CHAR, flags, guiflags, base, var, 1, def, 0, 0, 0, NULL, str, strhelp, strval, proc, NULL, from, to, cat)
@@ -127,7 +127,7 @@ static size_t ConvertLandscape(const char *value);
 	SDTG_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, from, to, cat)
 
 #define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, from, to, cat)
+	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, NULL, str, strhelp, strval, proc, from, to, cat)
 
 #define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat)\
 	SDTG_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat)


### PR DESCRIPTION
GCC gained -Wclass-memaccess & -Wsizeof-pointer-div.

class-memaccess is probably more of a bother than an actual issue, but
sizeof-pointer-div actually showed up some issues with attempting to
determine the length of some strings at compile time.