### PR TITLE
Change: Cache stations and links for whole map for linkgraph GUI to eliminate delay when scrolling or zooming

### DIFF
--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -716,6 +716,7 @@
     <ClCompile Include="..\src\core\alloc_func.cpp" />
     <ClInclude Include="..\src\core\alloc_func.hpp" />
     <ClInclude Include="..\src\core\alloc_type.hpp" />
+    <ClInclude Include="..\src\core\areaquery_type.hpp" />
     <ClInclude Include="..\src\core\backup_type.hpp" />
     <ClCompile Include="..\src\core\bitmath_func.cpp" />
     <ClInclude Include="..\src\core\bitmath_func.hpp" />
@@ -725,6 +726,7 @@
     <ClCompile Include="..\src\core\geometry_func.cpp" />
     <ClInclude Include="..\src\core\geometry_func.hpp" />
     <ClInclude Include="..\src\core\geometry_type.hpp" />
+    <ClInclude Include="..\src\core\linearquery_type.hpp" />
     <ClCompile Include="..\src\core\math_func.cpp" />
     <ClInclude Include="..\src\core\math_func.hpp" />
     <ClInclude Include="..\src\core\mem_func.hpp" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -1236,6 +1236,9 @@
     <ClInclude Include="..\src\core\alloc_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\core\areaquery_type.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\core\backup_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
@@ -1261,6 +1264,9 @@
       <Filter>Core Source Code</Filter>
     </ClInclude>
     <ClInclude Include="..\src\core\geometry_type.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\core\linearquery_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
     <ClCompile Include="..\src\core\math_func.cpp">

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -716,6 +716,7 @@
     <ClCompile Include="..\src\core\alloc_func.cpp" />
     <ClInclude Include="..\src\core\alloc_func.hpp" />
     <ClInclude Include="..\src\core\alloc_type.hpp" />
+    <ClInclude Include="..\src\core\areaquery_type.hpp" />
     <ClInclude Include="..\src\core\backup_type.hpp" />
     <ClCompile Include="..\src\core\bitmath_func.cpp" />
     <ClInclude Include="..\src\core\bitmath_func.hpp" />
@@ -725,6 +726,7 @@
     <ClCompile Include="..\src\core\geometry_func.cpp" />
     <ClInclude Include="..\src\core\geometry_func.hpp" />
     <ClInclude Include="..\src\core\geometry_type.hpp" />
+    <ClInclude Include="..\src\core\linearquery_type.hpp" />
     <ClCompile Include="..\src\core\math_func.cpp" />
     <ClInclude Include="..\src\core\math_func.hpp" />
     <ClInclude Include="..\src\core\mem_func.hpp" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -1236,6 +1236,9 @@
     <ClInclude Include="..\src\core\alloc_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\core\areaquery_type.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\core\backup_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
@@ -1261,6 +1264,9 @@
       <Filter>Core Source Code</Filter>
     </ClInclude>
     <ClInclude Include="..\src\core\geometry_type.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\core\linearquery_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
     <ClCompile Include="..\src\core\math_func.cpp">

--- a/source.list
+++ b/source.list
@@ -424,6 +424,7 @@ video/cocoa/cocoa_v.h
 core/alloc_func.cpp
 core/alloc_func.hpp
 core/alloc_type.hpp
+core/areaquery_type.hpp
 core/backup_type.hpp
 core/bitmath_func.cpp
 core/bitmath_func.hpp
@@ -433,6 +434,7 @@ core/enum_type.hpp
 core/geometry_func.cpp
 core/geometry_func.hpp
 core/geometry_type.hpp
+core/linearquery_type.hpp
 core/math_func.cpp
 core/math_func.hpp
 core/mem_func.hpp

