### PR TITLE
Add: Detect stable tags automatically, and set the 'stable' flag in '…

### DIFF
--- a/Makefile.src.in
+++ b/Makefile.src.in
@@ -92,6 +92,7 @@ VERSION  := $(shell echo "$(VERSIONS)" | cut -f 1 -d'	')
 ISODATE  := $(shell echo "$(VERSIONS)" | cut -f 2 -d'	')
 GITHASH  := $(shell echo "$(VERSIONS)" | cut -f 4 -d'	')
 ISTAG    := $(shell echo "$(VERSIONS)" | cut -f 5 -d'	')
+ISSTABLETAG := $(shell echo "$(VERSIONS)" | cut -f 6 -d'	')
 
 # Make sure we have something in VERSION and ISODATE
 ifeq ($(VERSION),)
@@ -277,10 +278,10 @@ endif
 # Revision files
 
 $(SRC_DIR)/rev.cpp: $(CONFIG_CACHE_VERSION) $(SRC_DIR)/rev.cpp.in
-	$(Q)cat $(SRC_DIR)/rev.cpp.in      | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!MODIFIED!!@$(MODIFIED)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g;s@!!ISTAG!!@$(ISTAG)@g" > $(SRC_DIR)/rev.cpp
+	$(Q)cat $(SRC_DIR)/rev.cpp.in      | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!MODIFIED!!@$(MODIFIED)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g;s@!!ISTAG!!@$(ISTAG)@g;s@!!ISSTABLETAG!!@$(ISSTABLETAG)@g" > $(SRC_DIR)/rev.cpp
 
 $(SRC_DIR)/os/windows/ottdres.rc: $(CONFIG_CACHE_VERSION) $(SRC_DIR)/os/windows/ottdres.rc.in
-	$(Q)cat $(SRC_DIR)/os/windows/ottdres.rc.in | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g;s@!!ISTAG!!@$(ISTAG)@g" > $(SRC_DIR)/os/windows/ottdres.rc
+	$(Q)cat $(SRC_DIR)/os/windows/ottdres.rc.in | sed "s@\!\!ISODATE\!\!@$(ISODATE)@g;s@!!VERSION!!@$(VERSION)@g;s@!!DATE!!@`date +%d.%m.%y`@g;s@!!GITHASH!!@$(GITHASH)@g;s@!!ISTAG!!@$(ISTAG)@g;s@!!ISSTABLETAG!!@$(ISSTABLETAG)@g" > $(SRC_DIR)/os/windows/ottdres.rc
 
 FORCE:
 

--- a/findversion.sh
+++ b/findversion.sh
@@ -83,9 +83,15 @@ if [ -d "$ROOT_DIR/.git" ]; then
 	if [ -n "$TAG" ]; then
 		VERSION="${TAG}"
 		ISTAG="1"
+		if [ -n "`echo \"${TAG}\" | grep \"^[0-9.]*$\"`" ]; then
+			ISSTABLETAG="1"
+		else
+			ISSTABLETAG="0"
+		fi
 	else
 		VERSION="${ISODATE}-${BRANCH}${hashprefix}${SHORTHASH}"
 		ISTAG="0"
+		ISSTABLETAG="0"
 	fi
 
 elif [ -f "$ROOT_DIR/.ottdrev" ]; then
@@ -102,6 +108,7 @@ else
 	TAG=""
 	VERSION=""
 	ISTAG="0"
+	ISSTABLETAG="0"
 fi
 
-echo "$VERSION	$ISODATE	$MODIFIED	$HASH	$ISTAG"
+echo "$VERSION	$ISODATE	$MODIFIED	$HASH	$ISTAG	$ISSTABLETAG"

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -82,7 +82,7 @@ const byte _openttd_revision_tagged = !!ISTAG!!;
  * final release will always have a lower version number than the released
  * version, thus making comparisons on specific revisions easy.
  */
-const uint32 _openttd_newgrf_version = 1 << 28 | 9 << 24 | 0 << 20 | 0 << 19 | 28004;
+const uint32 _openttd_newgrf_version = 1 << 28 | 9 << 24 | 0 << 20 | !!ISSTABLETAG!! << 19 | 28004;
 
 #ifdef __MORPHOS__
 /**


### PR DESCRIPTION
…_openttd_newgrf_version' accordingly.

In SVN we made changed between branches and tags:
* Set "stable" flag for stable tags, not for RC and beta.
* Disable assertions, enable stripping.

This implements the "stable" flag.
It does not do anything about the assertions.