### PR TITLE
Add: UDP query of game script

### DIFF
--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -311,6 +311,8 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet *p, NetworkAddress *client_
 		case PACKET_UDP_SERVER_UNREGISTER:    this->Receive_SERVER_UNREGISTER(p, client_addr);    break;
 		case PACKET_UDP_CLIENT_GET_NEWGRFS:   this->Receive_CLIENT_GET_NEWGRFS(p, client_addr);   break;
 		case PACKET_UDP_SERVER_NEWGRFS:       this->Receive_SERVER_NEWGRFS(p, client_addr);       break;
+		case PACKET_UDP_CLIENT_GET_GAMESCRIPT: this->Receive_CLIENT_GET_GAMESCRIPT(p, client_addr); break;
+		case PACKET_UDP_SERVER_GAMESCRIPT:    this->Receive_SERVER_GAMESCRIPT(p, client_addr);    break;
 		case PACKET_UDP_MASTER_SESSION_KEY:   this->Receive_MASTER_SESSION_KEY(p, client_addr);   break;
 
 		default:
@@ -344,4 +346,6 @@ void NetworkUDPSocketHandler::Receive_MASTER_RESPONSE_LIST(Packet *p, NetworkAdd
 void NetworkUDPSocketHandler::Receive_SERVER_UNREGISTER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_UNREGISTER, client_addr); }
 void NetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_GET_NEWGRFS, client_addr); }
 void NetworkUDPSocketHandler::Receive_SERVER_NEWGRFS(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_NEWGRFS, client_addr); }
+void NetworkUDPSocketHandler::Receive_CLIENT_GET_GAMESCRIPT(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_GET_GAMESCRIPT, client_addr); }
+void NetworkUDPSocketHandler::Receive_SERVER_GAMESCRIPT(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_GAMESCRIPT , client_addr); }
 void NetworkUDPSocketHandler::Receive_MASTER_SESSION_KEY(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_MASTER_SESSION_KEY, client_addr); }

--- a/src/network/core/udp.h
+++ b/src/network/core/udp.h
@@ -32,6 +32,8 @@ enum PacketUDPType {
 	PACKET_UDP_CLIENT_GET_NEWGRFS,   ///< Requests the name for a list of GRFs (GRF_ID and MD5)
 	PACKET_UDP_SERVER_NEWGRFS,       ///< Sends the list of NewGRF's requested.
 	PACKET_UDP_MASTER_SESSION_KEY,   ///< Sends a fresh session key to the client
+	PACKET_UDP_CLIENT_GET_GAMESCRIPT,///< Requests the name of a game script
+	PACKET_UDP_SERVER_GAMESCRIPT,    ///< Sends the gamescript info
 	PACKET_UDP_END,                  ///< Must ALWAYS be on the end of this list!! (period)
 };
 
@@ -209,6 +211,24 @@ protected:
 	 * @param client_addr The origin of the packet.
 	 */
 	virtual void Receive_SERVER_NEWGRFS(Packet *p, NetworkAddress *client_addr);
+
+	/**
+	 * The client requests information about GameScript.
+	 * @param p           The received packet.
+	 * @param client_addr The origin of the packet.
+	 */
+	virtual void Receive_CLIENT_GET_GAMESCRIPT(Packet *p, NetworkAddress *client_addr);
+
+	/**
+	 * The server returns information about gamescript.
+	 * uint8      Numer of GameScripts (0 or 1).
+	 * uint32     Version of GameScript
+	 * string     Short name of GameScript (4 bytes)
+	 * string     The name of the GameScript.
+	 * @param p           The received packet.
+	 * @param client_addr The origin of the packet.
+	 */
+	virtual void Receive_SERVER_GAMESCRIPT(Packet *p, NetworkAddress *client_addr);
 
 	/**
 	 * The master server sends us a session key.


### PR DESCRIPTION
Reopened from old flyspray issue #6211.

Patch adds a possibility to query OpenTTD server for running game scripts and returns its name and version if any present.

Goal of this fork is to also create ingame interface.