### PR TITLE
Codechange: Sprite sorting optimization

### DIFF
--- a/src/viewport_sprite_sorter_sse4.cpp
+++ b/src/viewport_sprite_sorter_sse4.cpp
@@ -17,6 +17,7 @@
 #include "viewport_sprite_sorter.h"
 
 #include <algorithm>
+#include <iostream>
 
 #include "safeguards.h"
 
@@ -27,8 +28,76 @@
 	#define LOAD_128 _mm_loadu_si128
 #endif
 
+	/** Sort parent sprites pointer array using SSE4.1 optimizations. */
+	void ViewportSortParentSpritesSSE41Orig(ParentSpriteToSortVector *psdv)
+	{
+		const __m128i mask_ptest = _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  0,  0,  0,  0);
+		auto const psdvend = psdv->end();
+		auto psd = psdv->begin();
+		while (psd != psdvend) {
+			ParentSpriteToDraw * const ps = *psd;
+
+			if (ps->comparison_done) {
+				psd++;
+				continue;
+			}
+
+			ps->comparison_done = true;
+
+			for (auto psd2 = psd + 1; psd2 != psdvend; psd2++) {
+				ParentSpriteToDraw * const ps2 = *psd2;
+
+				if (ps2->comparison_done) continue;
+
+				/*
+				 * Decide which comparator to use, based on whether the bounding boxes overlap
+				 *
+				 * Original code:
+				 * if (ps->xmax >= ps2->xmin && ps->xmin <= ps2->xmax && // overlap in X?
+				 *     ps->ymax >= ps2->ymin && ps->ymin <= ps2->ymax && // overlap in Y?
+				 *     ps->zmax >= ps2->zmin && ps->zmin <= ps2->zmax) { // overlap in Z?
+				 *
+				 * Above conditions are equivalent to:
+				 * 1/    !( (ps->xmax >= ps2->xmin) && (ps->ymax >= ps2->ymin) && (ps->zmax >= ps2->zmin)   &&    (ps->xmin <= ps2->xmax) && (ps->ymin <= ps2->ymax) && (ps->zmin <= ps2->zmax) )
+				 * 2/    !( (ps->xmax >= ps2->xmin) && (ps->ymax >= ps2->ymin) && (ps->zmax >= ps2->zmin)   &&    (ps2->xmax >= ps->xmin) && (ps2->ymax >= ps->ymin) && (ps2->zmax >= ps->zmin) )
+				 * 3/  !( ( (ps->xmax >= ps2->xmin) && (ps->ymax >= ps2->ymin) && (ps->zmax >= ps2->zmin) ) &&  ( (ps2->xmax >= ps->xmin) && (ps2->ymax >= ps->ymin) && (ps2->zmax >= ps->zmin) ) )
+				 * 4/ !( !( (ps->xmax <  ps2->xmin) || (ps->ymax <  ps2->ymin) || (ps->zmax <  ps2->zmin) ) && !( (ps2->xmax <  ps->xmin) || (ps2->ymax <  ps->ymin) || (ps2->zmax <  ps->zmin) ) )
+				 * 5/ PTEST <---------------------------------- rslt1 ---------------------------------->         <------------------------------ rslt2 -------------------------------------->
+				 */
+				__m128i ps1_max = LOAD_128((__m128i*) &ps->xmax);
+				__m128i ps2_min = LOAD_128((__m128i*) &ps2->xmin);
+				__m128i rslt1 = _mm_cmplt_epi32(ps1_max, ps2_min);
+				if (!_mm_testz_si128(mask_ptest, rslt1))
+					continue;
+
+				__m128i ps1_min = LOAD_128((__m128i*) &ps->xmin);
+				__m128i ps2_max = LOAD_128((__m128i*) &ps2->xmax);
+				__m128i rslt2 = _mm_cmplt_epi32(ps2_max, ps1_min);
+				if (_mm_testz_si128(mask_ptest, rslt2)) {
+					/* Use X+Y+Z as the sorting order, so sprites closer to the bottom of
+					 * the screen and with higher Z elevation, are drawn in front.
+					 * Here X,Y,Z are the coordinates of the "center of mass" of the sprite,
+					 * i.e. X=(left+right)/2, etc.
+					 * However, since we only care about order, don't actually divide / 2
+					 */
+					if (ps->xmin + ps->xmax + ps->ymin + ps->ymax + ps->zmin + ps->zmax <=
+							ps2->xmin + ps2->xmax + ps2->ymin + ps2->ymax + ps2->zmin + ps2->zmax) {
+						continue;
+					}
+				}
+
+				/* Move ps2 in front of ps */
+				ParentSpriteToDraw * const temp = ps2;
+				for (auto psd3 = psd2; psd3 > psd; psd3--) {
+					*psd3 = *(psd3 - 1);
+				}
+				*psd = temp;
+			}
+		}
+	}
+
 /** Sort parent sprites pointer array using SSE4.1 optimizations. */
-void ViewportSortParentSpritesSSE41(ParentSpriteToSortVector *psdv)
+void ViewportSortParentSpritesSSE41New(ParentSpriteToSortVector *psdv)
 {
 	const __m128i mask_ptest = _mm_setr_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  0,  0,  0,  0);
 	const __m128i mask_ptest2 = _mm_setr_epi8(-1, -1, -1, -1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0);
@@ -104,6 +173,26 @@ void ViewportSortParentSpritesSSE41(ParentSpriteToSortVector *psdv)
 			*psd = temp;
 			if (psd2 > psdMax) psdMax = psd2;
 		}
+	}
+}
+
+void ViewportSortParentSpritesSSE41(ParentSpriteToSortVector *psdv) {
+	auto inputOrig = *psdv;
+	/* pre-sort by xmin in ascending order */
+	std::sort(psdv->begin(), psdv->end(),
+			[](ParentSpriteToDraw * const & psd, ParentSpriteToDraw * const & psd2) -> bool {
+		return psd->xmin < psd2->xmin;
+	});
+	for (auto* ps : *psdv)
+		ps->comparison_done = false;
+	ViewportSortParentSpritesSSE41Orig(psdv);
+	auto resultOrig = *psdv;
+	*psdv = inputOrig;
+	for (auto* ps : *psdv)
+		ps->comparison_done = false;
+	ViewportSortParentSpritesSSE41New(psdv);
+	if (*psdv != resultOrig) {
+		std::cerr << "!";
 	}
 }
 


### PR DESCRIPTION
Another take on the sprite sorter optimization.

On top of the reverted 25ab9c1997f770f4a8a66bb3ad4b82ba87e3a977 ,
this patch adds the psdMax variable tracking the start of the
still intact pre-sorted portion of the parent sprite vector,
where the early bailout logic still works.