### PR TITLE
Fix warnings from GCC9

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,32 +580,20 @@ no graphical user interface; you would be building a dedicated server.
 The following compilers are known to compile OpenTTD:
 
 - Microsoft Visual C++ (MSVC) 2015, 2017 and 2019.
-- GNU Compiler Collection (GCC) 3.3 - 4.4, 4.6 - 4.8.
-    - Versions 4.1 and earlier give bogus warnings about uninitialised variables.
-    - Versions 4.4, 4.6 give bogus warnings about freeing non-heap objects.
-    - Versions 4.6 and later give invalid warnings when lto is enabled.
-- Intel C++ Compiler (ICC) 12.0.
-- Clang/LLVM 2.9 - 3.0
-   Version 2.9 gives bogus warnings about code nonconformity.
+- GNU Compiler Collection (GCC) 4.8 - 9.
+- Clang/LLVM 3.9 - 8
 
 The following compilers are known not to compile OpenTTD:
 
-- Microsoft Visual C++ (MSVC) 2013 and earlier.
-   These old versions do not support modern C++ language features.
-- GNU Compiler Collection (GCC) 3.2 and earlier.
-   These old versions fail due to OpenTTD's template usage.
-- GNU Compiler Collection (GCC) 4.5. It optimizes enums too aggressively.
-   See https://github.com/OpenTTD/OpenTTD/issues/5513 and references therein.
-- Intel C++ Compiler (ICC) 11.1 and earlier.
-    - Version 10.0 and earlier fail a configure check and fail with recent
-       system headers.
-    - Version 10.1 fails to compile station_gui.cpp.
-    - Version 11.1 fails with an internal error when compiling network.cpp.
-- Clang/LLVM 2.8 and earlier.
-- (Open) Watcom.
+In general, this is because these old versions do not (fully) support modern
+C++11 language features.
 
-If any of these compilers can compile OpenTTD again, please let us know.
-Patches to support more compilers are welcome.
+- Microsoft Visual C++ (MSVC) 2013 and earlier.
+- GNU Compiler Collection (GCC) 4.7 and earlier.
+- Clang/LLVM 3.8 and earlier.
+
+If any of these, or any other, compilers can compile OpenTTD, let us know.
+Pull requests to support more compilers are welcome.
 
 ### 7.3) Compilation of base sets
 

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -41,8 +41,8 @@ jobs:
     matrix:
       commit-checker:
         Tag: 'commit-checker'
-      linux-amd64-clang-3.8:
-        Tag: 'linux-amd64-clang-3.8'
+      linux-amd64-clang-3.9:
+        Tag: 'linux-amd64-clang-3.9'
       linux-amd64-gcc-6:
         Tag: 'linux-amd64-gcc-6'
       linux-i386-gcc-6:

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -142,7 +142,7 @@ public:
 			break;
 		}
 		Lex();
-		return ret;
+		return std::move(ret);
 	}
 	bool IsEndOfStatement() { return ((_lex._prevtoken == '\n') || (_token == SQUIRREL_EOB) || (_token == '}') || (_token == ';')); }
 	void OptionalSemicolon()

--- a/src/3rdparty/squirrel/squirrel/sqfuncproto.h
+++ b/src/3rdparty/squirrel/squirrel/sqfuncproto.h
@@ -20,12 +20,6 @@ struct SQOuterVar
 		_src=src;
 		_type=t;
 	}
-	SQOuterVar(const SQOuterVar &ov)
-	{
-		_type=ov._type;
-		_src=ov._src;
-		_name=ov._name;
-	}
 	SQOuterType _type;
 	SQObjectPtr _name;
 	SQObjectPtr _src;
