### PR TITLE
Fix: Fix build and link using Cygwin and Mingw32 for Windows 7 x64

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1562,7 +1562,7 @@ make_cflags_and_ldflags() {
 				LDFLAGS="$LDFLAGS -Wl,--subsystem,windows"
 			fi
 
-			LIBS="$LIBS -lws2_32 -lwinmm -lgdi32 -ldxguid -lole32 -limm32"
+			LIBS="$LIBS -lws2_32 -lwinmm -lusp10 -lgdi32 -ldxguid -lole32 -limm32"
 
 			if [ $cc_version -ge 404 ]; then
 				LDFLAGS_BUILD="$LDFLAGS_BUILD -static-libgcc -static-libstdc++"

--- a/src/depend/depend.cpp
+++ b/src/depend/depend.cpp
@@ -107,6 +107,23 @@ static char *strecat(char *dst, const char *src, const char *last)
 	return strecpy(dst, src, last);
 }
 
+#if defined(__CYGWIN__)
+/**
+ * Version of strdup copied from glibc.
+ * Duplicate S, returning an identical malloc'd string.
+ * @param s The string to duplicate.
+ */
+char *
+strdup (const char *s)
+{
+	size_t len = strlen(s) + 1;
+	void *n = malloc(len);
+
+	if (n == NULL) return NULL;
+	return (char *) memcpy(n, s, len);
+}
+#endif
+
 /**
  * Version of the standard free that accepts const pointers.
  * @param ptr The data to free.

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -31,6 +31,11 @@
 /* Windows has some different names for some types */
 typedef unsigned long in_addr_t;
 
+/* Handle cross-compilation with --build=*-*-cygwin --host=*-*-mingw32 */
+#if defined(__MINGW32__) && !defined(AI_ADDRCONFIG)
+#	define AI_ADDRCONFIG               0x00000400
+#endif
+
 #if !(defined(__MINGW32__) || defined(__CYGWIN__))
 	/* Windows has some different names for some types */
 	typedef SSIZE_T ssize_t;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -21,7 +21,10 @@
 	#include <unistd.h>
 	#define _GNU_SOURCE
 	#define TROUBLED_INTS
-	#include <strings.h>
+#endif
+
+#if defined(__HAIKU__) || defined(__CYGWIN__)
+#	include <strings.h> /* strncasecmp */
 #endif
 
 /* It seems that we need to include stdint.h before anything else
@@ -98,7 +101,7 @@
 	#define strcasecmp stricmp
 #endif
 
-#if defined(SUNOS) || defined(HPUX)
+#if defined(SUNOS) || defined(HPUX) || defined(__CYGWIN__)
 	#include <alloca.h>
 #endif
 
@@ -137,7 +140,7 @@
 	#include <malloc.h>
 #endif /* __WATCOMC__ */
 
-#if defined(__MINGW32__) || defined(__CYGWIN__)
+#if defined(__MINGW32__)
 	#include <malloc.h> // alloca()
 #endif
 
@@ -305,7 +308,7 @@
 typedef unsigned char byte;
 
 /* This is already defined in unix, but not in QNX Neutrino (6.x)*/
-#if (!defined(UNIX) && !defined(__CYGWIN__) && !defined(__HAIKU__)) || defined(__QNXNTO__)
+#if (!defined(UNIX) && !defined(__HAIKU__)) || defined(__QNXNTO__)
 	typedef unsigned int uint;
 #endif
 


### PR DESCRIPTION
I have a local Cygwin environment which I've been attempting to use to compile OpenTTD using the Mingw32 toolchain that you can install via the cygwin installer.

With all of the necessary components installed via the mingw32 variations (including lzma, which was hiding in the `mingw64-x86_64-xz` package), I configure and build like so:

```
MINGW32_BASEPATH=/usr/x86_64-w64-mingw32/sys-root/mingw
./configure --host=x86_64-w64-mingw32 --prefix=/usr/local/ \
            --with-lzo2=$MINGW32_BASEPATH/lib/liblzo2.a \
            PKG_CONFIG_LIBDIR="$MINGW32_BASEPATH/lib/pkgconfig"
make -j`nproc`
```

(To launch successfully I had to create a bundle and launch it from the bundle directory, `make install` doesn't work... but that's minor)

This series of commits fix the build issues and a startup DLL error with gdi32 which prevented compile and launch of OpenTTD on my Windows 7 x64 environment. For more details, see the individual commit messages.