### PR TITLE
Fix #5713: Use pathfinder to find closest ship depot

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -534,8 +534,13 @@ static int32 NPFFindDepot(AyStar *as, OpenListNode *current)
 	AyStarUserData *user = (AyStarUserData *)as->user_data;
 	/* It's not worth caching the result with NPF_FLAG_IS_TARGET here as below,
 	 * since checking the cache not that much faster than the actual check */
-	return IsDepotTypeTile(current->path.node.tile, user->type) ?
-		AYSTAR_FOUND_END_NODE : AYSTAR_DONE;
+	if (user->type != TRANSPORT_WATER) {
+		return IsDepotTypeTile(current->path.node.tile, user->type) ?
+			AYSTAR_FOUND_END_NODE : AYSTAR_DONE;
+	} else {
+		return IsShipDepotTile(current->path.node.tile) && GetShipDepotPart(current->path.node.tile) == DEPOT_PART_NORTH && IsTileOwner(current->path.node.tile, user->owner) ?
+			AYSTAR_FOUND_END_NODE : AYSTAR_DONE;
+	}
 }
 
 /** Find any safe and free tile. */
@@ -1153,6 +1158,20 @@ Trackdir NPFRoadVehicleChooseTrack(const RoadVehicle *v, TileIndex tile, DiagDir
 }
 
 /*** Ships ***/
+
+FindDepotData NPFShipFindNearestDepot(const Ship *v, int max_penalty)
+{
+	Trackdir trackdir = v->GetVehicleTrackdir();
+	Trackdir trackdir_rev = ReverseTrackdir(trackdir);
+
+	AyStarUserData user = { v->owner, TRANSPORT_WATER, INVALID_RAILTYPES, ROADTYPES_NONE };
+	NPFFoundTargetData ftd = NPFRouteToDepotBreadthFirstTwoWay(v->tile, trackdir, false, v->tile, trackdir_rev, false, NULL, &user, 0, max_penalty);
+	if (ftd.best_bird_dist != 0) return FindDepotData();
+
+	/* Found target */
+	/* Our caller wants the distance to depot. We provide it in distance manhattan */
+	return FindDepotData(ftd.node.tile, DistanceManhattan(v->tile, ftd.node.tile), NPFGetFlag(&ftd.node, NPF_FLAG_REVERSE));
+}
 
 Track NPFShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool &path_found)
 {

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -538,6 +538,10 @@ static int32 NPFFindDepot(AyStar *as, OpenListNode *current)
 		return IsDepotTypeTile(current->path.node.tile, user->type) ?
 			AYSTAR_FOUND_END_NODE : AYSTAR_DONE;
 	} else {
+		/* The tile where the ship actually "enters" the depot is the north tile.
+		 * Ship depots are also valid water tracks for ships from any company,
+		 * unlike the other depot types, so the pathfinder has to do a blind
+		 * search for a tile that matches these conditions. */
 		return IsShipDepotTile(current->path.node.tile) && GetShipDepotPart(current->path.node.tile) == DEPOT_PART_NORTH && IsTileOwner(current->path.node.tile, user->owner) ?
 			AYSTAR_FOUND_END_NODE : AYSTAR_DONE;
 	}

--- a/src/pathfinder/npf/npf_func.h
+++ b/src/pathfinder/npf/npf_func.h
@@ -39,6 +39,16 @@ FindDepotData NPFRoadVehicleFindNearestDepot(const RoadVehicle *v, int max_penal
 Trackdir NPFRoadVehicleChooseTrack(const RoadVehicle *v, TileIndex tile, DiagDirection enterdir, TrackdirBits trackdirs, bool &path_found);
 
 /**
+ * Used when user sends ship to the nearest depot or if ship needs servicing using NPF
+ * @param v            ship that needs to go to some depot
+ * @param max_penalty  max distance (in pathfinder penalty) from the current ship position
+ *                     (used also as optimization - the pathfinder can stop path finding if max_penalty
+ *                     was reached and no depot was seen)
+ * @return             the data about the depot
+ */
+FindDepotData NPFShipFindNearestDepot(const Ship *v, int max_penalty);
+
+/**
  * Finds the best path for given ship using NPF.
  * @param v        the ship that needs to find a path
  * @param tile     the tile to find the path from (should be next tile the ship is about to enter)

--- a/src/pathfinder/opf/opf_ship.h
+++ b/src/pathfinder/opf/opf_ship.h
@@ -28,4 +28,14 @@
  */
 Track OPFShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool &path_found);
 
