### PR TITLE
Add: Road vehicle path cache.

### DIFF
--- a/src/pathfinder/pathfinder_type.h
+++ b/src/pathfinder/pathfinder_type.h
@@ -43,6 +43,9 @@ static const int YAPF_INFINITE_PENALTY = 1000 * YAPF_TILE_LENGTH;
 /** Maximum length of ship path cache */
 static const int YAPF_SHIP_PATH_CACHE_LENGTH = 32;
 
+/** Maximum segments of road vehicle path cache */
+static const int YAPF_ROADVEH_PATH_CACHE_SEGMENTS = 8;
+
 /**
  * Helper container to find a depot
  */

--- a/src/pathfinder/yapf/yapf.h
+++ b/src/pathfinder/yapf/yapf.h
@@ -16,6 +16,7 @@
 #include "../../track_type.h"
 #include "../../vehicle_type.h"
 #include "../../ship.h"
+#include "../../roadveh.h"
 #include "../pathfinder_type.h"
 
 /**
@@ -45,7 +46,7 @@ bool YapfShipCheckReverse(const Ship *v);
  * @param path_found [out] Whether a path has been found (true) or has been guessed (false)
  * @return          the best trackdir for next turn or INVALID_TRACKDIR if the path could not be found
  */
-Trackdir YapfRoadVehicleChooseTrack(const RoadVehicle *v, TileIndex tile, DiagDirection enterdir, TrackdirBits trackdirs, bool &path_found);
+Trackdir YapfRoadVehicleChooseTrack(const RoadVehicle *v, TileIndex tile, DiagDirection enterdir, TrackdirBits trackdirs, bool &path_found, RoadVehPathCache &path_cache);
 
 /**
  * Finds the best path for given train using YAPF.

--- a/src/pathfinder/yapf/yapf_node.hpp
+++ b/src/pathfinder/yapf/yapf_node.hpp
@@ -67,6 +67,7 @@ struct CYapfNodeT {
 	Node       *m_parent;
 	int         m_cost;
 	int         m_estimate;
+	bool        m_is_choice;
 
 	inline void Set(Node *parent, TileIndex tile, Trackdir td, bool is_choice)
 	{
@@ -75,6 +76,7 @@ struct CYapfNodeT {
 		m_parent = parent;
 		m_cost = 0;
 		m_estimate = 0;
+		m_is_choice = is_choice;
 	}
 
 	inline Node *GetHashNext()
@@ -110,6 +112,11 @@ struct CYapfNodeT {
 	inline int GetCostEstimate() const
 	{
 		return m_estimate;
+	}
+
+	inline bool GetIsChoice() const
+	{
+		return m_is_choice;
 	}
 
 	inline bool operator<(const Node &other) const

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -392,7 +392,8 @@ public:
 				if (pNode->GetIsChoice() && steps < YAPF_ROADVEH_PATH_CACHE_SEGMENTS) {
 					TrackdirByte td;
 					td = pNode->GetTrackdir();
-					path_cache.push_front(td);
+					path_cache.td.push_front(td);
+					path_cache.tile.push_front(pNode->GetTile());
 				}
 				pNode = pNode->m_parent;
 			}
@@ -401,7 +402,10 @@ public:
 			assert(best_next_node.GetTile() == tile);
 			next_trackdir = best_next_node.GetTrackdir();
 			/* remove last element for the special case when tile == dest_tile */
