### PR TITLE
Add: Add .gitignore Exception for VSCode IDE Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ projects/*.VC.db
 projects/*.VC.opendb
 src/rev.cpp
 src/os/windows/ottdres.rc
+.vscode/
 
 /Makefile*
 !/Makefile.msvc


### PR DESCRIPTION
Adds an exception in .gitignore to ignore all files in the .vscode folder (Folder used to store environment-specific files for the IDE).