### PR TITLE
Change: show 'Max. Power' for vehicles rather than 'Power'

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3444,7 +3444,7 @@ STR_BUY_VEHICLE_SHIP_CAPTION                                    :New Ships
 STR_BUY_VEHICLE_AIRCRAFT_CAPTION                                :New Aircraft
 
 STR_PURCHASE_INFO_COST_WEIGHT                                   :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} Weight: {GOLD}{WEIGHT_SHORT}
-STR_PURCHASE_INFO_SPEED_POWER                                   :{BLACK}Speed: {GOLD}{VELOCITY}{BLACK} Power: {GOLD}{POWER}
+STR_PURCHASE_INFO_SPEED_POWER                                   :{BLACK}Speed: {GOLD}{VELOCITY}{BLACK} Max. Power: {GOLD}{POWER}
 STR_PURCHASE_INFO_SPEED                                         :{BLACK}Speed: {GOLD}{VELOCITY}
 STR_PURCHASE_INFO_SPEED_OCEAN                                   :{BLACK}Speed on ocean: {GOLD}{VELOCITY}
 STR_PURCHASE_INFO_SPEED_CANAL                                   :{BLACK}Speed on canal/river: {GOLD}{VELOCITY}
@@ -3595,8 +3595,8 @@ STR_ENGINE_PREVIEW_SHIP                                         :ship
 STR_ENGINE_PREVIEW_MONORAIL_LOCOMOTIVE                          :monorail locomotive
 STR_ENGINE_PREVIEW_MAGLEV_LOCOMOTIVE                            :maglev locomotive
 
-STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER                      :{BLACK}Cost: {CURRENCY_LONG} Weight: {WEIGHT_SHORT}{}Speed: {VELOCITY}  Power: {POWER}{}Running Cost: {CURRENCY_LONG}/yr{}Capacity: {CARGO_LONG}
-STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER_MAX_TE               :{BLACK}Cost: {CURRENCY_LONG} Weight: {WEIGHT_SHORT}{}Speed: {VELOCITY}  Power: {POWER}  Max. T.E.: {6:FORCE}{}Running Cost: {4:CURRENCY_LONG}/yr{}Capacity: {5:CARGO_LONG}
+STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER                      :{BLACK}Cost: {CURRENCY_LONG} Weight: {WEIGHT_SHORT}{}Speed: {VELOCITY}  Max. Power: {POWER}{}Running Cost: {CURRENCY_LONG}/yr{}Capacity: {CARGO_LONG}
+STR_ENGINE_PREVIEW_COST_WEIGHT_SPEED_POWER_MAX_TE               :{BLACK}Cost: {CURRENCY_LONG} Weight: {WEIGHT_SHORT}{}Speed: {VELOCITY}  Max. Power: {POWER}  Max. T.E.: {6:FORCE}{}Running Cost: {4:CURRENCY_LONG}/yr{}Capacity: {5:CARGO_LONG}
 STR_ENGINE_PREVIEW_COST_MAX_SPEED_CAP_RUNCOST                   :{BLACK}Cost: {CURRENCY_LONG} Max. Speed: {VELOCITY}{}Capacity: {CARGO_LONG}{}Running Cost: {CURRENCY_LONG}/yr
 STR_ENGINE_PREVIEW_COST_MAX_SPEED_TYPE_CAP_CAP_RUNCOST          :{BLACK}Cost: {CURRENCY_LONG} Max. Speed: {VELOCITY}{}Aircraft type: {STRING}{}Capacity: {CARGO_LONG}, {CARGO_LONG}{}Running Cost: {CURRENCY_LONG}/yr
 STR_ENGINE_PREVIEW_COST_MAX_SPEED_TYPE_CAP_RUNCOST              :{BLACK}Cost: {CURRENCY_LONG} Max. Speed: {VELOCITY}{}Aircraft type: {STRING}{}Capacity: {CARGO_LONG}{}Running Cost: {CURRENCY_LONG}/yr


### PR DESCRIPTION
It's possible for vehicles to change power, most likely due to checking railtype, also other vars in the consist.
  
This can be confusing for player in purchase / 'available trains' lists as the power value shown may not match the power value of the vehicle when built in a specific depot.  

- there is currently no way to check the railtype of a depot during purchase, and it is TMWFTLB https://github.com/OpenTTD/OpenTTD/issues/4410 
- even if depot could check railtype, there is no way to provide railtype in 'available trains' list

We handle other cases of variable properties by prefixing 'Max.', e.g. TE, speed, reliability etc.
I have done the same here as it seems by far the simplest solution, just a string change.

I rejected complicated solutions such as returning a range of power values to the cb in purchase list, or suppressing the display of the power value and replacing with extra buy menu text.

It's the responsibility of newgrf authors to return the correct value for max power to the purchase list.

Changed both purchase list and vehicle preview windows.  Didn't change vehicle info window, as that should display actual current power IMHO.

Issue (with vehicle set to use lowest power in purchase list, as safest way to not ruin player's network)
![double_trouble](https://user-images.githubusercontent.com/1780327/50535462-2f404900-0b42-11e9-86fc-e92c80646386.png)
Fix in context of purchase window (with vehicle set to use maximum power in purchase list)
<img width="1021" alt="double_trouble_fixed_2" src="https://user-images.githubusercontent.com/1780327/50535517-c5746f00-0b42-11e9-99a4-94c22785100b.png">
Fix in context of preview window
![max_power](https://user-images.githubusercontent.com/1780327/50535448-1172e400-0b42-11e9-8ab2-a3a283ebcd58.png)