@@ -34,13 +28,6 @@ struct SQOuterVar
 struct SQLocalVarInfo
 {
 	SQLocalVarInfo():_start_op(0),_end_op(0), _pos(0){}
-	SQLocalVarInfo(const SQLocalVarInfo &lvi)
-	{
-		_name=lvi._name;
-		_start_op=lvi._start_op;
-		_end_op=lvi._end_op;
-		_pos=lvi._pos;
-	}
 	SQObjectPtr _name;
 	SQUnsignedInteger _start_op;
 	SQUnsignedInteger _end_op;

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -502,14 +502,14 @@ SQObject SQFuncState::CreateString(const SQChar *s,SQInteger len)
 {
 	SQObjectPtr ns(SQString::Create(_sharedstate,s,len));
 	_table(_strings)->NewSlot(ns,(SQInteger)1);
-	return ns;
+	return std::move(ns);
 }
 
 SQObject SQFuncState::CreateTable()
 {
 	SQObjectPtr nt(SQTable::Create(_sharedstate,0));
 	_table(_strings)->NewSlot(nt,(SQInteger)1);
-	return nt;
+	return std::move(nt);
 }
 
 SQFunctionProto *SQFuncState::BuildProto()

--- a/src/3rdparty/squirrel/squirrel/sqvm.h
+++ b/src/3rdparty/squirrel/squirrel/sqvm.h
@@ -12,9 +12,8 @@
 void sq_base_register(HSQUIRRELVM v);
 
 struct SQExceptionTrap{
-	SQExceptionTrap() {}
-	SQExceptionTrap(SQInteger ss, SQInteger stackbase,SQInstruction *ip, SQInteger ex_target){ _stacksize = ss; _stackbase = stackbase; _ip = ip; _extarget = ex_target;}
-	SQExceptionTrap(const SQExceptionTrap &et) { (*this) = et;	}
+	SQExceptionTrap(SQInteger ss, SQInteger stackbase,SQInstruction *ip, SQInteger ex_target)
+		: _stackbase(stackbase), _stacksize(ss), _ip(ip), _extarget(ex_target) {}
 	SQInteger _stackbase;
 	SQInteger _stacksize;
 	SQInstruction *_ip;

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -72,9 +72,11 @@ static WindowDesc _errmsg_face_desc(
  * Copy the given data into our instance.
  * @param data The data to copy.
  */
-ErrorMessageData::ErrorMessageData(const ErrorMessageData &data)
+ErrorMessageData::ErrorMessageData(const ErrorMessageData &data) :
+	duration(data.duration), textref_stack_grffile(data.textref_stack_grffile), textref_stack_size(data.textref_stack_size),
+	summary_msg(data.summary_msg), detailed_msg(data.detailed_msg), position(data.position), face(data.face)
 {
-	*this = data;
+	memcpy(this->textref_stack, data.textref_stack, sizeof(this->textref_stack));
 	for (size_t i = 0; i < lengthof(this->strings); i++) {
 		if (this->strings[i] != nullptr) {
 			this->strings[i] = stredup(this->strings[i]);

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -512,7 +512,7 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 		/* Only a newline. */
 		this->buffer = nullptr;
 		l->emplace_back(this->runs.front().second, this->buffer, 0, 0);
-		return std::move(l); // Not supposed to be needed, but clang-3.8 barfs otherwise.
+		return l;
 	}
 
 	int offset = this->buffer - this->buffer_begin;
@@ -562,7 +562,7 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 					/* The character is wider than allowed width; don't know
 					 * what to do with this case... bail out! */
 					this->buffer = nullptr;
-					return std::move(l); // Not supposed to be needed, but clang-3.8 barfs otherwise.
+					return l;
 				}
 
 				if (last_space == nullptr) {
@@ -589,7 +589,7 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 		int w = l->GetWidth();
 		l->emplace_back(iter->second, begin, last_char - begin, w);
 	}
-	return std::move(l); // Not supposed to be needed, but clang-3.8 barfs otherwise.
+	return l;
 }
 
 /**

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -328,7 +328,7 @@ void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 	if (!new_song.LoadSong(song)) return;
 	DEBUG(driver, 2, "Win32-MIDI: PlaySong: Loaded song");
 
-	std::lock_guard mutex_lock(_midi.lock);
+	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 
 	_midi.next_file.MoveFrom(new_song);
 	_midi.next_segment.start = song.override_start;
@@ -348,7 +348,7 @@ void MusicDriver_Win32::PlaySong(const MusicSongInfo &song)
 void MusicDriver_Win32::StopSong()
 {
 	DEBUG(driver, 2, "Win32-MIDI: StopSong: entry");
-	std::lock_guard mutex_lock(_midi.lock);
+	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 	DEBUG(driver, 2, "Win32-MIDI: StopSong: setting flag");
 	_midi.do_stop = true;
 }
@@ -360,7 +360,7 @@ bool MusicDriver_Win32::IsSongPlaying()
 
 void MusicDriver_Win32::SetVolume(byte vol)
 {
-	std::lock_guard mutex_lock(_midi.lock);
+	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 	_midi.new_volume = vol;
 }
 
@@ -422,7 +422,7 @@ const char *MusicDriver_Win32::Start(const char * const *parm)
 
 void MusicDriver_Win32::Stop()
 {
-	std::lock_guard mutex_lock(_midi.lock);
+	std::lock_guard<std::mutex> mutex_lock(_midi.lock);
 
 	if (_midi.timer_id) {
 		timeKillEvent(_midi.timer_id);

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -369,7 +369,7 @@ const char *MusicDriver_Win32::Start(const char * const *parm)
 	DEBUG(driver, 2, "Win32-MIDI: Start: initializing");
 
 	int resolution = GetDriverParamInt(parm, "resolution", 5);
-	int port = GetDriverParamInt(parm, "port", -1);
+	uint port = (uint)GetDriverParamInt(parm, "port", UINT_MAX);
 	const char *portname = GetDriverParam(parm, "portname");
 
 	/* Enumerate ports either for selecting port by name, or for debug output */
@@ -392,7 +392,7 @@ const char *MusicDriver_Win32::Start(const char * const *parm)
 	}
 
 	UINT devid;
-	if (port < 0) {
+	if (port == UINT_MAX) {
 		devid = MIDI_MAPPER;
 	} else {
 		devid = (UINT)port;

--- a/src/music/win32_m.cpp
+++ b/src/music/win32_m.cpp
@@ -83,7 +83,7 @@ static void TransmitSysex(const byte *&msg_start, size_t &remaining)
 
 	/* prepare header */
 	MIDIHDR *hdr = CallocT<MIDIHDR>(1);
-	hdr->lpData = (LPSTR)msg_start;
+	hdr->lpData = reinterpret_cast<LPSTR>(const_cast<byte *>(msg_start));
 	hdr->dwBufferLength = msg_end - msg_start;
 	if (midiOutPrepareHeader(_midi.midi_out, hdr, sizeof(*hdr)) == MMSYSERR_NOERROR) {
 		/* transmit - just point directly into the data buffer */

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -91,15 +91,6 @@ public:
 		this->SetPort(port);
 	}
 
-	/**
-	 * Make a clone of another address
-	 * @param address the address to clone
-	 */
-	NetworkAddress(const NetworkAddress &address)
-	{
-		memcpy(this, &address, sizeof(*this));
-	}
-
 	const char *GetHostname();
 	void GetAddressAsString(char *buffer, const char *last, bool with_family = true);
 	const char *GetAddressAsString(bool with_family = true);

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -38,7 +38,7 @@ enum NetworkVehicleType {
 };
 
 /** 'Unique' identifier to be given to clients */
-enum ClientID {
+enum ClientID : uint32 {
 	INVALID_CLIENT_ID = 0, ///< Client is not part of anything
 	CLIENT_ID_SERVER  = 1, ///< Servers always have this ID
 	CLIENT_ID_FIRST   = 2, ///< The first client ID

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -47,14 +47,6 @@ protected:
 			this->tile_type = GetTileType(tile);
 			this->rail_type = GetTileRailType(tile);
 		}
-
-		TILE(const TILE &src)
-		{
-			tile = src.tile;
-			td = src.td;
-			tile_type = src.tile_type;
-			rail_type = src.rail_type;
-		}
 	};
 
 protected:

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -26,7 +26,7 @@ class ScriptClient : public ScriptObject {
 public:
 
 	/** Different constants related to ClientID. */
-	enum ClientID {
+	enum ClientID : uint32 {
 		CLIENT_INVALID = 0,  ///< Client is not part of anything
 		CLIENT_SERVER  = 1,  ///< Servers always have this ID
 		CLIENT_FIRST   = 2,  ///< The first client ID

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -965,7 +965,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_TD_LIST);
 	}
 
-	virtual void OnEditboxChanged(int wid)
+	void OnEditboxChanged(int wid) override
 	{
 		if (wid == WID_TD_FILTER) {
 			this->string_filter.SetFilterTerm(this->townname_editbox.text.buf);
@@ -1010,7 +1010,7 @@ public:
 					this->towns.Sort();
 					this->towns.shrink_to_fit();
 					this->towns.RebuildDone();
-					this->vscroll->SetCount(this->towns.size()); // Update scrollbar as well.
+					this->vscroll->SetCount((int)this->towns.size()); // Update scrollbar as well.
 				}
 				break;
 			default:

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -135,7 +135,7 @@ CommandCost CmdBuildVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 	/* Vehicle construction needs random bits, so we have to save the random
 	 * seeds to prevent desyncs. */
 	SavedRandomSeeds saved_seeds;
-	if (flags != subflags) SaveRandomSeeds(&saved_seeds);
+	SaveRandomSeeds(&saved_seeds);
 
 	Vehicle *v = nullptr;
 	switch (type) {
@@ -185,6 +185,7 @@ CommandCost CmdBuildVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 		}
 	}
 
+	/* Only restore if we actually did some refitting */
 	if (flags != subflags) RestoreRandomSeeds(saved_seeds);
 
 	return value;


### PR DESCRIPTION
Noisest one is [https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy](-Wdeprecated-copy)

Mostly fixed by removing explicit copy constructors in favour of implicit compiler, or removing the need for one (switching an array out with std::array)

Closes #7748
Closes #7751 