### PR TITLE
PR for Modernizing for C++11: replacing instances of SmallVector

### DIFF
--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -7,13 +7,130 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file smallvec_type.hpp Simple vector class that allows allocating an item without the need to copy this->data needlessly. */
+/** @file smallvec_type.hpp Simple vector class that allows allocating an item without the need to copy this->data needlessly.
+ * @note The std::vector adapter functions are _temporary_ substitutions for methods of SmallVector
+ */
 
 #ifndef SMALLVEC_TYPE_HPP
 #define SMALLVEC_TYPE_HPP
 
 #include "alloc_func.hpp"
 #include "mem_func.hpp"
+
+#include <vector>
+#include <algorithm>
+
+/** Get a const iterator to a matching element in the vector.
+ * @param vec the vector to be searched
+ * @param elem the element to search fo
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+typename std::vector<T>::const_iterator Find(const std::vector<T>& vec, const T& elem) {
+	return std::find(vec.begin(), vec.end(), elem);
+}
+
+/** Get a non-const iterator to a matching element in the vector.
+ * @param vec the vector to be searched
+ * @param elem the element to search for
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+typename std::vector<T>::iterator Find(std::vector<T>& vec, const T& elem) {
+	return std::find(vec.begin(), vec.end(), elem);
+}
+
+/** Get the index of the first matching element.
+ * @param vec the vector to be searched
+ * @param elem the element to search for
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+int FindIndex(const std::vector<T>& vec, const T& elem) {
+	auto it = Find(vec, elem);
+	if (vec.end() == it) return -1;
+	return std::distance(vec.begin(), it);
+}
+
+/** Check whether an element exists.
+ * @param vec the vector to be searched
+ * @param elem the element to search for
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+bool Contains(const std::vector<T>& vec, const T& elem) {
+	return Find(vec, elem) != vec.end();
+}
+
+/** Count instances of an element.
+ * @param vec the vector to be searched
+ * @param elem the element to count instances of
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+size_t Count(const std::vector<T>& vec, const T& elem) {
+	return std::count(vec.begin(), vec.end(), elem);
+}
+
+/** Append an element if it does not already exist in the vector.
+ * @param vec the vector to be modified
+ * @param elem the element to add for and remove if missing
+ * @tparam T the contained type of the vector
+ * @tparam U the universal reference type for perfect forwarding
+ */
+template <typename T, typename U>
+bool Include(std::vector<T>& vec, U&& elem) {
+	auto missing = not Contains(vec, elem);
+	if (missing) vec.push_back(std::forward<U>(elem));
+	return missing;
+}
+
+/** Remove an element referenced in the vector and move the last element to take its place.
+ * @param vec the vector to be modified
+ * @param it the element to remove
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+typename std::vector<T>::iterator Erase(std::vector<T>& vec, typename std::vector<T>::iterator it) {
+	assert(vec.begin() <= it and vec.end() > it);
+	if (std::prev(vec.end()) != it) std::swap(vec.back(), *it);
+	vec.pop_back();
+	return it;
+}
+
+/** Remove an element if it exists in the vector and move the last element to take its place.
+ * @param vec the vector to be modified
+ * @param elem the element to search for and remove if found
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+bool Exclude(std::vector<T>& vec, const T& elem) {
+	auto it = Find(vec, elem);
+	if (vec.end() == it) return false;
+	Erase(vec, it);
+	return true;
+}
+
+/** Clear a vector and then force it to reduce its capacity.
+ * @param vec the vector to be modified
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+void Reset(std::vector<T>& vec) {
+	vec.clear();
+	vec.shrink_to_fit();
+}
+
+/** Extend a vector by an amount and return an iterator to the new elements.
+ * @param vec the vector to be modified
+ * @param num the number of elements to add
+ * @tparam T the contained type of the vector
+ */
+template <typename T>
+typename std::vector<T>::iterator Extend(std::vector<T>& vec, size_t num) {
+	vec.resize(vec.size() + num);
+	return vec.end() - num;
+}
 
 /**
  * Simple vector template class.

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -77,7 +77,7 @@ static inline int32 BigMulS(const int32 a, const int32 b, const uint8 shift)
 	return (int32)((int64)a * (int64)b >> shift);
 }
 
-typedef SmallVector<Industry *, 16> SmallIndustryList;
+using SmallIndustryList = std::vector<Industry *> ;
 
 /**
  * Score info, values used for computing the detailed performance rating.
@@ -1057,7 +1057,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 		if (IndustryTemporarilyRefusesCargo(ind, cargo_type)) continue;
 
 		/* Insert the industry into _cargo_delivery_destinations, if not yet contained */
-		_cargo_delivery_destinations.Include(ind);
+		Include(_cargo_delivery_destinations, ind);
 
 		uint amount = min(num_pieces, 0xFFFFU - ind->incoming_cargo_waiting[cargo_index]);
 		ind->incoming_cargo_waiting[cargo_index] += amount;
@@ -1930,11 +1930,8 @@ void LoadUnloadStation(Station *st)
 	}
 
 	/* Call the production machinery of industries */
-	const Industry * const *isend = _cargo_delivery_destinations.End();
-	for (Industry **iid = _cargo_delivery_destinations.Begin(); iid != isend; iid++) {
-		TriggerIndustryProduction(*iid);
-	}
-	_cargo_delivery_destinations.Clear();
+	for (const auto &iid : _cargo_delivery_destinations) TriggerIndustryProduction(iid);
+	_cargo_delivery_destinations.clear();
 }
 
 /**

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -397,7 +397,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 	{
 		SortingBits order = _savegame_sort_order;
 		_savegame_sort_order = SORT_BY_NAME | SORT_ASCENDING;
-		QSortT(file_list.files.Begin(), file_list.files.Length(), CompareFiosItems);
+		QSortT(file_list.files.data(), file_list.Length(), CompareFiosItems);
 		_savegame_sort_order = order;
 	}
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -113,7 +113,7 @@ public:
 	 */
 	inline FiosItem *Append()
 	{
-		return this->files.Append();
+		return &*Extend(this->files, 1);
 	}
 
 	/**
@@ -122,7 +122,7 @@ public:
 	 */
 	inline uint Length() const
 	{
-		return this->files.Length();
+		return this->files.size();
 	}
 
 	/**
@@ -131,7 +131,7 @@ public:
 	 */
 	inline const FiosItem *Begin() const
 	{
-		return this->files.Begin();
+		return this->files.data();
 	}
 
 	/**
@@ -140,7 +140,7 @@ public:
 	 */
 	inline const FiosItem *End() const
 	{
-		return this->files.End();
+		return this->Begin() + this->Length();
 	}
 
 	/**
@@ -149,7 +149,7 @@ public:
 	 */
 	inline const FiosItem *Get(uint index) const
 	{
-		return this->files.Get(index);
+		return this->files.data() + index;
 	}
 
 	/**
@@ -158,7 +158,7 @@ public:
 	 */
 	inline FiosItem *Get(uint index)
 	{
-		return this->files.Get(index);
+		return this->files.data() + index;
 	}
 
 	inline const FiosItem &operator[](uint index) const
@@ -178,19 +178,19 @@ public:
 	/** Remove all items from the list. */
 	inline void Clear()
 	{
-		this->files.Clear();
+		this->files.clear();
 	}
 
 	/** Compact the list down to the smallest block size boundary. */
 	inline void Compact()
 	{
-		this->files.Compact();
+		this->files.shrink_to_fit();
 	}
 
 	void BuildFileList(AbstractFileType abstract_filetype, SaveLoadOperation fop);
 	const FiosItem *FindItem(const char *file);
 
