### PR TITLE
Various minor code cleanups found by scan-build

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -498,11 +498,6 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 		return l;
 	}
 
-	const WChar *begin = this->buffer;
-	const WChar *last_space = NULL;
-	const WChar *last_char = begin;
-	int width = 0;
-
 	int offset = this->buffer - this->buffer_begin;
 	FontMap::iterator iter = this->runs.Begin();
 	while (iter->first <= offset) {
@@ -513,6 +508,10 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 	const FontCache *fc = iter->second->fc;
 	const WChar *next_run = this->buffer_begin + iter->first;
 
+	const WChar *begin = this->buffer;
+	const WChar *last_space = NULL;
+	const WChar *last_char;
+	int width = 0;
 	for (;;) {
 		WChar c = *this->buffer;
 		last_char = this->buffer;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -508,7 +508,6 @@ public:
 				y += FONT_HEIGHT_NORMAL;
 
 				/* Get the additional purchase info text, if it has not already been queried. */
-				str = STR_NULL;
 				if (HasBit(indsp->callback_mask, CBM_IND_FUND_MORE_TEXT)) {
 					uint16 callback_res = GetIndustryCallback(CBID_INDUSTRY_FUND_MORE_TEXT, 0, 0, NULL, this->selected_type, INVALID_TILE);
 					if (callback_res != CALLBACK_FAILED && callback_res != 0x400) {

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -592,7 +592,6 @@ struct MusicTrackSelectionWindow : public Window {
 				break;
 			default:
 				NOT_REACHED();
-				break;
 		}
 	}
 };

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3472,8 +3472,6 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 								} else {
 									/* Declared as been valid, can be used */
 									itt[k].gfx = tempid;
-									size = k + 1;
-									copy_from = itt;
 								}
 							} else if (itt[k].gfx == 0xFF) {
 								itt[k].ti.x = (int8)GB(itt[k].ti.x, 0, 8);
@@ -3787,8 +3785,6 @@ static ChangeInfoResult AirportChangeInfo(uint airport, int numinfo, int prop, B
 								} else {
 									/* Declared as been valid, can be used */
 									att[k].gfx = tempid;
-									size = k + 1;
-									copy_from = att;
 								}
 							} else if (att[k].gfx == 0xFF) {
 								att[k].ti.x = (int8)GB(att[k].ti.x, 0, 8);

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -154,6 +154,7 @@ static uint32 RotateRight(uint32 val, uint32 rot)
 {
 	/* Do not rotate more than necessary */
 	rot %= 32;
+	assert(rot > 0);
 
 	return (val >> rot) | (val << (32 - rot));
 }

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -17,19 +17,6 @@
 #include "strings_type.h"
 #include "sound_type.h"
 
-/** Constants in the message options window. */
-enum MessageOptionsSpace {
-	MOS_WIDG_PER_SETTING      = 4,  ///< Number of widgets needed for each news category, starting at widget #WID_MO_START_OPTION.
-
-	MOS_LEFT_EDGE             = 6,  ///< Number of pixels between left edge of the window and the options buttons column.
-	MOS_COLUMN_SPACING        = 4,  ///< Number of pixels between the buttons and the description columns.
-	MOS_RIGHT_EDGE            = 6,  ///< Number of pixels between right edge of the window and the options descriptions column.
-	MOS_BUTTON_SPACE          = 10, ///< Additional space in the button with the option value (for better looks).
-
-	MOS_ABOVE_GLOBAL_SETTINGS = 6,  ///< Number of vertical pixels between the categories and the global options.
-	MOS_BOTTOM_EDGE           = 6,  ///< Number of pixels between bottom edge of the window and bottom of the global options.
-};
-
 /**
  * Type of news.
  */

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -124,8 +124,12 @@ struct CFollowTrackT
 		m_old_tile = old_tile;
 		m_old_td = old_td;
 		m_err = EC_NONE;
-		assert(((TrackStatusToTrackdirBits(GetTileTrackStatus(m_old_tile, TT(), IsRoadTT() ? RoadVehicle::From(m_veh)->compatible_roadtypes : 0)) & TrackdirToTrackdirBits(m_old_td)) != 0) ||
-		       (IsTram() && GetSingleTramBit(m_old_tile) != INVALID_DIAGDIR)); // Disable the assertion for single tram bits
+		assert(
+			((TrackStatusToTrackdirBits(
+				GetTileTrackStatus(m_old_tile, TT(), (IsRoadTT() && m_veh != NULL) ? RoadVehicle::From(m_veh)->compatible_roadtypes : 0)
+			) & TrackdirToTrackdirBits(m_old_td)) != 0) ||
+			(IsTram() && GetSingleTramBit(m_old_tile) != INVALID_DIAGDIR) // Disable the assertion for single tram bits
+		);
 		m_exitdir = TrackdirToExitdir(m_old_td);
 		if (ForcedReverse()) return true;
 		if (!CanExitOldTile()) return false;

--- a/src/pathfinder/opf/opf_ship.cpp
+++ b/src/pathfinder/opf/opf_ship.cpp
@@ -145,6 +145,7 @@ static uint FindShipTrack(const Ship *v, TileIndex tile, DiagDirection dir, Trac
 
 	Track best_track = INVALID_TRACK;
 
+	assert(bits != TRACK_BIT_NONE);
 	do {
 		Track i = RemoveFirstTrack(&bits);
 
@@ -176,7 +177,7 @@ good:;
 		best_length = pfs.best_length;
 bad:;
 
-	} while (bits != 0);
+	} while (bits != TRACK_BIT_NONE);
 
 	*track = best_track;
 	return best_bird_dist;

--- a/src/pathfinder/yapf/yapf_rail.cpp
+++ b/src/pathfinder/yapf/yapf_rail.cpp
@@ -28,6 +28,8 @@ template <typename Tpf> void DumpState(Tpf &pf1, Tpf &pf2)
 	pf2.DumpBase(dmp2);
 	FILE *f1 = fopen("yapf1.txt", "wt");
 	FILE *f2 = fopen("yapf2.txt", "wt");
+	assert(f1 != NULL);
+	assert(f2 != NULL);
 	fwrite(dmp1.m_out.Data(), 1, dmp1.m_out.Size(), f1);
 	fwrite(dmp2.m_out.Data(), 1, dmp2.m_out.Size(), f2);
 	fclose(f1);

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2897,11 +2897,9 @@ int TicksToLeaveDepot(const Train *v)
 		case DIAGDIR_NE: return  ((int)(v->x_pos & 0x0F) - ((_fractcoords_enter[dir] & 0x0F) - (length + 1)));
 		case DIAGDIR_SE: return -((int)(v->y_pos & 0x0F) - ((_fractcoords_enter[dir] >> 4)   + (length + 1)));
 		case DIAGDIR_SW: return -((int)(v->x_pos & 0x0F) - ((_fractcoords_enter[dir] & 0x0F) + (length + 1)));
-		default:
 		case DIAGDIR_NW: return  ((int)(v->y_pos & 0x0F) - ((_fractcoords_enter[dir] >> 4)   - (length + 1)));
+		default: NOT_REACHED();
 	}
