### PR TITLE
Fix #6938: Don't change company value to perform cost estimations

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -193,11 +193,8 @@ public:
 		StringID str = STR_LAND_AREA_INFORMATION_COST_TO_CLEAR_N_A;
 		Company *c = Company::GetIfValid(_local_company);
 		if (c != NULL) {
-			Money old_money = c->money;
-			c->money = INT64_MAX;
 			assert(_current_company == _local_company);
-			CommandCost costclear = DoCommand(tile, 0, 0, DC_NONE, CMD_LANDSCAPE_CLEAR);
-			c->money = old_money;
+			CommandCost costclear = DoCommand(tile, 0, 0, DC_QUERY_COST, CMD_LANDSCAPE_CLEAR);
 			if (costclear.Succeeded()) {
 				Money cost = costclear.GetCost();
 				if (cost < 0) {


### PR DESCRIPTION
These meddling kids dared to play with magic, but the ancients texts
weren't ready for that.
Refactors logic to estimate costs that dated to even before OpenTTD 0.1;