### PR TITLE
Change: Always apply inflation from 1920 to 2090, no matter the game start year.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -722,7 +722,7 @@ bool AddInflation(bool check_year)
 	 * inflation doesn't add anything after that either; it even makes playing
 	 * it impossible due to the diverging cost and income rates.
 	 */
-	if (check_year && (_cur_year - _settings_game.game_creation.starting_year) >= (ORIGINAL_MAX_YEAR - ORIGINAL_BASE_YEAR)) return true;
+	if (check_year && (_cur_year < ORIGINAL_BASE_YEAR || _cur_year >= ORIGINAL_MAX_YEAR)) return true;
 
 	if (_economy.inflation_prices == MAX_INFLATION || _economy.inflation_payment == MAX_INFLATION) return true;
 
@@ -913,6 +913,14 @@ void StartupEconomy()
 	_economy.infl_amount = _settings_game.difficulty.initial_interest;
 	_economy.infl_amount_pr = max(0, _settings_game.difficulty.initial_interest - 1);
 	_economy.fluct = GB(Random(), 0, 8) + 168;
+
+	if (_settings_game.economy.inflation) {
+		/* Apply inflation that happened before our game start year. */
+		int months = (min(_cur_year, ORIGINAL_MAX_YEAR) - ORIGINAL_BASE_YEAR) * 12;
+		for (int i = 0; i < months; i++) {
+			AddInflation(false);
+		}
+	}
 
 	/* Set up prices */
 	RecomputePrices();


### PR DESCRIPTION
## Motivation / Problem

With inflation dependent on the game start year, the cost of a new vehicle in the year X can be £100, £10000, or £1000000. This makes balancing costs for NewGRF sets mostly impossible.

Authors deal with mostly in two ways: Either completely ignore inflation and only balance for inflation off. Or balance against inflation starting at a specific year.

## Description

As NewGRF sets are not balanced for a variable inflation start anyway, this PR fixes the inflation period to a known value so there is a consistent target to balance against.

## Limitations

As income is also affected by inflation, the starting difficulty increases with the starting year. With well balanced sets, this should be managable.
