### PR TITLE
Feature: When filtering purchase list by cargo type, make buy button perform a refit if required.

### DIFF
--- a/bin/ai/regression/tst_regression/main.nut
+++ b/bin/ai/regression/tst_regression/main.nut
@@ -1704,6 +1704,19 @@ function Regression::Vehicle()
 	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17 3));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 3));
 
+	print("  --Refit--");
+	print("    GetBuildWithRefitCapacity(): " + AIVehicle.GetBuildWithRefitCapacity(28479, 211, 255));
+	print("    GetBuildWithRefitCapacity(): " + AIVehicle.GetBuildWithRefitCapacity(28479, 211, 0));
+	print("    GetBuildWithRefitCapacity(): " + AIVehicle.GetBuildWithRefitCapacity(28479, 211, 9));
+	print("    BuildVehicleWithRefit():     " + AIVehicle.BuildVehicleWithRefit(28479, 211, 9));
+	print("    GetCapacity():               " + AIVehicle.GetCapacity(20, 9));
+	print("    GetCapacity():               " + AIVehicle.GetCapacity(20, 5));
+	print("    GetRefitCapacity():          " + AIVehicle.GetRefitCapacity(20, 5));
+	print("    RefitVehicle():              " + AIVehicle.RefitVehicle(20, 5));
+	print("    GetCapacity():               " + AIVehicle.GetCapacity(20, 9));
+	print("    GetCapacity():               " + AIVehicle.GetCapacity(20, 5));
+	print("    SellVehicle():               " + AIVehicle.SellVehicle(20));
+
 	print("  --Errors--");
 	print("    RefitVehicle():        " + AIVehicle.RefitVehicle(12, 0));
 	print("    GetLastErrorString():  " + AIError.GetLastErrorString());

--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -9128,6 +9128,18 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetWagonAge():        0
   GetWagonEngineType(): 65535
   GetWagonAge():        -1
+  --Refit--
+    GetBuildWithRefitCapacity(): -1
+    GetBuildWithRefitCapacity(): 0
+    GetBuildWithRefitCapacity(): 160
+    BuildVehicleWithRefit():     20
+    GetCapacity():               160
+    GetCapacity():               0
+    GetRefitCapacity():          160
+    RefitVehicle():              true
+    GetCapacity():               0
+    GetCapacity():               160
+    SellVehicle():               true
   --Errors--
     RefitVehicle():        false
     GetLastErrorString():  ERR_VEHICLE_NOT_IN_DEPOT
@@ -9175,7 +9187,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     13 => 5489
     12 => 5489
   CurrentSpeed ListDump:
-    12 => 21
+    12 => 27
     17 => 0
     16 => 0
     14 => 0

--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -168,16 +168,16 @@ CargoArray GetCapacityOfArticulatedParts(EngineID engine)
  * @param engine Model to investigate.
  * @param[out] cargoes Total amount of units that can be transported, summed by cargo.
  * @param[out] refits Whether a (possibly partial) refit for each cargo is possible.
