### PR TITLE
Fix #7635: Game crash on exit scenario editor.

### DIFF
--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -105,7 +105,7 @@ struct BuildDocksToolbarWindow : Window {
 
 	~BuildDocksToolbarWindow()
 	{
-		if (_game_mode != GM_EDITOR && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
+		if (_game_mode == GM_NORMAL && this->IsWidgetLowered(WID_DT_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) DeleteWindowById(WC_SCEN_LAND_GEN, 0, false);
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -291,7 +291,7 @@ struct BuildRoadToolbarWindow : Window {
 
 	~BuildRoadToolbarWindow()
 	{
-		if (_game_mode != GM_EDITOR && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
+		if (_game_mode == GM_NORMAL && (this->IsWidgetLowered(WID_ROT_BUS_STATION) || this->IsWidgetLowered(WID_ROT_TRUCK_STATION))) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) DeleteWindowById(WC_SCEN_LAND_GEN, 0, false);
 	}
 


### PR DESCRIPTION
I think the `GM_NORMAL` is the only game mode when the station building widgets are available.