### PR TITLE
Fix: Industry coverage area is no longer rectangular.

### DIFF
--- a/bin/ai/regression/tst_regression/result.txt
+++ b/bin/ai/regression/tst_regression/result.txt
@@ -8534,7 +8534,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     19693 => 8
 
 --TileList_IndustryProducing--
-  Count():             92
+  Count():             90
   Location ListDump:
     46919 => 1
     46918 => 1
@@ -8626,8 +8626,6 @@ ERROR: IsEnd() is invalid as Begin() is never called
     44353 => 1
     44352 => 1
     44351 => 1
-    46920 => 0
-    46911 => 0
 
 --TileList_StationType--
   Count():             4

--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -34,6 +34,14 @@ public:
 		this->h = 0;
 	}
 
+	BitmapTileArea(const TileArea &ta)
+	{
+		this->tile = ta.tile;
+		this->w = ta.w;
+		this->h = ta.h;
+		this->data.resize(Index(this->w, this->h));
+	}
+
 	/**
 	 * Reset and clear the BitmapTileArea.
 	 */


### PR DESCRIPTION
AIs test station catchment in reverse to how players see station catchment.
This did not take account of non-rectangular station catchment areas, so AIs
could end up placing stations in locations that did not accept/deliver cargo.