+ * @param cargo_type Selected refitted cargo type
+ * @param cargo_capacity Capacity of selected refitted cargo type
  */
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits)
+void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint16 cargo_capacity)
 {
 	cargoes->Clear();
 	*refits = 0;
 
 	const Engine *e = Engine::Get(engine);
 
-	CargoID cargo_type;
-	uint16 cargo_capacity = GetVehicleDefaultCapacity(engine, &cargo_type);
 	if (cargo_type < NUM_CARGO && cargo_capacity > 0) {
 		(*cargoes)[cargo_type] += cargo_capacity;
 		if (IsEngineRefittable(engine)) SetBit(*refits, cargo_type);

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -294,7 +294,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 	if (refit_cargo == CT_INVALID) return CommandCost(); // incompatible cargoes
 
 	/* Build the new vehicle */
-	cost = DoCommand(old_veh->tile, e, 0, DC_EXEC | DC_AUTOREPLACE, GetCmdBuildVeh(old_veh));
+	cost = DoCommand(old_veh->tile, e | (CT_INVALID << 24), 0, DC_EXEC | DC_AUTOREPLACE, GetCmdBuildVeh(old_veh));
 	if (cost.Failed()) return cost;
 
 	Vehicle *new_veh = Vehicle::Get(_new_vehicle_id);

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -423,9 +423,16 @@ public:
 			/* Draw details panels. */
 			for (int side = 0; side < 2; side++) {
 				if (this->sel_engine[side] != INVALID_ENGINE) {
+					/* Use default engine details without refitting */
+					const Engine *e = Engine::Get(this->sel_engine[side]);
+					TestedEngineDetails ted;
+					ted.cost = 0;
+					ted.cargo = e->GetDefaultCargoType();
+					ted.capacity = e->GetDisplayDefaultCapacity(&ted.mail_capacity);
+
 					NWidgetBase *nwi = this->GetWidget<NWidgetBase>(side == 0 ? WID_RV_LEFT_DETAILS : WID_RV_RIGHT_DETAILS);
 					int text_end = DrawVehiclePurchaseInfo(nwi->pos_x + WD_FRAMETEXT_LEFT, nwi->pos_x + nwi->current_x - WD_FRAMETEXT_RIGHT,
-							nwi->pos_y + WD_FRAMERECT_TOP, this->sel_engine[side]);
+							nwi->pos_y + WD_FRAMERECT_TOP, this->sel_engine[side], ted);
 					needed_height = max(needed_height, text_end - (int)nwi->pos_y + WD_FRAMERECT_BOTTOM);
 				}
 			}

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -989,6 +989,22 @@ struct BuildVehicleWindow : Window {
 	int details_height;                         ///< Minimal needed height of the details panels (found so far).
 	Scrollbar *vscroll;
 
+	void SetBuyVehicleText()
+	{
+		NWidgetCore *widget = this->GetWidget<NWidgetCore>(WID_BV_BUILD);
+
+		bool refit = this->sel_engine != INVALID_ENGINE && this->cargo_filter[this->cargo_filter_criteria] != CF_ANY && this->cargo_filter[this->cargo_filter_criteria] != CF_NONE;
+		if (refit) refit = Engine::Get(this->sel_engine)->GetDefaultCargoType() != this->cargo_filter[this->cargo_filter_criteria];
+
+		if (refit) {
+			widget->widget_data = STR_BUY_VEHICLE_TRAIN_BUY_REFIT_VEHICLE_BUTTON + this->vehicle_type;
+			widget->tool_tip    = STR_BUY_VEHICLE_TRAIN_BUY_REFIT_VEHICLE_TOOLTIP + this->vehicle_type;
+		} else {
+			widget->widget_data = STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_BUTTON + this->vehicle_type;
+			widget->tool_tip    = STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_TOOLTIP + this->vehicle_type;
+		}
+	}
+
 	BuildVehicleWindow(WindowDesc *desc, TileIndex tile, VehicleType type) : Window(desc)
 	{
 		this->vehicle_type = type;
@@ -1031,10 +1047,6 @@ struct BuildVehicleWindow : Window {
 		widget = this->GetWidget<NWidgetCore>(WID_BV_SHOW_HIDE);
 		widget->tool_tip = STR_BUY_VEHICLE_TRAIN_HIDE_SHOW_TOGGLE_TOOLTIP + type;
 
-		widget = this->GetWidget<NWidgetCore>(WID_BV_BUILD);
-		widget->widget_data = STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_BUTTON + type;
-		widget->tool_tip    = STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_TOOLTIP + type;
-
 		widget = this->GetWidget<NWidgetCore>(WID_BV_RENAME);
 		widget->widget_data = STR_BUY_VEHICLE_TRAIN_RENAME_BUTTON + type;
 		widget->tool_tip    = STR_BUY_VEHICLE_TRAIN_RENAME_TOOLTIP + type;
@@ -1054,6 +1066,7 @@ struct BuildVehicleWindow : Window {
 		this->GenerateBuildList(); // generate the list, since we need it in the next line
 		/* Select the first engine in the list as default when opening the window */
 		if (this->eng_list.Length() > 0) this->sel_engine = this->eng_list[0];
+		this->SetBuyVehicleText();
 	}
 
 	/** Populate the filter list and set the cargo filter criteria. */
@@ -1111,8 +1124,10 @@ struct BuildVehicleWindow : Window {
 		this->eng_list.Filter(this->cargo_filter[this->cargo_filter_criteria]);
 		if (0 == this->eng_list.Length()) { // no engine passed through the filter, invalidate the previously selected engine
 			this->sel_engine = INVALID_ENGINE;
+			this->SetBuyVehicleText();
 		} else if (!this->eng_list.Contains(this->sel_engine)) { // previously selected engine didn't pass the filter, select the first engine of the list
 			this->sel_engine = this->eng_list[0];
+			this->SetBuyVehicleText();
 		}
 	}
 
@@ -1294,6 +1309,7 @@ struct BuildVehicleWindow : Window {
 				uint i = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_BV_LIST);
 				size_t num_items = this->eng_list.Length();
 				this->sel_engine = (i < num_items) ? this->eng_list[i] : INVALID_ENGINE;
+				this->SetBuyVehicleText();
 				this->SetDirty();
 				if (_ctrl_pressed) {
 					this->OnClick(pt, WID_BV_SHOW_HIDE, 1);
@@ -1323,7 +1339,9 @@ struct BuildVehicleWindow : Window {
 				EngineID sel_eng = this->sel_engine;
 				if (sel_eng != INVALID_ENGINE) {
 					CommandCallback *callback = (this->vehicle_type == VEH_TRAIN && RailVehInfo(sel_eng)->railveh_type == RAILVEH_WAGON) ? CcBuildWagon : CcBuildPrimaryVehicle;
-					DoCommandP(this->window_number, sel_eng, 0, GetCmdBuildVeh(this->vehicle_type), callback);
+					bool refit = this->cargo_filter[this->cargo_filter_criteria] != CF_ANY && this->cargo_filter[this->cargo_filter_criteria] != CF_NONE;
+					CargoID cargo = refit ? this->cargo_filter[this->cargo_filter_criteria] : CT_INVALID;
+					DoCommandP(this->window_number, sel_eng | (cargo << 24), 0, GetCmdBuildVeh(this->vehicle_type), callback);
 				}
 				break;
 			}
@@ -1411,6 +1429,13 @@ struct BuildVehicleWindow : Window {
 				break;
 			}
 
+			case WID_BV_BUILD:
+				*size = GetStringBoundingBox(STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_BUTTON + this->vehicle_type);
+				*size = maxdim(*size, GetStringBoundingBox(STR_BUY_VEHICLE_TRAIN_BUY_REFIT_VEHICLE_BUTTON + this->vehicle_type));
+				size->width += padding.width;
+				size->height += padding.height;
+				break;
+
 			case WID_BV_SHOW_HIDE:
 				*size = GetStringBoundingBox(STR_BUY_VEHICLE_TRAIN_HIDE_TOGGLE_BUTTON + this->vehicle_type);
 				*size = maxdim(*size, GetStringBoundingBox(STR_BUY_VEHICLE_TRAIN_SHOW_TOGGLE_BUTTON + this->vehicle_type));
@@ -1485,6 +1510,7 @@ struct BuildVehicleWindow : Window {
 					/* deactivate filter if criteria is 'Show All', activate it otherwise */
 					this->eng_list.SetFilterState(this->cargo_filter[this->cargo_filter_criteria] != CF_ANY);
 					this->eng_list.ForceRebuild();
+					this->SetBuyVehicleText();
 				}
 				break;
 		}

--- a/src/engine_func.h
+++ b/src/engine_func.h
@@ -26,7 +26,7 @@ extern const uint8 _engine_offsets[4];
 
 bool IsEngineBuildable(EngineID engine, VehicleType type, CompanyID company);
 bool IsEngineRefittable(EngineID engine);
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits);
+void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint16 cargo_capacity);
 void SetYearEngineAgingStops();
 void StartupOneEngine(Engine *e, Date aging_date);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3469,6 +3469,7 @@ STR_BUY_VEHICLE_SHIP_CAPTION                                    :New Ships
 STR_BUY_VEHICLE_AIRCRAFT_CAPTION                                :New Aircraft
 
 STR_PURCHASE_INFO_COST_WEIGHT                                   :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} Weight: {GOLD}{WEIGHT_SHORT}
+STR_PURCHASE_INFO_COST_REFIT_WEIGHT                             :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} (Refit Cost: {GOLD}{CURRENCY_LONG}{BLACK}) Weight: {GOLD}{WEIGHT_SHORT}
 STR_PURCHASE_INFO_SPEED_POWER                                   :{BLACK}Speed: {GOLD}{VELOCITY}{BLACK} Power: {GOLD}{POWER}
 STR_PURCHASE_INFO_SPEED                                         :{BLACK}Speed: {GOLD}{VELOCITY}
 STR_PURCHASE_INFO_SPEED_OCEAN                                   :{BLACK}Speed on ocean: {GOLD}{VELOCITY}
