### PR TITLE
Codechange: Change KRW currency rate

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -57,7 +57,7 @@ static const CurrencySpec origin_currency_specs[CURRENCY_END] = {
 	{    4, "", CF_NOEURO, "R$" NBSP,      "",               0, STR_GAME_OPTIONS_CURRENCY_BRL    }, ///< brazil real
 	{   31, "", 2011,      "",             NBSP "EEK",       1, STR_GAME_OPTIONS_CURRENCY_EEK    }, ///< estonian krooni
 	{    4, "", 2015,      "",             NBSP "Lt",        1, STR_GAME_OPTIONS_CURRENCY_LTL    }, ///< lithuanian litas
-	{ 1850, "", CF_NOEURO, "\xE2\x82\xA9", "",               0, STR_GAME_OPTIONS_CURRENCY_KRW    }, ///< south korean won
+	{ 1500, "", CF_NOEURO, "\xE2\x82\xA9", "",               0, STR_GAME_OPTIONS_CURRENCY_KRW    }, ///< south korean won
 	{   13, "", CF_NOEURO, "R" NBSP,       "",               0, STR_GAME_OPTIONS_CURRENCY_ZAR    }, ///< south african rand
 	{    1, "", CF_NOEURO, "",             "",               2, STR_GAME_OPTIONS_CURRENCY_CUSTOM }, ///< custom currency (add further languages below)
 	{    3, "", CF_NOEURO, "",             NBSP "GEL",       1, STR_GAME_OPTIONS_CURRENCY_GEL    }, ///< Georgian Lari


### PR DESCRIPTION
Since 2017, I think because of the Brexit, KRW against GBP has been about 1GBP≒1,500KRW.
OpenTTD is using 1GBP=1,850KRW, which makes very difficult to calculate.

This PR makes 1GBP=1,500KRW which is a close rate in nowadays, and also easier to calculate
But I have no idea if I change openttd's currency rate, please let me aware.