### PR TITLE
Fix #7433: don't use AirportSpec substitute if it's not set

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -100,6 +100,7 @@ AirportSpec AirportSpec::specs[NUM_AIRPORTS]; ///< Airport specifications.
 	assert(type < lengthof(AirportSpec::specs));
 	const AirportSpec *as = &AirportSpec::specs[type];
 	if (type >= NEW_AIRPORT_OFFSET && !as->enabled) {
+		if (_airport_mngr.GetGRFID(type) == 0) return as;
 		byte subst_id = _airport_mngr.GetSubstituteID(type);
 		if (subst_id == AT_INVALID) return as;
 		as = &AirportSpec::specs[subst_id];


### PR DESCRIPTION
Maybe not the right fix, but it works.
 I think `subst_id` can never be AT_INVALID, because default value for `OverrideManagerBase::mappingID[].substitute_id` is 0. But defaulting `substitute_id` to `invalid_ID` will probably need a savegame conversion, and I don't know if changing default substitute value for other managers will break stuff. 