### PR TITLE
K-d tree data structure for spatial lookups

### DIFF
--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -680,6 +680,7 @@
     <ClInclude Include="..\src\toolbar_gui.h" />
     <ClInclude Include="..\src\town.h" />
     <ClInclude Include="..\src\town_type.h" />
+    <ClInclude Include="..\src\town_kdtree.h" />
     <ClInclude Include="..\src\townname_func.h" />
     <ClInclude Include="..\src\townname_type.h" />
     <ClInclude Include="..\src\track_func.h" />

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -646,6 +646,7 @@
     <ClInclude Include="..\src\station_base.h" />
     <ClInclude Include="..\src\station_func.h" />
     <ClInclude Include="..\src\station_gui.h" />
+    <ClInclude Include="..\src\station_kdtree.h" />
     <ClInclude Include="..\src\station_type.h" />
     <ClInclude Include="..\src\statusbar_gui.h" />
     <ClInclude Include="..\src\stdafx.h" />

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -724,6 +724,7 @@
     <ClCompile Include="..\src\core\geometry_func.cpp" />
     <ClInclude Include="..\src\core\geometry_func.hpp" />
     <ClInclude Include="..\src\core\geometry_type.hpp" />
+    <ClInclude Include="..\src\core\kdtree.hpp" />
     <ClCompile Include="..\src\core\math_func.cpp" />
     <ClInclude Include="..\src\core\math_func.hpp" />
     <ClInclude Include="..\src\core\mem_func.hpp" />

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -698,6 +698,7 @@
     <ClInclude Include="..\src\vehicle_type.h" />
     <ClInclude Include="..\src\vehiclelist.h" />
     <ClInclude Include="..\src\viewport_func.h" />
+    <ClInclude Include="..\src\viewport_kdtree.h" />
     <ClInclude Include="..\src\viewport_sprite_sorter.h" />
     <ClInclude Include="..\src\viewport_type.h" />
     <ClInclude Include="..\src\water.h" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -1026,6 +1026,9 @@
     <ClInclude Include="..\src\station_gui.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\station_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\station_type.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -1260,6 +1260,9 @@
     <ClInclude Include="..\src\core\geometry_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\core\kdtree.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
     <ClCompile Include="..\src\core\math_func.cpp">
       <Filter>Core Source Code</Filter>
     </ClCompile>

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -1128,6 +1128,9 @@
     <ClInclude Include="..\src\town_type.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\town_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\townname_func.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -1182,6 +1182,9 @@
     <ClInclude Include="..\src\viewport_func.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\viewport_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\viewport_sprite_sorter.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -680,6 +680,7 @@
     <ClInclude Include="..\src\toolbar_gui.h" />
     <ClInclude Include="..\src\town.h" />
     <ClInclude Include="..\src\town_type.h" />
+    <ClInclude Include="..\src\town_kdtree.h" />
     <ClInclude Include="..\src\townname_func.h" />
     <ClInclude Include="..\src\townname_type.h" />
     <ClInclude Include="..\src\track_func.h" />

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -646,6 +646,7 @@
     <ClInclude Include="..\src\station_base.h" />
     <ClInclude Include="..\src\station_func.h" />
     <ClInclude Include="..\src\station_gui.h" />
+    <ClInclude Include="..\src\station_kdtree.h" />
     <ClInclude Include="..\src\station_type.h" />
     <ClInclude Include="..\src\statusbar_gui.h" />
     <ClInclude Include="..\src\stdafx.h" />

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -724,6 +724,7 @@
     <ClCompile Include="..\src\core\geometry_func.cpp" />
     <ClInclude Include="..\src\core\geometry_func.hpp" />
     <ClInclude Include="..\src\core\geometry_type.hpp" />
+    <ClInclude Include="..\src\core\kdtree.hpp" />
     <ClCompile Include="..\src\core\math_func.cpp" />
     <ClInclude Include="..\src\core\math_func.hpp" />
     <ClInclude Include="..\src\core\mem_func.hpp" />

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -698,6 +698,7 @@
     <ClInclude Include="..\src\vehicle_type.h" />
     <ClInclude Include="..\src\vehiclelist.h" />
     <ClInclude Include="..\src\viewport_func.h" />
+    <ClInclude Include="..\src\viewport_kdtree.h" />
     <ClInclude Include="..\src\viewport_sprite_sorter.h" />
     <ClInclude Include="..\src\viewport_type.h" />
     <ClInclude Include="..\src\water.h" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -1026,6 +1026,9 @@
     <ClInclude Include="..\src\station_gui.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\station_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\station_type.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -1260,6 +1260,9 @@
     <ClInclude Include="..\src\core\geometry_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\core\kdtree.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
     <ClCompile Include="..\src\core\math_func.cpp">
       <Filter>Core Source Code</Filter>
     </ClCompile>

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -1128,6 +1128,9 @@
     <ClInclude Include="..\src\town_type.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\town_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\townname_func.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -1182,6 +1182,9 @@
     <ClInclude Include="..\src\viewport_func.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\viewport_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\viewport_sprite_sorter.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -680,6 +680,7 @@
     <ClInclude Include="..\src\toolbar_gui.h" />
     <ClInclude Include="..\src\town.h" />
     <ClInclude Include="..\src\town_type.h" />
