### PR TITLE
Fix: ignore C++ standard library headers in depend

### DIFF
--- a/src/depend/depend.cpp
+++ b/src/depend/depend.cpp
@@ -507,6 +507,9 @@ private:
  */
 const char *GeneratePath(const char *dirname, const char *filename, bool local)
 {
+	/* Ignore C++ standard library headers. */
+	if (strchr(filename, '.') == nullptr) return nullptr;
+
 	if (local) {
 		if (access(filename, R_OK) == 0) return strdup(filename);
 


### PR DESCRIPTION
Depend was trying to open `objs/<buildtype>/thread` as a file, but couldn't and exit.