### PR TITLE
Fix #6407: Show snowy ground sprites for depots

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2472,9 +2472,8 @@ static void DrawTile_Track(TileInfo *ti)
 			if (image != SPR_FLAT_GRASS_TILE) image += rti->GetRailtypeSpriteOffset();
 		}
 
-		/* adjust ground tile for desert
-		 * don't adjust for snow, because snow in depots looks weird */
-		if (IsSnowRailGround(ti->tile) && _settings_game.game_creation.landscape == LT_TROPIC) {
+		/* Adjust ground tile for desert and snow. */
+		if (IsSnowRailGround(ti->tile)) {
 			if (image != SPR_FLAT_GRASS_TILE) {
 				image += rti->snow_offset; // tile with tracks
 			} else {


### PR DESCRIPTION
This is a quick fix by @KeldorKatarn:
https://github.com/KeldorKatarn/OpenTTD_PatchPack/commit/65e656b9d6b24476d074ec6b41830a8f197d535b

It has the drawback that snow is draw to the inside the depots as well, as the removed comment suggests.

![snow_in_depot](https://user-images.githubusercontent.com/48624099/61998588-8d221880-b0b2-11e9-9542-be6433ed6314.png)
