### PR TITLE
Change: Use default value for invalid settings instead of clamping to min or max value.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -450,8 +450,10 @@ static void Write_ValidateSetting(void *ptr, const SettingDesc *sd, int32 val)
 				/* Override the minimum value. No value below sdb->min, except special value 0 */
 				if (!(sdb->flags & SGF_0ISDISABLED) || val != 0) {
 					if (!(sdb->flags & SGF_MULTISTRING)) {
+						/* Clamp value-type setting to its valid range */
 						val = Clamp(val, sdb->min, sdb->max);
 					} else if (val < sdb->min || val > (int32)sdb->max) {
+						/* Reset invalid discrete setting (where different values change gameplay) to its default value */
 						val = (int32)(size_t)sdb->def;
 					}
 				}
@@ -462,8 +464,10 @@ static void Write_ValidateSetting(void *ptr, const SettingDesc *sd, int32 val)
 				uint32 uval = (uint32)val;
 				if (!(sdb->flags & SGF_0ISDISABLED) || uval != 0) {
 					if (!(sdb->flags & SGF_MULTISTRING)) {
+						/* Clamp value-type setting to its valid range */
 						uval = ClampU(uval, sdb->min, sdb->max);
 					} else if (uval < (uint)sdb->min || uval > sdb->max) {
+						/* Reset invalid discrete setting to its default value */
 						uval = (uint32)(size_t)sdb->def;
 					}
 				}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -449,7 +449,11 @@ static void Write_ValidateSetting(void *ptr, const SettingDesc *sd, int32 val)
 			case SLE_VAR_I32: {
 				/* Override the minimum value. No value below sdb->min, except special value 0 */
 				if (!(sdb->flags & SGF_0ISDISABLED) || val != 0) {
-				       if (val < sdb->min || val > (int32)sdb->max) val = (int32)(size_t)sdb->def;
+					if (!(sdb->flags & SGF_MULTISTRING)) {
+						val = Clamp(val, sdb->min, sdb->max);
+					} else if (val < sdb->min || val > (int32)sdb->max) {
+						val = (int32)(size_t)sdb->def;
+					}
 				}
 				break;
 			}
@@ -457,7 +461,11 @@ static void Write_ValidateSetting(void *ptr, const SettingDesc *sd, int32 val)
 				/* Override the minimum value. No value below sdb->min, except special value 0 */
 				uint32 uval = (uint32)val;
 				if (!(sdb->flags & SGF_0ISDISABLED) || uval != 0) {
-				       if (uval < (uint)sdb->min || uval > sdb->max) uval = (uint32)(size_t)sdb->def;
+					if (!(sdb->flags & SGF_MULTISTRING)) {
+						uval = ClampU(uval, sdb->min, sdb->max);
+					} else if (uval < (uint)sdb->min || uval > sdb->max) {
+						uval = (uint32)(size_t)sdb->def;
+					}
 				}
 				WriteValue(ptr, SLE_VAR_U32, (int64)uval);
 				return;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -448,13 +448,18 @@ static void Write_ValidateSetting(void *ptr, const SettingDesc *sd, int32 val)
 			case SLE_VAR_U16:
 			case SLE_VAR_I32: {
 				/* Override the minimum value. No value below sdb->min, except special value 0 */
-				if (!(sdb->flags & SGF_0ISDISABLED) || val != 0) val = Clamp(val, sdb->min, sdb->max);
+				if (!(sdb->flags & SGF_0ISDISABLED) || val != 0) {
+				       if (val < sdb->min || val > (int32)sdb->max) val = (int32)(size_t)sdb->def;
+				}
 				break;
 			}
 			case SLE_VAR_U32: {
 				/* Override the minimum value. No value below sdb->min, except special value 0 */
-				uint min = ((sdb->flags & SGF_0ISDISABLED) && (uint)val <= (uint)sdb->min) ? 0 : sdb->min;
-				WriteValue(ptr, SLE_VAR_U32, (int64)ClampU(val, min, sdb->max));
+				uint32 uval = (uint32)val;
+				if (!(sdb->flags & SGF_0ISDISABLED) || uval != 0) {
+				       if (uval < (uint)sdb->min || uval > sdb->max) uval = (uint32)(size_t)sdb->def;
+				}
+				WriteValue(ptr, SLE_VAR_U32, (int64)uval);
 				return;
 			}
 			case SLE_VAR_I64:


### PR DESCRIPTION
* If the range of a setting is reduced, the value is now reset to the default value instead clamp.
* Fixes uint32 values between 0 and min_value being accepted instead of clamped (oops, this one should maybe be separated.)
* ~~Breaks regression as the regression save has an absurdly high max_load value, which is now reset to 300k instead of clamped to 500k...~~