### PR TITLE
Feature: Show coverage area for existing stations and towns

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -79,6 +79,7 @@ struct BuildAirToolbarWindow : Window {
 
 	~BuildAirToolbarWindow()
 	{
+		if (this->IsWidgetLowered(WID_AT_AIRPORT)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) DeleteWindowById(WC_SCEN_LAND_GEN, 0, false);
 	}
 
@@ -143,6 +144,8 @@ struct BuildAirToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
+		if (this->IsWidgetLowered(WID_AT_AIRPORT)) SetViewportCatchmentStation(nullptr, true);
+
 		this->RaiseButtons();
 
 		DeleteWindowById(WC_BUILD_STATION, TRANSPORT_AIR);

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -105,6 +105,7 @@ struct BuildDocksToolbarWindow : Window {
 
 	~BuildDocksToolbarWindow()
 	{
+		if (this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) DeleteWindowById(WC_SCEN_LAND_GEN, 0, false);
 	}
 
@@ -248,6 +249,8 @@ struct BuildDocksToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
+		if (this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
+
 		this->RaiseButtons();
 
 		DeleteWindowById(WC_BUILD_STATION, TRANSPORT_WATER);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -237,6 +237,8 @@ STR_TOOLTIP_FILTER_CRITERIA                                     :{BLACK}Select f
 STR_BUTTON_SORT_BY                                              :{BLACK}Sort by
 STR_BUTTON_LOCATION                                             :{BLACK}Location
 STR_BUTTON_RENAME                                               :{BLACK}Rename
+STR_BUTTON_CATCHMENT                                            :{BLACK}Coverage
+STR_TOOLTIP_CATCHMENT                                           :{BLACK}Toggle coverage area display
 
 STR_TOOLTIP_CLOSE_WINDOW                                        :{BLACK}Close window
 STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS                              :{BLACK}Window title - drag this to move window

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -432,6 +432,7 @@ struct BuildRailToolbarWindow : Window {
 
 	~BuildRailToolbarWindow()
 	{
+		if (this->IsWidgetLowered(WID_RAT_BUILD_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) DeleteWindowById(WC_SCEN_LAND_GEN, 0, false);
 	}
 
@@ -743,6 +744,8 @@ struct BuildRailToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
+		if (this->IsWidgetLowered(WID_RAT_BUILD_STATION)) SetViewportCatchmentStation(nullptr, true);
+
 		this->RaiseButtons();
 		this->DisableWidget(WID_RAT_REMOVE);
 		this->SetWidgetDirty(WID_RAT_REMOVE);

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -327,6 +327,7 @@ struct BuildRoadToolbarWindow : Window {
 
 	~BuildRoadToolbarWindow()
 	{
+		if (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) DeleteWindowById(WC_SCEN_LAND_GEN, 0, false);
 	}
 
@@ -545,6 +546,8 @@ struct BuildRoadToolbarWindow : Window {
 
 	void OnPlaceObjectAbort() override
 	{
+		if (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION)) SetViewportCatchmentStation(nullptr, true);
+
 		this->RaiseButtons();
 		this->SetWidgetsDisabledState(true,
 				WID_ROT_REMOVE,

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -1259,6 +1259,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TV_CENTER_VIEW,                        "WID_TV_CENTER_VIEW");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TV_SHOW_AUTHORITY,                     "WID_TV_SHOW_AUTHORITY");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TV_CHANGE_NAME,                        "WID_TV_CHANGE_NAME");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TV_CATCHMENT,                          "WID_TV_CATCHMENT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TV_EXPAND,                             "WID_TV_EXPAND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TV_DELETE,                             "WID_TV_DELETE");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_TF_NEW_TOWN,                           "WID_TF_NEW_TOWN");

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -1115,6 +1115,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_ROADVEHS,                           "WID_SV_ROADVEHS");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_SHIPS,                              "WID_SV_SHIPS");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_PLANES,                             "WID_SV_PLANES");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_CATCHMENT,                          "WID_SV_CATCHMENT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_STL_CAPTION,                           "WID_STL_CAPTION");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_STL_LIST,                              "WID_STL_LIST");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_STL_SCROLLBAR,                         "WID_STL_SCROLLBAR");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -2498,6 +2498,7 @@ public:
 		WID_TV_CENTER_VIEW                           = ::WID_TV_CENTER_VIEW,                           ///< Center the main view on this town.
 		WID_TV_SHOW_AUTHORITY                        = ::WID_TV_SHOW_AUTHORITY,                        ///< Show the town authority window.
 		WID_TV_CHANGE_NAME                           = ::WID_TV_CHANGE_NAME,                           ///< Change the name of this town.
