### PR TITLE
Fix #6452: Reset only editable and visible settings from GUI

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -312,8 +312,6 @@ struct AISettingsWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_AIS_SCROLLBAR);
 		this->FinishInitNested(slot);  // Initializes 'this->line_height' as side effect.
 
-		this->SetWidgetDisabledState(WID_AIS_RESET, _game_mode != GM_MENU && Company::IsValidID(this->slot));
-
 		this->RebuildVisibleSettings();
 	}
 
@@ -522,10 +520,8 @@ struct AISettingsWindow : public Window {
 				break;
 
 			case WID_AIS_RESET:
-				if (_game_mode == GM_MENU || !Company::IsValidID(this->slot)) {
-					this->ai_config->ResetSettings();
-					this->SetDirty();
-				}
+				this->ai_config->ResetSettingsGUI();
+				this->SetDirty();
 				break;
 		}
 	}

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -129,6 +129,24 @@ void ScriptConfig::ResetSettings()
 	this->settings.clear();
 }
 
+void ScriptConfig::ResetSettingsGUI()
+{
+	for (SettingValueList::iterator it = this->settings.begin(); it != this->settings.end();) {
+		const ScriptConfigItem *config_item = this->info->GetConfigItem((*it).first);
+		assert(config_item != NULL);
+
+		bool editable = _game_mode == GM_MENU || ((*config_item).flags & SCRIPTCONFIG_INGAME) != 0;
+		bool visible = _settings_client.gui.ai_developer_tools || ((*config_item).flags & SCRIPTCONFIG_DEVELOPER) == 0;
+
+		if (editable && visible) {
+			free((*it).first);
+			it = this->settings.erase(it);
+		} else {
+			it++;
+		}
+	}
+}
+
 void ScriptConfig::AddRandomDeviation()
 {
 	for (ScriptConfigItemList::const_iterator it = this->GetConfigList()->begin(); it != this->GetConfigList()->end(); it++) {

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -137,6 +137,11 @@ public:
 	void ResetSettings();
 
 	/**
+	 * Reset only editable and visible settings to their default value.
+	 */
+	void ResetSettingsGUI();
+
+	/**
 	 * Randomize all settings the Script requested to be randomized.
 	 */
 	void AddRandomDeviation();


### PR DESCRIPTION
Also enables the Reset button while in-game for AI configs.