### PR TITLE
Fix: ALL_CARGOTYPES mask constant was 32 instead of 64 bits

### DIFF
--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -72,7 +72,7 @@ enum CargoType {
 
 typedef uint64 CargoTypes;
 
-static const CargoTypes ALL_CARGOTYPES = (CargoTypes)UINT32_MAX;
+static const CargoTypes ALL_CARGOTYPES = (CargoTypes)UINT64_MAX;
 
 /** Class for storing amounts of cargo */
 struct CargoArray {


### PR DESCRIPTION
NUM_CARGO and CargoTypes were increased from 32 to 64 cargoes/bits
respectively in commit 11ab3c4ea2f6a6d29efda8c9ba2af04194621ea7