### PR TITLE
Change: New layout for the Station view window

### DIFF
--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -1110,7 +1110,8 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_SCROLLBAR,                          "WID_SV_SCROLLBAR");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_ACCEPT_RATING_LIST,                 "WID_SV_ACCEPT_RATING_LIST");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_LOCATION,                           "WID_SV_LOCATION");
-	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_ACCEPTS_RATINGS,                    "WID_SV_ACCEPTS_RATINGS");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_ACCEPTS,                            "WID_SV_ACCEPTS");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_RATINGS,                            "WID_SV_RATINGS");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_RENAME,                             "WID_SV_RENAME");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_CLOSE_AIRPORT,                      "WID_SV_CLOSE_AIRPORT");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_SV_TRAINS,                             "WID_SV_TRAINS");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -2282,7 +2282,8 @@ public:
 		WID_SV_SCROLLBAR                             = ::WID_SV_SCROLLBAR,                             ///< Scrollbar.
 		WID_SV_ACCEPT_RATING_LIST                    = ::WID_SV_ACCEPT_RATING_LIST,                    ///< List of accepted cargoes / rating of cargoes.
 		WID_SV_LOCATION                              = ::WID_SV_LOCATION,                              ///< 'Location' button.
-		WID_SV_ACCEPTS_RATINGS                       = ::WID_SV_ACCEPTS_RATINGS,                       ///< 'Accepts' / 'Ratings' button.
+		WID_SV_ACCEPTS                               = ::WID_SV_ACCEPTS,                               ///< 'Accepts' button.
+		WID_SV_RATINGS                               = ::WID_SV_RATINGS,                               ///< 'Ratings' button.
 		WID_SV_RENAME                                = ::WID_SV_RENAME,                                ///< 'Rename' button.
 		WID_SV_CLOSE_AIRPORT                         = ::WID_SV_CLOSE_AIRPORT,                         ///< 'Close airport' button.
 		WID_SV_TRAINS                                = ::WID_SV_TRAINS,                                ///< List of scheduled trains button.

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -824,23 +824,24 @@ static const NWidgetPart _nested_station_view_widgets[] = {
 		NWidget(WWT_PANEL, COLOUR_GREY, WID_SV_WAITING), SetMinimalSize(237, 44), SetResize(1, 10), SetScrollbar(WID_SV_SCROLLBAR), EndContainer(),
 		NWidget(NWID_VSCROLLBAR, COLOUR_GREY, WID_SV_SCROLLBAR),
 	EndContainer(),
-	NWidget(WWT_PANEL, COLOUR_GREY, WID_SV_ACCEPT_RATING_LIST), SetMinimalSize(249, 23), SetResize(1, 0), EndContainer(),
 	NWidget(NWID_HORIZONTAL),
 		NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
-			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_LOCATION), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1),
-					SetDataTip(STR_BUTTON_LOCATION, STR_STATION_VIEW_CENTER_TOOLTIP),
-			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_ACCEPTS_RATINGS), SetMinimalSize(46, 12), SetResize(1, 0), SetFill(1, 1),
-					SetDataTip(STR_STATION_VIEW_RATINGS_BUTTON, STR_STATION_VIEW_RATINGS_TOOLTIP),
-			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_RENAME), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1),
-					SetDataTip(STR_BUTTON_RENAME, STR_STATION_VIEW_RENAME_TOOLTIP),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_ACCEPTS), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_STATION_VIEW_ACCEPTS_BUTTON, STR_STATION_VIEW_ACCEPTS_TOOLTIP),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_RATINGS), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_STATION_VIEW_RATINGS_BUTTON, STR_STATION_VIEW_RATINGS_TOOLTIP),
+			NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SV_CATCHMENT), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_BUTTON_CATCHMENT, STR_TOOLTIP_CATCHMENT),
 		EndContainer(),
