### PR TITLE
Fix #7411: Use industry production callback (if used) on initial industry cargo generation.

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1751,8 +1751,16 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	}
 
 	if (_generating_world) {
+		if (HasBit(indspec->callback_mask, CBM_IND_PRODUCTION_256_TICKS)) {
+			IndustryProductionCallback(i, 1);
+			for (size_t ci = 0; ci < lengthof(i->last_month_production); ci++) {
+				i->last_month_production[ci] = i->produced_cargo_waiting[ci] * 8;
+				i->produced_cargo_waiting[ci] = 0;
+			}
+		}
+
 		for (size_t ci = 0; ci < lengthof(i->last_month_production); ci++) {
-			i->last_month_production[ci] = i->production_rate[ci] * 8;
+			i->last_month_production[ci] += i->production_rate[ci] * 8;
 		}
 	}
 


### PR DESCRIPTION
Industry production callback was not called for initial cargo generation when generating the world, so NewGRFs had to implement otherwise unused properties.

Fixes #7411 