### PR TITLE
Use shift + click to show vehicles' group.

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1043,18 +1043,30 @@ static WindowDesc _train_group_desc(
  * Show the group window for the given company and vehicle type.
  * @param company The company to show the window for.
  * @param vehicle_type The type of vehicle to show it for.
+ * @param group The group to be selected. Defaults to INVALID_GROUP.
+ * @param need_existing_window Whether the existing window is needed. Defaults to false.
  */
-void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type)
+void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type, GroupID group = INVALID_GROUP, bool need_existing_window = false)
 {
 	if (!Company::IsValidID(company)) return;
 
-	WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
+	const WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
+	VehicleGroupWindow *w;
 	if (vehicle_type == VEH_TRAIN) {
-		AllocateWindowDescFront<VehicleGroupWindow>(&_train_group_desc, num);
+		w = AllocateWindowDescFront<VehicleGroupWindow>(&_train_group_desc, num, need_existing_window);
 	} else {
 		_other_group_desc.cls = GetWindowClassForVehicleType(vehicle_type);
-		AllocateWindowDescFront<VehicleGroupWindow>(&_other_group_desc, num);
+		w = AllocateWindowDescFront<VehicleGroupWindow>(&_other_group_desc, num, need_existing_window);
 	}
+	if (w != nullptr) w->SelectGroup(group);
+}
+
+/**
+ * Show the group window for the given vehicle.
+ * @param v The vehicle to show the window for.
+ */
+void ShowCompanyGroupForVehicle(const Vehicle *v) {
+	ShowCompanyGroup(v->owner, v->type, v->group_id, true);
 }
 
 /**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -737,6 +737,10 @@ public:
 
 				this->vehicle_sel = v->index;
 
+				if (_shift_pressed) {
+					this->SelectGroup(v->group_id);
+				}
+
 				SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
 				SetMouseCursorVehicle(v, EIT_IN_LIST);
 				_cursor.vehchain = true;

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -371,6 +371,7 @@ public:
 		this->groups.ForceRebuild();
 		this->groups.NeedResort();
 		this->BuildGroupList(vli.company);
+		this->group_sb->SetCount((uint)this->groups.size());
 
 		this->GetWidget<NWidgetCore>(WID_GL_CAPTION)->widget_data = STR_VEHICLE_LIST_TRAIN_CAPTION + this->vli.vtype;
 		this->GetWidget<NWidgetCore>(WID_GL_LIST_VEHICLE)->tool_tip = STR_VEHICLE_LIST_TRAIN_LIST_TOOLTIP + this->vli.vtype;
@@ -994,6 +995,29 @@ public:
 	{
 		if (this->vehicle_sel == vehicle) ResetObjectToPlace();
 	}
+
+	void SelectGroup(const GroupID g_id) {
+		if (g_id == INVALID_GROUP || g_id == this->vli.index) return;
+
+		this->vli.index = g_id;
+		if (g_id != ALL_GROUP && g_id != DEFAULT_GROUP) {
+			const Group *g = Group::Get(g_id);
+			int id_g = find_index(this->groups, g);
+			// The group's branch is maybe collapsed, so try to expand it
+			if (id_g == -1) {
+				for (auto pg = Group::GetIfValid(g->parent); pg != nullptr; pg = Group::GetIfValid(pg->parent)) {
+					pg->folded = false;
+				}
+				this->groups.ForceRebuild();
+				this->BuildGroupList(this->owner);
+				id_g = find_index(this->groups, g);
+			}
+			this->group_sb->ScrollTowards(id_g);
+		}
+		this->vehicles.ForceRebuild();
+		this->SetDirty();
+	}
+
 };
 
 

--- a/src/group_gui.h
+++ b/src/group_gui.h
@@ -15,7 +15,8 @@
 #include "company_type.h"
 #include "vehicle_type.h"
 
-void ShowCompanyGroup(CompanyID company, VehicleType veh);
+void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = INVALID_GROUP, bool need_existing_window = false);
+void ShowCompanyGroupForVehicle(const Vehicle *v);
 void DeleteGroupHighlightOfVehicle(const Vehicle *v);
 
 #endif /* GROUP_GUI_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -872,6 +872,9 @@ STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :{BIG_FONT}{BLAC
 STR_NEWS_NEW_VEHICLE_TYPE                                       :{BIG_FONT}{BLACK}{ENGINE}
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE                    :{BLACK}New {STRING} now available!  -  {ENGINE}
 
+STR_NEWS_SHOW_VEHICLE_GROUP                                     :{BLACK}Open group window
+STR_NEWS_SHOW_VEHICLE_GROUP_TOOLTIP                             :{BLACK}Open the group window and select the vehicle's group
+
 STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO                        :{WHITE}{STATION} no longer accepts {STRING}
 STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO_OR_CARGO               :{WHITE}{STATION} no longer accepts {STRING} or {STRING}
 STR_NEWS_STATION_NOW_ACCEPTS_CARGO                              :{WHITE}{STATION} now accepts {STRING}

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -192,6 +192,8 @@ static const NWidgetPart _nested_small_news_widgets[] = {
 			NWidget(NWID_VIEWPORT, INVALID_COLOUR, WID_N_VIEWPORT), SetPadding(1, 1, 1, 1), SetMinimalSize(274, 47), SetFill(1, 0),
 		EndContainer(),
 		NWidget(WWT_EMPTY, COLOUR_WHITE, WID_N_MESSAGE), SetMinimalSize(275, 20), SetFill(1, 0), SetPadding(0, 5, 0, 5),
+		NWidget(WWT_TEXTBTN, COLOUR_LIGHT_BLUE, WID_N_SHOW_GROUP), SetMinimalSize(275, 20), SetResize(1, 0), SetFill(1, 0),
+				SetDataTip(STR_NEWS_SHOW_VEHICLE_GROUP, STR_NEWS_SHOW_VEHICLE_GROUP_TOOLTIP),
 	EndContainer(),
 };
 
@@ -357,6 +359,19 @@ struct NewsWindow : Window {
 				str = GetEngineInfoString(engine);
 				break;
 			}
+
+			case WID_N_SHOW_GROUP:
+				if (this->ni->reftype1 != NR_VEHICLE) {
+					/* Hide 'Show group window' button if this news is not about a vehicle. */
+					size->width = 0;
+					size->height = 0;
+					resize->width = 0;
+					resize->height = 0;
+					fill->width = 0;
+					fill->height = 0;
+				}
+				break;
+
 			default:
 				return; // Do nothing
 		}
