### PR TITLE
Change: Pause running costs on standard road stops.

### DIFF
--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1593,7 +1593,8 @@ bool RoadVehicle::Tick()
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {
-		if (!(this->vehstatus & VS_STOPPED)) this->running_ticks++;
+		bool pause_running_cost = (this->current_order.GetType() == OT_LOADING || this->current_order.GetType() == OT_LEAVESTATION) && IsStandardRoadStopTile(this->tile);
+		if (!(this->vehstatus & VS_STOPPED) && !pause_running_cost) this->running_ticks++;
 		return RoadVehController(this);
 	}
 


### PR DESCRIPTION
https://www.tt-forums.net/viewtopic.php?p=1183356#p1183356

While a road vehicle is loading or unloading from a lorry or bus station with bays (non drive through), the running cost of the vehicle is paused.

The goals with this patch were a few:
- simulate engines being turned off
- another differentiation between standard road stations and drive through road stations
- improve profit for short distance routes