+		WID_TV_CATCHMENT                             = ::WID_TV_CATCHMENT,                             ///< Toggle catchment area highlight.
 		WID_TV_EXPAND                                = ::WID_TV_EXPAND,                                ///< Expand this town (scenario editor only).
 		WID_TV_DELETE                                = ::WID_TV_DELETE,                                ///< Delete this town (scenario editor only).
 	};

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -2287,6 +2287,7 @@ public:
 		WID_SV_ROADVEHS                              = ::WID_SV_ROADVEHS,                              ///< List of scheduled road vehs button.
 		WID_SV_SHIPS                                 = ::WID_SV_SHIPS,                                 ///< List of scheduled ships button.
 		WID_SV_PLANES                                = ::WID_SV_PLANES,                                ///< List of scheduled planes button.
+		WID_SV_CATCHMENT                             = ::WID_SV_CATCHMENT,                             ///< Toggle catchment area highlight.
 	};
 
 	/** Widgets of the #CompanyStationsWindow class. */

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1320,6 +1320,7 @@ static bool ChangeMaxHeightLevel(int32 p1)
 static bool StationCatchmentChanged(int32 p1)
 {
 	Station::RecomputeCatchmentForAll();
+	MarkWholeScreenDirty();
 	return true;
 }
 

--- a/src/tilehighlight_type.h
+++ b/src/tilehighlight_type.h
@@ -52,6 +52,8 @@ struct TileHighlightData {
 	Point outersize;     ///< Size, in tile "units", of the blue coverage area excluding the side of the selected area.
 	bool diagonal;       ///< Whether the dragged area is a 45 degrees rotated rectangle.
 
+	bool freeze;         ///< Freeze highlight in place.
+
 	Point new_pos;       ///< New value for \a pos; used to determine whether to redraw the selection.
 	Point new_size;      ///< New value for \a size; used to determine whether to redraw the selection.
 	Point new_outersize; ///< New value for \a outersize; used to determine whether to redraw the selection.

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -321,9 +321,22 @@ public:
 		this->SetWidgetDisabledState(WID_TV_CHANGE_NAME, _networking && !_network_server);
 	}
 
+	~TownViewWindow()
+	{
+		SetViewportCatchmentTown(Town::Get(this->window_number), false);
+	}
+
 	void SetStringParameters(int widget) const override
 	{
 		if (widget == WID_TV_CAPTION) SetDParam(0, this->town->index);
+	}
+
+	void OnPaint() override
+	{
+		extern const Town *_viewport_highlight_town;
+		this->SetWidgetLoweredState(WID_TV_CATCHMENT, _viewport_highlight_town == this->town);
+
+		this->DrawWidgets();
 	}
 
 	void DrawWidget(const Rect &r, int widget) const override
@@ -430,6 +443,10 @@ public:
 			case WID_TV_CHANGE_NAME: // rename
 				SetDParam(0, this->window_number);
 				ShowQueryString(STR_TOWN_NAME, STR_TOWN_VIEW_RENAME_TOWN_BUTTON, MAX_LENGTH_TOWN_NAME_CHARS, this, CS_ALPHANUMERAL, QSF_ENABLE_DEFAULT | QSF_LEN_IN_CHARS);
