### PR TITLE
Fix: Replace duplicate town name "Huacho"

### DIFF
--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -662,7 +662,7 @@ static const char * const _name_spanish_real[] = {
 	"Santa Cruz",
 	"Quito",
 	"Cuenca",
-	"Huacho",
+	"Medell\xC3\xADn",
 	"Tulc\xC3\xA1n",
 	"Esmeraldas",
 	"Ibarra",


### PR DESCRIPTION
Huacho appears twice in the Spanish town names list. This change removes
the second one.

This will have the effect of altering many town names in any older
savegame using Latin American town names. I think that's an
acceptable side effect for a new OpenTTD release, but if you have a
better solution let me know. Maybe some type of null "Dummy" value here?