### PR TITLE
Feature: Generate lock ready rivers upon world generation

### DIFF
--- a/src/water.h
+++ b/src/water.h
@@ -42,6 +42,9 @@ void MakeWaterKeepingClass(TileIndex tile, Owner o);
 bool RiverModifyDesertZone(TileIndex tile, void *data);
 static const uint RIVER_OFFSET_DESERT_DISTANCE = 5; ///< Circular tile search radius to create non-desert around a river tile.
 
+bool IsPossibleLockLocation(TileIndex tile);
+bool IsPossibleLockLocationOnDiagDir(TileIndex tile, DiagDirection dir);
+
 bool IsWateredTile(TileIndex tile, Direction from);
 
 /**

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -239,6 +239,30 @@ static CommandCost RemoveShipDepot(TileIndex tile, DoCommandFlag flags)
 	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_CLEAR_DEPOT_SHIP]);
 }
 
+bool IsPossibleLockLocation(TileIndex tile)
+{
+	DiagDirection dir = GetInclinedSlopeDirection(GetTileSlope(tile));
+	if (!IsValidDiagDirection(dir)) return false;
+
+	TileIndexDiff delta_mid = TileOffsByDiagDir(dir);
+	if (!IsTileFlat(tile + delta_mid)) return false;
+	if (!IsTileFlat(tile - delta_mid)) return false;
+
+	return true;
+}
+
+/**
+ * Tests whether a tile is suitable for a lock for the provided diagonal direction (axis).
+ * @param tile The middle tile of a lock.
+ * @param dir Any diagonal direction belonging to the same axis.
+ * @return true if a lock can be placed in the given direction.
+ */
+bool IsPossibleLockLocationOnDiagDir(TileIndex tile, DiagDirection dir)
+{
+	DiagDirection tdir = GetInclinedSlopeDirection(GetTileSlope(tile));
+	return (tdir == dir || tdir == ReverseDiagDir(dir)) && IsPossibleLockLocation(tile);
+}
+
 /**
  * Builds a lock.
  * @param tile Central tile of the lock.


### PR DESCRIPTION
This patch is intended to ease water construction, especially locks on rivers. The changes might be too subtle to notice, but I think they're helpful if you're familiar to the constraints of water-based transportation inland.

With this patch applied, and while on map generation, rivers are generated in a way that facilitate construction of locks on river rapids. It assures that the river source can be connected to its mouth, without the need to terraform land for locks. The player only needs to place locks on rapid tiles to connect each lock to the rest of the stream. In this manner, as long as ships can make 90 degree turns, ships can traverse the entire river.

~~Other features:~~
~~- Towns will not build bridges over rivers if a lock could be built under it, while growing during a game and/or during map generation.~~
Posted as separate: https://github.com/OpenTTD/OpenTTD/pull/7195

https://www.tt-forums.net/viewtopic.php?f=33&t=76075