### PR TITLE
Add: Mexican Peso currency

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -63,6 +63,7 @@ static const CurrencySpec origin_currency_specs[CURRENCY_END] = {
 	{    3, "", CF_NOEURO, "",             NBSP "GEL",       1, STR_GAME_OPTIONS_CURRENCY_GEL    }, ///< Georgian Lari
 	{ 4901, "", CF_NOEURO, "",             NBSP "Rls",       1, STR_GAME_OPTIONS_CURRENCY_IRR    }, ///< Iranian Rial
 	{   80, "", CF_NOEURO, "",             NBSP "rub",       1, STR_GAME_OPTIONS_CURRENCY_RUB    }, ///< New Russian Ruble
+	{   24, "", CF_NOEURO, "$",            "",               0, STR_GAME_OPTIONS_CURRENCY_MXN    }, ///< Mexican peso
 };
 
 /** Array of currencies used by the system */

--- a/src/currency.h
+++ b/src/currency.h
@@ -59,6 +59,7 @@ enum Currencies {
 	CURRENCY_GEL,       ///< Georgian Lari
 	CURRENCY_IRR,       ///< Iranian Rial
 	CURRENCY_RUB,       ///< New Russian Ruble
+	CURRENCY_MXN,       ///< Mexican Peso
 	CURRENCY_END,       ///< always the last item
 };
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -930,6 +930,7 @@ STR_GAME_OPTIONS_CURRENCY_CUSTOM                                :Custom...
 STR_GAME_OPTIONS_CURRENCY_GEL                                   :Georgian Lari (GEL)
 STR_GAME_OPTIONS_CURRENCY_IRR                                   :Iranian Rial (IRR)
 STR_GAME_OPTIONS_CURRENCY_RUB                                   :New Russian Ruble (RUB)
+STR_GAME_OPTIONS_CURRENCY_MXN                                   :Mexican Peso (MXN)
 ############ end of currency region
 
 STR_GAME_OPTIONS_ROAD_VEHICLES_FRAME                            :{BLACK}Road vehicles


### PR DESCRIPTION
OpenTTD doesn't have any pesos, so I've added Mexican pesos,
at its current exchange rate: £1 = 24.39MXN, rounded to 24.