### PR TITLE
Fix bit use and documentation for m8

### DIFF
--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -93,7 +93,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">-inherit-</td>
       <td class="bits"><span class="free">OOO</span>X XX<span class="free">OO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td rowspan=3>1</td>
@@ -156,7 +156,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
       <td class="bits">XXXX <span class="free">OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits">XXXX <span class="free">OOO</span>X</td>
       <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
       <td class="bits">XXXX XXXX</td>
@@ -320,7 +320,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">-inherit-</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">shipdepot</td>
@@ -333,7 +333,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">-inherit-</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td>8</td>
@@ -368,9 +368,9 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
       <td class="bits">-inherit-</td>
-      <td class="bits">-inherit-</td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits">-inherit-</td>
       <td class="bits"><span class="free">OO</span>XX XX<span class="free">OO</span></td>
       <td class="bits">-inherit-</td>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -173,7 +173,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">XX<span class="free">OO OO</span>XX</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits">XXX<span class="free">O</span> XXXX</td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td>3</td>
@@ -241,7 +241,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="option">~~~~ ~</span>XXX</td>
       <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
       <td class="bits">XX<span class="free">O</span>X XXXX</td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">dock</td>
@@ -254,7 +254,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="option">~~~~ ~</span>XXX</td>
       <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">airport</td>
@@ -267,7 +267,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">XXXX XXXX</td>
       <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
       <td class="bits">XXXX XXXX</td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">buoy</td>
@@ -280,7 +280,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="option">~~~~ ~~~~</span></td>
       <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">oilrig</td>
@@ -293,7 +293,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="option">~~~~ ~~~~</span></td>
       <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td rowspan=3>6</td>

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -269,6 +269,7 @@ static inline void MakeClear(TileIndex t, ClearGround g, uint density)
 	SetClearGroundDensity(t, g, density); // Sets m5
 	_me[t].m6 = 0;
 	_me[t].m7 = 0;
+	_me[t].m8 = 0;
 }
 
 
@@ -289,6 +290,7 @@ static inline void MakeField(TileIndex t, uint field_type, IndustryID industry)
 	SetClearGroundDensity(t, CLEAR_FIELDS, 3);
 	SB(_me[t].m6, 2, 4, 0);
 	_me[t].m7 = 0;
+	_me[t].m8 = 0;
 }
 
 /**

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -542,6 +542,7 @@ static inline void MakeStation(TileIndex t, Owner o, StationID sid, StationType 
 	SB(_me[t].m6, 2, 1, 0);
 	SB(_me[t].m6, 3, 3, st);
 	_me[t].m7 = 0;
+	_me[t].m8 = 0;
 }
 
 /**

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -148,7 +148,8 @@ extern CommandCost CanExpandRailStation(const BaseStation *st, TileArea &new_ta,
  * @param start_tile northern most tile where waypoint will be built
  * @param flags type of operation
  * @param p1 various bitstuffed elements
- * - p1 = (bit  4)    - orientation (Axis)
+ * - p1 = (bit  0- 5) - railtype (not used)
+ * - p1 = (bit  6)    - orientation (Axis)
  * - p1 = (bit  8-15) - width of waypoint
  * - p1 = (bit 16-23) - height of waypoint
  * - p1 = (bit 24)    - allow waypoints directly adjacent to other waypoints.
@@ -161,7 +162,7 @@ extern CommandCost CanExpandRailStation(const BaseStation *st, TileArea &new_ta,
 CommandCost CmdBuildRailWaypoint(TileIndex start_tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
 {
 	/* Unpack parameters */
-	Axis axis      = Extract<Axis, 4, 1>(p1);
+	Axis axis      = Extract<Axis, 6, 1>(p1);
 	byte width     = GB(p1,  8, 8);
 	byte height    = GB(p1, 16, 8);
 	bool adjacent  = HasBit(p1, 24);


### PR DESCRIPTION
After extending the map array in PR #6805 some bits in landscape_grid.html were wrong (some tile types do not have/store a railway type).
In the same PR, I have changed some -inherit- uses in that grid, as they can't inherit a meaning from a free byte or uint16 that has no meaning (trying to be consistent with other cases -see m4 for docks-).
It also fixes some uses of command bits and m8.