### PR TITLE
Fix #7478: Don't remove NewGRF objects on company take-over.

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -768,9 +768,10 @@ static void ChangeTileOwner_Object(TileIndex tile, Owner old_owner, Owner new_ow
 
 	bool do_clear = false;
 
-	if (IsObjectType(tile, OBJECT_OWNED_LAND) && new_owner != INVALID_OWNER) {
+	ObjectType type = GetObjectType(tile);
+	if ((type == OBJECT_OWNED_LAND || type >= NEW_OBJECT_OFFSET) && new_owner != INVALID_OWNER) {
 		SetTileOwner(tile, new_owner);
-	} else if (IsObjectType(tile, OBJECT_STATUE)) {
+	} else if (type == OBJECT_STATUE) {
 		Town *t = Object::GetByTile(tile)->town;
 		ClrBit(t->statues, old_owner);
 		if (new_owner != INVALID_OWNER && !HasBit(t->statues, new_owner)) {


### PR DESCRIPTION
Changing ownership of objects did not take account of custom objects, so treated them the same as Company HQ.

Fixes #7478.