### PR TITLE
Add: Shortcut for deleting all messages.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -466,6 +466,7 @@ STR_TOOLBAR_SOUND_MUSIC                                         :Sound/music
 ############ range for message menu starts
 STR_NEWS_MENU_LAST_MESSAGE_NEWS_REPORT                          :Last message/news report
 STR_NEWS_MENU_MESSAGE_HISTORY_MENU                              :Message history
+STR_NEWS_MENU_DELETE_ALL_MESSAGES                               :Delete all messages
 ############ range ends here
 
 ############ range for about menu starts

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -220,6 +220,7 @@ enum {
 	GHK_RESET_OBJECT_TO_PLACE,
 	GHK_DELETE_WINDOWS,
 	GHK_DELETE_NONVITAL_WINDOWS,
+	GHK_DELETE_ALL_MESSAGES,
 	GHK_REFRESH_SCREEN,
 	GHK_CRASH,
 	GHK_MONEY,
@@ -345,6 +346,7 @@ struct MainWindow : Window
 			case GHK_RESET_OBJECT_TO_PLACE: ResetObjectToPlace(); break;
 			case GHK_DELETE_WINDOWS: DeleteNonVitalWindows(); break;
 			case GHK_DELETE_NONVITAL_WINDOWS: DeleteAllNonVitalWindows(); break;
+			case GHK_DELETE_ALL_MESSAGES: DeleteAllMessages(); break;
 			case GHK_REFRESH_SCREEN: MarkWholeScreenDirty(); break;
 
 			case GHK_CRASH: // Crash the game
@@ -488,6 +490,7 @@ static Hotkey global_hotkeys[] = {
 	Hotkey(WKC_ESC, "reset_object_to_place", GHK_RESET_OBJECT_TO_PLACE),
 	Hotkey(WKC_DELETE, "delete_windows", GHK_DELETE_WINDOWS),
 	Hotkey(WKC_DELETE | WKC_SHIFT, "delete_all_windows", GHK_DELETE_NONVITAL_WINDOWS),
+	Hotkey(WKC_DELETE | WKC_CTRL, "delete_all_messages", GHK_DELETE_ALL_MESSAGES),
 	Hotkey('R' | WKC_CTRL, "refresh_screen", GHK_REFRESH_SCREEN),
 #if defined(_DEBUG)
 	Hotkey('0' | WKC_ALT, "crash_game", GHK_CRASH),

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1019,7 +1019,7 @@ static CallBackFunction MenuClickMusicWindow(int index)
 
 static CallBackFunction ToolbarNewspaperClick(Window *w)
 {
-	PopupMainToolbMenu(w, WID_TN_MESSAGES, STR_NEWS_MENU_LAST_MESSAGE_NEWS_REPORT, 2);
+	PopupMainToolbMenu(w, WID_TN_MESSAGES, STR_NEWS_MENU_LAST_MESSAGE_NEWS_REPORT, 3);
 	return CBF_NONE;
 }
 
@@ -1034,6 +1034,7 @@ static CallBackFunction MenuClickNewspaper(int index)
 	switch (index) {
 		case 0: ShowLastNewsMessage(); break;
 		case 1: ShowMessageHistory();  break;
+		case 2: DeleteAllMessages();   break;
 	}
 	return CBF_NONE;
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -39,6 +39,7 @@
 #include "framerate_type.h"
 #include "network/network_func.h"
 #include "guitimer_func.h"
+#include "news_func.h"
 
 #include "safeguards.h"
 
@@ -3368,6 +3369,17 @@ restart_search:
 			goto restart_search;
 		}
 	}
+}
+
+/**
+ * Delete all messages and their corresponding window (if any).
+ */
+void DeleteAllMessages()
+{
+	InitNewsItemStructs();
+	InvalidateWindowData(WC_STATUS_BAR, 0, SBI_NEWS_DELETED); // invalidate the statusbar
+	InvalidateWindowData(WC_MESSAGE_HISTORY, 0); // invalidate the message history
+	DeleteWindowById(WC_NEWS_WINDOW, 0); // close newspaper or general message window if shown
 }
 
 /**

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -40,6 +40,7 @@ void InvalidateWindowClassesData(WindowClass cls, int data = 0, bool gui_scope =
 
 void DeleteNonVitalWindows();
 void DeleteAllNonVitalWindows();
+void DeleteAllMessages();
 void DeleteConstructionWindows();
 void HideVitalWindows();
 void ShowVitalWindows();


### PR DESCRIPTION
Sometimes I get overflowed with news and messages (when cheating and changing the date or when resetting engines) and I want to delete only the messages and keep any other window open.
This PR adds a shortcut for deleting them. 