### PR TITLE
Add: Unique ID to savegames to prevent accidental overwriting

### DIFF
--- a/src/fios.h
+++ b/src/fios.h
@@ -80,6 +80,17 @@ struct LoadCheckData {
 		return this->checkable && this->error == INVALID_STRING_ID && this->grfconfig != NULL;
 	}
 
+	/**
+	 * Check whether the game has the same unique ID as the currently loaded one.
+	 * @return true if unique ID matches, or is not set in check data
+	 */
+	bool UniqueIdMatchesCurrentGame()
+	{
+		if (this->settings.game_creation.generation_unique_id == 0) return true;
+		if (this->settings.game_creation.generation_unique_id == _settings_game.game_creation.generation_unique_id) return true;
+		return false;
+	}
+
 	void Clear();
 };
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -265,6 +265,8 @@ static void SortSaveGameList(FileList &file_list)
 	QSortT(file_list.Get(sort_start), s_amount, CompareFiosItems);
 }
 
+void SaveGameConfirmationCallback(Window *w, bool confirmed);
+
 struct SaveLoadWindow : public Window {
 private:
 	static const uint EDITBOX_MAX_SIZE   =  50;
@@ -280,6 +282,8 @@ private:
 	StringFilter string_filter; ///< Filter for available games.
 	QueryString filter_editbox; ///< Filter editbox;
 	SmallVector<bool, 32> fios_items_shown; ///< Map of the filtered out fios items
+
+	friend void SaveGameConfirmationCallback(Window *w, bool confirmed);
 
 public:
 
@@ -463,6 +467,12 @@ public:
 					y = DrawStringMultiLine(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT,
 							y, r.bottom - WD_FRAMERECT_BOTTOM, _load_check_data.error, TC_RED);
 				} else {
+					/* Warning if save unique id differ when saving */
+					if (this->fop == SLO_SAVE && !_load_check_data.UniqueIdMatchesCurrentGame()) {
+						y = DrawStringMultiLine(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT,
+							y, r.bottom - WD_FRAMERECT_BOTTOM, STR_SAVELOAD_DIFFERENT_ID);
+					}
+
 					/* Mapsize */
 					SetDParam(0, _load_check_data.map_size_x);
 					SetDParam(1, _load_check_data.map_size_y);
@@ -731,8 +741,14 @@ public:
 			}
 		} else if (this->IsWidgetLowered(WID_SL_SAVE_GAME)) { // Save button clicked
 			if (this->abstract_filetype == FT_SAVEGAME || this->abstract_filetype == FT_SCENARIO) {
-				_switch_mode = SM_SAVE_GAME;
-				FiosMakeSavegameName(_file_to_saveload.name, this->filename_editbox.text.buf, lastof(_file_to_saveload.name));
+				if (!_load_check_data.UniqueIdMatchesCurrentGame()) {
+					/* The save has a different id to the current game */
+					/* Show a caption box asking whether the user is sure to overwrite the save */
+					ShowQuery(STR_SAVEGAME_UNMATCHING_ID_CAPTION, STR_SAVEGAME_UNMATCHING_ID_CONFIRMATION_TEXT, this, SaveGameConfirmationCallback);
+				} else {
+					/* We can safely overwrite the save */
+					SaveGameConfirmationCallback(this, true);
+				}
 			} else {
 				_switch_mode = SM_SAVE_HEIGHTMAP;
 				FiosMakeHeightmapName(_file_to_saveload.name, this->filename_editbox.text.buf, lastof(_file_to_saveload.name));
@@ -863,6 +879,20 @@ static WindowDesc _save_dialog_desc(
 	0,
 	_nested_save_dialog_widgets, lengthof(_nested_save_dialog_widgets)
 );
+
+/**
+ * Callback function for the savegame 'are you sure you want to overwrite save' window
+ * @param w Window which is calling this callback
+ * @param confirmed boolean value, true when yes was clicked, false otherwise
+ */
+void SaveGameConfirmationCallback(Window *w, bool confirmed)
+{
+	SaveLoadWindow *slw = dynamic_cast<SaveLoadWindow*>(w);
+	if (confirmed && slw != NULL) {
+		_switch_mode = SM_SAVE_GAME;
+		FiosMakeSavegameName(_file_to_saveload.name, slw->filename_editbox.text.buf, lastof(_file_to_saveload.name));
+	}
+}
 
 /**
  * Launch save/load dialog in the given mode.

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -69,6 +69,12 @@ bool IsGenerateWorldThreaded()
 	return _gw.threaded && !_gw.quit_thread;
 }
 
+void ResetGameUniqueId()
+{
+	/* Generates a unique id for the savegame, to avoid accidentally overwriting a save */
+	_settings_game.game_creation.generation_unique_id = _interactive_random.Next(UINT32_MAX - 1) + 1; /* Generates between [1,UINT32_MAX] */
+}
+
 /**
  * Clean up the 'mess' of generation. That is, show windows again, reset
  * thread variables, and delete the progress window.
@@ -105,6 +111,9 @@ static void _GenerateWorld(void *)
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
+
+		ResetGameUniqueId();
+
 		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
 

--- a/src/genworld.h
+++ b/src/genworld.h
@@ -83,6 +83,7 @@ enum GenWorldProgress {
 
 /* genworld.cpp */
 bool IsGenerateWorldThreaded();
+void ResetGameUniqueId();
 void GenerateWorldSetCallback(GWDoneProc *proc);
 void GenerateWorldSetAbortCallback(GWAbortProc *proc);
 void WaitTillGeneratedWorld();

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2778,6 +2778,7 @@ STR_SAVELOAD_DETAIL_NOT_AVAILABLE                               :{BLACK}No infor
 STR_SAVELOAD_DETAIL_COMPANY_INDEX                               :{SILVER}{COMMA}: {WHITE}{STRING1}
 STR_SAVELOAD_DETAIL_GRFSTATUS                                   :{SILVER}NewGRF: {WHITE}{STRING}
 STR_SAVELOAD_FILTER_TITLE                                       :{BLACK}Filter string:
+STR_SAVELOAD_DIFFERENT_ID                                       :{RED}Overwriting a different game file.
 
 STR_SAVELOAD_OSKTITLE                                           :{BLACK}Enter a name for the savegame
 
@@ -4154,6 +4155,8 @@ STR_GAME_SAVELOAD_ERROR_FILE_NOT_WRITEABLE                      :File not writea
 STR_GAME_SAVELOAD_ERROR_DATA_INTEGRITY_CHECK_FAILED             :Data integrity check failed
 STR_GAME_SAVELOAD_NOT_AVAILABLE                                 :<not available>
 STR_WARNING_LOADGAME_REMOVED_TRAMS                              :{WHITE}Game was saved in version without tram support. All trams have been removed
+STR_SAVEGAME_UNMATCHING_ID_CAPTION                              :{WHITE}Caution!
+STR_SAVEGAME_UNMATCHING_ID_CONFIRMATION_TEXT                    :{YELLOW}The savegame you are about to overwrite is not the same as the current one.{}Are you sure you want to do this?
 
 # Map generation messages
 STR_ERROR_COULD_NOT_CREATE_TOWN                                 :{WHITE}Map generation aborted...{}... no suitable town locations

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1110,6 +1110,8 @@ void SwitchToMode(SwitchMode new_mode)
 				if (_file_to_saveload.abstract_ftype == FT_SCENARIO) {
 					/* Reset engine pool to simplify changing engine NewGRFs in scenario editor. */
 					EngineOverrideManager::ResetToCurrentNewGRFConfig();
+					/* Give the new game a new unique id. */
+					ResetGameUniqueId();
 				}
 				/* Update the local company for a loaded game. It is either always
 				 * company #1 (eg 0) or in the case of a dedicated server a spectator */
@@ -1165,6 +1167,8 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 
 		case SM_SAVE_GAME: // Save game.
+			/* If saving from scenario editor, always reset the unique id before save, to make any "save as" operation count as a new file. */
+			if (_game_mode == GM_EDITOR) ResetGameUniqueId();
 			/* Make network saved games on pause compatible to singleplayer */
 			if (SaveOrLoad(_file_to_saveload.name, SLO_SAVE, DFT_GAME_FILE, NO_DIRECTORY) != SL_OK) {
 				SetDParamStr(0, GetSaveLoadErrorString());

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -55,6 +55,7 @@
 #include "../order_backup.h"
 #include "../error.h"
 #include "../disaster_vehicle.h"
+#include "../genworld.h"
 
 
 #include "saveload_internal.h"
@@ -3043,6 +3044,10 @@ bool AfterLoadGame()
 				}
 			}
 		}
