### PR TITLE
Fix #7227: Don't apply mouse-hasn't-moved test to scrollbars.

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2436,14 +2436,14 @@ static EventState HandleActiveWidget()
 				return ES_HANDLED;
 			}
 
-			/* If cursor hasn't moved, there is nothing to do. */
-			if (_cursor.delta.x == 0 && _cursor.delta.y == 0) return ES_HANDLED;
-
 			/* Handle scrollbar internally, or dispatch click event */
 			WidgetType type = w->GetWidget<NWidgetBase>(w->mouse_capture_widget)->type;
 			if (type == NWID_VSCROLLBAR || type == NWID_HSCROLLBAR) {
 				HandleScrollbarScrolling(w);
 			} else {
+				/* If cursor hasn't moved, there is nothing to do. */
+				if (_cursor.delta.x == 0 && _cursor.delta.y == 0) return ES_HANDLED;
+
 				Point pt = { _cursor.pos.x - w->left, _cursor.pos.y - w->top };
 				w->OnClick(pt, w->mouse_capture_widget, 0);
 			}


### PR DESCRIPTION
Up/down buttons on scrollbars required individual clicks instead of operating on a delay since #7227.