-		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SV_CLOSE_AIRPORT), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1),
-				SetDataTip(STR_STATION_VIEW_CLOSE_AIRPORT, STR_STATION_VIEW_CLOSE_AIRPORT_TOOLTIP),
-		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SV_CATCHMENT), SetMinimalSize(14, 12), SetFill(0, 1), SetDataTip(STR_BUTTON_CATCHMENT, STR_TOOLTIP_CATCHMENT),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_TRAINS), SetMinimalSize(14, 12), SetFill(0, 1), SetDataTip(STR_TRAIN, STR_STATION_VIEW_SCHEDULED_TRAINS_TOOLTIP),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_ROADVEHS), SetMinimalSize(14, 12), SetFill(0, 1), SetDataTip(STR_LORRY, STR_STATION_VIEW_SCHEDULED_ROAD_VEHICLES_TOOLTIP),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_SHIPS), SetMinimalSize(14, 12), SetFill(0, 1), SetDataTip(STR_SHIP, STR_STATION_VIEW_SCHEDULED_SHIPS_TOOLTIP),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_PLANES),  SetMinimalSize(14, 12), SetFill(0, 1), SetDataTip(STR_PLANE, STR_STATION_VIEW_SCHEDULED_AIRCRAFT_TOOLTIP),
+	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_GREY, WID_SV_ACCEPT_RATING_LIST), SetMinimalSize(249, 23), SetResize(1, 0), EndContainer(),
+	NWidget(NWID_HORIZONTAL),
+		NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_LOCATION), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_BUTTON_LOCATION, STR_STATION_VIEW_CENTER_TOOLTIP),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SV_RENAME), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_BUTTON_RENAME, STR_STATION_VIEW_RENAME_TOOLTIP),
+			NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_SV_CLOSE_AIRPORT), SetMinimalSize(45, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_STATION_VIEW_CLOSE_AIRPORT, STR_STATION_VIEW_CLOSE_AIRPORT_TOOLTIP),
+		EndContainer(),
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
 };
@@ -1347,13 +1348,14 @@ struct StationViewWindow : public Window {
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_SV_SCROLLBAR);
-		/* Nested widget tree creation is done in two steps to ensure that this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS_RATINGS) exists in UpdateWidgetSize(). */
+		/* Nested widget tree creation is done in two steps to ensure that this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS) exist in UpdateWidgetSize() (via IsShowAccepts()). */
 		this->FinishInitNested(window_number);
 
 		this->groupings[0] = GR_CARGO;
 		this->sortings[0] = ST_AS_GROUPING;
 		this->SelectGroupBy(_settings_client.gui.station_gui_group_order);
 		this->SelectSortBy(_settings_client.gui.station_gui_sort_by);
+		this->SetShowAccepts(true);
 		this->sort_orders[0] = SO_ASCENDING;
 		this->SelectSortOrder((SortOrder)_settings_client.gui.station_gui_sort_order);
 		this->owner = Station::Get(window_number)->owner;
@@ -1425,7 +1427,7 @@ struct StationViewWindow : public Window {
 				break;
 
 			case WID_SV_ACCEPT_RATING_LIST:
-				size->height = WD_FRAMERECT_TOP + ((this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS_RATINGS)->widget_data == STR_STATION_VIEW_RATINGS_BUTTON) ? this->accepts_lines : this->rating_lines) * FONT_HEIGHT_NORMAL + WD_FRAMERECT_BOTTOM;
+				size->height = WD_FRAMERECT_TOP + (this->IsShowAccepts() ? this->accepts_lines : this->rating_lines) * FONT_HEIGHT_NORMAL + WD_FRAMERECT_BOTTOM;
 				break;
 
 			case WID_SV_CLOSE_AIRPORT:
@@ -1466,7 +1468,7 @@ struct StationViewWindow : public Window {
 			/* Draw 'accepted cargo' or 'cargo ratings'. */
 			const NWidgetBase *wid = this->GetWidget<NWidgetBase>(WID_SV_ACCEPT_RATING_LIST);
 			const Rect r = {(int)wid->pos_x, (int)wid->pos_y, (int)(wid->pos_x + wid->current_x - 1), (int)(wid->pos_y + wid->current_y - 1)};
-			if (this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS_RATINGS)->widget_data == STR_STATION_VIEW_RATINGS_BUTTON) {
+			if (this->IsShowAccepts()) {
 				int lines = this->DrawAcceptedCargo(r);
 				if (lines > this->accepts_lines) { // Resize the widget, and perform re-initialization of the window.
 					this->accepts_lines = lines;
@@ -1899,6 +1901,27 @@ struct StationViewWindow : public Window {
 		return CeilDiv(y - r.top - WD_FRAMERECT_TOP, FONT_HEIGHT_NORMAL);
 	}
 
+	bool IsShowAccepts() const
+	{
+		return this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS)->IsDisabled();
+	}
+
+	void SetShowAccepts(bool show_accepts)
+	{
+		if (show_accepts == this->IsShowAccepts()) return;
+
+		this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS)->SetDisabled(show_accepts);
+		this->GetWidget<NWidgetCore>(WID_SV_RATINGS)->SetDisabled(!show_accepts);
+
+		int height_change;
+		if (show_accepts) {
+			height_change = this->accepts_lines - this->rating_lines;
+		} else {
+			height_change = this->rating_lines - this->accepts_lines;
+		}
+		this->ReInit(0, height_change * FONT_HEIGHT_NORMAL);
+	}
+
 	/**
 	 * Expand or collapse a specific row.
 	 * @param filter Parent of the row.
@@ -1953,20 +1976,13 @@ struct StationViewWindow : public Window {
 				}
 				break;
 
-			case WID_SV_ACCEPTS_RATINGS: {
-				/* Swap between 'accepts' and 'ratings' view. */
-				int height_change;
-				NWidgetCore *nwi = this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS_RATINGS);
-				if (this->GetWidget<NWidgetCore>(WID_SV_ACCEPTS_RATINGS)->widget_data == STR_STATION_VIEW_RATINGS_BUTTON) {
-					nwi->SetDataTip(STR_STATION_VIEW_ACCEPTS_BUTTON, STR_STATION_VIEW_ACCEPTS_TOOLTIP); // Switch to accepts view.
-					height_change = this->rating_lines - this->accepts_lines;
-				} else {
-					nwi->SetDataTip(STR_STATION_VIEW_RATINGS_BUTTON, STR_STATION_VIEW_RATINGS_TOOLTIP); // Switch to ratings view.
-					height_change = this->accepts_lines - this->rating_lines;
-				}
-				this->ReInit(0, height_change * FONT_HEIGHT_NORMAL);
+			case WID_SV_ACCEPTS:
+				this->SetShowAccepts(true);
 				break;
-			}
+
+			case WID_SV_RATINGS:
+				this->SetShowAccepts(false);
+				break;
 
 			case WID_SV_RENAME:
 				SetDParam(0, this->window_number);

--- a/src/widgets/station_widget.h
+++ b/src/widgets/station_widget.h
@@ -23,7 +23,8 @@ enum StationViewWidgets {
 	WID_SV_SCROLLBAR,          ///< Scrollbar.
 	WID_SV_ACCEPT_RATING_LIST, ///< List of accepted cargoes / rating of cargoes.
 	WID_SV_LOCATION,           ///< 'Location' button.
-	WID_SV_ACCEPTS_RATINGS,    ///< 'Accepts' / 'Ratings' button.
+	WID_SV_ACCEPTS,            ///< 'Accepts' button.
+	WID_SV_RATINGS,            ///< 'Ratings' button.
 	WID_SV_RENAME,             ///< 'Rename' button.
 	WID_SV_CLOSE_AIRPORT,      ///< 'Close airport' button.
 	WID_SV_TRAINS,             ///< List of scheduled trains button.


### PR DESCRIPTION
The old layout was getting very cramped in the buttons row, especially after #7446. The new layout moves "query" buttons to a separate row between cargo waiting and accepts/ratings panes.

![](https://0x0.st/zbTR.png)