+    <ClInclude Include="..\src\town_kdtree.h" />
     <ClInclude Include="..\src\townname_func.h" />
     <ClInclude Include="..\src\townname_type.h" />
     <ClInclude Include="..\src\track_func.h" />

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -646,6 +646,7 @@
     <ClInclude Include="..\src\station_base.h" />
     <ClInclude Include="..\src\station_func.h" />
     <ClInclude Include="..\src\station_gui.h" />
+    <ClInclude Include="..\src\station_kdtree.h" />
     <ClInclude Include="..\src\station_type.h" />
     <ClInclude Include="..\src\statusbar_gui.h" />
     <ClInclude Include="..\src\stdafx.h" />

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -724,6 +724,7 @@
     <ClCompile Include="..\src\core\geometry_func.cpp" />
     <ClInclude Include="..\src\core\geometry_func.hpp" />
     <ClInclude Include="..\src\core\geometry_type.hpp" />
+    <ClInclude Include="..\src\core\kdtree.hpp" />
     <ClCompile Include="..\src\core\math_func.cpp" />
     <ClInclude Include="..\src\core\math_func.hpp" />
     <ClInclude Include="..\src\core\mem_func.hpp" />

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -698,6 +698,7 @@
     <ClInclude Include="..\src\vehicle_type.h" />
     <ClInclude Include="..\src\vehiclelist.h" />
     <ClInclude Include="..\src\viewport_func.h" />
+    <ClInclude Include="..\src\viewport_kdtree.h" />
     <ClInclude Include="..\src\viewport_sprite_sorter.h" />
     <ClInclude Include="..\src\viewport_type.h" />
     <ClInclude Include="..\src\water.h" />

--- a/projects/openttd_vs142.vcxproj.filters
+++ b/projects/openttd_vs142.vcxproj.filters
@@ -1026,6 +1026,9 @@
     <ClInclude Include="..\src\station_gui.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\station_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\station_type.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs142.vcxproj.filters
+++ b/projects/openttd_vs142.vcxproj.filters
@@ -1260,6 +1260,9 @@
     <ClInclude Include="..\src\core\geometry_type.hpp">
       <Filter>Core Source Code</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\core\kdtree.hpp">
+      <Filter>Core Source Code</Filter>
+    </ClInclude>
     <ClCompile Include="..\src\core\math_func.cpp">
       <Filter>Core Source Code</Filter>
     </ClCompile>

--- a/projects/openttd_vs142.vcxproj.filters
+++ b/projects/openttd_vs142.vcxproj.filters
@@ -1128,6 +1128,9 @@
     <ClInclude Include="..\src\town_type.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\town_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\townname_func.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/projects/openttd_vs142.vcxproj.filters
+++ b/projects/openttd_vs142.vcxproj.filters
@@ -1182,6 +1182,9 @@
     <ClInclude Include="..\src\viewport_func.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\viewport_kdtree.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\viewport_sprite_sorter.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/source.list
+++ b/source.list
@@ -333,6 +333,7 @@ spritecache.h
 station_base.h
 station_func.h
 station_gui.h
+station_kdtree.h
 station_type.h
 statusbar_gui.h
 stdafx.h

--- a/source.list
+++ b/source.list
@@ -429,6 +429,7 @@ core/enum_type.hpp
 core/geometry_func.cpp
 core/geometry_func.hpp
 core/geometry_type.hpp
+core/kdtree.hpp
 core/math_func.cpp
 core/math_func.hpp
 core/mem_func.hpp

--- a/source.list
+++ b/source.list
@@ -385,6 +385,7 @@ vehicle_gui_base.h
 vehicle_type.h
 vehiclelist.h
 viewport_func.h
+viewport_kdtree.h
 viewport_sprite_sorter.h
 viewport_type.h
 water.h

--- a/source.list
+++ b/source.list
@@ -367,6 +367,7 @@ timetable.h
 toolbar_gui.h
 town.h
 town_type.h
+town_kdtree.h
 townname_func.h
 townname_type.h
 track_func.h

