### PR TITLE
Fix tooltips not appearing in some instances.

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2753,12 +2753,12 @@ struct IndustryCargoesWindow : public Window {
 		}
 	}
 
-	virtual void OnHover(Point pt, int widget)
+	bool OnTooltip(Point pt, int widget, TooltipCloseCondition close_cond)
 	{
-		if (widget != WID_IC_PANEL) return;
+		if (widget != WID_IC_PANEL) return false;
 
 		Point fieldxy, xy;
-		if (!CalculatePositionInWidget(pt, &fieldxy, &xy)) return;
+		if (!CalculatePositionInWidget(pt, &fieldxy, &xy)) return false;
 
 		const CargoesField *fld = this->fields[fieldxy.y].columns + fieldxy.x;
 		CargoID cid = INVALID_CARGO;
@@ -2777,9 +2777,9 @@ struct IndustryCargoesWindow : public Window {
 
 			case CFT_INDUSTRY:
 				if (fld->u.industry.ind_type < NUM_INDUSTRYTYPES && (this->ind_cargo >= NUM_INDUSTRYTYPES || fieldxy.x != 2)) {
-					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, 0, NULL, TCC_HOVER);
+					GuiShowTooltips(this, STR_INDUSTRY_CARGOES_INDUSTRY_TOOLTIP, 0, NULL, close_cond);
 				}
-				return;
+				return true;
 
 			default:
 				break;
@@ -2788,8 +2788,11 @@ struct IndustryCargoesWindow : public Window {
 			const CargoSpec *csp = CargoSpec::Get(cid);
 			uint64 params[5];
 			params[0] = csp->name;
-			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, 1, params, TCC_HOVER);
+			GuiShowTooltips(this, STR_INDUSTRY_CARGOES_CARGO_TOOLTIP, 1, params, close_cond);
+			return true;
 		}
+
+		return false;
 	}
 
 	virtual void OnResize()

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -559,7 +559,7 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 	}
 }
 
-bool LinkGraphLegendWindow::OnHoverCommon(Point pt, int widget, TooltipCloseCondition close_cond)
+bool LinkGraphLegendWindow::OnTooltip(Point pt, int widget, TooltipCloseCondition close_cond)
 {
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
 		if (this->IsWidgetDisabled(widget)) {
@@ -580,19 +580,6 @@ bool LinkGraphLegendWindow::OnHoverCommon(Point pt, int widget, TooltipCloseCond
 		params[0] = cargo->name;
 		GuiShowTooltips(this, STR_BLACK_STRING, 1, params, close_cond);
 		return true;
-	}
-	return false;
-}
-
-void LinkGraphLegendWindow::OnHover(Point pt, int widget)
-{
-	this->OnHoverCommon(pt, widget, TCC_HOVER);
-}
-
-bool LinkGraphLegendWindow::OnRightClick(Point pt, int widget)
-{
-	if (_settings_client.gui.hover_delay_ms == 0) {
-		return this->OnHoverCommon(pt, widget, TCC_RIGHT_CLICK);
 	}
 	return false;
 }

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -106,8 +106,7 @@ public:
 
 	virtual void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize);
 	virtual void DrawWidget(const Rect &r, int widget) const;
-	virtual void OnHover(Point pt, int widget);
-	virtual bool OnRightClick(Point pt, int widget);
+	virtual bool OnTooltip(Point pt, int widget, TooltipCloseCondition close_cond);
 	virtual void OnClick(Point pt, int widget, int click_count);
 	virtual void OnInvalidateData(int data = 0, bool gui_scope = true);
 
@@ -116,7 +115,6 @@ private:
 
 	void UpdateOverlayCompanies();
 	void UpdateOverlayCargoes();
-	bool OnHoverCommon(Point pt, int widget, TooltipCloseCondition close_cond);
 };
 
 #endif /* LINKGRAPH_GUI_H */

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -724,8 +724,8 @@ struct TooltipsWindow : public Window
 		 * we are dragging the tool. Normal tooltips work with hover or rmb. */
 		switch (this->close_cond) {
 			case TCC_RIGHT_CLICK: if (!_right_button_down) delete this; break;
-			case TCC_LEFT_CLICK: if (!_left_button_down) delete this; break;
 			case TCC_HOVER: if (!_mouse_hovering) delete this; break;
+			case TCC_NONE: break;
 		}
 	}
 };

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2508,10 +2508,15 @@ void UpdateTileSelection()
  * @param params (optional) up to 5 pieces of additional information that may be added to a tooltip
  * @param close_cond Condition for closing this tooltip.
  */
-static inline void ShowMeasurementTooltips(StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_cond = TCC_LEFT_CLICK)
+static inline void ShowMeasurementTooltips(StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_cond = TCC_NONE)
 {
 	if (!_settings_client.gui.measure_tooltip) return;
 	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, params, close_cond);
+}
+
+void HideMeasurementTooltips()
+{
+	DeleteWindowById(WC_TOOLTIPS, 0);
 }
 
 /** highlighting tiles while only going over them with the mouse */
@@ -2569,7 +2574,11 @@ void VpSetPresizeRange(TileIndex from, TileIndex to)
 	_thd.next_drawstyle = HT_RECT;
 
 	/* show measurement only if there is any length to speak of */
