### PR TITLE
Change: Always report error when ordering a road vehicle to wrong type of road stop.

### DIFF
--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -399,7 +399,7 @@ static Order GetOrderCmdFromTile(const Vehicle *v, TileIndex tile)
 				case VEH_SHIP:     facil = FACIL_DOCK;    break;
 				case VEH_TRAIN:    facil = FACIL_TRAIN;   break;
 				case VEH_AIRCRAFT: facil = FACIL_AIRPORT; break;
-				case VEH_ROAD:     facil = RoadVehicle::From(v)->IsBus() ? FACIL_BUS_STOP : FACIL_TRUCK_STOP; break;
+				case VEH_ROAD:     facil = FACIL_BUS_STOP | FACIL_TRUCK_STOP; break;
 				default: NOT_REACHED();
 			}
 			if (st->facilities & facil) {


### PR DESCRIPTION
Currently trying to order an articulated truck to a bus stop does nothing, but ordering it to a non-drive-through stop gives an error. This change makes both cases return an error.

Ordering to stops of different *transport* types is still ignored.