### PR TITLE
Ship cpu hog workaround for #6145

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -23,6 +23,7 @@
 #include "core/random_func.hpp"
 #include "aircraft.h"
 #include "roadveh.h"
+#include "ship.h"
 #include "station_base.h"
 #include "waypoint_base.h"
 #include "company_base.h"
@@ -929,7 +930,7 @@ CommandCost CmdInsertOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 				dist = GetOrderDistance(prev, &new_order, v);
 			}
 
-			if (dist >= 130) {
+			if (dist >= SHIP_MAX_ORDER_DISTANCE) {
 				return_cmd_error(STR_ERROR_TOO_FAR_FROM_PREVIOUS_DESTINATION);
 			}
 		}

--- a/src/ship.h
+++ b/src/ship.h
@@ -48,6 +48,8 @@ struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
 	void UpdateCache();
 };
 
+static const uint SHIP_MAX_ORDER_DISTANCE = 130;
+
 /**
  * Iterate over all ships.
  * @param var The variable used for iteration.

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -461,23 +461,10 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 
 	if (v->dest_tile == 0 || DistanceManhattan(tile, v->dest_tile) > SHIP_MAX_ORDER_DISTANCE + 5) {
 		/* No destination or destination too far, don't invoke pathfinder. */
-		static const TrackBits direction_to_trackbits[DIR_END] = {
-			TRACK_BIT_LEFT  | TRACK_BIT_RIGHT, // DIR_N
-			TRACK_BIT_X,                       // DIR_NE
-			TRACK_BIT_UPPER | TRACK_BIT_LOWER, // DIR_E
-			TRACK_BIT_Y,                       // DIR_SE
-			TRACK_BIT_LEFT  | TRACK_BIT_RIGHT, // DIR_S
-			TRACK_BIT_X,                       // DIR_SW
-			TRACK_BIT_UPPER | TRACK_BIT_LOWER, // DIR_W
-			TRACK_BIT_Y,                       // DIR_NW
-		};
-
-		TrackBits next_tracks = direction_to_trackbits[v->direction] & tracks;
-		if (next_tracks != TRACK_BIT_NONE) {
-			/* Continue in same direction when possible. */
-			track = (Track)FindFirstBit(next_tracks);
-		} else {
-			/* Pick a random track. */
+		track = TrackBitsToTrack(v->state);
+		if (track != TRACK_X && track != TRACK_Y) track = TrackToOppositeTrack(track);
+		if (!HasBit(tracks, track)) {
+			/* Can't continue in same direction so pick a random available track. */
 			do {
 				track = (Track)RandomRange(TRACK_END);
 			} while ((TrackToTrackBits(track) & tracks) == TRACK_BIT_NONE);

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -330,6 +330,9 @@ static bool CheckShipLeaveDepot(Ship *v)
 		return true;
 	}
 
+	/* Don't leave depot if no destination set */
+	if (v->dest_tile == 0) return true;
+
 	TileIndex tile = v->tile;
 	Axis axis = GetShipDepotAxis(tile);
 

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -465,6 +465,10 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 		if (track != TRACK_X && track != TRACK_Y) track = TrackToOppositeTrack(track);
 		if (!HasBit(tracks, track)) {
 			/* Can't continue in same direction so pick first available track. */
+			if (_settings_game.pf.forbid_90_deg) {
+				tracks &= ~TrackCrossesTracks(TrackdirToTrack(v->GetVehicleTrackdir()));
+				if (tracks == TRACK_BIT_NONE) return INVALID_TRACK;
+			}
 			track = FindFirstTrack(tracks);
 		}
 		path_found = false;

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -464,10 +464,8 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 		track = TrackBitsToTrack(v->state);
 		if (track != TRACK_X && track != TRACK_Y) track = TrackToOppositeTrack(track);
 		if (!HasBit(tracks, track)) {
-			/* Can't continue in same direction so pick a random available track. */
-			do {
-				track = (Track)RandomRange(TRACK_END);
-			} while ((TrackToTrackBits(track) & tracks) == TRACK_BIT_NONE);
+			/* Can't continue in same direction so pick first available track. */
+			track = FindFirstTrack(tracks);
 		}
 		path_found = false;
 	} else {

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -459,7 +459,7 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 	bool path_found = true;
 	Track track;
 
-	if (v->dest_tile == 0 || DistanceManhattan(tile, v->dest_tile) > 130) {
+	if (v->dest_tile == 0 || DistanceManhattan(tile, v->dest_tile) > SHIP_MAX_ORDER_DISTANCE + 5) {
 		/* No destination or destination too far, don't invoke pathfinder. */
 		static const TrackBits direction_to_trackbits[DIR_END] = {
 			TRACK_BIT_LEFT  | TRACK_BIT_RIGHT, // DIR_N

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -319,6 +319,14 @@ void Ship::UpdateDeltaXY()
 	this->z_extent      = 6;
 }
 
+/**
+ * Test-procedure for HasVehicleOnPos to check for a ship.
+ */
+static Vehicle *EnsureNoVisibleShipProc(Vehicle *v, void *data)
+{
+	return v->type == VEH_SHIP && (v->vehstatus & VS_HIDDEN) == 0 ? v : NULL;
+}
+
 static bool CheckShipLeaveDepot(Ship *v)
 {
 	if (!v->IsChainInDepot()) return false;
@@ -332,6 +340,10 @@ static bool CheckShipLeaveDepot(Ship *v)
 
 	/* Don't leave depot if no destination set */
 	if (v->dest_tile == 0) return true;
+
+	/* Don't leave depot if another vehicle is already entering/leaving */
+	/* This helps avoid CPU load if many ships are set to start at the same time */
+	if (HasVehicleOnPos(v->tile, NULL, &EnsureNoVisibleShipProc)) return true;
 
 	TileIndex tile = v->tile;
 	Axis axis = GetShipDepotAxis(tile);


### PR DESCRIPTION
Set of small changes that attempt to mitigate excessive CPU consumption of ships when pathfinding.