### PR TITLE
Add: Construction type icons to rail and road construction drop down lists.

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2010,7 +2010,17 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		*list->Append() = item;
 	}
 
+	Dimension d = { 0, 0 };
 	RailType rt;
+	/* Get largest icon size, to ensure text is aligned on each menu item. */
+	if (!for_replacement) {
+		FOR_ALL_SORTED_RAILTYPES(rt) {
+			if (!HasBit(used_railtypes, rt)) continue;
+			const RailtypeInfo *rti = GetRailTypeInfo(rt);
+			d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_rail));
+		}
+	}
+
 	FOR_ALL_SORTED_RAILTYPES(rt) {
 		/* If it's not used ever, don't show it to the user. */
 		if (!HasBit(used_railtypes, rt)) continue;
@@ -2018,7 +2028,14 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		const RailtypeInfo *rti = GetRailTypeInfo(rt);
 
 		StringID str = for_replacement ? rti->strings.replace_text : (rti->max_speed > 0 ? STR_TOOLBAR_RAILTYPE_VELOCITY : STR_JUST_STRING);
-		DropDownListParamStringItem *item = new DropDownListParamStringItem(str, rt, !HasBit(c->avail_railtypes, rt));
+		DropDownListParamStringItem *item;
+		if (for_replacement) {
+			item = new DropDownListParamStringItem(str, rt, !HasBit(c->avail_railtypes, rt));
+		} else {
+			DropDownListIconItem *iconitem = new DropDownListIconItem(rti->gui_sprites.build_x_rail, PAL_NONE, str, rt, !HasBit(c->avail_railtypes, rt));
+			iconitem->SetDimension(d);
+			item = iconitem;
+		}
 		item->SetParam(0, rti->strings.menu_text);
 		item->SetParam(1, rti->max_speed);
 		*list->Append() = item;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -903,7 +903,7 @@ static CallBackFunction ToolbarBuildRoadClick(Window *w)
 	DropDownList *list = new DropDownList();
 
 	/* Road is always visible and available. */
-	*list->Append() = new DropDownListStringItem(STR_ROAD_MENU_ROAD_CONSTRUCTION, ROADTYPE_ROAD, false);
+	*list->Append() = new DropDownListIconItem(SPR_IMG_ROAD_X_DIR, PAL_NONE, STR_ROAD_MENU_ROAD_CONSTRUCTION, ROADTYPE_ROAD, false);
 
 	/* Tram is only visible when there will be a tram, and available when that has been introduced. */
 	Engine *e;
@@ -911,7 +911,7 @@ static CallBackFunction ToolbarBuildRoadClick(Window *w)
 		if (!HasBit(e->info.climates, _settings_game.game_creation.landscape)) continue;
 		if (!HasBit(e->info.misc_flags, EF_ROAD_TRAM)) continue;
 
-		*list->Append() = new DropDownListStringItem(STR_ROAD_MENU_TRAM_CONSTRUCTION, ROADTYPE_TRAM, !HasBit(c->avail_roadtypes, ROADTYPE_TRAM));
+		*list->Append() = new DropDownListIconItem(SPR_IMG_TRAMWAY_X_DIR, PAL_NONE, STR_ROAD_MENU_TRAM_CONSTRUCTION, ROADTYPE_TRAM, !HasBit(c->avail_roadtypes, ROADTYPE_TRAM));
 		break;
 	}
 	ShowDropDownList(w, list, _last_built_roadtype, WID_TN_ROADS, 140, true, true);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -71,6 +71,40 @@ StringID DropDownListCharStringItem::String() const
 	return this->string;
 }
 
+DropDownListIconItem::DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked) : DropDownListParamStringItem(string, result, masked), sprite(sprite), pal(pal)
+{
+	this->dim = GetSpriteSize(sprite);
+	if (this->dim.height < (uint)FONT_HEIGHT_NORMAL) {
+		this->sprite_y = (FONT_HEIGHT_NORMAL - dim.height) / 2;
+		this->text_y = 0;
+	} else {
+		this->sprite_y = 0;
+		this->text_y = (dim.height - FONT_HEIGHT_NORMAL) / 2;
+	}
+}
+
+uint DropDownListIconItem::Height(uint width) const
+{
+	return max(this->dim.height, (uint)FONT_HEIGHT_NORMAL);
+}
+
+uint DropDownListIconItem::Width() const
+{
+	return DropDownListStringItem::Width() + this->dim.width + WD_FRAMERECT_LEFT;
+}
+
+void DropDownListIconItem::Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const
+{
+	bool rtl = _current_text_dir == TD_RTL;
+	DrawSprite(this->sprite, this->pal, rtl ? right - this->dim.width - WD_FRAMERECT_RIGHT : left + WD_FRAMERECT_LEFT, top + this->sprite_y);
+	DrawString(left + WD_FRAMERECT_LEFT + (rtl ? 0 : (this->dim.width + WD_FRAMERECT_LEFT)), right - WD_FRAMERECT_RIGHT - (rtl ? (this->dim.width + WD_FRAMERECT_RIGHT) : 0), top + this->text_y, this->String(), sel ? TC_WHITE : TC_BLACK);
+}
+
+void DropDownListIconItem::SetDimension(Dimension d)
+{
+	this->dim = d;
+}
+
 static const NWidgetPart _nested_dropdown_menu_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_PANEL, COLOUR_END, WID_DM_ITEMS), SetMinimalSize(1, 1), SetScrollbar(WID_DM_SCROLL), EndContainer(),

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -78,6 +78,24 @@ public:
 };
 
 /**
+ * List item with icon and string.
+ */
+class DropDownListIconItem : public DropDownListParamStringItem {
+	SpriteID sprite;
+	PaletteID pal;
+	Dimension dim;
+	uint sprite_y;
+	uint text_y;
+public:
+	DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked);
+
+	/* virtual */ uint Height(uint width) const;
+	/* virtual */ uint Width() const;
+	/* virtual */ void Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const;
+	void SetDimension(Dimension d);
+};
+
+/**
  * A drop down list is a collection of drop down list items.
  */
 typedef AutoDeleteSmallVector<const DropDownListItem *, 4> DropDownList;


### PR DESCRIPTION
Based on a patch I knocked up for r18931 back in 2010.

Example with a railtype NewGRF loaded:
![icons1](https://user-images.githubusercontent.com/639850/54083070-e31a3d80-4316-11e9-9272-8b3bb1efdc09.png)

And with a tram set:
![icons2](https://user-images.githubusercontent.com/639850/54083072-e9a8b500-4316-11e9-8716-ecaa12c3f9e1.png)