--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -1,0 +1,473 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file kdtree.hpp K-d tree template specialised for 2-dimensional Manhattan geometry */
+
+#ifndef KDTREE_HPP
+#define KDTREE_HPP
+
+#include "../stdafx.h"
+#include <vector>
+#include <algorithm>
+#include <limits>
+
+/**
+ * K-dimensional tree, specialised for 2-dimensional space.
+ * This is not intended as a primary storage of data, but as an index into existing data.
+ * Usually the type stored by this tree should be an index into an existing array.
+ *
+ * This implementation assumes Manhattan distances are used.
+ *
+ * Be careful when using this in game code, depending on usage pattern, the tree shape may
+ * end up different for different clients in multiplayer, causing iteration order to differ
+ * and possibly having elements returned in different order. The using code should be designed
+ * to produce the same result regardless of iteration order.
+ *
+ * The element type T must be less-than comparable for FindNearest to work.
+ *
+ * @tparam T       Type stored in the tree, should be cheap to copy.
+ * @tparam TxyFunc Functor type to extract coordinate from a T value and dimension index (0 or 1).
+ * @tparam CoordT  Type of coordinate values extracted via TxyFunc.
+ * @tparam DistT   Type to use for representing distance values.
+ */
+template <typename T, typename TxyFunc, typename CoordT, typename DistT>
+class Kdtree {
+	/** Type of a node in the tree */
+	struct node {
+		T      element;  ///< Element stored at node
+		size_t left;     ///< Index of node to the left, INVALID_NODE if none
+		size_t right;    ///< Index of node to the right, INVALID_NODE if none
+
+		node(T element) : element(element), left(INVALID_NODE), right(INVALID_NODE) { }
+	};
+
+	static const size_t INVALID_NODE = SIZE_MAX; ///< Index value indicating no-such-node
+
+	std::vector<node> nodes;       ///< Pool of all nodes in the tree
+	std::vector<size_t> free_list; ///< List of dead indices in the nodes vector
+	size_t root;                   ///< Index of root node
+	TxyFunc xyfunc;                ///< Functor to extract a coordinate from an element
+	size_t unbalanced;             ///< Number approximating how unbalanced the tree might be
+
+	/** Create one new node in the tree, return its index in the pool */
+	size_t AddNode(const T &element)
+	{
+		if (this->free_list.size() == 0) {
+			this->nodes.emplace_back(element);
+			return this->nodes.size() - 1;
+		} else {
+			size_t newidx = this->free_list.back();
+			this->free_list.pop_back();
+			this->nodes[newidx] = node{ element };
+			return newidx;
+		}
+	}
+
+	/** Find a coordinate value to split a range of elements at */
+	template <typename It>
+	CoordT SelectSplitCoord(It begin, It end, int level)
+	{
+		It mid = begin + (end - begin) / 2;
+		std::nth_element(begin, mid, end, [&](T a, T b) { return this->xyfunc(a, level % 2) < this->xyfunc(b, level % 2); });
+		return this->xyfunc(*mid, level % 2);
+	}
+
+	/** Construct a subtree from elements between begin and end iterators, return index of root */
+	template <typename It>
+	size_t BuildSubtree(It begin, It end, int level)
+	{
+		ptrdiff_t count = end - begin;
+
+		if (count == 0) {
+			return INVALID_NODE;
+		} else if (count == 1) {
+			return this->AddNode(*begin);
+		} else if (count > 1) {
+			CoordT split_coord = SelectSplitCoord(begin, end, level);
+			It split = std::partition(begin, end, [&](T v) { return this->xyfunc(v, level % 2) < split_coord; });
+			size_t newidx = this->AddNode(*split);
+			this->nodes[newidx].left = this->BuildSubtree(begin, split, level + 1);
+			this->nodes[newidx].right = this->BuildSubtree(split + 1, end, level + 1);
+			return newidx;
+		} else {
+			NOT_REACHED();
+		}
+	}
+
+	/** Rebuild the tree with all existing elements, optionally adding or removing one more */
+	bool Rebuild(const T *include_element, const T *exclude_element)
+	{
+		size_t initial_count = this->Count();
+		if (initial_count < 8) return false; // arbitrary value for "not worth rebalancing"
+
+		T root_element = this->nodes[this->root].element;
+		std::vector<T> elements = this->FreeSubtree(this->root);
+		elements.push_back(root_element);
+
+		if (include_element != NULL) {
+			elements.push_back(*include_element);
+			initial_count++;
+		}
+		if (exclude_element != NULL) {
+			typename std::vector<T>::iterator removed = std::remove(elements.begin(), elements.end(), *exclude_element);
+			elements.erase(removed, elements.end());
+			initial_count--;
+		}
+
+		this->Build(elements.begin(), elements.end());
+		assert(initial_count == this->Count());
+		return true;
+	}
+
+	/** Insert one element in the tree somewhere below node_idx */
+	void InsertRecursive(const T &element, size_t node_idx, int level)
+	{
+		/* Dimension index of current level */
+		int dim = level % 2;
+		/* Node reference */
+		node &n = this->nodes[node_idx];
+
+		/* Coordinate of element splitting at this node */
+		CoordT nc = this->xyfunc(n.element, dim);
+		/* Coordinate of the new element */
+		CoordT ec = this->xyfunc(element, dim);
+		/* Which side to insert on */
+		size_t &next = (ec < nc) ? n.left : n.right;
+
+		if (next == INVALID_NODE) {
+			/* New leaf */
+			size_t newidx = this->AddNode(element);
+			/* Vector may have been reallocated at this point, n and next are invalid */
+			node &nn = this->nodes[node_idx];
+			if (ec < nc) nn.left = newidx; else nn.right = newidx;
+		} else {
+			this->InsertRecursive(element, next, level + 1);
+		}
+	}
+
+	/**
+	 * Free all children of the given node
+	 * @return Collection of elements that were removed from tree.
+	 */
+	std::vector<T> FreeSubtree(size_t node_idx)
+	{
+		std::vector<T> subtree_elements;
+		node &n = this->nodes[node_idx];
+
+		/* We'll be appending items to the free_list, get index of our first item */
+		size_t first_free = this->free_list.size();
+		/* Prepare the descent with our children */
+		if (n.left != INVALID_NODE) this->free_list.push_back(n.left);
+		if (n.right != INVALID_NODE) this->free_list.push_back(n.right);
+		n.left = n.right = INVALID_NODE;
+
+		/* Recursively free the nodes being collected */
+		for (size_t i = first_free; i < this->free_list.size(); i++) {
+			node &fn = this->nodes[this->free_list[i]];
+			subtree_elements.push_back(fn.element);
+			if (fn.left != INVALID_NODE) this->free_list.push_back(fn.left);
+			if (fn.right != INVALID_NODE) this->free_list.push_back(fn.right);
+			fn.left = fn.right = INVALID_NODE;
+		}
+
+		return subtree_elements;
+	}
+
+	/**
+	 * Find and remove one element from the tree.
+	 * @param element   The element to search for
+	 * @param node_idx  Sub-tree to search in
+	 * @param level     Current depth in the tree
+	 * @return New root node index of the sub-tree processed
+	 */
+	size_t RemoveRecursive(const T &element, size_t node_idx, int level)
+	{
+		/* Node reference */
+		node &n = this->nodes[node_idx];
+
+		if (n.element == element) {
+			/* Remove this one */
+			this->free_list.push_back(node_idx);
+			if (n.left == INVALID_NODE && n.right == INVALID_NODE) {
+				/* Simple case, leaf, new child node for parent is "none" */
+				return INVALID_NODE;
+			} else {
+				/* Complex case, rebuild the sub-tree */
+				std::vector<T> subtree_elements = this->FreeSubtree(node_idx);
+				return this->BuildSubtree(subtree_elements.begin(), subtree_elements.end(), level);;
+			}
+		} else {
+			/* Search in a sub-tree */
+			/* Dimension index of current level */
+			int dim = level % 2;
+			/* Coordinate of element splitting at this node */
+			CoordT nc = this->xyfunc(n.element, dim);
+			/* Coordinate of the element being removed */
+			CoordT ec = this->xyfunc(element, dim);
+			/* Which side to remove from */
+			size_t next = (ec < nc) ? n.left : n.right;
+			assert(next != INVALID_NODE); // node must exist somewhere and must be found before a leaf is reached
+			/* Descend */
+			size_t new_branch = this->RemoveRecursive(element, next, level + 1);
+			if (new_branch != next) {
+				/* Vector may have been reallocated at this point, n and next are invalid */
+				node &nn = this->nodes[node_idx];
+				if (ec < nc) nn.left = new_branch; else nn.right = new_branch;
+			}
+			return node_idx;
+		}
+	}
+
+
+	DistT ManhattanDistance(const T &element, CoordT x, CoordT y) const
+	{
+		return abs((DistT)this->xyfunc(element, 0) - (DistT)x) + abs((DistT)this->xyfunc(element, 1) - (DistT)y);
+	}
+
+	/** A data element and its distance to a searched-for point */
+	using node_distance = std::pair<T, DistT>;
+	/** Ordering function for node_distance objects, elements with equal distance are ordered by less-than comparison */
+	static node_distance SelectNearestNodeDistance(const node_distance &a, const node_distance &b)
+	{
+		if (a.second < b.second) return a;
+		if (b.second < a.second) return b;
+		if (a.first < b.first) return a;
+		if (b.first < a.first) return b;
+		NOT_REACHED(); // a.first == b.first: same element must not be inserted twice
+	}
+	/** Search a sub-tree for the element nearest to a given point */
+	node_distance FindNearestRecursive(CoordT xy[2], size_t node_idx, int level) const
+	{
+		/* Dimension index of current level */
+		int dim = level % 2;
+		/* Node reference */
+		const node &n = this->nodes[node_idx];
+
+		/* Coordinate of element splitting at this node */
+		CoordT c = this->xyfunc(n.element, dim);
+		/* This node's distance to target */
+		DistT thisdist = ManhattanDistance(n.element, xy[0], xy[1]);
+		/* Assume this node is the best choice for now */
+		node_distance best = std::make_pair(n.element, thisdist);
+
+		/* Next node to visit */
+		size_t next = (xy[dim] < c) ? n.left : n.right;
+		if (next != INVALID_NODE) {
+			/* Check if there is a better node down the tree */
+			best = SelectNearestNodeDistance(best, this->FindNearestRecursive(xy, next, level + 1));
+		}
+
+		/* Check if the distance from current best is worse than distance from target to splitting line,
+		 * if it is we also need to check the other side of the split. */
+		size_t opposite = (xy[dim] >= c) ? n.left : n.right; // reverse of above
+		if (opposite != INVALID_NODE && best.second >= abs((int)xy[dim] - (int)c)) {
+			node_distance other_candidate = this->FindNearestRecursive(xy, opposite, level + 1);
+			best = SelectNearestNodeDistance(best, other_candidate);
+		}
+
+		return best;
+	}
+
+	template <typename Outputter>
+	void FindContainedRecursive(CoordT p1[2], CoordT p2[2], size_t node_idx, int level, Outputter outputter) const
+	{
+		/* Dimension index of current level */
+		int dim = level % 2;
+		/* Node reference */
+		const node &n = this->nodes[node_idx];
+
+		/* Coordinate of element splitting at this node */
+		CoordT ec = this->xyfunc(n.element, dim);
+		/* Opposite coordinate of element */
+		CoordT oc = this->xyfunc(n.element, 1 - dim);
+
+		/* Test if this element is within rectangle */
+		if (ec >= p1[dim] && ec < p2[dim] && oc >= p1[1 - dim] && oc < p2[1 - dim]) outputter(n.element);
+
+		/* Recurse left if part of rectangle is left of split */
+		if (p1[dim] < ec && n.left != INVALID_NODE) this->FindContainedRecursive(p1, p2, n.left, level + 1, outputter);
+
+		/* Recurse right if part of rectangle is right of split */
+		if (p2[dim] > ec && n.right != INVALID_NODE) this->FindContainedRecursive(p1, p2, n.right, level + 1, outputter);
+	}
+
+	/** Debugging function, counts number of occurrences of an element regardless of its correct position in the tree */
+	size_t CountValue(const T &element, size_t node_idx) const
+	{
+		if (node_idx == INVALID_NODE) return 0;
+		const node &n = this->nodes[node_idx];
+		return CountValue(element, n.left) + CountValue(element, n.right) + ((n.element == element) ? 1 : 0);
+	}
+
+	void IncrementUnbalanced(size_t amount = 1)
+	{
+		this->unbalanced += amount;
+	}
+
+	/** Check if the entire tree is in need of rebuilding */
+	bool IsUnbalanced()
+	{
+		size_t count = this->Count();
+		if (count < 8) return false;
+		return this->unbalanced > this->Count() / 4;
+	}
+
+	/** Verify that the invariant is true for a sub-tree, assert if not */
+	void CheckInvariant(size_t node_idx, int level, CoordT min_x, CoordT max_x, CoordT min_y, CoordT max_y)
+	{
+		if (node_idx == INVALID_NODE) return;
+
+		const node &n = this->nodes[node_idx];
+		CoordT cx = this->xyfunc(n.element, 0);
+		CoordT cy = this->xyfunc(n.element, 1);
+
+		assert(cx >= min_x);
+		assert(cx < max_x);
+		assert(cy >= min_y);
+		assert(cy < max_y);
+
+		if (level % 2 == 0) {
+			// split in dimension 0 = x
+			CheckInvariant(n.left,  level + 1, min_x, cx, min_y, max_y);
+			CheckInvariant(n.right, level + 1, cx, max_x, min_y, max_y);
+		} else {
+			// split in dimension 1 = y
+			CheckInvariant(n.left,  level + 1, min_x, max_x, min_y, cy);
+			CheckInvariant(n.right, level + 1, min_x, max_x, cy, max_y);
+		}
+	}
+
+	/** Verify the invariant for the entire tree, does nothing unless KDTREE_DEBUG is defined */
+	void CheckInvariant()
+	{
+#ifdef KDTREE_DEBUG
+		CheckInvariant(this->root, 0, std::numeric_limits<CoordT>::min(), std::numeric_limits<CoordT>::max(), std::numeric_limits<CoordT>::min(), std::numeric_limits<CoordT>::max());
+#endif
+	}
+
+public:
+	/** Construct a new Kdtree with the given xyfunc */
+	Kdtree(TxyFunc xyfunc) : root(INVALID_NODE), xyfunc(xyfunc), unbalanced(0) { }
+
+	/**
+	 * Clear and rebuild the tree from a new sequence of elements,
+	 * @tparam It    Iterator type for element sequence.
+	 * @param  begin First element in sequence.
+	 * @param  end   One past last element in sequence.
+	 */
+	template <typename It>
+	void Build(It begin, It end)
+	{
+		this->nodes.clear();
+		this->free_list.clear();
+		this->unbalanced = 0;
+		if (begin == end) return;
+		this->nodes.reserve(end - begin);
+
+		this->root = this->BuildSubtree(begin, end, 0);
+		CheckInvariant();
+	}
+
+	/**
+	 * Reconstruct the tree with the same elements, letting it be fully balanced.
+	 */
+	void Rebuild()
+	{
+		this->Rebuild(NULL, NULL);
+	}
+
+	/**
+	 * Insert a single element in the tree.
+	 * Repeatedly inserting single elements may cause the tree to become unbalanced.
+	 * Undefined behaviour if the element already exists in the tree.
+	 */
+	void Insert(const T &element)
+	{
+		if (this->Count() == 0) {
+			this->root = this->AddNode(element);
+		} else {
+			if (!this->IsUnbalanced() || !this->Rebuild(&element, NULL)) {
+				this->InsertRecursive(element, this->root, 0);
+				this->IncrementUnbalanced();
+			}
+			CheckInvariant();
+		}
+	}
+
+	/**
+	 * Remove a single element from the tree, if it exists.
+	 * Since elements are stored in interior nodes as well as leaf nodes, removing one may
+	 * require a larger sub-tree to be re-built. Because of this, worst case run time is
+	 * as bad as a full tree rebuild.
+	 */
+	void Remove(const T &element)
+	{
+		size_t count = this->Count();
+		if (count == 0) return;
+		if (!this->IsUnbalanced() || !this->Rebuild(NULL, &element)) {
+			/* If the removed element is the root node, this modifies this->root */
+			this->root = this->RemoveRecursive(element, this->root, 0);
+			this->IncrementUnbalanced();
+		}
+		CheckInvariant();
+	}
+
+	/** Get number of elements stored in tree */
+	size_t Count() const
+	{
+		assert(this->free_list.size() <= this->nodes.size());
+		return this->nodes.size() - this->free_list.size();
+	}
+
+	/**
+	 * Find the element closest to given coordinate, in Manhattan distance.
+	 * For multiple elements with the same distance, the one comparing smaller with
+	 * a less-than comparison is chosen.
+	 */
+	T FindNearest(CoordT x, CoordT y) const
+	{
+		assert(this->Count() > 0);
+
+		CoordT xy[2] = { x, y };
+		return this->FindNearestRecursive(xy, this->root, 0).first;
+	}
+
+	/**
+	* Find all items contained within the given rectangle.
+	* @note Start coordinates are inclusive, end coordinates are exclusive. x1<x2 && y1<y2 is a precondition.
+	* @param x1 Start first coordinate, points found are greater or equals to this.
+	* @param y1 Start second coordinate, points found are greater or equals to this.
+	* @param x2 End first coordinate, points found are less than this.
+	* @param y2 End second coordinate, points found are less than this.
+	* @param outputter Callback used to return values from the search.
+	*/
+	template <typename Outputter>
+	void FindContained(CoordT x1, CoordT y1, CoordT x2, CoordT y2, Outputter outputter) const
+	{
+		assert(x1 < x2);
+		assert(y1 < y2);
+
+		if (this->Count() == 0) return;
+
+		CoordT p1[2] = { x1, y1 };
+		CoordT p2[2] = { x2, y2 };
+		this->FindContainedRecursive(p1, p2, this->root, 0, outputter);
+	}
+
+	/**
+	 * Find all items contained within the given rectangle.
+	 * @note End coordinates are exclusive, x1<x2 && y1<y2 is a precondition.
+	 */
+	std::vector<T> FindContained(CoordT x1, CoordT y1, CoordT x2, CoordT y2) const
+	{
+		std::vector<T> result;
+		this->FindContained(x1, y1, x2, y2, [&result](T e) {result.push_back(e); });
+		return result;
+	}
+};
+
+#endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -28,6 +28,7 @@
 #include "core/pool_type.hpp"
 #include "game/game.hpp"
 #include "linkgraph/linkgraphschedule.h"