+				break;
+
+			case WID_TV_CATCHMENT:
+				SetViewportCatchmentTown(Town::Get(this->window_number), !this->IsWidgetLowered(WID_TV_CATCHMENT));
 				break;
 
 			case WID_TV_EXPAND: { // expand town - only available on Scenario editor
@@ -552,6 +569,7 @@ static const NWidgetPart _nested_town_game_view_widgets[] = {
 			NWidget(WWT_PUSHTXTBTN, COLOUR_BROWN, WID_TV_SHOW_AUTHORITY), SetMinimalSize(80, 12), SetFill(1, 1), SetResize(1, 0), SetDataTip(STR_TOWN_VIEW_LOCAL_AUTHORITY_BUTTON, STR_TOWN_VIEW_LOCAL_AUTHORITY_TOOLTIP),
 			NWidget(WWT_PUSHTXTBTN, COLOUR_BROWN, WID_TV_CHANGE_NAME), SetMinimalSize(80, 12), SetFill(1, 1), SetResize(1, 0), SetDataTip(STR_BUTTON_RENAME, STR_TOWN_VIEW_RENAME_TOOLTIP),
 		EndContainer(),
+		NWidget(WWT_TEXTBTN, COLOUR_BROWN, WID_TV_CATCHMENT), SetMinimalSize(14, 12), SetFill(0, 1), SetDataTip(STR_BUTTON_CATCHMENT, STR_TOOLTIP_CATCHMENT),
 		NWidget(WWT_RESIZEBOX, COLOUR_BROWN),
 	EndContainer(),
 };

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2445,6 +2445,8 @@ void UpdateTileSelection()
 	int x1;
 	int y1;
 
+	if (_thd.freeze) return;
+
 	HighLightStyle new_drawstyle = HT_NONE;
 	bool new_diagonal = false;
 

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -93,4 +93,8 @@ static inline void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset =
 
 Point GetViewportStationMiddle(const ViewPort *vp, const Station *st);
 
+struct Station;
+
+void SetViewportCatchmentStation(const Station *st, bool sel);
+
 #endif /* VIEWPORT_FUNC_H */

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -94,7 +94,9 @@ static inline void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset =
 Point GetViewportStationMiddle(const ViewPort *vp, const Station *st);
 
 struct Station;
+struct Town;
 
 void SetViewportCatchmentStation(const Station *st, bool sel);
+void SetViewportCatchmentTown(const Town *t, bool sel);
 
 #endif /* VIEWPORT_FUNC_H */

--- a/src/widgets/station_widget.h
+++ b/src/widgets/station_widget.h
@@ -30,6 +30,7 @@ enum StationViewWidgets {
 	WID_SV_ROADVEHS,           ///< List of scheduled road vehs button.
 	WID_SV_SHIPS,              ///< List of scheduled ships button.
 	WID_SV_PLANES,             ///< List of scheduled planes button.
+	WID_SV_CATCHMENT,          ///< Toggle catchment area highlight.
 };
 
 /** Widgets of the #CompanyStationsWindow class. */

--- a/src/widgets/town_widget.h
+++ b/src/widgets/town_widget.h
@@ -39,6 +39,7 @@ enum TownViewWidgets {
 	WID_TV_CENTER_VIEW,    ///< Center the main view on this town.
 	WID_TV_SHOW_AUTHORITY, ///< Show the town authority window.
 	WID_TV_CHANGE_NAME,    ///< Change the name of this town.
+	WID_TV_CATCHMENT,      ///< Toggle catchment area highlight.
 	WID_TV_EXPAND,         ///< Expand this town (scenario editor only).
 	WID_TV_DELETE,         ///< Delete this town (scenario editor only).
 };


### PR DESCRIPTION
This PR adds the following:

* Button in station window to toggle showing coverage area.
* Button in town window to toggle showing covered tiles.
* When placing a new station part, if the part would touch an existing station, that station's coverage area is drawn.