@@ -3479,8 +3480,10 @@ STR_PURCHASE_INFO_REFITTABLE                                    :(refittable)
 STR_PURCHASE_INFO_DESIGNED_LIFE                                 :{BLACK}Designed: {GOLD}{NUM}{BLACK} Life: {GOLD}{COMMA} year{P "" s}
 STR_PURCHASE_INFO_RELIABILITY                                   :{BLACK}Max. Reliability: {GOLD}{COMMA}%
 STR_PURCHASE_INFO_COST                                          :{BLACK}Cost: {GOLD}{CURRENCY_LONG}
+STR_PURCHASE_INFO_COST_REFIT                                    :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} (Refit Cost: {GOLD}{CURRENCY_LONG}{BLACK})
 STR_PURCHASE_INFO_WEIGHT_CWEIGHT                                :{BLACK}Weight: {GOLD}{WEIGHT_SHORT} ({WEIGHT_SHORT})
 STR_PURCHASE_INFO_COST_SPEED                                    :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} Speed: {GOLD}{VELOCITY}
+STR_PURCHASE_INFO_COST_REFIT_SPEED                              :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} (Refit Cost: {GOLD}{CURRENCY_LONG}{BLACK}) Speed: {GOLD}{VELOCITY}
 STR_PURCHASE_INFO_AIRCRAFT_CAPACITY                             :{BLACK}Capacity: {GOLD}{CARGO_LONG}, {CARGO_LONG}
 STR_PURCHASE_INFO_PWAGPOWER_PWAGWEIGHT                          :{BLACK}Powered Wagons: {GOLD}+{POWER}{BLACK} Weight: {GOLD}+{WEIGHT_SHORT}
 STR_PURCHASE_INFO_REFITTABLE_TO                                 :{BLACK}Refittable to: {GOLD}{STRING2}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3501,10 +3501,20 @@ STR_BUY_VEHICLE_ROAD_VEHICLE_BUY_VEHICLE_BUTTON                 :{BLACK}Buy Vehi
 STR_BUY_VEHICLE_SHIP_BUY_VEHICLE_BUTTON                         :{BLACK}Buy Ship
 STR_BUY_VEHICLE_AIRCRAFT_BUY_VEHICLE_BUTTON                     :{BLACK}Buy Aircraft
 