+/**
+ * Used when user sends ship to the nearest depot or if ship needs servicing using OPF.
+ * @param v            vehicle that needs to go to some depot
+ * @param max_distance max distance (in pathfinder penalty) from the current ship position
+ *                     (used also as optimization - the pathfinder can stop path finding if max_penalty
+ *                     was reached and no depot was seen)
+ * @return             the data about the depot
+ */
+FindDepotData OPFShipFindNearestDepot(const Ship *v, int max_distance);
+
 #endif /* OPF_SHIP_H */

--- a/src/pathfinder/yapf/yapf.h
+++ b/src/pathfinder/yapf/yapf.h
@@ -37,6 +37,16 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir,
 bool YapfShipCheckReverse(const Ship *v);
 
 /**
+ * Used when user sends ship to the nearest depot or if ship needs servicing using YAPF.
+ * @param v            vehicle that needs to go to some depot
+ * @param max_penalty  max distance (in pathfinder penalty) from the current ship position
+ *                     (used also as optimization - the pathfinder can stop path finding if max_penalty
+ *                     was reached and no depot was seen)
+ * @return             the data about the depot
+ */
+FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty);
+
+/**
  * Finds the best path for given road vehicle using YAPF.
  * @param v         the RV that needs to find a path
  * @param tile      the tile to find the path from (should be next tile the RV is about to enter)

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -149,6 +149,50 @@ public:
 		assert(best_trackdir == td1 || best_trackdir == td2);
 		return best_trackdir == td2;
 	}
+
+	static bool stFindNearestDepot(const Ship *v, TileIndex tile, Trackdir td1, Trackdir td2, int max_penalty, TileIndex *depot_tile, bool *reversed)
+	{
+		Tpf pf;
+		bool result = pf.FindNearestDepot(v, tile, td1, td2, max_penalty, depot_tile, reversed);
+		return result;
+	}
+
+	/**
+	 * Find the best depot for a ship.
+	 * @param v Vehicle
+	 * @param tile Tile of the vehicle.
+	 * @param td1 Trackdir of the vehicle.
+	 * @param td2 reversed Trackdir of the vehicle.
+	 * @param max_cost maximum pathfinder cost.
+	 * @param depot_tile the tile of the depot.
+	 * @param reversed whether the path to depot was found on reversed Trackdir.
+	 */
+	inline bool FindNearestDepot(const Ship *v, TileIndex tile, Trackdir td1, Trackdir td2, int max_cost, TileIndex *depot_tile, bool *reversed)
+	{
+		Tpf pf;
+		/* Set origin. */
+		pf.SetOrigin(tile, TrackdirToTrackdirBits(td1) | TrackdirToTrackdirBits(td2));
+		pf.SetMaxCost(max_cost);
+
+		/* find the best path */
+		bool bFound = pf.FindPath(v);
+		if (!bFound) return false;
+
+		/* some path found
+		 * get found depot tile */
+		Node *n = pf.GetBestNode();
+		*depot_tile = n->m_key.m_tile;
+
+		/* walk through the path back to the origin */
+		Node *pNode = n;
+		while (pNode->m_parent != NULL) {
+			pNode = pNode->m_parent;
+		}
+
+		/* if the origin node is the ship's Trackdir then we didn't reverse */
+		*reversed = (pNode->m_key.m_td != td1);
+		return true;
+	}
 };
 
 /** Cost Provider module of YAPF for ships */
@@ -162,6 +206,10 @@ public:
 	typedef typename Node::Key Key;               ///< key to hash tables
 
 protected:
+	int m_max_cost;
+
+	CYapfCostShipT() : m_max_cost(0) {}
+
 	/** to access inherited path finder */
 	Tpf& Yapf()
 	{
@@ -169,6 +217,11 @@ protected:
 	}
 
 public:
