### PR TITLE
Fix #7593: Crash in ScriptOrder::GetOrderDistance in VT_AIR mode

### DIFF
--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -667,8 +667,14 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 /* static */ uint ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)
 {
 	if (vehicle_type == ScriptVehicle::VT_AIR) {
-		if (ScriptTile::IsStationTile(origin_tile) && ::Station::GetByTile(origin_tile)->airport.tile != INVALID_TILE) origin_tile = ::Station::GetByTile(origin_tile)->airport.tile;
-		if (ScriptTile::IsStationTile(dest_tile) && ::Station::GetByTile(dest_tile)->airport.tile != INVALID_TILE) dest_tile = ::Station::GetByTile(dest_tile)->airport.tile;
+		if (ScriptTile::IsStationTile(origin_tile)) {
+			Station *orig_station = ::Station::GetByTile(origin_tile);
+			if (orig_station != nullptr && orig_station->airport.tile != INVALID_TILE) origin_tile = orig_station->airport.tile;
+		}
+		if (ScriptTile::IsStationTile(dest_tile)) {
+			Station *dest_station = ::Station::GetByTile(dest_tile);
+			if (dest_station != nullptr && dest_station->airport.tile != INVALID_TILE) dest_tile = dest_station->airport.tile;
+		}
 
 		return ScriptMap::DistanceSquare(origin_tile, dest_tile);
 	} else {


### PR DESCRIPTION
Null pointer dereference occurred when either origin_tile or dest_tile
were waypoint tiles.