### PR TITLE
Change: Increase maximum number of orders from 64000 to ~16.7m.

### DIFF
--- a/src/order_base.h
+++ b/src/order_base.h
@@ -21,7 +21,7 @@
 #include "vehicle_type.h"
 #include "date_type.h"
 
-typedef Pool<Order, OrderID, 256, 64000> OrderPool;
+typedef Pool<Order, OrderID, 256, 0xFF0000> OrderPool;
 typedef Pool<OrderList, OrderListID, 128, 64000> OrderListPool;
 extern OrderPool _order_pool;
 extern OrderListPool _orderlist_pool;

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -15,7 +15,7 @@
 #include "core/enum_type.hpp"
 
 typedef byte VehicleOrderID;  ///< The index of an order within its current vehicle (not pool related)
-typedef uint16 OrderID;
+typedef uint32 OrderID;
 typedef uint16 OrderListID;
 typedef uint16 DestinationID;
 
@@ -25,7 +25,7 @@ static const VehicleOrderID INVALID_VEH_ORDER_ID = 0xFF;
 static const VehicleOrderID MAX_VEH_ORDER_ID     = INVALID_VEH_ORDER_ID - 1;
 
 /** Invalid order (sentinel) */
-static const OrderID INVALID_ORDER = 0xFFFF;
+static const OrderID INVALID_ORDER = 0xFFFFFF;
 
 /**
  * Maximum number of orders in implicit-only lists before we start searching


### PR DESCRIPTION
This fixes #6968. Turns out it is apparently trivial to increase the maximum number of orders, and doesn't even need a bump, though #7219 is useful in that case.