### PR TITLE
Fix #7197: Invalidate depot buttons when necessary.

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1490,6 +1490,8 @@ void VehicleEnterDepot(Vehicle *v)
 	TriggerVehicle(v, VEHICLE_TRIGGER_DEPOT);
 	v->MarkDirty();
 
+	InvalidateWindowData(WC_VEHICLE_VIEW, v->index);
+
 	if (v->current_order.IsType(OT_GOTO_DEPOT)) {
 		SetWindowDirty(WC_VEHICLE_VIEW, v->index);
 

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -585,6 +585,7 @@ CommandCost CmdStartStopVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, 
 		SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
 		SetWindowDirty(WC_VEHICLE_DEPOT, v->tile);
 		SetWindowClassesDirty(GetWindowClassForVehicleType(v->type));
+		InvalidateWindowData(WC_VEHICLE_VIEW, v->index);
 	}
 	return CommandCost();
 }

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2503,6 +2503,8 @@ public:
 		this->GetWidget<NWidgetCore>(WID_VV_SHOW_ORDERS)->tool_tip      = STR_VEHICLE_VIEW_TRAIN_ORDERS_TOOLTIP + v->type;
 		this->GetWidget<NWidgetCore>(WID_VV_SHOW_DETAILS)->tool_tip     = STR_VEHICLE_VIEW_TRAIN_SHOW_DETAILS_TOOLTIP + v->type;
 		this->GetWidget<NWidgetCore>(WID_VV_CLONE)->tool_tip            = STR_VEHICLE_VIEW_CLONE_TRAIN_INFO + v->type;
+
+		this->UpdateButtonStatus();
 	}
 
 	~VehicleViewWindow()
@@ -2732,7 +2734,7 @@ public:
 		}
 	}
 
-	virtual void OnGameTick()
+	void UpdateButtonStatus()
 	{
 		const Vehicle *v = Vehicle::Get(this->window_number);
 		bool veh_stopped = v->IsStoppedInDepot();
@@ -2769,6 +2771,8 @@ public:
 			 * Nothing to do for this window. */
 			return;
 		}
+
+		this->UpdateButtonStatus();
 	}
 
 	virtual bool IsNewGRFInspectable() const


### PR DESCRIPTION
Invalidate depot buttons when necessary rather than during OnGameTick(). The later is not called since the window tick refactor, causing newly built vehicles to show incorrect buttons when built in pause mode.

Fixes #7197.