### PR TITLE
Remove AutoDeleteSmallVector and AutoFreeSmallVector

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -479,12 +479,12 @@ struct AISettingsWindow : public Window {
 							this->clicked_dropdown = true;
 							this->closing_dropdown = false;
 
-							DropDownList *list = new DropDownList();
+							DropDownList list;
 							for (int i = config_item.min_value; i <= config_item.max_value; i++) {
-								list->push_back(new DropDownListCharStringItem(config_item.labels->Find(i)->second, i, false));
+								list.emplace_back(new DropDownListCharStringItem(config_item.labels->Find(i)->second, i, false));
 							}
 
-							ShowDropDownListAt(this, list, old_val, -1, wi_rect, COLOUR_ORANGE, true);
+							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE, true);
 						}
 					}
 				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -214,12 +214,12 @@ class BuildAirportWindow : public PickerWindowBase {
 	Scrollbar *vscroll;
 
 	/** Build a dropdown list of available airport classes */
-	static DropDownList *BuildAirportClassDropDown()
+	static DropDownList BuildAirportClassDropDown()
 	{
-		DropDownList *list = new DropDownList();
+		DropDownList list;
 
 		for (uint i = 0; i < AirportClass::GetClassCount(); i++) {
-			list->push_back(new DropDownListStringItem(AirportClass::Get((AirportClassID)i)->name, i, false));
+			list.emplace_back(new DropDownListStringItem(AirportClass::Get((AirportClassID)i)->name, i, false));
 		}
 
 		return list;

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -467,10 +467,10 @@ public:
 				break;
 
 			case WID_RV_TRAIN_ENGINEWAGON_DROPDOWN: {
-				DropDownList *list = new DropDownList();
-				list->push_back(new DropDownListStringItem(STR_REPLACE_ENGINES, 1, false));
-				list->push_back(new DropDownListStringItem(STR_REPLACE_WAGONS, 0, false));
-				ShowDropDownList(this, list, this->replace_engines ? 1 : 0, WID_RV_TRAIN_ENGINEWAGON_DROPDOWN);
+				DropDownList list;
+				list.emplace_back(new DropDownListStringItem(STR_REPLACE_ENGINES, 1, false));
+				list.emplace_back(new DropDownListStringItem(STR_REPLACE_WAGONS, 0, false));
+				ShowDropDownList(this, std::move(list), this->replace_engines ? 1 : 0, WID_RV_TRAIN_ENGINEWAGON_DROPDOWN);
 				break;
 			}
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -602,18 +602,18 @@ private:
 			}
 		}
 
-		DropDownList *list = new DropDownList();
+		DropDownList list;
 		if (default_livery != NULL) {
 			/* Add COLOUR_END to put the colour out of range, but also allow us to show what the default is */
 			default_col = (primary ? default_livery->colour1 : default_livery->colour2) + COLOUR_END;
-			list->push_back(new DropDownListColourItem(default_col, false));
+			list.emplace_back(new DropDownListColourItem(default_col, false));
 		}
 		for (uint i = 0; i < lengthof(_colour_dropdown); i++) {
-			list->push_back(new DropDownListColourItem(i, HasBit(used_colours, i)));
+			list.emplace_back(new DropDownListColourItem(i, HasBit(used_colours, i)));
 		}
 
 		byte sel = (default_livery == NULL || HasBit(livery->in_use, primary ? 0 : 1)) ? (primary ? livery->colour1 : livery->colour2) : default_col;
-		ShowDropDownList(this, list, sel, widget);
+		ShowDropDownList(this, std::move(list), sel, widget);
 	}
 
 	static int CDECL GroupNameSorter(const Group * const *a, const Group * const *b)

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -553,7 +553,7 @@ DEF_CONSOLE_CMD(ConUnBan)
 	/* Try by IP. */
 	uint index;
 	for (index = 0; index < _network_ban_list.size(); index++) {
-		if (strcmp(_network_ban_list[index], argv[1]) == 0) break;
+		if (_network_ban_list[index] == argv[1]) break;
 	}
 
 	/* Try by index. */
@@ -563,9 +563,8 @@ DEF_CONSOLE_CMD(ConUnBan)
 
 	if (index < _network_ban_list.size()) {
 		char msg[64];
-		seprintf(msg, lastof(msg), "Unbanned %s", _network_ban_list[index]);
+		seprintf(msg, lastof(msg), "Unbanned %s", _network_ban_list[index].c_str());
 		IConsolePrint(CC_DEFAULT, msg);
-		free(_network_ban_list[index]);
 		_network_ban_list.erase(_network_ban_list.begin() + index);
 	} else {
 		IConsolePrint(CC_DEFAULT, "Invalid list index or IP not in ban-list.");
@@ -585,8 +584,8 @@ DEF_CONSOLE_CMD(ConBanList)
 	IConsolePrint(CC_DEFAULT, "Banlist: ");
 
 	uint i = 1;
-	for (char *entry : _network_ban_list) {
-		IConsolePrintF(CC_DEFAULT, "  %d) %s", i, entry);
+	for (const auto &entry : _network_ban_list) {
+		IConsolePrintF(CC_DEFAULT, "  %d) %s", i, entry.c_str());
 	}
 
 	return true;

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -99,6 +99,4 @@ public:
 	}
 };
 
-typedef AutoFreeSmallVector<char*> StringList; ///< Type for a list of strings.
-
 #endif /* SMALLVEC_TYPE_HPP */

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -69,34 +69,4 @@ T* grow(std::vector<T>& vec, std::size_t num)
 	return vec.data() + pos;
 }
 
-/**
- * Simple vector template class, with automatic free.
- *
- * @note There are no asserts in the class so you have
- *       to care about that you grab an item which is
- *       inside the list.
- *
- * @param T The type of the items stored, must be a pointer
- */
-template <typename T>
-class AutoFreeSmallVector : public std::vector<T> {
-public:
-	~AutoFreeSmallVector()
-	{
-		this->Clear();
-	}
-
-	/**
-	 * Remove all items from the list.
-	 */
-	inline void Clear()
-	{
-		for (T p : *this) {
-			free(p);
-		}
-
-		std::vector<T>::clear();
-	}
-};
-
 #endif /* SMALLVEC_TYPE_HPP */

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -99,36 +99,6 @@ public:
 	}
 };
 
