### PR TITLE
Feature: Minimap screenshot

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1349,10 +1349,11 @@ DEF_CONSOLE_CMD(ConAlias)
 DEF_CONSOLE_CMD(ConScreenShot)
 {
 	if (argc == 0) {
-		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [big | giant | no_con] [file name]'");
+		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [big | giant | no_con | minimap] [file name]'");
 		IConsoleHelp("'big' makes a zoomed-in screenshot of the visible area, 'giant' makes a screenshot of the "
 				"whole map, 'no_con' hides the console to create the screenshot. 'big' or 'giant' "
-				"screenshots are always drawn without console");
+				"screenshots are always drawn without console. "
+				"'minimap' makes a top-viewed minimap screenshot of whole world which represents one tile by one pixel.");
 		return true;
 	}
 
@@ -1369,6 +1370,10 @@ DEF_CONSOLE_CMD(ConScreenShot)
 		} else if (strcmp(argv[1], "giant") == 0) {
 			/* screenshot giant [filename] */
 			type = SC_WORLD;
+			if (argc > 2) name = argv[2];
+		} else if (strcmp(argv[1], "minimap") == 0) {
+			/* screenshot minimap [filename] */
+			type = SC_MINIMAP;
 			if (argc > 2) name = argv[2];
 		} else if (strcmp(argv[1], "no_con") == 0) {
 			/* screenshot no_con [filename] */

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -222,4 +222,10 @@ static const uint8 PC_GREEN              = 0xD0;           ///< Green palette co
 static const uint8 PC_DARK_BLUE          = 0x9D;           ///< Dark blue palette colour.
 static const uint8 PC_LIGHT_BLUE         = 0x98;           ///< Light blue palette colour.
 
+static const uint8 PC_ROUGH_LAND         = 0x52;           ///< Dark green palette colour for rough land.
+static const uint8 PC_GRASS_LAND         = 0x54;           ///< Dark green palette colour for grass land.
+static const uint8 PC_BARE_LAND          = 0x37;           ///< Brown palette colour for bare land.
+static const uint8 PC_FIELDS             = 0x25;           ///< Light brown palette colour for fields.
+static const uint8 PC_TREES              = 0x57;           ///< Green palette colour for trees.
+static const uint8 PC_WATER              = 0xC9;           ///< Dark blue palette colour for water.
 #endif /* GFX_FUNC_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4182,6 +4182,7 @@ STR_SCREENSHOT_ZOOMIN_SCREENSHOT                                :{BLACK}Fully zo
 STR_SCREENSHOT_DEFAULTZOOM_SCREENSHOT                           :{BLACK}Default zoom screenshot
 STR_SCREENSHOT_WORLD_SCREENSHOT                                 :{BLACK}Whole map screenshot
 STR_SCREENSHOT_HEIGHTMAP_SCREENSHOT                             :{BLACK}Heightmap screenshot
+STR_SCREENSHOT_MINIMAP_SCREENSHOT                               :{BLACK}Minimap screenshot
 
 # AI Parameters
 STR_AI_SETTINGS_CAPTION                                         :{WHITE}{STRING} Parameters

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -16,6 +16,7 @@
 #include "zoom_func.h"
 #include "core/endian_func.hpp"
 #include "saveload/saveload.h"
+#include "company_base.h"
 #include "company_func.h"
 #include "strings_func.h"
 #include "error.h"
@@ -65,6 +66,8 @@ struct ScreenshotFormat {
 	const char *extension;       ///< File extension.
 	ScreenshotHandlerProc *proc; ///< Function for writing the screenshot.
 };
+
+#define MKCOLOUR(x)         TO_LE32X(x)
 
 /*************************************************
  **** SCREENSHOT CODE FOR WINDOWS BITMAP (.BMP)
@@ -842,6 +845,10 @@ bool MakeScreenshot(ScreenshotType t, const char *name)
 			break;
 		}
 
+		case SC_MINIMAP:
+			ret = MakeMinimapWorldScreenshot();
+			break;
+
 		default:
 			NOT_REACHED();
 	}
@@ -854,4 +861,80 @@ bool MakeScreenshot(ScreenshotType t, const char *name)
 	}
 
 	return ret;
+}
+
+
+/**
+ * Return the owner of a tile to display it with in the small map in mode "Owner".
+ *
+ * @param tile The tile of which we would like to get the colour.
+ * @return The owner of tile in the small map in mode "Owner"
+ */
+static Owner GetMinimapOwner(TileIndex tile)
+{
+	Owner o;
+
+	if (IsTileType(tile, MP_VOID)) {
+		return OWNER_END;
+	} else {
+		switch (GetTileType(tile)) {
+		case MP_INDUSTRY: o = OWNER_DEITY;        break;
+		case MP_HOUSE:    o = OWNER_TOWN;         break;
+		default:          o = GetTileOwner(tile); break;
+			/* FIXME: For MP_ROAD there are multiple owners.
+			 * GetTileOwner returns the rail owner (level crossing) resp. the owner of ROADTYPE_ROAD (normal road),
+			 * even if there are no ROADTYPE_ROAD bits on the tile.
+			 */
+		}
+
+		return o;
+	}
+}
+
+static void MinimapScreenCallback(void *userdata, void *buf, uint y, uint pitch, uint n)
+{
+	uint32 *ubuf;
+	uint num, row, col;
+	byte val;
+	byte owner_colours[OWNER_END + 1];
+
+	/* Fill with the company colours */
+	for (const Company *c : Company::Iterate()) {
+		owner_colours[c->index] = MKCOLOUR(_colour_gradient[c->colour][5]);
+	}
+
+	/* Fill with some special colours */
+	owner_colours[OWNER_TOWN]    = PC_DARK_RED;
+	owner_colours[OWNER_NONE]    = PC_GRASS_LAND;
+	owner_colours[OWNER_WATER]   = PC_WATER;
+	owner_colours[OWNER_DEITY]   = PC_DARK_GREY; // industry
+	owner_colours[OWNER_END]     = PC_BLACK;
+
+	ubuf = (uint32 *)buf;
+	num = (pitch * n);
+	for (uint i = 0; i < num; i++) {
+		row = y + (int)(i / pitch);
+		col = (MapSizeX() - 1) - (i % pitch);
+
+		TileIndex tile = TileXY(col, row);
+		Owner o = GetMinimapOwner(tile);
+		val = owner_colours[o];
+
+		uint32 colour_buf = 0;
+		colour_buf  = (_cur_palette.palette[val].b << 0);
+		colour_buf |= (_cur_palette.palette[val].g << 8);
+		colour_buf |= (_cur_palette.palette[val].r << 16);
+
+		*ubuf = colour_buf;
+		*ubuf++;   // Skip alpha
+	}
+}
+
+/**
+ * Make a minimap screenshot.
+ */
+bool MakeMinimapWorldScreenshot()
+{
+	const ScreenshotFormat *sf = _screenshot_formats + _cur_screenshot_format;
+	return sf->proc(MakeScreenshotName(SCREENSHOT_NAME, sf->extension), MinimapScreenCallback, nullptr, MapSizeX(), MapSizeY(), 32, _cur_palette.palette);
 }

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -22,11 +22,13 @@ enum ScreenshotType {
 	SC_DEFAULTZOOM, ///< Zoomed to default zoom level screenshot of the visible area.
 	SC_WORLD,       ///< World screenshot.
 	SC_HEIGHTMAP,   ///< Heightmap of the world.
+	SC_MINIMAP,     ///< Minimap screenshot.
 };
 
 void SetupScreenshotViewport(ScreenshotType t, struct ViewPort *vp);
 bool MakeHeightmapScreenshot(const char *filename);
 bool MakeScreenshot(ScreenshotType t, const char *name);
+bool MakeMinimapWorldScreenshot();
 
 extern char _screenshot_format_name[8];
 extern uint _num_screenshot_formats;

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -41,6 +41,7 @@ struct ScreenshotWindow : Window {
 			case WID_SC_TAKE_DEFAULTZOOM: st = SC_DEFAULTZOOM; break;
 			case WID_SC_TAKE_WORLD:       st = SC_WORLD;       break;
 			case WID_SC_TAKE_HEIGHTMAP:   st = SC_HEIGHTMAP;   break;
+			case WID_SC_TAKE_MINIMAP:     st = SC_MINIMAP;     break;
 		}
 		TakeScreenshot(st);
 	}
