### PR TITLE
Fix: clang and MSVC warnings

### DIFF
--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -38,7 +38,7 @@ enum NetworkVehicleType {
 };
 
 /** 'Unique' identifier to be given to clients */
-enum ClientID {
+enum ClientID : uint32 {
 	INVALID_CLIENT_ID = 0, ///< Client is not part of anything
 	CLIENT_ID_SERVER  = 1, ///< Servers always have this ID
 	CLIENT_ID_FIRST   = 2, ///< The first client ID

--- a/src/script/api/script_client.hpp
+++ b/src/script/api/script_client.hpp
@@ -26,7 +26,7 @@ class ScriptClient : public ScriptObject {
 public:
 
 	/** Different constants related to ClientID. */
-	enum ClientID {
+	enum ClientID : uint32 {
 		CLIENT_INVALID = 0,  ///< Client is not part of anything
 		CLIENT_SERVER  = 1,  ///< Servers always have this ID
 		CLIENT_FIRST   = 2,  ///< The first client ID

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -965,7 +965,7 @@ public:
 		this->vscroll->SetCapacityFromWidget(this, WID_TD_LIST);
 	}
 
-	virtual void OnEditboxChanged(int wid)
+	void OnEditboxChanged(int wid) override
 	{
 		if (wid == WID_TD_FILTER) {
 			this->string_filter.SetFilterTerm(this->townname_editbox.text.buf);
@@ -1010,7 +1010,7 @@ public:
 					this->towns.Sort();
 					this->towns.shrink_to_fit();
 					this->towns.RebuildDone();
-					this->vscroll->SetCount(this->towns.size()); // Update scrollbar as well.
+					this->vscroll->SetCount((int)this->towns.size()); // Update scrollbar as well.
 				}
 				break;
 			default:


### PR DESCRIPTION
Fixes these clang warnings
```
/home/vsts/work/1/s/src/script/api/script_goal.cpp:141:36: warning: comparison of constant 65536 with expression of type 'ScriptClient::ClientID' is always true [-Wtautological-constant-out-of-range-compare]
        EnforcePrecondition(false, client < (1 << 16));
                                   ~~~~~~ ^ ~~~~~~~~~
/home/vsts/work/1/s/src/script/api/script_error.hpp:24:8: note: expanded from macro 'EnforcePrecondition'
        if (!(condition)) {                                           \
              ^~~~~~~~~
/home/vsts/work/1/s/src/town_gui.cpp:951:15: warning: 'OnEditboxChanged' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual void OnEditboxChanged(int wid)
                     ^
/home/vsts/work/1/s/src/widgets/../window_gui.h:733:15: note: overridden virtual function is here
        virtual void OnEditboxChanged(int widget) {}
```
and this MSVC 64bit warning
```
     2>d:\a\1\s\src\town_gui.cpp(996): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data [d:\a\1\s\projects\openttd_vs141.vcxproj]
```
