### PR TITLE
Feature: Improve restart command

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1078,7 +1078,22 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewEditorWorld();
 			break;
 
-		case SM_RESTARTGAME: // Restart --> 'Random game' with current settings
+		case SM_RESTARTGAME: // Restart --> Current settings preserved
+			if (_file_to_saveload.abstract_ftype == FT_SAVEGAME || _file_to_saveload.abstract_ftype == FT_SCENARIO) {
+				/* Restart current savegame/scenario */
+				_switch_mode = _game_mode == GM_EDITOR ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
+				SwitchToMode(_switch_mode);
+				break;
+			} else if (_file_to_saveload.abstract_ftype == FT_HEIGHTMAP) {
+				/* Restart current heightmap */
+				_switch_mode = _game_mode == GM_EDITOR ? SM_LOAD_HEIGHTMAP : SM_RESTART_HEIGHTMAP;
+				SwitchToMode(_switch_mode);
+				break;
+			}
+			/* No break here, to enter the next case:
+			 * Restart --> 'Random game' with current settings */
+			FALLTHROUGH;
+
 		case SM_NEWGAME: // New Game --> 'Random game'
 			if (_network_server) {
 				seprintf(_network_game_info.map_name, lastof(_network_game_info.map_name), "Random Map");
@@ -1112,11 +1127,12 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 		}
 
+		case SM_RESTART_HEIGHTMAP: // Load a heightmap and start a new game from it with current settings
 		case SM_START_HEIGHTMAP: // Load a heightmap and start a new game from it
 			if (_network_server) {
 				seprintf(_network_game_info.map_name, lastof(_network_game_info.map_name), "%s (Heightmap)", _file_to_saveload.title);
 			}
-			MakeNewGame(true, true);
+			MakeNewGame(true, new_mode == SM_START_HEIGHTMAP);
 			break;
 
 		case SM_LOAD_HEIGHTMAP: // Load heightmap from scenario editor

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -23,17 +23,18 @@ enum GameMode {
 /** Mode which defines what mode we're switching to. */
 enum SwitchMode {
 	SM_NONE,
-	SM_NEWGAME,         ///< New Game --> 'Random game'.
-	SM_RESTARTGAME,     ///< Restart --> 'Random game' with current settings.
-	SM_EDITOR,          ///< Switch to scenario editor.
-	SM_LOAD_GAME,       ///< Load game, Play Scenario.
-	SM_MENU,            ///< Switch to game intro menu.
-	SM_SAVE_GAME,       ///< Save game.
-	SM_SAVE_HEIGHTMAP,  ///< Save heightmap.
-	SM_GENRANDLAND,     ///< Generate random land within scenario editor.
-	SM_LOAD_SCENARIO,   ///< Load scenario from scenario editor.
-	SM_START_HEIGHTMAP, ///< Load a heightmap and start a new game from it.
-	SM_LOAD_HEIGHTMAP,  ///< Load heightmap from scenario editor.
+	SM_NEWGAME,           ///< New Game --> 'Random game'.
+	SM_RESTARTGAME,       ///< Restart --> 'Random game' with current settings.
+	SM_EDITOR,            ///< Switch to scenario editor.
+	SM_LOAD_GAME,         ///< Load game, Play Scenario.
+	SM_MENU,              ///< Switch to game intro menu.
+	SM_SAVE_GAME,         ///< Save game.
+	SM_SAVE_HEIGHTMAP,    ///< Save heightmap.
+	SM_GENRANDLAND,       ///< Generate random land within scenario editor.
+	SM_LOAD_SCENARIO,     ///< Load scenario from scenario editor.
+	SM_START_HEIGHTMAP,   ///< Load a heightmap and start a new game from it.
+	SM_LOAD_HEIGHTMAP,    ///< Load heightmap from scenario editor.
+	SM_RESTART_HEIGHTMAP, ///< Load a heightmap and start a new game from it with current settings.
 };
 
 /** Display Options */


### PR DESCRIPTION
When the `restart` command is issued, a normal map is always spawned.

This improvement takes into account the current state of `_file_to_saveload` to check if a savegame/scenario/heightmap was previously loaded, and loads the same resource again.