### PR TITLE
Fix #7414: Reinstate marking sign dirty before removal.

### DIFF
--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -100,6 +100,7 @@ CommandCost CmdRenameSign(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 		}
 	} else { // Delete sign
 		if (flags & DC_EXEC) {
+			si->sign.MarkDirty();
 			_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeSign(si->index));
 			delete si;
 


### PR DESCRIPTION
Sign is not marked dirty before removal, so viewport is not updated properly. Fixes 7414.