### PR TITLE
Add: [AzurePipelines] split the CI in two parts: building and commit checking

### DIFF
--- a/azure-pipelines-ci-checker.yml
+++ b/azure-pipelines-ci-checker.yml
@@ -1,0 +1,23 @@
+trigger:
+- master
+pr:
+- master
+
+jobs:
+- job: linux
+  displayName: 'Linux'
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  strategy:
+    matrix:
+      commit-checker: {}
+
+  steps:
+  - template: azure-pipelines/templates/ci-git-rebase.yml
+  # The dockers already have the dependencies installed
+  # The dockers already have OpenGFX installed
+  - template: azure-pipelines/templates/linux-build.yml
+    parameters:
+      Image: compile-farm-ci
+      Tag: $(Agent.JobName)

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -36,7 +36,6 @@ jobs:
 
   strategy:
     matrix:
-      commit-checker: {}
       linux-amd64-clang-3.8: {}
       linux-amd64-gcc-6: {}
       linux-i386-gcc-6: {}


### PR DESCRIPTION
This makes it a bit more clear to the user what went wrong; instead
of "everything", you can now see if either the building failed, or
that the commit checker failed.

Also, this means the commit checker reports back earlier, which
might help in the workflow.