### PR TITLE
Codechange: [AzurePipelines] Speed up non-published CI-builds by doing Debug Windows builds.

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -25,6 +25,7 @@ jobs:
   - template: azure-pipelines/templates/windows-build.yml
     parameters:
       BuildPlatform: $(BuildPlatform)
+      BuildConfiguration: Debug
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
       cd projects

--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -88,6 +88,7 @@ jobs:
   - template: windows-build.yml
     parameters:
       BuildPlatform: $(BuildPlatform)
+      BuildConfiguration: Release
   - bash: |
       set -ex
       make -f Makefile.msvc bundle_pdb bundle_zip PLATFORM=$(BundlePlatform) BUNDLE_NAME=openttd-$(Build.BuildNumber)-windows-$(BundlePlatform)

--- a/azure-pipelines/templates/windows-build.yml
+++ b/azure-pipelines/templates/windows-build.yml
@@ -7,5 +7,5 @@ steps:
   inputs:
     solution: 'projects/openttd_vs141.sln'
     platform: ${{ parameters.BuildPlatform }}
-    configuration: Release
+    configuration: ${{ parameters.BuildConfiguration }}
     maximumCpuCount: true


### PR DESCRIPTION
Lets see if it there is in fact a speed-up.