### PR TITLE
Fix: Really check for start_date once an AI company slot becomes available.

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -315,8 +315,8 @@
 		if (!Company::IsValidID(c)) return AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->GetSetting("start_date");
 	}
 
-	/* Currently no AI can be started, check again in a year. */
-	return DAYS_IN_YEAR;
+	/* Currently no AI can be started. Return a value higher than the maximum allowed for "start_date". */
+	return AI::START_NEXT_MAX + 1;
 }
 
 /* static */ char *AI::GetConsoleList(char *p, const char *last, bool newest_only)

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -711,7 +711,7 @@ void OnTick_Companies()
 		if (c->bankrupt_asked != 0) HandleBankruptcyTakeover(c);
 	}
 
-	if (_next_competitor_start == 0) {
+	if (_next_competitor_start == 0 || _next_competitor_start == AI::START_NEXT_MAX * DAY_TICKS) {
 		/* AI::GetStartNextTime() can return 0. */
 		_next_competitor_start = max(1, AI::GetStartNextTime() * DAY_TICKS);
 	}


### PR DESCRIPTION
<Samu> basically, if there's no slots, it checks daily, using the interval 3601 - 3600
<Samu> and never reaches 0
<Samu> if it gets a start_date lower than that 3601-3600 interval, then the real countdown starts, using that start_date value. When it reaches 0, it tries to make ai company