### PR TITLE
Add: [GitHub] enable probot/stale, to flush out stale issues/pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,34 @@
+daysUntilClose: 7
+staleLabel: stale
+closeComment: false
+exemptMilestones: true
+exemptAssignees: true
+
+issues:
+  daysUntilStale: 60
+  exemptLabels:
+  - pinned
+  - security
+  - "good first issue"
+  - regression
+  markComment: >
+    This issue has been automatically marked as stale because it has not had any activity in the last two months.
+
+    If you believe the issue is still relevant, please test on the latest nightly and report back.
+
+    It will be closed if no further activity occurs within 7 days.
+
+    Thank you for your contributions.
+
+pulls:
+  daysUntilStale: 30
+  exemptLabels:
+  - pinned
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had any activity in the last month.
+
+    Please feel free to give a status update now, ping for review, or re-open when it's ready.
+
+    It will be closed if no further activity occurs within 7 days.
+
+    Thank you for your contributions.


### PR DESCRIPTION
Stale bot checks if an issue hasn't had any attention in the last
60 days, or if a pull request hasn't had any attention in the last
30 days. If so, it marks it as stale. After 7 more days, it closes
the issue/pull request. Any activity on the issue/pull request
resets the timer.

This helps keeping the counter low, and the work manageable. There
is a lot of reasoning behind this idea, and other projects show it
really helps to keep the issue/pull request count low.

More information here: https://github.com/probot/stale