### PR TITLE
Fix #7226: No ship track due to "forbid 90 deg turns"-> Do not call pathfinders.

### DIFF
--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -510,9 +510,20 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 	return track;
 }
 
-static inline TrackBits GetAvailShipTracks(TileIndex tile, DiagDirection dir)
+/**
+ * Get the available water tracks on a tile for a ship entering a tile.
+ * @param tile The tile about to enter.
+ * @param dir The entry direction.
+ * @param trackdir The trackdir the ship has on the old tile.
+ * @return The available trackbits on the next tile.
+ */
+static inline TrackBits GetAvailShipTracks(TileIndex tile, DiagDirection dir, Trackdir trackdir)
 {
-	return GetTileShipTrackStatus(tile) & DiagdirReachesTracks(dir);
+	TrackBits tracks = GetTileShipTrackStatus(tile) & DiagdirReachesTracks(dir);
+
+	if (_settings_game.pf.forbid_90_deg) tracks &= ~TrackCrossesTracks(TrackdirToTrack(trackdir));
+
+	return tracks;
 }
 
 static const byte _ship_subcoord[4][6][3] = {
@@ -699,7 +710,7 @@ static void ShipController(Ship *v)
 
 			DiagDirection diagdir = DiagdirBetweenTiles(gp.old_tile, gp.new_tile);
 			assert(diagdir != INVALID_DIAGDIR);
-			tracks = GetAvailShipTracks(gp.new_tile, diagdir);
+			tracks = GetAvailShipTracks(gp.new_tile, diagdir, v->GetVehicleTrackdir());
 			if (tracks == TRACK_BIT_NONE) goto reverse_direction;
 
 			/* Choose a direction, and continue if we find one */


### PR DESCRIPTION
Don't call ship pathfinders if there is no available track due to "forbid 90 deg turns".

Don't know if OPF will be affected in a negative way by this patch. Probably it forbids 90 degrees turns for this pathfinder, and it may be unable of finding routes.