### PR TITLE
Prevent water construction where it could block nearby ships

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1410,7 +1410,7 @@ static CommandCost CheckIfIndustryTilesAreFree(TileIndex tile, const IndustryTil
 			}
 		} else {
 			CommandCost ret = EnsureNoVehicleOnGround(cur_tile);
-			if (ret.Succeeded()) ret = EnsureNoShipFromDiagDirs(cur_tile);
+			if (ret.Succeeded()) ret = EnsureNoShipOnDiagDirs(cur_tile);
 			if (ret.Failed()) return ret;
 			if (IsBridgeAbove(cur_tile)) return_cmd_error(STR_ERROR_SITE_UNSUITABLE);
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1410,6 +1410,7 @@ static CommandCost CheckIfIndustryTilesAreFree(TileIndex tile, const IndustryTil
 			}
 		} else {
 			CommandCost ret = EnsureNoVehicleOnGround(cur_tile);
+			if (ret.Succeeded()) ret = EnsureNoShipFromDiagDirs(cur_tile);
 			if (ret.Failed()) return ret;
 			if (IsBridgeAbove(cur_tile)) return_cmd_error(STR_ERROR_SITE_UNSUITABLE);
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -228,6 +228,7 @@ CommandCost CmdBuildObject(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 	if (type == OBJECT_OWNED_LAND) {
 		/* Owned land is special as it can be placed on any slope. */
 		cost.AddCost(DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR));
+		cost.AddCost(EnsureNoShipFromDiagDirs(tile));
 	} else {
 		/* Check the surface to build on. At this time we can't actually execute the
 		 * the CLEAR_TILE commands since the newgrf callback later on can check
@@ -248,11 +249,13 @@ CommandCost CmdBuildObject(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 					/* However, the tile has to be clear of vehicles. */
 					cost.AddCost(EnsureNoVehicleOnGround(t));
+					cost.AddCost(EnsureNoShipFromDiagDirs(t));
 				}
 			} else {
 				if (!allow_ground) return_cmd_error(STR_ERROR_MUST_BE_BUILT_ON_WATER);
 				/* For non-water tiles, we'll have to clear it before building. */
 				cost.AddCost(DoCommand(t, 0, 0, flags & ~DC_EXEC, CMD_LANDSCAPE_CLEAR));
+				cost.AddCost(EnsureNoShipFromDiagDirs(t));
 			}
 		}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -228,7 +228,7 @@ CommandCost CmdBuildObject(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 	if (type == OBJECT_OWNED_LAND) {
 		/* Owned land is special as it can be placed on any slope. */
 		cost.AddCost(DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR));
-		cost.AddCost(EnsureNoShipFromDiagDirs(tile));
+		cost.AddCost(EnsureNoShipOnDiagDirs(tile));
 	} else {
 		/* Check the surface to build on. At this time we can't actually execute the
 		 * the CLEAR_TILE commands since the newgrf callback later on can check
@@ -249,13 +249,13 @@ CommandCost CmdBuildObject(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 					/* However, the tile has to be clear of vehicles. */
 					cost.AddCost(EnsureNoVehicleOnGround(t));
-					cost.AddCost(EnsureNoShipFromDiagDirs(t));
+					cost.AddCost(EnsureNoShipOnDiagDirs(t));
 				}
 			} else {
 				if (!allow_ground) return_cmd_error(STR_ERROR_MUST_BE_BUILT_ON_WATER);
 				/* For non-water tiles, we'll have to clear it before building. */
 				cost.AddCost(DoCommand(t, 0, 0, flags & ~DC_EXEC, CMD_LANDSCAPE_CLEAR));
-				cost.AddCost(EnsureNoShipFromDiagDirs(t));
+				cost.AddCost(EnsureNoShipOnDiagDirs(t));
 			}
 		}
 

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -984,6 +984,7 @@ CommandCost CmdBuildTrainDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, u
 	}
 
 	cost.AddCost(DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR));
+	if (cost.Succeeded()) cost.AddCost(EnsureNoShipFromDiagDirs(tile));
 	if (cost.Failed()) return cost;
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -984,7 +984,7 @@ CommandCost CmdBuildTrainDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, u
 	}
 
 	cost.AddCost(DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR));
