### PR TITLE
Fix #6966: Only allow switching to a valid company.

### DIFF
--- a/src/script/api/script_companymode.cpp
+++ b/src/script/api/script_companymode.cpp
@@ -10,6 +10,7 @@
 /** @file script_companymode.cpp Implementation of ScriptCompanyMode. */
 
 #include "../../stdafx.h"
+#include "../../company_base.h"
 #include "script_companymode.hpp"
 
 #include "../../safeguards.h"
@@ -17,6 +18,7 @@
 ScriptCompanyMode::ScriptCompanyMode(int company)
 {
 	if (company < OWNER_BEGIN || company >= MAX_COMPANIES) company = INVALID_COMPANY;
+	if (!::Company::IsValidID(company)) company = INVALID_COMPANY;
 
 	this->last_company = ScriptObject::GetCompany();
 	ScriptObject::SetCompany((CompanyID)company);


### PR DESCRIPTION
Far from sure this is the one and only point for game-scripts that needs such a check, but it does fix the crash for #6966 