+STR_BUY_VEHICLE_TRAIN_BUY_REFIT_VEHICLE_BUTTON                  :{BLACK}Buy and Refit Vehicle
+STR_BUY_VEHICLE_ROAD_VEHICLE_BUY_REFIT_VEHICLE_BUTTON           :{BLACK}Buy and Refit Vehicle
+STR_BUY_VEHICLE_SHIP_BUY_REFIT_VEHICLE_BUTTON                   :{BLACK}Buy and Refit Ship
+STR_BUY_VEHICLE_AIRCRAFT_BUY_REFIT_VEHICLE_BUTTON               :{BLACK}Buy and Refit Aircraft
+
 STR_BUY_VEHICLE_TRAIN_BUY_VEHICLE_TOOLTIP                       :{BLACK}Buy the highlighted train vehicle. Shift+Click shows estimated cost without purchase
 STR_BUY_VEHICLE_ROAD_VEHICLE_BUY_VEHICLE_TOOLTIP                :{BLACK}Buy the highlighted road vehicle. Shift+Click shows estimated cost without purchase
 STR_BUY_VEHICLE_SHIP_BUY_VEHICLE_TOOLTIP                        :{BLACK}Buy the highlighted ship. Shift+Click shows estimated cost without purchase
 STR_BUY_VEHICLE_AIRCRAFT_BUY_VEHICLE_TOOLTIP                    :{BLACK}Buy the highlighted aircraft. Shift+Click shows estimated cost without purchase
