### PR TITLE
Fix a couple of livery related issues.

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -700,9 +700,6 @@ public:
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_SCL_MATRIX_SCROLLBAR);
 
-		this->square = GetSpriteSize(SPR_SQUARE);
-		this->line_height = max(this->square.height, (uint)FONT_HEIGHT_NORMAL) + 4;
-
 		if (group == INVALID_GROUP) {
 			this->livery_class = LC_OTHER;
 			this->sel = 1;
@@ -770,6 +767,9 @@ public:
 
 			case WID_SCL_MATRIX: {
 				/* 11 items in the default rail class */
+				this->square = GetSpriteSize(SPR_SQUARE);
+				this->line_height = max(this->square.height, (uint)FONT_HEIGHT_NORMAL) + 4;
+
 				size->height = 11 * this->line_height;
 				resize->width = 1;
 				resize->height = this->line_height;
@@ -784,6 +784,7 @@ public:
 				FALLTHROUGH;
 
 			case WID_SCL_PRI_COL_DROPDOWN: {
+				this->square = GetSpriteSize(SPR_SQUARE);
 				int padding = this->square.width + NWidgetScrollbar::GetVerticalDimension().width + 10;
 				for (const StringID *id = _colour_dropdown; id != endof(_colour_dropdown); id++) {
 					size->width = max(size->width, GetStringBoundingBox(*id).width + padding);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1813,11 +1813,12 @@ LiveryScheme GetEngineLiveryScheme(EngineID engine_type, EngineID parent_engine_
 					if (parent_engine_type == INVALID_ENGINE) {
 						return LS_PASSENGER_WAGON_STEAM;
 					} else {
+						bool is_mu = HasBit(EngInfo(parent_engine_type)->misc_flags, EF_RAIL_IS_MU);
 						switch (RailVehInfo(parent_engine_type)->engclass) {
 							default: NOT_REACHED();
 							case EC_STEAM:    return LS_PASSENGER_WAGON_STEAM;
-							case EC_DIESEL:   return LS_PASSENGER_WAGON_DIESEL;
-							case EC_ELECTRIC: return LS_PASSENGER_WAGON_ELECTRIC;
+							case EC_DIESEL:   return is_mu ? LS_DMU : LS_PASSENGER_WAGON_DIESEL;
+							case EC_ELECTRIC: return is_mu ? LS_EMU : LS_PASSENGER_WAGON_ELECTRIC;
 							case EC_MONORAIL: return LS_PASSENGER_WAGON_MONORAIL;
 							case EC_MAGLEV:   return LS_PASSENGER_WAGON_MAGLEV;
 						}


### PR DESCRIPTION
1. Livery window doesn't scale properly when GUI scale is changed whilst it is open.
2. DMU/EMU livery colours should apply to passengers carriages when the front engine is flagged as DMU/EMU.