### PR TITLE
Add: Warn players that company passwords are not truly secure

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2602,7 +2602,7 @@ struct CompanyWindow : Window
 					MarkWholeScreenDirty();
 				} else if (NetworkCompanyIsPassworded(company)) {
 					/* ask for the password */
-					ShowQueryString(STR_EMPTY, STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION, NETWORK_PASSWORD_LENGTH, this, CS_ALPHANUMERAL, QSF_NONE);
+					ShowQueryString(STR_EMPTY, STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION, NETWORK_PASSWORD_LENGTH, this, CS_ALPHANUMERAL, QSF_PASSWORD);
 				} else {
 					/* just send the join command */
 					NetworkClientRequestMove(company);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -265,6 +265,7 @@ STR_SHOW_HIDDEN_ENGINES_VEHICLE_AIRCRAFT_TOOLTIP                :{BLACK}By enabl
 STR_BUTTON_DEFAULT                                              :{BLACK}Default
 STR_BUTTON_CANCEL                                               :{BLACK}Cancel
 STR_BUTTON_OK                                                   :{BLACK}OK
+STR_WARNING_PASSWORD_SECURITY                                   :{YELLOW}Warning: Server administrators may be{}able to read any text entered here.
 
 # On screen keyboard window
 STR_OSK_KEYBOARD_LAYOUT                                         :`1234567890-=\qwertyuiop[]asdfghjkl;'  zxcvbnm,./ .

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -265,7 +265,7 @@ STR_SHOW_HIDDEN_ENGINES_VEHICLE_AIRCRAFT_TOOLTIP                :{BLACK}By enabl
 STR_BUTTON_DEFAULT                                              :{BLACK}Default
 STR_BUTTON_CANCEL                                               :{BLACK}Cancel
 STR_BUTTON_OK                                                   :{BLACK}OK
-STR_WARNING_PASSWORD_SECURITY                                   :{YELLOW}Warning: Server administrators may be{}able to read any text entered here.
+STR_WARNING_PASSWORD_SECURITY                                   :{YELLOW}Warning: Server administrators may be able to read any text entered here.
 
 # On screen keyboard window
 STR_OSK_KEYBOARD_LAYOUT                                         :`1234567890-=\qwertyuiop[]asdfghjkl;'  zxcvbnm,./ .

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -977,8 +977,6 @@ struct QueryStringWindow : public Window
 
 	void UpdateWarningStringSize()
 	{
-		NWidgetBase *text_wid = this->GetWidget<NWidgetBase>(WID_QS_WARNING);
-
 		if (this->flags & QSF_PASSWORD) {
 			assert(this->nested_root->smallest_x > 0);
 			this->warning_size.width = this->nested_root->current_x - (WD_FRAMETEXT_LEFT + WD_FRAMETEXT_RIGHT + WD_FRAMERECT_LEFT + WD_FRAMERECT_RIGHT);

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -981,6 +981,23 @@ struct QueryStringWindow : public Window
 			resize->width = 0;
 			size->width = 0;
 		}
+
+		if (widget == WID_QS_WARNINGBOX && (this->flags & QSF_PASSWORD) == 0) {
+			/* We don't want this widget to show! */
+			fill->width = 0;
+			resize->width = 0;
+			size->width = 0;
+		}
+		if (widget == WID_QS_WARNING) {
+			*size = GetStringBoundingBox(STR_WARNING_PASSWORD_SECURITY);
+		}
+	}
+
+	virtual void DrawWidget(const Rect &r, int widget) const
+	{
+		if (widget != WID_QS_WARNING) return;
+
+		DrawStringMultiLine(r.left, r.right, r.top, r.bottom, STR_WARNING_PASSWORD_SECURITY, TC_FROMSTRING, SA_CENTER);
 	}
 
 	void SetStringParameters(int widget) const override
@@ -1036,6 +1053,9 @@ static const NWidgetPart _nested_query_string_widgets[] = {
 	EndContainer(),
 	NWidget(WWT_PANEL, COLOUR_GREY),
 		NWidget(WWT_EDITBOX, COLOUR_GREY, WID_QS_TEXT), SetMinimalSize(256, 12), SetFill(1, 1), SetPadding(2, 2, 2, 2),
+	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_GREY, WID_QS_WARNINGBOX),
+		NWidget(WWT_LABEL, COLOUR_GREY, WID_QS_WARNING), SetPadding(WD_FRAMETEXT_TOP, WD_FRAMETEXT_RIGHT, WD_FRAMETEXT_BOTTOM, WD_FRAMETEXT_LEFT), SetFill(0, 1),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
 		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_QS_DEFAULT), SetMinimalSize(87, 12), SetFill(1, 1), SetDataTip(STR_BUTTON_DEFAULT, STR_NULL),

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2162,10 +2162,12 @@ void ShowNetworkNeedPassword(NetworkPasswordType npt)
 
 struct NetworkCompanyPasswordWindow : public Window {
 	QueryString password_editbox; ///< Password editbox.
+	Dimension warning_size;       ///< How much space to use for the warning text
 
 	NetworkCompanyPasswordWindow(WindowDesc *desc, Window *parent) : Window(desc), password_editbox(lengthof(_settings_client.network.default_company_pass))
 	{
 		this->InitNested(0);
+		this->UpdateWarningStringSize();
 
 		this->parent = parent;
 		this->querystrings[WID_NCP_PASSWORD] = &this->password_editbox;
@@ -2174,11 +2176,29 @@ struct NetworkCompanyPasswordWindow : public Window {
 		this->SetFocusedWidget(WID_NCP_PASSWORD);
 	}
 
+	void UpdateWarningStringSize()
+	{
+		assert(this->nested_root->smallest_x > 0);
+		this->warning_size.width = this->nested_root->current_x - (WD_FRAMETEXT_LEFT + WD_FRAMETEXT_RIGHT + WD_FRAMERECT_LEFT + WD_FRAMERECT_RIGHT);
+		this->warning_size.height = GetStringHeight(STR_WARNING_PASSWORD_SECURITY, this->warning_size.width);
+		this->warning_size.height += WD_FRAMETEXT_TOP + WD_FRAMETEXT_BOTTOM + WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM;
+
+		this->ReInit();
+	}
+
+	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
+	{
+		if (widget == WID_NCP_WARNING) {
+			*size = this->warning_size;
+		}
+	}
+
 	virtual void DrawWidget(const Rect &r, int widget) const
 	{
 		if (widget != WID_NCP_WARNING) return;
 
-		DrawStringMultiLine(r.left + WD_FRAMETEXT_LEFT, r.right - WD_FRAMETEXT_RIGHT, r.top + WD_FRAMERECT_TOP, r.bottom - WD_FRAMERECT_BOTTOM,
+		DrawStringMultiLine(r.left + WD_FRAMETEXT_LEFT, r.right - WD_FRAMETEXT_RIGHT,
+			r.top + WD_FRAMERECT_TOP, r.bottom - WD_FRAMERECT_BOTTOM,
 			STR_WARNING_PASSWORD_SECURITY, TC_FROMSTRING, SA_CENTER);
 	}
 
@@ -2228,9 +2248,7 @@ static const NWidgetPart _nested_network_company_password_window_widgets[] = {
 			EndContainer(),
 		EndContainer(),
 	EndContainer(),
-	NWidget(WWT_PANEL, COLOUR_GREY, WID_NCP_WARNING),
-		NWidget(WWT_LABEL, COLOUR_GREY), SetFill(0, 1), SetPadding(2, 2, 2, 2), SetDataTip(STR_WARNING_PASSWORD_SECURITY, STR_NULL),
-	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_GREY, WID_NCP_WARNING), EndContainer(),
 	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_NCP_CANCEL), SetFill(1, 0), SetDataTip(STR_BUTTON_CANCEL, STR_COMPANY_PASSWORD_CANCEL),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_NCP_OK), SetFill(1, 0), SetDataTip(STR_BUTTON_OK, STR_COMPANY_PASSWORD_OK),

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2157,7 +2157,7 @@ void ShowNetworkNeedPassword(NetworkPasswordType npt)
 		case NETWORK_GAME_PASSWORD:    caption = STR_NETWORK_NEED_GAME_PASSWORD_CAPTION; break;
 		case NETWORK_COMPANY_PASSWORD: caption = STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION; break;
 	}
