### PR TITLE
Fix #7400: WaterClass for tree tiles was not converted for old saves preventing industry creation.

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3111,6 +3111,13 @@ bool AfterLoadGame()
 		FOR_ALL_INDUSTRIES(ind) if (ind->neutral_station != NULL) ind->neutral_station->industry = ind;
 	}
 
+	{
+		/* Update water class for trees for all current savegame versions. */
+		for (TileIndex t = 0; t < map_size; t++) {
+			if (IsTileType(t, MP_TREES)) SetWaterClass(t, GetTreeGround(t) == TREE_GROUND_SHORE ? WATER_CLASS_SEA : WATER_CLASS_INVALID);
+		}
+	}
+
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3111,8 +3111,8 @@ bool AfterLoadGame()
 		FOR_ALL_INDUSTRIES(ind) if (ind->neutral_station != NULL) ind->neutral_station->industry = ind;
 	}
 
-	{
-		/* Update water class for trees for all current savegame versions. */
+	if (IsSavegameVersionBefore(SLV_TREES_WATER_CLASS)) {
+		/* Update water class for trees. */
 		for (TileIndex t = 0; t < map_size; t++) {
 			if (IsTileType(t, MP_TREES)) SetWaterClass(t, GetTreeGround(t) == TREE_GROUND_SHORE ? WATER_CLASS_SEA : WATER_CLASS_INVALID);
 		}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -297,6 +297,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_SERVE_NEUTRAL_INDUSTRIES,           ///< 210  PR#7234 Company stations can serve industries with attached neutral stations.
 	SLV_ROADVEH_PATH_CACHE,                 ///< 211  PR#7261 Add path cache for road vehicles.
 	SLV_REMOVE_OPF,                         ///< 212  PR#7245 Remove OPF.
+	SLV_TREES_WATER_CLASS,                  ///< 213  PR#7405 WaterClass update for tree tiles.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -277,6 +277,7 @@ static inline void MakeTree(TileIndex t, TreeType type, uint count, uint growth,
 {
 	SetTileType(t, MP_TREES);
 	SetTileOwner(t, OWNER_NONE);
+	SetWaterClass(t, ground == TREE_GROUND_SHORE ? WATER_CLASS_SEA : WATER_CLASS_INVALID);
 	_m[t].m2 = ground << 6 | density << 4 | 0;
 	_m[t].m3 = type;
 	_m[t].m4 = 0 << 5 | 0 << 2;


### PR DESCRIPTION
#7309 added WaterClass to tree tiles without performing any savegame conversion, causing problems for old saves. The information is easily rebuildable from the tree ground type, which this PR does on load unconditionally.

An alternative solution is to revert #7309 and explicitly test for trees with tree ground type shore. A  branch with that version is https://github.com/PeterN/OpenTTD/commits/fix-7400