### PR TITLE
Fix #6584: text layout problem in engine preview dialog

### DIFF
--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -108,7 +108,7 @@ struct EnginePreviewWindow : Window {
 
 		EngineID engine = this->window_number;
 		SetDParam(0, GetEngineCategoryName(engine));
-		int y = r.top + GetStringHeight(STR_ENGINE_PREVIEW_MESSAGE, r.right - r.top + 1);
+		int y = r.top + GetStringHeight(STR_ENGINE_PREVIEW_MESSAGE, r.right - r.left + 1);
 		y = DrawStringMultiLine(r.left, r.right, r.top, y, STR_ENGINE_PREVIEW_MESSAGE, TC_FROMSTRING, SA_CENTER) + WD_PAR_VSEP_WIDE;
 
 		SetDParam(0, engine);


### PR DESCRIPTION
With language set to German, there was a problem in this dialog box due to the long strings in this language. It looks like the call to `GetStringHeight()` here is using `r.top` to help calculate the max width, rather than `r.left`.

Before this patch:
![2019-01-28-215251_321x204_scrot](https://user-images.githubusercontent.com/59292/51881096-dbdf3780-2347-11e9-8a8c-65cbaa8a576a.png)

After:
![2019-01-28-215405_324x205_scrot](https://user-images.githubusercontent.com/59292/51881101-e13c8200-2347-11e9-974f-f9369cf90a9f.png)
