### PR TITLE
Fix #7479: Don't close construction windows when changing client name

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -104,15 +104,18 @@ void SetLocalCompany(CompanyID new_company)
 	/* company could also be COMPANY_SPECTATOR or OWNER_NONE */
 	assert(Company::IsValidID(new_company) || new_company == COMPANY_SPECTATOR || new_company == OWNER_NONE);
 
+	/* If actually changing to another company, several windows need closing */
+	bool switching_company = _local_company != new_company;
+
 	/* Delete the chat window, if you were team chatting. */
-	InvalidateWindowData(WC_SEND_NETWORK_MSG, DESTTYPE_TEAM, _local_company);
+	if (switching_company) InvalidateWindowData(WC_SEND_NETWORK_MSG, DESTTYPE_TEAM, _local_company);
 
 	assert(IsLocalCompany());
 
 	_current_company = _local_company = new_company;
 
 	/* Delete any construction windows... */
-	DeleteConstructionWindows();
+	if (switching_company) DeleteConstructionWindows();
 
 	/* ... and redraw the whole screen. */
 	MarkWholeScreenDirty();


### PR DESCRIPTION
As diagnosed in #7479, changing client name causes SetLocalCompany() to be called even when the company didn't actually change. Make sure a non-change doesn't close windows unnecessarily.