### PR TITLE
Fix #7784: up/down/home/end key behavior in SDL2

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -558,6 +558,10 @@ int VideoDriver_SDL::PollEvent()
 					keycode == WKC_NUM_ENTER ||
 					keycode == WKC_LEFT ||
 					keycode == WKC_RIGHT ||
+					keycode == WKC_UP ||
+					keycode == WKC_DOWN ||
+					keycode == WKC_HOME ||
+					keycode == WKC_END ||
 					keycode & WKC_META ||
 					keycode & WKC_SHIFT ||
 					keycode & WKC_CTRL ||


### PR DESCRIPTION
Closes #7784.