### PR TITLE
Change: Owner of vehicle with exclusive transport rights may now load cargo from neutral stations

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1518,6 +1518,17 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 	cur_company.Restore();
 }
 
+/**
+ * Test whether a vehicle can load cargo at a station even if exclusive transport rights are present.
+ * @param st Station with cargo waiting to be loaded.
+ * @param v Vehicle loading the cargo.
+ * @return true when a vehicle can load the cargo.
+ */
+static bool MayLoadUnderExclusiveRights(const Station *st, const Vehicle *v)
+{
+	return st->owner != OWNER_NONE || st->town->exclusive_counter == 0 || st->town->exclusivity == v->owner;
+}
+
 struct ReserveCargoAction {
 	Station *st;
 	StationIDStack *next_station;
@@ -1527,7 +1538,7 @@ struct ReserveCargoAction {
 
 	bool operator()(Vehicle *v)
 	{
-		if (v->cargo_cap > v->cargo.RemainingCount()) {
+		if (v->cargo_cap > v->cargo.RemainingCount() && MayLoadUnderExclusiveRights(st, v)) {
 			st->goods[v->cargo_type].cargo.Reserve(v->cargo_cap - v->cargo.RemainingCount(),
 					&v->cargo, st->xy, *next_station);
 		}
@@ -1751,7 +1762,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 		/* If there's goods waiting at the station, and the vehicle
 		 * has capacity for it, load it on the vehicle. */
 		uint cap_left = v->cargo_cap - v->cargo.StoredCount();
-		if (cap_left > 0 && (v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0 || ge->cargo.AvailableCount() > 0)) {
+		if (cap_left > 0 && (v->cargo.ActionCount(VehicleCargoList::MTA_LOAD) > 0 || ge->cargo.AvailableCount() > 0) && MayLoadUnderExclusiveRights(st, v)) {
 			if (v->cargo.StoredCount() == 0) TriggerVehicle(v, VEHICLE_TRIGGER_NEW_CARGO);
 			if (_settings_game.order.gradual_loading) cap_left = min(cap_left, GetLoadAmount(v));
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3853,7 +3853,7 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 		Station *st = *st_iter;
 
 		/* Is the station reserved exclusively for somebody else? */
-		if (st->town->exclusive_counter > 0 && st->town->exclusivity != st->owner) continue;
+		if (st->owner != OWNER_NONE && st->town->exclusive_counter > 0 && st->town->exclusivity != st->owner) continue;
 
 		if (st->goods[type].rating == 0) continue; // Lowest possible rating, better not to give cargo anymore
 


### PR DESCRIPTION
#6657 - followup of this issue
#7234 - will prevent no cargo in neutral station if this PR is merged