### PR TITLE
Fix: Script/AI construction of rail track and waypoints

### DIFF
--- a/bin/ai/regression/tst_regression/main.nut
+++ b/bin/ai/regression/tst_regression/main.nut
@@ -1018,7 +1018,36 @@ function Regression::Rail()
 	print("    BuildRail():                   " + AIRail.BuildRail(10002, 10003, 10006));
 	print("    HasTransportType():            " + AITile.HasTransportType(10005, AITile.TRANSPORT_RAIL));
 	print("    HasTransportType():            " + AITile.HasTransportType(10006, AITile.TRANSPORT_RAIL));
-	print("    RemoveRail():                  " + AIRail.RemoveRail(10005, 10004, 10001));
+	print("    RemoveRail():                  " + AIRail.RemoveRail(10006, 10005, 10002));
+	print("    HasTransportType():            " + AITile.HasTransportType(10004, AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(10005, AITile.TRANSPORT_RAIL));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(6200, AIRail.RAILTRACK_NE_SW));
+	print("    RemoveRailTrack():             " + AIRail.RemoveRailTrack(6200, AIRail.RAILTRACK_NW_NE));
+	print("    RemoveRailTrack():             " + AIRail.RemoveRailTrack(6200, AIRail.RAILTRACK_NE_SW));
+	print("    BuildRail():                   " + AIRail.BuildRail(6200, 6200 + 256, 6200 + (256 * 4)));
+	print("    HasTransportType():            " + AITile.HasTransportType(6200 + (256 * 3), AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(6200 + (256 * 4), AITile.TRANSPORT_RAIL));
+	print("    RemoveRail():                  " + AIRail.RemoveRail(6200 + (256 * 3), 6200 + (256 * 2), 6200 - 256));
+	print("    HasTransportType():            " + AITile.HasTransportType(6200 + (256 * 3), AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(6200 + (256 * 4), AITile.TRANSPORT_RAIL));
+	print("    BuildRailTrack():              " + AIRail.BuildRail(14706, 14705, 12907));
+	print("    HasTransportType():            " + AITile.HasTransportType(13421, AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(14191, AITile.TRANSPORT_RAIL));
+	print("    RemoveRail():                  " + AIRail.RemoveRail(12907, 13163, 14706));
+	print("    HasTransportType():            " + AITile.HasTransportType(13421, AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(14191, AITile.TRANSPORT_RAIL));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NW_SW));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NE_SE));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NW_NE));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_SW_SE));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NE_SW));
+	print("    DemolishTile():                " + AITile.DemolishTile(61533));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NE_SW));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NW_SE));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NW_NE));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_SW_SE));
+	print("    DemolishTile():                " + AITile.DemolishTile(61533));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(61533, AIRail.RAILTRACK_NW_SE));
 
 	print("  Depot");
 	print("    IsRailTile():                  " + AIRail.IsRailTile(33411));
@@ -1053,6 +1082,31 @@ function Regression::Rail()
 	print("    IsRailStationTile():           " + AIRail.IsRailStationTile(7957));
 	print("    IsRailStationTile():           " + AIRail.IsRailStationTile(7958));
 	print("    IsRailStationTile():           " + AIRail.IsRailStationTile(7959));
