### PR TITLE
Change: Make ships stop and change direction slowly instead of instantly turning.

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -273,8 +273,9 @@
  *  201   #6885   Extend NewGRF persistant storages.
  *  202   #6867   Increase industry cargo slots to 16 in, 16 out
  *  203   #7072   Add path cache for ships
+ *  204   #7065   Add extra rotation stages for ships.
  */
-extern const uint16 SAVEGAME_VERSION = 203; ///< Current savegame version of OpenTTD.
+extern const uint16 SAVEGAME_VERSION = 204; ///< Current savegame version of OpenTTD.
 
 SavegameType _savegame_type; ///< type of savegame we are loading
 FileToSaveLoad _file_to_saveload; ///< File to save or load in the openttd loop.

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -368,6 +368,14 @@ void AfterLoadVehicles(bool part_of_load)
 				v->SetServiceIntervalIsPercent(c->settings.vehicle.servint_ispercent);
 			}
 		}
+
+		if (IsSavegameVersionBefore(204)) {
+			/* Ship rotation added */
+			Ship *s;
+			FOR_ALL_SHIPS(s) {
+				s->rotation = s->direction;
+			}
+		}
 	}
 
 	CheckValidVehicles();
@@ -753,8 +761,9 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	static const SaveLoad _ship_desc[] = {
 		SLE_WRITEBYTE(Vehicle, type, VEH_SHIP),
 		SLE_VEH_INCLUDE(),
-		      SLE_VAR(Ship, state,     SLE_UINT8),
-		SLE_CONDDEQUE(Ship, path,      SLE_UINT8,  203, SL_MAX_VERSION),
+		      SLE_VAR(Ship, state,                     SLE_UINT8),
+		SLE_CONDDEQUE(Ship, path,                      SLE_UINT8,                  203, SL_MAX_VERSION),
+		  SLE_CONDVAR(Ship, rotation,                  SLE_UINT8,                  204, SL_MAX_VERSION),
 
 		SLE_CONDNULL(16, 2, 143), // old reserved space
 

--- a/src/ship.h
+++ b/src/ship.h
@@ -26,8 +26,9 @@ typedef std::deque<TrackdirByte> ShipPathCache;
  * All ships have this type.
  */
 struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
-	TrackBitsByte state; ///< The "track" the ship is following.
-	ShipPathCache path;  ///< Cached path.
+	TrackBitsByte state;    ///< The "track" the ship is following.
+	ShipPathCache path;     ///< Cached path.
+	DirectionByte rotation; ///< Visible direction.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Ship() : SpecializedVehicleBase() {}


### PR DESCRIPTION
With this patch, ships will now take up to 8 game ticks to make tight turns, which improves their appearance a bit. This is mostly visible when a ship is turning around at a dock.