### PR TITLE
Fix #7733: Crash when removing a dock next to an industry without a station

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2607,7 +2607,8 @@ void RemoveDockingTile(TileIndex t)
 		if (IsTileType(tile, MP_STATION)) {
 			UpdateStationDockingTiles(Station::GetByTile(tile));
 		} else if (IsTileType(tile, MP_INDUSTRY)) {
-			UpdateStationDockingTiles(Industry::GetByTile(tile)->neutral_station);
+			Station *neutral = Industry::GetByTile(tile)->neutral_station;
+			if (neutral != nullptr) UpdateStationDockingTiles(neutral);
 		}
 	}
 }


### PR DESCRIPTION
Pretty trivial