### PR TITLE
Codechange: Change element type used for rail type usage stats array in SetDefaultRailGui

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1908,7 +1908,7 @@ static void SetDefaultRailGui()
 	RailType rt = (RailType)(_settings_client.gui.default_rail_type + RAILTYPE_END);
 	if (rt == DEF_RAILTYPE_MOST_USED) {
 		/* Find the most used rail type */
-		RailType count[RAILTYPE_END];
+		uint count[RAILTYPE_END];
 		memset(count, 0, sizeof(count));
 		for (TileIndex t = 0; t < MapSize(); t++) {
 			if (IsTileType(t, MP_RAILWAY) || IsLevelCrossingTile(t) || HasStationTileRail(t) ||


### PR DESCRIPTION
The array is rail type sized in terms of number of elements.
Each element should be a unsigned integer, not a rail type itself.
Array elements are used as counters which are incremented whenever a tile of the corresponding rail type is found.
This fixes runtime warnings reported by UndefinedBehaviorSanitizer.