### PR TITLE
Fix #5685: Check for free wagons in ScriptVehicleList

### DIFF
--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -16,6 +16,7 @@
 #include "script_station.hpp"
 #include "../../depot_map.h"
 #include "../../vehicle_base.h"
+#include "../../train.h"
 
 #include "../../safeguards.h"
 
@@ -23,7 +24,7 @@ ScriptVehicleList::ScriptVehicleList()
 {
 	const Vehicle *v;
 	FOR_ALL_VEHICLES(v) {
-		if ((v->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && v->IsPrimaryVehicle()) this->AddItem(v->index);
+		if ((v->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()))) this->AddItem(v->index);
 	}
 }
 


### PR DESCRIPTION
Fixed issue #5685 (AI: wagons lost in depot because of lack of API feature) by adding in the suggested check for free wagons in ScriptVehicleList (and importing train.h so it would work). 