### PR TITLE
Fix 4da83d2f66: Remove measurement tooltips when completed.

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2514,7 +2514,7 @@ static inline void ShowMeasurementTooltips(StringID str, uint paramcount, const 
 	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, params, close_cond);
 }
 
-void HideMeasurementTooltips()
+static void HideMeasurementTooltips()
 {
 	DeleteWindowById(WC_TOOLTIPS, 0);
 }
@@ -3192,6 +3192,7 @@ EventState VpHandlePlaceSizingDrag()
 	}
 	SetTileSelectSize(1, 1);
 
+	HideMeasurementTooltips();
 	w->OnPlaceMouseUp(_thd.select_method, _thd.select_proc, _thd.selend, TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y));
 
 	return ES_HANDLED;


### PR DESCRIPTION
Tooltips were not removed on successful execution of a drag operation.