### PR TITLE
Change: Non-rectangular sparse station catchment area

### DIFF
--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -448,6 +448,7 @@
     <ClInclude Include="..\src\base_media_base.h" />
     <ClInclude Include="..\src\base_media_func.h" />
     <ClInclude Include="..\src\base_station_base.h" />
+    <ClInclude Include="..\src\bitmap_type.h" />
     <ClInclude Include="..\src\bmp.h" />
     <ClInclude Include="..\src\bridge.h" />
     <ClInclude Include="..\src\cargo_type.h" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -432,6 +432,9 @@
     <ClInclude Include="..\src\base_station_base.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\bitmap_type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\bmp.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -448,6 +448,7 @@
     <ClInclude Include="..\src\base_media_base.h" />
     <ClInclude Include="..\src\base_media_func.h" />
     <ClInclude Include="..\src\base_station_base.h" />
+    <ClInclude Include="..\src\bitmap_type.h" />
     <ClInclude Include="..\src\bmp.h" />
     <ClInclude Include="..\src\bridge.h" />
     <ClInclude Include="..\src\cargo_type.h" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -432,6 +432,9 @@
     <ClInclude Include="..\src\base_station_base.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\bitmap_type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\bmp.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -448,6 +448,7 @@
     <ClInclude Include="..\src\base_media_base.h" />
     <ClInclude Include="..\src\base_media_func.h" />
     <ClInclude Include="..\src\base_station_base.h" />
+    <ClInclude Include="..\src\bitmap_type.h" />
     <ClInclude Include="..\src\bmp.h" />
     <ClInclude Include="..\src\bridge.h" />
     <ClInclude Include="..\src\cargo_type.h" />

--- a/projects/openttd_vs142.vcxproj.filters
+++ b/projects/openttd_vs142.vcxproj.filters
@@ -432,6 +432,9 @@
     <ClInclude Include="..\src\base_station_base.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\bitmap_type.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\bmp.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/source.list
+++ b/source.list
@@ -135,6 +135,7 @@ autoslope.h
 base_media_base.h
 base_media_func.h
 base_station_base.h
+bitmap_type.h
 bmp.h
 bridge.h
 cargo_type.h

--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -1,0 +1,120 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file bitmap_type.hpp Bitmap functions. */
+
+#ifndef BITMAP_TYPE_HPP
+#define BITMAP_TYPE_HPP
+
+#include <vector>
+
+/** Represents a tile area containing containing individually set tiles.
+ * Each tile must be contained within the preallocated area.
+ * A std::vector<bool> is used to mark which tiles are contained.
+ */
+class BitmapTileArea : public TileArea {
+protected:
+	std::vector<bool> data;
+
+	inline uint Index(uint x, uint y) const { return y * this->w + x; }
+
+	inline uint Index(TileIndex tile) const { return Index(TileX(tile) - TileX(this->tile), TileY(tile) - TileY(this->tile)); }
+
+public:
+	BitmapTileArea()
+	{
+		this->tile = INVALID_TILE;
+		this->w = 0;
+		this->h = 0;
+	}
+
+	/**
+	 * Reset and clear the BitmapTileArea.
+	 */
+	void Reset()
+	{
+		this->tile = INVALID_TILE;
+		this->w = 0;
+		this->h = 0;
+		this->data.clear();
+	}
+
+	/**
+	 * Initialize the BitmapTileArea with the specified Rect.
+	 * @param rect Rect to use.
+	 */
+	void Initialize(Rect r)
+	{
+		this->tile = TileXY(r.left, r.top);
+		this->w = r.right - r.left + 1;
+		this->h = r.bottom - r.top + 1;
+		this->data.clear();
+		this->data.resize(Index(w, h));
+	}
+
+	/**
+	 * Add a tile as part of the tile area.
+	 * @param tile Tile to add.
+	 */
+	inline void SetTile(TileIndex tile)
+	{
+		assert(this->Contains(tile));
+		this->data[Index(tile)] = true;
+	}
+
+	/**
+	 * Clear a tile from the tile area.
+	 * @param tile Tile to clear
+	 */
+	inline void ClrTile(TileIndex tile)
+	{
+		assert(this->Contains(tile));
+		this->data[Index(tile)] = false;
+	}
+
+	/**
+	 * Test if a tile is part of the tile area.
+	 * @param tile Tile to check
+	 */
+	inline bool HasTile(TileIndex tile) const
+	{
+		return this->Contains(tile) && this->data[Index(tile)];
+	}
+};
+
+/** Iterator to iterate over all tiles belonging to a bitmaptilearea. */
+class BitmapTileIterator : public OrthogonalTileIterator {
+protected:
+	const BitmapTileArea *bitmap;
+public:
+	/**
+	 * Construct the iterator.
+	 * @param bitmap BitmapTileArea to iterate.
+	 */
+	BitmapTileIterator(const BitmapTileArea &bitmap) : OrthogonalTileIterator(bitmap), bitmap(&bitmap)
+	{
+		if (!this->bitmap->HasTile(TileIndex(this->tile))) ++(*this);
+	}
+
+	inline TileIterator& operator ++()
+	{
+		(*this).OrthogonalTileIterator::operator++();
+		while (this->tile != INVALID_TILE && !this->bitmap->HasTile(TileIndex(this->tile))) {
+			(*this).OrthogonalTileIterator::operator++();
+		}
+		return *this;
+	}
+
+	virtual TileIterator *Clone() const
+	{
+		return new BitmapTileIterator(*this);
+	}
+};
+
+#endif /* BITMAP_TYPE_HPP */

