### PR TITLE
Fix #7004: Redraw linkgraph overlay correctly after zoom

### DIFF
--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -187,7 +187,13 @@ bool DoZoomInOutWindow(ZoomStateChange how, Window *w)
 	return true;
 }
 
-void ZoomInOrOutToCursorWindow(bool in, Window *w)
+/**
+ * Zooms in or out the viewport based on the cursor position.
+ * @param in              Indicates that we are zooming inward.
+ * @param w               The window to zoom.
+ * @param rebuild_overlay Update the linkgraph overlay after zooming. (If false, the caller should ensure that the linkgraph is rebuilt sometime soon.)
+ */
+void ZoomInOrOutToCursorWindow(bool in, Window *w, bool rebuild_overlay)
 {
 	assert(w != NULL);
 
@@ -197,7 +203,7 @@ void ZoomInOrOutToCursorWindow(bool in, Window *w)
 
 		Point pt = GetTileZoomCenterWindow(in, w);
 		if (pt.x != -1) {
-			ScrollWindowTo(pt.x, pt.y, -1, w, true);
+			ScrollWindowTo(pt.x, pt.y, -1, w, true, rebuild_overlay);
 
 			DoZoomInOutWindow(in ? ZOOM_IN : ZOOM_OUT, w);
 		}
@@ -440,7 +446,9 @@ struct MainWindow : Window
 	virtual void OnMouseWheel(int wheel)
 	{
 		if (_settings_client.gui.scrollwheel_scrolling != 2) {
-			ZoomInOrOutToCursorWindow(wheel < 0, this);
+			/* Don't rebuild overlay yet... we need to wait for LINKGRAPH_DELAY ticks before updating. */
+			ZoomInOrOutToCursorWindow(wheel < 0, this, false);
+			this->refresh = LINKGRAPH_DELAY;
 		}
 	}
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2218,14 +2218,15 @@ void RebuildViewportOverlay(Window *w)
 
 /**
  * Scrolls the viewport in a window to a given location.
- * @param x       Desired x location of the map to scroll to (world coordinate).
- * @param y       Desired y location of the map to scroll to (world coordinate).
- * @param z       Desired z location of the map to scroll to (world coordinate). Use \c -1 to scroll to the height of the map at the \a x, \a y location.
- * @param w       %Window containing the viewport.
- * @param instant Jump to the location instead of slowly moving to it.
+ * @param x               Desired x location of the map to scroll to (world coordinate).
+ * @param y               Desired y location of the map to scroll to (world coordinate).
+ * @param z               Desired z location of the map to scroll to (world coordinate). Use \c -1 to scroll to the height of the map at the \a x, \a y location.
+ * @param w               %Window containing the viewport.
+ * @param instant         Jump to the location instead of slowly moving to it.
+ * @param rebuild_overlay Update the linkgraph overlay after scrolling. (If false, the caller should ensure that the linkgraph is rebuilt sometime soon.)
  * @return Destination of the viewport was changed (to activate other actions when the viewport is already at the desired position).
  */
-bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant)
+bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant, bool rebuild_overlay)
 {
 	/* The slope cannot be acquired outside of the map, so make sure we are always within the map. */
 	if (z == -1) {
@@ -2245,7 +2246,7 @@ bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant)
 	if (instant) {
 		w->viewport->scrollpos_x = pt.x;
 		w->viewport->scrollpos_y = pt.y;
-		RebuildViewportOverlay(w);
+		if (rebuild_overlay) RebuildViewportOverlay(w);
 	}
 
 	w->viewport->dest_scrollpos_x = pt.x;

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -32,7 +32,7 @@ void UpdateViewportPosition(Window *w);
 void MarkAllViewportsDirty(int left, int top, int right, int bottom);
 
 bool DoZoomInOutWindow(ZoomStateChange how, Window *w);
-void ZoomInOrOutToCursorWindow(bool in, Window * w);
+void ZoomInOrOutToCursorWindow(bool in, Window * w, bool rebuild_overlay = true);
 Point GetTileZoomCenterWindow(bool in, Window * w);
 void HandleZoomMessage(Window *w, const ViewPort *vp, byte widget_zoom_in, byte widget_zoom_out);
 
@@ -67,7 +67,7 @@ void SetTileSelectBigSize(int ox, int oy, int sx, int sy);
 void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom);
 
 bool ScrollWindowToTile(TileIndex tile, Window *w, bool instant = false);
-bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant = false);
+bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant = false, bool rebuild_overlay = true);
 
 void RebuildViewportOverlay(Window *w);
 

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -139,7 +139,8 @@ public:
 	virtual void OnMouseWheel(int wheel)
 	{
 		if (_settings_client.gui.scrollwheel_scrolling != 2) {
-			ZoomInOrOutToCursorWindow(wheel < 0, this);
+			/* rebuild_overlay is false for now, because there is currently no overlay for any ExtraViewportWindow. Only MainWindow can have the overlay. */
+			ZoomInOrOutToCursorWindow(wheel < 0, this, false);
 		}
 	}
 


### PR DESCRIPTION
Previously, when the user zooms in or out, the linkgraph overlay was recalculated before the zoom.  This caused some stations and edges to be missing from the visible region of the viewport.

Thanks for this enjoyable game!