### PR TITLE
Fix #7679: Check version when comparing scripts

### DIFF
--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -241,6 +241,10 @@ static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, S
 	for (int j = 0; j < 4 && *str != '\0'; j++, str++) id |= *str << (8 * j);
 
 	if (id != ci->unique_id) return false;
+	char script_version[6];
+	memset(script_version, 0, sizeof(script_version));
+	seprintf(script_version, lastof(script_version) - 1, "%u", info->GetVersion());
+	if (strcasecmp(script_version, ci->version) != 0) return false;
 	if (!md5sum) return true;
 
 	ScriptFileChecksumCreator checksum(dir);


### PR DESCRIPTION
# Problem
Script version is not checked when scripts are compared.

This goes against [documentation of the `import` Squirrel procedure](https://wiki.openttd.org/AI:Library#Using_Existing_Libraries), explicitely stating:
> The version check is very important. If you expect version 1, but on some users computer the library is in version 2, your AI will refuse to load. This is a good thing, as a new version means something changed with the existing functions, and your AI will most likely act up if you would use it. This early problem detection system should avoid many conflicts in the future.

Moreover this is a problem, as uneeded versions of libraries are downloaded for no reason, meaning extra work for no added value.

Dependencies are set for specific scripts, and the initial install does that properly. The use-case of issue #7679 where coming immediately back in the content downloader show available "upgrades" seems odd, as available content has not changed meanwhile.
It means either:
- Said upgrades are should not be detected as such

or
- The initial download should have taken care of them.

Both visions are developed hereafter.

# Projection on a cleverer upgrade detection
Hence a question opens itself: **How to define an upgrade?**

## This PR's proposal
**Upgrade = new version of an existing dependency**

### What this PR does
Since scripts define exact versions of their dependencies, a change upstream will need to be reflected in the script to be usable.
Since the `import` procedure of Squirrel script has a rigid version specification, it seems an "upgrade" can only mean the same script, both in name & version, ie in pseudo code: `oldScript.version == newScript.version && (oldScript.md5 != newScript.md5 || oldScript.shortName == newScript.shortName)`

### What would be left to do
In order to obtain a more logical `newScript.IsUpgrade(oldScript) && (oldScript.md5 != newScript.md5 || oldScript.shortName == newScript.shortName)` logic, it would require:
1. The `import` Squirrel procedure to support variable version(s) specification (like `1.*` or `>=1 && <2`, `1.2+` or `>=1.2`, `<3`)
2. New logic in https://github.com/OpenTTD/OpenTTD/blob/afbf6a59182d9b1ca36b9dab9bd391ad0ae6222f/src/script/script_scanner.cpp#L237 to compare versions based of this new versions specification, on order for the call https://github.com/OpenTTD/OpenTTD/blob/afbf6a59182d9b1ca36b9dab9bd391ad0ae6222f/src/network/network_content.cpp#L130 to detect a new version of the same script

..., but that is another story.

## Original thought?
**Upgrade = non-downloaded versions of a downloaded script**

This is closer to a *Check for other versions*, not even *Check for newer versions* as no version check was done *at all*.

If this vision is kept, it would be best if the button was reworded or its tooltip explanation & actual behaviour correlate.
It would then also be best to get all variants of a dependency on initial download, as it is inconsistent to immediately offer "upgrades" to scripts on the next visit of the content downloader, without available content having changed.