### PR TITLE
Revert: Sprite sorting optimisation sorted incorrectly.

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -88,7 +88,6 @@
 #include "command_func.h"
 #include "network/network_func.h"
 #include "framerate_type.h"
-#include "core/sort_func.hpp"
 
 #include <map>
 
@@ -1380,22 +1379,11 @@ static bool ViewportSortParentSpritesChecker()
 	return true;
 }
 
-static int CDECL CompareParentSprites(ParentSpriteToDraw * const *psd, ParentSpriteToDraw * const *psd2)
-{
-	const ParentSpriteToDraw *ps = *psd;
-	const ParentSpriteToDraw *ps2 = *psd2;
-	return ps->xmin - ps2->xmin;
-}
-
 /** Sort parent sprites pointer array */
 static void ViewportSortParentSprites(ParentSpriteToSortVector *psdv)
 {
 	ParentSpriteToDraw **psdvend = psdv->End();
 	ParentSpriteToDraw **psd = psdv->Begin();
-
-	/* pre-sort by xmin in ascending order */
-	QSortT(psd, psdvend - psd, CompareParentSprites);
-
 	while (psd != psdvend) {
 		ParentSpriteToDraw *ps = *psd;
 
@@ -1432,11 +1420,9 @@ static void ViewportSortParentSprites(ParentSpriteToSortVector *psdv)
 				 * I.e. every single order of X, Y, Z says ps2 is behind ps or they overlap.
 				 * That is: If one partial order says ps behind ps2, do not change the order.
 				 */
-				if (ps->xmax < ps2->xmin) {
-					/* all following sprites have xmin >= ps2->xmin */
-					break;
-				}
-				if (ps->ymax < ps2->ymin || ps->zmax < ps2->zmin) {
+				if (ps->xmax < ps2->xmin ||
+						ps->ymax < ps2->ymin ||
+						ps->zmax < ps2->zmin) {
 					continue;
 				}
 			}


### PR DESCRIPTION
This reverts commit 25ab9c1997f770f4a8a66bb3ad4b82ba87e3a977.

The optimisation consists of pre-sorting the bounding boxes in X direction.
During the actual sorting it then short-circuits loops with the assumption
```
/* all following sprites have xmin >= ps2->xmin */
```

However, the pre-sorting only applies as long as no sprites are moved.
"psd" is a vector iterator, thus the
```
/* Move ps2 in front of ps */
```
also affects elements including and after "psd".

This seems to be the core of this patch, so I do not see any other option, but revert.