### PR TITLE
Fix: [DorpsGek] don't report all pushes, but just those done by DorpsGek

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -1,13 +1,13 @@
 notifications:
+  global:
+    irc:
+      - openttd
+      - openttd.notice
+
   push:
-    irc:
-      - openttd
-      - openttd.notice
+    only:
+    - master
+    only-by:
+    - DorpsGek
   pull-request:
-    irc:
-      - openttd
-      - openttd.notice
   issue:
-    irc:
-      - openttd
-      - openttd.notice


### PR DESCRIPTION
Those are most often the translator updates, which are pushed
directly to master (and not via a Pull Request).