### PR TITLE
Change: Add CargoTypes type for cargo masks.

### DIFF
--- a/src/articulated_vehicles.h
+++ b/src/articulated_vehicles.h
@@ -18,9 +18,9 @@
 uint CountArticulatedParts(EngineID engine_type, bool purchase_window);
 CargoArray GetCapacityOfArticulatedParts(EngineID engine);
 void AddArticulatedParts(Vehicle *first);
-void GetArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type, uint32 *union_mask, uint32 *intersection_mask);
-uint32 GetUnionOfArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type);
-uint32 GetIntersectionOfArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type);
+void GetArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type, CargoTypes *union_mask, CargoTypes *intersection_mask);
+CargoTypes GetUnionOfArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type);
+CargoTypes GetIntersectionOfArticulatedRefitMasks(EngineID engine, bool include_initial_cargo_type);
 bool IsArticulatedVehicleCarryingDifferentCargoes(const Vehicle *v, CargoID *cargo_type);
 bool IsArticulatedVehicleRefittable(EngineID engine);
 bool IsArticulatedEngine(EngineID engine_type);

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -37,8 +37,8 @@ extern void ChangeVehicleViewWindow(VehicleID from_index, VehicleID to_index);
  */
 static bool EnginesHaveCargoInCommon(EngineID engine_a, EngineID engine_b)
 {
-	uint32 available_cargoes_a = GetUnionOfArticulatedRefitMasks(engine_a, true);
-	uint32 available_cargoes_b = GetUnionOfArticulatedRefitMasks(engine_b, true);
+	CargoTypes available_cargoes_a = GetUnionOfArticulatedRefitMasks(engine_a, true);
+	CargoTypes available_cargoes_b = GetUnionOfArticulatedRefitMasks(engine_b, true);
 	return (available_cargoes_a == 0 || available_cargoes_b == 0 || (available_cargoes_a & available_cargoes_b) != 0);
 }
 
