### PR TITLE
Change: Default setting of "Advertise" in server browser to "Yes"

### DIFF
--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3740,7 +3740,7 @@ var      = network.lan_internet
 type     = SLE_UINT8
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
-def      = 0
+def      = 1
 min      = 0
 max      = 1
 


### PR DESCRIPTION
When I first downloaded and launched OpenTTD a few years ago, I was confused that no multiplayer servers were showing. After 20 minutes of research I figured that I had to change this one option to "Yes". I feel that many other players have suffered this problem, and some may even be entirely turned off playing the game because of this.

I propose we change the default option to "Yes" so new players have an easier time browsing and playing online.