### PR TITLE
Fix 801cbea9c: operator< is not always the best idea

### DIFF
--- a/src/core/smallmap_type.hpp
+++ b/src/core/smallmap_type.hpp
@@ -164,16 +164,6 @@ struct SmallMap : std::vector<SmallPair<T, U> > {
 		n.first = key;
 		return n.second;
 	}
-
-	inline void SortByKey()
-	{
-		std::sort(std::vector<Pair>::begin(), std::vector<Pair>::end());
-	}
-
-	bool operator< (const Pair &other) const
-	{
-		return (*this).first < other.first;
-	}
 };
 
 #endif /* SMALLMAP_TYPE_HPP */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -154,10 +154,10 @@ void WindowDesc::LoadFromConfig()
 /**
  * Sort WindowDesc by ini_key.
  */
-bool WindowDesc::operator< (WindowDesc * const &other) const
+static bool DescSorter(WindowDesc* const &a, WindowDesc* const &b)
 {
-	if (this->ini_key != nullptr && other->ini_key != nullptr) return strcmp(this->ini_key, other->ini_key) < 0;
-	return this->ini_key != nullptr;
+	if (a->ini_key != nullptr && b->ini_key != nullptr) return strcmp(a->ini_key, b->ini_key) < 0;
+	return a->ini_key != nullptr;
 }
 
 /**
@@ -166,7 +166,7 @@ bool WindowDesc::operator< (WindowDesc * const &other) const
 void WindowDesc::SaveToConfig()
 {
 	/* Sort the stuff to get a nice ini file on first write */
-	std::sort(_window_descs->begin(), _window_descs->end());
+	std::sort(_window_descs->begin(), _window_descs->end(), DescSorter);
 
 	IniFile *ini = new IniFile();
 	ini->LoadFromDisk(_windows_file, NO_DIRECTORY);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -192,8 +192,6 @@ struct WindowDesc : ZeroedMemoryAllocator {
 	static void LoadFromConfig();
 	static void SaveToConfig();
 
-	bool operator< (WindowDesc * const &other) const;
-
 private:
 	int16 default_width_trad;      ///< Preferred initial width of the window (pixels at 1x zoom).
 	int16 default_height_trad;     ///< Preferred initial height of the window (pixels at 1x zoom).


### PR DESCRIPTION
Also removes unused and anyway broken SmallMap::SortByKey() function.