### PR TITLE
Change: Group processing of vehicle ticks by type of vehicle. This allows use of PerformanceCounter instead of PerformanceAccumulator.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2054,8 +2054,6 @@ bool Aircraft::Tick()
 {
 	if (!this->IsNormalAircraft()) return true;
 
-	PerformanceAccumulator framerate(PFE_GL_AIRCRAFT);
-
 	this->tick_counter++;
 
 	if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1588,8 +1588,6 @@ Money RoadVehicle::GetRunningCost() const
 
 bool RoadVehicle::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_ROADVEHS);
-
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -777,8 +777,6 @@ reverse_direction:
 
 bool Ship::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_SHIPS);
-
 	if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;
 
 	ShipController(this);

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3901,8 +3901,6 @@ Money Train::GetRunningCost() const
  */
 bool Train::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_TRAINS);
-
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {


### PR DESCRIPTION
This gives a large performance benefit in the case of lot of vehicles, and I suspect is no worse even with not many vehicles.

The performance impact is caused by PerformanceAccumulator spending a disprortionate amount of time doing its own sums.

This fixes #7247.