### PR TITLE
Fix: [Win32] Garbage in OS window title if branch name was too long.

### DIFF
--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -338,13 +338,13 @@ bool VideoDriver_Win32::MakeWindow(bool full_screen)
 		if (_wnd.main_wnd != NULL) {
 			if (!_window_maximize) SetWindowPos(_wnd.main_wnd, 0, 0, 0, w, h, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOMOVE);
 		} else {
-			TCHAR Windowtitle[50];
 			int x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
 			int y = (GetSystemMetrics(SM_CYSCREEN) - h) / 2;
 
-			_sntprintf(Windowtitle, lengthof(Windowtitle), _T("OpenTTD %s"), MB_TO_WIDE(_openttd_revision));
+			char window_title[64];
+			seprintf(window_title, lastof(window_title), "OpenTTD %s", _openttd_revision);
 
-			_wnd.main_wnd = CreateWindow(_T("OTTD"), Windowtitle, style, x, y, w, h, 0, 0, GetModuleHandle(NULL), 0);
+			_wnd.main_wnd = CreateWindow(_T("OTTD"), MB_TO_WIDE(window_title), style, x, y, w, h, 0, 0, GetModuleHandle(NULL), 0);
 			if (_wnd.main_wnd == NULL) usererror("CreateWindow failed");
 			ShowWindow(_wnd.main_wnd, showstyle);
 		}


### PR DESCRIPTION
This was caused because `_sntprintf` does not write a \0 on reaching the buffer limit.