### PR TITLE
Fix: Various reliability and correctness improvements to MIDI on Windows

### DIFF
--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -539,19 +539,19 @@ static void TransmitChannelMsg(IDirectMusicBuffer *buffer, REFERENCE_TIME rt, by
 	}
 }
 
-static void TransmitSysex(IDirectMusicBuffer *buffer, REFERENCE_TIME rt, byte *&msg_start, size_t &remaining)
+static void TransmitSysex(IDirectMusicBuffer *buffer, REFERENCE_TIME rt, const byte *&msg_start, size_t &remaining)
 {
 	/* Find end of message. */
-	byte *msg_end = msg_start;
+	const byte *msg_end = msg_start;
 	while (*msg_end != MIDIST_ENDSYSEX) msg_end++;
 	msg_end++; // Also include SysEx end byte.
 
-	if (buffer->PackUnstructured(rt, 0, msg_end - msg_start, msg_start) == E_OUTOFMEMORY) {
+	if (buffer->PackUnstructured(rt, 0, msg_end - msg_start, const_cast<LPBYTE>(msg_start)) == E_OUTOFMEMORY) {
 		/* Buffer is full, clear it and try again. */
 		_port->PlayBuffer(buffer);
 		buffer->Flush();
 
-		buffer->PackUnstructured(rt, 0, msg_end - msg_start, msg_start);
+		buffer->PackUnstructured(rt, 0, msg_end - msg_start, const_cast<LPBYTE>(msg_start));
 	}
 
 	/* Update position in buffer. */
@@ -559,7 +559,7 @@ static void TransmitSysex(IDirectMusicBuffer *buffer, REFERENCE_TIME rt, byte *&
 	msg_start = msg_end;
 }
 
-static void TransmitSysexConst(IDirectMusicBuffer *buffer, REFERENCE_TIME rt, byte *msg_start, size_t length)
+static void TransmitSysexConst(IDirectMusicBuffer *buffer, REFERENCE_TIME rt, const byte *msg_start, size_t length)
 {
 	TransmitSysex(buffer, rt, msg_start, length);
 }
@@ -752,7 +752,7 @@ static void MidiThreadProc()
 				block_time = playback_start_time + block.realtime * MIDITIME_TO_REFTIME;
 				DEBUG(driver, 9, "DMusic thread: Streaming block " PRINTF_SIZE " (cur=" OTTD_PRINTF64 ", block=" OTTD_PRINTF64 ")", current_block, (long long)(current_time / MS_TO_REFTIME), (long long)(block_time / MS_TO_REFTIME));
 
-				byte *data = block.data.data();
+				const byte *data = block.data.data();
 				size_t remaining = block.data.size();
 				byte last_status = 0;
 				while (remaining > 0) {

--- a/src/music/midi.h
+++ b/src/music/midi.h
@@ -141,4 +141,19 @@ enum MidiController {
 	MIDICT_MODE_POLY         = 127,
 };
 
+
+/** Well-known MIDI system exclusive message values for use with the MidiGetStandardSysexMessage function. */
+enum class MidiSysexMessage {
+	/** Reset device to General MIDI defaults */
+	ResetGM,
+	/** Reset device to (Roland) General Standard defaults */
+	ResetGS,
+	/** Reset device to (Yamaha) XG defaults */
+	ResetXG,
+	/** Set up Roland SoundCanvas reverb room as TTD does */
+	RolandSetReverb,
+};
+
+const byte *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length);
+
 #endif /* MUSIC_MIDI_H */

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -27,6 +27,37 @@
 static MidiFile *_midifile_instance = nullptr;
 
 /**
+ * Retrieve a well-known MIDI system exclusive message.
+ * @param msg Which sysex message to retrieve
+ * @param[out] length Receives the length of the returned buffer
+ * @return Pointer to byte buffer with sysex message
+ */
+const byte *MidiGetStandardSysexMessage(MidiSysexMessage msg, size_t &length)
+{
+	static byte reset_gm_sysex[] = { 0xF0, 0x7E, 0x00, 0x09, 0x01, 0xF7 };
+	static byte reset_gs_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7 };
+	static byte reset_xg_sysex[] = { 0xF0, 0x43, 0x10, 0x4C, 0x00, 0x00, 0x7E, 0x00, 0xF7 };
+	static byte roland_reverb_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x01, 0x30, 0x02, 0x04, 0x00, 0x40, 0x40, 0x00, 0x00, 0x09, 0xF7 };
+
+	switch (msg) {
+		case MidiSysexMessage::ResetGM:
+			length = lengthof(reset_gm_sysex);
+			return reset_gm_sysex;
+		case MidiSysexMessage::ResetGS:
+			length = lengthof(reset_gs_sysex);
+			return reset_gs_sysex;
+		case MidiSysexMessage::ResetXG:
+			length = lengthof(reset_xg_sysex);
+			return reset_xg_sysex;
+		case MidiSysexMessage::RolandSetReverb:
+			length = lengthof(roland_reverb_sysex);
+			return roland_reverb_sysex;
+		default:
+			NOT_REACHED();
+	}
+}
+
+/**
  * Owning byte buffer readable as a stream.
  * RAII-compliant to make teardown in error situations easier.
  */

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -74,10 +74,10 @@ static void TransmitChannelMsg(byte status, byte p1, byte p2 = 0)
 	midiOutShortMsg(_midi.midi_out, status | (p1 << 8) | (p2 << 16));
 }
 
