### PR TITLE
Change: AI/GS ScriptBridge::GetName takes one extra parameter to refer the vehicle type

### DIFF
--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -367,3 +367,10 @@ AIOrder.AIOF_UNLOAD_FLAGS <- AIOrder.OF_UNLOAD_FLAGS
 AIOrder.AIOF_LOAD_FLAGS <- AIOrder.OF_LOAD_FLAGS
 AIOrder.AIOF_DEPOT_FLAGS <- AIOrder.OF_DEPOT_FLAGS
 AIOrder.AIOF_INVALID <- AIOrder.OF_INVALID
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -119,3 +119,10 @@ AIOrder.AIOF_UNLOAD_FLAGS <- AIOrder.OF_UNLOAD_FLAGS
 AIOrder.AIOF_LOAD_FLAGS <- AIOrder.OF_LOAD_FLAGS
 AIOrder.AIOF_DEPOT_FLAGS <- AIOrder.OF_DEPOT_FLAGS
 AIOrder.AIOF_INVALID <- AIOrder.OF_INVALID
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -56,3 +56,10 @@ AIOrder.AIOF_UNLOAD_FLAGS <- AIOrder.OF_UNLOAD_FLAGS
 AIOrder.AIOF_LOAD_FLAGS <- AIOrder.OF_LOAD_FLAGS
 AIOrder.AIOF_DEPOT_FLAGS <- AIOrder.OF_DEPOT_FLAGS
 AIOrder.AIOF_INVALID <- AIOrder.OF_INVALID
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.2 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.3 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.4 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.5 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.6 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.7 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -8,3 +8,10 @@
  */
 
 AILog.Info("1.8 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+AIBridge._GetName <- AIBridge.GetName;
+AIBridge.GetName <- function(bridge_id)
+{
+	return AIBridge._GetName(bridge_id, AIVehicle.VT_RAIL);
+}

--- a/bin/ai/regression/tst_regression/main.nut
+++ b/bin/ai/regression/tst_regression/main.nut
@@ -253,7 +253,7 @@ function Regression::Bridge()
 		if (AIBridge.IsValidBridge(i)) j++;
 		print("  Bridge " + i);
 		print("    IsValidBridge():    " + AIBridge.IsValidBridge(i));
-		print("    GetName():          " + AIBridge.GetName(i));
+		print("    GetName():          " + AIBridge.GetName(i, AIVehicle.VT_RAIL));
 		print("    GetMaxSpeed():      " + AIBridge.GetMaxSpeed(i));
 		print("    GetPrice():         " + AIBridge.GetPrice(i, 5));
 		print("    GetMaxLength():     " + AIBridge.GetMaxLength(i));

--- a/bin/ai/regression/tst_regression/main.nut
+++ b/bin/ai/regression/tst_regression/main.nut
@@ -253,7 +253,11 @@ function Regression::Bridge()
 		if (AIBridge.IsValidBridge(i)) j++;
 		print("  Bridge " + i);
 		print("    IsValidBridge():    " + AIBridge.IsValidBridge(i));
-		print("    GetName():          " + AIBridge.GetName(i, AIVehicle.VT_RAIL));
+		print("    GetName():");
+		print("     VT_RAIL:           " + AIBridge.GetName(i, AIVehicle.VT_RAIL));
+		print("     VT_ROAD:           " + AIBridge.GetName(i, AIVehicle.VT_ROAD));
+		print("     VT_WATER:          " + AIBridge.GetName(i, AIVehicle.VT_WATER));
+		print("     VT_AIR:            " + AIBridge.GetName(i, AIVehicle.VT_AIR));
 		print("    GetMaxSpeed():      " + AIBridge.GetMaxSpeed(i));
 		print("    GetPrice():         " + AIBridge.GetPrice(i, 5));
 		print("    GetMaxLength():     " + AIBridge.GetMaxLength(i));

--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -867,105 +867,165 @@ ERROR: IsEnd() is invalid as Begin() is never called
 --Bridge--
   Bridge -1
     IsValidBridge():    false
-    GetName():          (null : 0x00000000)
+    GetName():
+     VT_RAIL:           (null : 0x00000000)
+     VT_ROAD:           (null : 0x00000000)
+     VT_WATER:          (null : 0x00000000)
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
     GetMinLength():     -1
   Bridge 0
     IsValidBridge():    true
-    GetName():          Wooden rail bridge
+    GetName():
+     VT_RAIL:           Wooden rail bridge
+     VT_ROAD:           Wooden road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      32
     GetPrice():         450
     GetMaxLength():     66
     GetMinLength():     2
   Bridge 1
     IsValidBridge():    true
-    GetName():          Concrete rail bridge
+    GetName():
+     VT_RAIL:           Concrete rail bridge
+     VT_ROAD:           Concrete road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      48
     GetPrice():         630
     GetMaxLength():     4
     GetMinLength():     2
   Bridge 2
     IsValidBridge():    true
-    GetName():          Steel girder rail bridge
+    GetName():
+     VT_RAIL:           Steel girder rail bridge
+     VT_ROAD:           Steel girder road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      64
     GetPrice():         811
     GetMaxLength():     7
     GetMinLength():     2
   Bridge 3
     IsValidBridge():    true
-    GetName():          Reinforced concrete suspension rail bridge
+    GetName():
+     VT_RAIL:           Reinforced concrete suspension rail bridge
+     VT_ROAD:           Reinforced concrete suspension road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      80
     GetPrice():         946
     GetMaxLength():     12
     GetMinLength():     4
   Bridge 4
     IsValidBridge():    true
-    GetName():          Steel suspension rail bridge
+    GetName():
+     VT_RAIL:           Steel suspension rail bridge
+     VT_ROAD:           Steel suspension road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      96
     GetPrice():         1042
     GetMaxLength():     66
     GetMinLength():     5
   Bridge 5
     IsValidBridge():    true
-    GetName():          Steel suspension rail bridge
+    GetName():
+     VT_RAIL:           Steel suspension rail bridge
+     VT_ROAD:           Steel suspension road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      112
     GetPrice():         1081
     GetMaxLength():     66
     GetMinLength():     5
   Bridge 6
     IsValidBridge():    true
-    GetName():          Steel cantilever rail bridge
+    GetName():
+     VT_RAIL:           Steel cantilever rail bridge
+     VT_ROAD:           Steel cantilever road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      160
     GetPrice():         1261
     GetMaxLength():     9
     GetMinLength():     5
   Bridge 7
     IsValidBridge():    true
-    GetName():          Steel cantilever rail bridge
+    GetName():
+     VT_RAIL:           Steel cantilever rail bridge
+     VT_ROAD:           Steel cantilever road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      208
     GetPrice():         1306
     GetMaxLength():     10
     GetMinLength():     5
   Bridge 8
     IsValidBridge():    true
-    GetName():          Steel cantilever rail bridge
+    GetName():
+     VT_RAIL:           Steel cantilever rail bridge
+     VT_ROAD:           Steel cantilever road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      240
     GetPrice():         1396
     GetMaxLength():     11
     GetMinLength():     5
   Bridge 9
     IsValidBridge():    true
-    GetName():          Steel girder rail bridge
+    GetName():
+     VT_RAIL:           Steel girder rail bridge
+     VT_ROAD:           Steel girder road bridge
+     VT_WATER:          Aqueduct
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      256
     GetPrice():         1351
     GetMaxLength():     4
     GetMinLength():     2
   Bridge 10
     IsValidBridge():    false
-    GetName():          (null : 0x00000000)
+    GetName():
+     VT_RAIL:           (null : 0x00000000)
+     VT_ROAD:           (null : 0x00000000)
+     VT_WATER:          (null : 0x00000000)
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
     GetMinLength():     -1
   Bridge 11
     IsValidBridge():    false
-    GetName():          (null : 0x00000000)
+    GetName():
+     VT_RAIL:           (null : 0x00000000)
+     VT_ROAD:           (null : 0x00000000)
+     VT_WATER:          (null : 0x00000000)
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
     GetMinLength():     -1
   Bridge 12
     IsValidBridge():    false
-    GetName():          (null : 0x00000000)
+    GetName():
+     VT_RAIL:           (null : 0x00000000)
+     VT_ROAD:           (null : 0x00000000)
+     VT_WATER:          (null : 0x00000000)
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1
     GetMinLength():     -1
   Bridge 13
     IsValidBridge():    false
-    GetName():          (null : 0x00000000)
+    GetName():
+     VT_RAIL:           (null : 0x00000000)
+     VT_ROAD:           (null : 0x00000000)
+     VT_WATER:          (null : 0x00000000)
+     VT_AIR:            (null : 0x00000000)
     GetMaxSpeed():      -1
     GetPrice():         -1
     GetMaxLength():     -1

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -23,3 +23,10 @@ GSNews.Create <- function(type, text, company)
 {
     return GSNews._Create(type, text, company, GSNews.NR_NONE, 0);
 }
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -23,3 +23,10 @@ GSNews.Create <- function(type, text, company)
 {
     return GSNews._Create(type, text, company, GSNews.NR_NONE, 0);
 }
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -15,3 +15,10 @@ GSNews.Create <- function(type, text, company)
 {
     return GSNews._Create(type, text, company, GSNews.NR_NONE, 0);
 }
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -8,3 +8,10 @@
  */
 
 GSLog.Info("1.5 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -8,3 +8,10 @@
  */
 
 GSLog.Info("1.6 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -8,3 +8,10 @@
  */
 
 GSLog.Info("1.7 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -8,3 +8,10 @@
  */
 
 GSLog.Info("1.8 API compatibility in effect.");
+
+/* 1.9 adds a vehicle type parameter. */
+GSBridge._GetName <- GSBridge.GetName;
+GSBridge.GetName <- function(bridge_id)
+{
+	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
+}

--- a/src/script/api/ai/ai_bridge.hpp.sq
+++ b/src/script/api/ai/ai_bridge.hpp.sq
@@ -37,7 +37,7 @@ void SQAIBridge_Register(Squirrel *engine)
 	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::IsValidBridge,     "IsValidBridge",     2, ".i");
 	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::IsBridgeTile,      "IsBridgeTile",      2, ".i");
 	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::GetBridgeID,       "GetBridgeID",       2, ".i");
-	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::GetName,           "GetName",           2, ".i");
+	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::GetName,           "GetName",           3, ".ii");
 	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::GetMaxSpeed,       "GetMaxSpeed",       2, ".i");
 	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::GetPrice,          "GetPrice",          3, ".ii");
 	SQAIBridge.DefSQStaticMethod(engine, &ScriptBridge::GetMaxLength,      "GetMaxLength",      2, ".i");

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -21,6 +21,9 @@
  * API additions:
  * \li AIAirport::GetMonthlyMaintenanceCost
  *