-	ShowQueryString(STR_EMPTY, caption, NETWORK_PASSWORD_LENGTH, w, CS_ALPHANUMERAL, QSF_NONE);
+	ShowQueryString(STR_EMPTY, caption, NETWORK_PASSWORD_LENGTH, w, CS_ALPHANUMERAL, QSF_PASSWORD);
 }
 
 struct NetworkCompanyPasswordWindow : public Window {
@@ -2172,6 +2172,14 @@ struct NetworkCompanyPasswordWindow : public Window {
 		this->password_editbox.cancel_button = WID_NCP_CANCEL;
 		this->password_editbox.ok_button = WID_NCP_OK;
 		this->SetFocusedWidget(WID_NCP_PASSWORD);
+	}
+
+	virtual void DrawWidget(const Rect &r, int widget) const
+	{
+		if (widget != WID_NCP_WARNING) return;
+
+		DrawStringMultiLine(r.left + WD_FRAMETEXT_LEFT, r.right - WD_FRAMETEXT_RIGHT, r.top + WD_FRAMERECT_TOP, r.bottom - WD_FRAMERECT_BOTTOM,
+			STR_WARNING_PASSWORD_SECURITY, TC_FROMSTRING, SA_CENTER);
 	}
 
 	void OnOk()
@@ -2219,6 +2227,9 @@ static const NWidgetPart _nested_network_company_password_window_widgets[] = {
 											SetDataTip(STR_COMPANY_PASSWORD_MAKE_DEFAULT, STR_COMPANY_PASSWORD_MAKE_DEFAULT_TOOLTIP),
 			EndContainer(),
 		EndContainer(),
+	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_GREY, WID_NCP_WARNING),
+		NWidget(WWT_LABEL, COLOUR_GREY), SetFill(0, 1), SetPadding(2, 2, 2, 2), SetDataTip(STR_WARNING_PASSWORD_SECURITY, STR_NULL),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_NCP_CANCEL), SetFill(1, 0), SetDataTip(STR_BUTTON_CANCEL, STR_COMPANY_PASSWORD_CANCEL),

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -636,6 +636,8 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_A_WEBSITE,                             "WID_A_WEBSITE");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_CAPTION,                            "WID_QS_CAPTION");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_TEXT,                               "WID_QS_TEXT");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_WARNING,                            "WID_QS_WARNING");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_WARNINGBOX,                         "WID_QS_WARNINGBOX");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_DEFAULT,                            "WID_QS_DEFAULT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_CANCEL,                             "WID_QS_CANCEL");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_OK,                                 "WID_QS_OK");
@@ -780,6 +782,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NCP_LABEL,                             "WID_NCP_LABEL");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NCP_PASSWORD,                          "WID_NCP_PASSWORD");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NCP_SAVE_AS_DEFAULT_PASSWORD,          "WID_NCP_SAVE_AS_DEFAULT_PASSWORD");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NCP_WARNING,                           "WID_NCP_WARNING");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NCP_CANCEL,                            "WID_NCP_CANCEL");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NCP_OK,                                "WID_NCP_OK");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_NGRFI_CAPTION,                         "WID_NGRFI_CAPTION");

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -637,7 +637,6 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_CAPTION,                            "WID_QS_CAPTION");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_TEXT,                               "WID_QS_TEXT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_WARNING,                            "WID_QS_WARNING");
-	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_WARNINGBOX,                         "WID_QS_WARNINGBOX");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_DEFAULT,                            "WID_QS_DEFAULT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_CANCEL,                             "WID_QS_CANCEL");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_QS_OK,                                 "WID_QS_OK");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1599,7 +1599,6 @@ public:
 		WID_QS_CAPTION                               = ::WID_QS_CAPTION,                               ///< Caption of the window.
 		WID_QS_TEXT                                  = ::WID_QS_TEXT,                                  ///< Text of the query.
 		WID_QS_WARNING                               = ::WID_QS_WARNING,                               ///< Warning label about password security