-static void TransmitSysex(byte *&msg_start, size_t &remaining)
+static void TransmitSysex(const byte *&msg_start, size_t &remaining)
 {
 	/* find end of message */
-	byte *msg_end = msg_start;
+	const byte *msg_end = msg_start;
 	while (*msg_end != MIDIST_ENDSYSEX) msg_end++;
 	msg_end++; /* also include sysex end byte */
 
@@ -98,7 +98,7 @@ static void TransmitSysex(byte *&msg_start, size_t &remaining)
 	msg_start = msg_end;
 }
 
-static void TransmitSysexConst(byte *msg_start, size_t length)
+static void TransmitSysexConst(const byte *msg_start, size_t length)
 {
 	TransmitSysex(msg_start, length);
 }
@@ -226,7 +226,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 			break;
 		}
 
-		byte *data = block.data.data();
+		const byte *data = block.data.data();
 		size_t remaining = block.data.size();
 		byte last_status = 0;
 		while (remaining > 0) {

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -312,10 +312,14 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 {
 	DEBUG(driver, 2, "Win32-MIDI: PlaySong: entry");
+
+	MidiFile new_song;
+	if (!new_song.LoadSong(song)) return;
+	DEBUG(driver, 2, "Win32-MIDI: PlaySong: Loaded song");
+
 	std::lock_guard mutex_lock(_midi.lock);
 
-	if (!_midi.next_file.LoadSong(song)) return;
-
+	_midi.next_file.MoveFrom(new_song);
 	_midi.next_segment.start = song.override_start;
 	_midi.next_segment.end = song.override_end;
 	_midi.next_segment.loop = song.loop;

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -43,7 +43,7 @@ static struct {
 
 	MidiFile current_file;           ///< file currently being played from
 	PlaybackSegment current_segment; ///< segment info for current playback
-	size_t playback_start_time;      ///< timestamp current file began playback
+	DWORD playback_start_time;       ///< timestamp current file began playback
 	size_t current_block;            ///< next block index to send
 	MidiFile next_file;              ///< upcoming file to play
 	PlaybackSegment next_segment;    ///< segment info for upcoming file
@@ -199,7 +199,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 					 * The delay compensation is needed to avoid time-compression of following messages.
 					 */
 					DEBUG(driver, 2, "Win32-MIDI: timer: start from block %d (ticktime %d, realtime %.3f, bytes %d)", (int)bl, (int)block.ticktime, ((int)block.realtime) / 1000.0, (int)preload_bytes);
-					_midi.playback_start_time -= block.realtime / 1000 - preload_bytes * 1000 / 3125;
+					_midi.playback_start_time -= block.realtime / 1000 - (DWORD)(preload_bytes * 1000 / 3125);
 					break;
 				}
 			}
@@ -209,7 +209,7 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 
 	/* play pending blocks */
 	DWORD current_time = timeGetTime();
-	size_t playback_time = current_time - _midi.playback_start_time;
+	DWORD playback_time = current_time - _midi.playback_start_time;
 	while (_midi.current_block < _midi.current_file.blocks.size()) {
 		MidiFile::DataBlock &block = _midi.current_file.blocks[_midi.current_block];
 

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -181,8 +181,8 @@ void CALLBACK TimerCallback(UINT uTimerID, UINT, DWORD_PTR dwUser, DWORD_PTR, DW
 	/* skip beginning of file? */
 	if (_midi.current_segment.start > 0 && _midi.current_block == 0 && _midi.current_segment.start_block == 0) {
 		/* find first block after start time and pretend playback started earlier
-		* this is to allow all blocks prior to the actual start to still affect playback,
-		* as they may contain important controller and program changes */
+		 * this is to allow all blocks prior to the actual start to still affect playback,
+		 * as they may contain important controller and program changes */
 		size_t preload_bytes = 0;
 		for (size_t bl = 0; bl < _midi.current_file.blocks.size(); bl++) {
 			MidiFile::DataBlock &block = _midi.current_file.blocks[bl];

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -98,9 +98,11 @@ static void TransmitSysex(const byte *&msg_start, size_t &remaining)
 	msg_start = msg_end;
 }
 
-static void TransmitSysexConst(const byte *msg_start, size_t length)
+static void TransmitStandardSysex(MidiSysexMessage msg)
 {
-	TransmitSysex(msg_start, length);
+	size_t length = 0;
+	const byte *data = MidiGetStandardSysexMessage(msg, length);
+	TransmitSysex(data, length);
 }
 
 /**
@@ -370,12 +372,10 @@ const char *MusicDriver_Win32::Start(const char * const *parm)
 	midiOutReset(_midi.midi_out);
 
 	/* Standard "Enable General MIDI" message */
-	static byte gm_enable_sysex[] = { 0xF0, 0x7E, 0x00, 0x09, 0x01, 0xF7 };
-	TransmitSysexConst(&gm_enable_sysex[0], sizeof(gm_enable_sysex));
+	TransmitStandardSysex(MidiSysexMessage::ResetGM);
 
 	/* Roland-specific reverb room control, used by the original game */
-	static byte roland_reverb_sysex[] = { 0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x01, 0x30, 0x02, 0x04, 0x00, 0x40, 0x40, 0x00, 0x00, 0x09, 0xF7 };
-	TransmitSysexConst(&roland_reverb_sysex[0], sizeof(roland_reverb_sysex));
+	TransmitStandardSysex(MidiSysexMessage::RolandSetReverb);
 
 	/* prepare multimedia timer */
 	TIMECAPS timecaps;


### PR DESCRIPTION
- Improve use of locks in Win32 driver to prevent more race conditions
- Share the standard SysEx message data between Win32 and DMusic drivers
- Send the GM reset SysEx message before each song to ensure correct reset of device
- Remove the manual controller resets as they are included in the GM reset

I probably should try to split this into multiple commits.

The last point is tested on a Roland and a Yamaha synth, both behave as expected.

Should fix #7438 (by resetting correctly between tracks)