### PR TITLE
Feature: Increased aircraft breakdown rate based on travelled tiles.

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -75,6 +75,7 @@ struct AircraftCache {
  */
 struct Aircraft FINAL : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	uint16 crashed_counter;        ///< Timer for handling crash animations.
+	uint16 flight_counter;         ///< Handler for flight distance since last takeoff.
 	byte pos;                      ///< Next desired position of the aircraft.
 	byte previous_pos;             ///< Previous desired position of the aircraft.
 	StationID targetairport;       ///< Airport to go to next.
@@ -135,6 +136,15 @@ struct Aircraft FINAL : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	uint16 GetRange() const
 	{
 		return this->acache.cached_max_range;
+	}
+
+	/** Increase flight_counter everytime the aircraft coordinates don't match. */
+	void UpdateFlightDistance(Aircraft *v, TileIndex old_pos, TileIndex new_pos)
+	{
+		if (old_pos == new_pos) return;
+		if (v->flight_counter == UINT16_MAX) return;
+
+		v->flight_counter = v->flight_counter < UINT16_MAX - 1 ? v->flight_counter + 1 : UINT16_MAX;
 	}
 };
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -892,6 +892,7 @@ static bool AircraftController(Aircraft *v)
 		if (u->cur_speed > 32) {
 			v->cur_speed = 0;
 			if (--u->cur_speed == 32) {
+				v->flight_counter = 0;
 				if (!PlayVehicleSound(v, VSE_START)) {
 					SndPlayVehicleFx(SND_18_HELICOPTER, v);
 				}
@@ -1110,6 +1111,7 @@ static bool AircraftController(Aircraft *v)
 
 		}
 
+		if (v->state == FLYING || v->state == ENDTAKEOFF || v->state == LANDING || v->state == HELILANDING) v->UpdateFlightDistance(v, TileVirtXY(v->x_pos, v->y_pos), TileVirtXY(gp.x, gp.y));
 		SetAircraftPosition(v, gp.x, gp.y, z);
 	} while (--count != 0);
 	return false;
@@ -1563,6 +1565,7 @@ static void AircraftEventHandler_TakeOff(Aircraft *v, const AirportFTAClass *apc
 {
 	PlayAircraftSound(v); // play takeoffsound for airplanes
 	v->state = STARTTAKEOFF;
+	v->flight_counter = 0;
 }
 
 static void AircraftEventHandler_StartTakeOff(Aircraft *v, const AirportFTAClass *apc)

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1256,6 +1256,10 @@ STR_CONFIG_SETTING_FREIGHT_TRAINS_HELPTEXT                      :Set the impact 
 STR_CONFIG_SETTING_PLANE_SPEED                                  :Plane speed factor: {STRING2}
 STR_CONFIG_SETTING_PLANE_SPEED_HELPTEXT                         :Set the relative speed of planes compared to other vehicle types, to reduce the amount of income of transport by aircraft
 STR_CONFIG_SETTING_PLANE_SPEED_VALUE                            :1 / {COMMA}
+STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST                         :Increased aircraft breakdown rate after: {STRING2}
+STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST_HELPTEXT                :If vehicle breakdowns are enabled, this sets how many tiles it takes for an aircraft to travel before it's forced to breakdown, if it hasn't already
+STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST_VALUE                   :{COMMA}{NBSP}tile{P "" s}
+STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST_VALUE_DISABLED          :Disabled
 STR_CONFIG_SETTING_PLANE_CRASHES                                :Number of plane crashes: {STRING2}
 STR_CONFIG_SETTING_PLANE_CRASHES_HELPTEXT                       :Set the chance of an aircraft crash happening
 STR_CONFIG_SETTING_PLANE_CRASHES_NONE                           :None
@@ -3755,6 +3759,9 @@ STR_VEHICLE_INFO_WEIGHT_POWER_MAX_SPEED_MAX_TE                  :{BLACK}Weight: 
 
 STR_VEHICLE_INFO_PROFIT_THIS_YEAR_LAST_YEAR                     :{BLACK}Profit this year: {LTBLUE}{CURRENCY_LONG} (last year: {CURRENCY_LONG})
 STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS                         :{BLACK}Reliability: {LTBLUE}{COMMA}%  {BLACK}Breakdowns since last service: {LTBLUE}{COMMA}
+STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS_FLOWN                   :{BLACK}Reliability: {LTBLUE}{COMMA}%  {BLACK}Breakdowns since last service: {LTBLUE}{COMMA}  {BLACK}Distance flown: {LTBLUE}{STRING2}
+STR_VEHICLE_INFO_FLOWN                                          :{COMMA}{NBSP}tile{P "" s}
+STR_VEHICLE_INFO_FLOWN_RED                                      :{RED}{COMMA}{NBSP}tile{P "" s}
 
 STR_VEHICLE_INFO_BUILT_VALUE                                    :{LTBLUE}{ENGINE} {BLACK}Built: {LTBLUE}{NUM}{BLACK} Value: {LTBLUE}{CURRENCY_LONG}
 STR_VEHICLE_INFO_NO_CAPACITY                                    :{BLACK}Capacity: {LTBLUE}None{STRING}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1696,7 +1696,6 @@ bool AfterLoadGame()
 		}
 	}
 
-
 	if (IsSavegameVersionBefore(SLV_93)) {
 		/* Rework of orders. */
 		Order *order;
@@ -3078,6 +3077,14 @@ bool AfterLoadGame()
 				s->z_pos = GetTileZ(s->tile) * (int)TILE_HEIGHT;
 			}
 		}
