### PR TITLE
Change: Update for French town name "Beaujolais"

### DIFF
--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -768,7 +768,7 @@ static const char * const _name_french_real[] = {
 	"Le Puy",
 	"Vichy",
 	"St. Valery",
-	"Beaujolais",
+	"Villefranche-sur-Sa\xC3\xB4ne",
 	"Reims",
 	"Albi",
 	"Paris",


### PR DESCRIPTION
Pointed out by MagicBuzz here:
    https://www.tt-forums.net/viewtopic.php?f=29&t=85567

There's no town in France called Beaujolais, but the current
name for the capital of the Beaujolais province is Villefranche-sur-Saône.