### PR TITLE
Fix #7119: When rotating a ship, apply an additional offset to avoid movement glitch.

### DIFF
--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -375,6 +375,17 @@ void AfterLoadVehicles(bool part_of_load)
 			FOR_ALL_SHIPS(s) {
 				s->rotation = s->direction;
 			}
+		} else {
+			Ship *s;
+			FOR_ALL_SHIPS(s) {
+				if (s->rotation == s->direction) continue;
+				/* In case we are rotating on gameload, set the rotation position to
+				 * the current position, otherwise the applied workaround offset would
+				 * be with respect to 0,0.
+				 */
+				s->rotation_x_pos = s->x_pos;
+				s->rotation_y_pos = s->y_pos;
+			}
 		}
 	}
 

--- a/src/ship.h
+++ b/src/ship.h
@@ -29,6 +29,8 @@ struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
 	TrackBitsByte state;    ///< The "track" the ship is following.
 	ShipPathCache path;     ///< Cached path.
 	DirectionByte rotation; ///< Visible direction.
+	int16 rotation_x_pos;   ///< NOSAVE: X Position before rotation.
+	int16 rotation_y_pos;   ///< NOSAVE: Y Position before rotation.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Ship() : SpecializedVehicleBase() {}

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -319,6 +319,15 @@ void Ship::UpdateDeltaXY()
 	this->x_extent      = bb[1];
 	this->y_extent      = bb[0];
 	this->z_extent      = 6;
+
+	if (this->direction != this->rotation) {
+		/* If we are rotating, then it is possible the ship was moved to its next position. In that
+		 * case, because we are still showing the old direction, the ship will appear to glitch sideways
+		 * slightly. We can work around this by applying an additional offset to make the ship appear
+		 * where it was before it moved. */
+		this->x_offs -= this->x_pos - this->rotation_x_pos;
+		this->y_offs -= this->y_pos - this->rotation_y_pos;
+	}
 }
 
 /**
@@ -678,6 +687,9 @@ static void ShipController(Ship *v)
 					/* Stop for rotation */
 					v->cur_speed = 0;
 					v->direction = new_direction;
+					/* Remember our current location to avoid movement glitch */
+					v->rotation_x_pos = v->x_pos;
+					v->rotation_y_pos = v->y_pos;
 					break;
 			}
 		}
@@ -704,6 +716,9 @@ getout:
 
 reverse_direction:
 	v->direction = ReverseDir(v->direction);
+	/* Remember our current location to avoid movement glitch */
+	v->rotation_x_pos = v->x_pos;
+	v->rotation_y_pos = v->y_pos;
 	v->cur_speed = 0;
 	v->path.clear();
 	goto getout;


### PR DESCRIPTION
This offset is derived from temporarily storing the ship's location before it was rotated.