### PR TITLE
Fix #7410: Sign position/width not set on initial creation.

### DIFF
--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -58,6 +58,7 @@ CommandCost CmdPlaceSign(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 		if (!StrEmpty(text)) {
 			si->name = stredup(text);
 		}
+		si->UpdateVirtCoord();
 		_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeSign(si->index));
 		InvalidateWindowData(WC_SIGN_LIST, 0, 0);
 		_new_sign_id = si->index;


### PR DESCRIPTION
Sign width was only updated when the text was changed. This seems to work for player-placed
signs as there is always a rename operation, however AIs can create a sign with text in one
go, in which case the width was never set.