+
+	print("  Waypoint");
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(12646, AIRail.RAILTRACK_NW_SE));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(12648, AIRail.RAILTRACK_NE_SW));
+	print("    BuildRailTrack():              " + AIRail.BuildRailTrack(12650, AIRail.RAILTRACK_NW_NE));
+	print("    BuildRailWaypoint():           " + AIRail.BuildRailWaypoint(12644));
+	print("    BuildRailWaypoint():           " + AIRail.BuildRailWaypoint(12646));
+	print("    BuildRailWaypoint():           " + AIRail.BuildRailWaypoint(12648));
+	print("    BuildRailWaypoint():           " + AIRail.BuildRailWaypoint(12650));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12644));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12646));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12648));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12650));
+	print("    RemoveRailWaypointTileRectangle():" + AIRail.RemoveRailWaypointTileRectangle(12644, 12646, false));
+	print("    RemoveRailWaypointTileRectangle():" + AIRail.RemoveRailWaypointTileRectangle(12648, 12650, true));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12644));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12646));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12648));
+	print("    IsRailWaypointTile():          " + AIRail.IsRailWaypointTile(12650));
+	print("    HasTransportType():            " + AITile.HasTransportType(12644, AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(12646, AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(12648, AITile.TRANSPORT_RAIL));
+	print("    HasTransportType():            " + AITile.HasTransportType(12650, AITile.TRANSPORT_RAIL));
+	print("    DemolishTile():                " + AITile.DemolishTile(12648));
+	print("    DemolishTile():                " + AITile.DemolishTile(12650));
 }
 
 function Regression::Road()
@@ -1441,7 +1495,7 @@ function Regression::TileList()
 		print("    " + i + " => " + list.GetValue(i));
 	}
 
-	list = AITileList_StationType(4, AIStation.STATION_BUS_STOP);
+	list = AITileList_StationType(6, AIStation.STATION_BUS_STOP);
 	print("");
 	print("--TileList_StationType--");
 	print("  Count():             " + list.Count());

--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -7334,6 +7334,35 @@ ERROR: IsEnd() is invalid as Begin() is never called
     HasTransportType():            true
     HasTransportType():            false
     RemoveRail():                  true
+    HasTransportType():            false
+    HasTransportType():            false
+    BuildRailTrack():              true
+    RemoveRailTrack():             false
+    RemoveRailTrack():             true
+    BuildRail():                   true
+    HasTransportType():            true
+    HasTransportType():            false
+    RemoveRail():                  true
+    HasTransportType():            true
+    HasTransportType():            false
+    BuildRailTrack():              true
+    HasTransportType():            true
+    HasTransportType():            true
+    RemoveRail():                  true
+    HasTransportType():            false
+    HasTransportType():            false
+    BuildRailTrack():              false
+    BuildRailTrack():              false
+    BuildRailTrack():              true
+    BuildRailTrack():              true
+    BuildRailTrack():              false
+    DemolishTile():                true
+    BuildRailTrack():              true
+    BuildRailTrack():              false
+    BuildRailTrack():              false
+    BuildRailTrack():              false
+    DemolishTile():                true
+    BuildRailTrack():              true
   Depot
     IsRailTile():                  false
     BuildRailDepot():              false
@@ -7362,6 +7391,30 @@ ERROR: IsEnd() is invalid as Begin() is never called
     IsRailStationTile():           false
     IsRailStationTile():           false
     IsRailStationTile():           false
+  Waypoint
+    BuildRailTrack():              true
+    BuildRailTrack():              true
+    BuildRailTrack():              true
+    BuildRailWaypoint():           false
+    BuildRailWaypoint():           true
+    BuildRailWaypoint():           true
+    BuildRailWaypoint():           false
+    IsRailWaypointTile():          false
+    IsRailWaypointTile():          true
+    IsRailWaypointTile():          true
+    IsRailWaypointTile():          false
+    RemoveRailWaypointTileRectangle():true
+    RemoveRailWaypointTileRectangle():true
+    IsRailWaypointTile():          false
+    IsRailWaypointTile():          false
+    IsRailWaypointTile():          false
+    IsRailWaypointTile():          false
+    HasTransportType():            false
+    HasTransportType():            false
+    HasTransportType():            true
+    HasTransportType():            true
+    DemolishTile():                true
+    DemolishTile():                true
 
 --RailTypeList--
   Count():             1
@@ -7485,9 +7538,9 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetName(0):               Look, a station
   GetLocation(1):           29253
   GetLocation(1000):        -1
-  GetStationID(33411):      4
+  GetStationID(33411):      6
   GetStationID(34411):      65535