+
+STR_BUY_VEHICLE_TRAIN_BUY_REFIT_VEHICLE_TOOLTIP                 :{BLACK}Buy and refit the highlighted train vehicle. Shift+Click shows estimated cost without purchase
+STR_BUY_VEHICLE_ROAD_VEHICLE_BUY_REFIT_VEHICLE_TOOLTIP          :{BLACK}Buy and refit the highlighted road vehicle. Shift+Click shows estimated cost without purchase
+STR_BUY_VEHICLE_SHIP_BUY_REFIT_VEHICLE_TOOLTIP                  :{BLACK}Buy and refit the highlighted ship. Shift+Click shows estimated cost without purchase
+STR_BUY_VEHICLE_AIRCRAFT_BUY_REFIT_VEHICLE_TOOLTIP              :{BLACK}Buy and refit the highlighted aircraft. Shift+Click shows estimated cost without purchase
 
 STR_BUY_VEHICLE_TRAIN_RENAME_BUTTON                             :{BLACK}Rename
 STR_BUY_VEHICLE_ROAD_VEHICLE_RENAME_BUTTON                      :{BLACK}Rename

--- a/src/script/api/ai/ai_vehicle.hpp.sq
+++ b/src/script/api/ai/ai_vehicle.hpp.sq
@@ -122,6 +122,8 @@ void SQAIVehicle_Register(Squirrel *engine)
 	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::IsInDepot,                      "IsInDepot",                      2, ".i");
 	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::IsStoppedInDepot,               "IsStoppedInDepot",               2, ".i");
 	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::BuildVehicle,                   "BuildVehicle",                   3, ".ii");
+	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::BuildVehicleWithRefit,          "BuildVehicleWithRefit",          4, ".iii");
+	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::GetBuildWithRefitCapacity,      "GetBuildWithRefitCapacity",      4, ".iii");
 	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::CloneVehicle,                   "CloneVehicle",                   4, ".iib");
 	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::MoveWagon,                      "MoveWagon",                      5, ".iiii");
 	SQAIVehicle.DefSQStaticMethod(engine, &ScriptVehicle::MoveWagonChain,                 "MoveWagonChain",                 5, ".iiii");

--- a/src/script/api/game/game_vehicle.hpp.sq
+++ b/src/script/api/game/game_vehicle.hpp.sq
@@ -123,6 +123,8 @@ void SQGSVehicle_Register(Squirrel *engine)
 	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::IsInDepot,                      "IsInDepot",                      2, ".i");
 	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::IsStoppedInDepot,               "IsStoppedInDepot",               2, ".i");
 	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::BuildVehicle,                   "BuildVehicle",                   3, ".ii");
+	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::BuildVehicleWithRefit,          "BuildVehicleWithRefit",          4, ".iii");
+	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::GetBuildWithRefitCapacity,      "GetBuildWithRefitCapacity",      4, ".iii");
 	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::CloneVehicle,                   "CloneVehicle",                   4, ".iib");
 	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::MoveWagon,                      "MoveWagon",                      5, ".iiii");
 	SQGSVehicle.DefSQStaticMethod(engine, &ScriptVehicle::MoveWagonChain,                 "MoveWagonChain",                 5, ".iiii");

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -70,7 +70,7 @@
 
 	EnforcePreconditionCustomError(VEHICLE_INVALID, !ScriptGameSettings::IsDisabledVehicleType((ScriptVehicle::VehicleType)type), ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED);
 
