### PR TITLE
Fix: Runway too short for large aircraft advice should not depend on plane crashes setting.

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1798,7 +1798,6 @@ void CheckOrders(const Vehicle *v)
 				} else if (v->type == VEH_AIRCRAFT &&
 							(AircraftVehInfo(v->engine_type)->subtype & AIR_FAST) &&
 							(st->airport.GetFTA()->flags & AirportFTAClass::SHORT_STRIP) &&
-							_settings_game.vehicle.plane_crashes != 0 &&
 							!_cheats.no_jetcrash.value &&
 							message == INVALID_STRING_ID) {
 					message = STR_NEWS_PLANE_USES_TOO_SHORT_RUNWAY;


### PR DESCRIPTION
Since #7302 plane crashes setting no longer affects whether large aircraft will crash at too short runways, so this test is removed for the order advice message as well.