+ * Other changes:
+ * \li AIBridge::GetName takes one extra parameter to refer the vehicle type
+ *
  * \b 1.8.0
  *
  * No changes

--- a/src/script/api/game/game_bridge.hpp.sq
+++ b/src/script/api/game/game_bridge.hpp.sq
@@ -37,7 +37,7 @@ void SQGSBridge_Register(Squirrel *engine)
 	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::IsValidBridge,     "IsValidBridge",     2, ".i");
 	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::IsBridgeTile,      "IsBridgeTile",      2, ".i");
 	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::GetBridgeID,       "GetBridgeID",       2, ".i");
-	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::GetName,           "GetName",           2, ".i");
+	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::GetName,           "GetName",           3, ".ii");
 	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::GetMaxSpeed,       "GetMaxSpeed",       2, ".i");
 	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::GetPrice,          "GetPrice",          3, ".ii");
 	SQGSBridge.DefSQStaticMethod(engine, &ScriptBridge::GetMaxLength,      "GetMaxLength",      2, ".i");

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -28,6 +28,9 @@
  * \li GSViewport::ScrollClientTo
  * \li GSGoal::QuestionClient
  *
+ * Other changes:
+ * \li GSBridge::GetName takes one extra parameter to refer the vehicle type
+ *
  * \b 1.8.0
  *
  * No changes

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -16,6 +16,7 @@
 #include "../../bridge_map.h"
 #include "../../strings_func.h"
 #include "../../date_func.h"
