### PR TITLE
fix typo in town growth rates

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3362,7 +3362,7 @@ static uint GetNormalGrowthRate(Town *t)
 {
 	static const uint16 _grow_count_values[2][6] = {
 		{ 120, 120, 120, 100,  80,  60 }, // Fund new buildings has been activated
-		{ 320, 420, 300, 220, 160, 100 }  // Normal values
+		{ 420, 420, 300, 220, 160, 100 }  // Normal values
 	};
 
 	int n = CountActiveStations(t);


### PR DESCRIPTION
In the normal town growth rates there appears to be a typo in the lowest growth rate.