### PR TITLE
Easier access for vehicles' group window.

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -369,6 +369,7 @@ public:
 		this->groups.ForceRebuild();
 		this->groups.NeedResort();
 		this->BuildGroupList(vli.company);
+		this->group_sb->SetCount((uint)this->groups.size());
 
 		this->GetWidget<NWidgetCore>(WID_GL_CAPTION)->widget_data = STR_VEHICLE_LIST_TRAIN_CAPTION + this->vli.vtype;
 		this->GetWidget<NWidgetCore>(WID_GL_LIST_VEHICLE)->tool_tip = STR_VEHICLE_LIST_TRAIN_LIST_TOOLTIP + this->vli.vtype;
@@ -992,6 +993,35 @@ public:
 	{
 		if (this->vehicle_sel == vehicle) ResetObjectToPlace();
 	}
+
+	/**
+	 * Selects the specified group in the list
+	 *
+	 * @param g_id The ID of the group to be selected
+	 */
+	void SelectGroup(const GroupID g_id)
+	{
+		if (g_id == INVALID_GROUP || g_id == this->vli.index) return;
+
+		this->vli.index = g_id;
+		if (g_id != ALL_GROUP && g_id != DEFAULT_GROUP) {
+			const Group *g = Group::Get(g_id);
+			int id_g = find_index(this->groups, g);
+			// The group's branch is maybe collapsed, so try to expand it
+			if (id_g == -1) {
+				for (auto pg = Group::GetIfValid(g->parent); pg != nullptr; pg = Group::GetIfValid(pg->parent)) {
+					pg->folded = false;
+				}
+				this->groups.ForceRebuild();
+				this->BuildGroupList(this->owner);
+				id_g = find_index(this->groups, g);
+			}
+			this->group_sb->ScrollTowards(id_g);
+		}
+		this->vehicles.ForceRebuild();
+		this->SetDirty();
+	}
+
 };
 
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1047,18 +1047,31 @@ static WindowDesc _train_group_desc(
  * Show the group window for the given company and vehicle type.
  * @param company The company to show the window for.
  * @param vehicle_type The type of vehicle to show it for.
+ * @param group The group to be selected. Defaults to INVALID_GROUP.
+ * @param need_existing_window Whether the existing window is needed. Defaults to false.
  */
-void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type)
+void ShowCompanyGroup(CompanyID company, VehicleType vehicle_type, GroupID group = INVALID_GROUP, bool need_existing_window = false)
 {
 	if (!Company::IsValidID(company)) return;
 
-	WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
+	const WindowNumber num = VehicleListIdentifier(VL_GROUP_LIST, vehicle_type, company).Pack();
+	VehicleGroupWindow *w;
 	if (vehicle_type == VEH_TRAIN) {
-		AllocateWindowDescFront<VehicleGroupWindow>(&_train_group_desc, num);
+		w = AllocateWindowDescFront<VehicleGroupWindow>(&_train_group_desc, num, need_existing_window);
 	} else {
 		_other_group_desc.cls = GetWindowClassForVehicleType(vehicle_type);
-		AllocateWindowDescFront<VehicleGroupWindow>(&_other_group_desc, num);
+		w = AllocateWindowDescFront<VehicleGroupWindow>(&_other_group_desc, num, need_existing_window);
 	}
+	if (w != nullptr) w->SelectGroup(group);
+}
+
+/**
+ * Show the group window for the given vehicle.
+ * @param v The vehicle to show the window for.
+ */
+void ShowCompanyGroupForVehicle(const Vehicle *v)
+{
+	ShowCompanyGroup(v->owner, v->type, v->group_id, true);
 }
 
 /**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -735,6 +735,10 @@ public:
 
 				this->vehicle_sel = v->index;
 
+				if (_ctrl_pressed) {
+					this->SelectGroup(v->group_id);
+				}
+
 				SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
 				SetMouseCursorVehicle(v, EIT_IN_LIST);
 				_cursor.vehchain = true;

--- a/src/group_gui.h
+++ b/src/group_gui.h
@@ -13,7 +13,8 @@
 #include "company_type.h"
 #include "vehicle_type.h"
 
-void ShowCompanyGroup(CompanyID company, VehicleType veh);
+void ShowCompanyGroup(CompanyID company, VehicleType veh, GroupID group = INVALID_GROUP, bool need_existing_window = false);
+void ShowCompanyGroupForVehicle(const Vehicle *v);
 void DeleteGroupHighlightOfVehicle(const Vehicle *v);
 
 #endif /* GROUP_GUI_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -870,6 +870,8 @@ STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :{BIG_FONT}{BLAC
 STR_NEWS_NEW_VEHICLE_TYPE                                       :{BIG_FONT}{BLACK}{ENGINE}
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE                    :{BLACK}New {STRING} now available!  -  {ENGINE}
 
+STR_NEWS_SHOW_VEHICLE_GROUP_TOOLTIP                             :{BLACK}Open the group window focused on the vehicle's group
+
 STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO                        :{WHITE}{STATION} no longer accepts {STRING}
 STR_NEWS_STATION_NO_LONGER_ACCEPTS_CARGO_OR_CARGO               :{WHITE}{STATION} no longer accepts {STRING} or {STRING}
 STR_NEWS_STATION_NOW_ACCEPTS_CARGO                              :{WHITE}{STATION} now accepts {STRING}

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -870,6 +870,7 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_VEH_NAME,                            "WID_N_VEH_NAME");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_VEH_SPR,                             "WID_N_VEH_SPR");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_VEH_INFO,                            "WID_N_VEH_INFO");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_N_SHOW_GROUP,                          "WID_N_SHOW_GROUP");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MH_STICKYBOX,                          "WID_MH_STICKYBOX");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MH_BACKGROUND,                         "WID_MH_BACKGROUND");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_MH_SCROLLBAR,                          "WID_MH_SCROLLBAR");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -1940,6 +1940,7 @@ public:
 		WID_N_VEH_NAME                               = ::WID_N_VEH_NAME,                               ///< Name of the new vehicle.
 		WID_N_VEH_SPR                                = ::WID_N_VEH_SPR,                                ///< Graphical display of the new vehicle.
 		WID_N_VEH_INFO                               = ::WID_N_VEH_INFO,                               ///< Some technical data of the new vehicle.
+		WID_N_SHOW_GROUP                             = ::WID_N_SHOW_GROUP,                             ///< Show vehicle's group
 	};
 
 	/** Widgets of the #MessageHistoryWindow class. */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1625,7 +1625,13 @@ public:
 				if (id_v >= this->vehicles.size()) return; // click out of list bound
 
 				const Vehicle *v = this->vehicles[id_v];
