### PR TITLE
Fix #7820: Heap use after free when removing oil rig

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -146,6 +146,8 @@ Industry::~Industry()
 	 * Also we must not decrement industry counts in that case. */
 	if (this->location.w == 0) return;
 
+	const bool has_neutral_station = this->neutral_station != nullptr;
+
 	TILE_AREA_LOOP(tile_cur, this->location) {
 		if (IsTileType(tile_cur, MP_INDUSTRY)) {
 			if (GetIndustryIndex(tile_cur) == this->index) {
@@ -159,7 +161,7 @@ Industry::~Industry()
 		}
 	}
 
-	if (this->neutral_station != nullptr) {
+	if (has_neutral_station) {
 		/* Remove possible docking tiles */
 		TILE_AREA_LOOP(tile_cur, this->location) {
 			ClearDockingTilesCheckingNeighbours(tile_cur);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4172,6 +4172,10 @@ void DeleteOilRig(TileIndex tile)
 
 	/* The oil rig station is not supposed to be shared with anything else */
 	assert(st->facilities == (FACIL_AIRPORT | FACIL_DOCK) && st->airport.type == AT_OILRIG);
+	if (st->industry != nullptr && st->industry->neutral_station == st) {
+		/* Don't leave dangling neutral station pointer */
+		st->industry->neutral_station = nullptr;
+	}
 	delete st;
 }
 


### PR DESCRIPTION
This fixes the heap use after free described in issue #7820