### PR TITLE
Fix 768a31b: Text layouter fallback could lead to wrong text formatting/display.

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -597,6 +597,7 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, const char *&str, 
 	Font *f = Layouter::GetFont(state.fontsize, state.cur_colour);
 
 	line.buffer = buff_begin;
+	fontMapping.Clear();
 
 	/*
 	 * Go through the whole string while adding Font instances to the font map


### PR DESCRIPTION
Some state from the previous layout attempt wasn't cleared and could cause the next layouter in the chain to misbehave.