### PR TITLE
GS method to control engine availability for a specific company

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -107,6 +107,7 @@ CommandProc CmdIncreaseLoan;
 CommandProc CmdDecreaseLoan;
 
 CommandProc CmdWantEnginePreview;
+CommandProc CmdEnableEngine;
 
 CommandProc CmdRenameVehicle;
 CommandProc CmdRenameEngine;
@@ -271,6 +272,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdDecreaseLoan,                                   0, CMDT_MONEY_MANAGEMENT      ), // CMD_DECREASE_LOAN
 
 	DEF_CMD(CmdWantEnginePreview,                              0, CMDT_VEHICLE_MANAGEMENT    ), // CMD_WANT_ENGINE_PREVIEW
+	DEF_CMD(CmdEnableEngine,                           CMD_DEITY, CMDT_VEHICLE_MANAGEMENT    ), // CMD_ENABLE_ENGINE
 
 	DEF_CMD(CmdRenameVehicle,                                  0, CMDT_OTHER_MANAGEMENT      ), // CMD_RENAME_VEHICLE
 	DEF_CMD(CmdRenameEngine,                          CMD_SERVER, CMDT_OTHER_MANAGEMENT      ), // CMD_RENAME_ENGINE

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -107,7 +107,7 @@ CommandProc CmdIncreaseLoan;
 CommandProc CmdDecreaseLoan;
 
 CommandProc CmdWantEnginePreview;
-CommandProc CmdEnableEngine;
+CommandProc CmdEngineCtrl;
 
 CommandProc CmdRenameVehicle;
 CommandProc CmdRenameEngine;
@@ -272,7 +272,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdDecreaseLoan,                                   0, CMDT_MONEY_MANAGEMENT      ), // CMD_DECREASE_LOAN
 
 	DEF_CMD(CmdWantEnginePreview,                              0, CMDT_VEHICLE_MANAGEMENT    ), // CMD_WANT_ENGINE_PREVIEW
