### PR TITLE
Fix network revision for tagged versions

### DIFF
--- a/Makefile.src.in
+++ b/Makefile.src.in
@@ -91,6 +91,7 @@ MODIFIED := $(shell echo "$(VERSIONS)" | cut -f 3 -d'	')
 VERSION  := $(shell echo "$(VERSIONS)" | cut -f 1 -d'	')
 ISODATE  := $(shell echo "$(VERSIONS)" | cut -f 2 -d'	')
 GITHASH  := $(shell echo "$(VERSIONS)" | cut -f 4 -d'	')
+ISTAG    := $(shell echo "$(VERSIONS)" | cut -f 5 -d'	')
 
 # Make sure we have something in VERSION and ISODATE
 ifeq ($(VERSION),)
@@ -276,10 +277,10 @@ endif
 # Revision files
 
 $(SRC_DIR)/rev.cpp: $(CONFIG_CACHE_VERSION) $(SRC_DIR)/rev.cpp.in
-	$(Q)cat $(SRC_DIR)/rev.cpp.in      | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!MODIFIED!!@$(MODIFIED)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g" > $(SRC_DIR)/rev.cpp
+	$(Q)cat $(SRC_DIR)/rev.cpp.in      | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!MODIFIED!!@$(MODIFIED)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g;s@!!ISTAG!!@$(ISTAG)@g" > $(SRC_DIR)/rev.cpp
 
 $(SRC_DIR)/os/windows/ottdres.rc: $(CONFIG_CACHE_VERSION) $(SRC_DIR)/os/windows/ottdres.rc.in
-	$(Q)cat $(SRC_DIR)/os/windows/ottdres.rc.in | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g" > $(SRC_DIR)/os/windows/ottdres.rc
+	$(Q)cat $(SRC_DIR)/os/windows/ottdres.rc.in | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g;s@!!ISTAG!!@$(ISTAG)@g" > $(SRC_DIR)/os/windows/ottdres.rc
 
 FORCE:
 

--- a/findversion.sh
+++ b/findversion.sh
@@ -82,8 +82,10 @@ if [ -d "$ROOT_DIR/.git" ]; then
 
 	if [ -n "$TAG" ]; then
 		VERSION="${TAG}"
+		ISTAG="1"
 	else
 		VERSION="${ISODATE}-${BRANCH}${hashprefix}${SHORTHASH}"
+		ISTAG="0"
 	fi
 
 elif [ -f "$ROOT_DIR/.ottdrev" ]; then
@@ -99,6 +101,7 @@ else
 	ISODATE=""
 	TAG=""
 	VERSION=""
+	ISTAG="0"
 fi
 
-echo "$VERSION	$ISODATE	$MODIFIED	$HASH"
+echo "$VERSION	$ISODATE	$MODIFIED	$HASH	$ISTAG"

--- a/projects/determineversion.vbs
+++ b/projects/determineversion.vbs
@@ -21,34 +21,40 @@ Sub FindReplaceInFile(filename, to_find, replacement)
 	file.Close
 End Sub
 
-Sub UpdateFile(modified, isodate, version, cur_date, githash, filename)
+Sub UpdateFile(modified, isodate, version, cur_date, githash, istag, filename)
 	FSO.CopyFile filename & ".in", filename
 	FindReplaceInFile filename, "!!MODIFIED!!", modified
 	FindReplaceInFile filename, "!!ISODATE!!", isodate
 	FindReplaceInFile filename, "!!VERSION!!", version
 	FindReplaceInFile filename, "!!DATE!!", cur_date
 	FindReplaceInFile filename, "!!GITHASH!!", githash
+	FindReplaceInFile filename, "!!ISTAG!!", istag
 End Sub
 
 Sub UpdateFiles(version)
-	Dim modified, isodate, cur_date, githash
+	Dim modified, isodate, cur_date, githash, istag
 	cur_date = DatePart("D", Date) & "." & DatePart("M", Date) & "." & DatePart("YYYY", Date)
 
 	If InStr(version, Chr(9)) Then
+		' Split string into field with tails
 		isodate  = Mid(version, InStr(version, Chr(9)) + 1)
 		modified = Mid(isodate, InStr(isodate, Chr(9)) + 1)
 		githash  = Mid(modified, InStr(modified, Chr(9)) + 1)
+		istag    = Mid(githash, InStr(githash, Chr(9)) + 1)
+		' Remove tails from fields
+		version  = Mid(version, 1, InStr(version, Chr(9)) - 1)
 		isodate  = Mid(isodate, 1, InStr(isodate, Chr(9)) - 1)
 		modified = Mid(modified, 1, InStr(modified, Chr(9)) - 1)
-		version  = Mid(version, 1, InStr(version, Chr(9)) - 1)
+		githash  = Mid(githash, 1, InStr(githash, Chr(9)) - 1)
 	Else
 		isodate = 0
 		modified = 1
 		githash = ""
+		istag = 0
 	End If
 
-	UpdateFile modified, isodate, version, cur_date, githash, "../src/rev.cpp"
-	UpdateFile modified, isodate, version, cur_date, githash, "../src/os/windows/ottdres.rc"
+	UpdateFile modified, isodate, version, cur_date, githash, istag, "../src/rev.cpp"
+	UpdateFile modified, isodate, version, cur_date, githash, istag, "../src/os/windows/ottdres.rc"
 End Sub
 
 Function DetermineVersion()
@@ -137,7 +143,7 @@ Function DetermineVersion()
 		DetermineVersion = "norev000"
 		modified = 1
 	Else
-		Dim version, hashprefix
+		Dim version, hashprefix, istag
 		If modified = 0 Then
 			hashprefix = "-g"
 		ElseIf modified = 2 Then
@@ -148,11 +154,13 @@ Function DetermineVersion()
 
 		If tag <> "" Then
 			version = tag
+			istag = 1
 		Else
 			version = isodate & "-" & branch & hashprefix & shorthash
+			istag = 0
 		End If
 
-		DetermineVersion = version & Chr(9) & isodate & Chr(9) & modified & Chr(9) & hash
+		DetermineVersion = version & Chr(9) & isodate & Chr(9) & modified & Chr(9) & hash & Chr(9) & istag
 	End If
 End Function
 

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -63,6 +63,13 @@ const char _openttd_revision_hash[] = "!!GITHASH!!";
 const byte _openttd_revision_modified = !!MODIFIED!!;
 
 /**
+ * Indicate whether this is a tagged version.
+ * If this is non-0, then _openttd_revision is the name of the tag,
+ * and the version is likely a beta, release candidate, or real release.
+ */
+const byte _openttd_revision_tagged = !!ISTAG!!;
+
+/**
  * The NewGRF revision of OTTD:
  * bits  meaning.
  * 28-31 major version

--- a/src/rev.h
+++ b/src/rev.h
@@ -16,6 +16,7 @@ extern const char _openttd_revision[];
 extern const char _openttd_build_date[];
 extern const char _openttd_revision_hash[];
 extern const byte _openttd_revision_modified;
+extern const byte _openttd_revision_tagged;
 extern const uint32 _openttd_newgrf_version;
 
 bool IsReleasedVersion();


### PR DESCRIPTION
When a build is made from a tagged version, the network revision should not be mangled with the git hash, the tag should just be used as-is.