### PR TITLE
Fix #7440: Remove town sign when deleting town, not add it once more

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2871,7 +2871,7 @@ CommandCost CmdDeleteTown(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 	/* The town destructor will delete the other things related to the town. */
 	if (flags & DC_EXEC) {
 		_town_kdtree.Remove(t->index);
-		_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeTown(t->index));
+		_viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeTown(t->index));
 		delete t;
 	}
 


### PR DESCRIPTION
Credit to @JGRennison for discovering the error.