### PR TITLE
Fix: [AzurePipelines] the repository OpenTTD-CF is renamed to CompileFarm

### DIFF
--- a/azure-pipelines/templates/windows-dependencies.yml
+++ b/azure-pipelines/templates/windows-dependencies.yml
@@ -1,7 +1,7 @@
 steps:
 - bash: |
     set -ex
-    curl -L https://github.com/OpenTTD/OpenTTD-CF/releases/download/latest/windows-dependencies.zip > windows-dependencies.zip
+    curl -L https://github.com/OpenTTD/CompileFarm/releases/download/latest/windows-dependencies.zip > windows-dependencies.zip
     unzip windows-dependencies.zip
     rm -f windows-dependencies.zip
   displayName: 'Download dependencies'


### PR DESCRIPTION
This is not an issue yet, as GitHub redirects the URL for a long period of time. But it is better to already fix it.