### PR TITLE
Codechange: Rework automatic service for helicopters (#6493)

### DIFF
--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -727,6 +727,8 @@ public:
 
 	bool NeedsAutorenewing(const Company *c, bool use_renew_setting = true) const;
 
+	bool HasPendingReplace() const;
+
 	bool NeedsServicing() const;
 	bool NeedsAutomaticServicing() const;
 


### PR DESCRIPTION
In order to verify if a helicopter with `serviceathelipad` has a pending replace, it's needed to call `HasPendingReplace` directly, as a seperate function, that can be used by `AircraftEventHandler_AtTerminal` and `CheckIfAircraftNeedsService`.

If a helicopter needs to be sent to a hangar during automatic service, and there are no airports with hangars in the orders (travelling between heliports), a nearby hangar outside the orders will be searched. If the distance to a found hangar is shorter than the distance to the helistation/airport the helicopter is headed to, the helicopter is sent to that hangar.

Also, when an aircraft (of any type) is at a terminal, it is checked whether it needs automatic servicing, and in the case of helicopter, due to the complexity of `serviceathelipad`, whether it has a pending replace, and then sent to the hangar of the airport, before being sent to takeoff.

These changes thus replace the two methods which were attempting to do the same.
- For the case of airplanes, the check was being done upon landing, which could result in canceling the automatic servicing order, only to have it re-applied on the next daily check.
- For the case of helicopters, the check was being done right after taking off, which is now handled via `CheckIfAircraftNeedsService` every day.