### PR TITLE
Add: windowshade for rail station construction window

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1029,6 +1029,7 @@ public:
 
 		this->DrawWidgets();
 
+		if (this->IsShaded()) return;
 		/* 'Accepts' and 'Supplies' texts. */
 		NWidgetBase *cov = this->GetWidget<NWidgetBase>(WID_BRAS_COVERAGE_TEXTS);
 		int top = cov->pos_y + WD_PAR_VSEP_NORMAL;
@@ -1378,6 +1379,7 @@ static const NWidgetPart _nested_station_builder_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN), SetDataTip(STR_STATION_BUILD_RAIL_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_SHADEBOX, COLOUR_DARK_GREEN),
 		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_BRAS_SHOW_NEWST_DEFSIZE),
 			NWidget(WWT_DEFSIZEBOX, COLOUR_DARK_GREEN),
 		EndContainer(),


### PR DESCRIPTION
Rationale for this: 

* I run OpenTTD at 2x UI zoom in a 13" screen
* I use newgrf stations
* The station construction window *always* fills most of the viewport, obscuring the map where I want to build
* I have to drag the station window, which puts it mostly out of the viewport, then drag it back if I want to change station tile or orientation
* windowshade is established in OpenTTD and is more convenient than dragging the window around 

There is a movie of the problem here: https://dev.openttdcoop.org/attachments/download/8265/building_stations.mov (76MB, H264, but .mov format sorry).