### PR TITLE
Codechange: Make std::stack use std::vector container in string formatting/drawing.

### DIFF
--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <string>
 #include <stack>
+#include <vector>
 
 #ifdef WITH_ICU_LAYOUT
 #include "layout/ParagraphLayout.h"
@@ -35,7 +36,7 @@ struct FontState {
 	FontSize fontsize;       ///< Current font size.
 	TextColour cur_colour;   ///< Current text colour.
 
-	std::stack<TextColour> colour_stack; ///< Stack of colours to assist with colour switching.
+	std::stack<TextColour, std::vector<TextColour>> colour_stack; ///< Stack of colours to assist with colour switching.
 
 	FontState() : fontsize(FS_END), cur_colour(TC_INVALID) {}
 	FontState(TextColour colour, FontSize fontsize) : fontsize(fontsize), cur_colour(colour) {}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -791,7 +791,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 	WChar b = '\0';
 	uint next_substr_case_index = 0;
 	char *buf_start = buff;
-	std::stack<const char *> str_stack;
+	std::stack<const char *, std::vector<const char *>> str_stack;
 	str_stack.push(str_arg);
 
 	for (;;) {


### PR DESCRIPTION
This is a very minor performance increase which can add up during operations such
as sorting. Performance impact my be platform/compiler dependent.

When sorting a list of 32k signs in the sign window, the following timings were noted:
- In master: 200-400ms/t
- With this change: 64-96ms/t