### PR TITLE
Scale oil refinery edge distance up by map size

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1219,6 +1219,29 @@ static CommandCost CheckNewIndustry_Forest(TileIndex tile)
 }
 
 /**
+ * Check if a tile is within a distance from map edges, scaled by map dimensions independently.
+ * Each dimension is checked independently, and dimensions smaller than 256 are not scaled.
+ * @param tile Which tile to check distance of.
+ * @param maxdist Normal distance on a 256x256 map.
+ * @return True if the tile is near the map edge.
+ */
+static bool CheckScaledDistanceFromEdge(TileIndex tile, uint maxdist)
+{
+	uint maxdist_x = maxdist;
+	uint maxdist_y = maxdist;
+
+	if (MapSizeX() > 256) maxdist_x *= MapSizeX() / 256;
+	if (MapSizeY() > 256) maxdist_y *= MapSizeY() / 256;
+
+	if (DistanceFromEdgeDir(tile, DIAGDIR_NE) < maxdist_x) return true;
+	if (DistanceFromEdgeDir(tile, DIAGDIR_NW) < maxdist_y) return true;
+	if (DistanceFromEdgeDir(tile, DIAGDIR_SW) < maxdist_x) return true;
+	if (DistanceFromEdgeDir(tile, DIAGDIR_SE) < maxdist_y) return true;
+
+	return false;
+}
+
+/**
  * Check the conditions of #CHECK_REFINERY (Industry should be positioned near edge of the map).
  * @param tile %Tile to perform the checking.
  * @return Succeeded or failed command.
@@ -1226,7 +1249,8 @@ static CommandCost CheckNewIndustry_Forest(TileIndex tile)
 static CommandCost CheckNewIndustry_OilRefinery(TileIndex tile)
 {
 	if (_game_mode == GM_EDITOR) return CommandCost();
-	if (DistanceFromEdge(TILE_ADDXY(tile, 1, 1)) < _settings_game.game_creation.oil_refinery_limit) return CommandCost();
+
+	if (CheckScaledDistanceFromEdge(TILE_ADDXY(tile, 1, 1), _settings_game.game_creation.oil_refinery_limit)) return CommandCost();
 
 	return_cmd_error(STR_ERROR_CAN_ONLY_BE_POSITIONED);
 }
@@ -1241,8 +1265,9 @@ extern bool _ignore_restrictions;
 static CommandCost CheckNewIndustry_OilRig(TileIndex tile)
 {
 	if (_game_mode == GM_EDITOR && _ignore_restrictions) return CommandCost();
+
 	if (TileHeight(tile) == 0 &&
-			DistanceFromEdge(TILE_ADDXY(tile, 1, 1)) < _settings_game.game_creation.oil_refinery_limit) return CommandCost();
+			CheckScaledDistanceFromEdge(TILE_ADDXY(tile, 1, 1), _settings_game.game_creation.oil_refinery_limit)) return CommandCost();
 
 	return_cmd_error(STR_ERROR_CAN_ONLY_BE_POSITIONED);
 }

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1326,8 +1326,8 @@ STR_CONFIG_SETTING_TERRAIN_TYPE                                 :Terrain type: {
 STR_CONFIG_SETTING_TERRAIN_TYPE_HELPTEXT                        :(TerraGenesis only) Hilliness of the landscape
 STR_CONFIG_SETTING_INDUSTRY_DENSITY                             :Industry density: {STRING2}
 STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Set how many industries should be generated and what level should be maintained during the game
-STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Maximum distance from edge for Oil refineries: {STRING2}
-STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Oil refineries are only constructed near the map border, that is at the coast for island maps
+STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Maximum distance from edge for Oil industries: {STRING2}
+STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limit for how far from the map border oil refineries and oil rigs can be constructed. On island maps this ensures they are near the coast. On maps larger than 256 tiles, this value is scaled up.
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT                              :Snow line height: {STRING2}
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Control at what height snow starts in sub-arctic landscape. Snow also affects industry generation and town growth requirements
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN                         :Roughness of terrain: {STRING2}


### PR DESCRIPTION
I was playing on a huge map and got annoyed at how relatively close to the edges oil refineries had to be built. I think it makes sense to scale the distance up on larger maps.