### PR TITLE
Fix #7224: Drag and drop vehicle group creation does not work correctly.

### DIFF
--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -537,7 +537,7 @@ CommandCost CmdAddVehicleGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, u
 
 	if (new_g == NEW_GROUP) {
 		/* Create new group. */
-		CommandCost ret = CmdCreateGroup(0, flags, v->type, 0, nullptr);
+		CommandCost ret = CmdCreateGroup(0, flags, v->type, INVALID_GROUP, nullptr);
 		if (ret.Failed()) return ret;
 
 		new_g = _new_group_id;


### PR DESCRIPTION
When drag and drop a vehicle into an empty slot in the vehicle group window it tries to create the new group as the subgroup of the first group (GroupID = 0). This is failing if the dragged vehicle's type is different than the first group's vehicle type.