### PR TITLE
Cleanup #6960: Remove parts of generate used only for MSVC pre-2015.

### DIFF
--- a/projects/generate
+++ b/projects/generate
@@ -124,17 +124,7 @@ load_main_data() {
 				gsub("	", "", $0);
 				gsub("^#", "", $0);
 				gsub("^ ", "", $0);
-
-				if (first_time != 0) {
-					print "#1		</Filter>";
-				} else {
-					first_time = 1;
-				}
-
 				filter = $0;
-				print "#1		<Filter";
-				print "#1			Name=\\""filter"\\"";
-				print "#1			>";
 				print "#3    <Filter Include=\\""filter"\\">";
 				printf "#3      <UniqueIdentifier>{c76ff9f1-1e62-46d8-8d55-%012d}</UniqueIdentifier>\n", i;
 				print "#3    </Filter>";
@@ -148,10 +138,6 @@ load_main_data() {
 			if (deep == skip) {
 				gsub("	", "", $0);
 				gsub("/", "\\\\", $0);
-				print "#1			<File";
-				print "#1				RelativePath=\\".\\\\'$file_prefix'"$0"\\"";
-				print "#1				>";
-				print "#1			</File>";
 				split($0, file, ".");
 				cltype = "ClInclude"
 				if (file[2] == "cpp") cltype = "ClCompile";
@@ -162,7 +148,6 @@ load_main_data() {
 				print "#4    </"cltype">";
 			}
 		}
-		END { print "#1		</Filter>"; }
 	'`"
 
 	eval "$2=\"\$RES\""
@@ -180,21 +165,6 @@ load_lang_data() {
 			continue
 		fi
 		RES="$RES
-#1			<File
-#1				RelativePath=\"..\\src\\lang\\"$i".txt\"
-#1				>
-#1				<FileConfiguration
-#1					Name=\"Debug|Win32\"
-#1					>
-#1					<Tool
-#1						Name=\"VCCustomBuildTool\"
-#1						Description=\"Generating "$i" language file\"
-#1						CommandLine=\"..\\objs\\strgen\\strgen.exe -s ..\\src\\lang -d ..\\bin\\lang &quot;\$(InputPath)&quot;&#x0D;&#x0A;exit 0&#x0D;&#x0A;\"
-#1						AdditionalDependencies=\"..\\src\\lang\\english.txt;..\\objs\\strgen\\strgen.exe\"
-#1						Outputs=\"..\\bin\\lang\\"$i".lng\"
-#1					/>
-#1				</FileConfiguration>
-#1			</File>
 #2    <CustomBuild Include=\"..\\src\\lang\\"$i".txt\">
 #2      <Message Condition=\"'\$(Configuration)|\$(Platform)'=='Debug|Win32'\">Generating "$i" language file</Message>
 #2      <Command Condition=\"'\$(Configuration)|\$(Platform)'=='Debug|Win32'\">..\\objs\\strgen\\strgen.exe -s ..\\src\\lang -d ..\\bin\\lang \"%(FullPath)\"</Command>
@@ -217,10 +187,6 @@ load_settings_data() {
 	do
 		i=`basename $i`
 		RES="$RES
-#1		<File
-#1			RelativePath=\"..\\src\\table\\"$i"\"
-#1			>
-#1		</File>
 #2    <None Include=\"..\\src\\table\\"$i"\" />
 #4    <None Include=\"..\\src\\table\\"$i"\">
 #4      <Filter>INI</Filter>
@@ -287,18 +253,15 @@ load_main_data "$ROOT_DIR/source.list" openttd
 openttdfiles=`echo "$openttd" | grep "^#4" | sed "s~#4~~g"`
 openttdfilters=`echo "$openttd" | grep "^#3" | sed "s~#3~~g"`
 openttdvcxproj=`echo "$openttd" | grep "^#2" | sed "s~#2~~g"`
-openttd=`echo "$openttd" | grep "^#1" | sed "s~#1~~g"`
 
 load_lang_data "$ROOT_DIR/src/lang/*.txt" lang
 langfiles=`echo "$lang" | grep "^#3" | sed "s~#3~~g"`
 langvcxproj=`echo "$lang" | grep "^#2" | sed "s~#2~~g"`
-lang=`echo "$lang" | grep "^#1" | sed "s~#1~~g"`
 
 load_settings_data "$ROOT_DIR/src/table/*.ini" settings
 settingsfiles=`echo "$settings" | grep "^#4" | sed "s~#4~~g"`
 settingscommand=`echo "$settings" | grep "^#3" | sed "s~#3~~g"`
 settingsvcxproj=`echo "$settings" | grep "^#2" | sed "s~#2~~g"`
-settings=`echo "$settings" | grep "^#1" | sed "s~#1~~g"`
 
 generate "$openttdvcxproj" "openttd_vs140.vcxproj"
 generate "$openttdfiles" "openttd_vs140.vcxproj.filters" "$openttdfilters"

--- a/projects/generate.vbs
+++ b/projects/generate.vbs
@@ -140,9 +140,8 @@ Sub headers_check(filename, dir)
 	End If
 End Sub
 
-Function load_main_data(filename, ByRef vcxproj, ByRef filters, ByRef files)
-	Dim res, file, line, deep, skip, first_filter, first_file, filter, cltype, index
-	res = ""
+Sub load_main_data(filename, ByRef vcxproj, ByRef filters, ByRef files)
+	Dim file, line, deep, skip, first_filter, first_file, filter, cltype, index
 	index = 0
 	' Read the source.list and process it
 	Set file = FSO.OpenTextFile(filename, 1, 0, 0)
@@ -176,16 +175,11 @@ Function load_main_data(filename, ByRef vcxproj, ByRef filters, ByRef files)
 					if deep = skip Then
 						line = Replace(line, "# ", "")
 						if first_filter <> 0 Then
-							res = res & "		</Filter>" & vbCrLf
 							filters = filters & vbCrLf
 						Else
 							first_filter = 1
 						End If
 						filter = line
-						res = res & _
-						"		<Filter" & vbCrLf & _
-						"			Name=" & Chr(34) & filter & Chr(34) & vbCrLf & _
-						"			>" & vbCrLf
 						filters = filters & _
 						"    <Filter Include="& Chr(34) & filter & Chr(34) & ">" & vbCrLf & _
 						"      <UniqueIdentifier>{c76ff9f1-1e62-46d8-8d55-" & String(12 - Len(CStr(index)), "0") & index & "}</UniqueIdentifier>" & vbCrLf & _
@@ -201,11 +195,6 @@ Function load_main_data(filename, ByRef vcxproj, ByRef filters, ByRef files)
 						Else
 							first_file = 1
 						End If
-						res = res & _
-						"			<File" & vbCrLf & _
-						"				RelativePath=" & Chr(34) & ".\..\src\" & line & Chr(34) & vbCrLf & _
-						"				>" & vbCrLf & _
-						"			</File>" & vbCrLf
 						Select Case Split(Line, ".")(1)
 							Case "cpp"
 								cltype = "ClCompile"
@@ -223,42 +212,22 @@ Function load_main_data(filename, ByRef vcxproj, ByRef filters, ByRef files)
 			End Select
 		End If
 	Wend
-	res = res & "		</Filter>"
 	file.Close()
-	load_main_data = res
-End Function
+End Sub
 
-Function load_lang_data(dir, ByRef vcxproj, ByRef files)
-	Dim res, folder, file, first_time
-	res = ""
+Sub load_lang_data(dir, ByRef vcxproj, ByRef files)
+	Dim folder, file, first_time
 	Set folder = FSO.GetFolder(dir)
 	For Each file In folder.Files
 		file = FSO.GetFileName(file)
 		If file <> "english.txt" And FSO.GetExtensionName(file) = "txt" Then
 			file = Left(file, Len(file) - 4)
 			If first_time <> 0 Then
-				res = res & vbCrLf
 				vcxproj = vcxproj & vbCrLf
 				files = files & vbCrLf
 			Else
 				first_time = 1
 			End If
-			res = res & _
-			"			<File" & vbCrLf & _
-			"				RelativePath=" & Chr(34) & "..\src\lang\" & file & ".txt" & Chr(34) & vbCrLf & _
-			"				>" & vbCrLf & _
-			"				<FileConfiguration" & vbCrLf & _
-			"					Name=" & Chr(34) & "Debug|Win32" & Chr(34) & vbCrLf & _
-			"					>" & vbCrLf & _
-			"					<Tool" & vbCrLf & _
-			"						Name=" & Chr(34) & "VCCustomBuildTool" & Chr(34) & vbCrLf & _
-			"						Description=" & Chr(34) & "Generating " & file & " language file" & Chr(34) & vbCrLf & _
-			"						CommandLine=" & Chr(34) & "..\objs\strgen\strgen.exe -s ..\src\lang -d ..\bin\lang &quot;$(InputPath)&quot;&#x0D;&#x0A;exit 0&#x0D;&#x0A;" & Chr(34) & vbCrLf & _
-			"						AdditionalDependencies=" & Chr(34) & "..\src\lang\english.txt;..\objs\strgen\strgen.exe" & Chr(34) & vbCrLf & _
-			"						Outputs=" & Chr(34) & "..\bin\lang\" & file & ".lng" & Chr(34) & vbCrLf & _
-			"					/>" & vbCrLf & _
-			"				</FileConfiguration>" & vbCrLf & _
-			"			</File>"
 			vcxproj = vcxproj & _
 			"    <CustomBuild Include=" & Chr(34) & "..\src\lang\" & file & ".txt" & Chr(34) & ">" & vbCrLf & _
 			"      <Message Condition=" & Chr(34) & "'$(Configuration)|$(Platform)'=='Debug|Win32'" & Chr(34) & ">Generating " & file & " language file</Message>" & vbCrLf & _
@@ -272,29 +241,21 @@ Function load_lang_data(dir, ByRef vcxproj, ByRef files)
 			"    </CustomBuild>"
 		End If
 	Next
-	load_lang_data = res
-End Function
+End Sub
 
-Function load_settings_data(dir, ByRef vcxproj, ByRef command, ByRef files)
-	Dim res, folder, file, first_time
-	res = ""
+Sub load_settings_data(dir, ByRef vcxproj, ByRef command, ByRef files)
+	Dim folder, file, first_time
 	command = "..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble"
 	Set folder = FSO.GetFolder(dir)
 	For Each file In folder.Files
 		file = FSO.GetFileName(file)
 		If FSO.GetExtensionName(file) = "ini" Then
 			if first_time <> 0 Then
-				res = res & vbCrLf
 				vcxproj = vcxproj & vbCrLf
 				files = files & vbCrLf
 			Else
 				first_time = 1
 			End If
-			res = res & _
-			"		<File" & vbCrLf & _
-			"			RelativePath=" & Chr(34) & "..\src\table\" & file & Chr(34) & vbCrLf & _
-			"			>" & vbCrLf & _
-			"		</File>"
 			vcxproj = vcxproj & _
 			"    <None Include=" & Chr(34) & "..\src\table\" & file & Chr(34) & " />"
 			command = command & " ..\src\table\" & file
@@ -304,8 +265,7 @@ Function load_settings_data(dir, ByRef vcxproj, ByRef command, ByRef files)
 			"    </None>"
 		End If
 	Next
-	load_settings_data = res
-End Function
+End Sub
 
 Sub generate(data, dest, data2)
 	Dim srcfile, destfile, line
@@ -358,22 +318,22 @@ End If
 safety_check ROOT_DIR & "/source.list"
 headers_check ROOT_DIR & "/source.list", ROOT_DIR & "\src\" ' Backslashes needed for DoFiles
 
-Dim openttd, openttdvcxproj, openttdfilters, openttdfiles
-openttd = load_main_data(ROOT_DIR & "/source.list", openttdvcxproj, openttdfilters, openttdfiles)
+Dim openttdvcxproj, openttdfilters, openttdfiles
+load_main_data ROOT_DIR & "/source.list", openttdvcxproj, openttdfilters, openttdfiles
 generate openttdvcxproj, ROOT_DIR & "/projects/openttd_vs140.vcxproj", Null
 generate openttdfiles, ROOT_DIR & "/projects/openttd_vs140.vcxproj.filters", openttdfilters
 generate openttdvcxproj, ROOT_DIR & "/projects/openttd_vs141.vcxproj", Null
 generate openttdfiles, ROOT_DIR & "/projects/openttd_vs141.vcxproj.filters", openttdfilters
 
-Dim lang, langvcxproj, langfiles
-lang = load_lang_data(ROOT_DIR & "/src/lang", langvcxproj, langfiles)
+Dim langvcxproj, langfiles
+load_lang_data ROOT_DIR & "/src/lang", langvcxproj, langfiles
 generate langvcxproj, ROOT_DIR & "/projects/langs_vs140.vcxproj", Null
 generate langfiles, ROOT_DIR & "/projects/langs_vs140.vcxproj.filters", Null
 generate langvcxproj, ROOT_DIR & "/projects/langs_vs141.vcxproj", Null
 generate langfiles, ROOT_DIR & "/projects/langs_vs141.vcxproj.filters", Null
 
-Dim settings, settingsvcxproj, settingscommand, settingsfiles
-settings = load_settings_data(ROOT_DIR & "/src/table", settingsvcxproj, settingscommand, settingsfiles)
+Dim settingsvcxproj, settingscommand, settingsfiles
+load_settings_data ROOT_DIR & "/src/table", settingsvcxproj, settingscommand, settingsfiles
 generate settingsvcxproj, ROOT_DIR & "/projects/settings_vs140.vcxproj", settingscommand
 generate settingsfiles, ROOT_DIR & "/projects/settings_vs140.vcxproj.filters", Null
 generate settingsvcxproj, ROOT_DIR & "/projects/settings_vs141.vcxproj", settingscommand


### PR DESCRIPTION
#6960 removed support for MSVC pre-2015, but some of the dynamic parts were still being generated (and discarded) by generate/generate.vbs