### PR TITLE
Add: List recently executed commands in crashlog output.

### DIFF
--- a/src/command_func.h
+++ b/src/command_func.h
@@ -66,6 +66,9 @@ static inline DoCommandFlag CommandFlagsToDCFlags(CommandFlags cmd_flags)
 	return flags;
 }
 
+void ClearRecentCommandLog();
+char *DumpRecentCommandLog(char *buffer, const char *last);
+
 /*** All command callbacks that exist ***/
 
 /* ai/ai_instance.cpp */

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -28,6 +28,7 @@
 #include "language.h"
 #include "fontcache.h"
 #include "news_gui.h"
+#include "command_func.h"
 
 #include "ai/ai_info.hpp"
 #include "game/game.hpp"
@@ -324,6 +325,19 @@ char *CrashLog::LogRecentNews(char *buffer, const char *last) const
 }
 
 /**
+ * Writes the recent command log data to the buffer.
+ * @param buffer The begin where to write at.
+ * @param last   The last position in the buffer to write to.
+ * @return the position of the \c '\0' character after the buffer.
+ */
+char *CrashLog::LogRecentCommands(char *buffer, const char *last) const
+{
+	buffer = DumpRecentCommandLog(buffer, last);
+	buffer += seprintf(buffer, last, "\n");
+	return buffer;
+}
+
+/**
  * Fill the crash log buffer with all data of a crash log.
  * @param buffer The begin where to write at.
  * @param last   The last position in the buffer to write to.
@@ -350,6 +364,7 @@ char *CrashLog::FillCrashLog(char *buffer, const char *last) const
 	buffer = this->LogModules(buffer, last);
 	buffer = this->LogGamelog(buffer, last);
 	buffer = this->LogRecentNews(buffer, last);
+	buffer = this->LogRecentCommands(buffer, last);
 
 	buffer += seprintf(buffer, last, "*** End of OpenTTD Crash Report ***\n");
 	return buffer;

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -86,6 +86,7 @@ protected:
 	char *LogLibraries(char *buffer, const char *last) const;
 	char *LogGamelog(char *buffer, const char *last) const;
 	char *LogRecentNews(char *buffer, const char *list) const;
+	char *LogRecentCommands(char *buffer, const char *last) const;
 
 public:
 	/** Stub destructor to silence some compilers. */

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -31,6 +31,7 @@
 #include "station_kdtree.h"
 #include "town_kdtree.h"
 #include "viewport_kdtree.h"
+#include "command_func.h"
 
 #include "safeguards.h"
 
@@ -62,6 +63,8 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	UnInitWindowSystem();
 
 	AllocateMap(size_x, size_y);
+
+	ClearRecentCommandLog();
 
 	_pause_mode = PM_UNPAUSED;
 	_fast_forward = 0;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -311,6 +311,8 @@ static void ShutdownGame()
 	FioCloseAll();
 
 	UninitFreeType();
+
+	ClearRecentCommandLog();
 }
 
 /**


### PR DESCRIPTION
This maintains a circular buffer of info on recent commands, and adds a section to the crash log.

This is useful for providing context and further information of what was occurring shortly prior to a crash.