### PR TITLE
GDI engine for font glyph rendering as a replacement for FreeType (take 2)

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -2786,6 +2786,12 @@ detect_png() {
 }
 
 detect_freetype() {
+	if  [ "$with_freetype" = "1" ] && ([ "$os" = "MINGW" ] || [ "$os" = "CYGWIN" ]); then
+		log 1 "checking freetype2... WIN32, skipping"
+		freetype_config=""
+		return 0
+	fi
+
 	detect_pkg_config "$with_freetype" "freetype2" "freetype_config" "2.2" "1"
 }
 

--- a/docs/Readme_Windows_MSVC.md
+++ b/docs/Readme_Windows_MSVC.md
@@ -32,7 +32,6 @@ by following the `Quick Start` intructions of their
 After this, you can install the dependencies OpenTTD needs. We advise to use
 the `static` versions, and OpenTTD currently needs the following dependencies:
 
-- freetype
 - liblzma
 - libpng
 - lzo
@@ -41,8 +40,8 @@ the `static` versions, and OpenTTD currently needs the following dependencies:
 To install both the x64 (64bit) and x86 (32bit) variants, you can use:
 
 ```ps
-.\vcpkg install freetype:x64-windows-static liblzma:x64-windows-static libpng:x64-windows-static lzo:x64-windows-static zlib:x64-windows-static
-.\vcpkg install freetype:x86-windows-static liblzma:x86-windows-static libpng:x86-windows-static lzo:x86-windows-static zlib:x86-windows-static
+.\vcpkg install liblzma:x64-windows-static libpng:x64-windows-static lzo:x64-windows-static zlib:x64-windows-static
+.\vcpkg install liblzma:x86-windows-static libpng:x86-windows-static lzo:x86-windows-static zlib:x86-windows-static
 ```
 
 ## TTD Graphics files

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -107,7 +107,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -172,7 +172,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -230,7 +230,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -293,7 +293,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>

--- a/projects/openttd_vs140.vcxproj.in
+++ b/projects/openttd_vs140.vcxproj.in
@@ -107,7 +107,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -172,7 +172,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -230,7 +230,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -293,7 +293,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -107,7 +107,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -172,7 +172,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -230,7 +230,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -293,7 +293,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>

--- a/projects/openttd_vs141.vcxproj.in
+++ b/projects/openttd_vs141.vcxproj.in
@@ -107,7 +107,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -172,7 +172,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -230,7 +230,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -293,7 +293,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -107,7 +107,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -172,7 +172,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -230,7 +230,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -293,7 +293,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>

--- a/projects/openttd_vs142.vcxproj.in
+++ b/projects/openttd_vs142.vcxproj.in
@@ -107,7 +107,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -172,7 +172,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -230,7 +230,7 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;WITH_ASSERT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -293,7 +293,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalIncludeDirectories>..\objs\langs;..\objs\settings;..\src\3rdparty\squirrel\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_FREETYPE;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32_ENABLE_DIRECTMUSIC_SUPPORT;WITH_XAUDIO2;WITH_SSE;WITH_ZLIB;WITH_LZO;WITH_LIBLZMA;WITH_PNG;WITH_UNISCRIBE;ENABLE_NETWORK;WITH_PERSONAL_DIR;PERSONAL_DIR="OpenTTD";_SQ64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -199,16 +199,16 @@ bool SpriteFontCache::GetDrawGlyphShadow()
 
 /* static */ FontCache *FontCache::caches[FS_END] = { new SpriteFontCache(FS_NORMAL), new SpriteFontCache(FS_SMALL), new SpriteFontCache(FS_LARGE), new SpriteFontCache(FS_MONO) };
 
-#ifdef WITH_FREETYPE
-#include <ft2build.h>
-#include FT_FREETYPE_H
-#include FT_GLYPH_H
-#include FT_TRUETYPE_TABLES_H
+#if defined(WITH_FREETYPE)
 
