### PR TITLE
Change: Desert tiles are now half-desert if a neighboured tile is non…

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -208,16 +208,19 @@ static void TileLoopClearAlps(TileIndex tile)
 }
 
 /**
- * Tests if at least one surrounding tile is desert
+ * Tests if at least one surrounding tile is non-desert
  * @param tile tile to check
- * @return does this tile have at least one desert tile around?
+ * @return does this tile have at least one non-desert tile around?
  */
-static inline bool NeighbourIsDesert(TileIndex tile)
+static inline bool NeighbourIsNormal(TileIndex tile)
 {
-	return GetTropicZone(tile + TileDiffXY(  1,  0)) == TROPICZONE_DESERT ||
-			GetTropicZone(tile + TileDiffXY( -1,  0)) == TROPICZONE_DESERT ||
-			GetTropicZone(tile + TileDiffXY(  0,  1)) == TROPICZONE_DESERT ||
-			GetTropicZone(tile + TileDiffXY(  0, -1)) == TROPICZONE_DESERT;
+	for (DiagDirection dir = DIAGDIR_BEGIN; dir < DIAGDIR_END; dir++) {
+		TileIndex t = tile + TileOffsByDiagDir(dir);
+		if (!IsValidTile(t)) continue;
+		if (GetTropicZone(t) != TROPICZONE_DESERT) return true;
+		if (HasTileWaterClass(t) && GetWaterClass(t) == WATER_CLASS_SEA) return true;
+	}
+	return false;
 }
 
 static void TileLoopClearDesert(TileIndex tile)
@@ -229,9 +232,7 @@ static void TileLoopClearDesert(TileIndex tile)
 	/* Expected desert level - 0 if it shouldn't be desert */
 	uint expected = 0;
 	if (GetTropicZone(tile) == TROPICZONE_DESERT) {
-		expected = 3;
-	} else if (NeighbourIsDesert(tile)) {
-		expected = 1;
+		expected = NeighbourIsNormal(tile) ? 1 : 3;
 	}
 
 	if (current == expected) return;


### PR DESCRIPTION
…-desert or sea/coast. (patch by frosch123) #4754

Patch is by frosch123, I'm gravedigging it.  

TL;DR: increase number of cases where desert tiles will show half-desert.

See my testing notes here https://github.com/OpenTTD/OpenTTD/issues/4754#issuecomment-379445706

Scenario Editor in 1.8.0 
<img width="354" alt="4754-1 8 0" src="https://user-images.githubusercontent.com/1780327/50734692-a6a55680-119a-11e9-90fb-ba51f8018636.png">
Scenario Editor with #4754 patch applied - note half tile next to river compared to 1.8.0 
<img width="482" alt="4754-patched" src="https://user-images.githubusercontent.com/1780327/50734694-aa38dd80-119a-11e9-942c-e5464630c83f.png">

Rivers built during random map gen are already created with non-desert tiles next to them, but the appearance is improved with this patch.