-	SmallVector<FiosItem, 32> files; ///< The list of files.
+	std::vector<FiosItem> files; ///< The list of files.
 };
 
 enum SortingBits {

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -118,7 +118,7 @@ private:
 	uint tiny_step_height; ///< Step height for the group list
 	Scrollbar *group_sb;
 
-	SmallVector<int, 16> indents; ///< Indentation levels
+	std::vector<int> indents; ///< Indentation levels
 
 	Dimension column_size[VGC_END]; ///< Size of the columns in the group list.
 
@@ -127,7 +127,7 @@ private:
 		for (const Group **g = source->Begin(); g != source->End(); g++) {
 			if ((*g)->parent == parent) {
 				*this->groups.Append() = *g;
-				*this->indents.Append() = indent;
+				this->indents.push_back(indent);
 				AddParents(source, (*g)->index, indent + 1);
 			}
 		}
@@ -166,7 +166,7 @@ private:
 		if (!this->groups.NeedRebuild()) return;
 
 		this->groups.Clear();
-		this->indents.Clear();
+		this->indents.clear();
 
 		GUIGroupList list;
 

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -202,7 +202,7 @@ const char *SaveKeycodes(const Hotkey *hotkey)
 {
 	static char buf[128];
 	buf[0] = '\0';
-	for (uint i = 0; i < hotkey->keycodes.Length(); i++) {
+	for (uint i = 0; i < hotkey->keycodes.size(); i++) {
 		const char *str = KeycodeToString(hotkey->keycodes[i]);
 		if (i > 0) strecat(buf, ",", lastof(buf));
 		strecat(buf, str, lastof(buf));
@@ -247,7 +247,7 @@ Hotkey::Hotkey(const uint16 *default_keycodes, const char *name, int num) :
  */
 void Hotkey::AddKeycode(uint16 keycode)
 {
-	this->keycodes.Include(keycode);
+	Include(this->keycodes, keycode);
 }
 
 HotkeyList::HotkeyList(const char *ini_group, Hotkey *items, GlobalHotkeyHandlerFunc global_hotkey_handler) :
@@ -272,7 +272,7 @@ void HotkeyList::Load(IniFile *ini)
 	for (Hotkey *hotkey = this->items; hotkey->name != NULL; ++hotkey) {
 		IniItem *item = group->GetItem(hotkey->name, false);
 		if (item != NULL) {
-			hotkey->keycodes.Clear();
+			hotkey->keycodes.clear();
 			if (item->value != NULL) ParseHotkeys(hotkey, item->value);
 		}
 	}
@@ -300,7 +300,7 @@ void HotkeyList::Save(IniFile *ini) const
 int HotkeyList::CheckMatch(uint16 keycode, bool global_only) const
 {
 	for (const Hotkey *list = this->items; list->name != NULL; ++list) {
-		if (list->keycodes.Contains(keycode | WKC_GLOBAL_HOTKEY) || (!global_only && list->keycodes.Contains(keycode))) {
+		if (Contains(list->keycodes, static_cast<uint16>(keycode | WKC_GLOBAL_HOTKEY)) || (!global_only && Contains(list->keycodes, keycode))) {
 			return list->num;
 		}
 	}

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -24,7 +24,7 @@ char *_hotkeys_file;
  * List of all HotkeyLists.
  * This is a pointer to ensure initialisation order with the various static HotkeyList instances.
  */
-static SmallVector<HotkeyList*, 16> *_hotkey_lists = NULL;
+static std::vector<HotkeyList*> *_hotkey_lists = NULL;
 
 /** String representation of a keycode */
 struct KeycodeNames {
@@ -253,13 +253,13 @@ void Hotkey::AddKeycode(uint16 keycode)
 HotkeyList::HotkeyList(const char *ini_group, Hotkey *items, GlobalHotkeyHandlerFunc global_hotkey_handler) :
 	global_hotkey_handler(global_hotkey_handler), ini_group(ini_group), items(items)
 {
-	if (_hotkey_lists == NULL) _hotkey_lists = new SmallVector<HotkeyList*, 16>();
-	*_hotkey_lists->Append() = this;
+	if (_hotkey_lists == NULL) _hotkey_lists = new std::vector<HotkeyList*>();
+	_hotkey_lists->push_back(this);
 }
 
 HotkeyList::~HotkeyList()
 {
-	_hotkey_lists->Erase(_hotkey_lists->Find(this));
+	Exclude(*_hotkey_lists, this);
 }
 
 /**
@@ -313,11 +313,11 @@ static void SaveLoadHotkeys(bool save)
 	IniFile *ini = new IniFile();
 	ini->LoadFromDisk(_hotkeys_file, NO_DIRECTORY);
 
-	for (HotkeyList **list = _hotkey_lists->Begin(); list != _hotkey_lists->End(); ++list) {
+	for (auto &list : *_hotkey_lists) {
 		if (save) {
-			(*list)->Save(ini);
+			list->Save(ini);
 		} else {
-			(*list)->Load(ini);
+			list->Load(ini);
 		}
 	}
 
@@ -340,11 +340,11 @@ void SaveHotkeysToConfig()
 
 void HandleGlobalHotkeys(WChar key, uint16 keycode)
 {
-	for (HotkeyList **list = _hotkey_lists->Begin(); list != _hotkey_lists->End(); ++list) {
-		if ((*list)->global_hotkey_handler == NULL) continue;
+	for (auto &list : *_hotkey_lists) {
+		if (list->global_hotkey_handler == NULL) continue;
 
-		int hotkey = (*list)->CheckMatch(keycode, true);
-		if (hotkey >= 0 && ((*list)->global_hotkey_handler(hotkey) == ES_HANDLED)) return;
+		int hotkey = list->CheckMatch(keycode, true);
+		if (hotkey >= 0 && (list->global_hotkey_handler(hotkey) == ES_HANDLED)) return;
 	}
 }
 

--- a/src/hotkeys.h
+++ b/src/hotkeys.h
@@ -29,7 +29,7 @@ struct Hotkey {
 
 	const char *name;
 	int num;
-	SmallVector<uint16, 1> keycodes;
+	std::vector<uint16> keycodes;
 };
 
 #define HOTKEY_LIST_END Hotkey((uint16)0, NULL, -1)

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2391,7 +2391,7 @@ static int WhoCanServiceIndustry(Industry *ind)
 	StationList stations;
 	FindStationsAroundTiles(ind->location, &stations);
 
-	if (stations.Length() == 0) return 0; // No stations found at all => nobody services
+	if (stations.empty()) return 0; // No stations found at all => nobody services
 
 	const Vehicle *v;
 	int result = 0;
@@ -2427,7 +2427,7 @@ static int WhoCanServiceIndustry(Industry *ind)
 				/* Same cargo produced by industry is dropped here => not serviced by vehicle v */
 				if ((o->GetUnloadType() & OUFB_UNLOAD) && !c_accepts) break;
 
-				if (stations.Contains(st)) {
+				if (Contains(stations, st)) {
 					if (v->owner == _local_company) return 2; // Company services industry
 					result = 1; // Competitor services industry
 				}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2096,7 +2096,7 @@ next_cargo: ;
 struct IndustryCargoesWindow : public Window {
 	static const int HOR_TEXT_PADDING, VERT_TEXT_PADDING;
 
-	typedef SmallVector<CargoesRow, 4> Fields;
+	using Fields = std::vector<CargoesRow>;
 
 	Fields fields;  ///< Fields to display in the #WID_IC_PANEL.
 	uint ind_cargo; ///< If less than #NUM_INDUSTRYTYPES, an industry type, else a cargo id + NUM_INDUSTRYTYPES.
@@ -2348,15 +2348,15 @@ struct IndustryCargoesWindow : public Window {
 		this->ind_cargo = it;
 		_displayed_industries.reset();
 		_displayed_industries.set(it);
-
-		this->fields.Clear();
-		CargoesRow *row = this->fields.Append();
-		row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
-		row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[2].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[3].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[4].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
-
+		{
+			this->fields.clear();
+			auto row = Extend(this->fields, 1);
+			row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
+			row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
+			row->columns[2].MakeEmpty(CFT_SMALL_EMPTY);
+			row->columns[3].MakeEmpty(CFT_SMALL_EMPTY);
+			row->columns[4].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
+		}
 		const IndustrySpec *central_sp = GetIndustrySpec(it);
 		bool houses_supply = HousesCanSupply(central_sp->accepts_cargo, lengthof(central_sp->accepts_cargo));
 		bool houses_accept = HousesCanAccept(central_sp->produced_cargo, lengthof(central_sp->produced_cargo));
@@ -2365,7 +2365,7 @@ struct IndustryCargoesWindow : public Window {
 		int num_cust = CountMatchingAcceptingIndustries(central_sp->produced_cargo, lengthof(central_sp->produced_cargo)) + houses_accept;
 		int num_indrows = max(3, max(num_supp, num_cust)); // One is needed for the 'it' industry, and 2 for the cargo labels.
 		for (int i = 0; i < num_indrows; i++) {
-			CargoesRow *row = this->fields.Append();
+			auto row = Extend(this->fields, 1);
 			row->columns[0].MakeEmpty(CFT_EMPTY);
 			row->columns[1].MakeCargo(central_sp->accepts_cargo, lengthof(central_sp->accepts_cargo));
 			row->columns[2].MakeEmpty(CFT_EMPTY);
@@ -2426,22 +2426,22 @@ struct IndustryCargoesWindow : public Window {
 		this->GetWidget<NWidgetCore>(WID_IC_CAPTION)->widget_data = STR_INDUSTRY_CARGOES_CARGO_CAPTION;
 		this->ind_cargo = cid + NUM_INDUSTRYTYPES;
 		_displayed_industries.reset();
-
-		this->fields.Clear();
-		CargoesRow *row = this->fields.Append();
-		row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
-		row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[2].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
-		row->columns[3].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[4].MakeEmpty(CFT_SMALL_EMPTY);
-
+		{
+			this->fields.clear();
+			auto row = Extend(this->fields, 1);
+			row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
+			row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
+			row->columns[2].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
+			row->columns[3].MakeEmpty(CFT_SMALL_EMPTY);
+			row->columns[4].MakeEmpty(CFT_SMALL_EMPTY);
+		}
 		bool houses_supply = HousesCanSupply(&cid, 1);
 		bool houses_accept = HousesCanAccept(&cid, 1);
 		int num_supp = CountMatchingProducingIndustries(&cid, 1) + houses_supply + 1; // Ensure room for the cargo label.
 		int num_cust = CountMatchingAcceptingIndustries(&cid, 1) + houses_accept;
 		int num_indrows = max(num_supp, num_cust);
 		for (int i = 0; i < num_indrows; i++) {
-			CargoesRow *row = this->fields.Append();
+			auto row = Extend(this->fields, 1);
 			row->columns[0].MakeEmpty(CFT_EMPTY);
 			row->columns[1].MakeCargo(&cid, 1);
 			row->columns[2].MakeEmpty(CFT_EMPTY);
@@ -2524,7 +2524,7 @@ struct IndustryCargoesWindow : public Window {
 
 		const NWidgetBase *nwp = this->GetWidget<NWidgetBase>(WID_IC_PANEL);
 		int vpos = -this->vscroll->GetPosition() * nwp->resize_y;
-		for (uint i = 0; i < this->fields.Length(); i++) {
+		for (uint i = 0; i < this->fields.size(); i++) {
 			int row_height = (i == 0) ? CargoesField::small_height : CargoesField::normal_height;
 			if (vpos + row_height >= 0) {
 				int xpos = left_pos;
@@ -2566,7 +2566,7 @@ struct IndustryCargoesWindow : public Window {
 		if (pt.y < vpos) return false;
 
 		int row = (pt.y - vpos) / CargoesField::normal_height; // row is relative to row 1.
-		if (row + 1 >= (int)this->fields.Length()) return false;
+		if (row + 1 >= (int)this->fields.size()) return false;
 		vpos = pt.y - vpos - row * CargoesField::normal_height; // Position in the row + 1 field
 		row++; // rebase row to match index of this->fields.
 

--- a/src/language.h
+++ b/src/language.h
@@ -96,7 +96,7 @@ struct LanguageMetadata : public LanguagePackHeader {
 };
 
 /** Type for the list of language meta data. */
-typedef SmallVector<LanguageMetadata, 4> LanguageList;
+using LanguageList = std::vector<LanguageMetadata>;
 
 /** The actual list of language meta data. */
 extern LanguageList _languages;

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -139,7 +139,7 @@ void LinkGraph::RemoveNode(NodeID id)
 		node_edges[id] = node_edges[last_node];
 	}
 	Station::Get(this->nodes[last_node].station)->goods[this->cargo].node = id;
-	this->nodes.Erase(this->nodes.Get(id));
+	Erase(this->nodes, this->nodes.begin() + id);
 	this->edges.EraseColumn(id);
 	/* Not doing EraseRow here, as having the extra invalid row doesn't hurt
 	 * and removing it would trigger a lot of memmove. The data has already
@@ -159,7 +159,7 @@ NodeID LinkGraph::AddNode(const Station *st)
 	const GoodsEntry &good = st->goods[this->cargo];
 
 	NodeID new_node = this->Size();
-	this->nodes.Append();
+	Extend(this->nodes, 1);
 	/* Avoid reducing the height of the matrix as that is expensive and we
 	 * most likely will increase it again later which is again expensive. */
 	this->edges.Resize(new_node + 1U,
@@ -283,7 +283,7 @@ void LinkGraph::Init(uint size)
 {
 	assert(this->Size() == 0);
 	this->edges.Resize(size, size);
-	this->nodes.Resize(size);
+	this->nodes.resize(size);
 
 	for (uint i = 0; i < size; ++i) {
 		this->nodes[i].Init();

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -435,7 +435,7 @@ public:
 		void RemoveEdge(NodeID to);
 	};
 
-	typedef SmallVector<BaseNode, 16> NodeVector;
+	using NodeVector = std::vector<BaseNode>;
 	typedef SmallMatrix<BaseEdge> EdgeMatrix;
 
 	/** Minimum effective distance for timeout calculation. */
@@ -496,7 +496,7 @@ public:
 	 * Get the current size of the component.
 	 * @return Size.
 	 */
-	inline uint Size() const { return this->nodes.Length(); }
+	inline uint Size() const { return this->nodes.size(); }
 
 	/**
 	 * Get date of last compression.

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -179,7 +179,7 @@ LinkGraphJob::~LinkGraphJob()
 void LinkGraphJob::Init()
 {
 	uint size = this->Size();
-	this->nodes.Resize(size);
+	this->nodes.resize(size);
 	this->edges.Resize(size, size);
 	for (uint i = 0; i < size; ++i) {
 		this->nodes[i].Init(this->link_graph[i].Supply());

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -50,7 +50,7 @@ private:
 		void Init(uint supply);
 	};
 
-	typedef SmallVector<NodeAnnotation, 16> NodeAnnotationVector;
+	using NodeAnnotationVector = std::vector<NodeAnnotation>;
 	typedef SmallMatrix<EdgeAnnotation> EdgeAnnotationMatrix;
 
 	friend const SaveLoad *GetLinkGraphJobDesc();

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -20,7 +20,7 @@
 #ifdef ENABLE_NETWORK
 
 class NetworkAddress;
-typedef SmallVector<NetworkAddress, 4> NetworkAddressList; ///< Type for a list of addresses.
+using NetworkAddressList = std::vector<NetworkAddress>; ///< Type for a list of addresses.
 typedef SmallMap<NetworkAddress, SOCKET, 4> SocketList;    ///< Type for a mapping between address and socket.
 
 /**

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -102,7 +102,18 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // GE
 		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
 
 		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
-		if (!broadcast->Contains(addr)) *broadcast->Append() = addr;
+		//if (!broadcast->Contains(addr)) *broadcast->Append() = addr;
+		//Include(*broadcast, addr);
+		//if (broadcast->end() == Find(*broadcast, addr)) broadcast->push_back(addr);
+		bool found = false;
+		for (const auto& elem : *broadcast) {
+			if (elem == addr) {
+				found = true;
+				break;
+			}
+		}
+		if (not found) broadcast->push_back(addr);
+		// missing operator ==(const&r)const {can't use Include()}
 	}
 	freeifaddrs(ifap);
 }
@@ -202,9 +213,9 @@ void NetworkFindBroadcastIPs(NetworkAddressList *broadcast)
 	/* Now display to the debug all the detected ips */
 	DEBUG(net, 3, "Detected broadcast addresses:");
 	int i = 0;
-	for (NetworkAddress *addr = broadcast->Begin(); addr != broadcast->End(); addr++) {
-		addr->SetPort(NETWORK_DEFAULT_PORT);
-		DEBUG(net, 3, "%d) %s", i++, addr->GetHostname());
+	for (auto &addr : *broadcast) {
+		addr.SetPort(NETWORK_DEFAULT_PORT);
+		DEBUG(net, 3, "%d) %s", i++, addr.GetHostname());
 	}
 }
 

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -21,7 +21,7 @@
 #include "../../safeguards.h"
 
 /** List of connections that are currently being created */
-static SmallVector<TCPConnecter *,  1> _tcp_connecters;
+static std::vector<TCPConnecter *> _tcp_connecters;
 
 /**
  * Create a new connecter for the given address
@@ -34,7 +34,7 @@ TCPConnecter::TCPConnecter(const NetworkAddress &address) :
 	sock(INVALID_SOCKET),
 	address(address)
 {
-	*_tcp_connecters.Append() = this;
+	_tcp_connecters.push_back(this);
 	if (!ThreadObject::New(TCPConnecter::ThreadEntry, this, &this->thread, "ottd:tcp")) {
 		this->Connect();
 	}
@@ -68,22 +68,22 @@ void TCPConnecter::Connect()
  */
 /* static */ void TCPConnecter::CheckCallbacks()
 {
-	for (TCPConnecter **iter = _tcp_connecters.Begin(); iter < _tcp_connecters.End(); /* nothing */) {
+	for (auto iter = _tcp_connecters.begin(); iter < _tcp_connecters.end(); /* nothing */) {
 		TCPConnecter *cur = *iter;
 		if ((cur->connected || cur->aborted) && cur->killed) {
-			_tcp_connecters.Erase(iter);
+			Erase(_tcp_connecters, iter);
 			if (cur->sock != INVALID_SOCKET) closesocket(cur->sock);
 			delete cur;
 			continue;
 		}
 		if (cur->connected) {
-			_tcp_connecters.Erase(iter);
+			Erase(_tcp_connecters, iter);
 			cur->OnConnect(cur->sock);
 			delete cur;
 			continue;
 		}
 		if (cur->aborted) {
-			_tcp_connecters.Erase(iter);
+			Erase(_tcp_connecters, iter);
 			cur->OnFailure();
 			delete cur;
 			continue;
@@ -95,7 +95,7 @@ void TCPConnecter::Connect()
 /** Kill all connection attempts. */
 /* static */ void TCPConnecter::KillAll()
 {
-	for (TCPConnecter **iter = _tcp_connecters.Begin(); iter != _tcp_connecters.End(); iter++) (*iter)->killed = true;
+	for (auto &c : _tcp_connecters) c->killed = true;
 }
 
 #endif /* ENABLE_NETWORK */

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -23,7 +23,7 @@
 #include "../../safeguards.h"
 
 /** List of open HTTP connections. */
-static SmallVector<NetworkHTTPSocketHandler *, 1> _http_connections;
+static std::vector<NetworkHTTPSocketHandler *> _http_connections;
 
 /**
  * Start the querying
@@ -65,7 +65,7 @@ NetworkHTTPSocketHandler::NetworkHTTPSocketHandler(SOCKET s,
 		return;
 	}
 
-	*_http_connections.Append() = this;
+	_http_connections.push_back(this);
 }
 
 /** Free whatever needs to be freed. */
@@ -299,15 +299,13 @@ int NetworkHTTPSocketHandler::Receive()
 /* static */ void NetworkHTTPSocketHandler::HTTPReceive()
 {
 	/* No connections, just bail out. */
-	if (_http_connections.Length() == 0) return;
+	if (_http_connections.empty()) return;
 
 	fd_set read_fd;
 	struct timeval tv;
 
 	FD_ZERO(&read_fd);
-	for (NetworkHTTPSocketHandler **iter = _http_connections.Begin(); iter < _http_connections.End(); iter++) {
-		FD_SET((*iter)->sock, &read_fd);
-	}
+	for (auto &c : _http_connections) FD_SET(c->sock, &read_fd);
 
 	tv.tv_sec = tv.tv_usec = 0; // don't block at all.
 #if !defined(__MORPHOS__) && !defined(__AMIGA__)
@@ -317,7 +315,7 @@ int NetworkHTTPSocketHandler::Receive()
 #endif
 	if (n == -1) return;
 
-	for (NetworkHTTPSocketHandler **iter = _http_connections.Begin(); iter < _http_connections.End(); /* nothing */) {
+	for (auto iter = _http_connections.begin(); iter < _http_connections.end(); /* nothing */) {
 		NetworkHTTPSocketHandler *cur = *iter;
 
 		if (FD_ISSET(cur->sock, &read_fd)) {
@@ -327,7 +325,7 @@ int NetworkHTTPSocketHandler::Receive()
 			if (ret <= 0) {
 				/* Then... the connection can be closed */
 				cur->CloseConnection();
-				_http_connections.Erase(iter);
+				Erase(_http_connections, iter);
 				delete cur;
 				continue;
 			}

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -151,9 +151,7 @@ public:
 		NetworkAddressList addresses;
 		GetBindAddresses(&addresses, port);
 
-		for (NetworkAddress *address = addresses.Begin(); address != addresses.End(); address++) {
-			address->Listen(SOCK_STREAM, &sockets);
-		}
+		for (auto &a : addresses) a.Listen(SOCK_STREAM, &sockets);
 
 		if (sockets.Length() == 0) {
 			DEBUG(net, 0, "[server] could not start network: could not create listening socket");

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -27,15 +27,13 @@
 NetworkUDPSocketHandler::NetworkUDPSocketHandler(NetworkAddressList *bind)
 {
 	if (bind != NULL) {
-		for (NetworkAddress *addr = bind->Begin(); addr != bind->End(); addr++) {
-			*this->bind.Append() = *addr;
-		}
+		for (auto &addr : *bind) this->bind.push_back(addr);
 	} else {
 		/* As hostname NULL and port 0/NULL don't go well when
 		 * resolving it we need to add an address for each of
 		 * the address families we support. */
-		*this->bind.Append() = NetworkAddress(NULL, 0, AF_INET);
-		*this->bind.Append() = NetworkAddress(NULL, 0, AF_INET6);
+		this->bind.emplace_back(nullptr, 0, AF_INET);
+		this->bind.emplace_back(nullptr, 0, AF_INET6);
 	}
 }
 
@@ -49,9 +47,7 @@ bool NetworkUDPSocketHandler::Listen()
 	/* Make sure socket is closed */
 	this->Close();
 
-	for (NetworkAddress *addr = this->bind.Begin(); addr != this->bind.End(); addr++) {
-		addr->Listen(SOCK_DGRAM, &this->sockets);
-	}
+	for (auto &addr : this->bind) addr.Listen(SOCK_DGRAM, &this->sockets);
 
 	return this->sockets.Length() != 0;
 }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -635,13 +635,11 @@ void NetworkAddServer(const char *b)
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port)
 {
 	for (char **iter = _network_bind_list.Begin(); iter != _network_bind_list.End(); iter++) {
-		*addresses->Append() = NetworkAddress(*iter, port);
+		addresses->emplace_back(*iter, port);
 	}
 
 	/* No address, so bind to everything. */
-	if (addresses->Length() == 0) {
-		*addresses->Append() = NetworkAddress("", port);
-	}
+	if (addresses->empty()) addresses->emplace_back("", port);
 }
 
 /* Generates the list of manually added hosts from NetworkGameList and

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -18,14 +18,14 @@
 #if defined(ENABLE_NETWORK)
 
 /** Vector with content info */
-typedef SmallVector<ContentInfo *, 16> ContentVector;
+using ContentVector = std::vector<ContentInfo *>;
 /** Vector with constant content info */
-typedef SmallVector<const ContentInfo *, 16> ConstContentVector;
+using ConstContentVector = std::vector<const ContentInfo *> ;
 
 /** Iterator for the content vector */
-typedef ContentInfo **ContentIterator;
+using ContentIterator = ContentVector::iterator;
 /** Iterator for the constant content vector */
-typedef const ContentInfo * const * ConstContentIterator;
+using ConstContentIterator = ContentVector::const_iterator;
 
 /** Callbacks for notifying others about incoming data */
 struct ContentCallback {
@@ -131,13 +131,13 @@ public:
 	void CheckDependencyState(ContentInfo *ci);
 
 	/** Get the number of content items we know locally. */
-	uint Length() const { return this->infos.Length(); }
+	uint Length() const { return this->infos.size(); }
 	/** Get the begin of the content inf iterator. */
-	ConstContentIterator Begin() const { return this->infos.Begin(); }
+	ConstContentIterator Begin() const { return this->infos.begin(); }
 	/** Get the nth position of the content inf iterator. */
-	ConstContentIterator Get(uint32 index) const { return this->infos.Get(index); }
+	ConstContentIterator Get(uint32 index) const { return this->Begin() + index; }
 	/** Get the end of the content inf iterator. */
-	ConstContentIterator End() const { return this->infos.End(); }
+	ConstContentIterator End() const { return this->infos.end(); }
 
 	void Clear();
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -334,7 +334,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 			pos = strecpy(pos, "do=searchgrfid&q=", last);
 
 			bool first = true;
-			for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
+			for (auto iter = this->content.Begin(); iter != this->content.End(); iter++) {
 				const ContentInfo *ci = *iter;
 				if (ci->state != ContentInfo::DOES_NOT_EXIST) continue;
 
@@ -436,7 +436,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	{
 		if (!this->content.Sort()) return;
 
-		for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
+		for (auto iter = this->content.Begin(); iter != this->content.End(); iter++) {
 			if (*iter == this->selected) {
 				this->list_pos = iter - this->content.Begin();
 				break;
@@ -479,7 +479,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		if (!changed) return;
 
 		/* update list position */
-		for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
+		for (auto iter = this->content.Begin(); iter != this->content.End(); iter++) {
 			if (*iter == this->selected) {
 				this->list_pos = iter - this->content.Begin();
 				return;
@@ -642,7 +642,7 @@ public:
 		int text_y_offset = WD_MATRIX_TOP + (line_height - FONT_HEIGHT_NORMAL) / 2;
 		uint y = r.top;
 		int cnt = 0;
-		for (ConstContentIterator iter = this->content.Get(this->vscroll->GetPosition()); iter != this->content.End() && cnt < this->vscroll->GetCapacity(); iter++, cnt++) {
+		for (auto iter = this->content.Get(this->vscroll->GetPosition()); iter != this->content.End() && cnt < this->vscroll->GetCapacity(); iter++, cnt++) {
 			const ContentInfo *ci = *iter;
 
 			if (ci == this->selected) GfxFillRect(r.left + 1, y + 1, r.right - 1, y + this->resize.step_height - 1, PC_GREY);
@@ -767,8 +767,7 @@ public:
 
 			char buf[DRAW_STRING_BUFFER] = "";
 			char *p = buf;
-			for (ConstContentIterator iter = tree.Begin(); iter != tree.End(); iter++) {
-				const ContentInfo *ci = *iter;
+			for (auto &ci : tree) {
 				if (ci == this->selected || ci->state != ContentInfo::SELECTED) continue;
 
 				p += seprintf(p, lastof(buf), buf == p ? "%s" : ", %s", ci->name);
@@ -991,7 +990,7 @@ public:
 		this->filesize_sum = 0;
 		bool show_select_all = false;
 		bool show_select_upgrade = false;
-		for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
+		for (auto iter = this->content.Begin(); iter != this->content.End(); iter++) {
 			const ContentInfo *ci = *iter;
 			switch (ci->state) {
 				case ContentInfo::SELECTED:

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -497,12 +497,12 @@ void ClientNetworkUDPSocketHandler::HandleIncomingNetworkGameInfoGRFConfig(GRFCo
 /** Broadcast to all ips */
 static void NetworkUDPBroadCast(NetworkUDPSocketHandler *socket)
 {
-	for (NetworkAddress *addr = _broadcast_list.Begin(); addr != _broadcast_list.End(); addr++) {
+	for (auto &addr : _broadcast_list) {
 		Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
 
-		DEBUG(net, 4, "[udp] broadcasting to %s", addr->GetHostname());
+		DEBUG(net, 4, "[udp] broadcasting to %s", addr.GetHostname());
 
-		socket->SendPacket(&p, addr, true, true);
+		socket->SendPacket(&p, &addr, true, true);
 	}
 }
 
@@ -670,7 +670,7 @@ void NetworkUDPInitialize()
 	GetBindAddresses(&server, _settings_client.network.server_port);
 	_udp_server_socket = new ServerNetworkUDPSocketHandler(&server);
 
-	server.Clear();
+	server.clear();
 	GetBindAddresses(&server, 0);
 	_udp_master_socket = new MasterNetworkUDPSocketHandler(&server);
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1564,9 +1564,9 @@ void ShowMissingContentWindow(const GRFConfig *list)
 		strecpy(ci->name, c->GetName(), lastof(ci->name));
 		ci->unique_id = BSWAP32(c->ident.grfid);
 		memcpy(ci->md5sum, HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum, sizeof(ci->md5sum));
-		*cv.Append() = ci;
+		cv.push_back(ci);
 	}
-	ShowNetworkContentListWindow(cv.Length() == 0 ? NULL : &cv, CONTENT_TYPE_NEWGRF);
+	ShowNetworkContentListWindow(cv.empty() ? NULL : &cv, CONTENT_TYPE_NEWGRF);
 }
 #endif
 

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -350,8 +350,7 @@ static uint32 GetDistanceFromNearbyHouse(uint8 parameter, TileIndex tile, HouseI
 
 			/* Collect acceptance stats. */
 			uint32 res = 0;
-			for (Station * const * st_iter = sl->Begin(); st_iter != sl->End(); st_iter++) {
-				const Station *st = *st_iter;
+			for (const auto &st : *sl) {
 				if (HasBit(st->goods[cid].status, GoodsEntry::GES_EVER_ACCEPTED))    SetBit(res, 0);
 				if (HasBit(st->goods[cid].status, GoodsEntry::GES_LAST_MONTH))       SetBit(res, 1);
 				if (HasBit(st->goods[cid].status, GoodsEntry::GES_CURRENT_MONTH))    SetBit(res, 2);

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -51,11 +51,11 @@ const SaveLoad *GetLinkGraphDesc()
  */
 const SaveLoad *GetLinkGraphJobDesc()
 {
-	static SmallVector<SaveLoad, 16> saveloads;
+	static std::vector<SaveLoad> saveloads;
 	static const char *prefix = "linkgraph.";
 
 	/* Build the SaveLoad array on first call and don't touch it later on */
-	if (saveloads.Length() == 0) {
+	if (saveloads.empty()) {
 		size_t offset_gamesettings = cpp_offsetof(GameSettings, linkgraph);
 		size_t offset_component = cpp_offsetof(LinkGraphJob, settings);
 
@@ -69,7 +69,7 @@ const SaveLoad *GetLinkGraphJobDesc()
 				char *&address = reinterpret_cast<char *&>(sl.address);
 				address -= offset_gamesettings;
 				address += offset_component;
-				*(saveloads.Append()) = sl;
+				saveloads.push_back(sl);
 			}
 			desc = GetSettingDescription(++setting);
 		}
@@ -82,8 +82,8 @@ const SaveLoad *GetLinkGraphJobDesc()
 
 		int i = 0;
 		do {
-			*(saveloads.Append()) = job_desc[i++];
-		} while (saveloads[saveloads.Length() - 1].cmd != SL_END);
+			saveloads.push_back(job_desc[i++]);
+		} while (saveloads[saveloads.size() - 1].cmd != SL_END);
 	}
 
 	return &saveloads[0];

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -42,7 +42,7 @@ struct OldWaypoint {
 };
 
 /** Temporary array with old waypoints. */
-static SmallVector<OldWaypoint, 16> _old_waypoints;
+static std::vector<OldWaypoint> _old_waypoints;
 
 /**
  * Update the waypoint orders to get the new waypoint ID.
@@ -52,10 +52,10 @@ static void UpdateWaypointOrder(Order *o)
 {
 	if (!o->IsType(OT_GOTO_WAYPOINT)) return;
 
-	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-		if (wp->index != o->GetDestination()) continue;
+	for (auto &wp : _old_waypoints) {
+		if (wp.index != o->GetDestination()) continue;
 
-		o->SetDestination((DestinationID)wp->new_index);
+		o->SetDestination((DestinationID)wp.new_index);
 		return;
 	}
 }
@@ -71,47 +71,47 @@ void MoveWaypointsToBaseStations()
 	 * id which was stored in m4 is now saved as a grf/id reference in the
 	 * waypoint struct. */
 	if (IsSavegameVersionBefore(17)) {
-		for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-			if (wp->delete_ctr != 0) continue; // The waypoint was deleted
+		for (auto &wp : _old_waypoints) {
+			if (wp.delete_ctr != 0) continue; // The waypoint was deleted
 
 			/* Waypoint indices were not added to the map prior to this. */
-			_m[wp->xy].m2 = (StationID)wp->index;
+			_m[wp.xy].m2 = (StationID)wp.index;
 
-			if (HasBit(_m[wp->xy].m3, 4)) {
-				wp->spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(_m[wp->xy].m4 + 1);
+			if (HasBit(_m[wp.xy].m3, 4)) {
+				wp.spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(_m[wp.xy].m4 + 1);
 			}
 		}
 	} else {
 		/* As of version 17, we recalculate the custom graphic ID of waypoints
 		 * from the GRF ID / station index. */
-		for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
+		for (auto &wp : _old_waypoints) {
 			StationClass* stclass = StationClass::Get(STAT_CLASS_WAYP);
 			for (uint i = 0; i < stclass->GetSpecCount(); i++) {
 				const StationSpec *statspec = stclass->GetSpec(i);
-				if (statspec != NULL && statspec->grf_prop.grffile->grfid == wp->grfid && statspec->grf_prop.local_id == wp->localidx) {
-					wp->spec = statspec;
+				if (statspec != NULL && statspec->grf_prop.grffile->grfid == wp.grfid && statspec->grf_prop.local_id == wp.localidx) {
+					wp.spec = statspec;
 					break;
 				}
 			}
 		}
 	}
 
-	if (!Waypoint::CanAllocateItem(_old_waypoints.Length())) SlError(STR_ERROR_TOO_MANY_STATIONS_LOADING);
+	if (!Waypoint::CanAllocateItem(_old_waypoints.size())) SlError(STR_ERROR_TOO_MANY_STATIONS_LOADING);
 
 	/* All saveload conversions have been done. Create the new waypoints! */
-	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-		Waypoint *new_wp = new Waypoint(wp->xy);
-		new_wp->town       = wp->town;
-		new_wp->town_cn    = wp->town_cn;
-		new_wp->name       = wp->name;
+	for (auto &wp : _old_waypoints) {
+		Waypoint *new_wp = new Waypoint(wp.xy);
+		new_wp->town       = wp.town;
+		new_wp->town_cn    = wp.town_cn;
+		new_wp->name       = wp.name;
 		new_wp->delete_ctr = 0; // Just reset delete counter for once.
-		new_wp->build_date = wp->build_date;
-		new_wp->owner      = wp->owner;
+		new_wp->build_date = wp.build_date;
+		new_wp->owner      = wp.owner;
 
 		new_wp->string_id = STR_SV_STNAME_WAYPOINT;
 
-		TileIndex t = wp->xy;
-		if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && _m[t].m2 == wp->index) {
+		TileIndex t = wp.xy;
+		if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && _m[t].m2 == wp.index) {
 			/* The tile might've been reserved! */
 			bool reserved = !IsSavegameVersionBefore(100) && HasBit(_m[t].m5, 4);
 
@@ -122,13 +122,13 @@ void MoveWaypointsToBaseStations()
 
 			SetRailStationReservation(t, reserved);
 
-			if (wp->spec != NULL) {
-				SetCustomStationSpecIndex(t, AllocateSpecToStation(wp->spec, new_wp, true));
+			if (wp.spec != NULL) {
+				SetCustomStationSpecIndex(t, AllocateSpecToStation(wp.spec, new_wp, true));
 			}
 			new_wp->rect.BeforeAddTile(t, StationRect::ADD_FORCE);
 		}
 
-		wp->new_index = new_wp->index;
+		wp.new_index = new_wp->index;
 	}
 
 	/* Update the orders of vehicles */
@@ -146,7 +146,7 @@ void MoveWaypointsToBaseStations()
 		UpdateWaypointOrder(&v->current_order);
 	}
 
-	_old_waypoints.Reset();
+	Reset(_old_waypoints);
 }
 
 static const SaveLoad _old_waypoint_desc[] = {
@@ -172,12 +172,12 @@ static const SaveLoad _old_waypoint_desc[] = {
 static void Load_WAYP()
 {
 	/* Precaution for when loading failed and it didn't get cleared */
-	_old_waypoints.Clear();
+	_old_waypoints.clear();
 
 	int index;
 
 	while ((index = SlIterateArray()) != -1) {
-		OldWaypoint *wp = _old_waypoints.Append();
+		auto wp = &*Extend(_old_waypoints, 1);
 		memset(wp, 0, sizeof(*wp));
 
 		wp->index = index;
@@ -187,27 +187,27 @@ static void Load_WAYP()
 
 static void Ptrs_WAYP()
 {
-	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-		SlObject(wp, _old_waypoint_desc);
+	for (auto &wp : _old_waypoints) {
+		SlObject(&wp, _old_waypoint_desc);
 
 		if (IsSavegameVersionBefore(12)) {
-			wp->town_cn = (wp->string_id & 0xC000) == 0xC000 ? (wp->string_id >> 8) & 0x3F : 0;
-			wp->town = ClosestTownFromTile(wp->xy, UINT_MAX);
+			wp.town_cn = (wp.string_id & 0xC000) == 0xC000 ? (wp.string_id >> 8) & 0x3F : 0;
+			wp.town = ClosestTownFromTile(wp.xy, UINT_MAX);
 		} else if (IsSavegameVersionBefore(122)) {
 			/* Only for versions 12 .. 122 */
-			if (!Town::IsValidID(wp->town_index)) {
+			if (!Town::IsValidID(wp.town_index)) {
 				/* Upon a corrupted waypoint we'll likely get here. The next step will be to
 				 * loop over all Ptrs procs to NULL the pointers. However, we don't know
 				 * whether we're in the NULL or "normal" Ptrs proc. So just clear the list
 				 * of old waypoints we constructed and then this waypoint (and the other
 				 * possibly corrupt ones) will not be queried in the NULL Ptrs proc run. */
-				_old_waypoints.Clear();
+				_old_waypoints.clear();
 				SlErrorCorrupt("Referencing invalid Town");
 			}
-			wp->town = Town::Get(wp->town_index);
+			wp.town = Town::Get(wp.town_index);
 		}
 		if (IsSavegameVersionBefore(84)) {
-			wp->name = CopyFromOldName(wp->string_id);
+			wp.name = CopyFromOldName(wp.string_id);
 		}
 	}
 }

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -134,7 +134,7 @@
 	Industry *ind = ::Industry::Get(industry_id);
 	StationList stations;
 	::FindStationsAroundTiles(ind->location, &stations);
-	return (int32)stations.Length();
+	return (int32)stations.size();
 }
 
 /* static */ int32 ScriptIndustry::GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile)

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -273,7 +273,7 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_LANG_DROPDOWN: { // Setup interface language dropdown
 				list = new DropDownList();
-				for (uint i = 0; i < _languages.Length(); i++) {
+				for (uint i = 0; i < _languages.size(); i++) {
 					if (&_languages[i] == _current_language) *selected_index = i;
 					*list->Append() = new DropDownListStringItem(SPECSTR_LANGUAGE_START + i, i, false);
 				}

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -110,7 +110,7 @@ public:
 	/** Clear the temporary storage. */
 	void Clear()
 	{
-		this->output_buffer.Clear();
+		this->output_buffer.clear();
 	}
 
 	/**
@@ -123,12 +123,12 @@ public:
 		if (length == 0) length = strlen(text);
 
 		if (length > 0 && this->BufferHasRoom()) {
-			int stored_size = this->output_buffer[this->output_buffer.Length() - 1].Add(text, length);
+			int stored_size = this->output_buffer.back().Add(text, length);
 			length -= stored_size;
 			text += stored_size;
 		}
 		while (length > 0) {
-			OutputBuffer *block = this->output_buffer.Append();
+			auto block = Extend(this->output_buffer, 1);
 			block->Clear(); // Initialize the new block.
 			int stored_size = block->Add(text, length);
 			length -= stored_size;
@@ -142,9 +142,7 @@ public:
 	 */
 	void Write(FILE *out_fp) const
 	{
-		for (const OutputBuffer *out_data = this->output_buffer.Begin(); out_data != this->output_buffer.End(); out_data++) {
-			out_data->Write(out_fp);
-		}
+		for (auto &out_data : this->output_buffer) out_data.Write(out_fp);
 	}
 
 private:
@@ -154,12 +152,10 @@ private:
 	 */
 	bool BufferHasRoom() const
 	{
-		uint num_blocks = this->output_buffer.Length();
-		return num_blocks > 0 && this->output_buffer[num_blocks - 1].HasRoom();
+		return (not this->output_buffer.empty()) and this->output_buffer.back().HasRoom();
 	}
 
-	typedef SmallVector<OutputBuffer, 2> OutputBufferVector; ///< Vector type for output buffers.
-	OutputBufferVector output_buffer; ///< Vector of blocks containing the stored output.
+	std::vector<OutputBuffer> output_buffer; ///< Vector of blocks containing the stored output.
 };
 
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3816,7 +3816,7 @@ void FindStationsAroundTiles(const TileArea &location, StationList *stations)
 			/* Insert the station in the set. This will fail if it has
 			 * already been added.
 			 */
-			stations->Include(st);
+			Include(*stations, st);
 		}
 	}
 }
@@ -3844,9 +3844,7 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 	uint best_rating1 = 0; // rating of st1
 	uint best_rating2 = 0; // rating of st2
 
-	for (Station * const *st_iter = all_stations->Begin(); st_iter != all_stations->End(); ++st_iter) {
-		Station *st = *st_iter;
-
+	for (auto &st : *all_stations) {
 		/* Is the station reserved exclusively for somebody else? */
 		if (st->town->exclusive_counter > 0 && st->town->exclusivity != st->owner) continue;
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2118,8 +2118,8 @@ struct TileAndStation {
 	StationID station; ///< StationID
 };
 
-static SmallVector<TileAndStation, 8> _deleted_stations_nearby;
-static SmallVector<StationID, 8> _stations_nearby_list;
+static std::vector<TileAndStation> _deleted_stations_nearby;
+static std::vector<StationID> _stations_nearby_list;
 
 /**
  * Add station on this tile to _stations_nearby_list if it's fully within the
@@ -2134,13 +2134,12 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	TileArea *ctx = (TileArea *)user_data;
 
 	/* First check if there were deleted stations here */
-	for (uint i = 0; i < _deleted_stations_nearby.Length(); i++) {
-		TileAndStation *ts = _deleted_stations_nearby.Get(i);
+	for (auto ts = _deleted_stations_nearby.begin(); ts < _deleted_stations_nearby.end(); /**/) {
 		if (ts->tile == tile) {
-			*_stations_nearby_list.Append() = _deleted_stations_nearby[i].station;
-			_deleted_stations_nearby.Erase(ts);
-			i--;
+			_stations_nearby_list.push_back(ts->station);
+			ts = Erase(_deleted_stations_nearby, ts);
 		}
+		else ++ts;
 	}
 
 	/* Check if own station and if we stay within station spread */
@@ -2152,10 +2151,10 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	if (!T::IsValidID(sid)) return false;
 
 	T *st = T::Get(sid);
-	if (st->owner != _local_company || _stations_nearby_list.Contains(sid)) return false;
+	if (st->owner != _local_company || Contains(_stations_nearby_list, sid)) return false;
 
 	if (st->rect.BeforeAddRect(ctx->tile, ctx->w, ctx->h, StationRect::ADD_TEST).Succeeded()) {
-		*_stations_nearby_list.Append() = sid;
+		_stations_nearby_list.push_back(sid);
 	}
 
 	return false; // We want to include *all* nearby stations
@@ -2175,8 +2174,8 @@ static const T *FindStationsNearby(TileArea ta, bool distant_join)
 {
 	TileArea ctx = ta;
 
-	_stations_nearby_list.Clear();
-	_deleted_stations_nearby.Clear();
+	_stations_nearby_list.clear();
+	_deleted_stations_nearby.clear();
 
 	/* Check the inside, to return, if we sit on another station */
 	TILE_AREA_LOOP(t, ta) {
@@ -2189,9 +2188,9 @@ static const T *FindStationsNearby(TileArea ta, bool distant_join)
 		if (T::IsExpected(st) && !st->IsInUse() && st->owner == _local_company) {
 			/* Include only within station spread (yes, it is strictly less than) */
 			if (max(DistanceMax(ta.tile, st->xy), DistanceMax(TILE_ADDXY(ta.tile, ta.w - 1, ta.h - 1), st->xy)) < _settings_game.station.station_spread) {
-				TileAndStation *ts = _deleted_stations_nearby.Append();
-				ts->tile = st->xy;
-				ts->station = st->index;
+				_deleted_stations_nearby.emplace_back();
+				_deleted_stations_nearby.back().tile = st->xy;
+				_deleted_stations_nearby.back().station = st->index;
 
 				/* Add the station when it's within where we're going to build */
 				if (IsInsideBS(TileX(st->xy), TileX(ctx.tile), ctx.w) &&
@@ -2257,8 +2256,8 @@ struct SelectStationWindow : Window {
 
 		/* Determine the widest string */
 		Dimension d = GetStringBoundingBox(T::EXPECTED_FACIL == FACIL_WAYPOINT ? STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT : STR_JOIN_STATION_CREATE_SPLITTED_STATION);
-		for (uint i = 0; i < _stations_nearby_list.Length(); i++) {
-			const T *st = T::Get(_stations_nearby_list[i]);
+		for (auto &nearby : _stations_nearby_list) {
+			const T *st = T::Get(nearby);
 			SetDParam(0, st->index);
 			SetDParam(1, st->facilities);
 			d = maxdim(d, GetStringBoundingBox(T::EXPECTED_FACIL == FACIL_WAYPOINT ? STR_STATION_LIST_WAYPOINT : STR_STATION_LIST_STATION));
@@ -2281,7 +2280,7 @@ struct SelectStationWindow : Window {
 			y += this->resize.step_height;
 		}
 
-		for (uint i = max<uint>(1, this->vscroll->GetPosition()); i <= _stations_nearby_list.Length(); ++i, y += this->resize.step_height) {
+		for (uint i = max<uint>(1, this->vscroll->GetPosition()); i <= _stations_nearby_list.size(); ++i, y += this->resize.step_height) {
 			/* Don't draw anything if it extends past the end of the window. */
 			if (i - this->vscroll->GetPosition() >= this->vscroll->GetCapacity()) break;
 
@@ -2300,7 +2299,7 @@ struct SelectStationWindow : Window {
 		bool distant_join = (st_index > 0);
 		if (distant_join) st_index--;
 
-		if (distant_join && st_index >= _stations_nearby_list.Length()) return;
+		if (distant_join && st_index >= _stations_nearby_list.size()) return;
 
 		/* Insert station to be joined into stored command */
 		SB(this->select_station_cmd.p2, 16, 16,
@@ -2335,7 +2334,7 @@ struct SelectStationWindow : Window {
 	{
 		if (!gui_scope) return;
 		FindStationsNearby<T>(this->area, true);
-		this->vscroll->SetCount(_stations_nearby_list.Length() + 1);
+		this->vscroll->SetCount(_stations_nearby_list.size() + 1);
 		this->SetDirty();
 	}
 };
@@ -2380,7 +2379,7 @@ static bool StationJoinerNeeded(const CommandContainer &cmd, TileArea ta)
 	 * If adjacent-stations is disabled and we are building next to a station, do not show the selection window.
 	 * but join the other station immediately. */
 	const T *st = FindStationsNearby<T>(ta, false);
-	return st == NULL && (_settings_game.station.adjacent_stations || _stations_nearby_list.Length() == 0);
+	return st == NULL && (_settings_game.station.adjacent_stations || _stations_nearby_list.empty());
 }
 
 /**

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -95,7 +95,7 @@ static const uint MAX_LENGTH_STATION_NAME_CHARS = 32; ///< The maximum length of
 typedef std::list<StationID> StationIDList;
 
 /** List of stations */
-typedef SmallVector<Station *, 2> StationList;
+using StationList = std::vector<Station *>;
 
 /**
  * Structure contains cached list of stations nearby. The list

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -596,8 +596,8 @@ class IcuStringIterator : public StringIterator
 	icu::BreakIterator *char_itr; ///< ICU iterator for characters.
 	icu::BreakIterator *word_itr; ///< ICU iterator for words.
 
-	SmallVector<UChar, 32> utf16_str;      ///< UTF-16 copy of the string.
-	SmallVector<size_t, 32> utf16_to_utf8; ///< Mapping from UTF-16 code point position to index in the UTF-8 source string.
+	std::vector<UChar> utf16_str;      ///< UTF-16 copy of the string.
+	std::vector<size_t> utf16_to_utf8; ///< Mapping from UTF-16 code point position to index in the UTF-8 source string.
 
 public:
 	IcuStringIterator() : char_itr(NULL), word_itr(NULL)
@@ -606,8 +606,8 @@ public:
 		this->char_itr = icu::BreakIterator::createCharacterInstance(icu::Locale(_current_language != NULL ? _current_language->isocode : "en"), status);
 		this->word_itr = icu::BreakIterator::createWordInstance(icu::Locale(_current_language != NULL ? _current_language->isocode : "en"), status);
 
-		*this->utf16_str.Append() = '\0';
-		*this->utf16_to_utf8.Append() = 0;
+		this->utf16_str.push_back('\0');
+		this->utf16_to_utf8.push_back(0);
 	}
 
 	virtual ~IcuStringIterator()
@@ -624,29 +624,29 @@ public:
 		 * for word break iterators (especially for CJK languages) in combination
 		 * with UTF-8 input. As a work around we have to convert the input to
 		 * UTF-16 and create a mapping back to UTF-8 character indices. */
-		this->utf16_str.Clear();
-		this->utf16_to_utf8.Clear();
+		this->utf16_str.clear();
+		this->utf16_to_utf8.clear();
 
 		while (*s != '\0') {
 			size_t idx = s - string_base;
 
 			WChar c = Utf8Consume(&s);
 			if (c < 0x10000) {
-				*this->utf16_str.Append() = (UChar)c;
+				this->utf16_str.emplace_back(c);
 			} else {
 				/* Make a surrogate pair. */
-				*this->utf16_str.Append() = (UChar)(0xD800 + ((c - 0x10000) >> 10));
-				*this->utf16_str.Append() = (UChar)(0xDC00 + ((c - 0x10000) & 0x3FF));
-				*this->utf16_to_utf8.Append() = idx;
+				this->utf16_str.emplace_back(0xD800 + ((c - 0x10000) >> 10));
+				this->utf16_str.emplace_back(0xDC00 + ((c - 0x10000) & 0x3FF));
+				this->utf16_to_utf8.push_back(idx);
 			}
-			*this->utf16_to_utf8.Append() = idx;
+			this->utf16_to_utf8.push_back(idx);
 		}
-		*this->utf16_str.Append() = '\0';
-		*this->utf16_to_utf8.Append() = s - string_base;
+		this->utf16_str.push_back('\0');
+		this->utf16_to_utf8.push_back(s - string_base);
 
 		UText text = UTEXT_INITIALIZER;
 		UErrorCode status = U_ZERO_ERROR;
-		utext_openUChars(&text, this->utf16_str.Begin(), this->utf16_str.Length() - 1, &status);
+		utext_openUChars(&text, this->utf16_str.data(), this->utf16_str.size() - 1, &status);
 		this->char_itr->setText(&text, status);
 		this->word_itr->setText(&text, status);
 		this->char_itr->first();
@@ -656,13 +656,7 @@ public:
 	virtual size_t SetCurPosition(size_t pos)
 	{
 		/* Convert incoming position to an UTF-16 string index. */
-		uint utf16_pos = 0;
-		for (uint i = 0; i < this->utf16_to_utf8.Length(); i++) {
-			if (this->utf16_to_utf8[i] == pos) {
-				utf16_pos = i;
-				break;
-			}
-		}
+		uint utf16_pos = FindIndex(this->utf16_to_utf8, pos);
 
 		/* isBoundary has the documented side-effect of setting the current
 		 * position to the first valid boundary equal to or greater than

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -28,7 +28,7 @@ static const WChar STATE_QUOTE2 = '"';
  */
 void StringFilter::SetFilterTerm(const char *str)
 {
-	this->word_index.Reset();
+	Reset(this->word_index);
 	this->word_matches = 0;
 	free(this->filter_buffer);
 
@@ -75,7 +75,7 @@ void StringFilter::SetFilterTerm(const char *str)
 
 		/* Add to word */
 		if (word == NULL) {
-			word = this->word_index.Append();
+			word = &*Extend(this->word_index, 1);
 			word->start = dest;
 			word->match = false;
 		}
@@ -91,10 +91,7 @@ void StringFilter::SetFilterTerm(const char *str)
 void StringFilter::ResetState()
 {
 	this->word_matches = 0;
-	const WordState *end = this->word_index.End();
-	for (WordState *it = this->word_index.Begin(); it != end; ++it) {
-		it->match = false;
-	}
+	for (auto &ws : this->word_index) ws.match = false;
 }
 
 /**
@@ -110,11 +107,10 @@ void StringFilter::AddLine(const char *str)
 	if (str == NULL) return;
 
 	bool match_case = this->case_sensitive != NULL && *this->case_sensitive;
-	const WordState *end = this->word_index.End();
-	for (WordState *it = this->word_index.Begin(); it != end; ++it) {
-		if (!it->match) {
-			if ((match_case ? strstr(str, it->start) : strcasestr(str, it->start)) != NULL) {
-				it->match = true;
+	for (auto &ws : this->word_index) {
+		if (not ws.match) {
+			if ((match_case ? strstr(str, ws.start) : strcasestr(str, ws.start)) != NULL) {
+				ws.match = true;
 				this->word_matches++;
 			}
 		}

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -39,7 +39,7 @@ private:
 	};
 
 	const char *filter_buffer;                     ///< Parsed filter string. Words separated by 0.
-	SmallVector<WordState, 4> word_index;          ///< Word index and filter state.
+	std::vector<WordState> word_index;          ///< Word index and filter state.
 	uint word_matches;                             ///< Summary of filter state: Number of words matched.
 
 	const bool *case_sensitive;                    ///< Match case-sensitively (usually a static variable).
@@ -58,7 +58,7 @@ public:
 	 * Check whether any filter words were entered.
 	 * @return true if no words were entered.
 	 */
-	bool IsEmpty() const { return this->word_index.Length() == 0; }
+	bool IsEmpty() const { return this->word_index.empty(); }
 
 	void ResetState();
 	void AddLine(const char *str);
@@ -68,7 +68,7 @@ public:
 	 * Get the matching state of the current item.
 	 * @return true if matched.
 	 */
-	bool GetState() const { return this->word_matches == this->word_index.Length(); }
+	bool GetState() const { return this->word_matches == this->word_index.size(); }
 };
 
 #endif /* STRINGFILTER_TYPE_H */

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -561,7 +561,7 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 
 	/* Remember all towns near this station (at least one house in its catchment radius)
 	 * which are destination of subsidised path. Do that only if needed */
-	SmallVector<const Town *, 2> towns_near;
+	std::vector<const Town *> towns_near;
 	if (!st->rect.IsEmpty()) {
 		Subsidy *s;
 		FOR_ALL_SUBSIDIES(s) {
@@ -577,7 +577,7 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 					TileIndex tile = TileXY(x, y);
 					if (!IsTileType(tile, MP_HOUSE)) continue;
 					const Town *t = Town::GetByTile(tile);
-					if (t->cache.part_of_subsidy & POS_DST) towns_near.Include(t);
+					if (t->cache.part_of_subsidy & POS_DST) Include(towns_near, t);
 				}
 			}
 			break;
@@ -602,9 +602,9 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 					}
 					break;
 				case ST_TOWN:
-					for (const Town * const *tp = towns_near.Begin(); tp != towns_near.End(); tp++) {
-						if (s->dst == (*tp)->index) {
-							assert((*tp)->cache.part_of_subsidy & POS_DST);
+					for (auto &tp : towns_near) {
+						if (s->dst == tp->index) {
+							assert(tp->cache.part_of_subsidy & POS_DST);
 							subsidised = true;
 							if (!s->IsAwarded()) s->AwardTo(company);
 						}

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -36,39 +36,40 @@ struct TextEffect : public ViewportSign {
 	}
 };
 
-static SmallVector<struct TextEffect, 32> _text_effects; ///< Text effects are stored there
+static std::vector<struct TextEffect> _text_effects; ///< Text effects are stored there
 
 /* Text Effects */
 TextEffectID AddTextEffect(StringID msg, int center, int y, uint8 duration, TextEffectMode mode)
 {
 	if (_game_mode == GM_MENU) return INVALID_TE_ID;
 
-	TextEffectID i;
-	for (i = 0; i < _text_effects.Length(); i++) {
-		if (_text_effects[i].string_id == INVALID_STRING_ID) break;
+	auto it = _text_effects.begin();
+	for (; it < _text_effects.end(); ++it) {
+		if (it->string_id == INVALID_STRING_ID) break;
 	}
-	if (i == _text_effects.Length()) _text_effects.Append();
-
-	TextEffect *te = _text_effects.Get(i);
+	if (_text_effects.end() == it) {
+		_text_effects.emplace_back();
+		it = std::prev(_text_effects.end());
+	}
 
 	/* Start defining this object */
-	te->string_id = msg;
-	te->duration = duration;
-	te->params_1 = GetDParam(0);
-	te->params_2 = GetDParam(1);
-	te->mode = mode;
+	it->string_id = msg;
+	it->duration = duration;
+	it->params_1 = GetDParam(0);
+	it->params_2 = GetDParam(1);
+	it->mode = mode;
 
 	/* Make sure we only dirty the new area */
-	te->width_normal = 0;
-	te->UpdatePosition(center, y, msg);
+	it->width_normal = 0;
+	it->UpdatePosition(center, y, msg);
 
-	return i;
+	return std::distance(_text_effects.begin(), it);
 }
 
 void UpdateTextEffect(TextEffectID te_id, StringID msg)
 {
 	/* Update details */
-	TextEffect *te = _text_effects.Get(te_id);
+	auto te = _text_effects.begin() + te_id;
 	if (msg == te->string_id && GetDParam(0) == te->params_1) return;
 	te->string_id = msg;
 	te->params_1 = GetDParam(0);
@@ -84,25 +85,24 @@ void RemoveTextEffect(TextEffectID te_id)
 
 void MoveAllTextEffects()
 {
-	const TextEffect *end = _text_effects.End();
-	for (TextEffect *te = _text_effects.Begin(); te != end; te++) {
-		if (te->string_id == INVALID_STRING_ID) continue;
-		if (te->mode != TE_RISING) continue;
+	for (auto &te : _text_effects) {
+		if (te.string_id == INVALID_STRING_ID) continue;
+		if (te.mode != TE_RISING) continue;
 
-		if (te->duration-- == 0) {
-			te->Reset();
+		if (te.duration-- == 0) {
+			te.Reset();
 			continue;
 		}
 
-		te->MarkDirty(ZOOM_LVL_OUT_8X);
-		te->top -= ZOOM_LVL_BASE;
-		te->MarkDirty(ZOOM_LVL_OUT_8X);
+		te.MarkDirty(ZOOM_LVL_OUT_8X);
+		te.top -= ZOOM_LVL_BASE;
+		te.MarkDirty(ZOOM_LVL_OUT_8X);
 	}
 }
 
 void InitTextEffects()
 {
-	_text_effects.Reset();
+	Reset(_text_effects);
 }
 
 void DrawTextEffects(DrawPixelInfo *dpi)
@@ -110,11 +110,10 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 	/* Don't draw the text effects when zoomed out a lot */
 	if (dpi->zoom > ZOOM_LVL_OUT_8X) return;
 
-	const TextEffect *end = _text_effects.End();
-	for (TextEffect *te = _text_effects.Begin(); te != end; te++) {
-		if (te->string_id == INVALID_STRING_ID) continue;
-		if (te->mode == TE_RISING || (_settings_client.gui.loading_indicators && !IsTransparencySet(TO_LOADING))) {
-			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, te, te->string_id, te->string_id - 1, STR_NULL, te->params_1, te->params_2);
+	for (auto &te : _text_effects) {
+		if (te.string_id == INVALID_STRING_ID) continue;
+		if (te.mode == TE_RISING || (_settings_client.gui.loading_indicators && !IsTransparencySet(TO_LOADING))) {
+			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, &te, te.string_id, te.string_id - 1, STR_NULL, te.params_1, te.params_2);
 		}
 	}
 }

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -86,8 +86,8 @@ uint TextfileWindow::GetContentHeight()
 	int max_width = this->GetWidget<NWidgetCore>(WID_TF_BACKGROUND)->current_x - WD_FRAMETEXT_LEFT - WD_FRAMERECT_RIGHT;
 
 	uint height = 0;
-	for (uint i = 0; i < this->lines.Length(); i++) {
-		height += GetStringHeight(this->lines[i], max_width, FS_MONO);
+	for (auto &l : this->lines) {
+		height += GetStringHeight(l, max_width, FS_MONO);
 	}
 
 	return height;
@@ -113,10 +113,10 @@ void TextfileWindow::SetupScrollbars()
 		this->hscroll->SetCount(0);
 	} else {
 		uint max_length = 0;
-		for (uint i = 0; i < this->lines.Length(); i++) {
-			max_length = max(max_length, GetStringBoundingBox(this->lines[i], FS_MONO).width);
+		for (auto &l : this->lines) {
+			max_length = max(max_length, GetStringBoundingBox(l, FS_MONO).width);
 		}
-		this->vscroll->SetCount(this->lines.Length() * FONT_HEIGHT_MONO);
+		this->vscroll->SetCount(this->lines.size() * FONT_HEIGHT_MONO);
 		this->hscroll->SetCount(max_length + WD_FRAMETEXT_LEFT + WD_FRAMETEXT_RIGHT);
 	}
 
@@ -152,11 +152,11 @@ void TextfileWindow::SetupScrollbars()
 	int line_height = FONT_HEIGHT_MONO;
 	int y_offset = -this->vscroll->GetPosition();
 
-	for (uint i = 0; i < this->lines.Length(); i++) {
+	for (auto &l : this->lines) {
 		if (IsWidgetLowered(WID_TF_WRAPTEXT)) {
-			y_offset = DrawStringMultiLine(0, right - x, y_offset, bottom - y, this->lines[i], TC_WHITE, SA_TOP | SA_LEFT, false, FS_MONO);
+			y_offset = DrawStringMultiLine(0, right - x, y_offset, bottom - y, l, TC_WHITE, SA_TOP | SA_LEFT, false, FS_MONO);
 		} else {
-			DrawString(-this->hscroll->GetPosition(), right - x, y_offset, this->lines[i], TC_WHITE, SA_TOP | SA_LEFT, false, FS_MONO);
+			DrawString(-this->hscroll->GetPosition(), right - x, y_offset, l, TC_WHITE, SA_TOP | SA_LEFT, false, FS_MONO);
 			y_offset += line_height; // margin to previous element
 		}
 	}
@@ -184,7 +184,7 @@ void TextfileWindow::SetupScrollbars()
 
 /* virtual */ const char *TextfileWindow::NextString()
 {
-	if (this->search_iterator >= this->lines.Length()) return NULL;
+	if (this->search_iterator >= this->lines.size()) return NULL;
 
 	return this->lines[this->search_iterator++];
 }
@@ -319,7 +319,7 @@ static void Xunzip(byte **bufp, size_t *sizep)
 {
 	if (textfile == NULL) return;
 
-	this->lines.Clear();
+	this->lines.clear();
 
 	/* Get text from file */
 	size_t filesize;
@@ -365,11 +365,11 @@ static void Xunzip(byte **bufp, size_t *sizep)
 	str_validate(p, this->text + filesize, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE);
 
 	/* Split the string on newlines. */
-	*this->lines.Append() = p;
+	this->lines.push_back(p);
 	for (; *p != '\0'; p++) {
 		if (*p == '\n') {
 			*p = '\0';
-			*this->lines.Append() = p + 1;
+			this->lines.push_back(p);
 		}
 	}
 

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -25,7 +25,7 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	Scrollbar *vscroll;                  ///< Vertical scrollbar.
 	Scrollbar *hscroll;                  ///< Horizontal scrollbar.
 	char *text;                          ///< Lines of text from the NewGRF's textfile.
-	SmallVector<const char *, 64> lines; ///< #text, split into lines in a table with lines.
+	std::vector<const char *> lines;     ///< #text, split into lines in a table with lines.
 	uint search_iterator;                ///< Iterator for the font check search.
 
 	static const int TOP_SPACING    = WD_FRAMETEXT_TOP;    ///< Additional spacing at the top of the #WID_TF_BACKGROUND widget.

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -834,7 +834,7 @@ static Train *FindGoodVehiclePos(const Train *src)
 }
 
 /** Helper type for lists/vectors of trains */
-typedef SmallVector<Train *, 16> TrainList;
+using TrainList = std::vector<Train *>;
 
 /**
  * Make a backup of a train into a train list.
@@ -843,7 +843,7 @@ typedef SmallVector<Train *, 16> TrainList;
  */
 static void MakeTrainBackup(TrainList &list, Train *t)
 {
-	for (; t != NULL; t = t->Next()) *list.Append() = t;
+	for (; t != NULL; t = t->Next()) list.push_back(t);
 }
 
 /**
@@ -853,12 +853,11 @@ static void MakeTrainBackup(TrainList &list, Train *t)
 static void RestoreTrainBackup(TrainList &list)
 {
 	/* No train, nothing to do. */
-	if (list.Length() == 0) return;
+	if (list.empty()) return;
 
 	Train *prev = NULL;
 	/* Iterate over the list and rebuild it. */
-	for (Train **iter = list.Begin(); iter != list.End(); iter++) {
-		Train *t = *iter;
+	for (auto &t : list) {
 		if (prev != NULL) {
 			prev->SetNext(t);
 		} else if (t->Previous() != NULL) {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -317,7 +317,7 @@ struct RefitOption {
 	}
 };
 
-typedef SmallVector<RefitOption, 32> SubtypeList; ///< List of refit subtypes associated to a cargo.
+using SubtypeList = std::vector<RefitOption> ; ///< List of refit subtypes associated to a cargo.
 
 /**
  * Draw the list of available refit options for a consist and highlight the selected refit option (if any).
@@ -347,7 +347,7 @@ static void DrawVehicleRefitWindow(const SubtypeList list[NUM_CARGO], const int 
 
 	/* Draw the list of subtypes for each cargo, and find the selected refit option (by its position). */
 	for (uint i = 0; current < pos + rows && i < NUM_CARGO; i++) {
-		for (uint j = 0; current < pos + rows && j < list[i].Length(); j++) {
+		for (uint j = 0; current < pos + rows && j < list[i].size(); j++) {
 			const RefitOption &refit = list[i][j];
 
 			/* Hide subtypes if sel[0] does not match */
@@ -359,11 +359,11 @@ static void DrawVehicleRefitWindow(const SubtypeList list[NUM_CARGO], const int 
 				continue;
 			}
 
-			if (list[i].Length() > 1) {
+			if (list[i].size() > 1) {
 				if (refit.subtype != 0xFF) {
 					/* Draw tree lines */
 					int ycenter = y + FONT_HEIGHT_NORMAL / 2;
-					GfxDrawLine(iconcenter, y - WD_MATRIX_TOP, iconcenter, j == list[i].Length() - 1 ? ycenter : y - WD_MATRIX_TOP + delta - 1, linecolour);
+					GfxDrawLine(iconcenter, y - WD_MATRIX_TOP, iconcenter, j == list[i].size() - 1 ? ycenter : y - WD_MATRIX_TOP + delta - 1, linecolour);
 					GfxDrawLine(iconcenter, ycenter, iconinner, ycenter, linecolour);
 				} else {
 					/* Draw expand/collapse icon */
@@ -406,7 +406,7 @@ struct RefitWindow : public Window {
 	 */
 	void BuildRefitList()
 	{
-		for (uint i = 0; i < NUM_CARGO; i++) this->list[i].Clear();
+		for (uint i = 0; i < NUM_CARGO; i++) this->list[i].clear();
 		Vehicle *v = Vehicle::Get(this->window_number);
 
 		/* Check only the selected vehicles. */
@@ -435,10 +435,10 @@ struct RefitWindow : public Window {
 					continue;
 				}
 
-				bool first_vehicle = this->list[current_index].Length() == 0;
+				bool first_vehicle = this->list[current_index].empty();
 				if (first_vehicle) {
 					/* Keeping the current subtype is always an option. It also serves as the option in case of no subtypes */
-					RefitOption *option = this->list[current_index].Append();
+					auto option = Extend(this->list[current_index], 1);
 					option->cargo   = cid;
 					option->subtype = 0xFF;
 					option->string  = STR_EMPTY;
@@ -473,16 +473,16 @@ struct RefitWindow : public Window {
 							option.cargo   = cid;
 							option.subtype = refit_cyc;
 							option.string  = subtype;
-							this->list[current_index].Include(option);
+							Include(this->list[current_index], option);
 						} else {
 							/* Intersect the subtypes of earlier vehicles with the subtypes of this vehicle */
 							if (subtype == STR_EMPTY) {
 								/* No more subtypes for this vehicle, delete all subtypes >= refit_cyc */
 								SubtypeList &l = this->list[current_index];
 								/* 0xFF item is in front, other subtypes are sorted. So just truncate the list in the right spot */
-								for (uint i = 1; i < l.Length(); i++) {
+								for (uint i = 1; i < l.size(); i++) {
 									if (l[i].subtype >= refit_cyc) {
-										l.Resize(i);
+										l.resize(i);
 										break;
 									}
 								}
@@ -491,10 +491,10 @@ struct RefitWindow : public Window {
 								/* Check whether the subtype matches with the subtype of earlier vehicles. */
 								uint pos = 1;
 								SubtypeList &l = this->list[current_index];
-								while (pos < l.Length() && l[pos].subtype != refit_cyc) pos++;
-								if (pos < l.Length() && l[pos].string != subtype) {
+								while (pos < l.size() && l[pos].subtype != refit_cyc) pos++;
+								if (pos < l.size() && l[pos].string != subtype) {
 									/* String mismatch, remove item keeping the order */
-									l.ErasePreservingOrder(pos);
+									l.erase(l.begin() + pos);
 								}
 							}
 						}
@@ -522,7 +522,7 @@ struct RefitWindow : public Window {
 		uint row = 0;
 
 		for (uint i = 0; i < NUM_CARGO; i++) {
-			for (uint j = 0; j < this->list[i].Length(); j++) {
+			for (uint j = 0; j < this->list[i].size(); j++) {
 				const RefitOption &refit = this->list[i][j];
 
 				/* Hide subtypes if sel[0] does not match */
@@ -547,7 +547,7 @@ struct RefitWindow : public Window {
 		uint row = 0;
 
 		for (uint i = 0; i < NUM_CARGO; i++) {
-			for (uint j = 0; j < this->list[i].Length(); j++) {
+			for (uint j = 0; j < this->list[i].size(); j++) {
 				const RefitOption &refit = this->list[i][j];
 
 				/* Hide subtypes if sel[0] does not match */
@@ -576,7 +576,7 @@ struct RefitWindow : public Window {
 		if (this->sel[0] < 0) return NULL;
 
 		SubtypeList &l = this->list[this->sel[0]];
-		if ((uint)this->sel[1] >= l.Length()) return NULL;
+		if ((uint)this->sel[1] >= l.size()) return NULL;
 
 		return &l[this->sel[1]];
 	}
@@ -617,7 +617,7 @@ struct RefitWindow : public Window {
 			this->sel[1] = 0;
 			this->cargo = NULL;
 			for (uint i = 0; this->cargo == NULL && i < NUM_CARGO; i++) {
-				for (uint j = 0; j < list[i].Length(); j++) {
+				for (uint j = 0; j < list[i].size(); j++) {
 					if (list[i][j] == current_refit_option) {
 						this->sel[0] = i;
 						this->sel[1] = j;
@@ -830,8 +830,8 @@ struct RefitWindow : public Window {
 
 				/* Check the width of all cargo information strings. */
 				for (uint i = 0; i < NUM_CARGO; i++) {
-					for (uint j = 0; j < this->list[i].Length(); j++) {
-						StringID string = this->GetCapacityString(&list[i][j]);
+					for (auto &elem : this->list[i]) {
+						StringID string = this->GetCapacityString(&elem);
 						if (string != INVALID_STRING_ID) {
 							Dimension dim = GetStringBoundingBox(string);
 							max_width = max(dim.width, max_width);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -233,17 +233,17 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 	v_for = v_for->GetFirstEnginePart();
 
 	/* Create a list of subtypes used by the various parts of v_for */
-	static SmallVector<StringID, 4> subtypes;
-	subtypes.Clear();
+	static std::vector<StringID> subtypes;
+	subtypes.clear();
 	for (; v_from != NULL; v_from = v_from->HasArticulatedPart() ? v_from->GetNextArticulatedPart() : NULL) {
 		const Engine *e_from = v_from->GetEngine();
 		if (!e_from->CanCarryCargo() || !HasBit(e_from->info.callback_mask, CBM_VEHICLE_CARGO_SUFFIX)) continue;
-		subtypes.Include(GetCargoSubtypeText(v_from));
+		Include(subtypes, GetCargoSubtypeText(v_from));
 	}
 
 	byte ret_refit_cyc = 0;
 	bool success = false;
-	if (subtypes.Length() > 0) {
+	if (not subtypes.empty()) {
 		/* Check whether any articulated part is refittable to 'dest_cargo_type' with a subtype listed in 'subtypes' */
 		for (Vehicle *v = v_for; v != NULL; v = v->HasArticulatedPart() ? v->GetNextArticulatedPart() : NULL) {
 			const Engine *e = v->GetEngine();
@@ -267,7 +267,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 				StringID subtype = GetCargoSubtypeText(v);
 				if (subtype == STR_EMPTY) break;
 
-				if (!subtypes.Contains(subtype)) continue;
+				if (not Contains(subtypes, subtype)) continue;
 
 				/* We found something matching. */
 				ret_refit_cyc = refit_cyc;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3174,7 +3174,7 @@ void Window::InvalidateData(int data, bool gui_scope)
 	this->SetDirty();
 	if (!gui_scope) {
 		/* Schedule GUI-scope invalidation for next redraw. */
-		*this->scheduled_invalidation_data.Append() = data;
+		this->scheduled_invalidation_data.push_back(data);
 	}
 	this->OnInvalidateData(data, gui_scope);
 }
@@ -3184,10 +3184,11 @@ void Window::InvalidateData(int data, bool gui_scope)
  */
 void Window::ProcessScheduledInvalidations()
 {
-	for (int *data = this->scheduled_invalidation_data.Begin(); this->window_class != WC_INVALID && data != this->scheduled_invalidation_data.End(); data++) {
-		this->OnInvalidateData(*data, true);
+	for (auto &data : this->scheduled_invalidation_data) {
+		if (WC_INVALID == this->window_class) break;
+		this->OnInvalidateData(data, true);
 	}
-	this->scheduled_invalidation_data.Clear();
+	this->scheduled_invalidation_data.clear();
 }
 
 /**

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -274,7 +274,7 @@ protected:
 	void InitializePositionSize(int x, int y, int min_width, int min_height);
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height);
 
-	SmallVector<int, 4> scheduled_invalidation_data;  ///< Data of scheduled OnInvalidateData() calls.
+	std::vector<int> scheduled_invalidation_data;  ///< Data of scheduled OnInvalidateData() calls.
 
 public:
 	Window(WindowDesc *desc);


### PR DESCRIPTION
After discussions on IRC about modernising the code to make it easier to work on, replacing non time-critical instances of SmallVector<T,S> with std::vector was deemed more practical than making SmallVector STL-like.

This allows use of range-based for loops and STL algorithms to improve expressiveness in the code base.

No changes to functionality have been made.

#6649