### PR TITLE
Feature: Configurable ending year

### DIFF
--- a/src/date.cpp
+++ b/src/date.cpp
@@ -27,6 +27,8 @@ Date      _date;       ///< Current date in days (day counter)
 DateFract _date_fract; ///< Fractional part of the day.
 uint16 _tick_counter;  ///< Ever incrementing (and sometimes wrapping) tick counter for setting off various events
 
+int32 _old_ending_year_slv_105; ///< Old ending year for savegames before SLV_105
+
 /**
  * Set the date.
  * @param date  New date
@@ -197,8 +199,8 @@ static void OnNewYear()
 
 	if (_cur_year == _settings_client.gui.semaphore_build_before) ResetSignalVariant();
 
-	/* check if we reached end of the game */
-	if (_cur_year == ORIGINAL_END_YEAR) {
+	/* check if we reached end of the game (end of ending year) */
+	if (_cur_year == _settings_game.game_creation.ending_year + 1) {
 		ShowEndGameChart();
 	/* check if we reached the maximum year, decrement dates by a year */
 	} else if (_cur_year == MAX_YEAR + 1) {

--- a/src/date_type.h
+++ b/src/date_type.h
@@ -84,6 +84,8 @@ static const Year MIN_YEAR = 0;
 
 /** The default starting year */
 static const Year DEF_START_YEAR = 1950;
+/** The default scoring end year */
+static const Year DEF_END_YEAR = ORIGINAL_END_YEAR - 1;
 
 /**
  * MAX_YEAR, nicely rounded value of the number of years that can

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1552,6 +1552,10 @@ STR_CONFIG_SETTING_NEWS_MESSAGES_FULL                           :Full
 STR_CONFIG_SETTING_COLOURED_NEWS_YEAR                           :Coloured news appears in: {STRING2}
 STR_CONFIG_SETTING_COLOURED_NEWS_YEAR_HELPTEXT                  :Year that the newspaper announcements get printed in colour. Before this year, it uses monochrome black/white
 STR_CONFIG_SETTING_STARTING_YEAR                                :Starting year: {STRING2}
+STR_CONFIG_SETTING_ENDING_YEAR                                  :Scoring end year: {STRING2}
+STR_CONFIG_SETTING_ENDING_YEAR_HELPTEXT                         :Year the game ends for scoring purposes. At the end of this year, the company's score is recorded and the high-score screen is displayed, but the players can continue playing after that.{}If this is before the starting year, the high-score screen is never displayed.
+STR_CONFIG_SETTING_ENDING_YEAR_VALUE                            :{NUM}
+STR_CONFIG_SETTING_ENDING_YEAR_ZERO                             :Never
 STR_CONFIG_SETTING_SMOOTH_ECONOMY                               :Enable smooth economy (more, smaller changes): {STRING2}
 STR_CONFIG_SETTING_SMOOTH_ECONOMY_HELPTEXT                      :When enabled, industry production changes more often, and in smaller steps. This setting has usually no effect, if industry types are provided by a NewGRF
 STR_CONFIG_SETTING_ALLOW_SHARES                                 :Allow buying shares from other companies: {STRING2}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -747,6 +747,15 @@ bool AfterLoadGame()
 		_settings_game.linkgraph.distribution_default = DT_MANUAL;
 	}
 
+	if (IsSavegameVersionBefore(SLV_105)) {
+		extern int32 _old_ending_year_slv_105; // in date.cpp
+		_settings_game.game_creation.ending_year = _old_ending_year_slv_105 - 1;
+	} else if (IsSavegameVersionBefore(SLV_ENDING_YEAR)) {
+		/* Ending year was a GUI setting before SLV_105, was removed in revision 683b65ee1 (svn r14755). */
+		/* This also converts scenarios, both when loading them into the editor, and when starting a new game. */
+		_settings_game.game_creation.ending_year = DEF_END_YEAR;
+	}
+
 	/* Load the sprites */
 	GfxLoadSprites();
 	LoadStringWidthTable();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -301,6 +301,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_SCRIPT_MEMLIMIT,                    ///< 215  PR#7516 Limit on AI/GS memory consumption.
 	SLV_MULTITILE_DOCKS,                    ///< 216  PR#7380 Multiple docks per station.
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
+	SLV_ENDING_YEAR,                        ///< 218  PR#7747 Configurable ending year.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1698,6 +1698,7 @@ static SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("economy.town_layout"));
 			genworld->Add(new SettingEntry("difficulty.industry_density"));
 			genworld->Add(new SettingEntry("gui.pause_on_newgame"));
+			genworld->Add(new SettingEntry("game_creation.ending_year"));
 		}
 
 		SettingsPage *environment = main->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -278,6 +278,7 @@ struct NetworkSettings {
 struct GameCreationSettings {
 	uint32 generation_seed;                  ///< noise seed for world generation
 	Year   starting_year;                    ///< starting date
+	Year   ending_year;                      ///< scoring end date
 	uint8  map_x;                            ///< X size of map
 	uint8  map_y;                            ///< Y size of map
 	byte   land_generator;                   ///< the landscape generator

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -47,6 +47,8 @@ static bool UpdateServerPassword(int32 p1);
 static bool UpdateRconPassword(int32 p1);
 static bool UpdateClientConfigValues(int32 p1);
 
+extern int32 _old_ending_year_slv_105;
+
 /* End - Callback Functions for the various settings */
 
 /* Some settings do not need to be synchronised when playing in multiplayer.
@@ -1402,9 +1404,30 @@ str      = STR_CONFIG_SETTING_STARTING_YEAR
 strval   = STR_JUST_INT
 cat      = SC_BASIC
 
-[SDT_NULL]
-length   = 4
+[SDTG_VAR]
+name     = ""old_ending_year_slv_105""
+var      = _old_ending_year_slv_105
+flags    = SLF_NOT_IN_CONFIG
+type     = SLE_INT32
 to       = SLV_105
+def      = DEF_END_YEAR
+min      = MIN_YEAR
+max      = MAX_YEAR
+
+[SDT_VAR]
+base     = GameSettings
+var      = game_creation.ending_year
+type     = SLE_INT32
+from     = SLV_ENDING_YEAR
+guiflags = SGF_0ISDISABLED
+def      = DEF_END_YEAR
+min      = MIN_YEAR
+max      = MAX_YEAR
+interval = 1
+str      = STR_CONFIG_SETTING_ENDING_YEAR
+strhelp  = STR_CONFIG_SETTING_ENDING_YEAR_HELPTEXT
+strval   = STR_CONFIG_SETTING_ENDING_YEAR_VALUE
+cat      = SC_ADVANCED
 
 [SDT_BOOL]
 base     = GameSettings


### PR DESCRIPTION
Adds two new settings:
- Game length, from 1 to 1000 years (50 year increments, defaults to 100), or zero for "fixed ending year"
- Scoring end year, default 2050

The new default with this change is new games will end 100 years after the starting date, old games loaded should keep the original ending year of 2050, and scenarios should not get a year stamped onto them until a game is started.

Known bug, which may not be a bug: Old scenarios get converted to original end year, instead of using the new setting.