### PR TITLE
Eliminate ICU for OSX

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -2890,10 +2890,22 @@ detect_fontconfig() {
 }
 
 detect_icu_layout() {
+	if [ "$with_cocoa" != "0" ] && [ "$with_icu_layout" = "1" ]; then
+		log 1 "checking icu-lx... OSX, skipping"
+		icu_layout_config=""
+		return 0
+	fi
+
 	detect_pkg_config "$with_icu_layout" "icu-lx" "icu_layout_config" "4.8" "1"
 }
 
 detect_icu_sort() {
+	if [ "$with_cocoa" != "0" ] && [ "$with_icu_sort" = "1" ]; then
+		log 1 "checking icu-i18n... OSX, skipping"
+		icu_sort_config=""
+		return 0
+	fi
+
 	detect_pkg_config "$with_icu_sort" "icu-i18n" "icu_sort_config" "4.8" "1"
 }
 

--- a/source.list
+++ b/source.list
@@ -413,6 +413,7 @@ music/qtmidi.h
 os/macosx/macos.h
 os/macosx/osx_stdafx.h
 os/macosx/splash.h
+os/macosx/string_osx.h
 sound/cocoa_s.h
 video/cocoa/cocoa_keys.h
 video/cocoa/cocoa_v.h
@@ -1167,6 +1168,7 @@ sound/null_s.cpp
 		music/cocoa_m.cpp
 		sound/cocoa_s.cpp
 		os/macosx/splash.cpp
+		os/macosx/string_osx.cpp
 	#end
 #end
 

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -210,6 +210,7 @@ class FreeTypeFontCache : public FontCache {
 private:
 	FT_Face face;  ///< The font face associated with this font.
 	int req_size;  ///< Requested font size.
+	int used_size; ///< Used font size.
 
 	typedef SmallMap<uint32, SmallPair<size_t, const void*> > FontTable; ///< Table with font table cache
 	FontTable font_tables; ///< Cached font tables.
@@ -243,6 +244,7 @@ private:
 public:
 	FreeTypeFontCache(FontSize fs, FT_Face face, int pixels);
 	~FreeTypeFontCache();
+	virtual int GetFontSize() const { return this->used_size; }
 	virtual SpriteID GetUnicodeGlyph(WChar key) { return this->parent->GetUnicodeGlyph(key); }
 	virtual void SetUnicodeGlyph(WChar key, SpriteID sprite) { this->parent->SetUnicodeGlyph(key, sprite); }
 	virtual void InitializeUnicodeGlyphMap() { this->parent->InitializeUnicodeGlyphMap(); }
@@ -291,6 +293,7 @@ void FreeTypeFontCache::SetFontSize(FontSize fs, FT_Face face, int pixels)
 			pixels = Clamp(min(head->Lowest_Rec_PPEM, 20) + diff, scaled_height, MAX_FONT_SIZE);
 		}
 	}
