### PR TITLE
Fix #7374: Ensure k-d trees are always updated when station sign moves

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -110,6 +110,12 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	 */
 	virtual void UpdateVirtCoord() = 0;
 
+	virtual void MoveSign(TileIndex new_xy)
+	{
+		this->xy = new_xy;
+		this->UpdateVirtCoord();
+	}
+
 	/**
 	 * Get the tile area for a given station type.
 	 * @param ta tile area to fill.

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -207,7 +207,7 @@ RoadStop *Station::GetPrimaryRoadStop(const RoadVehicle *v) const
 void Station::AddFacility(StationFacility new_facility_bit, TileIndex facil_xy)
 {
 	if (this->facilities == FACIL_NONE) {
-		this->xy = facil_xy;
+		this->MoveSign(facil_xy);
 		this->random_bits = Random();
 	}
 	this->facilities |= new_facility_bit;

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -492,6 +492,8 @@ public:
 
 	void UpdateVirtCoord() override;
 
+	void MoveSign(TileIndex new_xy) override;
+
 	void AfterStationTileSetChange(bool adding, StationType type);
 
 	uint GetPlatformLength(TileIndex tile, DiagDirection dir) const override;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -429,6 +429,23 @@ void Station::UpdateVirtCoord()
 	SetWindowDirty(WC_STATION_VIEW, this->index);
 }
 
+/**
+ * Move the station main coordinate somewhere else.
+ * @param new_xy new tile location of the sign
+ */
+void Station::MoveSign(TileIndex new_xy)
+{
+	if (this->xy == new_xy) return;
+
+	_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeStation(this->index));
+	_station_kdtree.Remove(this->index);
+
+	this->BaseStation::MoveSign(new_xy);
+
+	_station_kdtree.Insert(this->index);
+	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation(this->index));
+}
+
 /** Update the virtual coords needed to draw the station sign for all stations. */
 void UpdateAllStationVirtCoords()
 {
@@ -672,14 +689,7 @@ static void UpdateStationSignCoord(BaseStation *st)
 
 	/* clamp sign coord to be inside the station rect */
 	TileIndex new_xy = TileXY(ClampU(TileX(st->xy), r->left, r->right), ClampU(TileY(st->xy), r->top, r->bottom));
-	if (new_xy != st->xy) {
-		_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeStation(st->index));
-		_station_kdtree.Remove(st->index);
-		st->xy = new_xy;
-		_station_kdtree.Insert(st->index);
-		_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation(st->index));
-		st->UpdateVirtCoord();
-	}
+	st->MoveSign(new_xy);
 
 	if (!Station::IsExpected(st)) return;
 	Station *full_station = Station::From(st);


### PR DESCRIPTION
I'm unsure if this is _really_ really correct, there's several `UpdateVirtCoords()` sprinkled around elsewhere, but I think all of them are only about the sign text, making sure facilities icons are correct.