### PR TITLE
Change: skip reliability decay if servicing is disabled

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1222,7 +1222,10 @@ void CheckVehicleBreakdown(Vehicle *v)
 	int rel, rel_old;
 
 	/* decrease reliability */
-	v->reliability = rel = max((rel_old = v->reliability) - v->reliability_spd_dec, 0);
+	if (!_settings_game.order.no_servicing_if_no_breakdowns ||
+			_settings_game.difficulty.vehicle_breakdowns != 0) {
+		v->reliability = rel = max((rel_old = v->reliability) - v->reliability_spd_dec, 0);
+	}
 	if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 
 	if (v->breakdown_ctr != 0 || (v->vehstatus & VS_STOPPED) ||


### PR DESCRIPTION
prevents being stuck with 0 reliability if someone is crazy enough to switch breakdowns back on