### PR TITLE
Fix #6974: Add filter widget to api (and a double dot from somewhere)

### DIFF
--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -438,6 +438,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_CAPTION,                            "WID_SL_CAPTION");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_SORT_BYNAME,                        "WID_SL_SORT_BYNAME");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_SORT_BYDATE,                        "WID_SL_SORT_BYDATE");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_FILTER,                             "WID_SL_FILTER");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_BACKGROUND,                         "WID_SL_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_FILE_BACKGROUND,                    "WID_SL_FILE_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SL_HOME_BUTTON,                        "WID_SL_HOME_BUTTON");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1001,7 +1001,7 @@ public:
 	};
 
 	/* automatically generated from ../../widgets/cheat_widget.h */
-	/** Widgets of the #CheatWindow class.. */
+	/** Widgets of the #CheatWindow class. */
 	enum CheatWidgets {
 		WID_C_PANEL                                  = ::WID_C_PANEL,                                  ///< Panel where all cheats are shown in.
 	};
@@ -1272,6 +1272,7 @@ public:
 		WID_SL_CAPTION                               = ::WID_SL_CAPTION,                               ///< Caption of the window.
 		WID_SL_SORT_BYNAME                           = ::WID_SL_SORT_BYNAME,                           ///< Sort by name button.
 		WID_SL_SORT_BYDATE                           = ::WID_SL_SORT_BYDATE,                           ///< Sort by date button.
+		WID_SL_FILTER                                = ::WID_SL_FILTER,                                ///< Filter list of files
 		WID_SL_BACKGROUND                            = ::WID_SL_BACKGROUND,                            ///< Background of window.
 		WID_SL_FILE_BACKGROUND                       = ::WID_SL_FILE_BACKGROUND,                       ///< Background of file selection.
 		WID_SL_HOME_BUTTON                           = ::WID_SL_HOME_BUTTON,                           ///< Home button.


### PR DESCRIPTION
After running scripts, it seems a new widget has been added but scripts weren't executed.
There is a double dot removal as well.
Don't have much time now and I didn't review where this changes come from, so this PR needs a review. I leave this PR as this, hoping someone can have a look at it.