+#include "station_kdtree.h"
 #include "town_kdtree.h"
 
 #include "safeguards.h"
@@ -76,6 +77,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	LinkGraphSchedule::Clear();
 	PoolBase::Clean(PT_NORMAL);
 
+	RebuildStationKdtree();
 	RebuildTownKdtree();
 
 	ResetPersistentNewGRFData();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -28,6 +28,7 @@
 #include "core/pool_type.hpp"
 #include "game/game.hpp"
 #include "linkgraph/linkgraphschedule.h"
+#include "town_kdtree.h"
 
 #include "safeguards.h"
 
@@ -74,6 +75,8 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 
 	LinkGraphSchedule::Clear();
 	PoolBase::Clean(PT_NORMAL);
+
+	RebuildTownKdtree();
 
 	ResetPersistentNewGRFData();
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -30,6 +30,7 @@
 #include "linkgraph/linkgraphschedule.h"
 #include "station_kdtree.h"
 #include "town_kdtree.h"
+#include "viewport_kdtree.h"
 
 #include "safeguards.h"
 
@@ -79,6 +80,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 
 	RebuildStationKdtree();
 	RebuildTownKdtree();
+	RebuildViewportKdtree();
 
 	ResetPersistentNewGRFData();
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -537,6 +537,7 @@ bool AfterLoadGame()
 	GamelogTestMode();
 
 	RebuildTownKdtree();
