### PR TITLE
Fix: enable DPI-awareness for MINGW builds

### DIFF
--- a/Makefile.src.in
+++ b/Makefile.src.in
@@ -250,7 +250,7 @@ $(OBJS_MM): %.o: $(SRC_DIR)/%.mm $(DEP_MASK) $(FILE_DEP)
 
 $(OBJS_RC): %.o: $(SRC_DIR)/%.rc $(FILE_DEP)
 	$(E) '$(STAGE) Compiling resource $(<:$(SRC_DIR)/%.rc=%.rc)'
-	$(Q)$(WINDRES) -o $@ -I `basename $<` $<
+	$(Q)$(WINDRES) -o $@ $<
 
 $(BIN_DIR)/$(TTD): $(TTD)
 	$(Q)cp $(TTD) $(BIN_DIR)/$(TTD)

--- a/projects/dpi_aware.manifest
+++ b/projects/dpi_aware.manifest
@@ -1,7 +1,29 @@
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" >
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>True/PM</dpiAware>
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
     </windowsSettings>
   </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--This Id value indicates the application supports Windows Vista functionality -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!--This Id value indicates the application supports Windows 7 functionality-->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--This Id value indicates the application supports Windows 8 functionality-->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--This Id value indicates the application supports Windows 8.1 functionality-->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--This Id value indicates the application supports Windows 10 functionality-->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
 </assembly>

--- a/projects/os_versions.manifest
+++ b/projects/os_versions.manifest
@@ -12,6 +12,6 @@
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--This Id value indicates the application supports Windows 10 functionality-->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-	</application>
+    </application>
   </compatibility>
 </assembly>

--- a/src/os/windows/ottdres.rc.in
+++ b/src/os/windows/ottdres.rc.in
@@ -14,7 +14,7 @@
 #define APSTUDIO_HIDDEN_SYMBOLS
 #include "windows.h"
 #undef APSTUDIO_HIDDEN_SYMBOLS
-#ifdef MSVC
+#ifndef __MINGW32__
 #include "winres.h"
 #else
 #define IDC_STATIC              (-1)     // all static controls
@@ -116,6 +116,10 @@ BEGIN
 END
 
 #endif    // !_MAC
+
+#ifdef __MINGW32__
+1 24 "..\\..\\..\\projects\\dpi_aware.manifest"
+#endif
 
 #endif    // Neutral (Default) resources
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Reuse dpi_aware.manifest which was a left-over of pre-VS2015 projects removal