### PR TITLE
Codechange: Don't use SDL_CreateRGBSurfaceWithFormat()

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -307,7 +307,7 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 	_sdl_realscreen = newscreen;
 
 	if (bpp == 8) {
-		newscreen = SDL_CreateRGBSurfaceWithFormat(0, w, h, 8, SDL_PIXELFORMAT_INDEX8);
+		newscreen = SDL_CreateRGBSurface(0, w, h, 8, 0, 0, 0, 0);
 
 		if (newscreen == nullptr) {
 			DEBUG(driver, 0, "SDL2: Couldn't allocate shadow surface: %s", SDL_GetError());


### PR DESCRIPTION
This function requires libSDL 2.0.5 or higher. It looks like we don't
need to use it, and can just use the original SDL_CreateRGBSurface(),
with the masks set to 0, to trigger the default 8-bit format, which is
SDL_PIXELFORMAT_INDEX8.

Closes #7785

Note: this code path is activated by using an 8-bit blitter, like:

    ./bin/openttd -b 8bpp-simple