### PR TITLE
Codechange: Remove value mangling and field misuse in SLE_WRITEBYTE.

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1710,17 +1710,15 @@ bool SlObjectMember(void *ptr, const SaveLoad *sld)
 			}
 			break;
 
-		/* SL_WRITEBYTE translates a value of a variable to another one upon
-		 * saving or loading.
-		 * XXX - variable renaming abuse
-		 * game_value: the value of the variable ingame is abused by sld->version_from
-		 * file_value: the value of the variable in the savegame is abused by sld->version_to */
+		/* SL_WRITEBYTE writes a value to the savegame to identify the type of an object.
+		 * When loading, the value is read explictly with SlReadByte() to determine which
+		 * object description to use. */
 		case SL_WRITEBYTE:
 			switch (_sl.action) {
-				case SLA_SAVE: SlWriteByte(sld->version_to); break;
+				case SLA_SAVE: SlWriteByte(*(uint8 *)ptr); break;
 				case SLA_LOAD_CHECK:
-				case SLA_LOAD: *(byte *)ptr = sld->version_from; break;
-				case SLA_PTRS: break;
+				case SLA_LOAD:
+				case SLA_PTRS:
 				case SLA_NULL: break;
 				default: NOT_REACHED();
 			}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -355,7 +355,7 @@ typedef SaveLoad SaveLoadGlobVarList;
 #define SLE_CONDNULL(length, from, to) SLE_CONDARR(NullStruct, null, SLE_FILE_U8 | SLE_VAR_NULL | SLF_NOT_IN_CONFIG, length, from, to)
 
 /** Translate values ingame to different values in the savegame and vv. */
-#define SLE_WRITEBYTE(base, variable, value) SLE_GENERAL(SL_WRITEBYTE, base, variable, 0, 0, value, value)
+#define SLE_WRITEBYTE(base, variable) SLE_GENERAL(SL_WRITEBYTE, base, variable, 0, 0, 0, 0)
 
 #define SLE_VEH_INCLUDE() {false, SL_VEH_INCLUDE, 0, 0, 0, SL_MAX_VERSION, NULL, 0}
 #define SLE_ST_INCLUDE() {false, SL_ST_INCLUDE, 0, 0, 0, SL_MAX_VERSION, NULL, 0}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -414,7 +414,7 @@ static const SaveLoad _base_station_desc[] = {
 static OldPersistentStorage _old_st_persistent_storage;
 
 static const SaveLoad _station_desc[] = {
-	SLE_WRITEBYTE(Station, facilities,                 FACIL_NONE),
+	SLE_WRITEBYTE(Station, facilities),
 	SLE_ST_INCLUDE(),
 
 	      SLE_VAR(Station, train_station.tile,         SLE_UINT32),
@@ -448,7 +448,7 @@ static const SaveLoad _station_desc[] = {
 };
 
 static const SaveLoad _waypoint_desc[] = {
-	SLE_WRITEBYTE(Waypoint, facilities,                FACIL_WAYPOINT),
+	SLE_WRITEBYTE(Waypoint, facilities),
 	SLE_ST_INCLUDE(),
 
 	      SLE_VAR(Waypoint, town_cn,                   SLE_UINT16),

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -718,7 +718,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 
 
 	static const SaveLoad _train_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type, VEH_TRAIN),
+		SLE_WRITEBYTE(Vehicle, type),
 		SLE_VEH_INCLUDE(),
 		     SLE_VAR(Train, crash_anim_pos,      SLE_UINT16),
 		     SLE_VAR(Train, force_proceed,       SLE_UINT8),
@@ -739,7 +739,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	};
 
 	static const SaveLoad _roadveh_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type, VEH_ROAD),
+		SLE_WRITEBYTE(Vehicle, type),
 		SLE_VEH_INCLUDE(),
 		     SLE_VAR(RoadVehicle, state,                SLE_UINT8),
 		     SLE_VAR(RoadVehicle, frame,                SLE_UINT8),
@@ -759,7 +759,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	};
 
 	static const SaveLoad _ship_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type, VEH_SHIP),
+		SLE_WRITEBYTE(Vehicle, type),
 		SLE_VEH_INCLUDE(),
 		      SLE_VAR(Ship, state,                     SLE_UINT8),
 		SLE_CONDDEQUE(Ship, path,                      SLE_UINT8,                  203, SL_MAX_VERSION),
@@ -771,7 +771,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	};
 
 	static const SaveLoad _aircraft_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type, VEH_AIRCRAFT),
+		SLE_WRITEBYTE(Vehicle, type),
 		SLE_VEH_INCLUDE(),
 		     SLE_VAR(Aircraft, crashed_counter,       SLE_UINT16),
 		     SLE_VAR(Aircraft, pos,                   SLE_UINT8),
@@ -794,7 +794,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	};
 
 	static const SaveLoad _special_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type, VEH_EFFECT),
+		SLE_WRITEBYTE(Vehicle, type),
 
 		     SLE_VAR(Vehicle, subtype,               SLE_UINT8),
 
@@ -824,7 +824,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	};
 
 	static const SaveLoad _disaster_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type, VEH_DISASTER),
+		SLE_WRITEBYTE(Vehicle, type),
 
 		     SLE_REF(Vehicle, next,                  REF_VEHICLE_OLD),
 


### PR DESCRIPTION
The original translation functionality hasn't been used since 2007. This removes a tiny bit of confusing cruft.