### PR TITLE
Add: a TextColour flag to ignore colour changes from strings

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -316,7 +316,7 @@ static void SetColourRemap(TextColour colour)
 	 * would be invisible at best, but it actually makes it illegible. */
 	bool no_shade   = (colour & TC_NO_SHADE) != 0 || colour == TC_BLACK;
 	bool raw_colour = (colour & TC_IS_PALETTE_COLOUR) != 0;
-	colour &= ~(TC_NO_SHADE | TC_IS_PALETTE_COLOUR);
+	colour &= ~(TC_NO_SHADE | TC_IS_PALETTE_COLOUR | TC_FORCED);
 
 	_string_colourremap[1] = raw_colour ? (byte)colour : _string_colourmap[colour];
 	_string_colourremap[2] = no_shade ? 0 : 1;

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -46,7 +46,7 @@ struct FontState {
 	inline void SetColour(TextColour c)
 	{
 		assert(c >= TC_BLUE && c <= TC_BLACK);
-		this->cur_colour = c;
+		if ((this->cur_colour & TC_FORCED) == 0) this->cur_colour = c;
 	}
 
 	/**

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -267,6 +267,7 @@ enum TextColour {
 
 	TC_IS_PALETTE_COLOUR = 0x100, ///< Colour value is already a real palette colour index, not an index of a StringColour.
 	TC_NO_SHADE          = 0x200, ///< Do not add shading to this text colour.
+	TC_FORCED            = 0x400, ///< Ignore colour changes from strings.
 };
 DECLARE_ENUM_AS_BIT_SET(TextColour)
 


### PR DESCRIPTION
Passing a `TextColor` to `DrawString()` calls only set the initial colour used to draw a string. If the string contains colour changes, the text will be drawn using this new colour. This PR introduces `TC_FORCED` flag to use in combination with the `TextColor` (eg `TC_RED | TC_FORCED`) when calling `DrawString()`.

This change is mainly requested for #7843 but could be used in other places too.