### PR TITLE
Fix: Fluidsynth should not be added to VC project files

### DIFF
--- a/projects/generate
+++ b/projects/generate
@@ -74,6 +74,7 @@ enable_dedicated="0"
 enable_ai="1"
 with_cocoa="0"
 enable_directmusic="1"
+enable_fluidsynth="0"
 with_threads="1"
 file_prefix="..\\\\src\\\\"
 
@@ -132,6 +133,7 @@ load_main_data() {
 											"'$os'" != "CYGWIN" && "'$os'" != "MSVC" ) { next; }
 			if ($0 == "MSVC"        && "'$os'" != "MSVC")              { next; }
 			if ($0 == "DIRECTMUSIC" && "'$enable_directmusic'" != "1") { next; }
+			if ($0 == "FLUIDSYNTH"  && "'$enable_fluidsynth'" != "1")  { next; }
 			if ($0 == "LIBTIMIDITY" && "'$libtimidity'" == "" )        { next; }
 			if ($0 == "HAVE_THREAD" && "'$with_threads'" == "0")       { next; }
 


### PR DESCRIPTION
The `generate` script does define-checks backwards, and can't skip a block if it doesn't know about the keyword. So running it would add Fluidsynth files to the MSVC projects despite that not being supported (currently?).