### PR TITLE
[core] Implement SmallVector using std::vector

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -481,7 +481,7 @@ struct AISettingsWindow : public Window {
 
 							DropDownList *list = new DropDownList();
 							for (int i = config_item.min_value; i <= config_item.max_value; i++) {
-								*list->Append() = new DropDownListCharStringItem(config_item.labels->Find(i)->second, i, false);
+								list->push_back(new DropDownListCharStringItem(config_item.labels->Find(i)->second, i, false));
 							}
 
 							ShowDropDownListAt(this, list, old_val, -1, wi_rect, COLOUR_ORANGE, true);

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -219,7 +219,7 @@ class BuildAirportWindow : public PickerWindowBase {
 		DropDownList *list = new DropDownList();
 
 		for (uint i = 0; i < AirportClass::GetClassCount(); i++) {
-			*list->Append() = new DropDownListStringItem(AirportClass::Get((AirportClassID)i)->name, i, false);
+			list->push_back(new DropDownListStringItem(AirportClass::Get((AirportClassID)i)->name, i, false));
 		}
 
 		return list;

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -19,7 +19,7 @@
 #include "safeguards.h"
 
 /** The table/list with animated tiles. */
-SmallVector<TileIndex, 256> _animated_tiles;
+std::vector<TileIndex> _animated_tiles;
 
 /**
  * Removes the given tile from the animated tile table.

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -27,7 +27,7 @@ SmallVector<TileIndex, 256> _animated_tiles;
  */
 void DeleteAnimatedTile(TileIndex tile)
 {
-	TileIndex *to_remove = _animated_tiles.Find(tile);
+	TileIndex *to_remove = &*std::find(_animated_tiles.begin(), _animated_tiles.end(), tile);
 	if (to_remove != _animated_tiles.End()) {
 		/* The order of the remaining elements must stay the same, otherwise the animation loop may miss a tile. */
 		_animated_tiles.ErasePreservingOrder(to_remove);

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -53,8 +53,8 @@ void AnimateAnimatedTiles()
 {
 	PerformanceAccumulator framerate(PFE_GL_LANDSCAPE);
 
-	const TileIndex *ti = _animated_tiles.Begin();
-	while (ti < _animated_tiles.End()) {
+	const TileIndex *ti = _animated_tiles.data();
+	while (ti < _animated_tiles.data() + _animated_tiles.size()) {
 		const TileIndex curr = *ti;
 		AnimateTile(curr);
 		/* During the AnimateTile call, DeleteAnimatedTile could have been called,

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -27,10 +27,10 @@ SmallVector<TileIndex, 256> _animated_tiles;
  */
 void DeleteAnimatedTile(TileIndex tile)
 {
-	TileIndex *to_remove = &*std::find(_animated_tiles.begin(), _animated_tiles.end(), tile);
-	if (to_remove != _animated_tiles.End()) {
+	auto to_remove = std::find(_animated_tiles.begin(), _animated_tiles.end(), tile);
+	if (to_remove != _animated_tiles.end()) {
 		/* The order of the remaining elements must stay the same, otherwise the animation loop may miss a tile. */
-		_animated_tiles.ErasePreservingOrder(to_remove);
+		_animated_tiles.erase(to_remove);
 		MarkTileDirtyByTile(tile);
 	}
 }

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -43,7 +43,7 @@ void DeleteAnimatedTile(TileIndex tile)
 void AddAnimatedTile(TileIndex tile)
 {
 	MarkTileDirtyByTile(tile);
-	_animated_tiles.Include(tile);
+	include(_animated_tiles, tile);
 }
 
 /**

--- a/src/animated_tile.cpp
+++ b/src/animated_tile.cpp
@@ -75,5 +75,5 @@ void AnimateAnimatedTiles()
  */
 void InitializeAnimatedTiles()
 {
-	_animated_tiles.Clear();
+	_animated_tiles.clear();
 }

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -183,8 +183,8 @@ class ReplaceVehicleWindow : public Window {
 				this->vscroll[1]->SetCount(this->engines[1].size());
 				if (this->reset_sel_engine && this->sel_engine[1] != INVALID_ENGINE) {
 					int position = 0;
-					for (EngineID *it = this->engines[1].Begin(); it != this->engines[1].End(); ++it) {
-						if (*it == this->sel_engine[1]) break;
+					for (EngineID &eid : this->engines[1]) {
+						if (eid == this->sel_engine[1]) break;
 						++position;
 					}
 					this->vscroll[1]->ScrollTowards(position);

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -123,7 +123,7 @@ class ReplaceVehicleWindow : public Window {
 		byte side = draw_left ? 0 : 1;
 
 		GUIEngineList *list = &this->engines[side];
-		list->Clear();
+		list->clear();
 
 		const Engine *e;
 		FOR_ALL_ENGINES_OF_TYPE(e, type) {
@@ -170,7 +170,7 @@ class ReplaceVehicleWindow : public Window {
 			/* Either we got a request to rebuild the right engines list, or the left engines list selected a different engine */
 			if (this->sel_engine[0] == INVALID_ENGINE) {
 				/* Always empty the right engines list when nothing is selected in the left engines list */
-				this->engines[1].Clear();
+				this->engines[1].clear();
 				this->sel_engine[1] = INVALID_ENGINE;
 			} else {
 				if (this->reset_sel_engine && this->sel_engine[0] != INVALID_ENGINE) {

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -160,8 +160,8 @@ class ReplaceVehicleWindow : public Window {
 		if (this->engines[0].NeedRebuild()) {
 			/* We need to rebuild the left engines list */
 			this->GenerateReplaceVehList(true);
-			this->vscroll[0]->SetCount(this->engines[0].Length());
-			if (this->reset_sel_engine && this->sel_engine[0] == INVALID_ENGINE && this->engines[0].Length() != 0) {
+			this->vscroll[0]->SetCount(this->engines[0].size());
+			if (this->reset_sel_engine && this->sel_engine[0] == INVALID_ENGINE && this->engines[0].size() != 0) {
 				this->sel_engine[0] = this->engines[0][0];
 			}
 		}
@@ -180,7 +180,7 @@ class ReplaceVehicleWindow : public Window {
 				}
 				/* Regenerate the list on the right. Note: This resets sel_engine[1] to INVALID_ENGINE, if it is no longer available. */
 				this->GenerateReplaceVehList(false);
-				this->vscroll[1]->SetCount(this->engines[1].Length());
+				this->vscroll[1]->SetCount(this->engines[1].size());
 				if (this->reset_sel_engine && this->sel_engine[1] != INVALID_ENGINE) {
 					int position = 0;
 					for (EngineID *it = this->engines[1].Begin(); it != this->engines[1].End(); ++it) {
@@ -384,7 +384,7 @@ public:
 			case WID_RV_RIGHT_MATRIX: {
 				int side = (widget == WID_RV_LEFT_MATRIX) ? 0 : 1;
 				EngineID start  = this->vscroll[side]->GetPosition(); // what is the offset for the start (scrolling)
-				EngineID end    = min(this->vscroll[side]->GetCapacity() + start, this->engines[side].Length());
+				EngineID end    = min(this->vscroll[side]->GetCapacity() + start, this->engines[side].size());
 
 				/* Do the actual drawing */
 				DrawEngineList((VehicleType)this->window_number, r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + WD_FRAMERECT_TOP,
@@ -508,7 +508,7 @@ public:
 					click_side = 1;
 				}
 				uint i = this->vscroll[click_side]->GetScrolledRowFromWidget(pt.y, this, widget);
-				size_t engine_count = this->engines[click_side].Length();
+				size_t engine_count = this->engines[click_side].size();
 
 				EngineID e = engine_count > i ? this->engines[click_side][i] : INVALID_ENGINE;
 				if (e == this->sel_engine[click_side]) break; // we clicked the one we already selected

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -140,7 +140,7 @@ class ReplaceVehicleWindow : public Window {
 				if (!CheckAutoreplaceValidity(this->sel_engine[0], eid, _local_company)) continue;
 			}
 
-			*list->Append() = eid;
+			list->push_back(eid);
 			if (eid == this->sel_engine[side]) selected_engine = eid; // The selected engine is still in the list
 		}
 		this->sel_engine[side] = selected_engine; // update which engine we selected (the same or none, if it's not in the list anymore)
@@ -468,8 +468,8 @@ public:
 
 			case WID_RV_TRAIN_ENGINEWAGON_DROPDOWN: {
 				DropDownList *list = new DropDownList();
-				*list->Append() = new DropDownListStringItem(STR_REPLACE_ENGINES, 1, false);
-				*list->Append() = new DropDownListStringItem(STR_REPLACE_WAGONS, 0, false);
+				list->push_back(new DropDownListStringItem(STR_REPLACE_ENGINES, 1, false));
+				list->push_back(new DropDownListStringItem(STR_REPLACE_WAGONS, 0, false));
 				ShowDropDownList(this, list, this->replace_engines ? 1 : 0, WID_RV_TRAIN_ENGINEWAGON_DROPDOWN);
 				break;
 			}

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -76,9 +76,9 @@ struct BaseSet {
 	{
 		free(this->name);
 
-		for (TranslatedStrings::iterator iter = this->description.Begin(); iter != this->description.End(); iter++) {
-			free(iter->first);
-			free(iter->second);
+		for (auto &pair : this->description) {
+			free(pair.first);
+			free(pair.second);
 		}
 
 		for (uint i = 0; i < NUM_FILES; i++) {
@@ -122,16 +122,16 @@ struct BaseSet {
 	{
 		if (isocode != NULL) {
 			/* First the full ISO code */
-			for (TranslatedStrings::const_iterator iter = this->description.Begin(); iter != this->description.End(); iter++) {
-				if (strcmp(iter->first, isocode) == 0) return iter->second;
+			for (const auto &pair : this->description) {
+				if (strcmp(pair.first, isocode) == 0) return pair.second;
 			}
 			/* Then the first two characters */
-			for (TranslatedStrings::const_iterator iter = this->description.Begin(); iter != this->description.End(); iter++) {
-				if (strncmp(iter->first, isocode, 2) == 0) return iter->second;
+			for (const auto &pair : this->description) {
+				if (strncmp(pair.first, isocode, 2) == 0) return pair.second;
 			}
 		}
 		/* Then fall back */
-		return this->description.Begin()->second;
+		return this->description.front().second;
 	}
 
 	/**

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -113,11 +113,11 @@ private:
 	void BuildBridge(uint8 i)
 	{
 		switch ((TransportType)(this->type >> 15)) {
-			case TRANSPORT_RAIL: _last_railbridge_type = this->bridges->Get(i)->index; break;
-			case TRANSPORT_ROAD: _last_roadbridge_type = this->bridges->Get(i)->index; break;
+			case TRANSPORT_RAIL: _last_railbridge_type = this->bridges->at(i).index; break;
+			case TRANSPORT_ROAD: _last_roadbridge_type = this->bridges->at(i).index; break;
 			default: break;
 		}
-		DoCommandP(this->end_tile, this->start_tile, this->type | this->bridges->Get(i)->index,
+		DoCommandP(this->end_tile, this->start_tile, this->type | this->bridges->at(i).index,
 					CMD_BUILD_BRIDGE | CMD_MSG(STR_ERROR_CAN_T_BUILD_BRIDGE_HERE), CcBuildBridge);
 	}
 
@@ -187,10 +187,10 @@ public:
 				Dimension sprite_dim = {0, 0}; // Biggest bridge sprite dimension
 				Dimension text_dim   = {0, 0}; // Biggest text dimension
 				for (int i = 0; i < (int)this->bridges->size(); i++) {
-					const BridgeSpec *b = this->bridges->Get(i)->spec;
+					const BridgeSpec *b = this->bridges->at(i).spec;
 					sprite_dim = maxdim(sprite_dim, GetSpriteSize(b->sprite));
 
-					SetDParam(2, this->bridges->Get(i)->cost);
+					SetDParam(2, this->bridges->at(i).cost);
 					SetDParam(1, b->speed);
 					SetDParam(0, b->material);
 					text_dim = maxdim(text_dim, GetStringBoundingBox(_game_mode == GM_EDITOR ? STR_SELECT_BRIDGE_SCENEDIT_INFO : STR_SELECT_BRIDGE_INFO));
@@ -227,9 +227,9 @@ public:
 			case WID_BBS_BRIDGE_LIST: {
 				uint y = r.top;
 				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < (int)this->bridges->size(); i++) {
-					const BridgeSpec *b = this->bridges->Get(i)->spec;
+					const BridgeSpec *b = this->bridges->at(i).spec;
 
-					SetDParam(2, this->bridges->Get(i)->cost);
+					SetDParam(2, this->bridges->at(i).cost);
 					SetDParam(1, b->speed);
 					SetDParam(0, b->material);
 

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -416,12 +416,13 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 		for (BridgeType brd_type = 0; brd_type != MAX_BRIDGES; brd_type++) {
 			if (CheckBridgeAvailability(brd_type, bridge_len).Succeeded()) {
 				/* bridge is accepted, add to list */
-				BuildBridgeData *item = bl->Append();
-				item->index = brd_type;
-				item->spec = GetBridgeSpec(brd_type);
+				/*C++17: BuildBridgeData &item = */ bl->emplace_back();
+				BuildBridgeData &item = bl->back();
+				item.index = brd_type;
+				item.spec = GetBridgeSpec(brd_type);
 				/* Add to terraforming & bulldozing costs the cost of the
 				 * bridge itself (not computed with DC_QUERY_COST) */
-				item->cost = ret.GetCost() + (((int64)tot_bridgedata_len * _price[PR_BUILD_BRIDGE] * item->spec->price) >> 8) + infra_cost;
+				item.cost = ret.GetCost() + (((int64)tot_bridgedata_len * _price[PR_BUILD_BRIDGE] * item.spec->price) >> 8) + infra_cost;
 			}
 		}
 	}

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -153,7 +153,7 @@ public:
 		this->bridges->NeedResort();
 		this->SortBridgeList();
 
-		this->vscroll->SetCount(bl->Length());
+		this->vscroll->SetCount(bl->size());
 	}
 
 	~BuildBridgeWindow()
@@ -186,7 +186,7 @@ public:
 			case WID_BBS_BRIDGE_LIST: {
 				Dimension sprite_dim = {0, 0}; // Biggest bridge sprite dimension
 				Dimension text_dim   = {0, 0}; // Biggest text dimension
-				for (int i = 0; i < (int)this->bridges->Length(); i++) {
+				for (int i = 0; i < (int)this->bridges->size(); i++) {
 					const BridgeSpec *b = this->bridges->Get(i)->spec;
 					sprite_dim = maxdim(sprite_dim, GetSpriteSize(b->sprite));
 
@@ -226,7 +226,7 @@ public:
 
 			case WID_BBS_BRIDGE_LIST: {
 				uint y = r.top;
-				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < (int)this->bridges->Length(); i++) {
+				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < (int)this->bridges->size(); i++) {
 					const BridgeSpec *b = this->bridges->Get(i)->spec;
 
 					SetDParam(2, this->bridges->Get(i)->cost);
@@ -246,7 +246,7 @@ public:
 	EventState OnKeyPress(WChar key, uint16 keycode) override
 	{
 		const uint8 i = keycode - '1';
-		if (i < 9 && i < this->bridges->Length()) {
+		if (i < 9 && i < this->bridges->size()) {
 			/* Build the requested bridge */
 			this->BuildBridge(i);
 			delete this;
@@ -261,7 +261,7 @@ public:
 			default: break;
 			case WID_BBS_BRIDGE_LIST: {
 				uint i = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_BBS_BRIDGE_LIST);
-				if (i < this->bridges->Length()) {
+				if (i < this->bridges->size()) {
 					this->BuildBridge(i);
 					delete this;
 				}
@@ -426,7 +426,7 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 		}
 	}
 
-	if (bl != NULL && bl->Length() != 0) {
+	if (bl != NULL && bl->size() != 0) {
 		new BuildBridgeWindow(&_build_bridge_desc, start, end, type, bl);
 	} else {
 		delete bl;

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1228,7 +1228,7 @@ struct BuildVehicleWindow : Window {
 
 		this->filter.railtype = (this->listview_mode) ? RAILTYPE_END : GetRailType(this->window_number);
 
-		this->eng_list.Clear();
+		this->eng_list.clear();
 
 		/* Make list of all available train engines and wagons.
 		 * Also check to see if the previously selected engine is still available,
@@ -1276,7 +1276,7 @@ struct BuildVehicleWindow : Window {
 	{
 		EngineID sel_id = INVALID_ENGINE;
 
-		this->eng_list.Clear();
+		this->eng_list.clear();
 
 		const Engine *e;
 		FOR_ALL_ENGINES_OF_TYPE(e, VEH_ROAD) {
@@ -1295,7 +1295,7 @@ struct BuildVehicleWindow : Window {
 	void GenerateBuildShipList()
 	{
 		EngineID sel_id = INVALID_ENGINE;
-		this->eng_list.Clear();
+		this->eng_list.clear();
 
 		const Engine *e;
 		FOR_ALL_ENGINES_OF_TYPE(e, VEH_SHIP) {
@@ -1314,7 +1314,7 @@ struct BuildVehicleWindow : Window {
 	{
 		EngineID sel_id = INVALID_ENGINE;
 
-		this->eng_list.Clear();
+		this->eng_list.clear();
 
 		const Station *st = this->listview_mode ? NULL : Station::GetByTile(this->window_number);
 

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1246,7 +1246,7 @@ struct BuildVehicleWindow : Window {
 			/* Filter now! So num_engines and num_wagons is valid */
 			if (!FilterSingleEngine(eid)) continue;
 
-			*this->eng_list.Append() = eid;
+			this->eng_list.push_back(eid);
 
 			if (rvi->railveh_type != RAILVEH_WAGON) {
 				num_engines++;
@@ -1284,7 +1284,7 @@ struct BuildVehicleWindow : Window {
 			EngineID eid = e->index;
 			if (!IsEngineBuildable(eid, VEH_ROAD, _local_company)) continue;
 			if (!HasBit(this->filter.roadtypes, HasBit(EngInfo(eid)->misc_flags, EF_ROAD_TRAM) ? ROADTYPE_TRAM : ROADTYPE_ROAD)) continue;
-			*this->eng_list.Append() = eid;
+			this->eng_list.push_back(eid);
 
 			if (eid == this->sel_engine) sel_id = eid;
 		}
@@ -1302,7 +1302,7 @@ struct BuildVehicleWindow : Window {
 			if (!this->show_hidden_engines && e->IsHidden(_local_company)) continue;
 			EngineID eid = e->index;
 			if (!IsEngineBuildable(eid, VEH_SHIP, _local_company)) continue;
-			*this->eng_list.Append() = eid;
+			this->eng_list.push_back(eid);
 
 			if (eid == this->sel_engine) sel_id = eid;
 		}
@@ -1330,7 +1330,7 @@ struct BuildVehicleWindow : Window {
 			/* First VEH_END window_numbers are fake to allow a window open for all different types at once */
 			if (!this->listview_mode && !CanVehicleUseStation(eid, st)) continue;
 
-			*this->eng_list.Append() = eid;
+			this->eng_list.push_back(eid);
 			if (eid == this->sel_engine) sel_id = eid;
 		}
 

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1207,7 +1207,7 @@ struct BuildVehicleWindow : Window {
 		this->eng_list.Filter(this->cargo_filter[this->cargo_filter_criteria]);
 		if (0 == this->eng_list.size()) { // no engine passed through the filter, invalidate the previously selected engine
 			this->SelectEngine(INVALID_ENGINE);
-		} else if (!this->eng_list.Contains(this->sel_engine)) { // previously selected engine didn't pass the filter, select the first engine of the list
+		} else if (std::find(this->eng_list.begin(), this->eng_list.end(), this->sel_engine) == this->eng_list.end()) { // previously selected engine didn't pass the filter, select the first engine of the list
 			this->SelectEngine(this->eng_list[0]);
 		}
 	}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1345,7 +1345,7 @@ struct BuildVehicleWindow : Window {
 			default: NOT_REACHED();
 			case VEH_TRAIN:
 				this->GenerateBuildTrainList();
-				this->eng_list.Compact();
+				this->eng_list.shrink_to_fit();
 				this->eng_list.RebuildDone();
 				return; // trains should not reach the last sorting
 			case VEH_ROAD:
@@ -1364,7 +1364,7 @@ struct BuildVehicleWindow : Window {
 		_engine_sort_direction = this->descending_sort_order;
 		EngList_Sort(&this->eng_list, _engine_sort_functions[this->vehicle_type][this->sort_criteria]);
 
-		this->eng_list.Compact();
+		this->eng_list.shrink_to_fit();
 		this->eng_list.RebuildDone();
 	}
 

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -940,7 +940,7 @@ void DrawEngineList(VehicleType type, int l, int r, int y, const GUIEngineList *
 	static const int sprite_y_offsets[] = { -1, -1, -2, -2 };
 
 	/* Obligatory sanity checks! */
-	assert(max <= eng_list->Length());
+	assert(max <= eng_list->size());
 
 	bool rtl = _current_text_dir == TD_RTL;
 	int step_size = GetEngineListHeight(type);
@@ -1110,7 +1110,7 @@ struct BuildVehicleWindow : Window {
 		this->eng_list.ForceRebuild();
 		this->GenerateBuildList(); // generate the list, since we need it in the next line
 		/* Select the first engine in the list as default when opening the window */
-		if (this->eng_list.Length() > 0) {
+		if (this->eng_list.size() > 0) {
 			this->SelectEngine(this->eng_list[0]);
 		} else {
 			this->SelectEngine(INVALID_ENGINE);
@@ -1205,7 +1205,7 @@ struct BuildVehicleWindow : Window {
 	void FilterEngineList()
 	{
 		this->eng_list.Filter(this->cargo_filter[this->cargo_filter_criteria]);
-		if (0 == this->eng_list.Length()) { // no engine passed through the filter, invalidate the previously selected engine
+		if (0 == this->eng_list.size()) { // no engine passed through the filter, invalidate the previously selected engine
 			this->SelectEngine(INVALID_ENGINE);
 		} else if (!this->eng_list.Contains(this->sel_engine)) { // previously selected engine didn't pass the filter, select the first engine of the list
 			this->SelectEngine(this->eng_list[0]);
@@ -1388,7 +1388,7 @@ struct BuildVehicleWindow : Window {
 
 			case WID_BV_LIST: {
 				uint i = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_BV_LIST);
-				size_t num_items = this->eng_list.Length();
+				size_t num_items = this->eng_list.size();
 				this->SelectEngine((i < num_items) ? this->eng_list[i] : INVALID_ENGINE);
 				this->SetDirty();
 				if (_ctrl_pressed) {
@@ -1529,7 +1529,7 @@ struct BuildVehicleWindow : Window {
 	{
 		switch (widget) {
 			case WID_BV_LIST:
-				DrawEngineList(this->vehicle_type, r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + WD_FRAMERECT_TOP, &this->eng_list, this->vscroll->GetPosition(), min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->eng_list.Length()), this->sel_engine, false, DEFAULT_GROUP);
+				DrawEngineList(this->vehicle_type, r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + WD_FRAMERECT_TOP, &this->eng_list, this->vscroll->GetPosition(), min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->eng_list.size()), this->sel_engine, false, DEFAULT_GROUP);
 				break;
 
 			case WID_BV_SORT_ASCENDING_DESCENDING:
@@ -1541,7 +1541,7 @@ struct BuildVehicleWindow : Window {
 	void OnPaint() override
 	{
 		this->GenerateBuildList();
-		this->vscroll->SetCount(this->eng_list.Length());
+		this->vscroll->SetCount(this->eng_list.size());
 
 		this->SetWidgetsDisabledState(this->sel_engine == INVALID_ENGINE, WID_BV_SHOW_HIDE, WID_BV_BUILD, WID_BV_RENAME, WIDGET_LIST_END);
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -469,7 +469,7 @@ CommandCost DoCommand(TileIndex tile, uint32 p1, uint32 p2, DoCommandFlag flags,
 
 	/* only execute the test call if it's toplevel, or we're not execing. */
 	if (_docommand_recursive == 1 || !(flags & DC_EXEC) ) {
-		if (_docommand_recursive == 1) _cleared_object_areas.Clear();
+		if (_docommand_recursive == 1) _cleared_object_areas.clear();
 		SetTownRatingTestMode(true);
 		res = proc(tile, flags & ~DC_EXEC, p1, p2, text);
 		SetTownRatingTestMode(false);
@@ -492,7 +492,7 @@ CommandCost DoCommand(TileIndex tile, uint32 p1, uint32 p2, DoCommandFlag flags,
 
 	/* Execute the command here. All cost-relevant functions set the expenses type
 	 * themselves to the cost object at some point */
-	if (_docommand_recursive == 1) _cleared_object_areas.Clear();
+	if (_docommand_recursive == 1) _cleared_object_areas.clear();
 	res = proc(tile, flags, p1, p2, text);
 	if (res.Failed()) {
 error:
@@ -666,7 +666,7 @@ CommandCost DoCommandPInternal(TileIndex tile, uint32 p1, uint32 p2, uint32 cmd,
 	bool test_and_exec_can_differ = (cmd_flags & CMD_NO_TEST) != 0;
 
 	/* Test the command. */
-	_cleared_object_areas.Clear();
+	_cleared_object_areas.clear();
 	SetTownRatingTestMode(true);
 	BasePersistentStorageArray::SwitchMode(PSM_ENTER_TESTMODE);
 	CommandCost res = proc(tile, flags, p1, p2, text);
@@ -710,7 +710,7 @@ CommandCost DoCommandPInternal(TileIndex tile, uint32 p1, uint32 p2, uint32 cmd,
 
 	/* Actually try and execute the command. If no cost-type is given
 	 * use the construction one */
-	_cleared_object_areas.Clear();
+	_cleared_object_areas.clear();
 	BasePersistentStorageArray::SwitchMode(PSM_ENTER_COMMAND);
 	CommandCost res2 = proc(tile, flags | DC_EXEC, p1, p2, text);
 	BasePersistentStorageArray::SwitchMode(PSM_LEAVE_COMMAND);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -672,7 +672,7 @@ private:
 			AddChildren(&list, INVALID_GROUP, 0);
 		}
 
-		this->groups.Compact();
+		this->groups.shrink_to_fit();
 		this->groups.RebuildDone();
 	}
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -640,11 +640,11 @@ private:
 
 	void AddChildren(GUIGroupList *source, GroupID parent, int indent)
 	{
-		for (const Group **g = source->Begin(); g != source->End(); g++) {
-			if ((*g)->parent != parent) continue;
-			this->groups.push_back(*g);
+		for (const Group *g : *source) {
+			if (g->parent != parent) continue;
+			this->groups.push_back(g);
 			this->indents.push_back(indent);
-			AddChildren(source, (*g)->index, indent + 1);
+			AddChildren(source, g->index, indent + 1);
 		}
 	}
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -606,10 +606,10 @@ private:
 		if (default_livery != NULL) {
 			/* Add COLOUR_END to put the colour out of range, but also allow us to show what the default is */
 			default_col = (primary ? default_livery->colour1 : default_livery->colour2) + COLOUR_END;
-			*list->Append() = new DropDownListColourItem(default_col, false);
+			list->push_back(new DropDownListColourItem(default_col, false));
 		}
 		for (uint i = 0; i < lengthof(_colour_dropdown); i++) {
-			*list->Append() = new DropDownListColourItem(i, HasBit(used_colours, i));
+			list->push_back(new DropDownListColourItem(i, HasBit(used_colours, i)));
 		}
 
 		byte sel = (default_livery == NULL || HasBit(livery->in_use, primary ? 0 : 1)) ? (primary ? livery->colour1 : livery->colour2) : default_col;
@@ -642,8 +642,8 @@ private:
 	{
 		for (const Group **g = source->Begin(); g != source->End(); g++) {
 			if ((*g)->parent != parent) continue;
-			*this->groups.Append() = *g;
-			*this->indents.Append() = indent;
+			this->groups.push_back(*g);
+			this->indents.push_back(indent);
 			AddChildren(source, (*g)->index, indent + 1);
 		}
 	}
@@ -662,7 +662,7 @@ private:
 			const Group *g;
 			FOR_ALL_GROUPS(g) {
 				if (g->owner == owner && g->vehicle_type == vtype) {
-					*list.Append() = g;
+					list.push_back(g);
 				}
 			}
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -652,8 +652,8 @@ private:
 	{
 		if (!this->groups.NeedRebuild()) return;
 
-		this->groups.Clear();
-		this->indents.Clear();
+		this->groups.clear();
+		this->indents.clear();
 
 		if (this->livery_class >= LC_GROUP_RAIL) {
 			GUIGroupList list;

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -562,7 +562,7 @@ private:
 	uint rows;
 	uint line_height;
 	GUIGroupList groups;
-	SmallVector<int, 32> indents;
+	std::vector<int> indents;
 	Scrollbar *vscroll;
 
 	void ShowColourDropDownMenu(uint32 widget)

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -686,7 +686,7 @@ private:
 				}
 			}
 		} else {
-			this->rows = this->groups.Length();
+			this->rows = this->groups.size();
 		}
 
 		this->vscroll->SetCount(this->rows);
@@ -902,7 +902,7 @@ public:
 				}
 			}
 		} else {
-			uint max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->groups.Length());
+			uint max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->groups.size());
 			for (uint i = this->vscroll->GetPosition(); i < max; ++i) {
 				const Group *g = this->groups[i];
 				SetDParam(0, g->index);
@@ -942,7 +942,7 @@ public:
 					this->groups.ForceRebuild();
 					this->BuildGroupList((CompanyID)this->window_number);
 
-					if (this->groups.Length() > 0) {
+					if (this->groups.size() > 0) {
 						this->sel = this->groups[0]->index;
 					}
 				}
@@ -1029,7 +1029,7 @@ public:
 
 				if (!Group::IsValidID(this->sel)) {
 					this->sel = INVALID_GROUP;
-					if (this->groups.Length() > 0) this->sel = this->groups[0]->index;
+					if (this->groups.size() > 0) this->sel = this->groups[0]->index;
 				}
 
 				this->SetDirty();

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -585,8 +585,8 @@ DEF_CONSOLE_CMD(ConBanList)
 	IConsolePrint(CC_DEFAULT, "Banlist: ");
 
 	uint i = 1;
-	for (char **iter = _network_ban_list.Begin(); iter != _network_ban_list.End(); iter++, i++) {
-		IConsolePrintF(CC_DEFAULT, "  %d) %s", i, *iter);
+	for (char *entry : _network_ban_list) {
+		IConsolePrintF(CC_DEFAULT, "  %d) %s", i, entry);
 	}
 
 	return true;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -566,7 +566,7 @@ DEF_CONSOLE_CMD(ConUnBan)
 		seprintf(msg, lastof(msg), "Unbanned %s", _network_ban_list[index]);
 		IConsolePrint(CC_DEFAULT, msg);
 		free(_network_ban_list[index]);
-		_network_ban_list.Erase(_network_ban_list.Get(index));
+		_network_ban_list.erase(_network_ban_list.begin() + index);
 	} else {
 		IConsolePrint(CC_DEFAULT, "Invalid list index or IP not in ban-list.");
 		IConsolePrint(CC_DEFAULT, "For a list of banned IP's, see the command 'banlist'");

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -552,16 +552,16 @@ DEF_CONSOLE_CMD(ConUnBan)
 
 	/* Try by IP. */
 	uint index;
-	for (index = 0; index < _network_ban_list.Length(); index++) {
+	for (index = 0; index < _network_ban_list.size(); index++) {
 		if (strcmp(_network_ban_list[index], argv[1]) == 0) break;
 	}
 
 	/* Try by index. */
-	if (index >= _network_ban_list.Length()) {
+	if (index >= _network_ban_list.size()) {
 		index = atoi(argv[1]) - 1U; // let it wrap
 	}
 
-	if (index < _network_ban_list.Length()) {
+	if (index < _network_ban_list.size()) {
 		char msg[64];
 		seprintf(msg, lastof(msg), "Unbanned %s", _network_ban_list[index]);
 		IConsolePrint(CC_DEFAULT, msg);

--- a/src/core/pool_func.cpp
+++ b/src/core/pool_func.cpp
@@ -22,7 +22,7 @@
 {
 	PoolVector *pools = PoolBase::GetPools();
 	pools->Erase(pools->Find(this));
-	if (pools->Length() == 0) delete pools;
+	if (pools->size() == 0) delete pools;
 }
 
 /**

--- a/src/core/pool_func.cpp
+++ b/src/core/pool_func.cpp
@@ -31,10 +31,7 @@
  */
 /* static */ void PoolBase::Clean(PoolType pt)
 {
-	PoolVector *pools = PoolBase::GetPools();
-	PoolBase **end = pools->End();
-	for (PoolBase **ppool = pools->Begin(); ppool != end; ppool++) {
-		PoolBase *pool = *ppool;
+	for (PoolBase *pool : *PoolBase::GetPools()) {
 		if (pool->type & pt) pool->CleanPool();
 	}
 }

--- a/src/core/pool_func.cpp
+++ b/src/core/pool_func.cpp
@@ -21,7 +21,7 @@
 /* virtual */ PoolBase::~PoolBase()
 {
 	PoolVector *pools = PoolBase::GetPools();
-	pools->Erase(pools->Find(this));
+	pools->erase(std::find(pools->begin(), pools->end(), this));
 	if (pools->size() == 0) delete pools;
 }
 

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -26,7 +26,7 @@ enum PoolType {
 };
 DECLARE_ENUM_AS_BIT_SET(PoolType)
 
-typedef SmallVector<struct PoolBase *, 4> PoolVector; ///< Vector of pointers to PoolBase
+typedef std::vector<struct PoolBase *> PoolVector; ///< Vector of pointers to PoolBase
 
 /** Base class for base of all pools. */
 struct PoolBase {

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -50,7 +50,7 @@ struct PoolBase {
 	 */
 	PoolBase(PoolType pt) : type(pt)
 	{
-		*PoolBase::GetPools()->Append() = this;
+		PoolBase::GetPools()->push_back(this);
 	}
 
 	virtual ~PoolBase();

--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -39,7 +39,7 @@ struct SmallPair {
  *
  * @see SmallVector
  */
-template <typename T, typename U, uint S = 16>
+template <typename T, typename U>
 struct SmallMap : std::vector<SmallPair<T, U> > {
 	typedef ::SmallPair<T, U> Pair;
 	typedef Pair *iterator;

--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -115,7 +115,8 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	inline void Erase(Pair *pair)
 	{
 		assert(pair >= this->Begin() && pair < this->End());
-		SmallVector<Pair, S>::Erase(pair);
+		auto distance = pair - std::vector<Pair>::data();
+		std::vector<Pair>::erase(std::vector<Pair>::begin() + distance);
 	}
 
 	/**
@@ -126,11 +127,10 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 */
 	inline bool Erase(const T &key)
 	{
-		Pair *pair = this->Find(key);
-		if (pair == this->End())
-			return false;
+		auto pair = std::find(this->begin(), this->end(), key);
+		if (pair == this->end()) return false;
 
-		SmallVector<Pair, S>::Erase(pair);
+		std::vector<Pair>::erase(pair);
 		return true;
 	}
 

--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -27,6 +27,7 @@ struct SmallPair {
 
 	/** Initializes this Pair with data */
 	inline SmallPair(const T &first, const U &second) : first(first), second(second) { }
+	SmallPair() = default;
 };
 
 /**
@@ -56,8 +57,8 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 */
 	inline const Pair *Find(const T &key) const
 	{
-		for (uint i = 0; i < this->items; i++) {
-			if (key == this->data[i].first) return &this->data[i];
+		for (uint i = 0; i < std::vector<Pair>::size(); i++) {
+			if (key == std::vector<Pair>::operator[](i).first) return &std::vector<Pair>::operator[](i);
 		}
 		return this->End();
 	}
@@ -69,11 +70,22 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 */
 	inline Pair *Find(const T &key)
 	{
-		for (uint i = 0; i < this->items; i++) {
-			if (key == this->data[i].first) return &this->data[i];
+		for (uint i = 0; i < std::vector<Pair>::size(); i++) {
+			if (key == std::vector<Pair>::operator[](i).first) return &std::vector<Pair>::operator[](i);
 		}
 		return this->End();
 	}
+
+	inline const Pair *End() const
+	{
+		return &*std::vector<Pair>::end();
+	}
+
+	inline Pair *End()
+	{
+		return &*std::vector<Pair>::end();
+	}
+
 
 	/**
 	 * Tests whether a key is assigned in this map.
@@ -86,6 +98,16 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	}
 
 	/**
+	 * Tests whether a key is assigned in this map.
+	 * @param key key to test
+	 * @return true iff the item is present
+	 */
+	inline bool Contains(const T &key)
+	{
+		return this->Find(key) != this->End();
+	}
+
+	/**
 	 * Removes given pair from this map
 	 * @param pair pair to remove
 	 * @note it has to be pointer to pair in this map. It is overwritten by the last item.
@@ -93,7 +115,7 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	inline void Erase(Pair *pair)
 	{
 		assert(pair >= this->Begin() && pair < this->End());
-		*pair = this->data[--this->items];
+		SmallVector<Pair, S>::Erase(pair);
 	}
 
 	/**
@@ -104,13 +126,12 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 */
 	inline bool Erase(const T &key)
 	{
-		for (uint i = 0; i < this->items; i++) {
-			if (key == this->data[i].first) {
-				this->data[i] = this->data[--this->items];
-				return true;
-			}
-		}
-		return false;
+		Pair *pair = this->Find(key);
+		if (pair == this->End())
+			return false;
+
+		SmallVector<Pair, S>::Erase(pair);
+		return true;
 	}
 
 	/**
@@ -136,8 +157,8 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 */
 	inline U &operator[](const T &key)
 	{
-		for (uint i = 0; i < this->items; i++) {
-			if (key == this->data[i].first) return this->data[i].second;
+		for (uint i = 0; i < std::vector<Pair>::size(); i++) {
+			if (key == std::vector<Pair>::operator[](i).first) return std::vector<Pair>::operator[](i).second;
 		}
 		Pair *n = this->Append();
 		n->first = key;
@@ -146,7 +167,7 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 
 	inline void SortByKey()
 	{
-		QSortT(this->Begin(), this->items, KeySorter);
+		QSortT(this->Begin(), std::vector<Pair>::size(), KeySorter);
 	}
 
 	static int CDECL KeySorter(const Pair *a, const Pair *b)

--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -143,9 +143,7 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	inline bool Insert(const T &key, const U &data)
 	{
 		if (this->Contains(key)) return false;
-		Pair *n = this->Append();
-		n->first = key;
-		n->second = data;
+		std::vector<Pair>::emplace_back(key, data);
 		return true;
 	}
 
@@ -160,9 +158,10 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 		for (uint i = 0; i < std::vector<Pair>::size(); i++) {
 			if (key == std::vector<Pair>::operator[](i).first) return std::vector<Pair>::operator[](i).second;
 		}
-		Pair *n = this->Append();
-		n->first = key;
-		return n->second;
+		/*C++17: Pair &n = */ std::vector<Pair>::emplace_back();
+		Pair &n = std::vector<Pair>::back();
+		n.first = key;
+		return n.second;
 	}
 
 	inline void SortByKey()

--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -40,7 +40,7 @@ struct SmallPair {
  * @see SmallVector
  */
 template <typename T, typename U, uint S = 16>
-struct SmallMap : SmallVector<SmallPair<T, U>, S> {
+struct SmallMap : std::vector<SmallPair<T, U> > {
 	typedef ::SmallPair<T, U> Pair;
 	typedef Pair *iterator;
 	typedef const Pair *const_iterator;

--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -55,12 +55,13 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 * @param key key to find
 	 * @return &Pair(key, data) if found, this->End() if not
 	 */
-	inline const Pair *Find(const T &key) const
+	inline typename std::vector<Pair>::const_iterator Find(const T &key) const
 	{
-		for (uint i = 0; i < std::vector<Pair>::size(); i++) {
-			if (key == std::vector<Pair>::operator[](i).first) return &std::vector<Pair>::operator[](i);
+		typename std::vector<Pair>::const_iterator it;
+		for (it = std::vector<Pair>::begin(); it != std::vector<Pair>::end(); it++) {
+			if (key == it->first) return it;
 		}
-		return this->End();
+		return it;
 	}
 
 	/**
@@ -114,7 +115,7 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 	 */
 	inline void Erase(Pair *pair)
 	{
-		assert(pair >= this->Begin() && pair < this->End());
+		assert(pair >= std::vector<Pair>::data() && pair < this->End());
 		auto distance = pair - std::vector<Pair>::data();
 		std::vector<Pair>::erase(std::vector<Pair>::begin() + distance);
 	}
@@ -166,7 +167,7 @@ struct SmallMap : SmallVector<SmallPair<T, U>, S> {
 
 	inline void SortByKey()
 	{
-		QSortT(this->Begin(), std::vector<Pair>::size(), KeySorter);
+		QSortT(std::vector<Pair>::data(), std::vector<Pair>::size(), KeySorter);
 	}
 
 	static int CDECL KeySorter(const Pair *a, const Pair *b)

--- a/src/core/smallstack_type.hpp
+++ b/src/core/smallstack_type.hpp
@@ -74,7 +74,7 @@ private:
 		}
 
 		if (index >= this->data.size() && index < Tmax_size) {
-			this->data.Resize(index + 1);
+			this->data.resize(index + 1);
 		}
 		return index;
 	}

--- a/src/core/smallstack_type.hpp
+++ b/src/core/smallstack_type.hpp
@@ -87,7 +87,7 @@ private:
 	Tindex first_free;
 
 	ThreadMutex *mutex;
-	SmallVector<SimplePoolPoolItem, Tgrowth_step> data;
+	std::vector<SimplePoolPoolItem> data;
 };
 
 /**

--- a/src/core/smallstack_type.hpp
+++ b/src/core/smallstack_type.hpp
@@ -73,7 +73,7 @@ private:
 			if (!this->data[index].valid) return index;
 		}
 
-		if (index >= this->data.Length() && index < Tmax_size) {
+		if (index >= this->data.size() && index < Tmax_size) {
 			this->data.Resize(index + 1);
 		}
 		return index;

--- a/src/core/smallstack_type.hpp
+++ b/src/core/smallstack_type.hpp
@@ -106,6 +106,7 @@ struct SmallStackItem {
 	 */
 	inline SmallStackItem(const Titem &value, Tindex next) :
 		next(next), value(value) {}
+	SmallStackItem() = default;
 };
 
 /**

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -87,14 +87,6 @@ public:
 	}
 
 	/**
-	 * Compact the list down to the smallest block size boundary.
-	 */
-	inline void Compact()
-	{
-		std::vector<T>::shrink_to_fit();
-	}
-
-	/**
 	 * Append an item and return it.
 	 * @param to_add the number of items to append
 	 * @return pointer to newly allocated item

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -34,22 +34,6 @@ inline bool include(std::vector<T>& vec, const T &item)
 	return is_member;
 }
 
-
-/**
- * Simple vector template class.
- *
- * @note There are no asserts in the class so you have
- *       to care about that you grab an item which is
- *       inside the list.
- *
- * @tparam T The type of the items stored
- * @tparam S The steps of allocation
- */
-
-
-template <typename T, uint S>
-using SmallVector = std::vector<T>;
-
 /**
  * Helper function to get the index of an item
  * Consider using std::set, std::unordered_set or std::flat_set in new code
@@ -73,18 +57,17 @@ int find_index(std::vector<T> const& vec, T const& item)
  * Consider using std::back_inserter in new code
  *
  * @param vec A reference to the vector to be extended
- * @param num The number of elements to default-construct
+ * @param num Number of elements to be default-constructed
  *
  * @return Pointer to the first new element
  */
 template <typename T>
-inline T* grow(std::vector<T>& vec, std::size_t num)
+T* grow(std::vector<T>& vec, std::size_t num)
 {
-	const std::size_t pos = vec.size();
+	std::size_t const pos = vec.size();
 	vec.resize(pos + num);
 	return vec.data() + pos;
 }
-
 
 /**
  * Simple vector template class, with automatic free.
@@ -97,7 +80,7 @@ inline T* grow(std::vector<T>& vec, std::size_t num)
  * @param S The steps of allocation
  */
 template <typename T, uint S>
-class AutoFreeSmallVector : public SmallVector<T, S> {
+class AutoFreeSmallVector : public std::vector<T> {
 public:
 	~AutoFreeSmallVector()
 	{
@@ -128,7 +111,7 @@ public:
  * @param S The steps of allocation
  */
 template <typename T, uint S>
-class AutoDeleteSmallVector : public SmallVector<T, S> {
+class AutoDeleteSmallVector : public std::vector<T> {
 public:
 	~AutoDeleteSmallVector()
 	{

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -292,30 +292,6 @@ public:
 		assert(index <= std::vector<T>::size());
 		return this->Begin() + index;
 	}
-
-	/**
-	 * Get item "number" (const)
-	 *
-	 * @param index the position of the item
-	 * @return the item
-	 */
-	inline const T &operator[](uint index) const
-	{
-		assert(index < std::vector<T>::size());
-		return std::vector<T>::operator[](index);
-	}
-
-	/**
-	 * Get item "number"
-	 *
-	 * @param index the position of the item
-	 * @return the item
-	 */
-	inline T &operator[](uint index)
-	{
-		assert(index < std::vector<T>::size());
-		return std::vector<T>::operator[](index);
-	}
 };
 
 

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -77,9 +77,8 @@ T* grow(std::vector<T>& vec, std::size_t num)
  *       inside the list.
  *
  * @param T The type of the items stored, must be a pointer
- * @param S The steps of allocation
  */
-template <typename T, uint S>
+template <typename T>
 class AutoFreeSmallVector : public std::vector<T> {
 public:
 	~AutoFreeSmallVector()
@@ -108,9 +107,8 @@ public:
  *       inside the list.
  *
  * @param T The type of the items stored, must be a pointer
- * @param S The steps of allocation
  */
-template <typename T, uint S>
+template <typename T>
 class AutoDeleteSmallVector : public std::vector<T> {
 public:
 	~AutoDeleteSmallVector()
@@ -131,6 +129,6 @@ public:
 	}
 };
 
-typedef AutoFreeSmallVector<char*, 4> StringList; ///< Type for a list of strings.
+typedef AutoFreeSmallVector<char*> StringList; ///< Type for a list of strings.
 
 #endif /* SMALLVEC_TYPE_HPP */

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -18,6 +18,24 @@
 #include <algorithm>
 
 /**
+ * Helper function to append an item to a vector if it is not already contained
+ * Consider using std::set, std::unordered_set or std::flat_set in new code
+ *
+ * @param vec A reference to the vector to be extended
+ * @param item Reference to the item to be copy-constructed if not found
+ *
+ * @return Whether the item was already present
+ */
+template <typename T>
+inline bool include(std::vector<T>& vec, const T &item)
+{
+	const bool is_member = std::find(vec.begin(), vec.end(), item) != vec.end();
+	if (!is_member) vec.emplace_back(item);
+	return is_member;
+}
+
+
+/**
  * Simple vector template class.
  *
  * @note There are no asserts in the class so you have
@@ -65,19 +83,6 @@ public:
 	}
 
 	~SmallVector() = default;
-
-	/**
-	 * Tests whether a item is present in the vector, and appends it to the end if not.
-	 * The '!=' operator of T is used for comparison.
-	 * @param item Item to test for
-	 * @return true iff the item is was already present
-	 */
-	inline bool Include(const T &item)
-	{
-		bool is_member = std::find(std::vector<T>::begin(), std::vector<T>::end(), item) != std::vector<T>::end();
-		if (!is_member) std::vector<T>::emplace_back(item);
-		return is_member;
-	}
 
 	/**
 	 * Get the pointer to the first item (const)

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -67,17 +67,6 @@ public:
 	~SmallVector() = default;
 
 	/**
-	 * Append an item and return it.
-	 * @param to_add the number of items to append
-	 * @return pointer to newly allocated item
-	 */
-	inline T *Append(uint to_add = 1)
-	{
-		std::vector<T>::resize(std::vector<T>::size() + to_add);
-		return this->End() - to_add;
-	}
-
-	/**
 	 * Insert a new item at a specific position into the vector, moving all following items.
 	 * @param item Position at which the new item should be inserted
 	 * @return pointer to the new item
@@ -112,7 +101,7 @@ public:
 	inline bool Include(const T &item)
 	{
 		bool is_member = std::find(std::vector<T>::begin(), std::vector<T>::end(), item) != std::vector<T>::end();
-		if (!is_member) *this->Append() = item;
+		if (!is_member) std::vector<T>::emplace_back(item);
 		return is_member;
 	}
 
@@ -156,6 +145,23 @@ public:
 		return std::vector<T>::data() + std::vector<T>::size();
 	}
 };
+
+/**
+ * Helper function to extend a vector by more than one element
+ * Consider using std::back_inserter in new code
+ *
+ * @param vec A reference to the vector to be extended
+ * @param num The number of elements to default-construct
+ *
+ * @return Pointer to the first new element
+ */
+template <typename T>
+inline T* grow(std::vector<T>& vec, std::size_t num)
+{
+	const std::size_t pos = vec.size();
+	vec.resize(pos + num);
+	return vec.data() + pos;
+}
 
 
 /**

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -67,18 +67,6 @@ public:
 	~SmallVector() = default;
 
 	/**
-	 * Search for the first occurrence of an item.
-	 * The '!=' operator of T is used for comparison.
-	 * @param item Item to search for
-	 * @return The position of the item, or -1 when not present
-	 */
-	inline int FindIndex(const T &item) const
-	{
-		auto const it = std::find(std::vector<T>::begin(), std::vector<T>::end(), item);
-		return it == std::vector<T>::end() ? -1 : it - std::vector<T>::begin();
-	}
-
-	/**
 	 * Tests whether a item is present in the vector, and appends it to the end if not.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to test for
@@ -133,7 +121,25 @@ public:
 };
 
 /**
- * Helper function to extend a vector by more than one element
+ * Helper function to get the index of an item
+ * Consider using std::set, std::unordered_set or std::flat_set in new code
+ *
+ * @param vec A reference to the vector to be extended
+ * @param item Reference to the item to be search for
+ *
+ * @return Index of element if found, otherwise -1
+ */
+template <typename T>
+int find_index(std::vector<T> const& vec, T const& item)
+{
+	auto const it = std::find(vec.begin(), vec.end(), item);
+	if (it != vec.end()) return it - vec.begin();
+
+	return -1;
+}
+
+/**
+ * Helper function to append N default-constructed elements and get a pointer to the first new element
  * Consider using std::back_inserter in new code
  *
  * @param vec A reference to the vector to be extended

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -83,46 +83,6 @@ public:
 	}
 
 	~SmallVector() = default;
-
-	/**
-	 * Get the pointer to the first item (const)
-	 *
-	 * @return the pointer to the first item
-	 */
-	inline const T *Begin() const
-	{
-		return std::vector<T>::data();
-	}
-
-	/**
-	 * Get the pointer to the first item
-	 *
-	 * @return the pointer to the first item
-	 */
-	inline T *Begin()
-	{
-		return std::vector<T>::data();
-	}
-
-	/**
-	 * Get the pointer behind the last valid item (const)
-	 *
-	 * @return the pointer behind the last valid item
-	 */
-	inline const T *End() const
-	{
-		return std::vector<T>::data() + std::vector<T>::size();
-	}
-
-	/**
-	 * Get the pointer behind the last valid item
-	 *
-	 * @return the pointer behind the last valid item
-	 */
-	inline T *End()
-	{
-		return std::vector<T>::data() + std::vector<T>::size();
-	}
 };
 
 /**

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -106,26 +106,12 @@ public:
 	 * Search for the first occurrence of an item.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to search for
-	 * @return The position of the item, or End() when not present
-	 */
-	inline const T *Find(const T &item) const
-	{
-		const T *pos = this->Begin();
-		const T *end = this->End();
-		while (pos != end && *pos != item) pos++;
-		return pos;
-	}
-
-	/**
-	 * Search for the first occurrence of an item.
-	 * The '!=' operator of T is used for comparison.
-	 * @param item Item to search for
 	 * @return The position of the item, or -1 when not present
 	 */
 	inline int FindIndex(const T &item) const
 	{
-		auto const it = this->Find(item);
-		return it == this->End() ? -1 : it - this->Begin();
+		auto const it = std::find(std::vector<T>::begin(), std::vector<T>::end(), item);
+		return it == std::vector<T>::end() ? -1 : it - std::vector<T>::begin();
 	}
 
 	/**
@@ -136,7 +122,7 @@ public:
 	 */
 	inline bool Contains(const T &item) const
 	{
-		return this->Find(item) != this->End();
+		return std::find(std::vector<T>::begin(), std::vector<T>::end(), item) != std::vector<T>::end();
 	}
 
 	/**

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -98,15 +98,6 @@ public:
 	}
 
 	/**
-	 * Set the size of the vector, effectively truncating items from the end or appending uninitialised ones.
-	 * @param num_items Target size.
-	 */
-	inline void Resize(uint num_items)
-	{
-		std::vector<T>::resize(num_items);
-	}
-
-	/**
 	 * Insert a new item at a specific position into the vector, moving all following items.
 	 * @param item Position at which the new item should be inserted
 	 * @return pointer to the new item

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -180,19 +180,6 @@ public:
 		assert(index <= std::vector<T>::size());
 		return this->Begin() + index;
 	}
-
-	/**
-	 * Get the pointer to item "number"
-	 *
-	 * @param index the position of the item
-	 * @return the pointer to the item
-	 */
-	inline T *Get(uint index)
-	{
-		/* Allow access to the 'first invalid' item */
-		assert(index <= std::vector<T>::size());
-		return this->Begin() + index;
-	}
 };
 
 

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -60,22 +60,11 @@ public:
 	template <uint X>
 	SmallVector &operator=(const SmallVector<T, X> &other)
 	{
-		this->Assign(other);
+		std::vector<T>::operator=(other);
 		return *this;
 	}
 
 	~SmallVector() = default;
-
-	/**
-	 * Assign items from other vector.
-	 */
-	template <uint X>
-	inline void Assign(const SmallVector<T, X> &other)
-	{
-		if ((const void *)&other == (void *)this) return;
-
-		std::vector<T>::operator=(other);
-	}
 
 	/**
 	 * Append an item and return it.

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -78,14 +78,6 @@ public:
 	}
 
 	/**
-	 * Remove all items from the list.
-	 */
-	inline void Clear()
-	{
-		std::vector<T>::clear();
-	}
-
-	/**
 	 * Remove all items from the list and free allocated memory.
 	 */
 	inline void Reset()

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -67,20 +67,6 @@ public:
 	~SmallVector() = default;
 
 	/**
-	 * Insert a new item at a specific position into the vector, moving all following items.
-	 * @param item Position at which the new item should be inserted
-	 * @return pointer to the new item
-	 */
-	inline T *Insert(T *item)
-	{
-		assert(item >= this->Begin() && item <= this->End());
-
-		size_t start = item - this->Begin();
-		std::vector<T>::insert(std::vector<T>::begin() + start);
-		return this->Begin() + start;
-	}
-
-	/**
 	 * Search for the first occurrence of an item.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to search for

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -167,19 +167,6 @@ public:
 	{
 		return std::vector<T>::data() + std::vector<T>::size();
 	}
-
-	/**
-	 * Get the pointer to item "number" (const)
-	 *
-	 * @param index the position of the item
-	 * @return the pointer to the item
-	 */
-	inline const T *Get(uint index) const
-	{
-		/* Allow access to the 'first invalid' item */
-		assert(index <= std::vector<T>::size());
-		return this->Begin() + index;
-	}
 };
 
 

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -91,8 +91,8 @@ public:
 	 */
 	inline void Clear()
 	{
-		for (uint i = 0; i < std::vector<T>::size(); i++) {
-			free(std::vector<T>::operator[](i));
+		for (T p : *this) {
+			free(p);
 		}
 
 		std::vector<T>::clear();
@@ -121,8 +121,8 @@ public:
 	 */
 	inline void Clear()
 	{
-		for (uint i = 0; i < std::vector<T>::size(); i++) {
-			delete std::vector<T>::operator[](i);
+		for (T p : *this) {
+			delete p;
 		}
 
 		std::vector<T>::clear();

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -115,17 +115,6 @@ public:
 	}
 
 	/**
-	 * Tests whether a item is present in the vector.
-	 * The '!=' operator of T is used for comparison.
-	 * @param item Item to test for
-	 * @return true iff the item is present
-	 */
-	inline bool Contains(const T &item) const
-	{
-		return std::find(std::vector<T>::begin(), std::vector<T>::end(), item) != std::vector<T>::end();
-	}
-
-	/**
 	 * Removes given item from this vector
 	 * @param item item to remove
 	 * @note it has to be pointer to item in this map. It is overwritten by the last item.
@@ -145,7 +134,7 @@ public:
 	 */
 	inline bool Include(const T &item)
 	{
-		bool is_member = this->Contains(item);
+		bool is_member = std::find(std::vector<T>::begin(), std::vector<T>::end(), item) != std::vector<T>::end();
 		if (!is_member) *this->Append() = item;
 		return is_member;
 	}

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -78,15 +78,6 @@ public:
 	}
 
 	/**
-	 * Remove all items from the list and free allocated memory.
-	 */
-	inline void Reset()
-	{
-		std::vector<T>::clear();
-		std::vector<T>::shrink_to_fit();
-	}
-
-	/**
 	 * Append an item and return it.
 	 * @param to_add the number of items to append
 	 * @return pointer to newly allocated item

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -104,18 +104,6 @@ public:
 	}
 
 	/**
-	 * Removes given item from this vector
-	 * @param item item to remove
-	 * @note it has to be pointer to item in this map. It is overwritten by the last item.
-	 */
-	inline void Erase(T *item)
-	{
-		assert(item >= this->Begin() && item < this->End());
-		*item = std::vector<T>::back();
-		std::vector<T>::pop_back();
-	}
-
-	/**
 	 * Tests whether a item is present in the vector, and appends it to the end if not.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to test for

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -149,16 +149,6 @@ public:
 	}
 
 	/**
-	 * Remove items from the vector while preserving the order of other items.
-	 * @param item First item to remove.
-	 * @param count Number of consecutive items to remove.
-	 */
-	inline void ErasePreservingOrder(T *item, uint count = 1)
-	{
-		this->ErasePreservingOrder(item - this->Begin(), count);
-	}
-
-	/**
 	 * Tests whether a item is present in the vector, and appends it to the end if not.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to test for

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -45,45 +45,10 @@ inline bool include(std::vector<T>& vec, const T &item)
  * @tparam T The type of the items stored
  * @tparam S The steps of allocation
  */
+
+
 template <typename T, uint S>
-class SmallVector : public std::vector<T> {
-public:
-	SmallVector() = default;
-
-	/**
-	 * Copy constructor.
-	 * @param other The other vector to copy.
-	 */
-	SmallVector(const SmallVector &other) = default;
-
-	/**
-	 * Generic copy constructor.
-	 * @param other The other vector to copy.
-	 */
-	template <uint X>
-	SmallVector(const SmallVector<T, X> &other) : std::vector<T>(other)
-	{
-	}
-
-	/**
-	 * Assignment.
-	 * @param other The other vector to assign.
-	 */
-	SmallVector &operator=(const SmallVector &other) = default;
-
-	/**
-	 * Generic assignment.
-	 * @param other The other vector to assign.
-	 */
-	template <uint X>
-	SmallVector &operator=(const SmallVector<T, X> &other)
-	{
-		std::vector<T>::operator=(other);
-		return *this;
-	}
-
-	~SmallVector() = default;
-};
+using SmallVector = std::vector<T>;
 
 /**
  * Helper function to get the index of an item

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -120,20 +120,6 @@ public:
 	 * Search for the first occurrence of an item.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to search for
-	 * @return The position of the item, or End() when not present
-	 */
-	inline T *Find(const T &item)
-	{
-		T *pos = this->Begin();
-		const T *end = this->End();
-		while (pos != end && *pos != item) pos++;
-		return pos;
-	}
-
-	/**
-	 * Search for the first occurrence of an item.
-	 * The '!=' operator of T is used for comparison.
-	 * @param item Item to search for
 	 * @return The position of the item, or -1 when not present
 	 */
 	inline int FindIndex(const T &item) const

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -138,17 +138,6 @@ public:
 	}
 
 	/**
-	 * Remove items from the vector while preserving the order of other items.
-	 * @param pos First item to remove.
-	 * @param count Number of consecutive items to remove.
-	 */
-	void ErasePreservingOrder(uint pos, uint count = 1)
-	{
-		auto const it = std::vector<T>::begin() + pos;
-		std::vector<T>::erase(it, it + count);
-	}
-
-	/**
 	 * Tests whether a item is present in the vector, and appends it to the end if not.
 	 * The '!=' operator of T is used for comparison.
 	 * @param item Item to test for

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -218,16 +218,6 @@ public:
 	}
 
 	/**
-	 * Get the number of items in the list.
-	 *
-	 * @return The number of items in the list.
-	 */
-	inline uint Length() const
-	{
-		return std::vector<T>::size();
-	}
-
-	/**
 	 * Get the pointer to the first item (const)
 	 *
 	 * @return the pointer to the first item

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -75,14 +75,14 @@ struct SetDateWindow : Window {
 
 			case WID_SD_DAY:
 				for (uint i = 0; i < 31; i++) {
-					*list->Append() = new DropDownListStringItem(STR_DAY_NUMBER_1ST + i, i + 1, false);
+					list->push_back(new DropDownListStringItem(STR_DAY_NUMBER_1ST + i, i + 1, false));
 				}
 				selected = this->date.day;
 				break;
 
 			case WID_SD_MONTH:
 				for (uint i = 0; i < 12; i++) {
-					*list->Append() = new DropDownListStringItem(STR_MONTH_JAN + i, i, false);
+					list->push_back(new DropDownListStringItem(STR_MONTH_JAN + i, i, false));
 				}
 				selected = this->date.month;
 				break;
@@ -91,7 +91,7 @@ struct SetDateWindow : Window {
 				for (Year i = this->min_year; i <= this->max_year; i++) {
 					DropDownListParamStringItem *item = new DropDownListParamStringItem(STR_JUST_INT, i, false);
 					item->SetParam(0, i);
-					*list->Append() = item;
+					list->push_back(item);
 				}
 				selected = this->date.year;
 				break;

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -398,7 +398,7 @@ struct DepotWindow : Window {
 		uint16 rows_in_display = wid->current_y / wid->resize_y;
 
 		uint16 num = this->vscroll->GetPosition() * this->num_columns;
-		int maxval = min(this->vehicle_list.Length(), num + (rows_in_display * this->num_columns));
+		int maxval = min(this->vehicle_list.size(), num + (rows_in_display * this->num_columns));
 		int y;
 		for (y = r.top + 1; num < maxval; y += this->resize.step_height) { // Draw the rows
 			for (byte i = 0; i < this->num_columns && num < maxval; i++, num++) {
@@ -413,11 +413,11 @@ struct DepotWindow : Window {
 			}
 		}
 
-		maxval = min(this->vehicle_list.Length() + this->wagon_list.Length(), (this->vscroll->GetPosition() * this->num_columns) + (rows_in_display * this->num_columns));
+		maxval = min(this->vehicle_list.size() + this->wagon_list.size(), (this->vscroll->GetPosition() * this->num_columns) + (rows_in_display * this->num_columns));
 
 		/* Draw the train wagons without an engine in front. */
 		for (; num < maxval; num++, y += this->resize.step_height) {
-			const Vehicle *v = this->wagon_list[num - this->vehicle_list.Length()];
+			const Vehicle *v = this->wagon_list[num - this->vehicle_list.size()];
 			this->DrawVehicleInDepot(v, r.left, r.right, y);
 		}
 	}
@@ -465,7 +465,7 @@ struct DepotWindow : Window {
 
 		uint pos = ((row + this->vscroll->GetPosition()) * this->num_columns) + xt;
 
-		if (this->vehicle_list.Length() + this->wagon_list.Length() <= pos) {
+		if (this->vehicle_list.size() + this->wagon_list.size() <= pos) {
 			/* Clicking on 'line' / 'block' without a vehicle */
 			if (this->type == VEH_TRAIN) {
 				/* End the dragging */
@@ -478,12 +478,12 @@ struct DepotWindow : Window {
 		}
 
 		bool wagon = false;
-		if (this->vehicle_list.Length() > pos) {
+		if (this->vehicle_list.size() > pos) {
 			*veh = this->vehicle_list[pos];
 			/* Skip vehicles that are scrolled off the list */
 			if (this->type == VEH_TRAIN) x += this->hscroll->GetPosition();
 		} else {
-			pos -= this->vehicle_list.Length();
+			pos -= this->vehicle_list.size();
 			*veh = this->wagon_list[pos];
 			/* free wagons don't have an initial loco. */
 			x -= ScaleGUITrad(VEHICLEINFO_FULL_VEHICLE_WIDTH);
@@ -726,7 +726,7 @@ struct DepotWindow : Window {
 		/* determine amount of items for scroller */
 		if (this->type == VEH_TRAIN) {
 			uint max_width = ScaleGUITrad(VEHICLEINFO_FULL_VEHICLE_WIDTH);
-			for (uint num = 0; num < this->vehicle_list.Length(); num++) {
+			for (uint num = 0; num < this->vehicle_list.size(); num++) {
 				uint width = 0;
 				for (const Train *v = Train::From(this->vehicle_list[num]); v != NULL; v = v->Next()) {
 					width += v->GetDisplayImageWidth();
@@ -734,11 +734,11 @@ struct DepotWindow : Window {
 				max_width = max(max_width, width);
 			}
 			/* Always have 1 empty row, so people can change the setting of the train */
-			this->vscroll->SetCount(this->vehicle_list.Length() + this->wagon_list.Length() + 1);
+			this->vscroll->SetCount(this->vehicle_list.size() + this->wagon_list.size() + 1);
 			/* Always make it longer than the longest train, so you can attach vehicles at the end, and also see the next vertical tile separator line */
 			this->hscroll->SetCount(max_width + ScaleGUITrad(2 * VEHICLEINFO_FULL_VEHICLE_WIDTH + 1));
 		} else {
-			this->vscroll->SetCount(CeilDiv(this->vehicle_list.Length(), this->num_columns));
+			this->vscroll->SetCount(CeilDiv(this->vehicle_list.size(), this->num_columns));
 		}
 
 		/* Setup disabled buttons. */
@@ -811,7 +811,7 @@ struct DepotWindow : Window {
 
 			case WID_D_SELL_ALL:
 				/* Only open the confirmation window if there are anything to sell */
-				if (this->vehicle_list.Length() != 0 || this->wagon_list.Length() != 0) {
+				if (this->vehicle_list.size() != 0 || this->wagon_list.size() != 0) {
 					TileIndex tile = this->window_number;
 					byte vehtype = this->type;
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -77,7 +77,7 @@ static inline int32 BigMulS(const int32 a, const int32 b, const uint8 shift)
 	return (int32)((int64)a * (int64)b >> shift);
 }
 
-typedef SmallVector<Industry *, 16> SmallIndustryList;
+typedef std::vector<Industry *> SmallIndustryList;
 
 /**
  * Score info, values used for computing the detailed performance rating.

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1058,7 +1058,7 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 		if (IndustryTemporarilyRefusesCargo(ind, cargo_type)) continue;
 
 		/* Insert the industry into _cargo_delivery_destinations, if not yet contained */
-		_cargo_delivery_destinations.Include(ind);
+		include(_cargo_delivery_destinations, ind);
 
 		uint amount = min(num_pieces, 0xFFFFU - ind->incoming_cargo_waiting[cargo_index]);
 		ind->incoming_cargo_waiting[cargo_index] += amount;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1949,7 +1949,7 @@ void LoadUnloadStation(Station *st)
 	for (Industry **iid = _cargo_delivery_destinations.Begin(); iid != isend; iid++) {
 		TriggerIndustryProduction(*iid);
 	}
-	_cargo_delivery_destinations.Clear();
+	_cargo_delivery_destinations.clear();
 }
 
 /**

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1945,9 +1945,8 @@ void LoadUnloadStation(Station *st)
 	}
 
 	/* Call the production machinery of industries */
-	const Industry * const *isend = _cargo_delivery_destinations.End();
-	for (Industry **iid = _cargo_delivery_destinations.Begin(); iid != isend; iid++) {
-		TriggerIndustryProduction(*iid);
+	for (Industry *iid : _cargo_delivery_destinations) {
+		TriggerIndustryProduction(iid);
 	}
 	_cargo_delivery_destinations.clear();
 }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -511,12 +511,12 @@ void EngineOverrideManager::ResetToDefaultMapping()
  */
 EngineID EngineOverrideManager::GetID(VehicleType type, uint16 grf_local_id, uint32 grfid)
 {
-	const EngineIDMapping *end = this->End();
 	EngineID index = 0;
-	for (const EngineIDMapping *eid = this->Begin(); eid != end; eid++, index++) {
-		if (eid->type == type && eid->grfid == grfid && eid->internal_id == grf_local_id) {
+	for (const EngineIDMapping &eid : *this) {
+		if (eid.type == type && eid.grfid == grfid && eid.internal_id == grf_local_id) {
 			return index;
 		}
+		index++;
 	}
 	return INVALID_ENGINE;
 }
@@ -549,14 +549,14 @@ void SetupEngines()
 	_engine_pool.CleanPool();
 
 	assert(_engine_mngr.size() >= _engine_mngr.NUM_DEFAULT_ENGINES);
-	const EngineIDMapping *end = _engine_mngr.End();
 	uint index = 0;
-	for (const EngineIDMapping *eid = _engine_mngr.Begin(); eid != end; eid++, index++) {
+	for (const EngineIDMapping &eid : _engine_mngr) {
 		/* Assert is safe; there won't be more than 256 original vehicles
 		 * in any case, and we just cleaned the pool. */
 		assert(Engine::CanAllocateItem());
-		const Engine *e = new Engine(eid->type, eid->internal_id);
+		const Engine *e = new Engine(eid.type, eid.internal_id);
 		assert(e->index == index);
+		index++;
 	}
 }
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -487,7 +487,7 @@ StringID Engine::GetAircraftTypeText() const
  */
 void EngineOverrideManager::ResetToDefaultMapping()
 {
-	this->Clear();
+	this->clear();
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
 		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++) {
 			EngineIDMapping *eid = this->Append();

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -547,7 +547,7 @@ void SetupEngines()
 	DeleteWindowByClass(WC_ENGINE_PREVIEW);
 	_engine_pool.CleanPool();
 
-	assert(_engine_mngr.Length() >= _engine_mngr.NUM_DEFAULT_ENGINES);
+	assert(_engine_mngr.size() >= _engine_mngr.NUM_DEFAULT_ENGINES);
 	const EngineIDMapping *end = _engine_mngr.End();
 	uint index = 0;
 	for (const EngineIDMapping *eid = _engine_mngr.Begin(); eid != end; eid++, index++) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -490,11 +490,12 @@ void EngineOverrideManager::ResetToDefaultMapping()
 	this->clear();
 	for (VehicleType type = VEH_TRAIN; type <= VEH_AIRCRAFT; type++) {
 		for (uint internal_id = 0; internal_id < _engine_counts[type]; internal_id++) {
-			EngineIDMapping *eid = this->Append();
-			eid->type            = type;
-			eid->grfid           = INVALID_GRFID;
-			eid->internal_id     = internal_id;
-			eid->substitute_id   = internal_id;
+			/*C++17: EngineIDMapping &eid = */ this->emplace_back();
+			EngineIDMapping &eid = this->back();
+			eid.type            = type;
+			eid.grfid           = INVALID_GRFID;
+			eid.internal_id     = internal_id;
+			eid.substitute_id   = internal_id;
 		}
 	}
 }

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -156,7 +156,7 @@ struct EngineIDMapping {
  * Stores the mapping of EngineID to the internal id of newgrfs.
  * Note: This is not part of Engine, as the data in the EngineOverrideManager and the engine pool get resetted in different cases.
  */
-struct EngineOverrideManager : SmallVector<EngineIDMapping, 256> {
+struct EngineOverrideManager : std::vector<EngineIDMapping> {
 	static const uint NUM_DEFAULT_ENGINES; ///< Number of default entries
 
 	void ResetToDefaultMapping();

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -344,6 +344,6 @@ void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, ui
 	if (num_items < 2) return;
 	assert(begin < el->size());
 	assert(begin + num_items <= el->size());
-	QSortT(el->Get(begin), num_items, compare);
+	QSortT(el->data() + begin, num_items, compare);
 }
 

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -329,7 +329,7 @@ void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare)
 	/* out-of-bounds access at the next line for size == 0 (even with operator[] at some systems)
 	 * generally, do not sort if there are less than 2 items */
 	if (size < 2) return;
-	QSortT(el->Begin(), size, compare);
+	QSortT(el->data(), size, compare);
 }
 
 /**

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -325,7 +325,7 @@ void DrawVehicleEngine(int left, int right, int preferred_x, int y, EngineID eng
  */
 void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare)
 {
-	uint size = el->Length();
+	uint size = el->size();
 	/* out-of-bounds access at the next line for size == 0 (even with operator[] at some systems)
 	 * generally, do not sort if there are less than 2 items */
 	if (size < 2) return;
@@ -342,8 +342,8 @@ void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare)
 void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, uint begin, uint num_items)
 {
 	if (num_items < 2) return;
-	assert(begin < el->Length());
-	assert(begin + num_items <= el->Length());
+	assert(begin < el->size());
+	assert(begin + num_items <= el->size());
 	QSortT(el->Get(begin), num_items, compare);
 }
 

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -380,7 +380,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 	{
 		SortingBits order = _savegame_sort_order;
 		_savegame_sort_order = SORT_BY_NAME | SORT_ASCENDING;
-		QSortT(file_list.files.Begin(), file_list.files.Length(), CompareFiosItems);
+		QSortT(file_list.files.Begin(), file_list.files.size(), CompareFiosItems);
 		_savegame_sort_order = order;
 	}
 

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -655,7 +655,7 @@ struct ScenarioIdentifier {
 /**
  * Scanner to find the unique IDs of scenarios
  */
-class ScenarioScanner : protected FileScanner, public SmallVector<ScenarioIdentifier, 8> {
+class ScenarioScanner : protected FileScanner, public std::vector<ScenarioIdentifier> {
 	bool scanned; ///< Whether we've already scanned
 public:
 	/** Initialise */

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -706,7 +706,7 @@ public:
 
 		FioFCloseFile(f);
 
-		this->Include(id);
+		include(*this, id);
 		return true;
 	}
 };

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -380,7 +380,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 	{
 		SortingBits order = _savegame_sort_order;
 		_savegame_sort_order = SORT_BY_NAME | SORT_ASCENDING;
-		QSortT(file_list.files.Begin(), file_list.files.size(), CompareFiosItems);
+		QSortT(file_list.files.data(), file_list.files.size(), CompareFiosItems);
 		_savegame_sort_order = order;
 	}
 
@@ -724,10 +724,10 @@ const char *FindScenario(const ContentInfo *ci, bool md5sum)
 {
 	_scanner.Scan(false);
 
-	for (ScenarioIdentifier *id = _scanner.Begin(); id != _scanner.End(); id++) {
-		if (md5sum ? (memcmp(id->md5sum, ci->md5sum, sizeof(id->md5sum)) == 0)
-		           : (id->scenid == ci->unique_id)) {
-			return id->filename;
+	for (ScenarioIdentifier &id : _scanner) {
+		if (md5sum ? (memcmp(id.md5sum, ci->md5sum, sizeof(id.md5sum)) == 0)
+		           : (id.scenid == ci->unique_id)) {
+			return id.filename;
 		}
 	}
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -185,7 +185,7 @@ public:
 	/** Remove all items from the list. */
 	inline void Clear()
 	{
-		this->files.Clear();
+		this->files.clear();
 	}
 
 	/** Compact the list down to the smallest block size boundary. */

--- a/src/fios.h
+++ b/src/fios.h
@@ -120,7 +120,8 @@ public:
 	 */
 	inline FiosItem *Append()
 	{
-		return this->files.Append();
+		/*C++17: return &*/ this->files.emplace_back();
+		return &this->files.back();
 	}
 
 	/**

--- a/src/fios.h
+++ b/src/fios.h
@@ -129,7 +129,7 @@ public:
 	 */
 	inline uint Length() const
 	{
-		return this->files.Length();
+		return this->files.size();
 	}
 
 	/**

--- a/src/fios.h
+++ b/src/fios.h
@@ -198,7 +198,7 @@ public:
 	void BuildFileList(AbstractFileType abstract_filetype, SaveLoadOperation fop);
 	const FiosItem *FindItem(const char *file);
 
-	SmallVector<FiosItem, 32> files; ///< The list of files.
+	std::vector<FiosItem> files; ///< The list of files.
 };
 
 enum SortingBits {

--- a/src/fios.h
+++ b/src/fios.h
@@ -156,7 +156,7 @@ public:
 	 */
 	inline const FiosItem *Get(uint index) const
 	{
-		return this->files.Get(index);
+		return this->files.data() + index;
 	}
 
 	/**

--- a/src/fios.h
+++ b/src/fios.h
@@ -139,7 +139,7 @@ public:
 	 */
 	inline const FiosItem *Begin() const
 	{
-		return this->files.Begin();
+		return this->files.data();
 	}
 
 	/**
@@ -148,7 +148,7 @@ public:
 	 */
 	inline const FiosItem *End() const
 	{
-		return this->files.End();
+		return this->Begin() + this->Length();
 	}
 
 	/**

--- a/src/fios.h
+++ b/src/fios.h
@@ -165,7 +165,7 @@ public:
 	 */
 	inline FiosItem *Get(uint index)
 	{
-		return this->files.Get(index);
+		return this->files.data() + index;
 	}
 
 	inline const FiosItem &operator[](uint index) const

--- a/src/fios.h
+++ b/src/fios.h
@@ -191,7 +191,7 @@ public:
 	/** Compact the list down to the smallest block size boundary. */
 	inline void Compact()
 	{
-		this->files.Compact();
+		this->files.shrink_to_fit();
 	}
 
 	void BuildFileList(AbstractFileType abstract_filetype, SaveLoadOperation fop);

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -279,7 +279,7 @@ private:
 
 	StringFilter string_filter; ///< Filter for available games.
 	QueryString filter_editbox; ///< Filter editbox;
-	SmallVector<bool, 32> fios_items_shown; ///< Map of the filtered out fios items
+	std::vector<bool> fios_items_shown; ///< Map of the filtered out fios items
 
 	static void SaveGameConfirmationCallback(Window *w, bool confirmed)
 	{
@@ -824,7 +824,7 @@ public:
 
 			case SLIWD_FILTER_CHANGES:
 				/* Filter changes */
-				this->fios_items_shown.Resize(this->fios_items.Length());
+				this->fios_items_shown.resize(this->fios_items.Length());
 				uint items_shown_count = 0; ///< The number of items shown in the list
 				/* We pass through every fios item */
 				for (uint i = 0; i < this->fios_items.Length(); i++) {

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -61,7 +61,7 @@ void LoadCheckData::Clear()
 	for (CompanyPropertiesMap::iterator it = this->companies.Begin(); it != end; it++) {
 		delete it->second;
 	}
-	companies.Clear();
+	companies.clear();
 
 	GamelogFree(this->gamelog_action, this->gamelog_actions);
 	this->gamelog_action = NULL;

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -57,9 +57,8 @@ void LoadCheckData::Clear()
 	this->current_date = 0;
 	memset(&this->settings, 0, sizeof(this->settings));
 
-	const CompanyPropertiesMap::iterator end = this->companies.End();
-	for (CompanyPropertiesMap::iterator it = this->companies.Begin(); it != end; it++) {
-		delete it->second;
+	for (auto &pair : this->companies) {
+		delete pair.second;
 	}
 	companies.clear();
 
@@ -531,10 +530,9 @@ public:
 						if (y > y_max) break;
 
 						/* Companies / AIs */
-						CompanyPropertiesMap::const_iterator end = _load_check_data.companies.End();
-						for (CompanyPropertiesMap::const_iterator it = _load_check_data.companies.Begin(); it != end; it++) {
-							SetDParam(0, it->first + 1);
-							const CompanyProperties &c = *it->second;
+						for (auto &pair : _load_check_data.companies) {
+							SetDParam(0, pair.first + 1);
+							const CompanyProperties &c = *pair.second;
 							if (c.name != NULL) {
 								SetDParam(1, STR_JUST_RAW_STRING);
 								SetDParamStr(2, c.name);

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -411,8 +411,8 @@ FreeTypeFontCache::~FreeTypeFontCache()
 	this->face = NULL;
 	this->ClearFontCache();
 
-	for (FontTable::iterator iter = this->font_tables.Begin(); iter != this->font_tables.End(); iter++) {
-		free(iter->second.second);
+	for (auto &iter : this->font_tables) {
+		free(iter.second.second);
 	}
 }
 
@@ -633,7 +633,7 @@ GlyphID FreeTypeFontCache::MapCharToGlyph(WChar key)
 const void *FreeTypeFontCache::GetFontTable(uint32 tag, size_t &length)
 {
 	const FontTable::iterator iter = this->font_tables.Find(tag);
-	if (iter != this->font_tables.End()) {
+	if (iter != this->font_tables.data() + this->font_tables.size()) {
 		length = iter->second.first;
 		return iter->second.second;
 	}

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -212,7 +212,7 @@ struct StringNameWriter : HeaderWriter {
 
 	void WriteStringID(const char *name, int stringid)
 	{
-		if (stringid == (int)this->strings->Length()) *this->strings->Append() = stredup(name);
+		if (stringid == (int)this->strings->size()) *this->strings->Append() = stredup(name);
 	}
 
 	void Finalise(const StringData &data)
@@ -340,7 +340,7 @@ GameStrings *_current_data = NULL;
  */
 const char *GetGameStringPtr(uint id)
 {
-	if (id >= _current_data->cur_language->lines.Length()) return GetStringPtr(STR_UNDEFINED);
+	if (id >= _current_data->cur_language->lines.size()) return GetStringPtr(STR_UNDEFINED);
 	return _current_data->cur_language->lines[id];
 }
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -115,7 +115,7 @@ LanguageStrings *ReadRawLanguageStrings(const char *file)
 			while (i > 0 && (buffer[i - 1] == '\r' || buffer[i - 1] == '\n' || buffer[i - 1] == ' ')) i--;
 			buffer[i] = '\0';
 
-			*ret->lines.Append() = stredup(buffer, buffer + to_read - 1);
+			ret->lines.push_back(stredup(buffer, buffer + to_read - 1));
 
 			if (len > to_read) {
 				to_read = 0;
@@ -194,7 +194,7 @@ struct TranslationWriter : LanguageWriter {
 		char *dest = MallocT<char>(length + 1);
 		memcpy(dest, buffer, length);
 		dest[length] = '\0';
-		*this->strings->Append() = dest;
+		this->strings->push_back(dest);
 	}
 };
 
@@ -212,7 +212,7 @@ struct StringNameWriter : HeaderWriter {
 
 	void WriteStringID(const char *name, int stringid)
 	{
-		if (stringid == (int)this->strings->size()) *this->strings->Append() = stredup(name);
+		if (stringid == (int)this->strings->size()) this->strings->push_back(stredup(name));
 	}
 
 	void Finalise(const StringData &data)
@@ -246,7 +246,7 @@ public:
 	{
 		if (strcmp(filename, exclude) == 0) return true;
 
-		*gs->raw_strings.Append() = ReadRawLanguageStrings(filename);
+		gs->raw_strings.push_back(ReadRawLanguageStrings(filename));
 		return true;
 	}
 };
@@ -269,7 +269,7 @@ GameStrings *LoadTranslations()
 
 	GameStrings *gs = new GameStrings();
 	try {
-		*gs->raw_strings.Append() = ReadRawLanguageStrings(filename);
+		gs->raw_strings.push_back(ReadRawLanguageStrings(filename));
 
 		/* Scan for other language files */
 		LanguageScanner scanner(gs, filename);
@@ -324,8 +324,8 @@ void GameStrings::Compile()
 		translation_reader.ParseFile();
 		if (_errors != 0) throw std::exception();
 
-		LanguageStrings *compiled = *this->compiled_strings.Append() = new LanguageStrings((*p)->language);
-		TranslationWriter writer(&compiled->lines);
+		this->compiled_strings.push_back(new LanguageStrings((*p)->language));
+		TranslationWriter writer(&this->compiled_strings.back()->lines);
 		writer.WriteLang(data);
 	}
 }

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -32,9 +32,9 @@ struct GameStrings {
 	uint version;                  ///< The version of the language strings.
 	LanguageStrings *cur_language; ///< The current (compiled) language.
 
-	AutoDeleteSmallVector<LanguageStrings *, 4> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
-	AutoDeleteSmallVector<LanguageStrings *, 4> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
-	StringList string_names;                                      ///< The names of the compiled strings.
+	AutoDeleteSmallVector<LanguageStrings *> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
+	AutoDeleteSmallVector<LanguageStrings *> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
+	StringList string_names;                                   ///< The names of the compiled strings.
 
 	void Compile();
 };

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -178,6 +178,7 @@ struct GRFPresence{
 	bool was_missing;     ///< Grf was missing during some gameload in the past
 
 	GRFPresence(const GRFConfig *gc) : gc(gc), was_missing(false) {}
+	GRFPresence() = default;
 };
 typedef SmallMap<uint32, GRFPresence> GrfIDMapping;
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -289,7 +289,7 @@ static DropDownList *BuildMapsizeDropDown()
 	for (uint i = MIN_MAP_SIZE_BITS; i <= MAX_MAP_SIZE_BITS; i++) {
 		DropDownListParamStringItem *item = new DropDownListParamStringItem(STR_JUST_INT, i, false);
 		item->SetParam(0, 1LL << i);
-		*list->Append() = item;
+		list->push_back(item);
 	}
 
 	return list;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -511,7 +511,7 @@ int DrawString(int left, int right, int top, const char *str, TextColour colour,
 	Layouter layout(str, INT32_MAX, colour, fontsize);
 	if (layout.size() == 0) return 0;
 
-	return DrawLayoutLine(*layout.Begin(), top, left, right, align, underline, true);
+	return DrawLayoutLine(layout.front(), top, left, right, align, underline, true);
 }
 
 /**
@@ -647,8 +647,7 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, const char *st
 	int last_line = top;
 	int first_line = bottom;
 
-	for (const ParagraphLayouter::Line **iter = layout.Begin(); iter != layout.End(); iter++) {
-		const ParagraphLayouter::Line *line = *iter;
+	for (const ParagraphLayouter::Line *line : layout) {
 
 		int line_height = line->GetLeading();
 		if (y >= top && y < bottom) {

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -509,7 +509,7 @@ int DrawString(int left, int right, int top, const char *str, TextColour colour,
 	}
 
 	Layouter layout(str, INT32_MAX, colour, fontsize);
-	if (layout.Length() == 0) return 0;
+	if (layout.size() == 0) return 0;
 
 	return DrawLayoutLine(*layout.Begin(), top, left, right, align, underline, true);
 }
@@ -574,7 +574,7 @@ int GetStringLineCount(StringID str, int maxw)
 	GetString(buffer, str, lastof(buffer));
 
 	Layouter layout(buffer, maxw);
-	return layout.Length();
+	return layout.size();
 }
 
 /**

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -968,7 +968,7 @@ static void GfxBlitter(const Sprite * const sprite, int x, int y, BlitterMode mo
 		if (topleft <= clicked && clicked <= bottomright) {
 			uint offset = (((size_t)clicked - (size_t)topleft) / (blitter->GetScreenDepth() / 8)) % bp.pitch;
 			if (offset < (uint)bp.width) {
-				_newgrf_debug_sprite_picker.sprites.Include(sprite_id);
+				include(_newgrf_debug_sprite_picker.sprites, sprite_id);
 			}
 		}
 	}

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -600,7 +600,7 @@ static inline void GetLayouter(Layouter::LineCacheItem &line, const char *&str, 
 	Font *f = Layouter::GetFont(state.fontsize, state.cur_colour);
 
 	line.buffer = buff_begin;
-	fontMapping.Clear();
+	fontMapping.clear();
 
 	/*
 	 * Go through the whole string while adding Font instances to the font map
@@ -847,7 +847,7 @@ void Layouter::ResetFontCache(FontSize size)
 	for (FontColourMap::iterator it = fonts[size].Begin(); it != fonts[size].End(); ++it) {
 		delete it->second;
 	}
-	fonts[size].Clear();
+	fonts[size].clear();
 
 	/* We must reset the linecache since it references the just freed fonts */
 	ResetLineCache();

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -158,7 +158,7 @@ public:
 		int GetLeading() const { return l->getLeading(); }
 		int GetWidth() const   { return l->getWidth(); }
 		int CountRuns() const  { return l->countRuns(); }
-		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const { return *this->Get(run); }
+		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const { return this->at(run); }
 
 		int GetInternalCharLength(WChar c) const
 		{
@@ -458,7 +458,7 @@ int FallbackParagraphLayout::FallbackLine::CountRuns() const
  */
 const ParagraphLayouter::VisualRun *FallbackParagraphLayout::FallbackLine::GetVisualRun(int run) const
 {
-	return *this->Get(run);
+	return this->at(run);
 }
 
 /**

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -124,7 +124,7 @@ le_bool Font::getGlyphPoint(LEGlyphID glyph, le_int32 pointNumber, LEPoint &poin
 /**
  * Wrapper for doing layouts with ICU.
  */
-class ICUParagraphLayout : public AutoDeleteSmallVector<ParagraphLayouter::Line *, 4>, public ParagraphLayouter {
+class ICUParagraphLayout : public AutoDeleteSmallVector<ParagraphLayouter::Line *>, public ParagraphLayouter {
 	icu::ParagraphLayout *p; ///< The actual ICU paragraph layout.
 public:
 	/** Visual run contains data about the bit of text with the same font. */
@@ -143,7 +143,7 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class ICULine : public AutoDeleteSmallVector<ICUVisualRun *, 4>, public ParagraphLayouter::Line {
+	class ICULine : public AutoDeleteSmallVector<ICUVisualRun *>, public ParagraphLayouter::Line {
 		icu::ParagraphLayout::Line *l; ///< The actual ICU line.
 
 	public:
@@ -269,7 +269,7 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class FallbackLine : public AutoDeleteSmallVector<FallbackVisualRun *, 4>, public ParagraphLayouter::Line {
+	class FallbackLine : public AutoDeleteSmallVector<FallbackVisualRun *>, public ParagraphLayouter::Line {
 	public:
 		int GetLeading() const;
 		int GetWidth() const;

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -150,7 +150,7 @@ public:
 		ICULine(icu::ParagraphLayout::Line *l) : l(l)
 		{
 			for (int i = 0; i < l->countRuns(); i++) {
-				*this->Append() = new ICUVisualRun(l->getVisualRun(i));
+				this->push_back(new ICUVisualRun(l->getVisualRun(i)));
 			}
 		}
 		~ICULine() { delete l; }
@@ -498,7 +498,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 	if (*this->buffer == '\0') {
 		/* Only a newline. */
 		this->buffer = NULL;
-		*l->Append() = new FallbackVisualRun(this->runs.Begin()->second, this->buffer, 0, 0);
+		l->push_back(new FallbackVisualRun(this->runs.Begin()->second, this->buffer, 0, 0));
 		return l;
 	}
 
@@ -527,7 +527,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 
 		if (this->buffer == next_run) {
 			int w = l->GetWidth();
-			*l->Append() = new FallbackVisualRun(iter->second, begin, this->buffer - begin, w);
+			l->push_back(new FallbackVisualRun(iter->second, begin, this->buffer - begin, w));
 			iter++;
 			assert(iter != this->runs.End());
 
@@ -574,7 +574,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 
 	if (l->size() == 0 || last_char - begin != 0) {
 		int w = l->GetWidth();
-		*l->Append() = new FallbackVisualRun(iter->second, begin, last_char - begin, w);
+		l->push_back(new FallbackVisualRun(iter->second, begin, last_char - begin, w));
 	}
 	return l;
 }
@@ -720,7 +720,7 @@ Layouter::Layouter(const char *str, int maxw, TextColour colour, FontSize fontsi
 		/* Copy all lines into a local cache so we can reuse them later on more easily. */
 		const ParagraphLayouter::Line *l;
 		while ((l = line.layout->NextLine(maxw)) != NULL) {
-			*this->Append() = l;
+			this->push_back(l);
 		}
 
 	} while (c != '\0');
@@ -834,7 +834,7 @@ Font *Layouter::GetFont(FontSize size, TextColour colour)
 	if (it != fonts[size].End()) return it->second;
 
 	Font *f = new Font(size, colour);
-	*fonts[size].Append() = FontColourMap::Pair(colour, f);
+	fonts[size].emplace_back(colour, f);
 	return f;
 }
 

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -200,7 +200,7 @@ public:
 		}
 
 		/* Fill ICU's FontRuns with the right data. */
-		icu::FontRuns runs(fontMapping.Length());
+		icu::FontRuns runs(fontMapping.size());
 		for (FontMap::iterator iter = fontMapping.Begin(); iter != fontMapping.End(); iter++) {
 			runs.add(iter->second, iter->first);
 		}
@@ -432,7 +432,7 @@ int FallbackParagraphLayout::FallbackLine::GetLeading() const
  */
 int FallbackParagraphLayout::FallbackLine::GetWidth() const
 {
-	if (this->Length() == 0) return 0;
+	if (this->size() == 0) return 0;
 
 	/*
 	 * The last X position of a run contains is the end of that run.
@@ -449,7 +449,7 @@ int FallbackParagraphLayout::FallbackLine::GetWidth() const
  */
 int FallbackParagraphLayout::FallbackLine::CountRuns() const
 {
-	return this->Length();
+	return this->size();
 }
 
 /**
@@ -572,7 +572,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 		this->buffer++;
 	}
 
-	if (l->Length() == 0 || last_char - begin != 0) {
+	if (l->size() == 0 || last_char - begin != 0) {
 		int w = l->GetWidth();
 		*l->Append() = new FallbackVisualRun(iter->second, begin, last_char - begin, w);
 	}

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -150,7 +150,7 @@ public:
  *
  * It also accounts for the memory allocations and frees.
  */
-class Layouter : public AutoDeleteSmallVector<const ParagraphLayouter::Line *, 4> {
+class Layouter : public AutoDeleteSmallVector<const ParagraphLayouter::Line *> {
 	const char *string; ///< Pointer to the original string.
 
 	/** Key into the linecache */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1136,7 +1136,7 @@ private:
 	{
 		if (!this->companies.NeedRebuild()) return;
 
-		this->companies.Clear();
+		this->companies.clear();
 
 		const Company *c;
 		FOR_ALL_COMPANIES(c) {

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1143,7 +1143,7 @@ private:
 			*this->companies.Append() = c;
 		}
 
-		this->companies.Compact();
+		this->companies.shrink_to_fit();
 		this->companies.RebuildDone();
 	}
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1183,7 +1183,7 @@ public:
 		uint text_left     = rtl ? r.left + WD_FRAMERECT_LEFT : r.right - WD_FRAMERECT_LEFT - this->text_width;
 		uint text_right    = rtl ? r.left + WD_FRAMERECT_LEFT + this->text_width : r.right - WD_FRAMERECT_LEFT;
 
-		for (uint i = 0; i != this->companies.Length(); i++) {
+		for (uint i = 0; i != this->companies.size(); i++) {
 			const Company *c = this->companies[i];
 			DrawString(ordinal_left, ordinal_right, y, i + STR_ORDINAL_NUMBER_1ST, i == 0 ? TC_WHITE : TC_YELLOW);
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1140,7 +1140,7 @@ private:
 
 		const Company *c;
 		FOR_ALL_COMPANIES(c) {
-			*this->companies.Append() = c;
+			this->companies.push_back(c);
 		}
 
 		this->companies.shrink_to_fit();

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -129,8 +129,8 @@ private:
 	{
 		for (const Group **g = source->Begin(); g != source->End(); g++) {
 			if ((*g)->parent != parent) continue;
-			*this->groups.Append() = *g;
-			*this->indents.Append() = indent;
+			this->groups.push_back(*g);
+			this->indents.push_back(indent);
 			AddChildren(source, (*g)->index, indent + 1);
 		}
 	}
@@ -175,7 +175,7 @@ private:
 		const Group *g;
 		FOR_ALL_GROUPS(g) {
 			if (g->owner == owner && g->vehicle_type == this->vli.vtype) {
-				*list.Append() = g;
+				list.push_back(g);
 			}
 		}
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -184,7 +184,7 @@ private:
 
 		AddChildren(&list, INVALID_GROUP, 0);
 
-		this->groups.Compact();
+		this->groups.shrink_to_fit();
 		this->groups.RebuildDone();
 	}
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -127,11 +127,11 @@ private:
 
 	void AddChildren(GUIGroupList *source, GroupID parent, int indent)
 	{
-		for (const Group **g = source->Begin(); g != source->End(); g++) {
-			if ((*g)->parent != parent) continue;
-			this->groups.push_back(*g);
+		for (const Group *g : *source) {
+			if (g->parent != parent) continue;
+			this->groups.push_back(g);
 			this->indents.push_back(indent);
-			AddChildren(source, (*g)->index, indent + 1);
+			AddChildren(source, g->index, indent + 1);
 		}
 	}
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -167,8 +167,8 @@ private:
 	{
 		if (!this->groups.NeedRebuild()) return;
 
-		this->groups.Clear();
-		this->indents.Clear();
+		this->groups.clear();
+		this->indents.clear();
 
 		GUIGroupList list;
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -460,8 +460,8 @@ public:
 				if (IsDefaultGroupID(this->vli.index) || IsAllGroupID(this->vli.index)) {
 					SetDParam(0, STR_COMPANY_NAME);
 					SetDParam(1, this->vli.company);
-					SetDParam(2, this->vehicles.Length());
-					SetDParam(3, this->vehicles.Length());
+					SetDParam(2, this->vehicles.size());
+					SetDParam(3, this->vehicles.size());
 				} else {
 					const Group *g = Group::Get(this->vli.index);
 
@@ -483,17 +483,17 @@ public:
 
 		this->BuildGroupList(this->owner);
 
-		this->group_sb->SetCount(this->groups.Length());
-		this->vscroll->SetCount(this->vehicles.Length());
+		this->group_sb->SetCount(this->groups.size());
+		this->vscroll->SetCount(this->vehicles.size());
 
 		/* The drop down menu is out, *but* it may not be used, retract it. */
-		if (this->vehicles.Length() == 0 && this->IsWidgetLowered(WID_GL_MANAGE_VEHICLES_DROPDOWN)) {
+		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_GL_MANAGE_VEHICLES_DROPDOWN)) {
 			this->RaiseWidget(WID_GL_MANAGE_VEHICLES_DROPDOWN);
 			HideDropDownMenu(this);
 		}
 
 		/* Disable all lists management button when the list is empty */
-		this->SetWidgetsDisabledState(this->vehicles.Length() == 0 || _local_company != this->vli.company,
+		this->SetWidgetsDisabledState(this->vehicles.size() == 0 || _local_company != this->vli.company,
 				WID_GL_STOP_ALL,
 				WID_GL_START_ALL,
 				WID_GL_MANAGE_VEHICLES_DROPDOWN,
@@ -544,7 +544,7 @@ public:
 				Money this_year = 0;
 				Money last_year = 0;
 				uint32 occupancy = 0;
-				uint32 vehicle_count = this->vehicles.Length();
+				uint32 vehicle_count = this->vehicles.size();
 
 				for (uint i = 0; i < vehicle_count; i++) {
 					const Vehicle *v = this->vehicles[i];
@@ -580,7 +580,7 @@ public:
 
 			case WID_GL_LIST_GROUP: {
 				int y1 = r.top + WD_FRAMERECT_TOP;
-				int max = min(this->group_sb->GetPosition() + this->group_sb->GetCapacity(), this->groups.Length());
+				int max = min(this->group_sb->GetPosition() + this->group_sb->GetCapacity(), this->groups.size());
 				for (int i = this->group_sb->GetPosition(); i < max; ++i) {
 					const Group *g = this->groups[i];
 
@@ -590,7 +590,7 @@ public:
 
 					y1 += this->tiny_step_height;
 				}
-				if ((uint)this->group_sb->GetPosition() + this->group_sb->GetCapacity() > this->groups.Length()) {
+				if ((uint)this->group_sb->GetPosition() + this->group_sb->GetCapacity() > this->groups.size()) {
 					DrawGroupInfo(y1, r.left, r.right, NEW_GROUP);
 				}
 				break;
@@ -604,7 +604,7 @@ public:
 				if (this->vli.index != ALL_GROUP) {
 					/* Mark vehicles which are in sub-groups */
 					int y = r.top;
-					uint max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->vehicles.Length());
+					uint max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->vehicles.size());
 					for (uint i = this->vscroll->GetPosition(); i < max; ++i) {
 						const Vehicle *v = this->vehicles[i];
 						if (v->group_id != this->vli.index) {
@@ -658,7 +658,7 @@ public:
 
 			case WID_GL_LIST_GROUP: { // Matrix Group
 				uint id_g = this->group_sb->GetScrolledRowFromWidget(pt.y, this, WID_GL_LIST_GROUP, 0, this->tiny_step_height);
-				if (id_g >= this->groups.Length()) return;
+				if (id_g >= this->groups.size()) return;
 
 				this->group_sel = this->vli.index = this->groups[id_g]->index;
 
@@ -671,7 +671,7 @@ public:
 
 			case WID_GL_LIST_VEHICLE: { // Matrix Vehicle
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_GL_LIST_VEHICLE);
-				if (id_v >= this->vehicles.Length()) return; // click out of list bound
+				if (id_v >= this->vehicles.size()) return; // click out of list bound
 
 				const Vehicle *v = this->vehicles[id_v];
 				if (VehicleClicked(v)) break;
@@ -749,7 +749,7 @@ public:
 
 			case WID_GL_LIST_GROUP: { // Matrix group
 				uint id_g = this->group_sb->GetScrolledRowFromWidget(pt.y, this, WID_GL_LIST_GROUP, 0, this->tiny_step_height);
-				GroupID new_g = id_g >= this->groups.Length() ? INVALID_GROUP : this->groups[id_g]->index;
+				GroupID new_g = id_g >= this->groups.size() ? INVALID_GROUP : this->groups[id_g]->index;
 
 				if (this->group_sel != new_g && g->parent != new_g) {
 					DoCommandP(0, this->group_sel | (1 << 16), new_g, CMD_ALTER_GROUP | CMD_MSG(STR_ERROR_GROUP_CAN_T_SET_PARENT));
@@ -782,7 +782,7 @@ public:
 				this->SetDirty();
 
 				uint id_g = this->group_sb->GetScrolledRowFromWidget(pt.y, this, WID_GL_LIST_GROUP, 0, this->tiny_step_height);
-				GroupID new_g = id_g >= this->groups.Length() ? NEW_GROUP : this->groups[id_g]->index;
+				GroupID new_g = id_g >= this->groups.size() ? NEW_GROUP : this->groups[id_g]->index;
 
 				DoCommandP(0, new_g, vindex | (_ctrl_pressed ? 1 << 31 : 0), CMD_ADD_VEHICLE_GROUP | CMD_MSG(STR_ERROR_GROUP_CAN_T_ADD_VEHICLE), new_g == NEW_GROUP ? CcAddVehicleNewGroup : NULL);
 				break;
@@ -795,7 +795,7 @@ public:
 				this->SetDirty();
 
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_GL_LIST_VEHICLE);
-				if (id_v >= this->vehicles.Length()) return; // click out of list bound
+				if (id_v >= this->vehicles.size()) return; // click out of list bound
 
 				const Vehicle *v = this->vehicles[id_v];
 				if (!VehicleClicked(v) && vindex == v->index) {
@@ -834,7 +834,7 @@ public:
 				break;
 
 			case WID_GL_MANAGE_VEHICLES_DROPDOWN:
-				assert(this->vehicles.Length() != 0);
+				assert(this->vehicles.size() != 0);
 
 				switch (index) {
 					case ADI_REPLACE: // Replace window
@@ -895,7 +895,7 @@ public:
 
 			case WID_GL_LIST_GROUP: { // ... the list of custom groups.
 				uint id_g = this->group_sb->GetScrolledRowFromWidget(pt.y, this, WID_GL_LIST_GROUP, 0, this->tiny_step_height);
-				new_group_over = id_g >= this->groups.Length() ? NEW_GROUP : this->groups[id_g]->index;
+				new_group_over = id_g >= this->groups.size() ? NEW_GROUP : this->groups[id_g]->index;
 				break;
 			}
 		}

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -121,7 +121,7 @@ private:
 	uint tiny_step_height; ///< Step height for the group list
 	Scrollbar *group_sb;
 
-	SmallVector<int, 16> indents; ///< Indentation levels
+	std::vector<int> indents; ///< Indentation levels
 
 	Dimension column_size[VGC_END]; ///< Size of the columns in the group list.
 

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -273,7 +273,7 @@ void HotkeyList::Load(IniFile *ini)
 	for (Hotkey *hotkey = this->items; hotkey->name != NULL; ++hotkey) {
 		IniItem *item = group->GetItem(hotkey->name, false);
 		if (item != NULL) {
-			hotkey->keycodes.Clear();
+			hotkey->keycodes.clear();
 			if (item->value != NULL) ParseHotkeys(hotkey, item->value);
 		}
 	}

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -301,7 +301,9 @@ void HotkeyList::Save(IniFile *ini) const
 int HotkeyList::CheckMatch(uint16 keycode, bool global_only) const
 {
 	for (const Hotkey *list = this->items; list->name != NULL; ++list) {
-		if (list->keycodes.Contains(keycode | WKC_GLOBAL_HOTKEY) || (!global_only && list->keycodes.Contains(keycode))) {
+		auto begin = list->keycodes.begin();
+		auto end = list->keycodes.end();
+		if (std::find(begin, end, keycode | WKC_GLOBAL_HOTKEY) != end || (!global_only && std::find(begin, end, keycode) != end)) {
 			return list->num;
 		}
 	}

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -203,7 +203,7 @@ const char *SaveKeycodes(const Hotkey *hotkey)
 {
 	static char buf[128];
 	buf[0] = '\0';
-	for (uint i = 0; i < hotkey->keycodes.Length(); i++) {
+	for (uint i = 0; i < hotkey->keycodes.size(); i++) {
 		const char *str = KeycodeToString(hotkey->keycodes[i]);
 		if (i > 0) strecat(buf, ",", lastof(buf));
 		strecat(buf, str, lastof(buf));

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -255,7 +255,7 @@ HotkeyList::HotkeyList(const char *ini_group, Hotkey *items, GlobalHotkeyHandler
 	global_hotkey_handler(global_hotkey_handler), ini_group(ini_group), items(items)
 {
 	if (_hotkey_lists == NULL) _hotkey_lists = new SmallVector<HotkeyList*, 16>();
-	*_hotkey_lists->Append() = this;
+	_hotkey_lists->push_back(this);
 }
 
 HotkeyList::~HotkeyList()

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -260,7 +260,7 @@ HotkeyList::HotkeyList(const char *ini_group, Hotkey *items, GlobalHotkeyHandler
 
 HotkeyList::~HotkeyList()
 {
-	_hotkey_lists->Erase(_hotkey_lists->Find(this));
+	_hotkey_lists->erase(std::find(_hotkey_lists->begin(), _hotkey_lists->end(), this));
 }
 
 /**

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -24,7 +24,7 @@ char *_hotkeys_file;
  * List of all HotkeyLists.
  * This is a pointer to ensure initialisation order with the various static HotkeyList instances.
  */
-static SmallVector<HotkeyList*, 16> *_hotkey_lists = NULL;
+static std::vector<HotkeyList*> *_hotkey_lists = NULL;
 
 /** String representation of a keycode */
 struct KeycodeNames {
@@ -254,7 +254,7 @@ void Hotkey::AddKeycode(uint16 keycode)
 HotkeyList::HotkeyList(const char *ini_group, Hotkey *items, GlobalHotkeyHandlerFunc global_hotkey_handler) :
 	global_hotkey_handler(global_hotkey_handler), ini_group(ini_group), items(items)
 {
-	if (_hotkey_lists == NULL) _hotkey_lists = new SmallVector<HotkeyList*, 16>();
+	if (_hotkey_lists == NULL) _hotkey_lists = new std::vector<HotkeyList*>();
 	_hotkey_lists->push_back(this);
 }
 

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -248,7 +248,7 @@ Hotkey::Hotkey(const uint16 *default_keycodes, const char *name, int num) :
  */
 void Hotkey::AddKeycode(uint16 keycode)
 {
-	this->keycodes.Include(keycode);
+	include(this->keycodes, keycode);
 }
 
 HotkeyList::HotkeyList(const char *ini_group, Hotkey *items, GlobalHotkeyHandlerFunc global_hotkey_handler) :

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -316,11 +316,11 @@ static void SaveLoadHotkeys(bool save)
 	IniFile *ini = new IniFile();
 	ini->LoadFromDisk(_hotkeys_file, NO_DIRECTORY);
 
-	for (HotkeyList **list = _hotkey_lists->Begin(); list != _hotkey_lists->End(); ++list) {
+	for (HotkeyList *list : *_hotkey_lists) {
 		if (save) {
-			(*list)->Save(ini);
+			list->Save(ini);
 		} else {
-			(*list)->Load(ini);
+			list->Load(ini);
 		}
 	}
 
@@ -343,11 +343,11 @@ void SaveHotkeysToConfig()
 
 void HandleGlobalHotkeys(WChar key, uint16 keycode)
 {
-	for (HotkeyList **list = _hotkey_lists->Begin(); list != _hotkey_lists->End(); ++list) {
-		if ((*list)->global_hotkey_handler == NULL) continue;
+	for (HotkeyList *list : *_hotkey_lists) {
+		if (list->global_hotkey_handler == NULL) continue;
 
-		int hotkey = (*list)->CheckMatch(keycode, true);
-		if (hotkey >= 0 && ((*list)->global_hotkey_handler(hotkey) == ES_HANDLED)) return;
+		int hotkey = list->CheckMatch(keycode, true);
+		if (hotkey >= 0 && (list->global_hotkey_handler(hotkey) == ES_HANDLED)) return;
 	}
 }
 

--- a/src/hotkeys.h
+++ b/src/hotkeys.h
@@ -29,7 +29,7 @@ struct Hotkey {
 
 	const char *name;
 	int num;
-	SmallVector<uint16, 1> keycodes;
+	std::vector<uint16> keycodes;
 };
 
 #define HOTKEY_LIST_END Hotkey((uint16)0, NULL, -1)

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1884,7 +1884,7 @@ static CommandCost CreateNewIndustryHelper(TileIndex tile, IndustryType type, Do
 
 	*ip = NULL;
 
-	SmallVector<ClearedObjectArea, 1> object_areas(_cleared_object_areas);
+	std::vector<ClearedObjectArea> object_areas(_cleared_object_areas);
 	CommandCost ret = CheckIfIndustryTilesAreFree(tile, it, itspec_index, type, random_initial_bits, founder, creation_type, &custom_shape_check);
 	_cleared_object_areas = object_areas;
 	if (ret.Failed()) return ret;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1206,7 +1206,7 @@ protected:
 
 			const Industry *i;
 			FOR_ALL_INDUSTRIES(i) {
-				*this->industries.Append() = i;
+				this->industries.push_back(i);
 			}
 
 			this->industries.shrink_to_fit();
@@ -2415,12 +2415,13 @@ struct IndustryCargoesWindow : public Window {
 		_displayed_industries.set(it);
 
 		this->fields.clear();
-		CargoesRow *row = this->fields.Append();
-		row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
-		row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[2].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[3].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[4].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
+		/*C++17: CargoesRow &row = */ this->fields.emplace_back();
+		CargoesRow &row = this->fields.back();
+		row.columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
+		row.columns[1].MakeEmpty(CFT_SMALL_EMPTY);
+		row.columns[2].MakeEmpty(CFT_SMALL_EMPTY);
+		row.columns[3].MakeEmpty(CFT_SMALL_EMPTY);
+		row.columns[4].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
 
 		const IndustrySpec *central_sp = GetIndustrySpec(it);
 		bool houses_supply = HousesCanSupply(central_sp->accepts_cargo, lengthof(central_sp->accepts_cargo));
@@ -2430,12 +2431,13 @@ struct IndustryCargoesWindow : public Window {
 		int num_cust = CountMatchingAcceptingIndustries(central_sp->produced_cargo, lengthof(central_sp->produced_cargo)) + houses_accept;
 		int num_indrows = max(3, max(num_supp, num_cust)); // One is needed for the 'it' industry, and 2 for the cargo labels.
 		for (int i = 0; i < num_indrows; i++) {
-			CargoesRow *row = this->fields.Append();
-			row->columns[0].MakeEmpty(CFT_EMPTY);
-			row->columns[1].MakeCargo(central_sp->accepts_cargo, lengthof(central_sp->accepts_cargo));
-			row->columns[2].MakeEmpty(CFT_EMPTY);
-			row->columns[3].MakeCargo(central_sp->produced_cargo, lengthof(central_sp->produced_cargo));
-			row->columns[4].MakeEmpty(CFT_EMPTY);
+			/*C++17: CargoesRow &row = */ this->fields.emplace_back();
+			CargoesRow &row = this->fields.back();
+			row.columns[0].MakeEmpty(CFT_EMPTY);
+			row.columns[1].MakeCargo(central_sp->accepts_cargo, lengthof(central_sp->accepts_cargo));
+			row.columns[2].MakeEmpty(CFT_EMPTY);
+			row.columns[3].MakeCargo(central_sp->produced_cargo, lengthof(central_sp->produced_cargo));
+			row.columns[4].MakeEmpty(CFT_EMPTY);
 		}
 		/* Add central industry. */
 		int central_row = 1 + num_indrows / 2;
@@ -2493,12 +2495,13 @@ struct IndustryCargoesWindow : public Window {
 		_displayed_industries.reset();
 
 		this->fields.clear();
-		CargoesRow *row = this->fields.Append();
-		row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
-		row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[2].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
-		row->columns[3].MakeEmpty(CFT_SMALL_EMPTY);
-		row->columns[4].MakeEmpty(CFT_SMALL_EMPTY);
+		/*C++17: CargoesRow &row = */ this->fields.emplace_back();
+		CargoesRow &row = this->fields.back();
+		row.columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
+		row.columns[1].MakeEmpty(CFT_SMALL_EMPTY);
+		row.columns[2].MakeHeader(STR_INDUSTRY_CARGOES_CUSTOMERS);
+		row.columns[3].MakeEmpty(CFT_SMALL_EMPTY);
+		row.columns[4].MakeEmpty(CFT_SMALL_EMPTY);
 
 		bool houses_supply = HousesCanSupply(&cid, 1);
 		bool houses_accept = HousesCanAccept(&cid, 1);
@@ -2506,12 +2509,13 @@ struct IndustryCargoesWindow : public Window {
 		int num_cust = CountMatchingAcceptingIndustries(&cid, 1) + houses_accept;
 		int num_indrows = max(num_supp, num_cust);
 		for (int i = 0; i < num_indrows; i++) {
-			CargoesRow *row = this->fields.Append();
-			row->columns[0].MakeEmpty(CFT_EMPTY);
-			row->columns[1].MakeCargo(&cid, 1);
-			row->columns[2].MakeEmpty(CFT_EMPTY);
-			row->columns[3].MakeEmpty(CFT_EMPTY);
-			row->columns[4].MakeEmpty(CFT_EMPTY);
+			/*C++17: CargoesRow &row = */ this->fields.emplace_back();
+			CargoesRow &row = this->fields.back();
+			row.columns[0].MakeEmpty(CFT_EMPTY);
+			row.columns[1].MakeCargo(&cid, 1);
+			row.columns[2].MakeEmpty(CFT_EMPTY);
+			row.columns[3].MakeEmpty(CFT_EMPTY);
+			row.columns[4].MakeEmpty(CFT_EMPTY);
 		}
 
 		this->fields[num_indrows].MakeCargoLabel(0, false); // Add cargo labels at the left bottom.
@@ -2708,7 +2712,7 @@ struct IndustryCargoesWindow : public Window {
 				DropDownList *lst = new DropDownList;
 				const CargoSpec *cs;
 				FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
-					*lst->Append() = new DropDownListStringItem(cs->name, cs->Index(), false);
+					lst->push_back(new DropDownListStringItem(cs->name, cs->Index(), false));
 				}
 				if (lst->size() == 0) {
 					delete lst;
@@ -2725,7 +2729,7 @@ struct IndustryCargoesWindow : public Window {
 					IndustryType ind = _sorted_industry_types[i];
 					const IndustrySpec *indsp = GetIndustrySpec(ind);
 					if (!indsp->enabled) continue;
-					*lst->Append() = new DropDownListStringItem(indsp->name, ind, false);
+					lst->push_back(new DropDownListStringItem(indsp->name, ind, false));
 				}
 				if (lst->size() == 0) {
 					delete lst;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1209,7 +1209,7 @@ protected:
 				*this->industries.Append() = i;
 			}
 
-			this->industries.Compact();
+			this->industries.shrink_to_fit();
 			this->industries.RebuildDone();
 			this->vscroll->SetCount(this->industries.Length()); // Update scrollbar as well.
 		}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1202,7 +1202,7 @@ protected:
 	void BuildSortIndustriesList()
 	{
 		if (this->industries.NeedRebuild()) {
-			this->industries.Clear();
+			this->industries.clear();
 
 			const Industry *i;
 			FOR_ALL_INDUSTRIES(i) {
@@ -2414,7 +2414,7 @@ struct IndustryCargoesWindow : public Window {
 		_displayed_industries.reset();
 		_displayed_industries.set(it);
 
-		this->fields.Clear();
+		this->fields.clear();
 		CargoesRow *row = this->fields.Append();
 		row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
 		row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);
@@ -2492,7 +2492,7 @@ struct IndustryCargoesWindow : public Window {
 		this->ind_cargo = cid + NUM_INDUSTRYTYPES;
 		_displayed_industries.reset();
 
-		this->fields.Clear();
+		this->fields.clear();
 		CargoesRow *row = this->fields.Append();
 		row->columns[0].MakeHeader(STR_INDUSTRY_CARGOES_PRODUCERS);
 		row->columns[1].MakeEmpty(CFT_SMALL_EMPTY);

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2155,7 +2155,7 @@ next_cargo: ;
 struct IndustryCargoesWindow : public Window {
 	static const int HOR_TEXT_PADDING, VERT_TEXT_PADDING;
 
-	typedef SmallVector<CargoesRow, 4> Fields;
+	typedef std::vector<CargoesRow> Fields;
 
 	Fields fields;  ///< Fields to display in the #WID_IC_PANEL.
 	uint ind_cargo; ///< If less than #NUM_INDUSTRYTYPES, an industry type, else a cargo id + NUM_INDUSTRYTYPES.

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1211,7 +1211,7 @@ protected:
 
 			this->industries.shrink_to_fit();
 			this->industries.RebuildDone();
-			this->vscroll->SetCount(this->industries.Length()); // Update scrollbar as well.
+			this->vscroll->SetCount(this->industries.size()); // Update scrollbar as well.
 		}
 
 		if (!this->industries.Sort()) return;
@@ -1372,11 +1372,11 @@ public:
 			case WID_ID_INDUSTRY_LIST: {
 				int n = 0;
 				int y = r.top + WD_FRAMERECT_TOP;
-				if (this->industries.Length() == 0) {
+				if (this->industries.size() == 0) {
 					DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_INDUSTRY_DIRECTORY_NONE);
 					break;
 				}
-				for (uint i = this->vscroll->GetPosition(); i < this->industries.Length(); i++) {
+				for (uint i = this->vscroll->GetPosition(); i < this->industries.size(); i++) {
 					DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, this->GetIndustryString(this->industries[i]));
 
 					y += this->resize.step_height;
@@ -1411,7 +1411,7 @@ public:
 
 			case WID_ID_INDUSTRY_LIST: {
 				Dimension d = GetStringBoundingBox(STR_INDUSTRY_DIRECTORY_NONE);
-				for (uint i = 0; i < this->industries.Length(); i++) {
+				for (uint i = 0; i < this->industries.size(); i++) {
 					d = maxdim(d, GetStringBoundingBox(this->GetIndustryString(this->industries[i])));
 				}
 				resize->height = d.height;
@@ -1439,7 +1439,7 @@ public:
 
 			case WID_ID_INDUSTRY_LIST: {
 				uint p = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_ID_INDUSTRY_LIST, WD_FRAMERECT_TOP);
-				if (p < this->industries.Length()) {
+				if (p < this->industries.size()) {
 					if (_ctrl_pressed) {
 						ShowExtraViewPortWindow(this->industries[p]->location.tile);
 					} else {
@@ -2589,7 +2589,7 @@ struct IndustryCargoesWindow : public Window {
 
 		const NWidgetBase *nwp = this->GetWidget<NWidgetBase>(WID_IC_PANEL);
 		int vpos = -this->vscroll->GetPosition() * nwp->resize_y;
-		for (uint i = 0; i < this->fields.Length(); i++) {
+		for (uint i = 0; i < this->fields.size(); i++) {
 			int row_height = (i == 0) ? CargoesField::small_height : CargoesField::normal_height;
 			if (vpos + row_height >= 0) {
 				int xpos = left_pos;
@@ -2631,7 +2631,7 @@ struct IndustryCargoesWindow : public Window {
 		if (pt.y < vpos) return false;
 
 		int row = (pt.y - vpos) / CargoesField::normal_height; // row is relative to row 1.
-		if (row + 1 >= (int)this->fields.Length()) return false;
+		if (row + 1 >= (int)this->fields.size()) return false;
 		vpos = pt.y - vpos - row * CargoesField::normal_height; // Position in the row + 1 field
 		row++; // rebase row to match index of this->fields.
 
@@ -2710,7 +2710,7 @@ struct IndustryCargoesWindow : public Window {
 				FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
 					*lst->Append() = new DropDownListStringItem(cs->name, cs->Index(), false);
 				}
-				if (lst->Length() == 0) {
+				if (lst->size() == 0) {
 					delete lst;
 					break;
 				}
@@ -2727,7 +2727,7 @@ struct IndustryCargoesWindow : public Window {
 					if (!indsp->enabled) continue;
 					*lst->Append() = new DropDownListStringItem(indsp->name, ind, false);
 				}
-				if (lst->Length() == 0) {
+				if (lst->size() == 0) {
 					delete lst;
 					break;
 				}

--- a/src/language.h
+++ b/src/language.h
@@ -96,7 +96,7 @@ struct LanguageMetadata : public LanguagePackHeader {
 };
 
 /** Type for the list of language meta data. */
-typedef SmallVector<LanguageMetadata, 4> LanguageList;
+typedef std::vector<LanguageMetadata> LanguageList;
 
 /** The actual list of language meta data. */
 extern LanguageList _languages;

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -139,7 +139,7 @@ void LinkGraph::RemoveNode(NodeID id)
 		node_edges[id] = node_edges[last_node];
 	}
 	Station::Get(this->nodes[last_node].station)->goods[this->cargo].node = id;
-	this->nodes.Erase(this->nodes.Get(id));
+	this->nodes.erase(this->nodes.begin() + id);
 	this->edges.EraseColumn(id);
 	/* Not doing EraseRow here, as having the extra invalid row doesn't hurt
 	 * and removing it would trigger a lot of memmove. The data has already

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -159,7 +159,7 @@ NodeID LinkGraph::AddNode(const Station *st)
 	const GoodsEntry &good = st->goods[this->cargo];
 
 	NodeID new_node = this->Size();
-	this->nodes.Append();
+	this->nodes.emplace_back();
 	/* Avoid reducing the height of the matrix as that is expensive and we
 	 * most likely will increase it again later which is again expensive. */
 	this->edges.Resize(new_node + 1U,

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -281,7 +281,7 @@ void LinkGraph::Init(uint size)
 {
 	assert(this->Size() == 0);
 	this->edges.Resize(size, size);
-	this->nodes.Resize(size);
+	this->nodes.resize(size);
 
 	for (uint i = 0; i < size; ++i) {
 		this->nodes[i].Init();

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -496,7 +496,7 @@ public:
 	 * Get the current size of the component.
 	 * @return Size.
 	 */
-	inline uint Size() const { return this->nodes.Length(); }
+	inline uint Size() const { return this->nodes.size(); }
 
 	/**
 	 * Get date of last compression.

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -435,7 +435,7 @@ public:
 		void RemoveEdge(NodeID to);
 	};
 
-	typedef SmallVector<BaseNode, 16> NodeVector;
+	typedef std::vector<BaseNode> NodeVector;
 	typedef SmallMatrix<BaseEdge> EdgeMatrix;
 
 	/** Minimum effective distance for timeout calculation. */

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -179,7 +179,7 @@ LinkGraphJob::~LinkGraphJob()
 void LinkGraphJob::Init()
 {
 	uint size = this->Size();
-	this->nodes.Resize(size);
+	this->nodes.resize(size);
 	this->edges.Resize(size, size);
 	for (uint i = 0; i < size; ++i) {
 		this->nodes[i].Init(this->link_graph[i].Supply());

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -50,7 +50,7 @@ private:
 		void Init(uint supply);
 	};
 
-	typedef SmallVector<NodeAnnotation, 16> NodeAnnotationVector;
+	typedef std::vector<NodeAnnotation> NodeAnnotationVector;
 	typedef SmallMatrix<EdgeAnnotation> EdgeAnnotationMatrix;
 
 	friend const SaveLoad *GetLinkGraphJobDesc();

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -751,7 +751,7 @@ static void MidiThreadProc(void *)
 				block_time = playback_start_time + block.realtime * MIDITIME_TO_REFTIME;
 				DEBUG(driver, 9, "DMusic thread: Streaming block " PRINTF_SIZE " (cur=" OTTD_PRINTF64 ", block=" OTTD_PRINTF64 ")", current_block, (long long)(current_time / MS_TO_REFTIME), (long long)(block_time / MS_TO_REFTIME));
 
-				byte *data = block.data.Begin();
+				byte *data = block.data.data();
 				size_t remaining = block.data.size();
 				byte last_status = 0;
 				while (remaining > 0) {

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -686,7 +686,7 @@ static void MidiThreadProc(void *)
 				size_t preload_bytes = 0;
 				for (size_t bl = 0; bl < current_file.blocks.size(); bl++) {
 					MidiFile::DataBlock &block = current_file.blocks[bl];
-					preload_bytes += block.data.Length();
+					preload_bytes += block.data.size();
 					if (block.ticktime >= current_segment.start) {
 						if (current_segment.loop) {
 							DEBUG(driver, 2, "DMusic: timer: loop from block %d (ticktime %d, realtime %.3f, bytes %d)", (int)bl, (int)block.ticktime, ((int)block.realtime) / 1000.0, (int)preload_bytes);
@@ -752,7 +752,7 @@ static void MidiThreadProc(void *)
 				DEBUG(driver, 9, "DMusic thread: Streaming block " PRINTF_SIZE " (cur=" OTTD_PRINTF64 ", block=" OTTD_PRINTF64 ")", current_block, (long long)(current_time / MS_TO_REFTIME), (long long)(block_time / MS_TO_REFTIME));
 
 				byte *data = block.data.Begin();
-				size_t remaining = block.data.Length();
+				size_t remaining = block.data.size();
 				byte last_status = 0;
 				while (remaining > 0) {
 					/* MidiFile ought to have converted everything out of running status,

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -21,7 +21,6 @@
 #include "../console_func.h"
 #include "../console_internal.h"
 
-
 /* SMF reader based on description at: http://www.somascape.org/midi/tech/mfile.html */
 
 
@@ -217,7 +216,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 				case MIDIST_CONTROLLER:
 				case MIDIST_PITCHBEND:
 					/* 3 byte messages */
-					data = block->data.Append(3);
+					data = grow(block->data, 3);
 					data[0] = status;
 					if (!chunk.ReadBuffer(&data[1], 2)) {
 						return false;
@@ -226,7 +225,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 				case MIDIST_PROGCHG:
 				case MIDIST_CHANPRESS:
 					/* 2 byte messages */
-					data = block->data.Append(2);
+					data = grow(block->data, 2);
 					data[0] = status;
 					if (!chunk.ReadByte(data[1])) {
 						return false;
@@ -267,7 +266,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 			if (!chunk.ReadVariableLength(length)) {
 				return false;
 			}
-			byte *data = block->data.Append(length + 1);
+			byte *data = grow(block->data, length + 1);
 			data[0] = 0xF0;
 			if (!chunk.ReadBuffer(data + 1, length)) {
 				return false;
@@ -275,7 +274,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 			if (data[length] != 0xF7) {
 				/* Engage Casio weirdo mode - convert to normal sysex */
 				running_sysex = true;
-				*block->data.Append() = 0xF7;
+				block->data.push_back(0xF7);
 			} else {
 				running_sysex = false;
 			}
@@ -285,7 +284,7 @@ static bool ReadTrackChunk(FILE *file, MidiFile &target)
 			if (!chunk.ReadVariableLength(length)) {
 				return false;
 			}
-			byte *data = block->data.Append(length);
+			byte *data = grow(block->data, length);
 			if (!chunk.ReadBuffer(data, length)) {
 				return false;
 			}
@@ -336,7 +335,7 @@ static bool FixupMidiData(MidiFile &target)
 			merged_blocks.push_back(block);
 			last_ticktime = block.ticktime;
 		} else {
-			byte *datadest = merged_blocks.back().data.Append(block.data.size());
+			byte *datadest = grow(merged_blocks.back().data, block.data.size());
 			memcpy(datadest, block.data.Begin(), block.data.size());
 		}
 	}
@@ -508,14 +507,14 @@ struct MpsMachine {
 
 	static void AddMidiData(MidiFile::DataBlock &block, byte b1, byte b2)
 	{
-		*block.data.Append() = b1;
-		*block.data.Append() = b2;
+		block.data.push_back(b1);
+		block.data.push_back(b2);
 	}
 	static void AddMidiData(MidiFile::DataBlock &block, byte b1, byte b2, byte b3)
 	{
-		*block.data.Append() = b1;
-		*block.data.Append() = b2;
-		*block.data.Append() = b3;
+		block.data.push_back(b1);
+		block.data.push_back(b2);
+		block.data.push_back(b3);
 	}
 
 	/**

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -330,14 +330,14 @@ static bool FixupMidiData(MidiFile &target)
 	uint32 last_ticktime = 0;
 	for (size_t i = 0; i < target.blocks.size(); i++) {
 		MidiFile::DataBlock &block = target.blocks[i];
-		if (block.data.Length() == 0) {
+		if (block.data.size() == 0) {
 			continue;
 		} else if (block.ticktime > last_ticktime || merged_blocks.size() == 0) {
 			merged_blocks.push_back(block);
 			last_ticktime = block.ticktime;
 		} else {
-			byte *datadest = merged_blocks.back().data.Append(block.data.Length());
-			memcpy(datadest, block.data.Begin(), block.data.Length());
+			byte *datadest = merged_blocks.back().data.Append(block.data.size());
+			memcpy(datadest, block.data.Begin(), block.data.size());
 		}
 	}
 	std::swap(merged_blocks, target.blocks);

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -336,7 +336,7 @@ static bool FixupMidiData(MidiFile &target)
 			last_ticktime = block.ticktime;
 		} else {
 			byte *datadest = grow(merged_blocks.back().data, block.data.size());
-			memcpy(datadest, block.data.Begin(), block.data.size());
+			memcpy(datadest, block.data.data(), block.data.size());
 		}
 	}
 	std::swap(merged_blocks, target.blocks);
@@ -940,8 +940,8 @@ bool MidiFile::WriteSMF(const char *filename)
 		}
 
 		/* Write each block data command */
-		byte *dp = block.data.Begin();
-		while (dp < block.data.End()) {
+		byte *dp = block.data.data();
+		while (dp < block.data.data() + block.data.size()) {
 			/* Always zero delta time inside blocks */
 			if (needtime) {
 				fputc(0, f);

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -22,8 +22,8 @@ struct MusicSongInfo;
 
 struct MidiFile {
 	struct DataBlock {
-		uint32 ticktime;           ///< tick number since start of file this block should be triggered at
-		uint32 realtime;           ///< real-time (microseconds) since start of file this block should be triggered at
+		uint32 ticktime;        ///< tick number since start of file this block should be triggered at
+		uint32 realtime;        ///< real-time (microseconds) since start of file this block should be triggered at
 		std::vector<byte> data; ///< raw midi data contained in block
 		DataBlock(uint32 _ticktime = 0) : ticktime(_ticktime) { }
 	};

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -24,7 +24,7 @@ struct MidiFile {
 	struct DataBlock {
 		uint32 ticktime;           ///< tick number since start of file this block should be triggered at
 		uint32 realtime;           ///< real-time (microseconds) since start of file this block should be triggered at
-		SmallVector<byte, 8> data; ///< raw midi data contained in block
+		std::vector<byte> data; ///< raw midi data contained in block
 		DataBlock(uint32 _ticktime = 0) : ticktime(_ticktime) { }
 	};
 	struct TempoChange {

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -229,7 +229,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 			break;
 		}
 
-		byte *data = block.data.Begin();
+		byte *data = block.data.data();
 		size_t remaining = block.data.size();
 		byte last_status = 0;
 		while (remaining > 0) {

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -187,7 +187,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 		uint preload_bytes = 0;
 		for (size_t bl = 0; bl < _midi.current_file.blocks.size(); bl++) {
 			MidiFile::DataBlock &block = _midi.current_file.blocks[bl];
-			preload_bytes += block.data.Length();
+			preload_bytes += block.data.size();
 			if (block.ticktime >= _midi.current_segment.start) {
 				if (_midi.current_segment.loop) {
 					DEBUG(driver, 2, "Win32-MIDI: timer: loop from block %d (ticktime %d, realtime %.3f, bytes %d)", (int)bl, (int)block.ticktime, ((int)block.realtime)/1000.0, (int)preload_bytes);
@@ -230,7 +230,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 		}
 
 		byte *data = block.data.Begin();
-		size_t remaining = block.data.Length();
+		size_t remaining = block.data.size();
 		byte last_status = 0;
 		while (remaining > 0) {
 			/* MidiFile ought to have converted everything out of running status,

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -19,7 +19,7 @@
 
 class NetworkAddress;
 typedef std::vector<NetworkAddress> NetworkAddressList; ///< Type for a list of addresses.
-typedef SmallMap<NetworkAddress, SOCKET, 4> SocketList;    ///< Type for a mapping between address and socket.
+typedef SmallMap<NetworkAddress, SOCKET> SocketList;    ///< Type for a mapping between address and socket.
 
 /**
  * Wrapper for (un)resolved network addresses; there's no reason to transform

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -18,7 +18,7 @@
 #include "../../core/smallmap_type.hpp"
 
 class NetworkAddress;
-typedef SmallVector<NetworkAddress, 4> NetworkAddressList; ///< Type for a list of addresses.
+typedef std::vector<NetworkAddress> NetworkAddressList; ///< Type for a list of addresses.
 typedef SmallMap<NetworkAddress, SOCKET, 4> SocketList;    ///< Type for a mapping between address and socket.
 
 /**

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -100,7 +100,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // GE
 		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
 
 		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
-		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) *broadcast->Append() = addr;
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
 	}
 	freeifaddrs(ifap);
 }

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -136,7 +136,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Wi
 		memcpy(&address, &ifo[j].iiAddress.Address, sizeof(sockaddr));
 		((sockaddr_in*)&address)->sin_addr.s_addr = ifo[j].iiAddress.AddressIn.sin_addr.s_addr | ~ifo[j].iiNetmask.AddressIn.sin_addr.s_addr;
 		NetworkAddress addr(address, sizeof(sockaddr));
-		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) *broadcast->Append() = addr;
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
 	}
 
 	free(ifo);

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -76,7 +76,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // BE
 				memset(&address, 0, sizeof(address));
 				((sockaddr_in*)&address)->sin_addr.s_addr = htonl(ip | ~netmask);
 				NetworkAddress addr(address, sizeof(sockaddr));
-				if (!broadcast->Contains(addr)) *broadcast->Append() = addr;
+				if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) *broadcast->Append() = addr;
 			}
 			if (read < 0) {
 				break;
@@ -100,7 +100,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // GE
 		if (ifa->ifa_broadaddr->sa_family != AF_INET) continue;
 
 		NetworkAddress addr(ifa->ifa_broadaddr, sizeof(sockaddr));
-		if (!broadcast->Contains(addr)) *broadcast->Append() = addr;
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) *broadcast->Append() = addr;
 	}
 	freeifaddrs(ifap);
 }
@@ -136,7 +136,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // Wi
 		memcpy(&address, &ifo[j].iiAddress.Address, sizeof(sockaddr));
 		((sockaddr_in*)&address)->sin_addr.s_addr = ifo[j].iiAddress.AddressIn.sin_addr.s_addr | ~ifo[j].iiNetmask.AddressIn.sin_addr.s_addr;
 		NetworkAddress addr(address, sizeof(sockaddr));
-		if (!broadcast->Contains(addr)) *broadcast->Append() = addr;
+		if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) *broadcast->Append() = addr;
 	}
 
 	free(ifo);
@@ -174,7 +174,7 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // !G
 					(r.ifr_flags & IFF_BROADCAST) &&
 					ioctl(sock, SIOCGIFBRDADDR, &r) != -1) {
 				NetworkAddress addr(&r.ifr_broadaddr, sizeof(sockaddr));
-				if (!broadcast->Contains(addr)) *broadcast->Append() = addr;
+				if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) *broadcast->Append() = addr;
 			}
 		}
 

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -200,8 +200,8 @@ void NetworkFindBroadcastIPs(NetworkAddressList *broadcast)
 	/* Now display to the debug all the detected ips */
 	DEBUG(net, 3, "Detected broadcast addresses:");
 	int i = 0;
-	for (NetworkAddress *addr = broadcast->Begin(); addr != broadcast->End(); addr++) {
-		addr->SetPort(NETWORK_DEFAULT_PORT);
-		DEBUG(net, 3, "%d) %s", i++, addr->GetHostname());
+	for (NetworkAddress &addr : *broadcast) {
+		addr.SetPort(NETWORK_DEFAULT_PORT);
+		DEBUG(net, 3, "%d) %s", i++, addr.GetHostname());
 	}
 }

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -66,22 +66,22 @@ void TCPConnecter::Connect()
  */
 /* static */ void TCPConnecter::CheckCallbacks()
 {
-	for (TCPConnecter **iter = _tcp_connecters.Begin(); iter < _tcp_connecters.End(); /* nothing */) {
+	for (auto iter = _tcp_connecters.begin(); iter < _tcp_connecters.end(); /* nothing */) {
 		TCPConnecter *cur = *iter;
 		if ((cur->connected || cur->aborted) && cur->killed) {
-			_tcp_connecters.Erase(iter);
+			iter = _tcp_connecters.erase(iter);
 			if (cur->sock != INVALID_SOCKET) closesocket(cur->sock);
 			delete cur;
 			continue;
 		}
 		if (cur->connected) {
-			_tcp_connecters.Erase(iter);
+			iter = _tcp_connecters.erase(iter);
 			cur->OnConnect(cur->sock);
 			delete cur;
 			continue;
 		}
 		if (cur->aborted) {
-			_tcp_connecters.Erase(iter);
+			iter = _tcp_connecters.erase(iter);
 			cur->OnFailure();
 			delete cur;
 			continue;

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -32,7 +32,7 @@ TCPConnecter::TCPConnecter(const NetworkAddress &address) :
 	sock(INVALID_SOCKET),
 	address(address)
 {
-	*_tcp_connecters.Append() = this;
+	_tcp_connecters.push_back(this);
 	if (!ThreadObject::New(TCPConnecter::ThreadEntry, this, &this->thread, "ottd:tcp")) {
 		this->Connect();
 	}

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -93,5 +93,5 @@ void TCPConnecter::Connect()
 /** Kill all connection attempts. */
 /* static */ void TCPConnecter::KillAll()
 {
-	for (TCPConnecter **iter = _tcp_connecters.Begin(); iter != _tcp_connecters.End(); iter++) (*iter)->killed = true;
+	for (TCPConnecter *conn : _tcp_connecters) conn->killed = true;
 }

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -19,7 +19,7 @@
 #include "../../safeguards.h"
 
 /** List of connections that are currently being created */
-static SmallVector<TCPConnecter *,  1> _tcp_connecters;
+static std::vector<TCPConnecter *> _tcp_connecters;
 
 /**
  * Create a new connecter for the given address

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -311,7 +311,7 @@ int NetworkHTTPSocketHandler::Receive()
 	int n = select(FD_SETSIZE, &read_fd, NULL, NULL, &tv);
 	if (n == -1) return;
 
-	for (NetworkHTTPSocketHandler **iter = _http_connections.Begin(); iter < _http_connections.End(); /* nothing */) {
+	for (auto iter = _http_connections.begin(); iter < _http_connections.end(); /* nothing */) {
 		NetworkHTTPSocketHandler *cur = *iter;
 
 		if (FD_ISSET(cur->sock, &read_fd)) {
@@ -321,7 +321,7 @@ int NetworkHTTPSocketHandler::Receive()
 			if (ret <= 0) {
 				/* Then... the connection can be closed */
 				cur->CloseConnection();
-				_http_connections.Erase(iter);
+				iter = _http_connections.erase(iter);
 				delete cur;
 				continue;
 			}

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -21,7 +21,7 @@
 #include "../../safeguards.h"
 
 /** List of open HTTP connections. */
-static SmallVector<NetworkHTTPSocketHandler *, 1> _http_connections;
+static std::vector<NetworkHTTPSocketHandler *> _http_connections;
 
 /**
  * Start the querying

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -303,8 +303,8 @@ int NetworkHTTPSocketHandler::Receive()
 	struct timeval tv;
 
 	FD_ZERO(&read_fd);
-	for (NetworkHTTPSocketHandler **iter = _http_connections.Begin(); iter < _http_connections.End(); iter++) {
-		FD_SET((*iter)->sock, &read_fd);
+	for (NetworkHTTPSocketHandler *handler : _http_connections) {
+		FD_SET(handler->sock, &read_fd);
 	}
 
 	tv.tv_sec = tv.tv_usec = 0; // don't block at all.

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -63,7 +63,7 @@ NetworkHTTPSocketHandler::NetworkHTTPSocketHandler(SOCKET s,
 		return;
 	}
 
-	*_http_connections.Append() = this;
+	_http_connections.push_back(this);
 }
 
 /** Free whatever needs to be freed. */

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -297,7 +297,7 @@ int NetworkHTTPSocketHandler::Receive()
 /* static */ void NetworkHTTPSocketHandler::HTTPReceive()
 {
 	/* No connections, just bail out. */
-	if (_http_connections.Length() == 0) return;
+	if (_http_connections.size() == 0) return;
 
 	fd_set read_fd;
 	struct timeval tv;

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -164,7 +164,7 @@ public:
 		for (SocketList::iterator s = sockets.Begin(); s != sockets.End(); s++) {
 			closesocket(s->second);
 		}
-		sockets.Clear();
+		sockets.clear();
 		DEBUG(net, 1, "[%s] closed listeners", Tsocket::GetName());
 	}
 };

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -140,7 +140,7 @@ public:
 	 */
 	static bool Listen(uint16 port)
 	{
-		assert(sockets.Length() == 0);
+		assert(sockets.size() == 0);
 
 		NetworkAddressList addresses;
 		GetBindAddresses(&addresses, port);
@@ -149,7 +149,7 @@ public:
 			address->Listen(SOCK_STREAM, &sockets);
 		}
 
-		if (sockets.Length() == 0) {
+		if (sockets.size() == 0) {
 			DEBUG(net, 0, "[server] could not start network: could not create listening socket");
 			NetworkError(STR_NETWORK_ERROR_SERVER_START);
 			return false;

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -51,7 +51,7 @@ bool NetworkUDPSocketHandler::Listen()
 		addr->Listen(SOCK_DGRAM, &this->sockets);
 	}
 
-	return this->sockets.Length() != 0;
+	return this->sockets.size() != 0;
 }
 
 /**
@@ -80,7 +80,7 @@ NetworkRecvStatus NetworkUDPSocketHandler::CloseConnection(bool error)
  */
 void NetworkUDPSocketHandler::SendPacket(Packet *p, NetworkAddress *recv, bool all, bool broadcast)
 {
-	if (this->sockets.Length() == 0) this->Listen();
+	if (this->sockets.size() == 0) this->Listen();
 
 	for (SocketList::iterator s = this->sockets.Begin(); s != this->sockets.End(); s++) {
 		/* Make a local copy because if we resolve it we cannot

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -26,14 +26,14 @@ NetworkUDPSocketHandler::NetworkUDPSocketHandler(NetworkAddressList *bind)
 {
 	if (bind != NULL) {
 		for (NetworkAddress *addr = bind->Begin(); addr != bind->End(); addr++) {
-			*this->bind.Append() = *addr;
+			this->bind.push_back(*addr);
 		}
 	} else {
 		/* As hostname NULL and port 0/NULL don't go well when
 		 * resolving it we need to add an address for each of
 		 * the address families we support. */
-		*this->bind.Append() = NetworkAddress(NULL, 0, AF_INET);
-		*this->bind.Append() = NetworkAddress(NULL, 0, AF_INET6);
+		this->bind.emplace_back(nullptr, 0, AF_INET);
+		this->bind.emplace_back(nullptr, 0, AF_INET6);
 	}
 }
 

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -62,7 +62,7 @@ void NetworkUDPSocketHandler::Close()
 	for (SocketList::iterator s = this->sockets.Begin(); s != this->sockets.End(); s++) {
 		closesocket(s->second);
 	}
-	this->sockets.Clear();
+	this->sockets.clear();
 }
 
 NetworkRecvStatus NetworkUDPSocketHandler::CloseConnection(bool error)

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -632,8 +632,8 @@ void NetworkAddServer(const char *b)
  */
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port)
 {
-	for (char **iter = _network_bind_list.Begin(); iter != _network_bind_list.End(); iter++) {
-		addresses->emplace_back(*iter, port);
+	for (char *iter : _network_bind_list) {
+		addresses->emplace_back(iter, port);
 	}
 
 	/* No address, so bind to everything. */

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -633,12 +633,12 @@ void NetworkAddServer(const char *b)
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port)
 {
 	for (char **iter = _network_bind_list.Begin(); iter != _network_bind_list.End(); iter++) {
-		*addresses->Append() = NetworkAddress(*iter, port);
+		addresses->emplace_back(*iter, port);
 	}
 
 	/* No address, so bind to everything. */
 	if (addresses->size() == 0) {
-		*addresses->Append() = NetworkAddress("", port);
+		addresses->emplace_back("", port);
 	}
 }
 
@@ -650,7 +650,7 @@ void NetworkRebuildHostList()
 	_network_host_list.Clear();
 
 	for (NetworkGameList *item = _network_game_list; item != NULL; item = item->next) {
-		if (item->manually) *_network_host_list.Append() = stredup(item->address.GetAddressAsString(false));
+		if (item->manually) _network_host_list.push_back(stredup(item->address.GetAddressAsString(false)));
 	}
 }
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -637,7 +637,7 @@ void GetBindAddresses(NetworkAddressList *addresses, uint16 port)
 	}
 
 	/* No address, so bind to everything. */
-	if (addresses->Length() == 0) {
+	if (addresses->size() == 0) {
 		*addresses->Append() = NetworkAddress("", port);
 	}
 }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -110,7 +110,7 @@ struct PacketReader : LoadFilter {
 	{
 		this->read_bytes = 0;
 
-		this->block = this->blocks.Begin();
+		this->block = this->blocks.data();
 		this->buf   = *this->block++;
 		this->bufe  = this->buf + CHUNK;
 	}

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -41,7 +41,7 @@
 struct PacketReader : LoadFilter {
 	static const size_t CHUNK = 32 * 1024;  ///< 32 KiB chunks of memory.
 
-	AutoFreeSmallVector<byte *, 16> blocks; ///< Buffer with blocks of allocated memory.
+	AutoFreeSmallVector<byte *> blocks;     ///< Buffer with blocks of allocated memory.
 	byte *buf;                              ///< Buffer we're going to write to/read from.
 	byte *bufe;                             ///< End of the buffer we write to/read from.
 	byte **block;                           ///< The block we're reading from/writing to.

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -77,7 +77,7 @@ struct PacketReader : LoadFilter {
 		/* Allocate a new chunk and add the remaining data. */
 		pbuf += to_write;
 		to_write   = in_packet - to_write;
-		this->buf  = *this->blocks.Append() = CallocT<byte>(CHUNK);
+		this->blocks.push_back(this->buf = CallocT<byte>(CHUNK));
 		this->bufe = this->buf + CHUNK;
 
 		memcpy(this->buf, pbuf, to_write);

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -981,7 +981,7 @@ void ClientNetworkContentSocketHandler::CheckDependencyState(ContentInfo *ci)
 		if (c->state != ContentInfo::AUTOSELECTED) continue;
 
 		/* Only unselect when WE are the only parent. */
-		parents.Clear();
+		parents.clear();
 		this->ReverseLookupDependency(parents, c);
 
 		/* First check whether anything depends on us */
@@ -1000,7 +1000,7 @@ void ClientNetworkContentSocketHandler::CheckDependencyState(ContentInfo *ci)
 		if (force_selection) continue;
 
 		/* "Flood" search to find all items in the dependency graph*/
-		parents.Clear();
+		parents.clear();
 		this->ReverseLookupTreeDependency(parents, c);
 
 		/* Is there anything that is "force" selected?, if so... we're done. */
@@ -1033,8 +1033,8 @@ void ClientNetworkContentSocketHandler::Clear()
 {
 	for (ContentIterator iter = this->infos.Begin(); iter != this->infos.End(); iter++) delete *iter;
 
-	this->infos.Clear();
-	this->requested.Clear();
+	this->infos.clear();
+	this->requested.clear();
 }
 
 /*** CALLBACK ***/

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -555,7 +555,8 @@ void ClientNetworkContentSocketHandler::OnFailure()
 	uint files, bytes;
 	this->DownloadSelectedContent(files, bytes, true);
 
-	this->http_response.Reset();
+	this->http_response.clear();
+	this->http_response.shrink_to_fit();
 	this->http_response_index = -2;
 
 	if (this->curFile != NULL) {

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -930,7 +930,7 @@ void ClientNetworkContentSocketHandler::ReverseLookupTreeDependency(ConstContent
 		this->ReverseLookupDependency(parents, tree[i]);
 
 		for (ConstContentIterator piter = parents.Begin(); piter != parents.End(); piter++) {
-			tree.Include(*piter);
+			include(tree, *piter);
 		}
 	}
 }

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -165,7 +165,7 @@ bool ClientNetworkContentSocketHandler::Receive_SERVER_INFO(Packet *p)
 		return true;
 	}
 
-	*this->infos.Append() = ci;
+	this->infos.push_back(ci);
 
 	/* Incoming data means that we might need to reconsider dependencies */
 	for (ContentIterator iter = this->infos.Begin(); iter != this->infos.End(); iter++) {
@@ -278,7 +278,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 			}
 		}
 		if (!found) {
-			*this->infos.Append() = ci;
+			this->infos.push_back(ci);
 		} else {
 			delete ci;
 		}
@@ -300,7 +300,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContent(uint &files, uin
 		const ContentInfo *ci = *iter;
 		if (!ci->IsSelected() || ci->state == ContentInfo::ALREADY_HERE) continue;
 
-		*content.Append() = ci->id;
+		content.push_back(ci->id);
 		bytes += ci->filesize;
 	}
 
@@ -579,11 +579,11 @@ void ClientNetworkContentSocketHandler::OnReceiveData(const char *data, size_t l
 	if (this->http_response_index == -1) {
 		if (data != NULL) {
 			/* Append the rest of the response. */
-			memcpy(this->http_response.Append((uint)length), data, length);
+			memcpy(grow(this->http_response, (uint)length), data, length);
 			return;
 		} else {
 			/* Make sure the response is properly terminated. */
-			*this->http_response.Append() = '\0';
+			this->http_response.push_back('\0');
 
 			/* And prepare for receiving the rest of the data. */
 			this->http_response_index = 0;
@@ -905,7 +905,7 @@ void ClientNetworkContentSocketHandler::ReverseLookupDependency(ConstContentVect
 
 		for (uint i = 0; i < ci->dependency_count; i++) {
 			if (ci->dependencies[i] == child->id) {
-				*parents.Append() = ci;
+				parents.push_back(ci);
 				break;
 			}
 		}
@@ -919,7 +919,7 @@ void ClientNetworkContentSocketHandler::ReverseLookupDependency(ConstContentVect
  */
 void ClientNetworkContentSocketHandler::ReverseLookupTreeDependency(ConstContentVector &tree, const ContentInfo *child) const
 {
-	*tree.Append() = child;
+	tree.push_back(child);
 
 	/* First find all direct parents. We can't use the "normal" iterator as
 	 * we are including stuff into the vector and as such the vector's data

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -794,10 +794,9 @@ void ClientNetworkContentSocketHandler::SendReceive()
 void ClientNetworkContentSocketHandler::DownloadContentInfo(ContentID cid)
 {
 	/* When we tried to download it already, don't try again */
-	if (this->requested.Contains(cid)) return;
+	if (std::find(this->requested.begin(), this->requested.end(), cid) != this->requested.end()) return;
 
-	*this->requested.Append() = cid;
-	assert(this->requested.Contains(cid));
+	this->requested.push_back(cid);
 	this->RequestContentList(1, &cid);
 }
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -246,12 +246,12 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 
 	this->Connect();
 
-	assert(cv->Length() < 255);
-	assert(cv->Length() < (SEND_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8)) /
+	assert(cv->size() < 255);
+	assert(cv->size() < (SEND_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8)) /
 			(sizeof(uint8) + sizeof(uint32) + (send_md5sum ? /*sizeof(ContentInfo::md5sum)*/16 : 0)));
 
 	Packet *p = new Packet(send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID);
-	p->Send_uint8(cv->Length());
+	p->Send_uint8(cv->size());
 
 	for (ContentIterator iter = cv->Begin(); iter != cv->End(); iter++) {
 		const ContentInfo *ci = *iter;
@@ -304,7 +304,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContent(uint &files, uin
 		bytes += ci->filesize;
 	}
 
-	files = content.Length();
+	files = content.size();
 
 	/* If there's nothing to download, do nothing. */
 	if (files == 0) return;
@@ -322,7 +322,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContent(uint &files, uin
  */
 void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const ContentIDList &content)
 {
-	uint count = content.Length();
+	uint count = content.size();
 
 	/* Allocate memory for the whole request.
 	 * Requests are "id\nid\n..." (as strings), so assume the maximum ID,
@@ -350,7 +350,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const Conten
  */
 void ClientNetworkContentSocketHandler::DownloadSelectedContentFallback(const ContentIDList &content)
 {
-	uint count = content.Length();
+	uint count = content.size();
 	const ContentID *content_ids = content.Begin();
 	this->Connect();
 
@@ -607,7 +607,7 @@ void ClientNetworkContentSocketHandler::OnReceiveData(const char *data, size_t l
 		this->AfterDownload();
 	}
 
-	if ((uint)this->http_response_index >= this->http_response.Length()) {
+	if ((uint)this->http_response_index >= this->http_response.size()) {
 		/* It's not a real failure, but if there's
 		 * nothing more to download it helps with
 		 * cleaning up the stuff we allocated. */
@@ -653,7 +653,7 @@ void ClientNetworkContentSocketHandler::OnReceiveData(const char *data, size_t l
 		str = p + 1;
 		/* Is it a fallback URL? If so, just continue with the next one. */
 		if (strncmp(str, "ottd", 4) == 0) {
-			if ((uint)this->http_response_index >= this->http_response.Length()) {
+			if ((uint)this->http_response_index >= this->http_response.size()) {
 				/* Have we gone through all lines? */
 				this->OnFailure();
 				return;
@@ -925,7 +925,7 @@ void ClientNetworkContentSocketHandler::ReverseLookupTreeDependency(ConstContent
 	 * we are including stuff into the vector and as such the vector's data
 	 * store can be reallocated (and thus move), which means out iterating
 	 * pointer gets invalid. So fall back to the indices. */
-	for (uint i = 0; i < tree.Length(); i++) {
+	for (uint i = 0; i < tree.size(); i++) {
 		ConstContentVector parents;
 		this->ReverseLookupDependency(parents, tree[i]);
 

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -140,7 +140,7 @@ public:
 	void Clear();
 
 	/** Add a callback to this class */
-	void AddCallback(ContentCallback *cb) { this->callbacks.Include(cb); }
+	void AddCallback(ContentCallback *cb) { include(this->callbacks, cb); }
 	/** Remove a callback */
 	void RemoveCallback(ContentCallback *cb) { this->callbacks.erase(std::find(this->callbacks.begin(), this->callbacks.end(), cb)); }
 };

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -131,11 +131,11 @@ public:
 	/** Get the number of content items we know locally. */
 	uint Length() const { return this->infos.size(); }
 	/** Get the begin of the content inf iterator. */
-	ConstContentIterator Begin() const { return this->infos.Begin(); }
+	ConstContentIterator Begin() const { return this->infos.data(); }
 	/** Get the nth position of the content inf iterator. */
 	ConstContentIterator Get(uint32 index) const { return this->infos.data() + index; }
 	/** Get the end of the content inf iterator. */
-	ConstContentIterator End() const { return this->infos.End(); }
+	ConstContentIterator End() const { return this->Begin() + this->Length(); }
 
 	void Clear();
 

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -67,11 +67,11 @@ struct ContentCallback {
 class ClientNetworkContentSocketHandler : public NetworkContentSocketHandler, ContentCallback, HTTPCallback {
 protected:
 	typedef std::vector<ContentID> ContentIDList; ///< List of content IDs to (possibly) select.
-	std::vector<ContentCallback *> callbacks; ///< Callbacks to notify "the world"
-	ContentIDList requested;                     ///< ContentIDs we already requested (so we don't do it again)
-	ContentVector infos;                         ///< All content info we received
-	std::vector<char> http_response;       ///< The HTTP response to the requests we've been doing
-	int http_response_index;                     ///< Where we are, in the response, with handling it
+	std::vector<ContentCallback *> callbacks;     ///< Callbacks to notify "the world"
+	ContentIDList requested;                      ///< ContentIDs we already requested (so we don't do it again)
+	ContentVector infos;                          ///< All content info we received
+	std::vector<char> http_response;              ///< The HTTP response to the requests we've been doing
+	int http_response_index;                      ///< Where we are, in the response, with handling it
 
 	FILE *curFile;        ///< Currently downloaded file
 	ContentInfo *curInfo; ///< Information about the currently downloaded file

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -133,7 +133,7 @@ public:
 	/** Get the begin of the content inf iterator. */
 	ConstContentIterator Begin() const { return this->infos.Begin(); }
 	/** Get the nth position of the content inf iterator. */
-	ConstContentIterator Get(uint32 index) const { return this->infos.Get(index); }
+	ConstContentIterator Get(uint32 index) const { return this->infos.data() + index; }
 	/** Get the end of the content inf iterator. */
 	ConstContentIterator End() const { return this->infos.End(); }
 

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -129,7 +129,7 @@ public:
 	void CheckDependencyState(ContentInfo *ci);
 
 	/** Get the number of content items we know locally. */
-	uint Length() const { return this->infos.Length(); }
+	uint Length() const { return this->infos.size(); }
 	/** Get the begin of the content inf iterator. */
 	ConstContentIterator Begin() const { return this->infos.Begin(); }
 	/** Get the nth position of the content inf iterator. */

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -16,9 +16,9 @@
 #include "core/tcp_http.h"
 
 /** Vector with content info */
-typedef SmallVector<ContentInfo *, 16> ContentVector;
+typedef std::vector<ContentInfo *> ContentVector;
 /** Vector with constant content info */
-typedef SmallVector<const ContentInfo *, 16> ConstContentVector;
+typedef std::vector<const ContentInfo *> ConstContentVector;
 
 /** Iterator for the content vector */
 typedef ContentInfo **ContentIterator;
@@ -66,11 +66,11 @@ struct ContentCallback {
  */
 class ClientNetworkContentSocketHandler : public NetworkContentSocketHandler, ContentCallback, HTTPCallback {
 protected:
-	typedef SmallVector<ContentID, 4> ContentIDList; ///< List of content IDs to (possibly) select.
-	SmallVector<ContentCallback *, 2> callbacks; ///< Callbacks to notify "the world"
+	typedef std::vector<ContentID> ContentIDList; ///< List of content IDs to (possibly) select.
+	std::vector<ContentCallback *> callbacks; ///< Callbacks to notify "the world"
 	ContentIDList requested;                     ///< ContentIDs we already requested (so we don't do it again)
 	ContentVector infos;                         ///< All content info we received
-	SmallVector<char, 1024> http_response;       ///< The HTTP response to the requests we've been doing
+	std::vector<char> http_response;       ///< The HTTP response to the requests we've been doing
 	int http_response_index;                     ///< Where we are, in the response, with handling it
 
 	FILE *curFile;        ///< Currently downloaded file

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -142,7 +142,7 @@ public:
 	/** Add a callback to this class */
 	void AddCallback(ContentCallback *cb) { this->callbacks.Include(cb); }
 	/** Remove a callback */
-	void RemoveCallback(ContentCallback *cb) { this->callbacks.Erase(this->callbacks.Find(cb)); }
+	void RemoveCallback(ContentCallback *cb) { this->callbacks.erase(std::find(this->callbacks.begin(), this->callbacks.end(), cb)); }
 };
 
 extern ClientNetworkContentSocketHandler _network_content_client;

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -641,7 +641,7 @@ public:
 		int text_y_offset = WD_MATRIX_TOP + (line_height - FONT_HEIGHT_NORMAL) / 2;
 		uint y = r.top;
 		int cnt = 0;
-		for (ConstContentIterator iter = this->content.Get(this->vscroll->GetPosition()); iter != this->content.End() && cnt < this->vscroll->GetCapacity(); iter++, cnt++) {
+		for (ConstContentIterator iter = this->content.data() + this->vscroll->GetPosition(); iter != this->content.End() && cnt < this->vscroll->GetCapacity(); iter++, cnt++) {
 			const ContentInfo *ci = *iter;
 
 			if (ci == this->selected) GfxFillRect(r.left + 1, y + 1, r.right - 1, y + this->resize.step_height - 1, PC_GREY);
@@ -793,7 +793,7 @@ public:
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_NCL_MATRIX);
 				if (id_v >= this->content.size()) return; // click out of bounds
 
-				this->selected = *this->content.Get(id_v);
+				this->selected = this->content[id_v];
 				this->list_pos = id_v;
 
 				const NWidgetBase *checkbox = this->GetWidget<NWidgetBase>(WID_NCL_CHECKBOX);
@@ -923,7 +923,7 @@ public:
 			return ES_HANDLED;
 		}
 
-		this->selected = *this->content.Get(this->list_pos);
+		this->selected = this->content[this->list_pos];
 
 		if (this->UpdateFilterState()) {
 			this->content.ForceRebuild();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -176,8 +176,8 @@ public:
 	~NetworkContentDownloadStatusWindow()
 	{
 		TarScanner::Mode mode = TarScanner::NONE;
-		for (ContentType *iter = this->receivedTypes.Begin(); iter != this->receivedTypes.End(); iter++) {
-			switch (*iter) {
+		for (auto ctype : this->receivedTypes) {
+			switch (ctype) {
 				case CONTENT_TYPE_AI:
 				case CONTENT_TYPE_AI_LIBRARY:
 					/* AI::Rescan calls the scanner. */
@@ -210,8 +210,8 @@ public:
 		TarScanner::DoScan(mode);
 
 		/* Tell all the backends about what we've downloaded */
-		for (ContentType *iter = this->receivedTypes.Begin(); iter != this->receivedTypes.End(); iter++) {
-			switch (*iter) {
+		for (auto ctype : this->receivedTypes) {
+			switch (ctype) {
 				case CONTENT_TYPE_AI:
 				case CONTENT_TYPE_AI_LIBRARY:
 					AI::Rescan();
@@ -333,8 +333,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 			pos = strecpy(pos, "do=searchgrfid&q=", last);
 
 			bool first = true;
-			for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
-				const ContentInfo *ci = *iter;
+			for (const ContentInfo *ci : this->content) {
 				if (ci->state != ContentInfo::DOES_NOT_EXIST) continue;
 
 				if (!first) pos = strecpy(pos, ",", last);
@@ -635,8 +634,13 @@ public:
 		int sprite_y_offset = WD_MATRIX_TOP + (line_height - this->checkbox_size.height) / 2 - 1;
 		int text_y_offset = WD_MATRIX_TOP + (line_height - FONT_HEIGHT_NORMAL) / 2;
 		uint y = r.top;
-		int cnt = 0;
-		for (ConstContentIterator iter = this->content.data() + this->vscroll->GetPosition(); iter != this->content.End() && cnt < this->vscroll->GetCapacity(); iter++, cnt++) {
+
+		auto iter = this->content.begin() + this->vscroll->GetPosition();
+		auto end = iter + this->vscroll->GetCapacity();
+		if (end > this->content.end())
+			end = this->content.end();
+
+		for (/**/; iter != end; iter++) {
 			const ContentInfo *ci = *iter;
 
 			if (ci == this->selected) GfxFillRect(r.left + 1, y + 1, r.right - 1, y + this->resize.step_height - 1, PC_GREY);
@@ -761,8 +765,7 @@ public:
 
 			char buf[DRAW_STRING_BUFFER] = "";
 			char *p = buf;
-			for (ConstContentIterator iter = tree.Begin(); iter != tree.End(); iter++) {
-				const ContentInfo *ci = *iter;
+			for (const ContentInfo *ci : tree) {
 				if (ci == this->selected || ci->state != ContentInfo::SELECTED) continue;
 
 				p += seprintf(p, lastof(buf), buf == p ? "%s" : ", %s", ci->name);
@@ -985,8 +988,7 @@ public:
 		this->filesize_sum = 0;
 		bool show_select_all = false;
 		bool show_select_upgrade = false;
-		for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
-			const ContentInfo *ci = *iter;
+		for (const ContentInfo *ci : this->content) {
 			switch (ci->state) {
 				case ContentInfo::SELECTED:
 				case ContentInfo::AUTOSELECTED:
@@ -1158,7 +1160,7 @@ void ShowNetworkContentListWindow(ContentVector *cv, ContentType type1, ContentT
 	ShowErrorMessage(STR_CONTENT_NO_ZLIB, STR_CONTENT_NO_ZLIB_SUB, WL_ERROR);
 	/* Connection failed... clean up the mess */
 	if (cv != NULL) {
-		for (ContentIterator iter = cv->Begin(); iter != cv->End(); iter++) delete *iter;
+		for (ContentInfo *ci : *cv) delete ci;
 	}
 #endif /* WITH_ZLIB */
 }

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -397,7 +397,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		this->SetWidgetDisabledState(WID_NCL_SEARCH_EXTERNAL, this->auto_select && all_available);
 
 		this->FilterContentList();
-		this->content.Compact();
+		this->content.shrink_to_fit();
 		this->content.RebuildDone();
 		this->SortContentList();
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -401,7 +401,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		this->content.RebuildDone();
 		this->SortContentList();
 
-		this->vscroll->SetCount(this->content.Length()); // Update the scrollbar
+		this->vscroll->SetCount(this->content.size()); // Update the scrollbar
 		this->ScrollToSelected();
 	}
 
@@ -791,7 +791,7 @@ public:
 		switch (widget) {
 			case WID_NCL_MATRIX: {
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_NCL_MATRIX);
-				if (id_v >= this->content.Length()) return; // click out of bounds
+				if (id_v >= this->content.size()) return; // click out of bounds
 
 				this->selected = *this->content.Get(id_v);
 				this->list_pos = id_v;
@@ -815,7 +815,7 @@ public:
 			case WID_NCL_NAME:
 				if (this->content.SortType() == widget - WID_NCL_CHECKBOX) {
 					this->content.ToggleSortOrder();
-					if (this->content.Length() > 0) this->list_pos = this->content.Length() - this->list_pos - 1;
+					if (this->content.size() > 0) this->list_pos = this->content.size() - this->list_pos - 1;
 				} else {
 					this->content.SetSortType(widget - WID_NCL_CHECKBOX);
 					this->content.ForceResort();
@@ -874,7 +874,7 @@ public:
 				break;
 			case WKC_DOWN:
 				/* scroll down by one */
-				if (this->list_pos < (int)this->content.Length() - 1) this->list_pos++;
+				if (this->list_pos < (int)this->content.size() - 1) this->list_pos++;
 				break;
 			case WKC_PAGEUP:
 				/* scroll up a page */
@@ -882,7 +882,7 @@ public:
 				break;
 			case WKC_PAGEDOWN:
 				/* scroll down a page */
-				this->list_pos = min(this->list_pos + this->vscroll->GetCapacity(), (int)this->content.Length() - 1);
+				this->list_pos = min(this->list_pos + this->vscroll->GetCapacity(), (int)this->content.size() - 1);
 				break;
 			case WKC_HOME:
 				/* jump to beginning */
@@ -890,7 +890,7 @@ public:
 				break;
 			case WKC_END:
 				/* jump to end */
-				this->list_pos = this->content.Length() - 1;
+				this->list_pos = this->content.size() - 1;
 				break;
 
 			case WKC_SPACE:
@@ -914,7 +914,7 @@ public:
 				return ES_NOT_HANDLED;
 		}
 
-		if (this->content.Length() == 0) {
+		if (this->content.size() == 0) {
 			this->list_pos = 0; // above stuff may result in "-1".
 			if (this->UpdateFilterState()) {
 				this->content.ForceRebuild();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -435,12 +435,8 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	{
 		if (!this->content.Sort()) return;
 
-		for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
-			if (*iter == this->selected) {
-				this->list_pos = iter - this->content.Begin();
-				break;
-			}
-		}
+		int idx = find_index(this->content, this->selected);
+		if (idx >= 0) this->list_pos = idx;
 	}
 
 	/** Filter content by tags/name */
@@ -478,11 +474,10 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		if (!changed) return;
 
 		/* update list position */
-		for (ConstContentIterator iter = this->content.Begin(); iter != this->content.End(); iter++) {
-			if (*iter == this->selected) {
-				this->list_pos = iter - this->content.Begin();
-				return;
-			}
+		int idx = find_index(this->content, this->selected);
+		if (idx >= 0) {
+			this->list_pos = idx;
+			return;
 		}
 
 		/* previously selected item not in list anymore */

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -160,7 +160,7 @@ void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInf
 /** Window for showing the download status of content */
 struct NetworkContentDownloadStatusWindow : public BaseNetworkContentDownloadStatusWindow {
 private:
-	SmallVector<ContentType, 4> receivedTypes;     ///< Types we received so we can update their cache
+	std::vector<ContentType> receivedTypes;     ///< Types we received so we can update their cache
 
 public:
 	/**

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -274,7 +274,7 @@ public:
 	void OnDownloadProgress(const ContentInfo *ci, int bytes) override
 	{
 		BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(ci, bytes);
-		this->receivedTypes.Include(ci->type);
+		include(this->receivedTypes, ci->type);
 
 		/* When downloading is finished change cancel in ok */
 		if (this->downloaded_bytes == this->total_bytes) {

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -385,7 +385,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		if (!this->content.NeedRebuild()) return;
 
 		/* Create temporary array of games to use for listing */
-		this->content.Clear();
+		this->content.clear();
 
 		bool all_available = true;
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -391,7 +391,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 
 		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
 			if ((*iter)->state == ContentInfo::DOES_NOT_EXIST) all_available = false;
-			*this->content.Append() = *iter;
+			this->content.push_back(*iter);
 		}
 
 		this->SetWidgetDisabledState(WID_NCL_SEARCH_EXTERNAL, this->auto_select && all_available);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -267,7 +267,7 @@ protected:
 			this->servers.SetFilterState(false);
 		}
 
-		this->servers.Compact();
+		this->servers.shrink_to_fit();
 		this->servers.RebuildDone();
 		this->vscroll->SetCount(this->servers.Length());
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -250,7 +250,7 @@ protected:
 		if (!this->servers.NeedRebuild()) return;
 
 		/* Create temporary array of games to use for listing */
-		this->servers.Clear();
+		this->servers.clear();
 
 		for (NetworkGameList *ngl = _network_game_list; ngl != NULL; ngl = ngl->next) {
 			*this->servers.Append() = ngl;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1045,8 +1045,8 @@ void ShowNetworkGameWindow()
 	if (first) {
 		first = false;
 		/* Add all servers from the config file to our list. */
-		for (char **iter = _network_host_list.Begin(); iter != _network_host_list.End(); iter++) {
-			NetworkAddServer(*iter);
+		for (char *iter : _network_host_list) {
+			NetworkAddServer(iter);
 		}
 	}
 
@@ -1783,8 +1783,8 @@ struct NetworkClientListPopupWindow : Window {
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
 	{
 		Dimension d = *size;
-		for (const ClientListAction *action = this->actions.Begin(); action != this->actions.End(); action++) {
-			d = maxdim(GetStringBoundingBox(action->name), d);
+		for (const ClientListAction &action : this->actions) {
+			d = maxdim(GetStringBoundingBox(action.name), d);
 		}
 
 		d.height *= this->actions.size();
@@ -1798,7 +1798,7 @@ struct NetworkClientListPopupWindow : Window {
 		/* Draw the actions */
 		int sel = this->sel_index;
 		int y = r.top + WD_FRAMERECT_TOP;
-		for (const ClientListAction *action = this->actions.Begin(); action != this->actions.End(); action++, y += FONT_HEIGHT_NORMAL) {
+		for (const ClientListAction &action : this->actions) {
 			TextColour colour;
 			if (sel-- == 0) { // Selected item, highlight it
 				GfxFillRect(r.left + 1, y, r.right - 1, y + FONT_HEIGHT_NORMAL - 1, PC_BLACK);
@@ -1807,7 +1807,8 @@ struct NetworkClientListPopupWindow : Window {
 				colour = TC_BLACK;
 			}
 
-			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, action->name, colour);
+			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, action.name, colour);
+			y += FONT_HEIGHT_NORMAL;
 		}
 	}
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1728,7 +1728,7 @@ struct NetworkClientListPopupWindow : Window {
 	uint sel_index;
 	ClientID client_id;
 	Point desired_location;
-	SmallVector<ClientListAction, 2> actions; ///< Actions to execute
+	std::vector<ClientListAction> actions; ///< Actions to execute
 
 	/**
 	 * Add an action to the list of actions to execute.

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -269,7 +269,7 @@ protected:
 
 		this->servers.shrink_to_fit();
 		this->servers.RebuildDone();
-		this->vscroll->SetCount(this->servers.Length());
+		this->vscroll->SetCount(this->servers.size());
 
 		/* Sort the list of network games as requested. */
 		this->servers.Sort();
@@ -354,7 +354,7 @@ protected:
 	void UpdateListPos()
 	{
 		this->list_pos = SLP_INVALID;
-		for (uint i = 0; i != this->servers.Length(); i++) {
+		for (uint i = 0; i != this->servers.size(); i++) {
 			if (this->servers[i] == this->server) {
 				this->list_pos = i;
 				break;
@@ -564,7 +564,7 @@ public:
 			case WID_NG_MATRIX: {
 				uint16 y = r.top;
 
-				const int max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), (int)this->servers.Length());
+				const int max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), (int)this->servers.size());
 
 				for (int i = this->vscroll->GetPosition(); i < max; ++i) {
 					const NetworkGameList *ngl = this->servers[i];
@@ -710,7 +710,7 @@ public:
 			case WID_NG_INFO:    // Connectivity (green dot)
 				if (this->servers.SortType() == widget - WID_NG_NAME) {
 					this->servers.ToggleSortOrder();
-					if (this->list_pos != SLP_INVALID) this->list_pos = this->servers.Length() - this->list_pos - 1;
+					if (this->list_pos != SLP_INVALID) this->list_pos = this->servers.size() - this->list_pos - 1;
 				} else {
 					this->servers.SetSortType(widget - WID_NG_NAME);
 					this->servers.ForceResort();
@@ -722,7 +722,7 @@ public:
 
 			case WID_NG_MATRIX: { // Show available network games
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_NG_MATRIX);
-				this->server = (id_v < this->servers.Length()) ? this->servers[id_v] : NULL;
+				this->server = (id_v < this->servers.size()) ? this->servers[id_v] : NULL;
 				this->list_pos = (server == NULL) ? SLP_INVALID : id_v;
 				this->SetDirty();
 
@@ -819,7 +819,7 @@ public:
 
 		/* handle up, down, pageup, pagedown, home and end */
 		if (keycode == WKC_UP || keycode == WKC_DOWN || keycode == WKC_PAGEUP || keycode == WKC_PAGEDOWN || keycode == WKC_HOME || keycode == WKC_END) {
-			if (this->servers.Length() == 0) return ES_HANDLED;
+			if (this->servers.size() == 0) return ES_HANDLED;
 			switch (keycode) {
 				case WKC_UP:
 					/* scroll up by one */
@@ -829,7 +829,7 @@ public:
 				case WKC_DOWN:
 					/* scroll down by one */
 					if (this->list_pos == SLP_INVALID) return ES_HANDLED;
-					if (this->list_pos < this->servers.Length() - 1) this->list_pos++;
+					if (this->list_pos < this->servers.size() - 1) this->list_pos++;
 					break;
 				case WKC_PAGEUP:
 					/* scroll up a page */
@@ -839,7 +839,7 @@ public:
 				case WKC_PAGEDOWN:
 					/* scroll down a page */
 					if (this->list_pos == SLP_INVALID) return ES_HANDLED;
-					this->list_pos = min(this->list_pos + this->vscroll->GetCapacity(), (int)this->servers.Length() - 1);
+					this->list_pos = min(this->list_pos + this->vscroll->GetCapacity(), (int)this->servers.size() - 1);
 					break;
 				case WKC_HOME:
 					/* jump to beginning */
@@ -847,7 +847,7 @@ public:
 					break;
 				case WKC_END:
 					/* jump to end */
-					this->list_pos = this->servers.Length() - 1;
+					this->list_pos = this->servers.size() - 1;
 					break;
 				default: NOT_REACHED();
 			}
@@ -1789,7 +1789,7 @@ struct NetworkClientListPopupWindow : Window {
 			d = maxdim(GetStringBoundingBox(action->name), d);
 		}
 
-		d.height *= this->actions.Length();
+		d.height *= this->actions.size();
 		d.width += WD_FRAMERECT_LEFT + WD_FRAMERECT_RIGHT;
 		d.height += WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM;
 		*size = d;
@@ -1819,12 +1819,12 @@ struct NetworkClientListPopupWindow : Window {
 		uint index = (_cursor.pos.y - this->top - WD_FRAMERECT_TOP) / FONT_HEIGHT_NORMAL;
 
 		if (_left_button_down) {
-			if (index == this->sel_index || index >= this->actions.Length()) return;
+			if (index == this->sel_index || index >= this->actions.size()) return;
 
 			this->sel_index = index;
 			this->SetDirty();
 		} else {
-			if (index < this->actions.Length() && _cursor.pos.y >= this->top) {
+			if (index < this->actions.size() && _cursor.pos.y >= this->top) {
 				const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(this->client_id);
 				if (ci != NULL) this->actions[index].proc(ci);
 			}

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -253,7 +253,7 @@ protected:
 		this->servers.clear();
 
 		for (NetworkGameList *ngl = _network_game_list; ngl != NULL; ngl = ngl->next) {
-			*this->servers.Append() = ngl;
+			this->servers.push_back(ngl);
 		}
 
 		/* Apply the filter condition immediately, if a search string has been provided. */
@@ -1737,9 +1737,7 @@ struct NetworkClientListPopupWindow : Window {
 	 */
 	inline void AddAction(StringID name, ClientList_Action_Proc *proc)
 	{
-		ClientListAction *action = this->actions.Append();
-		action->name = name;
-		action->proc = proc;
+		this->actions.push_back({name, proc});
 	}
 
 	NetworkClientListPopupWindow(WindowDesc *desc, int x, int y, ClientID client_id) :

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2095,8 +2095,8 @@ uint NetworkServerKickOrBanIP(const char *ip, bool ban)
 	/* Add address to ban-list */
 	if (ban) {
 		bool contains = false;
-		for (char **iter = _network_ban_list.Begin(); iter != _network_ban_list.End(); iter++) {
-			if (strcmp(*iter, ip) == 0) {
+		for (char *iter : _network_ban_list) {
+			if (strcmp(iter, ip) == 0) {
 				contains = true;
 				break;
 			}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2101,7 +2101,7 @@ uint NetworkServerKickOrBanIP(const char *ip, bool ban)
 				break;
 			}
 		}
-		if (!contains) *_network_ban_list.Append() = stredup(ip);
+		if (!contains) _network_ban_list.push_back(stredup(ip));
 	}
 
 	uint n = 0;

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -495,12 +495,12 @@ void ClientNetworkUDPSocketHandler::HandleIncomingNetworkGameInfoGRFConfig(GRFCo
 /** Broadcast to all ips */
 static void NetworkUDPBroadCast(NetworkUDPSocketHandler *socket)
 {
-	for (NetworkAddress *addr = _broadcast_list.Begin(); addr != _broadcast_list.End(); addr++) {
+	for (NetworkAddress &addr : _broadcast_list) {
 		Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
 
-		DEBUG(net, 4, "[udp] broadcasting to %s", addr->GetHostname());
+		DEBUG(net, 4, "[udp] broadcasting to %s", addr.GetHostname());
 
-		socket->SendPacket(&p, addr, true, true);
+		socket->SendPacket(&p, &addr, true, true);
 	}
 }
 

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -668,7 +668,7 @@ void NetworkUDPInitialize()
 	GetBindAddresses(&server, _settings_client.network.server_port);
 	_udp_server_socket = new ServerNetworkUDPSocketHandler(&server);
 
-	server.Clear();
+	server.clear();
 	GetBindAddresses(&server, 0);
 	_udp_master_socket = new MasterNetworkUDPSocketHandler(&server);
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -391,9 +391,8 @@ void CDECL grfmsg(int severity, const char *str, ...)
  */
 static GRFFile *GetFileByGRFID(uint32 grfid)
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile * const *file = _grf_files.Begin(); file != end; file++) {
-		if ((*file)->grfid == grfid) return *file;
+	for (GRFFile * const file : _grf_files) {
+		if (file->grfid == grfid) return file;
 	}
 	return NULL;
 }
@@ -405,9 +404,8 @@ static GRFFile *GetFileByGRFID(uint32 grfid)
  */
 static GRFFile *GetFileByFilename(const char *filename)
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile * const *file = _grf_files.Begin(); file != end; file++) {
-		if (strcmp((*file)->filename, filename) == 0) return *file;
+	for (GRFFile * const file : _grf_files) {
+		if (strcmp(file->filename, filename) == 0) return file;
 	}
 	return NULL;
 }
@@ -1923,7 +1921,7 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 						/* On error, bail out immediately. Temporary GRF data was already freed */
 						if (_cur.skip_sprites < 0) return CIR_DISABLED;
 					}
-					dts->Clone(tmp_layout.Begin());
+					dts->Clone(tmp_layout.data());
 				}
 				break;
 
@@ -4826,7 +4824,7 @@ static void NewSpriteGroup(ByteReader *buf)
 
 			group->num_adjusts = adjusts.size();
 			group->adjusts = MallocT<DeterministicSpriteGroupAdjust>(group->num_adjusts);
-			MemCpyT(group->adjusts, adjusts.Begin(), group->num_adjusts);
+			MemCpyT(group->adjusts, adjusts.data(), group->num_adjusts);
 
 			std::vector<DeterministicSpriteGroupRange> ranges;
 			ranges.resize(buf->ReadByte());
@@ -8094,9 +8092,8 @@ static void InitializeGRFSpecial()
 /** Reset and clear all NewGRF stations */
 static void ResetCustomStations()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		StationSpec **&stations = (*file)->stations;
+	for (GRFFile * const file : _grf_files) {
+		StationSpec **&stations = file->stations;
 		if (stations == NULL) continue;
 		for (uint i = 0; i < NUM_STATIONS_PER_GRF; i++) {
 			if (stations[i] == NULL) continue;
@@ -8129,9 +8126,8 @@ static void ResetCustomStations()
 /** Reset and clear all NewGRF houses */
 static void ResetCustomHouses()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		HouseSpec **&housespec = (*file)->housespec;
+	for (GRFFile * const file : _grf_files) {
+		HouseSpec **&housespec = file->housespec;
 		if (housespec == NULL) continue;
 		for (uint i = 0; i < NUM_HOUSES_PER_GRF; i++) {
 			free(housespec[i]);
@@ -8145,9 +8141,8 @@ static void ResetCustomHouses()
 /** Reset and clear all NewGRF airports */
 static void ResetCustomAirports()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		AirportSpec **aslist = (*file)->airportspec;
+	for (GRFFile * const file : _grf_files) {
+		AirportSpec **aslist = file->airportspec;
 		if (aslist != NULL) {
 			for (uint i = 0; i < NUM_AIRPORTS_PER_GRF; i++) {
 				AirportSpec *as = aslist[i];
@@ -8166,10 +8161,10 @@ static void ResetCustomAirports()
 				}
 			}
 			free(aslist);
-			(*file)->airportspec = NULL;
+			file->airportspec = NULL;
 		}
 
-		AirportTileSpec **&airporttilespec = (*file)->airtspec;
+		AirportTileSpec **&airporttilespec = file->airtspec;
 		if (airporttilespec != NULL) {
 			for (uint i = 0; i < NUM_AIRPORTTILES_PER_GRF; i++) {
 				free(airporttilespec[i]);
@@ -8183,10 +8178,9 @@ static void ResetCustomAirports()
 /** Reset and clear all NewGRF industries */
 static void ResetCustomIndustries()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		IndustrySpec **&industryspec = (*file)->industryspec;
-		IndustryTileSpec **&indtspec = (*file)->indtspec;
+	for (GRFFile * const file : _grf_files) {
+		IndustrySpec **&industryspec = file->industryspec;
+		IndustryTileSpec **&indtspec = file->indtspec;
 
 		/* We are verifiying both tiles and industries specs loaded from the grf file
 		 * First, let's deal with industryspec */
@@ -8223,9 +8217,8 @@ static void ResetCustomIndustries()
 /** Reset and clear all NewObjects */
 static void ResetCustomObjects()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		ObjectSpec **&objectspec = (*file)->objectspec;
+	for (GRFFile * const file : _grf_files) {
+		ObjectSpec **&objectspec = file->objectspec;
 		if (objectspec == NULL) continue;
 		for (uint i = 0; i < NUM_OBJECTS_PER_GRF; i++) {
 			free(objectspec[i]);
@@ -8239,9 +8232,8 @@ static void ResetCustomObjects()
 /** Reset and clear all NewGRFs */
 static void ResetNewGRF()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		delete *file;
+	for (GRFFile * const file : _grf_files) {
+		delete file;
 	}
 
 	_grf_files.clear();
@@ -8760,9 +8752,8 @@ static void FinaliseHouseArray()
 	 * On the other hand, why 1930? Just 'fix' the houses with the lowest
 	 * minimum introduction date to 0.
 	 */
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		HouseSpec **&housespec = (*file)->housespec;
+	for (GRFFile * const file : _grf_files) {
+		HouseSpec **&housespec = file->housespec;
 		if (housespec == NULL) continue;
 
 		for (int i = 0; i < NUM_HOUSES_PER_GRF; i++) {
@@ -8774,7 +8765,7 @@ static void FinaliseHouseArray()
 			const HouseSpec *next2 = (i + 2 < NUM_HOUSES_PER_GRF ? housespec[i + 2] : NULL);
 			const HouseSpec *next3 = (i + 3 < NUM_HOUSES_PER_GRF ? housespec[i + 3] : NULL);
 
-			if (!IsHouseSpecValid(hs, next1, next2, next3, (*file)->filename)) continue;
+			if (!IsHouseSpecValid(hs, next1, next2, next3, file->filename)) continue;
 
 			_house_mngr.SetEntitySpec(hs);
 		}
@@ -8823,10 +8814,9 @@ static void FinaliseHouseArray()
  */
 static void FinaliseIndustriesArray()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		IndustrySpec **&industryspec = (*file)->industryspec;
-		IndustryTileSpec **&indtspec = (*file)->indtspec;
+	for (GRFFile * const file : _grf_files) {
+		IndustrySpec **&industryspec = file->industryspec;
+		IndustryTileSpec **&indtspec = file->indtspec;
 		if (industryspec != NULL) {
 			for (int i = 0; i < NUM_INDUSTRYTYPES_PER_GRF; i++) {
 				IndustrySpec *indsp = industryspec[i];
@@ -8894,9 +8884,8 @@ static void FinaliseIndustriesArray()
  */
 static void FinaliseObjectsArray()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		ObjectSpec **&objectspec = (*file)->objectspec;
+	for (GRFFile * const file : _grf_files) {
+		ObjectSpec **&objectspec = file->objectspec;
 		if (objectspec != NULL) {
 			for (int i = 0; i < NUM_OBJECTS_PER_GRF; i++) {
 				if (objectspec[i] != NULL && objectspec[i]->grf_prop.grffile != NULL && objectspec[i]->enabled) {
@@ -8914,9 +8903,8 @@ static void FinaliseObjectsArray()
  */
 static void FinaliseAirportsArray()
 {
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		AirportSpec **&airportspec = (*file)->airportspec;
+	for (GRFFile * const file : _grf_files) {
+		AirportSpec **&airportspec = file->airportspec;
 		if (airportspec != NULL) {
 			for (int i = 0; i < NUM_AIRPORTS_PER_GRF; i++) {
 				if (airportspec[i] != NULL && airportspec[i]->enabled) {
@@ -8925,7 +8913,7 @@ static void FinaliseAirportsArray()
 			}
 		}
 
-		AirportTileSpec **&airporttilespec = (*file)->airtspec;
+		AirportTileSpec **&airporttilespec = file->airtspec;
 		if (airporttilespec != NULL) {
 			for (uint i = 0; i < NUM_AIRPORTTILES_PER_GRF; i++) {
 				if (airporttilespec[i] != NULL && airporttilespec[i]->enabled) {
@@ -9286,10 +9274,9 @@ static void FinalisePriceBaseMultipliers()
 	}
 
 	/* Apply fallback prices for grf version < 8 */
-	const GRFFile * const *end = _grf_files.End();
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		if ((*file)->grf_version >= 8) continue;
-		PriceMultipliers &price_base_multipliers = (*file)->price_base_multipliers;
+	for (GRFFile * const file : _grf_files) {
+		if (file->grf_version >= 8) continue;
+		PriceMultipliers &price_base_multipliers = file->price_base_multipliers;
 		for (Price p = PR_BEGIN; p < PR_END; p++) {
 			Price fallback_price = _price_base_specs[p].fallback_price;
 			if (fallback_price != INVALID_PRICE && price_base_multipliers[p] == INVALID_PRICE_MODIFIER) {
@@ -9301,21 +9288,21 @@ static void FinalisePriceBaseMultipliers()
 	}
 
 	/* Decide local/global scope of price base multipliers */
-	for (GRFFile **file = _grf_files.Begin(); file != end; file++) {
-		PriceMultipliers &price_base_multipliers = (*file)->price_base_multipliers;
+	for (GRFFile * const file : _grf_files) {
+		PriceMultipliers &price_base_multipliers = file->price_base_multipliers;
 		for (Price p = PR_BEGIN; p < PR_END; p++) {
 			if (price_base_multipliers[p] == INVALID_PRICE_MODIFIER) {
 				/* No multiplier was set; set it to a neutral value */
 				price_base_multipliers[p] = 0;
 			} else {
-				if (!HasBit((*file)->grf_features, _price_base_specs[p].grf_feature)) {
+				if (!HasBit(file->grf_features, _price_base_specs[p].grf_feature)) {
 					/* The grf does not define any objects of the feature,
 					 * so it must be a difficulty setting. Apply it globally */
-					DEBUG(grf, 3, "'%s' sets global price base multiplier %d", (*file)->filename, p);
+					DEBUG(grf, 3, "'%s' sets global price base multiplier %d", file->filename, p);
 					SetPriceBaseMultiplier(p, price_base_multipliers[p]);
 					price_base_multipliers[p] = 0;
 				} else {
-					DEBUG(grf, 3, "'%s' sets local price base multiplier %d", (*file)->filename, p);
+					DEBUG(grf, 3, "'%s' sets local price base multiplier %d", file->filename, p);
 				}
 			}
 		}
@@ -9327,8 +9314,8 @@ extern void InitGRFTownGeneratorNames();
 /** Finish loading NewGRFs and execute needed post-processing */
 static void AfterLoadGRFs()
 {
-	for (StringIDMapping *it = _string_to_grf_mapping.Begin(); it != _string_to_grf_mapping.End(); it++) {
-		*it->target = MapGRFStringID(it->grfid, it->source);
+	for (StringIDMapping &it : _string_to_grf_mapping) {
+		*it.target = MapGRFStringID(it.grfid, it.source);
 	}
 	_string_to_grf_mapping.clear();
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -658,7 +658,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16 intern
 	e->grf_prop.grffile = file;
 
 	/* Reserve the engine slot */
-	assert(_engine_mngr.Length() == e->index);
+	assert(_engine_mngr.size() == e->index);
 	EngineIDMapping *eid = _engine_mngr.Append();
 	eid->type            = type;
 	eid->grfid           = scope_grfid; // Note: this is INVALID_GRFID if dynamic_engines is disabled, so no reservation
@@ -1058,7 +1058,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 			case 0x05: { // Track type
 				uint8 tracktype = buf->ReadByte();
 
-				if (tracktype < _cur.grffile->railtype_list.Length()) {
+				if (tracktype < _cur.grffile->railtype_list.size()) {
 					_gted[e->index].railtypelabel = _cur.grffile->railtype_list[tracktype];
 					break;
 				}
@@ -1200,7 +1200,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 					break;
 				}
 
-				if (_cur.grffile->railtype_list.Length() == 0) {
+				if (_cur.grffile->railtype_list.size() == 0) {
 					/* Use traction type to select between normal and electrified
 					 * rail only when no translation list is in place. */
 					if (_gted[e->index].railtypelabel == RAILTYPE_RAIL_LABEL     && engclass >= EC_ELECTRIC) _gted[e->index].railtypelabel = RAILTYPE_ELECTRIC_LABEL;
@@ -4799,7 +4799,7 @@ static void NewSpriteGroup(ByteReader *buf)
 				DeterministicSpriteGroupAdjust *adjust = adjusts.Append();
 
 				/* The first var adjust doesn't have an operation specified, so we set it to add. */
-				adjust->operation = adjusts.Length() == 1 ? DSGA_OP_ADD : (DeterministicSpriteGroupAdjustOperation)buf->ReadByte();
+				adjust->operation = adjusts.size() == 1 ? DSGA_OP_ADD : (DeterministicSpriteGroupAdjustOperation)buf->ReadByte();
 				adjust->variable  = buf->ReadByte();
 				if (adjust->variable == 0x7E) {
 					/* Link subroutine group */
@@ -4824,7 +4824,7 @@ static void NewSpriteGroup(ByteReader *buf)
 				/* Continue reading var adjusts while bit 5 is set. */
 			} while (HasBit(varadjust, 5));
 
-			group->num_adjusts = adjusts.Length();
+			group->num_adjusts = adjusts.size();
 			group->adjusts = MallocT<DeterministicSpriteGroupAdjust>(group->num_adjusts);
 			MemCpyT(group->adjusts, adjusts.Begin(), group->num_adjusts);
 
@@ -5085,7 +5085,7 @@ static CargoID TranslateCargo(uint8 feature, uint8 ctype)
 	if (feature == GSF_STATIONS && ctype == 0xFE) return CT_DEFAULT_NA;
 	if (ctype == 0xFF) return CT_PURCHASE;
 
-	if (_cur.grffile->cargo_list.Length() == 0) {
+	if (_cur.grffile->cargo_list.size() == 0) {
 		/* No cargo table, so use bitnum values */
 		if (ctype >= 32) {
 			grfmsg(1, "TranslateCargo: Cargo bitnum %d out of range (max 31), skipping.", ctype);
@@ -5105,8 +5105,8 @@ static CargoID TranslateCargo(uint8 feature, uint8 ctype)
 	}
 
 	/* Check if the cargo type is out of bounds of the cargo translation table */
-	if (ctype >= _cur.grffile->cargo_list.Length()) {
-		grfmsg(1, "TranslateCargo: Cargo type %d out of range (max %d), skipping.", ctype, _cur.grffile->cargo_list.Length() - 1);
+	if (ctype >= _cur.grffile->cargo_list.size()) {
+		grfmsg(1, "TranslateCargo: Cargo type %d out of range (max %d), skipping.", ctype, (unsigned int)_cur.grffile->cargo_list.size() - 1);
 		return CT_INVALID;
 	}
 
@@ -7850,8 +7850,8 @@ static bool HandleParameterInfo(ByteReader *buf)
 			continue;
 		}
 
-		if (id >= _cur.grfconfig->param_info.Length()) {
-			uint num_to_add = id - _cur.grfconfig->param_info.Length() + 1;
+		if (id >= _cur.grfconfig->param_info.size()) {
+			uint num_to_add = id - _cur.grfconfig->param_info.size() + 1;
 			GRFParameterInfo **newdata = _cur.grfconfig->param_info.Append(num_to_add);
 			MemSetT<GRFParameterInfo *>(newdata, 0, num_to_add);
 		}
@@ -8380,7 +8380,7 @@ static void BuildCargoTranslationMap()
 		const CargoSpec *cs = CargoSpec::Get(c);
 		if (!cs->IsValid()) continue;
 
-		if (_cur.grffile->cargo_list.Length() == 0) {
+		if (_cur.grffile->cargo_list.size() == 0) {
 			/* Default translation table, so just a straight mapping to bitnum */
 			_cur.grffile->cargo_map[c] = cs->bitnum;
 		} else {
@@ -8560,7 +8560,7 @@ static void CalculateRefitMasks()
 			{
 				const GRFFile *file = _gted[engine].defaultcargo_grf;
 				if (file == NULL) file = e->GetGRF();
-				if (file != NULL && file->grf_version >= 8 && file->cargo_list.Length() != 0) {
+				if (file != NULL && file->grf_version >= 8 && file->cargo_list.size() != 0) {
 					cargo_map_for_first_refittable = file->cargo_map;
 				}
 			}
@@ -9216,7 +9216,7 @@ static void FinalisePriceBaseMultipliers()
 	static const uint32 override_features = (1 << GSF_TRAINS) | (1 << GSF_ROADVEHICLES) | (1 << GSF_SHIPS) | (1 << GSF_AIRCRAFT);
 
 	/* Evaluate grf overrides */
-	int num_grfs = _grf_files.Length();
+	int num_grfs = _grf_files.size();
 	int *grf_overrides = AllocaM(int, num_grfs);
 	for (int i = 0; i < num_grfs; i++) {
 		grf_overrides[i] = -1;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8383,8 +8383,8 @@ static void BuildCargoTranslationMap()
 			_cur.grffile->cargo_map[c] = cs->bitnum;
 		} else {
 			/* Check the translation table for this cargo's label */
-			int index = _cur.grffile->cargo_list.FindIndex(cs->label);
-			if (index >= 0) _cur.grffile->cargo_map[c] = index;
+			int idx = find_index(_cur.grffile->cargo_list, {cs->label});
+			if (idx >= 0) _cur.grffile->cargo_map[c] = idx;
 		}
 	}
 }
@@ -9226,7 +9226,7 @@ static void FinalisePriceBaseMultipliers()
 		GRFFile *dest = GetFileByGRFID(override);
 		if (dest == NULL) continue;
 
-		grf_overrides[i] = _grf_files.FindIndex(dest);
+		grf_overrides[i] = find_index(_grf_files, dest);
 		assert(grf_overrides[i] >= 0);
 	}
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -65,7 +65,7 @@
  * served as subject to the initial testing of this codec. */
 
 /** List of all loaded GRF files */
-static SmallVector<GRFFile *, 16> _grf_files;
+static std::vector<GRFFile *> _grf_files;
 
 /** Miscellaneous GRF features, set by Action 0x0D, parameter 0x9E */
 byte _misc_grf_features = 0;
@@ -459,7 +459,7 @@ struct StringIDMapping {
 	StringID source;  ///< Source StringID (GRF local).
 	StringID *target; ///< Destination for mapping result.
 };
-typedef SmallVector<StringIDMapping, 16> StringIDMappingVector;
+typedef std::vector<StringIDMapping> StringIDMappingVector;
 static StringIDMappingVector _string_to_grf_mapping;
 
 /**
@@ -1901,7 +1901,7 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 					/* On error, bail out immediately. Temporary GRF data was already freed */
 					if (_cur.skip_sprites < 0) return CIR_DISABLED;
 
-					static SmallVector<DrawTileSeqStruct, 8> tmp_layout;
+					static std::vector<DrawTileSeqStruct> tmp_layout;
 					tmp_layout.clear();
 					for (;;) {
 						/* no relative bounding box support */
@@ -4787,7 +4787,7 @@ static void NewSpriteGroup(ByteReader *buf)
 				case 2: group->size = DSG_SIZE_DWORD; varsize = 4; break;
 			}
 
-			static SmallVector<DeterministicSpriteGroupAdjust, 16> adjusts;
+			static std::vector<DeterministicSpriteGroupAdjust> adjusts;
 			adjusts.clear();
 
 			/* Loop through the var adjusts. Unfortunately we don't know how many we have

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1906,7 +1906,7 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 					if (_cur.skip_sprites < 0) return CIR_DISABLED;
 
 					static SmallVector<DrawTileSeqStruct, 8> tmp_layout;
-					tmp_layout.Clear();
+					tmp_layout.clear();
 					for (;;) {
 						/* no relative bounding box support */
 						DrawTileSeqStruct *dtss = tmp_layout.Append();
@@ -2591,7 +2591,7 @@ static ChangeInfoResult LoadTranslationTable(uint gvid, int numinfo, ByteReader 
 		return CIR_INVALID_ID;
 	}
 
-	translation_table.Clear();
+	translation_table.clear();
 	for (int i = 0; i < numinfo; i++) {
 		uint32 item = buf->ReadDWord();
 		*translation_table.Append() = BSWAP32(item);
@@ -4791,7 +4791,7 @@ static void NewSpriteGroup(ByteReader *buf)
 			}
 
 			static SmallVector<DeterministicSpriteGroupAdjust, 16> adjusts;
-			adjusts.Clear();
+			adjusts.clear();
 
 			/* Loop through the var adjusts. Unfortunately we don't know how many we have
 			 * from the outset, so we shall have to keep reallocing. */
@@ -8246,7 +8246,7 @@ static void ResetNewGRF()
 		delete *file;
 	}
 
-	_grf_files.Clear();
+	_grf_files.clear();
 	_cur.grffile   = NULL;
 }
 
@@ -9332,7 +9332,7 @@ static void AfterLoadGRFs()
 	for (StringIDMapping *it = _string_to_grf_mapping.Begin(); it != _string_to_grf_mapping.End(); it++) {
 		*it->target = MapGRFStringID(it->grfid, it->source);
 	}
-	_string_to_grf_mapping.Clear();
+	_string_to_grf_mapping.clear();
 
 	/* Free the action 6 override sprites. */
 	for (GRFLineToSpriteOverride::iterator it = _grf_line_to_action6_sprite_override.begin(); it != _grf_line_to_action6_sprite_override.end(); it++) {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -637,7 +637,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16 intern
 
 		/* Reserve the engine slot */
 		if (!static_access) {
-			EngineIDMapping *eid = _engine_mngr.Get(engine);
+			EngineIDMapping *eid = _engine_mngr.data() + engine;
 			eid->grfid           = scope_grfid; // Note: this is INVALID_GRFID if dynamic_engines is disabled, so no reservation
 		}
 

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -122,10 +122,10 @@ struct GRFFile : ZeroedMemoryAllocator {
 
 	GRFLabel *label; ///< Pointer to the first label. This is a linked list, not an array.
 
-	SmallVector<CargoLabel, 4> cargo_list;          ///< Cargo translation table (local ID -> label)
+	std::vector<CargoLabel> cargo_list;          ///< Cargo translation table (local ID -> label)
 	uint8 cargo_map[NUM_CARGO];                     ///< Inverse cargo translation table (CargoID -> local ID)
 
-	SmallVector<RailTypeLabel, 4> railtype_list;    ///< Railtype translation table
+	std::vector<RailTypeLabel> railtype_list;    ///< Railtype translation table
 	RailTypeByte railtype_map[RAILTYPE_END];
 
 	CanalProperties canal_local_properties[CF_END]; ///< Canal properties as set by this NewGRF

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -122,10 +122,10 @@ struct GRFFile : ZeroedMemoryAllocator {
 
 	GRFLabel *label; ///< Pointer to the first label. This is a linked list, not an array.
 
-	std::vector<CargoLabel> cargo_list;          ///< Cargo translation table (local ID -> label)
+	std::vector<CargoLabel> cargo_list;             ///< Cargo translation table (local ID -> label)
 	uint8 cargo_map[NUM_CARGO];                     ///< Inverse cargo translation table (CargoID -> local ID)
 
-	std::vector<RailTypeLabel> railtype_list;    ///< Railtype translation table
+	std::vector<RailTypeLabel> railtype_list;       ///< Railtype translation table
 	RailTypeByte railtype_map[RAILTYPE_END];
 
 	CanalProperties canal_local_properties[CF_END]; ///< Canal properties as set by this NewGRF

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -82,10 +82,10 @@ CargoID GetCargoTranslation(uint8 cargo, const GRFFile *grffile, bool usebit)
 
 	/* Other cases use (possibly translated) cargobits */
 
-	if (grffile->cargo_list.Length() > 0) {
+	if (grffile->cargo_list.size() > 0) {
 		/* ...and the cargo is in bounds, then get the cargo ID for
 		 * the label */
-		if (cargo < grffile->cargo_list.Length()) return GetCargoIDByLabel(grffile->cargo_list[cargo]);
+		if (cargo < grffile->cargo_list.size()) return GetCargoIDByLabel(grffile->cargo_list[cargo]);
 	} else {
 		/* Else the cargo value is a 'climate independent' 'bitnum' */
 		return GetCargoIDByBitnum(cargo);

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -666,7 +666,8 @@ uint32 NewGRFSpriteLayout::PrepareLayout(uint32 orig_offset, uint32 newgrf_groun
 
 	/* Create a copy of the spritelayout, so we can modify some values.
 	 * Also include the groundsprite into the sequence for easier processing. */
-	DrawTileSeqStruct *result = result_seq.Append();
+	/*C++17: DrawTileSeqStruct *result = &*/ result_seq.emplace_back();
+	DrawTileSeqStruct *result = &result_seq.back();
 	result->image = ground;
 	result->delta_x = 0;
 	result->delta_y = 0;
@@ -674,10 +675,10 @@ uint32 NewGRFSpriteLayout::PrepareLayout(uint32 orig_offset, uint32 newgrf_groun
 
 	const DrawTileSeqStruct *dtss;
 	foreach_draw_tile_seq(dtss, this->seq) {
-		*result_seq.Append() = *dtss;
+		result_seq.push_back(*dtss);
 	}
-	result_seq.Append()->MakeTerminator();
-
+	result_seq.emplace_back() /*C++17: .MakeTerminator()*/;
+	result_seq.back().MakeTerminator();
 	/* Determine the var10 values the action-1-2-3 chains needs to be resolved for,
 	 * and apply the default sprite offsets (unless disabled). */
 	const TileLayoutRegisters *regs = this->registers;

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -661,7 +661,7 @@ void NewGRFSpriteLayout::AllocateRegisters()
  */
 uint32 NewGRFSpriteLayout::PrepareLayout(uint32 orig_offset, uint32 newgrf_ground_offset, uint32 newgrf_offset, uint constr_stage, bool separate_ground) const
 {
-	result_seq.Clear();
+	result_seq.clear();
 	uint32 var10_values = 0;
 
 	/* Create a copy of the spritelayout, so we can modify some values.

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -683,7 +683,7 @@ uint32 NewGRFSpriteLayout::PrepareLayout(uint32 orig_offset, uint32 newgrf_groun
 	 * and apply the default sprite offsets (unless disabled). */
 	const TileLayoutRegisters *regs = this->registers;
 	bool ground = true;
-	foreach_draw_tile_seq(result, result_seq.Begin()) {
+	foreach_draw_tile_seq(result, result_seq.data()) {
 		TileLayoutFlags flags = TLF_NOTHING;
 		if (regs != NULL) flags = regs->flags;
 
@@ -737,7 +737,7 @@ void NewGRFSpriteLayout::ProcessRegisters(uint8 resolved_var10, uint32 resolved_
 	DrawTileSeqStruct *result;
 	const TileLayoutRegisters *regs = this->registers;
 	bool ground = true;
-	foreach_draw_tile_seq(result, result_seq.Begin()) {
+	foreach_draw_tile_seq(result, result_seq.data()) {
 		TileLayoutFlags flags = TLF_NOTHING;
 		if (regs != NULL) flags = regs->flags;
 

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -579,7 +579,7 @@ bool Convert8bitBooleanCallback(const GRFFile *grffile, uint16 cbid, uint16 cb_r
 }
 
 
-/* static */ SmallVector<DrawTileSeqStruct, 8> NewGRFSpriteLayout::result_seq;
+/* static */ std::vector<DrawTileSeqStruct> NewGRFSpriteLayout::result_seq;
 
 /**
  * Clone the building sprites of a spritelayout.

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -170,7 +170,7 @@ struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
 	}
 
 private:
-	static SmallVector<DrawTileSeqStruct, 8> result_seq; ///< Temporary storage when preprocessing spritelayouts.
+	static std::vector<DrawTileSeqStruct> result_seq; ///< Temporary storage when preprocessing spritelayouts.
 };
 
 /**

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -164,7 +164,7 @@ struct NewGRFSpriteLayout : ZeroedMemoryAllocator, DrawTileSprites {
 	 */
 	const DrawTileSeqStruct *GetLayout(PalSpriteID *ground) const
 	{
-		DrawTileSeqStruct *front = result_seq.Begin();
+		DrawTileSeqStruct *front = result_seq.data();
 		*ground = front->image;
 		return front + 1;
 	}

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -83,7 +83,7 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	this->info->AddRef();
 	this->url->AddRef();
 	if (config.error != NULL) this->error = new GRFError(*config.error);
-	for (uint i = 0; i < config.param_info.Length(); i++) {
+	for (uint i = 0; i < config.param_info.size(); i++) {
 		if (config.param_info[i] == NULL) {
 			*this->param_info.Append() = NULL;
 		} else {
@@ -104,7 +104,7 @@ GRFConfig::~GRFConfig()
 	this->info->Release();
 	this->url->Release();
 
-	for (uint i = 0; i < this->param_info.Length(); i++) delete this->param_info[i];
+	for (uint i = 0; i < this->param_info.size(); i++) delete this->param_info[i];
 }
 
 /**
@@ -155,7 +155,7 @@ void GRFConfig::SetParameterDefaults()
 
 	if (!this->has_param_defaults) return;
 
-	for (uint i = 0; i < this->param_info.Length(); i++) {
+	for (uint i = 0; i < this->param_info.size(); i++) {
 		if (this->param_info[i] == NULL) continue;
 		this->param_info[i]->SetValue(this, this->param_info[i]->def_value);
 	}
@@ -261,7 +261,7 @@ GRFParameterInfo::GRFParameterInfo(GRFParameterInfo &info) :
 	num_bit(info.num_bit),
 	complete_labels(info.complete_labels)
 {
-	for (uint i = 0; i < info.value_names.Length(); i++) {
+	for (uint i = 0; i < info.value_names.size(); i++) {
 		SmallPair<uint32, GRFText *> *data = info.value_names.Get(i);
 		this->value_names.Insert(data->first, DuplicateGRFText(data->second));
 	}
@@ -272,7 +272,7 @@ GRFParameterInfo::~GRFParameterInfo()
 {
 	CleanUpGRFText(this->name);
 	CleanUpGRFText(this->desc);
-	for (uint i = 0; i < this->value_names.Length(); i++) {
+	for (uint i = 0; i < this->value_names.size(); i++) {
 		SmallPair<uint32, GRFText *> *data = this->value_names.Get(i);
 		CleanUpGRFText(data->second);
 	}
@@ -609,7 +609,7 @@ compatible_grf:
 				c->min_loadable_version = f->min_loadable_version;
 				c->num_valid_params = f->num_valid_params;
 				c->has_param_defaults = f->has_param_defaults;
-				for (uint i = 0; i < f->param_info.Length(); i++) {
+				for (uint i = 0; i < f->param_info.size(); i++) {
 					if (f->param_info[i] == NULL) {
 						*c->param_info.Append() = NULL;
 					} else {

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -182,9 +182,9 @@ void GRFConfig::SetSuitablePalette()
  */
 void GRFConfig::FinalizeParameterInfo()
 {
-	for (GRFParameterInfo **info = this->param_info.Begin(); info != this->param_info.End(); ++info) {
-		if (*info == NULL) continue;
-		(*info)->Finalize();
+	for (GRFParameterInfo *info : this->param_info) {
+		if (info == NULL) continue;
+		info->Finalize();
 	}
 }
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -85,9 +85,9 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	if (config.error != NULL) this->error = new GRFError(*config.error);
 	for (uint i = 0; i < config.param_info.size(); i++) {
 		if (config.param_info[i] == NULL) {
-			*this->param_info.Append() = NULL;
+			this->param_info.push_back(NULL);
 		} else {
-			*this->param_info.Append() = new GRFParameterInfo(*config.param_info[i]);
+			this->param_info.push_back(new GRFParameterInfo(*config.param_info[i]));
 		}
 	}
 }
@@ -611,9 +611,9 @@ compatible_grf:
 				c->has_param_defaults = f->has_param_defaults;
 				for (uint i = 0; i < f->param_info.size(); i++) {
 					if (f->param_info[i] == NULL) {
-						*c->param_info.Append() = NULL;
+						c->param_info.push_back(NULL);
 					} else {
-						*c->param_info.Append() = new GRFParameterInfo(*f->param_info[i]);
+						c->param_info.push_back(new GRFParameterInfo(*f->param_info[i]));
 					}
 				}
 			}

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -262,7 +262,7 @@ GRFParameterInfo::GRFParameterInfo(GRFParameterInfo &info) :
 	complete_labels(info.complete_labels)
 {
 	for (uint i = 0; i < info.value_names.size(); i++) {
-		SmallPair<uint32, GRFText *> *data = info.value_names.Get(i);
+		SmallPair<uint32, GRFText *> *data = info.value_names.data() + i;
 		this->value_names.Insert(data->first, DuplicateGRFText(data->second));
 	}
 }
@@ -273,7 +273,7 @@ GRFParameterInfo::~GRFParameterInfo()
 	CleanUpGRFText(this->name);
 	CleanUpGRFText(this->desc);
 	for (uint i = 0; i < this->value_names.size(); i++) {
-		SmallPair<uint32, GRFText *> *data = this->value_names.Get(i);
+		SmallPair<uint32, GRFText *> *data = this->value_names.data() + i;
 		CleanUpGRFText(data->second);
 	}
 }

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -133,7 +133,7 @@ struct GRFParameterInfo {
 	byte param_nr;         ///< GRF parameter to store content in
 	byte first_bit;        ///< First bit to use in the GRF parameter
 	byte num_bit;          ///< Number of bits to use for this parameter
-	SmallMap<uint32, struct GRFText *, 8> value_names; ///< Names for each value.
+	SmallMap<uint32, struct GRFText *> value_names; ///< Names for each value.
 	bool complete_labels;  ///< True if all values have a label.
 
 	uint32 GetValue(struct GRFConfig *config) const;
@@ -155,27 +155,27 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	GRFConfig(const GRFConfig &config);
 	~GRFConfig();
 
-	GRFIdentifier ident;                           ///< grfid and md5sum to uniquely identify newgrfs
-	uint8 original_md5sum[16];                     ///< MD5 checksum of original file if only a 'compatible' file was loaded
-	char *filename;                                ///< Filename - either with or without full path
-	GRFTextWrapper *name;                          ///< NOSAVE: GRF name (Action 0x08)
-	GRFTextWrapper *info;                          ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
-	GRFTextWrapper *url;                           ///< NOSAVE: URL belonging to this GRF.
-	GRFError *error;                               ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
+	GRFIdentifier ident;                        ///< grfid and md5sum to uniquely identify newgrfs
+	uint8 original_md5sum[16];                  ///< MD5 checksum of original file if only a 'compatible' file was loaded
+	char *filename;                             ///< Filename - either with or without full path
+	GRFTextWrapper *name;                       ///< NOSAVE: GRF name (Action 0x08)
+	GRFTextWrapper *info;                       ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
+	GRFTextWrapper *url;                        ///< NOSAVE: URL belonging to this GRF.
+	GRFError *error;                            ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
 
-	uint32 version;                                ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
-	uint32 min_loadable_version;                   ///< NOSAVE: Minimum compatible version a NewGRF can define
-	uint8 flags;                                   ///< NOSAVE: GCF_Flags, bitset
-	GRFStatus status;                              ///< NOSAVE: GRFStatus, enum
-	uint32 grf_bugs;                               ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
-	uint32 param[0x80];                            ///< GRF parameters
-	uint8 num_params;                              ///< Number of used parameters
-	uint8 num_valid_params;                        ///< NOSAVE: Number of valid parameters (action 0x14)
-	uint8 palette;                                 ///< GRFPalette, bitset
+	uint32 version;                             ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
+	uint32 min_loadable_version;                ///< NOSAVE: Minimum compatible version a NewGRF can define
+	uint8 flags;                                ///< NOSAVE: GCF_Flags, bitset
+	GRFStatus status;                           ///< NOSAVE: GRFStatus, enum
+	uint32 grf_bugs;                            ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
+	uint32 param[0x80];                         ///< GRF parameters
+	uint8 num_params;                           ///< Number of used parameters
+	uint8 num_valid_params;                     ///< NOSAVE: Number of valid parameters (action 0x14)
+	uint8 palette;                              ///< GRFPalette, bitset
 	std::vector<GRFParameterInfo *> param_info; ///< NOSAVE: extra information about the parameters
-	bool has_param_defaults;                       ///< NOSAVE: did this newgrf specify any defaults for it's parameters
+	bool has_param_defaults;                    ///< NOSAVE: did this newgrf specify any defaults for it's parameters
 
-	struct GRFConfig *next;                        ///< NOSAVE: Next item in the linked list
+	struct GRFConfig *next;                     ///< NOSAVE: Next item in the linked list
 
 	void CopyParams(const GRFConfig &src);
 

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -172,7 +172,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	uint8 num_params;                              ///< Number of used parameters
 	uint8 num_valid_params;                        ///< NOSAVE: Number of valid parameters (action 0x14)
 	uint8 palette;                                 ///< GRFPalette, bitset
-	SmallVector<GRFParameterInfo *, 4> param_info; ///< NOSAVE: extra information about the parameters
+	std::vector<GRFParameterInfo *> param_info; ///< NOSAVE: extra information about the parameters
 	bool has_param_defaults;                       ///< NOSAVE: did this newgrf specify any defaults for it's parameters
 
 	struct GRFConfig *next;                        ///< NOSAVE: Next item in the linked list

--- a/src/newgrf_debug.h
+++ b/src/newgrf_debug.h
@@ -29,7 +29,7 @@ struct NewGrfDebugSpritePicker {
 	NewGrfDebugSpritePickerMode mode;   ///< Current state
 	void *clicked_pixel;                ///< Clicked pixel (pointer to blitter buffer)
 	uint32 click_time;                  ///< Realtime tick when clicked to detect next frame
-	SmallVector<SpriteID, 256> sprites; ///< Sprites found
+	std::vector<SpriteID> sprites; ///< Sprites found
 };
 
 extern NewGrfDebugSpritePicker _newgrf_debug_sprite_picker;

--- a/src/newgrf_debug.h
+++ b/src/newgrf_debug.h
@@ -29,7 +29,7 @@ struct NewGrfDebugSpritePicker {
 	NewGrfDebugSpritePickerMode mode;   ///< Current state
 	void *clicked_pixel;                ///< Clicked pixel (pointer to blitter buffer)
 	uint32 click_time;                  ///< Realtime tick when clicked to detect next frame
-	std::vector<SpriteID> sprites; ///< Sprites found
+	std::vector<SpriteID> sprites;       ///< Sprites found
 };
 
 extern NewGrfDebugSpritePicker _newgrf_debug_sprite_picker;

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -986,7 +986,7 @@ struct SpriteAlignerWindow : Window {
 
 			case WID_SA_RESET_REL:
 				/* Reset the starting offsets for the current sprite. */
-				this->offs_start_map.Erase(this->current_sprite);
+				this->offs_start_map.erase(this->offs_start_map.begin() + this->current_sprite);
 				this->SetDirty();
 				break;
 		}

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -840,8 +840,8 @@ struct SpriteAlignerWindow : Window {
 				/* Relative offset is new absolute offset - starting absolute offset.
 				 * Show 0, 0 as the relative offsets if entry is not in the map (meaning they have not been changed yet).
 				 */
-				const SmallPair<SpriteID, XyOffs> *key_offs_pair = this->offs_start_map.Find(this->current_sprite);
-				if (key_offs_pair != this->offs_start_map.End()) {
+				const auto key_offs_pair = this->offs_start_map.Find(this->current_sprite);
+				if (key_offs_pair != this->offs_start_map.end()) {
 					SetDParam(0, spr->x_offs - key_offs_pair->second.first);
 					SetDParam(1, spr->y_offs - key_offs_pair->second.second);
 				} else {

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -47,7 +47,7 @@
 #include "safeguards.h"
 
 /** The sprite picker. */
-NewGrfDebugSpritePicker _newgrf_debug_sprite_picker = { SPM_NONE, NULL, 0, SmallVector<SpriteID, 256>() };
+NewGrfDebugSpritePicker _newgrf_debug_sprite_picker = { SPM_NONE, NULL, 0, std::vector<SpriteID>() };
 
 /**
  * Get the feature index related to the window number.
@@ -894,7 +894,7 @@ struct SpriteAlignerWindow : Window {
 				const NWidgetBase *nwid = this->GetWidget<NWidgetBase>(widget);
 				int step_size = nwid->resize_y;
 
-				SmallVector<SpriteID, 256> &list = _newgrf_debug_sprite_picker.sprites;
+				std::vector<SpriteID> &list = _newgrf_debug_sprite_picker.sprites;
 				int max = min<int>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), list.size());
 
 				int y = r.top + WD_FRAMERECT_TOP;

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -895,7 +895,7 @@ struct SpriteAlignerWindow : Window {
 				int step_size = nwid->resize_y;
 
 				SmallVector<SpriteID, 256> &list = _newgrf_debug_sprite_picker.sprites;
-				int max = min<int>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), list.Length());
+				int max = min<int>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), list.size());
 
 				int y = r.top + WD_FRAMERECT_TOP;
 				for (int i = this->vscroll->GetPosition(); i < max; i++) {
@@ -940,7 +940,7 @@ struct SpriteAlignerWindow : Window {
 				int step_size = nwid->resize_y;
 
 				uint i = this->vscroll->GetPosition() + (pt.y - nwid->pos_y) / step_size;
-				if (i < _newgrf_debug_sprite_picker.sprites.Length()) {
+				if (i < _newgrf_debug_sprite_picker.sprites.size()) {
 					SpriteID spr = _newgrf_debug_sprite_picker.sprites[i];
 					if (GetSpriteType(spr) == ST_NORMAL) this->current_sprite = spr;
 				}
@@ -1015,7 +1015,7 @@ struct SpriteAlignerWindow : Window {
 		if (data == 1) {
 			/* Sprite picker finished */
 			this->RaiseWidget(WID_SA_PICKER);
-			this->vscroll->SetCount(_newgrf_debug_sprite_picker.sprites.Length());
+			this->vscroll->SetCount(_newgrf_debug_sprite_picker.sprites.size());
 		}
 	}
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1233,7 +1233,7 @@ void CommitVehicleListOrderChanges()
 	FOR_ALL_ENGINES(e) {
 		*ordering.Append() = e->index;
 	}
-	QSortT(ordering.Begin(), ordering.Length(), EnginePreSort);
+	QSortT(ordering.Begin(), ordering.size(), EnginePreSort);
 
 	/* Apply Insertion-Sort operations */
 	const ListOrderChange *end = _list_order_changes.End();

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1231,13 +1231,12 @@ void CommitVehicleListOrderChanges()
 	FOR_ALL_ENGINES(e) {
 		ordering.push_back(e->index);
 	}
-	QSortT(ordering.Begin(), ordering.size(), EnginePreSort);
+	QSortT(ordering.data(), ordering.size(), EnginePreSort);
 
 	/* Apply Insertion-Sort operations */
-	const ListOrderChange *end = _list_order_changes.End();
-	for (const ListOrderChange *it = _list_order_changes.Begin(); it != end; ++it) {
-		EngineID source = it->engine;
-		uint local_target = it->target;
+	for (const ListOrderChange &it : _list_order_changes) {
+		EngineID source = it.engine;
+		uint local_target = it.target;
 
 		const EngineIDMapping *id_source = _engine_mngr.data() + source;
 		if (id_source->internal_id == local_target) continue;
@@ -1251,7 +1250,7 @@ void CommitVehicleListOrderChanges()
 		assert(source_index >= 0 && target_index >= 0);
 		assert(source_index != target_index);
 
-		EngineID *list = ordering.Begin();
+		EngineID *list = ordering.data();
 		if (source_index < target_index) {
 			--target_index;
 			for (int i = source_index; i < target_index; ++i) list[i] = list[i + 1];
@@ -1263,10 +1262,10 @@ void CommitVehicleListOrderChanges()
 	}
 
 	/* Store final sort-order */
-	const EngineID *idend = ordering.End();
 	uint index = 0;
-	for (const EngineID *it = ordering.Begin(); it != idend; ++it, ++index) {
-		Engine::Get(*it)->list_position = index;
+	for (const EngineID &eid : ordering) {
+		Engine::Get(eid)->list_position = index;
+		++index;
 	}
 
 	/* Clear out the queue */

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1196,9 +1196,7 @@ static SmallVector<ListOrderChange, 16> _list_order_changes;
 void AlterVehicleListOrder(EngineID engine, uint target)
 {
 	/* Add the list order change to a queue */
-	ListOrderChange *loc = _list_order_changes.Append();
-	loc->engine = engine;
-	loc->target = target;
+	_list_order_changes.push_back({engine, target});
 }
 
 /**
@@ -1231,7 +1229,7 @@ void CommitVehicleListOrderChanges()
 	SmallVector<EngineID, 16> ordering;
 	Engine *e;
 	FOR_ALL_ENGINES(e) {
-		*ordering.Append() = e->index;
+		ordering.push_back(e->index);
 	}
 	QSortT(ordering.Begin(), ordering.size(), EnginePreSort);
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1245,8 +1245,8 @@ void CommitVehicleListOrderChanges()
 		EngineID target = _engine_mngr.GetID(id_source->type, local_target, id_source->grfid);
 		if (target == INVALID_ENGINE) continue;
 
-		int source_index = ordering.FindIndex(source);
-		int target_index = ordering.FindIndex(target);
+		int source_index = find_index(ordering, source);
+		int target_index = find_index(ordering, target);
 
 		assert(source_index >= 0 && target_index >= 0);
 		assert(source_index != target_index);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1209,17 +1209,17 @@ void AlterVehicleListOrder(EngineID engine, uint target)
  */
 static int CDECL EnginePreSort(const EngineID *a, const EngineID *b)
 {
-	const EngineIDMapping *id_a = _engine_mngr.Get(*a);
-	const EngineIDMapping *id_b = _engine_mngr.Get(*b);
+	const EngineIDMapping &id_a = _engine_mngr.at(*a);
+	const EngineIDMapping &id_b = _engine_mngr.at(*b);
 
 	/* 1. Sort by engine type */
-	if (id_a->type != id_b->type) return (int)id_a->type - (int)id_b->type;
+	if (id_a.type != id_b.type) return (int)id_a.type - (int)id_b.type;
 
 	/* 2. Sort by scope-GRFID */
-	if (id_a->grfid != id_b->grfid) return id_a->grfid < id_b->grfid ? -1 : 1;
+	if (id_a.grfid != id_b.grfid) return id_a.grfid < id_b.grfid ? -1 : 1;
 
 	/* 3. Sort by local ID */
-	return (int)id_a->internal_id - (int)id_b->internal_id;
+	return (int)id_a.internal_id - (int)id_b.internal_id;
 }
 
 /**
@@ -1241,7 +1241,7 @@ void CommitVehicleListOrderChanges()
 		EngineID source = it->engine;
 		uint local_target = it->target;
 
-		const EngineIDMapping *id_source = _engine_mngr.Get(source);
+		const EngineIDMapping *id_source = _engine_mngr.data() + source;
 		if (id_source->internal_id == local_target) continue;
 
 		EngineID target = _engine_mngr.GetID(id_source->type, local_target, id_source->grfid);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1272,7 +1272,8 @@ void CommitVehicleListOrderChanges()
 	}
 
 	/* Clear out the queue */
-	_list_order_changes.Reset();
+	_list_order_changes.clear();
+	_list_order_changes.shrink_to_fit();
 }
 
 /**

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1185,7 +1185,7 @@ struct ListOrderChange {
 	uint target;      ///< local ID
 };
 
-static SmallVector<ListOrderChange, 16> _list_order_changes;
+static std::vector<ListOrderChange> _list_order_changes;
 
 /**
  * Record a vehicle ListOrderChange.
@@ -1226,7 +1226,7 @@ static int CDECL EnginePreSort(const EngineID *a, const EngineID *b)
 void CommitVehicleListOrderChanges()
 {
 	/* Pre-sort engines by scope-grfid and local index */
-	SmallVector<EngineID, 16> ordering;
+	std::vector<EngineID> ordering;
 	Engine *e;
 	FOR_ALL_ENGINES(e) {
 		ordering.push_back(e->index);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1481,7 +1481,7 @@ private:
 		}
 
 		this->avails.Filter(this->string_filter);
-		this->avails.Compact();
+		this->avails.shrink_to_fit();
 		this->avails.RebuildDone();
 		this->avails.Sort();
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1486,8 +1486,10 @@ private:
 		this->avails.Sort();
 
 		if (this->avail_sel != NULL) {
-			this->avail_pos = this->avails.FindIndex(this->avail_sel);
-			if (this->avail_pos < 0) this->avail_sel = NULL;
+			this->avail_pos = find_index(this->avails, this->avail_sel);
+			if (this->avail_pos == -1) {
+				this->avail_sel = NULL;
+			}
 		}
 
 		this->vscroll2->SetCount(this->avails.size()); // Update the scrollbar

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -378,7 +378,7 @@ struct NewGRFParametersWindow : public Window {
 
 							DropDownList *list = new DropDownList();
 							for (uint32 i = par_info->min_value; i <= par_info->max_value; i++) {
-								*list->Append() = new DropDownListCharStringItem(GetGRFStringFromGRFText(par_info->value_names.Find(i)->second), i, false);
+								list->push_back(new DropDownListCharStringItem(GetGRFStringFromGRFText(par_info->value_names.Find(i)->second), i, false));
 							}
 
 							ShowDropDownListAt(this, list, old_val, -1, wi_rect, COLOUR_ORANGE, true);
@@ -927,11 +927,11 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				DropDownList *list = new DropDownList();
 
 				/* Add 'None' option for clearing list */
-				*list->Append() = new DropDownListStringItem(STR_NONE, -1, false);
+				list->push_back(new DropDownListStringItem(STR_NONE, -1, false));
 
 				for (uint i = 0; i < _grf_preset_list.size(); i++) {
 					if (_grf_preset_list[i] != NULL) {
-						*list->Append() = new DropDownListCharStringItem(_grf_preset_list[i], i, false);
+						list->push_back(new DropDownListCharStringItem(_grf_preset_list[i], i, false));
 					}
 				}
 
@@ -1464,7 +1464,7 @@ private:
 			if (found) continue;
 
 			if (_settings_client.gui.newgrf_show_old_versions) {
-				*this->avails.Append() = c;
+				this->avails.push_back(c);
 			} else {
 				const GRFConfig *best = FindGRFConfig(c->ident.grfid, HasBit(c->flags, GCF_INVALID) ? FGCM_NEWEST : FGCM_NEWEST_VALID);
 				/*
@@ -1475,7 +1475,7 @@ private:
 				 * show that NewGRF!.
 				 */
 				if (best->version == 0 || best->ident.HasGrfIdentifier(c->ident.grfid, c->ident.md5sum)) {
-					*this->avails.Append() = c;
+					this->avails.push_back(c);
 				}
 			}
 		}
@@ -1558,7 +1558,7 @@ void ShowMissingContentWindow(const GRFConfig *list)
 		strecpy(ci->name, c->GetName(), lastof(ci->name));
 		ci->unique_id = BSWAP32(c->ident.grfid);
 		memcpy(ci->md5sum, HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum, sizeof(ci->md5sum));
-		*cv.Append() = ci;
+		cv.push_back(ci);
 	}
 	ShowNetworkContentListWindow(cv.size() == 0 ? NULL : &cv, CONTENT_TYPE_NEWGRF);
 }

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1456,7 +1456,7 @@ private:
 	{
 		if (!this->avails.NeedRebuild()) return;
 
-		this->avails.Clear();
+		this->avails.clear();
 
 		for (const GRFConfig *c = _all_grfs; c != NULL; c = c->next) {
 			bool found = false;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -166,7 +166,7 @@ struct NewGRFParametersWindow : public Window {
 		clicked_row(UINT_MAX),
 		editable(editable)
 	{
-		this->action14present = (c->num_valid_params != lengthof(c->param) || c->param_info.Length() != 0);
+		this->action14present = (c->num_valid_params != lengthof(c->param) || c->param_info.size() != 0);
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NP_SCROLLBAR);
@@ -220,7 +220,7 @@ struct NewGRFParametersWindow : public Window {
 			case WID_NP_DESCRIPTION:
 				/* Minimum size of 4 lines. The 500 is the default size of the window. */
 				Dimension suggestion = {500 - WD_FRAMERECT_LEFT - WD_FRAMERECT_RIGHT, (uint)FONT_HEIGHT_NORMAL * 4 + WD_TEXTPANEL_TOP + WD_TEXTPANEL_BOTTOM};
-				for (uint i = 0; i < this->grf_config->param_info.Length(); i++) {
+				for (uint i = 0; i < this->grf_config->param_info.size(); i++) {
 					const GRFParameterInfo *par_info = this->grf_config->param_info[i];
 					if (par_info == NULL) continue;
 					const char *desc = GetGRFStringFromGRFText(par_info->desc);
@@ -246,7 +246,7 @@ struct NewGRFParametersWindow : public Window {
 	void DrawWidget(const Rect &r, int widget) const override
 	{
 		if (widget == WID_NP_DESCRIPTION) {
-			const GRFParameterInfo *par_info = (this->clicked_row < this->grf_config->param_info.Length()) ? this->grf_config->param_info[this->clicked_row] : NULL;
+			const GRFParameterInfo *par_info = (this->clicked_row < this->grf_config->param_info.size()) ? this->grf_config->param_info[this->clicked_row] : NULL;
 			if (par_info == NULL) return;
 			const char *desc = GetGRFStringFromGRFText(par_info->desc);
 			if (desc == NULL) return;
@@ -265,7 +265,7 @@ struct NewGRFParametersWindow : public Window {
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
 		for (uint i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++) {
-			GRFParameterInfo *par_info = (i < this->grf_config->param_info.Length()) ? this->grf_config->param_info[i] : NULL;
+			GRFParameterInfo *par_info = (i < this->grf_config->param_info.size()) ? this->grf_config->param_info[i] : NULL;
 			if (par_info == NULL) par_info = GetDummyParameterInfo(i);
 			uint32 current_value = par_info->GetValue(this->grf_config);
 			bool selected = (i == this->clicked_row);
@@ -350,7 +350,7 @@ struct NewGRFParametersWindow : public Window {
 				if (_current_text_dir == TD_RTL) x = wid->current_x - 1 - x;
 				x -= 4;
 
-				GRFParameterInfo *par_info = (num < this->grf_config->param_info.Length()) ? this->grf_config->param_info[num] : NULL;
+				GRFParameterInfo *par_info = (num < this->grf_config->param_info.size()) ? this->grf_config->param_info[num] : NULL;
 				if (par_info == NULL) par_info = GetDummyParameterInfo(num);
 
 				/* One of the arrows is clicked */
@@ -431,7 +431,7 @@ struct NewGRFParametersWindow : public Window {
 	{
 		if (StrEmpty(str)) return;
 		int32 value = atoi(str);
-		GRFParameterInfo *par_info = ((uint)this->clicked_row < this->grf_config->param_info.Length()) ? this->grf_config->param_info[this->clicked_row] : NULL;
+		GRFParameterInfo *par_info = ((uint)this->clicked_row < this->grf_config->param_info.size()) ? this->grf_config->param_info[this->clicked_row] : NULL;
 		if (par_info == NULL) par_info = GetDummyParameterInfo(this->clicked_row);
 		uint32 val = Clamp<uint32>(value, par_info->min_value, par_info->max_value);
 		par_info->SetValue(this->grf_config, val);
@@ -441,7 +441,7 @@ struct NewGRFParametersWindow : public Window {
 	void OnDropdownSelect(int widget, int index) override
 	{
 		assert(this->clicked_dropdown);
-		GRFParameterInfo *par_info = ((uint)this->clicked_row < this->grf_config->param_info.Length()) ? this->grf_config->param_info[this->clicked_row] : NULL;
+		GRFParameterInfo *par_info = ((uint)this->clicked_row < this->grf_config->param_info.size()) ? this->grf_config->param_info[this->clicked_row] : NULL;
 		if (par_info == NULL) par_info = GetDummyParameterInfo(this->clicked_row);
 		par_info->SetValue(this->grf_config, index);
 		this->SetDirty();
@@ -747,7 +747,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case WID_NS_PRESET_LIST: {
 				Dimension d = GetStringBoundingBox(STR_NUM_CUSTOM);
-				for (uint i = 0; i < _grf_preset_list.Length(); i++) {
+				for (uint i = 0; i < _grf_preset_list.size(); i++) {
 					if (_grf_preset_list[i] != NULL) {
 						SetDParamStr(0, _grf_preset_list[i]);
 						d = maxdim(d, GetStringBoundingBox(STR_JUST_RAW_STRING));
@@ -882,7 +882,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				int offset_y = (step_height - FONT_HEIGHT_NORMAL) / 2;
 				uint y = r.top + WD_FRAMERECT_TOP;
 				uint min_index = this->vscroll2->GetPosition();
-				uint max_index = min(min_index + this->vscroll2->GetCapacity(), this->avails.Length());
+				uint max_index = min(min_index + this->vscroll2->GetCapacity(), this->avails.size());
 
 				for (uint i = min_index; i < max_index; i++) {
 					const GRFConfig *c = this->avails[i];
@@ -929,7 +929,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				/* Add 'None' option for clearing list */
 				*list->Append() = new DropDownListStringItem(STR_NONE, -1, false);
 
-				for (uint i = 0; i < _grf_preset_list.Length(); i++) {
+				for (uint i = 0; i < _grf_preset_list.size(); i++) {
 					if (_grf_preset_list[i] != NULL) {
 						*list->Append() = new DropDownListCharStringItem(_grf_preset_list[i], i, false);
 					}
@@ -1069,7 +1069,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				uint i = this->vscroll2->GetScrolledRowFromWidget(pt.y, this, WID_NS_AVAIL_LIST);
 				this->active_sel = NULL;
 				DeleteWindowByClass(WC_GRF_PARAMETERS);
-				if (i < this->avails.Length()) {
+				if (i < this->avails.size()) {
 					if (this->avail_sel != this->avails[i]) DeleteWindowByClass(WC_TEXTFILE);
 					this->avail_sel = this->avails[i];
 					this->avail_pos = i;
@@ -1175,7 +1175,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		GetGRFPresetList(&_grf_preset_list);
 
 		/* Switch to this preset */
-		for (uint i = 0; i < _grf_preset_list.Length(); i++) {
+		for (uint i = 0; i < _grf_preset_list.size(); i++) {
 			if (_grf_preset_list[i] != NULL && strcmp(_grf_preset_list[i], str) == 0) {
 				this->preset = i;
 				break;
@@ -1308,7 +1308,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case WKC_DOWN:
 				/* scroll down by one */
-				if (this->avail_pos < (int)this->avails.Length() - 1) this->avail_pos++;
+				if (this->avail_pos < (int)this->avails.size() - 1) this->avail_pos++;
 				break;
 
 			case WKC_PAGEUP:
@@ -1318,7 +1318,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case WKC_PAGEDOWN:
 				/* scroll down a page */
-				this->avail_pos = min(this->avail_pos + this->vscroll2->GetCapacity(), (int)this->avails.Length() - 1);
+				this->avail_pos = min(this->avail_pos + this->vscroll2->GetCapacity(), (int)this->avails.size() - 1);
 				break;
 
 			case WKC_HOME:
@@ -1328,14 +1328,14 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case WKC_END:
 				/* jump to end */
-				this->avail_pos = this->avails.Length() - 1;
+				this->avail_pos = this->avails.size() - 1;
 				break;
 
 			default:
 				return ES_NOT_HANDLED;
 		}
 
-		if (this->avails.Length() == 0) this->avail_pos = -1;
+		if (this->avails.size() == 0) this->avail_pos = -1;
 		if (this->avail_pos >= 0) {
 			this->active_sel = NULL;
 			DeleteWindowByClass(WC_GRF_PARAMETERS);
@@ -1490,7 +1490,7 @@ private:
 			if (this->avail_pos < 0) this->avail_sel = NULL;
 		}
 
-		this->vscroll2->SetCount(this->avails.Length()); // Update the scrollbar
+		this->vscroll2->SetCount(this->avails.size()); // Update the scrollbar
 	}
 
 	/**
@@ -1531,7 +1531,7 @@ private:
 
 		/* Select next (or previous, if last one) item in the list. */
 		int new_pos = this->avail_pos + 1;
-		if (new_pos >= (int)this->avails.Length()) new_pos = this->avail_pos - 1;
+		if (new_pos >= (int)this->avails.size()) new_pos = this->avail_pos - 1;
 		this->avail_pos = new_pos;
 		if (new_pos >= 0) this->avail_sel = this->avails[new_pos];
 
@@ -1560,7 +1560,7 @@ void ShowMissingContentWindow(const GRFConfig *list)
 		memcpy(ci->md5sum, HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum, sizeof(ci->md5sum));
 		*cv.Append() = ci;
 	}
-	ShowNetworkContentListWindow(cv.Length() == 0 ? NULL : &cv, CONTENT_TYPE_NEWGRF);
+	ShowNetworkContentListWindow(cv.size() == 0 ? NULL : &cv, CONTENT_TYPE_NEWGRF);
 }
 
 Listing NewGRFWindow::last_sorting     = {false, 0};
@@ -2049,7 +2049,7 @@ struct SavePresetWindow : public Window {
 		GetGRFPresetList(&this->presets);
 		this->selected = -1;
 		if (initial_text != NULL) {
-			for (uint i = 0; i < this->presets.Length(); i++) {
+			for (uint i = 0; i < this->presets.size(); i++) {
 				if (!strcmp(initial_text, this->presets[i])) {
 					this->selected = i;
 					break;
@@ -2065,7 +2065,7 @@ struct SavePresetWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_SVP_SCROLLBAR);
 		this->FinishInitNested(0);
 
-		this->vscroll->SetCount(this->presets.Length());
+		this->vscroll->SetCount(this->presets.size());
 		this->SetFocusedWidget(WID_SVP_EDITBOX);
 		if (initial_text != NULL) this->presetname_editbox.text.Assign(initial_text);
 	}
@@ -2080,12 +2080,12 @@ struct SavePresetWindow : public Window {
 			case WID_SVP_PRESET_LIST: {
 				resize->height = FONT_HEIGHT_NORMAL + 2U;
 				size->height = 0;
-				for (uint i = 0; i < this->presets.Length(); i++) {
+				for (uint i = 0; i < this->presets.size(); i++) {
 					Dimension d = GetStringBoundingBox(this->presets[i]);
 					size->width = max(size->width, d.width + WD_FRAMETEXT_LEFT + WD_FRAMETEXT_RIGHT);
 					resize->height = max(resize->height, d.height);
 				}
-				size->height = ClampU(this->presets.Length(), 5, 20) * resize->height + 1;
+				size->height = ClampU(this->presets.size(), 5, 20) * resize->height + 1;
 				break;
 			}
 		}
@@ -2101,7 +2101,7 @@ struct SavePresetWindow : public Window {
 				int offset_y = (step_height - FONT_HEIGHT_NORMAL) / 2;
 				uint y = r.top + WD_FRAMERECT_TOP;
 				uint min_index = this->vscroll->GetPosition();
-				uint max_index = min(min_index + this->vscroll->GetCapacity(), this->presets.Length());
+				uint max_index = min(min_index + this->vscroll->GetCapacity(), this->presets.size());
 
 				for (uint i = min_index; i < max_index; i++) {
 					if ((int)i == this->selected) GfxFillRect(r.left + 1, y, r.right - 1, y + step_height - 2, PC_DARK_BLUE);
@@ -2120,7 +2120,7 @@ struct SavePresetWindow : public Window {
 		switch (widget) {
 			case WID_SVP_PRESET_LIST: {
 				uint row = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_SVP_PRESET_LIST);
-				if (row < this->presets.Length()) {
+				if (row < this->presets.size()) {
 					this->selected = row;
 					this->presetname_editbox.text.Assign(this->presets[row]);
 					this->SetWidgetDirty(WID_SVP_PRESET_LIST);

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -139,7 +139,7 @@ SpriteID GetCustomSignalSprite(const RailtypeInfo *rti, TileIndex tile, SignalTy
 uint8 GetReverseRailTypeTranslation(RailType railtype, const GRFFile *grffile)
 {
 	/* No rail type table present, return rail type as-is */
-	if (grffile == NULL || grffile->railtype_list.Length() == 0) return railtype;
+	if (grffile == NULL || grffile->railtype_list.size() == 0) return railtype;
 
 	/* Look for a matching rail type label in the table */
 	RailTypeLabel label = GetRailTypeInfo(railtype)->label;

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -143,8 +143,9 @@ uint8 GetReverseRailTypeTranslation(RailType railtype, const GRFFile *grffile)
 
 	/* Look for a matching rail type label in the table */
 	RailTypeLabel label = GetRailTypeInfo(railtype)->label;
-	int index = grffile->railtype_list.FindIndex(label);
-	if (index >= 0) return index;
+
+	int idx = find_index(grffile->railtype_list, label);
+	if (idx >= 0) return idx;
 
 	/* If not found, return as invalid */
 	return 0xFF;

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -40,7 +40,7 @@ SoundEntry *AllocateSound(uint num)
 
 void InitializeSoundPool()
 {
-	_sounds.Clear();
+	_sounds.clear();
 
 	/* Copy original sound data to the pool */
 	SndCopyToPool();

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -49,14 +49,14 @@ void InitializeSoundPool()
 
 SoundEntry *GetSound(SoundID index)
 {
-	if (index >= _sounds.Length()) return NULL;
+	if (index >= _sounds.size()) return NULL;
 	return &_sounds[index];
 }
 
 
 uint GetNumSounds()
 {
-	return _sounds.Length();
+	return _sounds.size();
 }
 
 

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -32,7 +32,7 @@ static SmallVector<SoundEntry, 8> _sounds;
  */
 SoundEntry *AllocateSound(uint num)
 {
-	SoundEntry *sound = _sounds.Append(num);
+	SoundEntry *sound = grow(_sounds, num);
 	MemSetT(sound, 0, num);
 	return sound;
 }

--- a/src/newgrf_sound.cpp
+++ b/src/newgrf_sound.cpp
@@ -22,7 +22,7 @@
 
 #include "safeguards.h"
 
-static SmallVector<SoundEntry, 8> _sounds;
+static std::vector<SoundEntry> _sounds;
 
 
 /**

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -168,8 +168,8 @@ static byte _currentLangID = GRFLX_ENGLISH;  ///< by default, english is used.
 int LanguageMap::GetMapping(int newgrf_id, bool gender) const
 {
 	const SmallVector<Mapping, 1> &map = gender ? this->gender_map : this->case_map;
-	for (const Mapping *m = map.Begin(); m != map.End(); m++) {
-		if (m->newgrf_id == newgrf_id) return m->openttd_id;
+	for (const Mapping &m : map) {
+		if (m.newgrf_id == newgrf_id) return m.openttd_id;
 	}
 	return -1;
 }
@@ -183,8 +183,8 @@ int LanguageMap::GetMapping(int newgrf_id, bool gender) const
 int LanguageMap::GetReverseMapping(int openttd_id, bool gender) const
 {
 	const SmallVector<Mapping, 1> &map = gender ? this->gender_map : this->case_map;
-	for (const Mapping *m = map.Begin(); m != map.End(); m++) {
-		if (m->openttd_id == openttd_id) return m->newgrf_id;
+	for (const Mapping &m : map) {
+		if (m.openttd_id == openttd_id) return m.newgrf_id;
 	}
 	return -1;
 }
@@ -194,8 +194,8 @@ struct UnmappedChoiceList : ZeroedMemoryAllocator {
 	/** Clean everything up. */
 	~UnmappedChoiceList()
 	{
-		for (SmallPair<byte, char *> *p = this->strings.Begin(); p < this->strings.End(); p++) {
-			free(p->second);
+		for (SmallPair<byte, char *> p : this->strings) {
+			free(p.second);
 		}
 	}
 

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -167,7 +167,7 @@ static byte _currentLangID = GRFLX_ENGLISH;  ///< by default, english is used.
  */
 int LanguageMap::GetMapping(int newgrf_id, bool gender) const
 {
-	const SmallVector<Mapping, 1> &map = gender ? this->gender_map : this->case_map;
+	const std::vector<Mapping> &map = gender ? this->gender_map : this->case_map;
 	for (const Mapping &m : map) {
 		if (m.newgrf_id == newgrf_id) return m.openttd_id;
 	}
@@ -182,7 +182,7 @@ int LanguageMap::GetMapping(int newgrf_id, bool gender) const
  */
 int LanguageMap::GetReverseMapping(int openttd_id, bool gender) const
 {
-	const SmallVector<Mapping, 1> &map = gender ? this->gender_map : this->case_map;
+	const std::vector<Mapping> &map = gender ? this->gender_map : this->case_map;
 	for (const Mapping &m : map) {
 		if (m.openttd_id == openttd_id) return m.newgrf_id;
 	}

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -57,8 +57,8 @@ struct LanguageMap {
 	 * the genders/cases/plural OpenTTD IDs to the NewGRF's internal IDs. In this
 	 * case a NewGRF developer/translator might want a different translation for
 	 * both cases. Thus we are basically implementing a multi-map. */
-	SmallVector<Mapping, 1> gender_map; ///< Mapping of NewGRF and OpenTTD IDs for genders.
-	SmallVector<Mapping, 1> case_map;   ///< Mapping of NewGRF and OpenTTD IDs for cases.
+	std::vector<Mapping> gender_map; ///< Mapping of NewGRF and OpenTTD IDs for genders.
+	std::vector<Mapping> case_map;   ///< Mapping of NewGRF and OpenTTD IDs for cases.
 	int plural_form;                    ///< The plural form used for this language.
 
 	int GetMapping(int newgrf_id, bool gender) const;

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -59,7 +59,7 @@ struct LanguageMap {
 	 * both cases. Thus we are basically implementing a multi-map. */
 	std::vector<Mapping> gender_map; ///< Mapping of NewGRF and OpenTTD IDs for genders.
 	std::vector<Mapping> case_map;   ///< Mapping of NewGRF and OpenTTD IDs for cases.
-	int plural_form;                    ///< The plural form used for this language.
+	int plural_form;                 ///< The plural form used for this language.
 
 	int GetMapping(int newgrf_id, bool gender) const;
 	int GetReverseMapping(int openttd_id, bool gender) const;

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -92,6 +92,6 @@ struct ClearedObjectArea {
 };
 
 ClearedObjectArea *FindClearedObject(TileIndex tile);
-extern SmallVector<ClearedObjectArea, 4> _cleared_object_areas;
+extern std::vector<ClearedObjectArea> _cleared_object_areas;
 
 #endif /* OBJECT_BASE_H */

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -442,7 +442,7 @@ static void ReallyClearObjectTile(Object *o)
 	delete o;
 }
 
-SmallVector<ClearedObjectArea, 4> _cleared_object_areas;
+std::vector<ClearedObjectArea> _cleared_object_areas;
 
 /**
  * Find the entry in _cleared_object_areas which occupies a certain tile.

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -453,9 +453,8 @@ ClearedObjectArea *FindClearedObject(TileIndex tile)
 {
 	TileArea ta = TileArea(tile, 1, 1);
 
-	const ClearedObjectArea *end = _cleared_object_areas.End();
-	for (ClearedObjectArea *coa = _cleared_object_areas.Begin(); coa != end; coa++) {
-		if (coa->area.Intersects(ta)) return coa;
+	for (ClearedObjectArea &coa : _cleared_object_areas) {
+		if (coa.area.Intersects(ta)) return &coa;
 	}
 
 	return NULL;

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -530,9 +530,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags)
 			break;
 	}
 
-	ClearedObjectArea *cleared_area = _cleared_object_areas.Append();
-	cleared_area->first_tile = tile;
-	cleared_area->area = ta;
+	_cleared_object_areas.push_back({tile, ta});
 
 	if (flags & DC_EXEC) ReallyClearObjectTile(o);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1186,7 +1186,7 @@ static void CheckCaches()
 
 	uint i = 0;
 	FOR_ALL_TOWNS(t) {
-		if (MemCmpT(old_town_caches.Get(i), &t->cache) != 0) {
+		if (MemCmpT(old_town_caches.data() + i, &t->cache) != 0) {
 			DEBUG(desync, 2, "town cache mismatch: town %i", (int)t->index);
 		}
 		i++;
@@ -1202,7 +1202,7 @@ static void CheckCaches()
 
 	i = 0;
 	FOR_ALL_COMPANIES(c) {
-		if (MemCmpT(old_infrastructure.Get(i), &c->infrastructure) != 0) {
+		if (MemCmpT(old_infrastructure.data() + i, &c->infrastructure) != 0) {
 			DEBUG(desync, 2, "infrastructure cache mismatch: company %i", (int)c->index);
 		}
 		i++;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1174,7 +1174,7 @@ static void CheckCaches()
 	if (_debug_desync_level <= 1) return;
 
 	/* Check the town caches. */
-	SmallVector<TownCache, 4> old_town_caches;
+	std::vector<TownCache> old_town_caches;
 	Town *t;
 	FOR_ALL_TOWNS(t) {
 		old_town_caches.push_back(t->cache);
@@ -1193,7 +1193,7 @@ static void CheckCaches()
 	}
 
 	/* Check company infrastructure cache. */
-	SmallVector<CompanyInfrastructure, 4> old_infrastructure;
+	std::vector<CompanyInfrastructure> old_infrastructure;
 	Company *c;
 	FOR_ALL_COMPANIES(c) old_infrastructure.push_back(c->infrastructure);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -445,7 +445,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 
 		if (dedicated_host != NULL) {
 			_network_bind_list.Clear();
-			*_network_bind_list.Append() = stredup(dedicated_host);
+			_network_bind_list.push_back(stredup(dedicated_host));
 		}
 		if (dedicated_port != 0) _settings_client.network.server_port = dedicated_port;
 
@@ -1177,7 +1177,7 @@ static void CheckCaches()
 	SmallVector<TownCache, 4> old_town_caches;
 	Town *t;
 	FOR_ALL_TOWNS(t) {
-		MemCpyT(old_town_caches.Append(), &t->cache);
+		old_town_caches.push_back(t->cache);
 	}
 
 	extern void RebuildTownCaches();
@@ -1195,7 +1195,7 @@ static void CheckCaches()
 	/* Check company infrastructure cache. */
 	SmallVector<CompanyInfrastructure, 4> old_infrastructure;
 	Company *c;
-	FOR_ALL_COMPANIES(c) MemCpyT(old_infrastructure.Append(), &c->infrastructure);
+	FOR_ALL_COMPANIES(c) old_infrastructure.push_back(c->infrastructure);
 
 	extern void AfterLoadCompanyStats();
 	AfterLoadCompanyStats();

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1297,7 +1297,7 @@ public:
 			case WID_O_COND_VARIABLE: {
 				DropDownList *list = new DropDownList();
 				for (uint i = 0; i < lengthof(_order_conditional_variable); i++) {
-					*list->Append() = new DropDownListStringItem(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + _order_conditional_variable[i], _order_conditional_variable[i], false);
+					list->push_back(new DropDownListStringItem(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + _order_conditional_variable[i], _order_conditional_variable[i], false));
 				}
 				ShowDropDownList(this, list, this->vehicle->GetOrder(this->OrderGetSel())->GetConditionVariable(), WID_O_COND_VARIABLE);
 				break;

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -85,7 +85,7 @@ public:
 
 		virtual int GetLeading() const;
 		virtual int GetWidth() const;
-		virtual int CountRuns() const { return this->Length();  }
+		virtual int CountRuns() const { return this->size();  }
 		virtual const VisualRun *GetVisualRun(int run) const { return *this->Get(run);  }
 
 		int GetInternalCharLength(WChar c) const
@@ -256,7 +256,7 @@ int CoreTextParagraphLayout::CoreTextLine::GetLeading() const
  */
 int CoreTextParagraphLayout::CoreTextLine::GetWidth() const
 {
-	if (this->Length() == 0) return 0;
+	if (this->size() == 0) return 0;
 
 	int total_width = 0;
 	for (const CoreTextVisualRun * const *run = this->Begin(); run != this->End(); run++) {

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -78,7 +78,7 @@ public:
 				FontMap::const_iterator map = fontMapping.Begin();
 				while (map < fontMapping.End() - 1 && map->first <= chars.location) map++;
 
-				*this->Append() = new CoreTextVisualRun(run, map->second, buff);
+				this->push_back(new CoreTextVisualRun(run, map->second, buff));
 			}
 			CFRelease(line);
 		}

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -65,7 +65,7 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class CoreTextLine : public AutoDeleteSmallVector<CoreTextVisualRun *, 4>, public ParagraphLayouter::Line {
+	class CoreTextLine : public AutoDeleteSmallVector<CoreTextVisualRun *>, public ParagraphLayouter::Line {
 	public:
 		CoreTextLine(CTLineRef line, const FontMap &fontMapping, const CoreTextParagraphLayoutFactory::CharType *buff)
 		{

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -86,7 +86,7 @@ public:
 		virtual int GetLeading() const;
 		virtual int GetWidth() const;
 		virtual int CountRuns() const { return this->size();  }
-		virtual const VisualRun *GetVisualRun(int run) const { return *this->Get(run);  }
+		virtual const VisualRun *GetVisualRun(int run) const { return this->at(run);  }
 
 		int GetInternalCharLength(WChar c) const
 		{

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -424,7 +424,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 			if (!UniscribeShapeRun(this->text_buffer, run)) return NULL;
 		}
 
-		*line->Append() = new UniscribeVisualRun(run, cur_pos);
+		line->push_back(new UniscribeVisualRun(run, cur_pos));
 		cur_pos += run.total_advance;
 	}
 

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -106,7 +106,7 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class UniscribeLine : public AutoDeleteSmallVector<UniscribeVisualRun *, 4>, public ParagraphLayouter::Line {
+	class UniscribeLine : public AutoDeleteSmallVector<UniscribeVisualRun *>, public ParagraphLayouter::Line {
 	public:
 		virtual int GetLeading() const;
 		virtual int GetWidth() const;

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -111,7 +111,7 @@ public:
 		virtual int GetLeading() const;
 		virtual int GetWidth() const;
 		virtual int CountRuns() const { return this->size();  }
-		virtual const VisualRun *GetVisualRun(int run) const { return *this->Get(run);  }
+		virtual const VisualRun *GetVisualRun(int run) const { return this->at(run);  }
 
 		int GetInternalCharLength(WChar c) const
 		{

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -282,8 +282,8 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	if (length == 0) return NULL;
 
 	/* Can't layout our in-built sprite fonts. */
-	for (FontMap::const_iterator i = fontMapping.Begin(); i != fontMapping.End(); i++) {
-		if (i->second->fc->IsBuiltInFont()) return NULL;
+	for (auto const &pair : fontMapping) {
+		if (pair.second->fc->IsBuiltInFont()) return NULL;
 	}
 
 	/* Itemize text. */
@@ -296,12 +296,12 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 
 	int cur_pos = 0;
 	std::vector<SCRIPT_ITEM>::iterator cur_item = items.begin();
-	for (FontMap::const_iterator i = fontMapping.Begin(); i != fontMapping.End(); i++) {
-		while (cur_pos < i->first && cur_item != items.end() - 1) {
+	for (auto const &i : fontMapping) {
+		while (cur_pos < i.first && cur_item != items.end() - 1) {
 			/* Add a range that spans the intersection of the remaining item and font run. */
-			int stop_pos = min(i->first, (cur_item + 1)->iCharPos);
+			int stop_pos = min(i.first, (cur_item + 1)->iCharPos);
 			assert(stop_pos - cur_pos > 0);
-			ranges.push_back(UniscribeRun(cur_pos, stop_pos - cur_pos, i->second, cur_item->a));
+			ranges.push_back(UniscribeRun(cur_pos, stop_pos - cur_pos, i.second, cur_item->a));
 
 			/* Shape the range. */
 			if (!UniscribeShapeRun(buff, ranges.back())) {
@@ -448,8 +448,8 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 int UniscribeParagraphLayout::UniscribeLine::GetLeading() const
 {
 	int leading = 0;
-	for (const UniscribeVisualRun * const *run = this->Begin(); run != this->End(); run++) {
-		leading = max(leading, (*run)->GetLeading());
+	for (const UniscribeVisualRun *run : *this) {
+		leading = max(leading, run->GetLeading());
 	}
 
 	return leading;
@@ -462,8 +462,8 @@ int UniscribeParagraphLayout::UniscribeLine::GetLeading() const
 int UniscribeParagraphLayout::UniscribeLine::GetWidth() const
 {
 	int length = 0;
-	for (const UniscribeVisualRun * const *run = this->Begin(); run != this->End(); run++) {
-		length += (*run)->GetAdvance();
+	for (const UniscribeVisualRun *run : *this) {
+		length += run->GetAdvance();
 	}
 
 	return length;

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -110,7 +110,7 @@ public:
 	public:
 		virtual int GetLeading() const;
 		virtual int GetWidth() const;
-		virtual int CountRuns() const { return this->Length();  }
+		virtual int CountRuns() const { return this->size();  }
 		virtual const VisualRun *GetVisualRun(int run) const { return *this->Get(run);  }
 
 		int GetInternalCharLength(WChar c) const

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -304,7 +304,7 @@ RailType GetRailTypeByLabel(RailTypeLabel label, bool allow_alternate_labels)
 		/* Test if any rail type defines the label as an alternate. */
 		for (RailType r = RAILTYPE_BEGIN; r != RAILTYPE_END; r++) {
 			const RailtypeInfo *rti = GetRailTypeInfo(r);
-			if (rti->alternate_labels.Contains(label)) return r;
+			if (std::find(rti->alternate_labels.begin(), rti->alternate_labels.end(), label) != rti->alternate_labels.end()) return r;
 		}
 	}
 

--- a/src/rail.h
+++ b/src/rail.h
@@ -118,7 +118,7 @@ enum RailFenceOffset {
 };
 
 /** List of rail type labels. */
-typedef SmallVector<RailTypeLabel, 4> RailTypeLabelList;
+typedef std::vector<RailTypeLabel> RailTypeLabelList;
 
 /**
  * This struct contains all the info that is needed to draw and construct tracks.

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1747,7 +1747,7 @@ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 				break;
 		}
 
-		for (uint i = 0; i < vehicles_affected.Length(); ++i) {
+		for (uint i = 0; i < vehicles_affected.size(); ++i) {
 			TryPathReserve(vehicles_affected[i], true);
 		}
 	}

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -41,7 +41,7 @@
 #include "safeguards.h"
 
 /** Helper type for lists/vectors of trains */
-typedef SmallVector<Train *, 16> TrainList;
+typedef std::vector<Train *> TrainList;
 
 RailtypeInfo _railtypes[RAILTYPE_END];
 RailType _sorted_railtypes[RAILTYPE_END];
@@ -1603,7 +1603,7 @@ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 			continue;
 		}
 
-		SmallVector<Train *, 2> vehicles_affected;
+		std::vector<Train *> vehicles_affected;
 
 		/* Vehicle on the tile when not converting Rail <-> ElRail
 		 * Tunnels and bridges have special check later */

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -167,7 +167,7 @@ RailType AllocateRailType(RailTypeLabel label)
 			/* Set up new rail type */
 			*rti = _original_railtypes[RAILTYPE_RAIL];
 			rti->label = label;
-			rti->alternate_labels.Clear();
+			rti->alternate_labels.clear();
 
 			/* Make us compatible with ourself. */
 			rti->powered_railtypes    = (RailTypes)(1LL << rt);

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1754,8 +1754,8 @@ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 	if (flags & DC_EXEC) {
 		/* Railtype changed, update trains as when entering different track */
-		for (Train **v = affected_trains.Begin(); v != affected_trains.End(); v++) {
-			(*v)->ConsistChanged(CCF_TRACK);
+		for (Train *v : affected_trains) {
+			v->ConsistChanged(CCF_TRACK);
 		}
 	}
 

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1623,7 +1623,7 @@ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 					if (v != NULL && !HasPowerOnRail(v->railtype, totype)) {
 						/* No power on new rail type, reroute. */
 						FreeTrainTrackReservation(v);
-						*vehicles_affected.Append() = v;
+						vehicles_affected.push_back(v);
 					}
 				}
 
@@ -1705,7 +1705,7 @@ CommandCost CmdConvertRail(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 						if (v != NULL && !HasPowerOnRail(v->railtype, totype)) {
 							/* No power on new rail type, reroute. */
 							FreeTrainTrackReservation(v);
-							*vehicles_affected.Append() = v;
+							vehicles_affected.push_back(v);
 						}
 					}
 

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1534,7 +1534,7 @@ static Vehicle *UpdateTrainPowerProc(Vehicle *v, void *data)
 	if (v->type != VEH_TRAIN) return NULL;
 
 	TrainList *affected_trains = static_cast<TrainList*>(data);
-	affected_trains->Include(Train::From(v)->First());
+	include(*affected_trains, Train::From(v)->First());
 
 	return NULL;
 }

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2007,7 +2007,7 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 
 	if (all_option) {
 		DropDownListStringItem *item = new DropDownListStringItem(STR_REPLACE_ALL_RAILTYPE, INVALID_RAILTYPE, false);
-		*list->Append() = item;
+		list->push_back(item);
 	}
 
 	Dimension d = { 0, 0 };
@@ -2038,7 +2038,7 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		}
 		item->SetParam(0, rti->strings.menu_text);
 		item->SetParam(1, rti->max_speed);
-		*list->Append() = item;
+		list->push_back(item);
 	}
 	return list;
 }

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2942,7 +2942,7 @@ bool AfterLoadGame()
 		SmallVector<uint, 16> skip_frames;
 		FOR_ALL_ROADVEHICLES(v) {
 			if (!v->IsFrontEngine()) continue;
-			skip_frames.Clear();
+			skip_frames.clear();
 			TileIndex prev_tile = v->tile;
 			uint prev_tile_skip = 0;
 			uint cur_skip = 0;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2197,12 +2197,12 @@ bool AfterLoadGame()
 
 		extern SmallVector<TileIndex, 256> _animated_tiles;
 
-		for (TileIndex *tile = _animated_tiles.Begin(); tile < _animated_tiles.End(); /* Nothing */) {
+		for (auto tile = _animated_tiles.begin(); tile < _animated_tiles.end(); /* Nothing */) {
 			/* Remove if tile is not animated */
 			bool remove = _tile_type_procs[GetTileType(*tile)]->animate_tile_proc == NULL;
 
 			/* and remove if duplicate */
-			for (TileIndex *j = _animated_tiles.Begin(); !remove && j < tile; j++) {
+			for (auto j = _animated_tiles.begin(); !remove && j < tile; j++) {
 				remove = *tile == *j;
 			}
 
@@ -2981,9 +2981,12 @@ bool AfterLoadGame()
 			while (cur_skip > skip_frames[0]) {
 				RoadVehicle *u = v;
 				RoadVehicle *prev = NULL;
-				for (uint *it = skip_frames.Begin(); it != skip_frames.End(); ++it, prev = u, u = u->Next()) {
+				for (uint sf : skip_frames) {
 					extern bool IndividualRoadVehicleController(RoadVehicle *v, const RoadVehicle *prev);
-					if (*it >= cur_skip) IndividualRoadVehicleController(u, prev);
+					if (sf >= cur_skip) IndividualRoadVehicleController(u, prev);
+
+					prev = u;
+					u = u->Next();
 				}
 				cur_skip--;
 			}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2954,24 +2954,24 @@ bool AfterLoadGame()
 					cur_skip = prev_tile_skip;
 				}
 
-				uint *this_skip = skip_frames.Append();
-				*this_skip = prev_tile_skip;
+				/*C++17: uint &this_skip = */ skip_frames.push_back(prev_tile_skip);
+				uint &this_skip = skip_frames.back();
 
 				/* The following 3 curves now take longer than before */
 				switch (u->state) {
 					case 2:
 						cur_skip++;
-						if (u->frame <= (roadside ? 9 : 5)) *this_skip = cur_skip;
+						if (u->frame <= (roadside ? 9 : 5)) this_skip = cur_skip;
 						break;
 
 					case 4:
 						cur_skip++;
-						if (u->frame <= (roadside ? 5 : 9)) *this_skip = cur_skip;
+						if (u->frame <= (roadside ? 5 : 9)) this_skip = cur_skip;
 						break;
 
 					case 5:
 						cur_skip++;
-						if (u->frame <= (roadside ? 4 : 2)) *this_skip = cur_skip;
+						if (u->frame <= (roadside ? 4 : 2)) this_skip = cur_skip;
 						break;
 
 					default:

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2195,7 +2195,7 @@ bool AfterLoadGame()
 		/* Animated tiles would sometimes not be actually animated or
 		 * in case of old savegames duplicate. */
 
-		extern SmallVector<TileIndex, 256> _animated_tiles;
+		extern std::vector<TileIndex> _animated_tiles;
 
 		for (auto tile = _animated_tiles.begin(); tile < _animated_tiles.end(); /* Nothing */) {
 			/* Remove if tile is not animated */
@@ -2939,7 +2939,7 @@ bool AfterLoadGame()
 		 * So, make articulated parts catch up. */
 		RoadVehicle *v;
 		bool roadside = _settings_game.vehicle.road_side == 1;
-		SmallVector<uint, 16> skip_frames;
+		std::vector<uint> skip_frames;
 		FOR_ALL_ROADVEHICLES(v) {
 			if (!v->IsFrontEngine()) continue;
 			skip_frames.clear();

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -18,7 +18,7 @@
 
 #include "../safeguards.h"
 
-extern SmallVector<TileIndex, 256> _animated_tiles;
+extern std::vector<TileIndex> _animated_tiles;
 
 /**
  * Save the ANIT chunk.

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -25,8 +25,8 @@ extern SmallVector<TileIndex, 256> _animated_tiles;
  */
 static void Save_ANIT()
 {
-	SlSetLength(_animated_tiles.Length() * sizeof(*_animated_tiles.Begin()));
-	SlArray(_animated_tiles.Begin(), _animated_tiles.Length(), SLE_UINT32);
+	SlSetLength(_animated_tiles.size() * sizeof(*_animated_tiles.Begin()));
+	SlArray(_animated_tiles.Begin(), _animated_tiles.size(), SLE_UINT32);
 }
 
 /**

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -48,7 +48,7 @@ static void Load_ANIT()
 	}
 
 	uint count = (uint)SlGetFieldLength() / sizeof(*_animated_tiles.Begin());
-	_animated_tiles.Clear();
+	_animated_tiles.clear();
 	_animated_tiles.Append(count);
 	SlArray(_animated_tiles.Begin(), count, SLE_UINT32);
 }

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -25,8 +25,8 @@ extern SmallVector<TileIndex, 256> _animated_tiles;
  */
 static void Save_ANIT()
 {
-	SlSetLength(_animated_tiles.size() * sizeof(*_animated_tiles.Begin()));
-	SlArray(_animated_tiles.Begin(), _animated_tiles.size(), SLE_UINT32);
+	SlSetLength(_animated_tiles.size() * sizeof(_animated_tiles.front()));
+	SlArray(_animated_tiles.data(), _animated_tiles.size(), SLE_UINT32);
 }
 
 /**
@@ -47,10 +47,10 @@ static void Load_ANIT()
 		return;
 	}
 
-	uint count = (uint)SlGetFieldLength() / sizeof(*_animated_tiles.Begin());
+	uint count = (uint)SlGetFieldLength() / sizeof(_animated_tiles.front());
 	_animated_tiles.clear();
 	_animated_tiles.resize(_animated_tiles.size() + count);
-	SlArray(_animated_tiles.Begin(), count, SLE_UINT32);
+	SlArray(_animated_tiles.data(), count, SLE_UINT32);
 }
 
 /**

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -42,14 +42,14 @@ static void Load_ANIT()
 
 		for (int i = 0; i < 256; i++) {
 			if (anim_list[i] == 0) break;
-			*_animated_tiles.Append() = anim_list[i];
+			_animated_tiles.push_back(anim_list[i]);
 		}
 		return;
 	}
 
 	uint count = (uint)SlGetFieldLength() / sizeof(*_animated_tiles.Begin());
 	_animated_tiles.clear();
-	_animated_tiles.Append(count);
+	_animated_tiles.resize(_animated_tiles.size() + count);
 	SlArray(_animated_tiles.Begin(), count, SLE_UINT32);
 }
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -187,7 +187,7 @@ static void Save_EIDS()
 
 static void Load_EIDS()
 {
-	_engine_mngr.Clear();
+	_engine_mngr.clear();
 
 	while (SlIterateArray() != -1) {
 		EngineIDMapping *eid = _engine_mngr.Append();

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -177,11 +177,11 @@ static const SaveLoad _engine_id_mapping_desc[] = {
 
 static void Save_EIDS()
 {
-	const EngineIDMapping *end = _engine_mngr.End();
 	uint index = 0;
-	for (EngineIDMapping *eid = _engine_mngr.Begin(); eid != end; eid++, index++) {
+	for (EngineIDMapping &eid : _engine_mngr) {
 		SlSetArrayIndex(index);
-		SlObject(eid, _engine_id_mapping_desc);
+		SlObject(&eid, _engine_id_mapping_desc);
+		index++;
 	}
 }
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -190,7 +190,8 @@ static void Load_EIDS()
 	_engine_mngr.clear();
 
 	while (SlIterateArray() != -1) {
-		EngineIDMapping *eid = _engine_mngr.Append();
+		/*C++17: EngineIDMapping *eid = &*/ _engine_mngr.emplace_back();
+		EngineIDMapping *eid = &_engine_mngr.back();
 		SlObject(eid, _engine_id_mapping_desc);
 	}
 }

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -153,10 +153,10 @@ static void Load_GSTR()
 		LanguageStrings *ls = new LanguageStrings(_game_saveload_string != NULL ? _game_saveload_string : "");
 		for (uint i = 0; i < _game_saveload_strings; i++) {
 			SlObject(NULL, _game_language_string);
-			*ls->lines.Append() = stredup(_game_saveload_string != NULL ? _game_saveload_string : "");
+			ls->lines.push_back(stredup(_game_saveload_string != NULL ? _game_saveload_string : ""));
 		}
 
-		*_current_data->raw_strings.Append() = ls;
+		_current_data->raw_strings.push_back(ls);
 	}
 
 	/* If there were no strings in the savegame, set GameStrings to NULL */

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -132,7 +132,7 @@ static const SaveLoad _game_language_string[] = {
 static void SaveReal_GSTR(LanguageStrings *ls)
 {
 	_game_saveload_string  = ls->language;
-	_game_saveload_strings = ls->lines.Length();
+	_game_saveload_strings = ls->lines.size();
 
 	SlObject(NULL, _game_language_header);
 	for (uint i = 0; i < _game_saveload_strings; i++) {
@@ -160,7 +160,7 @@ static void Load_GSTR()
 	}
 
 	/* If there were no strings in the savegame, set GameStrings to NULL */
-	if (_current_data->raw_strings.Length() == 0) {
+	if (_current_data->raw_strings.size() == 0) {
 		delete _current_data;
 		_current_data = NULL;
 		return;
@@ -174,7 +174,7 @@ static void Save_GSTR()
 {
 	if (_current_data == NULL) return;
 
-	for (uint i = 0; i < _current_data->raw_strings.Length(); i++) {
+	for (uint i = 0; i < _current_data->raw_strings.size(); i++) {
 		SlSetArrayIndex(i);
 		SlAutolength((AutolengthProc *)SaveReal_GSTR, _current_data->raw_strings[i]);
 	}

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -17,7 +17,7 @@
 
 #include "../safeguards.h"
 
-static SmallVector<RailTypeLabel, RAILTYPE_END> _railtype_list;
+static std::vector<RailTypeLabel> _railtype_list;
 
 /**
  * Test if any saved rail type labels are different to the currently loaded
@@ -42,7 +42,7 @@ static bool NeedRailTypeConversion()
 void AfterLoadLabelMaps()
 {
 	if (NeedRailTypeConversion()) {
-		SmallVector<RailType, RAILTYPE_END> railtype_conversion_map;
+		std::vector<RailType> railtype_conversion_map;
 
 		for (uint i = 0; i < _railtype_list.size(); i++) {
 			RailType r = GetRailTypeByLabel(_railtype_list[i]);

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -26,7 +26,7 @@ static SmallVector<RailTypeLabel, RAILTYPE_END> _railtype_list;
  */
 static bool NeedRailTypeConversion()
 {
-	for (uint i = 0; i < _railtype_list.Length(); i++) {
+	for (uint i = 0; i < _railtype_list.size(); i++) {
 		if ((RailType)i < RAILTYPE_END) {
 			const RailtypeInfo *rti = GetRailTypeInfo((RailType)i);
 			if (rti->label != _railtype_list[i]) return true;
@@ -44,7 +44,7 @@ void AfterLoadLabelMaps()
 	if (NeedRailTypeConversion()) {
 		SmallVector<RailType, RAILTYPE_END> railtype_conversion_map;
 
-		for (uint i = 0; i < _railtype_list.Length(); i++) {
+		for (uint i = 0; i < _railtype_list.size(); i++) {
 			RailType r = GetRailTypeByLabel(_railtype_list[i]);
 			if (r == INVALID_RAILTYPE) r = RAILTYPE_BEGIN;
 

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -81,7 +81,7 @@ void AfterLoadLabelMaps()
 		}
 	}
 
-	_railtype_list.Clear();
+	_railtype_list.clear();
 }
 
 /** Container for a label for SaveLoad system */
@@ -108,7 +108,7 @@ static void Save_RAIL()
 
 static void Load_RAIL()
 {
-	_railtype_list.Clear();
+	_railtype_list.clear();
 
 	LabelObject lo;
 

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -48,7 +48,7 @@ void AfterLoadLabelMaps()
 			RailType r = GetRailTypeByLabel(_railtype_list[i]);
 			if (r == INVALID_RAILTYPE) r = RAILTYPE_BEGIN;
 
-			*railtype_conversion_map.Append() = r;
+			railtype_conversion_map.push_back(r);
 		}
 
 		for (TileIndex t = 0; t < MapSize(); t++) {
@@ -114,7 +114,7 @@ static void Load_RAIL()
 
 	while (SlIterateArray() != -1) {
 		SlObject(&lo, _label_object_desc);
-		*_railtype_list.Append() = (RailTypeLabel)lo.label;
+		_railtype_list.push_back((RailTypeLabel)lo.label);
 	}
 }
 

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -55,7 +55,7 @@ const SaveLoad *GetLinkGraphJobDesc()
 	static const char *prefix = "linkgraph.";
 
 	/* Build the SaveLoad array on first call and don't touch it later on */
-	if (saveloads.Length() == 0) {
+	if (saveloads.size() == 0) {
 		size_t offset_gamesettings = cpp_offsetof(GameSettings, linkgraph);
 		size_t offset_component = cpp_offsetof(LinkGraphJob, settings);
 
@@ -83,7 +83,7 @@ const SaveLoad *GetLinkGraphJobDesc()
 		int i = 0;
 		do {
 			*(saveloads.Append()) = job_desc[i++];
-		} while (saveloads[saveloads.Length() - 1].cmd != SL_END);
+		} while (saveloads[saveloads.size() - 1].cmd != SL_END);
 	}
 
 	return &saveloads[0];

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -51,7 +51,7 @@ const SaveLoad *GetLinkGraphDesc()
  */
 const SaveLoad *GetLinkGraphJobDesc()
 {
-	static SmallVector<SaveLoad, 16> saveloads;
+	static std::vector<SaveLoad> saveloads;
 	static const char *prefix = "linkgraph.";
 
 	/* Build the SaveLoad array on first call and don't touch it later on */

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -69,7 +69,7 @@ const SaveLoad *GetLinkGraphJobDesc()
 				char *&address = reinterpret_cast<char *&>(sl.address);
 				address -= offset_gamesettings;
 				address += offset_component;
-				*(saveloads.Append()) = sl;
+				saveloads.push_back(sl);
 			}
 			desc = GetSettingDescription(++setting);
 		}
@@ -82,7 +82,7 @@ const SaveLoad *GetLinkGraphJobDesc()
 
 		int i = 0;
 		do {
-			*(saveloads.Append()) = job_desc[i++];
+			saveloads.push_back(job_desc[i++]);
 		} while (saveloads[saveloads.size() - 1].cmd != SL_END);
 	}
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -651,7 +651,7 @@ static bool LoadOldAnimTileList(LoadgameState *ls, int num)
 	/* The first zero in the loaded array indicates the end of the list. */
 	for (int i = 0; i < 256; i++) {
 		if (anim_list[i] == 0) break;
-		*_animated_tiles.Append() = anim_list[i];
+		_animated_tiles.push_back(anim_list[i]);
 	}
 
 	return true;

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -491,7 +491,7 @@ static inline uint RemapOrderIndex(uint x)
 	return _savegame_type == SGT_TTO ? (x - 0x1AC4) / 2 : (x - 0x1C18) / 2;
 }
 
-extern SmallVector<TileIndex, 256> _animated_tiles;
+extern std::vector<TileIndex> _animated_tiles;
 extern char *_old_name_array;
 
 static uint32 _old_town_index;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -175,7 +175,7 @@ struct MemoryDumper {
 	 */
 	size_t GetSize() const
 	{
-		return this->blocks.Length() * MEMORY_CHUNK_SIZE - (this->bufe - this->buf);
+		return this->blocks.size() * MEMORY_CHUNK_SIZE - (this->bufe - this->buf);
 	}
 };
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -125,9 +125,9 @@ struct ReadBuffer {
 
 /** Container for dumping the savegame (quickly) to memory. */
 struct MemoryDumper {
-	AutoFreeSmallVector<byte *, 16> blocks; ///< Buffer with blocks of allocated memory.
-	byte *buf;                              ///< Buffer we're going to write to.
-	byte *bufe;                             ///< End of the buffer we write to.
+	AutoFreeSmallVector<byte *> blocks; ///< Buffer with blocks of allocated memory.
+	byte *buf;                          ///< Buffer we're going to write to.
+	byte *bufe;                         ///< End of the buffer we write to.
 
 	/** Initialise our variables. */
 	MemoryDumper() : buf(NULL), bufe(NULL)

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -143,7 +143,7 @@ struct MemoryDumper {
 		/* Are we at the end of this chunk? */
 		if (this->buf == this->bufe) {
 			this->buf = CallocT<byte>(MEMORY_CHUNK_SIZE);
-			*this->blocks.Append() = this->buf;
+			this->blocks.push_back(this->buf);
 			this->bufe = this->buf + MEMORY_CHUNK_SIZE;
 		}
 

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -42,7 +42,7 @@ struct OldWaypoint {
 };
 
 /** Temporary array with old waypoints. */
-static SmallVector<OldWaypoint, 16> _old_waypoints;
+static std::vector<OldWaypoint> _old_waypoints;
 
 /**
  * Update the waypoint orders to get the new waypoint ID.

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -172,7 +172,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 static void Load_WAYP()
 {
 	/* Precaution for when loading failed and it didn't get cleared */
-	_old_waypoints.Clear();
+	_old_waypoints.clear();
 
 	int index;
 
@@ -201,7 +201,7 @@ static void Ptrs_WAYP()
 				 * whether we're in the NULL or "normal" Ptrs proc. So just clear the list
 				 * of old waypoints we constructed and then this waypoint (and the other
 				 * possibly corrupt ones) will not be queried in the NULL Ptrs proc run. */
-				_old_waypoints.Clear();
+				_old_waypoints.clear();
 				SlErrorCorrupt("Referencing invalid Town");
 			}
 			wp->town = Town::Get(wp->town_index);

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -52,10 +52,10 @@ static void UpdateWaypointOrder(Order *o)
 {
 	if (!o->IsType(OT_GOTO_WAYPOINT)) return;
 
-	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-		if (wp->index != o->GetDestination()) continue;
+	for (OldWaypoint &wp : _old_waypoints) {
+		if (wp.index != o->GetDestination()) continue;
 
-		o->SetDestination((DestinationID)wp->new_index);
+		o->SetDestination((DestinationID)wp.new_index);
 		return;
 	}
 }
@@ -71,25 +71,25 @@ void MoveWaypointsToBaseStations()
 	 * id which was stored in m4 is now saved as a grf/id reference in the
 	 * waypoint struct. */
 	if (IsSavegameVersionBefore(SLV_17)) {
-		for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-			if (wp->delete_ctr != 0) continue; // The waypoint was deleted
+		for (OldWaypoint &wp : _old_waypoints) {
+			if (wp.delete_ctr != 0) continue; // The waypoint was deleted
 
 			/* Waypoint indices were not added to the map prior to this. */
-			_m[wp->xy].m2 = (StationID)wp->index;
+			_m[wp.xy].m2 = (StationID)wp.index;
 
-			if (HasBit(_m[wp->xy].m3, 4)) {
-				wp->spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(_m[wp->xy].m4 + 1);
+			if (HasBit(_m[wp.xy].m3, 4)) {
+				wp.spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(_m[wp.xy].m4 + 1);
 			}
 		}
 	} else {
 		/* As of version 17, we recalculate the custom graphic ID of waypoints
 		 * from the GRF ID / station index. */
-		for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
+		for (OldWaypoint &wp : _old_waypoints) {
 			StationClass* stclass = StationClass::Get(STAT_CLASS_WAYP);
 			for (uint i = 0; i < stclass->GetSpecCount(); i++) {
 				const StationSpec *statspec = stclass->GetSpec(i);
-				if (statspec != NULL && statspec->grf_prop.grffile->grfid == wp->grfid && statspec->grf_prop.local_id == wp->localidx) {
-					wp->spec = statspec;
+				if (statspec != NULL && statspec->grf_prop.grffile->grfid == wp.grfid && statspec->grf_prop.local_id == wp.localidx) {
+					wp.spec = statspec;
 					break;
 				}
 			}
@@ -99,19 +99,19 @@ void MoveWaypointsToBaseStations()
 	if (!Waypoint::CanAllocateItem(_old_waypoints.size())) SlError(STR_ERROR_TOO_MANY_STATIONS_LOADING);
 
 	/* All saveload conversions have been done. Create the new waypoints! */
-	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-		Waypoint *new_wp = new Waypoint(wp->xy);
-		new_wp->town       = wp->town;
-		new_wp->town_cn    = wp->town_cn;
-		new_wp->name       = wp->name;
+	for (OldWaypoint &wp : _old_waypoints) {
+		Waypoint *new_wp = new Waypoint(wp.xy);
+		new_wp->town       = wp.town;
+		new_wp->town_cn    = wp.town_cn;
+		new_wp->name       = wp.name;
 		new_wp->delete_ctr = 0; // Just reset delete counter for once.
-		new_wp->build_date = wp->build_date;
-		new_wp->owner      = wp->owner;
+		new_wp->build_date = wp.build_date;
+		new_wp->owner      = wp.owner;
 
 		new_wp->string_id = STR_SV_STNAME_WAYPOINT;
 
-		TileIndex t = wp->xy;
-		if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && _m[t].m2 == wp->index) {
+		TileIndex t = wp.xy;
+		if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && _m[t].m2 == wp.index) {
 			/* The tile might've been reserved! */
 			bool reserved = !IsSavegameVersionBefore(SLV_100) && HasBit(_m[t].m5, 4);
 
@@ -122,13 +122,13 @@ void MoveWaypointsToBaseStations()
 
 			SetRailStationReservation(t, reserved);
 
-			if (wp->spec != NULL) {
-				SetCustomStationSpecIndex(t, AllocateSpecToStation(wp->spec, new_wp, true));
+			if (wp.spec != NULL) {
+				SetCustomStationSpecIndex(t, AllocateSpecToStation(wp.spec, new_wp, true));
 			}
 			new_wp->rect.BeforeAddTile(t, StationRect::ADD_FORCE);
 		}
 
-		wp->new_index = new_wp->index;
+		wp.new_index = new_wp->index;
 	}
 
 	/* Update the orders of vehicles */
@@ -189,15 +189,15 @@ static void Load_WAYP()
 
 static void Ptrs_WAYP()
 {
-	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {
-		SlObject(wp, _old_waypoint_desc);
+	for (OldWaypoint &wp : _old_waypoints) {
+		SlObject(&wp, _old_waypoint_desc);
 
 		if (IsSavegameVersionBefore(SLV_12)) {
-			wp->town_cn = (wp->string_id & 0xC000) == 0xC000 ? (wp->string_id >> 8) & 0x3F : 0;
-			wp->town = ClosestTownFromTile(wp->xy, UINT_MAX);
+			wp.town_cn = (wp.string_id & 0xC000) == 0xC000 ? (wp.string_id >> 8) & 0x3F : 0;
+			wp.town = ClosestTownFromTile(wp.xy, UINT_MAX);
 		} else if (IsSavegameVersionBefore(SLV_122)) {
 			/* Only for versions 12 .. 122 */
-			if (!Town::IsValidID(wp->town_index)) {
+			if (!Town::IsValidID(wp.town_index)) {
 				/* Upon a corrupted waypoint we'll likely get here. The next step will be to
 				 * loop over all Ptrs procs to NULL the pointers. However, we don't know
 				 * whether we're in the NULL or "normal" Ptrs proc. So just clear the list
@@ -206,10 +206,10 @@ static void Ptrs_WAYP()
 				_old_waypoints.clear();
 				SlErrorCorrupt("Referencing invalid Town");
 			}
-			wp->town = Town::Get(wp->town_index);
+			wp.town = Town::Get(wp.town_index);
 		}
 		if (IsSavegameVersionBefore(SLV_84)) {
-			wp->name = CopyFromOldName(wp->string_id);
+			wp.name = CopyFromOldName(wp.string_id);
 		}
 	}
 }

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -146,7 +146,8 @@ void MoveWaypointsToBaseStations()
 		UpdateWaypointOrder(&v->current_order);
 	}
 
-	_old_waypoints.Reset();
+	_old_waypoints.clear();
+	_old_waypoints.shrink_to_fit();
 }
 
 static const SaveLoad _old_waypoint_desc[] = {

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -96,7 +96,7 @@ void MoveWaypointsToBaseStations()
 		}
 	}
 
-	if (!Waypoint::CanAllocateItem(_old_waypoints.Length())) SlError(STR_ERROR_TOO_MANY_STATIONS_LOADING);
+	if (!Waypoint::CanAllocateItem(_old_waypoints.size())) SlError(STR_ERROR_TOO_MANY_STATIONS_LOADING);
 
 	/* All saveload conversions have been done. Create the new waypoints! */
 	for (OldWaypoint *wp = _old_waypoints.Begin(); wp != _old_waypoints.End(); wp++) {

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -178,7 +178,8 @@ static void Load_WAYP()
 	int index;
 
 	while ((index = SlIterateArray()) != -1) {
-		OldWaypoint *wp = _old_waypoints.Append();
+		/*C++17: OldWaypoint *wp = &*/ _old_waypoints.emplace_back();
+		OldWaypoint *wp = &_old_waypoints.back();
 		memset(wp, 0, sizeof(*wp));
 
 		wp->index = index;

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -26,8 +26,8 @@ ScriptInfo::~ScriptInfo()
 		free((*it).name);
 		free((*it).description);
 		if (it->labels != NULL) {
-			for (LabelMapping::iterator it2 = (*it).labels->Begin(); it2 != (*it).labels->End(); it2++) {
-				free(it2->second);
+			for (auto &lbl_map : *(*it).labels) {
+				free(lbl_map.second);
 			}
 			delete it->labels;
 		}

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -32,7 +32,7 @@ namespace SQConvert {
 	struct SQAutoFreePointers : std::vector<void *> {
 		~SQAutoFreePointers()
 		{
-			for (uint i = 0; i < std::vector<void *>::size(); i++) free(std::vector<void *>::operator[](i));
+			for (void * p : *this) free(p);
 		}
 	};
 

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -117,7 +117,7 @@ namespace SQConvert {
 		sq_getstring(vm, -1, &tmp);
 		char *tmp_str = stredup(tmp);
 		sq_poptop(vm);
-		*ptr->Append() = (void *)tmp_str;
+		ptr->push_back((void *)tmp_str);
 		str_validate(tmp_str, tmp_str + strlen(tmp_str));
 		return tmp_str;
 	}
@@ -137,7 +137,7 @@ namespace SQConvert {
 		while (SQ_SUCCEEDED(sq_next(vm, -2))) {
 			SQInteger tmp;
 			if (SQ_SUCCEEDED(sq_getinteger(vm, -1, &tmp))) {
-				*data.Append() = (int32)tmp;
+				data.push_back((int32)tmp);
 			} else {
 				sq_pop(vm, 4);
 				throw sq_throwerror(vm, "a member of an array used as parameter to a function is not numeric");
@@ -151,7 +151,7 @@ namespace SQConvert {
 		arr->size = data.size();
 		memcpy(arr->array, data.Begin(), sizeof(int32) * data.size());
 
-		*ptr->Append() = arr;
+		ptr->push_back(arr);
 		return arr;
 	}
 

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -149,7 +149,7 @@ namespace SQConvert {
 
 		Array *arr = (Array*)MallocT<byte>(sizeof(Array) + sizeof(int32) * data.size());
 		arr->size = data.size();
-		memcpy(arr->array, data.Begin(), sizeof(int32) * data.size());
+		memcpy(arr->array, data.data(), sizeof(int32) * data.size());
 
 		ptr->push_back(arr);
 		return arr;

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -29,7 +29,7 @@ namespace SQConvert {
 	 *  comes out of scope. Useful to make sure you can use stredup(),
 	 *  without leaking memory.
 	 */
-	struct SQAutoFreePointers : SmallVector<void *, 1> {
+	struct SQAutoFreePointers : std::vector<void *> {
 		~SQAutoFreePointers()
 		{
 			for (uint i = 0; i < std::vector<void *>::size(); i++) free(std::vector<void *>::operator[](i));
@@ -132,7 +132,7 @@ namespace SQConvert {
 		sq_pushobject(vm, obj);
 		sq_pushnull(vm);
 
-		SmallVector<int32, 2> data;
+		std::vector<int32> data;
 
 		while (SQ_SUCCEEDED(sq_next(vm, -2))) {
 			SQInteger tmp;

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -32,7 +32,7 @@ namespace SQConvert {
 	struct SQAutoFreePointers : SmallVector<void *, 1> {
 		~SQAutoFreePointers()
 		{
-			for (uint i = 0; i < this->items; i++) free(this->data[i]);
+			for (uint i = 0; i < std::vector<void *>::size(); i++) free(std::vector<void *>::operator[](i));
 		}
 	};
 

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -147,9 +147,9 @@ namespace SQConvert {
 		}
 		sq_pop(vm, 2);
 
-		Array *arr = (Array*)MallocT<byte>(sizeof(Array) + sizeof(int32) * data.Length());
-		arr->size = data.Length();
-		memcpy(arr->array, data.Begin(), sizeof(int32) * data.Length());
+		Array *arr = (Array*)MallocT<byte>(sizeof(Array) + sizeof(int32) * data.size());
+		arr->size = data.size();
+		memcpy(arr->array, data.Begin(), sizeof(int32) * data.size());
 
 		*ptr->Append() = arr;
 		return arr;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -747,8 +747,8 @@ static void IniSaveSettingList(IniFile *ini, const char *grpname, StringList *li
 	if (group == NULL || list == NULL) return;
 	group->Clear();
 
-	for (char **iter = list->Begin(); iter != list->End(); iter++) {
-		group->GetItem(*iter, true)->SetValue("");
+	for (char *iter : *list) {
+		group->GetItem(iter, true)->SetValue("");
 	}
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -727,7 +727,7 @@ static void IniLoadSettingList(IniFile *ini, const char *grpname, StringList *li
 	list->Clear();
 
 	for (const IniItem *item = group->item; item != NULL; item = item->next) {
-		if (item->name != NULL) *list->Append() = stredup(item->name);
+		if (item->name != NULL) list->push_back(stredup(item->name));
 	}
 }
 
@@ -1777,7 +1777,7 @@ void GetGRFPresetList(GRFPresetList *list)
 	IniGroup *group;
 	for (group = ini->group; group != NULL; group = group->next) {
 		if (strncmp(group->name, "preset-", 7) == 0) {
-			*list->Append() = stredup(group->name + 7);
+			list->push_back(stredup(group->name + 7));
 		}
 	}
 

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -30,7 +30,7 @@ void IniSaveWindowSettings(IniFile *ini, const char *grpname, void *desc);
 
 /* Functions to load and save NewGRF settings to a separate
  * configuration file, used for presets. */
-typedef AutoFreeSmallVector<char *, 4> GRFPresetList;
+typedef AutoFreeSmallVector<char *> GRFPresetList;
 
 void GetGRFPresetList(GRFPresetList *list);
 struct GRFConfig *LoadGRFPresetFromConfig(const char *config_name);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -215,7 +215,7 @@ struct GameOptionsWindow : Window {
 					if (i == CURRENCY_CUSTOM) continue;
 					list->push_back(new DropDownListStringItem(*items, i, HasBit(disabled, i)));
 				}
-				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
+				QSortT(list->data(), list->size(), DropDownListStringItem::NatSortFunc);
 
 				/* Append custom currency at the end */
 				list->push_back(new DropDownListItem(-1, false)); // separator line
@@ -253,7 +253,7 @@ struct GameOptionsWindow : Window {
 					int result = _nb_orig_names + i;
 					list->push_back(new DropDownListStringItem(_grf_names[i], result, enabled_item != result && enabled_item >= 0));
 				}
-				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
+				QSortT(list->data(), list->size(), DropDownListStringItem::NatSortFunc);
 
 				int newgrf_size = list->size();
 				/* Insert newgrf_names at the top of the list */
@@ -266,7 +266,7 @@ struct GameOptionsWindow : Window {
 				for (int i = 0; i < _nb_orig_names; i++) {
 					list->push_back(new DropDownListStringItem(STR_GAME_OPTIONS_TOWN_NAME_ORIGINAL_ENGLISH + i, i, enabled_item != i && enabled_item >= 0));
 				}
-				QSortT(list->Begin() + newgrf_size, list->size() - newgrf_size, DropDownListStringItem::NatSortFunc);
+				QSortT(list->data() + newgrf_size, list->size() - newgrf_size, DropDownListStringItem::NatSortFunc);
 				break;
 			}
 
@@ -286,7 +286,7 @@ struct GameOptionsWindow : Window {
 					if (&_languages[i] == _current_language) *selected_index = i;
 					list->push_back(new DropDownListStringItem(SPECSTR_LANGUAGE_START + i, i, false));
 				}
-				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
+				QSortT(list->data(), list->size(), DropDownListStringItem::NatSortFunc);
 				break;
 			}
 
@@ -432,11 +432,11 @@ struct GameOptionsWindow : Window {
 				DropDownList *list = this->BuildDropDownList(widget, &selected);
 				if (list != NULL) {
 					/* Find the biggest item for the default size. */
-					for (const DropDownListItem * const *it = list->Begin(); it != list->End(); it++) {
+					for (const DropDownListItem * const ddli : *list) {
 						Dimension string_dim;
-						int width = (*it)->Width();
+						int width = ddli->Width();
 						string_dim.width = width + padding.width;
-						string_dim.height = (*it)->Height(width) + padding.height;
+						string_dim.height = ddli->Height(width) + padding.height;
 						*size = maxdim(*size, string_dim);
 					}
 					delete list;

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -129,7 +129,7 @@ static DropDownList *BuildSetDropDownList(int *selected_index, bool allow_select
 
 	DropDownList *list = new DropDownList();
 	for (int i = 0; i < n; i++) {
-		*list->Append() = new DropDownListCharStringItem(T::GetSet(i)->name, i, !allow_selection && (*selected_index != i));
+		list->push_back(new DropDownListCharStringItem(T::GetSet(i)->name, i, !allow_selection && (*selected_index != i)));
 	}
 
 	return list;
@@ -213,13 +213,13 @@ struct GameOptionsWindow : Window {
 				/* Add non-custom currencies; sorted naturally */
 				for (uint i = 0; i < CURRENCY_END; items++, i++) {
 					if (i == CURRENCY_CUSTOM) continue;
-					*list->Append() = new DropDownListStringItem(*items, i, HasBit(disabled, i));
+					list->push_back(new DropDownListStringItem(*items, i, HasBit(disabled, i)));
 				}
 				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
 
 				/* Append custom currency at the end */
-				*list->Append() = new DropDownListItem(-1, false); // separator line
-				*list->Append() = new DropDownListStringItem(STR_GAME_OPTIONS_CURRENCY_CUSTOM, CURRENCY_CUSTOM, HasBit(disabled, CURRENCY_CUSTOM));
+				list->push_back(new DropDownListItem(-1, false)); // separator line
+				list->push_back(new DropDownListStringItem(STR_GAME_OPTIONS_CURRENCY_CUSTOM, CURRENCY_CUSTOM, HasBit(disabled, CURRENCY_CUSTOM)));
 				break;
 			}
 
@@ -237,7 +237,7 @@ struct GameOptionsWindow : Window {
 				}
 
 				for (uint i = 0; *items != INVALID_STRING_ID; items++, i++) {
-					*list->Append() = new DropDownListStringItem(*items, i, HasBit(disabled, i));
+					list->push_back(new DropDownListStringItem(*items, i, HasBit(disabled, i)));
 				}
 				break;
 			}
@@ -251,20 +251,20 @@ struct GameOptionsWindow : Window {
 				/* Add and sort newgrf townnames generators */
 				for (int i = 0; i < _nb_grf_names; i++) {
 					int result = _nb_orig_names + i;
-					*list->Append() = new DropDownListStringItem(_grf_names[i], result, enabled_item != result && enabled_item >= 0);
+					list->push_back(new DropDownListStringItem(_grf_names[i], result, enabled_item != result && enabled_item >= 0));
 				}
 				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
 
 				int newgrf_size = list->size();
 				/* Insert newgrf_names at the top of the list */
 				if (newgrf_size > 0) {
-					*list->Append() = new DropDownListItem(-1, false); // separator line
+					list->push_back(new DropDownListItem(-1, false)); // separator line
 					newgrf_size++;
 				}
 
 				/* Add and sort original townnames generators */
 				for (int i = 0; i < _nb_orig_names; i++) {
-					*list->Append() = new DropDownListStringItem(STR_GAME_OPTIONS_TOWN_NAME_ORIGINAL_ENGLISH + i, i, enabled_item != i && enabled_item >= 0);
+					list->push_back(new DropDownListStringItem(STR_GAME_OPTIONS_TOWN_NAME_ORIGINAL_ENGLISH + i, i, enabled_item != i && enabled_item >= 0));
 				}
 				QSortT(list->Begin() + newgrf_size, list->size() - newgrf_size, DropDownListStringItem::NatSortFunc);
 				break;
@@ -275,7 +275,7 @@ struct GameOptionsWindow : Window {
 				*selected_index = _settings_client.gui.autosave;
 				const StringID *items = _autosave_dropdown;
 				for (uint i = 0; *items != INVALID_STRING_ID; items++, i++) {
-					*list->Append() = new DropDownListStringItem(*items, i, false);
+					list->push_back(new DropDownListStringItem(*items, i, false));
 				}
 				break;
 			}
@@ -284,7 +284,7 @@ struct GameOptionsWindow : Window {
 				list = new DropDownList();
 				for (uint i = 0; i < _languages.size(); i++) {
 					if (&_languages[i] == _current_language) *selected_index = i;
-					*list->Append() = new DropDownListStringItem(SPECSTR_LANGUAGE_START + i, i, false);
+					list->push_back(new DropDownListStringItem(SPECSTR_LANGUAGE_START + i, i, false));
 				}
 				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
 				break;
@@ -296,7 +296,7 @@ struct GameOptionsWindow : Window {
 				list = new DropDownList();
 				*selected_index = GetCurRes();
 				for (int i = 0; i < _num_resolutions; i++) {
-					*list->Append() = new DropDownListStringItem(SPECSTR_RESOLUTION_START + i, i, false);
+					list->push_back(new DropDownListStringItem(SPECSTR_RESOLUTION_START + i, i, false));
 				}
 				break;
 
@@ -305,7 +305,7 @@ struct GameOptionsWindow : Window {
 				*selected_index = ZOOM_LVL_OUT_4X - _gui_zoom;
 				const StringID *items = _gui_zoom_dropdown;
 				for (int i = 0; *items != INVALID_STRING_ID; items++, i++) {
-					*list->Append() = new DropDownListStringItem(*items, i, _settings_client.gui.zoom_min > ZOOM_LVL_OUT_4X - i);
+					list->push_back(new DropDownListStringItem(*items, i, _settings_client.gui.zoom_min > ZOOM_LVL_OUT_4X - i));
 				}
 				break;
 			}
@@ -315,7 +315,7 @@ struct GameOptionsWindow : Window {
 				*selected_index = ZOOM_LVL_OUT_4X - _font_zoom;
 				const StringID *items = _font_zoom_dropdown;
 				for (int i = 0; *items != INVALID_STRING_ID; items++, i++) {
-					*list->Append() = new DropDownListStringItem(*items, i, false);
+					list->push_back(new DropDownListStringItem(*items, i, false));
 				}
 				break;
 			}
@@ -1964,16 +1964,16 @@ struct GameSettingsWindow : Window {
 					 * we don't want to allow comparing with new game's settings. */
 					bool disabled = mode == RM_CHANGED_AGAINST_NEW && settings_ptr == &_settings_newgame;
 
-					*list->Append() = new DropDownListStringItem(_game_settings_restrict_dropdown[mode], mode, disabled);
+					list->push_back(new DropDownListStringItem(_game_settings_restrict_dropdown[mode], mode, disabled));
 				}
 				break;
 
 			case WID_GS_TYPE_DROPDOWN:
 				list = new DropDownList();
-				*list->Append() = new DropDownListStringItem(STR_CONFIG_SETTING_TYPE_DROPDOWN_ALL, ST_ALL, false);
-				*list->Append() = new DropDownListStringItem(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_INGAME, ST_GAME, false);
-				*list->Append() = new DropDownListStringItem(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_INGAME, ST_COMPANY, false);
-				*list->Append() = new DropDownListStringItem(STR_CONFIG_SETTING_TYPE_DROPDOWN_CLIENT, ST_CLIENT, false);
+				list->push_back(new DropDownListStringItem(STR_CONFIG_SETTING_TYPE_DROPDOWN_ALL, ST_ALL, false));
+				list->push_back(new DropDownListStringItem(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_GAME_INGAME, ST_GAME, false));
+				list->push_back(new DropDownListStringItem(_game_mode == GM_MENU ? STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_MENU : STR_CONFIG_SETTING_TYPE_DROPDOWN_COMPANY_INGAME, ST_COMPANY, false));
+				list->push_back(new DropDownListStringItem(STR_CONFIG_SETTING_TYPE_DROPDOWN_CLIENT, ST_CLIENT, false));
 				break;
 		}
 		return list;
@@ -2130,7 +2130,7 @@ struct GameSettingsWindow : Window {
 
 					DropDownList *list = new DropDownList();
 					for (int i = sdb->min; i <= (int)sdb->max; i++) {
-						*list->Append() = new DropDownListStringItem(sdb->str_val + i - sdb->min, i, false);
+						list->push_back(new DropDownListStringItem(sdb->str_val + i - sdb->min, i, false));
 					}
 
 					ShowDropDownListAt(this, list, value, -1, wi_rect, COLOUR_ORANGE, true);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -215,7 +215,7 @@ struct GameOptionsWindow : Window {
 					if (i == CURRENCY_CUSTOM) continue;
 					*list->Append() = new DropDownListStringItem(*items, i, HasBit(disabled, i));
 				}
-				QSortT(list->Begin(), list->Length(), DropDownListStringItem::NatSortFunc);
+				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
 
 				/* Append custom currency at the end */
 				*list->Append() = new DropDownListItem(-1, false); // separator line
@@ -253,9 +253,9 @@ struct GameOptionsWindow : Window {
 					int result = _nb_orig_names + i;
 					*list->Append() = new DropDownListStringItem(_grf_names[i], result, enabled_item != result && enabled_item >= 0);
 				}
-				QSortT(list->Begin(), list->Length(), DropDownListStringItem::NatSortFunc);
+				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
 
-				int newgrf_size = list->Length();
+				int newgrf_size = list->size();
 				/* Insert newgrf_names at the top of the list */
 				if (newgrf_size > 0) {
 					*list->Append() = new DropDownListItem(-1, false); // separator line
@@ -266,7 +266,7 @@ struct GameOptionsWindow : Window {
 				for (int i = 0; i < _nb_orig_names; i++) {
 					*list->Append() = new DropDownListStringItem(STR_GAME_OPTIONS_TOWN_NAME_ORIGINAL_ENGLISH + i, i, enabled_item != i && enabled_item >= 0);
 				}
-				QSortT(list->Begin() + newgrf_size, list->Length() - newgrf_size, DropDownListStringItem::NatSortFunc);
+				QSortT(list->Begin() + newgrf_size, list->size() - newgrf_size, DropDownListStringItem::NatSortFunc);
 				break;
 			}
 
@@ -282,11 +282,11 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_LANG_DROPDOWN: { // Setup interface language dropdown
 				list = new DropDownList();
-				for (uint i = 0; i < _languages.Length(); i++) {
+				for (uint i = 0; i < _languages.size(); i++) {
 					if (&_languages[i] == _current_language) *selected_index = i;
 					*list->Append() = new DropDownListStringItem(SPECSTR_LANGUAGE_START + i, i, false);
 				}
-				QSortT(list->Begin(), list->Length(), DropDownListStringItem::NatSortFunc);
+				QSortT(list->Begin(), list->size(), DropDownListStringItem::NatSortFunc);
 				break;
 			}
 

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -116,7 +116,7 @@ public:
 		if (length == 0) length = strlen(text);
 
 		if (length > 0 && this->BufferHasRoom()) {
-			int stored_size = this->output_buffer[this->output_buffer.Length() - 1].Add(text, length);
+			int stored_size = this->output_buffer[this->output_buffer.size() - 1].Add(text, length);
 			length -= stored_size;
 			text += stored_size;
 		}
@@ -147,7 +147,7 @@ private:
 	 */
 	bool BufferHasRoom() const
 	{
-		uint num_blocks = this->output_buffer.Length();
+		uint num_blocks = this->output_buffer.size();
 		return num_blocks > 0 && this->output_buffer[num_blocks - 1].HasRoom();
 	}
 

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -136,8 +136,8 @@ public:
 	 */
 	void Write(FILE *out_fp) const
 	{
-		for (const OutputBuffer *out_data = this->output_buffer.Begin(); out_data != this->output_buffer.End(); out_data++) {
-			out_data->Write(out_fp);
+		for (const OutputBuffer &out_data : output_buffer) {
+			out_data.Write(out_fp);
 		}
 	}
 

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -103,7 +103,7 @@ public:
 	/** Clear the temporary storage. */
 	void Clear()
 	{
-		this->output_buffer.Clear();
+		this->output_buffer.clear();
 	}
 
 	/**

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -152,7 +152,7 @@ private:
 		return num_blocks > 0 && this->output_buffer[num_blocks - 1].HasRoom();
 	}
 
-	typedef SmallVector<OutputBuffer, 2> OutputBufferVector; ///< Vector type for output buffers.
+	typedef std::vector<OutputBuffer> OutputBufferVector; ///< Vector type for output buffers.
 	OutputBufferVector output_buffer; ///< Vector of blocks containing the stored output.
 };
 

--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -121,9 +121,10 @@ public:
 			text += stored_size;
 		}
 		while (length > 0) {
-			OutputBuffer *block = this->output_buffer.Append();
-			block->Clear(); // Initialize the new block.
-			int stored_size = block->Add(text, length);
+			/*C++17: OutputBuffer &block =*/ this->output_buffer.emplace_back();
+			OutputBuffer &block = this->output_buffer.back();
+			block.Clear(); // Initialize the new block.
+			int stored_size = block.Add(text, length);
 			length -= stored_size;
 			text += stored_size;
 		}

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -67,7 +67,7 @@ struct SignList {
 
 		this->signs.SetFilterState(true);
 		this->FilterSignList();
-		this->signs.Compact();
+		this->signs.shrink_to_fit();
 		this->signs.RebuildDone();
 	}
 

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -60,7 +60,7 @@ struct SignList {
 
 		DEBUG(misc, 3, "Building sign list");
 
-		this->signs.Clear();
+		this->signs.clear();
 
 		const Sign *si;
 		FOR_ALL_SIGNS(si) *this->signs.Append() = si;

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -246,7 +246,7 @@ struct SignListWindow : Window, SignList {
 			}
 
 			case WID_SIL_FILTER_ENTER_BTN:
-				if (this->signs.Length() >= 1) {
+				if (this->signs.size() >= 1) {
 					const Sign *si = this->signs[0];
 					ScrollMainWindowToTile(TileVirtXY(si->x, si->y));
 				}
@@ -310,7 +310,7 @@ struct SignListWindow : Window, SignList {
 	{
 		if (this->signs.NeedRebuild()) {
 			this->BuildSignsList();
-			this->vscroll->SetCount(this->signs.Length());
+			this->vscroll->SetCount(this->signs.size());
 			this->SetWidgetDirty(WID_SIL_CAPTION);
 		}
 		this->SortSignsList();
@@ -471,7 +471,7 @@ struct SignWindow : Window, SignList {
 		/* Search through the list for the current sign, excluding
 		 * - the first sign if we want the previous sign or
 		 * - the last sign if we want the next sign */
-		uint end = this->signs.Length() - (next ? 1 : 0);
+		uint end = this->signs.size() - (next ? 1 : 0);
 		for (uint i = next ? 0 : 1; i < end; i++) {
 			if (this->cur_sign == this->signs[i]->index) {
 				/* We've found the current sign, so return the sign before/after it */
@@ -479,7 +479,7 @@ struct SignWindow : Window, SignList {
 			}
 		}
 		/* If we haven't found the current sign by now, return the last/first sign */
-		return this->signs[next ? 0 : this->signs.Length() - 1];
+		return next ? this->signs.front() : this->signs.back();
 	}
 
 	void SetStringParameters(int widget) const override

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -63,7 +63,7 @@ struct SignList {
 		this->signs.clear();
 
 		const Sign *si;
-		FOR_ALL_SIGNS(si) *this->signs.Append() = si;
+		FOR_ALL_SIGNS(si) this->signs.push_back(si);
 
 		this->signs.SetFilterState(true);
 		this->FilterSignList();

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -47,7 +47,7 @@ struct Filtering {
  * @tparam F Type of data fed as additional value to the filter function. @see FilterFunction
  */
 template <typename T, typename F = const char*>
-class GUIList : public SmallVector<T, 32> {
+class GUIList : public std::vector<T> {
 public:
 	typedef int CDECL SortFunction(const T*, const T*); ///< Signature of sort function.
 	typedef bool CDECL FilterFunction(const T*, F);     ///< Signature of filter function.

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -337,13 +337,12 @@ public:
 		if (!(this->flags & VL_FILTER)) return false;
 
 		bool changed = false;
-		for (uint iter = 0; iter < std::vector<T>::size();) {
-			T *item = &std::vector<T>::operator[](iter);
-			if (!decide(item, filter_data)) {
-				this->Erase(item);
+		for (auto it = std::vector<T>::begin(); it != std::vector<T>::end(); /* Nothing */) {
+			if (!decide(&*it, filter_data)) {
+				it = std::vector<T>::erase(it);
 				changed = true;
 			} else {
-				iter++;
+				it++;
 			}
 		}
 

--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -67,7 +67,7 @@ protected:
 	 */
 	bool IsSortable() const
 	{
-		return (this->data != NULL && this->items >= 2);
+		return std::vector<T>::size() >= 2;
 	}
 
 	/**
@@ -240,7 +240,7 @@ public:
 	{
 		this->flags ^= VL_DESC;
 
-		if (this->IsSortable()) MemReverseT(this->data, this->items);
+		if (this->IsSortable()) MemReverseT(std::vector<T>::data(), std::vector<T>::size());
 	}
 
 	/**
@@ -270,11 +270,11 @@ public:
 		if (this->flags & VL_FIRST_SORT) {
 			CLRBITS(this->flags, VL_FIRST_SORT);
 
-			QSortT(this->data, this->items, compare, desc);
+			QSortT(std::vector<T>::data(), std::vector<T>::size(), compare, desc);
 			return true;
 		}
 
-		GSortT(this->data, this->items, compare, desc);
+		GSortT(std::vector<T>::data(), std::vector<T>::size(), compare, desc);
 		return true;
 	}
 
@@ -337,8 +337,8 @@ public:
 		if (!(this->flags & VL_FILTER)) return false;
 
 		bool changed = false;
-		for (uint iter = 0; iter < this->items;) {
-			T *item = &this->data[iter];
+		for (uint iter = 0; iter < std::vector<T>::size();) {
+			T *item = &std::vector<T>::operator[](iter);
 			if (!decide(item, filter_data)) {
 				this->Erase(item);
 				changed = true;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -887,7 +887,7 @@ static CommandCost CheckFlatLandAirport(AirportTileTableIterator tile_iter, DoCo
  * @param numtracks Number of platforms.
  * @return The cost in case of success, or an error code if it failed.
  */
-static CommandCost CheckFlatLandRailStation(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, SmallVector<Train *, 4> &affected_vehicles, StationClassID spec_class, byte spec_index, byte plat_len, byte numtracks)
+static CommandCost CheckFlatLandRailStation(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, std::vector<Train *> &affected_vehicles, StationClassID spec_class, byte spec_index, byte plat_len, byte numtracks)
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	int allowed_z = -1;
@@ -1310,7 +1310,7 @@ CommandCost CmdBuildRailStation(TileIndex tile_org, DoCommandFlag flags, uint32 
 
 	/* Make sure the area below consists of clear tiles. (OR tiles belonging to a certain rail station) */
 	StationID est = INVALID_STATION;
-	SmallVector<Train *, 4> affected_vehicles;
+	std::vector<Train *> affected_vehicles;
 	/* Clear the land below the station. */
 	CommandCost cost = CheckFlatLandRailStation(new_location, flags, axis, &est, rt, affected_vehicles, spec_class, spec_index, plat_len, numtracks);
 	if (cost.Failed()) return cost;
@@ -1547,7 +1547,7 @@ restart:
  * @return the number of cleared tiles or an error.
  */
 template <class T>
-CommandCost RemoveFromRailBaseStation(TileArea ta, SmallVector<T *, 4> &affected_stations, DoCommandFlag flags, Money removal_cost, bool keep_rail)
+CommandCost RemoveFromRailBaseStation(TileArea ta, std::vector<T *> &affected_stations, DoCommandFlag flags, Money removal_cost, bool keep_rail)
 {
 	/* Count of the number of tiles removed */
 	int quantity = 0;
@@ -1660,7 +1660,7 @@ CommandCost CmdRemoveFromRailStation(TileIndex start, DoCommandFlag flags, uint3
 	if (start >= MapSize() || end >= MapSize()) return CMD_ERROR;
 
 	TileArea ta(start, end);
-	SmallVector<Station *, 4> affected_stations;
+	std::vector<Station *> affected_stations;
 
 	CommandCost ret = RemoveFromRailBaseStation(ta, affected_stations, flags, _price[PR_CLEAR_STATION_RAIL], HasBit(p2, 0));
 	if (ret.Failed()) return ret;
@@ -1694,7 +1694,7 @@ CommandCost CmdRemoveFromRailWaypoint(TileIndex start, DoCommandFlag flags, uint
 	if (start >= MapSize() || end >= MapSize()) return CMD_ERROR;
 
 	TileArea ta(start, end);
-	SmallVector<Waypoint *, 4> affected_stations;
+	std::vector<Waypoint *> affected_stations;
 
 	return RemoveFromRailBaseStation(ta, affected_stations, flags, _price[PR_CLEAR_WAYPOINT_RAIL], HasBit(p2, 0));
 }
@@ -1727,7 +1727,7 @@ CommandCost RemoveRailStation(T *st, DoCommandFlag flags, Money removal_cost)
 	TILE_AREA_LOOP(tile, ta) {
 		/* only remove tiles that are actually train station tiles */
 		if (st->TileBelongsToRailStation(tile)) {
-			SmallVector<T*, 4> affected_stations; // dummy
+			std::vector<T*> affected_stations; // dummy
 			CommandCost ret = RemoveFromRailBaseStation(TileArea(tile, 1, 1), affected_stations, flags, removal_cost, false);
 			if (ret.Failed()) return ret;
 			cost.AddCost(ret);
@@ -3521,7 +3521,7 @@ void DeleteStaleLinks(Station *from)
 					/* Have all vehicles refresh their next hops before deciding to
 					 * remove the node. */
 					OrderList *l;
-					SmallVector<Vehicle *, 32> vehicles;
+					std::vector<Vehicle *> vehicles;
 					FOR_ALL_ORDER_LISTS(l) {
 						bool found_from = false;
 						bool found_to = false;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -942,7 +942,7 @@ static CommandCost CheckFlatLandRailStation(TileArea tile_area, DoCommandFlag fl
 					if (HasBit(GetRailReservationTrackBits(tile_cur), track)) {
 						Train *v = GetTrainForReservation(tile_cur, track);
 						if (v != NULL) {
-							*affected_vehicles.Append() = v;
+							affected_vehicles.push_back(v);
 						}
 					}
 					CommandCost ret = DoCommand(tile_cur, 0, track, flags, CMD_REMOVE_SINGLE_RAIL);
@@ -1386,7 +1386,7 @@ CommandCost CmdBuildRailStation(TileIndex tile_org, DoCommandFlag flags, uint32 
 					/* Check for trains having a reservation for this tile. */
 					Train *v = GetTrainForReservation(tile, AxisToTrack(GetRailStationAxis(tile)));
 					if (v != NULL) {
-						*affected_vehicles.Append() = v;
+						affected_vehicles.push_back(v);
 						FreeTrainReservation(v);
 					}
 				}
@@ -3538,7 +3538,7 @@ void DeleteStaleLinks(Station *from)
 							}
 						}
 						if (!found_to || !found_from) continue;
-						*(vehicles.Append()) = l->GetFirstSharedVehicle();
+						vehicles.push_back(l->GetFirstSharedVehicle());
 					}
 
 					auto iter = vehicles.begin();

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1436,7 +1436,7 @@ CommandCost CmdBuildRailStation(TileIndex tile_org, DoCommandFlag flags, uint32 
 			tile_track += tile_delta ^ TileDiffXY(1, 1); // perpendicular to tile_delta
 		} while (--numtracks);
 
-		for (uint i = 0; i < affected_vehicles.Length(); ++i) {
+		for (uint i = 0; i < affected_vehicles.size(); ++i) {
 			/* Restore reservations of trains. */
 			RestoreTrainReservation(affected_vehicles[i]);
 		}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1622,8 +1622,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, SmallVector<T *, 4> &affected
 
 	if (quantity == 0) return error.Failed() ? error : CommandCost(STR_ERROR_THERE_IS_NO_STATION);
 
-	for (T **stp = affected_stations.Begin(); stp != affected_stations.End(); stp++) {
-		T *st = *stp;
+	for (T *st : affected_stations) {
 
 		/* now we need to make the "spanned" area of the railway station smaller
 		 * if we deleted something at the edges.
@@ -1667,8 +1666,7 @@ CommandCost CmdRemoveFromRailStation(TileIndex start, DoCommandFlag flags, uint3
 	if (ret.Failed()) return ret;
 
 	/* Do all station specific functions here. */
-	for (Station **stp = affected_stations.Begin(); stp != affected_stations.End(); stp++) {
-		Station *st = *stp;
+	for (Station *st : affected_stations) {
 
 		if (st->train_station.tile == INVALID_TILE) SetWindowWidgetDirty(WC_STATION_VIEW, st->index, WID_SV_TRAINS);
 		st->MarkTilesDirty(false);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1614,7 +1614,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, SmallVector<T *, 4> &affected
 
 			DeallocateSpecFromStation(st, specindex);
 
-			affected_stations.Include(st);
+			include(affected_stations, st);
 
 			if (v != NULL) RestoreTrainReservation(v);
 		}

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3541,8 +3541,8 @@ void DeleteStaleLinks(Station *from)
 						*(vehicles.Append()) = l->GetFirstSharedVehicle();
 					}
 
-					Vehicle **iter = vehicles.Begin();
-					while (iter != vehicles.End()) {
+					auto iter = vehicles.begin();
+					while (iter != vehicles.end()) {
 						Vehicle *v = *iter;
 
 						LinkRefresher::Run(v, false); // Don't allow merging. Otherwise lg might get deleted.
@@ -3556,10 +3556,10 @@ void DeleteStaleLinks(Station *from)
 							*iter = next_shared;
 							++iter;
 						} else {
-							vehicles.Erase(iter);
+							iter = vehicles.erase(iter);
 						}
 
-						if (iter == vehicles.End()) iter = vehicles.Begin();
+						if (iter == vehicles.end()) iter = vehicles.begin();
 					}
 				}
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -205,7 +205,7 @@ protected:
 		this->stations.shrink_to_fit();
 		this->stations.RebuildDone();
 
-		this->vscroll->SetCount(this->stations.Length()); // Update the scrollbar
+		this->vscroll->SetCount(this->stations.size()); // Update the scrollbar
 	}
 
 	/** Sort stations by their name */
@@ -411,7 +411,7 @@ public:
 
 			case WID_STL_LIST: {
 				bool rtl = _current_text_dir == TD_RTL;
-				int max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->stations.Length());
+				int max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->stations.size());
 				int y = r.top + WD_FRAMERECT_TOP;
 				for (int i = this->vscroll->GetPosition(); i < max; ++i) { // do until max number of stations of owner
 					const Station *st = this->stations[i];
@@ -498,7 +498,7 @@ public:
 		switch (widget) {
 			case WID_STL_LIST: {
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_STL_LIST, 0, FONT_HEIGHT_NORMAL);
-				if (id_v >= this->stations.Length()) return; // click out of list bound
+				if (id_v >= this->stations.size()) return; // click out of list bound
 
 				const Station *st = this->stations[id_v];
 				/* do not check HasStationInUse - it is slow and may be invalid */
@@ -2132,7 +2132,7 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	TileArea *ctx = (TileArea *)user_data;
 
 	/* First check if there were deleted stations here */
-	for (uint i = 0; i < _deleted_stations_nearby.Length(); i++) {
+	for (uint i = 0; i < _deleted_stations_nearby.size(); i++) {
 		TileAndStation *ts = _deleted_stations_nearby.Get(i);
 		if (ts->tile == tile) {
 			*_stations_nearby_list.Append() = _deleted_stations_nearby[i].station;
@@ -2255,7 +2255,7 @@ struct SelectStationWindow : Window {
 
 		/* Determine the widest string */
 		Dimension d = GetStringBoundingBox(T::EXPECTED_FACIL == FACIL_WAYPOINT ? STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT : STR_JOIN_STATION_CREATE_SPLITTED_STATION);
-		for (uint i = 0; i < _stations_nearby_list.Length(); i++) {
+		for (uint i = 0; i < _stations_nearby_list.size(); i++) {
 			const T *st = T::Get(_stations_nearby_list[i]);
 			SetDParam(0, st->index);
 			SetDParam(1, st->facilities);
@@ -2279,7 +2279,7 @@ struct SelectStationWindow : Window {
 			y += this->resize.step_height;
 		}
 
-		for (uint i = max<uint>(1, this->vscroll->GetPosition()); i <= _stations_nearby_list.Length(); ++i, y += this->resize.step_height) {
+		for (uint i = max<uint>(1, this->vscroll->GetPosition()); i <= _stations_nearby_list.size(); ++i, y += this->resize.step_height) {
 			/* Don't draw anything if it extends past the end of the window. */
 			if (i - this->vscroll->GetPosition() >= this->vscroll->GetCapacity()) break;
 
@@ -2298,7 +2298,7 @@ struct SelectStationWindow : Window {
 		bool distant_join = (st_index > 0);
 		if (distant_join) st_index--;
 
-		if (distant_join && st_index >= _stations_nearby_list.Length()) return;
+		if (distant_join && st_index >= _stations_nearby_list.size()) return;
 
 		/* Insert station to be joined into stored command */
 		SB(this->select_station_cmd.p2, 16, 16,
@@ -2333,7 +2333,7 @@ struct SelectStationWindow : Window {
 	{
 		if (!gui_scope) return;
 		FindStationsNearby<T>(this->area, true);
-		this->vscroll->SetCount(_stations_nearby_list.Length() + 1);
+		this->vscroll->SetCount(_stations_nearby_list.size() + 1);
 		this->SetDirty();
 	}
 };
@@ -2378,7 +2378,7 @@ static bool StationJoinerNeeded(const CommandContainer &cmd, TileArea ta)
 	 * If adjacent-stations is disabled and we are building next to a station, do not show the selection window.
 	 * but join the other station immediately. */
 	const T *st = FindStationsNearby<T>(ta, false);
-	return st == NULL && (_settings_game.station.adjacent_stations || _stations_nearby_list.Length() == 0);
+	return st == NULL && (_settings_game.station.adjacent_stations || _stations_nearby_list.size() == 0);
 }
 
 /**

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2133,7 +2133,7 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 
 	/* First check if there were deleted stations here */
 	for (uint i = 0; i < _deleted_stations_nearby.size(); i++) {
-		TileAndStation *ts = _deleted_stations_nearby.Get(i);
+		TileAndStation *ts = _deleted_stations_nearby.data() + i;
 		if (ts->tile == tile) {
 			*_stations_nearby_list.Append() = _deleted_stations_nearby[i].station;
 			_deleted_stations_nearby.Erase(ts);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -189,14 +189,14 @@ protected:
 						if (st->goods[j].HasRating()) {
 							num_waiting_cargo++; // count number of waiting cargo
 							if (HasBit(this->cargo_filter, j)) {
-								*this->stations.Append() = st;
+								this->stations.push_back(st);
 								break;
 							}
 						}
 					}
 					/* stations without waiting cargo */
 					if (num_waiting_cargo == 0 && this->include_empty) {
-						*this->stations.Append() = st;
+						this->stations.push_back(st);
 					}
 				}
 			}
@@ -2135,7 +2135,7 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	for (uint i = 0; i < _deleted_stations_nearby.size(); i++) {
 		auto ts = _deleted_stations_nearby.begin() + i;
 		if (ts->tile == tile) {
-			*_stations_nearby_list.Append() = _deleted_stations_nearby[i].station;
+			_stations_nearby_list.push_back(_deleted_stations_nearby[i].station);
 			_deleted_stations_nearby.erase(ts);
 			i--;
 		}
@@ -2153,7 +2153,7 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	if (st->owner != _local_company || std::find(_stations_nearby_list.begin(), _stations_nearby_list.end(), sid) != _stations_nearby_list.end()) return false;
 
 	if (st->rect.BeforeAddRect(ctx->tile, ctx->w, ctx->h, StationRect::ADD_TEST).Succeeded()) {
-		*_stations_nearby_list.Append() = sid;
+		_stations_nearby_list.push_back(sid);
 	}
 
 	return false; // We want to include *all* nearby stations
@@ -2187,9 +2187,7 @@ static const T *FindStationsNearby(TileArea ta, bool distant_join)
 		if (T::IsExpected(st) && !st->IsInUse() && st->owner == _local_company) {
 			/* Include only within station spread (yes, it is strictly less than) */
 			if (max(DistanceMax(ta.tile, st->xy), DistanceMax(TILE_ADDXY(ta.tile, ta.w - 1, ta.h - 1), st->xy)) < _settings_game.station.station_spread) {
-				TileAndStation *ts = _deleted_stations_nearby.Append();
-				ts->tile = st->xy;
-				ts->station = st->index;
+				_deleted_stations_nearby.push_back({st->xy, st->index});
 
 				/* Add the station when it's within where we're going to build */
 				if (IsInsideBS(TileX(st->xy), TileX(ctx.tile), ctx.w) &&

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2150,7 +2150,7 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	if (!T::IsValidID(sid)) return false;
 
 	T *st = T::Get(sid);
-	if (st->owner != _local_company || _stations_nearby_list.Contains(sid)) return false;
+	if (st->owner != _local_company || std::find(_stations_nearby_list.begin(), _stations_nearby_list.end(), sid) != _stations_nearby_list.end()) return false;
 
 	if (st->rect.BeforeAddRect(ctx->tile, ctx->w, ctx->h, StationRect::ADD_TEST).Succeeded()) {
 		*_stations_nearby_list.Append() = sid;

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2116,8 +2116,8 @@ struct TileAndStation {
 	StationID station; ///< StationID
 };
 
-static SmallVector<TileAndStation, 8> _deleted_stations_nearby;
-static SmallVector<StationID, 8> _stations_nearby_list;
+static std::vector<TileAndStation> _deleted_stations_nearby;
+static std::vector<StationID> _stations_nearby_list;
 
 /**
  * Add station on this tile to _stations_nearby_list if it's fully within the

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -178,7 +178,7 @@ protected:
 
 		DEBUG(misc, 3, "Building station list for company %d", owner);
 
-		this->stations.Clear();
+		this->stations.clear();
 
 		const Station *st;
 		FOR_ALL_STATIONS(st) {
@@ -2173,8 +2173,8 @@ static const T *FindStationsNearby(TileArea ta, bool distant_join)
 {
 	TileArea ctx = ta;
 
-	_stations_nearby_list.Clear();
-	_deleted_stations_nearby.Clear();
+	_stations_nearby_list.clear();
+	_deleted_stations_nearby.clear();
 
 	/* Check the inside, to return, if we sit on another station */
 	TILE_AREA_LOOP(t, ta) {

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -202,7 +202,7 @@ protected:
 			}
 		}
 
-		this->stations.Compact();
+		this->stations.shrink_to_fit();
 		this->stations.RebuildDone();
 
 		this->vscroll->SetCount(this->stations.Length()); // Update the scrollbar

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2133,10 +2133,10 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 
 	/* First check if there were deleted stations here */
 	for (uint i = 0; i < _deleted_stations_nearby.size(); i++) {
-		TileAndStation *ts = _deleted_stations_nearby.data() + i;
+		auto ts = _deleted_stations_nearby.begin() + i;
 		if (ts->tile == tile) {
 			*_stations_nearby_list.Append() = _deleted_stations_nearby[i].station;
-			_deleted_stations_nearby.Erase(ts);
+			_deleted_stations_nearby.erase(ts);
 			i--;
 		}
 	}

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -52,7 +52,7 @@ protected:
 	void BuildStoryPageList()
 	{
 		if (this->story_pages.NeedRebuild()) {
-			this->story_pages.Clear();
+			this->story_pages.clear();
 
 			const StoryPage *p;
 			FOR_ALL_STORY_PAGES(p) {
@@ -78,7 +78,7 @@ protected:
 	void BuildStoryPageElementList()
 	{
 		if (this->story_page_elements.NeedRebuild()) {
-			this->story_page_elements.Clear();
+			this->story_page_elements.clear();
 
 			const StoryPage *p = GetSelPage();
 			if (p != NULL) {

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -57,7 +57,7 @@ protected:
 			const StoryPage *p;
 			FOR_ALL_STORY_PAGES(p) {
 				if (this->IsPageAvailable(p)) {
-					*this->story_pages.Append() = p;
+					this->story_pages.push_back(p);
 				}
 			}
 
@@ -85,7 +85,7 @@ protected:
 				const StoryPageElement *pe;
 				FOR_ALL_STORY_PAGE_ELEMENTS(pe) {
 					if (pe->page == p->index) {
-						*this->story_page_elements.Append() = pe;
+						this->story_page_elements.push_back(pe);
 					}
 				}
 			}
@@ -248,7 +248,7 @@ protected:
 				item = str_item;
 			}
 
-			*list->Append() = item;
+			list->push_back(item);
 			page_num++;
 		}
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -61,7 +61,7 @@ protected:
 				}
 			}
 
-			this->story_pages.Compact();
+			this->story_pages.shrink_to_fit();
 			this->story_pages.RebuildDone();
 		}
 
@@ -90,7 +90,7 @@ protected:
 				}
 			}
 
-			this->story_page_elements.Compact();
+			this->story_page_elements.shrink_to_fit();
 			this->story_page_elements.RebuildDone();
 		}
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -130,8 +130,7 @@ protected:
 	int GetSelPageNum() const
 	{
 		int page_number = 0;
-		for (const StoryPage *const*iter = this->story_pages.Begin(); iter != this->story_pages.End(); iter++) {
-			const StoryPage *p = *iter;
+		for (const StoryPage *p : this->story_pages) {
 			if (p->index == this->selected_page_id) {
 				return page_number;
 			}
@@ -148,7 +147,7 @@ protected:
 		/* Verify that the selected page exist. */
 		if (!_story_page_pool.IsValidID(this->selected_page_id)) return false;
 
-		return (*this->story_pages.Begin())->index == this->selected_page_id;
+		return this->story_pages.front()->index == this->selected_page_id;
 	}
 
 	/**
@@ -160,7 +159,7 @@ protected:
 		if (!_story_page_pool.IsValidID(this->selected_page_id)) return false;
 
 		if (this->story_pages.size() <= 1) return true;
-		const StoryPage *last = *(this->story_pages.End() - 1);
+		const StoryPage *last = this->story_pages.back();
 		return last->index == this->selected_page_id;
 	}
 
@@ -195,8 +194,7 @@ protected:
 		/* Find the last available page which is previous to the current selected page. */
 		const StoryPage *last_available;
 		last_available = NULL;
-		for (const StoryPage *const*iter = this->story_pages.Begin(); iter != this->story_pages.End(); iter++) {
-			const StoryPage *p = *iter;
+		for (const StoryPage *p : this->story_pages) {
 			if (p->index == this->selected_page_id) {
 				if (last_available == NULL) return; // No previous page available.
 				this->SetSelectedPage(last_available->index);
@@ -214,12 +212,12 @@ protected:
 		if (!_story_page_pool.IsValidID(this->selected_page_id)) return;
 
 		/* Find selected page. */
-		for (const StoryPage *const*iter = this->story_pages.Begin(); iter != this->story_pages.End(); iter++) {
+		for (auto iter = this->story_pages.begin(); iter != this->story_pages.end(); iter++) {
 			const StoryPage *p = *iter;
 			if (p->index == this->selected_page_id) {
 				/* Select the page after selected page. */
 				iter++;
-				if (iter != this->story_pages.End()) {
+				if (iter != this->story_pages.end()) {
 					this->SetSelectedPage((*iter)->index);
 				}
 				return;
@@ -234,8 +232,7 @@ protected:
 	{
 		DropDownList *list = new DropDownList();
 		uint16 page_num = 1;
-		for (const StoryPage *const*iter = this->story_pages.Begin(); iter != this->story_pages.End(); iter++) {
-			const StoryPage *p = *iter;
+		for (const StoryPage *p : this->story_pages) {
 			bool current_page = p->index == this->selected_page_id;
 			DropDownListStringItem *item = NULL;
 			if (p->title != NULL) {
@@ -353,8 +350,7 @@ protected:
 		uint height = GetHeadHeight(max_width);
 
 		/* Body */
-		for (const StoryPageElement **iter = this->story_page_elements.Begin(); iter != this->story_page_elements.End(); iter++) {
-			const StoryPageElement *pe = *iter;
+		for (const StoryPageElement *pe : this->story_page_elements) {
 			height += element_vertical_dist;
 			height += GetPageElementHeight(*pe, max_width);
 		}
@@ -532,8 +528,7 @@ public:
 		y_offset = DrawStringMultiLine(0, right - x, y_offset, bottom - y, STR_STORY_BOOK_TITLE, TC_BLACK, SA_TOP | SA_HOR_CENTER);
 
 		/* Page elements */
-		for (const StoryPageElement *const*iter = this->story_page_elements.Begin(); iter != this->story_page_elements.End(); iter++) {
-			const StoryPageElement *const pe = *iter;
+		for (const StoryPageElement *const pe : this->story_page_elements) {
 			y_offset += line_height; // margin to previous element
 
 			switch (pe->type) {
@@ -650,8 +645,7 @@ public:
 				/* Detect if a page element was clicked. */
 				uint y = head_height;
 				uint element_vertical_dist = FONT_HEIGHT_NORMAL;
-				for (const StoryPageElement *const*iter = this->story_page_elements.Begin(); iter != this->story_page_elements.End(); iter++) {
-					const StoryPageElement *const pe = *iter;
+				for (const StoryPageElement *const pe : this->story_page_elements) {
 
 					y += element_vertical_dist; // margin row
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -159,7 +159,7 @@ protected:
 		/* Verify that the selected page exist. */
 		if (!_story_page_pool.IsValidID(this->selected_page_id)) return false;
 
-		if (this->story_pages.Length() <= 1) return true;
+		if (this->story_pages.size() <= 1) return true;
 		const StoryPage *last = *(this->story_pages.End() - 1);
 		return last->index == this->selected_page_id;
 	}
@@ -253,7 +253,7 @@ protected:
 		}
 
 		/* Check if list is empty. */
-		if (list->Length() == 0) {
+		if (list->size() == 0) {
 			delete list;
 			list = NULL;
 		}
@@ -444,8 +444,8 @@ public:
 	 */
 	void UpdatePrevNextDisabledState()
 	{
-		this->SetWidgetDisabledState(WID_SB_PREV_PAGE, story_pages.Length() == 0 || this->IsFirstPageSelected());
-		this->SetWidgetDisabledState(WID_SB_NEXT_PAGE, story_pages.Length() == 0 || this->IsLastPageSelected());
+		this->SetWidgetDisabledState(WID_SB_PREV_PAGE, story_pages.size() == 0 || this->IsFirstPageSelected());
+		this->SetWidgetDisabledState(WID_SB_NEXT_PAGE, story_pages.size() == 0 || this->IsLastPageSelected());
 		this->SetWidgetDirty(WID_SB_PREV_PAGE);
 		this->SetWidgetDirty(WID_SB_NEXT_PAGE);
 	}
@@ -575,7 +575,7 @@ public:
 			case WID_SB_SEL_PAGE: {
 
 				/* Get max title width. */
-				for (uint16 i = 0; i < this->story_pages.Length(); i++) {
+				for (uint16 i = 0; i < this->story_pages.size(); i++) {
 					const StoryPage *s = this->story_pages[i];
 
 					if (s->title != NULL) {
@@ -620,7 +620,7 @@ public:
 				if (list != NULL) {
 					/* Get the index of selected page. */
 					int selected = 0;
-					for (uint16 i = 0; i < this->story_pages.Length(); i++) {
+					for (uint16 i = 0; i < this->story_pages.size(); i++) {
 						const StoryPage *p = this->story_pages[i];
 						if (p->index == this->selected_page_id) break;
 						selected++;
@@ -694,7 +694,7 @@ public:
 			this->BuildStoryPageList();
 
 			/* Was the last page removed? */
-			if (this->story_pages.Length() == 0) {
+			if (this->story_pages.size() == 0) {
 				this->selected_generic_title[0] = '\0';
 			}
 
@@ -702,14 +702,14 @@ public:
 			if (!_story_page_pool.IsValidID(this->selected_page_id)) {
 				this->selected_page_id = INVALID_STORY_PAGE;
 			}
-			if (this->selected_page_id == INVALID_STORY_PAGE && this->story_pages.Length() > 0) {
+			if (this->selected_page_id == INVALID_STORY_PAGE && this->story_pages.size() > 0) {
 				/* No page is selected, but there exist at least one available.
 				 * => Select first page.
 				 */
 				this->SetSelectedPage(this->story_pages[0]->index);
 			}
 
-			this->SetWidgetDisabledState(WID_SB_SEL_PAGE, this->story_pages.Length() == 0);
+			this->SetWidgetDisabledState(WID_SB_SEL_PAGE, this->story_pages.size() == 0);
 			this->SetWidgetDirty(WID_SB_SEL_PAGE);
 			this->UpdatePrevNextDisabledState();
 		} else if (data >= 0 && this->selected_page_id == data) {

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -242,7 +242,7 @@ struct Buffer : SmallVector<byte, 256> {
 	 */
 	void AppendByte(byte value)
 	{
-		*this->Append() = value;
+		this->push_back(value);
 	}
 
 	/**
@@ -252,19 +252,19 @@ struct Buffer : SmallVector<byte, 256> {
 	void AppendUtf8(uint32 value)
 	{
 		if (value < 0x80) {
-			*this->Append() = value;
+			this->push_back(value);
 		} else if (value < 0x800) {
-			*this->Append() = 0xC0 + GB(value,  6, 5);
-			*this->Append() = 0x80 + GB(value,  0, 6);
+			this->push_back(0xC0 + GB(value,  6, 5));
+			this->push_back(0x80 + GB(value,  0, 6));
 		} else if (value < 0x10000) {
-			*this->Append() = 0xE0 + GB(value, 12, 4);
-			*this->Append() = 0x80 + GB(value,  6, 6);
-			*this->Append() = 0x80 + GB(value,  0, 6);
+			this->push_back(0xE0 + GB(value, 12, 4));
+			this->push_back(0x80 + GB(value,  6, 6));
+			this->push_back(0x80 + GB(value,  0, 6));
 		} else if (value < 0x110000) {
-			*this->Append() = 0xF0 + GB(value, 18, 3);
-			*this->Append() = 0x80 + GB(value, 12, 6);
-			*this->Append() = 0x80 + GB(value,  6, 6);
-			*this->Append() = 0x80 + GB(value,  0, 6);
+			this->push_back(0xF0 + GB(value, 18, 3));
+			this->push_back(0x80 + GB(value, 12, 6));
+			this->push_back(0x80 + GB(value,  6, 6));
+			this->push_back(0x80 + GB(value,  0, 6));
 		} else {
 			strgen_warning("Invalid unicode value U+0x%X", value);
 		}

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -1029,14 +1029,14 @@ void LanguageWriter::WriteLang(const StringData &data)
 				for (c = casep; c != NULL; c = c->next) {
 					buffer.AppendByte(c->caseidx);
 					/* Make some space for the 16-bit length */
-					uint pos = buffer.Length();
+					uint pos = buffer.size();
 					buffer.AppendByte(0);
 					buffer.AppendByte(0);
 					/* Write string */
 					PutCommandString(&buffer, c->string);
 					buffer.AppendByte(0); // terminate with a zero
 					/* Fill in the length */
-					uint size = buffer.Length() - (pos + 2);
+					uint size = buffer.size() - (pos + 2);
 					buffer[pos + 0] = GB(size, 8, 8);
 					buffer[pos + 1] = GB(size, 0, 8);
 				}
@@ -1044,8 +1044,8 @@ void LanguageWriter::WriteLang(const StringData &data)
 
 			if (cmdp != NULL) PutCommandString(&buffer, cmdp);
 
-			this->WriteLength(buffer.Length());
-			this->Write(buffer.Begin(), buffer.Length());
+			this->WriteLength(buffer.size());
+			this->Write(buffer.Begin(), buffer.size());
 			buffer.clear();
 		}
 	}

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -235,7 +235,7 @@ static ParsedCommandStruct _cur_pcs;
 static int _cur_argidx;
 
 /** The buffer for writing a single string. */
-struct Buffer : SmallVector<byte, 256> {
+struct Buffer : std::vector<byte> {
 	/**
 	 * Convenience method for adding a byte.
 	 * @param value The value to add.

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -1046,7 +1046,7 @@ void LanguageWriter::WriteLang(const StringData &data)
 
 			this->WriteLength(buffer.Length());
 			this->Write(buffer.Begin(), buffer.Length());
-			buffer.Clear();
+			buffer.clear();
 		}
 	}
 }

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -1045,7 +1045,7 @@ void LanguageWriter::WriteLang(const StringData &data)
 			if (cmdp != NULL) PutCommandString(&buffer, cmdp);
 
 			this->WriteLength(buffer.size());
-			this->Write(buffer.Begin(), buffer.size());
+			this->Write(buffer.data(), buffer.size());
 			buffer.clear();
 		}
 	}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -634,8 +634,8 @@ public:
 		this->char_itr = icu::BreakIterator::createCharacterInstance(icu::Locale(_current_language != NULL ? _current_language->isocode : "en"), status);
 		this->word_itr = icu::BreakIterator::createWordInstance(icu::Locale(_current_language != NULL ? _current_language->isocode : "en"), status);
 
-		*this->utf16_str.Append() = '\0';
-		*this->utf16_to_utf8.Append() = 0;
+		this->utf16_str.push_back('\0');
+		this->utf16_to_utf8.push_back(0);
 	}
 
 	virtual ~IcuStringIterator()
@@ -660,17 +660,17 @@ public:
 
 			WChar c = Utf8Consume(&s);
 			if (c < 0x10000) {
-				*this->utf16_str.Append() = (UChar)c;
+				this->utf16_str.push_back((UChar)c);
 			} else {
 				/* Make a surrogate pair. */
-				*this->utf16_str.Append() = (UChar)(0xD800 + ((c - 0x10000) >> 10));
-				*this->utf16_str.Append() = (UChar)(0xDC00 + ((c - 0x10000) & 0x3FF));
-				*this->utf16_to_utf8.Append() = idx;
+				this->utf16_str.push_back((UChar)(0xD800 + ((c - 0x10000) >> 10)));
+				this->utf16_str.push_back((UChar)(0xDC00 + ((c - 0x10000) & 0x3FF)));
+				this->utf16_to_utf8.push_back(idx);
 			}
-			*this->utf16_to_utf8.Append() = idx;
+			this->utf16_to_utf8.push_back(idx);
 		}
-		*this->utf16_str.Append() = '\0';
-		*this->utf16_to_utf8.Append() = s - string_base;
+		this->utf16_str.push_back('\0');
+		this->utf16_to_utf8.push_back(s - string_base);
 
 		UText text = UTEXT_INITIALIZER;
 		UErrorCode status = U_ZERO_ERROR;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -624,8 +624,8 @@ class IcuStringIterator : public StringIterator
 	icu::BreakIterator *char_itr; ///< ICU iterator for characters.
 	icu::BreakIterator *word_itr; ///< ICU iterator for words.
 
-	SmallVector<UChar, 32> utf16_str;      ///< UTF-16 copy of the string.
-	SmallVector<size_t, 32> utf16_to_utf8; ///< Mapping from UTF-16 code point position to index in the UTF-8 source string.
+	std::vector<UChar> utf16_str;      ///< UTF-16 copy of the string.
+	std::vector<size_t> utf16_to_utf8; ///< Mapping from UTF-16 code point position to index in the UTF-8 source string.
 
 public:
 	IcuStringIterator() : char_itr(NULL), word_itr(NULL)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -674,7 +674,7 @@ public:
 
 		UText text = UTEXT_INITIALIZER;
 		UErrorCode status = U_ZERO_ERROR;
-		utext_openUChars(&text, this->utf16_str.Begin(), this->utf16_str.size() - 1, &status);
+		utext_openUChars(&text, this->utf16_str.data(), this->utf16_str.size() - 1, &status);
 		this->char_itr->setText(&text, status);
 		this->word_itr->setText(&text, status);
 		this->char_itr->first();

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -652,8 +652,8 @@ public:
 		 * for word break iterators (especially for CJK languages) in combination
 		 * with UTF-8 input. As a work around we have to convert the input to
 		 * UTF-16 and create a mapping back to UTF-8 character indices. */
-		this->utf16_str.Clear();
-		this->utf16_to_utf8.Clear();
+		this->utf16_str.clear();
+		this->utf16_to_utf8.clear();
 
 		while (*s != '\0') {
 			size_t idx = s - string_base;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -674,7 +674,7 @@ public:
 
 		UText text = UTEXT_INITIALIZER;
 		UErrorCode status = U_ZERO_ERROR;
-		utext_openUChars(&text, this->utf16_str.Begin(), this->utf16_str.Length() - 1, &status);
+		utext_openUChars(&text, this->utf16_str.Begin(), this->utf16_str.size() - 1, &status);
 		this->char_itr->setText(&text, status);
 		this->word_itr->setText(&text, status);
 		this->char_itr->first();
@@ -685,7 +685,7 @@ public:
 	{
 		/* Convert incoming position to an UTF-16 string index. */
 		uint utf16_pos = 0;
-		for (uint i = 0; i < this->utf16_to_utf8.Length(); i++) {
+		for (uint i = 0; i < this->utf16_to_utf8.size(); i++) {
 			if (this->utf16_to_utf8[i] == pos) {
 				utf16_pos = i;
 				break;

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -76,9 +76,8 @@ void StringFilter::SetFilterTerm(const char *str)
 
 		/* Add to word */
 		if (word == NULL) {
-			word = this->word_index.Append();
-			word->start = dest;
-			word->match = false;
+			/*C++17: word = &*/ this->word_index.push_back({dest, false});
+			word = &this->word_index.back();
 		}
 
 		memcpy(dest, pos, len);

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -28,7 +28,8 @@ static const WChar STATE_QUOTE2 = '"';
  */
 void StringFilter::SetFilterTerm(const char *str)
 {
-	this->word_index.Reset();
+	this->word_index.clear();
+	this->word_index.shrink_to_fit();
 	this->word_matches = 0;
 	free(this->filter_buffer);
 

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -91,9 +91,8 @@ void StringFilter::SetFilterTerm(const char *str)
 void StringFilter::ResetState()
 {
 	this->word_matches = 0;
-	const WordState *end = this->word_index.End();
-	for (WordState *it = this->word_index.Begin(); it != end; ++it) {
-		it->match = false;
+	for (WordState &ws : this->word_index) {
+		ws.match = false;
 	}
 }
 
@@ -110,11 +109,10 @@ void StringFilter::AddLine(const char *str)
 	if (str == NULL) return;
 
 	bool match_case = this->case_sensitive != NULL && *this->case_sensitive;
-	const WordState *end = this->word_index.End();
-	for (WordState *it = this->word_index.Begin(); it != end; ++it) {
-		if (!it->match) {
-			if ((match_case ? strstr(str, it->start) : strcasestr(str, it->start)) != NULL) {
-				it->match = true;
+	for (WordState &ws : this->word_index) {
+		if (!ws.match) {
+			if ((match_case ? strstr(str, ws.start) : strcasestr(str, ws.start)) != NULL) {
+				ws.match = true;
 				this->word_matches++;
 			}
 		}

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -39,7 +39,7 @@ private:
 	};
 
 	const char *filter_buffer;                     ///< Parsed filter string. Words separated by 0.
-	std::vector<WordState> word_index;          ///< Word index and filter state.
+	std::vector<WordState> word_index;             ///< Word index and filter state.
 	uint word_matches;                             ///< Summary of filter state: Number of words matched.
 
 	const bool *case_sensitive;                    ///< Match case-sensitively (usually a static variable).

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -39,7 +39,7 @@ private:
 	};
 
 	const char *filter_buffer;                     ///< Parsed filter string. Words separated by 0.
-	SmallVector<WordState, 4> word_index;          ///< Word index and filter state.
+	std::vector<WordState> word_index;          ///< Word index and filter state.
 	uint word_matches;                             ///< Summary of filter state: Number of words matched.
 
 	const bool *case_sensitive;                    ///< Match case-sensitively (usually a static variable).

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -58,7 +58,7 @@ public:
 	 * Check whether any filter words were entered.
 	 * @return true if no words were entered.
 	 */
-	bool IsEmpty() const { return this->word_index.Length() == 0; }
+	bool IsEmpty() const { return this->word_index.size() == 0; }
 
 	void ResetState();
 	void AddLine(const char *str);
@@ -68,7 +68,7 @@ public:
 	 * Get the matching state of the current item.
 	 * @return true if matched.
 	 */
-	bool GetState() const { return this->word_matches == this->word_index.Length(); }
+	bool GetState() const { return this->word_matches == this->word_index.size(); }
 };
 
 #endif /* STRINGFILTER_TYPE_H */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1932,7 +1932,7 @@ static void GetLanguageList(const char *path)
 			} else if (GetLanguage(lmd.newgrflangid) != NULL) {
 				DEBUG(misc, 3, "%s's language ID is already known", lmd.file);
 			} else {
-				*_languages.Append() = lmd;
+				_languages.push_back(lmd);
 			}
 		}
 		closedir(dir);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1876,8 +1876,8 @@ int CDECL StringIDSorter(const StringID *a, const StringID *b)
  */
 const LanguageMetadata *GetLanguage(byte newgrflangid)
 {
-	for (const LanguageMetadata *lang = _languages.Begin(); lang != _languages.End(); lang++) {
-		if (newgrflangid == lang->newgrflangid) return lang;
+	for (const LanguageMetadata &lang : _languages) {
+		if (newgrflangid == lang.newgrflangid) return &lang;
 	}
 
 	return NULL;
@@ -1960,22 +1960,22 @@ void InitializeLanguagePacks()
 
 	const LanguageMetadata *chosen_language   = NULL; ///< Matching the language in the configuration file or the current locale
 	const LanguageMetadata *language_fallback = NULL; ///< Using pt_PT for pt_BR locale when pt_BR is not available
-	const LanguageMetadata *en_GB_fallback    = _languages.Begin(); ///< Fallback when no locale-matching language has been found
+	const LanguageMetadata *en_GB_fallback    = _languages.data(); ///< Fallback when no locale-matching language has been found
 
 	/* Find a proper language. */
-	for (const LanguageMetadata *lng = _languages.Begin(); lng != _languages.End(); lng++) {
+	for (const LanguageMetadata &lng : _languages) {
 		/* We are trying to find a default language. The priority is by
 		 * configuration file, local environment and last, if nothing found,
 		 * English. */
-		const char *lang_file = strrchr(lng->file, PATHSEPCHAR) + 1;
+		const char *lang_file = strrchr(lng.file, PATHSEPCHAR) + 1;
 		if (strcmp(lang_file, _config_language_file) == 0) {
-			chosen_language = lng;
+			chosen_language = &lng;
 			break;
 		}
 
-		if (strcmp (lng->isocode, "en_GB") == 0) en_GB_fallback    = lng;
-		if (strncmp(lng->isocode, lang, 5) == 0) chosen_language   = lng;
-		if (strncmp(lng->isocode, lang, 2) == 0) language_fallback = lng;
+		if (strcmp (lng.isocode, "en_GB") == 0) en_GB_fallback    = &lng;
+		if (strncmp(lng.isocode, lang, 5) == 0) chosen_language   = &lng;
+		if (strncmp(lng.isocode, lang, 2) == 0) language_fallback = &lng;
 	}
 
 	/* We haven't found the language in the config nor the one in the locale.

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1952,7 +1952,7 @@ void InitializeLanguagePacks()
 		FioAppendDirectory(path, lastof(path), sp, LANG_DIR);
 		GetLanguageList(path);
 	}
-	if (_languages.Length() == 0) usererror("No available language packs (invalid versions?)");
+	if (_languages.size() == 0) usererror("No available language packs (invalid versions?)");
 
 	/* Acquire the locale of the current system */
 	const char *lang = GetCurrentLocale("LC_MESSAGES");

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -564,7 +564,7 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 
 	/* Remember all towns near this station (at least one house in its catchment radius)
 	 * which are destination of subsidised path. Do that only if needed */
-	SmallVector<const Town *, 2> towns_near;
+	std::vector<const Town *> towns_near;
 	if (!st->rect.IsEmpty()) {
 		Subsidy *s;
 		FOR_ALL_SUBSIDIES(s) {

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -577,7 +577,7 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 			for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
 				if (!IsTileType(tile, MP_HOUSE)) continue;
 				const Town *t = Town::GetByTile(tile);
-				if (t->cache.part_of_subsidy & POS_DST) towns_near.Include(t);
+				if (t->cache.part_of_subsidy & POS_DST) include(towns_near, t);
 			}
 			break;
 		}

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -601,9 +601,9 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 					}
 					break;
 				case ST_TOWN:
-					for (const Town * const *tp = towns_near.Begin(); tp != towns_near.End(); tp++) {
-						if (s->dst == (*tp)->index) {
-							assert((*tp)->cache.part_of_subsidy & POS_DST);
+					for (const Town *tp : towns_near) {
+						if (s->dst == tp->index) {
+							assert(tp->cache.part_of_subsidy & POS_DST);
 							subsidised = true;
 							if (!s->IsAwarded()) s->AwardTo(company);
 						}

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -50,7 +50,7 @@ TextEffectID AddTextEffect(StringID msg, int center, int y, uint8 duration, Text
 	}
 	if (i == _text_effects.size()) _text_effects.Append();
 
-	TextEffect *te = _text_effects.Get(i);
+	TextEffect *te = _text_effects.data() + i;
 
 	/* Start defining this object */
 	te->string_id = msg;
@@ -69,7 +69,7 @@ TextEffectID AddTextEffect(StringID msg, int center, int y, uint8 duration, Text
 void UpdateTextEffect(TextEffectID te_id, StringID msg)
 {
 	/* Update details */
-	TextEffect *te = _text_effects.Get(te_id);
+	TextEffect *te = _text_effects.data() + te_id;
 	if (msg == te->string_id && GetDParam(0) == te->params_1) return;
 	te->string_id = msg;
 	te->params_1 = GetDParam(0);

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -108,7 +108,8 @@ void MoveAllTextEffects(uint delta_ms)
 
 void InitTextEffects()
 {
-	_text_effects.Reset();
+	_text_effects.clear();
+	_text_effects.shrink_to_fit();
 }
 
 void DrawTextEffects(DrawPixelInfo *dpi)

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -89,20 +89,19 @@ void MoveAllTextEffects(uint delta_ms)
 	uint count = texteffecttimer.CountElapsed(delta_ms);
 	if (count == 0) return;
 
-	const TextEffect *end = _text_effects.End();
-	for (TextEffect *te = _text_effects.Begin(); te != end; te++) {
-		if (te->string_id == INVALID_STRING_ID) continue;
-		if (te->mode != TE_RISING) continue;
+	for (TextEffect &te : _text_effects) {
+		if (te.string_id == INVALID_STRING_ID) continue;
+		if (te.mode != TE_RISING) continue;
 
-		if (te->duration < count) {
-			te->Reset();
+		if (te.duration < count) {
+			te.Reset();
 			continue;
 		}
 
-		te->MarkDirty(ZOOM_LVL_OUT_8X);
-		te->duration -= count;
-		te->top -= count * ZOOM_LVL_BASE;
-		te->MarkDirty(ZOOM_LVL_OUT_8X);
+		te.MarkDirty(ZOOM_LVL_OUT_8X);
+		te.duration -= count;
+		te.top -= count * ZOOM_LVL_BASE;
+		te.MarkDirty(ZOOM_LVL_OUT_8X);
 	}
 }
 
@@ -117,11 +116,10 @@ void DrawTextEffects(DrawPixelInfo *dpi)
 	/* Don't draw the text effects when zoomed out a lot */
 	if (dpi->zoom > ZOOM_LVL_OUT_8X) return;
 
-	const TextEffect *end = _text_effects.End();
-	for (TextEffect *te = _text_effects.Begin(); te != end; te++) {
-		if (te->string_id == INVALID_STRING_ID) continue;
-		if (te->mode == TE_RISING || (_settings_client.gui.loading_indicators && !IsTransparencySet(TO_LOADING))) {
-			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, te, te->string_id, te->string_id - 1, STR_NULL, te->params_1, te->params_2);
+	for (TextEffect &te : _text_effects) {
+		if (te.string_id == INVALID_STRING_ID) continue;
+		if (te.mode == TE_RISING || (_settings_client.gui.loading_indicators && !IsTransparencySet(TO_LOADING))) {
+			ViewportAddString(dpi, ZOOM_LVL_OUT_8X, &te, te.string_id, te.string_id - 1, STR_NULL, te.params_1, te.params_2);
 		}
 	}
 }

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -45,10 +45,10 @@ TextEffectID AddTextEffect(StringID msg, int center, int y, uint8 duration, Text
 	if (_game_mode == GM_MENU) return INVALID_TE_ID;
 
 	TextEffectID i;
-	for (i = 0; i < _text_effects.Length(); i++) {
+	for (i = 0; i < _text_effects.size(); i++) {
 		if (_text_effects[i].string_id == INVALID_STRING_ID) break;
 	}
-	if (i == _text_effects.Length()) _text_effects.Append();
+	if (i == _text_effects.size()) _text_effects.Append();
 
 	TextEffect *te = _text_effects.Get(i);
 

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -48,20 +48,20 @@ TextEffectID AddTextEffect(StringID msg, int center, int y, uint8 duration, Text
 	for (i = 0; i < _text_effects.size(); i++) {
 		if (_text_effects[i].string_id == INVALID_STRING_ID) break;
 	}
-	if (i == _text_effects.size()) _text_effects.Append();
+	if (i == _text_effects.size()) _text_effects.emplace_back();
 
-	TextEffect *te = _text_effects.data() + i;
+	TextEffect &te = _text_effects[i];
 
 	/* Start defining this object */
-	te->string_id = msg;
-	te->duration = duration;
-	te->params_1 = GetDParam(0);
-	te->params_2 = GetDParam(1);
-	te->mode = mode;
+	te.string_id = msg;
+	te.duration = duration;
+	te.params_1 = GetDParam(0);
+	te.params_2 = GetDParam(1);
+	te.mode = mode;
 
 	/* Make sure we only dirty the new area */
-	te->width_normal = 0;
-	te->UpdatePosition(center, y, msg);
+	te.width_normal = 0;
+	te.UpdatePosition(center, y, msg);
 
 	return i;
 }

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -37,7 +37,7 @@ struct TextEffect : public ViewportSign {
 	}
 };
 
-static SmallVector<struct TextEffect, 32> _text_effects; ///< Text effects are stored there
+static std::vector<struct TextEffect> _text_effects; ///< Text effects are stored there
 
 /* Text Effects */
 TextEffectID AddTextEffect(StringID msg, int center, int y, uint8 duration, TextEffectMode mode)

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -86,7 +86,7 @@ uint TextfileWindow::GetContentHeight()
 	int max_width = this->GetWidget<NWidgetCore>(WID_TF_BACKGROUND)->current_x - WD_FRAMETEXT_LEFT - WD_FRAMERECT_RIGHT;
 
 	uint height = 0;
-	for (uint i = 0; i < this->lines.Length(); i++) {
+	for (uint i = 0; i < this->lines.size(); i++) {
 		height += GetStringHeight(this->lines[i], max_width, FS_MONO);
 	}
 
@@ -113,10 +113,10 @@ void TextfileWindow::SetupScrollbars()
 		this->hscroll->SetCount(0);
 	} else {
 		uint max_length = 0;
-		for (uint i = 0; i < this->lines.Length(); i++) {
+		for (uint i = 0; i < this->lines.size(); i++) {
 			max_length = max(max_length, GetStringBoundingBox(this->lines[i], FS_MONO).width);
 		}
-		this->vscroll->SetCount(this->lines.Length() * FONT_HEIGHT_MONO);
+		this->vscroll->SetCount(this->lines.size() * FONT_HEIGHT_MONO);
 		this->hscroll->SetCount(max_length + WD_FRAMETEXT_LEFT + WD_FRAMETEXT_RIGHT);
 	}
 
@@ -152,7 +152,7 @@ void TextfileWindow::SetupScrollbars()
 	int line_height = FONT_HEIGHT_MONO;
 	int y_offset = -this->vscroll->GetPosition();
 
-	for (uint i = 0; i < this->lines.Length(); i++) {
+	for (uint i = 0; i < this->lines.size(); i++) {
 		if (IsWidgetLowered(WID_TF_WRAPTEXT)) {
 			y_offset = DrawStringMultiLine(0, right - x, y_offset, bottom - y, this->lines[i], TC_WHITE, SA_TOP | SA_LEFT, false, FS_MONO);
 		} else {
@@ -184,7 +184,7 @@ void TextfileWindow::SetupScrollbars()
 
 /* virtual */ const char *TextfileWindow::NextString()
 {
-	if (this->search_iterator >= this->lines.Length()) return NULL;
+	if (this->search_iterator >= this->lines.size()) return NULL;
 
 	return this->lines[this->search_iterator++];
 }

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -319,7 +319,7 @@ static void Xunzip(byte **bufp, size_t *sizep)
 {
 	if (textfile == NULL) return;
 
-	this->lines.Clear();
+	this->lines.clear();
 
 	/* Get text from file */
 	size_t filesize;

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -365,11 +365,11 @@ static void Xunzip(byte **bufp, size_t *sizep)
 	str_validate(p, this->text + filesize, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE);
 
 	/* Split the string on newlines. */
-	*this->lines.Append() = p;
+	this->lines.push_back(p);
 	for (; *p != '\0'; p++) {
 		if (*p == '\n') {
 			*p = '\0';
-			*this->lines.Append() = p + 1;
+			this->lines.push_back(p + 1);
 		}
 	}
 

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -21,12 +21,12 @@ const char *GetTextfile(TextfileType type, Subdirectory dir, const char *filenam
 
 /** Window for displaying a textfile */
 struct TextfileWindow : public Window, MissingGlyphSearcher {
-	TextfileType file_type;              ///< Type of textfile to view.
-	Scrollbar *vscroll;                  ///< Vertical scrollbar.
-	Scrollbar *hscroll;                  ///< Horizontal scrollbar.
-	char *text;                          ///< Lines of text from the NewGRF's textfile.
-	SmallVector<const char *, 64> lines; ///< #text, split into lines in a table with lines.
-	uint search_iterator;                ///< Iterator for the font check search.
+	TextfileType file_type;          ///< Type of textfile to view.
+	Scrollbar *vscroll;              ///< Vertical scrollbar.
+	Scrollbar *hscroll;              ///< Horizontal scrollbar.
+	char *text;                      ///< Lines of text from the NewGRF's textfile.
+	std::vector<const char *> lines; ///< #text, split into lines in a table with lines.
+	uint search_iterator;            ///< Iterator for the font check search.
 
 	static const int TOP_SPACING    = WD_FRAMETEXT_TOP;    ///< Additional spacing at the top of the #WID_TF_BACKGROUND widget.
 	static const int BOTTOM_SPACING = WD_FRAMETEXT_BOTTOM; ///< Additional spacing at the bottom of the #WID_TF_BACKGROUND widget.

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -298,10 +298,9 @@ CommandCost CmdSetTimetableStart(TileIndex tile, DoCommandFlag flags, uint32 p1,
 			QSortT(vehs.Begin(), vehs.size(), &VehicleTimetableSorter);
 		}
 
-		int base = vehs.FindIndex(v);
+		int idx = vehs.begin() - std::find(vehs.begin(), vehs.end(), v);
 
 		for (Vehicle **viter = vehs.Begin(); viter != vehs.End(); viter++) {
-			int idx = (viter - vehs.Begin()) - base;
 			Vehicle *w = *viter;
 
 			w->lateness_counter = 0;
@@ -309,6 +308,7 @@ CommandCost CmdSetTimetableStart(TileIndex tile, DoCommandFlag flags, uint32 p1,
 			/* Do multiplication, then division to reduce rounding errors. */
 			w->timetable_start = start_date + idx * total_duration / num_vehs / DAY_TICKS;
 			SetWindowDirty(WC_VEHICLE_TIMETABLE, w->index);
+			++idx;
 		}
 
 	}

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -281,7 +281,7 @@ CommandCost CmdSetTimetableStart(TileIndex tile, DoCommandFlag flags, uint32 p1,
 	if (timetable_all && !v->orders.list->IsCompleteTimetable()) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
-		SmallVector<Vehicle *, 8> vehs;
+		std::vector<Vehicle *> vehs;
 
 		if (timetable_all) {
 			for (Vehicle *w = v->orders.list->GetFirstSharedVehicle(); w != NULL; w = w->NextShared()) {

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -285,10 +285,10 @@ CommandCost CmdSetTimetableStart(TileIndex tile, DoCommandFlag flags, uint32 p1,
 
 		if (timetable_all) {
 			for (Vehicle *w = v->orders.list->GetFirstSharedVehicle(); w != NULL; w = w->NextShared()) {
-				*vehs.Append() = w;
+				vehs.push_back(w);
 			}
 		} else {
-			*vehs.Append() = v;
+			vehs.push_back(v);
 		}
 
 		int total_duration = v->orders.list->GetTimetableTotalDuration();

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -292,10 +292,10 @@ CommandCost CmdSetTimetableStart(TileIndex tile, DoCommandFlag flags, uint32 p1,
 		}
 
 		int total_duration = v->orders.list->GetTimetableTotalDuration();
-		int num_vehs = vehs.Length();
+		int num_vehs = vehs.size();
 
 		if (num_vehs >= 2) {
-			QSortT(vehs.Begin(), vehs.Length(), &VehicleTimetableSorter);
+			QSortT(vehs.Begin(), vehs.size(), &VehicleTimetableSorter);
 		}
 
 		int base = vehs.FindIndex(v);

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -295,13 +295,12 @@ CommandCost CmdSetTimetableStart(TileIndex tile, DoCommandFlag flags, uint32 p1,
 		int num_vehs = vehs.size();
 
 		if (num_vehs >= 2) {
-			QSortT(vehs.Begin(), vehs.size(), &VehicleTimetableSorter);
+			QSortT(vehs.data(), vehs.size(), &VehicleTimetableSorter);
 		}
 
 		int idx = vehs.begin() - std::find(vehs.begin(), vehs.end(), v);
 
-		for (Vehicle **viter = vehs.Begin(); viter != vehs.End(); viter++) {
-			Vehicle *w = *viter;
+		for (Vehicle *w : vehs) {
 
 			w->lateness_counter = 0;
 			ClrBit(w->vehicle_flags, VF_TIMETABLE_STARTED);

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -198,7 +198,7 @@ static void PopupMainToolbMenu(Window *w, int widget, StringID string, int count
 {
 	DropDownList *list = new DropDownList();
 	for (int i = 0; i < count; i++) {
-		*list->Append() = new DropDownListStringItem(string + i, i, false);
+		list->push_back(new DropDownListStringItem(string + i, i, false));
 	}
 	PopupMainToolbMenu(w, widget, list, 0);
 }
@@ -224,27 +224,27 @@ static void PopupMainCompanyToolbMenu(Window *w, int widget, int grey = 0)
 			if (!_networking) break;
 
 			/* Add the client list button for the companies menu */
-			*list->Append() = new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_CLIENT_LIST, CTMN_CLIENT_LIST, false);
+			list->push_back(new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_CLIENT_LIST, CTMN_CLIENT_LIST, false));
 
 			if (_local_company == COMPANY_SPECTATOR) {
-				*list->Append() = new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_NEW_COMPANY, CTMN_NEW_COMPANY, NetworkMaxCompaniesReached());
+				list->push_back(new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_NEW_COMPANY, CTMN_NEW_COMPANY, NetworkMaxCompaniesReached()));
 			} else {
-				*list->Append() = new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_SPECTATE, CTMN_SPECTATE, NetworkMaxSpectatorsReached());
+				list->push_back(new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_SPECTATE, CTMN_SPECTATE, NetworkMaxSpectatorsReached()));
 			}
 			break;
 
 		case WID_TN_STORY:
-			*list->Append() = new DropDownListStringItem(STR_STORY_BOOK_SPECTATOR, CTMN_SPECTATOR, false);
+			list->push_back(new DropDownListStringItem(STR_STORY_BOOK_SPECTATOR, CTMN_SPECTATOR, false));
 			break;
 
 		case WID_TN_GOAL:
-			*list->Append() = new DropDownListStringItem(STR_GOALS_SPECTATOR, CTMN_SPECTATOR, false);
+			list->push_back(new DropDownListStringItem(STR_GOALS_SPECTATOR, CTMN_SPECTATOR, false));
 			break;
 	}
 
 	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 		if (!Company::IsValidID(c)) continue;
-		*list->Append() = new DropDownListCompanyItem(c, false, HasBit(grey, c));
+		list->push_back(new DropDownListCompanyItem(c, false, HasBit(grey, c)));
 	}
 
 	PopupMainToolbMenu(w, widget, list, _local_company == COMPANY_SPECTATOR ? (widget == WID_TN_COMPANIES ? CTMN_CLIENT_LIST : CTMN_SPECTATOR) : (int)_local_company);
@@ -318,24 +318,24 @@ enum OptionMenuEntries {
 static CallBackFunction ToolbarOptionsClick(Window *w)
 {
 	DropDownList *list = new DropDownList();
-	*list->Append() = new DropDownListStringItem(STR_SETTINGS_MENU_GAME_OPTIONS,             OME_GAMEOPTIONS, false);
-	*list->Append() = new DropDownListStringItem(STR_SETTINGS_MENU_CONFIG_SETTINGS_TREE,     OME_SETTINGS, false);
+	list->push_back(new DropDownListStringItem(STR_SETTINGS_MENU_GAME_OPTIONS,             OME_GAMEOPTIONS, false));
+	list->push_back(new DropDownListStringItem(STR_SETTINGS_MENU_CONFIG_SETTINGS_TREE,     OME_SETTINGS, false));
 	/* Changes to the per-AI settings don't get send from the server to the clients. Clients get
 	 * the settings once they join but never update it. As such don't show the window at all
 	 * to network clients. */
-	if (!_networking || _network_server) *list->Append() = new DropDownListStringItem(STR_SETTINGS_MENU_SCRIPT_SETTINGS, OME_SCRIPT_SETTINGS, false);
-	*list->Append() = new DropDownListStringItem(STR_SETTINGS_MENU_NEWGRF_SETTINGS,          OME_NEWGRFSETTINGS, false);
-	*list->Append() = new DropDownListStringItem(STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS,     OME_TRANSPARENCIES, false);
-	*list->Append() = new DropDownListItem(-1, false);
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED,    OME_SHOW_TOWNNAMES, false, HasBit(_display_opt, DO_SHOW_TOWN_NAMES));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED, OME_SHOW_STATIONNAMES, false, HasBit(_display_opt, DO_SHOW_STATION_NAMES));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED,     OME_SHOW_WAYPOINTNAMES, false, HasBit(_display_opt, DO_SHOW_WAYPOINT_NAMES));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_SIGNS_DISPLAYED,         OME_SHOW_SIGNS, false, HasBit(_display_opt, DO_SHOW_SIGNS));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS,   OME_SHOW_COMPETITOR_SIGNS, false, HasBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_FULL_ANIMATION,          OME_FULL_ANIMATION, false, HasBit(_display_opt, DO_FULL_ANIMATION));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_FULL_DETAIL,             OME_FULL_DETAILS, false, HasBit(_display_opt, DO_FULL_DETAIL));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_TRANSPARENT_BUILDINGS,   OME_TRANSPARENTBUILDINGS, false, IsTransparencySet(TO_HOUSES));
-	*list->Append() = new DropDownListCheckedItem(STR_SETTINGS_MENU_TRANSPARENT_SIGNS,       OME_SHOW_STATIONSIGNS, false, IsTransparencySet(TO_SIGNS));
+	if (!_networking || _network_server) list->push_back(new DropDownListStringItem(STR_SETTINGS_MENU_SCRIPT_SETTINGS, OME_SCRIPT_SETTINGS, false));
+	list->push_back(new DropDownListStringItem(STR_SETTINGS_MENU_NEWGRF_SETTINGS,          OME_NEWGRFSETTINGS, false));
+	list->push_back(new DropDownListStringItem(STR_SETTINGS_MENU_TRANSPARENCY_OPTIONS,     OME_TRANSPARENCIES, false));
+	list->push_back(new DropDownListItem(-1, false));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_TOWN_NAMES_DISPLAYED,    OME_SHOW_TOWNNAMES, false, HasBit(_display_opt, DO_SHOW_TOWN_NAMES)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_STATION_NAMES_DISPLAYED, OME_SHOW_STATIONNAMES, false, HasBit(_display_opt, DO_SHOW_STATION_NAMES)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_WAYPOINTS_DISPLAYED,     OME_SHOW_WAYPOINTNAMES, false, HasBit(_display_opt, DO_SHOW_WAYPOINT_NAMES)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_SIGNS_DISPLAYED,         OME_SHOW_SIGNS, false, HasBit(_display_opt, DO_SHOW_SIGNS)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_SHOW_COMPETITOR_SIGNS,   OME_SHOW_COMPETITOR_SIGNS, false, HasBit(_display_opt, DO_SHOW_COMPETITOR_SIGNS)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_FULL_ANIMATION,          OME_FULL_ANIMATION, false, HasBit(_display_opt, DO_FULL_ANIMATION)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_FULL_DETAIL,             OME_FULL_DETAILS, false, HasBit(_display_opt, DO_FULL_DETAIL)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_TRANSPARENT_BUILDINGS,   OME_TRANSPARENTBUILDINGS, false, IsTransparencySet(TO_HOUSES)));
+	list->push_back(new DropDownListCheckedItem(STR_SETTINGS_MENU_TRANSPARENT_SIGNS,       OME_SHOW_STATIONSIGNS, false, IsTransparencySet(TO_SIGNS)));
 
 	ShowDropDownList(w, list, 0, WID_TN_SETTINGS, 140, true, true);
 	if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
@@ -464,10 +464,10 @@ enum MapMenuEntries {
 static CallBackFunction ToolbarMapClick(Window *w)
 {
 	DropDownList *list = new DropDownList();
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD,            MME_SHOW_SMALLMAP,          false);
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_EXTRA_VIEW_PORT,         MME_SHOW_EXTRAVIEWPORTS,    false);
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_LINGRAPH_LEGEND,         MME_SHOW_LINKGRAPH,         false);
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS,         false);
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD,            MME_SHOW_SMALLMAP,          false));
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_EXTRA_VIEW_PORT,         MME_SHOW_EXTRAVIEWPORTS,    false));
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_LINGRAPH_LEGEND,         MME_SHOW_LINKGRAPH,         false));
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS,         false));
 	PopupMainToolbMenu(w, WID_TN_SMALL_MAP, list, 0);
 	return CBF_NONE;
 }
@@ -475,11 +475,11 @@ static CallBackFunction ToolbarMapClick(Window *w)
 static CallBackFunction ToolbarScenMapTownDir(Window *w)
 {
 	DropDownList *list = new DropDownList();
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD,            MME_SHOW_SMALLMAP,          false);
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_EXTRA_VIEW_PORT,         MME_SHOW_EXTRAVIEWPORTS,    false);
-	*list->Append() = new DropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS,         false);
-	*list->Append() = new DropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY,         MME_SHOW_TOWNDIRECTORY,     false);
-	*list->Append() = new DropDownListStringItem(STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, MME_SHOW_INDUSTRYDIRECTORY, false);
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_MAP_OF_WORLD,            MME_SHOW_SMALLMAP,          false));
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_EXTRA_VIEW_PORT,         MME_SHOW_EXTRAVIEWPORTS,    false));
+	list->push_back(new DropDownListStringItem(STR_MAP_MENU_SIGN_LIST,               MME_SHOW_SIGNLISTS,         false));
+	list->push_back(new DropDownListStringItem(STR_TOWN_MENU_TOWN_DIRECTORY,         MME_SHOW_TOWNDIRECTORY,     false));
+	list->push_back(new DropDownListStringItem(STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, MME_SHOW_INDUSTRYDIRECTORY, false));
 	PopupMainToolbMenu(w, WID_TE_SMALL_MAP, list, 0);
 	return CBF_NONE;
 }
@@ -897,7 +897,7 @@ static CallBackFunction ToolbarBuildRoadClick(Window *w)
 	DropDownList *list = new DropDownList();
 
 	/* Road is always visible and available. */
-	*list->Append() = new DropDownListIconItem(SPR_IMG_ROAD_X_DIR, PAL_NONE, STR_ROAD_MENU_ROAD_CONSTRUCTION, ROADTYPE_ROAD, false);
+	list->push_back(new DropDownListIconItem(SPR_IMG_ROAD_X_DIR, PAL_NONE, STR_ROAD_MENU_ROAD_CONSTRUCTION, ROADTYPE_ROAD, false));
 
 	/* Tram is only visible when there will be a tram, and available when that has been introduced. */
 	Engine *e;
@@ -905,7 +905,7 @@ static CallBackFunction ToolbarBuildRoadClick(Window *w)
 		if (!HasBit(e->info.climates, _settings_game.game_creation.landscape)) continue;
 		if (!HasBit(e->info.misc_flags, EF_ROAD_TRAM)) continue;
 
-		*list->Append() = new DropDownListIconItem(SPR_IMG_TRAMWAY_X_DIR, PAL_NONE, STR_ROAD_MENU_TRAM_CONSTRUCTION, ROADTYPE_TRAM, !HasBit(c->avail_roadtypes, ROADTYPE_TRAM));
+		list->push_back(new DropDownListIconItem(SPR_IMG_TRAMWAY_X_DIR, PAL_NONE, STR_ROAD_MENU_TRAM_CONSTRUCTION, ROADTYPE_TRAM, !HasBit(c->avail_roadtypes, ROADTYPE_TRAM)));
 		break;
 	}
 	ShowDropDownList(w, list, _last_built_roadtype, WID_TN_ROADS, 140, true, true);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3457,7 +3457,7 @@ Town *ClosestTownFromTile(TileIndex tile, uint threshold)
 }
 
 static bool _town_rating_test = false; ///< If \c true, town rating is in test-mode.
-static SmallMap<const Town *, int, 4> _town_test_ratings; ///< Map of towns to modified ratings, while in town rating test-mode.
+static SmallMap<const Town *, int> _town_test_ratings; ///< Map of towns to modified ratings, while in town rating test-mode.
 
 /**
  * Switch the town rating to test-mode, to allow commands to be tested without affecting current ratings.

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3469,7 +3469,7 @@ void SetTownRatingTestMode(bool mode)
 	static int ref_count = 0; // Number of times test-mode is switched on.
 	if (mode) {
 		if (ref_count == 0) {
-			_town_test_ratings.Clear();
+			_town_test_ratings.clear();
 		}
 		ref_count++;
 	} else {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -659,7 +659,7 @@ private:
 
 			this->towns.shrink_to_fit();
 			this->towns.RebuildDone();
-			this->vscroll->SetCount(this->towns.Length()); // Update scrollbar as well.
+			this->vscroll->SetCount(this->towns.size()); // Update scrollbar as well.
 		}
 		/* Always sort the towns. */
 		this->last_town = NULL;
@@ -766,7 +766,7 @@ public:
 			case WID_TD_LIST: {
 				int n = 0;
 				int y = r.top + WD_FRAMERECT_TOP;
-				if (this->towns.Length() == 0) { // No towns available.
+				if (this->towns.size() == 0) { // No towns available.
 					DrawString(r.left + WD_FRAMERECT_LEFT, r.right, y, STR_TOWN_DIRECTORY_NONE);
 					break;
 				}
@@ -778,7 +778,7 @@ public:
 				int text_right = r.right - WD_FRAMERECT_RIGHT - (rtl ? icon_size.width + 2 : 0);
 				int icon_x = rtl ? r.right - WD_FRAMERECT_RIGHT - icon_size.width : r.left + WD_FRAMERECT_LEFT;
 
-				for (uint i = this->vscroll->GetPosition(); i < this->towns.Length(); i++) {
+				for (uint i = this->vscroll->GetPosition(); i < this->towns.size(); i++) {
 					const Town *t = this->towns[i];
 					assert(t->xy != INVALID_TILE);
 
@@ -826,7 +826,7 @@ public:
 			}
 			case WID_TD_LIST: {
 				Dimension d = GetStringBoundingBox(STR_TOWN_DIRECTORY_NONE);
-				for (uint i = 0; i < this->towns.Length(); i++) {
+				for (uint i = 0; i < this->towns.size(); i++) {
 					const Town *t = this->towns[i];
 
 					assert(t != NULL);
@@ -879,7 +879,7 @@ public:
 
 			case WID_TD_LIST: { // Click on Town Matrix
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_TD_LIST, WD_FRAMERECT_TOP);
-				if (id_v >= this->towns.Length()) return; // click out of town bounds
+				if (id_v >= this->towns.size()) return; // click out of town bounds
 
 				const Town *t = this->towns[id_v];
 				assert(t != NULL);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -654,7 +654,7 @@ private:
 
 			const Town *t;
 			FOR_ALL_TOWNS(t) {
-				*this->towns.Append() = t;
+				this->towns.push_back(t);
 			}
 
 			this->towns.shrink_to_fit();

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -650,7 +650,7 @@ private:
 	void BuildSortTownList()
 	{
 		if (this->towns.NeedRebuild()) {
-			this->towns.Clear();
+			this->towns.clear();
 
 			const Town *t;
 			FOR_ALL_TOWNS(t) {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -657,7 +657,7 @@ private:
 				*this->towns.Append() = t;
 			}
 
-			this->towns.Compact();
+			this->towns.shrink_to_fit();
 			this->towns.RebuildDone();
 			this->vscroll->SetCount(this->towns.Length()); // Update scrollbar as well.
 		}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -814,7 +814,7 @@ static Train *FindGoodVehiclePos(const Train *src)
 }
 
 /** Helper type for lists/vectors of trains */
-typedef SmallVector<Train *, 16> TrainList;
+typedef std::vector<Train *> TrainList;
 
 /**
  * Make a backup of a train into a train list.

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -833,7 +833,7 @@ static void MakeTrainBackup(TrainList &list, Train *t)
 static void RestoreTrainBackup(TrainList &list)
 {
 	/* No train, nothing to do. */
-	if (list.Length() == 0) return;
+	if (list.size() == 0) return;
 
 	Train *prev = NULL;
 	/* Iterate over the list and rebuild it. */

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -823,7 +823,7 @@ typedef SmallVector<Train *, 16> TrainList;
  */
 static void MakeTrainBackup(TrainList &list, Train *t)
 {
-	for (; t != NULL; t = t->Next()) *list.Append() = t;
+	for (; t != NULL; t = t->Next()) list.push_back(t);
 }
 
 /**

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -837,8 +837,7 @@ static void RestoreTrainBackup(TrainList &list)
 
 	Train *prev = NULL;
 	/* Iterate over the list and rebuild it. */
-	for (Train **iter = list.Begin(); iter != list.End(); iter++) {
-		Train *t = *iter;
+	for (Train *t : list) {
 		if (prev != NULL) {
 			prev->SetNext(t);
 		} else if (t->Previous() != NULL) {

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -332,7 +332,7 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != NULL; v = v->GetNextVehicle()) {
 			GetCargoSummaryOfArticulatedVehicle(v, &_cargo_summary);
-			num += max(1u, _cargo_summary.Length());
+			num += max(1u, (unsigned)_cargo_summary.size());
 
 			uint length = GetLengthOfArticulatedVehicle(v);
 			if (length > TRAIN_DETAILS_MAX_INDENT) num++;
@@ -400,7 +400,7 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 				dx = 0;
 			}
 
-			uint num_lines = max(1u, _cargo_summary.Length());
+			uint num_lines = max(1u, (unsigned)_cargo_summary.size());
 			for (uint i = 0; i < num_lines; i++) {
 				int sprite_width = max<int>(dx, ScaleGUITrad(TRAIN_DETAILS_MIN_INDENT)) + 3;
 				int data_left  = left + (rtl ? 0 : sprite_width);
@@ -412,7 +412,7 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 					}
 					switch (det_tab) {
 						case TDW_TAB_CARGO:
-							if (i < _cargo_summary.Length()) {
+							if (i < _cargo_summary.size()) {
 								TrainDetailsCargoTab(&_cargo_summary[i], data_left, data_right, py);
 							} else {
 								DrawString(data_left, data_right, py, STR_QUANTITY_N_A, TC_LIGHT_BLUE);
@@ -424,7 +424,7 @@ void DrawTrainDetails(const Train *v, int left, int right, int y, int vscroll_po
 							break;
 
 						case TDW_TAB_CAPACITY:
-							if (i < _cargo_summary.Length()) {
+							if (i < _cargo_summary.size()) {
 								TrainDetailsCapacityTab(&_cargo_summary[i], data_left, data_right, py);
 							} else {
 								SetDParam(0, STR_EMPTY);

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -280,7 +280,8 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *su
 
 		CargoSummaryItem *item = &*std::find(summary->begin(), summary->end(), new_item);
 		if (item == summary->End()) {
-			item = summary->Append();
+			/*C++17: item = &*/ summary->emplace_back();
+			item = &summary->back();
 			item->cargo = new_item.cargo;
 			item->subtype = new_item.subtype;
 			item->capacity = 0;

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -174,6 +174,12 @@ struct CargoSummaryItem {
 	{
 		return this->cargo != other.cargo || this->subtype != other.subtype;
 	}
+
+	/** Used by std::find() and similar functions */
+	inline bool operator == (const CargoSummaryItem &other) const
+	{
+		return !(this->cargo != other.cargo);
+	}
 };
 
 static const uint TRAIN_DETAILS_MIN_INDENT = 32; ///< Minimum indent level in the train details window
@@ -272,7 +278,7 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *su
 		new_item.subtype = GetCargoSubtypeText(v);
 		if (new_item.cargo == INVALID_CARGO && new_item.subtype == STR_EMPTY) continue;
 
-		CargoSummaryItem *item = summary->Find(new_item);
+		CargoSummaryItem *item = &*std::find(summary->begin(), summary->end(), new_item);
 		if (item == summary->End()) {
 			item = summary->Append();
 			item->cargo = new_item.cargo;

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -263,7 +263,7 @@ static void TrainDetailsCapacityTab(const CargoSummaryItem *item, int left, int 
  */
 static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *summary)
 {
-	summary->Clear();
+	summary->clear();
 	do {
 		if (!v->GetEngine()->CanCarryCargo()) continue;
 

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -278,10 +278,10 @@ static void GetCargoSummaryOfArticulatedVehicle(const Train *v, CargoSummary *su
 		new_item.subtype = GetCargoSubtypeText(v);
 		if (new_item.cargo == INVALID_CARGO && new_item.subtype == STR_EMPTY) continue;
 
-		CargoSummaryItem *item = &*std::find(summary->begin(), summary->end(), new_item);
-		if (item == summary->End()) {
-			/*C++17: item = &*/ summary->emplace_back();
-			item = &summary->back();
+		auto item = std::find(summary->begin(), summary->end(), new_item);
+		if (item == summary->end()) {
+			summary->emplace_back();
+			item = summary->end() - 1;
 			item->cargo = new_item.cargo;
 			item->subtype = new_item.subtype;
 			item->capacity = 0;

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -186,7 +186,7 @@ static const uint TRAIN_DETAILS_MIN_INDENT = 32; ///< Minimum indent level in th
 static const uint TRAIN_DETAILS_MAX_INDENT = 72; ///< Maximum indent level in the train details window; wider than this and we start on a new line
 
 /** Container for the cargo summary information. */
-typedef SmallVector<CargoSummaryItem, 2> CargoSummary;
+typedef std::vector<CargoSummaryItem> CargoSummary;
 /** Reused container of cargo details */
 static CargoSummary _cargo_summary;
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -681,9 +681,8 @@ CommandCost CmdBuildTunnel(TileIndex start_tile, DoCommandFlag flags, uint32 p1,
 		 * Do this for all tiles (like trees), not only objects. */
 		ClearedObjectArea *coa = FindClearedObject(end_tile);
 		if (coa == NULL) {
-			coa = _cleared_object_areas.Append();
-			coa->first_tile = end_tile;
-			coa->area = TileArea(end_tile, 1, 1);
+			/*C++17: coa = &*/ _cleared_object_areas.push_back({end_tile, TileArea(end_tile, 1, 1)});
+			coa = &_cleared_object_areas.back();
 		}
 
 		/* Hide the tile from the terraforming command */

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -698,8 +698,9 @@ CommandCost CmdBuildTunnel(TileIndex start_tile, DoCommandFlag flags, uint32 p1,
 		 * Deliberately clear the coa pointer to avoid leaving dangling pointers which could
 		 * inadvertently be dereferenced.
 		 */
-		assert(coa >= _cleared_object_areas.Begin() && coa < _cleared_object_areas.End());
-		size_t coa_index = coa - _cleared_object_areas.Begin();
+		ClearedObjectArea *begin = _cleared_object_areas.data();
+		assert(coa >= begin && coa < begin + _cleared_object_areas.size());
+		size_t coa_index = coa - begin;
 		assert(coa_index < UINT_MAX); // more than 2**32 cleared areas would be a bug in itself
 		coa = NULL;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1028,15 +1028,15 @@ void CallVehicleTicks()
 	}
 
 	Backup<CompanyByte> cur_company(_current_company, FILE_LINE);
-	for (AutoreplaceMap::iterator it = _vehicles_to_autoreplace.Begin(); it != _vehicles_to_autoreplace.End(); it++) {
-		v = it->first;
+	for (auto &it : _vehicles_to_autoreplace) {
+		v = it.first;
 		/* Autoreplace needs the current company set as the vehicle owner */
 		cur_company.Change(v->owner);
 
 		/* Start vehicle if we stopped them in VehicleEnteredDepotThisTick()
 		 * We need to stop them between VehicleEnteredDepotThisTick() and here or we risk that
 		 * they are already leaving the depot again before being replaced. */
-		if (it->second) v->vehstatus &= ~VS_STOPPED;
+		if (it.second) v->vehstatus &= ~VS_STOPPED;
 
 		/* Store the position of the effect as the vehicle pointer will become invalid later */
 		int x = v->x_pos;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -693,7 +693,8 @@ static AutoreplaceMap _vehicles_to_autoreplace;
 
 void InitializeVehicles()
 {
-	_vehicles_to_autoreplace.Reset();
+	_vehicles_to_autoreplace.clear();
+	_vehicles_to_autoreplace.shrink_to_fit();
 	ResetVehicleHash();
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2283,9 +2283,7 @@ void Vehicle::GetConsistFreeCapacities(SmallMap<CargoID, uint> &capacities) cons
 		if (v->cargo_cap == 0) continue;
 		SmallPair<CargoID, uint> *pair = capacities.Find(v->cargo_type);
 		if (pair == capacities.End()) {
-			pair = capacities.Append();
-			pair->first = v->cargo_type;
-			pair->second = v->cargo_cap - v->cargo.StoredCount();
+			capacities.push_back({v->cargo_type, v->cargo_cap - v->cargo.StoredCount()});
 		} else {
 			pair->second += v->cargo_cap - v->cargo.StoredCount();
 		}

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2899,10 +2899,10 @@ void GetVehicleSet(VehicleSet &set, Vehicle *v, uint8 num_vehicles)
 		for (; u != NULL && num_vehicles > 0; num_vehicles--) {
 			do {
 				/* Include current vehicle in the selection. */
-				set.Include(u->index);
+				include(set, u->index);
 
 				/* If the vehicle is multiheaded, add the other part too. */
-				if (u->IsMultiheaded()) set.Include(u->other_multiheaded_part->index);
+				if (u->IsMultiheaded()) include(set, u->other_multiheaded_part->index);
 
 				u = u->Next();
 			} while (u != NULL && u->IsArticulatedPart());

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -942,7 +942,7 @@ static void RunVehicleDayProc()
 
 void CallVehicleTicks()
 {
-	_vehicles_to_autoreplace.Clear();
+	_vehicles_to_autoreplace.clear();
 
 	RunVehicleDayProc();
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -688,7 +688,7 @@ void ResetVehicleColourMap()
  * List of vehicles that should check for autoreplace this tick.
  * Mapping of vehicle -> leave depot immediately after autoreplace.
  */
-typedef SmallMap<Vehicle *, bool, 4> AutoreplaceMap;
+typedef SmallMap<Vehicle *, bool> AutoreplaceMap;
 static AutoreplaceMap _vehicles_to_autoreplace;
 
 void InitializeVehicles()

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -422,17 +422,17 @@ static CommandCost RefitVehicle(Vehicle *v, bool only_this, uint8 num_vehicles, 
 
 	if (flags & DC_EXEC) {
 		/* Store the result */
-		for (RefitResult *result = refit_result.Begin(); result != refit_result.End(); result++) {
-			Vehicle *u = result->v;
-			u->refit_cap = (u->cargo_type == new_cid) ? min(result->capacity, u->refit_cap) : 0;
+		for (RefitResult &result : refit_result) {
+			Vehicle *u = result.v;
+			u->refit_cap = (u->cargo_type == new_cid) ? min(result.capacity, u->refit_cap) : 0;
 			if (u->cargo.TotalCount() > u->refit_cap) u->cargo.Truncate(u->cargo.TotalCount() - u->refit_cap);
 			u->cargo_type = new_cid;
-			u->cargo_cap = result->capacity;
-			u->cargo_subtype = result->subtype;
+			u->cargo_cap = result.capacity;
+			u->cargo_subtype = result.subtype;
 			if (u->type == VEH_AIRCRAFT) {
 				Vehicle *w = u->Next();
-				w->refit_cap = min(w->refit_cap, result->mail_capacity);
-				w->cargo_cap = result->mail_capacity;
+				w->refit_cap = min(w->refit_cap, result.mail_capacity);
+				w->cargo_cap = result.mail_capacity;
 				if (w->cargo.TotalCount() > w->refit_cap) w->cargo.Truncate(w->cargo.TotalCount() - w->refit_cap);
 			}
 		}

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -347,7 +347,7 @@ static CommandCost RefitVehicle(Vehicle *v, bool only_this, uint8 num_vehicles, 
 	}
 
 	static SmallVector<RefitResult, 16> refit_result;
-	refit_result.Clear();
+	refit_result.clear();
 
 	v->InvalidateNewGRFCacheOfChain();
 	byte actual_subtype = new_subtype;
@@ -442,7 +442,7 @@ static CommandCost RefitVehicle(Vehicle *v, bool only_this, uint8 num_vehicles, 
 		}
 	}
 
-	refit_result.Clear();
+	refit_result.clear();
 	_returned_refit_capacity = total_capacity;
 	_returned_mail_refit_capacity = total_mail_capacity;
 	return cost;

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -355,7 +355,7 @@ static CommandCost RefitVehicle(Vehicle *v, bool only_this, uint8 num_vehicles, 
 		/* Reset actual_subtype for every new vehicle */
 		if (!v->IsArticulatedPart()) actual_subtype = new_subtype;
 
-		if (v->type == VEH_TRAIN && !vehicles_to_refit.Contains(v->index) && !only_this) continue;
+		if (v->type == VEH_TRAIN && std::find(vehicles_to_refit.begin(), vehicles_to_refit.end(), v->index) == vehicles_to_refit.end() && !only_this) continue;
 
 		const Engine *e = v->GetEngine();
 		if (!e->CanCarryCargo()) continue;

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -417,11 +417,7 @@ static CommandCost RefitVehicle(Vehicle *v, bool only_this, uint8 num_vehicles, 
 		 *  - We have to call the refit cost callback with the pre-refit configuration of the chain because we want refit and
 		 *    autorefit to behave the same, and we need its result for auto_refit_allowed.
 		 */
-		RefitResult *result = refit_result.Append();
-		result->v = v;
-		result->capacity = amount;
-		result->mail_capacity = mail_capacity;
-		result->subtype = actual_subtype;
+		refit_result.push_back({v, amount, mail_capacity, actual_subtype});
 	}
 
 	if (flags & DC_EXEC) {

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -346,8 +346,7 @@ static CommandCost RefitVehicle(Vehicle *v, bool only_this, uint8 num_vehicles, 
 		v = v->First();
 	}
 
-	static SmallVector<RefitResult, 16> refit_result;
-	refit_result.clear();
+	std::vector<RefitResult> refit_result;
 
 	v->InvalidateNewGRFCacheOfChain();
 	byte actual_subtype = new_subtype;

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -652,7 +652,7 @@ CommandCost CmdMassStartStopVehicle(TileIndex tile, DoCommandFlag flags, uint32 
 		BuildDepotVehicleList(vli.vtype, tile, &list, NULL);
 	}
 
-	for (uint i = 0; i < list.Length(); i++) {
+	for (uint i = 0; i < list.size(); i++) {
 		const Vehicle *v = list[i];
 
 		if (!!(v->vehstatus & VS_STOPPED) != do_start) continue;
@@ -691,7 +691,7 @@ CommandCost CmdDepotSellAllVehicles(TileIndex tile, DoCommandFlag flags, uint32 
 
 	CommandCost last_error = CMD_ERROR;
 	bool had_success = false;
-	for (uint i = 0; i < list.Length(); i++) {
+	for (uint i = 0; i < list.size(); i++) {
 		CommandCost ret = DoCommand(tile, list[i]->index | (1 << 20), 0, flags, sell_command);
 		if (ret.Succeeded()) {
 			cost.AddCost(ret);
@@ -725,7 +725,7 @@ CommandCost CmdDepotMassAutoReplace(TileIndex tile, DoCommandFlag flags, uint32 
 	/* Get the list of vehicles in the depot */
 	BuildDepotVehicleList(vehicle_type, tile, &list, &list, true);
 
-	for (uint i = 0; i < list.Length(); i++) {
+	for (uint i = 0; i < list.size(); i++) {
 		const Vehicle *v = list[i];
 
 		/* Ensure that the vehicle completely in the depot */
@@ -1003,7 +1003,7 @@ static CommandCost SendAllVehiclesToDepot(DoCommandFlag flags, bool service, con
 
 	/* Send all the vehicles to a depot */
 	bool had_success = false;
-	for (uint i = 0; i < list.Length(); i++) {
+	for (uint i = 0; i < list.size(); i++) {
 		const Vehicle *v = list[i];
 		CommandCost ret = DoCommand(v->tile, v->index | (service ? DEPOT_SERVICE : 0U) | DEPOT_DONT_CANCEL, 0, flags, GetCmdSendToDepot(vli.vtype));
 

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -175,7 +175,7 @@ bool CanVehicleUseStation(const Vehicle *v, const struct Station *st);
 
 void ReleaseDisastersTargetingVehicle(VehicleID vehicle);
 
-typedef SmallVector<VehicleID, 2> VehicleSet;
+typedef std::vector<VehicleID> VehicleSet;
 void GetVehicleSet(VehicleSet &set, Vehicle *v, uint8 num_vehicles);
 
 void CheckCargoCapacity(Vehicle *v);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -234,7 +234,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 
 	/* Create a list of subtypes used by the various parts of v_for */
 	static SmallVector<StringID, 4> subtypes;
-	subtypes.Clear();
+	subtypes.clear();
 	for (; v_from != NULL; v_from = v_from->HasArticulatedPart() ? v_from->GetNextArticulatedPart() : NULL) {
 		const Engine *e_from = v_from->GetEngine();
 		if (!e_from->CanCarryCargo() || !HasBit(e_from->info.callback_mask, CBM_VEHICLE_CARGO_SUFFIX)) continue;
@@ -406,7 +406,7 @@ struct RefitWindow : public Window {
 	 */
 	void BuildRefitList()
 	{
-		for (uint i = 0; i < NUM_CARGO; i++) this->list[i].Clear();
+		for (uint i = 0; i < NUM_CARGO; i++) this->list[i].clear();
 		Vehicle *v = Vehicle::Get(this->window_number);
 
 		/* Check only the selected vehicles. */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -133,7 +133,7 @@ void BaseVehicleListWindow::BuildVehicleList()
 	this->unitnumber_digits = GetUnitNumberDigits(this->vehicles);
 
 	this->vehicles.RebuildDone();
-	this->vscroll->SetCount(this->vehicles.Length());
+	this->vscroll->SetCount(this->vehicles.size());
 }
 
 /**
@@ -193,8 +193,8 @@ void BaseVehicleListWindow::SortVehicleList()
 
 void DepotSortList(VehicleList *list)
 {
-	if (list->Length() < 2) return;
-	QSortT(list->Begin(), list->Length(), &VehicleNumberSorter);
+	if (list->size() < 2) return;
+	QSortT(list->Begin(), list->size(), &VehicleNumberSorter);
 }
 
 /** draw the vehicle profit button in the vehicle list window. */
@@ -243,7 +243,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 
 	byte ret_refit_cyc = 0;
 	bool success = false;
-	if (subtypes.Length() > 0) {
+	if (subtypes.size() > 0) {
 		/* Check whether any articulated part is refittable to 'dest_cargo_type' with a subtype listed in 'subtypes' */
 		for (Vehicle *v = v_for; v != NULL; v = v->HasArticulatedPart() ? v->GetNextArticulatedPart() : NULL) {
 			const Engine *e = v->GetEngine();
@@ -347,7 +347,7 @@ static void DrawVehicleRefitWindow(const SubtypeList list[NUM_CARGO], const int 
 
 	/* Draw the list of subtypes for each cargo, and find the selected refit option (by its position). */
 	for (uint i = 0; current < pos + rows && i < NUM_CARGO; i++) {
-		for (uint j = 0; current < pos + rows && j < list[i].Length(); j++) {
+		for (uint j = 0; current < pos + rows && j < list[i].size(); j++) {
 			const RefitOption &refit = list[i][j];
 
 			/* Hide subtypes if sel[0] does not match */
@@ -359,11 +359,11 @@ static void DrawVehicleRefitWindow(const SubtypeList list[NUM_CARGO], const int 
 				continue;
 			}
 
-			if (list[i].Length() > 1) {
+			if (list[i].size() > 1) {
 				if (refit.subtype != 0xFF) {
 					/* Draw tree lines */
 					int ycenter = y + FONT_HEIGHT_NORMAL / 2;
-					GfxDrawLine(iconcenter, y - WD_MATRIX_TOP, iconcenter, j == list[i].Length() - 1 ? ycenter : y - WD_MATRIX_TOP + delta - 1, linecolour);
+					GfxDrawLine(iconcenter, y - WD_MATRIX_TOP, iconcenter, j == list[i].size() - 1 ? ycenter : y - WD_MATRIX_TOP + delta - 1, linecolour);
 					GfxDrawLine(iconcenter, ycenter, iconinner, ycenter, linecolour);
 				} else {
 					/* Draw expand/collapse icon */
@@ -435,7 +435,7 @@ struct RefitWindow : public Window {
 					continue;
 				}
 
-				bool first_vehicle = this->list[current_index].Length() == 0;
+				bool first_vehicle = this->list[current_index].size() == 0;
 				if (first_vehicle) {
 					/* Keeping the current subtype is always an option. It also serves as the option in case of no subtypes */
 					RefitOption *option = this->list[current_index].Append();
@@ -480,7 +480,7 @@ struct RefitWindow : public Window {
 								/* No more subtypes for this vehicle, delete all subtypes >= refit_cyc */
 								SubtypeList &l = this->list[current_index];
 								/* 0xFF item is in front, other subtypes are sorted. So just truncate the list in the right spot */
-								for (uint i = 1; i < l.Length(); i++) {
+								for (uint i = 1; i < l.size(); i++) {
 									if (l[i].subtype >= refit_cyc) {
 										l.Resize(i);
 										break;
@@ -491,8 +491,8 @@ struct RefitWindow : public Window {
 								/* Check whether the subtype matches with the subtype of earlier vehicles. */
 								uint pos = 1;
 								SubtypeList &l = this->list[current_index];
-								while (pos < l.Length() && l[pos].subtype != refit_cyc) pos++;
-								if (pos < l.Length() && l[pos].string != subtype) {
+								while (pos < l.size() && l[pos].subtype != refit_cyc) pos++;
+								if (pos < l.size() && l[pos].string != subtype) {
 									/* String mismatch, remove item keeping the order */
 									l.ErasePreservingOrder(pos);
 								}
@@ -522,7 +522,7 @@ struct RefitWindow : public Window {
 		uint row = 0;
 
 		for (uint i = 0; i < NUM_CARGO; i++) {
-			for (uint j = 0; j < this->list[i].Length(); j++) {
+			for (uint j = 0; j < this->list[i].size(); j++) {
 				const RefitOption &refit = this->list[i][j];
 
 				/* Hide subtypes if sel[0] does not match */
@@ -547,7 +547,7 @@ struct RefitWindow : public Window {
 		uint row = 0;
 
 		for (uint i = 0; i < NUM_CARGO; i++) {
-			for (uint j = 0; j < this->list[i].Length(); j++) {
+			for (uint j = 0; j < this->list[i].size(); j++) {
 				const RefitOption &refit = this->list[i][j];
 
 				/* Hide subtypes if sel[0] does not match */
@@ -576,7 +576,7 @@ struct RefitWindow : public Window {
 		if (this->sel[0] < 0) return NULL;
 
 		SubtypeList &l = this->list[this->sel[0]];
-		if ((uint)this->sel[1] >= l.Length()) return NULL;
+		if ((uint)this->sel[1] >= l.size()) return NULL;
 
 		return &l[this->sel[1]];
 	}
@@ -617,7 +617,7 @@ struct RefitWindow : public Window {
 			this->sel[1] = 0;
 			this->cargo = NULL;
 			for (uint i = 0; this->cargo == NULL && i < NUM_CARGO; i++) {
-				for (uint j = 0; j < list[i].Length(); j++) {
+				for (uint j = 0; j < list[i].size(); j++) {
 					if (list[i][j] == current_refit_option) {
 						this->sel[0] = i;
 						this->sel[1] = j;
@@ -830,7 +830,7 @@ struct RefitWindow : public Window {
 
 				/* Check the width of all cargo information strings. */
 				for (uint i = 0; i < NUM_CARGO; i++) {
-					for (uint j = 0; j < this->list[i].Length(); j++) {
+					for (uint j = 0; j < this->list[i].size(); j++) {
 						StringID string = this->GetCapacityString(&list[i][j]);
 						if (string != INVALID_STRING_ID) {
 							Dimension dim = GetStringBoundingBox(string);
@@ -1388,7 +1388,7 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 	int vehicle_button_x = rtl ? right - GetSpriteSize(SPR_PROFIT_LOT).width : left;
 
 	int y = r.top;
-	uint max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->vehicles.Length());
+	uint max = min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->vehicles.size());
 	for (uint i = this->vscroll->GetPosition(); i < max; ++i) {
 		const Vehicle *v = this->vehicles[i];
 		StringID str;
@@ -1532,7 +1532,7 @@ public:
 			case WID_VL_CAPTION: {
 				switch (this->vli.type) {
 					case VL_SHARED_ORDERS: // Shared Orders
-						if (this->vehicles.Length() == 0) {
+						if (this->vehicles.size() == 0) {
 							/* We can't open this window without vehicles using this order
 							 * and we should close the window when deleting the order. */
 							NOT_REACHED();
@@ -1584,7 +1584,7 @@ public:
 		this->BuildVehicleList();
 		this->SortVehicleList();
 
-		if (this->vehicles.Length() == 0 && this->IsWidgetLowered(WID_VL_MANAGE_VEHICLES_DROPDOWN)) {
+		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_VL_MANAGE_VEHICLES_DROPDOWN)) {
 			HideDropDownMenu(this);
 		}
 
@@ -1598,7 +1598,7 @@ public:
 		}
 		if (this->owner == _local_company) {
 			this->SetWidgetDisabledState(WID_VL_AVAILABLE_VEHICLES, this->vli.type != VL_STANDARD);
-			this->SetWidgetsDisabledState(this->vehicles.Length() == 0,
+			this->SetWidgetsDisabledState(this->vehicles.size() == 0,
 				WID_VL_MANAGE_VEHICLES_DROPDOWN,
 				WID_VL_STOP_ALL,
 				WID_VL_START_ALL,
@@ -1626,7 +1626,7 @@ public:
 
 			case WID_VL_LIST: { // Matrix to show vehicles
 				uint id_v = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_VL_LIST);
-				if (id_v >= this->vehicles.Length()) return; // click out of list bound
+				if (id_v >= this->vehicles.size()) return; // click out of list bound
 
 				const Vehicle *v = this->vehicles[id_v];
 				if (!VehicleClicked(v)) ShowVehicleViewWindow(v);
@@ -1657,7 +1657,7 @@ public:
 				this->vehicles.SetSortType(index);
 				break;
 			case WID_VL_MANAGE_VEHICLES_DROPDOWN:
-				assert(this->vehicles.Length() != 0);
+				assert(this->vehicles.size() != 0);
 
 				switch (index) {
 					case ADI_REPLACE: // Replace window

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -106,8 +106,8 @@ const StringID BaseVehicleListWindow::vehicle_depot_name[] = {
 uint GetUnitNumberDigits(VehicleList &vehicles)
 {
 	uint unitnumber = 0;
-	for (const Vehicle **v = vehicles.Begin(); v != vehicles.End(); v++) {
-		unitnumber = max<uint>(unitnumber, (*v)->unitnumber);
+	for (const Vehicle *v : vehicles) {
+		unitnumber = max<uint>(unitnumber, v->unitnumber);
 	}
 
 	if (unitnumber >= 10000) return 5;
@@ -194,7 +194,7 @@ void BaseVehicleListWindow::SortVehicleList()
 void DepotSortList(VehicleList *list)
 {
 	if (list->size() < 2) return;
-	QSortT(list->Begin(), list->size(), &VehicleNumberSorter);
+	QSortT(list->data(), list->size(), &VehicleNumberSorter);
 }
 
 /** draw the vehicle profit button in the vehicle list window. */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -267,7 +267,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 				StringID subtype = GetCargoSubtypeText(v);
 				if (subtype == STR_EMPTY) break;
 
-				if (!subtypes.Contains(subtype)) continue;
+				if (std::find(subtypes.begin(), subtypes.end(), subtype) == subtypes.end()) continue;
 
 				/* We found something matching. */
 				ret_refit_cyc = refit_cyc;
@@ -414,7 +414,7 @@ struct RefitWindow : public Window {
 		GetVehicleSet(vehicles_to_refit, Vehicle::Get(this->selected_vehicle), this->num_vehicles);
 
 		do {
-			if (v->type == VEH_TRAIN && !vehicles_to_refit.Contains(v->index)) continue;
+			if (v->type == VEH_TRAIN && std::find(vehicles_to_refit.begin(), vehicles_to_refit.end(), v->index) == vehicles_to_refit.end()) continue;
 			const Engine *e = v->GetEngine();
 			CargoTypes cmask = e->info.refit_mask;
 			byte callback_mask = e->info.callback_mask;
@@ -747,14 +747,15 @@ struct RefitWindow : public Window {
 
 						for (Train *u = Train::From(v); u != NULL; u = u->Next()) {
 							/* Start checking. */
-							if (vehicles_to_refit.Contains(u->index) && left == INT32_MIN) {
+							const bool contained = std::find(vehicles_to_refit.begin(), vehicles_to_refit.end(), u->index) != vehicles_to_refit.end();
+							if (contained && left == INT32_MIN) {
 								left = x - this->hscroll->GetPosition() + r.left + this->vehicle_margin;
 								width = 0;
 							}
 
 							/* Draw a selection. */
-							if ((!vehicles_to_refit.Contains(u->index) || u->Next() == NULL) && left != INT32_MIN) {
-								if (u->Next() == NULL && vehicles_to_refit.Contains(u->index)) {
+							if ((!contained || u->Next() == NULL) && left != INT32_MIN) {
+								if (u->Next() == NULL && contained) {
 									int current_width = u->GetDisplayImageWidth();
 									width += current_width;
 									x += current_width;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -168,13 +168,13 @@ DropDownList *BaseVehicleListWindow::BuildActionDropdownList(bool show_autorepla
 {
 	DropDownList *list = new DropDownList();
 
-	if (show_autoreplace) *list->Append() = new DropDownListStringItem(STR_VEHICLE_LIST_REPLACE_VEHICLES, ADI_REPLACE, false);
-	*list->Append() = new DropDownListStringItem(STR_VEHICLE_LIST_SEND_FOR_SERVICING, ADI_SERVICE, false);
-	*list->Append() = new DropDownListStringItem(this->vehicle_depot_name[this->vli.vtype], ADI_DEPOT, false);
+	if (show_autoreplace) list->push_back(new DropDownListStringItem(STR_VEHICLE_LIST_REPLACE_VEHICLES, ADI_REPLACE, false));
+	list->push_back(new DropDownListStringItem(STR_VEHICLE_LIST_SEND_FOR_SERVICING, ADI_SERVICE, false));
+	list->push_back(new DropDownListStringItem(this->vehicle_depot_name[this->vli.vtype], ADI_DEPOT, false));
 
 	if (show_group) {
-		*list->Append() = new DropDownListStringItem(STR_GROUP_ADD_SHARED_VEHICLE, ADI_ADD_SHARED, false);
-		*list->Append() = new DropDownListStringItem(STR_GROUP_REMOVE_ALL_VEHICLES, ADI_REMOVE_ALL, false);
+		list->push_back(new DropDownListStringItem(STR_GROUP_ADD_SHARED_VEHICLE, ADI_ADD_SHARED, false));
+		list->push_back(new DropDownListStringItem(STR_GROUP_REMOVE_ALL_VEHICLES, ADI_REMOVE_ALL, false));
 	}
 
 	return list;
@@ -438,10 +438,7 @@ struct RefitWindow : public Window {
 				bool first_vehicle = this->list[current_index].size() == 0;
 				if (first_vehicle) {
 					/* Keeping the current subtype is always an option. It also serves as the option in case of no subtypes */
-					RefitOption *option = this->list[current_index].Append();
-					option->cargo   = cid;
-					option->subtype = 0xFF;
-					option->string  = STR_EMPTY;
+					this->list[current_index].push_back({cid, 0xFF, STR_EMPTY});
 				}
 
 				/* Check the vehicle's callback mask for cargo suffixes.

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -238,7 +238,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 	for (; v_from != NULL; v_from = v_from->HasArticulatedPart() ? v_from->GetNextArticulatedPart() : NULL) {
 		const Engine *e_from = v_from->GetEngine();
 		if (!e_from->CanCarryCargo() || !HasBit(e_from->info.callback_mask, CBM_VEHICLE_CARGO_SUFFIX)) continue;
-		subtypes.Include(GetCargoSubtypeText(v_from));
+		include(subtypes, GetCargoSubtypeText(v_from));
 	}
 
 	byte ret_refit_cyc = 0;
@@ -470,7 +470,7 @@ struct RefitWindow : public Window {
 							option.cargo   = cid;
 							option.subtype = refit_cyc;
 							option.string  = subtype;
-							this->list[current_index].Include(option);
+							include(this->list[current_index], option);
 						} else {
 							/* Intersect the subtypes of earlier vehicles with the subtypes of this vehicle */
 							if (subtype == STR_EMPTY) {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -482,7 +482,7 @@ struct RefitWindow : public Window {
 								/* 0xFF item is in front, other subtypes are sorted. So just truncate the list in the right spot */
 								for (uint i = 1; i < l.size(); i++) {
 									if (l[i].subtype >= refit_cyc) {
-										l.Resize(i);
+										l.resize(i);
 										break;
 									}
 								}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -233,7 +233,7 @@ byte GetBestFittingSubType(Vehicle *v_from, Vehicle *v_for, CargoID dest_cargo_t
 	v_for = v_for->GetFirstEnginePart();
 
 	/* Create a list of subtypes used by the various parts of v_for */
-	static SmallVector<StringID, 4> subtypes;
+	static std::vector<StringID> subtypes;
 	subtypes.clear();
 	for (; v_from != NULL; v_from = v_from->HasArticulatedPart() ? v_from->GetNextArticulatedPart() : NULL) {
 		const Engine *e_from = v_from->GetEngine();
@@ -317,7 +317,7 @@ struct RefitOption {
 	}
 };
 
-typedef SmallVector<RefitOption, 32> SubtypeList; ///< List of refit subtypes associated to a cargo.
+typedef std::vector<RefitOption> SubtypeList; ///< List of refit subtypes associated to a cargo.
 
 /**
  * Draw the list of available refit options for a consist and highlight the selected refit option (if any).

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -494,7 +494,7 @@ struct RefitWindow : public Window {
 								while (pos < l.size() && l[pos].subtype != refit_cyc) pos++;
 								if (pos < l.size() && l[pos].string != subtype) {
 									/* String mismatch, remove item keeping the order */
-									l.ErasePreservingOrder(pos);
+									l.erase(l.begin() + pos);
 								}
 							}
 						}

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -85,7 +85,7 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 				if (t->IsArticulatedPart() || t->IsRearDualheaded()) continue;
 				if (t->track != TRACK_BIT_DEPOT) continue;
 				if (wagons != NULL && t->First()->IsFreeWagon()) {
-					if (individual_wagons || t->IsFreeWagon()) *wagons->Append() = t;
+					if (individual_wagons || t->IsFreeWagon()) wagons->push_back(t);
 					continue;
 				}
 				break;
@@ -98,7 +98,7 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 
 		if (!v->IsPrimaryVehicle()) continue;
 
-		*engines->Append() = v;
+		engines->push_back(v);
 	}
 
 	/* Ensure the lists are not wasting too much space. If the lists are fresh
@@ -128,7 +128,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 					FOR_VEHICLE_ORDERS(v, order) {
 						if ((order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT) || order->IsType(OT_IMPLICIT))
 								&& order->GetDestination() == vli.index) {
-							*list->Append() = v;
+							list->push_back(v);
 							break;
 						}
 					}
@@ -142,7 +142,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 			if (v == NULL || v->type != vli.vtype || !v->IsPrimaryVehicle()) return false;
 
 			for (; v != NULL; v = v->NextShared()) {
-				*list->Append() = v;
+				list->push_back(v);
 			}
 			break;
 
@@ -151,7 +151,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 				FOR_ALL_VEHICLES(v) {
 					if (v->type == vli.vtype && v->IsPrimaryVehicle() &&
 							v->owner == vli.company && GroupIsInGroup(v->group_id, vli.index)) {
-						*list->Append() = v;
+						list->push_back(v);
 					}
 				}
 				break;
@@ -161,7 +161,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		case VL_STANDARD:
 			FOR_ALL_VEHICLES(v) {
 				if (v->type == vli.vtype && v->owner == vli.company && v->IsPrimaryVehicle()) {
-					*list->Append() = v;
+					list->push_back(v);
 				}
 			}
 			break;
@@ -173,7 +173,7 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 
 					FOR_VEHICLE_ORDERS(v, order) {
 						if (order->IsType(OT_GOTO_DEPOT) && !(order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) && order->GetDestination() == vli.index) {
-							*list->Append() = v;
+							list->push_back(v);
 							break;
 						}
 					}

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -103,8 +103,8 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 
 	/* Ensure the lists are not wasting too much space. If the lists are fresh
 	 * (i.e. built within a command) then this will actually do nothing. */
-	engines->Compact();
-	if (wagons != NULL && wagons != engines) wagons->Compact();
+	engines->shrink_to_fit();
+	if (wagons != NULL && wagons != engines) wagons->shrink_to_fit();
 }
 
 /**
@@ -184,6 +184,6 @@ bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli
 		default: return false;
 	}
 
-	list->Compact();
+	list->shrink_to_fit();
 	return true;
 }

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -70,8 +70,8 @@ bool VehicleListIdentifier::UnpackIfValid(uint32 data)
  */
 void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engines, VehicleList *wagons, bool individual_wagons)
 {
-	engines->Clear();
-	if (wagons != NULL && wagons != engines) wagons->Clear();
+	engines->clear();
+	if (wagons != NULL && wagons != engines) wagons->clear();
 
 	const Vehicle *v;
 	FOR_ALL_VEHICLES(v) {
@@ -115,7 +115,7 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
  */
 bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &vli)
 {
-	list->Clear();
+	list->clear();
 
 	const Vehicle *v;
 

--- a/src/vehiclelist.h
+++ b/src/vehiclelist.h
@@ -52,7 +52,7 @@ struct VehicleListIdentifier {
 };
 
 /** A list of vehicles. */
-typedef SmallVector<const Vehicle *, 32> VehicleList;
+typedef std::vector<const Vehicle *> VehicleList;
 
 bool GenerateVehicleSortList(VehicleList *list, const VehicleListIdentifier &identifier);
 void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine_list, VehicleList *wagon_list, bool individual_wagons = false);

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1620,11 +1620,11 @@ void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom
 
 	_cur_dpi = old_dpi;
 
-	_vd.string_sprites_to_draw.Clear();
-	_vd.tile_sprites_to_draw.Clear();
-	_vd.parent_sprites_to_draw.Clear();
-	_vd.parent_sprites_to_sort.Clear();
-	_vd.child_screen_sprites_to_draw.Clear();
+	_vd.string_sprites_to_draw.clear();
+	_vd.tile_sprites_to_draw.clear();
+	_vd.parent_sprites_to_draw.clear();
+	_vd.parent_sprites_to_sort.clear();
+	_vd.child_screen_sprites_to_draw.clear();
 }
 
 /**

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -598,7 +598,7 @@ void OffsetGroundSprite(int x, int y)
 	}
 
 	/* _vd.last_child == NULL if foundation sprite was clipped by the viewport bounds */
-	if (_vd.last_child != NULL) _vd.foundation[_vd.foundation_part] = _vd.parent_sprites_to_draw.Length() - 1;
+	if (_vd.last_child != NULL) _vd.foundation[_vd.foundation_part] = _vd.parent_sprites_to_draw.size() - 1;
 
 	_vd.foundation_offset[_vd.foundation_part].x = x * ZOOM_LVL_BASE;
 	_vd.foundation_offset[_vd.foundation_part].y = y * ZOOM_LVL_BASE;
@@ -824,7 +824,7 @@ void AddChildSpriteScreen(SpriteID image, PaletteID pal, int x, int y, bool tran
 		pal = PALETTE_TO_TRANSPARENT;
 	}
 
-	*_vd.last_child = _vd.child_screen_sprites_to_draw.Length();
+	*_vd.last_child = _vd.child_screen_sprites_to_draw.size();
 
 	ChildScreenSpriteToDraw *cs = _vd.child_screen_sprites_to_draw.Append();
 	cs->image = image;
@@ -1584,7 +1584,7 @@ void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom
 
 	DrawTextEffects(&_vd.dpi);
 
-	if (_vd.tile_sprites_to_draw.Length() != 0) ViewportDrawTileSprites(&_vd.tile_sprites_to_draw);
+	if (_vd.tile_sprites_to_draw.size() != 0) ViewportDrawTileSprites(&_vd.tile_sprites_to_draw);
 
 	ParentSpriteToDraw *psd_end = _vd.parent_sprites_to_draw.End();
 	for (ParentSpriteToDraw *it = _vd.parent_sprites_to_draw.Begin(); it != psd_end; it++) {
@@ -1611,7 +1611,7 @@ void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom
 		vp->overlay->Draw(&dp);
 	}
 
-	if (_vd.string_sprites_to_draw.Length() != 0) {
+	if (_vd.string_sprites_to_draw.size() != 0) {
 		/* translate to world coordinates */
 		dp.left = UnScaleByZoom(_vd.dpi.left, zoom);
 		dp.top = UnScaleByZoom(_vd.dpi.top, zoom);

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -153,10 +153,10 @@ enum SpriteCombineMode {
 	SPRITE_COMBINE_ACTIVE,   ///< %Sprite combining is active. #AddSortableSpriteToDraw outputs child sprites.
 };
 
-typedef SmallVector<TileSpriteToDraw, 64> TileSpriteToDrawVector;
-typedef SmallVector<StringSpriteToDraw, 4> StringSpriteToDrawVector;
-typedef SmallVector<ParentSpriteToDraw, 64> ParentSpriteToDrawVector;
-typedef SmallVector<ChildScreenSpriteToDraw, 16> ChildScreenSpriteToDrawVector;
+typedef std::vector<TileSpriteToDraw> TileSpriteToDrawVector;
+typedef std::vector<StringSpriteToDraw> StringSpriteToDrawVector;
+typedef std::vector<ParentSpriteToDraw> ParentSpriteToDrawVector;
+typedef std::vector<ChildScreenSpriteToDraw> ChildScreenSpriteToDrawVector;
 
 /** Data structure storing rendering information */
 struct ViewportDrawer {

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1468,7 +1468,7 @@ static void ViewportDrawParentSprites(const ParentSpriteToSortVector *psd, const
 
 		int child_idx = ps->first_child;
 		while (child_idx >= 0) {
-			const ChildScreenSpriteToDraw *cs = csstdv->Get(child_idx);
+			const ChildScreenSpriteToDraw *cs = csstdv->data() + child_idx;
 			child_idx = cs->next;
 			DrawSpriteViewport(cs->image, cs->pal, ps->left + cs->x, ps->top + cs->y, cs->sub);
 		}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -499,13 +499,14 @@ static void AddTileSpriteToDraw(SpriteID image, PaletteID pal, int32 x, int32 y,
 {
 	assert((image & SPRITE_MASK) < MAX_SPRITES);
 
-	TileSpriteToDraw *ts = _vd.tile_sprites_to_draw.Append();
-	ts->image = image;
-	ts->pal = pal;
-	ts->sub = sub;
+	/*C++17: TileSpriteToDraw &ts = */ _vd.tile_sprites_to_draw.emplace_back();
+	TileSpriteToDraw &ts = _vd.tile_sprites_to_draw.back();
+	ts.image = image;
+	ts.pal = pal;
+	ts.sub = sub;
 	Point pt = RemapCoords(x, y, z);
-	ts->x = pt.x + extra_offs_x;
-	ts->y = pt.y + extra_offs_y;
+	ts.x = pt.x + extra_offs_x;
+	ts.y = pt.y + extra_offs_y;
 }
 
 /**
@@ -708,29 +709,30 @@ void AddSortableSpriteToDraw(SpriteID image, PaletteID pal, int x, int y, int w,
 		return;
 	}
 
-	ParentSpriteToDraw *ps = _vd.parent_sprites_to_draw.Append();
-	ps->x = tmp_x;
-	ps->y = tmp_y;
+	/*C++17: ParentSpriteToDraw &ps = */ _vd.parent_sprites_to_draw.emplace_back();
+	ParentSpriteToDraw &ps = _vd.parent_sprites_to_draw.back();
+	ps.x = tmp_x;
+	ps.y = tmp_y;
 
-	ps->left = tmp_left;
-	ps->top  = tmp_top;
+	ps.left = tmp_left;
+	ps.top  = tmp_top;
 
-	ps->image = image;
-	ps->pal = pal;
-	ps->sub = sub;
-	ps->xmin = x + bb_offset_x;
-	ps->xmax = x + max(bb_offset_x, w) - 1;
+	ps.image = image;
+	ps.pal = pal;
+	ps.sub = sub;
+	ps.xmin = x + bb_offset_x;
+	ps.xmax = x + max(bb_offset_x, w) - 1;
 
-	ps->ymin = y + bb_offset_y;
-	ps->ymax = y + max(bb_offset_y, h) - 1;
+	ps.ymin = y + bb_offset_y;
+	ps.ymax = y + max(bb_offset_y, h) - 1;
 
-	ps->zmin = z + bb_offset_z;
-	ps->zmax = z + max(bb_offset_z, dz) - 1;
+	ps.zmin = z + bb_offset_z;
+	ps.zmax = z + max(bb_offset_z, dz) - 1;
 
-	ps->comparison_done = false;
-	ps->first_child = -1;
+	ps.comparison_done = false;
+	ps.first_child = -1;
 
-	_vd.last_child = &ps->first_child;
+	_vd.last_child = &ps.first_child;
 
 	if (_vd.combine_sprites == SPRITE_COMBINE_PENDING) _vd.combine_sprites = SPRITE_COMBINE_ACTIVE;
 }
@@ -826,33 +828,35 @@ void AddChildSpriteScreen(SpriteID image, PaletteID pal, int x, int y, bool tran
 
 	*_vd.last_child = _vd.child_screen_sprites_to_draw.size();
 
-	ChildScreenSpriteToDraw *cs = _vd.child_screen_sprites_to_draw.Append();
-	cs->image = image;
-	cs->pal = pal;
-	cs->sub = sub;
-	cs->x = scale ? x * ZOOM_LVL_BASE : x;
-	cs->y = scale ? y * ZOOM_LVL_BASE : y;
-	cs->next = -1;
+	/*C++17: ChildScreenSpriteToDraw &cs = */ _vd.child_screen_sprites_to_draw.emplace_back();
+	ChildScreenSpriteToDraw &cs = _vd.child_screen_sprites_to_draw.back();
+	cs.image = image;
+	cs.pal = pal;
+	cs.sub = sub;
+	cs.x = scale ? x * ZOOM_LVL_BASE : x;
+	cs.y = scale ? y * ZOOM_LVL_BASE : y;
+	cs.next = -1;
 
 	/* Append the sprite to the active ChildSprite list.
 	 * If the active ParentSprite is a foundation, update last_foundation_child as well.
 	 * Note: ChildSprites of foundations are NOT sequential in the vector, as selection sprites are added at last. */
-	if (_vd.last_foundation_child[0] == _vd.last_child) _vd.last_foundation_child[0] = &cs->next;
-	if (_vd.last_foundation_child[1] == _vd.last_child) _vd.last_foundation_child[1] = &cs->next;
-	_vd.last_child = &cs->next;
+	if (_vd.last_foundation_child[0] == _vd.last_child) _vd.last_foundation_child[0] = &cs.next;
+	if (_vd.last_foundation_child[1] == _vd.last_child) _vd.last_foundation_child[1] = &cs.next;
+	_vd.last_child = &cs.next;
 }
 
 static void AddStringToDraw(int x, int y, StringID string, uint64 params_1, uint64 params_2, Colours colour, uint16 width)
 {
 	assert(width != 0);
-	StringSpriteToDraw *ss = _vd.string_sprites_to_draw.Append();
-	ss->string = string;
-	ss->x = x;
-	ss->y = y;
-	ss->params[0] = params_1;
-	ss->params[1] = params_2;
-	ss->width = width;
-	ss->colour = colour;
+	/*C++17: StringSpriteToDraw &ss = */ _vd.string_sprites_to_draw.emplace_back();
+	StringSpriteToDraw &ss = _vd.string_sprites_to_draw.back();
+	ss.string = string;
+	ss.x = x;
+	ss.y = y;
+	ss.params[0] = params_1;
+	ss.params[1] = params_2;
+	ss.width = width;
+	ss.colour = colour;
 }
 
 
@@ -1588,7 +1592,7 @@ void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom
 
 	ParentSpriteToDraw *psd_end = _vd.parent_sprites_to_draw.End();
 	for (ParentSpriteToDraw *it = _vd.parent_sprites_to_draw.Begin(); it != psd_end; it++) {
-		*_vd.parent_sprites_to_sort.Append() = it;
+		_vd.parent_sprites_to_sort.push_back(it);
 	}
 
 	_vp_sprite_sorter(&_vd.parent_sprites_to_sort);

--- a/src/viewport_sprite_sorter.h
+++ b/src/viewport_sprite_sorter.h
@@ -41,7 +41,7 @@ struct ParentSpriteToDraw {
 	bool comparison_done;           ///< Used during sprite sorting: true if sprite has been compared with all other sprites
 };
 
-typedef SmallVector<ParentSpriteToDraw*, 64> ParentSpriteToSortVector;
+typedef std::vector<ParentSpriteToDraw*> ParentSpriteToSortVector;
 
 /** Type for method for checking whether a viewport sprite sorter exists. */
 typedef bool (*VpSorterChecker)();

--- a/src/viewport_sprite_sorter_sse4.cpp
+++ b/src/viewport_sprite_sorter_sse4.cpp
@@ -29,8 +29,8 @@
 void ViewportSortParentSpritesSSE41(ParentSpriteToSortVector *psdv)
 {
 	const __m128i mask_ptest = _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  0,  0,  0,  0);
-	ParentSpriteToDraw ** const psdvend = psdv->End();
-	ParentSpriteToDraw **psd = psdv->Begin();
+	auto const psdvend = psdv->end();
+	auto psd = psdv->begin();
 	while (psd != psdvend) {
 		ParentSpriteToDraw * const ps = *psd;
 
@@ -41,7 +41,7 @@ void ViewportSortParentSpritesSSE41(ParentSpriteToSortVector *psdv)
 
 		ps->comparison_done = true;
 
-		for (ParentSpriteToDraw **psd2 = psd + 1; psd2 != psdvend; psd2++) {
+		for (auto psd2 = psd + 1; psd2 != psdvend; psd2++) {
 			ParentSpriteToDraw * const ps2 = *psd2;
 
 			if (ps2->comparison_done) continue;
@@ -85,7 +85,7 @@ void ViewportSortParentSpritesSSE41(ParentSpriteToSortVector *psdv)
 
 			/* Move ps2 in front of ps */
 			ParentSpriteToDraw * const temp = ps2;
-			for (ParentSpriteToDraw **psd3 = psd2; psd3 > psd; psd3--) {
+			for (auto psd3 = psd2; psd3 > psd; psd3--) {
 				*psd3 = *(psd3 - 1);
 			}
 			*psd = temp;

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -509,7 +509,7 @@ void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int butt
 
 	for (uint i = 0; strings[i] != INVALID_STRING_ID; i++) {
 		if (!HasBit(hidden_mask, i)) {
-			*list->Append() = new DropDownListStringItem(strings[i], i, HasBit(disabled_mask, i));
+			list->push_back(new DropDownListStringItem(strings[i], i, HasBit(disabled_mask, i)));
 		}
 	}
 

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -174,8 +174,7 @@ struct DropdownWindow : Window {
 
 		/* Total length of list */
 		int list_height = 0;
-		for (const DropDownListItem * const *it = list->Begin(); it != list->End(); ++it) {
-			const DropDownListItem *item = *it;
+		for (const DropDownListItem *item : *list) {
 			list_height += item->Height(items_width);
 		}
 
@@ -230,13 +229,10 @@ struct DropdownWindow : Window {
 		int width = nwi->current_x - 4;
 		int pos   = this->vscroll->GetPosition();
 
-		const DropDownList *list = this->list;
-
-		for (const DropDownListItem * const *it = list->Begin(); it != list->End(); ++it) {
+		for (const DropDownListItem *item : *this->list) {
 			/* Skip items that are scrolled up */
 			if (--pos >= 0) continue;
 
-			const DropDownListItem *item = *it;
 			int item_height = item->Height(width);
 
 			if (y < item_height) {
@@ -259,8 +255,7 @@ struct DropdownWindow : Window {
 
 		int y = r.top + 2;
 		int pos = this->vscroll->GetPosition();
-		for (const DropDownListItem * const *it = this->list->Begin(); it != this->list->End(); ++it) {
-			const DropDownListItem *item = *it;
+		for (const DropDownListItem *item : *this->list) {
 			int item_height = item->Height(r.right - r.left + 1);
 
 			/* Skip items that are scrolled up */
@@ -389,8 +384,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 	/* Total height of list */
 	uint height = 0;
 
-	for (const DropDownListItem * const *it = list->Begin(); it != list->End(); ++it) {
-		const DropDownListItem *item = *it;
+	for (const DropDownListItem *item : *list) {
 		height += item->Height(width);
 		if (auto_width) max_item_width = max(max_item_width, item->Width() + 5);
 	}

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -151,7 +151,7 @@ struct DropdownWindow : Window {
 	DropdownWindow(Window *parent, const DropDownList *list, int selected, int button, bool instant_close, const Point &position, const Dimension &size, Colours wi_colour, bool scroll)
 			: Window(&_dropdown_desc)
 	{
-		assert(list->Length() > 0);
+		assert(list->size() > 0);
 
 		this->position = position;
 
@@ -180,8 +180,8 @@ struct DropdownWindow : Window {
 		}
 
 		/* Capacity is the average number of items visible */
-		this->vscroll->SetCapacity(size.height * (uint16)list->Length() / list_height);
-		this->vscroll->SetCount((uint16)list->Length());
+		this->vscroll->SetCapacity(size.height * (uint16)list->size() / list_height);
+		this->vscroll->SetCount((uint16)list->size());
 
 		this->parent_wnd_class = parent->window_class;
 		this->parent_wnd_num   = parent->window_number;
@@ -418,7 +418,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 		/* If the dropdown doesn't fully fit, we need a dropdown. */
 		if (height > available_height) {
 			scroll = true;
-			uint avg_height = height / list->Length();
+			uint avg_height = height / list->size();
 
 			/* Check at least there is space for one item. */
 			assert(available_height >= avg_height);
@@ -514,7 +514,7 @@ void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int butt
 	}
 
 	/* No entries in the list? */
-	if (list->Length() == 0) {
+	if (list->size() == 0) {
 		delete list;
 		return;
 	}

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -98,7 +98,7 @@ public:
 /**
  * A drop down list is a collection of drop down list items.
  */
-typedef AutoDeleteSmallVector<const DropDownListItem *, 4> DropDownList;
+typedef AutoDeleteSmallVector<const DropDownListItem *> DropDownList;
 
 void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int button, Rect wi_rect, Colours wi_colour, bool auto_width = false, bool instant_close = false);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -114,7 +114,7 @@ WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16 def_wi
 
 WindowDesc::~WindowDesc()
 {
-	_window_descs->Erase(_window_descs->Find(this));
+	_window_descs->erase(std::find(_window_descs->begin(), _window_descs->end(), this));
 }
 
 /**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3024,7 +3024,7 @@ void HandleMouseEvents()
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 		_newgrf_debug_sprite_picker.clicked_pixel = blitter->MoveTo(_screen.dst_ptr, _cursor.pos.x, _cursor.pos.y);
 		_newgrf_debug_sprite_picker.click_time = _realtime_tick;
-		_newgrf_debug_sprite_picker.sprites.Clear();
+		_newgrf_debug_sprite_picker.sprites.clear();
 		_newgrf_debug_sprite_picker.mode = SPM_REDRAW;
 		MarkWholeScreenDirty();
 	} else {
@@ -3255,7 +3255,7 @@ void Window::ProcessScheduledInvalidations()
 	for (int *data = this->scheduled_invalidation_data.Begin(); this->window_class != WC_INVALID && data != this->scheduled_invalidation_data.End(); data++) {
 		this->OnInvalidateData(*data, true);
 	}
-	this->scheduled_invalidation_data.Clear();
+	this->scheduled_invalidation_data.clear();
 }
 
 /**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -166,7 +166,7 @@ static int CDECL DescSorter(WindowDesc * const *a, WindowDesc * const *b)
 void WindowDesc::SaveToConfig()
 {
 	/* Sort the stuff to get a nice ini file on first write */
-	QSortT(_window_descs->Begin(), _window_descs->Length(), DescSorter);
+	QSortT(_window_descs->Begin(), _window_descs->size(), DescSorter);
 
 	IniFile *ini = new IniFile();
 	ini->LoadFromDisk(_windows_file, NO_DIRECTORY);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -109,7 +109,7 @@ WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16 def_wi
 	default_height_trad(def_height_trad)
 {
 	if (_window_descs == NULL) _window_descs = new SmallVector<WindowDesc*, 16>();
-	*_window_descs->Append() = this;
+	_window_descs->push_back(this);
 }
 
 WindowDesc::~WindowDesc()
@@ -3242,7 +3242,7 @@ void Window::InvalidateData(int data, bool gui_scope)
 	this->SetDirty();
 	if (!gui_scope) {
 		/* Schedule GUI-scope invalidation for next redraw. */
-		*this->scheduled_invalidation_data.Append() = data;
+		this->scheduled_invalidation_data.push_back(data);
 	}
 	this->OnInvalidateData(data, gui_scope);
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -85,7 +85,7 @@ SpecialMouseMode _special_mouse_mode; ///< Mode of the mouse.
  * List of all WindowDescs.
  * This is a pointer to ensure initialisation order with the various static WindowDesc instances.
  */
-static SmallVector<WindowDesc*, 16> *_window_descs = NULL;
+static std::vector<WindowDesc*> *_window_descs = NULL;
 
 /** Config file to store WindowDesc */
 char *_windows_file;
@@ -108,7 +108,7 @@ WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16 def_wi
 	default_width_trad(def_width_trad),
 	default_height_trad(def_height_trad)
 {
-	if (_window_descs == NULL) _window_descs = new SmallVector<WindowDesc*, 16>();
+	if (_window_descs == NULL) _window_descs = new std::vector<WindowDesc*>();
 	_window_descs->push_back(this);
 }
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -281,7 +281,7 @@ protected:
 	void InitializePositionSize(int x, int y, int min_width, int min_height);
 	virtual void FindWindowPlacementAndResize(int def_width, int def_height);
 
-	SmallVector<int, 4> scheduled_invalidation_data;  ///< Data of scheduled OnInvalidateData() calls.
+	std::vector<int> scheduled_invalidation_data;  ///< Data of scheduled OnInvalidateData() calls.
 
 public:
 	Window(WindowDesc *desc);


### PR DESCRIPTION
This the starting point for removing SmallVector by making SmallVector an adapter type.
This replaces #6817.

The public and protected interface to SmallVector are unchanged
SmallVector now requires that items be default constructible
This isn't an issue since some contained items were previously created
uninitialized.

Temporary default constructors are added to the following structs
- SmallPair
- SmallStackItem
- GRFPresence

Where vector<bool> is required, transition immediately to std::vector
to avoid returning proxy object references.