### PR TITLE
Codechange: Improve performance of town name refresh on viewports

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -28,6 +28,7 @@
 #include "core/pool_type.hpp"
 #include "game/game.hpp"
 #include "linkgraph/linkgraphschedule.h"
+#include "viewport_func.h"
 
 #include "safeguards.h"
 
@@ -95,6 +96,8 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	InitializeIndustries();
 	InitializeObjects();
 	InitializeBuildingCounts();
+
+	_towns_sign_filter.Uninitialize();
 
 	InitializeNPF();
 

--- a/src/town.h
+++ b/src/town.h
@@ -19,6 +19,7 @@
 #include "cargotype.h"
 #include "tilematrix_type.hpp"
 #include <list>
+#include <vector>
 
 template <typename T>
 struct BuildingCounts {
@@ -294,5 +295,40 @@ static inline uint16 TownTicksToGameTicks(uint16 ticks) {
 
 
 extern CargoTypes _town_cargoes_accepted;
+
+/** Data structure with cached data of towns. */
+/* ToDo: documentation */
+struct TownList {
+	std::vector<TownID> towns;
+
+private:
+	bool needs_resort; ///<
+	bool initialized;  ///<
+	uint size;         ///<
+
+	bool Sort();
+
+public:
+	TownList() : needs_resort(true), initialized(false), size(0) { }
+
+	void Uninitialize();
+
+	static bool CompareBySignTopPosition(TownID index_a, TownID index_b) {
+		return (Town::Get(index_a)->cache.sign.top < Town::Get(index_b)->cache.sign.top);
+	}
+
+	static bool CompareSignTopPositionWithValue(TownID index, int32 y) {
+		return (Town::Get(index)->cache.sign.top < y);
+	}
+
+	inline uint Size() {
+		return this->size;
+	}
+
+	bool Build();
+	void AddTown(TownID index);
+	void RemoveTown(TownID index);
+	uint FirstTownPosAfterYCoordinate(int32 y);
+};
 
 #endif /* TOWN_H */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -97,7 +97,7 @@
 #include "safeguards.h"
 
 Point _tile_fract_coords;
-
+TownList _towns_sign_filter;
 
 static const int MAX_TILE_EXTENT_LEFT   = ZOOM_LVL_BASE * TILE_PIXELS;                     ///< Maximum left   extent of tile relative to north corner.
 static const int MAX_TILE_EXTENT_RIGHT  = ZOOM_LVL_BASE * TILE_PIXELS;                     ///< Maximum right  extent of tile relative to north corner.
@@ -1219,7 +1219,14 @@ static void ViewportAddTownNames(DrawPixelInfo *dpi)
 	if (!HasBit(_display_opt, DO_SHOW_TOWN_NAMES) || _game_mode == GM_MENU) return;
 
 	const Town *t;
-	FOR_ALL_TOWNS(t) {
+
+	int sign_height = ScaleByZoom(VPSM_TOP + FONT_HEIGHT_NORMAL + VPSM_BOTTOM, dpi->zoom);
+
+	for (uint index = _towns_sign_filter.FirstTownPosAfterYCoordinate(dpi->top - sign_height);
+		index < _towns_sign_filter.Size() && Town::Get(_towns_sign_filter.towns[index])->cache.sign.top < (dpi->top + dpi->height);
+		index++) {
+
+		t = Town::Get(_towns_sign_filter.towns[index]);
 		ViewportAddString(dpi, ZOOM_LVL_OUT_16X, &t->cache.sign,
 				_settings_client.gui.population_in_label ? STR_VIEWPORT_TOWN_POP : STR_VIEWPORT_TOWN,
 				STR_VIEWPORT_TOWN_TINY_WHITE, STR_VIEWPORT_TOWN_TINY_BLACK,

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -17,6 +17,7 @@
 #include "window_type.h"
 #include "tile_map.h"
 #include "station_type.h"
+#include "town.h"
 
 static const int TILE_HEIGHT_STEP = 50; ///< One Z unit tile height difference is displayed as 50m.
 
@@ -77,6 +78,7 @@ bool ScrollMainWindowTo(int x, int y, int z = -1, bool instant = false);
 void UpdateAllVirtCoords();
 
 extern Point _tile_fract_coords;
+extern TownList _towns_sign_filter;
 
 void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset, int tile_height_override);
 


### PR DESCRIPTION
Instead of checking all town name signs, filter by the Y coordinate of the signs, and check only filtered town names.
A town gets into the filtered town if the Y coordinate of its sign is between the lines marked by the redraw box top and bottom. There is no filtering by the X coordinates, as the width of the town names can change in a wide range.
Time complexities:
 - original: O(#towns)
 - this one: O(log(#towns)) + O(#filtered_towns)

Performance improvement can be observed only in maps with high town count. On a 4096x4096 map with 30k towns (scenario editor) when scrolling on the map the time of viewport drawing went form 90 ms to 5 ms with this improvement (according to the framerate window).