### PR TITLE
Fix: Saving SDT_INTLIST handle unsigned values properly

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -471,7 +471,8 @@ enum VarTypes {
 	SLF_NO_NETWORK_SYNC = 1 << 10, ///< do not synchronize over network (but it is saved if SLF_NOT_IN_SAVE is not set)
 	SLF_ALLOW_CONTROL   = 1 << 11, ///< allow control codes in the strings
 	SLF_ALLOW_NEWLINE   = 1 << 12, ///< allow new lines in the strings
-	/* 3 more possible flags */
+	SLF_HEX             = 1 << 13, ///< print numbers as hex in the config file (only useful for unsigned)
+	/* 2 more possible flags */
 };
 
 typedef uint32 VarType;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -276,7 +276,7 @@ static void MakeIntList(char *buf, const char *last, const void *array, int nele
 			case SLE_VAR_U32: v = *(const uint32 *)p; p += 4; break;
 			default: NOT_REACHED();
 		}
-		buf += seprintf(buf, last, (i == 0) ? "%d" : ",%d", v);
+		buf += seprintf(buf, last, IsSignedVarMemType(type) ? ((i == 0) ? "%d" : ",%d") : ((i == 0) ? "%u" : ",%u"), v);
 	}
 }
 


### PR DESCRIPTION
This PR addresses a line that @PeterN wrote in the chat when he was trying out code to save a colour preset to the config file:

> `[22.03.19 00:49] <peter1138> colour_presets = -1957633922,-1336168961,-1790426469,-1784986981,1451692562,0,0,2077322240,0,0,0,0,0,0,0,0`

The first issue is that the values are written as signed, even though they are unsigned in the code. The first commit handles writing these values correctly, the second is about correctly reading the (now out-of-range) values back in

the third commit is a feature to write long numbers like this as hexadecimal (reading should already be possible)