### PR TITLE
Fix #7017: Conditional orders enum updated without savegame version bump

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3854,12 +3854,12 @@ STR_ORDER_CONDITIONAL_VARIABLE_TOOLTIP                          :{BLACK}Vehicle 
 # Conditional order variables, must follow order of OrderConditionVariable enum
 STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE                           :Load percentage
 STR_ORDER_CONDITIONAL_RELIABILITY                               :Reliability
-STR_ORDER_CONDITIONAL_MAX_RELIABILITY                           :Maximum reliability
 STR_ORDER_CONDITIONAL_MAX_SPEED                                 :Maximum speed
 STR_ORDER_CONDITIONAL_AGE                                       :Age (years)
 STR_ORDER_CONDITIONAL_REQUIRES_SERVICE                          :Requires service
 STR_ORDER_CONDITIONAL_UNCONDITIONALLY                           :Always
 STR_ORDER_CONDITIONAL_REMAINING_LIFETIME                        :Remaining lifetime (years)
+STR_ORDER_CONDITIONAL_MAX_RELIABILITY                           :Maximum reliability
 
 STR_ORDER_CONDITIONAL_COMPARATOR_TOOLTIP                        :{BLACK}How to compare the vehicle data to the given value
 STR_ORDER_CONDITIONAL_COMPARATOR_EQUALS                         :is equal to

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -118,12 +118,12 @@ DECLARE_ENUM_AS_BIT_SET(OrderDepotActionFlags)
 enum OrderConditionVariable {
 	OCV_LOAD_PERCENTAGE,    ///< Skip based on the amount of load
 	OCV_RELIABILITY,        ///< Skip based on the reliability
-	OCV_MAX_RELIABILITY,    ///< Skip based on the maximum reliability
 	OCV_MAX_SPEED,          ///< Skip based on the maximum speed
 	OCV_AGE,                ///< Skip based on the age
 	OCV_REQUIRES_SERVICE,   ///< Skip when the vehicle requires service
 	OCV_UNCONDITIONALLY,    ///< Always skip
 	OCV_REMAINING_LIFETIME, ///< Skip based on the remaining lifetime
+	OCV_MAX_RELIABILITY,    ///< Skip based on the maximum reliability
 	OCV_END
 };
 


### PR DESCRIPTION
PR #7017 changed the conditional orders conditions enum by adding a value in the middle. This breaks loading old savegames that use conditional orders. Fix this by moving the new enum value to the end, while keeping the UI list order the same.

Saving this orders list in 1.8.0:
![image](https://user-images.githubusercontent.com/1062071/50734212-17993e00-119c-11e9-9d09-d7d24f8d851e.png)

Loads as this orders list with the #7017 patch but without this fix:
![image](https://user-images.githubusercontent.com/1062071/50734216-27188700-119c-11e9-9d79-490a9b9daff6.png)