### PR TITLE
Fix: Use natural sort when sorting the file list.

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -57,7 +57,7 @@ bool FiosItem::operator< (const FiosItem &other) const
 	if ((_savegame_sort_order & SORT_BY_NAME) == 0 && (*this).mtime != other.mtime) {
 		r = (*this).mtime - other.mtime;
 	} else {
-		r = strcasecmp((*this).title, other.title);
+		r = strnatcmp((*this).title, other.title);
 	}
 	if (r == 0) return false;
 	return (_savegame_sort_order & SORT_DESCENDING) ? r > 0 : r < 0;


### PR DESCRIPTION
Current sorting of the list of files does work incorrectly (at least on Windows OS). See images below.

_Incorrect sorting in example of the Cyrillic chars:_

Current (incorrect) | With this fix (correct)
:---: | :---:
![sort_letters old](https://user-images.githubusercontent.com/11795932/64479735-b19a0600-d1c3-11e9-8d3f-8d16bd03428a.png) | ![sort_letters new](https://user-images.githubusercontent.com/11795932/64479736-b65eba00-d1c3-11e9-80f1-1c8a145947d4.png)

_Also a nice addition is the sorting of numbers:_

Current | With this fix
:---: | :---:
![sort_numbers old](https://user-images.githubusercontent.com/11795932/64479737-b8c11400-d1c3-11e9-8cd6-1cd029c0f61d.png) | ![sort_numbers new](https://user-images.githubusercontent.com/11795932/64479739-ba8ad780-d1c3-11e9-88b6-8b292f35f94e.png)
