### PR TITLE
Change: Shorten engine rail type drop down in autoreplace window.

### DIFF
--- a/src/rail.h
+++ b/src/rail.h
@@ -455,7 +455,8 @@ bool ValParamRailtype(const RailType rail);
 RailTypes AddDateIntroducedRailTypes(RailTypes current, Date date);
 
 RailType GetBestRailtype(const CompanyID company);
-RailTypes GetCompanyRailtypes(const CompanyID c);
+RailTypes GetCompanyRailtypes(CompanyID company, bool introduces = true);
+RailTypes GetRailTypes(bool introduces);
 
 RailType GetRailTypeByLabel(RailTypeLabel label, bool allow_alternate_labels = true);
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1989,20 +1989,20 @@ void InitializeRailGUI()
  */
 DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 {
-	RailTypes used_railtypes = RAILTYPES_NONE;
-
-	/* Find the used railtypes. */
-	Engine *e;
-	FOR_ALL_ENGINES_OF_TYPE(e, VEH_TRAIN) {
-		if (!HasBit(e->info.climates, _settings_game.game_creation.landscape)) continue;
-
-		used_railtypes |= GetRailTypeInfo(e->u.rail.railtype)->introduces_railtypes;
-	}
-
-	/* Get the date introduced railtypes as well. */
-	used_railtypes = AddDateIntroducedRailTypes(used_railtypes, MAX_DAY);
+	RailTypes used_railtypes;
+	RailTypes avail_railtypes;
 
 	const Company *c = Company::Get(_local_company);
+
+	/* Find the used railtypes. */
+	if (for_replacement) {
+		avail_railtypes = GetCompanyRailtypes(c->index, false);
+		used_railtypes  = GetRailTypes(false);
+	} else {
+		avail_railtypes = c->avail_railtypes;
+		used_railtypes  = GetRailTypes(true);
+	}
+
 	DropDownList *list = new DropDownList();
 
 	if (all_option) {
@@ -2030,9 +2030,9 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		StringID str = for_replacement ? rti->strings.replace_text : (rti->max_speed > 0 ? STR_TOOLBAR_RAILTYPE_VELOCITY : STR_JUST_STRING);
 		DropDownListParamStringItem *item;
 		if (for_replacement) {
-			item = new DropDownListParamStringItem(str, rt, !HasBit(c->avail_railtypes, rt));
+			item = new DropDownListParamStringItem(str, rt, !HasBit(avail_railtypes, rt));
 		} else {
-			DropDownListIconItem *iconitem = new DropDownListIconItem(rti->gui_sprites.build_x_rail, PAL_NONE, str, rt, !HasBit(c->avail_railtypes, rt));
+			DropDownListIconItem *iconitem = new DropDownListIconItem(rti->gui_sprites.build_x_rail, PAL_NONE, str, rt, !HasBit(avail_railtypes, rt));
 			iconitem->SetDimension(d);
 			item = iconitem;
 		}


### PR DESCRIPTION
In the autoreplace window, the rail type drop down is for choosing engines
of the given time. Many rail types do not have engines specifically designed for them,
and are merely compatible with other rail types. This list is thus unwieldy and many
options have no engines available.

As this drop down is for choosing _engine_ rail type rather than compatible rail types,
we can list just the rail types explicitly listed by engines.

Picture shows the change, on the left is master with all rail types in the list (these are not duplicates, they are different rail types with the same string), on the right is this PR with just the rail types specified for engines.

![railtype](https://user-images.githubusercontent.com/639850/55280703-0ede8100-5321-11e9-9601-596bff7a90c9.png)
