### PR TITLE
Fix: Missing m8 data in console when using Query tool

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -132,6 +132,7 @@ public:
 		DEBUG(misc, LANDINFOD_LEVEL, "m5     = %#x", _m[tile].m5);
 		DEBUG(misc, LANDINFOD_LEVEL, "m6     = %#x", _me[tile].m6);
 		DEBUG(misc, LANDINFOD_LEVEL, "m7     = %#x", _me[tile].m7);
+		DEBUG(misc, LANDINFOD_LEVEL, "m8     = %#x", _me[tile].m8);
 #undef LANDINFOD_LEVEL
 	}
 


### PR DESCRIPTION
When map array 8 was added, the Query tool wasn't updated to also print the value there to the console, in debug builds.