### PR TITLE
Add: Allow autoreplace with same model vehicle

### DIFF
--- a/src/autoreplace.cpp
+++ b/src/autoreplace.cpp
@@ -69,7 +69,18 @@ EngineID EngineReplacement(EngineRenewList erl, EngineID engine, GroupID group, 
 		/* We didn't find anything useful in the vehicle's own group so we will try ALL_GROUP */
 		er = GetEngineReplacement(erl, engine, ALL_GROUP);
 	}
-	if (replace_when_old != nullptr) *replace_when_old = er == nullptr ? false : er->replace_when_old;
+	if (replace_when_old != nullptr) {
+		if (er == nullptr) {
+			/* Not replacing */
+			*replace_when_old = false;
+		} else if (er->to == engine) {
+			/* When replacing with same model, only ever do it when old */
+			*replace_when_old = true;
+		} else {
+			/* Use player setting */
+			*replace_when_old = er->replace_when_old;
+		}
+	}
 	return er == nullptr ? INVALID_ENGINE : er->to;
 }
 

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -60,9 +60,6 @@ bool CheckAutoreplaceValidity(EngineID from, EngineID to, CompanyID company)
 {
 	assert(Engine::IsValidID(from) && Engine::IsValidID(to));
 
-	/* we can't replace an engine into itself (that would be autorenew) */
-	if (from == to) return false;
-
 	const Engine *e_from = Engine::Get(from);
 	const Engine *e_to = Engine::Get(to);
 	VehicleType type = e_from->type;


### PR DESCRIPTION
This is not what #7525 asks for, but I think it's just as good, or better. Remove the old restriction on autoreplacing vehicles with the same model, but instead add a check so autoreplace with same model only ever occurs when the vehicle is nearing end of life.