### PR TITLE
Fix #7421: Don't (directly) dereference std::vector::end() in SmallMap

### DIFF
--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -79,12 +79,12 @@ struct SmallMap : std::vector<SmallPair<T, U> > {
 
 	inline const Pair *End() const
 	{
-		return &*std::vector<Pair>::end();
+		return std::vector<Pair>::data() + std::vector<Pair>::size();
 	}
 
 	inline Pair *End()
 	{
-		return &*std::vector<Pair>::end();
+		return std::vector<Pair>::data() + std::vector<Pair>::size();
 	}
 
 


### PR DESCRIPTION
By no means a perfect fix, but it'll do for now?