### PR TITLE
Add: smart town name first steps - #7037

### DIFF
--- a/src/townname_func.h
+++ b/src/townname_func.h
@@ -19,5 +19,6 @@ char *GetTownName(char *buff, const TownNameParams *par, uint32 townnameparts, c
 char *GetTownName(char *buff, const Town *t, const char *last);
 bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names = NULL);
 bool GenerateTownName(uint32 *townnameparts, TownNames *town_names = NULL);
+bool GenerateTownName(uint32 *townnameparts, uint site_location_bits, TownNames *town_names = NULL);
 
 #endif /* TOWNNAME_FUNC_H */

--- a/src/townname_type.h
+++ b/src/townname_type.h
@@ -45,4 +45,10 @@ struct TownNameParams {
 	TownNameParams(const Town *t);
 };
 
+/**
+ * Town name features are used to map a tile's geographical features
+ * to appropriate town names.
+ */
+const uint TOWNNAME_FEATURE_CLOSE_TO_WATER = 1;
+
 #endif /* TOWNNAME_TYPE_H */


### PR DESCRIPTION
This adds structure for some basic town naming rules based on location.

When towns are generated, a mask is read for the random name, to see if
it's a suitable name for this town tile. Currently it just prevents
towns from being named with "Puerto" or "havn" if they're not near the
water, and will only do anything on Latin-American, Danish, or Norwegian
town names.