### PR TITLE
Fix #7625: Road infrastructure cost is correctly updated when upgrading your own roads.

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2269,12 +2269,12 @@ static Vehicle *UpdateRoadVehPowerProc(Vehicle *v, void *data)
 }
 
 /**
- * Checks the tile and returns whether the current player is allowed to convert the roadtype to another roadtype
+ * Checks the tile and returns whether the current player is allowed to convert the roadtype to another roadtype without taking ownership
  * @param owner the tile owner.
  * @param rtt Road/tram type.
  * @return whether the road is convertible
  */
-static bool CanConvertRoadType(Owner owner, RoadTramType rtt)
+static bool CanConvertUnownedRoadType(Owner owner, RoadTramType rtt)
 {
 	return (owner == OWNER_NONE || (owner == OWNER_TOWN && rtt == RTT_ROAD));
 }
@@ -2370,7 +2370,7 @@ CommandCost CmdConvertRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 		/* Trying to convert other's road */
 		Owner owner = GetRoadOwner(tile, rtt);
-		if (!CanConvertRoadType(owner, rtt)) {
+		if (!CanConvertUnownedRoadType(owner, rtt)) {
 			CommandCost ret = CheckOwnership(owner, tile);
 			if (ret.Failed()) {
 				error = ret;
@@ -2400,7 +2400,7 @@ CommandCost CmdConvertRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 			if (flags & DC_EXEC) { // we can safely convert, too
 				/* Update the company infrastructure counters. */
-				if (!IsRoadStopTile(tile) && CanConvertRoadType(owner, rtt) && owner != OWNER_TOWN) {
+				if (!IsRoadStopTile(tile) && owner == _current_company) {
 					ConvertRoadTypeOwner(tile, num_pieces, owner, from_type, to_type);
 				}
 
@@ -2447,7 +2447,7 @@ CommandCost CmdConvertRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 			if (flags & DC_EXEC) {
 				/* Update the company infrastructure counters. */
-				if (CanConvertRoadType(owner, rtt) && owner != OWNER_TOWN) {
+				if (owner == _current_company) {
 					ConvertRoadTypeOwner(tile, num_pieces, owner, from_type, to_type);
 					ConvertRoadTypeOwner(endtile, num_pieces, owner, from_type, to_type);
 					SetTunnelBridgeOwner(tile, endtile, _current_company);


### PR DESCRIPTION
This fixes the road infrastructure cost issues, while still allowing the player to not have to pay maintenance on roads that are part of towns or scenarios (presumably this was the intent).

Also changes `CanConvertRoadType`'s name to `CanConvertUnownedRoadType` to make more sense for what it does. The odd name choice is probably how the bug originated in the first place.

(ignore the previous commit visible in the issue which previously fixed this, which I can't get rid of because I deleted the branch - thanks GitHub)