### PR TITLE
Fix #6676: Prevent helicopters from stopping in midair during landing

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -45,6 +45,8 @@ enum AirVehicleFlags {
 	 * landscape at a fixed altitude. This only has effect when there are more than 15 height levels. */
 	VAF_IN_MAX_HEIGHT_CORRECTION = 1, ///< The vehicle is currently lowering its altitude because it hit the upper bound.
 	VAF_IN_MIN_HEIGHT_CORRECTION = 2, ///< The vehicle is currently raising its altitude because it hit the lower bound.
+
+	VAF_HELI_DIRECT_DESCENT      = 3, ///< The helicopter is descending directly at its destination (helipad or in front of hangar)
 };
 
 static const int ROTOR_Z_OFFSET         = 5;    ///< Z Offset between helicopter- and rotorsprite.

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -918,6 +918,8 @@ static bool AircraftController(Aircraft *v)
 
 	/* Helicopter landing. */
 	if (amd.flag & AMED_HELI_LOWER) {
+		SetBit(v->flags, VAF_HELI_DIRECT_DESCENT);
+
 		if (st == NULL) {
 			/* FIXME - AircraftController -> if station no longer exists, do not land
 			 * helicopter will circle until sign disappears, then go to next order
@@ -938,7 +940,10 @@ static bool AircraftController(Aircraft *v)
 			Vehicle *u = v->Next()->Next();
 
 			/*  Increase speed of rotors. When speed is 80, we've landed. */
-			if (u->cur_speed >= 80) return true;
+			if (u->cur_speed >= 80) {
+				ClrBit(v->flags, VAF_HELI_DIRECT_DESCENT);
+				return true;
+			}
 			u->cur_speed += 4;
 		} else {
 			count = UpdateAircraftSpeed(v);
@@ -1603,6 +1608,7 @@ static void AircraftEventHandler_Flying(Aircraft *v, const AirportFTAClass *apc)
 				uint16 tsubspeed = v->subspeed;
 				if (!AirportHasBlock(v, current, apc)) {
 					v->state = landingtype; // LANDING / HELILANDING
+					if (v->state == HELILANDING) SetBit(v->flags, VAF_HELI_DIRECT_DESCENT);
 					/* it's a bit dirty, but I need to set position to next position, otherwise
 					 * if there are multiple runways, plane won't know which one it took (because
 					 * they all have heading LANDING). And also occupy that block! */

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -542,7 +542,8 @@ CommandCost CmdStartStopVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, 
 		case VEH_AIRCRAFT: {
 			Aircraft *a = Aircraft::From(v);
 			/* cannot stop airplane when in flight, or when taking off / landing */
-			if (!(v->vehstatus & VS_CRASHED) && a->state >= STARTTAKEOFF && a->state < TERM7) return_cmd_error(STR_ERROR_AIRCRAFT_IS_IN_FLIGHT);
+			if (a->state >= STARTTAKEOFF && a->state < TERM7) return_cmd_error(STR_ERROR_AIRCRAFT_IS_IN_FLIGHT);
+			if (HasBit(a->flags, VAF_HELI_DIRECT_DESCENT)) return_cmd_error(STR_ERROR_AIRCRAFT_IS_IN_FLIGHT);
 			break;
 		}
 


### PR DESCRIPTION
This adds a new flag that gets stored in the savegame, but it should still be compatible both ways, hence no save version bump. The save version has also already been bumped a few times since last release ;)