-/**
- * Simple vector template class, with automatic delete.
- *
- * @note There are no asserts in the class so you have
- *       to care about that you grab an item which is
- *       inside the list.
- *
- * @param T The type of the items stored, must be a pointer
- */
-template <typename T>
-class AutoDeleteSmallVector : public std::vector<T> {
-public:
-	~AutoDeleteSmallVector()
-	{
-		this->Clear();
-	}
-
-	/**
-	 * Remove all items from the list.
-	 */
-	inline void Clear()
-	{
-		for (T p : *this) {
-			delete p;
-		}
-
-		std::vector<T>::clear();
-	}
-};
-
 typedef AutoFreeSmallVector<char*> StringList; ///< Type for a list of strings.
 
 #endif /* SMALLVEC_TYPE_HPP */

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -68,21 +68,21 @@ struct SetDateWindow : Window {
 	void ShowDateDropDown(int widget)
 	{
 		int selected;
-		DropDownList *list = new DropDownList();
+		DropDownList list;
 
 		switch (widget) {
 			default: NOT_REACHED();
 
 			case WID_SD_DAY:
 				for (uint i = 0; i < 31; i++) {
-					list->push_back(new DropDownListStringItem(STR_DAY_NUMBER_1ST + i, i + 1, false));
+					list.emplace_back(new DropDownListStringItem(STR_DAY_NUMBER_1ST + i, i + 1, false));
 				}
 				selected = this->date.day;
 				break;
 
 			case WID_SD_MONTH:
 				for (uint i = 0; i < 12; i++) {
-					list->push_back(new DropDownListStringItem(STR_MONTH_JAN + i, i, false));
+					list.emplace_back(new DropDownListStringItem(STR_MONTH_JAN + i, i, false));
 				}
 				selected = this->date.month;
 				break;
@@ -91,13 +91,13 @@ struct SetDateWindow : Window {
 				for (Year i = this->min_year; i <= this->max_year; i++) {
 					DropDownListParamStringItem *item = new DropDownListParamStringItem(STR_JUST_INT, i, false);
 					item->SetParam(0, i);
-					list->push_back(item);
+					list.emplace_back(item);
 				}
 				selected = this->date.year;
 				break;
 		}
 
-		ShowDropDownList(this, list, selected, widget);
+		ShowDropDownList(this, std::move(list), selected, widget);
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -29,12 +29,12 @@ struct LanguageStrings {
 
 /** Container for all the game strings. */
 struct GameStrings {
-	uint version;                  ///< The version of the language strings.
-	LanguageStrings *cur_language; ///< The current (compiled) language.
+	uint version;                                  ///< The version of the language strings.
+	std::shared_ptr<LanguageStrings> cur_language; ///< The current (compiled) language.
 
-	AutoDeleteSmallVector<LanguageStrings *> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
-	AutoDeleteSmallVector<LanguageStrings *> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
-	StringList string_names;                                   ///< The names of the compiled strings.
+	std::vector<std::unique_ptr<LanguageStrings>> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
+	std::vector<std::shared_ptr<LanguageStrings>> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
+	StringList string_names;                                        ///< The names of the compiled strings.
 
 	void Compile();
 };

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -282,14 +282,14 @@ static void LandscapeGenerationCallback(Window *w, bool confirmed)
 	if (confirmed) StartGeneratingLandscape((GenerateLandscapeWindowMode)w->window_number);
 }
 
-static DropDownList *BuildMapsizeDropDown()
+static DropDownList BuildMapsizeDropDown()
 {
-	DropDownList *list = new DropDownList();
+	DropDownList list;
 
 	for (uint i = MIN_MAP_SIZE_BITS; i <= MAX_MAP_SIZE_BITS; i++) {
 		DropDownListParamStringItem *item = new DropDownListParamStringItem(STR_JUST_INT, i, false);
 		item->SetParam(0, 1LL << i);
-		list->push_back(item);
+		list.emplace_back(item);
 	}
 
 	return list;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -376,7 +376,7 @@ static int DrawLayoutLine(const ParagraphLayouter::Line *line, int y, int left, 
 		 * another size would be chosen it won't have truncated too little for
 		 * the truncation dots.
 		 */
-		FontCache *fc = ((const Font*)line->GetVisualRun(0)->GetFont())->fc;
+		FontCache *fc = ((const Font*)line->GetVisualRun(0).GetFont())->fc;
 		GlyphID dot_glyph = fc->MapCharToGlyph('.');
 		dot_width = fc->GetGlyphWidth(dot_glyph);
 		dot_sprite = fc->GetGlyph(dot_glyph);
@@ -422,8 +422,8 @@ static int DrawLayoutLine(const ParagraphLayouter::Line *line, int y, int left, 
 	TextColour colour = TC_BLACK;
 	bool draw_shadow = false;
 	for (int run_index = 0; run_index < line->CountRuns(); run_index++) {
-		const ParagraphLayouter::VisualRun *run = line->GetVisualRun(run_index);
-		const Font *f = (const Font*)run->GetFont();
+		const ParagraphLayouter::VisualRun &run = line->GetVisualRun(run_index);
+		const Font *f = (const Font*)run.GetFont();
 
 		FontCache *fc = f->fc;
 		colour = f->colour;
@@ -435,15 +435,15 @@ static int DrawLayoutLine(const ParagraphLayouter::Line *line, int y, int left, 
 
 		draw_shadow = fc->GetDrawGlyphShadow() && (colour & TC_NO_SHADE) == 0 && colour != TC_BLACK;
 
-		for (int i = 0; i < run->GetGlyphCount(); i++) {
-			GlyphID glyph = run->GetGlyphs()[i];
+		for (int i = 0; i < run.GetGlyphCount(); i++) {
+			GlyphID glyph = run.GetGlyphs()[i];
 
 			/* Not a valid glyph (empty) */
 			if (glyph == 0xFFFF) continue;
 
-			int begin_x = (int)run->GetPositions()[i * 2]     + left - offset_x;
-			int end_x   = (int)run->GetPositions()[i * 2 + 2] + left - offset_x  - 1;
-			int top     = (int)run->GetPositions()[i * 2 + 1] + y;
+			int begin_x = (int)run.GetPositions()[i * 2]     + left - offset_x;
+			int end_x   = (int)run.GetPositions()[i * 2 + 2] + left - offset_x  - 1;
+			int top     = (int)run.GetPositions()[i * 2 + 1] + y;
 
 			/* Truncated away. */
 			if (truncation && (begin_x < min_x || end_x > max_x)) continue;

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -340,12 +340,12 @@ static void SetColourRemap(TextColour colour)
  * @return In case of left or center alignment the right most pixel we have drawn to.
  *         In case of right alignment the left most pixel we have drawn to.
  */
-static int DrawLayoutLine(const ParagraphLayouter::Line *line, int y, int left, int right, StringAlignment align, bool underline, bool truncation)
+static int DrawLayoutLine(const ParagraphLayouter::Line &line, int y, int left, int right, StringAlignment align, bool underline, bool truncation)
 {
-	if (line->CountRuns() == 0) return 0;
+	if (line.CountRuns() == 0) return 0;
 
-	int w = line->GetWidth();
-	int h = line->GetLeading();
+	int w = line.GetWidth();
+	int h = line.GetLeading();
 
 	/*
 	 * The following is needed for truncation.
@@ -376,7 +376,7 @@ static int DrawLayoutLine(const ParagraphLayouter::Line *line, int y, int left, 
 		 * another size would be chosen it won't have truncated too little for
 		 * the truncation dots.
 		 */
-		FontCache *fc = ((const Font*)line->GetVisualRun(0).GetFont())->fc;
+		FontCache *fc = ((const Font*)line.GetVisualRun(0).GetFont())->fc;
 		GlyphID dot_glyph = fc->MapCharToGlyph('.');
 		dot_width = fc->GetGlyphWidth(dot_glyph);
 		dot_sprite = fc->GetGlyph(dot_glyph);
@@ -421,8 +421,8 @@ static int DrawLayoutLine(const ParagraphLayouter::Line *line, int y, int left, 
 
 	TextColour colour = TC_BLACK;
 	bool draw_shadow = false;
-	for (int run_index = 0; run_index < line->CountRuns(); run_index++) {
-		const ParagraphLayouter::VisualRun &run = line->GetVisualRun(run_index);
+	for (int run_index = 0; run_index < line.CountRuns(); run_index++) {
+		const ParagraphLayouter::VisualRun &run = line.GetVisualRun(run_index);
 		const Font *f = (const Font*)run.GetFont();
 
 		FontCache *fc = f->fc;
@@ -512,7 +512,7 @@ int DrawString(int left, int right, int top, const char *str, TextColour colour,
 	Layouter layout(str, INT32_MAX, colour, fontsize);
 	if (layout.size() == 0) return 0;
 
-	return DrawLayoutLine(layout.front(), top, left, right, align, underline, true);
+	return DrawLayoutLine(*layout.front(), top, left, right, align, underline, true);
 }
 
 /**
@@ -648,14 +648,14 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, const char *st
 	int last_line = top;
 	int first_line = bottom;
 
-	for (const ParagraphLayouter::Line *line : layout) {
+	for (const auto &line : layout) {
 
 		int line_height = line->GetLeading();
 		if (y >= top && y < bottom) {
 			last_line = y + line_height;
 			if (first_line > y) first_line = y;
 
-			DrawLayoutLine(line, y, left, right, align, underline, false);
+			DrawLayoutLine(*line, y, left, right, align, underline, false);
 		}
 		y += line_height;
 	}

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -143,14 +143,14 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class ICULine : public AutoDeleteSmallVector<ICUVisualRun *>, public ParagraphLayouter::Line {
+	class ICULine : public std::vector<ICUVisualRun>, public ParagraphLayouter::Line {
 		icu::ParagraphLayout::Line *l; ///< The actual ICU line.
 
 	public:
 		ICULine(icu::ParagraphLayout::Line *l) : l(l)
 		{
 			for (int i = 0; i < l->countRuns(); i++) {
-				this->push_back(new ICUVisualRun(l->getVisualRun(i)));
+				this->emplace_back(l->getVisualRun(i));
 			}
 		}
 		~ICULine() override { delete l; }
@@ -158,7 +158,7 @@ public:
 		int GetLeading() const override { return l->getLeading(); }
 		int GetWidth() const override   { return l->getWidth(); }
 		int CountRuns() const override  { return l->countRuns(); }
-		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const override { return this->at(run); }
+		const ParagraphLayouter::VisualRun &GetVisualRun(int run) const override { return this->at(run); }
 
 		int GetInternalCharLength(WChar c) const override
 		{
@@ -259,6 +259,7 @@ public:
 
 	public:
 		FallbackVisualRun(Font *font, const WChar *chars, int glyph_count, int x);
+		FallbackVisualRun(FallbackVisualRun &&other) noexcept;
 		~FallbackVisualRun() override;
 		const Font *GetFont() const override;
 		int GetGlyphCount() const override;
@@ -269,12 +270,12 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class FallbackLine : public AutoDeleteSmallVector<FallbackVisualRun *>, public ParagraphLayouter::Line {
+	class FallbackLine : public std::vector<FallbackVisualRun>, public ParagraphLayouter::Line {
 	public:
 		int GetLeading() const override;
 		int GetWidth() const override;
 		int CountRuns() const override;
-		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const override;
+		const ParagraphLayouter::VisualRun &GetVisualRun(int run) const override;
 
 		int GetInternalCharLength(WChar c) const override { return 1; }
 	};
@@ -350,6 +351,18 @@ FallbackParagraphLayout::FallbackVisualRun::FallbackVisualRun(Font *font, const 
 	}
 }
 
+/** Move constructor for visual runs.*/
+FallbackParagraphLayout::FallbackVisualRun::FallbackVisualRun(FallbackVisualRun &&other) noexcept : font(other.font), glyph_count(other.glyph_count)
+{
+	this->positions = other.positions;
+	this->glyph_to_char = other.glyph_to_char;
+	this->glyphs = other.glyphs;
+
+	other.positions = NULL;
+	other.glyph_to_char = NULL;
+	other.glyphs = NULL;
+}
+
 /** Free all data. */
 FallbackParagraphLayout::FallbackVisualRun::~FallbackVisualRun()
 {
@@ -419,8 +432,8 @@ int FallbackParagraphLayout::FallbackVisualRun::GetLeading() const
 int FallbackParagraphLayout::FallbackLine::GetLeading() const
 {
 	int leading = 0;
-	for (const FallbackVisualRun * const &run : *this) {
-		leading = max(leading, run->GetLeading());
+	for (const auto &run : *this) {
+		leading = max(leading, run.GetLeading());
 	}
 
 	return leading;
@@ -439,8 +452,8 @@ int FallbackParagraphLayout::FallbackLine::GetWidth() const
 	 * Since there is no left-to-right support, taking this value of
 	 * the last run gives us the end of the line and thus the width.
 	 */
-	const ParagraphLayouter::VisualRun *run = this->GetVisualRun(this->CountRuns() - 1);
-	return (int)run->GetPositions()[run->GetGlyphCount() * 2];
+	const auto &run = this->GetVisualRun(this->CountRuns() - 1);
+	return (int)run.GetPositions()[run.GetGlyphCount() * 2];
 }
 
 /**
@@ -456,7 +469,7 @@ int FallbackParagraphLayout::FallbackLine::CountRuns() const
  * Get a specific visual run.
  * @return The visual run.
  */
-const ParagraphLayouter::VisualRun *FallbackParagraphLayout::FallbackLine::GetVisualRun(int run) const
+const ParagraphLayouter::VisualRun &FallbackParagraphLayout::FallbackLine::GetVisualRun(int run) const
 {
 	return this->at(run);
 }
@@ -498,7 +511,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 	if (*this->buffer == '\0') {
 		/* Only a newline. */
 		this->buffer = NULL;
-		l->push_back(new FallbackVisualRun(this->runs.front().second, this->buffer, 0, 0));
+		l->emplace_back(this->runs.front().second, this->buffer, 0, 0);
 		return l;
 	}
 
@@ -527,7 +540,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 
 		if (this->buffer == next_run) {
 			int w = l->GetWidth();
-			l->push_back(new FallbackVisualRun(iter->second, begin, this->buffer - begin, w));
+			l->emplace_back(iter->second, begin, this->buffer - begin, w);
 			iter++;
 			assert(iter != this->runs.End());
 
@@ -574,7 +587,7 @@ const ParagraphLayouter::Line *FallbackParagraphLayout::NextLine(int max_width)
 
 	if (l->size() == 0 || last_char - begin != 0) {
 		int w = l->GetWidth();
-		l->push_back(new FallbackVisualRun(iter->second, begin, last_char - begin, w));
+		l->emplace_back(iter->second, begin, last_char - begin, w);
 	}
 	return l;
 }
@@ -772,12 +785,12 @@ Point Layouter::GetCharPosition(const char *ch) const
 
 		/* Scan all runs until we've found our code point index. */
 		for (int run_index = 0; run_index < line->CountRuns(); run_index++) {
-			const ParagraphLayouter::VisualRun *run = line->GetVisualRun(run_index);
+			const ParagraphLayouter::VisualRun &run = line->GetVisualRun(run_index);
 
-			for (int i = 0; i < run->GetGlyphCount(); i++) {
+			for (int i = 0; i < run.GetGlyphCount(); i++) {
 				/* Matching glyph? Return position. */
-				if ((size_t)run->GetGlyphToCharMap()[i] == index) {
-					Point p = { (int)run->GetPositions()[i * 2], (int)run->GetPositions()[i * 2 + 1] };
+				if ((size_t)run.GetGlyphToCharMap()[i] == index) {
+					Point p = { (int)run.GetPositions()[i * 2], (int)run.GetPositions()[i * 2 + 1] };
 					return p;
 				}
 			}
@@ -798,18 +811,18 @@ const char *Layouter::GetCharAtPosition(int x) const
 	const ParagraphLayouter::Line *line = this->front();
 
 	for (int run_index = 0; run_index < line->CountRuns(); run_index++) {
-		const ParagraphLayouter::VisualRun *run = line->GetVisualRun(run_index);
+		const ParagraphLayouter::VisualRun &run = line->GetVisualRun(run_index);
 
-		for (int i = 0; i < run->GetGlyphCount(); i++) {
+		for (int i = 0; i < run.GetGlyphCount(); i++) {
 			/* Not a valid glyph (empty). */
-			if (run->GetGlyphs()[i] == 0xFFFF) continue;
+			if (run.GetGlyphs()[i] == 0xFFFF) continue;
 
-			int begin_x = (int)run->GetPositions()[i * 2];
-			int end_x   = (int)run->GetPositions()[i * 2 + 2];
+			int begin_x = (int)run.GetPositions()[i * 2];
+			int end_x   = (int)run.GetPositions()[i * 2 + 2];
 
 			if (IsInsideMM(x, begin_x, end_x)) {
 				/* Found our glyph, now convert to UTF-8 string index. */
-				size_t index = run->GetGlyphToCharMap()[i];
+				size_t index = run.GetGlyphToCharMap()[i];
 
 				size_t cur_idx = 0;
 				for (const char *str = this->string; *str != '\0'; ) {

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -134,12 +134,12 @@ public:
 	public:
 		ICUVisualRun(const icu::ParagraphLayout::VisualRun *vr) : vr(vr) { }
 
-		const Font *GetFont() const          { return (const Font*)vr->getFont(); }
-		int GetGlyphCount() const            { return vr->getGlyphCount(); }
-		const GlyphID *GetGlyphs() const     { return vr->getGlyphs(); }
-		const float *GetPositions() const    { return vr->getPositions(); }
-		int GetLeading() const               { return vr->getLeading(); }
-		const int *GetGlyphToCharMap() const { return vr->getGlyphToCharMap(); }
+		const Font *GetFont() const override          { return (const Font*)vr->getFont(); }
+		int GetGlyphCount() const override            { return vr->getGlyphCount(); }
+		const GlyphID *GetGlyphs() const override     { return vr->getGlyphs(); }
+		const float *GetPositions() const override    { return vr->getPositions(); }
+		int GetLeading() const override               { return vr->getLeading(); }
+		const int *GetGlyphToCharMap() const override { return vr->getGlyphToCharMap(); }
 	};
 
 	/** A single line worth of VisualRuns. */
@@ -153,14 +153,14 @@ public:
 				this->push_back(new ICUVisualRun(l->getVisualRun(i)));
 			}
 		}
-		~ICULine() { delete l; }
+		~ICULine() override { delete l; }
 
-		int GetLeading() const { return l->getLeading(); }
-		int GetWidth() const   { return l->getWidth(); }
-		int CountRuns() const  { return l->countRuns(); }
-		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const { return this->at(run); }
+		int GetLeading() const override { return l->getLeading(); }
+		int GetWidth() const override   { return l->getWidth(); }
+		int CountRuns() const override  { return l->countRuns(); }
+		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const override { return this->at(run); }
 
-		int GetInternalCharLength(WChar c) const
+		int GetInternalCharLength(WChar c) const override
 		{
 			/* ICU uses UTF-16 internally which means we need to account for surrogate pairs. */
 			return Utf8CharLen(c) < 4 ? 1 : 2;
@@ -168,10 +168,10 @@ public:
 	};
 
 	ICUParagraphLayout(icu::ParagraphLayout *p) : p(p) { }
-	~ICUParagraphLayout() { delete p; }
-	void Reflow() { p->reflow(); }
+	~ICUParagraphLayout() override { delete p; }
+	void Reflow() override  { p->reflow(); }
 
-	ParagraphLayouter::Line *NextLine(int max_width)
+	ParagraphLayouter::Line *NextLine(int max_width) override
 	{
 		icu::ParagraphLayout::Line *l = p->nextLine(max_width);
 		return l == NULL ? NULL : new ICULine(l);
@@ -259,24 +259,24 @@ public:
 
 	public:
 		FallbackVisualRun(Font *font, const WChar *chars, int glyph_count, int x);
-		~FallbackVisualRun();
-		const Font *GetFont() const;
-		int GetGlyphCount() const;
-		const GlyphID *GetGlyphs() const;
-		const float *GetPositions() const;
-		int GetLeading() const;
-		const int *GetGlyphToCharMap() const;
+		~FallbackVisualRun() override;
+		const Font *GetFont() const override;
+		int GetGlyphCount() const override;
+		const GlyphID *GetGlyphs() const override;
+		const float *GetPositions() const override;
+		int GetLeading() const override;
+		const int *GetGlyphToCharMap() const override;
 	};
 
 	/** A single line worth of VisualRuns. */
 	class FallbackLine : public AutoDeleteSmallVector<FallbackVisualRun *>, public ParagraphLayouter::Line {
 	public:
-		int GetLeading() const;
-		int GetWidth() const;
-		int CountRuns() const;
-		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const;
+		int GetLeading() const override;
+		int GetWidth() const override;
+		int CountRuns() const override;
+		const ParagraphLayouter::VisualRun *GetVisualRun(int run) const override;
 
-		int GetInternalCharLength(WChar c) const { return 1; }
+		int GetInternalCharLength(WChar c) const override { return 1; }
 	};
 
 	const WChar *buffer_begin; ///< Begin of the buffer.
@@ -284,8 +284,8 @@ public:
 	FontMap &runs;             ///< The fonts we have to use for this paragraph.
 
 	FallbackParagraphLayout(WChar *buffer, int length, FontMap &runs);
-	void Reflow();
-	const ParagraphLayouter::Line *NextLine(int max_width);
+	void Reflow() override;
+	const ParagraphLayouter::Line *NextLine(int max_width) override;
 };
 
 /**

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -142,7 +142,7 @@ public:
 	};
 
 	virtual void Reflow() = 0;
-	virtual const Line *NextLine(int max_width) = 0;
+	virtual std::unique_ptr<const Line> NextLine(int max_width) = 0;
 };
 
 /**
@@ -150,7 +150,7 @@ public:
  *
  * It also accounts for the memory allocations and frees.
  */
-class Layouter : public AutoDeleteSmallVector<const ParagraphLayouter::Line *> {
+class Layouter : public std::vector<std::unique_ptr<const ParagraphLayouter::Line>> {
 	const char *string; ///< Pointer to the original string.
 
 	/** Key into the linecache */

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -137,7 +137,7 @@ public:
 		virtual int GetLeading() const = 0;
 		virtual int GetWidth() const = 0;
 		virtual int CountRuns() const = 0;
-		virtual const VisualRun *GetVisualRun(int run) const = 0;
+		virtual const VisualRun &GetVisualRun(int run) const = 0;
 		virtual int GetInternalCharLength(WChar c) const = 0;
 	};
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -768,8 +768,7 @@ public:
 				break;
 
 			case WID_GL_MANAGE_VEHICLES_DROPDOWN: {
-				DropDownList *list = this->BuildActionDropdownList(true, Group::IsValidID(this->vli.index));
-				ShowDropDownList(this, list, 0, WID_GL_MANAGE_VEHICLES_DROPDOWN);
+				ShowDropDownList(this, this->BuildActionDropdownList(true, Group::IsValidID(this->vli.index)), 0, WID_GL_MANAGE_VEHICLES_DROPDOWN);
 				break;
 			}
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2709,34 +2709,30 @@ struct IndustryCargoesWindow : public Window {
 				break;
 
 			case WID_IC_CARGO_DROPDOWN: {
-				DropDownList *lst = new DropDownList;
+				DropDownList lst;
 				const CargoSpec *cs;
 				FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
-					lst->push_back(new DropDownListStringItem(cs->name, cs->Index(), false));
+					lst.emplace_back(new DropDownListStringItem(cs->name, cs->Index(), false));
 				}
-				if (lst->size() == 0) {
-					delete lst;
-					break;
+				if (!lst.empty()) {
+					int selected = (this->ind_cargo >= NUM_INDUSTRYTYPES) ? (int)(this->ind_cargo - NUM_INDUSTRYTYPES) : -1;
+					ShowDropDownList(this, std::move(lst), selected, WID_IC_CARGO_DROPDOWN, 0, true);
 				}
-				int selected = (this->ind_cargo >= NUM_INDUSTRYTYPES) ? (int)(this->ind_cargo - NUM_INDUSTRYTYPES) : -1;
-				ShowDropDownList(this, lst, selected, WID_IC_CARGO_DROPDOWN, 0, true);
 				break;
 			}
 
 			case WID_IC_IND_DROPDOWN: {
-				DropDownList *lst = new DropDownList;
+				DropDownList lst;
 				for (uint i = 0; i < NUM_INDUSTRYTYPES; i++) {
 					IndustryType ind = _sorted_industry_types[i];
 					const IndustrySpec *indsp = GetIndustrySpec(ind);
 					if (!indsp->enabled) continue;
-					lst->push_back(new DropDownListStringItem(indsp->name, ind, false));
+					lst.emplace_back(new DropDownListStringItem(indsp->name, ind, false));
 				}
-				if (lst->size() == 0) {
-					delete lst;
-					break;
+				if (!lst.empty()) {
+					int selected = (this->ind_cargo < NUM_INDUSTRYTYPES) ? (int)this->ind_cargo : -1;
+					ShowDropDownList(this, std::move(lst), selected, WID_IC_IND_DROPDOWN, 0, true);
 				}
-				int selected = (this->ind_cargo < NUM_INDUSTRYTYPES) ? (int)this->ind_cargo : -1;
-				ShowDropDownList(this, lst, selected, WID_IC_IND_DROPDOWN, 0, true);
 				break;
 			}
 		}

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -571,8 +571,7 @@ struct MusicTrackSelectionWindow : public Window {
 
 			case WID_MTS_MUSICSET: {
 				int selected = 0;
-				DropDownList *dropdown = BuildMusicSetDropDownList(&selected);
-				ShowDropDownList(this, dropdown, selected, widget, 0, true, false);
+				ShowDropDownList(this, BuildMusicSetDropDownList(&selected), selected, widget, 0, true, false);
 				break;
 			}
 

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -156,7 +156,7 @@ bool NetworkAddress::IsFamily(int family)
  * @note netmask without /n assumes all bits need to match.
  * @return true if this IP is within the netmask.
  */
-bool NetworkAddress::IsInNetmask(char *netmask)
+bool NetworkAddress::IsInNetmask(const char *netmask)
 {
 	/* Resolve it if we didn't do it already */
 	if (!this->IsResolved()) this->GetAddress();
@@ -166,17 +166,16 @@ bool NetworkAddress::IsInNetmask(char *netmask)
 	NetworkAddress mask_address;
 
 	/* Check for CIDR separator */
-	char *chr_cidr = strchr(netmask, '/');
+	const char *chr_cidr = strchr(netmask, '/');
 	if (chr_cidr != NULL) {
 		int tmp_cidr = atoi(chr_cidr + 1);
 
 		/* Invalid CIDR, treat as single host */
 		if (tmp_cidr > 0 || tmp_cidr < cidr) cidr = tmp_cidr;
 
-		/* Remove and then replace the / so that NetworkAddress works on the IP portion */
-		*chr_cidr = '\0';
-		mask_address = NetworkAddress(netmask, 0, this->address.ss_family);
-		*chr_cidr = '/';
+		/* Remove the / so that NetworkAddress works on the IP portion */
+		std::string ip_str(netmask, chr_cidr - netmask);
+		mask_address = NetworkAddress(ip_str.c_str(), 0, this->address.ss_family);
 	} else {
 		mask_address = NetworkAddress(netmask, 0, this->address.ss_family);
 	}

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -129,7 +129,7 @@ public:
 	}
 
 	bool IsFamily(int family);
-	bool IsInNetmask(char *netmask);
+	bool IsInNetmask(const char *netmask);
 
 	/**
 	 * Compare the address of this class with the address of another.

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -54,13 +54,13 @@ public:
 
 			/* Check if the client is banned */
 			bool banned = false;
-			for (char *entry : _network_ban_list) {
-				banned = address.IsInNetmask(entry);
+			for (const auto &entry : _network_ban_list) {
+				banned = address.IsInNetmask(entry.c_str());
 				if (banned) {
 					Packet p(Tban_packet);
 					p.PrepareToSend();
 
-					DEBUG(net, 1, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry);
+					DEBUG(net, 1, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry.c_str());
 
 					if (send(s, (const char*)p.buffer, p.size, 0) < 0) {
 						DEBUG(net, 0, "send failed with error %d", GET_LAST_ERROR());

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -632,8 +632,8 @@ void NetworkAddServer(const char *b)
  */
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port)
 {
-	for (char *iter : _network_bind_list) {
-		addresses->emplace_back(iter, port);
+	for (const auto &iter : _network_bind_list) {
+		addresses->emplace_back(iter.c_str(), port);
 	}
 
 	/* No address, so bind to everything. */
@@ -647,10 +647,10 @@ void GetBindAddresses(NetworkAddressList *addresses, uint16 port)
  * by the function that generates the config file. */
 void NetworkRebuildHostList()
 {
-	_network_host_list.Clear();
+	_network_host_list.clear();
 
 	for (NetworkGameList *item = _network_game_list; item != NULL; item = item->next) {
-		if (item->manually) _network_host_list.push_back(stredup(item->address.GetAddressAsString(false)));
+		if (item->manually) _network_host_list.emplace_back(item->address.GetAddressAsString(false));
 	}
 }
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -42,7 +42,7 @@
 struct PacketReader : LoadFilter {
 	static const size_t CHUNK = 32 * 1024;  ///< 32 KiB chunks of memory.
 
-	AutoFreeSmallVector<byte *> blocks;     ///< Buffer with blocks of allocated memory.
+	std::vector<byte *> blocks;             ///< Buffer with blocks of allocated memory.
 	byte *buf;                              ///< Buffer we're going to write to/read from.
 	byte *bufe;                             ///< End of the buffer we write to/read from.
 	byte **block;                           ///< The block we're reading from/writing to.
@@ -52,6 +52,13 @@ struct PacketReader : LoadFilter {
 	/** Initialise everything. */
 	PacketReader() : LoadFilter(NULL), buf(NULL), bufe(NULL), block(NULL), written_bytes(0), read_bytes(0)
 	{
+	}
+
+	~PacketReader() override
+	{
+		for (auto p : this->blocks) {
+			free(p);
+		}
 	}
 
 	/**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1045,8 +1045,8 @@ void ShowNetworkGameWindow()
 	if (first) {
 		first = false;
 		/* Add all servers from the config file to our list. */
-		for (char *iter : _network_host_list) {
-			NetworkAddServer(iter);
+		for (const auto &iter : _network_host_list) {
+			NetworkAddServer(iter.c_str());
 		}
 	}
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -2083,13 +2083,13 @@ uint NetworkServerKickOrBanIP(const char *ip, bool ban)
 	/* Add address to ban-list */
 	if (ban) {
 		bool contains = false;
-		for (char *iter : _network_ban_list) {
-			if (strcmp(iter, ip) == 0) {
+		for (const auto &iter : _network_ban_list) {
+			if (iter == ip) {
 				contains = true;
 				break;
 			}
 		}
-		if (!contains) _network_ban_list.push_back(stredup(ip));
+		if (!contains) _network_ban_list.emplace_back(ip);
 	}
 
 	uint n = 0;
@@ -2098,7 +2098,7 @@ uint NetworkServerKickOrBanIP(const char *ip, bool ban)
 	NetworkClientSocket *cs;
 	FOR_ALL_CLIENT_SOCKETS(cs) {
 		if (cs->client_id == CLIENT_ID_SERVER) continue;
-		if (cs->client_address.IsInNetmask(const_cast<char *>(ip))) {
+		if (cs->client_address.IsInNetmask(ip)) {
 			NetworkServerKickClient(cs->client_id);
 			n++;
 		}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -376,12 +376,12 @@ struct NewGRFParametersWindow : public Window {
 							this->clicked_dropdown = true;
 							this->closing_dropdown = false;
 
-							DropDownList *list = new DropDownList();
+							DropDownList list;
 							for (uint32 i = par_info->min_value; i <= par_info->max_value; i++) {
-								list->push_back(new DropDownListCharStringItem(GetGRFStringFromGRFText(par_info->value_names.Find(i)->second), i, false));
+								list.emplace_back(new DropDownListCharStringItem(GetGRFStringFromGRFText(par_info->value_names.Find(i)->second), i, false));
 							}
 
-							ShowDropDownListAt(this, list, old_val, -1, wi_rect, COLOUR_ORANGE, true);
+							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE, true);
 						}
 					}
 				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
@@ -924,19 +924,19 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 		switch (widget) {
 			case WID_NS_PRESET_LIST: {
-				DropDownList *list = new DropDownList();
+				DropDownList list;
 
 				/* Add 'None' option for clearing list */
-				list->push_back(new DropDownListStringItem(STR_NONE, -1, false));
+				list.emplace_back(new DropDownListStringItem(STR_NONE, -1, false));
 
 				for (uint i = 0; i < _grf_preset_list.size(); i++) {
 					if (_grf_preset_list[i] != NULL) {
-						list->push_back(new DropDownListCharStringItem(_grf_preset_list[i], i, false));
+						list.emplace_back(new DropDownListCharStringItem(_grf_preset_list[i], i, false));
 					}
 				}
 
 				this->DeleteChildWindows(WC_QUERY_STRING); // Remove the parameter query window
-				ShowDropDownList(this, list, this->preset, WID_NS_PRESET_LIST);
+				ShowDropDownList(this, std::move(list), this->preset, WID_NS_PRESET_LIST);
 				break;
 			}
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -445,8 +445,8 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		if (generation_seed != GENERATE_NEW_SEED) _settings_newgame.game_creation.generation_seed = generation_seed;
 
 		if (dedicated_host != NULL) {
-			_network_bind_list.Clear();
-			_network_bind_list.push_back(stredup(dedicated_host));
+			_network_bind_list.clear();
+			_network_bind_list.emplace_back(dedicated_host);
 		}
 		if (dedicated_port != 0) _settings_client.network.server_port = dedicated_port;
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -1295,11 +1295,11 @@ public:
 				break;
 
 			case WID_O_COND_VARIABLE: {
-				DropDownList *list = new DropDownList();
+				DropDownList list;
 				for (uint i = 0; i < lengthof(_order_conditional_variable); i++) {
-					list->push_back(new DropDownListStringItem(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + _order_conditional_variable[i], _order_conditional_variable[i], false));
+					list.emplace_back(new DropDownListStringItem(STR_ORDER_CONDITIONAL_LOAD_PERCENTAGE + _order_conditional_variable[i], _order_conditional_variable[i], false));
 				}
-				ShowDropDownList(this, list, this->vehicle->GetOrder(this->OrderGetSel())->GetConditionVariable(), WID_O_COND_VARIABLE);
+				ShowDropDownList(this, std::move(list), this->vehicle->GetOrder(this->OrderGetSel())->GetConditionVariable(), WID_O_COND_VARIABLE);
 				break;
 			}
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -54,13 +54,13 @@ public:
 	public:
 		CoreTextVisualRun(CTRunRef run, Font *font, const CoreTextParagraphLayoutFactory::CharType *buff);
 
-		virtual const GlyphID *GetGlyphs() const { return &this->glyphs[0]; }
-		virtual const float *GetPositions() const { return &this->positions[0]; }
-		virtual const int *GetGlyphToCharMap() const { return &this->glyph_to_char[0]; }
+		const GlyphID *GetGlyphs() const override { return &this->glyphs[0]; }
+		const float *GetPositions() const override { return &this->positions[0]; }
+		const int *GetGlyphToCharMap() const override { return &this->glyph_to_char[0]; }
 
-		virtual const Font *GetFont() const { return this->font;  }
-		virtual int GetLeading() const { return this->font->fc->GetHeight(); }
-		virtual int GetGlyphCount() const { return (int)this->glyphs.size(); }
+		const Font *GetFont() const override { return this->font;  }
+		int GetLeading() const override { return this->font->fc->GetHeight(); }
+		int GetGlyphCount() const override { return (int)this->glyphs.size(); }
 		int GetAdvance() const { return this->total_advance; }
 	};
 
@@ -83,12 +83,12 @@ public:
 			CFRelease(line);
 		}
 
-		virtual int GetLeading() const;
-		virtual int GetWidth() const;
-		virtual int CountRuns() const { return this->size();  }
-		virtual const VisualRun *GetVisualRun(int run) const { return this->at(run);  }
+		int GetLeading() const override;
+		int GetWidth() const override;
+		int CountRuns() const override { return this->size(); }
+		const VisualRun *GetVisualRun(int run) const override { return this->at(run);  }
 
-		int GetInternalCharLength(WChar c) const
+		int GetInternalCharLength(WChar c) const override
 		{
 			/* CoreText uses UTF-16 internally which means we need to account for surrogate pairs. */
 			return c >= 0x010000U ? 2 : 1;
@@ -100,17 +100,17 @@ public:
 		this->Reflow();
 	}
 
-	virtual ~CoreTextParagraphLayout()
+	~CoreTextParagraphLayout() override
 	{
 		CFRelease(this->typesetter);
 	}
 
-	virtual void Reflow()
+	void Reflow() override
 	{
 		this->cur_offset = 0;
 	}
 
-	virtual const Line *NextLine(int max_width);
+	const Line *NextLine(int max_width) override;
 };
 
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -53,6 +53,7 @@ public:
 
 	public:
 		CoreTextVisualRun(CTRunRef run, Font *font, const CoreTextParagraphLayoutFactory::CharType *buff);
+		CoreTextVisualRun(CoreTextVisualRun &&other) = default;
 
 		const GlyphID *GetGlyphs() const override { return &this->glyphs[0]; }
 		const float *GetPositions() const override { return &this->positions[0]; }
@@ -65,7 +66,7 @@ public:
 	};
 
 	/** A single line worth of VisualRuns. */
-	class CoreTextLine : public AutoDeleteSmallVector<CoreTextVisualRun *>, public ParagraphLayouter::Line {
+	class CoreTextLine : public std::vector<CoreTextVisualRun>, public ParagraphLayouter::Line {
 	public:
 		CoreTextLine(CTLineRef line, const FontMap &fontMapping, const CoreTextParagraphLayoutFactory::CharType *buff)
 		{
@@ -78,7 +79,7 @@ public:
 				auto map = fontMapping.begin();
 				while (map < fontMapping.end() - 1 && map->first <= chars.location) map++;
 
-				this->push_back(new CoreTextVisualRun(run, map->second, buff));
+				this->emplace_back(run, map->second, buff);
 			}
 			CFRelease(line);
 		}
@@ -86,7 +87,7 @@ public:
 		int GetLeading() const override;
 		int GetWidth() const override;
 		int CountRuns() const override { return this->size(); }
-		const VisualRun *GetVisualRun(int run) const override { return this->at(run);  }
+		const VisualRun &GetVisualRun(int run) const override { return this->at(run);  }
 
 		int GetInternalCharLength(WChar c) const override
 		{

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -111,7 +111,7 @@ public:
 		this->cur_offset = 0;
 	}
 
-	const Line *NextLine(int max_width) override;
+	std::unique_ptr<const Line> NextLine(int max_width) override;
 };
 
 
@@ -188,7 +188,7 @@ static CTRunDelegateCallbacks _sprite_font_callback = {
 	return typesetter != NULL ? new CoreTextParagraphLayout(typesetter, buff, length, fontMapping) : NULL;
 }
 
-/* virtual */ const CoreTextParagraphLayout::Line *CoreTextParagraphLayout::NextLine(int max_width)
+/* virtual */ std::unique_ptr<const ParagraphLayouter::Line> CoreTextParagraphLayout::NextLine(int max_width)
 {
 	if (this->cur_offset >= this->length) return NULL;
 
@@ -200,7 +200,7 @@ static CTRunDelegateCallbacks _sprite_font_callback = {
 	CTLineRef line = CTTypesetterCreateLine(this->typesetter, CFRangeMake(this->cur_offset, len));
 	this->cur_offset += len;
 
-	return line != NULL ? new CoreTextLine(line, this->font_map, this->text_buffer) : NULL;
+	return std::unique_ptr<const Line>(line != NULL ? new CoreTextLine(line, this->font_map, this->text_buffer) : NULL);
 }
 
 CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font *font, const CoreTextParagraphLayoutFactory::CharType *buff) : font(font)
@@ -244,8 +244,8 @@ CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font
 int CoreTextParagraphLayout::CoreTextLine::GetLeading() const
 {
 	int leading = 0;
-	for (const CoreTextVisualRun * const &run : *this) {
-		leading = max(leading, run->GetLeading());
+	for (const auto &run : *this) {
+		leading = max(leading, run.GetLeading());
 	}
 
 	return leading;
@@ -260,8 +260,8 @@ int CoreTextParagraphLayout::CoreTextLine::GetWidth() const
 	if (this->size() == 0) return 0;
 
 	int total_width = 0;
-	for (const CoreTextVisualRun * const &run : *this) {
-		total_width += run->GetAdvance();
+	for (const auto &run : *this) {
+		total_width += run.GetAdvance();
 	}
 
 	return total_width;

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -30,10 +30,10 @@ class OSXStringIterator : public StringIterator {
 	size_t cur_pos; ///< Current iteration position.
 
 public:
-	virtual void SetString(const char *s);
-	virtual size_t SetCurPosition(size_t pos);
-	virtual size_t Next(IterType what);
-	virtual size_t Prev(IterType what);
+	void SetString(const char *s) override;
+	size_t SetCurPosition(size_t pos) override;
+	size_t Next(IterType what) override;
+	size_t Prev(IterType what) override;
 
 	static StringIterator *Create();
 };

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -90,30 +90,30 @@ public:
 
 	public:
 		UniscribeVisualRun(const UniscribeRun &range, int x);
-		virtual ~UniscribeVisualRun()
+		~UniscribeVisualRun() override
 		{
 			free(this->glyph_to_char);
 		}
 
-		virtual const GlyphID *GetGlyphs() const { return &this->glyphs[0]; }
-		virtual const float *GetPositions() const { return &this->positions[0]; }
-		virtual const int *GetGlyphToCharMap() const;
+		const GlyphID *GetGlyphs() const override { return &this->glyphs[0]; }
+		const float *GetPositions() const override { return &this->positions[0]; }
+		const int *GetGlyphToCharMap() const override;
 
-		virtual const Font *GetFont() const { return this->font;  }
-		virtual int GetLeading() const { return this->font->fc->GetHeight(); }
-		virtual int GetGlyphCount() const { return this->num_glyphs; }
+		const Font *GetFont() const override { return this->font;  }
+		int GetLeading() const override { return this->font->fc->GetHeight(); }
+		int GetGlyphCount() const override { return this->num_glyphs; }
 		int GetAdvance() const { return this->total_advance; }
 	};
 
 	/** A single line worth of VisualRuns. */
 	class UniscribeLine : public AutoDeleteSmallVector<UniscribeVisualRun *>, public ParagraphLayouter::Line {
 	public:
-		virtual int GetLeading() const;
-		virtual int GetWidth() const;
-		virtual int CountRuns() const { return (uint)this->size();  }
-		virtual const VisualRun *GetVisualRun(int run) const { return this->at(run);  }
+		int GetLeading() const override;
+		int GetWidth() const override;
+		int CountRuns() const override { return (uint)this->size();  }
+		const VisualRun *GetVisualRun(int run) const override { return this->at(run);  }
 
-		int GetInternalCharLength(WChar c) const
+		int GetInternalCharLength(WChar c) const override
 		{
 			/* Uniscribe uses UTF-16 internally which means we need to account for surrogate pairs. */
 			return c >= 0x010000U ? 2 : 1;
@@ -125,15 +125,15 @@ public:
 		this->Reflow();
 	}
 
-	virtual ~UniscribeParagraphLayout() {}
+	~UniscribeParagraphLayout() override {}
 
-	virtual void Reflow()
+	void Reflow() override
 	{
 		this->cur_range = this->ranges.begin();
 		this->cur_range_offset = 0;
 	}
 
-	virtual const Line *NextLine(int max_width);
+	const Line *NextLine(int max_width) override;
 };
 
 void UniscribeResetScriptCache(FontSize size)

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -134,7 +134,7 @@ public:
 		this->cur_range_offset = 0;
 	}
 
-	const Line *NextLine(int max_width) override;
+	std::unique_ptr<const Line> NextLine(int max_width) override;
 };
 
 void UniscribeResetScriptCache(FontSize size)
@@ -318,7 +318,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	return new UniscribeParagraphLayout(ranges, buff);
 }
 
-/* virtual */ const ParagraphLayouter::Line *UniscribeParagraphLayout::NextLine(int max_width)
+/* virtual */ std::unique_ptr<const ParagraphLayouter::Line> UniscribeParagraphLayout::NextLine(int max_width)
 {
 	std::vector<UniscribeRun>::iterator start_run = this->cur_range;
 	std::vector<UniscribeRun>::iterator last_run = this->cur_range;
@@ -404,7 +404,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	if (FAILED(ScriptLayout((int)bidi_level.size(), &bidi_level[0], &vis_to_log[0], NULL))) return NULL;
 
 	/* Create line. */
-	UniscribeLine *line = new UniscribeLine();
+	std::unique_ptr<UniscribeLine> line(new UniscribeLine());
 
 	int cur_pos = 0;
 	for (std::vector<INT>::iterator l = vis_to_log.begin(); l != vis_to_log.end(); l++) {

--- a/src/os/windows/string_uniscribe.h
+++ b/src/os/windows/string_uniscribe.h
@@ -81,10 +81,10 @@ class UniscribeStringIterator : public StringIterator {
 	size_t cur_pos; ///< Current iteration position.
 
 public:
-	virtual void SetString(const char *s);
-	virtual size_t SetCurPosition(size_t pos);
-	virtual size_t Next(IterType what);
-	virtual size_t Prev(IterType what);
+	void SetString(const char *s) override;
+	size_t SetCurPosition(size_t pos) override;
+	size_t Next(IterType what) override;
+	size_t Prev(IterType what) override;
 };
 
 #endif /* defined(WITH_UNISCRIBE) */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1987,7 +1987,7 @@ void InitializeRailGUI()
  * @param all_option Whether to add an 'all types' item.
  * @return The populated and sorted #DropDownList.
  */
-DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
+DropDownList GetRailTypeDropDownList(bool for_replacement, bool all_option)
 {
 	RailTypes used_railtypes;
 	RailTypes avail_railtypes;
@@ -2003,11 +2003,10 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		used_railtypes  = GetRailTypes(true);
 	}
 
-	DropDownList *list = new DropDownList();
+	DropDownList list;
 
 	if (all_option) {
-		DropDownListStringItem *item = new DropDownListStringItem(STR_REPLACE_ALL_RAILTYPE, INVALID_RAILTYPE, false);
-		list->push_back(item);
+		list.emplace_back(new DropDownListStringItem(STR_REPLACE_ALL_RAILTYPE, INVALID_RAILTYPE, false));
 	}
 
 	Dimension d = { 0, 0 };
@@ -2038,7 +2037,7 @@ DropDownList *GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		}
 		item->SetParam(0, rti->strings.menu_text);
 		item->SetParam(1, rti->max_speed);
-		list->push_back(item);
+		list.emplace_back(item);
 	}
 	return list;
 }

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -19,6 +19,6 @@ struct Window *ShowBuildRailToolbar(RailType railtype);
 void ReinitGuiAfterToggleElrail(bool disable);
 bool ResetSignalVariant(int32 = 0);
 void InitializeRailGUI();
-DropDownList *GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
+DropDownList GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
 
 #endif /* RAIL_GUI_H */

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -150,13 +150,13 @@ static void Load_GSTR()
 		_game_saveload_string = NULL;
 		SlObject(NULL, _game_language_header);
 
-		LanguageStrings *ls = new LanguageStrings(_game_saveload_string != NULL ? _game_saveload_string : "");
+		std::unique_ptr<LanguageStrings> ls(new LanguageStrings(_game_saveload_string != NULL ? _game_saveload_string : ""));
 		for (uint i = 0; i < _game_saveload_strings; i++) {
 			SlObject(NULL, _game_language_string);
 			ls->lines.push_back(stredup(_game_saveload_string != NULL ? _game_saveload_string : ""));
 		}
 
-		_current_data->raw_strings.push_back(ls);
+		_current_data->raw_strings.push_back(std::move(ls));
 	}
 
 	/* If there were no strings in the savegame, set GameStrings to NULL */
@@ -176,7 +176,7 @@ static void Save_GSTR()
 
 	for (uint i = 0; i < _current_data->raw_strings.size(); i++) {
 		SlSetArrayIndex(i);
-		SlAutolength((AutolengthProc *)SaveReal_GSTR, _current_data->raw_strings[i]);
+		SlAutolength((AutolengthProc *)SaveReal_GSTR, _current_data->raw_strings[i].get());
 	}
 }
 

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -129,14 +129,14 @@ static const SaveLoad _game_language_string[] = {
 	 SLE_END()
 };
 
-static void SaveReal_GSTR(LanguageStrings *ls)
+static void SaveReal_GSTR(const LanguageStrings *ls)
 {
 	_game_saveload_string  = ls->language;
 	_game_saveload_strings = (uint)ls->lines.size();
 
 	SlObject(NULL, _game_language_header);
-	for (uint i = 0; i < _game_saveload_strings; i++) {
-		_game_saveload_string = ls->lines[i];
+	for (const auto &i : ls->lines) {
+		_game_saveload_string = i.c_str();
 		SlObject(NULL, _game_language_string);
 	}
 }
@@ -153,7 +153,7 @@ static void Load_GSTR()
 		std::unique_ptr<LanguageStrings> ls(new LanguageStrings(_game_saveload_string != NULL ? _game_saveload_string : ""));
 		for (uint i = 0; i < _game_saveload_strings; i++) {
 			SlObject(NULL, _game_language_string);
-			ls->lines.push_back(stredup(_game_saveload_string != NULL ? _game_saveload_string : ""));
+			ls->lines.emplace_back(_game_saveload_string != NULL ? _game_saveload_string : "");
 		}
 
 		_current_data->raw_strings.push_back(std::move(ls));

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -126,13 +126,20 @@ struct ReadBuffer {
 
 /** Container for dumping the savegame (quickly) to memory. */
 struct MemoryDumper {
-	AutoFreeSmallVector<byte *> blocks; ///< Buffer with blocks of allocated memory.
-	byte *buf;                          ///< Buffer we're going to write to.
-	byte *bufe;                         ///< End of the buffer we write to.
+	std::vector<byte *> blocks; ///< Buffer with blocks of allocated memory.
+	byte *buf;                  ///< Buffer we're going to write to.
+	byte *bufe;                 ///< End of the buffer we write to.
 
 	/** Initialise our variables. */
 	MemoryDumper() : buf(NULL), bufe(NULL)
 	{
+	}
+
+	~MemoryDumper()
+	{
+		for (auto p : this->blocks) {
+			free(p);
+		}
 	}
 
 	/**

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -14,6 +14,7 @@
 
 #include "core/smallvec_type.hpp"
 #include "company_type.h"
+#include "string_type.h"
 
 struct IniFile;
 
@@ -28,11 +29,7 @@ void SaveToConfig();
 void IniLoadWindowSettings(IniFile *ini, const char *grpname, void *desc);
 void IniSaveWindowSettings(IniFile *ini, const char *grpname, void *desc);
 
-/* Functions to load and save NewGRF settings to a separate
- * configuration file, used for presets. */
-typedef AutoFreeSmallVector<char *> GRFPresetList;
-
-void GetGRFPresetList(GRFPresetList *list);
+StringList GetGRFPresetList();
 struct GRFConfig *LoadGRFPresetFromConfig(const char *config_name);
 void SaveGRFPresetToConfig(const char *config_name, struct GRFConfig *config);
 void DeleteGRFPresetFromConfig(const char *config_name);

--- a/src/settings_gui.h
+++ b/src/settings_gui.h
@@ -24,7 +24,7 @@ void DrawArrowButtons(int x, int y, Colours button_colour, byte state, bool clic
 void DrawDropDownButton(int x, int y, Colours button_colour, bool state, bool clickable);
 void DrawBoolButton(int x, int y, bool state, bool clickable);
 
-DropDownList *BuildMusicSetDropDownList(int *selected_index);
+DropDownList BuildMusicSetDropDownList(int *selected_index);
 
 /* Actually implemented in music_gui.cpp */
 void ChangeMusicSet(int index);

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -83,6 +83,7 @@
 #include <cstdlib>
 #include <climits>
 #include <cassert>
+#include <memory>
 
 #ifndef SIZE_MAX
 	#define SIZE_MAX ((size_t)-1)

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -228,9 +228,9 @@ protected:
 	/**
 	 * Builds the page selector drop down list.
 	 */
-	DropDownList *BuildDropDownList() const
+	DropDownList BuildDropDownList() const
 	{
-		DropDownList *list = new DropDownList();
+		DropDownList list;
 		uint16 page_num = 1;
 		for (const StoryPage *p : this->story_pages) {
 			bool current_page = p->index == this->selected_page_id;
@@ -245,14 +245,8 @@ protected:
 				item = str_item;
 			}
 
-			list->push_back(item);
+			list.emplace_back(item);
 			page_num++;
-		}
-
-		/* Check if list is empty. */
-		if (list->size() == 0) {
-			delete list;
-			list = NULL;
 		}
 
 		return list;
@@ -611,8 +605,8 @@ public:
 	{
 		switch (widget) {
 			case WID_SB_SEL_PAGE: {
-				DropDownList *list = this->BuildDropDownList();
-				if (list != NULL) {
+				DropDownList list = this->BuildDropDownList();
+				if (!list.empty()) {
 					/* Get the index of selected page. */
 					int selected = 0;
 					for (uint16 i = 0; i < this->story_pages.size(); i++) {
@@ -621,7 +615,7 @@ public:
 						selected++;
 					}
 
-					ShowDropDownList(this, list, selected, widget);
+					ShowDropDownList(this, std::move(list), selected, widget);
 				}
 				break;
 			}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -638,13 +638,13 @@ public:
 		this->utf16_to_utf8.push_back(0);
 	}
 
-	virtual ~IcuStringIterator()
+	~IcuStringIterator() override
 	{
 		delete this->char_itr;
 		delete this->word_itr;
 	}
 
-	virtual void SetString(const char *s)
+	void SetString(const char *s) override
 	{
 		const char *string_base = s;
 
@@ -681,7 +681,7 @@ public:
 		this->word_itr->first();
 	}
 
-	virtual size_t SetCurPosition(size_t pos)
+	size_t SetCurPosition(size_t pos) override
 	{
 		/* Convert incoming position to an UTF-16 string index. */
 		uint utf16_pos = 0;
@@ -699,7 +699,7 @@ public:
 		return this->utf16_to_utf8[this->char_itr->current()];
 	}
 
-	virtual size_t Next(IterType what)
+	size_t Next(IterType what) override
 	{
 		int32_t pos;
 		switch (what) {
@@ -731,7 +731,7 @@ public:
 		return pos == icu::BreakIterator::DONE ? END : this->utf16_to_utf8[pos];
 	}
 
-	virtual size_t Prev(IterType what)
+	size_t Prev(IterType what) override
 	{
 		int32_t pos;
 		switch (what) {

--- a/src/string_type.h
+++ b/src/string_type.h
@@ -13,6 +13,8 @@
 #define STRING_TYPE_H
 
 #include "core/enum_type.hpp"
+#include <vector>
+#include <string>
 
 /** A non-breaking space. */
 #define NBSP "\xC2\xA0"
@@ -52,5 +54,9 @@ enum StringValidationSettings {
 	SVS_ALLOW_CONTROL_CODE         = 1 << 2, ///< Allow the special control codes.
 };
 DECLARE_ENUM_AS_BIT_SET(StringValidationSettings)
+
+
+/** Type for a list of strings. */
+typedef std::vector<std::string> StringList;
 
 #endif /* STRING_TYPE_H */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -164,17 +164,17 @@ Dimension BaseVehicleListWindow::GetActionDropdownSize(bool show_autoreplace, bo
  * @param show_group If true include group-related stuff.
  * @return Itemlist for dropdown
  */
-DropDownList *BaseVehicleListWindow::BuildActionDropdownList(bool show_autoreplace, bool show_group)
+DropDownList BaseVehicleListWindow::BuildActionDropdownList(bool show_autoreplace, bool show_group)
 {
-	DropDownList *list = new DropDownList();
+	DropDownList list;
 
-	if (show_autoreplace) list->push_back(new DropDownListStringItem(STR_VEHICLE_LIST_REPLACE_VEHICLES, ADI_REPLACE, false));
-	list->push_back(new DropDownListStringItem(STR_VEHICLE_LIST_SEND_FOR_SERVICING, ADI_SERVICE, false));
-	list->push_back(new DropDownListStringItem(this->vehicle_depot_name[this->vli.vtype], ADI_DEPOT, false));
+	if (show_autoreplace) list.emplace_back(new DropDownListStringItem(STR_VEHICLE_LIST_REPLACE_VEHICLES, ADI_REPLACE, false));
+	list.emplace_back(new DropDownListStringItem(STR_VEHICLE_LIST_SEND_FOR_SERVICING, ADI_SERVICE, false));
+	list.emplace_back(new DropDownListStringItem(this->vehicle_depot_name[this->vli.vtype], ADI_DEPOT, false));
 
 	if (show_group) {
-		list->push_back(new DropDownListStringItem(STR_GROUP_ADD_SHARED_VEHICLE, ADI_ADD_SHARED, false));
-		list->push_back(new DropDownListStringItem(STR_GROUP_REMOVE_ALL_VEHICLES, ADI_REMOVE_ALL, false));
+		list.emplace_back(new DropDownListStringItem(STR_GROUP_ADD_SHARED_VEHICLE, ADI_ADD_SHARED, false));
+		list.emplace_back(new DropDownListStringItem(STR_GROUP_REMOVE_ALL_VEHICLES, ADI_REMOVE_ALL, false));
 	}
 
 	return list;
@@ -1636,8 +1636,7 @@ public:
 				break;
 
 			case WID_VL_MANAGE_VEHICLES_DROPDOWN: {
-				DropDownList *list = this->BuildActionDropdownList(VehicleListIdentifier::UnPack(this->window_number).type == VL_STANDARD, false);
-				ShowDropDownList(this, list, 0, WID_VL_MANAGE_VEHICLES_DROPDOWN);
+				ShowDropDownList(this, this->BuildActionDropdownList(VehicleListIdentifier::UnPack(this->window_number).type == VL_STANDARD, false), 0, WID_VL_MANAGE_VEHICLES_DROPDOWN);
 				break;
 			}
 

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -47,7 +47,7 @@ struct BaseVehicleListWindow : public Window {
 	void SortVehicleList();
 	void BuildVehicleList();
 	Dimension GetActionDropdownSize(bool show_autoreplace, bool show_group);
-	DropDownList *BuildActionDropdownList(bool show_autoreplace, bool show_group);
+	DropDownList BuildActionDropdownList(bool show_autoreplace, bool show_group);
 };
 
 uint GetVehicleListHeight(VehicleType type, uint divisor = 1);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -51,11 +51,11 @@ void DropDownListStringItem::Draw(int left, int right, int top, int bottom, bool
  * @return true if \a first precedes \a second.
  * @warning All items in the list need to be derivates of DropDownListStringItem.
  */
-/* static */ int DropDownListStringItem::NatSortFunc(const DropDownListItem * const *first, const DropDownListItem * const * second)
+/* static */ int DropDownListStringItem::NatSortFunc(std::unique_ptr<const DropDownListItem> const &first, std::unique_ptr<const DropDownListItem> const &second)
 {
 	char buffer1[512], buffer2[512];
-	GetString(buffer1, static_cast<const DropDownListStringItem*>(*first)->String(), lastof(buffer1));
-	GetString(buffer2, static_cast<const DropDownListStringItem*>(*second)->String(), lastof(buffer2));
+	GetString(buffer1, static_cast<const DropDownListStringItem*>(first.get())->String(), lastof(buffer1));
+	GetString(buffer2, static_cast<const DropDownListStringItem*>(second.get())->String(), lastof(buffer2));
 	return strnatcmp(buffer1, buffer2);
 }
 
@@ -126,7 +126,7 @@ struct DropdownWindow : Window {
 	WindowClass parent_wnd_class; ///< Parent window class.
 	WindowNumber parent_wnd_num;  ///< Parent window number.
 	int parent_button;            ///< Parent widget number where the window is dropped from.
-	const DropDownList *list;     ///< List with dropdown menu items.
+	const DropDownList list;      ///< List with dropdown menu items.
 	int selected_index;           ///< Index of the selected item in the list.
 	byte click_delay;             ///< Timer to delay selection.
 	bool drag_mode;
@@ -148,10 +148,10 @@ struct DropdownWindow : Window {
 	 * @param wi_colour     Colour of the parent widget.
 	 * @param scroll        Dropdown menu has a scrollbar.
 	 */
-	DropdownWindow(Window *parent, const DropDownList *list, int selected, int button, bool instant_close, const Point &position, const Dimension &size, Colours wi_colour, bool scroll)
-			: Window(&_dropdown_desc)
+	DropdownWindow(Window *parent, DropDownList &&list, int selected, int button, bool instant_close, const Point &position, const Dimension &size, Colours wi_colour, bool scroll)
+			: Window(&_dropdown_desc), list(std::move(list))
 	{
-		assert(list->size() > 0);
+		assert(this->list.size() > 0);
 
 		this->position = position;
 
@@ -174,18 +174,17 @@ struct DropdownWindow : Window {
 
 		/* Total length of list */
 		int list_height = 0;
-		for (const DropDownListItem *item : *list) {
+		for (const auto &item : this->list) {
 			list_height += item->Height(items_width);
 		}
 
 		/* Capacity is the average number of items visible */
-		this->vscroll->SetCapacity(size.height * (uint16)list->size() / list_height);
-		this->vscroll->SetCount((uint16)list->size());
+		this->vscroll->SetCapacity(size.height * (uint16)this->list.size() / list_height);
+		this->vscroll->SetCount((uint16)this->list.size());
 
 		this->parent_wnd_class = parent->window_class;
 		this->parent_wnd_num   = parent->window_number;
 		this->parent_button    = button;
-		this->list             = list;
 		this->selected_index   = selected;
 		this->click_delay      = 0;
 		this->drag_mode        = true;
@@ -207,7 +206,6 @@ struct DropdownWindow : Window {
 			pt.y -= w2->top;
 			w2->OnDropdownClose(pt, this->parent_button, this->selected_index, this->instant_close);
 		}
-		delete this->list;
 	}
 
 	virtual Point OnInitialPosition(int16 sm_width, int16 sm_height, int window_number)
@@ -229,7 +227,7 @@ struct DropdownWindow : Window {
 		int width = nwi->current_x - 4;
 		int pos   = this->vscroll->GetPosition();
 
-		for (const DropDownListItem *item : *this->list) {
+		for (const auto &item : this->list) {
 			/* Skip items that are scrolled up */
 			if (--pos >= 0) continue;
 
@@ -255,7 +253,7 @@ struct DropdownWindow : Window {
 
 		int y = r.top + 2;
 		int pos = this->vscroll->GetPosition();
-		for (const DropDownListItem *item : *this->list) {
+		for (const auto &item : this->list) {
 			int item_height = item->Height(r.right - r.left + 1);
 
 			/* Skip items that are scrolled up */
@@ -357,8 +355,7 @@ struct DropdownWindow : Window {
 /**
  * Show a drop down list.
  * @param w        Parent window for the list.
- * @param list     Prepopulated DropDownList. Will be deleted when the list is
- *                 closed.
+ * @param list     Prepopulated DropDownList.
  * @param selected The initially selected list item.
  * @param button   The widget which is passed to Window::OnDropdownSelect and OnDropdownClose.
  *                 Unless you override those functions, this should be then widget index of the dropdown button.
@@ -368,7 +365,7 @@ struct DropdownWindow : Window {
  * @param instant_close Set to true if releasing mouse button should close the
  *                      list regardless of where the cursor is.
  */
-void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int button, Rect wi_rect, Colours wi_colour, bool auto_width, bool instant_close)
+void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button, Rect wi_rect, Colours wi_colour, bool auto_width, bool instant_close)
 {
 	DeleteWindowById(WC_DROPDOWN_MENU, 0);
 
@@ -384,7 +381,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 	/* Total height of list */
 	uint height = 0;
 
-	for (const DropDownListItem *item : *list) {
+	for (const auto &item : list) {
 		height += item->Height(width);
 		if (auto_width) max_item_width = max(max_item_width, item->Width() + 5);
 	}
@@ -412,7 +409,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 		/* If the dropdown doesn't fully fit, we need a dropdown. */
 		if (height > available_height) {
 			scroll = true;
-			uint avg_height = height / (uint)list->size();
+			uint avg_height = height / (uint)list.size();
 
 			/* Check at least there is space for one item. */
 			assert(available_height >= avg_height);
@@ -435,7 +432,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 
 	Point dw_pos = { w->left + (_current_text_dir == TD_RTL ? wi_rect.right + 1 - (int)width : wi_rect.left), top};
 	Dimension dw_size = {width, height};
-	DropdownWindow *dropdown = new DropdownWindow(w, list, selected, button, instant_close, dw_pos, dw_size, wi_colour, scroll);
+	DropdownWindow *dropdown = new DropdownWindow(w, std::move(list), selected, button, instant_close, dw_pos, dw_size, wi_colour, scroll);
 
 	/* The dropdown starts scrolling downwards when opening it towards
 	 * the top and holding down the mouse button. It can be fooled by
@@ -446,8 +443,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
 /**
  * Show a drop down list.
  * @param w        Parent window for the list.
- * @param list     Prepopulated DropDownList. Will be deleted when the list is
- *                 closed.
+ * @param list     Prepopulated DropDownList.
  * @param selected The initially selected list item.
  * @param button   The widget within the parent window that is used to determine
  *                 the list's location.
@@ -456,7 +452,7 @@ void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int b
  * @param instant_close Set to true if releasing mouse button should close the
  *                      list regardless of where the cursor is.
  */
-void ShowDropDownList(Window *w, const DropDownList *list, int selected, int button, uint width, bool auto_width, bool instant_close)
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, uint width, bool auto_width, bool instant_close)
 {
 	/* Our parent's button widget is used to determine where to place the drop
 	 * down list window. */
@@ -483,7 +479,7 @@ void ShowDropDownList(Window *w, const DropDownList *list, int selected, int but
 		}
 	}
 
-	ShowDropDownListAt(w, list, selected, button, wi_rect, wi_colour, auto_width, instant_close);
+	ShowDropDownListAt(w, std::move(list), selected, button, wi_rect, wi_colour, auto_width, instant_close);
 }
 
 /**
@@ -499,21 +495,15 @@ void ShowDropDownList(Window *w, const DropDownList *list, int selected, int but
  */
 void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32 disabled_mask, uint32 hidden_mask, uint width)
 {
-	DropDownList *list = new DropDownList();
+	DropDownList list;
 
 	for (uint i = 0; strings[i] != INVALID_STRING_ID; i++) {
 		if (!HasBit(hidden_mask, i)) {
-			list->push_back(new DropDownListStringItem(strings[i], i, HasBit(disabled_mask, i)));
+			list.emplace_back(new DropDownListStringItem(strings[i], i, HasBit(disabled_mask, i)));
 		}
 	}
 
-	/* No entries in the list? */
-	if (list->size() == 0) {
-		delete list;
-		return;
-	}
-
-	ShowDropDownList(w, list, selected, button, width);
+	if (!list.empty()) ShowDropDownList(w, std::move(list), selected, button, width);
 }
 
 /**

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -89,9 +89,9 @@ class DropDownListIconItem : public DropDownListParamStringItem {
 public:
 	DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked);
 
-	/* virtual */ uint Height(uint width) const;
-	/* virtual */ uint Width() const;
-	/* virtual */ void Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const;
+	uint Height(uint width) const override;
+	uint Width() const override;
+	void Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const override;
 	void SetDimension(Dimension d);
 };
 

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -49,7 +49,7 @@ public:
 	void Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const override;
 	virtual StringID String() const { return this->string; }
 
-	static int CDECL NatSortFunc(const DropDownListItem * const *first, const DropDownListItem * const *second);
+	static int NatSortFunc(std::unique_ptr<const DropDownListItem> const &first, std::unique_ptr<const DropDownListItem> const &second);
 };
 
 /**
@@ -98,10 +98,10 @@ public:
 /**
  * A drop down list is a collection of drop down list items.
  */
-typedef AutoDeleteSmallVector<const DropDownListItem *> DropDownList;
+typedef std::vector<std::unique_ptr<const DropDownListItem>> DropDownList;
 
-void ShowDropDownListAt(Window *w, const DropDownList *list, int selected, int button, Rect wi_rect, Colours wi_colour, bool auto_width = false, bool instant_close = false);
+void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button, Rect wi_rect, Colours wi_colour, bool auto_width = false, bool instant_close = false);
 
-void ShowDropDownList(Window *w, const DropDownList *list, int selected, int button, uint width = 0, bool auto_width = false, bool instant_close = false);
+void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, uint width = 0, bool auto_width = false, bool instant_close = false);
 
 #endif /* WIDGETS_DROPDOWN_TYPE_H */


### PR DESCRIPTION
Remove the last remains of SmallVector. For the replacement, `std::unique_ptr` takes care of the memory management. Use of references and move semantics makes ownership clear and reduces potentials for memory leaks. Current compilers should be able to optimize most of the copy/moves out, resulting in very little runtime overhead.

This got a bit bigger than expected and picked up some unrelated fixes I saw when in the area.

Commits 41b6916, 0266dcb, and b27d0af could be split out if needed.