### PR TITLE
Feature: Reverse train at waypoint orders (jgr)

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3868,6 +3868,9 @@ STR_ORDER_REFIT_AUTO_TOOLTIP                                    :{BLACK}Select w
 STR_ORDER_DROP_REFIT_AUTO                                       :Fixed cargo
 STR_ORDER_DROP_REFIT_AUTO_ANY                                   :Available cargo
 
+STR_ORDER_REVERSE                                               :{BLACK}Reverse
+STR_ORDER_REVERSE_TOOLTIP                                       :{BLACK}Change the reversing behaviour of the highlighted order.
+
 STR_ORDER_SERVICE                                               :{BLACK}Service
 STR_ORDER_DROP_GO_ALWAYS_DEPOT                                  :Always go
 STR_ORDER_DROP_SERVICE_DEPOT                                    :Service if needed
@@ -3920,6 +3923,8 @@ STR_ORDERS_VEH_WITH_SHARED_ORDERS_LIST_TOOLTIP                  :{BLACK}Show all
 # String parts to build the order string
 STR_ORDER_GO_TO_WAYPOINT                                        :Go via {WAYPOINT}
 STR_ORDER_GO_NON_STOP_TO_WAYPOINT                               :Go non-stop via {WAYPOINT}
+STR_ORDER_GO_TO_WAYPOINT_REVERSE                                :Go via and reverse at {WAYPOINT}
+STR_ORDER_GO_NON_STOP_TO_WAYPOINT_REVERSE                       :Go non-stop via and reverse at {WAYPOINT}
 
 STR_ORDER_SERVICE_AT                                            :Service at
 STR_ORDER_SERVICE_NON_STOP_AT                                   :Service non-stop at

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -137,6 +137,8 @@ public:
 	inline OrderDepotTypeFlags GetDepotOrderType() const { return (OrderDepotTypeFlags)GB(this->flags, 0, 3); }
 	/** What are we going to do when in the depot. */
 	inline OrderDepotActionFlags GetDepotActionType() const { return (OrderDepotActionFlags)GB(this->flags, 4, 3); }
+	/** What waypoint flags? */
+	inline OrderWaypointFlags GetWaypointFlags() const { return (OrderWaypointFlags)GB(this->flags, 0, 8); }
 	/** What variable do we have to compare? */
 	inline OrderConditionVariable GetConditionVariable() const { return (OrderConditionVariable)GB(this->dest, 11, 5); }
 	/** What is the comparator to use? */
@@ -158,6 +160,8 @@ public:
 	inline void SetDepotOrderType(OrderDepotTypeFlags depot_order_type) { SB(this->flags, 0, 3, depot_order_type); }
 	/** Set what we are going to do in the depot. */
 	inline void SetDepotActionType(OrderDepotActionFlags depot_service_type) { SB(this->flags, 4, 3, depot_service_type); }
+	/** Set waypoint flags. */
+	inline void SetWaypointFlags(OrderWaypointFlags waypoint_flags) { SB(this->flags, 0, 8, waypoint_flags); }
 	/** Set variable we have to compare. */
 	inline void SetConditionVariable(OrderConditionVariable condition_variable) { SB(this->dest, 11, 5, condition_variable); }
 	/** Set the comparator to use. */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1318,7 +1318,7 @@ CommandCost CmdModifyOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 			break;
 
 		case OT_GOTO_WAYPOINT:
-			if (mof != MOF_NON_STOP) return CMD_ERROR;
+			if (mof != MOF_NON_STOP && mof != MOF_WAYPOINT_FLAGS) return CMD_ERROR;
 			break;
 
 		case OT_CONDITIONAL:
@@ -1399,6 +1399,10 @@ CommandCost CmdModifyOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 		case MOF_COND_DESTINATION:
 			if (data >= v->GetNumOrders()) return CMD_ERROR;
+			break;
+
+		case MOF_WAYPOINT_FLAGS:
+			if (data != (data & OWF_REVERSE)) return CMD_ERROR;
 			break;
 	}
 
