### PR TITLE
Fix: don't show OS error box for non GUI video drivers

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -117,7 +117,9 @@ void CDECL error(const char *s, ...)
 	vseprintf(buf, lastof(buf), s, va);
 	va_end(va);
 
-	ShowOSErrorBox(buf, true);
+	if (VideoDriver::GetInstance() == NULL || VideoDriver::GetInstance()->HasGUI()) {
+		ShowOSErrorBox(buf, true);
+	}
 
 	/* Set the error message for the crash log and then invoke it. */
 	CrashLog::SetErrorMessage(buf);


### PR DESCRIPTION
Prevents CI hang when an assert happens during regression test.
OS error box will be still displayed for user errors.