-			if (path_found && !path_cache.empty()) path_cache.pop_back();
+			if (path_found && !path_cache.empty() && tile == v->dest_tile) {
+				path_cache.td.pop_back();
+				path_cache.tile.pop_back();
+			}
 		}
 		return next_trackdir;
 	}

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -96,7 +96,8 @@ public:
 			/* walk through the path back to the origin */
 			Node *pPrevNode = NULL;
 			while (pNode->m_parent != NULL) {
-				if (steps > 1 && --steps < YAPF_SHIP_PATH_CACHE_LENGTH) {
+				steps--;
+				if (steps > 0 && steps < YAPF_SHIP_PATH_CACHE_LENGTH) {
 					TrackdirByte td;
 					td = pNode->GetTrackdir();
 					path_cache.push_front(td);

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -83,7 +83,24 @@ static const byte RV_OVERTAKE_TIMEOUT = 35;
 void RoadVehUpdateCache(RoadVehicle *v, bool same_length = false);
 void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
 
-typedef std::deque<TrackdirByte> RoadVehPathCache;
+struct RoadVehPathCache {
+	std::deque<TrackdirByte> td;
+	std::deque<TileIndex> tile;
+
+	inline bool empty() const { return this->td.empty(); }
+
+	inline size_t size() const
+	{
+		assert(this->td.size() == this->tile.size());
+		return this->td.size();
+	}
+
+	inline void clear()
+	{
+		this->td.clear();
+		this->tile.clear();
+	}
+};
 
 /**
  * Buses, trucks and trams belong to this class.

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -18,6 +18,7 @@
 #include "track_func.h"
 #include "road_type.h"
 #include "newgrf_engine.h"
+#include <deque>
 
 struct RoadVehicle;
 
@@ -82,10 +83,13 @@ static const byte RV_OVERTAKE_TIMEOUT = 35;
 void RoadVehUpdateCache(RoadVehicle *v, bool same_length = false);
 void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
 
+typedef std::deque<TrackdirByte> RoadVehPathCache;
+
 /**
  * Buses, trucks and trams belong to this class.
  */
 struct RoadVehicle FINAL : public GroundVehicle<RoadVehicle, VEH_ROAD> {
+	RoadVehPathCache path;  ///< Cached path.
 	byte state;             ///< @see RoadVehicleStates
 	byte frame;
 	uint16 blocked_ctr;
@@ -125,6 +129,7 @@ struct RoadVehicle FINAL : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 
 	int GetCurrentMaxSpeed() const;
 	int UpdateSpeed();
+	void SetDestTile(TileIndex tile);
 
 protected: // These functions should not be called outside acceleration code.
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -295,6 +295,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_SHIP_CURVE_PENALTY,                 ///< 209  PR#7289 Configurable ship curve penalties.
 
 	SLV_SERVE_NEUTRAL_INDUSTRIES,           ///< 210  PR#7234 Company stations can serve industries with attached neutral stations.
+	SLV_ROADVEH_PATH_CACHE,                 ///< 211  PR#7261 Add path cache for road vehicles.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -759,7 +759,8 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		      SLE_VAR(RoadVehicle, overtaking_ctr,       SLE_UINT8),
 		      SLE_VAR(RoadVehicle, crashed_ctr,          SLE_UINT16),
 		      SLE_VAR(RoadVehicle, reverse_ctr,          SLE_UINT8),
-		SLE_CONDDEQUE(RoadVehicle, path,                SLE_UINT8,                  SLV_ROADVEH_PATH_CACHE, SL_MAX_VERSION),
+		SLE_CONDDEQUE(RoadVehicle, path.td,              SLE_UINT8,                  SLV_ROADVEH_PATH_CACHE, SL_MAX_VERSION),
+		SLE_CONDDEQUE(RoadVehicle, path.tile,            SLE_UINT32,                 SLV_ROADVEH_PATH_CACHE, SL_MAX_VERSION),
 
 		 SLE_CONDNULL(2,                                                               SLV_6,  SLV_69),
 		  SLE_CONDVAR(RoadVehicle, gv_flags,             SLE_UINT16,                 SLV_139, SL_MAX_VERSION),

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -752,21 +752,22 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 	static const SaveLoad _roadveh_desc[] = {
 		SLE_WRITEBYTE(Vehicle, type),
 		SLE_VEH_INCLUDE(),
-		     SLE_VAR(RoadVehicle, state,                SLE_UINT8),
-		     SLE_VAR(RoadVehicle, frame,                SLE_UINT8),
-		     SLE_VAR(RoadVehicle, blocked_ctr,          SLE_UINT16),
-		     SLE_VAR(RoadVehicle, overtaking,           SLE_UINT8),
-		     SLE_VAR(RoadVehicle, overtaking_ctr,       SLE_UINT8),
-		     SLE_VAR(RoadVehicle, crashed_ctr,          SLE_UINT16),
-		     SLE_VAR(RoadVehicle, reverse_ctr,          SLE_UINT8),
+		      SLE_VAR(RoadVehicle, state,                SLE_UINT8),
+		      SLE_VAR(RoadVehicle, frame,                SLE_UINT8),
+		      SLE_VAR(RoadVehicle, blocked_ctr,          SLE_UINT16),
+		      SLE_VAR(RoadVehicle, overtaking,           SLE_UINT8),
+		      SLE_VAR(RoadVehicle, overtaking_ctr,       SLE_UINT8),
+		      SLE_VAR(RoadVehicle, crashed_ctr,          SLE_UINT16),
+		      SLE_VAR(RoadVehicle, reverse_ctr,          SLE_UINT8),
+		SLE_CONDDEQUE(RoadVehicle, path,                SLE_UINT8,                  SLV_ROADVEH_PATH_CACHE, SL_MAX_VERSION),
 
-		SLE_CONDNULL(2,                                                               SLV_6,  SLV_69),
-		 SLE_CONDVAR(RoadVehicle, gv_flags,             SLE_UINT16,                 SLV_139, SL_MAX_VERSION),
-		SLE_CONDNULL(4,                                                              SLV_69, SLV_131),
-		SLE_CONDNULL(2,                                                               SLV_6, SLV_131),
-		SLE_CONDNULL(16,                                                              SLV_2, SLV_144), // old reserved space
+		 SLE_CONDNULL(2,                                                               SLV_6,  SLV_69),
+		  SLE_CONDVAR(RoadVehicle, gv_flags,             SLE_UINT16,                 SLV_139, SL_MAX_VERSION),
+		 SLE_CONDNULL(4,                                                              SLV_69, SLV_131),
+		 SLE_CONDNULL(2,                                                               SLV_6, SLV_131),
+		 SLE_CONDNULL(16,                                                              SLV_2, SLV_144), // old reserved space
 
-		     SLE_END()
+		      SLE_END()
 	};
 
 	static const SaveLoad _ship_desc[] = {


### PR DESCRIPTION
Modeled on the ship path cache, so not many surprises. The maximum length is in path-finder segments (effectively number of junctions) rather than tiles due to how YAPF works for RVs.

On my system with the Wentbourne save, road vehicle time dropped from 62.5ms/t to 19.75ms/t, which is pretty significant. Performance gains for a more normal number of road vehicles would of course be less.

![rvpathcache](https://user-images.githubusercontent.com/639850/53211306-9ce78d80-3638-11e9-9899-2ec0bd94eebe.png)

