### PR TITLE
Add #6887: Option to show zone inside local authority boundary of towns

### DIFF
--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -373,6 +373,17 @@ public:
 	}
 
 	/**
+	 * Clear the tree.
+	 */
+	void Clear()
+	{
+		this->nodes.clear();
+		this->free_list.clear();
+		this->unbalanced = 0;
+		return;
+	}
+
+	/**
 	 * Reconstruct the tree with the same elements, letting it be fully balanced.
 	 */
 	void Rebuild()

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3119,6 +3119,8 @@ STR_TOWN_VIEW_RENAME_TOWN_BUTTON                                :Rename Town
 
 # Town local authority window
 STR_LOCAL_AUTHORITY_CAPTION                                     :{WHITE}{TOWN} local authority
+STR_LOCAL_AUTHORITY_ZONE                                        :{BLACK}Zone
+STR_LOCAL_AUTHORITY_ZONE_TOOLTIP                                :{BLACK}Show zone within local authority boundaries
 STR_LOCAL_AUTHORITY_COMPANY_RATINGS                             :{BLACK}Transport company ratings:
 STR_LOCAL_AUTHORITY_COMPANY_RATING                              :{YELLOW}{COMPANY} {COMPANY_NUM}: {ORANGE}{STRING}
 STR_LOCAL_AUTHORITY_ACTIONS_TITLE                               :{BLACK}Actions available:

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -47,6 +47,7 @@ void InitializeAirportGui();
 void InitializeDockGui();
 void InitializeGraphGui();
 void InitializeObjectGui();
+void InitializeTownGui();
 void InitializeIndustries();
 void InitializeObjects();
 void InitializeTrees();
@@ -97,6 +98,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	InitializeDockGui();
 	InitializeGraphGui();
 	InitializeObjectGui();
+	InitializeTownGui();
 	InitializeAIGui();
 	InitializeTrees();
 	InitializeIndustries();

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -2494,6 +2494,7 @@ public:
 	/** Widgets of the #TownAuthorityWindow class. */
 	enum TownAuthorityWidgets {
 		WID_TA_CAPTION                               = ::WID_TA_CAPTION,                               ///< Caption of window.
+		WID_TA_ZONE_BUTTON                           = ::WID_TA_ZONE_BUTTON,                           ///< Turn on/off showing local authority zone.
 		WID_TA_RATING_INFO                           = ::WID_TA_RATING_INFO,                           ///< Overview with ratings for each company.
 		WID_TA_COMMAND_LIST                          = ::WID_TA_COMMAND_LIST,                          ///< List of commands for the player.
 		WID_TA_SCROLLBAR                             = ::WID_TA_SCROLLBAR,                             ///< Scrollbar of the list of commands.

--- a/src/town.h
+++ b/src/town.h
@@ -101,6 +101,8 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	bool larger_town;                ///< if this is a larger town and should grow more quickly
 	TownLayout layout;               ///< town specific road layout
 
+	bool show_zone;                  ///< NOSAVE: mark town to show the local authority zone in the viewports
+
 	std::list<PersistentStorage *> psa_list;
 
 	/**

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1746,6 +1746,7 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32 townnameparts, TownSize
 	 * similar towns they're unlikely to grow all in one tick */
 	t->grow_counter = t->index % TOWN_GROWTH_TICKS;
 	t->growth_rate = TownTicksToGameTicks(250);
+	t->show_zone = false;
 
 	_town_kdtree.Insert(t->index);
 

--- a/src/town_kdtree.h
+++ b/src/town_kdtree.h
@@ -15,6 +15,8 @@
 
 inline uint16 Kdtree_TownXYFunc(TownID tid, int dim) { return (dim == 0) ? TileX(Town::Get(tid)->xy) : TileY(Town::Get(tid)->xy); }
 typedef Kdtree<TownID, decltype(&Kdtree_TownXYFunc), uint16, int> TownKdtree;
+
 extern TownKdtree _town_kdtree;
+extern TownKdtree _town_local_authority_kdtree;
 
 #endif

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -24,6 +24,7 @@ enum TownDirectoryWidgets {
 /** Widgets of the #TownAuthorityWindow class. */
 enum TownAuthorityWidgets {
 	WID_TA_CAPTION,      ///< Caption of window.
+	WID_TA_ZONE_BUTTON,  ///< Turn on/off showing local authority zone.
 	WID_TA_RATING_INFO,  ///< Overview with ratings for each company.
 	WID_TA_COMMAND_LIST, ///< List of commands for the player.
 	WID_TA_SCROLLBAR,    ///< Scrollbar of the list of commands.


### PR DESCRIPTION
Can be found at town information > local authority window
Layout for button is same as Graph Keys
Turn on/off for every town individually