### PR TITLE
Codechange: Update town sign on population change only when population is shown.

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -423,7 +423,7 @@ static void ChangePopulation(Town *t, int mod)
 {
 	t->cache.population += mod;
 	InvalidateWindowData(WC_TOWN_VIEW, t->index); // Cargo requirements may appear/vanish for small populations
-	t->UpdateVirtCoord();
+	if (_settings_client.gui.population_in_label) t->UpdateVirtCoord();
 
 	InvalidateWindowData(WC_TOWN_DIRECTORY, 0, 1);
 }


### PR DESCRIPTION
Sign is updated only if the population is shown in the town sign.