### PR TITLE
Fix: Display tooltips on industry chains window even when "Show toolt…

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2753,12 +2753,12 @@ struct IndustryCargoesWindow : public Window {
 		}
 	}
 
-	virtual void OnHover(Point pt, int widget)
+	bool OnHoverCommon(Point pt, int widget, TooltipCloseCondition close_cond)
 	{
-		if (widget != WID_IC_PANEL) return;
+		if (widget != WID_IC_PANEL) return false;
 
 		Point fieldxy, xy;
-		if (!CalculatePositionInWidget(pt, &fieldxy, &xy)) return;
+		if (!CalculatePositionInWidget(pt, &fieldxy, &xy)) return true;
 
 		const CargoesField *fld = this->fields[fieldxy.y].columns + fieldxy.x;
 		CargoID cid = INVALID_CARGO;
@@ -2777,9 +2777,9 @@ struct IndustryCargoesWindow : public Window {
 
 			case CFT_INDUSTRY:
 				if (fld->u.industry.ind_type < NUM_INDUSTRYTYPES && (this->ind_cargo >= NUM_INDUSTRYTYPES || fieldxy.x != 2)) {
-					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, 0, NULL, TCC_HOVER);
+					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, 0, NULL, close_cond);
 				}
-				return;
+				return true;
 
 			default:
 				break;
@@ -2788,8 +2788,22 @@ struct IndustryCargoesWindow : public Window {
 			const CargoSpec *csp = CargoSpec::Get(cid);
 			uint64 params[5];
 			params[0] = csp->name;
-			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, 1, params, TCC_HOVER);
+			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, 1, params, close_cond);
 		}
+		return true;
+	}
+
+	virtual void OnHover(Point pt, int widget)
+	{
+		this->OnHoverCommon(pt, widget, TCC_HOVER);
+	}
+
+	virtual bool OnRightClick(Point pt, int widget)
+	{
+		if (_settings_client.gui.hover_delay_ms == 0) {
+			return this->OnHoverCommon(pt, widget, TCC_RIGHT_CLICK);
+		}
+		return false;
 	}
 
 	virtual void OnResize()


### PR DESCRIPTION
…ips" is set to right click.

The changes are based on how the "Cargo Flow Legend" window (linkgraph_gui.cpp) works.