### PR TITLE
Fix #6636: Airplanes could be sent to helicopter station depots

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -128,16 +128,15 @@ static StationID FindNearestHangar(const Aircraft *v)
 	const AircraftVehicleInfo *avi = AircraftVehInfo(v->engine_type);
 
 	FOR_ALL_STATIONS(st) {
-		if (st->owner != v->owner || !(st->facilities & FACIL_AIRPORT)) continue;
+		if (st->owner != v->owner || !(st->facilities & FACIL_AIRPORT) || !st->airport.HasHangar()) continue;
 
 		const AirportFTAClass *afc = st->airport.GetFTA();
-		if (!st->airport.HasHangar() || (
-					/* don't crash the plane if we know it can't land at the airport */
-					(afc->flags & AirportFTAClass::SHORT_STRIP) &&
-					(avi->subtype & AIR_FAST) &&
-					!_cheats.no_jetcrash.value)) {
-			continue;
-		}
+
+		/* don't crash the plane if we know it can't land at the airport */
+		if ((afc->flags & AirportFTAClass::SHORT_STRIP) && (avi->subtype & AIR_FAST) && !_cheats.no_jetcrash.value) continue;
+
+		/* the plane won't land at any helicopter station */
+		if (!(afc->flags & AirportFTAClass::AIRPLANES) && (avi->subtype & AIR_CTOL)) continue;
 
 		/* v->tile can't be used here, when aircraft is flying v->tile is set to 0 */
 		uint distance = DistanceSquare(vtile, st->airport.tile);
@@ -380,7 +379,7 @@ bool Aircraft::FindClosestDepot(TileIndex *location, DestinationID *destination,
 {
 	const Station *st = GetTargetAirportIfValid(this);
 	/* If the station is not a valid airport or if it has no hangars */
-	if (st == NULL || !st->airport.HasHangar()) {
+	if (st == NULL || !CanVehicleUseStation(this, st) || !st->airport.HasHangar()) {
 		/* the aircraft has to search for a hangar on its own */
 		StationID station = FindNearestHangar(this);
 


### PR DESCRIPTION
[nearest hangar bug.zip](https://github.com/OpenTTD/OpenTTD/files/2798120/nearest.hangar.bug.zip)
Savegame ready to reproduce bug.

Steps:
- demolish Gendingworth Airport
- send aircraft to hangar

Bug: goes to helidepot