### PR TITLE
Codechange: Check airport layout would fit within map before iterating tiles.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -130,6 +130,24 @@ bool AirportSpec::IsAvailable() const
 }
 
 /**
+ * Check if the airport would be within the map bounds at the given tile.
+ * @param table Selected layout table. This affects airport rotation, and therefore dimenions.
+ * @param tile Top corner of the airport.
+ * @return true iff the airport would be within the map bounds at the given tile.
+ */
+bool AirportSpec::IsWithinMapBounds(byte table, TileIndex tile) const
+{
+	if (table >= this->num_table) return false;
+
+	byte w = this->size_x;
+	byte h = this->size_y;
+	if (this->rotation[table] == DIR_E || this->rotation[table] == DIR_W) Swap(w, h);
+
+	return TileX(tile) + w < MapSizeX() &&
+		TileY(tile) + h < MapSizeY();
+}
+
+/**
  * This function initializes the airportspec array.
  */
 void AirportSpec::ResetAirports()

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -123,6 +123,7 @@ struct AirportSpec {
 	static AirportSpec *GetWithoutOverride(byte type);
 
 	bool IsAvailable() const;
+	bool IsWithinMapBounds(byte table, TileIndex index) const;
 
 	static void ResetAirports();
 

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -136,8 +136,10 @@
 	if (!::IsValidTile(tile)) return -1;
 	if (!IsAirportInformationAvailable(type)) return -1;
 
+	const AirportSpec *as = ::AirportSpec::Get(type);
+	if (!as->IsWithinMapBounds(0, tile)) return -1;
+
 	if (_settings_game.economy.station_noise_level) {
-		const AirportSpec *as = ::AirportSpec::Get(type);
 		AirportTileTableIterator it(as->table[0], tile);
 		uint dist;
 		AirportGetNearestTown(as, it, dist);
@@ -155,6 +157,8 @@
 	if (!IsAirportInformationAvailable(type)) return INVALID_TOWN;
 
 	const AirportSpec *as = AirportSpec::Get(type);
+	if (!as->IsWithinMapBounds(0, tile)) return INVALID_TOWN;
+
 	uint dist;
 	return AirportGetNearestTown(as, AirportTileTableIterator(as->table[0], tile), dist)->index;
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2268,6 +2268,7 @@ CommandCost CmdBuildAirport(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 	/* Check if a valid, buildable airport was chosen for construction */
 	const AirportSpec *as = AirportSpec::Get(airport_type);
 	if (!as->IsAvailable() || layout >= as->num_table) return CMD_ERROR;
+	if (!as->IsWithinMapBounds(layout, tile)) return CMD_ERROR;
 
 	Direction rotation = as->rotation[layout];
 	int w = as->size_x;


### PR DESCRIPTION
This prevents AIs from testing invalid locations for airport placement.