+	}
+
+	if (IsSavegameVersionBefore(SLV_PLANE_BREAKDOWN_DIST)) {
+		Aircraft *a;
+		FOR_ALL_AIRCRAFT(a) {
+			a->flight_counter = 0;
+		}
+		_settings_game.vehicle.plane_breakdown_dist = 0;
 	}
 
 	/* Station acceptance is some kind of cache */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -291,6 +291,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GROUP_LIVERIES,                     ///< 205  PR#7108 Livery storage change and group liveries.
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 Cargo monitor data packing fix to support 64 cargotypes.
+	SLV_PLANE_BREAKDOWN_DIST,               ///< 208          Increased aircraft breakdown rate based on travelled tiles.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -785,6 +785,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		SLE_WRITEBYTE(Vehicle, type),
 		SLE_VEH_INCLUDE(),
 		     SLE_VAR(Aircraft, crashed_counter,       SLE_UINT16),
+		 SLE_CONDVAR(Aircraft, flight_counter,        SLE_UINT16,                   SLV_PLANE_BREAKDOWN_DIST, SL_MAX_VERSION),
 		     SLE_VAR(Aircraft, pos,                   SLE_UINT8),
 
 		 SLE_CONDVAR(Aircraft, targetairport,         SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION, SLV_5),

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1694,6 +1694,7 @@ static SettingsContainer &GetSettingsTree()
 			disasters->Add(new SettingEntry("difficulty.disasters"));
 			disasters->Add(new SettingEntry("difficulty.economy"));
 			disasters->Add(new SettingEntry("difficulty.vehicle_breakdowns"));
+			disasters->Add(new SettingEntry("vehicle.plane_breakdown_dist"));
 			disasters->Add(new SettingEntry("vehicle.plane_crashes"));
 		}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -472,6 +472,7 @@ struct VehicleSettings {
 	bool   never_expire_vehicles;            ///< never expire vehicles
 	byte   extend_vehicle_life;              ///< extend vehicle life by this many years
 	byte   road_side;                        ///< the side of the road vehicles drive on
+	uint16 plane_breakdown_dist;             ///< distance before increasing breakdown chance during a flight
 	uint8  plane_crashes;                    ///< number of plane crashes, 0 = none, 1 = reduced, 2 = normal
 };
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1139,6 +1139,21 @@ strhelp  = STR_CONFIG_SETTING_PLANE_CRASHES_HELPTEXT
 strval   = STR_CONFIG_SETTING_PLANE_CRASHES_NONE
 cat      = SC_BASIC
 
+[SDT_VAR]
+base     = GameSettings
+var      = vehicle.plane_breakdown_dist
+type     = SLE_UINT16
+from     = SLV_PLANE_BREAKDOWN_DIST
+guiflags = SGF_0ISDISABLED
+def      = 500
+min      = 0
+max      = 65535
+interval = 15
+str      = STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST
+strhelp  = STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST_HELPTEXT
+strval   = STR_CONFIG_SETTING_PLANE_BREAKDOWN_DIST_VALUE
+cat      = SC_EXPERT
+
 ; station.join_stations
 [SDT_NULL]
 length   = 1

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1238,7 +1238,13 @@ void CheckVehicleBreakdown(Vehicle *v)
 
 	/* increase chance of failure */
 	int chance = v->breakdown_chance + 1;
-	if (Chance16I(1, 25, r)) chance += 25;
+	if (Chance16I(1, 25, r) || _settings_game.vehicle.plane_breakdown_dist &&
+			v->type == VEH_AIRCRAFT && !(v->vehstatus & VS_AIRCRAFT_BROKEN) &&
+		    (Aircraft::From(v)->state == FLYING || Aircraft::From(v)->state == ENDTAKEOFF ||
+			Aircraft::From(v)->state == LANDING || Aircraft::From(v)->state == HELILANDING) &&
+			Aircraft::From(v)->flight_counter >= _settings_game.vehicle.plane_breakdown_dist) {
+		chance += 25;
+	}
 	v->breakdown_chance = min(255, chance);
 
 	/* calculate reliability value to use in comparison */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2092,7 +2092,9 @@ struct VehicleDetailsWindow : Window {
 				/* Draw breakdown & reliability */
 				SetDParam(0, ToPercent16(v->reliability));
 				SetDParam(1, v->breakdowns_since_last_service);
-				DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS);
+				SetDParam(2, (_settings_game.difficulty.vehicle_breakdowns >= 1 && Aircraft::From(v)->flight_counter >= _settings_game.vehicle.plane_breakdown_dist && _settings_game.vehicle.plane_breakdown_dist) ? STR_VEHICLE_INFO_FLOWN_RED : STR_VEHICLE_INFO_FLOWN);
+				SetDParam(3, Aircraft::From(v)->flight_counter);
+				DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS_FLOWN);
 				break;
 			}
 


### PR DESCRIPTION
https://www.tt-forums.net/viewtopic.php?p=1184036#p1184036

This patch adds an expert game setting which increases the chances of an aircraft to breakdown every passing day after travelling a user defined number of tiles since last takeoff, ranging from 1 to 65535. If it's set to 0, the feature is disabled. Requires breakdowns being enabled, and it's only kicking in if the aircraft hasn't broken down yet.

Additionally, aircraft have a new property which allows them to keep track of their currently travelled distance by the means of a counter. Each time an aircraft moves from a tile to another, the count is increased by 1. The maximum limit of this counter is 65535, which is equivalent to saying that it has already changed its tile position 65535 times.

- Savegames before this patch will treat this game setting as disabled.
- Aircraft from savegames before this patch don't have the feature to keep track of distance travelled. This patch treats them as having travelled 0 tiles.
- Default value of this setting is 500 tiles. 0 disables it. It is increased or decreased in steps of 15 tiles when pressing the arrows.

![unnamed 1950-12-30](https://user-images.githubusercontent.com/43006711/53689655-57bb0e00-3d52-11e9-96d3-4a2db738d7d4.png)
