### PR TITLE
Fix #7062: Remove ship max order distance.

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -23,7 +23,6 @@
 #include "core/random_func.hpp"
 #include "aircraft.h"
 #include "roadveh.h"
-#include "ship.h"
 #include "station_base.h"
 #include "waypoint_base.h"
 #include "company_base.h"
@@ -899,42 +898,6 @@ CommandCost CmdInsertOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 	if (v->GetNumOrders() >= MAX_VEH_ORDER_ID) return_cmd_error(STR_ERROR_TOO_MANY_ORDERS);
 	if (!Order::CanAllocateItem()) return_cmd_error(STR_ERROR_NO_MORE_SPACE_FOR_ORDERS);
 	if (v->orders.list == NULL && !OrderList::CanAllocateItem()) return_cmd_error(STR_ERROR_NO_MORE_SPACE_FOR_ORDERS);
-
-	if (v->type == VEH_SHIP && _settings_game.pf.pathfinder_for_ships != VPF_NPF) {
-		/* Make sure the new destination is not too far away from the previous */
-		const Order *prev = NULL;
-		uint n = 0;
-
-		/* Find the last goto station or depot order before the insert location.
-		 * If the order is to be inserted at the beginning of the order list this
-		 * finds the last order in the list. */
-		const Order *o;
-		FOR_VEHICLE_ORDERS(v, o) {
-			switch (o->GetType()) {
-				case OT_GOTO_STATION:
-				case OT_GOTO_DEPOT:
-				case OT_GOTO_WAYPOINT:
-					prev = o;
-					break;
-
-				default: break;
-			}
-			if (++n == sel_ord && prev != NULL) break;
-		}
-		if (prev != NULL) {
-			uint dist;
-			if (new_order.IsType(OT_CONDITIONAL)) {
-				/* The order is not yet inserted, so we have to do the first iteration here. */
-				dist = GetOrderDistance(prev, v->GetOrder(new_order.GetConditionSkipToOrder()), v);
-			} else {
-				dist = GetOrderDistance(prev, &new_order, v);
-			}
-
-			if (dist >= SHIP_MAX_ORDER_DISTANCE) {
-				return_cmd_error(STR_ERROR_TOO_FAR_FROM_PREVIOUS_DESTINATION);
-			}
-		}
-	}
 
 	if (flags & DC_EXEC) {
 		Order *new_o = new Order();

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -256,9 +256,6 @@
 	if (!IsValidEngine(engine_id)) return 0;
 
 	switch (GetVehicleType(engine_id)) {
-		case ScriptVehicle::VT_WATER:
-			return _settings_game.pf.pathfinder_for_ships != VPF_NPF ? 129 : 0;
-
 		case ScriptVehicle::VT_AIR:
 			return ::Engine::Get(engine_id)->GetRange() * ::Engine::Get(engine_id)->GetRange();
 

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -449,9 +449,6 @@
 
 	const ::Vehicle *v = ::Vehicle::Get(vehicle_id);
 	switch (v->type) {
-		case VEH_SHIP:
-			return _settings_game.pf.pathfinder_for_ships != VPF_NPF ? 129 : 0;
-
 		case VEH_AIRCRAFT:
 			return ::Aircraft::From(v)->acache.cached_max_range_sqr;
 

--- a/src/ship.h
+++ b/src/ship.h
@@ -57,8 +57,6 @@ struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
 	void SetDestTile(TileIndex tile);
 };
 
-static const uint SHIP_MAX_ORDER_DISTANCE = 130;
-
 /**
  * Iterate over all ships.
  * @param var The variable used for iteration.

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -470,8 +470,8 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 	bool path_found = true;
 	Track track;
 
-	if (v->dest_tile == 0 || DistanceManhattan(tile, v->dest_tile) > SHIP_MAX_ORDER_DISTANCE + 5) {
-		/* No destination or destination too far, don't invoke pathfinder. */
+	if (v->dest_tile == 0) {
+		/* No destination, don't invoke pathfinder. */
 		track = TrackBitsToTrack(v->state);
 		if (!IsDiagonalTrack(track)) track = TrackToOppositeTrack(track);
 		if (!HasBit(tracks, track)) {


### PR DESCRIPTION
It is skipped when NPF is in use.
It is trivial to work around by adding and removing dummy orders.
It is mostly alleviated by the ship path cache in YAPF.