### PR TITLE
Emscripten support

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -81,6 +81,7 @@ set_default() {
 	with_iconv="1"
 	with_midi=""
 	with_midi_arg=""
+	with_libtimidity="1"
 	with_fluidsynth="1"
 	with_freetype="1"
 	with_fontconfig="1"
@@ -157,6 +158,7 @@ set_default() {
 		with_iconv
 		with_midi
 		with_midi_arg
+		with_libtimidity
 		with_fluidsynth
 		with_freetype
 		with_fontconfig
@@ -362,6 +364,10 @@ detect_params() {
 			--with-libpng)                with_png="2";;
 			--without-libpng)             with_png="0";;
 			--with-libpng=*)              with_png="$optarg";;
+
+			--with-libtimidity)           with_libtimidity="2";;
+			--without-libtimidity)        with_libtimidity="0";;
+			--with-libtimidity=*)         with_libtimidity="$optarg";;
 
 			--with-fluidsynth)            with_fluidsynth="2";;
 			--without-fluidsynth)         with_fluidsynth="0";;
@@ -870,6 +876,7 @@ check_params() {
 	detect_fontconfig
 	detect_icu_layout
 	detect_icu_sort
+	detect_libtimidity
 	detect_fluidsynth
 
 	if [ "$with_direct_music" != "0" ]; then
@@ -1782,6 +1789,17 @@ make_cflags_and_ldflags() {
 
 	if [ "$with_xaudio2" != "0" ]; then
 		CFLAGS="$CFLAGS -DWITH_XAUDIO2"
+	fi
+
+	if [ -n "$libtimidity_config" ]; then
+		CFLAGS="$CFLAGS -DLIBTIMIDITY"
+		CFLAGS="$CFLAGS `$libtimidity_config --cflags | tr '\n\r' '  '`"
+
+		if [ "$enable_static" != "0" ]; then
+			LIBS="$LIBS `$libtimidity_config --libs --static | tr '\n\r' '  '`"
+		else
+			LIBS="$LIBS `$libtimidity_config --libs | tr '\n\r' '  '`"
+		fi
 	fi
 
 	if [ -n "$fluidsynth" ]; then
@@ -2714,6 +2732,10 @@ detect_lzo2() {
 	detect_library "$with_lzo2" "lzo2" "liblzo2.a" "lzo/" "lzo1x.h"
 }
 
+detect_libtimidity() {
+	detect_pkg_config "$with_libtimidity" "libtimidity" "libtimidity_config" "0.1" "1"
+}
+
 detect_fluidsynth() {
 	detect_library "$with_fluidsynth" "fluidsynth" "" "" "fluidsynth.h"
 }
@@ -3507,6 +3529,8 @@ showhelp() {
 	echo "  --with-midi=midi               define which midi-player to use"
 	echo "  --with-midi-arg=arg            define which args to use for the"
 	echo "                                 midi-player"
+	echo "  --with-libtimidity[=\"pkg-config libtimidity\"]"
+	echo "                                 enables libtimidity support"
 	echo "  --with-fluidsynth              enables fluidsynth support"
 	echo "  --with-allegro[=\"pkg-config allegro\"]"
 	echo "                                 enables Allegro video driver support"

--- a/configure
+++ b/configure
@@ -122,6 +122,7 @@ AWKCOMMAND='
 		                 "'$os'" != "CYGWIN" && "'$os'" != "MSVC") { next; }
 		if ($0 == "MSVC"        && "'$os'" != "MSVC")              { next; }
 		if ($0 == "DIRECTMUSIC" && "'$with_direct_music'" == "0")  { next; }
+		if ($0 == "LIBTIMIDITY" && "'$libtimidity_config'" == "" ) { next; }
 		if ($0 == "FLUIDSYNTH"  && "'$fluidsynth'" == "" )         { next; }
 		if ($0 == "USE_XAUDIO2" && "'$with_xaudio2'" == "0")       { next; }
 		if ($0 == "USE_THREADS" && "'$with_threads'" == "0")       { next; }

--- a/projects/generate
+++ b/projects/generate
@@ -78,6 +78,7 @@ enable_ai="1"
 with_cocoa="0"
 enable_directmusic="1"
 enable_fluidsynth="0"
+enable_libtimidity="0"
 with_threads="1"
 file_prefix="..\\\\\\\\src\\\\\\\\"
 
@@ -138,6 +139,7 @@ load_main_data() {
 			if ($0 == "MSVC"        && "'$os'" != "MSVC")              { next; }
 			if ($0 == "DIRECTMUSIC" && "'$enable_directmusic'" != "1") { next; }
 			if ($0 == "FLUIDSYNTH"  && "'$enable_fluidsynth'" != "1")  { next; }
+			if ($0 == "LIBTIMIDITY" && "'$enable_libtimidity'" != "1" ){ next; }
 			if ($0 == "USE_XAUDIO2" && "'$with_xaudio2'" == "0")       { next; }
 			if ($0 == "USE_THREADS" && "'$with_threads'" == "0")       { next; }
 

--- a/source.list
+++ b/source.list
@@ -410,6 +410,7 @@ zoom_type.h
 	music/bemidi.h
 	music/cocoa_m.h
 	music/extmidi.h
+	music/libtimidity.h
 	music/fluidsynth.h
 	music/os2_m.h
 	music/qtmidi.h
@@ -1127,6 +1128,9 @@ music/midifile.cpp
 	#end
 	#if HAIKU
 		music/bemidi.cpp
+	#end
+	#if LIBTIMIDITY
+		music/libtimidity.cpp
 	#end
 	#if FLUIDSYNTH
 		music/fluidsynth.cpp

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -6,7 +6,11 @@
 
 #include <squirrel.h>
 #include "sqpcheader.h"
+/* Isolate type macro from math.h, it clashes with some implementations. */
+#pragma push_macro("type")
+#undef type
 #include <math.h>
+#pragma pop_macro("type")
 #include "sqopcodes.h"
 #include "sqfuncproto.h"
 #include "sqvm.h"

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -164,7 +164,9 @@ struct DrawPixelInfo {
 union Colour {
 	uint32 data; ///< Conversion of the channel information to a 32 bit number.
 	struct {
-#if TTD_ENDIAN == TTD_BIG_ENDIAN
+#if defined(__EMSCRIPTEN__)
+		uint8 r, g, b, a;
+#elif TTD_ENDIAN == TTD_BIG_ENDIAN
 		uint8 a, r, g, b; ///< colour channels in BE order
 #else
 		uint8 b, g, r, a; ///< colour channels in LE order
@@ -179,7 +181,9 @@ union Colour {
 	 * @param a The channel for the alpha/transparency.
 	 */
 	Colour(uint8 r, uint8 g, uint8 b, uint8 a = 0xFF) :
-#if TTD_ENDIAN == TTD_BIG_ENDIAN
+#if defined(__EMSCRIPTEN__)
+		r(r), g(g), b(b), a(a)
+#elif TTD_ENDIAN == TTD_BIG_ENDIAN
 		a(a), r(r), g(g), b(b)
 #else
 		b(b), g(g), r(r), a(a)

--- a/src/music/libtimidity.cpp
+++ b/src/music/libtimidity.cpp
@@ -57,14 +57,14 @@ static void RenderLibtimidityStream(int16 *buffer, size_t samples)
 const char *MusicDriver_LibTimidity::Start(const char * const *param)
 {
 	_midi.status = MIDI_STOPPED;
-	_midi.song = NULL;
+	_midi.song = nullptr;
 	_midi.volume = 127;
 
-	if (mid_init(param == NULL ? NULL : const_cast<char *>(param[0])) < 0) {
+	if (mid_init(param == nullptr ? nullptr : const_cast<char *>(param[0])) < 0) {
 		/* If init fails, it can be because no configuration was found.
 		 *  If it was not forced via param, try to load it without a
 		 *  configuration. Who knows that works. */
-		if (param != NULL || mid_init_no_config() < 0) {
+		if (param != nullptr || mid_init_no_config() < 0) {
 			return "error initializing timidity";
 		}
 	}
@@ -77,12 +77,12 @@ const char *MusicDriver_LibTimidity::Start(const char * const *param)
 	_midi.options.channels = 2;
 	_midi.options.buffer_size = _midi.options.rate;
 
-	return NULL;
+	return nullptr;
 }
 
 void MusicDriver_LibTimidity::Stop()
 {
-	MxSetMusicSource(NULL);
+	MxSetMusicSource(nullptr);
 	if (_midi.status == MIDI_PLAYING) this->StopSong();
 	mid_exit();
 }
@@ -95,7 +95,7 @@ void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
 	if (filename.empty()) return;
 
 	_midi.stream = mid_istream_open_file(filename.c_str());
-	if (_midi.stream == NULL) {
+	if (_midi.stream == nullptr) {
 		DEBUG(driver, 0, "Could not open music file");
 		return;
 	}
@@ -104,7 +104,7 @@ void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
 	mid_istream_close(_midi.stream);
 	_midi.song_length = mid_song_get_total_time(_midi.song);
 
-	if (_midi.song == NULL) {
+	if (_midi.song == nullptr) {
 		DEBUG(driver, 1, "Invalid MIDI file");
 		return;
 	}
@@ -117,9 +117,9 @@ void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
 void MusicDriver_LibTimidity::StopSong()
 {
 	_midi.status = MIDI_STOPPED;
-	/* mid_song_free cannot handle NULL! */
-	if (_midi.song != NULL) mid_song_free(_midi.song);
-	_midi.song = NULL;
+	/* mid_song_free cannot handle nullptr! */
+	if (_midi.song != nullptr) mid_song_free(_midi.song);
+	_midi.song = nullptr;
 }
 
 bool MusicDriver_LibTimidity::IsSongPlaying()
@@ -138,5 +138,5 @@ bool MusicDriver_LibTimidity::IsSongPlaying()
 void MusicDriver_LibTimidity::SetVolume(byte vol)
 {
 	_midi.volume = vol;
-	if (_midi.song != NULL) mid_song_set_volume(_midi.song, vol * 100 / 127);
+	if (_midi.song != nullptr) mid_song_set_volume(_midi.song, vol * 100 / 127);
 }

--- a/src/music/libtimidity.cpp
+++ b/src/music/libtimidity.cpp
@@ -42,6 +42,7 @@ static struct {
 	MidiState status;
 	uint32 song_length;
 	uint32 song_position;
+	byte volume;
 } _midi; ///< Metadata about the midi we're playing.
 
 /** Factory for the libtimidity driver. */
@@ -57,6 +58,7 @@ const char *MusicDriver_LibTimidity::Start(const char * const *param)
 {
 	_midi.status = MIDI_STOPPED;
 	_midi.song = NULL;
+	_midi.volume = 127;
 
 	if (mid_init(param == NULL ? NULL : const_cast<char *>(param[0])) < 0) {
 		/* If init fails, it can be because no configuration was found.
@@ -107,6 +109,7 @@ void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
 		return;
 	}
 
+	SetVolume(_midi.volume);
 	mid_song_start(_midi.song);
 	_midi.status = MIDI_PLAYING;
 }
@@ -134,5 +137,6 @@ bool MusicDriver_LibTimidity::IsSongPlaying()
 
 void MusicDriver_LibTimidity::SetVolume(byte vol)
 {
-	if (_midi.song != NULL) mid_song_set_volume(_midi.song, vol);
+	_midi.volume = vol;
+	if (_midi.song != NULL) mid_song_set_volume(_midi.song, vol * 100 / 127);
 }

--- a/src/music/libtimidity.cpp
+++ b/src/music/libtimidity.cpp
@@ -1,0 +1,128 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file libtimidity.cpp Playing music via the timidity library. */
+
+#include "../stdafx.h"
+#include "../openttd.h"
+#include "../sound_type.h"
+#include "../debug.h"
+#include "libtimidity.h"
+#include "midifile.hpp"
+#include "../base_media_base.h"
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <timidity.h>
+
+#include "../safeguards.h"
+
+/** The state of playing. */
+enum MidiState {
+	MIDI_STOPPED = 0,
+	MIDI_PLAYING = 1,
+};
+
+static struct {
+	MidIStream *stream;
+	MidSongOptions options;
+	MidSong *song;
+
+	MidiState status;
+	uint32 song_length;
+	uint32 song_position;
+} _midi; ///< Metadata about the midi we're playing.
+
+/** Factory for the libtimidity driver. */
+static FMusicDriver_LibTimidity iFMusicDriver_LibTimidity;
+
+const char *MusicDriver_LibTimidity::Start(const char * const *param)
+{
+	_midi.status = MIDI_STOPPED;
+	_midi.song = NULL;
+
+	if (mid_init(param == NULL ? NULL : const_cast<char *>(param[0])) < 0) {
+		/* If init fails, it can be because no configuration was found.
+		 *  If it was not forced via param, try to load it without a
+		 *  configuration. Who knows that works. */
+		if (param != NULL || mid_init_no_config() < 0) {
+			return "error initializing timidity";
+		}
+	}
+	DEBUG(driver, 1, "successfully initialised timidity");
+
+	_midi.options.rate = 44100;
+	_midi.options.format = MID_AUDIO_S16LSB;
+	_midi.options.channels = 2;
+	_midi.options.buffer_size = _midi.options.rate;
+
+	return NULL;
+}
+
+void MusicDriver_LibTimidity::Stop()
+{
+	if (_midi.status == MIDI_PLAYING) this->StopSong();
+	mid_exit();
+}
+
+void MusicDriver_LibTimidity::PlaySong(const MusicSongInfo &song)
+{
+	std::string filename = MidiFile::GetSMFFile(song);
+
+	this->StopSong();
+	if (filename.empty()) return;
+
+	_midi.stream = mid_istream_open_file(filename.c_str());
+	if (_midi.stream == NULL) {
+		DEBUG(driver, 0, "Could not open music file");
+		return;
+	}
+
+	_midi.song = mid_song_load(_midi.stream, &_midi.options);
+	mid_istream_close(_midi.stream);
+	_midi.song_length = mid_song_get_total_time(_midi.song);
+
+	if (_midi.song == NULL) {
+		DEBUG(driver, 1, "Invalid MIDI file");
+		return;
+	}
+
+	mid_song_start(_midi.song);
+	_midi.status = MIDI_PLAYING;
+}
+
+void MusicDriver_LibTimidity::StopSong()
+{
+	_midi.status = MIDI_STOPPED;
+	/* mid_song_free cannot handle NULL! */
+	if (_midi.song != NULL) mid_song_free(_midi.song);
+	_midi.song = NULL;
+}
+
+bool MusicDriver_LibTimidity::IsSongPlaying()
+{
+	if (_midi.status == MIDI_PLAYING) {
+		_midi.song_position = mid_song_get_time(_midi.song);
+		if (_midi.song_position >= _midi.song_length) {
+			_midi.status = MIDI_STOPPED;
+			_midi.song_position = 0;
+		}
+	}
+
+	return (_midi.status == MIDI_PLAYING);
+}
+
+void MusicDriver_LibTimidity::SetVolume(byte vol)
+{
+	if (_midi.song != NULL) mid_song_set_volume(_midi.song, vol);
+}

--- a/src/music/libtimidity.h
+++ b/src/music/libtimidity.h
@@ -1,0 +1,41 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file libtimidity.h Base for LibTimidity music playback. */
+
+#ifndef MUSIC_LIBTIMIDITY_H
+#define MUSIC_LIBTIMIDITY_H
+
+#include "music_driver.hpp"
+
+/** Music driver making use of libtimidity. */
+class MusicDriver_LibTimidity : public MusicDriver {
+public:
+	/* virtual */ const char *Start(const char * const *param);
+
+	/* virtual */ void Stop();
+
+	/* virtual */ void PlaySong(const MusicSongInfo &song);
+
+	/* virtual */ void StopSong();
+
+	/* virtual */ bool IsSongPlaying();
+
+	/* virtual */ void SetVolume(byte vol);
+	/* virtual */ const char *GetName() const { return "libtimidity"; }
+};
+
+/** Factory for the libtimidity driver. */
+class FMusicDriver_LibTimidity : public DriverFactoryBase {
+public:
+	FMusicDriver_LibTimidity() : DriverFactoryBase(Driver::DT_MUSIC, 5, "libtimidity", "LibTimidity MIDI Driver") {}
+	/* virtual */ Driver *CreateInstance() const { return new MusicDriver_LibTimidity(); }
+};
+
+#endif /* MUSIC_LIBTIMIDITY_H */

--- a/src/music/libtimidity.h
+++ b/src/music/libtimidity.h
@@ -17,25 +17,25 @@
 /** Music driver making use of libtimidity. */
 class MusicDriver_LibTimidity : public MusicDriver {
 public:
-	/* virtual */ const char *Start(const char * const *param);
+	const char *Start(const char * const *param) override;
 
-	/* virtual */ void Stop();
+	void Stop() override;
 
-	/* virtual */ void PlaySong(const MusicSongInfo &song);
+	void PlaySong(const MusicSongInfo &song) override;
 
-	/* virtual */ void StopSong();
+	void StopSong() override;
 
-	/* virtual */ bool IsSongPlaying();
+	bool IsSongPlaying() override;
 
-	/* virtual */ void SetVolume(byte vol);
-	/* virtual */ const char *GetName() const { return "libtimidity"; }
+	void SetVolume(byte vol) override;
+	const char *GetName() const override { return "libtimidity"; }
 };
 
 /** Factory for the libtimidity driver. */
 class FMusicDriver_LibTimidity : public DriverFactoryBase {
 public:
 	FMusicDriver_LibTimidity() : DriverFactoryBase(Driver::DT_MUSIC, 5, "libtimidity", "LibTimidity MIDI Driver") {}
-	/* virtual */ Driver *CreateInstance() const { return new MusicDriver_LibTimidity(); }
+	Driver *CreateInstance() const override { return new MusicDriver_LibTimidity(); }
 };
 
 #endif /* MUSIC_LIBTIMIDITY_H */

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -129,11 +129,15 @@ public:
 	 */
 	int CompareTo(NetworkAddress &address)
 	{
+#ifdef __EMSCRIPTEN__
+		return strcmp(GetHostname(), address.GetHostname());
+#else /* __EMSCRIPTEN__ */
 		int r = this->GetAddressLength() - address.GetAddressLength();
 		if (r == 0) r = this->address.ss_family - address.address.ss_family;
 		if (r == 0) r = memcmp(&this->address, &address.address, this->address_length);
 		if (r == 0) r = this->GetPort() - address.GetPort();
 		return r;
+#endif /* __EMSCRIPTEN__ */
 	}
 
 	/**

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -150,12 +150,16 @@ typedef unsigned long in_addr_t;
  */
 static inline bool SetNonBlocking(SOCKET d)
 {
+#ifdef __EMSCRIPTEN__
+	return true;
+#else /* __EMSCRIPTEN__ */
 #ifdef _WIN32
 	u_long nonblocking = 1;
-#else
+#else /* _WIN32 */
 	int nonblocking = 1;
-#endif
+#endif /* !_WIN32 */
 	return ioctlsocket(d, FIONBIO, &nonblocking) == 0;
+#endif /* !__EMSCRIPTEN__ */
 }
 
 /**

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -236,7 +236,14 @@ bool NetworkTCPSocketHandler::CanSendReceive()
 	FD_SET(this->sock, &write_fd);
 
 	tv.tv_sec = tv.tv_usec = 0; // don't block at all.
-	if (select(FD_SETSIZE, &read_fd, &write_fd, nullptr, &tv) < 0) return false;
+
+#ifndef __EMSCRIPTEN__
+	int nfds = FD_SETSIZE;
+#else /* !__EMSCRIPTEN__ */
+	/* Emscripten select supports only 64 nfds (Emscripten #1711) */
+	int nfds = 64;
+#endif /* __EMSCRIPTEN__ */
+	if (select(nfds, &read_fd, &write_fd, nullptr, &tv) < 0) return false;
 
 	this->writable = !!FD_ISSET(this->sock, &write_fd);
 	return FD_ISSET(this->sock, &read_fd) != 0;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2412,6 +2412,10 @@ static void SaveFileStart()
 	_sl.saveinprogress = true;
 }
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 /** Update the gui accordingly when saving is done and release locks on saveload. */
 static void SaveFileDone()
 {
@@ -2420,6 +2424,10 @@ static void SaveFileDone()
 
 	InvalidateWindowData(WC_STATUS_BAR, 0, SBI_SAVELOAD_FINISH);
 	_sl.saveinprogress = false;
+
+#ifdef __EMSCRIPTEN__
+	EM_ASM(if (window["save_data"]) save_data());
+#endif
 }
 
 /** Set the error message from outside of the actual loading/saving of the game (AfterLoadGame and friends) */

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -639,19 +639,91 @@ void VideoDriver_SDL::Stop()
 	}
 }
 
-void VideoDriver_SDL::MainLoop()
+void VideoDriver_SDL::LoopOnce()
 {
-	uint32 cur_ticks = SDL_GetTicks();
-	uint32 last_cur_ticks = cur_ticks;
-	uint32 next_tick = cur_ticks + MILLISECONDS_PER_TICK;
 	uint32 mod;
 	int numkeys;
 	const Uint8 *keys;
 
+	uint32 prev_cur_ticks = cur_ticks; // to check for wrapping
+	InteractiveRandom(); // randomness
+
+	while (PollEvent() == -1) {}
+	if (_exit_game) return;
+
+	mod = SDL_GetModState();
+	keys = SDL_GetKeyboardState(&numkeys);
+
+#if defined(_DEBUG)
+	if (_shift_pressed)
+#else
+	/* Speedup when pressing tab, except when using ALT+TAB
+	 * to switch to another application */
+	if (keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0)
+#endif /* defined(_DEBUG) */
+	{
+		if (!_networking && _game_mode != GM_MENU) _fast_forward |= 2;
+	} else if (_fast_forward & 2) {
+		_fast_forward = 0;
+	}
+
+	cur_ticks = SDL_GetTicks();
+	if (SDL_TICKS_PASSED(cur_ticks, next_tick) || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
+		_realtime_tick += cur_ticks - last_cur_ticks;
+		last_cur_ticks = cur_ticks;
+		next_tick = cur_ticks + MILLISECONDS_PER_TICK;
+
+		bool old_ctrl_pressed = _ctrl_pressed;
+
+		_ctrl_pressed  = !!(mod & KMOD_CTRL);
+		_shift_pressed = !!(mod & KMOD_SHIFT);
+
+		/* determine which directional keys are down */
+		_dirkeys =
+			(keys[SDL_SCANCODE_LEFT]  ? 1 : 0) |
+			(keys[SDL_SCANCODE_UP]    ? 2 : 0) |
+			(keys[SDL_SCANCODE_RIGHT] ? 4 : 0) |
+			(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
+		if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
+
+		/* The gameloop is the part that can run asynchronously. The rest
+		 * except sleeping can't. */
+		if (_draw_mutex != nullptr) draw_lock.unlock();
+
+		GameLoop();
+
+		if (_draw_mutex != nullptr) draw_lock.lock();
+
+		UpdateWindows();
+		_local_palette = _cur_palette;
+	} else {
+		/* Release the thread while sleeping */
+		if (_draw_mutex != nullptr) draw_lock.unlock();
+		CSleep(1);
+		if (_draw_mutex != nullptr) draw_lock.lock();
+
+		NetworkDrawChatMessage();
+		DrawMouseCursor();
+	}
+
+	/* End of the critical part. */
+	if (_draw_mutex != nullptr && !HasModalProgress()) {
+		_draw_signal->notify_one();
+	} else {
+		/* Oh, we didn't have threads, then just draw unthreaded */
+		CheckPaletteAnim();
+		DrawSurfaceToScreen();
+	}
+}
+
+void VideoDriver_SDL::MainLoop()
+{
+	cur_ticks = SDL_GetTicks();
+	last_cur_ticks = cur_ticks;
+	next_tick = cur_ticks + MILLISECONDS_PER_TICK;
+
 	CheckPaletteAnim();
 
-	std::thread draw_thread;
-	std::unique_lock<std::recursive_mutex> draw_lock;
 	if (_draw_threaded) {
 		/* Initialise the mutex first, because that's the thing we *need*
 		 * directly in the newly created thread. */
@@ -682,76 +754,8 @@ void VideoDriver_SDL::MainLoop()
 
 	DEBUG(driver, 1, "SDL2: using %sthreads", _draw_threaded ? "" : "no ");
 
-	for (;;) {
-		uint32 prev_cur_ticks = cur_ticks; // to check for wrapping
-		InteractiveRandom(); // randomness
-
-		while (PollEvent() == -1) {}
-		if (_exit_game) break;
-
-		mod = SDL_GetModState();
-		keys = SDL_GetKeyboardState(&numkeys);
-
-#if defined(_DEBUG)
-		if (_shift_pressed)
-#else
-		/* Speedup when pressing tab, except when using ALT+TAB
-		 * to switch to another application */
-		if (keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0)
-#endif /* defined(_DEBUG) */
-		{
-			if (!_networking && _game_mode != GM_MENU) _fast_forward |= 2;
-		} else if (_fast_forward & 2) {
-			_fast_forward = 0;
-		}
-
-		cur_ticks = SDL_GetTicks();
-		if (SDL_TICKS_PASSED(cur_ticks, next_tick) || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
-			_realtime_tick += cur_ticks - last_cur_ticks;
-			last_cur_ticks = cur_ticks;
-			next_tick = cur_ticks + MILLISECONDS_PER_TICK;
-
-			bool old_ctrl_pressed = _ctrl_pressed;
-
-			_ctrl_pressed  = !!(mod & KMOD_CTRL);
-			_shift_pressed = !!(mod & KMOD_SHIFT);
-
-			/* determine which directional keys are down */
-			_dirkeys =
-				(keys[SDL_SCANCODE_LEFT]  ? 1 : 0) |
-				(keys[SDL_SCANCODE_UP]    ? 2 : 0) |
-				(keys[SDL_SCANCODE_RIGHT] ? 4 : 0) |
-				(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
-			if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
-
-			/* The gameloop is the part that can run asynchronously. The rest
-			 * except sleeping can't. */
-			if (_draw_mutex != nullptr) draw_lock.unlock();
-
-			GameLoop();
-
-			if (_draw_mutex != nullptr) draw_lock.lock();
-
-			UpdateWindows();
-			_local_palette = _cur_palette;
-		} else {
-			/* Release the thread while sleeping */
-			if (_draw_mutex != nullptr) draw_lock.unlock();
-			CSleep(1);
-			if (_draw_mutex != nullptr) draw_lock.lock();
-
-			NetworkDrawChatMessage();
-			DrawMouseCursor();
-		}
-
-		/* End of the critical part. */
-		if (_draw_mutex != nullptr && !HasModalProgress()) {
-			_draw_signal->notify_one();
-		} else {
-			/* Oh, we didn't have threads, then just draw unthreaded */
-			CheckPaletteAnim();
-			DrawSurfaceToScreen();
-		}
+	while (!_exit_game) {
+		LoopOnce();
 	}
 
 	if (_draw_mutex != nullptr) {

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -639,6 +639,16 @@ void VideoDriver_SDL::Stop()
 	}
 }
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+
+void em_loop(void *arg)
+{
+	VideoDriver_SDL *drv = (VideoDriver_SDL*)arg;
+	drv->LoopOnce();
+}
+#endif
+
 void VideoDriver_SDL::LoopOnce()
 {
 	uint32 mod;
@@ -697,10 +707,12 @@ void VideoDriver_SDL::LoopOnce()
 		UpdateWindows();
 		_local_palette = _cur_palette;
 	} else {
+#ifndef __EMSCRIPTEN__
 		/* Release the thread while sleeping */
 		if (_draw_mutex != nullptr) draw_lock.unlock();
 		CSleep(1);
 		if (_draw_mutex != nullptr) draw_lock.lock();
+#endif
 
 		NetworkDrawChatMessage();
 		DrawMouseCursor();
@@ -754,9 +766,13 @@ void VideoDriver_SDL::MainLoop()
 
 	DEBUG(driver, 1, "SDL2: using %sthreads", _draw_threaded ? "" : "no ");
 
+#ifndef __EMSCRIPTEN__
 	while (!_exit_game) {
 		LoopOnce();
 	}
+#else
+	emscripten_set_main_loop_arg(em_loop, this, 0, 1);
+#endif
 
 	if (_draw_mutex != nullptr) {
 		_draw_continue = false;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -14,8 +14,16 @@
 
 #include "video_driver.hpp"
 
+#ifdef __EMSCRIPTEN__
+void em_loop(void *arg);
+#endif
+
 /** The SDL video driver. */
 class VideoDriver_SDL : public VideoDriver {
+#ifdef __EMSCRIPTEN__
+	friend void em_loop(void *arg);
+#endif
+
 public:
 	const char *Start(const char * const *param) override;
 

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -25,6 +25,8 @@ public:
 
 	void MainLoop() override;
 
+	void LoopOnce();
+
 	bool ChangeResolution(int w, int h) override;
 
 	bool ToggleFullscreen(bool fullscreen) override;
@@ -41,6 +43,12 @@ public:
 private:
 	int PollEvent();
 	bool CreateMainSurface(uint w, uint h, bool resize);
+
+	uint32 cur_ticks;
+	uint32 last_cur_ticks;
+	uint32 next_tick;
+	std::thread draw_thread;
+	std::unique_lock<std::recursive_mutex> draw_lock;
 };
 
 /** Factory for the SDL video driver. */

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -75,7 +75,9 @@ static void UpdatePalette(bool init = false)
 		pal[i].unused = 0;
 	}
 
-	SDL_SetColors(_sdl_screen, pal, _local_palette.first_dirty, _local_palette.count_dirty);
+	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 8) {
+		SDL_SetColors(_sdl_screen, pal, _local_palette.first_dirty, _local_palette.count_dirty);
+	}
 
 	if (_sdl_screen != _sdl_realscreen && init) {
 		/* When using a shadow surface, also set our palette on the real screen. This lets SDL
@@ -717,6 +719,9 @@ void VideoDriver_SDL::MainLoop()
 			_fast_forward = 0;
 		}
 
+		if (_sdl_screen == _sdl_realscreen)
+			SDL_LockSurface(_sdl_realscreen);
+
 		cur_ticks = SDL_GetTicks();
 		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
 			_realtime_tick += cur_ticks - last_cur_ticks;
@@ -762,6 +767,9 @@ void VideoDriver_SDL::MainLoop()
 			NetworkDrawChatMessage();
 			DrawMouseCursor();
 		}
+
+		if (_sdl_screen == _sdl_realscreen)
+			SDL_UnlockSurface(_sdl_realscreen);
 
 		/* End of the critical part. */
 		if (_draw_mutex != nullptr && !HasModalProgress()) {

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -14,8 +14,16 @@
 
 #include "video_driver.hpp"
 
+#ifdef __EMSCRIPTEN__
+void em_loop(void *arg);
+#endif
+
 /** The SDL video driver. */
 class VideoDriver_SDL : public VideoDriver {
+#ifdef __EMSCRIPTEN__
+	friend void em_loop(void *arg);
+#endif
+
 public:
 	const char *Start(const char * const *param) override;
 

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -27,6 +27,8 @@ public:
 
 	bool ChangeResolution(int w, int h) override;
 
+	void LoopOnce();
+
 	bool ToggleFullscreen(bool fullscreen) override;
 
 	bool AfterBlitterChange() override;
@@ -42,6 +44,12 @@ private:
 	int PollEvent();
 	bool CreateMainSurface(uint w, uint h);
 	void SetupKeyboard();
+
+	uint32 cur_ticks;
+	uint32 last_cur_ticks;
+	uint32 next_tick;
+	std::thread draw_thread;
+	std::unique_lock<std::recursive_mutex> draw_lock;
 };
 
 /** Factory for the SDL video driver. */


### PR DESCRIPTION
This is currently WIP, but I would appreciate feedback on it.
Libtimidity is restored with mixer output, Emscripten support is added and various fixes for Emscripten quirks are applied.
Dockerfile for build environment is here: https://github.com/Milek7/openttd-emscripten-dockerfile/tree/sdl1

It currently works on SDL1 on 32bpp blitter (8bpp blitter doesn't work, I suspect broken SDL palette support in emscripten shim). It doesn't look correct though, because html provides BGRA buffer and all blitters assume RGBA. Modifying `union Colour` works, but this is hacky solution.

It works too on SDL2 branch, with significantly better performance, both on 8bpp (with correct colors) and 32bpp (same BGRA issue, but it is faster than 8bpp). Maybe this PR should wait on SDL2, as it works much better on it.

Network is handled by emscripten as WebSockets, both UDP and TCP. It requires proxy, like this one: https://gist.github.com/Milek7/b921ec9f8d875fe2d5a8b06bfd533834
sockaddr sizes and NetworkAddress comparing needs to be investigated, current workaround is to delete domain name after resolving, and comparing generated hostnames by strcmp. Using original code caused duplicated entries in gamelist as UDP queries received weren't matched to correct entry.