### PR TITLE
Fix #7626: Allow building of drive-through stops over one-way/blocked roads owned by towns (instead of crashing).

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1004,7 +1004,7 @@ static CommandCost CheckFlatLandRoadStop(TileArea tile_area, DoCommandFlag flags
 
 					if (RoadTypeIsRoad(rt) && !HasPowerOnRoad(rt, road_rt)) return_cmd_error(STR_ERROR_NO_SUITABLE_ROAD);
 
-					if (GetDisallowedRoadDirections(cur_tile) != DRD_NONE) {
+					if (GetDisallowedRoadDirections(cur_tile) != DRD_NONE && road_owner != OWNER_TOWN) {
 						CommandCost ret = CheckOwnership(road_owner);
 						if (ret.Failed()) return ret;
 					}


### PR DESCRIPTION
Originally I thought about showing an error and preventing the stop from being built to prevent people from destroying a town's one-way system, but you can do that regardless by just removing the roads, so I don't think it really matters.
Makes more sense to just allow the stop to be placed.