--- a/src/core/areaquery_type.hpp
+++ b/src/core/areaquery_type.hpp
@@ -1,0 +1,109 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file areaquery_type.hpp 2D segment tree class; O(1) insertion of area, O(K + R*C) retrieval of items within a given area (where K is the number of items in an area at most 4x the size of the given area, and R and C are the effective number of rows and columns being queried respectively). */
+
+#ifndef AREAQUERY_TYPE_HPP
+#define AREAQUERY_TYPE_HPP
+
+#include "linearquery_type.hpp"
+
+#include <memory>
+
+/**
+ * Area query template class.
+ *
+ * @note There are no asserts in the class so you have
+ *       to care about that you grab an item which is
+ *       inside the list.
+ *
+ * @tparam T The type of the items stored
+ */
+template <typename T>
+class AreaQueryTree {
+private:
+	SegmentTree<LinearQueryTree<T>> data;
+
+public:
+	AreaQueryTree() {}
+
+	/**
+	 * Constructs an empty area query tree with the given size.
+	 * @param height The height of the tree (expressed as a power of two).
+	 * @param width The width of the tree (expressed as a power of two).
+	 */
+	AreaQueryTree(uint8 height, uint8 width) : data(height)
+	{
+		this->data.ForEachElement([&](LinearQueryTree<T>& tree) {
+			tree.Resize(width);
+		});
+	}
+
+	/**
+	 * Clear all the data from the tree.  Note: It can be made faster by ensuring that the underlying vector capacity is left unchanged (because most of the time we would have exactly the same number of items in the vector afer rebuilding the cache).
+	 */
+	void Clear()
+	{
+		this->data.ForEachElement([](LinearQueryTree<T>& tree) {
+			tree.Clear();
+		});
+	}
+
+	/**
+	 * Resize the tree (may or may not preserve existing data).
+	 */
+	bool Resize(uint8 height, uint8 width)
+	{
+		if (this->data.Resize(height)) {
+			this->data.ForEachElement([&](LinearQueryTree<T>& tree) {
+				tree.Resize(width);
+			});
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Emplaces a new item into the area query tree, associated with a given rectangle.  O(1).
+	 * @param rect The rectangle associated with this item.
+	 * @param args Arguments to use to construct the new item in-place.
+	 */
+	template <typename ...TArgs>
+	T& Emplace(uint left, uint top, uint right, uint bottom, TArgs &&...args)
+	{
+		return this->data.Get(top, bottom).Emplace(left, right, std::forward<TArgs>(args)...);
+	}
+
+	/**
+	 * Calls the given callback once per item in the area query tree; invokes callback(T) once per item.  O(K + R*C).
+	 * @param rect The rectangle to query.
+	 * @param callback Callback to invoke once per item.
+	 */
+	template <typename TCallback>
+	void Query(uint left, uint top, uint right, uint bottom, TCallback callback)
+	{
+		this->data.Query(top, bottom, [&](LinearQueryTree<T>& tree) {
+			/* Note: Can optimize by calculating `first_set` and `depth` for the LinearQueryTree, because all our LinearQueryTrees use the same  `first_set` and `depth` arguments. */
+			tree.Query(left, right, callback);
+		});
+	}
+
+	template <typename TCallback>
+	void Query(uint left, uint top, uint right, uint bottom, TCallback callback) const
+	{
+		this->data.Query(top, bottom, [&](const LinearQueryTree<T>& tree) {
+			/* Note: Can optimize by calculating `first_set` and `depth` for the LinearQueryTree, because all our LinearQueryTrees use the same  `first_set` and `depth` arguments. */
+			tree.Query(left, right, callback);
+		});
+	}
+
+};
+
+
+#endif /* AREAQUERY_TYPE_HPP */

--- a/src/core/bitmath_func.cpp
+++ b/src/core/bitmath_func.cpp
@@ -66,7 +66,7 @@ uint8 FindFirstBit(uint32 x)
  */
 uint8 FindLastBit(uint64 x)
 {
-	if (x == 0) return 0;
+	if (x == 0) return static_cast<uint8>(-1);
 
 	uint8 pos = 0;
 

--- a/src/core/bitmath_func.cpp
+++ b/src/core/bitmath_func.cpp
@@ -79,3 +79,17 @@ uint8 FindLastBit(uint64 x)
 
 	return pos;
 }
+uint8 FindLastBit(uint32 x)
+{
+	if (x == 0) return static_cast<uint8>(-1);
+
+	uint8 pos = 0;
+
+	if ((x & 0xffff0000U) != 0) { x >>= 16; pos += 16; }
+	if ((x & 0x0000ff00U) != 0) { x >>= 8;  pos += 8; }
+	if ((x & 0x000000f0U) != 0) { x >>= 4;  pos += 4; }
+	if ((x & 0x0000000cU) != 0) { x >>= 2;  pos += 2; }
+	if ((x & 0x00000002U) != 0) { pos += 1; }
+
+	return pos;
+}

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -226,6 +226,13 @@ static inline uint8 FindFirstBit2x64(const int value)
 
 uint8 FindFirstBit(uint32 x);
 uint8 FindLastBit(uint64 x);
+uint8 FindLastBit(uint32 x);
+inline uint8 FindLastBit(int64 x) {
+	return FindLastBit(static_cast<uint64>(x));
+}
+inline uint8 FindLastBit(int32 x) {
+	return FindLastBit(static_cast<uint32>(x));
+}
 
 /**
  * Clear the first bit in an integer.

--- a/src/core/linearquery_type.hpp
+++ b/src/core/linearquery_type.hpp
@@ -1,0 +1,276 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file linearquery_type.hpp 1D segment tree class; O(1) insertion of area, O(K + L) retrieval of items within a given area (where K is the number of items in an area at most 2x the size of the given area, and L is the size of the subrange being queried respectively). */
+
+#ifndef LINEARQUERY_TYPE_HPP
+#define LINEARQUERY_TYPE_HPP
+
+#include "bitmath_func.hpp"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+/**
+ * Segment tree class that can do efficient enumeration of segments that intersect a given range.
+ * Note: In all functions, `end` is inclusive of that element itself, i.e. the range is [begin, end] and NOT [begin, end).
+ *
+ * @tparam T The type of the items stored
+ */
+template <typename T>
+class SegmentTree {
+private:
+	uint8 size;
+	std::unique_ptr<T[]> data; // data[1] is the full range, data[2-3] are the two half-ranges, data[4-7] are the four quarter-ranges, etc.
+	enum : uint8 {
+		INVALID_SIZE = static_cast<uint8>(-1)
+	};
+
+public:
+	SegmentTree() : size(INVALID_SIZE) {}
+	SegmentTree(const SegmentTree&) = delete;
+	SegmentTree& operator=(const SegmentTree&) = delete;
+	SegmentTree(SegmentTree&& other) : size(other.size), data(std::move(other.data))
+	{
+		other.size = INVALID_SIZE;
+		other.data = nullptr;
+	}
+	SegmentTree& operator=(SegmentTree&& other)
+	{
+		this->size = other.size;
+		this->data = std::move(other.data);
+		other.size = INVALID_SIZE;
+		other.data = nullptr;
+	}
+
+	/**
+	 * Constructs an segment tree with the given size.
+	 * @param size The size of the tree (expressed as a power of two, i.e. 2^(size) is the number of distinct positions in the line).
+	 */
+	SegmentTree(uint8 size) : size(size)
+	{
+		assert(this->size != INVALID_SIZE);
+		this->data = std::make_unique<T[]>(static_cast<std::size_t>(1) << (size + 1));
+	}
+
+	/**
+	 * Resizes the tree.
+	 * @param size The desired size.
+	 * @return True if the size was actually changed (if the size is unchanged, then existing data is guaranteed to be preserved).
+	 */
+	bool Resize(uint8 size)
+	{
+		assert(size != INVALID_SIZE);
+		if (this->size != size) {
+			this->data = std::make_unique<T[]>(static_cast<std::size_t>(1) << (size + 1));
+			this->size = size;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Invokes callback(T) for each element of the segment tree (in arbitrary order).
+	 */
+	template <typename TCallback>
+	void ForEachElement(TCallback callback) const
+	{
+		const uint real_size = (1u << (this->size + 1));
+		for (uint i = 1; i < real_size; ++i) {
+			assert(i > 0 && i < (1u << (this->size + 1)));
+			callback(this->data[i]);
+		}
+	}
+
+	/**
+	 * Resolves the index into the data array, associated with a given range.  O(1) assuming FindLastBit is O(1).
+	 * @param begin The start of the range.
+	 * @param end The end of the range.
+	 * @return The desired index into the data array.
+	 */
+	uint ResolveDataIndex(uint begin, uint end)
+	{
+		assert(this->size != INVALID_SIZE);
+		assert(begin <= end);
+		assert(end < (1u << this->size));
+
+		/* Find the position (from LSB) of the first bit that differs; this determines the depth of the chosen range. */
+		const uint8 first_set = FindLastBit(begin ^ end) + 1;
+
+		/* Find the depth in the tree, 1-based.  '1' means the full range, '2' means the half-range, etc. */
+		const uint8 depth = this->size - first_set;
+
+		/* Find the index into the data that is chosen to store this new item. */
+		const uint data_index = (1u << depth) + (begin >> first_set);
+
+		return data_index;
+	}
+
+	/**
+	 * Gets the element at that particular index.
+	 * @param data_index The index into the data array.
+	 * @return A reference to the element at that particular index.
+	 */
+	T& Get(uint data_index)
+	{
+		assert(this->size != INVALID_SIZE);
+		assert(data_index > 0 && data_index < (1u << (this->size + 1)));
+
+		return this->data[data_index];
+	}
+
+	/**
+	 * Gets the element associated with a given range.  O(1) assuming FindLastBit is O(1).
+	 * @param begin The start of the range.
+	 * @param end The end of the range.
+	 * @return A reference to the element at that particular index.
+	 */
+	T& Get(uint begin, uint end)
+	{
+		return Get(ResolveDataIndex(begin, end));
+	}
+
+	/**
+	 * Calls the given callback once per element in the segment tree; invokes callback(T) once per element.  O(K + L).
+	 * It might also call the callback on other random elements that are outside the range, so the caller should ascertain that each called element is indeed within the desired range.
+	 * @param begin The start of the range.
+	 * @param end The end of the range.
+	 * @param callback Callback to invoke once per element.
+	 */
+	template <typename TCallback>
+	void Query(uint begin, uint end, TCallback callback)
+	{
+		assert(this->size != INVALID_SIZE);
+		assert(begin <= end);
+		assert(end < (1u << this->size));
+
+		for (uint8 depth = 0; depth <= this->size; ++depth) {
+			const uint8 stride = this->size - depth;
+
+			const uint real_end = (1u << depth) + (end >> stride);
+
+			for (uint i = (1u << depth) + (begin >> stride); i <= real_end; ++i) {
+				assert(i > 0 && i < (1u << (this->size + 1)));
+				callback(this->data[i]);
+			}
+		}
+	}
+
+	template <typename TCallback>
+	void Query(uint begin, uint end, TCallback callback) const
+	{
+		assert(this->size != INVALID_SIZE);
+		assert(begin <= end);
+		assert(end < (1u << this->size));
+
+		for (uint8 depth = 0; depth <= this->size; ++depth) {
+			const uint8 stride = this->size - depth;
+
+			const uint real_end = (1u << depth) + (end >> stride);
+
+			for (uint i = (1u << depth) + (begin >> stride); i <= real_end; ++i) {
+				assert(i > 0 && i < (1u << (this->size + 1)));
+				callback(const_cast<const T&>(this->data[i]));
+			}
+		}
+	}
+
+
+};
+
+/**
+ * Linear query template class.
+ *
+ * @note There are no asserts in the class so you have
+ *       to care about that you grab an item which is
+ *       inside the list.
+ *
+ * @tparam T The type of the items stored
+ */
+template <typename T>
+class LinearQueryTree {
+private:
+	SegmentTree<std::vector<T>> data;
+
+public:
+	LinearQueryTree() {}
+
+	/**
+	 * Constructs an empty linear query tree with the given size.
+	 * @param size The size of the tree (expressed as a power of two, i.e. 2^(size) is the number of distinct positions in the line).
+	 */
+	LinearQueryTree(uint8 size) : data(size) {}
+
+	/**
+	 * Clear all the data from the tree.  Note: It can be made faster by ensuring that the underlying vector capacity is left unchanged (because most of the time we would have exactly the same number of items in the vector afer rebuilding the cache).
+	 */
+	void Clear()
+	{
+		this->data.ForEachElement([](std::vector<T>& vec) {
+			vec.clear();
+		});
+	}
+
+	/**
+	 * Resizes the tree.
+	 * @param size The desired size.
+	 * @return True if the size was actually changed (if the size is unchanged, then existing data is guaranteed to be preserved).
+	 */
+	bool Resize(uint8 size)
+	{
+		return this->data.Resize(size);
+	}
+
+	/**
+	 * Emplaces a new item into the linear query tree, associated with a given range.  O(1) assuming FindLastBit is O(1).
+	 * @param begin The start of the range.
+	 * @param end The end of the range.
+	 * @param args Arguments to use to construct the new item in-place.
+	 */
+	template <typename ...TArgs>
+	T& Emplace(uint begin, uint end, TArgs &&...args)
+	{
+		std::vector<T>& vec = this->data.Get(begin, end);
+		vec.emplace_back(std::forward<TArgs>(args)...);
+		return vec.back();
+	}
+
+	/**
+	 * Calls the given callback once per item in the linear query tree; invokes callback(T) once per item.  O(K + L).
+	 * It might also call the callback on other random items that are outside the range, so the caller should ascertain that each called item is indeed within the desired range.
+	 * @param begin The start of the range.
+	 * @param end The end of the range.
+	 * @param callback Callback to invoke once per item.
+	 */
+	template <typename TCallback>
+	void Query(uint begin, uint end, TCallback callback)
+	{
+		this->data.Query(begin, end, [&callback](std::vector<T>& vec) {
+			for (T& item : vec) {
+				callback(item);
+			}
+		});
+	}
+
+	template <typename TCallback>
+	void Query(uint begin, uint end, TCallback callback) const
+	{
+		this->data.Query(begin, end, [&callback](const std::vector<T>& vec) {
+			for (const T& item : vec) {
+				callback(item);
+			}
+		});
+	}
+
+
+};
+
+
+#endif /* LINEARQUERY_TYPE_HPP */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -436,7 +436,8 @@ protected:
 						 * integer, so at about 31 bits because of the sign bit, the
 						 * least significant bits are removed.
 						 */
-						int mult_range = FindLastBit(x_axis_offset) + FindLastBit(abs(datapoint));
+						const int64 abs_datapoint = abs(datapoint);
+						int mult_range = (x_axis_offset ? FindLastBit(x_axis_offset) : 0) + (abs_datapoint ? FindLastBit(abs_datapoint) : 0);
 						int reduce_range = max(mult_range - 31, 0);
 
 						/* Handle negative values differently (don't shift sign) */

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -437,7 +437,6 @@ struct MainWindow : Window
 		this->viewport->scrollpos_y += ScaleByZoom(delta.y, this->viewport->zoom);
 		this->viewport->dest_scrollpos_x = this->viewport->scrollpos_x;
 		this->viewport->dest_scrollpos_y = this->viewport->scrollpos_y;
-		this->refresh.SetInterval(LINKGRAPH_DELAY);
 	}
 
 	virtual void OnMouseWheel(int wheel)
@@ -452,7 +451,6 @@ struct MainWindow : Window
 		if (this->viewport != NULL) {
 			NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_M_VIEWPORT);
 			nvp->UpdateViewportCoordinates(this);
-			this->refresh.SetInterval(LINKGRAPH_DELAY);
 		}
 	}
 

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -236,6 +236,7 @@ enum {
 
 struct MainWindow : Window
 {
+	/* Timer to refresh the cargo flow legend that is drawn on the main map */
 	GUITimer refresh;
 
 	/* Refresh times in milliseconds */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -712,8 +712,6 @@ void SmallMapWindow::SetZoomLevel(ZoomLevelChange change, const Point *zoom_pt)
 			Point new_tile = this->PixelToTile(zoom_pt->x, zoom_pt->y, &sub);
 			this->SetNewScroll(this->scroll_x + (tile.x - new_tile.x) * TILE_SIZE,
 					this->scroll_y + (tile.y - new_tile.y) * TILE_SIZE, sub);
-		} else if (this->map_type == SMT_LINKSTATS) {
-			this->overlay->RebuildCache();
 		}
 		this->SetWidgetDisabledState(WID_SM_ZOOM_IN,  this->zoom == zoomlevels[MIN_ZOOM_INDEX]);
 		this->SetWidgetDisabledState(WID_SM_ZOOM_OUT, this->zoom == zoomlevels[MAX_ZOOM_INDEX]);
@@ -1624,7 +1622,6 @@ void SmallMapWindow::SetNewScroll(int sx, int sy, int sub)
 	this->scroll_x = sx;
 	this->scroll_y = sy;
 	this->subscroll = sub;
-	if (this->map_type == SMT_LINKSTATS) this->overlay->RebuildCache();
 }
 
 /* virtual */ void SmallMapWindow::OnScroll(Point delta)

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3073,14 +3073,30 @@ void ResetObjectToPlace()
 
 Point GetViewportStationMiddle(const ViewPort *vp, const Station *st)
 {
+	return ViewportFromRemappedCoords(vp, GetRemappedStationMiddle(st));
+}
+
+Point GetRemappedStationMiddle(const Station *st)
+{
 	int x = TileX(st->xy) * TILE_SIZE;
 	int y = TileY(st->xy) * TILE_SIZE;
 	int z = GetSlopePixelZ(Clamp(x, 0, MapSizeX() * TILE_SIZE - 1), Clamp(y, 0, MapSizeY() * TILE_SIZE - 1));
 
-	Point p = RemapCoords(x, y, z);
-	p.x = UnScaleByZoom(p.x - vp->virtual_left, vp->zoom) + vp->left;
-	p.y = UnScaleByZoom(p.y - vp->virtual_top, vp->zoom) + vp->top;
-	return p;
+	return RemapCoords(x, y, z);
+}
+
+Point ViewportFromRemappedCoords(const ViewPort *vp, const Point &p)
+{
+	return Point{
+		UnScaleByZoom(p.x - vp->virtual_left, vp->zoom) + vp->left,
+		UnScaleByZoom(p.y - vp->virtual_top, vp->zoom) + vp->top };
+}
+
+Point RemappedFromViewportCoords(const ViewPort *vp, const Point &p)
+{
+	return Point{
+		ScaleByZoom(p.x - vp->left, vp->zoom) + vp->virtual_left,
+		ScaleByZoom(p.y - vp->top, vp->zoom) + vp->virtual_top };
 }
 
 /** Helper class for getting the best sprite sorter. */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1676,7 +1676,6 @@ void UpdateViewportPosition(Window *w)
 		int delta_x = w->viewport->dest_scrollpos_x - w->viewport->scrollpos_x;
 		int delta_y = w->viewport->dest_scrollpos_y - w->viewport->scrollpos_y;
 
-		bool update_overlay = false;
 		if (delta_x != 0 || delta_y != 0) {
 			if (_settings_client.gui.smooth_scroll) {
 				int max_scroll = ScaleByMapSize1D(512 * ZOOM_LVL_BASE);
@@ -1687,14 +1686,11 @@ void UpdateViewportPosition(Window *w)
 				w->viewport->scrollpos_x = w->viewport->dest_scrollpos_x;
 				w->viewport->scrollpos_y = w->viewport->dest_scrollpos_y;
 			}
-			update_overlay = (w->viewport->scrollpos_x == w->viewport->dest_scrollpos_x &&
-								w->viewport->scrollpos_y == w->viewport->dest_scrollpos_y);
 		}
 
 		ClampViewportToMap(vp, &w->viewport->scrollpos_x, &w->viewport->scrollpos_y);
 
 		SetViewportPosition(w, w->viewport->scrollpos_x, w->viewport->scrollpos_y);
-		if (update_overlay) RebuildViewportOverlay(w);
 	}
 }
 
