### PR TITLE
Fix #7372: FindStationsAroundTiles() with caching returns no result for industry tiles.

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3831,7 +3831,7 @@ void FindStationsAroundTiles(const TileArea &location, StationList *stations, bo
 		/* Industries and towns maintain a list of nearby stations */
 		if (IsTileType(location.tile, MP_INDUSTRY)) {
 			/* Industry nearby stations are already filtered by catchment. */
-			stations = &Industry::GetByTile(location.tile)->stations_near;
+			*stations = Industry::GetByTile(location.tile)->stations_near;
 			return;
 		} else if (IsTileType(location.tile, MP_HOUSE)) {
 			/* Town nearby stations need to be filtered per tile. */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3822,10 +3822,10 @@ static void AddNearbyStationsByCatchment(TileIndex tile, StationList *stations, 
  * Find all stations around a rectangular producer (industry, house, headquarter, ...)
  *
  * @param location The location/area of the producer
- * @param stations The list to store the stations in
+ * @param[out] stations The list to store the stations in
  * @param use_nearby Use nearby station list of industry/town associated with location.tile
  */
-void FindStationsAroundTiles(const TileArea &location, StationList *stations, bool use_nearby)
+void FindStationsAroundTiles(const TileArea &location, StationList * const stations, bool use_nearby)
 {
 	if (use_nearby) {
 		/* Industries and towns maintain a list of nearby stations */


### PR DESCRIPTION
Currently this can only be triggered by NewGRF house tiles querying for cargo acceptance history
of nearby stations (var 0x64) with a tile offset, and providing an offset that happens to point
to an industry tile. This serves no useful purpose.