### PR TITLE
Fix #6839: OLD_GM_DIR midi search path got lost

### DIFF
--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1013,6 +1013,8 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 		char filename[MAX_PATH];
 		if (FioFindFullPath(filename, lastof(filename), Subdirectory::BASESET_DIR, song.filename)) {
 			return std::string(filename);
+		} else if (FioFindFullPath(filename, lastof(filename), Subdirectory::OLD_GM_DIR, song.filename)) {
+			return std::string(filename);
 		} else {
 			return std::string();
 		}


### PR DESCRIPTION
Fixes actually finding the music from a music set - the .obm file is still found in gm/, but not the music