-				if (!VehicleClicked(v)) ShowVehicleViewWindow(v);
+				if (!VehicleClicked(v)) {
+					if (_ctrl_pressed) {
+						ShowCompanyGroupForVehicle(v);
+					} else {
+						ShowVehicleViewWindow(v);
+					}
+				}
 				break;
 			}
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2698,7 +2698,11 @@ public:
 				}
 				break;
 			case WID_VV_SHOW_DETAILS: // show details
-				ShowVehicleDetailsWindow(v);
+				if (_ctrl_pressed) {
+					ShowCompanyGroupForVehicle(v);
+				} else {
+					ShowVehicleDetailsWindow(v);
+				}
 				break;
 			case WID_VV_CLONE: // clone vehicle
 				/* Suppress the vehicle GUI when share-cloning.

--- a/src/widgets/news_widget.h
+++ b/src/widgets/news_widget.h
@@ -31,6 +31,7 @@ enum NewsWidgets {
 	WID_N_VEH_NAME,    ///< Name of the new vehicle.
 	WID_N_VEH_SPR,     ///< Graphical display of the new vehicle.
 	WID_N_VEH_INFO,    ///< Some technical data of the new vehicle.
+	WID_N_SHOW_GROUP,  ///< Show vehicle's group
 };
 
 /** Widgets of the #MessageHistoryWindow class. */


### PR DESCRIPTION
This is the follow-up PR of #7582.

I changed the shift+click combinations to control+click, removed the right click options from the vehicle news window, and added the functionality to the vehicle lists windows also.

I as well moved the button from the bottom of the vehicle news window to the caption bar, because I am not really liked the way it looked.
![vehicle_news](https://user-images.githubusercontent.com/48624099/67600422-69827300-f772-11e9-9997-d002ec2d0d6a.png)
