### PR TITLE
Fix: Poor contrast in cargo dest flow legend window cargo labels

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1111,16 +1111,17 @@ void DoPaletteAnimations()
 /**
  * Determine a contrasty text colour for a coloured background.
  * @param background Background colour.
+ * @param threshold Background colour brightness threshold below which the background is considered dark and TC_WHITE is returned, range: 0 - 255, default 128.
  * @return TC_BLACK or TC_WHITE depending on what gives a better contrast.
  */
-TextColour GetContrastColour(uint8 background)
+TextColour GetContrastColour(uint8 background, uint8 threshold)
 {
 	Colour c = _cur_palette.palette[background];
 	/* Compute brightness according to http://www.w3.org/TR/AERT#color-contrast.
 	 * The following formula computes 1000 * brightness^2, with brightness being in range 0 to 255. */
 	uint sq1000_brightness = c.r * c.r * 299 + c.g * c.g * 587 + c.b * c.b * 114;
-	/* Compare with threshold brightness 128 (50%) */
-	return sq1000_brightness < 128 * 128 * 1000 ? TC_WHITE : TC_BLACK;
+	/* Compare with threshold brightness which defaults to 128 (50%) */
+	return sq1000_brightness < ((uint) threshold) * ((uint) threshold) * 1000 ? TC_WHITE : TC_BLACK;
 }
 
 /**

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -187,7 +187,7 @@ int GetCharacterHeight(FontSize size);
 
 extern DrawPixelInfo *_cur_dpi;
 
-TextColour GetContrastColour(uint8 background);
+TextColour GetContrastColour(uint8 background, uint8 threshold = 128);
 
 /**
  * All 16 colour gradients

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -496,7 +496,7 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 		if (this->IsWidgetDisabled(widget)) return;
 		CargoSpec *cargo = CargoSpec::Get(widget - WID_LGL_CARGO_FIRST);
 		GfxFillRect(r.left + 2, r.top + 2, r.right - 2, r.bottom - 2, cargo->legend_colour);
-		DrawString(r.left, r.right, (r.top + r.bottom + 1 - FONT_HEIGHT_SMALL) / 2, cargo->abbrev, TC_BLACK, SA_HOR_CENTER);
+		DrawString(r.left, r.right, (r.top + r.bottom + 1 - FONT_HEIGHT_SMALL) / 2, cargo->abbrev, GetContrastColour(cargo->legend_colour, 73), SA_HOR_CENTER);
 	}
 }
 


### PR DESCRIPTION
Select foreground colour depending on the brightness of the background.

Previously all cargo labels were rendered using black text, even
the background cargo colour was dark/black.
As an example: FIRS coal was black text on a black background.