### PR TITLE
Replace Window::scrolling_scrollbar with Window::mouse_capture_widget

### DIFF
--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -799,7 +799,7 @@ struct MusicWindow : public Window {
 
 				byte *vol = (widget == WID_M_MUSIC_VOL) ? &_settings_client.music.music_vol : &_settings_client.music.effect_vol;
 
-				byte new_vol = x * 127 / this->GetWidget<NWidgetBase>(widget)->current_x;
+				byte new_vol = Clamp(x * 127 / (int)this->GetWidget<NWidgetBase>(widget)->current_x, 0, 127);
 				if (_current_text_dir == TD_RTL) new_vol = 127 - new_vol;
 				/* Clamp to make sure min and max are properly settable */
 				if (new_vol > 124) new_vol = 127;
@@ -810,7 +810,7 @@ struct MusicWindow : public Window {
 					this->SetDirty();
 				}
 
-				_left_button_clicked = false;
+				if (click_count > 0) this->mouse_capture_widget = widget;
 				break;
 			}
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1401,15 +1401,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 {
 	switch (widget) {
 		case WID_SM_MAP: { // Map window
-			/*
-			 * XXX: scrolling with the left mouse button is done by subsequently
-			 * clicking with the left mouse button; clicking once centers the
-			 * large map at the selected point. So by unclicking the left mouse
-			 * button here, it gets reclicked during the next inputloop, which
-			 * would make it look like the mouse is being dragged, while it is
-			 * actually being (virtually) clicked every inputloop.
-			 */
-			_left_button_clicked = false;
+			if (click_count > 0) this->mouse_capture_widget = widget;
 
 			const NWidgetBase *wid = this->GetWidget<NWidgetBase>(WID_SM_MAP);
 			Window *w = FindWindowById(WC_MAIN_WINDOW, 0);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -99,7 +99,7 @@ static void ScrollbarClickPositioning(Window *w, NWidgetScrollbar *sb, int x, in
 			_scroller_click_timeout = 3;
 			sb->UpdatePosition(rtl ? 1 : -1);
 		}
-		w->scrolling_scrollbar = sb->index;
+		w->mouse_capture_widget = sb->index;
 	} else if (pos >= ma - button_size) {
 		/* Pressing the lower button? */
 		SetBit(sb->disp_flags, NDB_SCROLLBAR_DOWN);
@@ -108,7 +108,7 @@ static void ScrollbarClickPositioning(Window *w, NWidgetScrollbar *sb, int x, in
 			_scroller_click_timeout = 3;
 			sb->UpdatePosition(rtl ? -1 : 1);
 		}
-		w->scrolling_scrollbar = sb->index;
+		w->mouse_capture_widget = sb->index;
 	} else {
 		Point pt = HandleScrollbarHittest(sb, mi, ma, sb->type == NWID_HSCROLLBAR);
 
@@ -119,7 +119,7 @@ static void ScrollbarClickPositioning(Window *w, NWidgetScrollbar *sb, int x, in
 		} else {
 			_scrollbar_start_pos = pt.x - mi - button_size;
 			_scrollbar_size = ma - mi - button_size * 2;
-			w->scrolling_scrollbar = sb->index;
+			w->mouse_capture_widget = sb->index;
 			_cursorpos_drag_start = _cursor.pos;
 		}
 	}
@@ -2038,7 +2038,7 @@ void NWidgetScrollbar::Draw(const Window *w)
 
 	bool up_lowered = HasBit(this->disp_flags, NDB_SCROLLBAR_UP);
 	bool down_lowered = HasBit(this->disp_flags, NDB_SCROLLBAR_DOWN);
-	bool middle_lowered = !(this->disp_flags & ND_SCROLLBAR_BTN) && w->scrolling_scrollbar == this->index;
+	bool middle_lowered = !(this->disp_flags & ND_SCROLLBAR_BTN) && w->mouse_capture_widget == this->index;
 
 	if (this->type == NWID_HSCROLLBAR) {
 		DrawHorizontalScrollbar(r, this->colour, up_lowered, middle_lowered, down_lowered, this);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -327,7 +327,7 @@ public:
 	NWidgetStacked *shade_select;    ///< Selection widget (#NWID_SELECTION) to use for shading the window. If \c NULL, window cannot shade.
 	Dimension unshaded_size;         ///< Last known unshaded size (only valid while shaded).
 
-	int scrolling_scrollbar;         ///< Widgetindex of just being dragged scrollbar. -1 if none is active.
+	int mouse_capture_widget;        ///< Widgetindex of current mouse capture widget (e.g. dragged scrollbar). -1 if no widget has mouse capture.
 
 	Window *parent;                  ///< Parent window.
 	Window *z_front;                 ///< The window in front of us in z-order.


### PR DESCRIPTION
This allows us to support generic widget scrolling/dragging. Scrollbars are now handled by testing that the widget type is `NWID_VSCROLLBAR` or `NWID_HSCROLLBAR`, otherwise an `OnClick()` event is dispatched to the window with `click_count` of zero (logically no additional clicks have been made).

This is followed up by setting `mouse_capture_widget` when dragging a music window volume slider, see #7209 for reference.

And for completeness, click-left dragging the smallmap is improved (and matches right-click dragging behaviour) by setting `mouse_capture_widget`.