--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -151,9 +151,9 @@ void AddCargoDelivery(CargoID cargo_type, CompanyID company, uint32 amount, Sour
 	if (iter != _cargo_deliveries.end()) iter->second += amount;
 
 	/* Industry delivery. */
-	for (const Industry * const *ip = st->industries_near.Begin(); ip != st->industries_near.End(); ip++) {
-		if ((*ip)->index != dest) continue;
-		CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, (*ip)->index);
+	for (Industry *ind : st->industries_near) {
+		if (ind->index != dest) continue;
+		CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, ind->index);
 		CargoMonitorMap::iterator iter = _cargo_deliveries.find(num);
 		if (iter != _cargo_deliveries.end()) iter->second += amount;
 	}

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1044,8 +1044,9 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 
 	uint accepted = 0;
 
-	for (uint i = 0; i < st->industries_near.Length() && num_pieces != 0; i++) {
-		Industry *ind = st->industries_near[i];
+	for (Industry *ind : st->industries_near) {
+		if (num_pieces == 0) break;
+
 		if (ind->index == source) continue;
 
 		if (!_settings_game.station.serve_neutral_industries) {

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1049,11 +1049,6 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 
 		if (ind->index == source) continue;
 
-		if (!_settings_game.station.serve_neutral_industries) {
-			/* If this industry is only served by its neutral station, check it's us. */
-			if (ind->neutral_station != NULL && ind->neutral_station != st) continue;
-		}
-
 		uint cargo_index;
 		for (cargo_index = 0; cargo_index < lengthof(ind->accepts_cargo); cargo_index++) {
 			if (cargo_type == ind->accepts_cargo[cargo_index]) break;

--- a/src/industry.h
+++ b/src/industry.h
@@ -63,6 +63,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	byte was_cargo_delivered;           ///< flag that indicate this has been the closest industry chosen for cargo delivery by a station. see DeliverGoodsToIndustry
 
 	PartOfSubsidyByte part_of_subsidy;  ///< NOSAVE: is this industry a source/destination of a subsidy?
+	StationList stations_near;          ///< NOSAVE: List of nearby stations.
 
 	OwnerByte founder;                  ///< Founder of the industry
 	Date construction_date;             ///< Date of the construction of the industry

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -521,7 +521,7 @@ static bool TransportIndustryGoods(TileIndex tile)
 
 	if (i->neutral_station != NULL && !_settings_game.station.serve_neutral_industries) {
 		/* Industry has a neutral station. Use it and ignore any other nearby stations. */
-		*neutral.Append() = i->neutral_station;
+		neutral.insert(i->neutral_station);
 	}
 
 	for (uint j = 0; j < lengthof(i->produced_cargo_waiting); j++) {
@@ -534,7 +534,7 @@ static bool TransportIndustryGoods(TileIndex tile)
 
 			i->this_month_production[j] += cw;
 
-			uint am = MoveGoodsToStation(i->produced_cargo[j], cw, ST_INDUSTRY, i->index, neutral.Length() != 0 ? &neutral : stations.GetStations());
+			uint am = MoveGoodsToStation(i->produced_cargo[j], cw, ST_INDUSTRY, i->index, neutral.size() != 0 ? &neutral : stations.GetStations());
 			i->this_month_transported[j] += am;
 
 			moved_cargo |= (am != 0);
@@ -2907,3 +2907,8 @@ extern const TileTypeProcs _tile_type_industry_procs = {
 	GetFoundation_Industry,      // get_foundation_proc
 	TerraformTile_Industry,      // terraform_tile_proc
 };
+
+bool IndustryCompare::operator() (const Industry *lhs, const Industry *rhs) const
+{
+	return lhs->index < rhs->index;
+}

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -182,6 +182,10 @@ Industry::~Industry()
 
 	DeleteSubsidyWith(ST_INDUSTRY, this->index);
 	CargoPacket::InvalidateAllFrom(ST_INDUSTRY, this->index);
+
+	for (Station *st : this->stations_near) {
+		st->industries_near.erase(this);
+	}
 }
 
 /**
@@ -191,7 +195,6 @@ Industry::~Industry()
 void Industry::PostDestructor(size_t index)
 {
 	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, 0);
-	Station::RecomputeIndustriesNearForAll();
 }
 
 
@@ -516,14 +519,6 @@ static bool TransportIndustryGoods(TileIndex tile)
 	const IndustrySpec *indspec = GetIndustrySpec(i->type);
 	bool moved_cargo = false;
 
-	StationFinder stations(i->location);
-	StationList neutral;
-
-	if (i->neutral_station != NULL && !_settings_game.station.serve_neutral_industries) {
-		/* Industry has a neutral station. Use it and ignore any other nearby stations. */
-		neutral.insert(i->neutral_station);
-	}
-
 	for (uint j = 0; j < lengthof(i->produced_cargo_waiting); j++) {
 		uint cw = min(i->produced_cargo_waiting[j], 255);
 		if (cw > indspec->minimal_cargo && i->produced_cargo[j] != CT_INVALID) {
@@ -534,7 +529,7 @@ static bool TransportIndustryGoods(TileIndex tile)
 
 			i->this_month_production[j] += cw;
 
-			uint am = MoveGoodsToStation(i->produced_cargo[j], cw, ST_INDUSTRY, i->index, neutral.size() != 0 ? &neutral : stations.GetStations());
+			uint am = MoveGoodsToStation(i->produced_cargo[j], cw, ST_INDUSTRY, i->index, &i->stations_near);
 			i->this_month_transported[j] += am;
 
 			moved_cargo |= (am != 0);
@@ -1651,6 +1646,37 @@ static void AdvertiseIndustryOpening(const Industry *ind)
 }
 
 /**
+ * Populate an industry's list of nearby stations, and if it accepts any cargo, also
+ * add the industry to each station's nearby industry list.
+ * @param ind Industry
+ */
+static void PopulateStationsNearby(Industry *ind)
+{
+	if (ind->neutral_station != NULL && !_settings_game.station.serve_neutral_industries) {
+		/* Industry has a neutral station. Use it and ignore any other nearby stations. */
+		ind->stations_near.insert(ind->neutral_station);
+		ind->neutral_station->industries_near.clear();
+		ind->neutral_station->industries_near.insert(ind);
+		return;
+	}
+
+	/* Get our list of nearby stations. */
+	FindStationsAroundTiles(ind->location, &ind->stations_near, false);
+
+	/* Test if industry can accept cargo */
+	uint cargo_index;
+	for (cargo_index = 0; cargo_index < lengthof(ind->accepts_cargo); cargo_index++) {
+		if (ind->accepts_cargo[cargo_index] != CT_INVALID) break;
+	}
+	if (cargo_index >= lengthof(ind->accepts_cargo)) return;
+
+	/* Cargo is accepted, add industry to nearby stations nearby industry list. */
+	for (Station *st : ind->stations_near) {
+		st->industries_near.insert(ind);
+	}
+}
+
+/**
  * Put an industry on the map.
  * @param i       Just allocated poolitem, mostly empty.
  * @param tile    North tile of the industry.
@@ -1823,7 +1849,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	}
 	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, 0);
 
-	Station::RecomputeIndustriesNearForAll();
+	if (!_generating_world) PopulateStationsNearby(i);
 }
 
 /**
@@ -2428,11 +2454,7 @@ static void CanCargoServiceIndustry(CargoID cargo, Industry *ind, bool *c_accept
  */
 static int WhoCanServiceIndustry(Industry *ind)
 {
-	/* Find all stations within reach of the industry */
-	StationList stations;
-	FindStationsAroundTiles(ind->location, &stations);
-
-	if (stations.size() == 0) return 0; // No stations found at all => nobody services
+	if (ind->stations_near.size() == 0) return 0; // No stations found at all => nobody services
 
 	const Vehicle *v;
 	int result = 0;
@@ -2468,7 +2490,7 @@ static int WhoCanServiceIndustry(Industry *ind)
 				/* Same cargo produced by industry is dropped here => not serviced by vehicle v */
 				if ((o->GetUnloadType() & OUFB_UNLOAD) && !c_accepts) break;
 
-				if (stations.find(st) != stations.end()) {
+				if (ind->stations_near.find(st) != ind->stations_near.end()) {
 					if (v->owner == _local_company) return 2; // Company services industry
 					result = 1; // Competitor services industry
 				}

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2432,7 +2432,7 @@ static int WhoCanServiceIndustry(Industry *ind)
 	StationList stations;
 	FindStationsAroundTiles(ind->location, &stations);
 
-	if (stations.Length() == 0) return 0; // No stations found at all => nobody services
+	if (stations.size() == 0) return 0; // No stations found at all => nobody services
 
 	const Vehicle *v;
 	int result = 0;
@@ -2468,7 +2468,7 @@ static int WhoCanServiceIndustry(Industry *ind)
 				/* Same cargo produced by industry is dropped here => not serviced by vehicle v */
 				if ((o->GetUnloadType() & OUFB_UNLOAD) && !c_accepts) break;
 
-				if (stations.Contains(st)) {
+				if (stations.find(st) != stations.end()) {
 					if (v->owner == _local_company) return 2; // Company services industry
 					result = 1; // Competitor services industry
 				}

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -350,8 +350,7 @@ static uint32 GetDistanceFromNearbyHouse(uint8 parameter, TileIndex tile, HouseI
 
 			/* Collect acceptance stats. */
 			uint32 res = 0;
-			for (Station * const * st_iter = sl->Begin(); st_iter != sl->End(); st_iter++) {
-				const Station *st = *st_iter;
+			for (Station *st : *sl) {
 				if (HasBit(st->goods[cid].status, GoodsEntry::GES_EVER_ACCEPTED))    SetBit(res, 0);
 				if (HasBit(st->goods[cid].status, GoodsEntry::GES_LAST_MONTH))       SetBit(res, 1);
 				if (HasBit(st->goods[cid].status, GoodsEntry::GES_CURRENT_MONTH))    SetBit(res, 2);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -285,7 +285,6 @@ static void InitializeWindowsAndCaches()
 
 	GroupStatistics::UpdateAfterLoad();
 
-	Station::RecomputeIndustriesNearForAll();
 	RebuildSubsidisedSourceAndDestinationCache();
 
 	/* Towns have a noise controlled number of airports system
@@ -3103,6 +3102,9 @@ bool AfterLoadGame()
 		Industry *ind;
 		FOR_ALL_INDUSTRIES(ind) if (ind->neutral_station != NULL) ind->neutral_station->industry = ind;
 	}
+
+	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
+	Station::RecomputeCatchmentForAll();
 
 	/* Station acceptance is some kind of cache */
 	if (IsSavegameVersionBefore(SLV_127)) {

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -134,7 +134,7 @@
 	Industry *ind = ::Industry::Get(industry_id);
 	StationList stations;
 	::FindStationsAroundTiles(ind->location, &stations);
-	return (int32)stations.Length();
+	return (int32)stations.size();
 }
 
 /* static */ int32 ScriptIndustry::GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile)

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -132,9 +132,7 @@
 	if (!IsValidIndustry(industry_id)) return -1;
 
 	Industry *ind = ::Industry::Get(industry_id);
-	StationList stations;
-	::FindStationsAroundTiles(ind->location, &stations);
-	return (int32)stations.size();
+	return (int32)ind->stations_near.size();
 }
 
 /* static */ int32 ScriptIndustry::GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1302,7 +1302,7 @@ static bool ChangeMaxHeightLevel(int32 p1)
 
 static bool StationCatchmentChanged(int32 p1)
 {
-	Station::RecomputeIndustriesNearForAll();
+	Station::RecomputeCatchmentForAll();
 	return true;
 }
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -307,8 +307,8 @@ Rect Station::GetCatchmentRect() const
 
 /** Rect and pointer to IndustryVector */
 struct RectAndIndustryVector {
-	Rect rect;                       ///< The rectangle to search the industries in.
-	IndustryVector *industries_near; ///< The nearby industries.
+	Rect rect;                     ///< The rectangle to search the industries in.
+	IndustryList *industries_near; ///< The nearby industries.
 };
 
 /**
@@ -328,7 +328,7 @@ static bool FindIndustryToDeliver(TileIndex ind_tile, void *user_data)
 	Industry *ind = Industry::GetByTile(ind_tile);
 
 	/* Don't check further if this industry is already in the list */
-	if (riv->industries_near->Contains(ind)) return false;
+	if (riv->industries_near->find(ind) != riv->industries_near->end()) return false;
 
 	/* Only process tiles in the station acceptance rectangle */
 	int x = TileX(ind_tile);
@@ -342,7 +342,7 @@ static bool FindIndustryToDeliver(TileIndex ind_tile, void *user_data)
 	}
 	if (cargo_index >= lengthof(ind->accepts_cargo)) return false;
 
-	*riv->industries_near->Append() = ind;
+	riv->industries_near->insert(ind);
 
 	return false;
 }
@@ -353,12 +353,12 @@ static bool FindIndustryToDeliver(TileIndex ind_tile, void *user_data)
  */
 void Station::RecomputeIndustriesNear()
 {
-	this->industries_near.Clear();
+	this->industries_near.clear();
 	if (this->rect.IsEmpty()) return;
 
 	if (!_settings_game.station.serve_neutral_industries && this->industry != NULL) {
 		/* Station is associated with an industry, so we only need to deliver to that industry. */
-		*this->industries_near.Append() = this->industry;
+		this->industries_near.insert(this->industry);
 		return;
 	}
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -571,3 +571,8 @@ Money AirportMaintenanceCost(Owner owner)
 	/* 3 bits fraction for the maintenance cost factor. */
 	return total_cost >> 3;
 }
+
+bool StationCompare::operator() (const Station *lhs, const Station *rhs) const
+{
+	return lhs->index < rhs->index;
+}

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -19,6 +19,7 @@
 #include "industry_type.h"
 #include "linkgraph/linkgraph_type.h"
 #include "newgrf_storage.h"
+#include "bitmap_type.h"
 #include <map>
 #include <set>
 
@@ -467,6 +468,8 @@ public:
 
 	IndustryType indtype;   ///< Industry type to get the name from
 
+	BitmapTileArea catchment_tiles; ///< NOSAVE: Set of individual tiles covered by catchment area
+
 	StationHadVehicleOfTypeByte had_vehicle_of_type;
 
 	byte time_since_load;
@@ -493,11 +496,18 @@ public:
 
 	/* virtual */ uint GetPlatformLength(TileIndex tile, DiagDirection dir) const;
 	/* virtual */ uint GetPlatformLength(TileIndex tile) const;
-	void RecomputeIndustriesNear();
-	static void RecomputeIndustriesNearForAll();
+	void RecomputeCatchment();
+	static void RecomputeCatchmentForAll();
 
 	uint GetCatchmentRadius() const;
 	Rect GetCatchmentRect() const;
+	bool CatchmentCoversTown(TownID t) const;
+	void RemoveFromAllNearbyLists();
+
+	inline bool TileIsInCatchment(TileIndex tile) const
+	{
+		return this->catchment_tiles.HasTile(tile);
+	}
 
 	/* virtual */ inline bool TileBelongsToRailStation(TileIndex tile) const
 	{

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -20,6 +20,7 @@
 #include "linkgraph/linkgraph_type.h"
 #include "newgrf_storage.h"
 #include <map>
+#include <set>
 
 typedef Pool<BaseStation, StationID, 32, 64000> StationPool;
 extern StationPool _station_pool;
@@ -440,7 +441,11 @@ private:
 	}
 };
 
-typedef SmallVector<Industry *, 2> IndustryVector;
+struct IndustryCompare {
+	bool operator() (const Industry *lhs, const Industry *rhs) const;
+};
+
+typedef std::set<Industry *, IndustryCompare> IndustryList;
 
 /** Station data structure */
 struct Station FINAL : SpecializedStation<Station, false> {
@@ -472,8 +477,8 @@ public:
 	GoodsEntry goods[NUM_CARGO];  ///< Goods at this station
 	CargoTypes always_accepted;       ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
 
-	IndustryVector industries_near; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
-	Industry *industry;             ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
+	IndustryList industries_near; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
+	Industry *industry;           ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
 
 	Station(TileIndex tile = INVALID_TILE);
 	~Station();

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3839,7 +3839,7 @@ void FindStationsAroundTiles(const TileArea &location, StationList *stations)
 			/* Insert the station in the set. This will fail if it has
 			 * already been added.
 			 */
-			stations->Include(st);
+			stations->insert(st);
 		}
 	}
 }
@@ -3867,9 +3867,7 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 	uint best_rating1 = 0; // rating of st1
 	uint best_rating2 = 0; // rating of st2
 
-	for (Station * const *st_iter = all_stations->Begin(); st_iter != all_stations->End(); ++st_iter) {
-		Station *st = *st_iter;
-
+	for (Station *st : *all_stations) {
 		/* Is the station reserved exclusively for somebody else? */
 		if (st->owner != OWNER_NONE && st->town->exclusive_counter > 0 && st->town->exclusivity != st->owner) continue;
 

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -23,13 +23,13 @@
 
 void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint radius);
 
-void FindStationsAroundTiles(const TileArea &location, StationList *stations);
+void FindStationsAroundTiles(const TileArea &location, StationList *stations, bool use_nearby = true);
 
 void ShowStationViewWindow(StationID station);
 void UpdateAllStationVirtCoords();
 
 CargoArray GetProductionAroundTiles(TileIndex tile, int w, int h, int rad);
-CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted = NULL, const Industry *ind = NULL);
+CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted = NULL);
 
 void UpdateStationAcceptance(Station *st, bool show_msg);
 

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -12,9 +12,9 @@
 #ifndef STATION_TYPE_H
 #define STATION_TYPE_H
 
-#include "core/smallvec_type.hpp"
 #include "core/smallstack_type.hpp"
 #include "tilearea_type.h"
+#include <set>
 
 typedef uint16 StationID;
 typedef uint16 RoadStopID;
@@ -90,8 +90,12 @@ enum CatchmentArea {
 
 static const uint MAX_LENGTH_STATION_NAME_CHARS = 32; ///< The maximum length of a station name in characters including '\0'
 
+struct StationCompare {
+	bool operator() (const Station *lhs, const Station *rhs) const;
+};
+
 /** List of stations */
-typedef SmallVector<Station *, 2> StationList;
+typedef std::set<Station *, StationCompare> StationList;
 
 /**
  * Structure contains cached list of stations nearby. The list

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -573,15 +573,11 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 			if (s->cargo_type != cargo_type || s->src_type != src_type || s->src != src) continue;
 			if (s->IsAwarded() && s->awarded != company) continue;
 
-			Rect rect = st->GetCatchmentRect();
-
-			for (int y = rect.top; y <= rect.bottom; y++) {
-				for (int x = rect.left; x <= rect.right; x++) {
-					TileIndex tile = TileXY(x, y);
-					if (!IsTileType(tile, MP_HOUSE)) continue;
-					const Town *t = Town::GetByTile(tile);
-					if (t->cache.part_of_subsidy & POS_DST) towns_near.Include(t);
-				}
+			BitmapTileIterator it(st->catchment_tiles);
+			for (TileIndex tile = it; tile != INVALID_TILE; tile = ++it) {
+				if (!IsTileType(tile, MP_HOUSE)) continue;
+				const Town *t = Town::GetByTile(tile);
+				if (t->cache.part_of_subsidy & POS_DST) towns_near.Include(t);
 			}
 			break;
 		}

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -596,9 +596,9 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 		if (s->cargo_type == cargo_type && s->src_type == src_type && s->src == src && (!s->IsAwarded() || s->awarded == company)) {
 			switch (s->dst_type) {
 				case ST_INDUSTRY:
-					for (const Industry * const *ip = st->industries_near.Begin(); ip != st->industries_near.End(); ip++) {
-						if (s->dst == (*ip)->index) {
-							assert((*ip)->part_of_subsidy & POS_DST);
+					for (Industry *ind : st->industries_near) {
+						if (s->dst == ind->index) {
+							assert(ind->part_of_subsidy & POS_DST);
 							subsidised = true;
 							if (!s->IsAwarded()) s->AwardTo(company);
 						}

--- a/src/town.h
+++ b/src/town.h
@@ -88,6 +88,7 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	CargoTypes cargo_produced;       ///< Bitmap of all cargoes produced by houses in this town.
 	AcceptanceMatrix cargo_accepted; ///< Bitmap of cargoes accepted by houses for each 4*4 map square of the town.
 	CargoTypes cargo_accepted_total; ///< NOSAVE: Bitmap of all cargoes accepted by houses in this town.
+	StationList stations_near;       ///< NOSAVE: List of nearby stations.
 
 	uint16 time_until_rebuild;     ///< time until we rebuild a house
 


### PR DESCRIPTION
This patch changes station catchment from a single rectangle covering the largest catchment radius of the station, to individual tiles based on the catchment radius of the station tiles near them.

The non-saved calculated set of catchment tiles is stored off-map within the station class. This set is then tested against when cargo is delivered to and from industries and towns.

~~Adds a third station catchment area option:~~

Original fixed-size catchment area:
![catchment0](https://user-images.githubusercontent.com/639850/52896588-30950600-31c2-11e9-86f9-837d4bdb1319.png)

Modified variable-size catchment area:
![catchment1](https://user-images.githubusercontent.com/639850/52896591-32f76000-31c2-11e9-9061-72fdcb09b24b.png)

New non-rectangular sparse catchment area:
![catchment2](https://user-images.githubusercontent.com/639850/52896594-3559ba00-31c2-11e9-8b03-a23b1ce6f77a.png)


