### PR TITLE
Change: Make ships stop in locks to move up/down instead of following the slope.

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -289,6 +289,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_SHIP_ROTATION,                      ///< 204  PR#7065 Add extra rotation stages for ships.
 
 	SLV_GROUP_LIVERIES,                     ///< 205  PR#7108 Livery storage change and group liveries.
+	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };


### PR DESCRIPTION
This needs some saveload conversion code.
It may also be desirable to make it a game setting.

Video of this in action: https://www.youtube.com/watch?v=sD4oOe-8Bk8