### PR TITLE
Fix: Allow git worktree in version detection; drop svn, hg.

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1059,18 +1059,8 @@ check_params() {
 		fi
 	fi
 
-	if [ -d "$ROOT_DIR/.svn" ] && [ -n "`svn help 2>/dev/null`" ]; then
-		log 1 "checking revision... svn detection"
-	elif [ -d "$ROOT_DIR/../.svn" ] && [ -n "`svn help 2>/dev/null`" ] && [ -n "`LC_ALL=C svn info $ROOT_DIR/.. | grep '^URL:.*tags$'`" ]; then
-		# subversion changed its behaviour; now not all folders have a .svn folder,
-		# but only the root folder. Since making tags requires a (sparse) checkout
-		# of the tags folder, the folder of the tag does not have a .svn folder
-		# anymore and this fails to detect the subversion repository checkout.
-		log 1 "checking revision... svn detection (tag)"
-	elif [ -d "$ROOT_DIR/.git" ] && [ -n "`git help 2>/dev/null`" ]; then
+	if { [ -d "$ROOT_DIR/.git" ] || [ -f "$ROOT_DIR/.git" ]; } && [ -n "`git help 2>/dev/null`" ]; then
 		log 1 "checking revision... git detection"
-	elif [ -d "$ROOT_DIR/.hg" ] && [ -n "`HGPLAIN= hg help 2>/dev/null`" ]; then
-		log 1 "checking revision... hg detection"
 	elif [ -f "$ROOT_DIR/.ottdrev" ]; then
 		log 1 "checking revision... source tarball"
 	else

--- a/findversion.sh
+++ b/findversion.sh
@@ -59,7 +59,7 @@ ROOT_DIR=`pwd`
 # Determine if we are using a modified version
 # Assume the dir is not modified
 MODIFIED="0"
-if [ -d "$ROOT_DIR/.git" ]; then
+if [ -d "$ROOT_DIR/.git" ] || [ -f "$ROOT_DIR/.git" ]; then
 	# We are a git checkout
 	# Refresh the index to make sure file stat info is in sync, then look for modifications
 	git update-index --refresh >/dev/null


### PR DESCRIPTION
If $ROOT_DIR is a linked working tree from git-worktree(1), then
$ROOT_DIR/.git is a regular file instead of a directory.  Allow this
when deciding whether to use git to detect OpenTTD's version.

Drop checks for svn and hg in config.lib, because findversion.sh
hasn't used svn nor hg since 192770e6da.