### PR TITLE
Fix #6233: Improve lock pricing and infrastructure counting, to achieve better consistency

### DIFF
--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -7266,7 +7266,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         true
   IsLockTile():         true
   IsCanalTile():        true
-  GetBankBalance():     465070
+  GetBankBalance():     461320
 
 --AIWaypointList(BUOY)--
   Count():             1
@@ -7285,7 +7285,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         false
   IsLockTile():         false
   IsCanalTile():        false
-  GetBankBalance():     459675
+  GetBankBalance():     452175
   BuildWaterDepot():    true
   BuildDock():          true
 

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -180,8 +180,11 @@ void AfterLoadCompanyStats()
 						if (IsShipDepot(tile)) c->infrastructure.water += LOCK_DEPOT_TILE_FACTOR;
 						if (IsLock(tile) && GetLockPart(tile) == LOCK_PART_MIDDLE) {
 							/* The middle tile specifies the owner of the lock. */
-							c->infrastructure.water += 3 * LOCK_DEPOT_TILE_FACTOR; // the middle tile specifies the owner of the
-							break; // do not count the middle tile as canal
+							c->infrastructure.water += 3 * LOCK_DEPOT_TILE_FACTOR;
+
+							/* Only count the middle tile as canal if the tile is not river. */
+							if (GetWaterClass(tile) != WATER_CLASS_RIVER) c->infrastructure.water++;
+							break;
 						}
 					}
 				}

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -258,9 +258,14 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlag 
 
 	/* middle tile */
 	WaterClass wc_middle = IsWaterTile(tile) ? GetWaterClass(tile) : WATER_CLASS_CANAL;
-	ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
-	if (ret.Failed()) return ret;
-	cost.AddCost(ret);
+
+	if (!IsWaterTile(tile)) {
+		ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
+		if (ret.Failed()) return ret;
+		cost.AddCost(ret);
+		/* Add an extra cost only if not building on a river. */
+		cost.AddCost(_price[PR_BUILD_CANAL]);
+	}
 
 	/* lower tile */
 	if (!IsWaterTile(tile - delta)) {
@@ -296,6 +301,7 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlag 
 		if (c != NULL) {
 			/* Counts for the water. */
 			if (!IsWaterTile(tile - delta)) c->infrastructure.water++;
+			if (!IsWaterTile(tile)) c->infrastructure.water++;
 			if (!IsWaterTile(tile + delta)) c->infrastructure.water++;
 			/* Count for the lock itself. */
 			c->infrastructure.water += 3 * LOCK_DEPOT_TILE_FACTOR; // Lock is three tiles.
@@ -322,6 +328,8 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlag 
  */
 static CommandCost RemoveLock(TileIndex tile, DoCommandFlag flags)
 {
+	CommandCost cost(EXPENSES_CONSTRUCTION);
+
 	if (GetTileOwner(tile) != OWNER_NONE) {
 		CommandCost ret = CheckTileOwnership(tile);
 		if (ret.Failed()) return ret;
@@ -335,6 +343,9 @@ static CommandCost RemoveLock(TileIndex tile, DoCommandFlag flags)
 	if (ret.Succeeded()) ret = EnsureNoVehicleOnGround(tile - delta);
 	if (ret.Failed()) return ret;
 
+	/* Add an extra cost only if it was not built on a river. */
+	if (GetWaterClass(tile) != WATER_CLASS_RIVER) cost.AddCost(_price[PR_CLEAR_CANAL]);
+
 	if (flags & DC_EXEC) {
 		/* Remove middle part from company infrastructure count. */
 		Company *c = Company::GetIfValid(GetTileOwner(tile));
@@ -346,6 +357,7 @@ static CommandCost RemoveLock(TileIndex tile, DoCommandFlag flags)
 		if (GetWaterClass(tile) == WATER_CLASS_RIVER) {
 			MakeRiver(tile, Random());
 		} else {
+			if (c != NULL) c->infrastructure.water--; // Make sure it's not a leftover or neutral lock.
 			DoClearSquare(tile);
 		}
 		MakeWaterKeepingClass(tile + delta, GetTileOwner(tile + delta));
@@ -355,7 +367,9 @@ static CommandCost RemoveLock(TileIndex tile, DoCommandFlag flags)
 		MarkCanalsAndRiversAroundDirty(tile + delta);
 	}
 
-	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_CLEAR_LOCK]);
+	cost.AddCost(_price[PR_CLEAR_LOCK]);
+	return cost;
+
 }
 
 /**
@@ -1274,9 +1288,15 @@ static void ChangeTileOwner_Water(TileIndex tile, Owner old_owner, Owner new_own
 	bool is_lock_middle = IsLock(tile) && GetLockPart(tile) == LOCK_PART_MIDDLE;
 
 	/* No need to dirty company windows here, we'll redraw the whole screen anyway. */
-	if (is_lock_middle) Company::Get(old_owner)->infrastructure.water -= 3 * LOCK_DEPOT_TILE_FACTOR; // Lock has three parts.
+	if (is_lock_middle) {
+		Company::Get(old_owner)->infrastructure.water -= 3 * LOCK_DEPOT_TILE_FACTOR; // Lock has three parts.
+		if (GetWaterClass(tile) == WATER_CLASS_CANAL) Company::Get(old_owner)->infrastructure.water--;
+	}
 	if (new_owner != INVALID_OWNER) {
-		if (is_lock_middle) Company::Get(new_owner)->infrastructure.water += 3 * LOCK_DEPOT_TILE_FACTOR; // Lock has three parts.
+		if (is_lock_middle) {
+			Company::Get(new_owner)->infrastructure.water += 3 * LOCK_DEPOT_TILE_FACTOR; // Lock has three parts.
+			if (GetWaterClass(tile) == WATER_CLASS_CANAL) Company::Get(new_owner)->infrastructure.water++;
+		}
 		/* Only subtract from the old owner here if the new owner is valid,
 		 * otherwise we clear ship depots and canal water below. */
 		if (GetWaterClass(tile) == WATER_CLASS_CANAL && !is_lock_middle) {


### PR DESCRIPTION
When building lock:
- don't add the cost for clearing river
- if not building on a river, simulate canal build price and add it to the landscape clearing cost
- if not building on a river, simulate canal maintenance count

When removing lock:
- if it was not built on a river, simulate the cost for clearing a canal tile and add it to the cost for clearing the lock itself
- if it was not built on a river, subtract canal maintenance count

When transfering ownership:
- old owner: subtract canal maintenance count if it was not built on a river
- new owner: simulate canal maintenance count if it was not built on a river

After loading a savegame:
- simulate canal maintenance count if it was not built on a river