### PR TITLE
Feature: Framerate display window

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - 4.4) [Files in tar (archives)](#44-files-in-tar-archives)
 - 5.0) [OpenTTD features](#50-openttd-features)
     - 5.1) [Logging of potentially dangerous actions](#51-logging-of-potentially-dangerous-actions)
+    - 5.2) [Frame rate and performance metrics](#52-frame-rate-and-performance-metrics)
 - 6.0) [Configuration file](#60-configuration-file)
 - 7.0) [Compiling](#70-compiling)
     - 7.1) [Required/optional libraries](#71-requiredoptional-libraries)
@@ -439,14 +440,30 @@ The Help menu in-game has a function to open the Frame rate window. This
 window shows various real-time performance statistics, measuring what parts
 of the game require the most processing power currently.
 
-Clicking a line in the lower part of the window (showing 'ms' measurements)
-opens a graph window, giving detailed readings on each tick simulated by the
-game.
-
 A summary of the statistics can also be retrieved from the console with the
 `fps` command. This is especially useful on dedicated servers, where the
 administrator might want to determine what's limiting performance in a slow
 game.
+
+The frame rate is given as two figures, the simulation rate and the graphics
+frame rate. Usually these are identical, as the screen is rendered exactly
+once per simulated tick, but in the future there might be support for graphics
+and simulation running at different rates. When the game is paused, the
+simulation rate drops to zero.
+
+In addition to the simulation rate, a game speed factor is also calculated.
+This is based on the target simulation speed, which is 30 milliseconds per
+game tick. At that speed, the expected frame rate is 33.33 frames/second, and
+the game speed factor is how close to that target the actual rate is. When
+the game is in fast forward mode, the game speed factor shows how much
+speed up is achieved.
+
+The lower part of the window shows timing statistics for individual parts of
+the game. The times shown are short-term and long-term averages of how long
+it takes to process one tick of game time, all figures are in milliseconds.
+
+Clicking a line in the lower part of the window opens a graph window, giving
+detailed readings on each tick simulated by the game.
 
 The following is an explanation of the different statistics:
 
@@ -477,19 +494,6 @@ The following is an explanation of the different statistics:
 - *Sound mixing* - Speed of mixing active audio samples together. Usually
   this should be very fast (in the range of 0-3 ms), if it is slow, consider
   switching to the NoSound set.
-
-The frame rate is given as two figures, the simulation rate and the graphics
-frame rate. Usually these are identical, as the screen is rendered exactly
-once per simulated tick, but in the future there might be support for graphics
-and simulation running at different rates. When the game is paused, the
-simulation rate drops to zero.
-
-In addition to the simulation rate, a game speed factor is also calculated.
-This is based on the idea simulation speed, which is 30 milliseconds per game
-tick. At that speed, the expected frame rate is 33.33 frames/second, and the
-game speed factor is how close to that ideal the actual rate is. When the game
-is in fast forward mode, the game speed factor shows how much speed up is
-achieved.
 
 If the frame rate window is shaded, the title bar will instead show just the
 current simulation rate and the game speed factor.

--- a/README.md
+++ b/README.md
@@ -433,6 +433,67 @@ No personal information is stored.
 You can show the game log by typing 'gamelog' in the console or by running
 OpenTTD in debug mode.
 
+### 5.2) Frame rate and performance metrics
+
+The Help menu in-game has a function to open the Frame rate window. This
+window shows various real-time performance statistics, measuring what parts
+of the game require the most processing power currently.
+
+Clicking a line in the lower part of the window (showing 'ms' measurements)
+opens a graph window, giving detailed readings on each tick simulated by the
+game.
+
+A summary of the statistics can also be retrieved from the console with the
+`fps` command. This is especially useful on dedicated servers, where the
+administrator might want to determine what's limiting performance in a slow
+game.
+
+The following is an explanation of the different statistics:
+
+- *Game loop* - Total processing time used per simulated "tick" in the game.
+  This includes all pathfinding, world updates, and economy handling.
+- *Cargo handling* - Time spent loading/unloading cargo at stations, and
+  industries and towns sending/retrieving cargo from stations.
+- *Train ticks*, *Road vehicle ticks*, *Ship ticks*, *Aircraft ticks* -
+  Time spent on pathfinding and other processing for each player vehicle type.
+- *World ticks* - Time spent on other world/landscape processing. This
+  includes towns growing, building animations, updates of farmland and trees,
+  and station rating updates.
+- *Link graph delay* - Time overruns of the cargo distribution link graph
+  update thread. Usually the link graph is updated in a background thread,
+  but these updates need to synchronise with the main game loop occasionally,
+  if the time spent on link graph updates is longer than the time taken to
+  otherwise simulate the game while it was updating, these delays are counted
+  in this figure.
+- *Graphics rendering* - Total time spent rendering all graphics, including
+  both GUI and world viewports. This typically spikes when panning the view
+  around, and when more things are happening on screen at once.
+- *World viewport rendering* - Isolated time spent rendering just world
+  viewports. If this figure is significantly lower than the total graphics
+  rendering time, most time is spent rendering GUI than rendering world.
+- *Video output* - Speed of copying the rendered graphics to the display
+  adapter. Usually this should be very fast (in the range of 0-3 ms), large
+  values for this can indicate a graphics driver problem.
+- *Sound mixing* - Speed of mixing active audio samples together. Usually
+  this should be very fast (in the range of 0-3 ms), if it is slow, consider
+  switching to the NoSound set.
+
+The frame rate is given as two figures, the simulation rate and the graphics
+frame rate. Usually these are identical, as the screen is rendered exactly
+once per simulated tick, but in the future there might be support for graphics
+and simulation running at different rates. When the game is paused, the
+simulation rate drops to zero.
+
+In addition to the simulation rate, a game speed factor is also calculated.
+This is based on the idea simulation speed, which is 30 milliseconds per game
+tick. At that speed, the expected frame rate is 33.33 frames/second, and the
+game speed factor is how close to that ideal the actual rate is. When the game
+is in fast forward mode, the game speed factor shows how much speed up is
+achieved.
+
+If the frame rate window is shaded, the title bar will instead show just the
+current simulation rate and the game speed factor.
+
 ## 6.0) Configuration file
 
 The configuration file for OpenTTD (openttd.cfg) is in a simple Windows-like

--- a/projects/openttd_vs100.vcxproj
+++ b/projects/openttd_vs100.vcxproj
@@ -481,6 +481,7 @@
     <ClInclude Include="..\src\fios.h" />
     <ClInclude Include="..\src\fontcache.h" />
     <ClInclude Include="..\src\fontdetection.h" />
+    <ClInclude Include="..\src\framerate_type.h" />
     <ClInclude Include="..\src\base_consist.h" />
     <ClInclude Include="..\src\gamelog.h" />
     <ClInclude Include="..\src\gamelog_internal.h" />
@@ -731,6 +732,7 @@
     <ClCompile Include="..\src\engine_gui.cpp" />
     <ClCompile Include="..\src\error_gui.cpp" />
     <ClCompile Include="..\src\fios_gui.cpp" />
+    <ClCompile Include="..\src\framerate_gui.cpp" />
     <ClCompile Include="..\src\genworld_gui.cpp" />
     <ClCompile Include="..\src\goal_gui.cpp" />
     <ClCompile Include="..\src\graph_gui.cpp" />

--- a/projects/openttd_vs100.vcxproj.filters
+++ b/projects/openttd_vs100.vcxproj.filters
@@ -600,6 +600,9 @@
     <ClInclude Include="..\src\fontdetection.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\framerate_type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\base_consist.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1348,6 +1351,9 @@
       <Filter>GUI Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\fios_gui.cpp">
+      <Filter>GUI Source Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\framerate_gui.cpp">
       <Filter>GUI Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\genworld_gui.cpp">

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -502,6 +502,7 @@
     <ClInclude Include="..\src\fios.h" />
     <ClInclude Include="..\src\fontcache.h" />
     <ClInclude Include="..\src\fontdetection.h" />
+    <ClInclude Include="..\src\framerate_type.h" />
     <ClInclude Include="..\src\base_consist.h" />
     <ClInclude Include="..\src\gamelog.h" />
     <ClInclude Include="..\src\gamelog_internal.h" />
@@ -752,6 +753,7 @@
     <ClCompile Include="..\src\engine_gui.cpp" />
     <ClCompile Include="..\src\error_gui.cpp" />
     <ClCompile Include="..\src\fios_gui.cpp" />
+    <ClCompile Include="..\src\framerate_gui.cpp" />
     <ClCompile Include="..\src\genworld_gui.cpp" />
     <ClCompile Include="..\src\goal_gui.cpp" />
     <ClCompile Include="..\src\graph_gui.cpp" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -600,6 +600,9 @@
     <ClInclude Include="..\src\fontdetection.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\framerate_type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\base_consist.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1348,6 +1351,9 @@
       <Filter>GUI Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\fios_gui.cpp">
+      <Filter>GUI Source Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\framerate_gui.cpp">
       <Filter>GUI Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\genworld_gui.cpp">

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -502,6 +502,7 @@
     <ClInclude Include="..\src\fios.h" />
     <ClInclude Include="..\src\fontcache.h" />
     <ClInclude Include="..\src\fontdetection.h" />
+    <ClInclude Include="..\src\framerate_type.h" />
     <ClInclude Include="..\src\base_consist.h" />
     <ClInclude Include="..\src\gamelog.h" />
     <ClInclude Include="..\src\gamelog_internal.h" />
@@ -752,6 +753,7 @@
     <ClCompile Include="..\src\engine_gui.cpp" />
     <ClCompile Include="..\src\error_gui.cpp" />
     <ClCompile Include="..\src\fios_gui.cpp" />
+    <ClCompile Include="..\src\framerate_gui.cpp" />
     <ClCompile Include="..\src\genworld_gui.cpp" />
     <ClCompile Include="..\src\goal_gui.cpp" />
     <ClCompile Include="..\src\graph_gui.cpp" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -600,6 +600,9 @@
     <ClInclude Include="..\src\fontdetection.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\framerate_type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\base_consist.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1348,6 +1351,9 @@
       <Filter>GUI Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\fios_gui.cpp">
+      <Filter>GUI Source Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\framerate_gui.cpp">
       <Filter>GUI Source Code</Filter>
     </ClCompile>
     <ClCompile Include="..\src\genworld_gui.cpp">

--- a/projects/openttd_vs80.vcproj
+++ b/projects/openttd_vs80.vcproj
@@ -1111,6 +1111,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\..\src\framerate_type.h"
+				>
+			</File>
+			<File
 				RelativePath=".\..\src\base_consist.h"
 				>
 			</File>
@@ -2116,6 +2120,10 @@
 			</File>
 			<File
 				RelativePath=".\..\src\fios_gui.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\framerate_gui.cpp"
 				>
 			</File>
 			<File

--- a/projects/openttd_vs90.vcproj
+++ b/projects/openttd_vs90.vcproj
@@ -1108,6 +1108,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\..\src\framerate_type.h"
+				>
+			</File>
+			<File
 				RelativePath=".\..\src\base_consist.h"
 				>
 			</File>
@@ -2113,6 +2117,10 @@
 			</File>
 			<File
 				RelativePath=".\..\src\fios_gui.cpp"
+				>
+			</File>
+			<File
+				RelativePath=".\..\src\framerate_gui.cpp"
 				>
 			</File>
 			<File

--- a/source.list
+++ b/source.list
@@ -193,6 +193,7 @@ fileio_type.h
 fios.h
 fontcache.h
 fontdetection.h
+framerate_type.h
 base_consist.h
 gamelog.h
 gamelog_internal.h
@@ -462,6 +463,7 @@ dock_gui.cpp
 engine_gui.cpp
 error_gui.cpp
 fios_gui.cpp
+framerate_gui.cpp
 genworld_gui.cpp
 goal_gui.cpp
 graph_gui.cpp

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -37,6 +37,7 @@
 #include "core/backup_type.hpp"
 #include "zoom_func.h"
 #include "disaster_vehicle.h"
+#include "framerate_type.h"
 
 #include "table/strings.h"
 
@@ -2037,6 +2038,8 @@ static bool AircraftEventHandler(Aircraft *v, int loop)
 bool Aircraft::Tick()
 {
 	if (!this->IsNormalAircraft()) return true;
+
+	PerformanceAccumulator framerate(PFE_ACC_GL_AIRCRAFT);
 
 	this->tick_counter++;
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2039,7 +2039,7 @@ bool Aircraft::Tick()
 {
 	if (!this->IsNormalAircraft()) return true;
 
-	PerformanceAccumulator framerate(PFE_ACC_GL_AIRCRAFT);
+	PerformanceAccumulator framerate(PFE_GL_AIRCRAFT);
 
 	this->tick_counter++;
 

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -14,6 +14,7 @@
 #include "core/smallvec_type.hpp"
 #include "tile_cmd.h"
 #include "viewport_func.h"
+#include "framerate_type.h"
 
 #include "safeguards.h"
 
@@ -50,6 +51,8 @@ void AddAnimatedTile(TileIndex tile)
  */
 void AnimateAnimatedTiles()
 {
+	PerformanceAccumulator framerate(PFE_GL_LANDSCAPE);
+
 	const TileIndex *ti = _animated_tiles.Begin();
 	while (ti < _animated_tiles.End()) {
 		const TileIndex curr = *ti;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1894,6 +1894,18 @@ static void IConsoleDebugLibRegister()
 	IConsoleAliasRegister("dbg_echo2",      "echo %!");
 }
 #endif
+DEF_CONSOLE_CMD(ConFramerate)
+{
+	extern void DoShowFramerate(); // framerate_gui.cpp
+
+	if (argc == 0) {
+		IConsoleHelp("Show framerate and game speed information");
+		return true;
+	}
+
+	DoShowFramerate();
+	return true;
+}
 
 /*******************************
  * console command registration
@@ -2025,6 +2037,7 @@ void IConsoleStdLibRegister()
 #ifdef _DEBUG
 	IConsoleDebugLibRegister();
 #endif
+	IConsoleCmdRegister("fps", ConFramerate);
 
 	/* NewGRF development stuff */
 	IConsoleCmdRegister("reload_newgrfs",  ConNewGRFReload, ConHookNewGRFDeveloperTool);

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1894,16 +1894,35 @@ static void IConsoleDebugLibRegister()
 	IConsoleAliasRegister("dbg_echo2",      "echo %!");
 }
 #endif
+
 DEF_CONSOLE_CMD(ConFramerate)
 {
 	extern void ConPrintFramerate(); // framerate_gui.cpp
 
 	if (argc == 0) {
-		IConsoleHelp("Show framerate and game speed information");
+		IConsoleHelp("Show frame rate and game speed information");
 		return true;
 	}
 
 	ConPrintFramerate();
+	return true;
+}
+
+DEF_CONSOLE_CMD(ConFramerateWindow)
+{
+	extern void ShowFramerateWindow();
+
+	if (argc == 0) {
+		IConsoleHelp("Open the frame rate window");
+		return true;
+	}
+
+	if (_network_dedicated) {
+		IConsoleError("Can not open frame rate window on a dedicated server");
+		return false;
+	}
+
+	ShowFramerateWindow();
 	return true;
 }
 
@@ -2037,7 +2056,8 @@ void IConsoleStdLibRegister()
 #ifdef _DEBUG
 	IConsoleDebugLibRegister();
 #endif
-	IConsoleCmdRegister("fps", ConFramerate);
+	IConsoleCmdRegister("fps",     ConFramerate);
+	IConsoleCmdRegister("fps_wnd", ConFramerateWindow);
 
 	/* NewGRF development stuff */
 	IConsoleCmdRegister("reload_newgrfs",  ConNewGRFReload, ConHookNewGRFDeveloperTool);

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1896,14 +1896,14 @@ static void IConsoleDebugLibRegister()
 #endif
 DEF_CONSOLE_CMD(ConFramerate)
 {
-	extern void DoShowFramerate(); // framerate_gui.cpp
+	extern void ConPrintFramerate(); // framerate_gui.cpp
 
 	if (argc == 0) {
 		IConsoleHelp("Show framerate and game speed information");
 		return true;
 	}
 
-	DoShowFramerate();
+	ConPrintFramerate();
 	return true;
 }
 

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -136,9 +136,11 @@ void ShowFrametimeGraphWindow(FramerateElement elem);
 
 
 enum FramerateWindowWidgets {
-	WID_FRW_CAPTION,
-	WID_FRW_TOGGLE_SIZE,
-	WID_FRW_DETAILSPANEL,
+	WID_FRW_CAPTION_SMALL,
+	WID_FRW_TOGGLE_SIZE1,
+	WID_FRW_TOGGLE_SIZE2,
+	WID_FRW_SEL_NORMAL,
+	WID_FRW_SEL_SMALL,
 	WID_FRW_RATE_GAMELOOP,
 	WID_FRW_RATE_BLITTER,
 	WID_FRW_RATE_FACTOR,
@@ -149,20 +151,28 @@ enum FramerateWindowWidgets {
 };
 
 static const NWidgetPart _framerate_window_widgets[] = {
-	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
-		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_FRAMERATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
-		NWidget(WWT_IMGBTN, COLOUR_GREY, WID_FRW_TOGGLE_SIZE), SetDataTip(SPR_LARGE_SMALL_WINDOW, STR_TOOLTIP_TOGGLE_LARGE_SMALL_WINDOW),
-		NWidget(WWT_STICKYBOX, COLOUR_GREY),
-	EndContainer(),
-	NWidget(WWT_PANEL, COLOUR_GREY),
-		NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
-			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_GAMELOOP), SetDataTip(STR_FRAMERATE_RATE_GAMELOOP, STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP),
-			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_BLITTER),  SetDataTip(STR_FRAMERATE_RATE_BLITTER,  STR_FRAMERATE_RATE_BLITTER_TOOLTIP),
-			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_FACTOR),   SetDataTip(STR_FRAMERATE_SPEED_FACTOR,  STR_FRAMERATE_SPEED_FACTOR_TOOLTIP),
+	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_FRW_SEL_SMALL),
+		NWidget(NWID_HORIZONTAL),
+			NWidget(WWT_CLOSEBOX, COLOUR_GREY),
+			NWidget(WWT_CAPTION, COLOUR_GREY, WID_FRW_CAPTION_SMALL), SetDataTip(STR_FRAMERATE_CAPTION_SMALL, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+			NWidget(WWT_IMGBTN, COLOUR_GREY, WID_FRW_TOGGLE_SIZE1), SetDataTip(SPR_LARGE_SMALL_WINDOW, STR_TOOLTIP_TOGGLE_LARGE_SMALL_WINDOW),
+			NWidget(WWT_STICKYBOX, COLOUR_GREY),
 		EndContainer(),
 	EndContainer(),
-	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_FRW_DETAILSPANEL),
+	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_FRW_SEL_NORMAL), NWidget(NWID_VERTICAL),
+		NWidget(NWID_HORIZONTAL),
+			NWidget(WWT_CLOSEBOX, COLOUR_GREY),
+			NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_FRAMERATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+			NWidget(WWT_IMGBTN, COLOUR_GREY, WID_FRW_TOGGLE_SIZE2), SetDataTip(SPR_LARGE_SMALL_WINDOW, STR_TOOLTIP_TOGGLE_LARGE_SMALL_WINDOW),
+			NWidget(WWT_STICKYBOX, COLOUR_GREY),
+		EndContainer(),
+		NWidget(WWT_PANEL, COLOUR_GREY),
+			NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
+				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_GAMELOOP), SetDataTip(STR_FRAMERATE_RATE_GAMELOOP, STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP),
+				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_BLITTER),  SetDataTip(STR_FRAMERATE_RATE_BLITTER,  STR_FRAMERATE_RATE_BLITTER_TOOLTIP),
+				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_FACTOR),   SetDataTip(STR_FRAMERATE_SPEED_FACTOR,  STR_FRAMERATE_SPEED_FACTOR_TOOLTIP),
+			EndContainer(),
+		EndContainer(),
 		NWidget(WWT_PANEL, COLOUR_GREY),
 			NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
 				NWidget(NWID_HORIZONTAL), SetPIP(0, 6, 0),
