### PR TITLE
Fix #7570: Show Github URL in the crashlog window

### DIFF
--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -203,7 +203,7 @@ public:
 		char message[1024];
 		seprintf(message, lastof(message),
 				 "Please send the generated crash information and the last (auto)save to the developers. "
-				 "This will greatly help debugging. The correct place to do this is http://bugs.openttd.org.\n\n"
+				 "This will greatly help debugging. The correct place to do this is https://github.com/OpenTTD/OpenTTD/issues.\n\n"
 				 "Generated file(s):\n%s\n%s\n%s",
 				 this->filename_log, this->filename_save, this->filename_screenshot);
 

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -582,7 +582,7 @@ static bool _expanded;
 static const TCHAR _crash_desc[] =
 	_T("A serious fault condition occurred in the game. The game will shut down.\n")
 	_T("Please send the crash information and the crash.dmp file (if any) to the developers.\n")
-	_T("This will greatly help debugging. The correct place to do this is http://bugs.openttd.org. ")
+	_T("This will greatly help debugging. The correct place to do this is https://github.com/OpenTTD/OpenTTD/issues. ")
 	_T("The information contained in the report is displayed below.\n")
 	_T("Press \"Emergency save\" to attempt saving the game. Generated file(s):\n")
 	_T("%s");


### PR DESCRIPTION
The crashlog window was still pointing to the old bugs.openttd.org, updated to GitHub.