### PR TITLE
Fix #7021: Better revision strings for network and gamelog

### DIFF
--- a/Makefile.src.in
+++ b/Makefile.src.in
@@ -90,6 +90,7 @@ MODIFIED := $(shell echo "$(VERSIONS)" | cut -f 3 -d'	')
 # Use autodetected revisions
 VERSION  := $(shell echo "$(VERSIONS)" | cut -f 1 -d'	')
 ISODATE  := $(shell echo "$(VERSIONS)" | cut -f 2 -d'	')
+GITHASH  := $(shell echo "$(VERSIONS)" | cut -f 3 -d'	')
 
 # Make sure we have something in VERSION and ISODATE
 ifeq ($(VERSION),)
@@ -275,10 +276,10 @@ endif
 # Revision files
 
 $(SRC_DIR)/rev.cpp: $(CONFIG_CACHE_VERSION) $(SRC_DIR)/rev.cpp.in
-	$(Q)cat $(SRC_DIR)/rev.cpp.in      | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!MODIFIED!!@$(MODIFIED)@g;s@!!DATE!!@`date +%d.%m.%y`@g" > $(SRC_DIR)/rev.cpp
+	$(Q)cat $(SRC_DIR)/rev.cpp.in      | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!MODIFIED!!@$(MODIFIED)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g" > $(SRC_DIR)/rev.cpp
 
 $(SRC_DIR)/os/windows/ottdres.rc: $(CONFIG_CACHE_VERSION) $(SRC_DIR)/os/windows/ottdres.rc.in
-	$(Q)cat $(SRC_DIR)/os/windows/ottdres.rc.in | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!DATE!!@`date +%d.%m.%y`@g" > $(SRC_DIR)/os/windows/ottdres.rc
+	$(Q)cat $(SRC_DIR)/os/windows/ottdres.rc.in | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g" > $(SRC_DIR)/os/windows/ottdres.rc
 
 FORCE:
 

--- a/findversion.sh
+++ b/findversion.sh
@@ -67,20 +67,25 @@ if [ -d "$ROOT_DIR/.git" ]; then
 		MODIFIED="2"
 	fi
 	HASH=`LC_ALL=C git rev-parse --verify HEAD 2>/dev/null`
-	SHORTHASH=`echo ${HASH} | cut -c1-8`
+	SHORTHASH=`echo ${HASH} | cut -c1-10`
 	ISODATE=`LC_ALL=C git show -s --pretty='format:%ci' HEAD | "$AWK" '{ gsub("-", "", $1); print $1 }'`
 	BRANCH="`git symbolic-ref -q HEAD 2>/dev/null | sed 's@.*/@@'`"
 	TAG="`git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null | sed 's@\^0$@@'`"
 
+	if [ "$MODIFIED" -eq "0" ]; then
+		hashprefix="-g"
+	elif [ "$MODIFIED" -eq "2" ]; then
+		hashprefix="-m"
+	else
+		hashprefix="-u"
+	fi
+
 	if [ -n "$TAG" ]; then
 		VERSION="${TAG}"
 	else
-		VERSION="${ISODATE}-${BRANCH}-g${SHORTHASH}"
+		VERSION="${ISODATE}-${BRANCH}${hashprefix}${SHORTHASH}"
 	fi
 
-	if [ "$MODIFIED" -eq "2" ]; then
-		VERSION="${VERSION}M"
-	fi
 elif [ -f "$ROOT_DIR/.ottdrev" ]; then
 	# We are an exported source bundle
 	cat $ROOT_DIR/.ottdrev

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -12,7 +12,6 @@
 #ifndef GAMELOG_INTERNAL_H
 #define GAMELOG_INTERNAL_H
 
-#include "network/core/config.h"
 #include "gamelog.h"
 
 /** Type of logged change */
@@ -33,6 +32,8 @@ enum GamelogChangeType {
 };
 
 
