### PR TITLE
Fix #7274, Fix #7043: Town bridges store town indexes in map array.

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 
 <head>
@@ -1443,6 +1443,7 @@
    <td>
     <ul>
      <li>m1 bits 4..0: <a href="#OwnershipInfo">owner</a></li>
+     <li>m2: Index into the array of towns (owning town for town bridges; closest town otherwise, INVALID_TOWN if there is no town or we are creating a town)</li>
      <li>m3 bits 7..4: <a href="#OwnershipInfo">owner</a> of tram</li>
      <li>m5 bit 4: pbs reservation state for railway</li>
      <li>m5 bits 7 clear: tunnel entrance/exit</li>

--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 
 <head>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -368,7 +368,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">XXXX XXXX XXXX XXXX</td>
       <td class="bits">-inherit-</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits">-inherit-</td>

--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -124,13 +124,14 @@ static inline void SetBridgeMiddle(TileIndex t, Axis a)
  * @param d          the direction this ramp must be facing
  * @param tt         the transport type of the bridge
  * @param rt         the road or rail type
+ * @param town       Town ID if the road is a town-owned road.
  * @note this function should not be called directly.
  */
-static inline void MakeBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt, uint rt)
+static inline void MakeBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt, uint rt, TownID town)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);
-	_m[t].m2 = 0;
+	_m[t].m2 = town;
 	_m[t].m3 = 0;
 	_m[t].m4 = 0;
 	_m[t].m5 = 1 << 7 | tt << 2 | d;
@@ -148,10 +149,11 @@ static inline void MakeBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, D
  * @param bridgetype the type of bridge this bridge ramp belongs to
  * @param d          the direction this ramp must be facing
  * @param r          the road type of the bridge
+ * @param town       Town ID if the road is a town-owned road.
  */
-static inline void MakeRoadBridgeRamp(TileIndex t, Owner o, Owner owner_road, Owner owner_tram, BridgeType bridgetype, DiagDirection d, RoadTypes r)
+static inline void MakeRoadBridgeRamp(TileIndex t, Owner o, Owner owner_road, Owner owner_tram, BridgeType bridgetype, DiagDirection d, RoadTypes r, TownID town)
 {
-	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_ROAD, 0);
+	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_ROAD, 0, town);
 	SetRoadOwner(t, ROADTYPE_ROAD, owner_road);
 	if (owner_tram != OWNER_TOWN) SetRoadOwner(t, ROADTYPE_TRAM, owner_tram);
 	SetRoadTypes(t, r);
