### PR TITLE
[OSX] Use high-precision scrolling properties for 2D scrolling

### DIFF
--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -581,7 +581,10 @@ static bool QZ_PollEvent()
 
 			/* Use precise scrolling-specific deltas if they're supported. */
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
-			if ([event respondsToSelector:@selector(scrollingDeltaX)]) {
+			if ([event respondsToSelector:@selector(hasPreciseScrollingDeltas)]) {
+				/* No precise deltas indicates a scroll wheel is being used, so we don't want 2D scrolling. */
+				if (![ event hasPreciseScrollingDeltas ]) break;
+
 				deltaX = [ event scrollingDeltaX ] * 0.5f;
 				deltaY = [ event scrollingDeltaY ] * 0.5f;
 			} else

--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -575,9 +575,25 @@ static bool QZ_PollEvent()
 				_cursor.wheel++;
 			} /* else: deltaY was 0.0 and we don't want to do anything */
 
-			/* Set the scroll count for scrollwheel scrolling */
-			_cursor.h_wheel -= (int)([ event deltaX ] * 5 * _settings_client.gui.scrollwheel_multiplier);
-			_cursor.v_wheel -= (int)([ event deltaY ] * 5 * _settings_client.gui.scrollwheel_multiplier);
+			/* Update the scroll count for 2D scrolling */
+			CGFloat deltaX;
+			CGFloat deltaY;
+
+			/* Use precise scrolling-specific deltas if they're supported. */
+#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
+			if ([event respondsToSelector:@selector(scrollingDeltaX)]) {
+				deltaX = [ event scrollingDeltaX ] * 0.5f;
+				deltaY = [ event scrollingDeltaY ] * 0.5f;
+			} else
+#endif
+			{
+				deltaX = [ event deltaX ] * 5;
+				deltaY = [ event deltaY ] * 5;
+			}
+
+			_cursor.h_wheel -= (int)(deltaX * _settings_client.gui.scrollwheel_multiplier);
+			_cursor.v_wheel -= (int)(deltaY * _settings_client.gui.scrollwheel_multiplier);
+
 			break;
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)


### PR DESCRIPTION
- Changed 2D scrolling to use the recommended `scrollingDeltaX/Y` properties. This results in fluid panning/scrolling across the map (when scrolling at low speeds). Resolves #6800.
- Prevented scrolling using a traditional scroll wheel mouse from causing 2D scrolling. It will instead fall back to normal scrolling, triggering zoom (unless the "Function of scrollwheel" setting is set to "Off"). This matches behaviour of other apps like Apple Maps.