### PR TITLE
Fix: [AzurePipelines] vcpkg is now preinstalled on Windows images

### DIFF
--- a/azure-pipelines/templates/windows-dependencies.yml
+++ b/azure-pipelines/templates/windows-dependencies.yml
@@ -1,10 +1,14 @@
 steps:
 - bash: |
     set -ex
+
     curl -L https://github.com/OpenTTD/CompileFarm/releases/download/latest/windows-dependencies.zip > windows-dependencies.zip
     unzip windows-dependencies.zip
     rm -f windows-dependencies.zip
-  displayName: 'Download dependencies'
-  workingDirectory: $(Build.ArtifactStagingDirectory)
-- script: $(Build.ArtifactStagingDirectory)\windows-dependencies\vcpkg.exe integrate install
+
+    mv windows-dependencies/installed /c/vcpkg/
+    rm -rf windows-dependencies
   displayName: 'Install dependencies'
+  workingDirectory: $(Build.ArtifactStagingDirectory)
+- script: c:\vcpkg\vcpkg.exe integrate install
+  displayName: 'Integrate vcpkg'


### PR DESCRIPTION
So instead of integrating our own, we only copy our precompiled
binaries into the right folder.