### PR TITLE
Revert #7837, 7e22f243e: OpenTTD tries to replicate the original game mechanics.

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3360,9 +3360,14 @@ static int CountActiveStations(Town *t)
  */
 static uint GetNormalGrowthRate(Town *t)
 {
+	/**
+	 * Note:
+	 * Unserviced+unfunded towns get an additional malus in UpdateTownGrowth(),
+	 * so the "320" is actually not better than the "420".
+	 */
 	static const uint16 _grow_count_values[2][6] = {
 		{ 120, 120, 120, 100,  80,  60 }, // Fund new buildings has been activated
-		{ 420, 420, 300, 220, 160, 100 }  // Normal values
+		{ 320, 420, 300, 220, 160, 100 }  // Normal values
 	};
 
 	int n = CountActiveStations(t);


### PR DESCRIPTION
Making numbers look nice and correlate is no goal, and in this case they actually did not correlate.