### PR TITLE
Feature: Selective demolition tool.

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -424,6 +424,13 @@ enum CommandPauseLevel {
 	CMDPL_ALL_ACTIONS,     ///< All actions may be executed.
 };
 
+/** Demolition modes */
+enum DemolitionMode : byte {
+	DM_ALL,          ///< Demolish everything
+	DM_TREES,        ///< Demolish trees
+	DM_COMPANY_PROPS ///< Demolish company properties
+};
+
 /**
  * Defines the callback type for all command handler functions.
  *

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -251,6 +251,10 @@ STR_TOOLTIP_VSCROLL_BAR_SCROLLS_LIST                            :{BLACK}Scroll b
 STR_TOOLTIP_HSCROLL_BAR_SCROLLS_LIST                            :{BLACK}Scroll bar - scrolls list left/right
 STR_TOOLTIP_DEMOLISH_BUILDINGS_ETC                              :{BLACK}Demolish buildings etc. on a square of land. Ctrl selects the area diagonally. Shift toggles building/showing cost estimate
 
+STR_DEMOLISH_EVERYTHING_TOOLTIP                                 :{BLACK}Demolish everything
+STR_DEMOLISH_TREES_TOOLTIP                                      :{BLACK}Demolish trees
+STR_DEMOLISH_COMPANY_PROPERTIES_TOOLTIP                         :{BLACK}Demolish company properties
+
 # Show engines button
 STR_SHOW_HIDDEN_ENGINES_VEHICLE_TRAIN                           :{BLACK}Show hidden
 STR_SHOW_HIDDEN_ENGINES_VEHICLE_ROAD_VEHICLE                    :{BLACK}Show hidden

--- a/src/widgets/terraform_widget.h
+++ b/src/widgets/terraform_widget.h
@@ -44,4 +44,11 @@ enum EditorTerraformToolbarWidgets {
 	WID_ETT_RESET_LANDSCAPE,                     ///< Button for removing all company-owned property.
 };
 
+/** Widgets of the #DemolitionModeSelectionWindow class. */
+enum DemolitionModeSelectionWidgets {
+	WID_DM_ALL,           ///< Demolish everything
+	WID_DM_TREES,         ///< Demolish trees
+	WID_DM_COMPANY_PROPS, ///< Demolish company properties
+};
+
 #endif /* WIDGETS_TERRAFORM_WIDGET_H */

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -442,6 +442,12 @@ enum WindowClass {
 	WC_SCEN_LAND_GEN,
 
 	/**
+	 * Demolition selection mode; %Window numbers:
+	 *   - 0 = #DemolitionModeSelectionWidgets
+	 */
+	WC_DEMOLITION_MODE_SELECTION,
+
+	/**
 	 * Generate landscape (newgame); %Window numbers:
 	 *   - GLWM_SCENARIO = #CreateScenarioWidgets
 	 *   - #GenerateLandscapeWindowMode = #GenerateLandscapeWidgets


### PR DESCRIPTION
Idea from #7394.

Known bug(?):
The demolish button does not stay lowered because the drop-down list window raises back up when it closes. And I do not know how to keep it down. Maybe I need to get a paperweight. :)