### PR TITLE
Fix iconv and clang version detection on OSX

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1331,7 +1331,8 @@ make_compiler_cflags() {
 		fi
 	elif echo "$version_line" | grep -q "clang"; then
 		# Enable some things only for certain clang versions
-		cc_version="`$1 -v 2>&1 | head -n 1 | sed s@[^0-9]@@g | cut -c 1-2`"
+		# Need to try really hard to get the version line, because OSX clang likes to hide its true version
+		cc_version="`$1 -v 2>&1 | grep -i version | head -n 1 | sed s@[^0-9]@@g | cut -c 1-2`"
 
 		# aliasing rules are not held in openttd code
 		flags="$flags -fno-strict-aliasing"

--- a/config.lib
+++ b/config.lib
@@ -1317,8 +1317,6 @@ make_compiler_cflags() {
 		if [ $cc_version -ge 110 ]; then
 			# remark #2259: non-pointer conversion from ... to ... may lose significant bits
 			flags="$flags -wd2259"
-			# Use c++0x mode so static_assert() is available
-			cxxflags="$cxxflags -std=c++0x"
 		fi
 
 		if [ "$enable_lto" != "0" ]; then
@@ -1380,11 +1378,6 @@ make_compiler_cflags() {
 			flags="$flags -Wno-unused-variable"
 		fi
 
-		if [ "$cc_version" -ge "33" ]; then
-			# clang completed C++11 support in version 3.3
-			flags="$flags -std=c++11"
-		fi
-
 		# rdynamic is used to get useful stack traces from crash reports.
 		ldflags="$ldflags -rdynamic"
 
@@ -1443,12 +1436,6 @@ make_compiler_cflags() {
 			flags="$flags -Wnon-virtual-dtor"
 		fi
 
-		if [ $cc_version -ge 403 ] && [ $cc_version -lt 600 ]; then
-			# Use gnu++0x mode so static_assert() is available.
-			# Don't use c++0x, it breaks mingw (with gcc 4.4.0).
-			cxxflags="$cxxflags -std=gnu++0x"
-		fi
-
 		if [ $cc_version -eq 405 ]; then
 			# Prevent optimisation supposing enums are in a range specified by the standard
 			# For details, see http://gcc.gnu.org/PR43680
@@ -1470,7 +1457,7 @@ make_compiler_cflags() {
 		if [ $cc_version -ge 600 ]; then
 			# -flifetime-dse=2 (default since GCC 6) doesn't play
 			# well with our custom pool item allocator
-			cxxflags="$cxxflags -flifetime-dse=1 -std=gnu++14"
+			cxxflags="$cxxflags -flifetime-dse=1"
 		fi
 
 		if [ "$enable_lto" != "0" ]; then
@@ -1533,6 +1520,8 @@ make_cflags_and_ldflags() {
 
 	CFLAGS="$CFLAGS -D$os"
 	CFLAGS_BUILD="$CFLAGS_BUILD -D$os"
+	CXXFLAGS="$CXXFLAGS -std=c++11"
+	CXXFLAGS_BUILD="$CXXFLAGS_BUILD -std=c++11"
 
 	if [ "$enable_debug" = "0" ]; then
 		# No debug, add default stuff

--- a/config.lib
+++ b/config.lib
@@ -2927,10 +2927,16 @@ detect_iconv() {
 	# Try to find iconv.h, seems to only thing to detect iconv with
 
 	if [ "$with_iconv" = "1" ] || [ "$with_iconv" = "" ] || [ "$with_iconv" = "2" ]; then
-		iconv=`ls -1 /usr/include 2>/dev/null | grep "iconv.h"`
-		if [ -z "$iconv" ]; then
-			iconv=`ls -1 /usr/local/include 2>/dev/null | grep "iconv.h"`
-		fi
+		# Iterate over search paths
+		iconv=""
+		search_paths=`LC_ALL=C $cxx_host $OSX_SYSROOT $CFLAGS -E - -v </dev/null 2>&1 | \
+		              $awk '/#include <...> search starts here:/{flag=1;next}/End of search list./{flag=0}flag'`
+		for path in $search_paths; do
+			iconv=`ls -1 $path 2>/dev/null | grep "iconv.h"`
+			if [ -n "$iconv" ]; then
+				break
+			fi
+		done
 	else
 		# Make sure it exists
 		iconv=`ls $with_iconv/include/iconv.h 2>/dev/null`


### PR DESCRIPTION
Rationale:

Under OSX, clang is actually all compilers - `cc`, `gcc` & `clang`. We already grep the output of --version to get that `gcc` might actually be `clang`, but the version number is hidden. For reasons best known to themselves, Apple have decided to completely remove the "actual" `clang` version number and use [their own](https://en.wikipedia.org/wiki/Xcode#Latest_versions).

This screws with the `CFLAGS` somewhat, as several of them are specific to compiler versions.

It turns out that `gcc -v` under OSX actually outputs
```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/c++/4.2.1
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
which isn't exactly what we were expecting. Coupled with the fact that the clang "version number" is determined by taking the first 2 digits from the first line of output, and we get version... 10

This is solved by only taking the lines containing "version", which seems to be constant between all variants. We then get version "91", which is still inaccurate, but actually works for our purposes

As for iconv, for some reason on @andythenorth's system `iconv.h` is only in `/usr/local/Cellar/libiconv/1.15/include/iconv.h`, and the configure script only searches within `/usr/include` & `/usr/local/include`. This seems fairly arbitrary anyway, so some magic involving the compiler output (which seems to be consistent between gcc & clang) and awk gets us a list of search paths to ...search within