+static const uint GAMELOG_REVISION_LENGTH = 15;
+
 /** Contains information about one logged change */
 struct LoggedChange {
 	GamelogChangeType ct; ///< Type of change logged in this struct
@@ -42,7 +43,7 @@ struct LoggedChange {
 			byte landscape;  ///< landscape (temperate, arctic, ...)
 		} mode;
 		struct {
-			char text[NETWORK_REVISION_LENGTH]; ///< revision string, _openttd_revision
+			char text[GAMELOG_REVISION_LENGTH]; ///< revision string, _openttd_revision
 			uint32 newgrf;   ///< _openttd_newgrf_version
 			uint16 slver;    ///< _sl_version
 			byte modified;   ///< _openttd_revision_modified

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -43,7 +43,7 @@ static const uint NETWORK_NAME_LENGTH             =   80;         ///< The maxim
 static const uint NETWORK_COMPANY_NAME_LENGTH     =  128;         ///< The maximum length of the company name, in bytes including '\0'
 static const uint NETWORK_HOSTNAME_LENGTH         =   80;         ///< The maximum length of the host name, in bytes including '\0'
 static const uint NETWORK_SERVER_ID_LENGTH        =   33;         ///< The maximum length of the network id of the servers, in bytes including '\0'
-static const uint NETWORK_REVISION_LENGTH         =   15;         ///< The maximum length of the revision, in bytes including '\0'
+static const uint NETWORK_REVISION_LENGTH         =   33;         ///< The maximum length of the revision, in bytes including '\0'
 static const uint NETWORK_PASSWORD_LENGTH         =   33;         ///< The maximum length of the password, in bytes including '\0' (must be >= NETWORK_SERVER_ID_LENGTH)
 static const uint NETWORK_CLIENTS_LENGTH          =  200;         ///< The maximum length for the list of clients that controls a company, in bytes including '\0'
 static const uint NETWORK_CLIENT_NAME_LENGTH      =   25;         ///< The maximum length of a client's name, in bytes including '\0'

--- a/src/network/core/game.h
+++ b/src/network/core/game.h
@@ -56,6 +56,8 @@ struct NetworkGameInfo : NetworkServerGameInfo {
 	byte map_set;                                   ///< Graphical set
 };
 
+const char * GetNetworkRevisionString();
+
 #endif /* ENABLE_NETWORK */
 
 #endif /* NETWORK_CORE_GAME_H */

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -45,14 +45,14 @@ NetworkHTTPSocketHandler::NetworkHTTPSocketHandler(SOCKET s,
 	redirect_depth(depth),
 	sock(s)
 {
-	size_t bufferSize = strlen(url) + strlen(host) + strlen(_openttd_revision) + (data == NULL ? 0 : strlen(data)) + 128;
+	size_t bufferSize = strlen(url) + strlen(host) + strlen(GetNetworkRevisionString()) + (data == NULL ? 0 : strlen(data)) + 128;
 	char *buffer = AllocaM(char, bufferSize);
 
 	DEBUG(net, 7, "[tcp/http] requesting %s%s", host, url);
 	if (data != NULL) {
-		seprintf(buffer, buffer + bufferSize - 1, "POST %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: OpenTTD/%s\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s\r\n", url, host, _openttd_revision, (int)strlen(data), data);
+		seprintf(buffer, buffer + bufferSize - 1, "POST %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: OpenTTD/%s\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s\r\n", url, host, GetNetworkRevisionString(), (int)strlen(data), data);
 	} else {
-		seprintf(buffer, buffer + bufferSize - 1, "GET %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: OpenTTD/%s\r\n\r\n", url, host, _openttd_revision);
+		seprintf(buffer, buffer + bufferSize - 1, "GET %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: OpenTTD/%s\r\n\r\n", url, host, GetNetworkRevisionString());
 	}
 
 	ssize_t size = strlen(buffer);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1101,12 +1101,67 @@ void NetworkShutDown()
 }
 
 /**
+ * How many hex digits of the git hash to include in network revision string.
+ * Determined as 10 hex digits + 2 characters for -g/-u/-m prefix.
+ */
+static const uint GITHASH_SUFFIX_LEN = 12;
+
+/**
+ * Get the network version string used by this build.
+ * The returned string is guaranteed to be at most NETWORK_REVISON_LENGTH bytes.
+ */
+const char * GetNetworkRevisionString()
+{
+	/* This will be allocated on heap and never free'd, but only once so not a "real" leak. */
+	static char *network_revision = nullptr;
+
+	if (!network_revision) {
+		/* Start by taking a chance on the full revision string. */
+		network_revision = stredup(_openttd_revision);
+		/* Ensure it's not longer than the packet buffer length. */
+		if (strlen(network_revision) >= NETWORK_REVISION_LENGTH) network_revision[NETWORK_REVISION_LENGTH - 1] = '\0';
+
+		/* Release version names are not mangled further. */
+		if (IsReleasedVersion()) return network_revision;
+
+		/* Prepare a prefix of the git hash.
+		* Size is length + 1 for terminator, +2 for -g prefix. */
+		assert(_openttd_revision_modified < 3);
+		char githash_suffix[GITHASH_SUFFIX_LEN + 1] = "-";
+		githash_suffix[1] = "gum"[_openttd_revision_modified];
+		for (uint i = 2; i < GITHASH_SUFFIX_LEN; i++) {
+			githash_suffix[i] = _openttd_revision_hash[i-2];
+		}
+
+		/* Where did the hash start in the original string?
+		 * Overwrite from that position, unless that would go past end of packet buffer length. */
+		ptrdiff_t hashofs = strrchr(_openttd_revision, '-') - _openttd_revision;
+		if (hashofs + strlen(githash_suffix) + 1 > NETWORK_REVISION_LENGTH) hashofs = strlen(network_revision) - strlen(githash_suffix);
+		/* Replace the git hash in revision string. */
+		strecpy(network_revision + hashofs, githash_suffix, network_revision + NETWORK_REVISION_LENGTH);
+		assert(strlen(network_revision) < NETWORK_REVISION_LENGTH); // strlen does not include terminator, constant does, hence strictly less than
+	}
+
+	return network_revision;
+}
+
+static const char *ExtractNetworkRevisionHash(const char *revstr)
+{
+	return strrchr(revstr, '-');
+}
+
+/**
  * Checks whether the given version string is compatible with our version.
+ * First tries to match the full string, if that fails, attempts to compare just git hashes.
  * @param other the version string to compare to
  */
 bool IsNetworkCompatibleVersion(const char *other)
 {
-	return strncmp(_openttd_revision, other, NETWORK_REVISION_LENGTH - 1) == 0;
+	if (strncmp(GetNetworkRevisionString(), other, NETWORK_REVISION_LENGTH - 1) == 0) return true;
+
+	const char *hash1 = ExtractNetworkRevisionHash(GetNetworkRevisionString());
+	const char *hash2 = ExtractNetworkRevisionHash(other);
+	return hash1 && hash2 && (strncmp(hash1, hash2, GITHASH_SUFFIX_LEN) == 0);
 }
 
 #endif /* ENABLE_NETWORK */

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -172,7 +172,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendWelcome()
 	Packet *p = new Packet(ADMIN_PACKET_SERVER_WELCOME);
 
 	p->Send_string(_settings_client.network.server_name);
-	p->Send_string(_openttd_revision);
+	p->Send_string(GetNetworkRevisionString());
 	p->Send_bool  (_network_dedicated);
 
 	p->Send_string(_network_game_info.map_name);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -343,7 +343,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 	SetWindowDirty(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
 
 	Packet *p = new Packet(PACKET_CLIENT_JOIN);
-	p->Send_string(_openttd_revision);
+	p->Send_string(GetNetworkRevisionString());
 	p->Send_uint32(_openttd_newgrf_version);
 	p->Send_string(_settings_client.network.client_name); // Client name
 	p->Send_uint8 (_network_join_as);     // PlayAs

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -191,7 +191,7 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, Networ
 
 	strecpy(ngi.map_name, _network_game_info.map_name, lastof(ngi.map_name));
 	strecpy(ngi.server_name, _settings_client.network.server_name, lastof(ngi.server_name));
-	strecpy(ngi.server_revision, _openttd_revision, lastof(ngi.server_revision));
+	strecpy(ngi.server_revision, GetNetworkRevisionString(), lastof(ngi.server_revision));
 
 	Packet packet(PACKET_UDP_SERVER_RESPONSE);
 	this->SendNetworkGameInfo(&packet, &ngi);

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -48,6 +48,11 @@ const char _openttd_revision[] = "!!VERSION!!";
 const char _openttd_build_date[] = __DATE__ " " __TIME__;
 
 /**
+ * The git revision hash of this version.
+ */
+const char _openttd_revision_hash[] = "!!GITHASH!!";
+
+/**
  * Let us know if current build was modified. This detection
  * works even in the case when revision string is overridden by
  * --revision argument.

--- a/src/rev.h
+++ b/src/rev.h
@@ -14,6 +14,7 @@
 
 extern const char _openttd_revision[];
 extern const char _openttd_build_date[];
+extern const char _openttd_revision_hash[];
 extern const byte _openttd_revision_modified;
 extern const uint32 _openttd_newgrf_version;
 

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -29,7 +29,7 @@ static const SaveLoad _glog_mode_desc[] = {
 };
 
 static const SaveLoad _glog_revision_desc[] = {
-	SLE_ARR(LoggedChange, revision.text,     SLE_UINT8,  NETWORK_REVISION_LENGTH),
+	SLE_ARR(LoggedChange, revision.text,     SLE_UINT8,  GAMELOG_REVISION_LENGTH),
 	SLE_VAR(LoggedChange, revision.newgrf,   SLE_UINT32),
 	SLE_VAR(LoggedChange, revision.slver,    SLE_UINT16),
 	SLE_VAR(LoggedChange, revision.modified, SLE_UINT8),


### PR DESCRIPTION
Bug #7021 really covers two separate but related issues:
1. The network revision field sent for network server status queries is too short to hold many git revision strings as implemented currently, this can lead to mismatched client/server versions looking identical.
2. The gamelog revision string is limited to the same too short length, leading to gamelog not recognizing two versions as different and not writing entries about version changes.

This patchset does several things:
* Include the full git revision hash in `rev.cpp`.
* Change the revision string format to not use an M suffix for "modified", but a "g", "u" or "m" prefix to the hash for clean, unknown, modified status.
* Use 10 hex digits of git hash for revision string.
* Fix some additional inconsistencies between `findversion.sh` and `determineversion.vbs`.
* Make gamelog revision string use a different length constant than network revision string, such that network revision string length can be increased.
* Change the format used for gamelog revision strings: For release versions use the version name from `_ottd_revision`, and all other use a prefix of the git revision hash.
* Increase the size of the network revision string to fill the rest of the potential size of the server query packet, i.e. from 15 to 33 bytes. This allows up to 32 bytes of `_ottd_revision` to be included, which should cover the master branch, and most other short branch names.
* Ensure the 10 digit prefix of the git hash is always included in the network revision string.
* Compare network revision strings by git hash prefix, if a full string comparison does not match.
* Fix #7021 :)