### PR TITLE
Change: Consider any cargo with passenger town effect for passenger-type subsidies.

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -36,6 +36,11 @@ CargoTypes _cargo_mask;
 CargoTypes _standard_cargo_mask;
 
 /**
+ * Bitmask of cargo types that behave as passengers towards towns (TE_PASSENGERS)
+ */
+CargoTypes _passengers_cargo_mask;
+
+/**
  * Set up the default cargo types for the given landscape type.
  * @param l Landscape
  */
@@ -53,6 +58,7 @@ void SetupCargoForClimate(LandscapeID l)
 	}
 
 	_cargo_mask = 0;
+	_passengers_cargo_mask = 0;
 
 	for (CargoID i = 0; i < lengthof(_default_climate_cargo[l]); i++) {
 		CargoLabel cl = _default_climate_cargo[l][i];
@@ -74,6 +80,7 @@ void SetupCargoForClimate(LandscapeID l)
 
 				/* Populate the available cargo mask */
 				SetBit(_cargo_mask, i);
+				if (_default_cargo[j].town_effect == TE_PASSENGERS) SetBit(_passengers_cargo_mask, i);
 				break;
 			}
 		}

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -131,6 +131,7 @@ private:
 
 extern CargoTypes _cargo_mask;
 extern CargoTypes _standard_cargo_mask;
+extern CargoTypes _passengers_cargo_mask;
 
 void SetupCargoForClimate(LandscapeID l);
 CargoID GetCargoIDByLabel(CargoLabel cl);

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2997,6 +2997,12 @@ static ChangeInfoResult CargoChangeInfo(uint cid, int numinfo, int prop, ByteRea
 						FALLTHROUGH;
 					case 0xFF: cs->town_effect = TE_NONE; break;
 				}
+
+				if (cs->town_effect == TE_PASSENGERS) {
+					SetBit(_passengers_cargo_mask, cid + i);
+				} else {
+					ClrBit(_passengers_cargo_mask, cid + i);
+				}
 				break;
 			}
 


### PR DESCRIPTION
Subsidies are hardcoded to treat CT_PASSENGERS specially.

This change changes this so that any cargo type with TE_PASSENGERS is treated this way (e.g. Tourists from ECS Town)