-	if (cost.Succeeded()) cost.AddCost(EnsureNoShipFromDiagDirs(tile));
+	if (cost.Succeeded()) cost.AddCost(EnsureNoShipOnDiagDirs(tile));
 	if (cost.Failed()) return cost;
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -690,6 +690,9 @@ do_clear:;
 		CommandCost ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
 		cost.AddCost(ret);
+
+		ret = EnsureNoShipFromDiagDirs(tile);
+		if (ret.Failed()) return ret;
 	}
 
 	if (other_bits != pieces) {
@@ -1028,6 +1031,7 @@ CommandCost CmdBuildRoadDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 	}
 
 	cost.AddCost(DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR));
+	if (cost.Succeeded()) cost.AddCost(EnsureNoShipFromDiagDirs(tile));
 	if (cost.Failed()) return cost;
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -691,7 +691,7 @@ do_clear:;
 		if (ret.Failed()) return ret;
 		cost.AddCost(ret);
 
-		ret = EnsureNoShipFromDiagDirs(tile);
+		ret = EnsureNoShipOnDiagDirs(tile);
 		if (ret.Failed()) return ret;
 	}
 
@@ -1031,7 +1031,7 @@ CommandCost CmdBuildRoadDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 	}
 
 	cost.AddCost(DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR));
-	if (cost.Succeeded()) cost.AddCost(EnsureNoShipFromDiagDirs(tile));
+	if (cost.Succeeded()) cost.AddCost(EnsureNoShipOnDiagDirs(tile));
 	if (cost.Failed()) return cost;
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -790,7 +790,7 @@ static CommandCost CheckFlatLandAirport(AirportTileTableIterator tile_iter, DoCo
 		if (ret.Failed()) return ret;
 		cost.AddCost(ret);
 
-		ret = EnsureNoShipFromDiagDirs(tile_cur);
+		ret = EnsureNoShipOnDiagDirs(tile_iter);
 		if (ret.Failed()) return ret;
 	}
 
@@ -986,7 +986,7 @@ static CommandCost CheckFlatLandRoadStop(TileArea tile_area, DoCommandFlag flags
 				if (ret.Failed()) return ret;
 				cost.AddCost(ret);
 
-				ret = EnsureNoShipFromDiagDirs(cur_tile);
+				ret = EnsureNoShipOnDiagDirs(cur_tile);
 				if (ret.Failed()) return ret;
 			}
 
