### PR TITLE
TTD Windows music fixups

### DIFF
--- a/bin/baseset/orig_win.obm
+++ b/bin/baseset/orig_win.obm
@@ -142,5 +142,17 @@ GM_TT19.GM = Funk Central
 GM_TT20.GM = Jammit
 GM_TT21.GM = Movin' On
 
+; MIDI timecodes where the playback should attemp to start and stop short.
+; This is to allow fixing undesired silences in original MIDI files.
+; However not all music drivers may support this.
+[timingtrim]
+; Theme has two beats silence at the beginning which prevents clean looping.
+GM_TT00.GM = 768:53760
+; Can't Get There From Here from the Windows version has a long silence at the end,
+; followed by a solo repeat. This isn't in the original DOS version music and is likely
+; unintentional from the people who converted the music from the DOS version.
+; Actual song ends after measure 152.
+GM_TT10.GM = 0:235008
+
 [origin]
 default      = You can find it on your Transport Tycoon Deluxe CD-ROM.

--- a/media/baseset/orig_win.obm
+++ b/media/baseset/orig_win.obm
@@ -90,5 +90,17 @@ GM_TT19.GM = Funk Central
 GM_TT20.GM = Jammit
 GM_TT21.GM = Movin' On
 
+; MIDI timecodes where the playback should attemp to start and stop short.
+; This is to allow fixing undesired silences in original MIDI files.
+; However not all music drivers may support this.
+[timingtrim]
+; Theme has two beats silence at the beginning which prevents clean looping.
+GM_TT00.GM = 768:53760
+; Can't Get There From Here from the Windows version has a long silence at the end,
+; followed by a solo repeat. This isn't in the original DOS version music and is likely
+; unintentional from the people who converted the music from the DOS version.
+; Actual song ends after measure 152.
+GM_TT10.GM = 0:235008
+
 [origin]
 default      = You can find it on your Transport Tycoon Deluxe CD-ROM.

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -26,6 +26,7 @@ struct ContentInfo;
 struct MD5File {
 	/** The result of a checksum check */
 	enum ChecksumResult {
+		CR_UNKNOWN,  ///< The file has not been checked yet
 		CR_MATCH,    ///< The file did exist and the md5 checksum did match
 		CR_MISMATCH, ///< The file did exist, just the md5 checksum did not match
 		CR_NO_FILE,  ///< The file did not exist
@@ -34,6 +35,7 @@ struct MD5File {
 	const char *filename;        ///< filename
 	uint8 hash[16];              ///< md5 sum of the file
 	const char *missing_warning; ///< warning when this file is missing
+	ChecksumResult check_result; ///< cached result of md5 check
 
 	ChecksumResult CheckMD5(Subdirectory subdir, size_t max_size) const;
 };

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -301,6 +301,8 @@ struct MusicSongInfo {
 	const char *filename;    ///< file on disk containing song (when used in MusicSet class, this pointer is owned by MD5File object for the file)
 	MusicTrackType filetype; ///< decoder required for song file
 	int cat_index;           ///< entry index in CAT file, for filetype==MTT_MPSMIDI
+	int override_start;      ///< MIDI ticks to skip over in beginning
+	int override_end;        ///< MIDI tick to end the song at (0 if no override)
 };
 
 /** All data of a music set. */

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -301,6 +301,7 @@ struct MusicSongInfo {
 	const char *filename;    ///< file on disk containing song (when used in MusicSet class, this pointer is owned by MD5File object for the file)
 	MusicTrackType filetype; ///< decoder required for song file
 	int cat_index;           ///< entry index in CAT file, for filetype==MTT_MPSMIDI
+	bool loop;               ///< song should play in a tight loop if possible, never ending
 	int override_start;      ///< MIDI ticks to skip over in beginning
 	int override_end;        ///< MIDI tick to end the song at (0 if no override)
 };

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -129,7 +129,8 @@ bool BaseSet<T, Tnum_files, Tsearch_in_tars>::FillSetDetails(IniFile *ini, const
 			file->missing_warning = stredup(item->value);
 		}
 
-		switch (T::CheckMD5(file, BASESET_DIR)) {
+		file->check_result = T::CheckMD5(file, BASESET_DIR);
+		switch (file->check_result) {
 			case MD5File::CR_MATCH:
 				this->valid_files++;
 				this->found_files++;

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -128,7 +128,7 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 		IniGroup *timingtrim = ini->GetGroup("timingtrim");
 		for (uint i = 0, j = 1; i < lengthof(this->songinfo); i++) {
 			const char *filename = this->files[i].filename;
-			if (names == NULL || StrEmpty(filename)) {
+			if (names == NULL || StrEmpty(filename) || this->files[i].check_result == MD5File::CR_NO_FILE) {
 				this->songinfo[i].songname[0] = '\0';
 				continue;
 			}
@@ -143,7 +143,8 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 				char *songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
 				if (songname == NULL) {
 					DEBUG(grf, 0, "Base music set song missing from CAT file: %s/%d", filename, this->songinfo[i].cat_index);
-					return false;
+					this->songinfo[i].songname[0] = '\0';
+					continue;
 				}
 				strecpy(this->songinfo[i].songname, songname, lastof(this->songinfo[i].songname));
 				free(songname);

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -693,6 +693,9 @@ static void MidiThreadProc(void *)
 							current_segment.start_block = bl;
 							break;
 						} else {
+							/* Skip the transmission delay compensation performed in the Win32 MIDI driver.
+							 * The DMusic driver will most likely be used with the MS softsynth, which is not subject to transmission delays.
+							 */
 							DEBUG(driver, 2, "DMusic: timer: start from block %d (ticktime %d, realtime %.3f, bytes %d)", (int)bl, (int)block.ticktime, ((int)block.realtime) / 1000.0, (int)preload_bytes);
 							playback_start_time -= block.realtime * MIDITIME_TO_REFTIME;
 							break;

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -832,8 +832,8 @@ static void MidiThreadProc(void *)
 			/* end? */
 			if (current_block == current_file.blocks.size()) {
 				if (current_segment.loop) {
-					current_block = 0;
-					clock->GetTime(&playback_start_time);
+					current_block = current_segment.start_block;
+					playback_start_time = block_time - current_file.blocks[current_block].realtime * MIDITIME_TO_REFTIME;
 				} else {
 					_playback.do_stop = true;
 				}
@@ -1237,7 +1237,7 @@ void MusicDriver_DMusic::PlaySong(const MusicSongInfo &song)
 
 	_playback.next_segment.start = song.override_start;
 	_playback.next_segment.end = song.override_end;
-	_playback.next_segment.loop = false;
+	_playback.next_segment.loop = song.loop;
 
 	_playback.do_start = true;
 	SetEvent(_thread_event);

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -209,10 +209,6 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 	while (_midi.current_block < _midi.current_file.blocks.size()) {
 		MidiFile::DataBlock &block = _midi.current_file.blocks[_midi.current_block];
 
-		/* check that block is not in the future */
-		if (block.realtime / 1000 > playback_time) {
-			break;
-		}
 		/* check that block isn't at end-of-song override */
 		if (_midi.current_segment.end > 0 && block.ticktime >= _midi.current_segment.end) {
 			if (_midi.current_segment.loop) {
@@ -221,6 +217,10 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 			} else {
 				_midi.do_stop = true;
 			}
+			break;
+		}
+		/* check that block is not in the future */
+		if (block.realtime / 1000 > playback_time) {
 			break;
 		}
 
@@ -315,8 +315,8 @@ void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 		return;
 	}
 
-	_midi.next_segment.start = 0;
-	_midi.next_segment.end = 0;
+	_midi.next_segment.start = song.override_start;
+	_midi.next_segment.end = song.override_end;
 	_midi.next_segment.loop = false;
 
 	DEBUG(driver, 2, "Win32-MIDI: PlaySong: setting flag");

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -302,8 +302,8 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 	/* end? */
 	if (_midi.current_block == _midi.current_file.blocks.size()) {
 		if (_midi.current_segment.loop) {
-			_midi.current_block = 0;
-			_midi.playback_start_time = timeGetTime();
+			_midi.current_block = _midi.current_segment.start_block;
+			_midi.playback_start_time = timeGetTime() - _midi.current_file.blocks[_midi.current_block].realtime / 1000;
 		} else {
 			_midi.do_stop = true;
 		}
@@ -322,7 +322,7 @@ void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 
 	_midi.next_segment.start = song.override_start;
 	_midi.next_segment.end = song.override_end;
-	_midi.next_segment.loop = false;
+	_midi.next_segment.loop = song.loop;
 
 	DEBUG(driver, 2, "Win32-MIDI: PlaySong: setting flag");
 	_midi.do_stop = _midi.playing;

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -191,6 +191,7 @@ static void DoPlaySong()
 		FioFindFullPath(filename, lastof(filename), OLD_GM_DIR, songinfo.filename);
 	}
 	songinfo.filename = filename; // non-owned pointer
+	songinfo.loop = (_game_mode == GM_MENU) && (_music_wnd_cursong == 1);
 	MusicDriver::GetInstance()->PlaySong(songinfo);
 	SetWindowDirty(WC_MUSIC_WINDOW, 0);
 }


### PR DESCRIPTION
This patchset tries to work around two issues with the MIDI files included in TTD for Windows: The title song has a bit of delay at the beginning, causing it to loop poorly, and "Can't get there from here" has a very long silence at the end, which is not there in the original DOS version music.