-
-	return 0; // make compilers happy
 }
 
 /**

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -449,6 +449,7 @@ enum Roadside {
 	ROADSIDE_GRASS            = 1, ///< Road on grass
 	ROADSIDE_PAVED            = 2, ///< Road with paved sidewalks
 	ROADSIDE_STREET_LIGHTS    = 3, ///< Road with street lights on paved sidewalks
+	// 4 is unused for historical reasons
 	ROADSIDE_TREES            = 5, ///< Road with trees on paved sidewalks
 	ROADSIDE_GRASS_ROAD_WORKS = 6, ///< Road on grass with road works
 	ROADSIDE_PAVED_ROAD_WORKS = 7, ///< Road with sidewalks and road works

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -265,7 +265,7 @@ static SavegameType DetermineOldSavegameType(FILE *f, char *title, const char *l
 			case SGT_TTD: title = strecpy(title, "(TTD) ", last);    break;
 			default:      title = strecpy(title, "(broken) ", last); break;
 		}
-		title = strecpy(title, temp, last);
+		strecpy(title, temp, last);
 	}
 
 	return type;

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -92,7 +92,7 @@ void Script_CreateDummy(HSQUIRRELVM vm, StringID string, const char *type)
 		p = newline + 1;
 	} while (newline != NULL);
 
-	dp = strecpy(dp, "  }\n}\n", lastof(dummy_script));
+	strecpy(dp, "  }\n}\n", lastof(dummy_script));
 
 	/* 3) We translate the error message in the character format that Squirrel wants.
 	 *    We can use the fact that the wchar string printing also uses %s to print

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -372,7 +372,10 @@ static bool CompareFiles(const char *n1, const char *n2)
 	if (f2 == NULL) return false;
 
 	FILE *f1 = fopen(n1, "rb");
-	if (f1 == NULL) error("can't open %s", n1);
+	if (f1 == NULL) {
+		fclose(f2);
+		error("can't open %s", n1);
+	}
 
 	size_t l1, l2;
 	do {

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -215,7 +215,10 @@ bool CompareFiles(const char *n1, const char *n2)
 	if (f2 == NULL) return false;
 
 	FILE *f1 = fopen(n1, "rb");
-	if (f1 == NULL) error("can't open %s", n1);
+	if (f1 == NULL) {
+		fclose(f2);
+		error("can't open %s", n1);
+	}
 
 	size_t l1, l2;
 	do {

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -170,7 +170,7 @@ void str_fix_scc_encoded(char *str, const char *last)
 		if ((len == 0 && str + 4 > last) || str + len > last) break;
 
 		WChar c;
-		len = Utf8Decode(&c, str);
+		Utf8Decode(&c, str);
 		if (c == '\0') break;
 
 		if (c == 0xE028 || c == 0xE02A) {

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -351,9 +351,8 @@ bool IsValidChar(WChar key, CharSetFilter afilter)
 		case CS_NUMERAL_SPACE: return (key >= '0' && key <= '9') || key == ' ';
 		case CS_ALPHA:         return IsPrintable(key) && !(key >= '0' && key <= '9');
 		case CS_HEXADECIMAL:   return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
+		default: NOT_REACHED();
 	}
-
-	return false;
 }
 
 #ifdef WIN32

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -819,7 +819,6 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				sub_args.ClearTypeInformation();
 				memset(sub_args_need_free, 0, sizeof(sub_args_need_free));
 
-				const char *s = str;
 				char *p;
 				uint32 stringid = strtoul(str, &p, 16);
 				if (*p != ':' && *p != '\0') {
@@ -838,7 +837,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				int i = 0;
 				while (*p != '\0' && i < 20) {
 					uint64 param;
-					s = ++p;
+					const char *s = ++p;
 
 					/* Find the next value */
 					bool instring = false;

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -719,7 +719,7 @@ void UpdateTownCargoTotal(Town *t)
 static void UpdateTownCargoes(Town *t, TileIndex start, bool update_total = true)
 {
 	CargoArray accepted, produced;
-	CargoTypes dummy;
+	CargoTypes dummy = 0;
 
 	/* Gather acceptance for all houses in an area around the start tile.
 	 * The area is composed of the square the tile is in, extended one square in all

--- a/src/track_func.h
+++ b/src/track_func.h
@@ -61,7 +61,7 @@ static inline bool IsValidTrackdirForRoadVehicle(Trackdir trackdir)
  */
 static inline bool IsValidTrackdir(Trackdir trackdir)
 {
-	return (1 << trackdir & TRACKDIR_BIT_MASK) != TRACKDIR_BIT_NONE;
+	return trackdir != INVALID_TRACKDIR && ((1 << trackdir & TRACKDIR_BIT_MASK) != TRACKDIR_BIT_NONE);
 }
 
 /**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -874,7 +874,7 @@ static void RemoveFromConsist(Train *part, bool chain = false)
 static void InsertInConsist(Train *dst, Train *chain)
 {
 	/* We do not want to add something in the middle of an articulated part. */
-	assert(dst->Next() == NULL || !dst->Next()->IsArticulatedPart());
+	assert(dst != NULL && (dst->Next() == NULL || !dst->Next()->IsArticulatedPart()));
 
 	chain->Last()->SetNext(dst->Next());
 	dst->SetNext(chain);

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -159,40 +159,27 @@ static inline const PalSpriteID *GetBridgeSpriteTable(int index, BridgePieces ta
 
 
 /**
- * Determines the foundation for the north bridge head, and tests if the resulting slope is valid.
+ * Determines the foundation for the bridge head, and tests if the resulting slope is valid.
  *
+ * @param bridge_piece Direction of the bridge head.
  * @param axis Axis of the bridge
  * @param tileh Slope of the tile under the north bridge head; returns slope on top of foundation
  * @param z TileZ corresponding to tileh, gets modified as well
  * @return Error or cost for bridge foundation
  */
-static CommandCost CheckBridgeSlopeNorth(Axis axis, Slope *tileh, int *z)
+static CommandCost CheckBridgeSlope(BridgePieces bridge_piece, Axis axis, Slope *tileh, int *z)
 {
+	assert(bridge_piece == BRIDGE_PIECE_NORTH || bridge_piece == BRIDGE_PIECE_SOUTH);
+
 	Foundation f = GetBridgeFoundation(*tileh, axis);
 	*z += ApplyFoundationToSlope(f, tileh);
 
-	Slope valid_inclined = (axis == AXIS_X ? SLOPE_NE : SLOPE_NW);
-	if ((*tileh != SLOPE_FLAT) && (*tileh != valid_inclined)) return CMD_ERROR;
-
-	if (f == FOUNDATION_NONE) return CommandCost();
-
-	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_FOUNDATION]);
-}
-
-/**
- * Determines the foundation for the south bridge head, and tests if the resulting slope is valid.
- *
- * @param axis Axis of the bridge
- * @param tileh Slope of the tile under the south bridge head; returns slope on top of foundation
- * @param z TileZ corresponding to tileh, gets modified as well
- * @return Error or cost for bridge foundation
- */
-static CommandCost CheckBridgeSlopeSouth(Axis axis, Slope *tileh, int *z)
-{
-	Foundation f = GetBridgeFoundation(*tileh, axis);
-	*z += ApplyFoundationToSlope(f, tileh);
-
-	Slope valid_inclined = (axis == AXIS_X ? SLOPE_SW : SLOPE_SE);
+	Slope valid_inclined;
+	if (bridge_piece == BRIDGE_PIECE_NORTH) {
+		valid_inclined = (axis == AXIS_X ? SLOPE_NE : SLOPE_NW);
+	} else {
+		valid_inclined = (axis == AXIS_X ? SLOPE_SW : SLOPE_SE);
+	}
 	if ((*tileh != SLOPE_FLAT) && (*tileh != valid_inclined)) return CMD_ERROR;
 
 	if (f == FOUNDATION_NONE) return CommandCost();
@@ -315,8 +302,8 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 	Slope tileh_end = GetTileSlope(tile_end, &z_end);
 	bool pbs_reservation = false;
 
-	CommandCost terraform_cost_north = CheckBridgeSlopeNorth(direction, &tileh_start, &z_start);
-	CommandCost terraform_cost_south = CheckBridgeSlopeSouth(direction, &tileh_end,   &z_end);
+	CommandCost terraform_cost_north = CheckBridgeSlope(BRIDGE_PIECE_NORTH, direction, &tileh_start, &z_start);
+	CommandCost terraform_cost_south = CheckBridgeSlope(BRIDGE_PIECE_SOUTH, direction, &tileh_end,   &z_end);
 
 	/* Aqueducts can't be built of flat land. */
 	if (transport_type == TRANSPORT_WATER && (tileh_start == SLOPE_FLAT || tileh_end == SLOPE_FLAT)) return_cmd_error(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
@@ -1899,11 +1886,11 @@ static CommandCost TerraformTile_TunnelBridge(TileIndex tile, DoCommandFlag flag
 
 		/* Check if new slope is valid for bridges in general (so we can safely call GetBridgeFoundation()) */
 		if ((direction == DIAGDIR_NW) || (direction == DIAGDIR_NE)) {
-			CheckBridgeSlopeSouth(axis, &tileh_old, &z_old);
-			res = CheckBridgeSlopeSouth(axis, &tileh_new, &z_new);
+			CheckBridgeSlope(BRIDGE_PIECE_SOUTH, axis, &tileh_old, &z_old);
+			res = CheckBridgeSlope(BRIDGE_PIECE_SOUTH, axis, &tileh_new, &z_new);
 		} else {
-			CheckBridgeSlopeNorth(axis, &tileh_old, &z_old);
-			res = CheckBridgeSlopeNorth(axis, &tileh_new, &z_new);
+			CheckBridgeSlope(BRIDGE_PIECE_NORTH, axis, &tileh_old, &z_old);
+			res = CheckBridgeSlope(BRIDGE_PIECE_NORTH, axis, &tileh_new, &z_new);
 		}
 
 		/* Surface slope is valid and remains unchanged? */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2445,7 +2445,6 @@ void UpdateTileSelection()
 					break;
 				default:
 					NOT_REACHED();
-					break;
 			}
 			_thd.new_pos.x = x1 & ~TILE_UNIT_MASK;
 			_thd.new_pos.y = y1 & ~TILE_UNIT_MASK;

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -895,7 +895,7 @@ static void GetTileDesc_Water(TileIndex tile, TileDesc *td)
 				case WATER_CLASS_SEA:   td->str = STR_LAI_WATER_DESCRIPTION_WATER; break;
 				case WATER_CLASS_CANAL: td->str = STR_LAI_WATER_DESCRIPTION_CANAL; break;
 				case WATER_CLASS_RIVER: td->str = STR_LAI_WATER_DESCRIPTION_RIVER; break;
-				default: NOT_REACHED(); break;
+				default: NOT_REACHED();
 			}
 			break;
 		case WATER_TILE_COAST: td->str = STR_LAI_WATER_DESCRIPTION_COAST_OR_RIVERBANK; break;
@@ -904,7 +904,7 @@ static void GetTileDesc_Water(TileIndex tile, TileDesc *td)
 			td->str = STR_LAI_WATER_DESCRIPTION_SHIP_DEPOT;
 			td->build_date = Depot::GetByTile(tile)->build_date;
 			break;
-		default: NOT_REACHED(); break;
+		default: NOT_REACHED();
 	}
 
 	td->owner[0] = GetTileOwner(tile);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2752,18 +2752,17 @@ static void HandleAutoscroll()
 	y -= vp->top;
 
 	/* here allows scrolling in both x and y axis */
