### PR TITLE
Add: Hover tool-tips to cargo dest flow legend window

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2288,6 +2288,7 @@ STR_LINKGRAPH_LEGEND_CAPTION                                    :{BLACK}Cargo Fl
 STR_LINKGRAPH_LEGEND_ALL                                        :{BLACK}All
 STR_LINKGRAPH_LEGEND_NONE                                       :{BLACK}None
 STR_LINKGRAPH_LEGEND_SELECT_COMPANIES                           :{BLACK}Select companies to be displayed
+STR_LINKGRAPH_LEGEND_COMPANY_TOOLTIP                            :{BLACK}{STRING}{}{COMPANY}
 
 # Linkgraph legend window and linkgraph legend in smallmap
 STR_LINKGRAPH_LEGEND_UNUSED                                     :{TINY_FONT}{BLACK}unused

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -319,7 +319,7 @@ void LinkGraphOverlay::SetCompanyMask(uint32 company_mask)
 /** Make a number of rows with buttons for each company for the linkgraph legend window. */
 NWidgetBase *MakeCompanyButtonRowsLinkGraphGUI(int *biggest_index)
 {
-	return MakeCompanyButtonRows(biggest_index, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST, 3, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES);
+	return MakeCompanyButtonRows(biggest_index, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST, 3, STR_NULL);
 }
 
 NWidgetBase *MakeSaturationLegendLinkGraphGUI(int *biggest_index)
@@ -498,6 +498,44 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 		GfxFillRect(r.left + 2, r.top + 2, r.right - 2, r.bottom - 2, cargo->legend_colour);
 		DrawString(r.left, r.right, (r.top + r.bottom + 1 - FONT_HEIGHT_SMALL) / 2, cargo->abbrev, TC_BLACK, SA_HOR_CENTER);
 	}
+}
+
+bool LinkGraphLegendWindow::OnHoverCommon(Point pt, int widget, TooltipCloseCondition close_cond)
+{
+	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
+		if (this->IsWidgetDisabled(widget)) {
+			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_SELECT_COMPANIES, 0, NULL, close_cond);
+		} else {
+			uint64 params[2];
+			CompanyID cid = (CompanyID)(widget - WID_LGL_COMPANY_FIRST);
+			params[0] = STR_LINKGRAPH_LEGEND_SELECT_COMPANIES;
+			params[1] = cid;
+			GuiShowTooltips(this, STR_LINKGRAPH_LEGEND_COMPANY_TOOLTIP, 2, params, close_cond);
+		}
+		return true;
+	}
+	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
+		if (this->IsWidgetDisabled(widget)) return false;
+		CargoSpec *cargo = CargoSpec::Get(widget - WID_LGL_CARGO_FIRST);
+		uint64 params[1];
+		params[0] = cargo->name;
+		GuiShowTooltips(this, STR_BLACK_STRING, 1, params, close_cond);
+		return true;
+	}
+	return false;
+}
+
+void LinkGraphLegendWindow::OnHover(Point pt, int widget)
+{
+	this->OnHoverCommon(pt, widget, TCC_HOVER);
+}
+
+bool LinkGraphLegendWindow::OnRightClick(Point pt, int widget)
+{
+	if (_settings_client.gui.hover_delay_ms == 0) {
+		return this->OnHoverCommon(pt, widget, TCC_RIGHT_CLICK);
+	}
+	return false;
 }
 
 /**

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -15,6 +15,7 @@
 #include "../company_func.h"
 #include "../station_base.h"
 #include "../widget_type.h"
+#include "../window_gui.h"
 #include "linkgraph_base.h"
 #include <map>
 #include <vector>
@@ -101,6 +102,8 @@ public:
 
 	virtual void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize);
 	virtual void DrawWidget(const Rect &r, int widget) const;
+	virtual void OnHover(Point pt, int widget);
+	virtual bool OnRightClick(Point pt, int widget);
 	virtual void OnClick(Point pt, int widget, int click_count);
 	virtual void OnInvalidateData(int data = 0, bool gui_scope = true);
 
@@ -109,6 +112,7 @@ private:
 
 	void UpdateOverlayCompanies();
 	void UpdateOverlayCargoes();
+	bool OnHoverCommon(Point pt, int widget, TooltipCloseCondition close_cond);
 };
 
 #endif /* LINKGRAPH_GUI_H */


### PR DESCRIPTION
This is to improve the usability of the window.
The two-letter abbreviations are not always clear, in particular
when using a large number of cargoes.
The company colours can be ambiguous when there are a large
number of companies.