### PR TITLE
Codechange: Use std::vector for industry tile layouts

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -647,6 +647,7 @@ public:
 		/* We do not need to protect ourselves against "Random Many Industries" in this mode */
 		const IndustrySpec *indsp = GetIndustrySpec(this->selected_type);
 		uint32 seed = InteractiveRandom();
+		uint32 layout_index = InteractiveRandomRange((uint32)indsp->layouts.size());
 
 		if (_game_mode == GM_EDITOR) {
 			/* Show error if no town exists at all */
@@ -660,14 +661,14 @@ public:
 			_generating_world = true;
 			_ignore_restrictions = true;
 
-			DoCommandP(tile, (InteractiveRandomRange(indsp->num_table) << 8) | this->selected_type, seed,
+			DoCommandP(tile, (layout_index << 8) | this->selected_type, seed,
 					CMD_BUILD_INDUSTRY | CMD_MSG(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY), &CcBuildIndustry);
 
 			cur_company.Restore();
 			_ignore_restrictions = false;
 			_generating_world = false;
 		} else {
-			success = DoCommandP(tile, (InteractiveRandomRange(indsp->num_table) << 8) | this->selected_type, seed, CMD_BUILD_INDUSTRY | CMD_MSG(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY));
+			success = DoCommandP(tile, (layout_index << 8) | this->selected_type, seed, CMD_BUILD_INDUSTRY | CMD_MSG(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY));
 		}
 
 		/* If an industry has been built, just reset the cursor and the system */

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -13,6 +13,7 @@
 #define INDUSTRYTYPE_H
 
 #include <array>
+#include <vector>
 #include "map_type.h"
 #include "slope_type.h"
 #include "industry_type.h"
@@ -23,7 +24,6 @@
 
 enum IndustryCleanupType {
 	CLEAN_RANDOMSOUNDS,    ///< Free the dynamically allocated sounds table
-	CLEAN_TILELAYOUT,      ///< Free the dynamically allocated tile layout structure
 };
 
 /** Available types of industry lifetimes. */
@@ -93,17 +93,20 @@ enum IndustryTileSpecialFlags {
 };
 DECLARE_ENUM_AS_BIT_SET(IndustryTileSpecialFlags)
 
-struct IndustryTileTable {
+/** Definition of one tile in an industry tile layout */
+struct IndustryTileLayoutTile {
 	TileIndexDiffC ti;
 	IndustryGfx gfx;
 };
+
+/** A complete tile layout for an industry is a list of tiles */
+using IndustryTileLayout = std::vector<IndustryTileLayoutTile>;
 
 /**
  * Defines the data structure for constructing industry.
  */
 struct IndustrySpec {
-	const IndustryTileTable * const *table;     ///< List of the tiles composing the industry
-	byte num_table;                             ///< Number of elements in the table
+	std::vector<IndustryTileLayout> layouts;    ///< List of possible tile layouts for the industry
 	uint8 cost_multiplier;                      ///< Base construction cost multiplier.
 	uint32 removal_cost_multiplier;             ///< Base removal cost multiplier.
 	uint32 prospecting_chance;                  ///< Chance prospecting succeeds
@@ -143,6 +146,8 @@ struct IndustrySpec {
 	Money GetConstructionCost() const;
 	Money GetRemovalCost() const;
 	bool UsesSmoothEconomy() const;
+
+	~IndustrySpec();
 };
 
 /**

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -279,7 +279,7 @@ void IndustryOverrideManager::SetEntitySpec(IndustrySpec *inds)
 	}
 
 	/* Now that we know we can use the given id, copy the spec to its final destination... */
-	memcpy(&_industry_specs[ind_id], inds, sizeof(*inds));
+	_industry_specs[ind_id] = *inds;
 	/* ... and mark it as usable*/
 	_industry_specs[ind_id].enabled = true;
 }

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -520,7 +520,7 @@ uint16 GetIndustryCallback(CallbackID callback, uint32 param1, uint32 param2, In
  * @param creation_type The circumstances the industry is created under.
  * @return Succeeded or failed command.
  */
-CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, uint layout, uint32 seed, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type)
+CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, size_t layout, uint32 seed, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type)
 {
 	const IndustrySpec *indspec = GetIndustrySpec(type);
 
@@ -529,7 +529,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, uin
 	ind.location.tile = tile;
 	ind.location.w = 0; // important to mark the industry invalid
 	ind.type = type;
-	ind.selected_layout = layout;
+	ind.selected_layout = (byte)layout;
 	ind.town = ClosestTownFromTile(tile, UINT_MAX);
 	ind.random = initial_random_bits;
 	ind.founder = founder;

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -89,7 +89,7 @@ enum IndustryAvailabilityCallType {
 uint16 GetIndustryCallback(CallbackID callback, uint32 param1, uint32 param2, Industry *industry, IndustryType type, TileIndex tile);
 uint32 GetIndustryIDAtOffset(TileIndex new_tile, const Industry *i, uint32 cur_grfid);
 void IndustryProductionCallback(Industry *ind, int reason);
-CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, uint layout, uint32 seed, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
+CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, size_t layout, uint32 seed, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
 uint32 GetIndustryProbabilityCallback(IndustryType type, IndustryAvailabilityCallType creation_type, uint32 default_prob);
 bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoID cargo_type);
 

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -212,13 +212,13 @@ extern bool IsSlopeRefused(Slope current, Slope refused);
  * @param its           Tile specification.
  * @param type          Industry type.
  * @param gfx           Gfx of the tile.
- * @param itspec_index  Layout.
+ * @param layout_index  Layout.
  * @param initial_random_bits Random bits of industry after construction
  * @param founder       Industry founder
  * @param creation_type The circumstances the industry is created under.
  * @return Succeeded or failed command.
  */
-CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, uint itspec_index, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type)
+CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, size_t layout_index, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type)
 {
 	Industry ind;
 	ind.index = INVALID_INDUSTRY;
@@ -228,7 +228,7 @@ CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind
 	ind.random = initial_random_bits;
 	ind.founder = founder;
 
-	uint16 callback_res = GetIndustryTileCallback(CBID_INDTILE_SHAPE_CHECK, 0, creation_type << 8 | itspec_index, gfx, &ind, ind_tile);
+	uint16 callback_res = GetIndustryTileCallback(CBID_INDTILE_SHAPE_CHECK, 0, creation_type << 8 | (uint32)layout_index, gfx, &ind, ind_tile);
 	if (callback_res == CALLBACK_FAILED) {
 		if (!IsSlopeRefused(GetTileSlope(ind_tile), its->slopes_refused)) return CommandCost();
 		return_cmd_error(STR_ERROR_SITE_UNSUITABLE);

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -57,7 +57,7 @@ struct IndustryTileResolverObject : public ResolverObject {
 
 bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const IndustryTileSpec *inds);
 uint16 GetIndustryTileCallback(CallbackID callback, uint32 param1, uint32 param2, IndustryGfx gfx_id, Industry *industry, TileIndex tile);
-CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, uint itspec_index, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
+CommandCost PerformIndustryTileSlopeCheck(TileIndex ind_base_tile, TileIndex ind_tile, const IndustryTileSpec *its, IndustryType type, IndustryGfx gfx, size_t layout_index, uint16 initial_random_bits, Owner founder, IndustryAvailabilityCallType creation_type);
 
 void AnimateNewIndustryTile(TileIndex tile);
 bool StartStopIndustryTileAnimation(TileIndex tile, IndustryAnimationTrigger iat, uint32 random = Random());

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -123,7 +123,8 @@
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
 	uint32 seed = ::InteractiveRandom();
-	return ScriptObject::DoCommand(tile, (1 << 16) | (::InteractiveRandomRange(::GetIndustrySpec(industry_type)->num_table) << 8) | industry_type, seed, CMD_BUILD_INDUSTRY);
+	uint32 layout_index = ::InteractiveRandomRange((uint32)::GetIndustrySpec(industry_type)->layouts.size());
+	return ScriptObject::DoCommand(tile, (1 << 16) | (layout_index << 8) | industry_type, seed, CMD_BUILD_INDUSTRY);
 }
 
 /* static */ bool ScriptIndustryType::ProspectIndustry(IndustryType industry_type)

--- a/src/table/build_industry.h
+++ b/src/table/build_industry.h
@@ -22,22 +22,16 @@
  */
 #define MK(x, y, m) {{x, y}, m}
 
-/**
- * Terminator of industry tiles layout definition
- */
-#define MKEND {{-0x80, 0}, 0}
-
-static const IndustryTileTable _tile_table_coal_mine_0[] = {
+static const IndustryTileLayout _tile_table_coal_mine_0 {
 	MK(1, 1, 0),
 	MK(1, 2, 2),
 	MK(0, 0, 5),
 	MK(1, 0, 6),
 	MK(2, 0, 3),
 	MK(2, 2, 3),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_coal_mine_1[] = {
+static const IndustryTileLayout _tile_table_coal_mine_1 {
 	MK(1, 1, 0),
 	MK(1, 2, 2),
 	MK(2, 0, 0),
@@ -47,20 +41,18 @@ static const IndustryTileTable _tile_table_coal_mine_1[] = {
 	MK(0, 1, 4),
 	MK(0, 2, 4),
 	MK(2, 2, 4),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_coal_mine_2[] = {
+static const IndustryTileLayout _tile_table_coal_mine_2 {
 	MK(0, 0, 0),
 	MK(0, 1, 2),
 	MK(0, 2, 5),
 	MK(1, 0, 3),
 	MK(1, 1, 3),
 	MK(1, 2, 6),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_coal_mine_3[] = {
+static const IndustryTileLayout _tile_table_coal_mine_3 {
 	MK(0, 1, 0),
 	MK(0, 2, 2),
 	MK(0, 3, 4),
@@ -71,17 +63,16 @@ static const IndustryTileTable _tile_table_coal_mine_3[] = {
 	MK(2, 0, 6),
 	MK(2, 1, 4),
 	MK(2, 2, 3),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_coal_mine[] = {
+static const std::vector<IndustryTileLayout> _tile_table_coal_mine {
 	_tile_table_coal_mine_0,
 	_tile_table_coal_mine_1,
 	_tile_table_coal_mine_2,
 	_tile_table_coal_mine_3,
 };
 
-static const IndustryTileTable _tile_table_power_station_0[] = {
+static const IndustryTileLayout _tile_table_power_station_0 {
 	MK(0, 0, 7),
 	MK(0, 1, 9),
 	MK(1, 0, 7),
@@ -90,10 +81,9 @@ static const IndustryTileTable _tile_table_power_station_0[] = {
 	MK(2, 1, 8),
 	MK(3, 0, 10),
 	MK(3, 1, 10),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_power_station_1[] = {
+static const IndustryTileLayout _tile_table_power_station_1 {
 	MK(0, 1, 7),
 	MK(0, 2, 7),
 	MK(1, 0, 8),
@@ -102,26 +92,24 @@ static const IndustryTileTable _tile_table_power_station_1[] = {
 	MK(2, 0, 9),
 	MK(2, 1, 10),
 	MK(2, 2, 9),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_power_station_2[] = {
+static const IndustryTileLayout _tile_table_power_station_2 {
 	MK(0, 0, 7),
 	MK(0, 1, 7),
 	MK(1, 0, 9),
 	MK(1, 1, 8),
 	MK(2, 0, 10),
 	MK(2, 1, 9),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_power_station[] = {
+static const std::vector<IndustryTileLayout> _tile_table_power_station {
 	_tile_table_power_station_0,
 	_tile_table_power_station_1,
 	_tile_table_power_station_2,
 };
 
-static const IndustryTileTable _tile_table_sawmill_0[] = {
+static const IndustryTileLayout _tile_table_sawmill_0 {
 	MK(1, 0, 14),
 	MK(1, 1, 12),
 	MK(1, 2, 11),
@@ -130,10 +118,9 @@ static const IndustryTileTable _tile_table_sawmill_0[] = {
 	MK(0, 0, 15),
 	MK(0, 1, 15),
 	MK(0, 2, 12),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_sawmill_1[] = {
+static const IndustryTileLayout _tile_table_sawmill_1 {
 	MK(0, 0, 15),
 	MK(0, 1, 11),
 	MK(0, 2, 14),
@@ -142,15 +129,14 @@ static const IndustryTileTable _tile_table_sawmill_1[] = {
 	MK(1, 2, 12),
 	MK(2, 0, 11),
 	MK(2, 1, 13),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_sawmill[] = {
+static const std::vector<IndustryTileLayout> _tile_table_sawmill {
 	_tile_table_sawmill_0,
 	_tile_table_sawmill_1,
 };
 
-static const IndustryTileTable _tile_table_forest_0[] = {
+static const IndustryTileLayout _tile_table_forest_0 {
 	MK(0, 0, 16),
 	MK(0, 1, 16),
 	MK(0, 2, 16),
@@ -169,10 +155,9 @@ static const IndustryTileTable _tile_table_forest_0[] = {
 	MK(3, 3, 16),
 	MK(1, 4, 16),
 	MK(2, 4, 16),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_forest_1[] = {
+static const IndustryTileLayout _tile_table_forest_1 {
 	MK(0, 0, 16),
 	MK(1, 0, 16),
 	MK(2, 0, 16),
@@ -196,15 +181,14 @@ static const IndustryTileTable _tile_table_forest_1[] = {
 	MK(1, 4, 16),
 	MK(2, 4, 16),
 	MK(3, 4, 16),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_forest[] = {
+static const std::vector<IndustryTileLayout> _tile_table_forest {
 	_tile_table_forest_0,
 	_tile_table_forest_1,
 };
 
-static const IndustryTileTable _tile_table_oil_refinery_0[] = {
+static const IndustryTileLayout _tile_table_oil_refinery_0 {
 	MK(0, 0, 20),
 	MK(0, 1, 21),
 	MK(0, 2, 22),
@@ -220,10 +204,9 @@ static const IndustryTileTable _tile_table_oil_refinery_0[] = {
 	MK(3, 3, 18),
 	MK(2, 0, 23),
 	MK(3, 1, 23),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_oil_refinery_1[] = {
+static const IndustryTileLayout _tile_table_oil_refinery_1 {
 	MK(0, 0, 18),
 	MK(0, 1, 18),
 	MK(0, 2, 21),
@@ -239,15 +222,14 @@ static const IndustryTileTable _tile_table_oil_refinery_1[] = {
 	MK(2, 3, 22),
 	MK(1, 4, 23),
 	MK(2, 4, 23),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_oil_refinery[] = {
+static const std::vector<IndustryTileLayout> _tile_table_oil_refinery {
 	_tile_table_oil_refinery_0,
 	_tile_table_oil_refinery_1,
 };
 
-static const IndustryTileTable _tile_table_oil_rig_0[] = {
+static const IndustryTileLayout _tile_table_oil_rig_0 {
 	MK(0, 0, 24),
 	MK(0, 1, 24),
 	MK(0, 2, 25),
@@ -306,14 +288,13 @@ static const IndustryTileTable _tile_table_oil_rig_0[] = {
 	MK(2, 3, 255),
 	MK(2, 2, 255),
 	MK(2, 1, 255),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_oil_rig[] = {
+static const std::vector<IndustryTileLayout> _tile_table_oil_rig {
 	_tile_table_oil_rig_0,
 };
 
-static const IndustryTileTable _tile_table_factory_0[] = {
+static const IndustryTileLayout _tile_table_factory_0 {
 	MK(0, 0, 39),
 	MK(0, 1, 40),
 	MK(1, 0, 41),
@@ -326,10 +307,9 @@ static const IndustryTileTable _tile_table_factory_0[] = {
 	MK(2, 2, 40),
 	MK(3, 1, 41),
 	MK(3, 2, 42),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_factory_1[] = {
+static const IndustryTileLayout _tile_table_factory_1 {
 	MK(0, 0, 39),
 	MK(0, 1, 40),
 	MK(1, 0, 41),
@@ -342,15 +322,14 @@ static const IndustryTileTable _tile_table_factory_1[] = {
 	MK(1, 3, 40),
 	MK(2, 2, 41),
 	MK(2, 3, 42),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_factory[] = {
+static const std::vector<IndustryTileLayout> _tile_table_factory {
 	_tile_table_factory_0,
 	_tile_table_factory_1,
 };
 
-static const IndustryTileTable _tile_table_printing_works_0[] = {
+static const IndustryTileLayout _tile_table_printing_works_0 {
 	MK(0, 0, 43),
 	MK(0, 1, 44),
 	MK(1, 0, 45),
@@ -363,10 +342,9 @@ static const IndustryTileTable _tile_table_printing_works_0[] = {
 	MK(2, 2, 44),
 	MK(3, 1, 45),
 	MK(3, 2, 46),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_printing_works_1[] = {
+static const IndustryTileLayout _tile_table_printing_works_1 {
 	MK(0, 0, 43),
 	MK(0, 1, 44),
 	MK(1, 0, 45),
@@ -379,15 +357,14 @@ static const IndustryTileTable _tile_table_printing_works_1[] = {
 	MK(1, 3, 44),
 	MK(2, 2, 45),
 	MK(2, 3, 46),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_printing_works[] = {
+static const std::vector<IndustryTileLayout> _tile_table_printing_works {
 	_tile_table_printing_works_0,
 	_tile_table_printing_works_1,
 };
 
-static const IndustryTileTable _tile_table_steel_mill_0[] = {
+static const IndustryTileLayout _tile_table_steel_mill_0 {
 	MK(2, 1, 52),
 	MK(2, 2, 53),
 	MK(3, 1, 54),
@@ -400,10 +377,9 @@ static const IndustryTileTable _tile_table_steel_mill_0[] = {
 	MK(1, 2, 57),
 	MK(2, 0, 56),
 	MK(3, 0, 57),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_steel_mill_1[] = {
+static const IndustryTileLayout _tile_table_steel_mill_1 {
 	MK(0, 0, 52),
 	MK(0, 1, 53),
 	MK(1, 0, 54),
@@ -418,15 +394,14 @@ static const IndustryTileTable _tile_table_steel_mill_1[] = {
 	MK(3, 2, 57),
 	MK(1, 3, 56),
 	MK(2, 3, 57),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_steel_mill[] = {
+static const std::vector<IndustryTileLayout> _tile_table_steel_mill {
 	_tile_table_steel_mill_0,
 	_tile_table_steel_mill_1,
 };
 
-static const IndustryTileTable _tile_table_farm_0[] = {
+static const IndustryTileLayout _tile_table_farm_0 {
 	MK(1, 0, 33),
 	MK(1, 1, 34),
 	MK(1, 2, 36),
@@ -436,10 +411,9 @@ static const IndustryTileTable _tile_table_farm_0[] = {
 	MK(2, 0, 35),
 	MK(2, 1, 38),
 	MK(2, 2, 38),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_farm_1[] = {
+static const IndustryTileLayout _tile_table_farm_1 {
 	MK(1, 1, 33),
 	MK(1, 2, 34),
 	MK(0, 0, 35),
@@ -452,10 +426,9 @@ static const IndustryTileTable _tile_table_farm_1[] = {
 	MK(2, 1, 37),
 	MK(2, 2, 38),
 	MK(2, 3, 38),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_farm_2[] = {
+static const IndustryTileLayout _tile_table_farm_2 {
 	MK(2, 0, 33),
 	MK(2, 1, 34),
 	MK(0, 0, 36),
@@ -468,16 +441,15 @@ static const IndustryTileTable _tile_table_farm_2[] = {
 	MK(1, 3, 37),
 	MK(2, 2, 37),
 	MK(2, 3, 35),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_farm[] = {
+static const std::vector<IndustryTileLayout> _tile_table_farm {
 	_tile_table_farm_0,
 	_tile_table_farm_1,
 	_tile_table_farm_2,
 };
 
-static const IndustryTileTable _tile_table_copper_mine_0[] = {
+static const IndustryTileLayout _tile_table_copper_mine_0 {
 	MK(0, 0, 47),
 	MK(0, 1, 49),
 	MK(0, 2, 51),
@@ -486,10 +458,9 @@ static const IndustryTileTable _tile_table_copper_mine_0[] = {
 	MK(1, 2, 50),
 	MK(2, 0, 51),
 	MK(2, 1, 51),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_copper_mine_1[] = {
+static const IndustryTileLayout _tile_table_copper_mine_1 {
 	MK(0, 0, 50),
 	MK(0, 1, 47),
 	MK(0, 2, 49),
@@ -499,48 +470,44 @@ static const IndustryTileTable _tile_table_copper_mine_1[] = {
 	MK(2, 0, 51),
 	MK(2, 1, 47),
 	MK(2, 2, 49),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_copper_mine[] = {
+static const std::vector<IndustryTileLayout> _tile_table_copper_mine {
 	_tile_table_copper_mine_0,
 	_tile_table_copper_mine_1,
 };
 
-static const IndustryTileTable _tile_table_oil_well_0[] = {
+static const IndustryTileLayout _tile_table_oil_well_0 {
 	MK(0, 0, 29),
 	MK(1, 0, 29),
 	MK(2, 0, 29),
 	MK(0, 1, 29),
 	MK(0, 2, 29),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_oil_well_1[] = {
+static const IndustryTileLayout _tile_table_oil_well_1 {
 	MK(0, 0, 29),
 	MK(1, 0, 29),
 	MK(1, 1, 29),
 	MK(2, 2, 29),
 	MK(2, 3, 29),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_oil_well[] = {
+static const std::vector<IndustryTileLayout> _tile_table_oil_well {
 	_tile_table_oil_well_0,
 	_tile_table_oil_well_1,
 };
 
-static const IndustryTileTable _tile_table_bank_0[] = {
+static const IndustryTileLayout _tile_table_bank_0 {
 	MK(0, 0, 58),
 	MK(1, 0, 59),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_bank[] = {
+static const std::vector<IndustryTileLayout> _tile_table_bank {
 	_tile_table_bank_0,
 };
 
-static const IndustryTileTable _tile_table_food_process_0[] = {
+static const IndustryTileLayout _tile_table_food_process_0 {
 	MK(0, 0, 60),
 	MK(1, 0, 60),
 	MK(2, 0, 60),
@@ -553,10 +520,9 @@ static const IndustryTileTable _tile_table_food_process_0[] = {
 	MK(0, 3, 62),
 	MK(1, 3, 62),
 	MK(2, 3, 63),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_food_process_1[] = {
+static const IndustryTileLayout _tile_table_food_process_1 {
 	MK(0, 0, 61),
 	MK(1, 0, 60),
 	MK(2, 0, 61),
@@ -571,15 +537,14 @@ static const IndustryTileTable _tile_table_food_process_1[] = {
 	MK(3, 2, 60),
 	MK(0, 3, 62),
 	MK(1, 3, 62),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_food_process[] = {
+static const std::vector<IndustryTileLayout> _tile_table_food_process {
 	_tile_table_food_process_0,
 	_tile_table_food_process_1,
 };
 
-static const IndustryTileTable _tile_table_paper_mill_0[] = {
+static const IndustryTileLayout _tile_table_paper_mill_0 {
 	MK(0, 0, 64),
 	MK(1, 0, 65),
 	MK(2, 0, 66),
@@ -592,14 +557,13 @@ static const IndustryTileTable _tile_table_paper_mill_0[] = {
 	MK(1, 2, 71),
 	MK(2, 2, 71),
 	MK(3, 2, 70),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_paper_mill[] = {
+static const std::vector<IndustryTileLayout> _tile_table_paper_mill {
 	_tile_table_paper_mill_0,
 };
 
-static const IndustryTileTable _tile_table_gold_mine_0[] = {
+static const IndustryTileLayout _tile_table_gold_mine_0 {
 	MK(0, 0, 72),
 	MK(0, 1, 73),
 	MK(0, 2, 74),
@@ -616,24 +580,22 @@ static const IndustryTileTable _tile_table_gold_mine_0[] = {
 	MK(3, 1, 85),
 	MK(3, 2, 86),
 	MK(3, 3, 87),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_gold_mine[] = {
+static const std::vector<IndustryTileLayout> _tile_table_gold_mine {
 	_tile_table_gold_mine_0,
 };
 
-static const IndustryTileTable _tile_table_bank2_0[] = {
+static const IndustryTileLayout _tile_table_bank2_0 {
 	MK(0, 0, 89),
 	MK(1, 0, 90),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_bank2[] = {
+static const std::vector<IndustryTileLayout> _tile_table_bank2 {
 	_tile_table_bank2_0,
 };
 
-static const IndustryTileTable _tile_table_diamond_mine_0[] = {
+static const IndustryTileLayout _tile_table_diamond_mine_0 {
 	MK(0, 0, 91),
 	MK(0, 1, 92),
 	MK(0, 2, 93),
@@ -643,14 +605,13 @@ static const IndustryTileTable _tile_table_diamond_mine_0[] = {
 	MK(2, 0, 97),
 	MK(2, 1, 98),
 	MK(2, 2, 99),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_diamond_mine[] = {
+static const std::vector<IndustryTileLayout> _tile_table_diamond_mine {
 	_tile_table_diamond_mine_0,
 };
 
-static const IndustryTileTable _tile_table_iron_mine_0[] = {
+static const IndustryTileLayout _tile_table_iron_mine_0 {
 	MK(0, 0, 100),
 	MK(0, 1, 101),
 	MK(0, 2, 102),
@@ -667,14 +628,13 @@ static const IndustryTileTable _tile_table_iron_mine_0[] = {
 	MK(3, 1, 113),
 	MK(3, 2, 114),
 	MK(3, 3, 115),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_iron_mine[] = {
+static const std::vector<IndustryTileLayout> _tile_table_iron_mine {
 	_tile_table_iron_mine_0,
 };
 
-static const IndustryTileTable _tile_table_fruit_plantation_0[] = {
+static const IndustryTileLayout _tile_table_fruit_plantation_0 {
 	MK(0, 0, 116),
 	MK(0, 1, 116),
 	MK(0, 2, 116),
@@ -695,14 +655,13 @@ static const IndustryTileTable _tile_table_fruit_plantation_0[] = {
 	MK(4, 1, 116),
 	MK(4, 2, 116),
 	MK(4, 3, 116),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_fruit_plantation[] = {
+static const std::vector<IndustryTileLayout> _tile_table_fruit_plantation {
 	_tile_table_fruit_plantation_0,
 };
 
-static const IndustryTileTable _tile_table_rubber_plantation_0[] = {
+static const IndustryTileLayout _tile_table_rubber_plantation_0 {
 	MK(0, 0, 117),
 	MK(0, 1, 117),
 	MK(0, 2, 117),
@@ -723,35 +682,32 @@ static const IndustryTileTable _tile_table_rubber_plantation_0[] = {
 	MK(4, 1, 117),
 	MK(4, 2, 117),
 	MK(4, 3, 117),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_rubber_plantation[] = {
+static const std::vector<IndustryTileLayout> _tile_table_rubber_plantation {
 	_tile_table_rubber_plantation_0,
 };
 
-static const IndustryTileTable _tile_table_water_supply_0[] = {
+static const IndustryTileLayout _tile_table_water_supply_0 {
 	MK(0, 0, 118),
 	MK(0, 1, 119),
 	MK(1, 0, 118),
 	MK(1, 1, 119),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_water_supply[] = {
+static const std::vector<IndustryTileLayout> _tile_table_water_supply {
 	_tile_table_water_supply_0,
 };
 
-static const IndustryTileTable _tile_table_water_tower_0[] = {
+static const IndustryTileLayout _tile_table_water_tower_0 {
 	MK(0, 0, 120),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_water_tower[] = {
+static const std::vector<IndustryTileLayout> _tile_table_water_tower {
 	_tile_table_water_tower_0,
 };
 
-static const IndustryTileTable _tile_table_factory2_0[] = {
+static const IndustryTileLayout _tile_table_factory2_0 {
 	MK(0, 0, 121),
 	MK(0, 1, 122),
 	MK(1, 0, 123),
@@ -760,10 +716,9 @@ static const IndustryTileTable _tile_table_factory2_0[] = {
 	MK(0, 3, 122),
 	MK(1, 2, 123),
 	MK(1, 3, 124),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_factory2_1[] = {
+static const IndustryTileLayout _tile_table_factory2_1 {
 	MK(0, 0, 121),
 	MK(0, 1, 122),
 	MK(1, 0, 123),
@@ -772,15 +727,14 @@ static const IndustryTileTable _tile_table_factory2_1[] = {
 	MK(2, 1, 122),
 	MK(3, 0, 123),
 	MK(3, 1, 124),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_factory2[] = {
+static const std::vector<IndustryTileLayout> _tile_table_factory2 {
 	_tile_table_factory2_0,
 	_tile_table_factory2_1,
 };
 
-static const IndustryTileTable _tile_table_farm2_0[] = {
+static const IndustryTileLayout _tile_table_farm2_0 {
 	MK(1, 0, 33),
 	MK(1, 1, 34),
 	MK(1, 2, 36),
@@ -790,10 +744,9 @@ static const IndustryTileTable _tile_table_farm2_0[] = {
 	MK(2, 0, 35),
 	MK(2, 1, 38),
 	MK(2, 2, 38),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_farm2_1[] = {
+static const IndustryTileLayout _tile_table_farm2_1 {
 	MK(1, 1, 33),
 	MK(1, 2, 34),
 	MK(0, 0, 35),
@@ -806,10 +759,9 @@ static const IndustryTileTable _tile_table_farm2_1[] = {
 	MK(2, 1, 37),
 	MK(2, 2, 38),
 	MK(2, 3, 38),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_farm2_2[] = {
+static const IndustryTileLayout _tile_table_farm2_2 {
 	MK(2, 0, 33),
 	MK(2, 1, 34),
 	MK(0, 0, 36),
@@ -822,28 +774,26 @@ static const IndustryTileTable _tile_table_farm2_2[] = {
 	MK(1, 3, 37),
 	MK(2, 2, 37),
 	MK(2, 3, 35),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_farm2[] = {
+static const std::vector<IndustryTileLayout> _tile_table_farm2 {
 	_tile_table_farm2_0,
 	_tile_table_farm2_1,
 	_tile_table_farm2_2,
 };
 
-static const IndustryTileTable _tile_table_lumber_mill_0[] = {
+static const IndustryTileLayout _tile_table_lumber_mill_0 {
 	MK(0, 0, 125),
 	MK(0, 1, 126),
 	MK(1, 0, 127),
 	MK(1, 1, 128),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_lumber_mill[] = {
+static const std::vector<IndustryTileLayout> _tile_table_lumber_mill {
 	_tile_table_lumber_mill_0,
 };
 
-static const IndustryTileTable _tile_table_cotton_candy_0[] = {
+static const IndustryTileLayout _tile_table_cotton_candy_0 {
 	MK(0, 0, 129),
 	MK(0, 1, 129),
 	MK(0, 2, 129),
@@ -862,10 +812,9 @@ static const IndustryTileTable _tile_table_cotton_candy_0[] = {
 	MK(3, 3, 129),
 	MK(1, 4, 129),
 	MK(2, 4, 129),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_cotton_candy_1[] = {
+static const IndustryTileLayout _tile_table_cotton_candy_1 {
 	MK(0, 0, 129),
 	MK(1, 0, 129),
 	MK(2, 0, 129),
@@ -889,15 +838,14 @@ static const IndustryTileTable _tile_table_cotton_candy_1[] = {
 	MK(1, 4, 129),
 	MK(2, 4, 129),
 	MK(3, 4, 129),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_cotton_candy[] = {
+static const std::vector<IndustryTileLayout> _tile_table_cotton_candy {
 	_tile_table_cotton_candy_0,
 	_tile_table_cotton_candy_1,
 };
 
-static const IndustryTileTable _tile_table_candy_factory_0[] = {
+static const IndustryTileLayout _tile_table_candy_factory_0 {
 	MK(0, 0, 131),
 	MK(0, 1, 132),
 	MK(1, 0, 133),
@@ -910,10 +858,9 @@ static const IndustryTileTable _tile_table_candy_factory_0[] = {
 	MK(2, 2, 132),
 	MK(3, 1, 133),
 	MK(3, 2, 134),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_candy_factory_1[] = {
+static const IndustryTileLayout _tile_table_candy_factory_1 {
 	MK(0, 0, 131),
 	MK(0, 1, 132),
 	MK(1, 0, 133),
@@ -926,15 +873,14 @@ static const IndustryTileTable _tile_table_candy_factory_1[] = {
 	MK(1, 3, 132),
 	MK(2, 2, 133),
 	MK(2, 3, 134),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_candy_factory[] = {
+static const std::vector<IndustryTileLayout> _tile_table_candy_factory {
 	_tile_table_candy_factory_0,
 	_tile_table_candy_factory_1,
 };
 
-static const IndustryTileTable _tile_table_battery_farm_0[] = {
+static const IndustryTileLayout _tile_table_battery_farm_0 {
 	MK(0, 0, 135),
 	MK(0, 1, 135),
 	MK(0, 2, 135),
@@ -955,14 +901,13 @@ static const IndustryTileTable _tile_table_battery_farm_0[] = {
 	MK(4, 1, 135),
 	MK(4, 2, 135),
 	MK(4, 3, 135),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_battery_farm[] = {
+static const std::vector<IndustryTileLayout> _tile_table_battery_farm {
 	_tile_table_battery_farm_0,
 };
 
-static const IndustryTileTable _tile_table_cola_wells_0[] = {
+static const IndustryTileLayout _tile_table_cola_wells_0 {
 	MK(0, 0, 137),
 	MK(0, 1, 137),
 	MK(0, 2, 137),
@@ -971,10 +916,9 @@ static const IndustryTileTable _tile_table_cola_wells_0[] = {
 	MK(1, 2, 137),
 	MK(2, 1, 137),
 	MK(2, 2, 137),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_cola_wells_1[] = {
+static const IndustryTileLayout _tile_table_cola_wells_1 {
 	MK(0, 1, 137),
 	MK(0, 2, 137),
 	MK(0, 3, 137),
@@ -982,27 +926,25 @@ static const IndustryTileTable _tile_table_cola_wells_1[] = {
 	MK(1, 1, 137),
 	MK(1, 2, 137),
 	MK(2, 1, 137),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_cola_wells[] = {
+static const std::vector<IndustryTileLayout> _tile_table_cola_wells {
 	_tile_table_cola_wells_0,
 	_tile_table_cola_wells_1,
 };
 
-static const IndustryTileTable _tile_table_toy_shop_0[] = {
+static const IndustryTileLayout _tile_table_toy_shop_0 {
 	MK(0, 0, 138),
 	MK(0, 1, 139),
 	MK(1, 0, 140),
 	MK(1, 1, 141),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_toy_shop[] = {
+static const std::vector<IndustryTileLayout> _tile_table_toy_shop {
 	_tile_table_toy_shop_0,
 };
 
-static const IndustryTileTable _tile_table_toy_factory_0[] = {
+static const IndustryTileLayout _tile_table_toy_factory_0 {
 	MK(0, 0, 147),
 	MK(0, 1, 142),
 	MK(1, 0, 147),
@@ -1011,45 +953,41 @@ static const IndustryTileTable _tile_table_toy_factory_0[] = {
 	MK(2, 1, 144),
 	MK(3, 0, 146),
 	MK(3, 1, 145),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_toy_factory[] = {
+static const std::vector<IndustryTileLayout> _tile_table_toy_factory {
 	_tile_table_toy_factory_0,
 };
 
-static const IndustryTileTable _tile_table_plastic_fountain_0[] = {
+static const IndustryTileLayout _tile_table_plastic_fountain_0 {
 	MK(0, 0, 148),
 	MK(0, 1, 151),
 	MK(0, 2, 154),
-	MKEND
 };
 
-static const IndustryTileTable _tile_table_plastic_fountain_1[] = {
+static const IndustryTileLayout _tile_table_plastic_fountain_1 {
 	MK(0, 0, 148),
 	MK(1, 0, 151),
 	MK(2, 0, 154),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_plastic_fountain[] = {
+static const std::vector<IndustryTileLayout> _tile_table_plastic_fountain {
 	_tile_table_plastic_fountain_0,
 	_tile_table_plastic_fountain_1,
 };
 
-static const IndustryTileTable _tile_table_fizzy_drink_0[] = {
+static const IndustryTileLayout _tile_table_fizzy_drink_0 {
 	MK(0, 0, 156),
 	MK(0, 1, 157),
 	MK(1, 0, 158),
 	MK(1, 1, 159),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_fizzy_drink[] = {
+static const std::vector<IndustryTileLayout> _tile_table_fizzy_drink {
 	_tile_table_fizzy_drink_0,
 };
 
-static const IndustryTileTable _tile_table_bubble_generator_0[] = {
+static const IndustryTileLayout _tile_table_bubble_generator_0 {
 	MK(0, 0, 163),
 	MK(0, 1, 160),
 	MK(1, 0, 163),
@@ -1062,25 +1000,23 @@ static const IndustryTileTable _tile_table_bubble_generator_0[] = {
 	MK(1, 3, 161),
 	MK(2, 2, 163),
 	MK(2, 3, 162),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_bubble_generator[] = {
+static const std::vector<IndustryTileLayout> _tile_table_bubble_generator {
 	_tile_table_bubble_generator_0,
 };
 
-static const IndustryTileTable _tile_table_toffee_quarry_0[] = {
+static const IndustryTileLayout _tile_table_toffee_quarry_0 {
 	MK(0, 0, 164),
 	MK(1, 0, 165),
 	MK(2, 0, 166),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_toffee_quarry[] = {
+static const std::vector<IndustryTileLayout> _tile_table_toffee_quarry {
 	_tile_table_toffee_quarry_0,
 };
 
-static const IndustryTileTable _tile_table_sugar_mine_0[] = {
+static const IndustryTileLayout _tile_table_sugar_mine_0 {
 	MK(0, 0, 167),
 	MK(0, 1, 168),
 	MK(1, 0, 169),
@@ -1089,15 +1025,13 @@ static const IndustryTileTable _tile_table_sugar_mine_0[] = {
 	MK(2, 1, 172),
 	MK(3, 0, 173),
 	MK(3, 1, 174),
-	MKEND
 };
 
-static const IndustryTileTable * const _tile_table_sugar_mine[] = {
+static const std::vector<IndustryTileLayout> _tile_table_sugar_mine {
 	_tile_table_sugar_mine_0,
 };
 
 #undef MK
-#undef MKEND
 
 /** Array with saw sound, for sawmill */
 static const uint8 _sawmill_sounds[] = { SND_28_SAWMILL };
@@ -1195,7 +1129,7 @@ enum IndustryTypes {
 
 #define MI(tbl, sndc, snd, d, pc, ai1, ai2, ai3, ai4, ag1, ag2, ag3, ag4, col, \
 			c1, c2, c3, proc, p1, r1, p2, r2, m, a1, im1, a2, im2, a3, im3, pr, clim, bev, in, intx, s1, s2, s3) \
-		{tbl, lengthof(tbl), d, 0, pc, {c1, c2, c3}, proc, \
+		{tbl, d, 0, pc, {c1, c2, c3}, proc, \
 		{p1, p2, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID}, \
 		{r1, r2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, m, \
 		{a1, a2, a3, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID, CT_INVALID}, \


### PR DESCRIPTION
This is secretly preparation for implementing [procedural industry layouts](https://wiki.openttd.org/User:Nielsmh/Industry_procedural_layouts), as you can tell by the branch name.

Tested working with default industries, FIRS 2, FIRS 3, SPI 1.32, and several ECS vectors.