### PR TITLE
Add: AI/GS GetMonthlyMaintenanceCost

### DIFF
--- a/src/script/api/ai/ai_airport.hpp.sq
+++ b/src/script/api/ai/ai_airport.hpp.sq
@@ -52,6 +52,7 @@ void SQAIAirport_Register(Squirrel *engine)
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNoiseLevelIncrease,         "GetNoiseLevelIncrease",         3, ".ii");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNearestTown,                "GetNearestTown",                3, ".ii");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMaintenanceCostFactor,      "GetMaintenanceCostFactor",      2, ".i");
+	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMonthlyMaintenanceCost,     "GetMonthlyMaintenanceCost",     2, ".i");
 
 	SQAIAirport.PostRegister(engine);
 }

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -18,6 +18,8 @@
  * \b 1.9.0
  *
  * 1.9.0 is not yet released. The following changes are not set in stone yet.
+ * API additions:
+ * \li AIAirport::GetMonthlyMaintenanceCost
  *
  * \b 1.8.0
  *

--- a/src/script/api/game/game_airport.hpp.sq
+++ b/src/script/api/game/game_airport.hpp.sq
@@ -52,6 +52,7 @@ void SQGSAirport_Register(Squirrel *engine)
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNoiseLevelIncrease,         "GetNoiseLevelIncrease",         3, ".ii");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNearestTown,                "GetNearestTown",                3, ".ii");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMaintenanceCostFactor,      "GetMaintenanceCostFactor",      2, ".i");
+	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMonthlyMaintenanceCost,     "GetMonthlyMaintenanceCost",     2, ".i");
 
 	SQGSAirport.PostRegister(engine);
 }

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -19,6 +19,7 @@
  *
  * 1.9.0 is not yet released. The following changes are not set in stone yet.
  * API additions:
+ * \li GSAirport::GetMonthlyMaintenanceCost
  * \li GSClient
  * \li GSClientList
  * \li GSClientList_Company

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -163,3 +163,10 @@
 
 	return AirportSpec::Get(type)->maintenance_cost;
 }
+
+/* static */ Money ScriptAirport::GetMonthlyMaintenanceCost(AirportType type)
+{
+	if (!IsAirportInformationAvailable(type)) return -1;
+
+	return (int64)GetMaintenanceCostFactor(type) * _price[PR_INFRASTRUCTURE_AIRPORT] >> 3;
+}

--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -201,6 +201,14 @@ public:
 	 * @return Maintenance cost factor of the airport type.
 	 */
 	static uint16 GetMaintenanceCostFactor(AirportType type);
+
+	/**
+	 * Get the monthly maintenance cost of an airport type.
+	 * @param type The airport type to get the monthly maintenance cost of.
+	 * @pre IsAirportInformationAvailable(type)
+	 * @return Monthly maintenance cost of the airport type.
+	 */
+	static Money GetMonthlyMaintenanceCost(AirportType type);
 };
 
 #endif /* SCRIPT_AIRPORT_HPP */


### PR DESCRIPTION
API addition which allows AI/GS scripts to retrieve the monthly maintenance cost of an airport type.