### PR TITLE
Feature: Hide block signal tools by default

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1556,6 +1556,8 @@ STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE                  :Automatically b
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT         :Set the year when electric signals will be used for tracks. Before this year, non-electric signals will be used (which have the exact same function, but different looks)
 STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI                            :Enable the signal GUI: {STRING2}
 STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI_HELPTEXT                   :Display a window for choosing signal types to build, instead of only window-less signal-type rotation with Ctrl+clicking on built signals
+STR_CONFIG_SETTING_SHOW_BLOCKSIGNALS                            :Enable building block signals: {STRING2}
+STR_CONFIG_SETTING_SHOW_BLOCKSIGNALS_HELPTEXT                   :Show the tools for building block signals and pre-signals. Usage of block signals and path signals is discouraged, since path signals usually solve the same problems better. Existing block signals will continue working.
 STR_CONFIG_SETTING_DEFAULT_SIGNAL_TYPE                          :Signal type to build by default: {STRING2}
 STR_CONFIG_SETTING_DEFAULT_SIGNAL_TYPE_HELPTEXT                 :Default signal type to use
 STR_CONFIG_SETTING_DEFAULT_SIGNAL_NORMAL                        :Block signals

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1559,6 +1559,7 @@ static SettingsContainer &GetSettingsTree()
 				construction->Add(new SettingEntry("gui.quick_goto"));
 				construction->Add(new SettingEntry("gui.default_rail_type"));
 				construction->Add(new SettingEntry("gui.disable_unsuitable_building"));
+				construction->Add(new SettingEntry("gui.show_blocksignals"));
 			}
 
 			interface->Add(new SettingEntry("gui.autosave"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -147,6 +147,7 @@ struct GUISettings {
 	uint8  graph_line_thickness;             ///< the thickness of the lines in the various graph guis
 	uint8  osk_activation;                   ///< Mouse gesture to trigger the OSK.
 	byte   starting_colour;                  ///< default color scheme for the company to start a new game with
+	bool   show_blocksignals;                ///< show tools to build block signals (and pre-signals)
 
 	uint16 console_backlog_timeout;          ///< the minimum amount of time items should be in the console backlog before they will be removed in ~3 seconds granularity.
 	uint16 console_backlog_length;           ///< the minimum amount of items in the console backlog before items will be removed.

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2915,6 +2915,15 @@ strhelp  = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI_HELPTEXT
 proc     = CloseSignalGUI
 cat      = SC_EXPERT
 
+[SDTC_BOOL]
+var      = gui.show_blocksignals
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+def      = false
+str      = STR_CONFIG_SETTING_SHOW_BLOCKSIGNALS
+strhelp  = STR_CONFIG_SETTING_SHOW_BLOCKSIGNALS_HELPTEXT
+proc     = CloseSignalGUI
+cat      = SC_EXPERT
+
 [SDTC_VAR]
 var      = gui.coloured_news_year
 type     = SLE_INT32


### PR DESCRIPTION
Please stop building block signals and especially pre-signals. They're for the most part a bad idea and your networks will function much better with PBS. Let's hide it behind an Expert level setting.