### PR TITLE
Fix: Crash on waypoint selection window

### DIFF
--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2408,7 +2408,7 @@ struct SelectStationWindow : Window {
 
 	void OnMouseOver(Point pt, int widget) override
 	{
-		if (widget != WID_JS_PANEL) {
+		if (widget != WID_JS_PANEL || T::EXPECTED_FACIL == FACIL_WAYPOINT) {
 			SetViewportCatchmentStation(nullptr, true);
 			return;
 		}


### PR DESCRIPTION
The game crashes when joining waypoints, since waypoints have no coverage.
