### PR TITLE
Change: Add scrollbar to cargo legend in cargo payment rates window.

### DIFF
--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -546,7 +546,8 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CPR_FOOTER,                            "WID_CPR_FOOTER");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CPR_ENABLE_CARGOES,                    "WID_CPR_ENABLE_CARGOES");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CPR_DISABLE_CARGOES,                   "WID_CPR_DISABLE_CARGOES");
-	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CPR_CARGO_FIRST,                       "WID_CPR_CARGO_FIRST");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CPR_MATRIX,                            "WID_CPR_MATRIX");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CPR_MATRIX_SCROLLBAR,                  "WID_CPR_MATRIX_SCROLLBAR");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_CL_BACKGROUND,                         "WID_CL_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_PRD_SCORE_FIRST,                       "WID_PRD_SCORE_FIRST");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_PRD_SCORE_LAST,                        "WID_PRD_SCORE_LAST");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1439,7 +1439,8 @@ public:
 		WID_CPR_FOOTER                               = ::WID_CPR_FOOTER,                               ///< Footer.
 		WID_CPR_ENABLE_CARGOES                       = ::WID_CPR_ENABLE_CARGOES,                       ///< Enable cargoes button.
 		WID_CPR_DISABLE_CARGOES                      = ::WID_CPR_DISABLE_CARGOES,                      ///< Disable cargoes button.
-		WID_CPR_CARGO_FIRST                          = ::WID_CPR_CARGO_FIRST,                          ///< First cargo in the list.
+		WID_CPR_MATRIX                               = ::WID_CPR_MATRIX,                               ///< Cargo list.
+		WID_CPR_MATRIX_SCROLLBAR                     = ::WID_CPR_MATRIX_SCROLLBAR,                     ///< Cargo list scrollbar.
 	};
 
 	/** Widget of the #CompanyLeagueWindow class. */

--- a/src/widgets/graph_widget.h
+++ b/src/widgets/graph_widget.h
@@ -49,7 +49,8 @@ enum CargoPaymentRatesWidgets {
 	WID_CPR_FOOTER,          ///< Footer.
 	WID_CPR_ENABLE_CARGOES,  ///< Enable cargoes button.
 	WID_CPR_DISABLE_CARGOES, ///< Disable cargoes button.
-	WID_CPR_CARGO_FIRST,     ///< First cargo in the list.
+	WID_CPR_MATRIX,          ///< Cargo list.
+	WID_CPR_MATRIX_SCROLLBAR,///< Cargo list scrollbar.
 };
 
 /** Widget of the #CompanyLeagueWindow class. */


### PR DESCRIPTION
Replaces the cargo legend buttons with a matrix and scrollbar. This avoids the graph payment rate window becoming taller than the screen when there are lots of cargo types available.