### PR TITLE
Fix #7481: Don't modify oil rig stations during removal

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3967,16 +3967,9 @@ void DeleteOilRig(TileIndex tile)
 
 	MakeWaterKeepingClass(tile, OWNER_NONE);
 
-	st->dock_tile = INVALID_TILE;
-	st->airport.Clear();
-	st->facilities &= ~(FACIL_AIRPORT | FACIL_DOCK);
-	st->airport.flags = 0;
-
-	st->rect.AfterRemoveTile(st, tile);
-
-	st->UpdateVirtCoord();
-	st->RecomputeCatchment();
-	if (!st->IsInUse()) delete st;
+	/* The oil rig station is not supposed to be shared with anything else */
+	assert(st->facilities == (FACIL_AIRPORT | FACIL_DOCK) && st->airport.type == AT_OILRIG);
+	delete st;
 }
 
 static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_owner)


### PR DESCRIPTION
I'm not sure if this approach is entirely safe. The DeleteOilRig function is called from two places, the Industry destructor, and in afterload. The afterload call is for cleaning up orphan oil rig stations without oil rig, sometimes left over in old saves. I don't have a save of that kind on hand to test, so I don't know if it's safe.

I'm also not completely sure that the new assert can't trigger under certain (broken) situations, if a player has somehow managed to join their station with an oil rig station.