### PR TITLE
Fix: grammar in a bunch of comments

### DIFF
--- a/src/core/random_func.hpp
+++ b/src/core/random_func.hpp
@@ -29,7 +29,7 @@ struct Randomizer {
 	void SetSeed(uint32 seed);
 };
 extern Randomizer _random; ///< Random used in the game state calculations
-extern Randomizer _interactive_random; ///< Random used every else where is does not (directly) influence the game state
+extern Randomizer _interactive_random; ///< Random used everywhere else, where it does not (directly) influence the game state
 
 /** Stores the state of all random number generators */
 struct SavedRandomSeeds {

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -132,9 +132,9 @@ static inline void SetTileType(TileIndex tile, TileType type)
 }
 
 /**
- * Checks if a tile is a give tiletype.
+ * Checks if a tile is a given tiletype.
  *
- * This function checks if a tile got the given tiletype.
+ * This function checks if a tile has the given tiletype.
  *
  * @param tile The tile to check
  * @param type The type to check against

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -54,7 +54,7 @@ enum Ratings {
 	RATING_GROWTH_UP_STEP    =   5, ///< when a town grows, all companies have rating increased a bit ...
 	RATING_GROWTH_MAXIMUM    = RATING_MEDIOCRE, ///< ... up to RATING_MEDIOCRE
 	RATING_STATION_UP_STEP   =  12, ///< when a town grows, company gains reputation for all well serviced stations ...
-	RATING_STATION_DOWN_STEP = -15, ///< ... but loses for bad serviced stations
+	RATING_STATION_DOWN_STEP = -15, ///< ... but loses for badly serviced stations
 
 	RATING_TUNNEL_BRIDGE_DOWN_STEP = -250, ///< penalty for removing town owned tunnel or bridge
 	RATING_TUNNEL_BRIDGE_MINIMUM   =    0, ///< minimum rating after removing tunnel or bridge

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -121,17 +121,17 @@ bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names)
  */
 bool GenerateTownName(uint32 *townnameparts, TownNames *town_names)
 {
-	/* Do not set too low tries, since when we run out of names, we loop
-	 * for #tries only one time anyway - then we stop generating more
-	 * towns. Do not show it too high neither, since looping through all
-	 * the other towns may take considerable amount of time (10000 is
-	 * too much). */
 	TownNameParams par(_settings_game.game_creation.town_name);
 
 	/* This function is called very often without entering the gameloop
 	 * inbetween. So reset layout cache to prevent it from growing too big. */
 	Layouter::ReduceLineCache();
 
+	/* Do not set i too low, since when we run out of names, we loop
+	 * for #tries only one time anyway - then we stop generating more
+	 * towns. Do not set it too high either, since looping through all
+	 * the other towns may take considerable amount of time (10000 is
+	 * too much). */
 	for (int i = 1000; i != 0; i--) {
 		uint32 r = _generating_world ? Random() : InteractiveRandom();
 		if (!VerifyTownName(r, &par, town_names)) continue;
@@ -1045,7 +1045,7 @@ static const TownNameGeneratorParams _town_name_generators[] = {
 
 
 /**
- * Generates town name from given seed. a language.
+ * Generates town name from given seed.
  * @param buf output buffer
  * @param last end of buffer
  * @param lang town name language

--- a/src/townname_type.h
+++ b/src/townname_type.h
@@ -23,7 +23,7 @@
 typedef std::set<std::string> TownNames;
 
 /**
- * Struct holding a parameters used to generate town name.
+ * Struct holding parameters used to generate town name.
  * Speeds things up a bit because these values are computed only once per name generation.
  */
 struct TownNameParams {


### PR DESCRIPTION
I found a bunch of minor grammar problems when reading the town name
generation code related to #7037.