### PR TITLE
Fix #7783, #7816: SDL2: Fix various issues with keyboard input

### DIFF
--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -374,6 +374,11 @@ struct IConsoleWindow : Window
 		this->Scroll(-wheel);
 	}
 
+	void OnFocus() override
+	{
+		VideoDriver::GetInstance()->EditBoxGainedFocus();
+	}
+
 	void OnFocusLost() override
 	{
 		VideoDriver::GetInstance()->EditBoxLostFocus();

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -358,40 +358,43 @@ struct VkMapping {
 	SDL_Keycode vk_from;
 	byte vk_count;
 	byte map_to;
+	bool unprintable;
 };
 
-#define AS(x, z) {x, 0, z}
-#define AM(x, y, z, w) {x, (byte)(y - x), z}
+#define AS(x, z) {x, 0, z, false}
+#define AM(x, y, z, w) {x, (byte)(y - x), z, false}
+#define AS_UP(x, z) {x, 0, z, true}
+#define AM_UP(x, y, z, w) {x, (byte)(y - x), z, true}
 
 static const VkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
-	AS(SDLK_PAGEUP,   WKC_PAGEUP),
-	AS(SDLK_PAGEDOWN, WKC_PAGEDOWN),
-	AS(SDLK_UP,     WKC_UP),
-	AS(SDLK_DOWN,   WKC_DOWN),
-	AS(SDLK_LEFT,   WKC_LEFT),
-	AS(SDLK_RIGHT,  WKC_RIGHT),
+	AS_UP(SDLK_PAGEUP,   WKC_PAGEUP),
+	AS_UP(SDLK_PAGEDOWN, WKC_PAGEDOWN),
+	AS_UP(SDLK_UP,     WKC_UP),
+	AS_UP(SDLK_DOWN,   WKC_DOWN),
+	AS_UP(SDLK_LEFT,   WKC_LEFT),
+	AS_UP(SDLK_RIGHT,  WKC_RIGHT),
 
-	AS(SDLK_HOME,   WKC_HOME),
-	AS(SDLK_END,    WKC_END),
+	AS_UP(SDLK_HOME,   WKC_HOME),
+	AS_UP(SDLK_END,    WKC_END),
 
-	AS(SDLK_INSERT, WKC_INSERT),
-	AS(SDLK_DELETE, WKC_DELETE),
+	AS_UP(SDLK_INSERT, WKC_INSERT),
+	AS_UP(SDLK_DELETE, WKC_DELETE),
 
 	/* Map letters & digits */
 	AM(SDLK_a, SDLK_z, 'A', 'Z'),
 	AM(SDLK_0, SDLK_9, '0', '9'),
 
-	AS(SDLK_ESCAPE,    WKC_ESC),
-	AS(SDLK_PAUSE,     WKC_PAUSE),
-	AS(SDLK_BACKSPACE, WKC_BACKSPACE),
+	AS_UP(SDLK_ESCAPE,    WKC_ESC),
+	AS_UP(SDLK_PAUSE,     WKC_PAUSE),
+	AS_UP(SDLK_BACKSPACE, WKC_BACKSPACE),
 
 	AS(SDLK_SPACE,     WKC_SPACE),
 	AS(SDLK_RETURN,    WKC_RETURN),
 	AS(SDLK_TAB,       WKC_TAB),
 
 	/* Function keys */
-	AM(SDLK_F1, SDLK_F12, WKC_F1, WKC_F12),
+	AM_UP(SDLK_F1, SDLK_F12, WKC_F1, WKC_F12),
 
 	/* Numeric part. */
 	AM(SDLK_KP_0, SDLK_KP_9, '0', '9'),
@@ -420,10 +423,12 @@ static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, WChar *character)
 {
 	const VkMapping *map;
 	uint key = 0;
+	bool unprintable = false;
 
 	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {
 		if ((uint)(sym->sym - map->vk_from) <= map->vk_count) {
 			key = sym->sym - map->vk_from + map->map_to;
+			unprintable = map->unprintable;
 			break;
 		}
 	}
@@ -441,7 +446,8 @@ static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, WChar *character)
 	if (sym->mod & KMOD_GUI ||
 		sym->mod & KMOD_SHIFT ||
 		sym->mod & KMOD_CTRL ||
-		sym->mod & KMOD_ALT) {
+		sym->mod & KMOD_ALT ||
+		unprintable) {
 		*character = WKC_NONE;
 	} else {
 		*character = sym->sym;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -365,7 +365,8 @@ struct VkMapping {
 
 static const VkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
-	AM(SDLK_PAGEUP, SDLK_PAGEDOWN, WKC_PAGEUP, WKC_PAGEDOWN),
+	AS(SDLK_PAGEUP,   WKC_PAGEUP),
+	AS(SDLK_PAGEDOWN, WKC_PAGEDOWN),
 	AS(SDLK_UP,     WKC_UP),
 	AS(SDLK_DOWN,   WKC_DOWN),
 	AS(SDLK_LEFT,   WKC_LEFT),

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -428,18 +428,7 @@ static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, WChar *character)
 	}
 
 	/* check scancode for BACKQUOTE key, because we want the key left of "1", not anything else (on non-US keyboards) */