-/** Font cache for fonts that are based on a freetype font. */
-class FreeTypeFontCache : public FontCache {
-private:
-	FT_Face face;  ///< The font face associated with this font.
+FreeTypeSettings _freetype;
+
+static const byte FACE_COLOUR = 1;
+static const byte SHADOW_COLOUR = 2;
+
+/** Font cache for fonts that are based on a TrueType font. */
+class TrueTypeFontCache : public FontCache {
+protected:
 	int req_size;  ///< Requested font size.
 	int used_size; ///< Used font size.
 
@@ -239,31 +239,233 @@ private:
 
 	GlyphEntry *GetGlyphPtr(GlyphID key);
 	void SetGlyphPtr(GlyphID key, const GlyphEntry *glyph, bool duplicate = false);
-	void SetFontSize(FontSize fs, FT_Face face, int pixels);
+
+	virtual const void *InternalGetFontTable(uint32 tag, size_t &length) = 0;
+	virtual const Sprite *InternalGetGlyph(GlyphID key, bool aa) = 0;
 
 public:
-	FreeTypeFontCache(FontSize fs, FT_Face face, int pixels);
-	~FreeTypeFontCache();
+	TrueTypeFontCache(FontSize fs, int pixels);
+	virtual ~TrueTypeFontCache();
 	virtual int GetFontSize() const { return this->used_size; }
 	virtual SpriteID GetUnicodeGlyph(WChar key) { return this->parent->GetUnicodeGlyph(key); }
 	virtual void SetUnicodeGlyph(WChar key, SpriteID sprite) { this->parent->SetUnicodeGlyph(key, sprite); }
 	virtual void InitializeUnicodeGlyphMap() { this->parent->InitializeUnicodeGlyphMap(); }
-	virtual void ClearFontCache();
 	virtual const Sprite *GetGlyph(GlyphID key);
+	virtual const void *GetFontTable(uint32 tag, size_t &length);
+	virtual void ClearFontCache();
 	virtual uint GetGlyphWidth(GlyphID key);
 	virtual bool GetDrawGlyphShadow();
+	virtual bool IsBuiltInFont() { return false; }
+};
+
+/**
+ * Create a new TrueTypeFontCache.
+ * @param fs     The font size that is going to be cached.
+ * @param pixels The number of pixels this font should be high.
+ */
+TrueTypeFontCache::TrueTypeFontCache(FontSize fs, int pixels) : FontCache(fs), req_size(pixels), glyph_to_sprite(nullptr)
+{
+}
+
+/**
+ * Free everything that was allocated for this font cache.
+ */
+TrueTypeFontCache::~TrueTypeFontCache()
+{
+	this->ClearFontCache();
+
+	for (auto &iter : this->font_tables) {
+		free(iter.second.second);
+	}
+}
+
+/**
+ * Reset cached glyphs.
+ */
+void TrueTypeFontCache::ClearFontCache()
+{
+	if (this->glyph_to_sprite == nullptr) return;
+
+	for (int i = 0; i < 256; i++) {
+		if (this->glyph_to_sprite[i] == nullptr) continue;
+
+		for (int j = 0; j < 256; j++) {
+			if (this->glyph_to_sprite[i][j].duplicate) continue;
+			free(this->glyph_to_sprite[i][j].sprite);
+		}
+
+		free(this->glyph_to_sprite[i]);
+	}
+
+	free(this->glyph_to_sprite);
+	this->glyph_to_sprite = nullptr;
+
+	Layouter::ResetFontCache(this->fs);
+}
+
+
+TrueTypeFontCache::GlyphEntry *TrueTypeFontCache::GetGlyphPtr(GlyphID key)
+{
+	if (this->glyph_to_sprite == nullptr) return nullptr;
+	if (this->glyph_to_sprite[GB(key, 8, 8)] == nullptr) return nullptr;
+	return &this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)];
+}
+
+void TrueTypeFontCache::SetGlyphPtr(GlyphID key, const GlyphEntry *glyph, bool duplicate)
+{
+	if (this->glyph_to_sprite == nullptr) {
+		DEBUG(freetype, 3, "Allocating root glyph cache for size %u", this->fs);
+		this->glyph_to_sprite = CallocT<GlyphEntry*>(256);
+	}
+
+	if (this->glyph_to_sprite[GB(key, 8, 8)] == nullptr) {
+		DEBUG(freetype, 3, "Allocating glyph cache for range 0x%02X00, size %u", GB(key, 8, 8), this->fs);
+		this->glyph_to_sprite[GB(key, 8, 8)] = CallocT<GlyphEntry>(256);
+	}
+
+	DEBUG(freetype, 4, "Set glyph for unicode character 0x%04X, size %u", key, this->fs);
+	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].sprite = glyph->sprite;
+	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].width = glyph->width;
+	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].duplicate = duplicate;
+}
+
+static void *AllocateFont(size_t size)
+{
+	return MallocT<byte>(size);
+}
+
+
+/* Check if a glyph should be rendered with anti-aliasing. */
+static bool GetFontAAState(FontSize size)
+{
+	/* AA is only supported for 32 bpp */
+	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
+
+	switch (size) {
+		default: NOT_REACHED();
+		case FS_NORMAL: return _freetype.medium.aa;
+		case FS_SMALL:  return _freetype.small.aa;
+		case FS_LARGE:  return _freetype.large.aa;
+		case FS_MONO:   return _freetype.mono.aa;
+	}
+}
+
+bool TrueTypeFontCache::GetDrawGlyphShadow()
+{
+	return this->fs == FS_NORMAL && GetFontAAState(FS_NORMAL);
+}
+
+uint TrueTypeFontCache::GetGlyphWidth(GlyphID key)
+{
+	if ((key & SPRITE_GLYPH) != 0) return this->parent->GetGlyphWidth(key);
+
+	GlyphEntry *glyph = this->GetGlyphPtr(key);
+	if (glyph == nullptr || glyph->sprite == nullptr) {
+		this->GetGlyph(key);
+		glyph = this->GetGlyphPtr(key);
+	}
+
+	return glyph->width;
+}
+
+const Sprite *TrueTypeFontCache::GetGlyph(GlyphID key)
+{
+	if ((key & SPRITE_GLYPH) != 0) return this->parent->GetGlyph(key);
+
+	/* Check for the glyph in our cache */
+	GlyphEntry *glyph = this->GetGlyphPtr(key);
+	if (glyph != nullptr && glyph->sprite != nullptr) return glyph->sprite;
+
+	if (key == 0) {
+		GlyphID question_glyph = this->MapCharToGlyph('?');
+		if (question_glyph == 0) {
+			/* The font misses the '?' character. Use built-in sprite.
+			 * Note: We cannot use the baseset as this also has to work in the bootstrap GUI. */
+#define CPSET { 0, 0, 0, 0, 1 }
+#define CP___ { 0, 0, 0, 0, 0 }
+			static SpriteLoader::CommonPixel builtin_questionmark_data[10 * 8] = {
+				CP___, CP___, CPSET, CPSET, CPSET, CPSET, CP___, CP___,
+				CP___, CPSET, CPSET, CP___, CP___, CPSET, CPSET, CP___,
+				CP___, CP___, CP___, CP___, CP___, CPSET, CPSET, CP___,
+				CP___, CP___, CP___, CP___, CPSET, CPSET, CP___, CP___,
+				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
+				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
+				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
+				CP___, CP___, CP___, CP___, CP___, CP___, CP___, CP___,
+				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
+				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
+			};
+#undef CPSET
+#undef CP___
+			static const SpriteLoader::Sprite builtin_questionmark = {
+				10, // height
+				8,  // width
+				0,  // x_offs
+				0,  // y_offs
+				ST_FONT,
+				builtin_questionmark_data
+			};
+
+			Sprite *spr = BlitterFactory::GetCurrentBlitter()->Encode(&builtin_questionmark, AllocateFont);
+			assert(spr != nullptr);
+			GlyphEntry new_glyph;
+			new_glyph.sprite = spr;
+			new_glyph.width  = spr->width + (this->fs != FS_NORMAL);
+			this->SetGlyphPtr(key, &new_glyph, false);
+			return new_glyph.sprite;
+		} else {
+			/* Use '?' for missing characters. */
+			this->GetGlyph(question_glyph);
+			glyph = this->GetGlyphPtr(question_glyph);
+			this->SetGlyphPtr(key, glyph, true);
+			return glyph->sprite;
+		}
+	}
+
+	return this->InternalGetGlyph(key, GetFontAAState(this->fs));
+}
+
+const void *TrueTypeFontCache::GetFontTable(uint32 tag, size_t &length)
+{
+	const FontTable::iterator iter = this->font_tables.Find(tag);
+	if (iter != this->font_tables.data() + this->font_tables.size()) {
+		length = iter->second.first;
+		return iter->second.second;
+	}
+
+	const void *result = this->InternalGetFontTable(tag, length);
+
+	this->font_tables.Insert(tag, SmallPair<size_t, const void *>(length, result));
+	return result;
+}
+
+
+#ifdef WITH_FREETYPE
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_GLYPH_H
+#include FT_TRUETYPE_TABLES_H
+
+/** Font cache for fonts that are based on a freetype font. */
+class FreeTypeFontCache : public TrueTypeFontCache {
+private:
+	FT_Face face;  ///< The font face associated with this font.
+
+	void SetFontSize(FontSize fs, FT_Face face, int pixels);
+	virtual const void *InternalGetFontTable(uint32 tag, size_t &length);
+	virtual const Sprite *InternalGetGlyph(GlyphID key, bool aa);
+
+public:
+	FreeTypeFontCache(FontSize fs, FT_Face face, int pixels);
+	~FreeTypeFontCache();
+	virtual void ClearFontCache();
 	virtual GlyphID MapCharToGlyph(WChar key);
-	virtual const void *GetFontTable(uint32 tag, size_t &length);
 	virtual const char *GetFontName() { return face->family_name; }
 	virtual bool IsBuiltInFont() { return false; }
 };
 
 FT_Library _library = nullptr;
 
