### PR TITLE
Feature: Move players to company accepting take-over offer.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -293,8 +293,15 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 	 * are the current local company. */
 	Backup<CompanyByte> cur_company(_current_company, old_owner, FILE_LINE);
 #ifdef ENABLE_NETWORK
-	/* In all cases, make spectators of clients connected to that company */
-	if (_networking) NetworkClientsToSpectators(old_owner);
+	if (_networking) {
+		if (Company::IsValidHumanID(new_owner) && Company::Get(new_owner)->settings.merge_players) {
+			/* Move clients to the new company */
+			NetworkClientsToCompany(old_owner, new_owner);
+		} else {
+			/* Make spectators of clients connected to that company */
+			NetworkClientsToSpectators(old_owner);
+		}
+	}
 #endif /* ENABLE_NETWORK */
 	if (old_owner == _local_company) {
 		/* Single player cheated to AI company.

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1494,6 +1494,8 @@ STR_CONFIG_SETTING_SERVINT_AIRCRAFT                             :Default service
 STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT                    :Set the default service interval for new aircraft, if no explicit service interval is set for the vehicle
 STR_CONFIG_SETTING_SERVINT_SHIPS                                :Default service interval for ships: {STRING2}
 STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT                       :Set the default service interval for new ships, if no explicit service interval is set for the vehicle
+STR_CONFIG_SETTING_MERGE_PLAYERS                                :Move players to purchasing company at liquidation: {STRING2}
+STR_CONFIG_SETTING_MERGE_PLAYERS_HELPTEXT                       :Enable to move all players from the offered company to the current company when accepting a take-over offer.
 STR_CONFIG_SETTING_NOSERVICE                                    :Disable servicing when breakdowns set to none: {STRING2}
 STR_CONFIG_SETTING_NOSERVICE_HELPTEXT                           :When enabled, vehicles do not get serviced if they cannot break down
 STR_CONFIG_SETTING_WAGONSPEEDLIMITS                             :Enable wagon speed limits: {STRING2}

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1240,6 +1240,26 @@ void NetworkClientsToSpectators(CompanyID cid)
 }
 
 /**
+ * Move the clients of a company to another company.
+ * @param cid_from The company to move the clients from.
+ * @param cid_to The company to move the clients to.
+ */
+void NetworkClientsToCompany(CompanyID cid_from, CompanyID cid_to)
+{
+	if (!_network_server) return;
+
+	Backup<CompanyByte> cur_company(_current_company, FILE_LINE);
+
+	NetworkClientInfo *ci;
+	FOR_ALL_CLIENT_INFOS(ci) {
+		if (ci->client_playas != cid_from) continue;
+		NetworkServerDoMove(ci->client_id, cid_to);
+	}
+
+	cur_company.Restore();
+}
+
+/**
  * Send the server our name.
  */
 void NetworkUpdateClientName()

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -53,6 +53,7 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
+void NetworkClientsToCompany(CompanyID cid_from, CompanyID cid_to);
 void NetworkClientConnectGame(NetworkAddress address, CompanyID join_as, const char *join_server_password = NULL, const char *join_company_password = NULL);
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3080,6 +3080,13 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_MERGE_PLAYERS)) {
+		Company * c;
+		FOR_ALL_COMPANIES(c) {
+			c->settings.merge_players = false;
+		}
+	}
+
 	/* Station acceptance is some kind of cache */
 	if (IsSavegameVersionBefore(SLV_127)) {
 		Station *st;

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -313,6 +313,8 @@ static const SaveLoad _company_settings_desc[] = {
 	SLE_CONDVAR(Company, settings.vehicle.servint_aircraft,  SLE_UINT16,     SLV_120, SL_MAX_VERSION),
 	SLE_CONDVAR(Company, settings.vehicle.servint_ships,     SLE_UINT16,     SLV_120, SL_MAX_VERSION),
 
+	SLE_CONDVAR(Company, settings.merge_players,               SLE_BOOL, SLV_MERGE_PLAYERS, SL_MAX_VERSION),
+
 	SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
 
 	SLE_END()
@@ -334,6 +336,8 @@ static const SaveLoad _company_settings_skip_desc[] = {
 	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_roadveh
 	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_aircraft
 	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_ships
+
+	SLE_CONDNULL(1, SLV_MERGE_PLAYERS, SL_MAX_VERSION),    // settings.merge_players
 
 	SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -291,6 +291,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GROUP_LIVERIES,                     ///< 205  PR#7108 Livery storage change and group liveries.
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 Cargo monitor data packing fix to support 64 cargotypes.
+	SLV_MERGE_PLAYERS,                      ///< 208          Move players to company accepting take-over offer.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1624,6 +1624,7 @@ static SettingsContainer &GetSettingsTree()
 			company->Add(new SettingEntry("vehicle.servint_roadveh"));
 			company->Add(new SettingEntry("vehicle.servint_ships"));
 			company->Add(new SettingEntry("vehicle.servint_aircraft"));
+			company->Add(new SettingEntry("company.merge_players"));
 		}
 
 		SettingsPage *accounting = main->Add(new SettingsPage(STR_CONFIG_SETTING_ACCOUNTING));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -546,6 +546,7 @@ struct CompanySettings {
 	uint32 engine_renew_money;               ///< minimum amount of money before autorenew is used
 	bool renew_keep_length;                  ///< sell some wagons if after autoreplace the train is longer than before
 	VehicleDefaultSettings vehicle;          ///< default settings for vehicles
+	bool merge_players;                      ///< move players from offering company to purchasing company on buyout
 };
 
 /** All settings together for the game. */

--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -133,6 +133,13 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
 proc     = UpdateIntervalAircraft
 
+[SDT_BOOL]
+base     = CompanySettings
+var      = merge_players
+def      = false
+str      = STR_CONFIG_SETTING_MERGE_PLAYERS
+strhelp  = STR_CONFIG_SETTING_MERGE_PLAYERS_HELPTEXT
+
 [SDT_END]
 
 


### PR DESCRIPTION
https://www.tt-forums.net/viewtopic.php?p=1201341#p1201341

Adds a company setting which allows to move the players of the offering company to the purchasing company when the company accepts the take-over offer.

When loading savegames before this patch, set it to disabled for each company.
Defaulted to disabled.