### PR TITLE
Feature: Add autosave and sendmap save formats

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -848,6 +848,8 @@ void NORETURN SlErrorCorruptFmt(const char *format, ...);
 bool SaveloadCrashWithMissingNewGRFs();
 
 extern char _savegame_format[8];
+extern char _sendmap_format[8];
+extern char _autosave_format[8];
 extern bool _do_autosave;
 
 #endif /* SAVELOAD_H */

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -138,6 +138,20 @@ var      = _savegame_format
 def      = NULL
 cat      = SC_EXPERT
 
+[SDTG_STR]
+name     = ""sendmap_format""
+type     = SLE_STRB
+var      = _sendmap_format
+def      = NULL
+cat      = SC_EXPERT
+
+[SDTG_STR]
+name     = ""autosave_format""
+type     = SLE_STRB
+var      = _autosave_format
+def      = NULL
+cat      = SC_EXPERT
+
 [SDTG_BOOL]
 name     = ""rightclick_emulate""
 var      = _rightclick_emulate


### PR DESCRIPTION
a) The encoding part of a server savegame is now started on a different thread to minimize the impact of the stall that occurs after writting all the game state into memory, but there are some limitations:
a.1) When a client joins and the server is performing a savegame, the server stalls for the remaining duration that is still needed to finish encoding the savegame.
a.2) When a client joins and is receiving the map, and the server is not set to pause on join, no autosave (or any save) will be performed should a client still be receiving the map and the encoding part is not yet finished.

b) Added 2 more configurable parameters in openttd.cfg, "sendmap_format" and "autosave_format" on top of "savegame_format". Search for these 3 lines inside openttd.cfg file, under [misc] section:

[misc]
savegame_format =
sendmap_format =
autosave_format =

b.1) These 2 new parameters accept the same valid values as the existant one:
- savegame_format sets the format of manual save games.
- autosave_format sets the format of autosave save games.
- sendmap_format sets the format that is used by a server when sending a map to a client joining.

b.2) Each of these 3 formats also include 2 additional compression level defaults to complement the already existant default:
- fast
- default
- slow

As it currently stands, only lzma and zlib benefit from these added defaults.
- lzma:0 .. lzma:9 (fast: 0, default: 2, slow: 2)
- zlib:0 .. zlib:9 (fast: 1, default: 6, slow: 6)

b.3) OpenTTD resorts to these default compression levels if they're not set in the configuration parameters, and only when certain game conditions match:
- fast when the current running game is the host of a network game or if an autosave occurs when the current running game is in fast forward mode.
- slow when the current running game is the host of a network game and a client is joining in.
- default whenever the criterias above don't occur.