### PR TITLE
Add: AI/GS IsNoiseLevelIncreaseAllowed

### DIFF
--- a/src/script/api/ai/ai_airport.hpp.sq
+++ b/src/script/api/ai/ai_airport.hpp.sq
@@ -50,6 +50,7 @@ void SQAIAirport_Register(Squirrel *engine)
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::RemoveAirport,                 "RemoveAirport",                 2, ".i");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetAirportType,                "GetAirportType",                2, ".i");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNoiseLevelIncrease,         "GetNoiseLevelIncrease",         3, ".ii");
+	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::IsNoiseLevelIncreaseAllowed,   "IsNoiseLevelIncreaseAllowed",   3, ".ii");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNearestTown,                "GetNearestTown",                3, ".ii");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMaintenanceCostFactor,      "GetMaintenanceCostFactor",      2, ".i");
 	SQAIAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMonthlyMaintenanceCost,     "GetMonthlyMaintenanceCost",     2, ".i");

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -26,6 +26,7 @@
  * \li AIGroup::GetSecondaryColour
  * \li AIVehicle::BuildVehicleWithRefit
  * \li AIVehicle::GetBuildWithRefitCapacity
+ * \li AIAirport::IsNoiseLevelIncreaseAllowed
  *
  * \b 1.9.0
  *

--- a/src/script/api/game/game_airport.hpp.sq
+++ b/src/script/api/game/game_airport.hpp.sq
@@ -50,6 +50,7 @@ void SQGSAirport_Register(Squirrel *engine)
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::RemoveAirport,                 "RemoveAirport",                 2, ".i");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetAirportType,                "GetAirportType",                2, ".i");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNoiseLevelIncrease,         "GetNoiseLevelIncrease",         3, ".ii");
+	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::IsNoiseLevelIncreaseAllowed,   "IsNoiseLevelIncreaseAllowed",   3, ".ii");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetNearestTown,                "GetNearestTown",                3, ".ii");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMaintenanceCostFactor,      "GetMaintenanceCostFactor",      2, ".i");
 	SQGSAirport.DefSQStaticMethod(engine, &ScriptAirport::GetMonthlyMaintenanceCost,     "GetMonthlyMaintenanceCost",     2, ".i");

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -18,6 +18,9 @@
  * \b 1.10.0
  *
  * This version is not yet released. The following changes are not set in stone yet.
+
+ * API additions:
+ * \li GSAirport::IsNoiseLevelIncreaseAllowed
  *
  * API additions:
  * \li GSVehicle::BuildVehicleWithRefit

--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -185,6 +185,17 @@ public:
 	static int GetNoiseLevelIncrease(TileIndex tile, AirportType type);
 
 	/**
+	 * Checks whether the noise that will be added to the nearest town if an airport would be
+	 *  built at this tile is allowed.
+	 * @param tile The tile to check.
+	 * @param type The AirportType to check.
+	 * @pre IsAirportInformationAvailable(type).
+	 * @return true if and only if the noise level increase added by the airport is allowed.
+	 * @note The noise will be added to the town with TownID GetNearestTown(tile, type).
+	 */
+	static bool IsNoiseLevelIncreaseAllowed(TileIndex tile, AirportType type);
+
+	/**
 	 * Get the TownID of the town whose local authority will influence
 	 *  an airport at some tile.
 	 * @param tile The tile to check.


### PR DESCRIPTION
API addition that may be used to check whether the noise that will be added to the nearest town if an airport would be built at a tile is allowed.