### PR TITLE
Fix: Out of bounds tile access in ErrmsgWindow::OnInitialPosition

### DIFF
--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -224,7 +224,7 @@ public:
 		int scr_top = GetMainViewTop() + 20;
 		int scr_bot = GetMainViewBottom() - 20;
 
-		Point pt = RemapCoords2(this->position.x, this->position.y);
+		Point pt = RemapCoords(this->position.x, this->position.y, GetSlopePixelZOutsideMap(this->position.x, this->position.y));
 		const ViewPort *vp = FindWindowById(WC_MAIN_WINDOW, 0)->viewport;
 		if (this->face == INVALID_COMPANY) {
 			/* move x pos to opposite corner */


### PR DESCRIPTION
This fixes part A of #7619, but not part B.

Vehicle::x_pos and Vehicle::y_pos are not required to be within the map bounds.
See also: GetTileHeightBelowAircraft()