@@ -87,6 +88,7 @@ static const NWidgetPart _nested_screenshot[] = {
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SC_TAKE_DEFAULTZOOM), SetFill(1, 1), SetDataTip(STR_SCREENSHOT_DEFAULTZOOM_SCREENSHOT, 0), SetMinimalTextLines(2, 0),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SC_TAKE_WORLD), SetFill(1, 1), SetDataTip(STR_SCREENSHOT_WORLD_SCREENSHOT, 0), SetMinimalTextLines(2, 0),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SC_TAKE_HEIGHTMAP), SetFill(1, 1), SetDataTip(STR_SCREENSHOT_HEIGHTMAP_SCREENSHOT, 0), SetMinimalTextLines(2, 0),
+		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_SC_TAKE_MINIMAP), SetFill(1, 1), SetDataTip(STR_SCREENSHOT_MINIMAP_SCREENSHOT, 0), SetMinimalTextLines(2, 0),
 	EndContainer(),
 };
 

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -2186,6 +2186,7 @@ public:
 		WID_SC_TAKE_DEFAULTZOOM                      = ::WID_SC_TAKE_DEFAULTZOOM,                      ///< Button for taking a screenshot at normal zoom
 		WID_SC_TAKE_WORLD                            = ::WID_SC_TAKE_WORLD,                            ///< Button for taking a screenshot of the whole world
 		WID_SC_TAKE_HEIGHTMAP                        = ::WID_SC_TAKE_HEIGHTMAP,                        ///< Button for taking a heightmap "screenshot"