-FreeTypeSettings _freetype;
-
-static const byte FACE_COLOUR   = 1;
-static const byte SHADOW_COLOUR = 2;
 
 /**
  * Create a new FreeTypeFontCache.
@@ -271,7 +473,7 @@ static const byte SHADOW_COLOUR = 2;
  * @param face   The font that has to be loaded.
  * @param pixels The number of pixels this font should be high.
  */
-FreeTypeFontCache::FreeTypeFontCache(FontSize fs, FT_Face face, int pixels) : FontCache(fs), face(face), req_size(pixels), glyph_to_sprite(nullptr)
+FreeTypeFontCache::FreeTypeFontCache(FontSize fs, FT_Face face, int pixels) : TrueTypeFontCache(fs, pixels), face(face)
 {
 	assert(face != nullptr);
 
@@ -410,10 +612,6 @@ FreeTypeFontCache::~FreeTypeFontCache()
 	FT_Done_Face(this->face);
 	this->face = nullptr;
 	this->ClearFontCache();
-
-	for (auto &iter : this->font_tables) {
-		free(iter.second.second);
-	}
 }
 
 /**
@@ -424,130 +622,14 @@ void FreeTypeFontCache::ClearFontCache()
 	/* Font scaling might have changed, determine font size anew if it was automatically selected. */
 	if (this->face != nullptr) this->SetFontSize(this->fs, this->face, this->req_size);
 