-	DEF_CMD(CmdEnableEngine,                           CMD_DEITY, CMDT_VEHICLE_MANAGEMENT    ), // CMD_ENABLE_ENGINE
+	DEF_CMD(CmdEngineCtrl,                             CMD_DEITY, CMDT_VEHICLE_MANAGEMENT    ), // CMD_ENGINE_CTRL
 
 	DEF_CMD(CmdRenameVehicle,                                  0, CMDT_OTHER_MANAGEMENT      ), // CMD_RENAME_VEHICLE
 	DEF_CMD(CmdRenameEngine,                          CMD_SERVER, CMDT_OTHER_MANAGEMENT      ), // CMD_RENAME_ENGINE

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -240,7 +240,7 @@ enum Commands {
 	CMD_DECREASE_LOAN,                ///< decrease the loan from the bank
 
 	CMD_WANT_ENGINE_PREVIEW,          ///< confirm the preview of an engine
-	CMD_ENABLE_ENGINE,                ///< enable engine for a company
+	CMD_ENGINE_CTRL,                  ///< control availability of the engine for companies
 
 	CMD_RENAME_VEHICLE,               ///< rename a whole vehicle
 	CMD_RENAME_ENGINE,                ///< rename a engine (in the engine list)

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -240,6 +240,7 @@ enum Commands {
 	CMD_DECREASE_LOAN,                ///< decrease the loan from the bank
 
 	CMD_WANT_ENGINE_PREVIEW,          ///< confirm the preview of an engine
+	CMD_ENABLE_ENGINE,                ///< enable engine for a company
 
 	CMD_RENAME_VEHICLE,               ///< rename a whole vehicle
 	CMD_RENAME_ENGINE,                ///< rename a engine (in the engine list)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -716,11 +716,11 @@ void StartupEngines()
 }
 
 /**
- * Company \a company accepts engine \a eid for preview.
- * @param eid Engine being accepted (is under preview).
- * @param company Current company previewing the engine.
+ * Allows engine \a eid to be used by a company \a company.
+ * @param eid The engine to enable.
+ * @param company The company to allow using the engine.
  */
-static void AcceptEnginePreview(EngineID eid, CompanyID company)
+static void EnableEngineForCompany(EngineID eid, CompanyID company)
 {
 	Engine *e = Engine::Get(eid);
 	Company *c = Company::Get(company);
@@ -734,15 +734,29 @@ static void AcceptEnginePreview(EngineID eid, CompanyID company)
 		c->avail_roadtypes = AddDateIntroducedRoadTypes(c->avail_roadtypes | GetRoadTypeInfo(e->u.road.roadtype)->introduces_roadtypes, _date);
 	}
 
-	e->preview_company = INVALID_COMPANY;
-	e->preview_asked = (CompanyMask)-1;
 	if (company == _local_company) {
 		AddRemoveEngineFromAutoreplaceAndBuildWindows(e->type);
-	}
 
-	/* Update the toolbar. */
-	if (e->type == VEH_ROAD) InvalidateWindowData(WC_BUILD_TOOLBAR, TRANSPORT_ROAD);
-	if (e->type == VEH_SHIP) InvalidateWindowData(WC_BUILD_TOOLBAR, TRANSPORT_WATER);
+		/* Update the toolbar. */
+		InvalidateWindowData(WC_MAIN_TOOLBAR, 0);
+		if (e->type == VEH_ROAD) InvalidateWindowData(WC_BUILD_TOOLBAR, TRANSPORT_ROAD);
+		if (e->type == VEH_SHIP) InvalidateWindowData(WC_BUILD_TOOLBAR, TRANSPORT_WATER);
+	}
+}
+
+/**
+ * Company \a company accepts engine \a eid for preview.
+ * @param eid Engine being accepted (is under preview).
+ * @param company Current company previewing the engine.
+ */
+static void AcceptEnginePreview(EngineID eid, CompanyID company)
+{
+	Engine *e = Engine::Get(eid);
+
+	e->preview_company = INVALID_COMPANY;
+	e->preview_asked = (CompanyMask)-1;
+
+	EnableEngineForCompany(eid, company);
 
 	/* Notify preview window, that it might want to close.
 	 * Note: We cannot directly close the window.
@@ -898,6 +912,25 @@ CommandCost CmdWantEnginePreview(TileIndex tile, DoCommandFlag flags, uint32 p1,
 	if (e == nullptr || !(e->flags & ENGINE_EXCLUSIVE_PREVIEW) || e->preview_company != _current_company) return CMD_ERROR;
 
 	if (flags & DC_EXEC) AcceptEnginePreview(p1, _current_company);
+
+	return CommandCost();
+}
+
+/**
+ * Allow a specific company to use an engine
+ * @param tile unused
+ * @param flags operation to perform
+ * @param p1 engine id
+ * @param p2 company id
+ * @param text unused
+ * @return the cost of this operation or an error
+ */
+CommandCost CmdEnableEngine(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+{
+	if (_current_company != OWNER_DEITY) return CMD_ERROR;
+	if (!Engine::IsValidID(p1) || !Company::IsValidID(p2)) return CMD_ERROR;
+
+	if (flags & DC_EXEC) EnableEngineForCompany((EngineID)p1, (CompanyID)p2);
 
 	return CommandCost();
 }

--- a/src/script/api/game/game_engine.hpp.sq
+++ b/src/script/api/game/game_engine.hpp.sq
@@ -48,6 +48,7 @@ void SQGSEngine_Register(Squirrel *engine)
 	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::IsArticulated,           "IsArticulated",           2, ".i");
 	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::GetPlaneType,            "GetPlaneType",            2, ".i");
 	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::GetMaximumOrderDistance, "GetMaximumOrderDistance", 2, ".i");
+	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::EnableForCompany,        "EnableForCompany",        3, ".ii");
 
 	SQGSEngine.PostRegister(engine);
 }

--- a/src/script/api/game/game_engine.hpp.sq
+++ b/src/script/api/game/game_engine.hpp.sq
@@ -49,6 +49,7 @@ void SQGSEngine_Register(Squirrel *engine)
 	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::GetPlaneType,            "GetPlaneType",            2, ".i");
 	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::GetMaximumOrderDistance, "GetMaximumOrderDistance", 2, ".i");
 	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::EnableForCompany,        "EnableForCompany",        3, ".ii");
