### PR TITLE
Add newheightmapgame command (addresses #2155)

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1049,6 +1049,52 @@ DEF_CONSOLE_CMD(ConNewGame)
 	return true;
 }
 
+DEF_CONSOLE_CMD(ConNewHeightMapGame)
+{
+    bool answer = true;
+
+	if (argc == 0) {
+        IConsoleHelp("Load a game by name or index. Usage: 'newheightmapgame [<file | number> [seed]]'");
+		IConsoleHelp("The server can force a new game using 'newheightmapgame'; any client joined will rejoin after the server is done generating the new game.");
+    }
+
+    if (argc >=1 && argc <= 3) {
+        const char *file = NULL;
+
+        if (argc == 1) {
+            file = _file_to_saveload.title;
+        }
+
+        if (argc >= 2) {
+            file = argv[1];
+        }
+
+//        _console_file_list.ValidateFileList();
+		_console_file_list.BuildFileList(FT_HEIGHTMAP, SLO_LOAD);
+        const FiosItem *item = _console_file_list.FindItem(file);
+        if (item != NULL) {
+            if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
+                _switch_mode = SM_LOAD_HEIGHTMAP;
+                _file_to_saveload.SetMode(item->type);
+                _file_to_saveload.SetName(FiosBrowseTo(item));
+                _file_to_saveload.SetTitle(item->title);
+
+                StartNewHeightMapGameWithoutGUI((argc == 3) ? strtoul(argv[2], NULL, 10) : GENERATE_NEW_SEED);
+            } else {
+                IConsolePrintF(CC_ERROR, "%s: Not a heightmap.", file);
+            }
+        } else {
+            IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+        }
+
+        _console_file_list.InvalidateFileList();
+    }
+
+    if (argc > 3) answer = false;
+
+    return answer;
+}
+
 DEF_CONSOLE_CMD(ConRestart)
 {
 	if (argc == 0) {
@@ -1943,6 +1989,7 @@ void IConsoleStdLibRegister()
 	IConsoleCmdRegister("list_cmds",    ConListCommands);
 	IConsoleCmdRegister("list_aliases", ConListAliases);
 	IConsoleCmdRegister("newgame",      ConNewGame);
+	IConsoleCmdRegister("newheightmapgame",      ConNewHeightMapGame);
 	IConsoleCmdRegister("restart",      ConRestart);
 	IConsoleCmdRegister("getseed",      ConGetSeed);
 	IConsoleCmdRegister("getdate",      ConGetDate);

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1051,48 +1051,48 @@ DEF_CONSOLE_CMD(ConNewGame)
 
 DEF_CONSOLE_CMD(ConNewHeightMapGame)
 {
-    bool answer = true;
+	bool answer = true;
 
 	if (argc == 0) {
-        IConsoleHelp("Load a game by name or index. Usage: 'newheightmapgame [<file | number> [seed]]'");
+		IConsoleHelp("Load a game by name or index. Usage: 'newheightmapgame [<file | number> [seed]]'");
 		IConsoleHelp("The server can force a new game using 'newheightmapgame'; any client joined will rejoin after the server is done generating the new game.");
-    }
+	}
 
-    if (argc >=1 && argc <= 3) {
-        const char *file = NULL;
+	if (argc >=1 && argc <= 3) {
+		const char *file = NULL;
 
-        if (argc == 1) {
-            file = _file_to_saveload.title;
-        }
+		if (argc == 1) {
+			file = _file_to_saveload.title;
+		}
 
-        if (argc >= 2) {
-            file = argv[1];
-        }
+		if (argc >= 2) {
+			file = argv[1];
+		}
 
-//        _console_file_list.ValidateFileList();
+//		_console_file_list.ValidateFileList();
 		_console_file_list.BuildFileList(FT_HEIGHTMAP, SLO_LOAD);
-        const FiosItem *item = _console_file_list.FindItem(file);
-        if (item != NULL) {
-            if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
-                _switch_mode = SM_LOAD_HEIGHTMAP;
-                _file_to_saveload.SetMode(item->type);
-                _file_to_saveload.SetName(FiosBrowseTo(item));
-                _file_to_saveload.SetTitle(item->title);
+		const FiosItem *item = _console_file_list.FindItem(file);
+		if (item != NULL) {
+			if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
+				_switch_mode = SM_LOAD_HEIGHTMAP;
+				_file_to_saveload.SetMode(item->type);
+				_file_to_saveload.SetName(FiosBrowseTo(item));
+				_file_to_saveload.SetTitle(item->title);
 
-                StartNewHeightMapGameWithoutGUI((argc == 3) ? strtoul(argv[2], NULL, 10) : GENERATE_NEW_SEED);
-            } else {
-                IConsolePrintF(CC_ERROR, "%s: Not a heightmap.", file);
-            }
-        } else {
-            IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
-        }
+				StartNewHeightMapGameWithoutGUI((argc == 3) ? strtoul(argv[2], NULL, 10) : GENERATE_NEW_SEED);
+			} else {
+				IConsolePrintF(CC_ERROR, "%s: Not a heightmap.", file);
+			}
+		} else {
+			IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		}
 
-        _console_file_list.InvalidateFileList();
-    }
+		_console_file_list.InvalidateFileList();
+	}
 