+	this->used_size = pixels;
 
 	FT_Error err = FT_Set_Pixel_Sizes(this->face, 0, pixels);
 	if (err != FT_Err_Ok) {

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -65,6 +65,12 @@ public:
 	inline int GetUnitsPerEM() const { return this->units_per_em; }
 
 	/**
+	 * Get the nominal font size of the font.
+	 * @return The nominal font size.
+	 */
+	virtual int GetFontSize() const { return this->height; }
+
+	/**
 	 * Get the SpriteID mapped to the given key
 	 * @param key The key to get the sprite for.
 	 * @return The sprite.

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -25,6 +25,10 @@
 #include "os/windows/string_uniscribe.h"
 #endif /* WITH_UNISCRIBE */
 
+#ifdef WITH_COCOA
+#include "os/macosx/string_osx.h"
+#endif
+
 #include "safeguards.h"
 
 
@@ -670,7 +674,7 @@ Layouter::Layouter(const char *str, int maxw, TextColour colour, FontSize fontsi
 		} else {
 			/* Line is new, layout it */
 			FontState old_state = state;
-#if defined(WITH_ICU_LAYOUT) || defined(WITH_UNISCRIBE)
+#if defined(WITH_ICU_LAYOUT) || defined(WITH_UNISCRIBE) || defined(WITH_COCOA)
 			const char *old_str = str;
 #endif
 
@@ -691,6 +695,16 @@ Layouter::Layouter(const char *str, int maxw, TextColour colour, FontSize fontsi
 #ifdef WITH_UNISCRIBE
 			if (line.layout == NULL) {
 				GetLayouter<UniscribeParagraphLayoutFactory>(line, str, state);
+				if (line.layout == NULL) {
+					state = old_state;
+					str = old_str;
+				}
+			}
+#endif
+
+#ifdef WITH_COCOA
+			if (line.layout == NULL) {
+				GetLayouter<CoreTextParagraphLayoutFactory>(line, str, state);
 				if (line.layout == NULL) {
 					state = old_state;
 					str = old_str;
@@ -840,6 +854,9 @@ void Layouter::ResetFontCache(FontSize size)
 
 #if defined(WITH_UNISCRIBE)
 	UniscribeResetScriptCache(size);
+#endif
+#if defined(WITH_COCOA)
+	MacOSResetScriptCache(size);
 #endif
 }
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -22,13 +22,9 @@
 #include "../debug.h"
 #include "../base_media_base.h"
 
-#define Rect        OTTDRect
-#define Point       OTTDPoint
 #include <CoreServices/CoreServices.h>
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
-#undef Rect
-#undef Point
 
 #include "../safeguards.h"
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -11,6 +11,7 @@
 
 #include "../../stdafx.h"
 #include "string_osx.h"
+#include "../../string_func.h"
 #include "macos.h"
 
 #include <CoreFoundation/CoreFoundation.h>
@@ -56,11 +57,132 @@ int MacOSStringCompare(const char *s1, const char *s2)
 	return (int)res + 2;
 }
 
+
+/* virtual */ void OSXStringIterator::SetString(const char *s)
+{
+	const char *string_base = s;
+
+	this->utf16_to_utf8.clear();
+	this->str_info.clear();
+	this->cur_pos = 0;
+
+	/* CoreText operates on UTF-16, thus we have to convert the input string.
+	 * To be able to return proper offsets, we have to create a mapping at the same time. */
+	std::vector<UniChar> utf16_str;     ///< UTF-16 copy of the string.
+	while (*s != '\0') {
+		size_t idx = s - string_base;
+
+		WChar c = Utf8Consume(&s);
+		if (c < 0x10000) {
+			utf16_str.push_back((UniChar)c);
+		} else {
+			/* Make a surrogate pair. */
+			utf16_str.push_back((UniChar)(0xD800 + ((c - 0x10000) >> 10)));
+			utf16_str.push_back((UniChar)(0xDC00 + ((c - 0x10000) & 0x3FF)));
+			this->utf16_to_utf8.push_back(idx);
+		}
+		this->utf16_to_utf8.push_back(idx);
+	}
+	this->utf16_to_utf8.push_back(s - string_base);
+
+	/* Query CoreText for word and cluster break information. */
+	this->str_info.resize(utf16_to_utf8.size());
+
+	if (utf16_str.size() > 0) {
+		CFStringRef str = CFStringCreateWithCharactersNoCopy(kCFAllocatorDefault, &utf16_str[0], utf16_str.size(), kCFAllocatorNull);
+
+		/* Get cluster breaks. */
+		for (CFIndex i = 0; i < CFStringGetLength(str); ) {
+			CFRange r = CFStringGetRangeOfComposedCharactersAtIndex(str, i);
+			this->str_info[r.location].char_stop = true;
+
+			i += r.length;
+		}
+
+		/* Get word breaks. */
+		CFStringTokenizerRef tokenizer = CFStringTokenizerCreate(kCFAllocatorDefault, str, CFRangeMake(0, CFStringGetLength(str)), kCFStringTokenizerUnitWordBoundary, _osx_locale);
+
+		CFStringTokenizerTokenType tokenType = kCFStringTokenizerTokenNone;
+		while ((tokenType = CFStringTokenizerAdvanceToNextToken(tokenizer)) != kCFStringTokenizerTokenNone) {
+			/* Skip tokens that are white-space or punctuation tokens. */
+			if ((tokenType & kCFStringTokenizerTokenHasNonLettersMask) != kCFStringTokenizerTokenHasNonLettersMask) {
+				CFRange r = CFStringTokenizerGetCurrentTokenRange(tokenizer);
+				this->str_info[r.location].word_stop = true;
+			}
+		}
+
+		CFRelease(tokenizer);
+		CFRelease(str);
+	}
+
+	/* End-of-string is always a valid stopping point. */
+	this->str_info.back().char_stop = true;
+	this->str_info.back().word_stop = true;
+}
+
+/* virtual */ size_t OSXStringIterator::SetCurPosition(size_t pos)
+{
+	/* Convert incoming position to an UTF-16 string index. */
+	size_t utf16_pos = 0;
+	for (size_t i = 0; i < this->utf16_to_utf8.size(); i++) {
+		if (this->utf16_to_utf8[i] == pos) {
+			utf16_pos = i;
+			break;
+		}
+	}
+
+	/* Sanitize in case we get a position inside a grapheme cluster. */
+	while (utf16_pos > 0 && !this->str_info[utf16_pos].char_stop) utf16_pos--;
+	this->cur_pos = utf16_pos;
+
+	return this->utf16_to_utf8[this->cur_pos];
+}
+
+/* virtual */ size_t OSXStringIterator::Next(IterType what)
+{
+	assert(this->cur_pos <= this->utf16_to_utf8.size());
+	assert(what == StringIterator::ITER_CHARACTER || what == StringIterator::ITER_WORD);
+
+	if (this->cur_pos == this->utf16_to_utf8.size()) return END;
+
+	do {
+		this->cur_pos++;
+	} while (this->cur_pos < this->utf16_to_utf8.size() && (what  == ITER_WORD ? !this->str_info[this->cur_pos].word_stop : !this->str_info[this->cur_pos].char_stop));
+
+	return this->cur_pos == this->utf16_to_utf8.size() ? END : this->utf16_to_utf8[this->cur_pos];
+}
+
+/* virtual */ size_t OSXStringIterator::Prev(IterType what)
+{
+	assert(this->cur_pos <= this->utf16_to_utf8.size());
+	assert(what == StringIterator::ITER_CHARACTER || what == StringIterator::ITER_WORD);
+
+	if (this->cur_pos == 0) return END;
+
+	do {
+		this->cur_pos--;
+	} while (this->cur_pos > 0 && (what == ITER_WORD ? !this->str_info[this->cur_pos].word_stop : !this->str_info[this->cur_pos].char_stop));
+
+	return this->utf16_to_utf8[this->cur_pos];
+}
+
+/* static */ StringIterator *OSXStringIterator::Create()
+{
+	if (!MacOSVersionIsAtLeast(10, 5, 0)) return NULL;
+
+	return new OSXStringIterator();
+}
+
 #else
 void MacOSSetCurrentLocaleName(const char *iso_code) {}
 
 int MacOSStringCompare(const char *s1, const char *s2)
 {
 	return 0;
+}
+
+/* static */ StringIterator *OSXStringIterator::Create()
+{
+	return NULL;
 }
 #endif /* (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5) */

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -1,0 +1,66 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_osx.cpp Functions related to localized text support on OSX. */
+
+#include "../../stdafx.h"
+#include "string_osx.h"
+#include "macos.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+
+
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+static CFLocaleRef _osx_locale = NULL;
+
+/** Store current language locale as a CoreFounation locale. */
+void MacOSSetCurrentLocaleName(const char *iso_code)
+{
+	if (!MacOSVersionIsAtLeast(10, 5, 0)) return;
+
+	if (_osx_locale != NULL) CFRelease(_osx_locale);
+
+	CFStringRef iso = CFStringCreateWithCString(kCFAllocatorNull, iso_code, kCFStringEncodingUTF8);
+	_osx_locale = CFLocaleCreate(kCFAllocatorDefault, iso);
+	CFRelease(iso);
+}
+
+/**
+ * Compares two strings using case insensitive natural sort.
+ *
+ * @param s1 First string to compare.
+ * @param s2 Second string to compare.
+ * @return 1 if s1 < s2, 2 if s1 == s2, 3 if s1 > s2, or 0 if not supported by the OS.
+ */
+int MacOSStringCompare(const char *s1, const char *s2)
+{
+	static bool supported = MacOSVersionIsAtLeast(10, 5, 0);
+	if (!supported) return 0;
+
+	CFStringCompareFlags flags = kCFCompareCaseInsensitive | kCFCompareNumerically | kCFCompareLocalized | kCFCompareWidthInsensitive | kCFCompareForcedOrdering;
+
+	CFStringRef cf1 = CFStringCreateWithCString(kCFAllocatorDefault, s1, kCFStringEncodingUTF8);
+	CFStringRef cf2 = CFStringCreateWithCString(kCFAllocatorDefault, s2, kCFStringEncodingUTF8);
+
+	CFComparisonResult res = CFStringCompareWithOptionsAndLocale(cf1, cf2, CFRangeMake(0, CFStringGetLength(cf1)), flags, _osx_locale);
+
+	CFRelease(cf1);
+	CFRelease(cf2);
+
+	return (int)res + 2;
+}
+
+#else
+void MacOSSetCurrentLocaleName(const char *iso_code) {}
+
+int MacOSStringCompare(const char *s1, const char *s2)
+{
+	return 0;
+}
+#endif /* (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5) */

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -1,0 +1,19 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_osx.h Functions related to localized text support on OSX. */
+
+#ifndef STRING_OSX_H
+#define STRING_OSX_H
+
+
+void MacOSSetCurrentLocaleName(const char *iso_code);
+int MacOSStringCompare(const char *s1, const char *s2);
+
+#endif /* STRING_OSX_H */

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -38,7 +38,52 @@ public:
 	static StringIterator *Create();
 };
 
+/**
+ * Helper class to construct a new #CoreTextParagraphLayout.
+ */
+class CoreTextParagraphLayoutFactory {
+public:
+	/** Helper for GetLayouter, to get the right type. */
+	typedef UniChar CharType;
+	/** Helper for GetLayouter, to get whether the layouter supports RTL. */
+	static const bool SUPPORTS_RTL = true;
 
+	/**
+	 * Get the actual ParagraphLayout for the given buffer.
+	 * @param buff The begin of the buffer.
+	 * @param buff_end The location after the last element in the buffer.
+	 * @param fontMapping THe mapping of the fonts.
+	 * @return The ParagraphLayout instance.
+	 */
+	static ParagraphLayouter *GetParagraphLayout(CharType *buff, CharType *buff_end, FontMap &fontMapping);
+
+	/**
+	 * Append a wide character to the internal buffer.
+	 * @param buff        The buffer to append to.
+	 * @param buffer_last The end of the buffer.
+	 * @param c           The character to add.
+	 * @return The number of buffer spaces that were used.
+	 */
+	static size_t AppendToBuffer(CharType *buff, const CharType *buffer_last, WChar c)
+	{
+		if (c >= 0x010000U) {
+			/* Character is encoded using surrogates in UTF-16. */
+			if (buff + 1 <= buffer_last) {
+				buff[0] = (CharType)(((c - 0x010000U) >> 10) + 0xD800);
+				buff[1] = (CharType)(((c - 0x010000U) & 0x3FF) + 0xDC00);
+			} else {
+				/* Not enough space in buffer. */
+				*buff = 0;
+			}
+			return 2;
+		} else {
+			*buff = (CharType)(c & 0xFFFF);
+			return 1;
+		}
+	}
+};
+
+void MacOSResetScriptCache(FontSize size);
 void MacOSSetCurrentLocaleName(const char *iso_code);
 int MacOSStringCompare(const char *s1, const char *s2);
 

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -12,6 +12,32 @@
 #ifndef STRING_OSX_H
 #define STRING_OSX_H
 
+#include "../../gfx_layout.h"
+#include "../../string_base.h"
+#include <vector>
+
+/** String iterator using CoreText as a backend. */
+class OSXStringIterator : public StringIterator {
+	/** Break info for a character. */
+	struct CharInfo {
+		bool word_stop : 1; ///< Code point is suitable as a word break.
+		bool char_stop : 1; ///< Code point is the start of a grapheme cluster, i.e. a "character".
+	};
+
+	std::vector<CharInfo> str_info;      ///< Break information for each code point.
+	std::vector<size_t>   utf16_to_utf8; ///< Mapping from UTF-16 code point position to index in the UTF-8 source string.
+
+	size_t cur_pos; ///< Current iteration position.
+
+public:
+	virtual void SetString(const char *s);
+	virtual size_t SetCurPosition(size_t pos);
+	virtual size_t Next(IterType what);
+	virtual size_t Prev(IterType what);
+
+	static StringIterator *Create();
+};
+
 
 void MacOSSetCurrentLocaleName(const char *iso_code);
 int MacOSStringCompare(const char *s1, const char *s2);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -33,6 +33,10 @@
 #include "os/windows/string_uniscribe.h"
 #endif
 
+#if defined(WITH_COCOA)
+#include "os/macosx/string_osx.h"
+#endif
+
 #ifdef WITH_ICU_SORT
 /* Required by strnatcmp. */
 #include <unicode/ustring.h>
@@ -590,6 +594,11 @@ int strnatcmp(const char *s1, const char *s2, bool ignore_garbage_at_front)
 
 #if defined(WIN32) && !defined(STRGEN) && !defined(SETTINGSGEN)
 	int res = OTTDStringCompare(s1, s2);
+	if (res != 0) return res - 2; // Convert to normal C return values.
+#endif
+
+#if defined(WITH_COCOA) && !defined(STRGEN) && !defined(SETTINGSGEN)
+	int res = MacOSStringCompare(s1, s2);
 	if (res != 0) return res - 2; // Convert to normal C return values.
 #endif
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -874,9 +874,19 @@ public:
 	}
 };
 
