### PR TITLE
Feature: Distribute cargo to multiple stations or industries

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3933,11 +3933,11 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 	amount *= best_station->goods[type].rating + 1;
 
 	/* several stations around */
-	uint ratings_sum = 0;
+	uint ratings_square_sum = 0;
 	for (Station * const *st_iter = used_stations.Begin(); st_iter != used_stations.End(); ++st_iter) {
 		Station *st = *st_iter;
 
-		ratings_sum += st->goods[type].rating;
+		ratings_square_sum += st->goods[type].rating * st->goods[type].rating;
 	}
 
 	uint moved = 0;
@@ -3951,13 +3951,13 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 			 * this case is the rounding difference from the last time this calculation is done.
 			 * In reality that will mean the bonus will be pretty low. Nevertheless, the best
 			 * station should always get the most cargo regardless of rounding issues. */
-			uint cur_worst = amount * st->goods[type].rating / ratings_sum;
+			uint cur_worst = amount * st->goods[type].rating * st->goods[type].rating / ratings_square_sum;
 
 			/* And then send the cargo to the stations! */
 			moved += UpdateStationWaiting(st, type, cur_worst, source_type, source_id);
 
 			amount -= cur_worst;
-			ratings_sum -= st->goods[type].rating;
+			ratings_square_sum -= st->goods[type].rating * st->goods[type].rating;
 		} else {
 			/* These two UpdateStationWaiting's can't be in the statement as then the order
 			 * of execution would be undefined and that could cause desyncs with callbacks. */


### PR DESCRIPTION
Changes the way cargo amounts appear on multiple stations, and the way cargo is received by multiple industries accepting that same cargo type.

For stations, instead of spliting the load between the two highest rating stations for that cargo, it splits to all nearby stations, while still considering station rating from highest to lowest. The higher the rating, the more it receives.
![uyzrvzz](https://user-images.githubusercontent.com/43006711/52301709-fb4b1580-2982-11e9-9d50-1d47e7211c11.png)

For industries, instead of the first nearby industry accepting the cargo, the amount is distributed piece by piece, at random, to any accepting industries within the station catchment area.
![7wjqrjg](https://user-images.githubusercontent.com/43006711/52301719-ff773300-2982-11e9-9e72-cd6ae59e4d6d.png)

https://www.tt-forums.net/viewtopic.php?p=1193758