+	inline void SetMaxCost(int max_cost)
+	{
+		m_max_cost = max_cost;
+	}
+
 	/**
 	 * Called by YAPF to calculate the cost from the origin to the given node.
 	 *  Calculates only the cost of given node, adds it to the parent node cost
@@ -192,8 +245,45 @@ public:
 		byte speed_frac = (GetEffectiveWaterClass(n.GetTile()) == WATER_CLASS_SEA) ? svi->ocean_speed_frac : svi->canal_speed_frac;
 		if (speed_frac > 0) c += YAPF_TILE_LENGTH * (1 + tf->m_tiles_skipped) * speed_frac / (256 - speed_frac);
 
+		/* Finish if we already exceeded the maximum path cost (i.e. when
+		 * searching for the nearest depot). */
+		if (m_max_cost > 0 && (n.m_parent->m_cost + c) > m_max_cost) return false;
+
 		/* apply it */
 		n.m_cost = n.m_parent->m_cost + c;
+		return true;
+	}
+};
+
+template <class Types>
+class CYapfDestinationAnyDepotShipT
+{
+public:
+	typedef typename Types::Tpf Tpf;                     ///< the pathfinder class (derived from THIS class)
+	typedef typename Types::TrackFollower TrackFollower;
+	typedef typename Types::NodeList::Titem Node;        ///< this will be our node type
+	typedef typename Node::Key Key;                      ///< key to hash tables
+
+	/** to access inherited path finder */
+	Tpf& Yapf()
+	{
+		return *static_cast<Tpf *>(this);
+	}
+
+	/** Called by YAPF to detect if node ends in the desired destination */
+	inline bool PfDetectDestination(Node &n)
+	{
+		bool bDest = (IsShipDepotTile(n.m_key.m_tile) && GetShipDepotPart(n.m_key.m_tile) == DEPOT_PART_NORTH) && IsTileOwner(n.m_key.m_tile, Yapf().GetVehicle()->owner);
+		return bDest;
+	}
+
+	/**
+	 * Called by YAPF to calculate cost estimate. Calculates distance to the destination
+	 *  adds it to the actual cost from origin and stores the sum to the Node::m_estimate
+	 */
+	inline bool PfCalcEstimate(Node &n)
+	{
+		n.m_estimate = n.m_cost;
 		return true;
 	}
 };
@@ -202,11 +292,11 @@ public:
  * Config struct of YAPF for ships.
  *  Defines all 6 base YAPF modules as classes providing services for CYapfBaseT.
  */
-template <class Tpf_, class Ttrack_follower, class Tnode_list>
+template <class Tpf_, class Ttrack_follower, class Tnode_list, template <class Types> class CYapfDestinationTileT>
 struct CYapfShip_TypesT
 {
 	/** Types - shortcut for this struct type */
-	typedef CYapfShip_TypesT<Tpf_, Ttrack_follower, Tnode_list>  Types;
+	typedef CYapfShip_TypesT<Tpf_, Ttrack_follower, Tnode_list, CYapfDestinationTileT>  Types;
 
 	/** Tpf - pathfinder type */
 	typedef Tpf_                              Tpf;
@@ -225,11 +315,15 @@ struct CYapfShip_TypesT
 };
 
 /* YAPF type 1 - uses TileIndex/Trackdir as Node key, allows 90-deg turns */
-struct CYapfShip1 : CYapfT<CYapfShip_TypesT<CYapfShip1, CFollowTrackWater    , CShipNodeListTrackDir> > {};
+struct CYapfShip1         : CYapfT<CYapfShip_TypesT<CYapfShip1        , CFollowTrackWater    , CShipNodeListTrackDir, CYapfDestinationTileT> > {};
 /* YAPF type 2 - uses TileIndex/DiagDirection as Node key, allows 90-deg turns */
-struct CYapfShip2 : CYapfT<CYapfShip_TypesT<CYapfShip2, CFollowTrackWater    , CShipNodeListExitDir > > {};
+struct CYapfShip2         : CYapfT<CYapfShip_TypesT<CYapfShip2        , CFollowTrackWater    , CShipNodeListExitDir , CYapfDestinationTileT> > {};
 /* YAPF type 3 - uses TileIndex/Trackdir as Node key, forbids 90-deg turns */