+		WID_SC_TAKE_MINIMAP                          = ::WID_SC_TAKE_MINIMAP,                          ///< Button for taking a minimap screenshot
 	};
 
 	/* automatically generated from ../../widgets/settings_widget.h */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -40,13 +40,6 @@ static uint8 _linkstat_colours_in_legenda[] = {0, 1, 3, 5, 7, 9, 11};
 
 static const int NUM_NO_COMPANY_ENTRIES = 4; ///< Number of entries in the owner legend that are not companies.
 
-static const uint8 PC_ROUGH_LAND      = 0x52; ///< Dark green palette colour for rough land.
-static const uint8 PC_GRASS_LAND      = 0x54; ///< Dark green palette colour for grass land.
-static const uint8 PC_BARE_LAND       = 0x37; ///< Brown palette colour for bare land.
-static const uint8 PC_FIELDS          = 0x25; ///< Light brown palette colour for fields.
-static const uint8 PC_TREES           = 0x57; ///< Green palette colour for trees.
-static const uint8 PC_WATER           = 0xC9; ///< Dark blue palette colour for water.
-
 /** Macro for ordinary entry of LegendAndColour */
 #define MK(a, b) {a, b, INVALID_INDUSTRYTYPE, 0, INVALID_COMPANY, true, false, false}
 

--- a/src/widgets/screenshot_widget.h
+++ b/src/widgets/screenshot_widget.h
@@ -18,6 +18,7 @@ enum ScreenshotWindowWidgets {
 	WID_SC_TAKE_DEFAULTZOOM, ///< Button for taking a screenshot at normal zoom
 	WID_SC_TAKE_WORLD,       ///< Button for taking a screenshot of the whole world
 	WID_SC_TAKE_HEIGHTMAP,   ///< Button for taking a heightmap "screenshot"
+	WID_SC_TAKE_MINIMAP,     ///< Button for taking a minimap screenshot
 };
 
 


### PR DESCRIPTION
This command is introduced at [this tt-forum post](https://www.tt-forums.net/viewtopic.php?p=848661#p848661) and already implemented in [JGRPP](https://github.com/JGRennison/OpenTTD-patches/commit/019e8625360880c7fa62088c5a37efb3867db0fe#diff-8279d9ae98d882b6483afde886b1a01b) as ``minimap owner <file_name>``

This feature extends ``screenshot`` command to take top-viewed screenshot as ``screenshot topview``.
Its output looks like this (from title game):
![minimap](https://user-images.githubusercontent.com/10726524/68066893-93472580-fd82-11e9-9854-16dd6bb4c75a.png)

And adds a dropdown menu:
![image](https://user-images.githubusercontent.com/10726524/69003543-66c90700-0947-11ea-988e-3e4ee05cb0c8.png)


eg)
``screenshot minimap``
``screenshot minimap <filename>``

Most part of this code is not from me, but from [here](https://github.com/JGRennison/OpenTTD-patches/commit/019e8625360880c7fa62088c5a37efb3867db0fe#diff-8279d9ae98d882b6483afde886b1a01b).
I have no idea if I dare could make a PR although its original author is not me.
Please let me know if it is not allowed or there is any problem.

Btw, it is quite useful command to show users server's status via website.
I am using JGRPP's ``minimap`` command to show my server's status in [my website](https://telk.kr/ottd/server/stored)