### PR TITLE
Update: Visual Studio 2019 insists on upgrading the solution file

### DIFF
--- a/projects/openttd_vs142.sln
+++ b/projects/openttd_vs142.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28516.95
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openttd", "openttd_vs142.vcxproj", "{668328A0-B40E-4CDB-BD72-D0064424414A}"
 EndProject
@@ -96,6 +95,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1DE4D2BD-DBC4-4304-907E-34994EEAA4C1}
 	EndGlobalSection
 	GlobalSection(DPCodeReviewSolutionGUID) = preSolution
 		DPCodeReviewSolutionGUID = {00000000-0000-0000-0000-000000000000}


### PR DESCRIPTION
Every time I build, Visual Studio 2019 clobbers my working copy with this change. Should probably integrate it.