### PR TITLE
Fix: Fix company performance rating calculation.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -260,7 +260,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 			/* Skip the total */
 			if (i == SCORE_TOTAL) continue;
 			/*  Check the score */
-			s = Clamp(_score_part[owner][i], 0, _score_info[i].needed) * _score_info[i].score / _score_info[i].needed;
+			s = Clamp<int64>(_score_part[owner][i], 0, _score_info[i].needed) * _score_info[i].score / _score_info[i].needed;
 			score += s;
 			total_score += _score_info[i].score;
 		}


### PR DESCRIPTION
Company performance rating calculation does not take into account the companies' money when those exceeds INT_MAX.