### PR TITLE
Feature: Auto-restart loads the original resources again

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1608,7 +1608,20 @@ static void NetworkCheckRestartMap()
 	if (_settings_client.network.restart_game_year != 0 && _cur_year >= _settings_client.network.restart_game_year) {
 		DEBUG(net, 0, "Auto-restarting map. Year %d reached", _cur_year);
 
-		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
+		_settings_newgame.game_creation.generation_seed = GENERATE_NEW_SEED;
+		switch(_file_to_saveload.abstract_ftype) {
+			case FT_SAVEGAME:
+			case FT_SCENARIO:
+				_switch_mode = SM_LOAD_GAME;
+				break;
+
+			case FT_HEIGHTMAP:
+				_switch_mode = SM_START_HEIGHTMAP;
+				break;
+
+			default:
+				_switch_mode = SM_NEWGAME;
+		}
 	}
 }
 


### PR DESCRIPTION
If the game was started loading a savegame or scenario, auto-restart will load a new random map.
This is inconsistent with the case in which a heightmap was loaded, as in that case the heightmap is kept as a basis for a new game.
This proposal solves this heterogeneity be considering the originally loaded resource shall be kept, hence savegames & scenarios shall be reloaded