### PR TITLE
Change: Separate forbid 90 deg for trains and ships

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1200,8 +1200,10 @@ STR_CONFIG_SETTING_TRAIN_SLOPE_STEEPNESS_HELPTEXT               :Steepness of a 
 STR_CONFIG_SETTING_PERCENTAGE                                   :{COMMA}%
 STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS                 :Slope steepness for road vehicles: {STRING2}
 STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS_HELPTEXT        :Steepness of a sloped tile for a road vehicle. Higher values make it more difficult to climb a hill
-STR_CONFIG_SETTING_FORBID_90_DEG                                :Forbid trains and ships from making 90° turns: {STRING2}
-STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT                       :90 degree turns occur when a horizontal track is directly followed by a vertical track piece on the adjacent tile, thus making the train turn by 90 degree when traversing the tile edge instead of the usual 45 degrees for other track combinations. This also applies to the turning radius of ships
+STR_CONFIG_SETTING_FORBID_90_DEG                                :Forbid trains from making 90° turns: {STRING2}
+STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT                       :90 degree turns occur when a horizontal track is directly followed by a vertical track piece on the adjacent tile, thus making the train turn by 90 degree when traversing the tile edge instead of the usual 45 degrees for other track combinations
+STR_CONFIG_SETTING_FORBID_90_DEG_SHIPS                          :Forbid ships from making 90° turns: {STRING2}
+STR_CONFIG_SETTING_FORBID_90_DEG_SHIPS_HELPTEXT                 :90 degree turns occur when a horizontal track is directly followed by a vertical track piece on the adjacent tile, thus making the ship turn by 90 degree when traversing the tile edge instead of the usual 45 degrees for other track combinations
 STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS                        :Allow to join stations not directly adjacent: {STRING2}
 STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS_HELPTEXT               :Allow adding parts to a station without directly touching the existing parts. Needs Ctrl+Click while placing the new parts
 STR_CONFIG_SETTING_INFLATION                                    :Inflation: {STRING2}

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -835,8 +835,8 @@ static TrackdirBits GetDriveableTrackdirBits(TileIndex dst_tile, Trackdir src_tr
 	/* Select only trackdirs we can reach from our current trackdir */
 	trackdirbits &= TrackdirReachesTrackdirs(src_trackdir);
 
-	/* Filter out trackdirs that would make 90 deg turns for trains */
-	if (_settings_game.pf.forbid_90_deg && (type == TRANSPORT_RAIL || type == TRANSPORT_WATER)) trackdirbits &= ~TrackdirCrossesTrackdirs(src_trackdir);
+	/* Filter out trackdirs that would make 90 deg turns for trains and ships */
+	if (_settings_game.pf.forbid_90_deg && type == TRANSPORT_RAIL || _settings_game.pf.forbid_90_deg_ships && type == TRANSPORT_WATER) trackdirbits &= ~TrackdirCrossesTrackdirs(src_trackdir);
 
 	DEBUG(npf, 6, "After filtering: (%d, %d), possible trackdirs: 0x%X", TileX(dst_tile), TileY(dst_tile), trackdirbits);
 

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -239,7 +239,7 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir,
 	PfnChooseShipTrack pfnChooseShipTrack = CYapfShip2::ChooseShipTrack; // default: ExitDir, allow 90-deg
 
 	/* check if non-default YAPF type needed */
-	if (_settings_game.pf.forbid_90_deg) {
+	if (_settings_game.pf.forbid_90_deg_ships) {
 		pfnChooseShipTrack = &CYapfShip3::ChooseShipTrack; // Trackdir, forbid 90-deg
 	} else if (_settings_game.pf.yapf.disable_node_optimization) {
 		pfnChooseShipTrack = &CYapfShip1::ChooseShipTrack; // Trackdir, allow 90-deg
@@ -259,7 +259,7 @@ bool YapfShipCheckReverse(const Ship *v)
 	PfnCheckReverseShip pfnCheckReverseShip = CYapfShip2::CheckShipReverse; // default: ExitDir, allow 90-deg
 
 	/* check if non-default YAPF type needed */
-	if (_settings_game.pf.forbid_90_deg) {
+	if (_settings_game.pf.forbid_90_deg_ships) {
 		pfnCheckReverseShip = &CYapfShip3::CheckShipReverse; // Trackdir, forbid 90-deg
 	} else if (_settings_game.pf.yapf.disable_node_optimization) {
 		pfnCheckReverseShip = &CYapfShip1::CheckShipReverse; // Trackdir, allow 90-deg

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3080,6 +3080,11 @@ bool AfterLoadGame()
 		}
 	}
 
+	/* Previous versions didn't have separate 90-deg settings */
+	if (IsSavegameVersionBefore(SLV_FORBID_90_DEG_SHIPS)) {
+		_settings_game.pf.forbid_90_deg_ships = _settings_game.pf.forbid_90_deg;
+	}
+
 	/* Station acceptance is some kind of cache */
 	if (IsSavegameVersionBefore(SLV_127)) {
 		Station *st;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -291,6 +291,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GROUP_LIVERIES,                     ///< 205  PR#7108 Livery storage change and group liveries.
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 Cargo monitor data packing fix to support 64 cargotypes.
+	SLV_FORBID_90_DEG_SHIPS,                ///< 208  PR#7314 Separate Forbid 90-deg settings for trains and ships.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1658,6 +1658,7 @@ static SettingsContainer &GetSettingsTree()
 				routing->Add(new SettingEntry("difficulty.line_reverse_mode"));
 				routing->Add(new SettingEntry("pf.reverse_at_signals"));
 				routing->Add(new SettingEntry("pf.forbid_90_deg"));
+				routing->Add(new SettingEntry("pf.forbid_90_deg_ships"));
 				routing->Add(new SettingEntry("pf.pathfinder_for_roadvehs"));
 				routing->Add(new SettingEntry("pf.pathfinder_for_ships"));
 			}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -429,6 +429,7 @@ struct PathfinderSettings {
 
 	bool   roadveh_queue;                    ///< buggy road vehicle queueing
 	bool   forbid_90_deg;                    ///< forbid trains to make 90 deg turns
+	bool   forbid_90_deg_ships;              ///< forbid ships to make 90 deg turns
 
 	bool   reverse_at_signals;               ///< whether to reverse at signals at all
 	byte   wait_oneway_signal;               ///< waitingtime in days before a oneway signal

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -476,7 +476,7 @@ static Track ChooseShipTrack(Ship *v, TileIndex tile, DiagDirection enterdir, Tr
 		if (!IsDiagonalTrack(track)) track = TrackToOppositeTrack(track);
 		if (!HasBit(tracks, track)) {
 			/* Can't continue in same direction so pick first available track. */
-			if (_settings_game.pf.forbid_90_deg) {
+			if (_settings_game.pf.forbid_90_deg_ships) {
 				tracks &= ~TrackCrossesTracks(TrackdirToTrack(v->GetVehicleTrackdir()));
 				if (tracks == TRACK_BIT_NONE) return INVALID_TRACK;
 			}
@@ -522,7 +522,7 @@ static inline TrackBits GetAvailShipTracks(TileIndex tile, DiagDirection dir, Tr
 	TrackBits tracks = GetTileShipTrackStatus(tile) & DiagdirReachesTracks(dir);
 
 	/* Do not remove 90 degree turns for OPF, as it isn't able to find paths taking it into account. */
-	if (_settings_game.pf.forbid_90_deg && _settings_game.pf.pathfinder_for_ships != VPF_OPF) tracks &= ~TrackCrossesTracks(TrackdirToTrack(trackdir));
+	if (_settings_game.pf.forbid_90_deg_ships && _settings_game.pf.pathfinder_for_ships != VPF_OPF) tracks &= ~TrackCrossesTracks(TrackdirToTrack(trackdir));
 
 	return tracks;
 }

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -821,6 +821,15 @@ var      = pf.forbid_90_deg
 def      = false
 str      = STR_CONFIG_SETTING_FORBID_90_DEG
 strhelp  = STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT
+cat      = SC_EXPERT
+
+[SDT_BOOL]
+base     = GameSettings
+var      = pf.forbid_90_deg_ships
+def      = false
+from     = SLV_FORBID_90_DEG_SHIPS
+str      = STR_CONFIG_SETTING_FORBID_90_DEG_SHIPS
+strhelp  = STR_CONFIG_SETTING_FORBID_90_DEG_SHIPS_HELPTEXT
 proc     = InvalidateShipPathCache
 cat      = SC_EXPERT
 


### PR DESCRIPTION
https://www.tt-forums.net/viewtopic.php?p=1184322#p1184322

This patch splits the game setting "Forbid trains and ships from making 90º turns" into 2 separate settings:
- "Forbid trains from making 90º turns" - this game setting is re-using the value of the old setting for savegame conversion purposes.
- "Forbid ships from making 90º turns" - this game setting is new and copies the value of the old setting into it during savegame conversion.
- ship and train pathfinders have hopefully been dealt with, by using their respective vehicle type when checking the values of these settings as separate.
- new strings are added for ships.
- the old train strings have their text slighty modified, to accomodate the new behaviour (is for train only)