@@ -2511,7 +2511,7 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 	ret = DoCommand(tile_cur, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 	if (ret.Failed()) return ret;
 
-	ret = EnsureNoShipFromDiagDirs(tile_cur, (1 << direction | 1 << ChangeDiagDir(direction, DIAGDIRDIFF_90RIGHT) | 1 << ChangeDiagDir(direction, DIAGDIRDIFF_90LEFT)));
+	ret = EnsureNoShipOnDiagDirs(tile_cur, (1 << direction | 1 << ChangeDiagDir(direction, DIAGDIRDIFF_90RIGHT) | 1 << ChangeDiagDir(direction, DIAGDIRDIFF_90LEFT)));
 	if (ret.Failed()) return ret;
 
 	tile_cur += TileOffsByDiagDir(direction);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -789,6 +789,9 @@ static CommandCost CheckFlatLandAirport(AirportTileTableIterator tile_iter, DoCo
 		ret = DoCommand(tile_iter, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
 		cost.AddCost(ret);
+
+		ret = EnsureNoShipFromDiagDirs(tile_cur);
+		if (ret.Failed()) return ret;
 	}
 
 	return cost;
@@ -982,6 +985,9 @@ static CommandCost CheckFlatLandRoadStop(TileArea tile_area, DoCommandFlag flags
 				ret = DoCommand(cur_tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 				if (ret.Failed()) return ret;
 				cost.AddCost(ret);
+
+				ret = EnsureNoShipFromDiagDirs(cur_tile);
+				if (ret.Failed()) return ret;
 			}
 
 			uint roadbits_to_build = CountBits(rts) * 2 - num_roadbits;
@@ -2503,6 +2509,9 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 	WaterClass wc = GetWaterClass(tile_cur);
 
 	ret = DoCommand(tile_cur, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
+	if (ret.Failed()) return ret;
+
+	ret = EnsureNoShipFromDiagDirs(tile_cur, (1 << direction | 1 << ChangeDiagDir(direction, DIAGDIRDIFF_90RIGHT) | 1 << ChangeDiagDir(direction, DIAGDIRDIFF_90LEFT)));
 	if (ret.Failed()) return ret;
 
 	tile_cur += TileOffsByDiagDir(direction);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2114,7 +2114,7 @@ static inline bool CanBuildHouseHere(TileIndex tile, bool noslope)
 
 	/* can we clear the land? */
 	if (DoCommand(tile, 0, 0, DC_AUTO | DC_NO_WATER, CMD_LANDSCAPE_CLEAR).Failed()) return false;
-	return EnsureNoShipFromDiagDirs(tile).Succeeded();
+	return EnsureNoShipOnDiagDirs(tile).Succeeded();
 }
 
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -12,6 +12,7 @@
 #include "stdafx.h"
 #include "road_internal.h" /* Cleaning up road bits */
 #include "road_cmd.h"
+#include "vehicle_func.h"
 #include "landscape.h"
 #include "viewport_func.h"
 #include "cmd_helper.h"
@@ -2112,7 +2113,8 @@ static inline bool CanBuildHouseHere(TileIndex tile, bool noslope)
 	if (IsBridgeAbove(tile)) return false;
 
 	/* can we clear the land? */
-	return DoCommand(tile, 0, 0, DC_AUTO | DC_NO_WATER, CMD_LANDSCAPE_CLEAR).Succeeded();
+	if (DoCommand(tile, 0, 0, DC_AUTO | DC_NO_WATER, CMD_LANDSCAPE_CLEAR).Failed()) return false;
+	return EnsureNoShipFromDiagDirs(tile).Succeeded();
 }
 
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -375,7 +375,7 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 		/* Try and clear the start landscape */
 		CommandCost ret = DoCommand(tile_start, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
-		if (EnsureNoShipFromDiagDirs(tile_start).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
+		if (EnsureNoShipOnDiagDirs(tile_start).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
 		cost = ret;
 
 		if (terraform_cost_north.Failed() || (terraform_cost_north.GetCost() != 0 && !allow_on_slopes)) return_cmd_error(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
@@ -384,7 +384,7 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 		/* Try and clear the end landscape */
 		ret = DoCommand(tile_end, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
-		if (EnsureNoShipFromDiagDirs(tile_end).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
+		if (EnsureNoShipOnDiagDirs(tile_end).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
 		cost.AddCost(ret);
 
 		/* false - end tile slope check */

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -375,6 +375,7 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 		/* Try and clear the start landscape */
 		CommandCost ret = DoCommand(tile_start, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
+		if (EnsureNoShipFromDiagDirs(tile_start).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
 		cost = ret;
 
 		if (terraform_cost_north.Failed() || (terraform_cost_north.GetCost() != 0 && !allow_on_slopes)) return_cmd_error(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
@@ -383,6 +384,7 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 		/* Try and clear the end landscape */
 		ret = DoCommand(tile_end, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
+		if (EnsureNoShipFromDiagDirs(tile_end).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
 		cost.AddCost(ret);
 
 		/* false - end tile slope check */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -576,7 +576,7 @@ static Vehicle *EnsureNoShipOnTrackProc(Vehicle *v, void *data)
  * @return Succeeded command (no neighbouring ship) or failed command (a
  *         neighbouring ship is found)
  */
-CommandCost EnsureNoShipFromDiagDirs(TileIndex tile, byte diag_dir_mask)
+CommandCost EnsureNoShipOnDiagDirs(TileIndex tile, byte diag_dir_mask)
 {
 	if (!IsValidTile(tile)) return CommandCost();
 

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -165,6 +165,7 @@ static inline uint32 GetCmdSendToDepot(const BaseVehicle *v)
 
 CommandCost EnsureNoVehicleOnGround(TileIndex tile);
 CommandCost EnsureNoTrainOnTrackBits(TileIndex tile, TrackBits track_bits);
+CommandCost EnsureNoShipFromDiagDirs(TileIndex tile, byte diag_dir_byte = (1 << DIAGDIR_NE | 1 << DIAGDIR_SE | 1 << DIAGDIR_SW | 1 << DIAGDIR_NW));
 
 extern VehicleID _new_vehicle_id;
 extern uint16 _returned_refit_capacity;

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -165,7 +165,7 @@ static inline uint32 GetCmdSendToDepot(const BaseVehicle *v)
 
 CommandCost EnsureNoVehicleOnGround(TileIndex tile);
 CommandCost EnsureNoTrainOnTrackBits(TileIndex tile, TrackBits track_bits);
-CommandCost EnsureNoShipFromDiagDirs(TileIndex tile, byte diag_dir_byte = (1 << DIAGDIR_NE | 1 << DIAGDIR_SE | 1 << DIAGDIR_SW | 1 << DIAGDIR_NW));
+CommandCost EnsureNoShipOnDiagDirs(TileIndex tile, byte diag_dir_mask = (1 << DIAGDIR_NE | 1 << DIAGDIR_SE | 1 << DIAGDIR_SW | 1 << DIAGDIR_NW));
 
 extern VehicleID _new_vehicle_id;
 extern uint16 _returned_refit_capacity;

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -136,8 +136,8 @@ CommandCost CmdBuildShipDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 	}
 
 	byte diag_dir_mask = (axis == AXIS_X) ? (1 << DIAGDIR_SE | 1 << DIAGDIR_NW) : (1 << DIAGDIR_NE | 1 << DIAGDIR_SW);
-	ret = EnsureNoShipFromDiagDirs(tile, diag_dir_mask);
-	if (ret.Succeeded()) ret = EnsureNoShipFromDiagDirs(tile2, diag_dir_mask);
+	ret = EnsureNoShipOnDiagDirs(tile, diag_dir_mask);
+	if (ret.Succeeded()) ret = EnsureNoShipOnDiagDirs(tile2, diag_dir_mask);
 	if (ret.Failed()) return ret;
 
 	if (flags & DC_EXEC) {
@@ -262,8 +262,8 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlag 
 	if (ret.Failed()) return ret;
 
 	byte diag_dir_mask = (dir == DIAGDIR_NE || dir == DIAGDIR_SW) ? (1 << DIAGDIR_SE | 1 << DIAGDIR_NW) : (1 << DIAGDIR_NE | 1 << DIAGDIR_SW);
-	ret = EnsureNoShipFromDiagDirs(tile + delta, diag_dir_mask);
-	if (ret.Succeeded()) ret = EnsureNoShipFromDiagDirs(tile - delta, diag_dir_mask);
+	ret = EnsureNoShipOnDiagDirs(tile + delta, diag_dir_mask);
+	if (ret.Succeeded()) ret = EnsureNoShipOnDiagDirs(tile - delta, diag_dir_mask);
 	if (ret.Failed()) return ret;
 
 	/* middle tile */
@@ -1324,7 +1324,7 @@ static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlag flags, int 
 	if (IsWaterTile(tile) && IsCanal(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_CANAL_FIRST);
 
 	CommandCost ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
-	if (ret.Succeeded() && EnsureNoShipFromDiagDirs(tile).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
+	if (ret.Succeeded() && EnsureNoShipOnDiagDirs(tile).Failed()) return_cmd_error(STR_ERROR_SHIP_IN_THE_WAY);
 	return ret;
 }
 


### PR DESCRIPTION
Additional checks which helps prevent ships from becoming stuck upon doing certain actions:
building of industries, objects, rail depots, roads, road vehicle depots, town houses, bridge heads, airports, docks, ship depots, locks, and terraforming of tiles containing water.


As an example, this would prevent the situation caused in #6273.

It happens in AI games, too.
![nonocab - v5 2051-01-26](https://user-images.githubusercontent.com/43006711/46670364-e4113c80-cbc9-11e8-826c-5e76cbccb9b0.png)
![nonocab - v5 - 2 2051-01-26](https://user-images.githubusercontent.com/43006711/46670365-e4113c80-cbc9-11e8-8dd9-f817366b41be.png)

