### PR TITLE
Fix aa7ca7fe6: Linkgraph node index order must be maintained due to other references.

### DIFF
--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -139,7 +139,10 @@ void LinkGraph::RemoveNode(NodeID id)
 		node_edges[id] = node_edges[last_node];
 	}
 	Station::Get(this->nodes[last_node].station)->goods[this->cargo].node = id;
-	this->nodes.erase(this->nodes.begin() + id);
+	/* Erase node by swapping with the last element. Node index is referenced
+	 * directly from station goods entries so the order and position must remain. */
+	this->nodes[id] = this->nodes.back();
+	this->nodes.pop_back();
 	this->edges.EraseColumn(id);
 	/* Not doing EraseRow here, as having the extra invalid row doesn't hurt
 	 * and removing it would trigger a lot of memmove. The data has already


### PR DESCRIPTION
Linkgraph nodes require a specific order that was maintained by swapping just the last
element for the node to be removed. std::vector::erase() changed this to removing the
node is then shuffling the remain items down, which upsets other references to this
indices. This causes deleted nodes to still be referenced and vice-versa.

This is fixed by switching back to the original swap & pop method.