### PR TITLE
Fix 148e5b41d6: Uninitialized variable usage.

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1225,8 +1225,8 @@ void CheckVehicleBreakdown(Vehicle *v)
 	if (!_settings_game.order.no_servicing_if_no_breakdowns ||
 			_settings_game.difficulty.vehicle_breakdowns != 0) {
 		v->reliability = rel = max((rel_old = v->reliability) - v->reliability_spd_dec, 0);
+		if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 	}
-	if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 
 	if (v->breakdown_ctr != 0 || (v->vehstatus & VS_STOPPED) ||
 			_settings_game.difficulty.vehicle_breakdowns < 1 ||


### PR DESCRIPTION
Fixed by moving the call to invalidate the vehicle details window into the if () condition as well.