### PR TITLE
Fix: CompanyEconomy documentation

### DIFF
--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -363,7 +363,7 @@ protected:
 	 * uint8   ID of the company.
 	 * uint64  Money.
 	 * uint64  Loan.
-	 * uint64  Income.
+	 * int64   Income.
 	 * uint16  Delivered cargo (this quarter).
 	 * uint64  Company value (last quarter).
 	 * uint16  Performance (last quarter).


### PR DESCRIPTION
Company income was described as an unsigned integer, but it should be signed.