### PR TITLE
Fix: AI/GS settings with the flag SCRIPTCONFIG_RANDOM could be altered after loading from a savegame.

### DIFF
--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -35,11 +35,16 @@ ScriptConfigItem _start_date_config = {
 
 AIConfig::AIConfig(const AIConfig *config) : ScriptConfig(config)
 {
-	/* Override start_date as per AIConfig::AddRandomDeviation().
-	 * This is necessary because the ScriptConfig constructor will instead call
-	 * ScriptConfig::AddRandomDeviation(). */
-	int start_date = config->GetSetting("start_date");
-	this->SetSetting("start_date", start_date != 0 ? max(1, this->GetSetting("start_date")) : 0);
+	if (this->info == nullptr) {
+		this->PushExtraConfigList();
+		this->AddRandomDeviation();
+	} else {
+		/* Override start_date as per AIConfig::AddRandomDeviation().
+		 * This is necessary because the ScriptConfig constructor will instead call
+		 * ScriptConfig::AddRandomDeviation(). */
+		int start_date = config->GetSetting("start_date");
+		this->SetSetting("start_date", start_date != 0 ? max(1, this->GetSetting("start_date")) : 0);
+	}
 }
 
 /* static */ AIConfig *AIConfig::GetConfig(CompanyID company, ScriptSettingSource source)

--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -131,7 +131,7 @@ void AIConfig::SetSetting(const char *name, int value)
 	ScriptConfig::SetSetting(name, value);
 }
 
-void AIConfig::AddRandomDeviation()
+void AIConfig::AddRandomDeviation(bool all)
 {
 	int start_date = this->GetSetting("start_date");
 
@@ -139,5 +139,9 @@ void AIConfig::AddRandomDeviation()
 
 	/* start_date = 0 is a special case, where random deviation does not occur.
 	 * If start_date was not already 0, then a minimum value of 1 must apply. */
-	this->SetSetting("start_date", start_date != 0 ? max(1, this->GetSetting("start_date")) : 0);
+	if (all && start_date != 0) {
+		start_date = max(1, this->GetSetting("start_date"));
+	}
+
+	this->SetSetting("start_date", start_date);
 }

--- a/src/ai/ai_config.hpp
+++ b/src/ai/ai_config.hpp
@@ -30,7 +30,7 @@ public:
 
 	int GetSetting(const char *name) const override;
 	void SetSetting(const char *name, int value) override;
-	void AddRandomDeviation() override;
+	void AddRandomDeviation(bool all = true) override;
 
 	/**
 	 * When ever the AI Scanner is reloaded, all infos become invalid. This

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -37,7 +37,7 @@ void ScriptConfig::Change(const char *name, int version, bool force_exact_match,
 				this->SetSetting((*it).name, InteractiveRandomRange((*it).max_value + 1 - (*it).min_value) + (*it).min_value);
 			}
 		}
-		this->AddRandomDeviation();
+		this->AddRandomDeviation(false);
 	}
 }
 
@@ -127,7 +127,7 @@ void ScriptConfig::ResetSettings()
 	this->settings.clear();
 }
 
-void ScriptConfig::AddRandomDeviation()
+void ScriptConfig::AddRandomDeviation(bool all)
 {
 	for (ScriptConfigItemList::const_iterator it = this->GetConfigList()->begin(); it != this->GetConfigList()->end(); it++) {
 		if ((*it).random_deviation != 0) {

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -29,7 +29,7 @@ void ScriptConfig::Change(const char *name, int version, bool force_exact_match,
 
 	this->ClearConfigList();
 
-	if (_game_mode == GM_NORMAL && this->info != nullptr) {
+	if (_game_mode == GM_NORMAL && _switch_mode != SM_LOAD_GAME && this->info != nullptr) {
 		/* If we're in an existing game and the Script is changed, set all settings
 		 *  for the Script that have the random flag to a random value. */
 		for (ScriptConfigItemList::const_iterator it = this->info->GetConfigList()->begin(); it != this->info->GetConfigList()->end(); it++) {

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -136,8 +136,9 @@ public:
 
 	/**
 	 * Randomize all settings the Script requested to be randomized.
+	 * @param all if set to false, then all but "start_date" settings are randomized.
 	 */
-	virtual void AddRandomDeviation();
+	virtual void AddRandomDeviation(bool all = true);
 
 	/**
 	 * Is this config attached to an Script? In other words, is there a Script


### PR DESCRIPTION
Non-Random AI/GS configured in the main menu with their settings left at their defaults, could have their SCRIPTCONFIG_RANDOM flagged settings randomized when loading from a saved game.

This patch anchors them as unchangeable to prevent game load from randomizing them.