+	RebuildStationKdtree();
 
 	if (IsSavegameVersionBefore(SLV_98)) GamelogGRFAddList(_grfconfig);
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -19,6 +19,7 @@
 #include "../network/network_func.h"
 #include "../gfxinit.h"
 #include "../viewport_func.h"
+#include "../viewport_kdtree.h"
 #include "../industry.h"
 #include "../clear_map.h"
 #include "../vehicle_func.h"
@@ -221,6 +222,7 @@ void UpdateAllVirtCoords()
 	UpdateAllStationVirtCoords();
 	UpdateAllSignVirtCoords();
 	UpdateAllTownVirtCoords();
+	RebuildViewportKdtree();
 }
 
 /**
@@ -538,6 +540,9 @@ bool AfterLoadGame()
 
 	RebuildTownKdtree();
 	RebuildStationKdtree();
+	/* This needs to be done even before conversion, because some conversions will destroy objects
+	 * that otherwise won't exist in the tree. */
+	RebuildViewportKdtree();
 
 	if (IsSavegameVersionBefore(SLV_98)) GamelogGRFAddList(_grfconfig);
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -536,6 +536,8 @@ bool AfterLoadGame()
 	GamelogTestRevision();
 	GamelogTestMode();
 
+	RebuildTownKdtree();
+
 	if (IsSavegameVersionBefore(SLV_98)) GamelogGRFAddList(_grfconfig);
 
 	if (IsSavegameVersionBefore(SLV_119)) {

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -28,6 +28,7 @@ void RebuildTownCaches()
 {
 	Town *town;
 	InitializeBuildingCounts();
+	RebuildTownKdtree();
 
 	/* Reset town population and num_houses */
 	FOR_ALL_TOWNS(town) {

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -16,6 +16,7 @@
 #include "signs_func.h"
 #include "command_func.h"
 #include "tilehighlight_func.h"
+#include "viewport_kdtree.h"
 #include "window_func.h"
 #include "string_func.h"
 
@@ -57,7 +58,7 @@ CommandCost CmdPlaceSign(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 		if (!StrEmpty(text)) {
 			si->name = stredup(text);
 		}
-		si->UpdateVirtCoord();
+		_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeSign(si->index));
 		InvalidateWindowData(WC_SIGN_LIST, 0, 0);
 		_new_sign_id = si->index;
 	}
@@ -98,7 +99,7 @@ CommandCost CmdRenameSign(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 		}
 	} else { // Delete sign
 		if (flags & DC_EXEC) {
-			si->sign.MarkDirty();
+			_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeSign(si->index));
 			delete si;
 
 			InvalidateWindowData(WC_SIGN_LIST, 0, 0);

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -21,6 +21,7 @@
 #include "vehiclelist.h"
 #include "core/pool_func.hpp"
 #include "station_base.h"
+#include "station_kdtree.h"
 #include "roadstop_base.h"
 #include "industry.h"
 #include "town.h"
@@ -35,6 +36,20 @@
 /** The pool of stations. */
 StationPool _station_pool("Station");
 INSTANTIATE_POOL_METHODS(Station)
+
+
+StationKdtree _station_kdtree(Kdtree_StationXYFunc);
+
+void RebuildStationKdtree()
+{
+	std::vector<StationID> stids;
+	BaseStation *st;
+	FOR_ALL_STATIONS(st) {
+		stids.push_back(st->index);
+	}
+	_station_kdtree.Build(stids.begin(), stids.end());
+}
+
 
 BaseStation::~BaseStation()
 {
@@ -146,6 +161,8 @@ Station::~Station()
 	}
 
 	CargoPacket::InvalidateAllFrom(this->index);
+
+	_station_kdtree.Remove(this->index);
 }
 
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -14,6 +14,7 @@
 #include "company_base.h"
 #include "roadveh.h"
 #include "viewport_func.h"
+#include "viewport_kdtree.h"
 #include "date_func.h"
 #include "command_func.h"
 #include "news_func.h"
@@ -163,6 +164,7 @@ Station::~Station()
 	CargoPacket::InvalidateAllFrom(this->index);
 
 	_station_kdtree.Remove(this->index);
+	_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeStation(this->index));
 }
 
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -556,4 +556,6 @@ public:
 	}
 };
 
