### PR TITLE
Add: 'getsysdate' console command

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1309,21 +1309,21 @@ DEF_CONSOLE_CMD(ConGetDate)
 
 	YearMonthDay ymd;
 	ConvertDateToYMD(_date, &ymd);
-	IConsolePrintF(CC_DEFAULT, "Date: %d-%02d-%02d", ymd.day, ymd.month + 1, ymd.year);
+	IConsolePrintF(CC_DEFAULT, "Date: %02d-%02d-%04d", ymd.day, ymd.month + 1, ymd.year);
 	return true;
 }
 
 DEF_CONSOLE_CMD(ConGetSysDate)
 {
 	if (argc == 0) {
-		IConsoleHelp("Returns the current date (day-month-year) of your system. Usage: 'getsysdate'");
+		IConsoleHelp("Returns the current date (year-month-day) of your system. Usage: 'getsysdate'");
 		return true;
 	}
 
 	time_t t;
 	time(&t);
 	auto timeinfo = localtime(&t);
-	IConsolePrintF(CC_DEFAULT, "System Date: %d-%02d-%02d %d:%d:%d", timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
+	IConsolePrintF(CC_DEFAULT, "System Date: %04d-%02d-%02d %02d:%02d:%02d", timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
 	return true;
 }
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -9,6 +9,7 @@
 
 /** @file console_cmds.cpp Implementation of the console hooks. */
 
+#include <time.h>
 #include "stdafx.h"
 #include "console_internal.h"
 #include "debug.h"
@@ -1312,6 +1313,21 @@ DEF_CONSOLE_CMD(ConGetDate)
 	return true;
 }
 
+DEF_CONSOLE_CMD(ConGetSysDate)
+{
+	if (argc == 0) {
+		IConsoleHelp("Returns the current date (day-month-year) of your system. Usage: 'getsysdate'");
+		return true;
+	}
+
+	time_t t;
+	struct tm * timeinfo;
+	time(&t);
+	timeinfo = localtime(&t);
+	IConsolePrintF(CC_DEFAULT, "System Date: %d/%d/%d %d:%d:%d", timeinfo->tm_year + 1900, timeinfo->tm_mon, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
+	return true;
+}
+
 
 DEF_CONSOLE_CMD(ConAlias)
 {
@@ -1925,6 +1941,7 @@ void IConsoleStdLibRegister()
 	IConsoleCmdRegister("restart",      ConRestart);
 	IConsoleCmdRegister("getseed",      ConGetSeed);
 	IConsoleCmdRegister("getdate",      ConGetDate);
+	IConsoleCmdRegister("getsysdate",   ConGetSysDate);
 	IConsoleCmdRegister("quit",         ConExit);
 	IConsoleCmdRegister("resetengines", ConResetEngines, ConHookNoNetwork);
 	IConsoleCmdRegister("reset_enginepool", ConResetEnginePool, ConHookNoNetwork);

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -9,7 +9,6 @@
 
 /** @file console_cmds.cpp Implementation of the console hooks. */
 
-#include <time.h>
 #include "stdafx.h"
 #include "console_internal.h"
 #include "debug.h"
@@ -40,6 +39,7 @@
 #include "engine_base.h"
 #include "game/game.hpp"
 #include "table/strings.h"
+#include <time.h>
 
 #include "safeguards.h"
 
@@ -1321,10 +1321,9 @@ DEF_CONSOLE_CMD(ConGetSysDate)
 	}
 
 	time_t t;
-	struct tm * timeinfo;
 	time(&t);
-	timeinfo = localtime(&t);
-	IConsolePrintF(CC_DEFAULT, "System Date: %d/%d/%d %d:%d:%d", timeinfo->tm_year + 1900, timeinfo->tm_mon, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
+	auto timeinfo = localtime(&t);
+	IConsolePrintF(CC_DEFAULT, "System Date: %d-%02d-%02d %d:%d:%d", timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
 	return true;
 }
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1303,13 +1303,13 @@ DEF_CONSOLE_CMD(ConGetSeed)
 DEF_CONSOLE_CMD(ConGetDate)
 {
 	if (argc == 0) {
-		IConsoleHelp("Returns the current date (day-month-year) of the game. Usage: 'getdate'");
+		IConsoleHelp("Returns the current date (year-month-day) of the game. Usage: 'getdate'");
 		return true;
 	}
 
 	YearMonthDay ymd;
 	ConvertDateToYMD(_date, &ymd);
-	IConsolePrintF(CC_DEFAULT, "Date: %02d-%02d-%04d", ymd.day, ymd.month + 1, ymd.year);
+	IConsolePrintF(CC_DEFAULT, "Date: %04d-%02d-%02d", ymd.year, ymd.month + 1, ymd.day);
 	return true;
 }
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1309,7 +1309,7 @@ DEF_CONSOLE_CMD(ConGetDate)
 
 	YearMonthDay ymd;
 	ConvertDateToYMD(_date, &ymd);
-	IConsolePrintF(CC_DEFAULT, "Date: %d-%d-%d", ymd.day, ymd.month + 1, ymd.year);
+	IConsolePrintF(CC_DEFAULT, "Date: %d-%02d-%02d", ymd.day, ymd.month + 1, ymd.year);
 	return true;
 }
 


### PR DESCRIPTION
Add ``getsysdate`` console command to display system's local time, which is might be useful to check current time in script logging.
I have been felt that there is no command to match game date and system time, it might be helpful.

Please let me aware if something is wrong.