### PR TITLE
Fix: IniLoadFile::LoadFromDisk seems to expect filename, BaseMedia<Tbase_set>::AddFile provides fullpath

### DIFF
--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -159,9 +159,9 @@ bool BaseMedia<Tbase_set>::AddFile(const char *filename, size_t basepath_length,
 
 	Tbase_set *set = new Tbase_set();
 	IniFile *ini = new IniFile();
-	ini->LoadFromDisk(filename, BASESET_DIR);
-
 	char *path = stredup(filename + basepath_length);
+	ini->LoadFromDisk(path, BASESET_DIR);
+
 	char *psep = strrchr(path, PATHSEPCHAR);
 	if (psep != NULL) {
 		psep[1] = '\0';


### PR DESCRIPTION
⚠Behaviour of `IniLoadFile::LoadFromDisk` to be confirmed⚠

The following call is done with a full path:
https://github.com/OpenTTD/OpenTTD/blob/7e7563f15f999cac5c140cb93e917905a9450df4/src/base_media_func.h#L162
Since that function adds search paths to the provided filename, it results in unecessary failed file searches, eventually falling back to the original, which is then found and processed, as seen in the attached [filtered output](https://github.com/OpenTTD/OpenTTD/files/2947957/output_filtered.txt).
That behaviour wastes processing time/disk filesystem queries and could potentially hurt file discovery.

Fix merely moves up an existing instruction already transforming a full path in a file name.