### PR TITLE
Fix: Incorrect display of industry production around tiles.

### DIFF
--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -8536,7 +8536,6 @@ ERROR: IsEnd() is invalid as Begin() is never called
 --TileList_IndustryProducing--
   Count():             92
   Location ListDump:
-    46920 => 1
     46919 => 1
     46918 => 1
     46917 => 1
@@ -8545,7 +8544,6 @@ ERROR: IsEnd() is invalid as Begin() is never called
     46914 => 1
     46913 => 1
     46912 => 1
-    46911 => 1
     46664 => 1
     46663 => 1
     46662 => 1
@@ -8628,6 +8626,8 @@ ERROR: IsEnd() is invalid as Begin() is never called
     44353 => 1
     44352 => 1
     44351 => 1
+    46920 => 0
+    46911 => 0
 
 --TileList_StationType--
   Count():             4

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -512,21 +512,21 @@ CargoArray GetProductionAroundTiles(TileIndex tile, int w, int h, int rad)
 	assert(w > 0);
 	assert(h > 0);
 
+	std::set<IndustryID> industries;
 	TileArea ta(TileXY(x1, y1), TileXY(x2 - 1, y2 - 1));
 
 	/* Loop over all tiles to get the produced cargo of
 	 * everything except industries */
-	TILE_AREA_LOOP(tile, ta) AddProducedCargo(tile, produced);
+	TILE_AREA_LOOP(tile, ta) {
+		if (IsTileType(tile, MP_INDUSTRY)) industries.insert(GetIndustryIndex(tile));
+		AddProducedCargo(tile, produced);
+	}
 
-	/* Loop over the industries. They produce cargo for
-	 * anything that is within 'rad' from their bounding
-	 * box. As such if you have e.g. a oil well the tile
-	 * area loop might not hit an industry tile while
-	 * the industry would produce cargo for the station.
+	/* Loop over the seen industries. They produce cargo for
+	 * anything that is within 'rad' of any one of their tiles.
 	 */
-	const Industry *i;
-	FOR_ALL_INDUSTRIES(i) {
-		if (!ta.Intersects(i->location)) continue;
+	for (IndustryID industry : industries) {
+		const Industry *i = Industry::Get(industry);
 		/* Skip industry with neutral station */
 		if (i->neutral_station != NULL && !_settings_game.station.serve_neutral_industries) continue;
 


### PR DESCRIPTION
Display of industry production around tiles (as shown when placing a station)
did not take account of the station catchment changes, so still showed production
from an industry even if it was not covered by a tile.

This is fixed by making a set of nearby industries that are covered, instead of
looping over all possible industries.