### PR TITLE
Fix: [AzurePipelines] manifest.sh didn't know when it was a stable release

### DIFF
--- a/azure-pipelines/manifest.sh
+++ b/azure-pipelines/manifest.sh
@@ -15,7 +15,7 @@ if [ ! -e .version ] || [ ! -e .release_date ]; then
 fi
 
 # Find the name based on the version
-if [ "${ISSTABLERELEASE}" = "true" ]; then
+if [ -e .is_stable ]; then
     isTesting=$(cat .version | grep "RC\|beta" || true)
     if [ -z "${isTesting}" ]; then
         NAME="stable"

--- a/azure-pipelines/templates/release-manifest.yml
+++ b/azure-pipelines/templates/release-manifest.yml
@@ -1,3 +1,6 @@
+parameters:
+  IsStableRelease: false
+
 steps:
 - task: DownloadBuildArtifacts@0
   displayName: 'Download all bundles'
@@ -5,6 +8,10 @@ steps:
     downloadType: specific
     itemPattern: 'bundles/*'
     downloadPath: '$(Build.ArtifactStagingDirectory)'
+- ${{ if eq(parameters.IsStableRelease, true) }}:
+  - script: |
+      touch .is_stable
+    displayName: 'Mark as stable release'
 - script: |
     set -ex
     ./azure-pipelines/manifest.sh ../a/bundles/

--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -164,6 +164,9 @@ jobs:
   steps:
   - template: release-fetch-source.yml
   - template: release-manifest.yml
+    ${{ if eq(parameters.IsStableRelease, true) }}:
+      parameters:
+        IsStableRelease: true
   - template: release-bundles.yml
     parameters:
       CalculateChecksums: false


### PR DESCRIPTION
In result, the name of the release was wrong, causing confusing
in tools using the manifest.yaml.