-  GetStationID(33411):      4
+  GetStationID(33411):      6
   HasRoadType(3, TRAM):     false
   HasRoadType(3, ROAD):     false
   HasRoadType(33411, TRAM): false

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -204,7 +204,7 @@
 	EnforcePrecondition(false, GetRailTracks(tile) == RAILTRACK_NE_SW || GetRailTracks(tile) == RAILTRACK_NW_SE);
 	EnforcePrecondition(false, IsRailTypeAvailable(GetCurrentRailType()));
 
-	return ScriptObject::DoCommand(tile, GetCurrentRailType() | (GetRailTracks(tile) == RAILTRACK_NE_SW ? AXIS_X : AXIS_Y) << 4 | 1 << 8 | 1 << 16, STAT_CLASS_WAYP | INVALID_STATION << 16, CMD_BUILD_RAIL_WAYPOINT);
+	return ScriptObject::DoCommand(tile, GetCurrentRailType() | (GetRailTracks(tile) == RAILTRACK_NE_SW ? AXIS_X : AXIS_Y) << 6 | 1 << 8 | 1 << 16, STAT_CLASS_WAYP | INVALID_STATION << 16, CMD_BUILD_RAIL_WAYPOINT);
 }
 
 /* static */ bool ScriptRail::RemoveRailWaypointTileRectangle(TileIndex tile, TileIndex tile2, bool keep_rail)
@@ -288,16 +288,16 @@ static uint32 SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 	int diag_offset = abs(abs((int)::TileX(*to) - (int)::TileX(tile)) - abs((int)::TileY(*to) - (int)::TileY(tile)));
 	uint32 p2 = 0;
 	if (::TileY(from) == ::TileY(*to)) {
-		p2 |= (TRACK_X << 4);
+		p2 |= (TRACK_X << 6);
 		*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
 	} else if (::TileX(from) == ::TileX(*to)) {
-		p2 |= (TRACK_Y << 4);
+		p2 |= (TRACK_Y << 6);
 		*to -= ::MapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
 	} else if (::TileY(from) < ::TileY(tile)) {
 		if (::TileX(*to) < ::TileX(tile)) {
-			p2 |= (TRACK_UPPER << 4);
+			p2 |= (TRACK_UPPER << 6);
 		} else {
-			p2 |= (TRACK_LEFT << 4);
+			p2 |= (TRACK_LEFT << 6);
 		}
 		if (diag_offset != 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
@@ -306,9 +306,9 @@ static uint32 SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		}
 	} else if (::TileY(from) > ::TileY(tile)) {
 		if (::TileX(*to) < ::TileX(tile)) {
-			p2 |= (TRACK_RIGHT << 4);
+			p2 |= (TRACK_RIGHT << 6);
 		} else {
-			p2 |= (TRACK_LOWER << 4);
+			p2 |= (TRACK_LOWER << 6);
 		}
 		if (diag_offset != 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
@@ -317,9 +317,9 @@ static uint32 SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		}
 	} else if (::TileX(from) < ::TileX(tile)) {
 		if (::TileY(*to) < ::TileY(tile)) {
-			p2 |= (TRACK_UPPER << 4);
+			p2 |= (TRACK_UPPER << 6);
 		} else {
-			p2 |= (TRACK_RIGHT << 4);
+			p2 |= (TRACK_RIGHT << 6);
 		}
 		if (diag_offset == 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
@@ -328,9 +328,9 @@ static uint32 SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		}
 	} else if (::TileX(from) > ::TileX(tile)) {
 		if (::TileY(*to) < ::TileY(tile)) {
-			p2 |= (TRACK_LEFT << 4);
+			p2 |= (TRACK_LEFT << 6);
 		} else {
-			p2 |= (TRACK_LOWER << 4);
+			p2 |= (TRACK_LOWER << 6);
 		}
 		if (diag_offset == 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);


### PR DESCRIPTION
Scripts/AIs could not build rail track or waypoints as these command calls were not updated when the bit command p1/p2 bit allocations were changed to accommodate the increase to 64 rail types in bf8d7df734.