@@ -2059,16 +2055,6 @@ bool HandleViewportClicked(const ViewPort *vp, int x, int y)
 	return result;
 }
 
-void RebuildViewportOverlay(Window *w)
-{
-	if (w->viewport->overlay != NULL &&
-			w->viewport->overlay->GetCompanyMask() != 0 &&
-			w->viewport->overlay->GetCargoMask() != 0) {
-		w->viewport->overlay->RebuildCache();
-		w->SetDirty();
-	}
-}
-
 /**
  * Scrolls the viewport in a window to a given location.
  * @param x       Desired x location of the map to scroll to (world coordinate).
@@ -2098,7 +2084,6 @@ bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant)
 	if (instant) {
 		w->viewport->scrollpos_x = pt.x;
 		w->viewport->scrollpos_y = pt.y;
-		RebuildViewportOverlay(w);
 	}
 
 	w->viewport->dest_scrollpos_x = pt.x;

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -69,8 +69,6 @@ void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom
 bool ScrollWindowToTile(TileIndex tile, Window *w, bool instant = false);
 bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant = false);
 
-void RebuildViewportOverlay(Window *w);
-
 bool ScrollMainWindowToTile(TileIndex tile, bool instant = false);
 bool ScrollMainWindowTo(int x, int y, int z = -1, bool instant = false);
 

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -92,5 +92,8 @@ static inline void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset =
 }
 
 Point GetViewportStationMiddle(const ViewPort *vp, const Station *st);
+Point GetRemappedStationMiddle(const Station *st);
+Point ViewportFromRemappedCoords(const ViewPort *vp, const Point &p);
+Point RemappedFromViewportCoords(const ViewPort *vp, const Point &p);
 
 #endif /* VIEWPORT_FUNC_H */


