### PR TITLE
Fix: Direct the aircraft to the correct location of the hangar when skipping to a go to hangar order

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -2093,6 +2093,13 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 			} else {
 				if (v->type != VEH_AIRCRAFT) {
 					v->SetDestTile(Depot::Get(order->GetDestination())->xy);
+				} else {
+					Aircraft *a = Aircraft::From(v);
+					DestinationID destination = a->current_order.GetDestination();
+					if (a->targetairport != destination) {
+						/* The aircraft is now heading for a different hangar than the next in the orders */
+						a->SetDestTile(a->GetOrderStationLocation(destination));
+					}
 				}
 				return true;
 			}


### PR DESCRIPTION
When manually skipping to a 'go to hangar' order in the order list, while the aircraft is flying, direct the aircraft to the correct location of the hangar.