-		WID_QS_WARNINGBOX                            = ::WID_QS_WARNINGBOX,                            ///< Container for warning label
 		WID_QS_DEFAULT                               = ::WID_QS_DEFAULT,                               ///< Default button.
 		WID_QS_CANCEL                                = ::WID_QS_CANCEL,                                ///< Cancel button.
 		WID_QS_OK                                    = ::WID_QS_OK,                                    ///< OK button.

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1598,6 +1598,8 @@ public:
 	enum QueryStringWidgets {
 		WID_QS_CAPTION                               = ::WID_QS_CAPTION,                               ///< Caption of the window.
 		WID_QS_TEXT                                  = ::WID_QS_TEXT,                                  ///< Text of the query.
+		WID_QS_WARNING                               = ::WID_QS_WARNING,                               ///< Warning label about password security
+		WID_QS_WARNINGBOX                            = ::WID_QS_WARNINGBOX,                            ///< Container for warning label
 		WID_QS_DEFAULT                               = ::WID_QS_DEFAULT,                               ///< Default button.
 		WID_QS_CANCEL                                = ::WID_QS_CANCEL,                                ///< Cancel button.
 		WID_QS_OK                                    = ::WID_QS_OK,                                    ///< OK button.
@@ -1817,6 +1819,7 @@ public:
 		WID_NCP_LABEL                                = ::WID_NCP_LABEL,                                ///< Label in front of the password field.
 		WID_NCP_PASSWORD                             = ::WID_NCP_PASSWORD,                             ///< Input field for the password.
 		WID_NCP_SAVE_AS_DEFAULT_PASSWORD             = ::WID_NCP_SAVE_AS_DEFAULT_PASSWORD,             ///< Toggle 'button' for saving the current password as default password.
+		WID_NCP_WARNING                              = ::WID_NCP_WARNING,                              ///< Warning text about password security
 		WID_NCP_CANCEL                               = ::WID_NCP_CANCEL,                               ///< Close the window without changing anything.
 		WID_NCP_OK                                   = ::WID_NCP_OK,                                   ///< Safe the password etc.
 	};

