### PR TITLE
Fix: Round up deltas for smooth scrolling, so that target will eventually be reached

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -346,6 +346,23 @@ static inline int RoundDivSU(int a, uint b)
 	}
 }
 
+/**
+ * Computes (a / b) rounded away from zero.
+ * @param a Numerator
+ * @param b Denominator
+ * @return Quotient, rounded away from zero
+ */
+static inline int DivAwayFromZero(int a, uint b)
+{
+	const int _b = static_cast<int>(b);
+	if (a > 0) {
+		return (a + _b - 1) / _b;
+	} else {
+		/* Note: Behaviour of negative numerator division is truncation toward zero. */
+		return (a - _b + 1) / _b;
+	}
+}
+
 uint32 IntSqrt(uint32 num);
 
 #endif /* MATH_FUNC_HPP */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1813,8 +1813,8 @@ void UpdateViewportPosition(Window *w)
 			if (_settings_client.gui.smooth_scroll) {
 				int max_scroll = ScaleByMapSize1D(512 * ZOOM_LVL_BASE);
 				/* Not at our desired position yet... */
-				w->viewport->scrollpos_x += Clamp(delta_x / 4, -max_scroll, max_scroll);
-				w->viewport->scrollpos_y += Clamp(delta_y / 4, -max_scroll, max_scroll);
+				w->viewport->scrollpos_x += Clamp(DivAwayFromZero(delta_x, 4), -max_scroll, max_scroll);
+				w->viewport->scrollpos_y += Clamp(DivAwayFromZero(delta_y, 4), -max_scroll, max_scroll);
 			} else {
 				w->viewport->scrollpos_x = w->viewport->dest_scrollpos_x;
 				w->viewport->scrollpos_y = w->viewport->dest_scrollpos_y;


### PR DESCRIPTION
When smooth scrolling is enabled, the original code rounds the deltas toward zero.  This means that the scroll position will never actually reach the destination scroll position (when the difference is 3, there will be no more scrolling in the original code).  Rounding away from zero fixes this problem.

This bug also causes the cargo flow legend overlay to not be redrawn when smooth scrolling is enabled, because variable `update_overlay` in function `UpdateViewportPosition` never becomes `true`.

To observe the bug in the original code:
1) Enable smooth scrolling in the settings.
2) Zoom to the default zoom level.
3) Open a station window by clicking on a station.
4) Scroll the viewport to somewhere else.
5) Click the "Location" button on the station window.
6) Wait until the scrolling stops.
7) Disable smooth scrolling in the settings.
8) Click the "Location" button.  **Observe that the screen moves slightly despite supposedly already being scrolled to the station.**