### PR TITLE
Change: Include _current_company in crashlog AI config line

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -194,7 +194,7 @@ char *CrashLog::LogConfiguration(char *buffer, const char *last) const
 			FontCache::Get(FS_MONO)->GetFontName()
 	);
 
-	buffer += seprintf(buffer, last, "AI Configuration (local: %i):\n", (int)_local_company);
+	buffer += seprintf(buffer, last, "AI Configuration (local: %i) (current: %i):\n", (int)_local_company, (int)_current_company);
 	const Company *c;
 	FOR_ALL_COMPANIES(c) {
 		if (c->ai_info == NULL) {


### PR DESCRIPTION
_current_company is not currently logged anywhere in the crashlog.
_local_company is logged, despite being much less useful than _current_company.
This change logs _current_company alongside _local_company.