### PR TITLE
Fix #7004: Mark linkgraph dirty to be rebuilt on next draw call.

### DIFF
--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -239,8 +239,12 @@ void LinkGraphOverlay::AddLinks(const Station *from, const Station *to)
  * Draw the linkgraph overlay or some part of it, in the area given.
  * @param dpi Area to be drawn to.
  */
-void LinkGraphOverlay::Draw(const DrawPixelInfo *dpi) const
+void LinkGraphOverlay::Draw(const DrawPixelInfo *dpi)
 {
+	if (this->dirty) {
+		this->RebuildCache();
+		this->dirty = false;
+	}
 	this->DrawLinks(dpi);
 	this->DrawStationDots(dpi);
 }

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -56,10 +56,12 @@ public:
 			window(w), widget_id(wid), cargo_mask(cargo_mask), company_mask(company_mask), scale(scale)
 	{}
 
-	void RebuildCache();
-	void Draw(const DrawPixelInfo *dpi) const;
+	void Draw(const DrawPixelInfo *dpi);
 	void SetCargoMask(CargoTypes cargo_mask);
 	void SetCompanyMask(uint32 company_mask);
+
+	/** Mark the linkgraph dirty to be rebuilt next time Draw() is called. */
+	void SetDirty() { this->dirty = true; }
 
 	/** Get a bitmask of the currently shown cargoes. */
 	CargoTypes GetCargoMask() { return this->cargo_mask; }
@@ -75,6 +77,7 @@ protected:
 	LinkMap cached_links;              ///< Cache for links to reduce recalculation.
 	StationSupplyList cached_stations; ///< Cache for stations to be drawn.
 	uint scale;                        ///< Width of link lines.
+	bool dirty;                        ///< Set if overlay should be rebuilt.
 
 	Point GetStationMiddle(const Station *st) const;
 
@@ -85,6 +88,7 @@ protected:
 	bool IsLinkVisible(Point pta, Point ptb, const DrawPixelInfo *dpi, int padding = 0) const;
 	bool IsPointVisible(Point pt, const DrawPixelInfo *dpi, int padding = 0) const;
 	void GetWidgetDpi(DrawPixelInfo *dpi) const;
+	void RebuildCache();
 
 	static void AddStats(uint new_cap, uint new_usg, uint new_flow, bool new_shared, LinkProperties &cargo);
 	static void DrawVertex(int x, int y, int size, int colour, int border_colour);

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -267,7 +267,7 @@ struct MainWindow : Window
 			return;
 		}
 
-		this->viewport->overlay->RebuildCache();
+		this->viewport->overlay->SetDirty();
 		this->GetWidget<NWidgetBase>(WID_M_VIEWPORT)->SetDirty(this);
 	}
 

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -713,7 +713,7 @@ void SmallMapWindow::SetZoomLevel(ZoomLevelChange change, const Point *zoom_pt)
 			this->SetNewScroll(this->scroll_x + (tile.x - new_tile.x) * TILE_SIZE,
 					this->scroll_y + (tile.y - new_tile.y) * TILE_SIZE, sub);
 		} else if (this->map_type == SMT_LINKSTATS) {
-			this->overlay->RebuildCache();
+			this->overlay->SetDirty();
 		}
 		this->SetWidgetDisabledState(WID_SM_ZOOM_IN,  this->zoom == zoomlevels[MIN_ZOOM_INDEX]);
 		this->SetWidgetDisabledState(WID_SM_ZOOM_OUT, this->zoom == zoomlevels[MAX_ZOOM_INDEX]);
@@ -1290,7 +1290,7 @@ void SmallMapWindow::SwitchMapType(SmallMapType map_type)
 
 	this->SetupWidgetData();
 
-	if (map_type == SMT_LINKSTATS) this->overlay->RebuildCache();
+	if (map_type == SMT_LINKSTATS) this->overlay->SetDirty();
 	if (map_type != SMT_INDUSTRY) this->BreakIndustryChainLink();
 	this->SetDirty();
 }
@@ -1573,7 +1573,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 		if (this->overlay->GetCompanyMask() != company_mask) {
 			this->overlay->SetCompanyMask(company_mask);
 		} else {
-			this->overlay->RebuildCache();
+			this->overlay->SetDirty();
 		}
 	}
 	_smallmap_industry_highlight_state = !_smallmap_industry_highlight_state;
@@ -1616,7 +1616,7 @@ void SmallMapWindow::SetNewScroll(int sx, int sy, int sub)
 	this->scroll_x = sx;
 	this->scroll_y = sy;
 	this->subscroll = sub;
-	if (this->map_type == SMT_LINKSTATS) this->overlay->RebuildCache();
+	if (this->map_type == SMT_LINKSTATS) this->overlay->SetDirty();
 }
 
 /* virtual */ void SmallMapWindow::OnScroll(Point delta)

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2070,7 +2070,7 @@ void RebuildViewportOverlay(Window *w)
 	if (w->viewport->overlay != NULL &&
 			w->viewport->overlay->GetCompanyMask() != 0 &&
 			w->viewport->overlay->GetCargoMask() != 0) {
-		w->viewport->overlay->RebuildCache();
+		w->viewport->overlay->SetDirty();
 		w->SetDirty();
 	}
 }


### PR DESCRIPTION
Previously the linkgraph was rebuilt before the viewport extents were finalized.

This is an alternative to #7005.