### PR TITLE
Fix #7311: External configuration file does not change directories

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1221,7 +1221,7 @@ void DeterminePaths(const char *exe)
 	} else
 #endif
 	{
-		_personal_dir = config_dir;
+		_personal_dir = _searchpaths[SP_PERSONAL_DIR];
 	}
 
 	/* Make the necessary folders */


### PR DESCRIPTION
`_personal_dir` gets replaced by `config_dir` outside of the XDG triggers if a configuration file is specified.
This makes directories path computation fail to find content sitting in normal game arborescence, such as the autoload directory.

This prosposal aims at preventing this behaviour, by not touching the arborescence when a configuration file is specified.
Discovered & loaded files should thus be more consistent across executions.

Any drawback?