@@ -173,9 +173,8 @@ static void TransferCargo(Vehicle *old_veh, Vehicle *new_head, bool part_of_chai
  */
 static bool VerifyAutoreplaceRefitForOrders(const Vehicle *v, EngineID engine_type)
 {
-
-	uint32 union_refit_mask_a = GetUnionOfArticulatedRefitMasks(v->engine_type, false);
-	uint32 union_refit_mask_b = GetUnionOfArticulatedRefitMasks(engine_type, false);
+	CargoTypes union_refit_mask_a = GetUnionOfArticulatedRefitMasks(v->engine_type, false);
+	CargoTypes union_refit_mask_b = GetUnionOfArticulatedRefitMasks(engine_type, false);
 
 	const Order *o;
 	const Vehicle *u = (v->type == VEH_TRAIN) ? v->First() : v;
@@ -201,7 +200,7 @@ static bool VerifyAutoreplaceRefitForOrders(const Vehicle *v, EngineID engine_ty
  */
 static CargoID GetNewCargoTypeForReplace(Vehicle *v, EngineID engine_type, bool part_of_chain)
 {
-	uint32 available_cargo_types, union_mask;
+	CargoTypes available_cargo_types, union_mask;
 	GetArticulatedRefitMasks(engine_type, true, &union_mask, &available_cargo_types);
 
 	if (union_mask == 0) return CT_NO_REFIT; // Don't try to refit an engine with no cargo capacity

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -71,7 +71,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	uint16 random_bits;             ///< Random bits assigned to this station
 	byte waiting_triggers;          ///< Waiting triggers (NewGRF) for this station
 	uint8 cached_anim_triggers;     ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
-	uint32 cached_cargo_triggers;   ///< NOSAVE: Combined cargo trigger bitmask
+	CargoTypes cached_cargo_triggers; ///< NOSAVE: Combined cargo trigger bitmask
 
 	TileArea train_station;         ///< Tile area the train 'station' part covers
 	StationRect rect;               ///< NOSAVE: Station spread out rectangle maintained by StationRect::xxx() functions

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -524,7 +524,7 @@ const StringID _engine_sort_listing[][12] = {{
 static bool CDECL CargoFilter(const EngineID *eid, const CargoID cid)
 {
 	if (cid == CF_ANY) return true;
-	uint32 refit_mask = GetUnionOfArticulatedRefitMasks(*eid, true) & _standard_cargo_mask;
+	CargoTypes refit_mask = GetUnionOfArticulatedRefitMasks(*eid, true) & _standard_cargo_mask;
 	return (cid == CF_NONE ? refit_mask == 0 : HasBit(refit_mask, cid));
 }
 
@@ -535,7 +535,7 @@ static GUIEngineList::FilterFunction * const _filter_funcs[] = {
 static int DrawCargoCapacityInfo(int left, int right, int y, EngineID engine)
 {
 	CargoArray cap;
-	uint32 refits;
+	CargoTypes refits;
 	GetArticulatedVehicleCargoesAndRefits(engine, &cap, &refits);
 
 	for (CargoID c = 0; c < NUM_CARGO; c++) {

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -22,7 +22,7 @@
 typedef byte CargoID;
 
 /** Available types of cargo */
-enum CargoTypes {
+enum CargoType {
 	/* Temperate */
 	CT_PASSENGERS   =  0,
 	CT_COAL         =  1,
@@ -69,6 +69,10 @@ enum CargoTypes {
 	CT_NO_REFIT     = 0xFE, ///< Do not refit cargo of a vehicle (used in vehicle orders and auto-replace/auto-new).
 	CT_INVALID      = 0xFF, ///< Invalid cargo type.
 };
+
+typedef uint32 CargoTypes;
+
+static const CargoTypes ALL_CARGOTYPES = (CargoTypes)UINT32_MAX;
 
 /** Class for storing amounts of cargo */
 struct CargoArray {

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -28,12 +28,12 @@ CargoSpec CargoSpec::array[NUM_CARGO];
  * Bitmask of cargo types available. This includes phony cargoes like regearing cargoes.
  * Initialized during a call to #SetupCargoForClimate.
  */
-uint32 _cargo_mask;
+CargoTypes _cargo_mask;
 
 /**
  * Bitmask of real cargo types available. Phony cargoes like regearing cargoes are excluded.
  */
-uint32 _standard_cargo_mask;
+CargoTypes _standard_cargo_mask;
 
 /**
  * Set up the default cargo types for the given landscape type.

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -129,8 +129,8 @@ private:
 	friend void SetupCargoForClimate(LandscapeID l);
 };
 
-extern uint32 _cargo_mask;
-extern uint32 _standard_cargo_mask;
+extern CargoTypes _cargo_mask;
+extern CargoTypes _standard_cargo_mask;
 
 void SetupCargoForClimate(LandscapeID l);
 CargoID GetCargoIDByLabel(CargoLabel cl);
@@ -156,7 +156,7 @@ static inline bool IsCargoInClass(CargoID c, CargoClass cc)
 		if ((var = CargoSpec::Get(cargospec_index))->IsValid())
 #define FOR_ALL_CARGOSPECS(var) FOR_ALL_CARGOSPECS_FROM(var, 0)
 
-#define FOR_EACH_SET_CARGO_ID(var, cargo_bits) FOR_EACH_SET_BIT_EX(CargoID, var, uint, cargo_bits)
+#define FOR_EACH_SET_CARGO_ID(var, cargo_bits) FOR_EACH_SET_BIT_EX(CargoID, var, CargoTypes, cargo_bits)
 
 /**
  * Loop header for iterating over cargoes, sorted by name. This includes phony cargoes like regearing cargoes.

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1366,14 +1366,14 @@ struct IsEmptyAction
 struct PrepareRefitAction
 {
 	CargoArray &consist_capleft; ///< Capacities left in the consist.
-	uint32 &refit_mask;          ///< Bitmask of possible refit cargoes.
+	CargoTypes &refit_mask;          ///< Bitmask of possible refit cargoes.
 
 	/**
 	 * Create a refit preparation action.
 	 * @param consist_capleft Capacities left in consist, to be updated here.
 	 * @param refit_mask Refit mask to be constructed from refit information of vehicles.
 	 */
-	PrepareRefitAction(CargoArray &consist_capleft, uint32 &refit_mask) :
+	PrepareRefitAction(CargoArray &consist_capleft, CargoTypes &refit_mask) :
 		consist_capleft(consist_capleft), refit_mask(refit_mask) {}
 
 	/**
@@ -1469,7 +1469,7 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 
 	Backup<CompanyByte> cur_company(_current_company, v->owner, FILE_LINE);
 
-	uint32 refit_mask = v->GetEngine()->info.refit_mask;
+	CargoTypes refit_mask = v->GetEngine()->info.refit_mask;
 
 	/* Remove old capacity from consist capacity and collect refit mask. */
 	IterateVehicleParts(v_start, PrepareRefitAction(consist_capleft, refit_mask));
@@ -1627,10 +1627,10 @@ static void LoadUnloadVehicle(Vehicle *front)
 	bool completely_emptied = true;
 	bool anything_unloaded  = false;
 	bool anything_loaded    = false;
-	uint32 full_load_amount = 0;
-	uint32 cargo_not_full   = 0;
-	uint32 cargo_full       = 0;
-	uint32 reservation_left = 0;
+	CargoTypes full_load_amount = 0;
+	CargoTypes cargo_not_full   = 0;
+	CargoTypes cargo_full       = 0;
+	CargoTypes reservation_left = 0;
 
 	front->cur_speed = 0;
 
@@ -1838,7 +1838,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 				/* if the aircraft carries passengers and is NOT full, then
 				 * continue loading, no matter how much mail is in */
 				if ((front->type == VEH_AIRCRAFT && IsCargoInClass(front->cargo_type, CC_PASSENGERS) && front->cargo_cap > front->cargo.StoredCount()) ||
-						(cargo_not_full && (cargo_full & ~cargo_not_full) == 0)) { // There are still non-full cargoes
+						(cargo_not_full != 0 && (cargo_full & ~cargo_not_full) == 0)) { // There are still non-full cargoes
 					finished_loading = false;
 				}
 			} else if (cargo_not_full != 0) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -752,7 +752,7 @@ static CompanyID GetPreviewCompany(Engine *e)
 	CompanyID best_company = INVALID_COMPANY;
 
 	/* For trains the cargomask has no useful meaning, since you can attach other wagons */
-	uint32 cargomask = e->type != VEH_TRAIN ? GetUnionOfArticulatedRefitMasks(e->index, true) : (uint32)-1;
+	CargoTypes cargomask = e->type != VEH_TRAIN ? GetUnionOfArticulatedRefitMasks(e->index, true) : ALL_CARGOTYPES;
 
 	int32 best_hist = -1;
 	const Company *c;
@@ -1117,7 +1117,9 @@ bool IsEngineRefittable(EngineID engine)
 
 	/* Is there any cargo except the default cargo? */
 	CargoID default_cargo = e->GetDefaultCargoType();
-	return default_cargo != CT_INVALID && ei->refit_mask != 1U << default_cargo;
+	CargoTypes default_cargo_mask = 0;
+	SetBit(default_cargo_mask, default_cargo);
+	return default_cargo != CT_INVALID && ei->refit_mask != default_cargo_mask;
 }
 
 /**

--- a/src/engine_func.h
+++ b/src/engine_func.h
@@ -26,7 +26,7 @@ extern const uint8 _engine_offsets[4];
 
 bool IsEngineBuildable(EngineID engine, VehicleType type, CompanyID company);
 bool IsEngineRefittable(EngineID engine);
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, uint32 *refits);
+void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits);
 void SetYearEngineAgingStops();
 void StartupOneEngine(Engine *e, Date aging_date);
 

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -137,7 +137,7 @@ struct EngineInfo {
 	byte load_amount;
 	byte climates;      ///< Climates supported by the engine.
 	CargoID cargo_type;
-	uint32 refit_mask;
+	CargoTypes refit_mask;
 	byte refit_cost;
 	byte misc_flags;    ///< Miscellaneous flags. @see EngineMiscFlags
 	byte callback_mask; ///< Bitmask of vehicle callbacks that have to be called

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -390,7 +390,7 @@ static Foundation GetFoundation_Industry(TileIndex tile, Slope tileh)
 	return FlatteningFoundation(tileh);
 }
 
-static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, uint32 *always_accepted)
+static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted)
 {
 	IndustryGfx gfx = GetIndustryGfx(tile);
 	const IndustryTileSpec *itspec = GetIndustryTileSpec(gfx);

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -298,7 +298,7 @@ Point LinkGraphOverlay::GetStationMiddle(const Station *st) const
  * Set a new cargo mask and rebuild the cache.
  * @param cargo_mask New cargo mask.
  */
-void LinkGraphOverlay::SetCargoMask(uint32 cargo_mask)
+void LinkGraphOverlay::SetCargoMask(CargoTypes cargo_mask)
 {
 	this->cargo_mask = cargo_mask;
 	this->RebuildCache();
@@ -435,7 +435,7 @@ void LinkGraphLegendWindow::SetOverlay(LinkGraphOverlay *overlay) {
 			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, HasBit(companies, c));
 		}
 	}
-	uint32 cargoes = this->overlay->GetCargoMask();
+	CargoTypes cargoes = this->overlay->GetCargoMask();
 	for (uint c = 0; c < NUM_CARGO; c++) {
 		if (!this->IsWidgetDisabled(WID_LGL_CARGO_FIRST + c)) {
 			this->SetWidgetLoweredState(WID_LGL_CARGO_FIRST + c, HasBit(cargoes, c));
@@ -519,7 +519,7 @@ void LinkGraphLegendWindow::UpdateOverlayCompanies()
  */
 void LinkGraphLegendWindow::UpdateOverlayCargoes()
 {
-	uint32 mask = 0;
+	CargoTypes mask = 0;
 	for (uint c = 0; c < NUM_CARGO; c++) {
 		if (this->IsWidgetDisabled(c + WID_LGL_CARGO_FIRST)) continue;
 		if (!this->IsWidgetLowered(c + WID_LGL_CARGO_FIRST)) continue;

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -51,17 +51,17 @@ public:
 	 * @param company_mask Bitmask of companies to be shown.
 	 * @param scale Desired thickness of lines and size of station dots.
 	 */
-	LinkGraphOverlay(const Window *w, uint wid, uint32 cargo_mask, uint32 company_mask, uint scale) :
+	LinkGraphOverlay(const Window *w, uint wid, CargoTypes cargo_mask, uint32 company_mask, uint scale) :
 			window(w), widget_id(wid), cargo_mask(cargo_mask), company_mask(company_mask), scale(scale)
 	{}
 
 	void RebuildCache();
 	void Draw(const DrawPixelInfo *dpi) const;
-	void SetCargoMask(uint32 cargo_mask);
+	void SetCargoMask(CargoTypes cargo_mask);
 	void SetCompanyMask(uint32 company_mask);
 
 	/** Get a bitmask of the currently shown cargoes. */
-	uint32 GetCargoMask() { return this->cargo_mask; }
+	CargoTypes GetCargoMask() { return this->cargo_mask; }
 
 	/** Get a bitmask of the currently shown companies. */
 	uint32 GetCompanyMask() { return this->company_mask; }
@@ -69,7 +69,7 @@ public:
 protected:
 	const Window *window;              ///< Window to be drawn into.
 	const uint widget_id;              ///< ID of Widget in Window to be drawn to.
-	uint32 cargo_mask;                 ///< Bitmask of cargos to be displayed.
+	CargoTypes cargo_mask;             ///< Bitmask of cargos to be displayed.
 	uint32 company_mask;               ///< Bitmask of companies to be displayed.
 	LinkMap cached_links;              ///< Cache for links to reduce recalculation.
 	StationSupplyList cached_stations; ///< Cache for stations to be drawn.

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -56,7 +56,7 @@ static const GRFFile *GetHouseSpecGrf(HouseID house_id)
  */
 HouseResolverObject::HouseResolverObject(HouseID house_id, TileIndex tile, Town *town,
 		CallbackID callback, uint32 param1, uint32 param2,
-		bool not_yet_constructed, uint8 initial_random_bits, uint32 watched_cargo_triggers)
+		bool not_yet_constructed, uint8 initial_random_bits, CargoTypes watched_cargo_triggers)
 	: ResolverObject(GetHouseSpecGrf(house_id), callback, param1, param2),
 	house_scope(*this, house_id, tile, town, not_yet_constructed, initial_random_bits, watched_cargo_triggers),
 	town_scope(*this, town, not_yet_constructed) // Don't access StorePSA if house is not yet constructed.
@@ -409,7 +409,7 @@ static uint32 GetDistanceFromNearbyHouse(uint8 parameter, TileIndex tile, HouseI
 }
 
 uint16 GetHouseCallback(CallbackID callback, uint32 param1, uint32 param2, HouseID house_id, Town *town, TileIndex tile,
-		bool not_yet_constructed, uint8 initial_random_bits, uint32 watched_cargo_triggers)
+		bool not_yet_constructed, uint8 initial_random_bits, CargoTypes watched_cargo_triggers)
 {
 	assert(IsValidTile(tile) && (not_yet_constructed || IsTileType(tile, MP_HOUSE)));
 
@@ -472,13 +472,13 @@ void DrawNewHouseTile(TileInfo *ti, HouseID house_id)
 }
 
 /* Simple wrapper for GetHouseCallback to keep the animation unified. */
-uint16 GetSimpleHouseCallback(CallbackID callback, uint32 param1, uint32 param2, const HouseSpec *spec, Town *town, TileIndex tile, uint32 extra_data)
+uint16 GetSimpleHouseCallback(CallbackID callback, uint32 param1, uint32 param2, const HouseSpec *spec, Town *town, TileIndex tile, CargoTypes extra_data)
 {
 	return GetHouseCallback(callback, param1, param2, spec - HouseSpec::Get(0), town, tile, false, 0, extra_data);
 }
 
 /** Helper class for animation control. */
-struct HouseAnimationBase : public AnimationBase<HouseAnimationBase, HouseSpec, Town, uint32, GetSimpleHouseCallback> {
+struct HouseAnimationBase : public AnimationBase<HouseAnimationBase, HouseSpec, Town, CargoTypes, GetSimpleHouseCallback> {
 	static const CallbackID cb_animation_speed      = CBID_HOUSE_ANIMATION_SPEED;
 	static const CallbackID cb_animation_next_frame = CBID_HOUSE_ANIMATION_NEXT_FRAME;
 
@@ -633,7 +633,7 @@ void TriggerHouse(TileIndex t, HouseTrigger trigger)
  * @param trigger_cargoes Cargo types that triggered the callback.
  * @param random Random bits.
  */
-void DoWatchedCargoCallback(TileIndex tile, TileIndex origin, uint32 trigger_cargoes, uint16 random)
+void DoWatchedCargoCallback(TileIndex tile, TileIndex origin, CargoTypes trigger_cargoes, uint16 random)
 {
 	TileIndexDiffC diff = TileIndexToTileIndexDiffC(origin, tile);
 	uint32 cb_info = random << 16 | (uint8)diff.y << 8 | (uint8)diff.x;
@@ -646,7 +646,7 @@ void DoWatchedCargoCallback(TileIndex tile, TileIndex origin, uint32 trigger_car
  * @param trigger_cargoes Triggering cargo types.
  * @pre IsTileType(t, MP_HOUSE)
  */
-void WatchedCargoCallback(TileIndex tile, uint32 trigger_cargoes)
+void WatchedCargoCallback(TileIndex tile, CargoTypes trigger_cargoes)
 {
 	assert(IsTileType(tile, MP_HOUSE));
 	HouseID id = GetHouseType(tile);

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -25,7 +25,7 @@ struct HouseScopeResolver : public ScopeResolver {
 	Town *town;                    ///< Town of this house.
 	bool not_yet_constructed;      ///< True for construction check.
 	uint16 initial_random_bits;    ///< Random bits during construction checks.
-	uint32 watched_cargo_triggers; ///< Cargo types that triggered the watched cargo callback.
+	CargoTypes watched_cargo_triggers; ///< Cargo types that triggered the watched cargo callback.
 
 	/**
 	 * Constructor of a house scope resolver.
@@ -38,7 +38,7 @@ struct HouseScopeResolver : public ScopeResolver {
 	 * @param watched_cargo_triggers Cargo types that triggered the watched cargo callback.
 	 */
 	HouseScopeResolver(ResolverObject &ro, HouseID house_id, TileIndex tile, Town *town,
-			bool not_yet_constructed, uint8 initial_random_bits, uint32 watched_cargo_triggers)
+			bool not_yet_constructed, uint8 initial_random_bits, CargoTypes watched_cargo_triggers)
 		: ScopeResolver(ro), house_id(house_id), tile(tile), town(town), not_yet_constructed(not_yet_constructed),
 		initial_random_bits(initial_random_bits), watched_cargo_triggers(watched_cargo_triggers)
 	{
@@ -56,7 +56,7 @@ struct HouseResolverObject : public ResolverObject {
 
 	HouseResolverObject(HouseID house_id, TileIndex tile, Town *town,
 			CallbackID callback = CBID_NO_CALLBACK, uint32 param1 = 0, uint32 param2 = 0,
-			bool not_yet_constructed = false, uint8 initial_random_bits = 0, uint32 watched_cargo_triggers = 0);
+			bool not_yet_constructed = false, uint8 initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0);
 
 	/* virtual */ ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0)
 	{
@@ -97,8 +97,8 @@ void AnimateNewHouseTile(TileIndex tile);
 void AnimateNewHouseConstruction(TileIndex tile);
 
 uint16 GetHouseCallback(CallbackID callback, uint32 param1, uint32 param2, HouseID house_id, Town *town, TileIndex tile,
-		bool not_yet_constructed = false, uint8 initial_random_bits = 0, uint32 watched_cargo_triggers = 0);
-void WatchedCargoCallback(TileIndex tile, uint32 trigger_cargoes);
+		bool not_yet_constructed = false, uint8 initial_random_bits = 0, CargoTypes watched_cargo_triggers = 0);
+void WatchedCargoCallback(TileIndex tile, CargoTypes trigger_cargoes);
 
 bool CanDeleteHouse(TileIndex tile);
 

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -963,7 +963,7 @@ void TriggerStationRandomisation(Station *st, TileIndex tile, StationRandomTrigg
 	uint32 whole_reseed = 0;
 	ETileArea area = ETileArea(st, tile, tas[trigger]);
 
-	uint32 empty_mask = 0;
+	CargoTypes empty_mask = 0;
 	if (trigger == SRT_CARGO_TAKEN) {
 		/* Create a bitmask of completely empty cargo types to be matched */
 		for (CargoID i = 0; i < NUM_CARGO; i++) {

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -153,7 +153,7 @@ struct StationSpec {
 	 */
 	uint16 cargo_threshold;
 
-	uint32 cargo_triggers; ///< Bitmask of cargo types which cause trigger re-randomizing
+	CargoTypes cargo_triggers; ///< Bitmask of cargo types which cause trigger re-randomizing
 
 	byte callback_mask; ///< Bitmask of station callbacks that have to be called
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -540,7 +540,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags)
 	return cost;
 }
 
-static void AddAcceptedCargo_Object(TileIndex tile, CargoArray &acceptance, uint32 *always_accepted)
+static void AddAcceptedCargo_Object(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted)
 {
 	if (!IsObjectType(tile, OBJECT_HQ)) return;
 

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -295,7 +295,7 @@ static void Load_TOWN()
 		SlObject(&t->cargo_accepted, GetTileMatrixDesc());
 		if (t->cargo_accepted.area.w != 0) {
 			uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
-			t->cargo_accepted.data = MallocT<uint32>(arr_len);
+			t->cargo_accepted.data = MallocT<CargoTypes>(arr_len);
 			SlArray(t->cargo_accepted.data, arr_len, SLE_UINT32);
 
 			/* Rebuild total cargo acceptance. */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1351,7 +1351,7 @@ void SmallMapWindow::SelectLegendItem(int click_pos, LegendAndColour *legend, in
  */
 void SmallMapWindow::SetOverlayCargoMask()
 {
-	uint32 cargo_mask = 0;
+	CargoTypes cargo_mask = 0;
 	for (int i = 0; i != _smallmap_cargo_count; ++i) {
 		if (_legend_linkstats[i].show_on_map) SetBit(cargo_mask, _legend_linkstats[i].type);
 	}

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -470,7 +470,7 @@ public:
 	byte last_vehicle_type;
 	std::list<Vehicle *> loading_vehicles;
 	GoodsEntry goods[NUM_CARGO];  ///< Goods at this station
-	uint32 always_accepted;       ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
+	CargoTypes always_accepted;       ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
 
 	IndustryVector industries_near; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -440,12 +440,12 @@ void UpdateAllStationVirtCoords()
  * @param st Station to query
  * @return the expected mask
  */
-static uint GetAcceptanceMask(const Station *st)
+static CargoTypes GetAcceptanceMask(const Station *st)
 {
-	uint mask = 0;
+	CargoTypes mask = 0;
 
 	for (CargoID i = 0; i < NUM_CARGO; i++) {
-		if (HasBit(st->goods[i].status, GoodsEntry::GES_ACCEPTANCE)) mask |= 1 << i;
+		if (HasBit(st->goods[i].status, GoodsEntry::GES_ACCEPTANCE)) SetBit(mask, i);
 	}
 	return mask;
 }
@@ -524,7 +524,7 @@ CargoArray GetProductionAroundTiles(TileIndex tile, int w, int h, int rad)
  * @param rad Search radius in addition to given area
  * @param always_accepted bitmask of cargo accepted by houses and headquarters; can be NULL
  */
-CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, uint32 *always_accepted)
+CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted)
 {
 	CargoArray acceptance;
 	if (always_accepted != NULL) *always_accepted = 0;
@@ -562,7 +562,7 @@ CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, uint3
 void UpdateStationAcceptance(Station *st, bool show_msg)
 {
 	/* old accepted goods types */
-	uint old_acc = GetAcceptanceMask(st);
+	CargoTypes old_acc = GetAcceptanceMask(st);
 
 	/* And retrieve the acceptance. */
 	CargoArray acceptance;
@@ -595,7 +595,7 @@ void UpdateStationAcceptance(Station *st, bool show_msg)
 	}
 
 	/* Only show a message in case the acceptance was actually changed. */
-	uint new_acc = GetAcceptanceMask(st);
+	CargoTypes new_acc = GetAcceptanceMask(st);
 	if (old_acc == new_acc) return;
 
 	/* show a message to report that the acceptance was changed? */
@@ -3186,7 +3186,7 @@ static VehicleEnterTileStatus VehicleEnter_Station(Vehicle *v, TileIndex tile, i
 void TriggerWatchedCargoCallbacks(Station *st)
 {
 	/* Collect cargoes accepted since the last big tick. */
-	uint cargoes = 0;
+	CargoTypes cargoes = 0;
 	for (CargoID cid = 0; cid < NUM_CARGO; cid++) {
 		if (HasBit(st->goods[cid].status, GoodsEntry::GES_ACCEPTED_BIGTICK)) SetBit(cargoes, cid);
 	}

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -28,7 +28,7 @@ void ShowStationViewWindow(StationID station);
 void UpdateAllStationVirtCoords();
 
 CargoArray GetProductionAroundTiles(TileIndex tile, int w, int h, int rad);
-CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, uint32 *always_accepted = NULL);
+CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted = NULL);
 
 void UpdateStationAcceptance(Station *st, bool show_msg);
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -56,7 +56,7 @@
 int DrawStationCoverageAreaText(int left, int right, int top, StationCoverageType sct, int rad, bool supplies)
 {
 	TileIndex tile = TileVirtXY(_thd.pos.x, _thd.pos.y);
-	uint32 cargo_mask = 0;
+	CargoTypes cargo_mask = 0;
 	if (_thd.drawstyle == HT_RECT && tile < MapSize()) {
 		CargoArray cargoes;
 		if (supplies) {
@@ -156,8 +156,8 @@ protected:
 	static Listing last_sorting;
 	static byte facilities;               // types of stations of interest
 	static bool include_empty;            // whether we should include stations without waiting cargo
-	static const uint32 cargo_filter_max;
-	static uint32 cargo_filter;           // bitmap of cargo types to include
+	static const CargoTypes cargo_filter_max;
+	static CargoTypes cargo_filter;           // bitmap of cargo types to include
 	static const Station *last_station;
 
 	/* Constants for sorting stations */
@@ -654,8 +654,8 @@ public:
 Listing CompanyStationsWindow::last_sorting = {false, 0};
 byte CompanyStationsWindow::facilities = FACIL_TRAIN | FACIL_TRUCK_STOP | FACIL_BUS_STOP | FACIL_AIRPORT | FACIL_DOCK;
 bool CompanyStationsWindow::include_empty = true;
-const uint32 CompanyStationsWindow::cargo_filter_max = UINT32_MAX;
-uint32 CompanyStationsWindow::cargo_filter = UINT32_MAX;
+const CargoTypes CompanyStationsWindow::cargo_filter_max = ALL_CARGOTYPES;
+CargoTypes CompanyStationsWindow::cargo_filter = ALL_CARGOTYPES;
 const Station *CompanyStationsWindow::last_station = NULL;
 
 /* Availible station sorting functions */
@@ -1799,7 +1799,7 @@ struct StationViewWindow : public Window {
 	{
 		const Station *st = Station::Get(this->window_number);
 
-		uint32 cargo_mask = 0;
+		CargoTypes cargo_mask = 0;
 		for (CargoID i = 0; i < NUM_CARGO; i++) {
 			if (HasBit(st->goods[i].status, GoodsEntry::GES_ACCEPTANCE)) SetBit(cargo_mask, i);
 		}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1147,7 +1147,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 			}
 
 			case SCC_CARGO_LIST: { // {CARGO_LIST}
-				uint32 cmask = args->GetInt32(SCC_CARGO_LIST);
+				CargoTypes cmask = args->GetInt32(SCC_CARGO_LIST);
 				bool first = true;
 
 				const CargoSpec *cs;

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -334,7 +334,7 @@ bool FindSubsidyTownCargoRoute()
 	/* Select a random town. */
 	const Town *src_town = Town::GetRandom();
 
-	uint32 town_cargo_produced = src_town->cargo_produced;
+	CargoTypes town_cargo_produced = src_town->cargo_produced;
 
 	/* Passenger subsidies are not handled here. */
 	ClrBit(town_cargo_produced, CT_PASSENGERS);

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -81,7 +81,7 @@ typedef CommandCost ClearTileProc(TileIndex tile, DoCommandFlag flags);
  * @param acceptance      Storage destination of the cargo acceptance in 1/8
  * @param always_accepted Bitmask of always accepted cargo types
  */
-typedef void AddAcceptedCargoProc(TileIndex tile, CargoArray &acceptance, uint32 *always_accepted);
+typedef void AddAcceptedCargoProc(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted);
 
 /**
  * Tile callback function signature for obtaining a tile description
@@ -165,11 +165,11 @@ VehicleEnterTileStatus VehicleEnterTile(Vehicle *v, TileIndex tile, int x, int y
 void ChangeTileOwner(TileIndex tile, Owner old_owner, Owner new_owner);
 void GetTileDesc(TileIndex tile, TileDesc *td);
 
-static inline void AddAcceptedCargo(TileIndex tile, CargoArray &acceptance, uint32 *always_accepted)
+static inline void AddAcceptedCargo(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted)
 {
 	AddAcceptedCargoProc *proc = _tile_type_procs[GetTileType(tile)]->add_accepted_cargo_proc;
 	if (proc == NULL) return;
-	uint32 dummy = 0; // use dummy bitmask so there don't need to be several 'always_accepted != NULL' checks
+	CargoTypes dummy = 0; // use dummy bitmask so there don't need to be several 'always_accepted != NULL' checks
 	proc(tile, acceptance, always_accepted == NULL ? &dummy : always_accepted);
 }
 

--- a/src/town.h
+++ b/src/town.h
@@ -26,7 +26,7 @@ struct BuildingCounts {
 	T class_count[HOUSE_CLASS_MAX];
 };
 
-typedef TileMatrix<uint32, 4> AcceptanceMatrix;
+typedef TileMatrix<CargoTypes, 4> AcceptanceMatrix;
 
 static const uint CUSTOM_TOWN_NUMBER_DIFFICULTY  = 4; ///< value for custom town number in difficulty settings
 static const uint CUSTOM_TOWN_MAX_NUMBER = 5000;  ///< this is the maximum number of towns a user can specify in customisation
@@ -85,9 +85,9 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	inline byte GetPercentTransported(CargoID cid) const { return this->supplied[cid].old_act * 256 / (this->supplied[cid].old_max + 1); }
 
 	/* Cargo production and acceptance stats. */
-	uint32 cargo_produced;           ///< Bitmap of all cargoes produced by houses in this town.
+	CargoTypes cargo_produced;       ///< Bitmap of all cargoes produced by houses in this town.
 	AcceptanceMatrix cargo_accepted; ///< Bitmap of cargoes accepted by houses for each 4*4 map square of the town.
-	uint32 cargo_accepted_total;     ///< NOSAVE: Bitmap of all cargoes accepted by houses in this town.
+	CargoTypes cargo_accepted_total; ///< NOSAVE: Bitmap of all cargoes accepted by houses in this town.
 
 	uint16 time_until_rebuild;     ///< time until we rebuild a house
 
@@ -293,6 +293,6 @@ static inline uint16 TownTicksToGameTicks(uint16 ticks) {
 }
 
 
-extern uint32 _town_cargoes_accepted;
+extern CargoTypes _town_cargoes_accepted;
 
 #endif /* TOWN_H */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -53,7 +53,7 @@
 #include "safeguards.h"
 
 TownID _new_town_id;
-uint32 _town_cargoes_accepted; ///< Bitmap of all cargoes accepted by houses.
+CargoTypes _town_cargoes_accepted; ///< Bitmap of all cargoes accepted by houses.
 
 /* Initialize the town-pool */
 TownPool _town_pool("Town");
@@ -601,14 +601,14 @@ static void AddProducedCargo_Town(TileIndex tile, CargoArray &produced)
 	}
 }
 
-static inline void AddAcceptedCargoSetMask(CargoID cargo, uint amount, CargoArray &acceptance, uint32 *always_accepted)
+static inline void AddAcceptedCargoSetMask(CargoID cargo, uint amount, CargoArray &acceptance, CargoTypes *always_accepted)
 {
 	if (cargo == CT_INVALID || amount == 0) return;
 	acceptance[cargo] += amount;
 	SetBit(*always_accepted, cargo);
 }
 
-static void AddAcceptedCargo_Town(TileIndex tile, CargoArray &acceptance, uint32 *always_accepted)
+static void AddAcceptedCargo_Town(TileIndex tile, CargoArray &acceptance, CargoTypes *always_accepted)
 {
 	const HouseSpec *hs = HouseSpec::Get(GetHouseType(tile));
 	CargoID accepts[3];
@@ -719,7 +719,7 @@ void UpdateTownCargoTotal(Town *t)
 static void UpdateTownCargoes(Town *t, TileIndex start, bool update_total = true)
 {
 	CargoArray accepted, produced;
-	uint32 dummy;
+	CargoTypes dummy;
 
 	/* Gather acceptance for all houses in an area around the start tile.
 	 * The area is composed of the square the tile is in, extended one square in all
@@ -733,7 +733,7 @@ static void UpdateTownCargoes(Town *t, TileIndex start, bool update_total = true
 	}
 
 	/* Create bitmap of produced and accepted cargoes. */
-	uint32 acc = 0;
+	CargoTypes acc = 0;
 	for (uint cid = 0; cid < NUM_CARGO; cid++) {
 		if (accepted[cid] >= 8) SetBit(acc, cid);
 		if (produced[cid] > 0) SetBit(t->cargo_produced, cid);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -219,7 +219,7 @@ bool Vehicle::NeedsServicing() const
 		if (replace_when_old && !v->NeedsAutorenewing(c, false)) continue;
 
 		/* Check refittability */
-		uint32 available_cargo_types, union_mask;
+		CargoTypes available_cargo_types, union_mask;
 		GetArticulatedRefitMasks(new_engine, true, &union_mask, &available_cargo_types);
 		/* Is there anything to refit? */
 		if (union_mask != 0) {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -416,7 +416,7 @@ struct RefitWindow : public Window {
 		do {
 			if (v->type == VEH_TRAIN && !vehicles_to_refit.Contains(v->index)) continue;
 			const Engine *e = v->GetEngine();
-			uint32 cmask = e->info.refit_mask;
+			CargoTypes cmask = e->info.refit_mask;
 			byte callback_mask = e->info.callback_mask;
 
 			/* Skip this engine if it does not carry anything */
@@ -1043,9 +1043,9 @@ void ShowVehicleRefitWindow(const Vehicle *v, VehicleOrderID order, Window *pare
 uint ShowRefitOptionsList(int left, int right, int y, EngineID engine)
 {
 	/* List of cargo types of this engine */
-	uint32 cmask = GetUnionOfArticulatedRefitMasks(engine, false);
+	CargoTypes cmask = GetUnionOfArticulatedRefitMasks(engine, false);
 	/* List of cargo types available in this climate */
-	uint32 lmask = _cargo_mask;
+	CargoTypes lmask = _cargo_mask;
 
 	/* Draw nothing if the engine is not refittable */
 	if (HasAtMostOneBit(cmask)) return y;


### PR DESCRIPTION
This patch adds a CargoTypes type for cargo bitmasks, instead of a using mix of uint/uint32. A couple of tests have been changed but otherwise there should be no functional difference. I believe all occurrences have been covered.