### PR TITLE
Codechange: fix Intel C++ Compiler linking issues.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -783,6 +783,7 @@ int GetAircraftFlightLevel(T *v, bool takeoff)
 }
 
 template int GetAircraftFlightLevel(DisasterVehicle *v, bool takeoff);
+template int GetAircraftFlightLevel(Aircraft *v, bool takeoff);
 
 /**
  * Find the entry point to an airport depending on direction which


### PR DESCRIPTION
`GetAircraftFlightLevel<Aircraft>` is only used in static functions inside aircraft_cmd.cpp. With GCC, Clang and MSVC this is not an issue, but on ICC fails linking, because it doesn't find this version of this template. Possibly these two pieces of information are linked.
Explicit defining the function fixes the issue.