--- a/src/textbuf_gui.h
+++ b/src/textbuf_gui.h
@@ -22,6 +22,7 @@ enum QueryStringFlags {
 	QSF_ACCEPT_UNCHANGED = 0x01, ///< return success even when the text didn't change
 	QSF_ENABLE_DEFAULT   = 0x02, ///< enable the 'Default' button ("\0" is returned)
 	QSF_LEN_IN_CHARS     = 0x04, ///< the length of the string is counted in characters
+	QSF_PASSWORD         = 0x08, ///< password entry box, show warning about password security
 };
 
 DECLARE_ENUM_AS_BIT_SET(QueryStringFlags)

--- a/src/widgets/misc_widget.h
+++ b/src/widgets/misc_widget.h
@@ -30,12 +30,12 @@ enum AboutWidgets {
 
 /** Widgets of the #QueryStringWindow class. */
 enum QueryStringWidgets {
-	WID_QS_CAPTION,    ///< Caption of the window.
-	WID_QS_TEXT,       ///< Text of the query.
-	WID_QS_WARNING,    ///< Warning label about password security
-	WID_QS_DEFAULT,    ///< Default button.
-	WID_QS_CANCEL,     ///< Cancel button.
-	WID_QS_OK,         ///< OK button.
+	WID_QS_CAPTION, ///< Caption of the window.
+	WID_QS_TEXT,    ///< Text of the query.
+	WID_QS_WARNING, ///< Warning label about password security
+	WID_QS_DEFAULT, ///< Default button.
+	WID_QS_CANCEL,  ///< Cancel button.
+	WID_QS_OK,      ///< OK button.
 };
 
 /** Widgets of the #QueryWindow class. */

--- a/src/widgets/misc_widget.h
+++ b/src/widgets/misc_widget.h
@@ -30,11 +30,13 @@ enum AboutWidgets {
 
 /** Widgets of the #QueryStringWindow class. */
 enum QueryStringWidgets {
-	WID_QS_CAPTION, ///< Caption of the window.
-	WID_QS_TEXT,    ///< Text of the query.
-	WID_QS_DEFAULT, ///< Default button.
-	WID_QS_CANCEL,  ///< Cancel button.
-	WID_QS_OK,      ///< OK button.
+	WID_QS_CAPTION,    ///< Caption of the window.
+	WID_QS_TEXT,       ///< Text of the query.
+	WID_QS_WARNING,    ///< Warning label about password security
+	WID_QS_WARNINGBOX, ///< Container for warning label
+	WID_QS_DEFAULT,    ///< Default button.
+	WID_QS_CANCEL,     ///< Cancel button.
+	WID_QS_OK,         ///< OK button.
 };
 
 /** Widgets of the #QueryWindow class. */

--- a/src/widgets/misc_widget.h
+++ b/src/widgets/misc_widget.h
@@ -33,7 +33,6 @@ enum QueryStringWidgets {
 	WID_QS_CAPTION,    ///< Caption of the window.
 	WID_QS_TEXT,       ///< Text of the query.
 	WID_QS_WARNING,    ///< Warning label about password security
-	WID_QS_WARNINGBOX, ///< Container for warning label
 	WID_QS_DEFAULT,    ///< Default button.
 	WID_QS_CANCEL,     ///< Cancel button.
 	WID_QS_OK,         ///< OK button.

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -122,6 +122,7 @@ enum NetworkCompanyPasswordWidgets {
 	WID_NCP_LABEL,                    ///< Label in front of the password field.
 	WID_NCP_PASSWORD,                 ///< Input field for the password.
 	WID_NCP_SAVE_AS_DEFAULT_PASSWORD, ///< Toggle 'button' for saving the current password as default password.
+	WID_NCP_WARNING,                  ///< Warning text about password security
 	WID_NCP_CANCEL,                   ///< Close the window without changing anything.
 	WID_NCP_OK,                       ///< Safe the password etc.
 };


### PR DESCRIPTION
Add a warning text to password entry windows, to remind players that the protocol is not truly secure.

![image](https://user-images.githubusercontent.com/1062071/54076886-df53d000-42b0-11e9-9cd8-9dfef16254b1.png)

Currently has an issue with sizing/spacing in the more generic text entry window, without the "Default password" button:
![image](https://user-images.githubusercontent.com/1062071/54076903-19bd6d00-42b1-11e9-9c95-86ada35c964d.png)