-struct CYapfShip3 : CYapfT<CYapfShip_TypesT<CYapfShip3, CFollowTrackWaterNo90, CShipNodeListTrackDir> > {};
+struct CYapfShip3         : CYapfT<CYapfShip_TypesT<CYapfShip3        , CFollowTrackWaterNo90, CShipNodeListTrackDir, CYapfDestinationTileT> > {};
+
+struct CYapfShipAnyDepot1 : CYapfT<CYapfShip_TypesT<CYapfShipAnyDepot1, CFollowTrackWater    , CShipNodeListTrackDir, CYapfDestinationAnyDepotShipT> > {};
+struct CYapfShipAnyDepot2 : CYapfT<CYapfShip_TypesT<CYapfShipAnyDepot2, CFollowTrackWater    , CShipNodeListExitDir , CYapfDestinationAnyDepotShipT> > {};
+struct CYapfShipAnyDepot3 : CYapfT<CYapfShip_TypesT<CYapfShipAnyDepot3, CFollowTrackWaterNo90, CShipNodeListTrackDir, CYapfDestinationAnyDepotShipT> > {};
 
 /** Ship controller helper - path finder invoker */
 Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool &path_found, ShipPathCache &path_cache)
@@ -247,6 +341,31 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir,
 
 	Trackdir td_ret = pfnChooseShipTrack(v, tile, enterdir, tracks, path_found, path_cache);
 	return (td_ret != INVALID_TRACKDIR) ? TrackdirToTrack(td_ret) : INVALID_TRACK;
+}
+
+FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty)
+{
+	FindDepotData fdd;
+
+	Trackdir td = v->GetVehicleTrackdir();
+	Trackdir td_rev = ReverseTrackdir(td);
+	TileIndex tile = v->tile;
+
+	/* default is YAPF type 2 */
+	typedef bool(*PfnFindNearestDepot)(const Ship*, TileIndex, Trackdir, Trackdir, int, TileIndex*, bool*);
+	PfnFindNearestDepot pfnFindNearestDepot = &CYapfShipAnyDepot2::stFindNearestDepot;
+
+	/* check if non-default YAPF type should be used */
+	if (_settings_game.pf.forbid_90_deg) {
+		pfnFindNearestDepot = &CYapfShipAnyDepot3::stFindNearestDepot; // Trackdir, forbid 90-deg
+	} else if (_settings_game.pf.yapf.disable_node_optimization) {
+		pfnFindNearestDepot = &CYapfShipAnyDepot1::stFindNearestDepot; // Trackdir, allow 90-deg
+	}
+
+	bool ret = pfnFindNearestDepot(v, tile, td, td_rev, max_penalty, &fdd.tile, &fdd.reverse);
+
+	fdd.best_length = ret ? DistanceManhattan(tile, fdd.tile) : UINT_MAX; // distance manhattan or NOT_FOUND
+	return fdd;
 }
 
 bool YapfShipCheckReverse(const Ship *v)

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -176,11 +176,11 @@ static FindDepotData FindClosestReachableShipDepot(const Ship *v, int max_distan
 	if ((IsShipDepotTile(v->tile) && GetShipDepotPart(v->tile) == DEPOT_PART_NORTH) && IsTileOwner(v->tile, v->owner)) return FindDepotData(v->tile, 0);
 
 	switch (_settings_game.pf.pathfinder_for_ships) {
-		case VPF_OPF: return OPFShipFindNearestDepot(v, max_distance);
-		case VPF_NPF: return NPFShipFindNearestDepot(v, max_distance);
+		case VPF_OPF : return  OPFShipFindNearestDepot(v, max_distance);
+		case VPF_NPF : return  NPFShipFindNearestDepot(v, max_distance);
 		case VPF_YAPF: return YapfShipFindNearestDepot(v, max_distance);
 
-	default: NOT_REACHED();
+		default: NOT_REACHED();
 	}
 }
 


### PR DESCRIPTION
When ships are asked to find the closest depot, the depot that is provided is not always reachable. This patch provides the closest reachable ship depot, by utilizing the pathfinder (Original, NPF or Yapf) first. Only if it fails, it would then be provided by the original method, distance manhattan based.

https://www.tt-forums.net/viewtopic.php?f=33&t=76137
