### PR TITLE
Codechange: Isolate type macro from math.h in Squirrel code

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -6,7 +6,10 @@
 
 #include <squirrel.h>
 #include "sqpcheader.h"
+#pragma push_macro("type")
+#undef type
 #include <math.h>
+#pragma pop_macro("type")
 #include "sqopcodes.h"
 #include "sqfuncproto.h"
 #include "sqvm.h"


### PR DESCRIPTION
type macro from Squirrel code clashes with Emscripten math.h.
This is likely Emscripten fault because it shouldn't define own identifiers without __ prefix, but, eh.