@@ -167,7 +169,7 @@ static inline void MakeRoadBridgeRamp(TileIndex t, Owner o, Owner owner_road, Ow
  */
 static inline void MakeRailBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, DiagDirection d, RailType r)
 {
-	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_RAIL, r);
+	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_RAIL, r, 0);
 }
 
 /**
@@ -178,7 +180,7 @@ static inline void MakeRailBridgeRamp(TileIndex t, Owner o, BridgeType bridgetyp
  */
 static inline void MakeAqueductBridgeRamp(TileIndex t, Owner o, DiagDirection d)
 {
-	MakeBridgeRamp(t, o, 0, d, TRANSPORT_WATER, 0);
+	MakeBridgeRamp(t, o, 0, d, TRANSPORT_WATER, 0, 0);
 }
 
 #endif /* BRIDGE_MAP_H */

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -215,7 +215,7 @@ struct BuildDocksToolbarWindow : Window {
 				break;
 
 			case WID_DT_BUILD_AQUEDUCT: // Build aqueduct button
-				DoCommandP(tile, GetOtherAqueductEnd(tile), TRANSPORT_WATER << 15, CMD_BUILD_BRIDGE | CMD_MSG(STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE), CcBuildBridge);
+				DoCommandP(tile, GetOtherAqueductEnd(tile) | TRANSPORT_WATER << 24, 0, CMD_BUILD_BRIDGE | CMD_MSG(STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE), CcBuildBridge);
 				break;
 
 			default: NOT_REACHED();

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -493,7 +493,7 @@ CommandCost CmdBuildRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 	 * if a non-company is building the road */
 	if ((Company::IsValidID(company) && p2 != 0) || (company == OWNER_TOWN && !Town::IsValidID(p2)) || (company == OWNER_DEITY && p2 != 0)) return CMD_ERROR;
 	if (company != OWNER_TOWN) {
-		const Town *town = CalcClosestTownFromTile(tile);
+		const Town *town = ClosestTownFromTile(tile, UINT_MAX);
 		p2 = (town != NULL) ? town->index : INVALID_TOWN;
 
 		if (company == OWNER_DEITY) {
@@ -1445,7 +1445,7 @@ void UpdateNearestTownForRoadTiles(bool invalidate)
 	assert(!invalidate || _generating_world);
 
 	for (TileIndex t = 0; t < MapSize(); t++) {
-		if (IsTileType(t, MP_ROAD) && !IsRoadDepot(t) && !HasTownOwnedRoad(t)) {
+		if (((IsTileType(t, MP_ROAD) && !IsRoadDepot(t)) || (IsTileType(t, MP_TUNNELBRIDGE) && IsBridge(t) && GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD)) && !HasTownOwnedRoad(t)) {
 			TownID tid = INVALID_TOWN;
 			if (!invalidate) {
 				const Town *town = CalcClosestTownFromTile(t);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3080,6 +3080,10 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_TOWN_BRIDGES) && !IsSavegameVersionBefore(SLV_103)) {
+		UpdateNearestTownForRoadTiles(false);
+	}
+
 	/* Station acceptance is some kind of cache */
 	if (IsSavegameVersionBefore(SLV_127)) {
 		Station *st;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -291,6 +291,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GROUP_LIVERIES,                     ///< 205  PR#7108 Livery storage change and group liveries.
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 Cargo monitor data packing fix to support 64 cargotypes.
+	SLV_TOWN_BRIDGES,                       ///< 208  PR#7282 Town bridges store town indexes in map array.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -80,29 +80,30 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY || vehicle_type == ScriptVehicle::VT_ROAD);
 
 	uint type = 0;
+	uint start_type = start;
 	switch (vehicle_type) {
 		case ScriptVehicle::VT_ROAD:
-			type |= (TRANSPORT_ROAD << 15);
+			start_type |= (TRANSPORT_ROAD << 24);
 			type |= (::RoadTypeToRoadTypes((::RoadType)ScriptObject::GetRoadType()) << 8);
 			break;
 		case ScriptVehicle::VT_RAIL:
-			type |= (TRANSPORT_RAIL << 15);
+			start_type |= (TRANSPORT_RAIL << 24);
 			type |= (ScriptRail::GetCurrentRailType() << 8);
 			break;
 		case ScriptVehicle::VT_WATER:
-			type |= (TRANSPORT_WATER << 15);
+			start_type |= (TRANSPORT_WATER << 24);
 			break;
 		default: NOT_REACHED();
 	}
 
 	/* For rail and water we do nothing special */
 	if (vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER) {
-		return ScriptObject::DoCommand(end, start, type | bridge_id, CMD_BUILD_BRIDGE);
+		return ScriptObject::DoCommand(end, start_type, type | bridge_id, CMD_BUILD_BRIDGE);
 	}
 
 	ScriptObject::SetCallbackVariable(0, start);
 	ScriptObject::SetCallbackVariable(1, end);
-	return ScriptObject::DoCommand(end, start, type | bridge_id, CMD_BUILD_BRIDGE, NULL, &::_DoCommandReturnBuildBridge1);
+	return ScriptObject::DoCommand(end, start_type, type | bridge_id, CMD_BUILD_BRIDGE, NULL, &::_DoCommandReturnBuildBridge1);
 }
 
 /* static */ bool ScriptBridge::_BuildBridgeRoad1()

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -90,7 +90,7 @@ Town::~Town()
 				break;
 
 			case MP_TUNNELBRIDGE:
-				assert(!IsTileOwner(tile, OWNER_TOWN) || ClosestTownFromTile(tile, UINT_MAX) != this);
+				assert(_generating_world || !IsTileOwner(tile, OWNER_TOWN) || ClosestTownFromTile(tile, UINT_MAX) != this);
 				break;
 
 			default:
@@ -2739,7 +2739,7 @@ CommandCost CmdDeleteTown(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 				break;
 
 			case MP_TUNNELBRIDGE:
-				try_clear = IsTileOwner(tile, OWNER_TOWN) && ClosestTownFromTile(tile, UINT_MAX) == t;
+				try_clear = !_generating_world && IsTileOwner(tile, OWNER_TOWN) && ClosestTownFromTile(tile, UINT_MAX) == t;
 				break;
 
 			case MP_HOUSE:

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1061,6 +1061,8 @@ static bool GrowTownWithRoad(const Town *t, TileIndex tile, RoadBits rcmd)
  */
 static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDirection bridge_dir)
 {
+	if (_generating_world && t->cache.population == 0) return false;
+
 	assert(bridge_dir < DIAGDIR_END);
 
 	const Slope slope = GetTileSlope(tile);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -86,11 +86,8 @@ Town::~Town()
 				break;
 
 			case MP_ROAD:
-				assert(!HasTownOwnedRoad(tile) || GetTownIndex(tile) != this->index);
-				break;
-
 			case MP_TUNNELBRIDGE:
-				assert(_generating_world || !IsTileOwner(tile, OWNER_TOWN) || ClosestTownFromTile(tile, UINT_MAX) != this);
+				assert(!HasTownOwnedRoad(tile) || GetTownIndex(tile) != this->index);
 				break;
 
 			default:
@@ -1061,8 +1058,6 @@ static bool GrowTownWithRoad(const Town *t, TileIndex tile, RoadBits rcmd)
  */
 static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDirection bridge_dir)
 {
-	if (_generating_world && t->cache.population == 0) return false;
-
 	assert(bridge_dir < DIAGDIR_END);
 
 	const Slope slope = GetTileSlope(tile);
@@ -1107,8 +1102,8 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 		byte bridge_type = RandomRange(MAX_BRIDGES - 1);
 
 		/* Can we actually build the bridge? */
-		if (DoCommand(tile, bridge_tile, bridge_type | ROADTYPES_ROAD << 8 | TRANSPORT_ROAD << 15, CommandFlagsToDCFlags(GetCommandFlags(CMD_BUILD_BRIDGE)), CMD_BUILD_BRIDGE).Succeeded()) {
-			DoCommand(tile, bridge_tile, bridge_type | ROADTYPES_ROAD << 8 | TRANSPORT_ROAD << 15, DC_EXEC | CommandFlagsToDCFlags(GetCommandFlags(CMD_BUILD_BRIDGE)), CMD_BUILD_BRIDGE);
+		if (DoCommand(tile, bridge_tile | TRANSPORT_ROAD << 24, bridge_type | ROADTYPES_ROAD << 8 | t->index << 16, CommandFlagsToDCFlags(GetCommandFlags(CMD_BUILD_BRIDGE)), CMD_BUILD_BRIDGE).Succeeded()) {
+			DoCommand(tile, bridge_tile | TRANSPORT_ROAD << 24, bridge_type | ROADTYPES_ROAD << 8 | t->index << 16, DC_EXEC | CommandFlagsToDCFlags(GetCommandFlags(CMD_BUILD_BRIDGE)), CMD_BUILD_BRIDGE);
 			_grow_town_result = GROWTH_SUCCEED;
 			return true;
 		}
@@ -1417,6 +1412,17 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile)
 		if (cur_rb == ROAD_NONE) return false;
 
 		if (IsTileType(tile, MP_TUNNELBRIDGE)) {
+			if (IsBridge(tile) && IsRoadOwner(tile, ROADTYPE_ROAD, OWNER_NONE) && GetRoadTypes(tile) == ROADTYPES_ROAD && _game_mode == GM_EDITOR) {
+				/* If we are in the SE, and this bridge-piece has no town owner yet, it just found an
+				 * owner :) (happy happy happy bridge now) */
+				TileIndex other_end = GetOtherBridgeEnd(tile);
+				SetTileOwner(tile, OWNER_TOWN);
+				SetTileOwner(other_end, OWNER_TOWN);
+				SetRoadOwner(tile, ROADTYPE_ROAD, OWNER_TOWN);
+				SetRoadOwner(other_end, ROADTYPE_ROAD, OWNER_TOWN);
+				SetTownIndex(tile, t->index);
+				SetTownIndex(other_end, t->index);
+			}
 			/* Only build in the direction away from the tunnel or bridge. */
 			target_dir = ReverseDiagDir(GetTunnelBridgeDirection(tile));
 		} else {
@@ -2737,11 +2743,8 @@ CommandCost CmdDeleteTown(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 		bool try_clear = false;
 		switch (GetTileType(tile)) {
 			case MP_ROAD:
-				try_clear = HasTownOwnedRoad(tile) && GetTownIndex(tile) == t->index;
-				break;
-
 			case MP_TUNNELBRIDGE:
-				try_clear = !_generating_world && IsTileOwner(tile, OWNER_TOWN) && ClosestTownFromTile(tile, UINT_MAX) == t;
+				try_clear = HasTownOwnedRoad(tile) && GetTownIndex(tile) == t->index;
 				break;
 
 			case MP_HOUSE:
@@ -3333,6 +3336,10 @@ Town *ClosestTownFromTile(TileIndex tile, uint threshold)
 	switch (GetTileType(tile)) {
 		case MP_ROAD:
 			if (IsRoadDepot(tile)) return CalcClosestTownFromTile(tile, threshold);
+			FALLTHROUGH;
+
+		case MP_TUNNELBRIDGE:
+			if (IsTileType(tile, MP_TUNNELBRIDGE) && (IsTunnel(tile) || GetTunnelBridgeTransportType(tile) != TRANSPORT_ROAD)) return CalcClosestTownFromTile(tile, threshold);
 
 			if (!HasTownOwnedRoad(tile)) {
 				TownID tid = GetTownIndex(tile);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1412,7 +1412,7 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile)
 		if (cur_rb == ROAD_NONE) return false;
 
 		if (IsTileType(tile, MP_TUNNELBRIDGE)) {
-			if (IsBridge(tile) && IsRoadOwner(tile, ROADTYPE_ROAD, OWNER_NONE) && GetRoadTypes(tile) == ROADTYPES_ROAD && _game_mode == GM_EDITOR) {
+			if (IsBridge(tile) && IsRoadOwner(tile, ROADTYPE_ROAD, OWNER_NONE) && _game_mode == GM_EDITOR) {
 				/* If we are in the SE, and this bridge-piece has no town owner yet, it just found an
 				 * owner :) (happy happy happy bridge now) */
 				TileIndex other_end = GetOtherBridgeEnd(tile);

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -13,17 +13,19 @@
 #define TOWN_MAP_H
 
 #include "road_map.h"
+#include "bridge_map.h"
+#include "tunnelbridge_map.h"
 #include "house.h"
 
 /**
  * Get the index of which town this house/street is attached to.
  * @param t the tile
- * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
+ * @pre IsTileType(t, MP_HOUSE), or IsTileType(t, MP_ROAD) but not a road depot or IsTileType(t, MP_TUNNELBRIDGE) a road bridge
  * @return TownID
  */
 static inline TownID GetTownIndex(TileIndex t)
 {
-	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
+	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)) || (IsTileType(t, MP_TUNNELBRIDGE) && IsBridge(t) && GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD));
 	return _m[t].m2;
 }
 
@@ -31,11 +33,11 @@ static inline TownID GetTownIndex(TileIndex t)
  * Set the town index for a road or house tile.
  * @param t the tile
  * @param index the index of the town
- * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
+ * @pre IsTileType(t, MP_HOUSE), or IsTileType(t, MP_ROAD) but not a road depot or IsTileType(t, MP_TUNNELBRIDGE) a road bridge
  */
 static inline void SetTownIndex(TileIndex t, TownID index)
 {
-	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
+	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)) || (IsTileType(t, MP_TUNNELBRIDGE) && IsBridge(t) && GetTunnelBridgeTransportType(t) == TRANSPORT_ROAD));
 	_m[t].m2 = index;
 }
 


### PR DESCRIPTION
This also addresses the source of the stalls of #7274.

~~This patch is assuming that towns that generated with 0 population didn't build any bridges. It may not be correct. Needs better investigation.~~