-    if (argc > 3) answer = false;
+	if (argc > 3) answer = false;
 
-    return answer;
+	return answer;
 }
 
 DEF_CONSOLE_CMD(ConRestart)

--- a/src/genworld.h
+++ b/src/genworld.h
@@ -98,6 +98,7 @@ void IncreaseGeneratingWorldProgress(GenWorldProgress cls);
 void PrepareGenerateWorldProgress();
 void ShowGenerateWorldProgress();
 void StartNewGameWithoutGUI(uint32 seed);
+void StartNewHeightMapGameWithoutGUI(uint32 seed);
 void ShowCreateScenario();
 void StartScenarioEditor();
 

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -878,6 +878,24 @@ void StartNewGameWithoutGUI(uint32 seed)
 	StartGeneratingLandscape(GLWM_GENERATE);
 }
 
+/**
+ * Start a normal game from a heightmap file without the GUI.
+ * @param seed The seed of the new game.
+ */
+void StartNewHeightMapGameWithoutGUI(uint32 seed)
+{
+	/* GenerateWorld takes care of the possible GENERATE_NEW_SEED value in 'seed' */
+	_settings_newgame.game_creation.generation_seed = seed;
+
+    uint x = 0;
+    uint y = 0;
+
+    /* If the function returns negative, it means there was a problem loading the heightmap */
+    if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name, &x, &y)) return;
+
+	StartGeneratingLandscape(GLWM_HEIGHTMAP);
+}
+
 struct CreateScenarioWindow : public Window
 {
 	uint widget_id;

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -887,11 +887,11 @@ void StartNewHeightMapGameWithoutGUI(uint32 seed)
 	/* GenerateWorld takes care of the possible GENERATE_NEW_SEED value in 'seed' */
 	_settings_newgame.game_creation.generation_seed = seed;
 
-    uint x = 0;
-    uint y = 0;
+	uint x = 0;
+	uint y = 0;
 
-    /* If the function returns negative, it means there was a problem loading the heightmap */
-    if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name, &x, &y)) return;
+	/* If the function returns negative, it means there was a problem loading the heightmap */
+	if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name, &x, &y)) return;
 
 	StartGeneratingLandscape(GLWM_HEIGHTMAP);
 }


### PR DESCRIPTION
Work inspired by the latest patch from old FlySpray bug tracker: https://bugs.openttd.org/task/2155/getfile/8568/Heightmap_Console_command.patch:
- Added `newheightmapgame` command accepting up to 2 parameters (file name, title or index to load - mandatory, and an optional seed)
- The short version with no argument reload the current heightmap with a random seed
Sadly, there is no clean way to have a 2-arguments version where the second one would be the seed, as it would conflict with the 2-arguments version where the integer represent the file ID. Even if file ID was to be discarded, there would be some complicated and dangerous checks to check if the 2nd parameter is a string or an integer that could potentially introduce vulnerabilities.