### PR TITLE
Fix: [Windows] OpenTTD window may be inactive when an error happens

### DIFF
--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -79,7 +79,7 @@ bool LoadLibraryList(Function proc[], const char *dll)
 void ShowOSErrorBox(const char *buf, bool system)
 {
 	MyShowCursor(true);
-	MessageBox(GetActiveWindow(), OTTD2FS(buf), _T("Error!"), MB_ICONSTOP);
+	MessageBox(GetActiveWindow(), OTTD2FS(buf), _T("Error!"), MB_ICONSTOP | MB_TASKMODAL);
 }
 
 void OSOpenBrowser(const char *url)


### PR DESCRIPTION
If OpenTTD window is inactive when a message box is displayed then input for OpenTTD window are not blocked, and subsequent message boxes are linked to the last displayed message box. If the error happens in a section of code where `_local_company != _current_company` the assert in `HandleMouseEvents()` will be triggered if mouse moves over OpenTTD window and there will be flood with message boxes. Using `MB_TASKMODAL` prevents that.

Another option would be to use `_wnd.main_hwnd` from win32 video driver.
