### PR TITLE
Fix: Displaying issue with the message about airplanes heading to airports with short runways

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1799,7 +1799,8 @@ void CheckOrders(const Vehicle *v)
 							(st->airport.GetFTA()->flags & AirportFTAClass::SHORT_STRIP) &&
 							_settings_game.vehicle.plane_crashes != 0 &&
 							!_cheats.no_jetcrash.value &&
-							message == INVALID_STRING_ID) {
+							(message == INVALID_STRING_ID ||
+							message == STR_NEWS_PLANE_USES_TOO_SHORT_RUNWAY)) {
 					message = STR_NEWS_PLANE_USES_TOO_SHORT_RUNWAY;
 				}
 			}


### PR DESCRIPTION
If there was more than 1 airport with short runways in the orders, this message would not display, another one would which could be misleading or confusing.