+#include "table/strings.h"
 
 #include "../../safeguards.h"
 
@@ -135,11 +136,12 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	return ScriptObject::DoCommand(tile, 0, 0, CMD_LANDSCAPE_CLEAR);
 }
 
-/* static */ char *ScriptBridge::GetName(BridgeID bridge_id)
+/* static */ char *ScriptBridge::GetName(BridgeID bridge_id, ScriptVehicle::VehicleType vehicle_type)
 {
+	EnforcePrecondition(NULL, vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER);
 	if (!IsValidBridge(bridge_id)) return NULL;
 
-	return GetString(::GetBridgeSpec(bridge_id)->transport_name[0]);
+	return GetString(vehicle_type == ScriptVehicle::VT_WATER ? STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT : ::GetBridgeSpec(bridge_id)->transport_name[vehicle_type]);
 }
 
 /* static */ int32 ScriptBridge::GetMaxSpeed(BridgeID bridge_id)

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -66,10 +66,12 @@ public:
 	/**
 	 * Get the name of a bridge.
 	 * @param bridge_id The bridge to get the name of.
+	 * @param vehicle_type The vehicle-type of bridge to get the name of.
 	 * @pre IsValidBridge(bridge_id).
+	 * @pre vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER
 	 * @return The name the bridge has.
 	 */
-	static char *GetName(BridgeID bridge_id);
+	static char *GetName(BridgeID bridge_id, ScriptVehicle::VehicleType vehicle_type);
 
 	/**
 	 * Get the maximum speed of a bridge.


### PR DESCRIPTION
When I was working with my AI and wanted to retrieve the name of bridges, I was always getting the rail name version of that bridge even though I was working with roads. With this change I can now chose from all three vehicle types that have bridges. It's merely a name display issue.