### PR TITLE
Change: [AzurePipelines] Use a minimum OSX version of 10.9 during building.

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -55,6 +55,9 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
 
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: 10.9
+
   steps:
   - template: azure-pipelines/templates/ci-git-rebase.yml
   - template: azure-pipelines/templates/osx-dependencies.yml

--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -135,6 +135,9 @@ jobs:
     vmImage: 'macOS-10.13'
   dependsOn: source
 
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: 10.9
+
   steps:
   - template: release-fetch-source.yml
   - template: osx-dependencies.yml


### PR DESCRIPTION
OpenTTD sources are still written in a way to work down to OSX 10.4 or so, as long as you can obtain a C++11 capable compiler. 10.9 is the minimal useful C++11 target using only Apple stuff out-of-the-box.

This should not impact any current OSX versions and we don't necessarily need to change the website description. I just don't see a need to exclude users just because.