-	if (this->glyph_to_sprite == nullptr) return;
-
-	for (int i = 0; i < 256; i++) {
-		if (this->glyph_to_sprite[i] == nullptr) continue;
-
-		for (int j = 0; j < 256; j++) {
-			if (this->glyph_to_sprite[i][j].duplicate) continue;
-			free(this->glyph_to_sprite[i][j].sprite);
-		}
-
-		free(this->glyph_to_sprite[i]);
-	}
-
-	free(this->glyph_to_sprite);
-	this->glyph_to_sprite = nullptr;
-
-	Layouter::ResetFontCache(this->fs);
-}
-
-FreeTypeFontCache::GlyphEntry *FreeTypeFontCache::GetGlyphPtr(GlyphID key)
-{
-	if (this->glyph_to_sprite == nullptr) return nullptr;
-	if (this->glyph_to_sprite[GB(key, 8, 8)] == nullptr) return nullptr;
-	return &this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)];
+	this->TrueTypeFontCache::ClearFontCache();
 }
 
 
-void FreeTypeFontCache::SetGlyphPtr(GlyphID key, const GlyphEntry *glyph, bool duplicate)
+const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 {
-	if (this->glyph_to_sprite == nullptr) {
-		DEBUG(freetype, 3, "Allocating root glyph cache for size %u", this->fs);
-		this->glyph_to_sprite = CallocT<GlyphEntry*>(256);
-	}
-
-	if (this->glyph_to_sprite[GB(key, 8, 8)] == nullptr) {
-		DEBUG(freetype, 3, "Allocating glyph cache for range 0x%02X00, size %u", GB(key, 8, 8), this->fs);
-		this->glyph_to_sprite[GB(key, 8, 8)] = CallocT<GlyphEntry>(256);
-	}
-
-	DEBUG(freetype, 4, "Set glyph for unicode character 0x%04X, size %u", key, this->fs);
-	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].sprite    = glyph->sprite;
-	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].width     = glyph->width;
-	this->glyph_to_sprite[GB(key, 8, 8)][GB(key, 0, 8)].duplicate = duplicate;
-}
-
-static void *AllocateFont(size_t size)
-{
-	return MallocT<byte>(size);
-}
-
-
-/* Check if a glyph should be rendered with antialiasing */
-static bool GetFontAAState(FontSize size)
-{
-	/* AA is only supported for 32 bpp */
-	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
-
-	switch (size) {
-		default: NOT_REACHED();
-		case FS_NORMAL: return _freetype.medium.aa;
-		case FS_SMALL:  return _freetype.small.aa;
-		case FS_LARGE:  return _freetype.large.aa;
-		case FS_MONO:   return _freetype.mono.aa;
-	}
-}
-
-
-const Sprite *FreeTypeFontCache::GetGlyph(GlyphID key)
-{
-	if ((key & SPRITE_GLYPH) != 0) return this->parent->GetGlyph(key);
-
-	/* Check for the glyph in our cache */
-	GlyphEntry *glyph = this->GetGlyphPtr(key);
-	if (glyph != nullptr && glyph->sprite != nullptr) return glyph->sprite;
-
 	FT_GlyphSlot slot = this->face->glyph;
 
-	bool aa = GetFontAAState(this->fs);
-
-	GlyphEntry new_glyph;
-	if (key == 0) {
-		GlyphID question_glyph = this->MapCharToGlyph('?');
-		if (question_glyph == 0) {
-			/* The font misses the '?' character. Use built-in sprite.
-			 * Note: We cannot use the baseset as this also has to work in the bootstrap GUI. */
-#define CPSET { 0, 0, 0, 0, 1 }
-#define CP___ { 0, 0, 0, 0, 0 }
-			static SpriteLoader::CommonPixel builtin_questionmark_data[10 * 8] = {
-				CP___, CP___, CPSET, CPSET, CPSET, CPSET, CP___, CP___,
-				CP___, CPSET, CPSET, CP___, CP___, CPSET, CPSET, CP___,
-				CP___, CP___, CP___, CP___, CP___, CPSET, CPSET, CP___,
-				CP___, CP___, CP___, CP___, CPSET, CPSET, CP___, CP___,
-				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
-				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
-				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
-				CP___, CP___, CP___, CP___, CP___, CP___, CP___, CP___,
-				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
-				CP___, CP___, CP___, CPSET, CPSET, CP___, CP___, CP___,
-			};
-#undef CPSET
-#undef CP___
-			static const SpriteLoader::Sprite builtin_questionmark = {
-				10, // height
-				8,  // width
-				0,  // x_offs
-				0,  // y_offs
-				ST_FONT,
-				builtin_questionmark_data
-			};
-
-			Sprite *spr = BlitterFactory::GetCurrentBlitter()->Encode(&builtin_questionmark, AllocateFont);
-			assert(spr != nullptr);
-			new_glyph.sprite = spr;
-			new_glyph.width  = spr->width + (this->fs != FS_NORMAL);
-			this->SetGlyphPtr(key, &new_glyph, false);
-			return new_glyph.sprite;
-		} else {
-			/* Use '?' for missing characters. */
-			this->GetGlyph(question_glyph);
-			glyph = this->GetGlyphPtr(question_glyph);
-			this->SetGlyphPtr(key, glyph, true);
-			return glyph->sprite;
-		}
-	}
 	FT_Load_Glyph(this->face, key, aa ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
 	FT_Render_Glyph(this->face->glyph, aa ? FT_RENDER_MODE_NORMAL : FT_RENDER_MODE_MONO);
 
@@ -591,6 +673,7 @@ const Sprite *FreeTypeFontCache::GetGlyph(GlyphID key)
 		}
 	}
 
