### PR TITLE
Codechange: Avoid call to memcpy using null pointer in TooltipsWindow constructor

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -656,7 +656,7 @@ struct TooltipsWindow : public Window
 		this->string_id = str;
 		assert_compile(sizeof(this->params[0]) == sizeof(params[0]));
 		assert(paramcount <= lengthof(this->params));
-		memcpy(this->params, params, sizeof(this->params[0]) * paramcount);
+		if (paramcount > 0) memcpy(this->params, params, sizeof(this->params[0]) * paramcount);
 		this->paramcount = paramcount;
 		this->close_cond = close_tooltip;
 


### PR DESCRIPTION
Strictly speaking, calling memcpy with src as a nullptr is undefined behaviour
and the optimiser is entitled to delete any null ptr checks which occur afterwards.
This removes the warning emitted by UndefinedBehaviorSantizer.