### PR TITLE
Fix multiplayer emergency save

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -125,6 +125,7 @@ struct PacketReader : LoadFilter {
 void ClientNetworkEmergencySave()
 {
 	if (!_settings_client.gui.autosave_on_network_disconnect) return;
+	if (!_networking) return;
 
 	const char *filename = "netsave.sav";
 	DEBUG(net, 0, "Client: Performing emergency save (%s)", filename);
@@ -211,6 +212,8 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 			res != NETWORK_RECV_STATUS_SERVER_BANNED) {
 		SendError(errorno);
 	}
+
+	ClientNetworkEmergencySave();
 
 	_switch_mode = SM_MENU;
 	this->CloseConnection(res);
@@ -1173,7 +1176,6 @@ void ClientNetworkGameSocketHandler::CheckConnection()
 	if (lag > 20) {
 		this->NetworkGameSocketHandler::CloseConnection();
 		ShowErrorMessage(STR_NETWORK_ERROR_LOSTCONNECTION, INVALID_STRING_ID, WL_CRITICAL);
-		ClientNetworkEmergencySave();
 		return;
 	}
 


### PR DESCRIPTION
This should (hopefully) make saves due to desync happen correctly, and avoid saving twice when the server stops responding and times out.

Also adds a hotkey to help in testing desync behaviour.