+void RebuildStationKdtree();
+
 #endif /* STATION_BASE_H */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -14,6 +14,7 @@
 #include "bridge_map.h"
 #include "cmd_helper.h"
 #include "viewport_func.h"
+#include "viewport_kdtree.h"
 #include "command_func.h"
 #include "town.h"
 #include "news_func.h"
@@ -672,9 +673,11 @@ static void UpdateStationSignCoord(BaseStation *st)
 	/* clamp sign coord to be inside the station rect */
 	TileIndex new_xy = TileXY(ClampU(TileX(st->xy), r->left, r->right), ClampU(TileY(st->xy), r->top, r->bottom));
 	if (new_xy != st->xy) {
+		_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeStation(st->index));
 		_station_kdtree.Remove(st->index);
 		st->xy = new_xy;
 		_station_kdtree.Insert(st->index);
+		_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation(st->index));
 		st->UpdateVirtCoord();
 	}
 
@@ -715,6 +718,7 @@ static CommandCost BuildStationPart(Station **st, DoCommandFlag flags, bool reus
 		if (flags & DC_EXEC) {
 			*st = new Station(area.tile);
 			_station_kdtree.Insert((*st)->index);
+			_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation((*st)->index));
 
 			(*st)->town = ClosestTownFromTile(area.tile, UINT_MAX);
 			(*st)->string_id = GenerateStationName(*st, area.tile, name_class);
@@ -3968,6 +3972,7 @@ void BuildOilRig(TileIndex tile)
 	st->rect.BeforeAddTile(tile, StationRect::ADD_FORCE);
 
 	st->UpdateVirtCoord();
+	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation(st->index));
 	st->RecomputeCatchment();
 	UpdateStationAcceptance(st, false);
 }

