### PR TITLE
Fix b3fd7879: Ignore command flags when verifying script commands

### DIFF
--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -23,6 +23,7 @@
 #include "../script_instance.hpp"
 #include "../script_fatalerror.hpp"
 #include "script_error.hpp"
+#include "../../debug.h"
 
 #include "../../safeguards.h"
 
@@ -85,18 +86,22 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 
 /* static */ void ScriptObject::SetLastCommand(TileIndex tile, uint32 p1, uint32 p2, uint32 cmd)
 {
-	GetStorage()->last_tile = tile;
-	GetStorage()->last_p1 = p1;
-	GetStorage()->last_p2 = p2;
-	GetStorage()->last_cmd = cmd;
+	ScriptStorage *s = GetStorage();
+	DEBUG(script, 6, "SetLastCommand company=%02d tile=%06x p1=%08x p2=%08x cmd=%d", s->root_company, tile, p1, p2, cmd);
+	s->last_tile = tile;
+	s->last_p1 = p1;
+	s->last_p2 = p2;
+	s->last_cmd = cmd & CMD_ID_MASK;
 }
 
 /* static */ bool ScriptObject::CheckLastCommand(TileIndex tile, uint32 p1, uint32 p2, uint32 cmd)
 {
-	if (GetStorage()->last_tile != tile) return false;
-	if (GetStorage()->last_p1 != p1) return false;
-	if (GetStorage()->last_p2 != p2) return false;
-	if (GetStorage()->last_cmd != cmd) return false;
+	ScriptStorage *s = GetStorage();
+	DEBUG(script, 6, "CheckLastCommand company=%02d tile=%06x p1=%08x p2=%08x cmd=%d", s->root_company, tile, p1, p2, cmd);
+	if (s->last_tile != tile) return false;
+	if (s->last_p1 != p1) return false;
+	if (s->last_p2 != p2) return false;
+	if (s->last_cmd != (cmd & CMD_ID_MASK)) return false;
 	return true;
 }
 

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -684,7 +684,10 @@ bool ScriptInstance::DoCommandCallback(const CommandCost &result, TileIndex tile
 {
 	ScriptObject::ActiveInstance active(this);
 
-	if (!ScriptObject::CheckLastCommand(tile, p1, p2, cmd)) return false;
+	if (!ScriptObject::CheckLastCommand(tile, p1, p2, cmd)) {
+		DEBUG(script, 1, "DoCommandCallback terminating a script, last command does not match expected command");
+		return false;
+	}
 
 	ScriptObject::SetLastCommandRes(result.Succeeded());
 


### PR DESCRIPTION
Multiplayer games has the server add some flags to the cmd value during the handling. These flags should not be included in the verification, mask them out. Without this masking out, scripts tend to die when executing their first command in multiplayer.