### PR TITLE
Fix: Creating a cargo subsidy with a town as source was not considering min population.

### DIFF
--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -333,6 +333,7 @@ bool FindSubsidyTownCargoRoute()
 
 	/* Select a random town. */
 	const Town *src_town = Town::GetRandom();
+	if (src_town->cache.population < SUBSIDY_CARGO_MIN_POPULATION) return false;
 
 	CargoTypes town_cargo_produced = src_town->cargo_produced;
 


### PR DESCRIPTION
SUBSIDY_CARGO_MIN_POPULATION was defined but not used anywhere. I suppose it was for this.