--- a/src/station_kdtree.h
+++ b/src/station_kdtree.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file station_kdtree.h Declarations for accessing the k-d tree of stations */
+
+#ifndef STATION_KDTREE_H
+#define STATION_KDTREE_H
+
+#include "core/kdtree.hpp"
+#include "core/math_func.hpp"
+#include "station_base.h"
+#include "map_func.h"
+
+inline uint16 Kdtree_StationXYFunc(StationID stid, int dim) { return (dim == 0) ? TileX(BaseStation::Get(stid)->xy) : TileY(BaseStation::Get(stid)->xy); }
+typedef Kdtree<StationID, decltype(&Kdtree_StationXYFunc), uint16, int> StationKdtree;
+extern StationKdtree _station_kdtree;
+
+/**
+ * Call a function on all stations whose sign is within a radius of a center tile.
+ * @param center  Central tile to search around.
+ * @param radius  Distance in both X and Y to search within.
+ * @param func    The function to call, must take a single parameter which is Station*.
+ */
+template <typename Func>
+void ForAllStationsRadius(TileIndex center, uint radius, Func func)
+{
+	uint16 x1, y1, x2, y2;
+	x1 = (uint16)max<int>(0, TileX(center) - radius);
+	x2 = (uint16)min<int>(TileX(center) + radius + 1, MapSizeX());
+	y1 = (uint16)max<int>(0, TileY(center) - radius);
+	y2 = (uint16)min<int>(TileY(center) + radius + 1, MapSizeY());
+
+	_station_kdtree.FindContained(x1, y1, x2, y2, [&](StationID id) {
+		func(Station::Get(id));
+	});
+}
+
+#endif

--- a/src/town.h
+++ b/src/town.h
@@ -145,6 +145,9 @@ void UpdateAllTownVirtCoords();
 void ShowTownViewWindow(TownID town);
 void ExpandTown(Town *t);
 
