### PR TITLE
Fix #7672: more than 32 resolutions may be available

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1673,7 +1673,7 @@ static char *GetSpecialNameString(char *buff, int ind, StringParameters *args, c
 	}
 
 	/* resolution size? */
-	if (IsInsideMM(ind, (SPECSTR_RESOLUTION_START - 0x70E4), (SPECSTR_RESOLUTION_END - 0x70E4) + 1)) {
+	if (IsInsideBS(ind, (SPECSTR_RESOLUTION_START - 0x70E4), _resolutions.size())) {
 		int i = ind - (SPECSTR_RESOLUTION_START - 0x70E4);
 		buff += seprintf(
 			buff, last, "%ux%u", _resolutions[i].width, _resolutions[i].height

--- a/src/strings_type.h
+++ b/src/strings_type.h
@@ -93,9 +93,8 @@ enum SpecialStrings {
 	SPECSTR_LANGUAGE_START     = 0x7100,
 	SPECSTR_LANGUAGE_END       = SPECSTR_LANGUAGE_START + MAX_LANG - 1,
 
-	/* reserve 32 strings for various screen resolutions */
+	/* reserve strings for various screen resolutions MUST BE THE LAST VALUE IN THIS ENUM */
 	SPECSTR_RESOLUTION_START   = SPECSTR_LANGUAGE_END + 1,
-	SPECSTR_RESOLUTION_END     = SPECSTR_RESOLUTION_START + 0x1F,
 };
 
 #endif /* STRINGS_TYPE_H */


### PR DESCRIPTION
Since https://github.com/OpenTTD/OpenTTD/commit/9195f2337a7c4f9154058877093bbb74db33cf32 and the usage of std::vector, the number of resolution is no longer limited to 32 (except for OSX)