### PR TITLE
Add: Unique ID to savegames to prevent accidental overwriting

### DIFF
--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -463,6 +463,14 @@ public:
 					y = DrawStringMultiLine(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT,
 							y, r.bottom - WD_FRAMERECT_BOTTOM, _load_check_data.error, TC_RED);
 				} else {
+					/* Warning if save unique id differ when saving */
+					if (this->fop == SLO_SAVE &&
+							_load_check_data.settings.game_creation.generation_unique_id != 0 && /* Don't warn if the save has no id (old save) */
+							_load_check_data.settings.game_creation.generation_unique_id != _settings_game.game_creation.generation_unique_id) {
+						y = DrawStringMultiLine(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT,
+							y, r.bottom - WD_FRAMERECT_BOTTOM, STR_SAVELOAD_DIFFERENT_ID);
+					}
+
 					/* Mapsize */
 					SetDParam(0, _load_check_data.map_size_x);
 					SetDParam(1, _load_check_data.map_size_y);

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -105,6 +105,11 @@ static void _GenerateWorld(void *)
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
+
+		/* Generates a unique id for the savegame, to avoid accidentally overwriting a save */
+		/* We keep id 0 for old savegames that don't have an id */
+		_settings_game.game_creation.generation_unique_id = _interactive_random.Next(UINT32_MAX - 1) + 1; /* Generates between [1,UINT32_MAX] */
+
 		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4150,6 +4150,8 @@ STR_GAME_SAVELOAD_ERROR_FILE_NOT_WRITEABLE                      :File not writea
 STR_GAME_SAVELOAD_ERROR_DATA_INTEGRITY_CHECK_FAILED             :Data integrity check failed
 STR_GAME_SAVELOAD_NOT_AVAILABLE                                 :<not available>
 STR_WARNING_LOADGAME_REMOVED_TRAMS                              :{WHITE}Game was saved in version without tram support. All trams have been removed
+STR_SAVEGAME_UNMATCHING_ID_CAPTION                              :{WHITE}Caution!
+STR_SAVEGAME_UNMATCHING_ID_CONFIRMATION_TEXT                    :{YELLOW}The savegame you are about to overwrite is not the same as the current one.{}Are you sure you want to do this?
 
 # Map generation messages
 STR_ERROR_COULD_NOT_CREATE_TOWN                                 :{WHITE}Map generation aborted...{}... no suitable town locations

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2773,6 +2773,7 @@ STR_SAVELOAD_DETAIL_NOT_AVAILABLE                               :{BLACK}No infor
 STR_SAVELOAD_DETAIL_COMPANY_INDEX                               :{SILVER}{COMMA}: {WHITE}{STRING1}
 STR_SAVELOAD_DETAIL_GRFSTATUS                                   :{SILVER}NewGRF: {WHITE}{STRING}
 STR_SAVELOAD_FILTER_TITLE                                       :{BLACK}Filter string:
+STR_SAVELOAD_DIFFERENT_ID                                       :{RED}Not the same game as you are saving.
 
 STR_SAVELOAD_OSKTITLE                                           :{BLACK}Enter a name for the savegame
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3045,6 +3045,12 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(203)) {
+		/* Generate a random id for savegames that didn't have one */
+		/* We keep id 0 for old savegames that don't have an id */
+		_settings_game.game_creation.generation_unique_id = _interactive_random.Next(UINT32_MAX-1) + 1; /* Generates between [1;UINT32_MAX] */
+	}
+
 	/* Station acceptance is some kind of cache */
 	if (IsSavegameVersionBefore(127)) {
 		Station *st;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -270,8 +270,9 @@
  *  200   #6805   Extend railtypes to 64, adding uint16 to map array.
  *  201   #6885   Extend NewGRF persistant storages.
  *  202   #6867   Increase industry cargo slots to 16 in, 16 out
+ *  203   #6973   Add unique id to savegames
  */
-extern const uint16 SAVEGAME_VERSION = 202; ///< Current savegame version of OpenTTD.
+extern const uint16 SAVEGAME_VERSION = 203; ///< Current savegame version of OpenTTD.
 
 SavegameType _savegame_type; ///< type of savegame we are loading
 FileToSaveLoad _file_to_saveload; ///< File to save or load in the openttd loop.

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -283,6 +283,7 @@ struct NetworkSettings {
 /** Settings related to the creation of games. */
 struct GameCreationSettings {
 	uint32 generation_seed;                  ///< noise seed for world generation
+	uint32 generation_unique_id;             ///< random id to differentiate savegames
 	Year   starting_year;                    ///< starting date
 	uint8  map_x;                            ///< X size of map
 	uint8  map_y;                            ///< Y size of map

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2210,6 +2210,15 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 base     = GameSettings
+var      = game_creation.generation_unique_id
+type     = SLE_UINT32
+from     = 203
+def      = 0
+min      = 0
+max      = UINT32_MAX
+
+[SDT_VAR]
+base     = GameSettings
 var      = game_creation.tree_placer
 type     = SLE_UINT8
 from     = 30


### PR DESCRIPTION
This PR adds a new randomly generated unique ID as a setting to savegames to avoid accidental overwriting of another savegame in the save dialog.
The ID is automatically generated :
- When a new world is generated
- When an old savegame (prior to this new version) is loaded

When the user attempts to overwrite a save with a different ID, a warning popup shows and a message is also shown in the details of the save.