### PR TITLE
Change: Dark Blue company and water were indistinguishable in small map. Make water darker.

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -47,7 +47,7 @@ static const uint8 PC_GRASS_LAND      = 0x54; ///< Dark green palette colour for
 static const uint8 PC_BARE_LAND       = 0x37; ///< Brown palette colour for bare land.
 static const uint8 PC_FIELDS          = 0x25; ///< Light brown palette colour for fields.
 static const uint8 PC_TREES           = 0x57; ///< Green palette colour for trees.
-static const uint8 PC_WATER           = 0xCA; ///< Dark blue palette colour for water.
+static const uint8 PC_WATER           = 0xC9; ///< Dark blue palette colour for water.
 
 /** Macro for ordinary entry of LegendAndColour */
 #define MK(a, b) {a, b, INVALID_INDUSTRYTYPE, 0, INVALID_COMPANY, true, false, false}


### PR DESCRIPTION
Dark Blue Company and Water were indistinguishable.

With patch:
![Radingstone Transport, 2051-07-05](https://user-images.githubusercontent.com/43006711/55210479-7f7d8480-51df-11e9-82d8-25ddcd644b17.png)

Without:
![Radingstone Transport, 2051-09-09](https://user-images.githubusercontent.com/43006711/55242390-0b6dcb80-5235-11e9-99d1-246b0db2a02f.png)
