### PR TITLE
Change: Remove direction parameter from Vehicle::UpdateDeltaXY.

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -90,7 +90,7 @@ struct Aircraft FINAL : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	virtual ~Aircraft() { this->PreDestructor(); }
 
 	void MarkDirty();
-	void UpdateDeltaXY(Direction direction);
+	void UpdateDeltaXY();
 	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_AIRCRAFT_INC : EXPENSES_AIRCRAFT_RUN; }
 	bool IsPrimaryVehicle() const                  { return this->IsNormalAircraft(); }
 	void GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const;

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -42,7 +42,7 @@
 
 #include "safeguards.h"
 
-void Aircraft::UpdateDeltaXY(Direction direction)
+void Aircraft::UpdateDeltaXY()
 {
 	this->x_offs = -1;
 	this->y_offs = -1;
@@ -303,10 +303,10 @@ CommandCost CmdBuildAircraft(TileIndex tile, DoCommandFlag flags, const Engine *
 		u->engine_type = e->index;
 
 		v->subtype = (avi->subtype & AIR_CTOL ? AIR_AIRCRAFT : AIR_HELICOPTER);
-		v->UpdateDeltaXY(INVALID_DIR);
+		v->UpdateDeltaXY();
 
 		u->subtype = AIR_SHADOW;
-		u->UpdateDeltaXY(INVALID_DIR);
+		u->UpdateDeltaXY();
 
 		v->reliability = e->reliability;
 		v->reliability_spd_dec = e->reliability_spd_dec;
@@ -363,7 +363,7 @@ CommandCost CmdBuildAircraft(TileIndex tile, DoCommandFlag flags, const Engine *
 			w->random_bits = VehicleRandomBits();
 			/* Use rotor's air.state to store the rotor animation frame */
 			w->state = HRS_ROTOR_STOPPED;
-			w->UpdateDeltaXY(INVALID_DIR);
+			w->UpdateDeltaXY();
 
 			u->SetNext(w);
 			w->UpdatePosition();
@@ -1361,7 +1361,7 @@ static void AircraftEntersTerminal(Aircraft *v)
  */
 static void AircraftLandAirplane(Aircraft *v)
 {
-	v->UpdateDeltaXY(INVALID_DIR);
+	v->UpdateDeltaXY();
 
 	if (!PlayVehicleSound(v, VSE_TOUCHDOWN)) {
 		SndPlayVehicleFx(SND_17_SKID_PLANE, v);
@@ -1553,7 +1553,7 @@ static void AircraftEventHandler_TakeOff(Aircraft *v, const AirportFTAClass *apc
 static void AircraftEventHandler_StartTakeOff(Aircraft *v, const AirportFTAClass *apc)
 {
 	v->state = ENDTAKEOFF;
-	v->UpdateDeltaXY(INVALID_DIR);
+	v->UpdateDeltaXY();
 }
 
 static void AircraftEventHandler_EndTakeOff(Aircraft *v, const AirportFTAClass *apc)
@@ -1566,7 +1566,7 @@ static void AircraftEventHandler_EndTakeOff(Aircraft *v, const AirportFTAClass *
 static void AircraftEventHandler_HeliTakeOff(Aircraft *v, const AirportFTAClass *apc)
 {
 	v->state = FLYING;
-	v->UpdateDeltaXY(INVALID_DIR);
+	v->UpdateDeltaXY();
 
 	/* get the next position to go to, differs per airport */
 	AircraftNextAirportPos_and_Order(v);
@@ -1632,7 +1632,7 @@ static void AircraftEventHandler_Landing(Aircraft *v, const AirportFTAClass *apc
 static void AircraftEventHandler_HeliLanding(Aircraft *v, const AirportFTAClass *apc)
 {
 	v->state = HELIENDLANDING;
-	v->UpdateDeltaXY(INVALID_DIR);
+	v->UpdateDeltaXY();
 }
 
 static void AircraftEventHandler_EndLanding(Aircraft *v, const AirportFTAClass *apc)

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -164,7 +164,7 @@ DisasterVehicle::DisasterVehicle(int x, int y, Direction direction, DisasterSubT
 	this->direction = direction;
 	this->tile = TileVirtXY(x, y);
 	this->subtype = subtype;
-	this->UpdateDeltaXY(INVALID_DIR);
+	this->UpdateDeltaXY();
 	this->owner = OWNER_NONE;
 	this->image_override = 0;
 	this->current_order.Free();
@@ -973,7 +973,7 @@ void ReleaseDisastersTargetingVehicle(VehicleID vehicle)
 	}
 }
 
-void DisasterVehicle::UpdateDeltaXY(Direction direction)
+void DisasterVehicle::UpdateDeltaXY()
 {
 	this->x_offs        = -1;
 	this->y_offs        = -1;

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -48,7 +48,7 @@ struct DisasterVehicle FINAL : public SpecializedVehicle<DisasterVehicle, VEH_DI
 	virtual ~DisasterVehicle() {}
 
 	void UpdatePosition(int x, int y, int z);
-	void UpdateDeltaXY(Direction direction);
+	void UpdateDeltaXY();
 	void UpdateImage();
 	bool Tick();
 };

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -603,7 +603,7 @@ EffectVehicle *CreateEffectVehicle(int x, int y, int z, EffectVehicleType type)
 	v->y_pos = y;
 	v->z_pos = z;
 	v->tile = 0;
-	v->UpdateDeltaXY(INVALID_DIR);
+	v->UpdateDeltaXY();
 	v->vehstatus = VS_UNCLICKABLE;
 
 	_effect_init_procs[type](v);
@@ -647,7 +647,7 @@ bool EffectVehicle::Tick()
 	return _effect_tick_procs[this->subtype](this);
 }
 
-void EffectVehicle::UpdateDeltaXY(Direction direction)
+void EffectVehicle::UpdateDeltaXY()
 {
 	this->x_offs        = 0;
 	this->y_offs        = 0;

--- a/src/effectvehicle_base.h
+++ b/src/effectvehicle_base.h
@@ -32,7 +32,7 @@ struct EffectVehicle FINAL : public SpecializedVehicle<EffectVehicle, VEH_EFFECT
 	/** We want to 'destruct' the right class. */
 	virtual ~EffectVehicle() {}
 
-	void UpdateDeltaXY(Direction direction);
+	void UpdateDeltaXY();
 	bool Tick();
 	TransparencyOption GetTransparencyOption() const;
 };

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -105,7 +105,7 @@ struct RoadVehicle FINAL : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	friend struct GroundVehicle<RoadVehicle, VEH_ROAD>; // GroundVehicle needs to use the acceleration functions defined at RoadVehicle.
 
 	void MarkDirty();
-	void UpdateDeltaXY(Direction direction);
+	void UpdateDeltaXY();
 	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_ROADVEH_INC : EXPENSES_ROADVEH_RUN; }
 	bool IsPrimaryVehicle() const { return this->IsFrontEngine(); }
 	void GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -403,7 +403,7 @@ void RoadVehicle::MarkDirty()
 	this->CargoChanged();
 }
 
-void RoadVehicle::UpdateDeltaXY(Direction direction)
+void RoadVehicle::UpdateDeltaXY()
 {
 	static const int8 _delta_xy_table[8][10] = {
 		/* y_extent, x_extent, y_offs, x_offs, y_bb_offs, x_bb_offs, y_extent_shorten, x_extent_shorten, y_bb_offs_shorten, x_bb_offs_shorten */
@@ -418,9 +418,9 @@ void RoadVehicle::UpdateDeltaXY(Direction direction)
 	};
 
 	int shorten = VEHICLE_LENGTH - this->gcache.cached_veh_length;
-	if (!IsDiagonalDirection(direction)) shorten >>= 1;
+	if (!IsDiagonalDirection(this->direction)) shorten >>= 1;
 
-	const int8 *bb = _delta_xy_table[direction];
+	const int8 *bb = _delta_xy_table[this->direction];
 	this->x_bb_offs     = bb[5] + bb[9] * shorten;
 	this->y_bb_offs     = bb[4] + bb[8] * shorten;;
 	this->x_offs        = bb[3];

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -461,7 +461,7 @@ void AfterLoadVehicles(bool part_of_load)
 			default: break;
 		}
 
-		v->UpdateDeltaXY(v->direction);
+		v->UpdateDeltaXY();
 		v->coord.left = INVALID_COORD;
 		v->UpdatePosition();
 		v->UpdateViewport(false);

--- a/src/ship.h
+++ b/src/ship.h
@@ -30,7 +30,7 @@ struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
 	virtual ~Ship() { this->PreDestructor(); }
 
 	void MarkDirty();
-	void UpdateDeltaXY(Direction direction);
+	void UpdateDeltaXY();
 	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_SHIP_INC : EXPENSES_SHIP_RUN; }
 	void PlayLeaveStationSound() const;
 	bool IsPrimaryVehicle() const { return true; }

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -296,7 +296,7 @@ TileIndex Ship::GetOrderStationLocation(StationID station)
 	}
 }
 
-void Ship::UpdateDeltaXY(Direction direction)
+void Ship::UpdateDeltaXY()
 {
 	static const int8 _delta_xy_table[8][4] = {
 		/* y_extent, x_extent, y_offs, x_offs */
@@ -310,7 +310,7 @@ void Ship::UpdateDeltaXY(Direction direction)
 		{32,  6, -16,  -3}, // NW
 	};
 
-	const int8 *bb = _delta_xy_table[direction];
+	const int8 *bb = _delta_xy_table[this->direction];
 	this->x_offs        = bb[3];
 	this->y_offs        = bb[2];
 	this->x_extent      = bb[1];
@@ -670,7 +670,7 @@ CommandCost CmdBuildShip(TileIndex tile, DoCommandFlag flags, const Engine *e, u
 		v->y_pos = y;
 		v->z_pos = GetSlopePixelZ(x, y);
 
-		v->UpdateDeltaXY(v->direction);
+		v->UpdateDeltaXY();
 		v->vehstatus = VS_HIDDEN | VS_STOPPED | VS_DEFPAL;
 
 		v->spritenum = svi->image_index;

--- a/src/train.h
+++ b/src/train.h
@@ -110,7 +110,7 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 	friend struct GroundVehicle<Train, VEH_TRAIN>; // GroundVehicle needs to use the acceleration functions defined at Train.
 
 	void MarkDirty();
-	void UpdateDeltaXY(Direction direction);
+	void UpdateDeltaXY();
 	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_TRAIN_INC : EXPENSES_TRAIN_RUN; }
 	void PlayLeaveStationSound() const;
 	bool IsPrimaryVehicle() const { return this->IsFrontEngine(); }

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1442,7 +1442,7 @@ CommandCost CmdSellRailWagon(DoCommandFlag flags, Vehicle *t, uint16 data, uint3
 	return cost;
 }
 
-void Train::UpdateDeltaXY(Direction direction)
+void Train::UpdateDeltaXY()
 {
 	/* Set common defaults. */
 	this->x_offs    = -1;
@@ -1453,7 +1453,7 @@ void Train::UpdateDeltaXY(Direction direction)
 	this->x_bb_offs =  0;
 	this->y_bb_offs =  0;
 
-	if (!IsDiagonalDirection(direction)) {
+	if (!IsDiagonalDirection(this->direction)) {
 		static const int _sign_table[] =
 		{
 			/* x, y */
@@ -1466,12 +1466,12 @@ void Train::UpdateDeltaXY(Direction direction)
 		int half_shorten = (VEHICLE_LENGTH - this->gcache.cached_veh_length) / 2;
 
 		/* For all straight directions, move the bound box to the centre of the vehicle, but keep the size. */
-		this->x_offs -= half_shorten * _sign_table[direction];
-		this->y_offs -= half_shorten * _sign_table[direction + 1];
+		this->x_offs -= half_shorten * _sign_table[this->direction];
+		this->y_offs -= half_shorten * _sign_table[this->direction + 1];
 		this->x_extent += this->x_bb_offs = half_shorten * _sign_table[direction];
 		this->y_extent += this->y_bb_offs = half_shorten * _sign_table[direction + 1];
 	} else {
-		switch (direction) {
+		switch (this->direction) {
 				/* Shorten southern corner of the bounding box according the vehicle length
 				 * and center the bounding box on the vehicle. */
 			case DIR_NE:
@@ -3361,7 +3361,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 		}
 
 		/* update image of train, as well as delta XY */
-		v->UpdateDeltaXY(v->direction);
+		v->UpdateDeltaXY();
 
 		v->x_pos = gp.x;
 		v->y_pos = gp.y;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -366,9 +366,8 @@ public:
 	/**
 	 * Updates the x and y offsets and the size of the sprite used
 	 * for this vehicle.
-	 * @param direction the direction the vehicle is facing
 	 */
-	virtual void UpdateDeltaXY(Direction direction) {}
+	virtual void UpdateDeltaXY() {}
 
 	/**
 	 * Determines the effective direction-specific vehicle movement speed.
@@ -1139,7 +1138,7 @@ struct SpecializedVehicle : public Vehicle {
 
 		/* Explicitly choose method to call to prevent vtable dereference -
 		 * it gives ~3% runtime improvements in games with many vehicles */
-		if (update_delta) ((T *)this)->T::UpdateDeltaXY(this->direction);
+		if (update_delta) ((T *)this)->T::UpdateDeltaXY();
 		VehicleSpriteSeq seq;
 		((T *)this)->T::GetImage(this->direction, EIT_ON_MAP, &seq);
 		if (force_update || this->sprite_seq != seq) {


### PR DESCRIPTION
The value is either unused or always the same as this->direction, so does not need to be explicitly provided.