@@ -1488,6 +1492,10 @@ CommandCost CmdModifyOrder(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 			case MOF_COND_DESTINATION:
 				order->SetConditionSkipToOrder(data);
+				break;
+
+			case MOF_WAYPOINT_FLAGS:
+				order->SetWaypointFlags((OrderWaypointFlags)data);
 				break;
 
 			default: NOT_REACHED();

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -315,10 +315,13 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 			}
 			break;
 
-		case OT_GOTO_WAYPOINT:
-			SetDParam(0, (order->GetNonStopType() & ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS) ? STR_ORDER_GO_NON_STOP_TO_WAYPOINT : STR_ORDER_GO_TO_WAYPOINT);
+		case OT_GOTO_WAYPOINT: {
+			StringID str = (order->GetNonStopType() & ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS) ? STR_ORDER_GO_NON_STOP_TO_WAYPOINT : STR_ORDER_GO_TO_WAYPOINT;
+			if (order->GetWaypointFlags() & OWF_REVERSE) str += STR_ORDER_GO_TO_WAYPOINT_REVERSE - STR_ORDER_GO_TO_WAYPOINT;
+			SetDParam(0, str);
 			SetDParam(1, order->GetDestination());
 			break;
+		}
 
 		case OT_CONDITIONAL:
 			SetDParam(1, order->GetConditionSkipToOrder() + 1);
@@ -490,6 +493,7 @@ private:
 		/* WID_O_SEL_TOP_LEFT */
 		DP_LEFT_LOAD       = 0, ///< Display 'load' in the left button of the top row of the train/rv order window.
 		DP_LEFT_REFIT      = 1, ///< Display 'refit' in the left button of the top row of the train/rv order window.
+		DP_LEFT_REVERSE    = 2, ///< Display 'reverse' in the left button of the top row of the train/rv order window.
 
 		/* WID_O_SEL_TOP_MIDDLE */
 		DP_MIDDLE_UNLOAD   = 0, ///< Display 'unload' in the middle button of the top row of the train/rv order window.
@@ -1000,13 +1004,14 @@ public:
 						row_sel->SetDisplayedPlane(DP_ROW_LOAD);
 					} else {
 						train_row_sel->SetDisplayedPlane(DP_GROUNDVEHICLE_ROW_NORMAL);
-						left_sel->SetDisplayedPlane(DP_LEFT_LOAD);
+						left_sel->SetDisplayedPlane(DP_LEFT_REVERSE);
 						middle_sel->SetDisplayedPlane(DP_MIDDLE_UNLOAD);
 						right_sel->SetDisplayedPlane(DP_RIGHT_EMPTY);
 						this->EnableWidget(WID_O_NON_STOP);
 						this->SetWidgetLoweredState(WID_O_NON_STOP, order->GetNonStopType() & ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS);
+						this->EnableWidget(WID_O_REVERSE);
+						this->SetWidgetLoweredState(WID_O_REVERSE, order->GetWaypointFlags() & OWF_REVERSE);
 					}
-					this->DisableWidget(WID_O_FULL_LOAD);
 					this->DisableWidget(WID_O_UNLOAD);
 					this->DisableWidget(WID_O_REFIT_DROPDOWN);
 					break;
@@ -1288,6 +1293,17 @@ public:
 				}
 				break;
 
+			case WID_O_REVERSE: {
+				VehicleOrderID sel_ord = this->OrderGetSel();
+				const Order *order = this->vehicle->GetOrder(sel_ord);
+
+				if (order == NULL) break;
+
+				DoCommandP(this->vehicle->tile, this->vehicle->index + (sel_ord << 20), MOF_WAYPOINT_FLAGS | (order->GetWaypointFlags() ^ OWF_REVERSE) << 4,
+						CMD_MODIFY_ORDER | CMD_MSG(STR_ERROR_CAN_T_MODIFY_THIS_ORDER));
+				break;
+			}
+
 			case WID_O_TIMETABLE_VIEW:
 				ShowTimetableWindow(this->vehicle);
 				break;