+	GlyphEntry new_glyph;
 	new_glyph.sprite = BlitterFactory::GetCurrentBlitter()->Encode(&sprite, AllocateFont);
 	new_glyph.width  = slot->advance.x >> 6;
 
@@ -599,25 +682,6 @@ const Sprite *FreeTypeFontCache::GetGlyph(GlyphID key)
 	return new_glyph.sprite;
 }
 
-
-bool FreeTypeFontCache::GetDrawGlyphShadow()
-{
-	return this->fs == FS_NORMAL && GetFontAAState(FS_NORMAL);
-}
-
-
-uint FreeTypeFontCache::GetGlyphWidth(GlyphID key)
-{
-	if ((key & SPRITE_GLYPH) != 0) return this->parent->GetGlyphWidth(key);
-
-	GlyphEntry *glyph = this->GetGlyphPtr(key);
-	if (glyph == nullptr || glyph->sprite == nullptr) {
-		this->GetGlyph(key);
-		glyph = this->GetGlyphPtr(key);
-	}
-
-	return glyph->width;
-}
 
 GlyphID FreeTypeFontCache::MapCharToGlyph(WChar key)
 {
@@ -630,14 +694,8 @@ GlyphID FreeTypeFontCache::MapCharToGlyph(WChar key)
 	return FT_Get_Char_Index(this->face, key);
 }
 
-const void *FreeTypeFontCache::GetFontTable(uint32 tag, size_t &length)
+const void *FreeTypeFontCache::InternalGetFontTable(uint32 tag, size_t &length)
 {
-	const FontTable::iterator iter = this->font_tables.Find(tag);
-	if (iter != this->font_tables.data() + this->font_tables.size()) {
-		length = iter->second.first;
-		return iter->second.second;
-	}
-
 	FT_ULong len = 0;
 	FT_Byte *result = nullptr;
 
@@ -647,13 +705,14 @@ const void *FreeTypeFontCache::GetFontTable(uint32 tag, size_t &length)
 		result = MallocT<FT_Byte>(len);
 		FT_Load_Sfnt_Table(this->face, tag, 0, result, &len);
 	}
-	length = len;
 
-	this->font_tables.Insert(tag, SmallPair<size_t, const void *>(length, result));
+	length = len;
 	return result;
 }
 
 #endif /* WITH_FREETYPE */
