### PR TITLE
Fix some GUI scaling

### DIFF
--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -199,6 +199,16 @@ void ZoomInOrOutToCursorWindow(bool in, Window *w)
 	}
 }
 
+void FixTitleGameZoom()
+{
+	if (_game_mode != GM_MENU) return;
+
+	ViewPort *vp = FindWindowByClass(WC_MAIN_WINDOW)->viewport;
+	vp->zoom = _gui_zoom;
+	vp->virtual_width = ScaleByZoom(vp->width, vp->zoom);
+	vp->virtual_height = ScaleByZoom(vp->height, vp->zoom);
+}
+
 static const struct NWidgetPart _nested_main_window_widgets[] = {
 	NWidget(NWID_VIEWPORT, INVALID_COLOUR, WID_M_VIEWPORT), SetResize(1, 1),
 };

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -331,6 +331,11 @@ struct NewsWindow : Window {
 				*size = maxdim(*size, GetSpriteSize(SPR_GRADIENT));
 				break;
 
+			case WID_N_MGR_NAME:
+				SetDParamStr(0, static_cast<const CompanyNewsInformation *>(this->ni->free_data)->president_name);
+				str = STR_JUST_RAW_STRING;
+				break;
+
 			case WID_N_MESSAGE:
 				CopyInDParam(0, this->ni->params, lengthof(this->ni->params));
 				str = this->ni->string_id;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -62,6 +62,7 @@
 #include "town.h"
 #include "subsidy_func.h"
 #include "gfx_layout.h"
+#include "viewport_func.h"
 #include "viewport_sprite_sorter.h"
 #include "framerate_type.h"
 
@@ -336,6 +337,7 @@ static void LoadIntroGame(bool load_newgrfs = true)
 		SetLocalCompany(COMPANY_FIRST);
 	}
 
+	FixTitleGameZoom();
 	_pause_mode = PM_UNPAUSED;
 	_cursor.fix_at = false;
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -37,6 +37,7 @@
 #include "stringfilter_type.h"
 #include "querystring_gui.h"
 #include "fontcache.h"
+#include "zoom_func.h"
 
 #include <vector>
 
@@ -542,6 +543,7 @@ struct GameOptionsWindow : Window {
 				_gui_zoom = (ZoomLevel)(ZOOM_LVL_OUT_4X - index);
 				UpdateCursorSize();
 				UpdateAllVirtCoords();
+				FixTitleGameZoom();
 				ReInitAllWindows();
 				break;
 

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -27,6 +27,7 @@
 #include "toolbar_gui.h"
 #include "core/geometry_func.hpp"
 #include "guitimer_func.h"
+#include "zoom_func.h"
 
 #include "widgets/statusbar_widget.h"
 
@@ -166,7 +167,7 @@ struct StatusBarWindow : Window {
 					DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + WD_FRAMERECT_TOP, STR_STATUSBAR_PAUSED, TC_FROMSTRING, SA_HOR_CENTER);
 				} else if (this->ticker_scroll < TICKER_STOP && FindWindowById(WC_NEWS_WINDOW, 0) == nullptr && _statusbar_news_item != nullptr && _statusbar_news_item->string_id != 0) {
 					/* Draw the scrolling news text */
-					if (!DrawScrollingStatusText(_statusbar_news_item, this->ticker_scroll, r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + WD_FRAMERECT_TOP, r.bottom)) {
+					if (!DrawScrollingStatusText(_statusbar_news_item, ScaleGUITrad(this->ticker_scroll), r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + WD_FRAMERECT_TOP, r.bottom)) {
 						InvalidateWindowData(WC_STATUS_BAR, 0, SBI_NEWS_DELETED);
 						if (Company::IsValidID(_local_company)) {
 							/* This is the default text */

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -34,6 +34,7 @@ void MarkAllViewportsDirty(int left, int top, int right, int bottom);
 bool DoZoomInOutWindow(ZoomStateChange how, Window *w);
 void ZoomInOrOutToCursorWindow(bool in, Window * w);
 Point GetTileZoomCenterWindow(bool in, Window * w);
+void FixTitleGameZoom();
 void HandleZoomMessage(Window *w, const ViewPort *vp, byte widget_zoom_in, byte widget_zoom_out);
 
 /**

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2634,7 +2634,7 @@ static int MakeNWidget(const NWidgetPart *parts, int count, NWidgetBase **dest, 
 				NWidgetResizeBase *nwrb = dynamic_cast<NWidgetResizeBase *>(*dest);
 				if (nwrb != nullptr) {
 					assert(parts->u.xy.x >= 0 && parts->u.xy.y >= 0);
-					nwrb->SetMinimalSize(parts->u.xy.x, parts->u.xy.y);
+					nwrb->SetMinimalSize(ScaleGUITrad(parts->u.xy.x), ScaleGUITrad(parts->u.xy.y));
 				}
 				break;
 			}
@@ -2664,7 +2664,7 @@ static int MakeNWidget(const NWidgetPart *parts, int count, NWidgetBase **dest, 
 			}
 
 			case WPT_PADDING:
-				if (*dest != nullptr) (*dest)->SetPadding(parts->u.padding.top, parts->u.padding.right, parts->u.padding.bottom, parts->u.padding.left);
+				if (*dest != nullptr) (*dest)->SetPadding(ScaleGUITrad(parts->u.padding.top), ScaleGUITrad(parts->u.padding.right), ScaleGUITrad(parts->u.padding.bottom), ScaleGUITrad(parts->u.padding.left));
 				break;
 
 			case WPT_PIPSPACE: {


### PR DESCRIPTION
Various GUI elements were not being scaled appropriately with UI scale set to 2x and 4x. Especially newspapers and query boxes were too narrow.

This also scales up the news ticker scroll speed by UI scale, as it otherwise goes by too slow to clear the screen.

Zooming the title game by GUI scale should also avoid most problems like the following, 1.9 title game in 3840 pixel wide showing far more than planned for:
![image](https://user-images.githubusercontent.com/1062071/56616281-4a692400-661d-11e9-92da-d4a292903a9a.png)
