### PR TITLE
Change: Synchronize randomness in vehicle introduction…

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -652,7 +652,14 @@ void StartupOneEngine(Engine *e, Date aging_date)
 	/* Don't randomise the start-date in the first two years after gamestart to ensure availability
 	 * of engines in early starting games.
 	 * Note: TTDP uses fixed 1922 */
+	SavedRandomSeeds saved_seeds;
+	SaveRandomSeeds(&saved_seeds);
+	SetRandomSeed(_settings_game.game_creation.generation_seed ^
+	              ei->base_intro ^
+	              e->type ^
+	              e->GetGRFID());
 	uint32 r = Random();
+
 	e->intro_date = ei->base_intro <= ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (Date)GB(r, 0, 9) + ei->base_intro;
 	if (e->intro_date <= _date) {
 		e->age = (aging_date - e->intro_date) >> 5;
@@ -672,6 +679,7 @@ void StartupOneEngine(Engine *e, Date aging_date)
 
 	e->reliability_spd_dec = ei->decay_speed << 2;
 
+	RestoreRandomSeeds(saved_seeds);
 	CalcEngineReliability(e);
 
 	/* prevent certain engines from ever appearing. */


### PR DESCRIPTION
...so all vehicles introduced simultaneously will stay at the same date

we could add a NewGRF flag somewhere to toggle old vs. new behaviour, but for trains misc_flags (prop 27) is already full. the others have a few "reserved, do not use" bits.