### PR TITLE
Fix #7334: Ship lost after crossing bridge due to path cache not being consumed while on final bridge end.

### DIFF
--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -759,6 +759,10 @@ static void ShipController(Ship *v)
 			if ((v->vehstatus & VS_HIDDEN) == 0) v->Vehicle::UpdateViewport(true);
 			return;
 		}
+
+		/* Ship is back on the bridge head, we need to comsume its path
+		 * cache entry here as we didn't have to choose a ship track. */
+		if (!v->path.empty()) v->path.pop_front();
 	}
 
 	/* update image of ship, as well as delta XY */


### PR DESCRIPTION
Fixes #7334.

An alternative method would be to not add the bridge tile to the path cache in the first place, however that requires checking every tile within the path to see if it's a bridge tile (not particularly slow but it adds up), whereas this method merely removes one entry from the cache when necessary.

This needs to be backported to 1.9.