### PR TITLE
Allow the center tile to always get a house when playing with 3x3/Better

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1267,7 +1267,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 		if (!IsValidTile(house_tile)) return;
 
-		if (target_dir != DIAGDIR_END && (_settings_game.economy.allow_town_roads || _generating_world)) {
+		if (target_dir != DIAGDIR_END) {
 			switch (t1->layout) {
 				default: NOT_REACHED();
 


### PR DESCRIPTION
This small change was made after a [topic on the TT-Forums](https://www.tt-forums.net/viewtopic.php?f=29&t=84313) about an issue I noticed during gameplay. Basically, if you play with _"towns are allowed to build roads"_ turned off, the algorithm that determines where houses are built misses a branch somewhere. This results in occasional gaps showing up, especially when using the 3x3 road layout:

<img width="192" alt="screen shot 2018-12-07 at 17 01 33 2" src="https://user-images.githubusercontent.com/1507745/49659655-fcc09600-fa44-11e8-88d8-57a86781fabb.png">

If you do give towns the ability to construct their own roads, this does not happen and the gaps get filled up with houses like normal.

It seems to me that removing the whole check for both these variables fixes the problem, allowing the houses to be built even with the setting turned off.

<img width="341" alt="screen shot 2018-12-07 at 17 01 33" src="https://user-images.githubusercontent.com/1507745/49659865-6d67b280-fa45-11e8-9cc6-0f781e3820ff.png">

Since I'm new to contributing, I'm not sure if it's the right way to go. I can also understand that maybe we need a setting for this? Please let me know 🙂