@@ -1556,6 +1572,8 @@ static const NWidgetPart _nested_orders_train_widgets[] = {
 															SetDataTip(STR_ORDER_TOGGLE_FULL_LOAD, STR_ORDER_TOOLTIP_FULL_LOAD), SetResize(1, 0),
 					NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_O_REFIT), SetMinimalSize(93, 12), SetFill(1, 0),
 															SetDataTip(STR_ORDER_REFIT, STR_ORDER_REFIT_TOOLTIP), SetResize(1, 0),
+					NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_O_REVERSE), SetMinimalSize(93, 12), SetFill(1, 0),
+															SetDataTip(STR_ORDER_REVERSE, STR_ORDER_REVERSE_TOOLTIP), SetResize(1, 0),
 				EndContainer(),
 				NWidget(NWID_SELECTION, INVALID_COLOUR, WID_O_SEL_TOP_MIDDLE),
 					NWidget(NWID_BUTTON_DROPDOWN, COLOUR_GREY, WID_O_UNLOAD), SetMinimalSize(93, 12), SetFill(1, 0),

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -113,6 +113,14 @@ enum OrderDepotActionFlags {
 DECLARE_ENUM_AS_BIT_SET(OrderDepotActionFlags)
 
 /**
+ * Flags for go to waypoint orders
+ */
+enum OrderWaypointFlags {
+	OWF_DEFAULT          = 0,      ///< Default waypoint behaviour
+};
+DECLARE_ENUM_AS_BIT_SET(OrderWaypointFlags)
+
+/**
  * Variables (of a vehicle) to 'cause' skipping on.
  */
 enum OrderConditionVariable {

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -117,6 +117,7 @@ DECLARE_ENUM_AS_BIT_SET(OrderDepotActionFlags)
  */
 enum OrderWaypointFlags {
 	OWF_DEFAULT          = 0,      ///< Default waypoint behaviour
+	OWF_REVERSE          = 1 << 0, ///< Reverse train at the waypoint
 };
 DECLARE_ENUM_AS_BIT_SET(OrderWaypointFlags)
 
@@ -164,6 +165,7 @@ enum ModifyOrderFlags {
 	MOF_COND_COMPARATOR, ///< A comparator changes.
 	MOF_COND_VALUE,      ///< The value to set the condition to.
 	MOF_COND_DESTINATION,///< Change the destination of a conditional order.
+	MOF_WAYPOINT_FLAGS,  ///< Change the waypoint flags
 	MOF_END
 };
 template <> struct EnumPropsT<ModifyOrderFlags> : MakeEnumPropsT<ModifyOrderFlags, byte, MOF_NON_STOP, MOF_END, MOF_END, 4> {};

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -292,6 +292,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_SHIPS_STOP_IN_LOCKS,                ///< 206  PR#7150 Ship/lock movement changes.
 	SLV_FIX_CARGO_MONITOR,                  ///< 207  PR#7175 v1.9  Cargo monitor data packing fix to support 64 cargotypes.
 	SLV_TOWN_CARGOGEN,                      ///< 208  PR#6965 New algorithms for town building cargo generation.
+	SLV_ORDER_REVERSE_AT_WAYPOINT,          ///< 209  PR#.... Reverse at waypoint orders.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -745,6 +745,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(2, SLV_2, SLV_20),
 		 SLE_CONDVAR(Train, gv_flags,            SLE_UINT16,                 SLV_139, SL_MAX_VERSION),
 		SLE_CONDNULL(11, SLV_2, SLV_144), // old reserved space
+		 SLE_CONDVAR(Train, reverse_distance,    SLE_UINT16,                 SLV_ORDER_REVERSE_AT_WAYPOINT, SL_MAX_VERSION),
 
 		     SLE_END()
 	};

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3142,6 +3142,11 @@ static VehicleEnterTileStatus VehicleEnter_Station(Vehicle *v, TileIndex tile, i
 {
 	if (v->type == VEH_TRAIN) {
 		StationID station_id = GetStationIndex(tile);
+		if (v->current_order.IsType(OT_GOTO_WAYPOINT) && v->current_order.GetDestination() == station_id && v->current_order.GetWaypointFlags() & OWF_REVERSE) {
+			Train *t = Train::From(v);
+			// reverse at waypoint
+			if (t->reverse_distance == 0) t->reverse_distance = t->gcache.cached_total_length;
+		}
 		if (!v->current_order.ShouldStopAtStation(v, station_id)) return VETSB_CONTINUE;
 		if (!IsRailStation(tile) || !v->IsFrontEngine()) return VETSB_CONTINUE;
 

--- a/src/train.h
+++ b/src/train.h
@@ -102,6 +102,8 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 	/** Ticks waiting in front of a signal, ticks being stuck or a counter for forced proceeding through signals. */
 	uint16 wait_counter;
 
+	uint16 reverse_distance;
+
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Train() : GroundVehicleBase() {}
 	/** We want to 'destruct' the right class. */

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -613,6 +613,7 @@ static CommandCost CmdBuildRailWagon(TileIndex tile, DoCommandFlag flags, const 
 		v->owner = _current_company;
 		v->track = TRACK_BIT_DEPOT;
 		v->vehstatus = VS_HIDDEN | VS_DEFPAL;
+		v->reverse_distance = 0;
 
 		v->SetWagon();
 
@@ -747,6 +748,7 @@ CommandCost CmdBuildRailVehicle(TileIndex tile, DoCommandFlag flags, const Engin
 		v->refit_cap = 0;
 		v->last_station_visited = INVALID_STATION;
 		v->last_loading_station = INVALID_STATION;
+		v->reverse_distance = 0;
 
 		v->engine_type = e->index;
 		v->gcache.first_engine = INVALID_ENGINE; // needs to be set before first callback
@@ -1803,6 +1805,8 @@ void ReverseTrainDirection(Train *v)
 	if (IsRailDepotTile(v->tile)) {
 		InvalidateWindowData(WC_VEHICLE_DEPOT, v->tile);
 	}
+
+	v->reverse_distance = 0;
 
 	/* Clear path reservation in front if train is not stuck. */
 	if (!HasBit(v->flags, VRF_TRAIN_STUCK)) FreeTrainTrackReservation(v);
@@ -3094,6 +3098,22 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 	Train *prev;
 	bool direction_changed = false; // has direction of any part changed?
 
+	if (reverse && v->reverse_distance == 1) {
+		goto reverse_train_direction;
+	}
+
+	if (v->reverse_distance > 1) {
+		v->vehstatus |= VS_TRAIN_SLOWING;
+		int target_speed;
+		if (_settings_game.vehicle.train_acceleration_model == AM_REALISTIC) {
+			target_speed = ((v->reverse_distance - 1) * 5) / 2;
+		} else {
+			target_speed = (v->reverse_distance - 1) * 10 - 5;
+		}
+		uint16 spd = max(0, target_speed);
+		if (spd < v->cur_speed) v->cur_speed = spd;
+	}
+
 	/* For every vehicle after and including the given vehicle */
 	for (prev = v->Previous(); v != nomove; prev = v, v = v->Next()) {
 		DiagDirection enterdir = DIAGDIR_BEGIN;
@@ -3108,6 +3128,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 					/* Inside depot */
 					gp.x = v->x_pos;
 					gp.y = v->y_pos;
+					v->reverse_distance = 0;
 				} else {
 					/* Not inside depot */
 
@@ -3344,6 +3365,9 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 		v->x_pos = gp.x;
 		v->y_pos = gp.y;
 		v->UpdatePosition();
+		if (v->reverse_distance > 1) {
+			v->reverse_distance--;
+		}
 
 		/* update the Z position of the vehicle */
 		int old_z = v->UpdateInclination(gp.new_tile != gp.old_tile, false);

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3085,6 +3085,17 @@ static Vehicle *CheckTrainAtSignal(Vehicle *v, void *data)
 	return t;
 }
 
+uint16 ReversingDistanceTargetSpeed(const Train *v)
+{
+	int target_speed;
+	if (_settings_game.vehicle.train_acceleration_model == AM_REALISTIC) {
+		target_speed = ((v->reverse_distance - 1) * 5) / 2;
+	} else {
+		target_speed = (v->reverse_distance - 1) * 10 - 5;
+	}
+	return max(0, target_speed);
+}
+
 /**
  * Move a vehicle chain one movement stop forwards.
  * @param v First vehicle to move.
@@ -3103,14 +3114,7 @@ bool TrainController(Train *v, Vehicle *nomove, bool reverse)
 	}
 
 	if (v->reverse_distance > 1) {
-		v->vehstatus |= VS_TRAIN_SLOWING;
-		int target_speed;
-		if (_settings_game.vehicle.train_acceleration_model == AM_REALISTIC) {
-			target_speed = ((v->reverse_distance - 1) * 5) / 2;
-		} else {
-			target_speed = (v->reverse_distance - 1) * 10 - 5;
-		}
-		uint16 spd = max(0, target_speed);
+		uint16 spd = ReversingDistanceTargetSpeed(v);
 		if (spd < v->cur_speed) v->cur_speed = spd;
 	}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1452,6 +1452,7 @@ void VehicleEnterDepot(Vehicle *v)
 			t->force_proceed = TFP_NONE;
 			ClrBit(t->flags, VRF_TOGGLE_REVERSE);
 			t->ConsistChanged(CCF_ARRANGE);
+			t->reverse_distance = 0;
 			break;
 		}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2504,6 +2504,8 @@ static void SpawnAdvancedVisualEffect(const Vehicle *v)
 	}
 }
 
+uint16 ReversingDistanceTargetSpeed(const Train *v);
+
 /**
  * Draw visual effects (smoke and/or sparks) for a vehicle chain.
  * @pre this->IsPrimaryVehicle()
@@ -2532,10 +2534,12 @@ void Vehicle::ShowVisualEffect() const
 		/* For trains, do not show any smoke when:
 		 * - the train is reversing
 		 * - is entering a station with an order to stop there and its speed is equal to maximum station entering speed
+		 * - is approaching a reversing point and its speed is equal to maximum approach speed
 		 */
 		if (HasBit(t->flags, VRF_REVERSING) ||
 				(IsRailStationTile(t->tile) && t->IsFrontEngine() && t->current_order.ShouldStopAtStation(t, GetStationIndex(t->tile)) &&
-				t->cur_speed >= max_speed)) {
+				t->cur_speed >= max_speed) ||
+				(t->reverse_distance >= 1 && t->cur_speed >= ReversingDistanceTargetSpeed(t))) {
 			return;
 		}
 	}

--- a/src/widgets/order_widget.h
+++ b/src/widgets/order_widget.h
@@ -29,6 +29,7 @@ enum OrderWidgets {
 	WID_O_SERVICE,                   ///< Select service (at depot).
 	WID_O_EMPTY,                     ///< Placeholder for refit dropdown when not owner.
 	WID_O_REFIT_DROPDOWN,            ///< Open refit options.
+	WID_O_REVERSE,                   ///< Select waypoint reverse type
 	WID_O_COND_VARIABLE,             ///< Choose condition variable.
 	WID_O_COND_COMPARATOR,           ///< Choose condition type.
 	WID_O_COND_VALUE,                ///< Choose condition value.


### PR DESCRIPTION
This adds an order type to reverse trains at waypoints. This is, admittedly, somewhat frivolous (teaching pathfinders to do similar might be more useful.)

Cherry-picked from jgrpp with conflicts and savegame changes resolved by me.