### PR TITLE
Fix #7673: [Script] allow removal of custom town text

### DIFF
--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -58,9 +58,11 @@
 {
 	CCountedPtr<Text> counter(text);
 
-	EnforcePrecondition(false, text != nullptr);
-	const char *encoded_text = text->GetEncodedText();
-	EnforcePreconditionEncodedText(false, encoded_text);
+	const char *encoded_text = nullptr;
+	if (text != nullptr) {
+		encoded_text = text->GetEncodedText();
+		EnforcePreconditionEncodedText(false, encoded_text);
+	}
 	EnforcePrecondition(false, IsValidTown(town_id));
 
 	return ScriptObject::DoCommand(::Town::Get(town_id)->xy, town_id, 0, CMD_TOWN_SET_TEXT, encoded_text);

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -146,7 +146,7 @@ public:
 	/**
 	 * Rename a town.
 	 * @param town_id The town to rename
-	 * @param name The new name of the town. If nullptr or an empty string is passed, the town name will be reset to the default name.
+	 * @param name The new name of the town. If null is passed, the town name will be reset to the default name.
 	 * @pre IsValidTown(town_id).
 	 * @return True if the action succeeded.
 	 * @api -ai
@@ -156,7 +156,7 @@ public:
 	/**
 	 * Set the custom text of a town, shown in the GUI.
 	 * @param town_id The town to set the custom text of.
-	 * @param text The text to set it to (can be either a raw string, or a ScriptText object).
+	 * @param text The text to set it to (can be either a raw string, or a ScriptText object). If null is passed, the text will be removed.
 	 * @pre IsValidTown(town_id).
 	 * @return True if the action succeeded.
 	 * @api -ai


### PR DESCRIPTION
I just cloned `ScriptTown::SetName()` behaviour. Also fixed an error in the docs. 