### PR TITLE
Feature: Configure minimum share trading years

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -2030,7 +2030,7 @@ CommandCost CmdBuyShareInCompany(TileIndex tile, DoCommandFlag flags, uint32 p1,
 	if (c == nullptr || !_settings_game.economy.allow_shares || _current_company == target_company) return CMD_ERROR;
 
 	/* Protect new companies from hostile takeovers */
-	if (_cur_year - c->inaugurated_year < 6) return_cmd_error(STR_ERROR_PROTECTED);
+	if (_cur_year - c->inaugurated_year < _settings_game.economy.min_years_for_shares) return_cmd_error(STR_ERROR_PROTECTED);
 
 	/* Those lines are here for network-protection (clients can be slow) */
 	if (GetAmountOwnedBy(c, COMPANY_SPECTATOR) == 0) return cost;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1556,6 +1556,8 @@ STR_CONFIG_SETTING_SMOOTH_ECONOMY                               :Enable smooth e
 STR_CONFIG_SETTING_SMOOTH_ECONOMY_HELPTEXT                      :When enabled, industry production changes more often, and in smaller steps. This setting has usually no effect, if industry types are provided by a NewGRF
 STR_CONFIG_SETTING_ALLOW_SHARES                                 :Allow buying shares from other companies: {STRING2}
 STR_CONFIG_SETTING_ALLOW_SHARES_HELPTEXT                        :When enabled, allow buying and selling of company shares. Shares will only be available for companies reaching a certain age
+STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES                         :Minimum company age to trade shares: {STRING2}
+STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_HELPTEXT                :Set the minimum age of a company for others to be able to buy and sell shares from them.
 STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE                         :Percentage of leg profit to pay in feeder systems: {STRING2}
 STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE_HELPTEXT                :Percentage of income given to the intermediate legs in feeder systems, giving more control over the income
 STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY                         :When dragging, place signals every: {STRING2}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -302,6 +302,7 @@ enum SaveLoadVersion : uint16 {
 
 	SLV_SCRIPT_MEMLIMIT,                    ///< 215  PR#7516 Limit on AI/GS memory consumption.
 	SLV_MULTITILE_DOCKS,                    ///< 216  PR#7380 Multiple docks per station.
+	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1768,6 +1768,7 @@ static SettingsContainer &GetSettingsTree()
 
 			ai->Add(new SettingEntry("economy.give_money"));
 			ai->Add(new SettingEntry("economy.allow_shares"));
+			ai->Add(new SettingEntry("economy.min_years_for_shares"));
 		}
 
 		main->Init();

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -472,6 +472,7 @@ struct EconomySettings {
 	bool   bribe;                            ///< enable bribing the local authority
 	bool   smooth_economy;                   ///< smooth economy
 	bool   allow_shares;                     ///< allow the buying/selling of shares
+	uint8  min_years_for_shares;             ///< minimum age of a company for it to trade shares
 	uint8  feeder_payment_share;             ///< percentage of leg payment to virtually pay in feeder systems
 	byte   dist_local_authority;             ///< distance for town local authority, default 20
 	bool   exclusive_rights;                 ///< allow buying exclusive rights

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1428,6 +1428,7 @@ proc     = InvalidateCompanyWindow
 base     = GameSettings
 var      = economy.min_years_for_shares
 type     = SLE_UINT8
+from     = SLV_TRADING_AGE
 def      = 6
 min      = 0
 max      = 255

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1426,6 +1426,19 @@ proc     = InvalidateCompanyWindow
 
 [SDT_VAR]
 base     = GameSettings
+var      = economy.min_years_for_shares
+type     = SLE_UINT8
+def      = 6
+min      = 0
+max      = 255
+interval = 1
+str      = STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES
+strhelp  = STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_HELPTEXT
+strval   = STR_JUST_INT
+cat      = SC_EXPERT
+
+[SDT_VAR]
+base     = GameSettings
 var      = economy.feeder_payment_share
 type     = SLE_UINT8
 from     = SLV_134


### PR DESCRIPTION
Currently a company must be at least 6 years old to be able to trade shares. This is a hardcoded value.
This pull request changes that hardcoded value to a configurable uint8. It is set as an expert setting and defaults to 6.