+void RebuildTownKdtree();
+
+
 /**
  * Action types that a company must ask permission for to a town authority.
  * @see CheckforTownRating

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -14,6 +14,7 @@
 #include "road_cmd.h"
 #include "landscape.h"
 #include "viewport_func.h"
+#include "viewport_kdtree.h"
 #include "cmd_helper.h"
 #include "command_func.h"
 #include "industry.h"
@@ -1713,6 +1714,7 @@ static void DoCreateTown(Town *t, TileIndex tile, uint32 townnameparts, TownSize
 	t->townnameparts = townnameparts;
 
 	t->UpdateVirtCoord();
+	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeTown(t->index));
 	InvalidateWindowData(WC_TOWN_DIRECTORY, 0, 0);
 
 	t->InitializeLayout(layout);
@@ -2869,6 +2871,7 @@ CommandCost CmdDeleteTown(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 	/* The town destructor will delete the other things related to the town. */
 	if (flags & DC_EXEC) {
 		_town_kdtree.Remove(t->index);
+		_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeTown(t->index));
 		delete t;
 	}
 

--- a/src/town_kdtree.h
+++ b/src/town_kdtree.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file town_kdtree.h Declarations for accessing the k-d tree of towns */
+
+#ifndef TOWN_KDTREE_H
+#define TOWN_KDTREE_H
+
+#include "core/kdtree.hpp"
+#include "town.h"
+
+inline uint16 Kdtree_TownXYFunc(TownID tid, int dim) { return (dim == 0) ? TileX(Town::Get(tid)->xy) : TileY(Town::Get(tid)->xy); }
+typedef Kdtree<TownID, decltype(&Kdtree_TownXYFunc), uint16, int> TownKdtree;
+extern TownKdtree _town_kdtree;
+
+#endif

--- a/src/viewport_kdtree.h
+++ b/src/viewport_kdtree.h
@@ -1,0 +1,83 @@
+/*
+* This file is part of OpenTTD.
+* OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+* OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file town_kdtree.h Declarations for accessing the k-d tree of towns */
+
+#ifndef VIEWPORT_KDTREE_H
+#define VIEWPORT_KDTREE_H
+
+#include "core/kdtree.hpp"
+#include "viewport_type.h"
+#include "station_base.h"
+#include "town_type.h"
+#include "signs_base.h"
+
+struct ViewportSignKdtreeItem {
+	enum ItemType : uint16 {
+		VKI_STATION,
+		VKI_WAYPOINT,
+		VKI_TOWN,
+		VKI_SIGN,
+	};
+	ItemType type;
+	union {
+		StationID station;
+		TownID town;
+		SignID sign;
+	} id;
+	int32 center;
+	int32 top;
+
+	bool operator== (const ViewportSignKdtreeItem &other) const
+	{
+		if (this->type != other.type) return false;
+		switch (this->type) {
+			case VKI_STATION:
+			case VKI_WAYPOINT:
+				return this->id.station == other.id.station;
+			case VKI_TOWN:
+				return this->id.town == other.id.town;
+			case VKI_SIGN:
+				return this->id.sign == other.id.sign;
+			default:
+				NOT_REACHED();
+		}
+	}
+
+	bool operator< (const ViewportSignKdtreeItem &other) const
+	{
+		if (this->type != other.type) return this->type < other.type;
+		switch (this->type) {
+			case VKI_STATION:
+			case VKI_WAYPOINT:
+				return this->id.station < other.id.station;
+			case VKI_TOWN:
+				return this->id.town < other.id.town;
+			case VKI_SIGN:
+				return this->id.sign < other.id.sign;
+			default:
+				NOT_REACHED();
+		}
+	}
+
+	static ViewportSignKdtreeItem MakeStation(StationID id);
+	static ViewportSignKdtreeItem MakeWaypoint(StationID id);
+	static ViewportSignKdtreeItem MakeTown(TownID id);
+	static ViewportSignKdtreeItem MakeSign(SignID id);
+};
+
+inline int32 Kdtree_ViewportSignXYFunc(const ViewportSignKdtreeItem &item, int dim)
+{
+	return (dim == 0) ? item.center : item.top;
+}
+
+typedef Kdtree<ViewportSignKdtreeItem, decltype(&Kdtree_ViewportSignXYFunc), int32, int32> ViewportSignKdtree;
+extern ViewportSignKdtree _viewport_sign_kdtree;
+
+void RebuildViewportKdtree();
+
+#endif

--- a/src/waypoint.cpp
+++ b/src/waypoint.cpp
@@ -15,6 +15,7 @@
 #include "window_func.h"
 #include "newgrf_station.h"
 #include "waypoint_base.h"
+#include "viewport_kdtree.h"
 
 #include "safeguards.h"
 
@@ -54,4 +55,5 @@ Waypoint::~Waypoint()
 	if (CleaningPool()) return;
 	DeleteWindowById(WC_WAYPOINT_VIEW, this->index);
 	RemoveOrderFromAllVehicles(OT_GOTO_WAYPOINT, this->index);
+	_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeWaypoint(this->index));
 }


### PR DESCRIPTION
Implements a [k-d tree data structure](https://en.wikipedia.org/wiki/K-d_tree) for spatial indexes of map objects that don't move very often. Right now this is used for stations and towns (their sign location).

The k-d tree allows fast lookup of the nearest indexed point to a given point, and fast iteration of indexed points within a rectangle (orthogonal tile area).

Currently, testing shows no particular improvement. This is expected since almost all the operations changed to use the tree currently are responses to player commands, i.e. building and removing stations.