### PR TITLE
More than max_no_competitors could be created in network games

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -135,8 +135,15 @@ public:
 
 	/**
 	 * Get the number of days before the next AI should start.
+	 * @param count For which Nth AI to retrieve the starting date.
 	 */
-	static int GetStartNextTime();
+	static int GetStartNextTime(uint count = 0);
+
+	/**
+	 * Get the associated company index the next AI should start with.
+	 * @param count For which Nth AI to retrieve the starting company.
+	 */
+	static CompanyID GetStartNextCompany(uint count = 0);
 
 	/** Wrapper function for AIScanner::GetAIConsoleList */
 	static char *GetConsoleList(char *p, const char *last, bool newest_only = false);

--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -304,15 +304,32 @@
 	}
 }
 
-/* static */ int AI::GetStartNextTime()
+/* static */ int AI::GetStartNextTime(uint count)
 {
 	/* Find the first company which doesn't exist yet */
 	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
-		if (!Company::IsValidID(c)) return AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->GetSetting("start_date");
+		if (!Company::IsValidID(c)) {
+			if (count == 0) return AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->GetSetting("start_date");
+			count--;
+		}
 	}
 
 	/* Currently no AI can be started, check again in a year. */
 	return DAYS_IN_YEAR;
+}
+
+/* static */ CompanyID AI::GetStartNextCompany(uint count)
+{
+	/* Find the first company which doesn't exist yet */
+	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
+		if (!Company::IsValidID(c)) {
+			if (count == 0) return c;
+			count--;
+		}
+	}
+
+	/* Currently no AI can be started. */
+	return INVALID_COMPANY;
 }
 
 /* static */ char *AI::GetConsoleList(char *p, const char *last, bool newest_only)

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -1289,8 +1289,8 @@ struct AIDebugWindow : public Window {
 			case WID_AID_RELOAD_TOGGLE:
 				if (ai_debug_company == OWNER_DEITY) break;
 				/* First kill the company of the AI, then start a new one. This should start the current AI again */
-				DoCommandP(0, CCA_DELETE | ai_debug_company << 16 | CRR_MANUAL << 24, 0, CMD_COMPANY_CTRL);
-				DoCommandP(0, CCA_NEW_AI | ai_debug_company << 16, 0, CMD_COMPANY_CTRL);
+				DoCommandP(0, CCA_DELETE | ai_debug_company << 4 | CRR_MANUAL << 12, 0, CMD_COMPANY_CTRL);
+				DoCommandP(0, CCA_NEW_AI | ai_debug_company << 4 | (1 << ai_debug_company) << 12, 0, CMD_COMPANY_CTRL);
 				break;
 
 			case WID_AID_SETTINGS:

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -606,6 +606,7 @@ void MaybeStartNewCompany()
 		uint count = CountBits(ais_to_start);
 		if (_networking && current_companies + count >= _settings_client.network.max_companies) break;
 		if (current_ais + count >= (uint)_settings_game.difficulty.max_no_competitors) break;
+		if (current_companies + count >= MAX_COMPANIES) break;
 
 		CompanyID company = AI::GetStartNextCompany(count);
 		assert(company != INVALID_COMPANY);

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -15,6 +15,7 @@
 #include "gfx_type.h"
 #include "vehicle_type.h"
 
+void MaybeStartNewCompany();
 bool MayCompanyTakeOver(CompanyID cbig, CompanyID small);
 void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner);
 void GetNameOfOwner(Owner owner, TileIndex tile);

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -845,7 +845,7 @@ DEF_CONSOLE_CMD(ConResetCompany)
 	}
 
 	/* It is safe to remove this company */
-	DoCommandP(0, CCA_DELETE | index << 16 | CRR_MANUAL << 24, 0, CMD_COMPANY_CTRL);
+	DoCommandP(0, CCA_DELETE | index << 4 | CRR_MANUAL << 12, 0, CMD_COMPANY_CTRL);
 	IConsolePrint(CC_DEFAULT, "Company deleted.");
 
 	return true;
@@ -1182,8 +1182,14 @@ DEF_CONSOLE_CMD(ConStartAI)
 		}
 	}
 
+	CompanyID company_id = AI::GetStartNextCompany();
+	if (company_id == INVALID_COMPANY) {
+		IConsoleWarning("Can't start a new AI (no more free slots).");
+		return true;
+	}
+
 	/* Start a new AI company */
-	DoCommandP(0, CCA_NEW_AI | INVALID_COMPANY << 16, 0, CMD_COMPANY_CTRL);
+	DoCommandP(0, CCA_NEW_AI | INVALID_COMPANY << 4 | (1 << company_id) << 12, 0, CMD_COMPANY_CTRL);
 
 	return true;
 }
@@ -1218,8 +1224,8 @@ DEF_CONSOLE_CMD(ConReloadAI)
 	}
 
 	/* First kill the company of the AI, then start a new one. This should start the current AI again */
-	DoCommandP(0, CCA_DELETE | company_id << 16 | CRR_MANUAL << 24, 0,CMD_COMPANY_CTRL);
-	DoCommandP(0, CCA_NEW_AI | company_id << 16, 0, CMD_COMPANY_CTRL);
+	DoCommandP(0, CCA_DELETE | company_id << 4 | CRR_MANUAL << 12, 0, CMD_COMPANY_CTRL);
+	DoCommandP(0, CCA_NEW_AI | company_id << 4 | (1 << company_id) << 12, 0, CMD_COMPANY_CTRL);
 	IConsolePrint(CC_DEFAULT, "AI reloaded.");
 
 	return true;
