### PR TITLE
Fix: Put last SVN revision back in NewGRF version number

### DIFF
--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -64,13 +64,13 @@ const byte _openttd_revision_modified = !!MODIFIED!!;
  * 24-27 minor version
  * 20-23 build
  *    19 1 if it is a release, 0 if it is not.
- *  0-18 used to be the SVN revision, currently unused
+ *  0-18 used to be the SVN revision, now just last revision before switch to git
  *
  * The 19th bit is there so the development/betas/alpha, etc. leading to a
  * final release will always have a lower version number than the released
  * version, thus making comparisons on specific revisions easy.
  */
-const uint32 _openttd_newgrf_version = 1 << 28 | 9 << 24 | 0 << 20 | 0 << 19;
+const uint32 _openttd_newgrf_version = 1 << 28 | 9 << 24 | 0 << 20 | 28004 << 19;
 
 #ifdef __MORPHOS__
 /**

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -70,7 +70,7 @@ const byte _openttd_revision_modified = !!MODIFIED!!;
  * final release will always have a lower version number than the released
  * version, thus making comparisons on specific revisions easy.
  */
-const uint32 _openttd_newgrf_version = 1 << 28 | 9 << 24 | 0 << 20 | 28004 << 19;
+const uint32 _openttd_newgrf_version = 1 << 28 | 9 << 24 | 0 << 20 | 0 << 19 | 28004;
 
 #ifdef __MORPHOS__
 /**


### PR DESCRIPTION
This is necessary to be compatible with some Game Scripts that might trigger compatibility modes if the SVN revision part is wrong. Potentially some NewGRFs might also be affected.

See for example [SuperLib's Helper class](https://dev.openttdcoop.org/projects/superlib/repository/entry/helper.nut#L280), containing this function:

    function _SuperLib_Helper::HasWorldGenBug()
    {
    	local version = _SuperLib_Helper.GetOpenTTDVersion();
    
    	if (version.Major == 0 || (version.Major == 1 && version.Minor <= 3)) {
    		return version.Revision < 25339;
    	} else {
    		return version.Revision < 25305;
    	}
    }

If this function sees a Revision value of zero, it might trigger a workaround not required, causing a regression in scripts dependent on this. The MinimalGS example, for one, will trigger this.