### PR TITLE
Change: Do not display a newspaper about old vehicles for which repla…

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1348,8 +1348,11 @@ void AgeVehicle(Vehicle *v)
 	/* Don't warn about non-primary or not ours vehicles or vehicles that are crashed */
 	if (v->Previous() != NULL || v->owner != _local_company || (v->vehstatus & VS_CRASHED) != 0) return;
 
+	const Company *c = Company::Get(v->owner);
 	/* Don't warn if a renew is active */
-	if (Company::Get(v->owner)->settings.engine_renew && v->GetEngine()->company_avail != 0) return;
+	if (c->settings.engine_renew && v->GetEngine()->company_avail != 0) return;
+	/* Don't warn if a replacement is active */
+	if (EngineHasReplacementForCompany(c, v->engine_type, v->group_id)) return;
 
 	StringID str;
 	if (age == -DAYS_IN_LEAP_YEAR) {


### PR DESCRIPTION
…cement is activated.

Usually when the first vehicle getting old in a group, which has an obsolete engine, I set up a replacement for it. However I still getting warning messages about the other vehicles in the group which has the same engine. This can be a little bothering as its spamming the news messages, although the problem will be solved as soon as the vehicles visit a depot. So I think the remaining warnings could be skipped like in the case of renew.