### PR DESCRIPTION
This is a replacement for #7005 that fully eliminates the need for the cache refresh delay after scrolling and zooming.  It uses a 2D segment tree data structure to store a cache of the cargo flow legend for the whole map (previously, the cache only stored the stations and links that might be visible).  The eliminates the need to rebuild the cache when the user scrolls or zooms around the map, so we don't need to add the additional LINKGRAPH_DELAY after those user actions anymore.

There does not seem to be any noticeable slowdown in the game when using my patch.

Note on algorithmic complexity:
- The cost of `LinkGraphOverlay::RebuildCache()` remains the same because insertion of a station or link into the data structure is still O(1) (assuming that we have O(1) `FindFirstSet` which I can write in another PR).
- The cost of enumerating visible edges and stations is O(N+RC) where N is the number of possibly-visible stations/links (it is around 2x of the old implementation and the difference is not noticeable), and R*C is a small constant depending on the size of the visible region of the map (this is quite small, less than 100 even when fully zoomed out).

Note on existing lag (not caused by this patch):
The existing implementation (as well as this patch) gets noticeably jerky when the number of possibly-visible links is large.  This is mainly due to the `Blitter::DrawLine()` function that is called to draw all those edges pixel by pixel.  It could be alleviated in the future by doing a bit more math in `LinkGraphOverlay::IsLinkVisible()` to prune a few more cases to determine that an edge is definitely off-screen (software solution, I can probably implement this some other time), or a fix for `Blitter::DrawLine()` that utilizes the GPU to draw lines instead of drawing pixel-by-pixel (hardware solution, I don't know how to do this).

![image](https://user-images.githubusercontent.com/6948096/51537494-b48cf400-1e89-11e9-8253-d31d5a50c6f2.png)

To observe the lag mentioned above, go to https://wiki.openttdcoop.org/PublicServer:Archive_-_Hall_of_Fame and download Pro Zone Game 13 Final, then load it and enable the cargo flow legend for all companies and all cargo types.