-#define scrollspeed 3
+	static const int SCROLLSPEED = 3;
 	if (x - 15 < 0) {
-		w->viewport->dest_scrollpos_x += ScaleByZoom((x - 15) * scrollspeed, vp->zoom);
+		w->viewport->dest_scrollpos_x += ScaleByZoom((x - 15) * SCROLLSPEED, vp->zoom);
 	} else if (15 - (vp->width - x) > 0) {
-		w->viewport->dest_scrollpos_x += ScaleByZoom((15 - (vp->width - x)) * scrollspeed, vp->zoom);
+		w->viewport->dest_scrollpos_x += ScaleByZoom((15 - (vp->width - x)) * SCROLLSPEED, vp->zoom);
 	}
 	if (y - 15 < 0) {
-		w->viewport->dest_scrollpos_y += ScaleByZoom((y - 15) * scrollspeed, vp->zoom);
+		w->viewport->dest_scrollpos_y += ScaleByZoom((y - 15) * SCROLLSPEED, vp->zoom);
 	} else if (15 - (vp->height - y) > 0) {
-		w->viewport->dest_scrollpos_y += ScaleByZoom((15 - (vp->height - y)) * scrollspeed, vp->zoom);
+		w->viewport->dest_scrollpos_y += ScaleByZoom((15 - (vp->height - y)) * SCROLLSPEED, vp->zoom);
 	}
-#undef scrollspeed
 }
 
 enum MouseClick {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -938,6 +938,8 @@ static void DrawOverlappedWindow(Window *w, int left, int top, int right, int bo
 void DrawOverlappedWindowForAll(int left, int top, int right, int bottom)
 {
 	Window *w;
+
+	DrawPixelInfo *old_dpi = _cur_dpi;
 	DrawPixelInfo bk;
 	_cur_dpi = &bk;
 
@@ -951,6 +953,7 @@ void DrawOverlappedWindowForAll(int left, int top, int right, int bottom)
 			DrawOverlappedWindow(w, max(left, w->left), max(top, w->top), min(right, w->left + w->width), min(bottom, w->top + w->height));
 		}
 	}
+	_cur_dpi = old_dpi;
 }
 
 /**


### PR DESCRIPTION
Various things found by running `scan-build sh -c './configure && make'` with all checkers turned on. Mostly missing null checks and dead code. Vast numbers of false positives that were ignored.

Documentation fixes were found by going through the output of `doxygen`, ignoring missing documentation warnings. Nearly all fixed, but some left that aren't clear how to be fixed (usually related to attributes being referred to before they're declared? Maybe the explicit `#` could be removed)

Commits are almost entirely self-contained, so probably best to review individually