@@ -452,6 +467,12 @@ struct NewsWindow : Window {
 			case WID_N_VIEWPORT:
 				break; // Ignore clicks
 
+			case WID_N_SHOW_GROUP:
+				if (this->ni->reftype1 == NR_VEHICLE) {
+					const Vehicle *v = Vehicle::Get(this->ni->ref1);
+					ShowCompanyGroupForVehicle(v);
+				}
+				break;
 			default:
 				if (this->ni->reftype1 == NR_VEHICLE) {
 					const Vehicle *v = Vehicle::Get(this->ni->ref1);

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -34,6 +34,7 @@
 #include "company_base.h"
 #include "settings_internal.h"
 #include "guitimer_func.h"
+#include "group_gui.h"
 
 #include "widgets/news_widget.h"
 
@@ -469,6 +470,19 @@ struct NewsWindow : Window {
 				}
 				break;
 		}
+	}
+
+	bool OnRightClick(Point pt, int widget) override
+	{
+		switch (widget) {
+			default:
+				if (this->ni->reftype1 == NR_VEHICLE) {
+					const Vehicle *v = Vehicle::Get(this->ni->ref1);
+					ShowCompanyGroupForVehicle(v);
+				}
+				return true;
+		}
+		return false;
 	}
 
 	EventState OnKeyPress(WChar key, uint16 keycode) override

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -872,6 +872,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_VEH_NAME,                            "WID_N_VEH_NAME");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_VEH_SPR,                             "WID_N_VEH_SPR");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_VEH_INFO,                            "WID_N_VEH_INFO");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_SHOW_GROUP,                          "WID_N_SHOW_GROUP");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MH_STICKYBOX,                          "WID_MH_STICKYBOX");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MH_BACKGROUND,                         "WID_MH_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MH_SCROLLBAR,                          "WID_MH_SCROLLBAR");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1942,6 +1942,7 @@ public:
 		WID_N_VEH_NAME                               = ::WID_N_VEH_NAME,                               ///< Name of the new vehicle.
 		WID_N_VEH_SPR                                = ::WID_N_VEH_SPR,                                ///< Graphical display of the new vehicle.
 		WID_N_VEH_INFO                               = ::WID_N_VEH_INFO,                               ///< Some technical data of the new vehicle.
+		WID_N_SHOW_GROUP                             = ::WID_N_SHOW_GROUP,                             ///< Show vehicle's group
 	};
 
 	/** Widgets of the #MessageHistoryWindow class. */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2700,7 +2700,11 @@ public:
 				}
 				break;
 			case WID_VV_SHOW_DETAILS: // show details
-				ShowVehicleDetailsWindow(v);
+				if (_shift_pressed) {
+					ShowCompanyGroupForVehicle(v);
+				} else {
+					ShowVehicleDetailsWindow(v);
+				}
 				break;
 			case WID_VV_CLONE: // clone vehicle
 				/* Suppress the vehicle GUI when share-cloning.

--- a/src/widgets/news_widget.h
+++ b/src/widgets/news_widget.h
@@ -33,6 +33,7 @@ enum NewsWidgets {
 	WID_N_VEH_NAME,    ///< Name of the new vehicle.
 	WID_N_VEH_SPR,     ///< Graphical display of the new vehicle.
 	WID_N_VEH_INFO,    ///< Some technical data of the new vehicle.
+	WID_N_SHOW_GROUP,  ///< Show vehicle's group
 };
 
 /** Widgets of the #MessageHistoryWindow class. */


### PR DESCRIPTION
AFAIK currently if we would like to do something with the vehicles in a vehicle's group, we have to find the vehicle in the vehicle group window to see the group's name it belongs to. Than we have to find that group in the list and select it, and just after that can we use the manage list functions. I think this is a little bit circumstantial.

This PR tries to make that process easier. We can use shift + click in the vehicle group and in the vehicle view window to select the vehicle's group.