### PR TITLE
Update CONTRIBUTING.md symlink instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ git clone https://github.com/OpenTTD/OpenTTD-git-hooks.git openttd_hooks
 cd openttd
 git remote add upstream https://github.com/OpenTTD/OpenTTD.git
 cd .git/hooks
-ln -s -t . ../../../openttd_hooks/hooks/*
+ln -s ../../../openttd_hooks/hooks/* .
 ```
 
 2. If you cloned a while ago, get the latest changes from upstream:


### PR DESCRIPTION
L110, "ln -s -t . ../../../openttd_hooks/hooks/*" fails on at leat OS X.

"ln -s ../../../openttd_hooks/hooks/* ." appears to achieve the desired result, at least on OS X.  

This is 'works for me', I'm not aware of implications for other platforms.  irc discussion 3rd June 2018 seemed to think the change was OK. 
