### PR TITLE
Add #2155: newheightmapgame command

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1055,6 +1055,52 @@ DEF_CONSOLE_CMD(ConNewGame)
 	return true;
 }
 
+DEF_CONSOLE_CMD(ConNewHeightMapGame)
+{
+	if (argc == 0) {
+		IConsoleHelp("Load a game by name or index. Usage: 'newheightmapgame [<file | number> [seed]]'");
+		IConsoleHelp("The server can force a new game using 'newheightmapgame'; any client joined will rejoin after the server is done generating the new game.");
+		return true;
+	}
+
+	if (argc > 3) return false;
+
+	bool heightmap_loaded = true;
+	const char *file = NULL;
+
+	if (argc == 1) {
+		file = _file_to_saveload.title;
+	}
+
+	if (argc >= 2) {
+		file = argv[1];
+	}
+
+	/* ConLoad command actually uses
+	_console_file_list.ValidateFileList()
+	here, but for this procedure build a file list for mere savegames, instead of merely validating */
+	_console_file_list.BuildFileList(FT_HEIGHTMAP, SLO_LOAD);
+	const FiosItem *item = _console_file_list.FindItem(file);
+	if (item != NULL) {
+		if (GetAbstractFileType(item->type) == FT_HEIGHTMAP) {
+			_switch_mode = SM_LOAD_HEIGHTMAP;
+			_file_to_saveload.SetMode(item->type);
+			_file_to_saveload.SetName(FiosBrowseTo(item));
+			_file_to_saveload.SetTitle(item->title);
+
+			StartNewGameWithoutGUI((argc == 3) ? strtoul(argv[2], NULL, 10) : GENERATE_NEW_SEED);
+		} else {
+			IConsolePrintF(CC_ERROR, "%s: Not a heightmap.", file);
+		}
+	} else {
+		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+	}
+
+	_console_file_list.InvalidateFileList();
+
+	return heightmap_loaded;
+}
+
 DEF_CONSOLE_CMD(ConRestart)
 {
 	if (argc == 0) {
@@ -2089,6 +2135,7 @@ void IConsoleStdLibRegister()
 	IConsoleCmdRegister("list_cmds",    ConListCommands);
 	IConsoleCmdRegister("list_aliases", ConListAliases);
 	IConsoleCmdRegister("newgame",      ConNewGame);
+	IConsoleCmdRegister("newheightmapgame",      ConNewHeightMapGame);
 	IConsoleCmdRegister("restart",      ConRestart);
 	IConsoleCmdRegister("getseed",      ConGetSeed);
 	IConsoleCmdRegister("getdate",      ConGetDate);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -517,7 +517,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, FileList &file_list)
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-static FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last)
+FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -566,7 +566,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, FileList &file_list)
 	FiosGetFileList(fop, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-static FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last)
+FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files

--- a/src/fios.h
+++ b/src/fios.h
@@ -225,5 +225,7 @@ void FiosMakeHeightmapName(char *buf, const char *name, const char *last);
 void FiosMakeSavegameName(char *buf, const char *name, const char *last);
 
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last);
+FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last);
+FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const char *file, const char *ext, char *title, const char *last);
 
 #endif /* FIOS_H */

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -865,7 +865,7 @@ void StartScenarioEditor()
 }
 
 /**
- * Start a normal game without the GUI.
+ * Start a normal/heightmap game without the GUI.
  * @param seed The seed of the new game.
  */
 void StartNewGameWithoutGUI(uint32 seed)
@@ -873,7 +873,20 @@ void StartNewGameWithoutGUI(uint32 seed)
 	/* GenerateWorld takes care of the possible GENERATE_NEW_SEED value in 'seed' */
 	_settings_newgame.game_creation.generation_seed = seed;
 
-	StartGeneratingLandscape(GLWM_GENERATE);
+
+	GenerateLandscapeWindowMode mode = GLWM_GENERATE;
+
+	if(_file_to_saveload.abstract_ftype == FT_HEIGHTMAP) {
+		uint x = 0;
+		uint y = 0;
+
+		/* If the function returns false, it means there was a problem loading the heightmap */
+		if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name, &x, &y)) return;
+
+		mode = GLWM_HEIGHTMAP;
+	}
+
+	StartGeneratingLandscape(mode);
 }
 
 struct CreateScenarioWindow : public Window

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -997,14 +997,14 @@ static void MakeNewEditorWorldDone()
 	SetLocalCompany(OWNER_NONE);
 }
 
-static void MakeNewEditorWorld()
+static void MakeNewEditorWorld(bool from_heightmap)
 {
 	_game_mode = GM_EDITOR;
 
 	ResetGRFConfig(true);
 
 	GenerateWorldSetCallback(&MakeNewEditorWorldDone);
-	GenerateWorld(GWM_EMPTY, 1 << _settings_game.game_creation.map_x, 1 << _settings_game.game_creation.map_y);
+	GenerateWorld(from_heightmap ? GWM_HEIGHTMAP : GWM_EMPTY, 1 << _settings_game.game_creation.map_x, 1 << _settings_game.game_creation.map_y);
 }
 
 /**
@@ -1048,7 +1048,7 @@ bool SafeLoad(const char *filename, SaveLoadOperation fop, DetailedFileType dft,
 			switch (ogm) {
 				default:
 				case GM_MENU:   LoadIntroGame();      break;
-				case GM_EDITOR: MakeNewEditorWorld(); break;
+				case GM_EDITOR: MakeNewEditorWorld(false); break;
 			}
 			return false;
 
@@ -1064,7 +1064,7 @@ void SwitchToMode(SwitchMode new_mode)
 	if (new_mode != SM_SAVE_GAME) {
 		/* If the network is active, make it not-active */
 		if (_networking) {
-			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
+			if (_network_server && (new_mode == SM_LOAD_GAME || new_mode == SM_START_HEIGHTMAP || new_mode == SM_NEWGAME || new_mode == SM_RESTARTGAME)) {
 				NetworkReboot();
 			} else {
 				NetworkDisconnect();
@@ -1094,7 +1094,7 @@ void SwitchToMode(SwitchMode new_mode)
 
 	switch (new_mode) {
 		case SM_EDITOR: // Switch to scenario editor
-			MakeNewEditorWorld();
+			MakeNewEditorWorld(false);
 			break;
 
 		case SM_RESTARTGAME: // Restart --> Current settings preserved
@@ -1155,10 +1155,7 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 
 		case SM_LOAD_HEIGHTMAP: // Load heightmap from scenario editor
-			SetLocalCompany(OWNER_NONE);
-
-			GenerateWorld(GWM_HEIGHTMAP, 1 << _settings_game.game_creation.map_x, 1 << _settings_game.game_creation.map_y);
-			MarkWholeScreenDirty();
+			MakeNewEditorWorld(true);
 			break;
 
 		case SM_LOAD_SCENARIO: { // Load scenario from scenario editor


### PR DESCRIPTION
Work inspired by the latest patch from old FlySpray bug tracker: https://bugs.openttd.org/task/2155/getfile/8568/Heightmap_Console_command.patch in #2155:
- Added `newheightmapgame` command accepting up to 2 parameters (file name, title or index to load - mandatory, and an optional seed)
- The short version with no argument reloads the current heightmap with a random seed
Sadly, there is no clean way to have a 2-arguments version where the second one would be the seed, as it would conflict with the 2-arguments version where the integer represent the file ID. Even if file ID was to be discarded, there would be some complicated and dangerous checks to check if the 2nd parameter is a string or an integer that could potentially introduce vulnerabilities.