### PR TITLE
Add #5654: Initializing graph GUI

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1580,3 +1580,9 @@ void ShowPerformanceRatingDetail()
 {
 	AllocateWindowDescFront<PerformanceRatingDetailWindow>(&_performance_rating_detail_desc, 0);
 }
+
+void InitializeGraphGui()
+{
+	_legend_excluded_companies = 0;
+	_legend_excluded_cargo = 0;
+}

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -42,6 +42,7 @@ void InitializeRailGui();
 void InitializeRoadGui();
 void InitializeAirportGui();
 void InitializeDockGui();
+void InitializeGraphGui();
 void InitializeObjectGui();
 void InitializeIndustries();
 void InitializeObjects();
@@ -87,6 +88,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	InitializeRoadGui();
 	InitializeAirportGui();
 	InitializeDockGui();
+	InitializeGraphGui();
 	InitializeObjectGui();
 	InitializeAIGui();
 	InitializeTrees();


### PR DESCRIPTION
Graph GUI was not initialized in InitializeGame(), so player key and cargo selection for the graphs was kept for the next game as well.