### PR TITLE
Add BACKSPACE as a mappable hotkey

### DIFF
--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -41,6 +41,7 @@ static const KeycodeNames _keycode_to_name[] = {
 	{"GLOBAL", WKC_GLOBAL_HOTKEY},
 	{"ESC", WKC_ESC},
 	{"DEL", WKC_DELETE},
+	{"BACKSPACE", WKC_BACKSPACE},
 	{"RETURN", WKC_RETURN},
 	{"BACKQUOTE", WKC_BACKQUOTE},
 	{"F1", WKC_F1},


### PR DESCRIPTION
On the tin — make "BACKSPACE" a mappable hotkey. It already exists in the codebase — https://github.com/OpenTTD/OpenTTD/blob/ca5b68145ad6f9631b72635fdfa0ab3a1937b707/src/gfx_type.h#L42 — just not in the hotkey parser.