### PR TITLE
Fix #6647: Missing property in vehicle copying

### DIFF
--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -717,7 +717,7 @@ public:
 
 		this->current_order = src->current_order;
 		this->dest_tile  = src->dest_tile;
-		
+
 		this->last_station_visited = src->last_station_visited;
 
 		this->profit_this_year = src->profit_this_year;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -717,8 +717,6 @@ public:
 
 		this->current_order = src->current_order;
 		this->dest_tile  = src->dest_tile;
-		
-		this->last_station_visited = src->last_station_visited;
 
 		this->profit_this_year = src->profit_this_year;
 		this->profit_last_year = src->profit_last_year;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -717,6 +717,8 @@ public:
 
 		this->current_order = src->current_order;
 		this->dest_tile  = src->dest_tile;
+		
+		this->last_station_visited = src->last_station_visited;
 
 		this->profit_this_year = src->profit_this_year;
 		this->profit_last_year = src->profit_last_year;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -717,7 +717,7 @@ public:
 
 		this->current_order = src->current_order;
 		this->dest_tile  = src->dest_tile;
-
+		
 		this->last_station_visited = src->last_station_visited;
 
 		this->profit_this_year = src->profit_this_year;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -718,6 +718,8 @@ public:
 		this->current_order = src->current_order;
 		this->dest_tile  = src->dest_tile;
 
+		this->last_station_visited = src->last_station_visited;
+
 		this->profit_this_year = src->profit_this_year;
 		this->profit_last_year = src->profit_last_year;
 	}


### PR DESCRIPTION
last_station_visited was not copied when performing autorenew, which caused [#6647](https://github.com/OpenTTD/OpenTTD/issues/6647)