### PR TITLE
Change #6060: Allow drawing dropdown lists with scrollbars above and fix scrolling movement

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -407,7 +407,12 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 
 	Point dw_pos = { w->left + (_current_text_dir == TD_RTL ? wi_rect.right + 1 - (int)width : wi_rect.left), top};
 	Dimension dw_size = {width, height};
-	new DropdownWindow(w, list, selected, button, instant_close, dw_pos, dw_size, wi_colour, scroll);
+	DropdownWindow *dropdown = new DropdownWindow(w, list, selected, button, instant_close, dw_pos, dw_size, wi_colour, scroll);
+
+	/* The dropdown starts scrolling downwards when opening it towards
+	 * the top and holding down the mouse button. It can be fooled by
+	 * opening the dropdown scrolled to the very bottom.  */
+	if (above && scroll) dropdown->vscroll->UpdatePosition(INT_MAX);
 }
 
 /**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3516,8 +3516,9 @@ void ChangeVehicleViewports(VehicleID from_index, VehicleID to_index)
  */
 void RelocateAllWindows(int neww, int newh)
 {
-	Window *w;
+	DeleteWindowById(WC_DROPDOWN_MENU, 0);
 
+	Window *w;
 	FOR_ALL_WINDOWS_FROM_BACK(w) {
 		int left, top;
 		/* XXX - this probably needs something more sane. For example specifying


### PR DESCRIPTION
Rewrite of the code for choosing where to open a dropdown.

With this patch, dropdown can be created above the opening widget and with scrollbar enabled.

In case of opening above and with scrollbar, list is moved to show the last items. Otherwise, if mouse button is held down, it starts scrolling down without moving the mouse.