### PR TITLE
Build improvements and fixes with MSYS2/MinGW

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1781,7 +1781,7 @@ make_cflags_and_ldflags() {
 		CFLAGS="$CFLAGS `$freetype_config --cflags | tr '\n\r' '  '`"
 
 		if [ "$enable_static" != "0" ]; then
-			LIBS="$LIBS `$freetype_config --libs --static | tr '\n\r' '  '`"
+			LIBS="$LIBS `$freetype_config --libs --static | tr '\n\r' '  '` -lfreetype"
 		else
 			LIBS="$LIBS `$freetype_config --libs | tr '\n\r' '  '`"
 		fi

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -102,21 +102,19 @@ private:
 	bool ReadDLSWave(FILE *f, DWORD list_length, long offset);
 };
 
-#pragma pack(2)
 /** A RIFF chunk header. */
-struct ChunkHeader {
+PACK_N(struct ChunkHeader {
 	FOURCC type;  ///< Chunk type.
 	DWORD length; ///< Length of the chunk, not including the chunk header itself.
-};
+}, 2);
 
 /** Buffer format for a DLS wave download. */
-struct WAVE_DOWNLOAD {
+PACK_N(struct WAVE_DOWNLOAD {
 	DMUS_DOWNLOADINFO   dlInfo;
 	ULONG               ulOffsetTable[2];
 	DMUS_WAVE           dmWave;
 	DMUS_WAVEDATA       dmWaveData;
-};
-#pragma pack()
+}, 2);
 
 struct PlaybackSegment {
 	uint32 start, end;

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -805,16 +805,15 @@ int OTTDStringCompare(const char *s1, const char *s2)
 }
 
 #ifdef _MSC_VER
-/* Code from MSDN: https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx */
+/* Based on code from MSDN: https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx */
 const DWORD MS_VC_EXCEPTION = 0x406D1388;
-#pragma pack(push,8)
-typedef struct {
+
+PACK_N(struct THREADNAME_INFO {
 	DWORD dwType;     ///< Must be 0x1000.
 	LPCSTR szName;    ///< Pointer to name (in user addr space).
 	DWORD dwThreadID; ///< Thread ID (-1=caller thread).
 	DWORD dwFlags;    ///< Reserved for future use, must be zero.
-} THREADNAME_INFO;
-#pragma pack(pop)
+}, 8);
 
 /**
  * Signal thread name to any attached debuggers.

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -71,22 +71,15 @@ struct ScreenshotFormat {
 /*************************************************
  **** SCREENSHOT CODE FOR WINDOWS BITMAP (.BMP)
  *************************************************/
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#pragma pack(push, 1)
-#endif
 
 /** BMP File Header (stored in little endian) */
-struct BitmapFileHeader {
+PACK(struct BitmapFileHeader {
 	uint16 type;
 	uint32 size;
 	uint32 reserved;
 	uint32 off_bits;
-} GCC_PACK;
+});
 assert_compile(sizeof(BitmapFileHeader) == 14);
-
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#pragma pack(pop)
-#endif
 
 /** BMP Info Header (stored in little endian) */
 struct BitmapInfoHeader {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -133,7 +133,6 @@
 	#define NORETURN __attribute__ ((noreturn))
 	#define CDECL
 	#define __int64 long long
-	#define GCC_PACK __attribute__((packed))
 	/* Warn about functions using 'printf' format syntax. First argument determines which parameter
 	 * is the format string, second argument is start of values passed to printf. */
 	#define WARN_FORMAT(string, args) __attribute__ ((format (printf, string, args)))
@@ -158,7 +157,6 @@
 #if defined(__WATCOMC__)
 	#define NORETURN
 	#define CDECL
-	#define GCC_PACK
 	#define WARN_FORMAT(string, args)
 	#define FINAL
 	#define FALLTHROUGH
@@ -224,7 +222,6 @@
 	#endif
 
 	#define CDECL _cdecl
-	#define GCC_PACK
 	#define WARN_FORMAT(string, args)
 	#define FINAL sealed
 
@@ -302,6 +299,16 @@
 	#define PATHSEP "/"
 	#define PATHSEPCHAR '/'
 #endif
+
+#if defined(_MSC_VER) || defined(__WATCOMC__)
+#	define PACK_N(type_dec, n) __pragma(pack(push, n)) type_dec; __pragma(pack(pop))
+#elif defined(__MINGW32__)
+#	define PRAGMA(x) _Pragma(#x)
+#	define PACK_N(type_dec, n) PRAGMA(pack(push, n)) type_dec; PRAGMA(pack(pop))
+#else
+#	define PACK_N(type_dec, n) type_dec __attribute__((__packed__, aligned(n)))
+#endif
+#define PACK(type_dec) PACK_N(type_dec, 1)
 
 /* MSVCRT of course has to have a different syntax for long long *sigh* */
 #if defined(_MSC_VER) || defined(__MINGW32__)


### PR DESCRIPTION
No, I've not tested with old MSYS. Seems feasible to drop support for it, tbh

Summary:
Without `-lfreetype` being at the end of the list, there are errors about missing symbols at link time, see https://github.com/harfbuzz/harfbuzz/issues/720
MinGW-gcc has an [issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991) with \_\_attribute__((packed)) at the moment, and apparently -mms-bitfields is default anyway, so switch things around to make use of that.
And no, I don't know how nothing else caught that CR_UNKNOWN wasn't in the switch statement. Maybe they're clever enough to know it's not actually used?

There's also still a remaining warning relating to printf with a long integer (seemingly doesn't recognise `%I64d` (`%lld` is worse)), but @glx22 says that's probably not fixable