-	if (!ScriptObject::DoCommand(depot, engine_id, 0, ::GetCmdBuildVeh(type), NULL, &ScriptInstance::DoCommandReturnVehicleID)) return VEHICLE_INVALID;
+	if (!ScriptObject::DoCommand(depot, engine_id | (CT_INVALID << 24), 0, ::GetCmdBuildVeh(type), NULL, &ScriptInstance::DoCommandReturnVehicleID)) return VEHICLE_INVALID;
 
 	/* In case of test-mode, we return VehicleID 0 */
 	return 0;

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -321,6 +321,41 @@ public:
 	static VehicleID BuildVehicle(TileIndex depot, EngineID engine_id);
 
 	/**
+	 * Builds a vehicle with the given engine at the given depot and refits it to the given cargo.
+	 * @param depot The depot where the vehicle will be build.
+	 * @param engine_id The engine to use for this vehicle.
+	 * @param cargo The cargo to refit to.
+	 * @pre The tile at depot has a depot that can build the engine and
+	 *   is owned by you.
+	 * @pre ScriptEngine::IsBuildable(engine_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo).
+	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @exception ScriptVehicle::ERR_VEHICLE_TOO_MANY
+	 * @exception ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED
+	 * @exception ScriptVehicle::ERR_VEHICLE_WRONG_DEPOT
+	 * @return The VehicleID of the new vehicle, or an invalid VehicleID when
+	 *   it failed. Check the return value using IsValidVehicle. In test-mode
+	 *   0 is returned if it was successful; any other value indicates failure.
+	 * @note In Test Mode it means you can't assign orders yet to this vehicle,
+	 *   as the vehicle isn't really built yet. Build it for real first before
+	 *   assigning orders.
+	 */
+	static VehicleID BuildVehicleWithRefit(TileIndex depot, EngineID engine_id, CargoID cargo);
+
+	/**
+	 * Gets the capacity of a vehicle built at the given depot with the given engine and refitted to the given cargo.
+	 * @param depot The depot where the vehicle will be build.
+	 * @param engine_id The engine to use for this vehicle.
+	 * @param cargo The cargo to refit to.
+	 * @pre The tile at depot has a depot that can build the engine and
+	 *   is owned by you.
+	 * @pre ScriptEngine::IsBuildable(engine_id).
+	 * @pre ScriptCargo::IsValidCargo(cargo).
+	 * @return The capacity the vehicle will have when refited.
+	 */
+	static int GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo);
+
+	/**
 	 * Clones a vehicle at the given depot, copying or cloning its orders.
 	 * @param depot The depot where the vehicle will be build.
 	 * @param vehicle_id The vehicle to use as example for the new vehicle.
@@ -563,6 +598,11 @@ public:
 	static uint GetMaximumOrderDistance(VehicleID vehicle_id);
 
 private:
+	/**
+	 * Internal function used by BuildVehicle(WithRefit).
+	 */
+	static VehicleID _BuildVehicleInternal(TileIndex depot, EngineID engine_id, CargoID cargo);
+
 	/**
 	 * Internal function used by SellWagon(Chain).
 	 */

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -148,6 +148,9 @@ CommandCost CmdBuildVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 
 		if (refitting) {
 			value.AddCost(CmdRefitVehicle(tile, flags, v->index, cargo, NULL));
+		} else {
+			/* Fill in non-refitted capacities */
+			_returned_refit_capacity = e->GetDisplayDefaultCapacity(&_returned_mail_refit_capacity);
 		}
 
 		if (flags & DC_EXEC) {

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -37,7 +37,15 @@ enum VehicleInvalidateWindowData {
 	VIWD_AUTOREPLACE       = -4, ///< Autoreplace replaced the vehicle.
 };
 
-int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number);
+/** Extra information about refitted cargo and capacity */
+struct TestedEngineDetails {
+	Money cost;           ///< Refit cost
+	CargoID cargo;        ///< Cargo type
+	uint16 capacity;      ///< Cargo capacity
+	uint16 mail_capacity; ///< Mail capacity if available
+};
+
+int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, TestedEngineDetails &te);
 
 void DrawTrainImage(const Train *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip, VehicleID drag_dest = INVALID_VEHICLE);
 void DrawRoadVehImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip = 0);


### PR DESCRIPTION
This solves a user-experience issue where purchasing a vehicle ends up with the 'wrong' cargo type.

This turned out to be quite nasty to implement as testing a refit cost requires a vehicle to be present. This is achieved similarly to how autoreplace works, by buying the vehicle and then selling it again, if in test mode.