### PR TITLE
Change: [Pipelines] Remove jessie builds from release pipeline

### DIFF
--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -119,14 +119,14 @@ jobs:
           Tag: 'linux-ubuntu-bionic-i386-gcc'
         linux-ubuntu-bionic-amd64-gcc:
           Tag: 'linux-ubuntu-bionic-amd64-gcc'
-        linux-debian-jessie-i386-gcc:
-          Tag: 'linux-debian-jessie-i386-gcc'
-        linux-debian-jessie-amd64-gcc:
-          Tag: 'linux-debian-jessie-amd64-gcc'
         linux-debian-stretch-i386-gcc:
           Tag: 'linux-debian-stretch-i386-gcc'
         linux-debian-stretch-amd64-gcc:
           Tag: 'linux-debian-stretch-amd64-gcc'
+        linux-debian-buster-i386-gcc:
+          Tag: 'linux-debian-buster-i386-gcc'
+        linux-debian-buster-amd64-gcc:
+          Tag: 'linux-debian-buster-amd64-gcc'
 
     steps:
     - template: release-fetch-source.yml

--- a/os/debian/rules
+++ b/os/debian/rules
@@ -29,7 +29,7 @@ include /usr/share/dpkg/buildflags.mk
 # to be explicit about the dependencies, in case we're not running in a
 # clean build root.
 override_dh_auto_configure:
-	./configure $(CROSS) --prefix-dir=/usr --install-dir=debian/openttd --without-allegro --with-zlib --with-sdl --with-png --with-freetype --with-fontconfig --with-icu --with-liblzo2 --with-lzma --without-xdg-basedir --without-iconv --disable-strip CFLAGS="$(CFLAGS) $(CPPFLAGS)" CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" CFLAGS_BUILD="$(CFLAGS) $(CPPFLAGS)" CXXFLAGS_BUILD="$(CXXFLAGS) $(CPPFLAGS)" LDFLAGS_BUILD="$(LDFLAGS)"
+	./configure $(CROSS) --prefix-dir=/usr --install-dir=debian/openttd --without-allegro --with-zlib --with-sdl --with-png --with-freetype --with-fontconfig --with-icu-sort --with-liblzo2 --with-lzma --without-xdg-basedir --without-iconv --disable-strip CFLAGS="$(CFLAGS) $(CPPFLAGS)" CXXFLAGS="$(CXXFLAGS) $(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" CFLAGS_BUILD="$(CFLAGS) $(CPPFLAGS)" CXXFLAGS_BUILD="$(CXXFLAGS) $(CPPFLAGS)" LDFLAGS_BUILD="$(LDFLAGS)"
 
 # Do some extra installation
 override_dh_auto_install:


### PR DESCRIPTION
Compiler is too old, now fails to compile OTTD. Possible we could fix the image to add a newer compiler instead, but since jessie is now "oldoldstable", probably not worth the effort to provide these builds ourselves.

When OpenTTD/CompileFarm#39 is merged, i can amend to add buster builds in their place