### PR TITLE
Fix #6659: Bus stations can be demolished when not in demolish mode

### DIFF
--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -633,22 +633,28 @@ struct BuildRoadToolbarWindow : Window {
 					break;
 
 				case DDSP_BUILD_BUSSTOP:
-					PlaceRoadStop(start_tile, end_tile, (_ctrl_pressed << 5) | RoadTypeToRoadTypes(_cur_roadtype) << 2 | ROADSTOP_BUS, CMD_BUILD_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_build_station[ROADSTOP_BUS]));
-					break;
-
-				case DDSP_BUILD_TRUCKSTOP:
-					PlaceRoadStop(start_tile, end_tile, (_ctrl_pressed << 5) | RoadTypeToRoadTypes(_cur_roadtype) << 2 | ROADSTOP_TRUCK, CMD_BUILD_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_build_station[ROADSTOP_TRUCK]));
-					break;
-
 				case DDSP_REMOVE_BUSSTOP: {
-					TileArea ta(start_tile, end_tile);
-					DoCommandP(ta.tile, ta.w | ta.h << 8, (_ctrl_pressed << 1) | ROADSTOP_BUS, CMD_REMOVE_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_remove_station[ROADSTOP_BUS]), CcPlaySound_SPLAT_OTHER);
+					if(this->IsWidgetLowered(WID_ROT_BUS_STATION)) {
+						if(_remove_button_clicked) {
+							TileArea ta(start_tile, end_tile);
+							DoCommandP(ta.tile, ta.w | ta.h << 8, (_ctrl_pressed << 1) | ROADSTOP_BUS, CMD_REMOVE_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_remove_station[ROADSTOP_BUS]), CcPlaySound_SPLAT_OTHER);
+						} else {
+							PlaceRoadStop(start_tile, end_tile, (_ctrl_pressed << 5) | RoadTypeToRoadTypes(_cur_roadtype) << 2 | ROADSTOP_BUS, CMD_BUILD_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_build_station[ROADSTOP_BUS]));
+						}
+					}
 					break;
 				}
 
+				case DDSP_BUILD_TRUCKSTOP:
 				case DDSP_REMOVE_TRUCKSTOP: {
-					TileArea ta(start_tile, end_tile);
-					DoCommandP(ta.tile, ta.w | ta.h << 8, (_ctrl_pressed << 1) | ROADSTOP_TRUCK, CMD_REMOVE_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_remove_station[ROADSTOP_TRUCK]), CcPlaySound_SPLAT_OTHER);
+					if(this->IsWidgetLowered(WID_ROT_TRUCK_STATION)) {
+						if(_remove_button_clicked) {
+							TileArea ta(start_tile, end_tile);
+							DoCommandP(ta.tile, ta.w | ta.h << 8, (_ctrl_pressed << 1) | ROADSTOP_TRUCK, CMD_REMOVE_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_remove_station[ROADSTOP_TRUCK]), CcPlaySound_SPLAT_OTHER);
+						} else {
+							PlaceRoadStop(start_tile, end_tile, (_ctrl_pressed << 5) | RoadTypeToRoadTypes(_cur_roadtype) << 2 | ROADSTOP_TRUCK, CMD_BUILD_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_build_station[ROADSTOP_TRUCK]));
+						}
+					}
 					break;
 				}
 			}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -633,9 +633,9 @@ struct BuildRoadToolbarWindow : Window {
 					break;
 
 				case DDSP_BUILD_BUSSTOP:
-				case DDSP_REMOVE_BUSSTOP: {
-					if(this->IsWidgetLowered(WID_ROT_BUS_STATION)) {
-						if(_remove_button_clicked) {
+				case DDSP_REMOVE_BUSSTOP:
+					if (this->IsWidgetLowered(WID_ROT_BUS_STATION)) {
+						if (_remove_button_clicked) {
 							TileArea ta(start_tile, end_tile);
 							DoCommandP(ta.tile, ta.w | ta.h << 8, (_ctrl_pressed << 1) | ROADSTOP_BUS, CMD_REMOVE_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_remove_station[ROADSTOP_BUS]), CcPlaySound_SPLAT_OTHER);
 						} else {
@@ -643,12 +643,11 @@ struct BuildRoadToolbarWindow : Window {
 						}
 					}
 					break;
-				}
 
 				case DDSP_BUILD_TRUCKSTOP:
-				case DDSP_REMOVE_TRUCKSTOP: {
-					if(this->IsWidgetLowered(WID_ROT_TRUCK_STATION)) {
-						if(_remove_button_clicked) {
+				case DDSP_REMOVE_TRUCKSTOP:
+					if (this->IsWidgetLowered(WID_ROT_TRUCK_STATION)) {
+						if (_remove_button_clicked) {
 							TileArea ta(start_tile, end_tile);
 							DoCommandP(ta.tile, ta.w | ta.h << 8, (_ctrl_pressed << 1) | ROADSTOP_TRUCK, CMD_REMOVE_ROAD_STOP | CMD_MSG(_road_type_infos[_cur_roadtype].err_remove_station[ROADSTOP_TRUCK]), CcPlaySound_SPLAT_OTHER);
 						} else {
@@ -656,7 +655,6 @@ struct BuildRoadToolbarWindow : Window {
 						}
 					}
 					break;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
For Bus and Road stations only, if you are in demolish mode and click on the station
without releasing the button. Then you cancel demolish mode with R key.
Finally you release the mouse button. The station was demolished, instead of being built.

The demolish mode was not checked when mouse up event occured.