### PR TITLE
Fix #6574: Go to takeoff if no hangar

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1539,7 +1539,7 @@ static void AircraftEventHandler_AtTerminal(Aircraft *v, const AirportFTAClass *
 			go_to_hangar = Station::Get(v->targetairport)->airport.HasHangar();
 	}
 
-	if (go_to_hangar) {
+	if (go_to_hangar && Station::Get(v->targetairport)->airport.HasHangar()) {
 		v->state = HANGAR;
 	} else {
 		/* airplane goto state takeoff, helicopter to helitakeoff */


### PR DESCRIPTION
Sends the aircraft to takeoff if the airport it's currently at, got no hangar even if the order is to go to hangar.