-	if (distance > 1) ShowMeasurementTooltips(STR_MEASURE_LENGTH, 1, &distance, TCC_HOVER);
+	if (distance > 1) {
+		ShowMeasurementTooltips(STR_MEASURE_LENGTH, 1, &distance);
+	} else {
+		HideMeasurementTooltips();
+	}
 }
 
 static void VpStartPreSizing()
@@ -3221,7 +3230,10 @@ void SetObjectToPlace(CursorID icon, PaletteID pal, HighLightStyle mode, WindowC
 		 * this function might in some cases reset the newly set object to
 		 * place or not properly reset the original selection. */
 		_thd.window_class = WC_INVALID;
-		if (w != NULL) w->OnPlaceObjectAbort();
+		if (w != NULL) {
+			w->OnPlaceObjectAbort();
+			HideMeasurementTooltips();
+		}
 	}
 
 	/* Mark the old selection dirty, in case the selection shape or colour changes */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -770,16 +770,17 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 	NWidgetCore *wid = w->nested_root->GetWidgetFromPos(x, y);
 	if (wid == NULL) return;
 
+	Point pt = { x, y };
+
 	/* No widget to handle, or the window is not interested in it. */
 	if (wid->index >= 0) {
-		Point pt = { x, y };
 		if (w->OnRightClick(pt, wid->index)) return;
 	}
 
 	/* Right-click close is enabled and there is a closebox */
 	if (_settings_client.gui.right_mouse_wnd_close && w->nested_root->GetWidgetOfType(WWT_CLOSEBOX)) {
 		delete w;
-	} else if (_settings_client.gui.hover_delay_ms == 0 && wid->tool_tip != 0) {
+	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->tool_tip != 0) {
 		GuiShowTooltips(w, wid->tool_tip, 0, NULL, TCC_RIGHT_CLICK);
 	}
 }
@@ -797,8 +798,10 @@ static void DispatchHoverEvent(Window *w, int x, int y)
 	/* No widget to handle */
 	if (wid == NULL) return;
 
+	Point pt = { x, y };
+
 	/* Show the tooltip if there is any */
-	if (wid->tool_tip != 0) {
+	if (!w->OnTooltip(pt, wid->index, TCC_HOVER) && wid->tool_tip != 0) {
 		GuiShowTooltips(w, wid->tool_tip);
 		return;
 	}
@@ -806,7 +809,6 @@ static void DispatchHoverEvent(Window *w, int x, int y)
 	/* Widget has no index, so the window is not interested in it. */
 	if (wid->index < 0) return;
 
-	Point pt = { x, y };
 	w->OnHover(pt, wid->index);
 }
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -265,6 +265,13 @@ struct ViewportData : ViewPort {
 
 struct QueryString;
 
+/* misc_gui.cpp */
+enum TooltipCloseCondition {
+	TCC_RIGHT_CLICK,
+	TCC_HOVER,
+	TCC_NONE,
+};
+
 /**
  * Data structure for an opened window
  */
@@ -629,11 +636,19 @@ public:
 	virtual bool OnRightClick(Point pt, int widget) { return false; }
 
 	/**
-	 * The mouse is hovering over a widget in the window, perform an action for it, like opening a custom tooltip.
+	 * The mouse is hovering over a widget in the window, perform an action for it.
 	 * @param pt     The point where the mouse is hovering.
 	 * @param widget The widget where the mouse is hovering.
 	 */
 	virtual void OnHover(Point pt, int widget) {}
+
+	/**
+	 * Event to display a custom tooltip.
+	 * @param pt     The point where the mouse is located.
+	 * @param widget The widget where the mouse is located.
+	 * @return True if the event is handled, false if it is ignored.
+	 */
+	virtual bool OnTooltip(Point pt, int widget, TooltipCloseCondition close_cond) { return false; }
 
 	/**
 	 * An 'object' is being dragged at the provided position, highlight the target if possible.
@@ -869,13 +884,6 @@ Wcls *AllocateWindowDescFront(WindowDesc *desc, int window_number, bool return_e
 }
 
 void RelocateAllWindows(int neww, int newh);
-
-/* misc_gui.cpp */
-enum TooltipCloseCondition {
-	TCC_RIGHT_CLICK,
-	TCC_HOVER,
-	TCC_NONE,
-};
 
 void GuiShowTooltips(Window *parent, StringID str, uint paramcount = 0, const uint64 params[] = NULL, TooltipCloseCondition close_tooltip = TCC_HOVER);
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -873,8 +873,8 @@ void RelocateAllWindows(int neww, int newh);
 /* misc_gui.cpp */
 enum TooltipCloseCondition {
 	TCC_RIGHT_CLICK,
-	TCC_LEFT_CLICK,
 	TCC_HOVER,
+	TCC_NONE,
 };
 
 void GuiShowTooltips(Window *parent, StringID str, uint paramcount = 0, const uint64 params[] = NULL, TooltipCloseCondition close_tooltip = TCC_HOVER);


### PR DESCRIPTION
* Fix #7386: Measurement tooltip for tunnels, aqueducts & docks did not display or flickered.
* Fix #7384: Industry Chain tooltips did not display on right-click.

