### PR TITLE
Change: Add pid, file, line number & function/procedure name to debug messages

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -33,7 +33,7 @@
  * @param name Category
  * @param level Debugging level, higher levels means more detailed information.
  */
-#define DEBUG(name, level, ...) if ((level) == 0 || _debug_ ## name ## _level >= (level)) debug(#name, __VA_ARGS__)
+#define DEBUG(name, level, ...) if ((level) == 0 || _debug_ ## name ## _level >= (level)) debug(__FILE__, __LINE__, __func__, #name, __VA_ARGS__)
 
 extern int _debug_driver_level;
 extern int _debug_grf_level;
@@ -54,7 +54,7 @@ extern int _debug_console_level;
 extern int _debug_random_level;
 #endif
 
-void CDECL debug(const char *dbg, const char *format, ...) WARN_FORMAT(2, 3);
+void CDECL debug(const char *file, const int line, const char *func, const char *dbg, const char *format, ...) WARN_FORMAT(5, 6);
 
 char *DumpDebugFacilityNames(char *buf, char *last);
 void SetDebugString(const char *s);


### PR DESCRIPTION
Using added information helps pinpointing where information comes from, especially when tracing function/procedure use or getting a global picture of deep/recursive calls.

However, unlike timestamp, there is no existing option to rely on to make this addition conditional, which might be somewhat wished, as the addition make debug lines way longer than before.

1. Making that unconditional (as it is)?
2. Making that conditional, using the timestamp option?
3. Making that condition, creating a new option?