### PR TITLE
Add #6887: Highlight tiles within local authority of towns

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3075,6 +3075,8 @@ STR_TOWN_VIEW_RENAME_TOWN_BUTTON                                :Rename Town
 
 # Town local authority window
 STR_LOCAL_AUTHORITY_CAPTION                                     :{WHITE}{TOWN} local authority
+STR_LOCAL_AUTHORITY_ZONE                                        :{BLACK}Zone
+STR_LOCAL_AUTHORITY_ZONE_TOOLTIP                                :{BLACK}Show zone within local authority boundaries
 STR_LOCAL_AUTHORITY_COMPANY_RATINGS                             :{BLACK}Transport company ratings:
 STR_LOCAL_AUTHORITY_COMPANY_RATING                              :{YELLOW}{COMPANY} {COMPANY_NUM}: {ORANGE}{STRING}
 STR_LOCAL_AUTHORITY_ACTIONS_TITLE                               :{BLACK}Actions available:

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -31,6 +31,7 @@ uint _map_tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
 Tile *_m = NULL;          ///< Tiles of the map
 TileExtended *_me = NULL; ///< Extended Tiles of the map
+TileCache *_mc = NULL;    ///< Caches Tiles of the map
 
 
 /**
@@ -60,9 +61,11 @@ void AllocateMap(uint size_x, uint size_y)
 
 	free(_m);
 	free(_me);
+	free(_mc);
 
 	_m = CallocT<Tile>(_map_size);
 	_me = CallocT<TileExtended>(_map_size);
+	_mc = CallocT<TileCache>(_map_size);
 }
 
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -43,6 +43,14 @@ extern Tile *_m;
  */
 extern TileExtended *_me;
 
+/**
+ * Pointer to the cache tile-array.
+ *
+ * This variable points to the cache tile-array which contains
+ * cached information on the tiles of the map.
+ */
+extern TileCache *_mc;
+
 void AllocateMap(uint size_x, uint size_y);
 
 /**

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -43,7 +43,7 @@ struct TileExtended {
  * Data is not stored in save files.
  */
 struct TileCache {
-	byte c1;   ///< bit 0-7: free
+	byte c1;   ///< bit 0: town authority; bit 1-7: free
 };
 
 assert_compile(sizeof(TileCache) == 1);

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -39,6 +39,16 @@ struct TileExtended {
 };
 
 /**
+ * Data cache that is stored per tile.
+ * Data is not stored in save files.
+ */
+struct TileCache {
+	byte c1;   ///< bit 0-7: free
+};
+
+assert_compile(sizeof(TileCache) == 1);
+
+/**
  * An offset value between to tiles.
  *
  * This value is used for the difference between

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -2473,6 +2473,7 @@ public:
 	/** Widgets of the #TownAuthorityWindow class. */
 	enum TownAuthorityWidgets {
 		WID_TA_CAPTION                               = ::WID_TA_CAPTION,                               ///< Caption of window.
+		WID_TA_ZONE_BUTTON                           = ::WID_TA_ZONE_BUTTON,                           ///< Turn on/off showing local authority zone.
 		WID_TA_RATING_INFO                           = ::WID_TA_RATING_INFO,                           ///< Overview with ratings for each company.
 		WID_TA_COMMAND_LIST                          = ::WID_TA_COMMAND_LIST,                          ///< List of commands for the player.
 		WID_TA_SCROLLBAR                             = ::WID_TA_SCROLLBAR,                             ///< Scrollbar of the list of commands.

--- a/src/town.h
+++ b/src/town.h
@@ -100,6 +100,8 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	bool larger_town;              ///< if this is a larger town and should grow more quickly
 	TownLayoutByte layout;         ///< town specific road layout
 
+	bool show_zone;                ///< mark town to show the local authority zone in the viewports
+
 	std::list<PersistentStorage *> psa_list;
 
 	/**
@@ -179,7 +181,7 @@ Town *CalcClosestTownFromTile(TileIndex tile, uint threshold = UINT_MAX);
 #define FOR_ALL_TOWNS(var) FOR_ALL_TOWNS_FROM(var, 0)
 
 void ResetHouses();
-
+void ToggleTownZoneDisplay(Town *t);
 void ClearTownHouse(Town *t, TileIndex tile);
 void UpdateTownMaxPass(Town *t);
 void UpdateTownRadius(Town *t);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1601,6 +1601,7 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32 townnameparts, TownSize
 	 * similar towns they're unlikely to grow all in one tick */
 	t->grow_counter = t->index % TOWN_GROWTH_TICKS;
 	t->growth_rate = TownTicksToGameTicks(250);
+	t->show_zone = false;
 
 	/* Set the default cargo requirement for town growth */
 	switch (_settings_game.game_creation.landscape) {
@@ -3558,4 +3559,25 @@ void ResetHouses()
 
 	/* Reset any overrides that have been set. */
 	_house_mngr.ResetOverride();
+}
+
+/**
+ * Checks all tiles within local autority and turn highlighting on/off for tiles belinging to the town.
+ * @param *town town selected to turn on/off the zone display
+ */
+void ToggleTownZoneDisplay(Town *town)
+{
+	int max_dist = _settings_game.economy.dist_local_authority;
+	bool new_show_state = !town->show_zone;
+	town->show_zone = new_show_state;
+
+	for (int dx = -max_dist; dx <= max_dist; dx++) {
+		int max_y = Delta(max_dist, dx);
+		for (int dy = -max_y; dy <= max_y; dy++) {
+			TileIndex t = TileAddWrap(town->xy, dx, dy);
+			if (t != INVALID_TILE) {
+				if (CalcClosestTownFromTile(t, max_dist) == town) SetTownZoneTileHighlight(t, new_show_state);
+			}
+		}
+	}
 }

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -45,6 +45,7 @@ static const NWidgetPart _nested_town_authority_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_TA_CAPTION), SetDataTip(STR_LOCAL_AUTHORITY_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_TEXTBTN, COLOUR_BROWN, WID_TA_ZONE_BUTTON), SetMinimalSize(50, 0), SetMinimalTextLines(1, WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM + 2), SetDataTip(STR_LOCAL_AUTHORITY_ZONE, STR_LOCAL_AUTHORITY_ZONE_TOOLTIP),
 		NWidget(WWT_SHADEBOX, COLOUR_BROWN),
 		NWidget(WWT_DEFSIZEBOX, COLOUR_BROWN),
 		NWidget(WWT_STICKYBOX, COLOUR_BROWN),
