### PR TITLE
Adjust violet smallmap colour 1 shade darker after #7436

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -274,7 +274,7 @@ struct SmallMapColourScheme {
 static SmallMapColourScheme _heightmap_schemes[] = {
 	{NULL, _green_map_heights,      lengthof(_green_map_heights),      MKCOLOUR_XXXX(0x54)}, ///< Green colour scheme.
 	{NULL, _dark_green_map_heights, lengthof(_dark_green_map_heights), MKCOLOUR_XXXX(0x62)}, ///< Dark green colour scheme.
-	{NULL, _violet_map_heights,     lengthof(_violet_map_heights),     MKCOLOUR_XXXX(0x82)}, ///< Violet colour scheme.
+	{NULL, _violet_map_heights,     lengthof(_violet_map_heights),     MKCOLOUR_XXXX(0x81)}, ///< Violet colour scheme.
 };
 
 /**


### PR DESCRIPTION
#7436 changed the smallmap sea blue, so that it no longer conflates with dark blue company colour.  That is a clear improvement generally.

However the smallmap colour options include violet.  For me, following this change, whilst the blue and the violet are distinguishable as separate colours in the smallmap, the coastline is now very undifferentiated and hard to see the shape of.

This is highly subjective, and no-one else who tried could replicate the issue.  My display has a currently uncommon P3 wide-gamut colour space, which is likely a factor.  Notably other wide-gamut displays may be implementing the alternative Adobe RGB colour space, which has a wider range of blues than P3.  Simulating Adobe RGB on my display does reduces the problem, which adds weight to the idea that this is caused by colour spaces.

So after that fascinating tour into colour spaces, I made the violet 1 shade darker than previously.

Which fixes the problem.

I can't find any negative side effects.

I tested for legibility problems with company colours, they're all fine to my eye.

A number of other people in irc compared the before and after, and nobody reported any problems at the time of writing.

Violet smallmap after 7436
<img width="1128" alt="sea_went_away" src="https://user-images.githubusercontent.com/1780327/55281860-093d6700-5332-11e9-904d-6e869aafa24d.png">

Violet smallmap as adjusted by this PR
<img width="1128" alt="sea_came_back" src="https://user-images.githubusercontent.com/1780327/55281861-0d698480-5332-11e9-89d2-5c0bd9871c4c.png">

Things I also considered and rejected here:
- I tested violet 2 shades darker, but 1 shade darker is fine
- I tested adjustments to both the green smallmap options, this confirmed that the greens are ok 'as is', no change necessary
- I considered changing the violet heightmap range, but it looks fine 'as is' to my eye, no change there.  Notably the green  smallmap option uses completely different hue for flat / heightmap

I'm using 'smallmap' because that's what it's called in settings GUI. I usually call it mini-map, but eh :) 