+#if defined(WITH_COCOA) && !defined(STRGEN) && !defined(SETTINGSGEN)
+/* static */ StringIterator *StringIterator::Create()
+{
+	StringIterator *i = OSXStringIterator::Create();
+	if (i != NULL) return i;
+
+	return new DefaultStringIterator();
+}
+#else
 /* static */ StringIterator *StringIterator::Create()
 {
 	return new DefaultStringIterator();
 }
+#endif /* defined(WITH_COCOA) && !defined(STRGEN) && !defined(SETTINGSGEN) */
 
 #endif

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2138,7 +2138,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 	/* Update the font with cache */
 	LoadStringWidthTable(searcher->Monospace());
 
-#if !defined(WITH_ICU_LAYOUT) && !defined(WITH_UNISCRIBE)
+#if !defined(WITH_ICU_LAYOUT) && !defined(WITH_UNISCRIBE) && !defined(WITH_COCOA)
 	/*
 	 * For right-to-left languages we need the ICU library. If
 	 * we do not have support for that library we warn the user

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1791,6 +1791,11 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 	Win32SetCurrentLocaleName(_current_language->isocode);
 #endif
 
+#ifdef WITH_COCOA
+	extern void MacOSSetCurrentLocaleName(const char *iso_code);
+	MacOSSetCurrentLocaleName(_current_language->isocode);
+#endif
+
 #ifdef WITH_ICU_SORT
 	/* Delete previous collator. */
 	if (_current_collator != NULL) {


### PR DESCRIPTION
This PR provides native OSX implementations for string sorting, caret handling, and text layout. While it is still possible to use ICU for these on OSX, the default build will not depend on it anymore.