### PR TITLE
Fix #6631: In singleplayer, you cannot buyout one human-player company as another

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1111,11 +1111,11 @@ void SwitchToMode(SwitchMode new_mode)
 #endif /* ENABLE_NETWORK */
 
 				/* Change Human companies to AI */
-				Company *c;
-				FOR_ALL_COMPANIES(c) {
-					if (Company::Get(_local_company) != c && !c->is_ai) {
-						c->is_ai = true;
-						if (!_networking || _network_server) {
+				if (!_networking || _network_server) {
+					Company *c;
+					FOR_ALL_COMPANIES(c) {
+						if (Company::Get(_local_company) != c && !c->is_ai) {
+							c->is_ai = true;
 							AI::StartNew(c->index);
 							AI::BroadcastNewEvent(new ScriptEventCompanyNew(c->index), c->index);
 							Game::NewEvent(new ScriptEventCompanyNew(c->index));

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1109,6 +1109,20 @@ void SwitchToMode(SwitchMode new_mode)
 					seprintf(_network_game_info.map_name, lastof(_network_game_info.map_name), "%s (Loaded game)", _file_to_saveload.title);
 				}
 #endif /* ENABLE_NETWORK */
+
+				/* Change Human companies to AI */
+				Company *c;
+				FOR_ALL_COMPANIES(c) {
+					if (Company::Get(_local_company) != c && !c->is_ai) {
+						c->is_ai = true;
+						if (!_networking || _network_server) {
+							AI::StartNew(c->index);
+							AI::BroadcastNewEvent(new ScriptEventCompanyNew(c->index), c->index);
+							Game::NewEvent(new ScriptEventCompanyNew(c->index));
+						}
+					}
+				}
+
 			}
 			break;
 		}


### PR DESCRIPTION
When a multiplayer saved game is loaded (in single player mode), you cannot buy other human companies. As a result, these companies are "ghosts" in the game.
This patch converts human players to AIs, except the current company.
The company name is automatically changed but all equipments are same.