### PR TITLE
Fix #7606: Game crash when trying to clean up a crashed script

### DIFF
--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -91,6 +91,10 @@ void ScriptInstance::Initialize(const char *main_script, const char *instance_na
 		/* Create the main-class */
 		this->instance = new SQObject();
 		if (!this->engine->CreateClassInstance(instance_name, this->controller, this->instance)) {
+			/* If CreateClassInstance has returned false instance has not been
+			 * registered with squirrel, so avoid trying to Release it by clearing it now */
+			delete this->instance;
+			this->instance = nullptr;
 			this->Died();
 			return;
 		}
@@ -156,6 +160,7 @@ void ScriptInstance::Died()
 	this->last_allocated_memory = this->GetAllocatedMemory(); // Update cache
 
 	if (this->instance != nullptr) this->engine->ReleaseObject(this->instance);
+	delete this->instance;
 	delete this->engine;
 	this->instance = nullptr;
 	this->engine = nullptr;

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -89,7 +89,7 @@ void ScriptInstance::Initialize(const char *main_script, const char *instance_na
 		}
 
 		/* Create the main-class */
-		this->instance = MallocT<SQObject>(1);
+		this->instance = new SQObject();
 		if (!this->engine->CreateClassInstance(instance_name, this->controller, this->instance)) {
 			this->Died();
 			return;
@@ -139,7 +139,7 @@ ScriptInstance::~ScriptInstance()
 	if (engine != nullptr) delete this->engine;
 	delete this->storage;
 	delete this->controller;
-	free(this->instance);
+	delete this->instance;
 }
 
 void ScriptInstance::Continue()


### PR DESCRIPTION
Not been able to reproduce the crash myself, but based on looking at the code and provided stacktrace this seems to be the only possibility.

Basically if `CreateClassInstance` has returned false, then `this->instance` has not been added to squirrel's internal object store. So when `Died` tries to release the object, everything falls over.

I'm not quite sure how `CreateClassInstance` can be made to return false, but as best as I can tell that's what happened here.