@@ -173,7 +183,7 @@ static const NWidgetPart _framerate_window_widgets[] = {
 				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_INFO_DATA_POINTS), SetDataTip(STR_FRAMERATE_DATA_POINTS, 0x0),
 			EndContainer(),
 		EndContainer(),
-	EndContainer(),
+	EndContainer(), EndContainer(),
 };
 
 struct FramerateWindow : Window {
@@ -184,14 +194,14 @@ struct FramerateWindow : Window {
 	FramerateWindow(WindowDesc *desc, WindowNumber number) : Window(desc)
 	{
 		this->InitNested(number);
-		this->SetSmall(true);
+		this->SetSmall(false);
 	}
 
 	void SetSmall(bool small)
 	{
 		this->small = small;
-		int plane = this->small ? SZSP_NONE : 0;
-		this->GetWidget<NWidgetStacked>(WID_FRW_DETAILSPANEL)->SetDisplayedPlane(plane);
+		this->GetWidget<NWidgetStacked>(WID_FRW_SEL_NORMAL)->SetDisplayedPlane(this->small ? SZSP_NONE : 0);
+		this->GetWidget<NWidgetStacked>(WID_FRW_SEL_SMALL)->SetDisplayedPlane(this->small ? 0 : SZSP_NONE);
 		this->ReInit();
 	}
 
@@ -237,6 +247,14 @@ struct FramerateWindow : Window {
 		double value;
 
 		switch (widget) {
+			case WID_FRW_CAPTION_SMALL:
+				value = GetFramerate(FRAMERATE_GAMELOOP);
+				SetDParamGoodWarnBadRate(value, FRAMERATE_GAMELOOP);
+				value /= _framerate_expected_rate[FRAMERATE_GAMELOOP];
+				SetDParam(3, (int)(value * 100));
+				SetDParam(4, 2);
+				break;
+
 			case WID_FRW_RATE_GAMELOOP:
 				value = GetFramerate(FRAMERATE_GAMELOOP);
 				SetDParamGoodWarnBadRate(value, FRAMERATE_GAMELOOP);
@@ -260,6 +278,15 @@ struct FramerateWindow : Window {
 	virtual void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize)
 	{
 		switch (widget) {
+			case WID_FRW_CAPTION_SMALL:
+				SetDParam(0, STR_FRAMERATE_FPS_GOOD);
+				SetDParam(1, 999999);
+				SetDParam(2, 2);
+				SetDParam(3, 999999);
+				SetDParam(4, 2);
+				*size = GetStringBoundingBox(STR_FRAMERATE_CAPTION_SMALL);
+				break;
+
 			case WID_FRW_RATE_GAMELOOP:
 				SetDParamGoodWarnBadRate(9999.99, FRAMERATE_GAMELOOP);
 				*size = GetStringBoundingBox(STR_FRAMERATE_RATE_GAMELOOP);
@@ -269,7 +296,7 @@ struct FramerateWindow : Window {
 				*size = GetStringBoundingBox(STR_FRAMERATE_RATE_BLITTER);
 				break;
 			case WID_FRW_RATE_FACTOR:
-				SetDParam(0, 99999);
+				SetDParam(0, 999999);
 				SetDParam(1, 2);
 				*size = GetStringBoundingBox(STR_FRAMERATE_SPEED_FACTOR);
 				break;
@@ -345,7 +372,8 @@ struct FramerateWindow : Window {
 	virtual void OnClick(Point pt, int widget, int click_count)
 	{
 		switch (widget) {
-			case WID_FRW_TOGGLE_SIZE:
+			case WID_FRW_TOGGLE_SIZE1:
+			case WID_FRW_TOGGLE_SIZE2:
 				this->SetSmall(!this->small);
 				break;
 

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -45,6 +45,20 @@ namespace {
 			this->num_valid = min(NUM_FRAMERATE_POINTS, this->num_valid + 1);
 		}
 
+		void BeginAccumulate(TimingMeasurement start_time)
+		{
+			this->next_index += 1;
+			if (this->next_index >= NUM_FRAMERATE_POINTS) this->next_index = 0;
+			this->timestamps[this->next_index] = start_time;
+			this->durations[this->next_index] = 0;
+			this->num_valid = min(NUM_FRAMERATE_POINTS, this->num_valid + 1);
+		}
+
+		void AddAccumulate(TimingMeasurement duration)
+		{
+			this->durations[this->next_index] += duration;
+		}
+
 		double GetAverageDurationMilliseconds(int count)
 		{
 			count = min(count, this->num_valid);
@@ -133,6 +147,25 @@ PerformanceMeasurer::~PerformanceMeasurer()
 void PerformanceMeasurer::SetExpectedRate(double rate)
 {
 	_pf_data[elem].expected_rate = rate;
+}
+
+
+PerformanceAccumulator::PerformanceAccumulator(PerformanceElement elem)
+{
+	assert(elem < PFE_MAX);
+
+	this->elem = elem;
+	this->start_time = GetPerformanceTimer();
+}
+
+PerformanceAccumulator::~PerformanceAccumulator()
+{
+	_pf_data[this->elem].AddAccumulate(GetPerformanceTimer() - this->start_time);
+}
+
+void PerformanceAccumulator::Reset(PerformanceElement elem)
+{
+	_pf_data[elem].BeginAccumulate(GetPerformanceTimer());
 }
 
 

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -621,33 +621,45 @@ void ConPrintFramerate()
 
 	static char *MEASUREMENT_NAMES[PFE_MAX] = {
 		"Game loop",
-		"GL station ticks",
-		"GL train ticks",
-		"GL road vehicle ticks",
-		"GL ship ticks",
-		"GL aircraft ticks",
+		"  GL station ticks",
+		"  GL train ticks",
+		"  GL road vehicle ticks",
+		"  GL ship ticks",
+		"  GL aircraft ticks",
 		"Drawing",
-		"Viewport drawing",
+		"  Viewport drawing",
 		"Video output",
 		"Sound mixing",
 	};
 
-	for (auto e = PFE_FIRST; e < PFE_MAX; e = (PerformanceElement)(e + 1)) {
+	static const PerformanceElement rate_elements[] = { PFE_GAMELOOP, PFE_DRAWING, PFE_VIDEO };
+
+	bool printed_anything = false;
+
+	for (auto e : rate_elements) {
 		auto &pf = _pf_data[e];
+		if (pf.num_valid == 0) continue;
 		IConsolePrintF(TC_GREEN, "%s rate: %.2ffps  %.2ffps  %.2ffps  (expected: %.2ffps)",
 			MEASUREMENT_NAMES[e],
 			pf.GetRate(count1),
 			pf.GetRate(count2),
 			pf.GetRate(count3),
 			pf.expected_rate);
+		printed_anything = true;
 	}
 
 	for (auto e = PFE_FIRST; e < PFE_MAX; e = (PerformanceElement)(e + 1)) {
 		auto &pf = _pf_data[e];
+		if (pf.num_valid == 0) continue;
 		IConsolePrintF(TC_LIGHT_BLUE, "%s times: %.2fms  %.2fms  %.2fms",
 			MEASUREMENT_NAMES[e],
 			pf.GetAverageDurationMilliseconds(count1),
 			pf.GetAverageDurationMilliseconds(count2),
 			pf.GetAverageDurationMilliseconds(count3));
+		printed_anything = true;
+	}
+
+	if (!printed_anything) {
+		IConsoleWarning("No performance measurements have been taken yet");
 	}
 }

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -506,9 +506,9 @@ static const NWidgetPart _frametime_graph_window_widgets[] = {
 };
 
 struct FrametimeGraphWindow : Window {
-	int vertical_scale;     ///< number of TIMESTAMP_PRECISION units vertically
-	int horizontal_scale;   ///< number of half-second units horizontally
-	int scale_update_timer; ///< ticks left before next scale update
+	int vertical_scale;       ///< number of TIMESTAMP_PRECISION units vertically
+	int horizontal_scale;     ///< number of half-second units horizontally
+	uint32 next_scale_update; ///< realtime tick for next scale update
 
 	PerformanceElement element; ///< what element this window renders graph for
 	Dimension graph_size;       ///< size of the main graph area (excluding axis labels)
@@ -518,7 +518,7 @@ struct FrametimeGraphWindow : Window {
 		this->element = (PerformanceElement)number;
 		this->horizontal_scale = 4;
 		this->vertical_scale = TIMESTAMP_PRECISION / 10;
-		this->scale_update_timer = 0;
+		this->next_scale_update = 0;
 
 		this->InitNested(number);
 	}
@@ -634,10 +634,8 @@ struct FrametimeGraphWindow : Window {
 	{
 		this->SetDirty();
 
-		if (this->scale_update_timer > 0) {
-			this->scale_update_timer--;
-		} else {
-			this->scale_update_timer = 10;
+		if (this->next_scale_update < _realtime_tick) {
+			this->next_scale_update = _realtime_tick + 500;
 			this->UpdateScale();
 		}
 	}

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -383,7 +383,7 @@ struct FramerateWindow : Window {
 		DrawString(r.left, r.right, y, heading_str, TC_FROMSTRING, SA_CENTER);
 		y += FONT_HEIGHT_NORMAL + VSPACING;
 
-		for (auto e = PFE_FIRST; e < PFE_MAX; e = (PerformanceElement)(e + 1)) {
+		for (auto e = PFE_FIRST; e < PFE_MAX; e++) {
 			double value = get_value_func(e);
 			SetDParamGoodWarnBadDuration(value);
 			DrawString(r.left, r.right, y, STR_FRAMERATE_VALUE, TC_FROMSTRING, SA_RIGHT);
@@ -735,7 +735,7 @@ void ConPrintFramerate()
 		printed_anything = true;
 	}
 
-	for (auto e = PFE_FIRST; e < PFE_MAX; e = (PerformanceElement)(e + 1)) {
+	for (auto e = PFE_FIRST; e < PFE_MAX; e++) {
 		auto &pf = _pf_data[e];
 		if (pf.num_valid == 0) continue;
 		IConsolePrintF(TC_LIGHT_BLUE, "%s times: %.2fms  %.2fms  %.2fms",

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -140,13 +140,9 @@ void ShowFrametimeGraphWindow(FramerateElement elem);
 
 
 enum FramerateWindowWidgets {
-	WID_FRW_CAPTION_SMALL,
-	WID_FRW_TOGGLE_SIZE1,
-	WID_FRW_TOGGLE_SIZE2,
-	WID_FRW_SEL_NORMAL,
-	WID_FRW_SEL_SMALL,
+	WID_FRW_CAPTION,
 	WID_FRW_RATE_GAMELOOP,
-	WID_FRW_RATE_BLITTER,
+	WID_FRW_RATE_DRAWING,
 	WID_FRW_RATE_FACTOR,
 	WID_FRW_INFO_DATA_POINTS,
 	WID_FRW_TIMES_NAMES,
@@ -155,39 +151,29 @@ enum FramerateWindowWidgets {
 };
 
 static const NWidgetPart _framerate_window_widgets[] = {
-	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_FRW_SEL_SMALL),
-		NWidget(NWID_HORIZONTAL),
-			NWidget(WWT_CLOSEBOX, COLOUR_GREY),
-			NWidget(WWT_CAPTION, COLOUR_GREY, WID_FRW_CAPTION_SMALL), SetDataTip(STR_FRAMERATE_CAPTION_SMALL, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
-			NWidget(WWT_IMGBTN, COLOUR_GREY, WID_FRW_TOGGLE_SIZE1), SetDataTip(SPR_LARGE_SMALL_WINDOW, STR_TOOLTIP_TOGGLE_LARGE_SMALL_WINDOW),
-			NWidget(WWT_STICKYBOX, COLOUR_GREY),
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
+		NWidget(WWT_CAPTION, COLOUR_GREY, WID_FRW_CAPTION), SetDataTip(STR_FRAMERATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_SHADEBOX, COLOUR_GREY),
+		NWidget(WWT_STICKYBOX, COLOUR_GREY),
+	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_GREY),
+		NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_GAMELOOP), SetDataTip(STR_FRAMERATE_RATE_GAMELOOP, STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_DRAWING),  SetDataTip(STR_FRAMERATE_RATE_BLITTER,  STR_FRAMERATE_RATE_BLITTER_TOOLTIP),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_FACTOR),   SetDataTip(STR_FRAMERATE_SPEED_FACTOR,  STR_FRAMERATE_SPEED_FACTOR_TOOLTIP),
 		EndContainer(),
 	EndContainer(),
-	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_FRW_SEL_NORMAL), NWidget(NWID_VERTICAL),
-		NWidget(NWID_HORIZONTAL),
-			NWidget(WWT_CLOSEBOX, COLOUR_GREY),
-			NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_FRAMERATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
-			NWidget(WWT_IMGBTN, COLOUR_GREY, WID_FRW_TOGGLE_SIZE2), SetDataTip(SPR_LARGE_SMALL_WINDOW, STR_TOOLTIP_TOGGLE_LARGE_SMALL_WINDOW),
-			NWidget(WWT_STICKYBOX, COLOUR_GREY),
-		EndContainer(),
-		NWidget(WWT_PANEL, COLOUR_GREY),
-			NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
-				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_GAMELOOP), SetDataTip(STR_FRAMERATE_RATE_GAMELOOP, STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP),
-				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_BLITTER),  SetDataTip(STR_FRAMERATE_RATE_BLITTER,  STR_FRAMERATE_RATE_BLITTER_TOOLTIP),
-				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_FACTOR),   SetDataTip(STR_FRAMERATE_SPEED_FACTOR,  STR_FRAMERATE_SPEED_FACTOR_TOOLTIP),
+	NWidget(WWT_PANEL, COLOUR_GREY),
+		NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
+			NWidget(NWID_HORIZONTAL), SetPIP(0, 6, 0),
+				NWidget(WWT_EMPTY, COLOUR_GREY, WID_FRW_TIMES_NAMES),
+				NWidget(WWT_EMPTY, COLOUR_GREY, WID_FRW_TIMES_CURRENT),
+				NWidget(WWT_EMPTY, COLOUR_GREY, WID_FRW_TIMES_AVERAGE),
 			EndContainer(),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_INFO_DATA_POINTS), SetDataTip(STR_FRAMERATE_DATA_POINTS, 0x0),
 		EndContainer(),
-		NWidget(WWT_PANEL, COLOUR_GREY),
-			NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
-				NWidget(NWID_HORIZONTAL), SetPIP(0, 6, 0),
-					NWidget(WWT_EMPTY, COLOUR_GREY, WID_FRW_TIMES_NAMES),
-					NWidget(WWT_EMPTY, COLOUR_GREY, WID_FRW_TIMES_CURRENT),
-					NWidget(WWT_EMPTY, COLOUR_GREY, WID_FRW_TIMES_AVERAGE),
-				EndContainer(),
-				NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_INFO_DATA_POINTS), SetDataTip(STR_FRAMERATE_DATA_POINTS, 0x0),
-			EndContainer(),
-		EndContainer(),
-	EndContainer(), EndContainer(),
+	EndContainer(),
 };
 
 struct FramerateWindow : Window {
@@ -198,19 +184,21 @@ struct FramerateWindow : Window {
 	FramerateWindow(WindowDesc *desc, WindowNumber number) : Window(desc)
 	{
 		this->InitNested(number);
-		this->SetSmall(false);
-	}
-
-	void SetSmall(bool small)
-	{
-		this->small = small;
-		this->GetWidget<NWidgetStacked>(WID_FRW_SEL_NORMAL)->SetDisplayedPlane(this->small ? SZSP_NONE : 0);
-		this->GetWidget<NWidgetStacked>(WID_FRW_SEL_SMALL)->SetDisplayedPlane(this->small ? 0 : SZSP_NONE);
-		this->ReInit();
+		this->small = this->IsShaded();
 	}
 
 	virtual void OnTick()
 	{
+		if (this->small != this->IsShaded()) {
+			this->small = this->IsShaded();
+			auto caption = this->GetWidget<NWidgetLeaf>(WID_FRW_CAPTION);
+			if (this->small) {
+				caption->SetDataTip(STR_FRAMERATE_CAPTION_SMALL, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS);
+			} else {
+				caption->SetDataTip(STR_FRAMERATE_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS);
+			}
+		}
+
 		this->SetDirty();
 	}
 
@@ -251,7 +239,8 @@ struct FramerateWindow : Window {
 		double value;
 
 		switch (widget) {
-			case WID_FRW_CAPTION_SMALL:
+			case WID_FRW_CAPTION:
+				if (!this->small) break;
 				value = _pf_data[FRAMERATE_GAMELOOP].GetRate();
 				SetDParamGoodWarnBadRate(value, FRAMERATE_GAMELOOP);
 				value /= _pf_data[FRAMERATE_GAMELOOP].expected_rate;
@@ -263,7 +252,7 @@ struct FramerateWindow : Window {
 				value = _pf_data[FRAMERATE_GAMELOOP].GetRate();
 				SetDParamGoodWarnBadRate(value, FRAMERATE_GAMELOOP);
 				break;
-			case WID_FRW_RATE_BLITTER:
+			case WID_FRW_RATE_DRAWING:
 				value = _pf_data[FRAMERATE_DRAWING].GetRate();
 				SetDParamGoodWarnBadRate(value, FRAMERATE_DRAWING);
 				break;
@@ -282,20 +271,11 @@ struct FramerateWindow : Window {
 	virtual void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize)
 	{
 		switch (widget) {
-			case WID_FRW_CAPTION_SMALL:
-				SetDParam(0, STR_FRAMERATE_FPS_GOOD);
-				SetDParam(1, 999999);
-				SetDParam(2, 2);
-				SetDParam(3, 999999);
-				SetDParam(4, 2);
-				*size = GetStringBoundingBox(STR_FRAMERATE_CAPTION_SMALL);
-				break;
-
 			case WID_FRW_RATE_GAMELOOP:
 				SetDParamGoodWarnBadRate(9999.99, FRAMERATE_GAMELOOP);
 				*size = GetStringBoundingBox(STR_FRAMERATE_RATE_GAMELOOP);
 				break;
-			case WID_FRW_RATE_BLITTER:
+			case WID_FRW_RATE_DRAWING:
 				SetDParamGoodWarnBadRate(9999.99, FRAMERATE_DRAWING);
 				*size = GetStringBoundingBox(STR_FRAMERATE_RATE_BLITTER);
 				break;
@@ -376,11 +356,6 @@ struct FramerateWindow : Window {
 	virtual void OnClick(Point pt, int widget, int click_count)
 	{
 		switch (widget) {
-			case WID_FRW_TOGGLE_SIZE1:
-			case WID_FRW_TOGGLE_SIZE2:
-				this->SetSmall(!this->small);
-				break;
-
 			case WID_FRW_TIMES_NAMES:
 			case WID_FRW_TIMES_CURRENT:
 			case WID_FRW_TIMES_AVERAGE: {

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -429,8 +429,8 @@ struct FrametimeGraphWindow : Window {
 			SetDParam(0, this->horizontal_scale / 2);
 			auto size_s_label = GetStringBoundingBox(STR_FRAMERATE_GRAPH_SECONDS);
 
-			graph_size.width = this->horizontal_scale * max<uint>(100, size_s_label.width + 10) / 2;
 			graph_size.height = max<uint>(100, 10 * (size_ms_label.height + 1));
+			graph_size.width = max<uint>(2 * graph_size.height, this->horizontal_scale *  (size_s_label.width + 10) / 2 );
 			*size = graph_size;
 
 			size->width += size_ms_label.width + 2;

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -262,7 +262,12 @@ static WindowDesc _framerate_display_desc(
 );
 
 
-void DoShowFramerate()
+void ShowFramerateWindow()
+{
+	AllocateWindowDescFront<FramerateWindow>(&_framerate_display_desc, 0);
+}
+
+void ConPrintFramerate()
 {
 	const int count1 = NUM_FRAMERATE_POINTS / 1;
 	const int count2 = NUM_FRAMERATE_POINTS / 4;
@@ -293,6 +298,4 @@ void DoShowFramerate()
 			GetAverageDuration(e, count2),
 			GetAverageDuration(e, count3));
 	}
-
-	AllocateWindowDescFront<FramerateWindow>(&_framerate_display_desc, 0);
 }

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -1,0 +1,251 @@
+/* $Id$ */
+
+/*
+* This file is part of OpenTTD.
+* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file framerate_gui.cpp GUI for displaying framerate/game speed information. */
+
+#include "framerate_type.h"
+#include "gfx_func.h"
+#include "window_gui.h"
+#include "strings_func.h"
+#include "debug.h"
+#include "console_func.h"
+#include "console_type.h"
+
+
+namespace {
+
+	const int NUM_FRAMERATE_POINTS = 128;
+
+	static uint32 _framerate_measurements[FRAMERATE_MAX][NUM_FRAMERATE_POINTS] = {};
+	static int _framerate_next_measurement_point[FRAMERATE_MAX] = {};
+
+	void StoreMeasurement(FramerateElement elem, uint32 value)
+	{
+		_framerate_measurements[elem][_framerate_next_measurement_point[elem]] = value;
+		_framerate_next_measurement_point[elem] += 1;
+		_framerate_next_measurement_point[elem] %= NUM_FRAMERATE_POINTS;
+	}
+
+	template <int Points>
+	double GetAverageMeasurement(FramerateElement elem)
+	{
+		assert(elem > FRAMERATE_OVERALL); // overall is absolute times, not difference times
+		assert(elem < FRAMERATE_MAX);
+
+		int first_point = _framerate_next_measurement_point[elem] - Points - 1;
+		while (first_point < 0) first_point += NUM_FRAMERATE_POINTS;
+
+		double sumtime = 0;
+		for (int i = first_point; i < first_point + Points; i++) {
+			sumtime += _framerate_measurements[elem][i % NUM_FRAMERATE_POINTS];
+		}
+
+		return sumtime / Points;
+	}
+
+	template <int Points>
+	uint32 GetOverallAverage()
+	{
+		int first, last;
+
+		first = _framerate_next_measurement_point[FRAMERATE_OVERALL] - Points;
+		last = _framerate_next_measurement_point[FRAMERATE_OVERALL] - 1;
+		if (first < 0) first += NUM_FRAMERATE_POINTS;
+		if (last < 0) last += NUM_FRAMERATE_POINTS;
+
+		return (_framerate_measurements[FRAMERATE_OVERALL][last] - _framerate_measurements[FRAMERATE_OVERALL][first]) / Points;
+	}
+
+	double MillisecondsToFps(uint32 ms)
+	{
+		return 1000.0 / ms;
+	}
+
+}
+
+
+FramerateMeasurer::FramerateMeasurer(FramerateElement elem)
+{
+	assert(elem > FRAMERATE_OVERALL); // not allowed to measure "overall", happens automatically with gameloop
+	assert(elem < FRAMERATE_MAX);
+	this->elem = elem;
+
+	this->start_time = GetTime();
+
+	if (elem == FRAMERATE_GAMELOOP) {
+		StoreMeasurement(FRAMERATE_OVERALL, this->start_time);
+	}
+}
+
+FramerateMeasurer::~FramerateMeasurer()
+{
+	StoreMeasurement(this->elem, GetTime() - this->start_time);
+}
+
+
+enum FramerateWindowWidgets {
+	WID_FRW_CAPTION,
+	WID_FRW_CURRENT_FPS,
+	WID_FRW_TIMES_GAMELOOP,
+	WID_FRW_TIMES_DRAWING,
+	WID_FRW_TIMES_VIDEO,
+};
+
+struct FramerateWindow : Window {
+
+	FramerateWindow(WindowDesc *desc, WindowNumber number) : Window(desc)
+	{
+		this->InitNested(number);
+	}
+
+	virtual void OnInvalidateData(int data = 0, bool gui_scope = true)
+	{
+		if (!gui_scope) return;
+		this->SetDirty();
+	}
+
+	virtual void OnTick()
+	{
+		this->InvalidateData();
+	}
+
+	static void SetDParmGoodWarnBadSmall(double value, double threshold_good, double threshold_bad)
+	{
+		uint tpl;
+		if (value < threshold_good) tpl = STR_FRAMERATE_VALUE_GOOD;
+		else if (value > threshold_bad) tpl = STR_FRAMERATE_VALUE_BAD;
+		else tpl = STR_FRAMERATE_VALUE_WARN;
+		value = min(9999.99, value);
+		SetDParam(0, tpl);
+		SetDParam(1, (int)(value * 100));
+		SetDParam(2, 2);
+	}
+
+	static void SetDParmGoodWarnBadLarge(double value, double threshold_good, double threshold_bad)
+	{
+		uint tpl;
+		if (value > threshold_good) tpl = STR_FRAMERATE_VALUE_GOOD;
+		else if (value < threshold_bad) tpl = STR_FRAMERATE_VALUE_BAD;
+		else tpl = STR_FRAMERATE_VALUE_WARN;
+		value = min(9999.99, value);
+		SetDParam(0, tpl);
+		SetDParam(1, (int)(value * 100));
+		SetDParam(2, 2);
+	}
+
+	virtual void SetStringParameters(int widget) const
+	{
+		static char text_value[FRAMERATE_MAX][32];
+		double value;
+
+		switch (widget) {
+			case WID_FRW_CURRENT_FPS:
+				value = MillisecondsToFps(GetOverallAverage<NUM_FRAMERATE_POINTS>());
+				SetDParmGoodWarnBadLarge(value, 20, 32); // "target" framerate is 33.33, anything less indicates a performance problem
+				break;
+			case WID_FRW_TIMES_GAMELOOP:
+				value = GetAverageMeasurement<NUM_FRAMERATE_POINTS>(FRAMERATE_GAMELOOP);
+				SetDParmGoodWarnBadSmall(value, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				break;
+			case WID_FRW_TIMES_DRAWING:
+				value = GetAverageMeasurement<NUM_FRAMERATE_POINTS>(FRAMERATE_DRAWING);
+				SetDParmGoodWarnBadSmall(value, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				break;
+			case WID_FRW_TIMES_VIDEO:
+				value = GetAverageMeasurement<NUM_FRAMERATE_POINTS>(FRAMERATE_VIDEO);
+				SetDParmGoodWarnBadSmall(value, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				break;
+		}
+	}
+
+	virtual void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize)
+	{
+		switch (widget) {
+			case WID_FRW_CURRENT_FPS:
+				SetDParmGoodWarnBadLarge(9999.99, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				*size = GetStringBoundingBox(STR_FRAMERATE_DISPLAY_CURRENT_FPS);
+				break;
+
+			case WID_FRW_TIMES_GAMELOOP:
+				SetDParmGoodWarnBadSmall(9999.99, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				*size = GetStringBoundingBox(STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP);
+				break;
+
+			case WID_FRW_TIMES_DRAWING:
+				SetDParmGoodWarnBadSmall(9999.99, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				*size = GetStringBoundingBox(STR_FRAMERATE_DISPLAY_TIMES_DRAWING);
+				break;
+
+			case WID_FRW_TIMES_VIDEO:
+				SetDParmGoodWarnBadSmall(9999.99, MILLISECONDS_PER_TICK / 3, MILLISECONDS_PER_TICK);
+				*size = GetStringBoundingBox(STR_FRAMERATE_DISPLAY_TIMES_VIDEO);
+				break;
+
+			default:
+				Window::UpdateWidgetSize(widget, size, padding, fill, resize);
+				break;
+		}
+	}
+};
+
+static const NWidgetPart _framerate_window_widgets[] = {
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_CLOSEBOX, COLOUR_GREY),
+		NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_FRAMERATE_DISPLAY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_STICKYBOX, COLOUR_GREY),
+	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_GREY),
+		NWidget(NWID_VERTICAL), SetPIP(0, 3, 0), SetPadding(3, 3, 3, 3),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_CURRENT_FPS),    SetDataTip(STR_FRAMERATE_DISPLAY_CURRENT_FPS,    STR_FRAMERATE_DISPLAY_CURRENT_FPS_TOOLTIP),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_TIMES_GAMELOOP), SetDataTip(STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP, STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP_TOOLTIP),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_TIMES_DRAWING),  SetDataTip(STR_FRAMERATE_DISPLAY_TIMES_DRAWING,  STR_FRAMERATE_DISPLAY_TIMES_DRAWING_TOOLTIP),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_TIMES_VIDEO),    SetDataTip(STR_FRAMERATE_DISPLAY_TIMES_VIDEO,    STR_FRAMERATE_DISPLAY_TIMES_VIDEO_TOOLTIP),
+		EndContainer(),
+	EndContainer(),
+};
+
+static WindowDesc _framerate_display_desc(
+	WDP_AUTO, "framerate_display", 60, 40,
+	WC_FRAMERATE_DISPLAY, WC_NONE,
+	0,
+	_framerate_window_widgets, lengthof(_framerate_window_widgets)
+);
+
+
+void DoShowFramerate()
+{
+	const int count1 = NUM_FRAMERATE_POINTS / 1;
+	const int count2 = NUM_FRAMERATE_POINTS / 4;
+	const int count3 = NUM_FRAMERATE_POINTS / 8;
+
+	IConsolePrintF(TC_SILVER, "Based on num. data points: %d %d %d", count1, count2, count3);
+
+	IConsolePrintF(TC_LIGHT_BLUE, "Overall framerate: %.2ffps  %.2ffps  %.2ffps",
+		MillisecondsToFps(GetOverallAverage<count1>()),
+		MillisecondsToFps(GetOverallAverage<count2>()),
+		MillisecondsToFps(GetOverallAverage<count3>()));
+
+	static char *MEASUREMENT_NAMES[FRAMERATE_MAX] = {
+		"Overall",
+		"Gameloop",
+		"Drawing",
+		"Video output",
+	};
+
+	for (FramerateElement e = FRAMERATE_OVERALL; e < FRAMERATE_MAX; e = (FramerateElement)(e + 1)) {
+		if (e == FRAMERATE_OVERALL) continue;
+		IConsolePrintF(TC_LIGHT_BLUE, "%s times: %.2fms  %.2fms  %.2fms",
+			MEASUREMENT_NAMES[e],
+			GetAverageMeasurement<count1>(e),
+			GetAverageMeasurement<count2>(e),
+			GetAverageMeasurement<count3>(e));
+	}
+
+	AllocateWindowDescFront<FramerateWindow>(&_framerate_display_desc, 0);
+}

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -113,12 +113,19 @@ namespace {
 		}
 	};
 
+	static const double GL_RATE = 1000.0 / MILLISECONDS_PER_TICK;
+
 	PerformanceData _pf_data[PFE_MAX] = {
-		PerformanceData(1000.0 / MILLISECONDS_PER_TICK), // PFE_GAMELOOP
-		PerformanceData(1000.0 / MILLISECONDS_PER_TICK), // PFE_DRAWING
-		PerformanceData(1000.0 / MILLISECONDS_PER_TICK), // PFE_ACC_DRAWWORLD
-		PerformanceData(60.0),                           // PFE_VIDEO
-		PerformanceData(1000.0 * 8192 / 44100),          // PFE_SOUND
+		PerformanceData(GL_RATE),               // PFE_GAMELOOP
+		PerformanceData(GL_RATE),               // PFE_ACC_GL_ECONOMY
+		PerformanceData(GL_RATE),               // PFE_ACC_GL_TRAINS
+		PerformanceData(GL_RATE),               // PFE_ACC_GL_ROADVEHS
+		PerformanceData(GL_RATE),               // PFE_ACC_GL_SHIPS
+		PerformanceData(GL_RATE),               // PFE_ACC_GL_AIRCRAFT
+		PerformanceData(GL_RATE),               // PFE_DRAWING
+		PerformanceData(GL_RATE),               // PFE_ACC_DRAWWORLD
+		PerformanceData(60.0),                  // PFE_VIDEO
+		PerformanceData(1000.0 * 8192 / 44100), // PFE_SOUND
 	};
 
 }
@@ -614,6 +621,11 @@ void ConPrintFramerate()
 
 	static char *MEASUREMENT_NAMES[PFE_MAX] = {
 		"Game loop",
+		"GL station ticks",
+		"GL train ticks",
+		"GL road vehicle ticks",
+		"GL ship ticks",
+		"GL aircraft ticks",
 		"Drawing",
 		"Viewport drawing",
 		"Video output",

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -10,6 +10,7 @@
 /** @file framerate_gui.cpp GUI for displaying framerate/game speed information. */
 
 #include "framerate_type.h"
+#include <chrono>
 #include "gfx_func.h"
 #include "window_gui.h"
 #include "table/sprites.h"
@@ -91,23 +92,12 @@ namespace {
 }
 
 
-#ifdef WIN32
-#include <windows.h>
+static std::chrono::high_resolution_clock _hr_clock;
 static TimingMeasurement GetPerformanceTimer()
 {
-	LARGE_INTEGER pfc, pfq;
-	if (QueryPerformanceFrequency(&pfq) && QueryPerformanceCounter(&pfc)) {
-		return pfc.QuadPart * TIMESTAMP_PRECISION / pfq.QuadPart;
-	} else {
-		return GetTickCount() * 1000;
-	}
+	auto usec = std::chrono::time_point_cast<std::chrono::microseconds>(_hr_clock.now());
+	return usec.time_since_epoch().count();
 }
-#else
-static TimingMeasurement GetPerformanceTimer()
-{
-	return GetTime() * 1000;
-}
-#endif
 
 
 FramerateMeasurer::FramerateMeasurer(FramerateElement elem)

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -128,6 +128,7 @@ enum FramerateWindowWidgets {
 	WID_FRW_DETAILSPANEL,
 	WID_FRW_RATE_GAMELOOP,
 	WID_FRW_RATE_BLITTER,
+	WID_FRW_RATE_FACTOR,
 	WID_FRW_INFO_DATA_POINTS,
 	WID_FRW_TIMES_NAMES,
 	WID_FRW_TIMES_CURRENT,
@@ -145,6 +146,7 @@ static const NWidgetPart _framerate_window_widgets[] = {
 		NWidget(NWID_VERTICAL), SetPadding(6), SetPIP(0, 3, 0),
 			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_GAMELOOP), SetDataTip(STR_FRAMERATE_RATE_GAMELOOP, STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP),
 			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_BLITTER),  SetDataTip(STR_FRAMERATE_RATE_BLITTER,  STR_FRAMERATE_RATE_BLITTER_TOOLTIP),
+			NWidget(WWT_TEXT, COLOUR_GREY, WID_FRW_RATE_FACTOR),   SetDataTip(STR_FRAMERATE_SPEED_FACTOR,  STR_FRAMERATE_SPEED_FACTOR_TOOLTIP),
 		EndContainer(),
 	EndContainer(),
 	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_FRW_DETAILSPANEL),
@@ -230,6 +232,12 @@ struct FramerateWindow : Window {
 				value = GetFramerate(FRAMERATE_DRAWING, 8);
 				SetDParamGoodWarnBadRate(value, FRAMERATE_DRAWING);
 				break;
+			case WID_FRW_RATE_FACTOR:
+				value = GetFramerate(FRAMERATE_GAMELOOP, 8);
+				value /= _framerate_expected_rate[FRAMERATE_GAMELOOP];
+				SetDParam(0, (int)(value * 100));
+				SetDParam(1, 2);
+				break;
 			case WID_FRW_INFO_DATA_POINTS:
 				SetDParam(0, NUM_FRAMERATE_POINTS);
 				break;
@@ -246,6 +254,11 @@ struct FramerateWindow : Window {
 			case WID_FRW_RATE_BLITTER:
 				SetDParamGoodWarnBadRate(9999.99, FRAMERATE_DRAWING);
 				*size = GetStringBoundingBox(STR_FRAMERATE_RATE_BLITTER);
+				break;
+			case WID_FRW_RATE_FACTOR:
+				SetDParam(0, 99999);
+				SetDParam(1, 2);
+				*size = GetStringBoundingBox(STR_FRAMERATE_SPEED_FACTOR);
 				break;
 
 			case WID_FRW_TIMES_NAMES: {

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -639,7 +639,7 @@ struct FrametimeGraphWindow : Window {
 				int y = Scinterlate(y_zero, y_max, 0, (int)vert_divisions, (int)division);
 				GfxDrawLine(x_zero, y, x_max, y, c_grid);
 				if (division % 2 == 0) {
-					if (this->vertical_scale > TIMESTAMP_PRECISION) {
+					if ((TimingMeasurement)this->vertical_scale > TIMESTAMP_PRECISION) {
 						SetDParam(0, this->vertical_scale * division / 10 / TIMESTAMP_PRECISION);
 						DrawString(r.left, x_zero - 2, y - FONT_HEIGHT_SMALL, STR_FRAMERATE_GRAPH_SECONDS, TC_GREY, SA_RIGHT | SA_FORCE, false, FS_SMALL);
 					} else {

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -149,6 +149,8 @@ namespace {
 		PerformanceData(1),                     // PFE_ACC_GL_ROADVEHS
 		PerformanceData(1),                     // PFE_ACC_GL_SHIPS
 		PerformanceData(1),                     // PFE_ACC_GL_AIRCRAFT
+		PerformanceData(1),                     // PFE_GL_LANDSCAPE
+		PerformanceData(1),                     // PFE_GL_LINKGRAPH
 		PerformanceData(GL_RATE),               // PFE_DRAWING
 		PerformanceData(1),                     // PFE_ACC_DRAWWORLD
 		PerformanceData(60.0),                  // PFE_VIDEO
@@ -758,6 +760,8 @@ void ConPrintFramerate()
 		"  GL road vehicle ticks",
 		"  GL ship ticks",
 		"  GL aircraft ticks",
+		"  GL landscape ticks",
+		"  GL link graph delays",
 		"Drawing",
 		"  Viewport drawing",
 		"Video output",

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -116,6 +116,7 @@ namespace {
 	PerformanceData _pf_data[PFE_MAX] = {
 		PerformanceData(1000.0 / MILLISECONDS_PER_TICK), // PFE_GAMELOOP
 		PerformanceData(1000.0 / MILLISECONDS_PER_TICK), // PFE_DRAWING
+		PerformanceData(1000.0 / MILLISECONDS_PER_TICK), // PFE_ACC_DRAWWORLD
 		PerformanceData(60.0),                           // PFE_VIDEO
 		PerformanceData(1000.0 * 8192 / 44100),          // PFE_SOUND
 	};
@@ -614,6 +615,7 @@ void ConPrintFramerate()
 	static char *MEASUREMENT_NAMES[PFE_MAX] = {
 		"Game loop",
 		"Drawing",
+		"Viewport drawing",
 		"Video output",
 		"Sound mixing",
 	};

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -601,10 +601,11 @@ struct FrametimeGraphWindow : Window {
 	}
 
 	/** Scale and interpolate a value from a source range into a destination range */
-	static inline int Scinterlate(int dst_min, int dst_max, int src_min, int src_max, int value)
+	template<typename T>
+	static inline T Scinterlate(T dst_min, T dst_max, T src_min, T src_max, T value)
 	{
-		int dst_diff = dst_max - dst_min;
-		int src_diff = src_max - src_min;
+		T dst_diff = dst_max - dst_min;
+		T src_diff = src_max - src_min;
 		return (value - src_min) * dst_diff / src_diff + dst_min;
 	}
 
@@ -660,7 +661,7 @@ struct FrametimeGraphWindow : Window {
 			/* Position of last rendered data point */
 			Point lastpoint{
 				x_max,
-				Scinterlate(y_zero, y_max, 0, this->vertical_scale, (int)durations[point])
+				(int)Scinterlate<int64>(y_zero, y_max, 0, this->vertical_scale, (int)durations[point])
 			};
 			/* Timestamp of last rendered data point */
 			TimingMeasurement lastts = timestamps[point];
@@ -690,8 +691,8 @@ struct FrametimeGraphWindow : Window {
 
 				/* Draw line from previous point to new point */
 				Point newpoint{
-					Scinterlate(x_zero, x_max, 0, draw_horz_scale, draw_horz_scale - time_sum),
-					Scinterlate(y_zero, y_max, 0, draw_vert_scale, (int)value)
+					(int)Scinterlate<int64>(x_zero, x_max, 0, draw_horz_scale, draw_horz_scale - time_sum),
+					(int)Scinterlate<int64>(y_zero, y_max, 0, draw_vert_scale, value)
 				};
 				assert(newpoint.x <= lastpoint.x);
 				GfxDrawLine(lastpoint.x, lastpoint.y, newpoint.x, newpoint.y, c_lines);

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -1,0 +1,36 @@
+/* $Id$ */
+
+/*
+* This file is part of OpenTTD.
+* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef FRAMERATE_GUI_H
+#define FRAMERATE_GUI_H
+
+#include "stdafx.h"
+
+enum FramerateElement {
+	FRAMERATE_OVERALL,  ///< Time taken between gameloop iterations. Must be first.
+	FRAMERATE_GAMELOOP, ///< Speed of gameloop processing.
+	FRAMERATE_DRAWING,  ///< Speed of drawing world and GUI.
+	FRAMERATE_VIDEO,    ///< Speed of painting drawn video buffer.
+	FRAMERATE_MAX,      ///< End of enum, must be last.
+};
+
+/**
+ * RAII class for measuring elements of framerate.
+ * Construct an object with the appropriate element parameter when processing begins,
+ * time is automatically taken when the object goes out of scope again.
+ */
+class FramerateMeasurer {
+	FramerateElement elem;
+	uint32 start_time;
+public:
+	FramerateMeasurer(FramerateElement elem);
+	~FramerateMeasurer();
+};
+
+#endif /* FRAMERATE_GUI_H */

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -21,6 +21,8 @@ enum FramerateElement {
 	FRAMERATE_MAX,            ///< End of enum, must be last.
 };
 
+typedef uint32 TimingMeasurement;
+
 /**
  * RAII class for measuring elements of framerate.
  * Construct an object with the appropriate element parameter when processing begins,
@@ -28,7 +30,7 @@ enum FramerateElement {
  */
 class FramerateMeasurer {
 	FramerateElement elem;
-	uint32 start_time;
+	TimingMeasurement start_time;
 public:
 	FramerateMeasurer(FramerateElement elem);
 	~FramerateMeasurer();

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -13,13 +13,18 @@
 #include "stdafx.h"
 
 enum PerformanceElement {
-	PFE_GAMELOOP,       ///< Speed of gameloop processing.
+	PFE_GAMELOOP,        ///< Speed of gameloop processing.
 	PFE_FIRST = PFE_GAMELOOP,
-	PFE_DRAWING,        ///< Speed of drawing world and GUI.
-	PFE_ACC_DRAWWORLD,  ///< Time spent drawing world viewports in GUI
-	PFE_VIDEO,          ///< Speed of painting drawn video buffer.
-	PFE_SOUND,          ///< Speed of mixing audio samples
-	PFE_MAX,            ///< End of enum, must be last.
+	PFE_ACC_GL_ECONOMY,  ///< Time spent processing cargo movement
+	PFE_ACC_GL_TRAINS,   ///< Time spent processing trains
+	PFE_ACC_GL_ROADVEHS, ///< Time spend processing road vehicles
+	PFE_ACC_GL_SHIPS,    ///< Time spent processing ships
+	PFE_ACC_GL_AIRCRAFT, ///< Time spent processing aircraft
+	PFE_DRAWING,         ///< Speed of drawing world and GUI.
+	PFE_ACC_DRAWWORLD,   ///< Time spent drawing world viewports in GUI
+	PFE_VIDEO,           ///< Speed of painting drawn video buffer.
+	PFE_SOUND,           ///< Speed of mixing audio samples
+	PFE_MAX,             ///< End of enum, must be last.
 };
 
 typedef uint64 TimingMeasurement;

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -24,7 +24,7 @@ enum PerformanceElement {
 typedef uint64 TimingMeasurement;
 
 /**
- * RAII class for measuring elements of performance.
+ * RAII class for measuring simple elements of performance.
  * Construct an object with the appropriate element parameter when processing begins,
  * time is automatically taken when the object goes out of scope again.
  */
@@ -35,6 +35,20 @@ public:
 	PerformanceMeasurer(PerformanceElement elem);
 	~PerformanceMeasurer();
 	void SetExpectedRate(double rate);
+};
+
+/**
+ * RAII class for measuring multi-step elements of performance.
+ * At the beginning of a frame, call Reset on the element, then construct an object in the scope where
+ * each processing cycle happens. The measurements are summed between resets.
+ */
+class PerformanceAccumulator {
+	PerformanceElement elem;
+	TimingMeasurement start_time;
+public:
+	PerformanceAccumulator(PerformanceElement elem);
+	~PerformanceAccumulator();
+	static void Reset(PerformanceElement elem);
 };
 
 void ShowFramerateWindow();

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -11,6 +11,7 @@
 #define FRAMERATE_GUI_H
 
 #include "stdafx.h"
+#include "core/enum_type.hpp"
 
 enum PerformanceElement {
 	PFE_GAMELOOP,        ///< Speed of gameloop processing.
@@ -26,6 +27,7 @@ enum PerformanceElement {
 	PFE_SOUND,           ///< Speed of mixing audio samples
 	PFE_MAX,             ///< End of enum, must be last.
 };
+DECLARE_POSTFIX_INCREMENT(PerformanceElement)
 
 typedef uint64 TimingMeasurement;
 

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -35,4 +35,6 @@ public:
 	void SetExpectedRate(double rate);
 };
 
+void ShowFramerateWindow();
+
 #endif /* FRAMERATE_GUI_H */

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -16,6 +16,7 @@ enum PerformanceElement {
 	PFE_GAMELOOP,       ///< Speed of gameloop processing.
 	PFE_FIRST = PFE_GAMELOOP,
 	PFE_DRAWING,        ///< Speed of drawing world and GUI.
+	PFE_ACC_DRAWWORLD,  ///< Time spent drawing world viewports in GUI
 	PFE_VIDEO,          ///< Speed of painting drawn video buffer.
 	PFE_SOUND,          ///< Speed of mixing audio samples
 	PFE_MAX,            ///< End of enum, must be last.

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -12,28 +12,28 @@
 
 #include "stdafx.h"
 
-enum FramerateElement {
-	FRAMERATE_GAMELOOP,       ///< Speed of gameloop processing.
-	FRAMERATE_FIRST = FRAMERATE_GAMELOOP,
-	FRAMERATE_DRAWING,        ///< Speed of drawing world and GUI.
-	FRAMERATE_VIDEO,          ///< Speed of painting drawn video buffer.
-	FRAMERATE_SOUND,          ///< Speed of mixing audio samples
-	FRAMERATE_MAX,            ///< End of enum, must be last.
+enum PerformanceElement {
+	PFE_GAMELOOP,       ///< Speed of gameloop processing.
+	PFE_FIRST = PFE_GAMELOOP,
+	PFE_DRAWING,        ///< Speed of drawing world and GUI.
+	PFE_VIDEO,          ///< Speed of painting drawn video buffer.
+	PFE_SOUND,          ///< Speed of mixing audio samples
+	PFE_MAX,            ///< End of enum, must be last.
 };
 
 typedef uint64 TimingMeasurement;
 
 /**
- * RAII class for measuring elements of framerate.
+ * RAII class for measuring elements of performance.
  * Construct an object with the appropriate element parameter when processing begins,
  * time is automatically taken when the object goes out of scope again.
  */
-class FramerateMeasurer {
-	FramerateElement elem;
+class PerformanceMeasurer {
+	PerformanceElement elem;
 	TimingMeasurement start_time;
 public:
-	FramerateMeasurer(FramerateElement elem);
-	~FramerateMeasurer();
+	PerformanceMeasurer(PerformanceElement elem);
+	~PerformanceMeasurer();
 	void SetExpectedRate(double rate);
 };
 

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -14,20 +14,20 @@
 #include "core/enum_type.hpp"
 
 enum PerformanceElement {
-	PFE_GAMELOOP,        ///< Speed of gameloop processing.
-	PFE_FIRST = PFE_GAMELOOP,
-	PFE_ACC_GL_ECONOMY,  ///< Time spent processing cargo movement
-	PFE_ACC_GL_TRAINS,   ///< Time spent processing trains
-	PFE_ACC_GL_ROADVEHS, ///< Time spend processing road vehicles
-	PFE_ACC_GL_SHIPS,    ///< Time spent processing ships
-	PFE_ACC_GL_AIRCRAFT, ///< Time spent processing aircraft
-	PFE_GL_LANDSCAPE,    ///< Time spent processing other world features
-	PFE_GL_LINKGRAPH,    ///< Time spent waiting for link graph background jobs
-	PFE_DRAWING,         ///< Speed of drawing world and GUI.
-	PFE_ACC_DRAWWORLD,   ///< Time spent drawing world viewports in GUI
-	PFE_VIDEO,           ///< Speed of painting drawn video buffer.
-	PFE_SOUND,           ///< Speed of mixing audio samples
-	PFE_MAX,             ///< End of enum, must be last.
+	PFE_FIRST = 0,
+	PFE_GAMELOOP = 0,  ///< Speed of gameloop processing.
+	PFE_GL_ECONOMY,    ///< Time spent processing cargo movement
+	PFE_GL_TRAINS,     ///< Time spent processing trains
+	PFE_GL_ROADVEHS,   ///< Time spend processing road vehicles
+	PFE_GL_SHIPS,      ///< Time spent processing ships
+	PFE_GL_AIRCRAFT,   ///< Time spent processing aircraft
+	PFE_GL_LANDSCAPE,  ///< Time spent processing other world features
+	PFE_GL_LINKGRAPH,  ///< Time spent waiting for link graph background jobs
+	PFE_DRAWING,       ///< Speed of drawing world and GUI.
+	PFE_DRAWWORLD,     ///< Time spent drawing world viewports in GUI
+	PFE_VIDEO,         ///< Speed of painting drawn video buffer.
+	PFE_SOUND,         ///< Speed of mixing audio samples
+	PFE_MAX,           ///< End of enum, must be last.
 };
 DECLARE_POSTFIX_INCREMENT(PerformanceElement)
 

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -17,6 +17,7 @@ enum FramerateElement {
 	FRAMERATE_FIRST = FRAMERATE_GAMELOOP,
 	FRAMERATE_DRAWING,  ///< Speed of drawing world and GUI.
 	FRAMERATE_VIDEO,    ///< Speed of painting drawn video buffer.
+	FRAMERATE_SOUND,    ///< Speed of mixing audio samples
 	FRAMERATE_MAX,      ///< End of enum, must be last.
 };
 
@@ -31,6 +32,7 @@ class FramerateMeasurer {
 public:
 	FramerateMeasurer(FramerateElement elem);
 	~FramerateMeasurer();
+	void SetExpectedRate(double rate);
 };
 
 #endif /* FRAMERATE_GUI_H */

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -13,8 +13,8 @@
 #include "stdafx.h"
 
 enum FramerateElement {
-	FRAMERATE_OVERALL,  ///< Time taken between gameloop iterations. Must be first.
 	FRAMERATE_GAMELOOP, ///< Speed of gameloop processing.
+	FRAMERATE_FIRST = FRAMERATE_GAMELOOP,
 	FRAMERATE_DRAWING,  ///< Speed of drawing world and GUI.
 	FRAMERATE_VIDEO,    ///< Speed of painting drawn video buffer.
 	FRAMERATE_MAX,      ///< End of enum, must be last.

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -41,6 +41,7 @@ public:
 	PerformanceMeasurer(PerformanceElement elem);
 	~PerformanceMeasurer();
 	void SetExpectedRate(double rate);
+	static void Paused(PerformanceElement elem);
 };
 
 /**

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -13,12 +13,12 @@
 #include "stdafx.h"
 
 enum FramerateElement {
-	FRAMERATE_GAMELOOP, ///< Speed of gameloop processing.
+	FRAMERATE_GAMELOOP,       ///< Speed of gameloop processing.
 	FRAMERATE_FIRST = FRAMERATE_GAMELOOP,
-	FRAMERATE_DRAWING,  ///< Speed of drawing world and GUI.
-	FRAMERATE_VIDEO,    ///< Speed of painting drawn video buffer.
-	FRAMERATE_SOUND,    ///< Speed of mixing audio samples
-	FRAMERATE_MAX,      ///< End of enum, must be last.
+	FRAMERATE_DRAWING,        ///< Speed of drawing world and GUI.
+	FRAMERATE_VIDEO,          ///< Speed of painting drawn video buffer.
+	FRAMERATE_SOUND,          ///< Speed of mixing audio samples
+	FRAMERATE_MAX,            ///< End of enum, must be last.
 };
 
 /**

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -21,6 +21,8 @@ enum PerformanceElement {
 	PFE_ACC_GL_ROADVEHS, ///< Time spend processing road vehicles
 	PFE_ACC_GL_SHIPS,    ///< Time spent processing ships
 	PFE_ACC_GL_AIRCRAFT, ///< Time spent processing aircraft
+	PFE_GL_LANDSCAPE,    ///< Time spent processing other world features
+	PFE_GL_LINKGRAPH,    ///< Time spent waiting for link graph background jobs
 	PFE_DRAWING,         ///< Speed of drawing world and GUI.
 	PFE_ACC_DRAWWORLD,   ///< Time spent drawing world viewports in GUI
 	PFE_VIDEO,           ///< Speed of painting drawn video buffer.

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -21,7 +21,7 @@ enum FramerateElement {
 	FRAMERATE_MAX,            ///< End of enum, must be last.
 };
 
-typedef uint32 TimingMeasurement;
+typedef uint64 TimingMeasurement;
 
 /**
  * RAII class for measuring elements of framerate.

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -76,7 +76,6 @@ void HandleTextInput(const char *str, bool marked = false, const char *caret = N
 void HandleCtrlChanged();
 void HandleMouseEvents();
 void CSleep(int milliseconds);
-uint32 GetTime(); ///< Get a timestamp in milliseconds
 void UpdateWindows();
 
 void DrawMouseCursor();

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -76,6 +76,7 @@ void HandleTextInput(const char *str, bool marked = false, const char *caret = N
 void HandleCtrlChanged();
 void HandleMouseEvents();
 void CSleep(int milliseconds);
+uint32 GetTime(); ///< Get a timestamp in milliseconds
 void UpdateWindows();
 
 void DrawMouseCursor();

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -32,6 +32,7 @@
 #include "company_func.h"
 #include "pathfinder/npf/aystar.h"
 #include "saveload/saveload.h"
+#include "framerate_type.h"
 #include <list>
 #include <set>
 
@@ -720,6 +721,8 @@ TileIndex _cur_tileloop_tile;
  */
 void RunTileLoop()
 {
+	PerformanceAccumulator framerate(PFE_GL_LANDSCAPE);
+
 	/* The pseudorandom sequence of tiles is generated using a Galois linear feedback
 	 * shift register (LFSR). This allows a deterministic pseudorandom ordering, but
 	 * still with minimal state and fast iteration. */
@@ -1304,10 +1307,14 @@ void OnTick_LinkGraph();
 
 void CallLandscapeTick()
 {
-	OnTick_Town();
-	OnTick_Trees();
-	OnTick_Station();
-	OnTick_Industry();
+	{
+		PerformanceAccumulator framerate(PFE_GL_LANDSCAPE);
+
+		OnTick_Town();
+		OnTick_Trees();
+		OnTick_Station();
+		OnTick_Industry();
+	}
 
 	OnTick_Companies();
 	OnTick_LinkGraph();

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2720,6 +2720,11 @@ STR_FRAMERATE_GRAPH_MILLISECONDS                                :{TINY_FONT}{COM
 STR_FRAMERATE_GRAPH_SECONDS                                     :{TINY_FONT}{COMMA} s
 ############ Leave those lines in this order!!
 STR_FRAMERATE_GAMELOOP                                          :{WHITE}Game loop total:
+STR_FRAMERATE_GL_ECONOMY                                        :{WHITE}  Cargo handling:
+STR_FRAMERATE_GL_TRAINS                                         :{WHITE}  Train ticks:
+STR_FRAMERATE_GL_ROADVEHS                                       :{WHITE}  Road vehicle ticks:
+STR_FRAMERATE_GL_SHIPS                                          :{WHITE}  Ship ticks:
+STR_FRAMERATE_GL_AIRCRAFT                                       :{WHITE}  Aircraft ticks:
 STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics rendering:
 STR_FRAMERATE_DRAWING_VIEWPORTS                                 :{WHITE}  World viewports:
 STR_FRAMERATE_VIDEO                                             :{WHITE}Video output:
@@ -2727,6 +2732,11 @@ STR_FRAMERATE_SOUND                                             :{WHITE}Sound mi
 ############ End of leave-in-this-order
 ############ Leave those lines in this order!!
 STR_FRAMETIME_CAPTION_GAMELOOP                                  :Game loop
+STR_FRAMETIME_CAPTION_GL_ECONOMY                                :Cargo handling
+STR_FRAMETIME_CAPTION_GL_TRAINS                                 :Train ticks
+STR_FRAMETIME_CAPTION_GL_ROADVEHS                               :Road vehicle ticks
+STR_FRAMETIME_CAPTION_GL_SHIPS                                  :Ship ticks
+STR_FRAMETIME_CAPTION_GL_AIRCRAFT                               :Aircraft ticks
 STR_FRAMETIME_CAPTION_DRAWING                                   :Graphics rendering
 STR_FRAMETIME_CAPTION_DRAWING_VIEWPORTS                         :World viewport rendering
 STR_FRAMETIME_CAPTION_VIDEO                                     :Video output

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2704,6 +2704,8 @@ STR_FRAMERATE_DISPLAY_DRAWING                                   :{WHITE}Screen d
 STR_FRAMERATE_DISPLAY_DRAWING_TOOLTIP                           :{BLACK}Time spent per frame on compositing game graphics
 STR_FRAMERATE_DISPLAY_VIDEO                                     :{WHITE}Video output:
 STR_FRAMERATE_DISPLAY_VIDEO_TOOLTIP                             :{BLACK}Time spent per frame to send finished graphics to screen
+STR_FRAMERATE_DISPLAY_SOUND                                     :{WHITE}Sound mixing:
+STR_FRAMERATE_DISPLAY_SOUND_TOOLTIP                             :{BLACK}Time spent per buffer to mix audio samples
 STR_FRAMERATE_DISPLAY_VALUE                                     :{STRING2}
 STR_FRAMERATE_MS_GOOD                                           :{LTBLUE}{DECIMAL}{WHITE} ms
 STR_FRAMERATE_MS_WARN                                           :{YELLOW}{DECIMAL}{WHITE} ms

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2720,6 +2720,13 @@ STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics
 STR_FRAMERATE_VIDEO                                             :{WHITE}Video output:
 STR_FRAMERATE_SOUND                                             :{WHITE}Sound mixing:
 ############ End of leave-in-this-order
+############ Leave those lines in this order!!
+STR_FRAMETIME_CAPTION_GAMELOOP                                  :Game loop
+STR_FRAMETIME_CAPTION_DRAWING                                   :Graphics rendering
+STR_FRAMETIME_CAPTION_VIDEO                                     :Video output
+STR_FRAMETIME_CAPTION_SOUND                                     :Sound mixing
+############ End of leave-in-this-order
+
 
 # Save/load game/scenario
 STR_SAVELOAD_SAVE_CAPTION                                       :{WHITE}Save Game

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2698,22 +2698,28 @@ STR_ABOUT_VERSION                                               :{BLACK}OpenTTD 
 STR_ABOUT_COPYRIGHT_OPENTTD                                     :{BLACK}OpenTTD {COPYRIGHT} 2002-2018 The OpenTTD team
 
 # Framerate display window
-STR_FRAMERATE_DISPLAY_CAPTION                                   :{WHITE}Frame rate
-STR_FRAMERATE_DISPLAY_GAMELOOP                                  :{WHITE}Game loop:
-STR_FRAMERATE_DISPLAY_GAMELOOP_TOOLTIP                          :{BLACK}Time spent per tick to calculate economy, move vehicles, etc.
-STR_FRAMERATE_DISPLAY_DRAWING                                   :{WHITE}Screen drawing:
-STR_FRAMERATE_DISPLAY_DRAWING_TOOLTIP                           :{BLACK}Time spent per frame on compositing game graphics
-STR_FRAMERATE_DISPLAY_VIDEO                                     :{WHITE}Video output:
-STR_FRAMERATE_DISPLAY_VIDEO_TOOLTIP                             :{BLACK}Time spent per frame to send finished graphics to screen
-STR_FRAMERATE_DISPLAY_SOUND                                     :{WHITE}Sound mixing:
-STR_FRAMERATE_DISPLAY_SOUND_TOOLTIP                             :{BLACK}Time spent per buffer to mix audio samples
-STR_FRAMERATE_DISPLAY_VALUE                                     :{STRING2}
+STR_FRAMERATE_CAPTION                                           :{WHITE}Frame rate
+STR_FRAMERATE_RATE_GAMELOOP                                     :{WHITE}Simulation rate: {STRING2}
+STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP                             :{BLACK}Number of game ticks simulated per second.
+STR_FRAMERATE_RATE_BLITTER                                      :{WHITE}Graphics frame rate: {STRING2}
+STR_FRAMERATE_RATE_BLITTER_TOOLTIP                              :{BLACK}Number of video frames rendered per second.
+STR_FRAMERATE_CURRENT                                           :{WHITE}Current
+STR_FRAMERATE_AVERAGE                                           :{WHITE}Average
+STR_FRAMERATE_WORST                                             :{WHITE}Worst
+STR_FRAMERATE_DATA_POINTS                                       :{WHITE}Data based on {COMMA} measurements
+STR_FRAMERATE_VALUE                                             :{STRING2}
 STR_FRAMERATE_MS_GOOD                                           :{LTBLUE}{DECIMAL}{WHITE} ms
 STR_FRAMERATE_MS_WARN                                           :{YELLOW}{DECIMAL}{WHITE} ms
 STR_FRAMERATE_MS_BAD                                            :{RED}{DECIMAL}{WHITE} ms
 STR_FRAMERATE_FPS_GOOD                                          :{LTBLUE}{DECIMAL}{WHITE} frames/s
 STR_FRAMERATE_FPS_WARN                                          :{YELLOW}{DECIMAL}{WHITE} frames/s
 STR_FRAMERATE_FPS_BAD                                           :{RED}{DECIMAL}{WHITE} frames/s
+############ Leave those lines in this order!!
+STR_FRAMERATE_GAMELOOP                                          :{WHITE}Game loop total:
+STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics rendering:
+STR_FRAMERATE_VIDEO                                             :{WHITE}Video output:
+STR_FRAMERATE_SOUND                                             :{WHITE}Sound mixing:
+############ End of leave-in-this-order
 
 # Save/load game/scenario
 STR_SAVELOAD_SAVE_CAPTION                                       :{WHITE}Save Game

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2725,6 +2725,8 @@ STR_FRAMERATE_GL_TRAINS                                         :{WHITE}  Train 
 STR_FRAMERATE_GL_ROADVEHS                                       :{WHITE}  Road vehicle ticks:
 STR_FRAMERATE_GL_SHIPS                                          :{WHITE}  Ship ticks:
 STR_FRAMERATE_GL_AIRCRAFT                                       :{WHITE}  Aircraft ticks:
+STR_FRAMERATE_GL_LANDSCAPE                                      :{WHITE}  World ticks:
+STR_FRAMERATE_GL_LINKGRAPH                                      :{WHITE}  Link graph delay:
 STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics rendering:
 STR_FRAMERATE_DRAWING_VIEWPORTS                                 :{WHITE}  World viewports:
 STR_FRAMERATE_VIDEO                                             :{WHITE}Video output:
@@ -2737,6 +2739,8 @@ STR_FRAMETIME_CAPTION_GL_TRAINS                                 :Train ticks
 STR_FRAMETIME_CAPTION_GL_ROADVEHS                               :Road vehicle ticks
 STR_FRAMETIME_CAPTION_GL_SHIPS                                  :Ship ticks
 STR_FRAMETIME_CAPTION_GL_AIRCRAFT                               :Aircraft ticks
+STR_FRAMETIME_CAPTION_GL_LANDSCAPE                              :World ticks
+STR_FRAMETIME_CAPTION_GL_LINKGRAPH                              :Link graph delay
 STR_FRAMETIME_CAPTION_DRAWING                                   :Graphics rendering
 STR_FRAMETIME_CAPTION_DRAWING_VIEWPORTS                         :World viewport rendering
 STR_FRAMETIME_CAPTION_VIDEO                                     :Video output

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2709,7 +2709,6 @@ STR_FRAMERATE_SPEED_FACTOR_TOOLTIP                              :{BLACK}How fast
 STR_FRAMERATE_CURRENT                                           :{WHITE}Current
 STR_FRAMERATE_AVERAGE                                           :{WHITE}Average
 STR_FRAMERATE_DATA_POINTS                                       :{WHITE}Data based on {COMMA} measurements
-STR_FRAMERATE_VALUE                                             :{STRING2}
 STR_FRAMERATE_MS_GOOD                                           :{LTBLUE}{DECIMAL}{WHITE} ms
 STR_FRAMERATE_MS_WARN                                           :{YELLOW}{DECIMAL}{WHITE} ms
 STR_FRAMERATE_MS_BAD                                            :{RED}{DECIMAL}{WHITE} ms

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2705,7 +2705,6 @@ STR_FRAMERATE_RATE_BLITTER                                      :{WHITE}Graphics
 STR_FRAMERATE_RATE_BLITTER_TOOLTIP                              :{BLACK}Number of video frames rendered per second.
 STR_FRAMERATE_CURRENT                                           :{WHITE}Current
 STR_FRAMERATE_AVERAGE                                           :{WHITE}Average
-STR_FRAMERATE_WORST                                             :{WHITE}Worst
 STR_FRAMERATE_DATA_POINTS                                       :{WHITE}Data based on {COMMA} measurements
 STR_FRAMERATE_VALUE                                             :{STRING2}
 STR_FRAMERATE_MS_GOOD                                           :{LTBLUE}{DECIMAL}{WHITE} ms
@@ -2715,7 +2714,7 @@ STR_FRAMERATE_FPS_GOOD                                          :{LTBLUE}{DECIMA
 STR_FRAMERATE_FPS_WARN                                          :{YELLOW}{DECIMAL}{WHITE} frames/s
 STR_FRAMERATE_FPS_BAD                                           :{RED}{DECIMAL}{WHITE} frames/s
 STR_FRAMERATE_GRAPH_MILLISECONDS                                :{TINY_FONT}{COMMA} ms
-STR_FRAMERATE_GRAPH_SECONDS                                     :{TINY_FONT}{COMMA} second{P "" s}
+STR_FRAMERATE_GRAPH_SECONDS                                     :{TINY_FONT}{COMMA} s
 ############ Leave those lines in this order!!
 STR_FRAMERATE_GAMELOOP                                          :{WHITE}Game loop total:
 STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics rendering:

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2698,17 +2698,19 @@ STR_ABOUT_COPYRIGHT_OPENTTD                                     :{BLACK}OpenTTD 
 
 # Framerate display window
 STR_FRAMERATE_DISPLAY_CAPTION                                   :{WHITE}Frame rate
-STR_FRAMERATE_VALUE_GOOD                                        :{LTBLUE}{DECIMAL}{WHITE}
-STR_FRAMERATE_VALUE_WARN                                        :{YELLOW}{DECIMAL}{WHITE}
-STR_FRAMERATE_VALUE_BAD                                         :{RED}{DECIMAL}{WHITE}
-STR_FRAMERATE_DISPLAY_CURRENT_FPS                               :{WHITE}Current: {STRING2} frames/sec
-STR_FRAMERATE_DISPLAY_CURRENT_FPS_TOOLTIP                       :{BLACK}How many times a second the game loop is called to process world state
-STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP                            :{WHITE}Game loop time: {STRING2} milliseconds
-STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP_TOOLTIP                    :{BLACK}Time spent per tick to calculate economy, move vehicles, etc.
-STR_FRAMERATE_DISPLAY_TIMES_DRAWING                             :{WHITE}Screen drawing time: {STRING2} milliseconds
-STR_FRAMERATE_DISPLAY_TIMES_DRAWING_TOOLTIP                     :{BLACK}Time spent per frame on compositing game graphics
-STR_FRAMERATE_DISPLAY_TIMES_VIDEO                               :{WHITE}Video output time: {STRING2} milliseconds
-STR_FRAMERATE_DISPLAY_TIMES_VIDEO_TOOLTIP                       :{BLACK}Time spent per frame to send finished graphics to screen
+STR_FRAMERATE_DISPLAY_GAMELOOP                                  :{WHITE}Game loop:
+STR_FRAMERATE_DISPLAY_GAMELOOP_TOOLTIP                          :{BLACK}Time spent per tick to calculate economy, move vehicles, etc.
+STR_FRAMERATE_DISPLAY_DRAWING                                   :{WHITE}Screen drawing:
+STR_FRAMERATE_DISPLAY_DRAWING_TOOLTIP                           :{BLACK}Time spent per frame on compositing game graphics
+STR_FRAMERATE_DISPLAY_VIDEO                                     :{WHITE}Video output:
+STR_FRAMERATE_DISPLAY_VIDEO_TOOLTIP                             :{BLACK}Time spent per frame to send finished graphics to screen
+STR_FRAMERATE_DISPLAY_VALUE                                     :{STRING2}
+STR_FRAMERATE_MS_GOOD                                           :{LTBLUE}{DECIMAL}{WHITE} ms
+STR_FRAMERATE_MS_WARN                                           :{YELLOW}{DECIMAL}{WHITE} ms
+STR_FRAMERATE_MS_BAD                                            :{RED}{DECIMAL}{WHITE} ms
+STR_FRAMERATE_FPS_GOOD                                          :{LTBLUE}{DECIMAL}{WHITE} frames/s
+STR_FRAMERATE_FPS_WARN                                          :{YELLOW}{DECIMAL}{WHITE} frames/s
+STR_FRAMERATE_FPS_BAD                                           :{RED}{DECIMAL}{WHITE} frames/s
 
 # Save/load game/scenario
 STR_SAVELOAD_SAVE_CAPTION                                       :{WHITE}Save Game

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2721,12 +2721,14 @@ STR_FRAMERATE_GRAPH_SECONDS                                     :{TINY_FONT}{COM
 ############ Leave those lines in this order!!
 STR_FRAMERATE_GAMELOOP                                          :{WHITE}Game loop total:
 STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics rendering:
+STR_FRAMERATE_DRAWING_VIEWPORTS                                 :{WHITE}  World viewports:
 STR_FRAMERATE_VIDEO                                             :{WHITE}Video output:
 STR_FRAMERATE_SOUND                                             :{WHITE}Sound mixing:
 ############ End of leave-in-this-order
 ############ Leave those lines in this order!!
 STR_FRAMETIME_CAPTION_GAMELOOP                                  :Game loop
 STR_FRAMETIME_CAPTION_DRAWING                                   :Graphics rendering
+STR_FRAMETIME_CAPTION_DRAWING_VIEWPORTS                         :World viewport rendering
 STR_FRAMETIME_CAPTION_VIDEO                                     :Video output
 STR_FRAMETIME_CAPTION_SOUND                                     :Sound mixing
 ############ End of leave-in-this-order

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2714,6 +2714,8 @@ STR_FRAMERATE_MS_BAD                                            :{RED}{DECIMAL}{
 STR_FRAMERATE_FPS_GOOD                                          :{LTBLUE}{DECIMAL}{WHITE} frames/s
 STR_FRAMERATE_FPS_WARN                                          :{YELLOW}{DECIMAL}{WHITE} frames/s
 STR_FRAMERATE_FPS_BAD                                           :{RED}{DECIMAL}{WHITE} frames/s
+STR_FRAMERATE_GRAPH_MILLISECONDS                                :{TINY_FONT}{COMMA} ms
+STR_FRAMERATE_GRAPH_SECONDS                                     :{TINY_FONT}{COMMA} second{P "" s}
 ############ Leave those lines in this order!!
 STR_FRAMERATE_GAMELOOP                                          :{WHITE}Game loop total:
 STR_FRAMERATE_DRAWING                                           :{WHITE}Graphics rendering:

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2699,6 +2699,7 @@ STR_ABOUT_COPYRIGHT_OPENTTD                                     :{BLACK}OpenTTD 
 
 # Framerate display window
 STR_FRAMERATE_CAPTION                                           :{WHITE}Frame rate
+STR_FRAMERATE_CAPTION_SMALL                                     :{STRING2}{WHITE} ({DECIMAL}x)
 STR_FRAMERATE_RATE_GAMELOOP                                     :{WHITE}Simulation rate: {STRING2}
 STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP                             :{BLACK}Number of game ticks simulated per second.
 STR_FRAMERATE_RATE_BLITTER                                      :{WHITE}Graphics frame rate: {STRING2}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -475,6 +475,7 @@ STR_ABOUT_MENU_SCREENSHOT                                       :Screenshot
 STR_ABOUT_MENU_ZOOMIN_SCREENSHOT                                :Fully zoomed in screenshot
 STR_ABOUT_MENU_DEFAULTZOOM_SCREENSHOT                           :Default zoom screenshot
 STR_ABOUT_MENU_GIANT_SCREENSHOT                                 :Whole map screenshot
+STR_ABOUT_MENU_SHOW_FRAMERATE                                   :Show frame rate
 STR_ABOUT_MENU_ABOUT_OPENTTD                                    :About 'OpenTTD'
 STR_ABOUT_MENU_SPRITE_ALIGNER                                   :Sprite aligner
 STR_ABOUT_MENU_TOGGLE_BOUNDING_BOXES                            :Toggle bounding boxes

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2696,6 +2696,20 @@ STR_ABOUT_ORIGINAL_COPYRIGHT                                    :{BLACK}Original
 STR_ABOUT_VERSION                                               :{BLACK}OpenTTD version {REV}
 STR_ABOUT_COPYRIGHT_OPENTTD                                     :{BLACK}OpenTTD {COPYRIGHT} 2002-2018 The OpenTTD team
 
+# Framerate display window
+STR_FRAMERATE_DISPLAY_CAPTION                                   :{WHITE}Frame rate
+STR_FRAMERATE_VALUE_GOOD                                        :{LTBLUE}{DECIMAL}{WHITE}
+STR_FRAMERATE_VALUE_WARN                                        :{YELLOW}{DECIMAL}{WHITE}
+STR_FRAMERATE_VALUE_BAD                                         :{RED}{DECIMAL}{WHITE}
+STR_FRAMERATE_DISPLAY_CURRENT_FPS                               :{WHITE}Current: {STRING2} frames/sec
+STR_FRAMERATE_DISPLAY_CURRENT_FPS_TOOLTIP                       :{BLACK}How many times a second the game loop is called to process world state
+STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP                            :{WHITE}Game loop time: {STRING2} milliseconds
+STR_FRAMERATE_DISPLAY_TIMES_GAMELOOP_TOOLTIP                    :{BLACK}Time spent per tick to calculate economy, move vehicles, etc.
+STR_FRAMERATE_DISPLAY_TIMES_DRAWING                             :{WHITE}Screen drawing time: {STRING2} milliseconds
+STR_FRAMERATE_DISPLAY_TIMES_DRAWING_TOOLTIP                     :{BLACK}Time spent per frame on compositing game graphics
+STR_FRAMERATE_DISPLAY_TIMES_VIDEO                               :{WHITE}Video output time: {STRING2} milliseconds
+STR_FRAMERATE_DISPLAY_TIMES_VIDEO_TOOLTIP                       :{BLACK}Time spent per frame to send finished graphics to screen
+
 # Save/load game/scenario
 STR_SAVELOAD_SAVE_CAPTION                                       :{WHITE}Save Game
 STR_SAVELOAD_LOAD_CAPTION                                       :{WHITE}Load Game

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2703,6 +2703,8 @@ STR_FRAMERATE_RATE_GAMELOOP                                     :{WHITE}Simulati
 STR_FRAMERATE_RATE_GAMELOOP_TOOLTIP                             :{BLACK}Number of game ticks simulated per second.
 STR_FRAMERATE_RATE_BLITTER                                      :{WHITE}Graphics frame rate: {STRING2}
 STR_FRAMERATE_RATE_BLITTER_TOOLTIP                              :{BLACK}Number of video frames rendered per second.
+STR_FRAMERATE_SPEED_FACTOR                                      :{WHITE}Current game speed factor: {DECIMAL}x
+STR_FRAMERATE_SPEED_FACTOR_TOOLTIP                              :{BLACK}How fast the game is currently running, compared to the expected speed at normal simulation rate.
 STR_FRAMERATE_CURRENT                                           :{WHITE}Current
 STR_FRAMERATE_AVERAGE                                           :{WHITE}Average
 STR_FRAMERATE_DATA_POINTS                                       :{WHITE}Data based on {COMMA} measurements

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -15,6 +15,7 @@
 #include "demands.h"
 #include "mcf.h"
 #include "flowmapper.h"
+#include "../framerate_type.h"
 
 #include "../safeguards.h"
 
@@ -151,6 +152,7 @@ void OnTick_LinkGraph()
 	if (offset == 0) {
 		LinkGraphSchedule::instance.SpawnNext();
 	} else if (offset == _settings_game.linkgraph.recalc_interval / 2) {
+		PerformanceMeasurer framerate(PFE_GL_LINKGRAPH);
 		LinkGraphSchedule::instance.JoinNext();
 	}
 }

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -12,6 +12,7 @@
 #include "stdafx.h"
 #include <math.h>
 #include "core/math_func.hpp"
+#include "framerate_type.h"
 
 #include "safeguards.h"
 
@@ -138,6 +139,13 @@ static void MxCloseChannel(MixerChannel *mc)
 
 void MxMixSamples(void *buffer, uint samples)
 {
+	FramerateMeasurer framerate(FRAMERATE_SOUND);
+	static uint last_samples = 0;
+	if (samples != last_samples) {
+		framerate.SetExpectedRate((double)_play_rate / samples);
+		last_samples = samples;
+	}
+
 	MixerChannel *mc;
 
 	/* Clear the buffer */

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -139,7 +139,7 @@ static void MxCloseChannel(MixerChannel *mc)
 
 void MxMixSamples(void *buffer, uint samples)
 {
-	FramerateMeasurer framerate(FRAMERATE_SOUND);
+	PerformanceMeasurer framerate(PFE_SOUND);
 	static uint last_samples = 0;
 	if (samples != last_samples) {
 		framerate.SetExpectedRate((double)_play_rate / samples);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1344,6 +1344,7 @@ void StateGameLoop()
 		PerformanceMeasurer::Paused(PFE_ACC_GL_ROADVEHS);
 		PerformanceMeasurer::Paused(PFE_ACC_GL_SHIPS);
 		PerformanceMeasurer::Paused(PFE_ACC_GL_AIRCRAFT);
+		PerformanceMeasurer::Paused(PFE_GL_LANDSCAPE);
 
 		UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1338,6 +1338,13 @@ void StateGameLoop()
 {
 	/* don't execute the state loop during pause */
 	if (_pause_mode != PM_UNPAUSED) {
+		PerformanceMeasurer::Paused(PFE_GAMELOOP);
+		PerformanceMeasurer::Paused(PFE_ACC_GL_ECONOMY);
+		PerformanceMeasurer::Paused(PFE_ACC_GL_TRAINS);
+		PerformanceMeasurer::Paused(PFE_ACC_GL_ROADVEHS);
+		PerformanceMeasurer::Paused(PFE_ACC_GL_SHIPS);
+		PerformanceMeasurer::Paused(PFE_ACC_GL_AIRCRAFT);
+
 		UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS
 		Game::GameLoop();
@@ -1345,6 +1352,8 @@ void StateGameLoop()
 		CallWindowTickEvent();
 		return;
 	}
+
+	PerformanceMeasurer framerate(PFE_GAMELOOP);
 	if (HasModalProgress()) return;
 
 	Layouter::ReduceLineCache();
@@ -1423,8 +1432,6 @@ static void DoAutosave()
 
 void GameLoop()
 {
-	PerformanceMeasurer framerate(PFE_GAMELOOP);
-
 	if (_game_mode == GM_BOOTSTRAP) {
 #ifdef ENABLE_NETWORK
 		/* Check for UDP stuff */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1423,7 +1423,7 @@ static void DoAutosave()
 
 void GameLoop()
 {
-	FramerateMeasurer framerate(FRAMERATE_GAMELOOP);
+	PerformanceMeasurer framerate(PFE_GAMELOOP);
 
 	if (_game_mode == GM_BOOTSTRAP) {
 #ifdef ENABLE_NETWORK

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1339,11 +1339,11 @@ void StateGameLoop()
 	/* don't execute the state loop during pause */
 	if (_pause_mode != PM_UNPAUSED) {
 		PerformanceMeasurer::Paused(PFE_GAMELOOP);
-		PerformanceMeasurer::Paused(PFE_ACC_GL_ECONOMY);
-		PerformanceMeasurer::Paused(PFE_ACC_GL_TRAINS);
-		PerformanceMeasurer::Paused(PFE_ACC_GL_ROADVEHS);
-		PerformanceMeasurer::Paused(PFE_ACC_GL_SHIPS);
-		PerformanceMeasurer::Paused(PFE_ACC_GL_AIRCRAFT);
+		PerformanceMeasurer::Paused(PFE_GL_ECONOMY);
+		PerformanceMeasurer::Paused(PFE_GL_TRAINS);
+		PerformanceMeasurer::Paused(PFE_GL_ROADVEHS);
+		PerformanceMeasurer::Paused(PFE_GL_SHIPS);
+		PerformanceMeasurer::Paused(PFE_GL_AIRCRAFT);
 		PerformanceMeasurer::Paused(PFE_GL_LANDSCAPE);
 
 		UpdateLandscapingLimits();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1354,6 +1354,7 @@ void StateGameLoop()
 	}
 
 	PerformanceMeasurer framerate(PFE_GAMELOOP);
+	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
 	if (HasModalProgress()) return;
 
 	Layouter::ReduceLineCache();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -63,6 +63,7 @@
 #include "subsidy_func.h"
 #include "gfx_layout.h"
 #include "viewport_sprite_sorter.h"
+#include "framerate_type.h"
 
 #include "linkgraph/linkgraphschedule.h"
 
@@ -1422,6 +1423,8 @@ static void DoAutosave()
 
 void GameLoop()
 {
+	FramerateMeasurer framerate(FRAMERATE_GAMELOOP);
+
 	if (_game_mode == GM_BOOTSTRAP) {
 #ifdef ENABLE_NETWORK
 		/* Check for UDP stuff */

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -35,6 +35,7 @@
 #include "core/backup_type.hpp"
 #include "newgrf.h"
 #include "zoom_func.h"
+#include "framerate_type.h"
 
 #include "table/strings.h"
 
@@ -1587,6 +1588,8 @@ Money RoadVehicle::GetRunningCost() const
 
 bool RoadVehicle::Tick()
 {
+	PerformanceAccumulator framerate(PFE_ACC_GL_ROADVEHS);
+
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1588,7 +1588,7 @@ Money RoadVehicle::GetRunningCost() const
 
 bool RoadVehicle::Tick()
 {
-	PerformanceAccumulator framerate(PFE_ACC_GL_ROADVEHS);
+	PerformanceAccumulator framerate(PFE_GL_ROADVEHS);
 
 	this->tick_counter++;
 

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -34,6 +34,7 @@
 #include "company_base.h"
 #include "tunnelbridge_map.h"
 #include "zoom_func.h"
+#include "framerate_type.h"
 
 #include "table/strings.h"
 
@@ -638,6 +639,8 @@ reverse_direction:
 
 bool Ship::Tick()
 {
+	PerformanceAccumulator framerate(PFE_ACC_GL_SHIPS);
+
 	if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;
 
 	ShipController(this);

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -639,7 +639,7 @@ reverse_direction:
 
 bool Ship::Tick()
 {
-	PerformanceAccumulator framerate(PFE_ACC_GL_SHIPS);
+	PerformanceAccumulator framerate(PFE_GL_SHIPS);
 
 	if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -47,6 +47,7 @@
 #include "goal_base.h"
 #include "story_base.h"
 #include "toolbar_gui.h"
+#include "framerate_type.h"
 
 #include "widgets/toolbar_widget.h"
 
@@ -1045,7 +1046,7 @@ static CallBackFunction PlaceLandBlockInfo()
 
 static CallBackFunction ToolbarHelpClick(Window *w)
 {
-	PopupMainToolbMenu(w, WID_TN_HELP, STR_ABOUT_MENU_LAND_BLOCK_INFO, _settings_client.gui.newgrf_developer_tools ? 12 : 9);
+	PopupMainToolbMenu(w, WID_TN_HELP, STR_ABOUT_MENU_LAND_BLOCK_INFO, _settings_client.gui.newgrf_developer_tools ? 13 : 10);
 	return CBF_NONE;
 }
 
@@ -1147,10 +1148,11 @@ static CallBackFunction MenuClickHelp(int index)
 		case  5: MenuClickLargeWorldScreenshot(SC_ZOOMEDIN);    break;
 		case  6: MenuClickLargeWorldScreenshot(SC_DEFAULTZOOM); break;
 		case  7: MenuClickLargeWorldScreenshot(SC_WORLD);       break;
-		case  8: ShowAboutWindow();                break;
-		case  9: ShowSpriteAlignerWindow();        break;
-		case 10: ToggleBoundingBoxes();            break;
-		case 11: ToggleDirtyBlocks();              break;
+		case  8: ShowFramerateWindow();            break;
+		case  9: ShowAboutWindow();                break;
+		case 10: ShowSpriteAlignerWindow();        break;
+		case 11: ToggleBoundingBoxes();            break;
+		case 12: ToggleDirtyBlocks();              break;
 	}
 	return CBF_NONE;
 }

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3903,7 +3903,7 @@ Money Train::GetRunningCost() const
  */
 bool Train::Tick()
 {
-	PerformanceAccumulator framerate(PFE_ACC_GL_TRAINS);
+	PerformanceAccumulator framerate(PFE_GL_TRAINS);
 
 	this->tick_counter++;
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -35,6 +35,7 @@
 #include "order_backup.h"
 #include "zoom_func.h"
 #include "newgrf_debug.h"
+#include "framerate_type.h"
 
 #include "table/strings.h"
 #include "table/train_cmd.h"
@@ -3902,6 +3903,8 @@ Money Train::GetRunningCost() const
  */
 bool Train::Tick()
 {
+	PerformanceAccumulator framerate(PFE_ACC_GL_TRAINS);
+
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -52,6 +52,7 @@
 #include "gamelog.h"
 #include "linkgraph/linkgraph.h"
 #include "linkgraph/refresh.h"
+#include "framerate_type.h"
 
 #include "table/strings.h"
 
@@ -945,8 +946,15 @@ void CallVehicleTicks()
 
 	RunVehicleDayProc();
 
-	Station *st;
-	FOR_ALL_STATIONS(st) LoadUnloadStation(st);
+	{
+		PerformanceMeasurer framerate(PFE_ACC_GL_ECONOMY);
+		Station *st;
+		FOR_ALL_STATIONS(st) LoadUnloadStation(st);
+	}
+	PerformanceAccumulator::Reset(PFE_ACC_GL_TRAINS);
+	PerformanceAccumulator::Reset(PFE_ACC_GL_ROADVEHS);
+	PerformanceAccumulator::Reset(PFE_ACC_GL_SHIPS);
+	PerformanceAccumulator::Reset(PFE_ACC_GL_AIRCRAFT);
 
 	Vehicle *v;
 	FOR_ALL_VEHICLES(v) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -947,14 +947,14 @@ void CallVehicleTicks()
 	RunVehicleDayProc();
 
 	{
-		PerformanceMeasurer framerate(PFE_ACC_GL_ECONOMY);
+		PerformanceMeasurer framerate(PFE_GL_ECONOMY);
 		Station *st;
 		FOR_ALL_STATIONS(st) LoadUnloadStation(st);
 	}
-	PerformanceAccumulator::Reset(PFE_ACC_GL_TRAINS);
-	PerformanceAccumulator::Reset(PFE_ACC_GL_ROADVEHS);
-	PerformanceAccumulator::Reset(PFE_ACC_GL_SHIPS);
-	PerformanceAccumulator::Reset(PFE_ACC_GL_AIRCRAFT);
+	PerformanceAccumulator::Reset(PFE_GL_TRAINS);
+	PerformanceAccumulator::Reset(PFE_GL_ROADVEHS);
+	PerformanceAccumulator::Reset(PFE_GL_SHIPS);
+	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
 
 	Vehicle *v;
 	FOR_ALL_VEHICLES(v) {

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -57,7 +57,7 @@ void VideoDriver_Allegro::MakeDirty(int left, int top, int width, int height)
 
 static void DrawSurfaceToScreen()
 {
-	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+	PerformanceMeasurer framerate(PFE_VIDEO);
 
 	int n = _num_dirty_rects;
 	if (n == 0) return;

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -464,10 +464,7 @@ void VideoDriver_Allegro::Stop()
 #if defined(UNIX) || defined(__OS2__) || defined(DOS)
 # include <sys/time.h> /* gettimeofday */
 
-# ifndef DOS /* GetTime() needs to be exported on DOS, only place it's implemented there */
-static
-# endif
-uint32 GetTime()
+static uint32 GetTime()
 {
 	struct timeval tim;
 

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -24,6 +24,7 @@
 #include "../network/network.h"
 #include "../core/random_func.hpp"
 #include "../core/math_func.hpp"
+#include "../framerate_type.h"
 #include "allegro_v.h"
 #include <allegro.h>
 
@@ -56,6 +57,8 @@ void VideoDriver_Allegro::MakeDirty(int left, int top, int width, int height)
 
 static void DrawSurfaceToScreen()
 {
+	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+
 	int n = _num_dirty_rects;
 	if (n == 0) return;
 
@@ -461,7 +464,10 @@ void VideoDriver_Allegro::Stop()
 #if defined(UNIX) || defined(__OS2__) || defined(DOS)
 # include <sys/time.h> /* gettimeofday */
 
-static uint32 GetTime()
+# ifndef DOS /* GetTime() needs to be exported on DOS, only place it's implemented there */
+static
+# endif
+uint32 GetTime()
 {
 	struct timeval tim;
 

--- a/src/video/cocoa/wnd_quartz.mm
+++ b/src/video/cocoa/wnd_quartz.mm
@@ -33,6 +33,7 @@
 #include "cocoa_v.h"
 #include "../../core/math_func.hpp"
 #include "../../gfx_func.h"
+#include "../../framerate_type.h"
 
 /* On some old versions of MAC OS this may not be defined.
  * Those versions generally only produce code for PPC. So it should be safe to
@@ -431,6 +432,8 @@ WindowQuartzSubdriver::~WindowQuartzSubdriver()
 
 void WindowQuartzSubdriver::Draw(bool force_update)
 {
+	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+
 	/* Check if we need to do anything */
 	if (this->num_dirty_rects == 0 || [ this->window isMiniaturized ]) return;
 

--- a/src/video/cocoa/wnd_quartz.mm
+++ b/src/video/cocoa/wnd_quartz.mm
@@ -432,7 +432,7 @@ WindowQuartzSubdriver::~WindowQuartzSubdriver()
 
 void WindowQuartzSubdriver::Draw(bool force_update)
 {
-	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+	PerformanceMeasurer framerate(PFE_VIDEO);
 
 	/* Check if we need to do anything */
 	if (this->num_dirty_rects == 0 || [ this->window isMiniaturized ]) return;

--- a/src/video/cocoa/wnd_quickdraw.mm
+++ b/src/video/cocoa/wnd_quickdraw.mm
@@ -362,7 +362,7 @@ WindowQuickdrawSubdriver::~WindowQuickdrawSubdriver()
 
 void WindowQuickdrawSubdriver::Draw(bool force_update)
 {
-	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+	PerformanceMeasurer framerate(PFE_VIDEO);
 
 	/* Check if we need to do anything */
 	if (this->num_dirty_rects == 0 || [ this->window isMiniaturized ]) return;

--- a/src/video/cocoa/wnd_quickdraw.mm
+++ b/src/video/cocoa/wnd_quickdraw.mm
@@ -32,6 +32,7 @@
 #include "cocoa_v.h"
 #include "../../core/math_func.hpp"
 #include "../../gfx_func.h"
+#include "../../framerate_type.h"
 
 /**
  * Important notice regarding all modifications!!!!!!!
@@ -361,6 +362,8 @@ WindowQuickdrawSubdriver::~WindowQuickdrawSubdriver()
 
 void WindowQuickdrawSubdriver::Draw(bool force_update)
 {
+	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+
 	/* Check if we need to do anything */
 	if (this->num_dirty_rects == 0 || [ this->window isMiniaturized ]) return;
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -199,7 +199,7 @@ static bool InputWaiting()
 	return select(STDIN + 1, &readfds, NULL, NULL, &tv) > 0;
 }
 
-uint32 GetTime()
+static uint32 GetTime()
 {
 	struct timeval tim;
 
@@ -207,21 +207,17 @@ uint32 GetTime()
 	return tim.tv_usec / 1000 + tim.tv_sec * 1000;
 }
 
-#elif defined(WIN32)
+#else
 
 static bool InputWaiting()
 {
 	return WaitForSingleObject(_hInputReady, 1) == WAIT_OBJECT_0;
 }
 
-uint32 GetTime()
+static uint32 GetTime()
 {
 	return GetTickCount();
 }
-
-#else
-
-#error Unsupported platform, needs implementation of InputWaiting() and GetTime()
 
 #endif
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -199,7 +199,7 @@ static bool InputWaiting()
 	return select(STDIN + 1, &readfds, NULL, NULL, &tv) > 0;
 }
 
-static uint32 GetTime()
+uint32 GetTime()
 {
 	struct timeval tim;
 
@@ -207,17 +207,21 @@ static uint32 GetTime()
 	return tim.tv_usec / 1000 + tim.tv_sec * 1000;
 }
 
-#else
+#elif defined(WIN32)
 
 static bool InputWaiting()
 {
 	return WaitForSingleObject(_hInputReady, 1) == WAIT_OBJECT_0;
 }
 
-static uint32 GetTime()
+uint32 GetTime()
 {
 	return GetTickCount();
 }
+
+#else
+
+#error Unsupported platform, needs implementation of InputWaiting() and GetTime()
 
 #endif
 

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -149,7 +149,7 @@ static void CheckPaletteAnim()
 
 static void DrawSurfaceToScreen()
 {
-	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+	PerformanceMeasurer framerate(PFE_VIDEO);
 
 	int n = _num_dirty_rects;
 	if (n == 0) return;

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -23,6 +23,7 @@
 #include "../core/random_func.hpp"
 #include "../core/math_func.hpp"
 #include "../fileio_func.h"
+#include "../framerate_type.h"
 #include "sdl_v.h"
 #include <SDL.h>
 
@@ -148,6 +149,8 @@ static void CheckPaletteAnim()
 
 static void DrawSurfaceToScreen()
 {
+	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+
 	int n = _num_dirty_rects;
 	if (n == 0) return;
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -26,7 +26,6 @@
 #include "../framerate_type.h"
 #include "win32_v.h"
 #include <windows.h>
-#include <mmsystem.h>
 #include <imm.h>
 
 #include "../safeguards.h"
@@ -1148,8 +1147,6 @@ const char *VideoDriver_Win32::Start(const char * const *parm)
 	_wnd.width_org  = _cur_resolution.width;
 	_wnd.height_org = _cur_resolution.height;
 
-	timeBeginPeriod(MILLISECONDS_PER_TICK);
-
 	AllocateDibSection(_cur_resolution.width, _cur_resolution.height);
 	this->MakeWindow(_fullscreen);
 
@@ -1162,8 +1159,6 @@ const char *VideoDriver_Win32::Start(const char * const *parm)
 
 void VideoDriver_Win32::Stop()
 {
-	timeEndPeriod(MILLISECONDS_PER_TICK);
-
 	DeleteObject(_wnd.gdi_palette);
 	DeleteObject(_wnd.dib_sect);
 	DestroyWindow(_wnd.main_wnd);
@@ -1190,7 +1185,7 @@ static void CheckPaletteAnim()
 void VideoDriver_Win32::MainLoop()
 {
 	MSG mesg;
-	uint32 cur_ticks = timeGetTime();
+	uint32 cur_ticks = GetTickCount();
 	uint32 last_cur_ticks = cur_ticks;
 	uint32 next_tick = cur_ticks + MILLISECONDS_PER_TICK;
 
@@ -1246,7 +1241,7 @@ void VideoDriver_Win32::MainLoop()
 			_fast_forward = 0;
 		}
 
-		cur_ticks = timeGetTime();
+		cur_ticks = GetTickCount();
 		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
 			_realtime_tick += cur_ticks - last_cur_ticks;
 			last_cur_ticks = cur_ticks;

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -23,6 +23,7 @@
 #include "../progress.h"
 #include "../window_gui.h"
 #include "../window_func.h"
+#include "../framerate_type.h"
 #include "win32_v.h"
 #include <windows.h>
 #include <imm.h>
@@ -359,6 +360,8 @@ bool VideoDriver_Win32::MakeWindow(bool full_screen)
 /** Do palette animation and blit to the window. */
 static void PaintWindow(HDC dc)
 {
+	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+
 	HDC dc2 = CreateCompatibleDC(dc);
 	HBITMAP old_bmp = (HBITMAP)SelectObject(dc2, _wnd.dib_sect);
 	HPALETTE old_palette = SelectPalette(dc, _wnd.gdi_palette, FALSE);

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -361,7 +361,7 @@ bool VideoDriver_Win32::MakeWindow(bool full_screen)
 /** Do palette animation and blit to the window. */
 static void PaintWindow(HDC dc)
 {
-	FramerateMeasurer framerate(FRAMERATE_VIDEO);
+	PerformanceMeasurer framerate(PFE_VIDEO);
 
 	HDC dc2 = CreateCompatibleDC(dc);
 	HBITMAP old_bmp = (HBITMAP)SelectObject(dc2, _wnd.dib_sect);

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -26,6 +26,7 @@
 #include "../framerate_type.h"
 #include "win32_v.h"
 #include <windows.h>
+#include <mmsystem.h>
 #include <imm.h>
 
 #include "../safeguards.h"
@@ -1147,6 +1148,8 @@ const char *VideoDriver_Win32::Start(const char * const *parm)
 	_wnd.width_org  = _cur_resolution.width;
 	_wnd.height_org = _cur_resolution.height;
 
+	timeBeginPeriod(MILLISECONDS_PER_TICK);
+
 	AllocateDibSection(_cur_resolution.width, _cur_resolution.height);
 	this->MakeWindow(_fullscreen);
 
@@ -1159,6 +1162,8 @@ const char *VideoDriver_Win32::Start(const char * const *parm)
 
 void VideoDriver_Win32::Stop()
 {
+	timeEndPeriod(MILLISECONDS_PER_TICK);
+
 	DeleteObject(_wnd.gdi_palette);
 	DeleteObject(_wnd.dib_sect);
 	DestroyWindow(_wnd.main_wnd);
@@ -1185,7 +1190,7 @@ static void CheckPaletteAnim()
 void VideoDriver_Win32::MainLoop()
 {
 	MSG mesg;
-	uint32 cur_ticks = GetTickCount();
+	uint32 cur_ticks = timeGetTime();
 	uint32 last_cur_ticks = cur_ticks;
 	uint32 next_tick = cur_ticks + MILLISECONDS_PER_TICK;
 
@@ -1241,7 +1246,7 @@ void VideoDriver_Win32::MainLoop()
 			_fast_forward = 0;
 		}
 
-		cur_ticks = GetTickCount();
+		cur_ticks = timeGetTime();
 		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
 			_realtime_tick += cur_ticks - last_cur_ticks;
 			last_cur_ticks = cur_ticks;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1655,7 +1655,7 @@ static inline void ViewportDraw(const ViewPort *vp, int left, int top, int right
  */
 void Window::DrawViewport() const
 {
-	PerformanceAccumulator framerate(PFE_ACC_DRAWWORLD);
+	PerformanceAccumulator framerate(PFE_DRAWWORLD);
 
 	DrawPixelInfo *dpi = _cur_dpi;
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -87,6 +87,7 @@
 #include "company_base.h"
 #include "command_func.h"
 #include "network/network_func.h"
+#include "framerate_type.h"
 
 #include <map>
 
@@ -1654,6 +1655,8 @@ static inline void ViewportDraw(const ViewPort *vp, int left, int top, int right
  */
 void Window::DrawViewport() const
 {
+	PerformanceAccumulator framerate(PFE_ACC_DRAWWORLD);
+
 	DrawPixelInfo *dpi = _cur_dpi;
 
 	dpi->left += this->left;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3079,7 +3079,7 @@ void InputLoop()
 void UpdateWindows()
 {
 	PerformanceMeasurer framerate(PFE_DRAWING);
-	PerformanceAccumulator::Reset(PFE_ACC_DRAWWORLD);
+	PerformanceAccumulator::Reset(PFE_DRAWWORLD);
 
 	Window *w;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3079,6 +3079,7 @@ void InputLoop()
 void UpdateWindows()
 {
 	PerformanceMeasurer framerate(PFE_DRAWING);
+	PerformanceAccumulator::Reset(PFE_ACC_DRAWWORLD);
 
 	Window *w;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3078,7 +3078,7 @@ void InputLoop()
  */
 void UpdateWindows()
 {
-	FramerateMeasurer framerate(FRAMERATE_DRAWING);
+	PerformanceMeasurer framerate(PFE_DRAWING);
 
 	Window *w;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -36,6 +36,7 @@
 #include "error.h"
 #include "game/game.hpp"
 #include "video/video_driver.hpp"
+#include "framerate_type.h"
 
 #include "safeguards.h"
 
@@ -3077,6 +3078,8 @@ void InputLoop()
  */
 void UpdateWindows()
 {
+	FramerateMeasurer framerate(FRAMERATE_DRAWING);
+
 	Window *w;
 
 	static int highlight_timer = 1;

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -687,6 +687,12 @@ enum WindowClass {
 	 */
 	WC_FRAMERATE_DISPLAY,
 
+	/**
+	 * Frame time graph; %Window numbers:
+	 *   - 0 = #FramerateDisplayWidgets
+	 */
+	WC_FRAMETIME_GRAPH,
+
 	WC_INVALID = 0xFFFF, ///< Invalid window.
 };
 

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -681,6 +681,12 @@ enum WindowClass {
 	 */
 	WC_SAVE_PRESET,
 
+	/**
+	 * Framerate display; %Window numbers:
+	 *   - 0 = #FramerateDisplayWidgets
+	 */
+	WC_FRAMERATE_DISPLAY,
+
 	WC_INVALID = 0xFFFF, ///< Invalid window.
 };
 


### PR DESCRIPTION
Frame rate and various game loop/graphics timing measurements and graphs. Accessible via the Help menu, and can print some stats in the console via the `fps` command.

![image](https://user-images.githubusercontent.com/1062071/41561790-24911adc-734b-11e8-801b-baebaca33900.gif)

There should be hooks into all video output drivers, but platforms should be tested that the video output measurement is actually meaningful, and that the timer used for measurements is sufficiently accurate.

Tested working on:
- [x] Windows (Win32)
- [ ] Windows (SDL)
- [x] Mac
- [x] Linux (SDL)
- [ ] DOS (Allegro)
- [ ] OS/2

-----

Original first image:
![image](https://user-images.githubusercontent.com/1062071/41196473-29d3a7c8-6c41-11e8-80b3-c4e8440c8ab2.png)