### PR TITLE
Fix #7235: Ensure catchment area of neutral station covers entire industry.

### DIFF
--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -57,11 +57,20 @@ public:
 	 * Initialize the BitmapTileArea with the specified Rect.
 	 * @param rect Rect to use.
 	 */
-	void Initialize(Rect r)
+	void Initialize(const Rect &r)
 	{
 		this->tile = TileXY(r.left, r.top);
 		this->w = r.right - r.left + 1;
 		this->h = r.bottom - r.top + 1;
+		this->data.clear();
+		this->data.resize(Index(w, h));
+	}
+
+	void Initialize(const TileArea &ta)
+	{
+		this->tile = ta.tile;
+		this->w = ta.w;
+		this->h = ta.h;
 		this->data.clear();
 		this->data.resize(Index(w, h));
 	}

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -421,10 +421,10 @@ void Station::RecomputeCatchment()
 		this->catchment_tiles.Reset();
 		return;
 	}
-	this->catchment_tiles.Initialize(GetCatchmentRect());
 
 	if (!_settings_game.station.serve_neutral_industries && this->industry != nullptr) {
 		/* Station is associated with an industry, so we only need to deliver to that industry. */
+		this->catchment_tiles.Initialize(this->industry->location);
 		TILE_AREA_LOOP(tile, this->industry->location) {
 			if (IsTileType(tile, MP_INDUSTRY) && GetIndustryIndex(tile) == this->industry->index) {
 				this->catchment_tiles.SetTile(tile);
@@ -439,6 +439,8 @@ void Station::RecomputeCatchment()
 		this->industries_near.insert(this->industry);
 		return;
 	}
+
+	this->catchment_tiles.Initialize(GetCatchmentRect());
 
 	/* Loop finding all station tiles */
 	TileArea ta(TileXY(this->rect.left, this->rect.top), TileXY(this->rect.right, this->rect.bottom));


### PR DESCRIPTION
Large industries could contain tiles that were not covered by the station's 'natural' catchment area, causing an assertion failure.