### PR TITLE
Fix #7142: Missing map bounds check when building long roads.

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -809,7 +809,9 @@ do_clear:;
  */
 static bool CanConnectToRoad(TileIndex tile, RoadType rt, DiagDirection dir)
 {
-	RoadBits bits = GetAnyRoadBits(tile + TileOffsByDiagDir(dir), rt, false);
+	tile += TileOffsByDiagDir(dir);
+	if (!IsValidTile(tile)) return false;
+	RoadBits bits = GetAnyRoadBits(tile, rt, false);
 	return (bits & DiagDirToRoadBits(ReverseDiagDir(dir))) != 0;
 }
 


### PR DESCRIPTION
Missing bounds check in CanConnectToRoad() causes assertion when freeform_edges is false, as described in #7142.