### PR TITLE
Add: Configurable ship curve penalties (YAPF)

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -169,6 +169,21 @@ protected:
 	}
 
 public:
+	inline int CurveCost(Trackdir td1, Trackdir td2)
+	{
+		assert(IsValidTrackdir(td1));
+		assert(IsValidTrackdir(td2));
+
+		if (HasTrackdir(TrackdirCrossesTrackdirs(td1), td2)) {
+			/* 90-deg curve penalty */
+			return Yapf().PfGetSettings().ship_curve90_penalty;
+		} else if (td2 != NextTrackdir(td1)) {
+			/* 45-deg curve penalty */
+			return Yapf().PfGetSettings().ship_curve45_penalty;
+		}
+		return 0;
+	}
+
 	/**
 	 * Called by YAPF to calculate the cost from the origin to the given node.
 	 *  Calculates only the cost of given node, adds it to the parent node cost
@@ -179,10 +194,7 @@ public:
 		/* base tile cost depending on distance */
 		int c = IsDiagonalTrackdir(n.GetTrackdir()) ? YAPF_TILE_LENGTH : YAPF_TILE_CORNER_LENGTH;
 		/* additional penalty for curves */
-		if (n.GetTrackdir() != NextTrackdir(n.m_parent->GetTrackdir())) {
-			/* new trackdir does not match the next one when going straight */
-			c += YAPF_TILE_LENGTH;
-		}
+		c += CurveCost(n.m_parent->GetTrackdir(), n.GetTrackdir());
 
 		/* Skipped tile cost for aqueducts. */
 		c += YAPF_TILE_LENGTH * tf->m_tiles_skipped;

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -241,6 +241,16 @@ struct CYapfShip1 : CYapfT<CYapfShip_TypesT<CYapfShip1, CFollowTrackWater    , C
 /* YAPF type 2 - uses TileIndex/DiagDirection as Node key */
 struct CYapfShip2 : CYapfT<CYapfShip_TypesT<CYapfShip2, CFollowTrackWater    , CShipNodeListExitDir > > {};
 
+static inline bool RequireTrackdirKey()
+{
+	/* If the two curve penalties are not equal, then it is not possible to use the
+	 * ExitDir keyed node list, as it there will be key overlap. Using Trackdir keyed
+	 * nodes means potentially more paths are tested, which would be wasteful if it's
+	 * not necessary.
+	 */
+	return _settings_game.pf.yapf.ship_curve45_penalty != _settings_game.pf.yapf.ship_curve90_penalty;
+}
+
 /** Ship controller helper - path finder invoker */
 Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool &path_found, ShipPathCache &path_cache)
 {
@@ -249,7 +259,7 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir,
 	PfnChooseShipTrack pfnChooseShipTrack = CYapfShip2::ChooseShipTrack; // default: ExitDir
 
 	/* check if non-default YAPF type needed */
-	if (_settings_game.pf.yapf.disable_node_optimization) {
+	if (_settings_game.pf.yapf.disable_node_optimization || RequireTrackdirKey()) {
 		pfnChooseShipTrack = &CYapfShip1::ChooseShipTrack; // Trackdir
 	}
 
@@ -267,7 +277,7 @@ bool YapfShipCheckReverse(const Ship *v)
 	PfnCheckReverseShip pfnCheckReverseShip = CYapfShip2::CheckShipReverse; // default: ExitDir
 
 	/* check if non-default YAPF type needed */
-	if (_settings_game.pf.yapf.disable_node_optimization) {
+	if (_settings_game.pf.yapf.disable_node_optimization || RequireTrackdirKey()) {
 		pfnCheckReverseShip = &CYapfShip1::CheckShipReverse; // Trackdir
 	}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -292,6 +292,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 v1.9  Cargo monitor data packing fix to support 64 cargotypes.
 	SLV_TOWN_CARGOGEN,                      ///< 208  PR#6965 New algorithms for town building cargo generation.
+	SLV_SHIP_CURVE_PENALTY,                 ///< 209  PR#7289 Configurable ship curve penalties.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -418,6 +418,8 @@ struct YAPFSettings {
 	uint32 rail_longer_platform_per_tile_penalty;  ///< penalty for longer  station platform than train (per tile)
 	uint32 rail_shorter_platform_penalty;          ///< penalty for shorter station platform than train
 	uint32 rail_shorter_platform_per_tile_penalty; ///< penalty for shorter station platform than train (per tile)
+	uint32 ship_curve45_penalty;                   ///< penalty for 45-deg curve for ships
+	uint32 ship_curve90_penalty;                   ///< penalty for 90-deg curve for ships
 };
 
 /** Settings related to all pathfinders. */

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2163,6 +2163,26 @@ min      = 0
 max      = 1000000
 cat      = SC_EXPERT
 
+[SDT_VAR]
+base     = GameSettings
+var      = pf.yapf.ship_curve45_penalty
+type     = SLE_UINT
+from     = SLV_SHIP_CURVE_PENALTY
+def      = 1 * YAPF_TILE_LENGTH
+min      = 0
+max      = 1000000
+cat      = SC_EXPERT
+
+[SDT_VAR]
+base     = GameSettings
+var      = pf.yapf.ship_curve90_penalty
+type     = SLE_UINT
+from     = SLV_SHIP_CURVE_PENALTY
+def      = 6 * YAPF_TILE_LENGTH
+min      = 0
+max      = 1000000
+cat      = SC_EXPERT
+
 ##
 [SDT_VAR]
 base     = GameSettings


### PR DESCRIPTION
Add separate penalties for 45- and 90-degree curves for ships, similar to trains. Default penalties are the same, but may want tweaking.

This makes ships prefer a route with 45-degree turns, but they can still take 90-degree turns and not get stuck.