-#if defined(_WIN32) || defined(__OS2__)
-	if (sym->scancode == 41) key = WKC_BACKQUOTE;
-#elif defined(__APPLE__)
-	if (sym->scancode == 10) key = WKC_BACKQUOTE;
-#elif defined(__SVR4) && defined(__sun)
-	if (sym->scancode == 60) key = WKC_BACKQUOTE;
-	if (sym->scancode == 49) key = WKC_BACKSPACE;
-#elif defined(__sgi__)
-	if (sym->scancode == 22) key = WKC_BACKQUOTE;
-#else
-	if (sym->scancode == 49) key = WKC_BACKQUOTE;
-#endif
+	if (sym->scancode == SDL_SCANCODE_GRAVE) key = WKC_BACKQUOTE;
 
 	/* META are the command keys on mac */
 	if (sym->mod & KMOD_GUI)   key |= WKC_META;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -37,10 +37,19 @@ public:
 
 	bool ClaimMousePointer() override;
 
+	void EditBoxGainedFocus() override;
+
+	void EditBoxLostFocus() override;
+
 	const char *GetName() const override { return "sdl"; }
 private:
 	int PollEvent();
 	bool CreateMainSurface(uint w, uint h, bool resize);
+
+	/**
+	 * This is true to indicate that keyboard input is in text input mode, and SDL_TEXTINPUT events are enabled.
+	 */
+	bool edit_box_focused;
 };
 
 /** Factory for the SDL video driver. */

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -94,6 +94,11 @@ public:
 	virtual void EditBoxLostFocus() {}
 
 	/**
+	 * An edit box gained the input focus
+	 */
+	virtual void EditBoxGainedFocus() {}
+
+	/**
 	 * Get the currently active instance of the video driver.
 	 */
 	static VideoDriver *GetInstance() {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -499,11 +499,20 @@ bool Window::SetFocusedWidget(int widget_index)
 		if (this->nested_focus->type == WWT_EDITBOX) VideoDriver::GetInstance()->EditBoxLostFocus();
 	}
 	this->nested_focus = this->GetWidget<NWidgetCore>(widget_index);
+	if (this->nested_focus->type == WWT_EDITBOX) VideoDriver::GetInstance()->EditBoxGainedFocus();
 	return true;
 }
 
 /**
- * Called when window looses focus
+ * Called when window gains focus
+ */
+void Window::OnFocus()
+{
+	if (this->nested_focus != nullptr && this->nested_focus->type == WWT_EDITBOX) VideoDriver::GetInstance()->EditBoxGainedFocus();
+}
+
+/**
+ * Called when window loses focus
  */
 void Window::OnFocusLost()
 {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -467,6 +467,15 @@ bool EditBoxInGlobalFocus()
 }
 
 /**
+ * Check if a console is focused.
+ * @return returns true if the focused window is a console, else false
+ */
+bool FocusedWindowIsConsole()
+{
+	return _focused_window && _focused_window->window_class == WC_CONSOLE;
+}
+
+/**
  * Makes no widget on this window have focus. The function however doesn't change which window has focus.
  */
 void Window::UnfocusFocusedWidget()

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -55,6 +55,7 @@ void DeleteWindowById(WindowClass cls, WindowNumber number, bool force = true);
 void DeleteWindowByClass(WindowClass cls);
 
 bool EditBoxInGlobalFocus();
+bool FocusedWindowIsConsole();
 Point GetCaretPosition();
 
 #endif /* WINDOW_FUNC_H */

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -592,10 +592,7 @@ public:
 	 */
 	virtual void SetStringParameters(int widget) const {}
 
-	/**
-	 * Called when window gains focus
-	 */
-	virtual void OnFocus() {}
+	virtual void OnFocus();
 
 	virtual void OnFocusLost();
 


### PR DESCRIPTION
SDL2:
* Fix input using only the shift key modifier being interpreted as non-text input or as a hotkey in edit contexts (#7783, #7816).
* Fix page down key.
* Fix backtick key scancode handling.
* Fix up/down keys in non-console edit context typing: '?' character
* Fix F1-F12 keys in edit context typing: '?' character
