### PR TITLE
Fix: saving crash.sav when disconnected from network game

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -283,7 +283,16 @@
 {
 	if (!_networking || _network_server) {
 		Company *c = Company::GetIfValid(company);
-		assert(c != nullptr && c->ai_instance != nullptr);
+
+		assert(c != nullptr);
+		if (c->ai_instance == nullptr) {
+			/* c->ai_instance can be null if this was a network client
+			 * that's been disconnected from the server. So, it
+			 * doesn't have access to the ai instance. Just save an
+			 * empty instance. */
+			AIInstance::SaveEmpty();
+			return;
+		}
 
 		Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
 		c->ai_instance->Save();


### PR DESCRIPTION
This fixes an assertion failure created by the scenario
outlined here:
https://github.com/OpenTTD/OpenTTD/issues/6598#issuecomment-518474358

When a client gets disconnected from a network game that has an AI, and
then crashes, it tries to write a crash.sav. Attempting to save the AI
instance here, which doesn't exist on the client, causes the assertion
failure.

This change allows openttd to crash properly in this awkward scenario :P

crash.sav and crash.png are now written:

    Writing crash log to disk...
    Crash log written to /home/nik/.openttd/crash.log. Please add this file
    to any bug reports.

    Writing crash savegame...
    Crash savegame written to /home/nik/.openttd/crash.sav. Please add this
    file and the last (auto)save to any bug reports.

    Writing crash screenshot...
    Crash screenshot written to /home/nik/.openttd/crash.png. Please add
    this file to any bug reports.

    Aborted