### PR TITLE
Change: Use vehicle model age for station rating calculation

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1767,7 +1767,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 
 		/* if last speed is 0, we treat that as if no vehicle has ever visited the station. */
 		ge->last_speed = min(t, 255);
-		ge->last_age = min(_cur_year - front->build_year, 255);
+		ge->last_age = Clamp((_date - front->GetEngine()->intro_date) / DAYS_IN_YEAR, 0, 255);
 		ge->time_since_pickup = 0;
 
 		assert(v->cargo_cap >= v->cargo.StoredCount());

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -248,7 +248,7 @@ struct GoodsEntry {
 	byte last_speed;
 
 	/**
-	 * Age in years (up to 255) of the last vehicle that tried to load this cargo.
+	 * Years (up to 255) since introduction of the last vehicle type that tried to load this cargo.
 	 * This does not imply there was any cargo to load.
 	 */
 	byte last_age;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3548,9 +3548,9 @@ static void UpdateStationRating(Station *st)
 			if (Company::IsValidID(st->owner) && HasBit(st->town->statues, st->owner)) rating += 26;
 
 			byte age = ge->last_age;
-			if (age < 3) rating += 10;
-			if (age < 2) rating += 10;
-			if (age < 1) rating += 13;
+			if (age < 10) rating += 10;
+			if (age < 5) rating += 10;
+			if (age < 2) rating += 13;
 
 			{
 				int or_ = ge->rating; // old rating


### PR DESCRIPTION
The age of the vehicle itself is prone to exploitation, since you can just keep replacing vehicles with a new of the same type. Basing the station rating on how recent the vehicle model is instead encourages the player to upgrade the vehicle park regularly.