### PR TITLE
Feature: Game setting to define how industries with neutral stations accept and supply cargo from/to surrounding stations.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1047,6 +1047,25 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 		Industry *ind = st->industries_near[i];
 		if (ind->index == source) continue;
 
+		if (!_settings_game.station.serve_neutral_industries) {
+			if (HasIndustryStation(ind)) {
+				/* A company owned station accepts the cargo, but the catchment area may have picked up more industries accepting it,
+				 * some with attached neutral stations, some without.
+				 * Check whether the cargo being delivered at the company station can be accepted by the industries providing their own stations. */
+				if (!IsOilRig(st->xy)) continue;
+
+				/* The station accepting the cargo is a neutral station (station 1) belonging to an industry (industry 1),
+				 * but there may be other neutral stations nearby (station n) belonging to their respective industries (industry n).
+				 * Is the station accepting the cargo (station 1) a part of the industry it's attached to (industry 1)? */
+				if (!IsStationIndustryPair(st, ind->index)) continue;
+			} else {
+				/* The station accepting the cargo is a neutral station, but the catchment area may have picked up more industries accepting it,
+				 * some with attached neutral stations, some without.
+				 * Check whether the cargo being delivered at the neutral station can be accepted by the industries without neutral stations. */
+				if (IsOilRig(st->xy)) continue;
+			}
+		}
+
 		uint cargo_index;
 		for (cargo_index = 0; cargo_index < lengthof(ind->accepts_cargo); cargo_index++) {
 			if (cargo_type == ind->accepts_cargo[cargo_index]) break;

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -31,7 +31,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update);
 void StartupIndustryDailyChanges(bool init_counter);
 
 Money GetTransportedGoodsIncome(uint num_pieces, uint dist, byte transit_days, CargoID cargo_type);
-uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList *all_stations);
+uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList *all_stations, bool st_ind = false);
 
 void PrepareUnload(Vehicle *front_v);
 void LoadUnloadStation(Station *st);

--- a/src/industry.h
+++ b/src/industry.h
@@ -18,6 +18,7 @@
 #include "industry_map.h"
 #include "industrytype.h"
 #include "tilearea_type.h"
+#include "station_base.h"
 
 
 typedef Pool<Industry, IndustryID, 64, 64000> IndustryPool;
@@ -165,6 +166,14 @@ void PlantRandomFarmField(const Industry *i);
 void ReleaseDisastersTargetingIndustry(IndustryID);
 
 bool IsTileForestIndustry(TileIndex tile);
+
+/* Check whether an industry provides its own station */
+bool HasIndustryStation(const Industry *i);
+
+/* Check whether a neutral station belongs to the given industry */
+bool IsStationIndustryPair(const Station *st, IndustryID i = INVALID_INDUSTRY);
+
+IndustryID GetStationIndustryIndex(const Station *st);
 
 #define FOR_ALL_INDUSTRIES_FROM(var, start) FOR_ALL_ITEMS_FROM(Industry, industry_index, var, start)
 #define FOR_ALL_INDUSTRIES(var) FOR_ALL_INDUSTRIES_FROM(var, 0)

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1176,6 +1176,8 @@ STR_CONFIG_SETTING_AUTOSLOPE                                    :Allow landscapi
 STR_CONFIG_SETTING_AUTOSLOPE_HELPTEXT                           :Allow landscaping under buildings and tracks without removing them
 STR_CONFIG_SETTING_CATCHMENT                                    :Allow more realistically sized catchment areas: {STRING2}
 STR_CONFIG_SETTING_CATCHMENT_HELPTEXT                           :Have differently sized catchment areas for different types of stations and airports
+STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES                     :Company stations can serve industries with attached neutral stations: {STRING2}
+STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :When enabled, industries with attached stations (such as Oil Rigs) may also be served by company owned stations built nearby. When disabled, these industries may only be served by their attached stations. Any nearby company stations won't be able to serve them, nor will the attached station serve anything else other than the industry
 STR_CONFIG_SETTING_EXTRADYNAMITE                                :Allow removal of more town-owned roads, bridges and tunnels: {STRING2}
 STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT                       :Make it easier to remove town-owned infrastructure and buildings
 STR_CONFIG_SETTING_TRAIN_LENGTH                                 :Maximum length of trains: {STRING2}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3080,6 +3080,10 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_SERVE_NEUTRAL_INDUSTRIES)) {
+		_settings_game.station.serve_neutral_industries = true;
+	}
+
 	/* Station acceptance is some kind of cache */
 	if (IsSavegameVersionBefore(SLV_127)) {
 		Station *st;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -291,6 +291,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GROUP_LIVERIES,                     ///< 205  PR#7108 Livery storage change and group liveries.
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 Cargo monitor data packing fix to support 64 cargotypes.
+	SLV_SERVE_NEUTRAL_INDUSTRIES,           ///< 208  PR#7204 Company stations can serve industries with attached neutral stations.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1712,6 +1712,7 @@ static SettingsContainer &GetSettingsTree()
 				industries->Add(new SettingEntry("economy.multiple_industry_per_town"));
 				industries->Add(new SettingEntry("game_creation.oil_refinery_limit"));
 				industries->Add(new SettingEntry("economy.smooth_economy"));
+				industries->Add(new SettingEntry("station.serve_neutral_industries"));
 			}
 
 			SettingsPage *cdist = environment->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT_CARGODIST));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -524,6 +524,7 @@ struct LinkGraphSettings {
 /** Settings related to stations. */
 struct StationSettings {
 	bool   modified_catchment;               ///< different-size catchment areas
+	bool   serve_neutral_industries;         ///< company stations can serve industries with attached neutral stations
 	bool   adjacent_stations;                ///< allow stations to be built directly adjacent to other stations
 	bool   distant_join_stations;            ///< allow to join non-adjacent stations
 	bool   never_expire_airports;            ///< never expire airports

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -19,6 +19,7 @@
 #include "economy_func.h"
 #include "rail.h"
 #include "linkgraph/linkgraph_type.h"
+#include "industry_type.h"
 
 void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint radius);
 
@@ -28,7 +29,7 @@ void ShowStationViewWindow(StationID station);
 void UpdateAllStationVirtCoords();
 
 CargoArray GetProductionAroundTiles(TileIndex tile, int w, int h, int rad);
-CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted = NULL);
+CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted = NULL, IndustryID st_ind = INVALID_INDUSTRY);
 
 void UpdateStationAcceptance(Station *st, bool show_msg);
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1206,6 +1206,15 @@ cat      = SC_EXPERT
 
 [SDT_BOOL]
 base     = GameSettings
+var      = station.serve_neutral_industries
+def      = true
+from     = SLV_SERVE_NEUTRAL_INDUSTRIES
+str      = STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES
+strhelp  = STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT
+cat      = SC_EXPERT
+
+[SDT_BOOL]
+base     = GameSettings
 var      = order.gradual_loading
 from     = SLV_40
 guiflags = SGF_NO_NETWORK


### PR DESCRIPTION
This patch changes the way Oil Rig industries (or other industries with attached neutral stations) accept or supply cargo to stations nearby.

Adds an expert game setting, located under Environment/Industries which allow disabling or enabling the behaviour:
- "Company stations can serve industries with attached neutral stations" - When enabled, industries with attached stations (such as Oil Rigs) may also be served by company owned stations built nearby. When disabled, these industries may only be served by their attached stations. Any nearby company stations won't be able to serve them, nor will the attached station serve anything else other than the industry.

It is defaulted to enabled.
Savegame conversion will treat it as being enabled whenever loading savegames before this patch.