### PR TITLE
Fix: Variable 0x85 had no bounds checks.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5907,7 +5907,8 @@ static uint32 GetParamVal(byte param, uint32 *cond_val)
 				/* Supported in Action 0x07 and 0x09, not 0x0D */
 				return 0;
 			} else {
-				uint32 param_val = _ttdpatch_flags[*cond_val / 0x20];
+				uint32 index = *cond_val / 0x20;
+				uint32 param_val = index < lengthof(_ttdpatch_flags) ? _ttdpatch_flags[index] : 0;
 				*cond_val %= 0x20;
 				return param_val;
 			}


### PR DESCRIPTION
Not sure whether to spawn an error, or whether to just read 0.