+	}
+
+	if (IsSavegameVersionBefore(205)) {
+		ResetGameUniqueId();
 	}
 
 	/* Station acceptance is some kind of cache */

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -274,8 +274,9 @@
  *  202   #6867   Increase industry cargo slots to 16 in, 16 out
  *  203   #7072   Add path cache for ships
  *  204   #7065   Add extra rotation stages for ships.
+ *  205   #6973   Add unique id to savegames
  */
-extern const uint16 SAVEGAME_VERSION = 204; ///< Current savegame version of OpenTTD.
+extern const uint16 SAVEGAME_VERSION = 205; ///< Current savegame version of OpenTTD.
 
 SavegameType _savegame_type; ///< type of savegame we are loading
 FileToSaveLoad _file_to_saveload; ///< File to save or load in the openttd loop.

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -284,6 +284,7 @@ struct NetworkSettings {
 /** Settings related to the creation of games. */
 struct GameCreationSettings {
 	uint32 generation_seed;                  ///< noise seed for world generation
+	uint32 generation_unique_id;             ///< random id to differentiate savegames
 	Year   starting_year;                    ///< starting date
 	uint8  map_x;                            ///< X size of map
 	uint8  map_y;                            ///< Y size of map

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2213,6 +2213,15 @@ cat      = SC_EXPERT
 
 [SDT_VAR]
 base     = GameSettings
+var      = game_creation.generation_unique_id
+type     = SLE_UINT32
+from     = 205
+def      = 0
+min      = 0
+max      = UINT32_MAX
+
+[SDT_VAR]
+base     = GameSettings
 var      = game_creation.tree_placer
 type     = SLE_UINT8
 from     = 30


### PR DESCRIPTION
This PR adds a new randomly generated unique ID as a setting to savegames to avoid accidental overwriting of another savegame in the save dialog.
The ID is automatically generated :
- When a new world is generated
- When an old savegame (prior to this new version) is loaded

When the user attempts to overwrite a save with a different ID, a warning popup shows and a message is also shown in the details of the save.

This is a "rescue" of  #6973.