### PR TITLE
Fix: Narrowing cast in one storybook command

### DIFF
--- a/src/story.cpp
+++ b/src/story.cpp
@@ -154,7 +154,7 @@ CommandCost CmdCreateStoryPageElement(TileIndex tile, DoCommandFlag flags, uint3
 {
 	if (!StoryPageElement::CanAllocateItem()) return CMD_ERROR;
 
-	StoryPageID page_id = (CompanyID)GB(p1, 0, 16);
+	StoryPageID page_id = (StoryPageID)GB(p1, 0, 16);
 	StoryPageElementType type = Extract<StoryPageElementType, 16, 8>(p1);
 
 	/* Allow at most 128 elements per page. */


### PR DESCRIPTION
CompanyID is 8 bit wide, so this incorrect cast would make it impossible to create story page elements for pages past 255.