### PR TITLE
Fix: Spelling in code comment

### DIFF
--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -363,7 +363,7 @@ private:
 class ScriptEventCompanyAskMerger : public ScriptEvent {
 public:
 	/**
-	 * @param owner The company that can be bough.
+	 * @param owner The company that can be bought.
 	 * @param value The value/costs of buying the company.
 	 */
 	ScriptEventCompanyAskMerger(Owner owner, int32 value) :


### PR DESCRIPTION
This is my first contribution to a git project but I think I did everything correctly.
Line 366 contained the word "bough" when it should be "bought"