@@ -1255,7 +1261,7 @@ DEF_CONSOLE_CMD(ConStopAI)
 	}
 
 	/* Now kill the company of the AI. */
-	DoCommandP(0, CCA_DELETE | company_id << 16 | CRR_MANUAL << 24, 0, CMD_COMPANY_CTRL);
+	DoCommandP(0, CCA_DELETE | company_id << 4 | CRR_MANUAL << 12, 0, CMD_COMPANY_CTRL);
 	IConsolePrint(CC_DEFAULT, "AI stopped, company deleted.");
 
 	return true;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -623,7 +623,7 @@ static void CompanyCheckBankrupt(Company *c)
 			 * player we are sure (the above check) that we are not the local
 			 * company and thus we won't be moved. */
 			if (!_networking || _network_server) {
-				DoCommandP(0, CCA_DELETE | (c->index << 16) | (CRR_BANKRUPT << 24), 0, CMD_COMPANY_CTRL);
+				DoCommandP(0, CCA_DELETE | (c->index << 4) | (CRR_BANKRUPT << 12), 0, CMD_COMPANY_CTRL);
 				return;
 			}
 			break;

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1114,14 +1114,14 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet 
 	 * to match the company in the packet. If it doesn't, the client has done
 	 * something pretty naughty (or a bug), and will be kicked
 	 */
-	if (!(cp.cmd == CMD_COMPANY_CTRL && cp.p1 == 0 && ci->client_playas == COMPANY_NEW_COMPANY) && ci->client_playas != cp.company) {
+	if (!(cp.cmd == CMD_COMPANY_CTRL && (CompanyCtrlAction)GB(cp.p1, 0, 4) == CCA_NEW && ci->client_playas == COMPANY_NEW_COMPANY) && ci->client_playas != cp.company) {
 		IConsolePrintF(CC_ERROR, "WARNING: client %d (IP: %s) tried to execute a command as company %d, kicking...",
 		               ci->client_playas + 1, this->GetClientIP(), cp.company + 1);
 		return this->SendError(NETWORK_ERROR_COMPANY_MISMATCH);
 	}
 
 	if (cp.cmd == CMD_COMPANY_CTRL) {
-		if (cp.p1 != 0 || cp.company != COMPANY_SPECTATOR) {
+		if ((CompanyCtrlAction)GB(cp.p1, 0, 4) != CCA_NEW || cp.company != COMPANY_SPECTATOR) {
 			return this->SendError(NETWORK_ERROR_CHEATER);
 		}
 
@@ -1668,7 +1668,7 @@ static void NetworkAutoCleanCompanies()
 			/* Is the company empty for autoclean_unprotected-months, and is there no protection? */
 			if (_settings_client.network.autoclean_unprotected != 0 && _network_company_states[c->index].months_empty > _settings_client.network.autoclean_unprotected && StrEmpty(_network_company_states[c->index].password)) {
 				/* Shut the company down */
-				DoCommandP(0, CCA_DELETE | c->index << 16 | CRR_AUTOCLEAN << 24, 0, CMD_COMPANY_CTRL);
+				DoCommandP(0, CCA_DELETE | c->index << 4 | CRR_AUTOCLEAN << 12, 0, CMD_COMPANY_CTRL);
 				IConsolePrintF(CC_DEFAULT, "Auto-cleaned company #%d with no password", c->index + 1);
 			}
 			/* Is the company empty for autoclean_protected-months, and there is a protection? */
@@ -1682,7 +1682,7 @@ static void NetworkAutoCleanCompanies()
 			/* Is the company empty for autoclean_novehicles-months, and has no vehicles? */
 			if (_settings_client.network.autoclean_novehicles != 0 && _network_company_states[c->index].months_empty > _settings_client.network.autoclean_novehicles && vehicles_in_company[c->index] == 0) {
 				/* Shut the company down */
-				DoCommandP(0, CCA_DELETE | c->index << 16 | CRR_AUTOCLEAN << 24, 0, CMD_COMPANY_CTRL);
+				DoCommandP(0, CCA_DELETE | c->index << 4 | CRR_AUTOCLEAN << 12, 0, CMD_COMPANY_CTRL);
 				IConsolePrintF(CC_DEFAULT, "Auto-cleaned company #%d with no vehicles", c->index + 1);
 			}
 		} else {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -880,6 +880,9 @@ static void MakeNewGameDone()
 		SetLocalCompany(COMPANY_SPECTATOR);
 		if (_settings_client.gui.pause_on_newgame) DoCommandP(0, PM_PAUSED_NORMAL, 1, CMD_PAUSE);
 		IConsoleCmdExec("exec scripts/game_start.scr 0");
+
+		/* Check if the first AI is set to start immediately */
+		if (_game_mode == GM_NORMAL && AI::CanStartNew() && AI::GetStartNextTime() == 0) MaybeStartNewCompany();
 		return;
 	}
 
@@ -914,6 +917,10 @@ static void MakeNewGameDone()
 
 	CheckEngines();
 	CheckIndustries();
+
+	/* Check if the first AI is set to start immediately */
+	if (_game_mode == GM_NORMAL && AI::CanStartNew() && AI::GetStartNextTime() == 0) MaybeStartNewCompany();
+
 	MarkWholeScreenDirty();
 }
 


### PR DESCRIPTION
Description: There is a max number of commands_per_frame that can cause the starting of a company to be delayed by another tick. I was seeing 5 AIs being started when I've set max_no_competitors only to 4.

https://github.com/OpenTTD/OpenTTD/commit/011257dc8804175dd7d1e839e97e796c0a88aee6 causes it.