### PR TITLE
Feature: Add aircraft type dropdown in Autoreplace window

### DIFF
--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -40,4 +40,6 @@ extern EngList_SortTypeFunction * const _engine_sort_functions[][11];
 uint GetEngineListHeight(VehicleType type);
 void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selected, int button);
 
+extern int _autoreplace_last_selected_aircraft_type;
+
 #endif /* ENGINE_GUI_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3732,6 +3732,13 @@ STR_REPLACE_MAGLEV_VEHICLES                                     :Maglev Vehicles
 STR_REPLACE_ROAD_VEHICLES                                       :Road Vehicles
 STR_REPLACE_TRAM_VEHICLES                                       :Tramway Vehicles
 
+STR_REPLACE_HELP_AIRCRAFT_TYPE_DROPDOWN                         :{BLACK}List the type of aircraft you want the left selected aircraft to be replaced with
+STR_REPLACE_ALL_AIRCRAFT_TYPES                                  :All aircraft types
+STR_REPLACE_SAME_AIRCRAFT_TYPE                                  :Same aircraft type
+STR_REPLACE_HELICOPTER                                          :Helicopter
+STR_REPLACE_SMALL_AEROPLANE                                     :Small aeroplane
+STR_REPLACE_LARGE_AEROPLANE                                     :Large aeroplane
+
 STR_REPLACE_REMOVE_WAGON                                        :{BLACK}Wagon removal: {ORANGE}{STRING}
 STR_REPLACE_REMOVE_WAGON_HELP                                   :{BLACK}Make autoreplace keep the length of a train the same by removing wagons (starting at the front), if replacing the engine would make the train longer
 

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -229,6 +229,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_RV_RAIL_ROAD_TYPE_DROPDOWN,            "WID_RV_RAIL_ROAD_TYPE_DROPDOWN");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_RV_TRAIN_ENGINEWAGON_DROPDOWN,         "WID_RV_TRAIN_ENGINEWAGON_DROPDOWN");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_RV_TRAIN_WAGONREMOVE_TOGGLE,           "WID_RV_TRAIN_WAGONREMOVE_TOGGLE");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_RV_AIRCRAFT_TYPE_DROPDOWN,             "WID_RV_AIRCRAFT_TYPE_DROPDOWN");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_BB_BACKGROUND,                         "WID_BB_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_BAFD_QUESTION,                         "WID_BAFD_QUESTION");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_BAFD_YES,                              "WID_BAFD_YES");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -965,6 +965,9 @@ public:
 		/* Train only widgets. */
 		WID_RV_TRAIN_ENGINEWAGON_DROPDOWN            = ::WID_RV_TRAIN_ENGINEWAGON_DROPDOWN,            ///< Dropdown to select engines and/or wagons.
 		WID_RV_TRAIN_WAGONREMOVE_TOGGLE              = ::WID_RV_TRAIN_WAGONREMOVE_TOGGLE,              ///< Button to toggle removing wagons.
+
+		/* Aircraft only widget. */
+		WID_RV_AIRCRAFT_TYPE_DROPDOWN                = ::WID_RV_AIRCRAFT_TYPE_DROPDOWN,                ///< Dropdown menu to select aircraft type.
 	};
 
 	/* automatically generated from ../../widgets/bootstrap_widget.h */

--- a/src/widgets/autoreplace_widget.h
+++ b/src/widgets/autoreplace_widget.h
@@ -38,6 +38,9 @@ enum ReplaceVehicleWidgets {
 	/* Train only widgets. */
 	WID_RV_TRAIN_ENGINEWAGON_DROPDOWN, ///< Dropdown to select engines and/or wagons.
 	WID_RV_TRAIN_WAGONREMOVE_TOGGLE, ///< Button to toggle removing wagons.
+
+	/* Aircraft only widget. */
+	WID_RV_AIRCRAFT_TYPE_DROPDOWN,   ///< Dropdown menu to select aircraft type.
 };
 
 #endif /* WIDGETS_AUTOREPLACE_WIDGET_H */


### PR DESCRIPTION
a) Adds an Aircraft type dropdown for the Autoreplace window, with 5 possible choices to pick from.

a1) 'All aircraft types' - Lists, on the right side, all aircraft types, regardless of the type of aircraft selected on the left side.

a2) 'Same aircraft type' - Lists, on the right side, only aircraft that match the type of aircraft selected on the left side.
- if a helicopter is selected on the left side, then on the right side, only helicopters are listed.
- if a small aeroplane is selected on the left side, then on the right side, only small aeroplanes are listed.
- if a large aeroplane is selected on the left side, then on the right side, only large aeroplanes are listed.

a3) 'Helicopter' - Lists, on the right side, only helicopters, regardless of the type of aircraft selected on the left side.

a4) 'Small aeroplane' - Lists, on the right side, only small aeroplanes, regardless of the type of aircraft selected on the left side.

a5) 'Large aeroplane' - Lists, on the right side, only large aeroplanes, regardless of the type of aircraft selected on the left side.

~~b) This allows helicopters to be autoreplaced with aeroplanes and vice versa. Failure to do so would mean the replacement is being done in an incompatible hangar, but at least the possibility is there.~~ Posted separate, as #7505