### PR TITLE
Fix: Avoid using stat to retrieve file modification times on Windows (#7731)

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -300,13 +300,29 @@ bool FiosFileScanner::AddFile(const char *filename, size_t basepath_length, cons
 
 	FiosItem *fios = file_list.Append();
 #ifdef _WIN32
-	struct _stat sb;
-	if (_tstat(OTTD2FS(filename), &sb) == 0) {
+	// Retrieve the file modified date using GetFileTime rather than stat to work around an obscure MSVC bug that affects Windows XP
+	HANDLE fh = CreateFile(OTTD2FS(filename), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+
+	if (fh != INVALID_HANDLE_VALUE) {
+		FILETIME ft;
+		ULARGE_INTEGER ft_int64;
+
+		if (GetFileTime(fh, nullptr, nullptr, &ft) != 0) {
+			ft_int64.HighPart = ft.dwHighDateTime;
+			ft_int64.LowPart = ft.dwLowDateTime;
+
+			// Convert from hectonanoseconds since 01/01/1601 to seconds since 01/01/1970
+			fios->mtime = ft_int64.QuadPart / 10000000ULL - 11644473600ULL;
+		} else {
+			fios->mtime = 0;
+		}
+
+		CloseHandle(fh);
 #else
 	struct stat sb;
 	if (stat(filename, &sb) == 0) {
-#endif
 		fios->mtime = sb.st_mtime;
+#endif
 	} else {
 		fios->mtime = 0;
 	}


### PR DESCRIPTION
Arguable whether it's worth the effort fixing this one, but the attached changes fix the issue reported in #7731. I've tested with MSVC 2019 and a Windows XP VM and the file sorting works correctly. Since our builds do still work on XP SP3 it doesn't seem unreasonable to fix issues that are straightforward, but I would maintain that XP is still very much unsupported at this stage!