### PR TITLE
Some Industry vars missing from #6867

### DIFF
--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -312,12 +312,14 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 			CargoID cargo = GetCargoTranslation(parameter, this->ro.grffile);
 			int index = this->industry->GetCargoProducedIndex(cargo);
 			if (index < 0) return 0; // invalid cargo
-			if (variable == 0x69) return this->industry->produced_cargo_waiting[index];
-			if (variable == 0x6A) return this->industry->this_month_production[index];
-			if (variable == 0x6B) return this->industry->this_month_transported[index];
-			if (variable == 0x6C) return this->industry->last_month_production[index];
-			if (variable == 0x6D) return this->industry->last_month_transported[index];
-			NOT_REACHED();
+			switch (variable) {
+				case 0x69: return this->industry->produced_cargo_waiting[index];
+				case 0x6A: return this->industry->this_month_production[index];
+				case 0x6B: return this->industry->this_month_transported[index];
+				case 0x6C: return this->industry->last_month_production[index];
+				case 0x6D: return this->industry->last_month_transported[index];
+				default: NOT_REACHED();
+			}
 		}
 
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -308,7 +308,9 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 		case 0x6A:
 		case 0x6B:
 		case 0x6C:
-		case 0x6D: {
+		case 0x6D:
+		case 0x70:
+		case 0x71: {
 			CargoID cargo = GetCargoTranslation(parameter, this->ro.grffile);
 			int index = this->industry->GetCargoProducedIndex(cargo);
 			if (index < 0) return 0; // invalid cargo
@@ -318,6 +320,8 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 				case 0x6B: return this->industry->this_month_transported[index];
 				case 0x6C: return this->industry->last_month_production[index];
 				case 0x6D: return this->industry->last_month_transported[index];
+				case 0x70: return this->industry->production_rate[index];
+				case 0x71: return this->industry->last_month_pct_transported[index];
 				default: NOT_REACHED();
 			}
 		}


### PR DESCRIPTION
| New Var | Old Var | Description |
|------------|-----------|----------------|
| 70 | 8E, 8F | Primary industry production rate |
| 71 | 9C, 9D | Last month transported (FF = 100%) |

The other two missing ones (88/89 and 90/91/92) are the cargo type being produced, that doesn't quite make sense when the parameter is already a cargo type.