@@ -112,6 +113,7 @@ public:
 			this->sel_index = -1;
 		}
 
+		this->SetWidgetLoweredState(WID_TA_ZONE_BUTTON, this->town->show_zone);
 		this->SetWidgetDisabledState(WID_TA_EXECUTE, this->sel_index == -1);
 
 		this->DrawWidgets();
@@ -258,6 +260,12 @@ public:
 	virtual void OnClick(Point pt, int widget, int click_count)
 	{
 		switch (widget) {
+			case WID_TA_ZONE_BUTTON:
+				ToggleTownZoneDisplay(this->town);
+				this->SetWidgetLoweredState(widget, this->town->show_zone);
+				MarkWholeScreenDirty();
+				break;
+
 			case WID_TA_COMMAND_LIST: {
 				int y = this->GetRowFromWidget(pt.y, WID_TA_COMMAND_LIST, 1, FONT_HEIGHT_NORMAL);
 				if (!IsInsideMM(y, 0, 5)) return;

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -366,4 +366,24 @@ static inline void MakeHouseTile(TileIndex t, TownID tid, byte counter, byte sta
 	SetHouseProcessingTime(t, HouseSpec::Get(type)->processing_time);
 }
 
+/**
+ * Sets the highligh status of the tile indicating town authority.
+ * @param t tile index within the local authority boundary of a town
+ * @param state bool whether the higlight is set for the tile
+ * @note the intended use is purely visual, not game logic related
+ */
+static inline void SetTownZoneTileHighlight(TileIndex t, bool status)
+{
+	SB(_mc[t].c1, 0, 1, status);
+}
+
+/**
+ * Gets the highligh status of the tile indicating town authority.
+ * @param t any valid tile index
+ */
+static inline bool GetTownZoneTileHighlight(TileIndex t)
+{
+	return GB(_mc[t].c1, 0, 1);
+}
+
 #endif /* TOWN_MAP_H */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1009,11 +1009,41 @@ static void DrawAutorailSelection(const TileInfo *ti, uint autorail_type)
 }
 
 /**
+ * Checks if the specified tile should be highlghted as a tile within town authority
+ * @param tile tile index to be checked
+ */
+static bool TileInActiveTownZone(TileIndex tile)
+{
+	Town *town;
+
+	/* Check tiles where town ownership is possible */
+	switch (GetTileType(tile)) {
+		case MP_ROAD:
+			if (IsRoadDepot(tile) || !HasTownOwnedRoad(tile)) break;
+			FALLTHROUGH;
+
+		case MP_HOUSE:
+			town = Town::GetByTile(tile);
+			return town->show_zone;
+
+		default: break;
+	}
+
+	/* If not owned by town check map for saved indicaton */
+	return GetTownZoneTileHighlight(tile);
+}
+
+/**
  * Checks if the specified tile is selected and if so draws selection using correct selectionstyle.
  * @param *ti TileInfo Tile that is being drawn
  */
 static void DrawTileSelection(const TileInfo *ti)
 {
+	/* Show local authority zone of towns. */
+	if (TileInActiveTownZone(ti->tile)) {
+		DrawTileSelectionRect(ti, PALETTE_CRASH);
+	}
+
 	/* Draw a red error square? */
 	bool is_redsq = _thd.redsq == ti->tile;
 	if (is_redsq) DrawTileSelectionRect(ti, PALETTE_TILE_RED_PULSATING);

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -24,6 +24,7 @@ enum TownDirectoryWidgets {
 /** Widgets of the #TownAuthorityWindow class. */
 enum TownAuthorityWidgets {
 	WID_TA_CAPTION,      ///< Caption of window.
+	WID_TA_ZONE_BUTTON,  ///< Turn on/off showing local authority zone.
 	WID_TA_RATING_INFO,  ///< Overview with ratings for each company.
 	WID_TA_COMMAND_LIST, ///< List of commands for the player.
 	WID_TA_SCROLLBAR,    ///< Scrollbar of the list of commands.


### PR DESCRIPTION
Reworked version of [Add #6887: Option to show zone inside local authority boundary of towns #7025](https://github.com/OpenTTD/OpenTTD/pull/7025)
Caching the information on which tiles to highlight instead of calculating it on every redraw.
Currently using the first bit of _me.m8 to show a proof of concept, I can move it to a separate cache if this caching approach is better than the recalculating approach.