### PR TITLE
Change: Allow dock to be constructed in more locations

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2562,9 +2562,9 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 	if (ret.Failed()) return ret;
 
 	tile_cur += TileOffsByDiagDir(direction);
-	if (!IsTileType(tile_cur, MP_WATER) || !IsTileFlat(tile_cur)) {
-		return_cmd_error(STR_ERROR_SITE_UNSUITABLE);
-	}
+
+	/* Ensure the location where ships dock, has water tracks. */
+	if (TrackStatusToTrackBits(GetTileTrackStatus(tile_cur, TRANSPORT_WATER, 0)) == TRACK_BIT_NONE) return_cmd_error(STR_ERROR_SITE_UNSUITABLE);
 
 	TileArea dock_area = TileArea(tile + ToTileIndexDiff(_dock_tileoffs_chkaround[direction]),
 			_dock_w_chk[direction], _dock_h_chk[direction]);


### PR DESCRIPTION
In regards to the 3rd tile:
- It allows construction if it is an aqueduct head.
- It allows construction if it is a buoy.
- It allows construction if it is a water tile with one corner raised and without a rail track on the opposite corner.
- It allows construction if it is a water tile with one corner raised and with a rail track on the opposite corner.

Note: Some AIs are not prepared to deal with water tiles with one corner raised.

https://www.tt-forums.net/viewtopic.php?f=33&t=75221