+
+#endif /* defined(WITH_FREETYPE) */
 
 /**
  * (Re)initialize the freetype related things, i.e. load the non-sprite fonts.

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -737,6 +737,7 @@ public:
 	virtual GlyphID MapCharToGlyph(WChar key);
 	virtual const char *GetFontName() { return WIDE_TO_MB(this->logfont.lfFaceName); }
 	virtual bool IsBuiltInFont() { return false; }
+	virtual void *GetOSHandle() { return &this->logfont; }
 };
 
 
@@ -960,13 +961,16 @@ static void LoadWin32Font(FontSize fs)
 
 	LOGFONT logfont;
 	MemSetT(&logfont, 0);
+	if (settings->os_handle != nullptr) logfont = *(const LOGFONT *)settings->os_handle;
 
-	logfont.lfWeight = strcasestr(settings->font, " bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
-	logfont.lfPitchAndFamily = fs == FS_MONO ? FIXED_PITCH : VARIABLE_PITCH;
-	logfont.lfCharSet = DEFAULT_CHARSET;
-	logfont.lfOutPrecision = OUT_OUTLINE_PRECIS;
-	logfont.lfClipPrecision = CLIP_DEFAULT_PRECIS;
-	convert_to_fs(settings->font, logfont.lfFaceName, lengthof(logfont.lfFaceName), false);
+	if (logfont.lfFaceName[0] == 0) {
+		logfont.lfWeight = strcasestr(settings->font, " bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
+		logfont.lfPitchAndFamily = fs == FS_MONO ? FIXED_PITCH : VARIABLE_PITCH;
+		logfont.lfCharSet = DEFAULT_CHARSET;
+		logfont.lfOutPrecision = OUT_OUTLINE_PRECIS;
+		logfont.lfClipPrecision = CLIP_DEFAULT_PRECIS;
+		convert_to_fs(settings->font, logfont.lfFaceName, lengthof(logfont.lfFaceName), false);
+	}
 
 	HFONT font = CreateFontIndirect(&logfont);
 	if (font == nullptr) {

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -202,7 +202,7 @@ static inline bool GetDrawGlyphShadow(FontSize size)
 	return FontCache::Get(size)->GetDrawGlyphShadow();
 }
 
-#ifdef WITH_FREETYPE
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 
 /** Settings for a single freetype font. */
 struct FreeTypeSubSetting {
@@ -221,7 +221,7 @@ struct FreeTypeSettings {
 
 extern FreeTypeSettings _freetype;
 
-#endif /* WITH_FREETYPE */
+#endif /* defined(WITH_FREETYPE) || defined(_WIN32) */
 
 void InitFreeType(bool monospace);
 void UninitFreeType();

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -126,6 +126,15 @@ public:
 	virtual const void *GetFontTable(uint32 tag, size_t &length) = 0;
 
 	/**
+	 * Get the native OS font handle, if there is one.
+	 * @return Opaque OS font handle.
+	 */
+	virtual void *GetOSHandle()
+	{
+		return nullptr;
+	}
+
+	/**
 	 * Get the name of this font.
 	 * @return The name of the font.
 	 */
@@ -209,6 +218,8 @@ struct FreeTypeSubSetting {
 	char font[MAX_PATH]; ///< The name of the font, or path to the font.
 	uint size;           ///< The (requested) size of the font.
 	bool aa;             ///< Whether to do anti aliasing or not.
+
+	const void *os_handle = nullptr; ///< Optional native OS font info.
 };
 
 /** Settings for the freetype fonts. */

--- a/src/fontdetection.cpp
+++ b/src/fontdetection.cpp
@@ -9,7 +9,7 @@
 
 /** @file fontdetection.cpp Detection of the right font. */
 
-#ifdef WITH_FREETYPE
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 
 #include "stdafx.h"
 #include "debug.h"
@@ -17,7 +17,9 @@
 #include "string_func.h"
 #include "strings_func.h"
 
+#ifdef WITH_FREETYPE
 extern FT_Library _library;
+#endif /* WITH_FREETYPE */
 
 /**
  * Get the font loaded into a Freetype face by using a font-name.
@@ -37,6 +39,7 @@ extern FT_Library _library;
 
 #include "safeguards.h"
 
+#ifdef WITH_FREETYPE
 /**
  * Get the short DOS 8.3 format for paths.
  * FreeType doesn't support Unicode filenames and Windows' fopen (as used
@@ -241,6 +244,7 @@ err2:
 err1:
 	return ret_font_name == nullptr ? WIDE_TO_MB((const TCHAR*)logfont->elfFullName) : ret_font_name;
 }
+#endif /* WITH_FREETYPE */
 
 class FontList {
 protected:
@@ -317,6 +321,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	char font_name[MAX_PATH];
 	convert_from_fs((const TCHAR *)logfont->elfFullName, font_name, lengthof(font_name));
 
+#ifdef WITH_FREETYPE
 	/* Add english name after font name */
 	const char *english_name = GetEnglishFontName(logfont);
 	strecpy(font_name + strlen(font_name) + 1, english_name, lastof(font_name));
@@ -337,6 +342,9 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	}
 
 	if (!found) return 1;
+#else
+	const char *english_name = font_name;
+#endif /* WITH_FREETYPE */
 
 	info->callback->SetFontNames(info->settings, font_name);
 	if (info->callback->FindMissingGlyphs(nullptr)) return 1;

--- a/src/fontdetection.cpp
+++ b/src/fontdetection.cpp
@@ -346,7 +346,9 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	const char *english_name = font_name;
 #endif /* WITH_FREETYPE */
 
-	info->callback->SetFontNames(info->settings, font_name);
+	PLOGFONT os_data = MallocT<LOGFONT>(1);
+	*os_data = logfont->elfLogFont;
+	info->callback->SetFontNames(info->settings, font_name, os_data);
 	if (info->callback->FindMissingGlyphs(nullptr)) return 1;
 	DEBUG(freetype, 1, "Fallback font: %s (%s)", font_name, english_name);
 	return 0; // stop enumerating

--- a/src/fontdetection.h
+++ b/src/fontdetection.h
@@ -27,6 +27,9 @@
  */
 FT_Error GetFontByFaceName(const char *font_name, FT_Face *face);
 
+#endif /* WITH_FREETYPE */
+
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 /**
  * We would like to have a fallback font as the current one
  * doesn't contain all characters we need.
@@ -39,6 +42,6 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face);
  */
 bool SetFallbackFont(FreeTypeSettings *settings, const char *language_isocode, int winlangid, class MissingGlyphSearcher *callback);
 
-#endif /* WITH_FREETYPE */
+#endif /* defined(WITH_FREETYPE) || defined(WIN32)*/
 
 #endif

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -148,6 +148,8 @@ void UniscribeResetScriptCache(FontSize size)
 /** Load the matching native Windows font. */
 static HFONT HFontFromFont(Font *font)
 {
+	if (font->fc->GetOSHandle() != nullptr) return CreateFontIndirect((PLOGFONT)font->fc->GetOSHandle());
+
 	LOGFONT logfont;
 	ZeroMemory(&logfont, sizeof(LOGFONT));
 	logfont.lfHeight = font->fc->GetHeight();

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -197,15 +197,19 @@ static bool UniscribeShapeRun(const UniscribeParagraphLayoutFactory::CharType *b
 				}
 				for (int i = 0; i < range.len; i++) {
 					if (buff[range.pos + i] >= SCC_SPRITE_START && buff[range.pos + i] <= SCC_SPRITE_END) {
-						range.ft_glyphs[range.char_to_glyph[i]] = range.font->fc->MapCharToGlyph(buff[range.pos + i]);
-						range.offsets[range.char_to_glyph[i]].dv = range.font->fc->GetAscender() - range.font->fc->GetGlyph(range.ft_glyphs[range.char_to_glyph[i]])->height - 1; // Align sprite glyphs to font baseline.
+						auto pos = range.char_to_glyph[i];
+						range.ft_glyphs[pos] = range.font->fc->MapCharToGlyph(buff[range.pos + i]);
+						range.offsets[pos].dv = range.font->fc->GetAscender() - range.font->fc->GetGlyph(range.ft_glyphs[pos])->height - 1; // Align sprite glyphs to font baseline.
+						range.advances[pos] = range.font->fc->GetGlyphWidth(range.ft_glyphs[pos]);
 					}
 				}
 
-				/* FreeType and GDI/Uniscribe seems to occasionally disagree over the width of a glyph. */
 				range.total_advance = 0;
 				for (size_t i = 0; i < range.advances.size(); i++) {
+#ifdef WITH_FREETYPE
+					/* FreeType and GDI/Uniscribe seems to occasionally disagree over the width of a glyph. */
 					if (range.advances[i] > 0 && range.ft_glyphs[i] != 0xFFFF) range.advances[i] = range.font->fc->GetGlyphWidth(range.ft_glyphs[i]);
+#endif
 					range.total_advance += range.advances[i];
 				}
 				break;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -39,7 +39,7 @@
 #include "sound_func.h"
 #include "company_func.h"
 #include "rev.h"
-#ifdef WITH_FREETYPE
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 #include "fontcache.h"
 #endif
 #include "textbuf_gui.h"
@@ -68,7 +68,7 @@
 #include "void_map.h"
 #include "station_base.h"
 
-#if defined(WITH_FREETYPE)
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 #define HAS_TRUETYPE_FONT
 #endif
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -68,6 +68,10 @@
 #include "void_map.h"
 #include "station_base.h"
 
+#if defined(WITH_FREETYPE)
+#define HAS_TRUETYPE_FONT
+#endif
+
 #include "table/strings.h"
 #include "table/settings.h"
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2070,7 +2070,7 @@ class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
 
 	void SetFontNames(FreeTypeSettings *settings, const char *font_name) override
 	{
-#ifdef WITH_FREETYPE
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 		strecpy(settings->small.font,  font_name, lastof(settings->small.font));
 		strecpy(settings->medium.font, font_name, lastof(settings->medium.font));
 		strecpy(settings->large.font,  font_name, lastof(settings->large.font));
@@ -2096,7 +2096,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 	static LanguagePackGlyphSearcher pack_searcher;
 	if (searcher == nullptr) searcher = &pack_searcher;
 	bool bad_font = !base_font || searcher->FindMissingGlyphs(nullptr);
-#ifdef WITH_FREETYPE
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 	if (bad_font) {
 		/* We found an unprintable character... lets try whether we can find
 		 * a fallback font that can print the characters in the current language. */

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -275,8 +275,9 @@ public:
 	 * Set the right font names.
 	 * @param settings  The settings to modify.
 	 * @param font_name The new font name.
+	 * @param os_data Opaque pointer to OS-specific data.
 	 */
-	virtual void SetFontNames(struct FreeTypeSettings *settings, const char *font_name) = 0;
+	virtual void SetFontNames(struct FreeTypeSettings *settings, const char *font_name, const void *os_data = nullptr) = 0;
 
 	bool FindMissingGlyphs(const char **str);
 };

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -144,35 +144,35 @@ var      = _rightclick_emulate
 def      = false
 
 [SDTG_STR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_font""
 type     = SLE_STRB
 var      = _freetype.small.font
 def      = nullptr
 
 [SDTG_STR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_font""
 type     = SLE_STRB
 var      = _freetype.medium.font
 def      = nullptr
 
 [SDTG_STR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_font""
 type     = SLE_STRB
 var      = _freetype.large.font
 def      = nullptr
 
 [SDTG_STR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_font""
 type     = SLE_STRB
 var      = _freetype.mono.font
 def      = nullptr
 
 [SDTG_VAR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_size""
 type     = SLE_UINT
 var      = _freetype.small.size
@@ -181,7 +181,7 @@ min      = 0
 max      = 72
 
 [SDTG_VAR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_size""
 type     = SLE_UINT
 var      = _freetype.medium.size
@@ -190,7 +190,7 @@ min      = 0
 max      = 72
 
 [SDTG_VAR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_size""
 type     = SLE_UINT
 var      = _freetype.large.size
@@ -199,7 +199,7 @@ min      = 0
 max      = 72
 
 [SDTG_VAR]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_size""
 type     = SLE_UINT
 var      = _freetype.mono.size
@@ -208,25 +208,25 @@ min      = 0
 max      = 72
 
 [SDTG_BOOL]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_aa""
 var      = _freetype.small.aa
 def      = false
 
 [SDTG_BOOL]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_aa""
 var      = _freetype.medium.aa
 def      = false
 
 [SDTG_BOOL]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_aa""
 var      = _freetype.large.aa
 def      = false
 
 [SDTG_BOOL]
-ifdef    = WITH_FREETYPE
+ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_aa""
 var      = _freetype.mono.aa
 def      = false

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -194,11 +194,13 @@ void TextfileWindow::SetupScrollbars()
 	return true;
 }
 
-/* virtual */ void TextfileWindow::SetFontNames(FreeTypeSettings *settings, const char *font_name)
+/* virtual */ void TextfileWindow::SetFontNames(FreeTypeSettings *settings, const char *font_name, const void *os_data)
 {
 #if defined(WITH_FREETYPE) || defined(_WIN32)
 	strecpy(settings->mono.font, font_name, lastof(settings->mono.font));
-#endif /* WITH_FREETYPE */
+	free(settings->mono.os_handle);
+	settings->mono.os_handle = os_data;
+#endif
 }
 
 #if defined(WITH_ZLIB)

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -196,7 +196,7 @@ void TextfileWindow::SetupScrollbars()
 
 /* virtual */ void TextfileWindow::SetFontNames(FreeTypeSettings *settings, const char *font_name)
 {
-#ifdef WITH_FREETYPE
+#if defined(WITH_FREETYPE) || defined(_WIN32)
 	strecpy(settings->mono.font, font_name, lastof(settings->mono.font));
 #endif /* WITH_FREETYPE */
 }

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -43,7 +43,7 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	FontSize DefaultSize() override;
 	const char *NextString() override;
 	bool Monospace() override;
-	void SetFontNames(FreeTypeSettings *settings, const char *font_name) override;
+	void SetFontNames(FreeTypeSettings *settings, const char *font_name, const void *os_data) override;
 
 	virtual void LoadTextfile(const char *textfile, Subdirectory dir);
 


### PR DESCRIPTION
Rebased PR #6980 which unfortunately can't be reopened. Might fix #7511.

Old description:
> This PR supplies a native Windows GDI font rendering back-end. It drops FreeType as a required lib, OTOH it is one more code path to maintain while FreeType isn't really causing problems.

> Building with FreeType is still possible and will take precedence over the GDI renderer, but
the project files don't include FreeType any more by default. Combining GDI rendering with ICU text layout is untested.