+	SQGSEngine.DefSQStaticMethod(engine, &ScriptEngine::DisableForCompany,       "DisableForCompany",       3, ".ii");
 
 	SQGSEngine.PostRegister(engine);
 }

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -27,6 +27,8 @@
  * \li GSRoad::RoadVehHasPowerOnRoad
  * \li GSRoad::ConvertRoadType
  * \li GSRoad::GetMaxSpeed
+ * \li GSEngine::EnableForCompany
+ * \li GSEngine::DisableForCompany
  *
  * \b 1.9.0
  *

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -278,3 +278,15 @@
 			return 0;
 	}
 }
+
+
+/* static */ bool ScriptEngine::EnableForCompany(EngineID engine_id, ScriptCompany::CompanyID company)
+{
+	company = ScriptCompany::ResolveCompanyID(company);
+
+	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforcePrecondition(false, IsValidEngine(engine_id));
+	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
+
+	return ScriptObject::DoCommand(0, engine_id, company, CMD_ENABLE_ENGINE);
+}

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -279,7 +279,6 @@
 	}
 }
 
-
 /* static */ bool ScriptEngine::EnableForCompany(EngineID engine_id, ScriptCompany::CompanyID company)
 {
 	company = ScriptCompany::ResolveCompanyID(company);
@@ -288,5 +287,16 @@
 	EnforcePrecondition(false, IsValidEngine(engine_id));
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
-	return ScriptObject::DoCommand(0, engine_id, company, CMD_ENABLE_ENGINE);
+	return ScriptObject::DoCommand(0, engine_id, (uint32)company | (1 << 31), CMD_ENGINE_CTRL);
+}
+
+/* static */ bool ScriptEngine::DisableForCompany(EngineID engine_id, ScriptCompany::CompanyID company)
+{
+	company = ScriptCompany::ResolveCompanyID(company);
+
+	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforcePrecondition(false, IsValidEngine(engine_id));
+	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
+
+	return ScriptObject::DoCommand(0, engine_id, company, CMD_ENGINE_CTRL);
 }

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -291,7 +291,7 @@ public:
 	static uint GetMaximumOrderDistance(EngineID engine_id);
 
 	/**
-	 * Allow the engine to be used by a company regardles of its introduction date.
+	 * Allows a company to use an engine before its intro date or after retirement.
 	 * @param engine_id The engine to enable.
 	 * @param company_id The company to allow using the engine.
 	 * @pre IsValidEngine(engine_id).
@@ -300,6 +300,18 @@ public:
 	 * @api -ai
 	 */
 	static bool EnableForCompany(EngineID engine_id, ScriptCompany::CompanyID company_id);
+
+	/**
+	 * Forbids a company to use an engine before its natural retirement.
+	 * @param engine_id The engine to disable.
+	 * @param company_id The company to forbid using the engine.
+	 * @pre IsValidEngine(engine_id).
+	 * @pre ScriptCompany.ResolveCompanyID(company_id) != ScriptCompany::COMPANY_INVALID.
+	 * @return True if the action succeeded.
+	 * @api -ai
+	 */
+	static bool DisableForCompany(EngineID engine_id, ScriptCompany::CompanyID company_id);
+
 };
 
 #endif /* SCRIPT_ENGINE_HPP */

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -289,6 +289,17 @@ public:
 	 * @see ScriptOrder::GetOrderDistance
 	 */
 	static uint GetMaximumOrderDistance(EngineID engine_id);
+
+	/**
+	 * Allow the engine to be used by a company regardles of its introduction date.
+	 * @param engine_id The engine to enable.
+	 * @param company_id The company to allow using the engine.
+	 * @pre IsValidEngine(engine_id).
+	 * @pre ScriptCompany.ResolveCompanyID(company_id) != ScriptCompany::COMPANY_INVALID.
+	 * @return True if the action succeeded.
+	 * @api -ai
+	 */
+	static bool EnableForCompany(EngineID engine_id, ScriptCompany::CompanyID company_id);
 };
 
 #endif /* SCRIPT_ENGINE_HPP */


### PR DESCRIPTION
Just a simple method that uses existing Engine::company_avail mask and allows GS to do tech trees and such.

GS for testing: [techstump.zip](https://github.com/OpenTTD/OpenTTD/files/3753188/techstump.zip)
