### PR TITLE
[WIP] Change: add support for next/previous railtype global hotkeys

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -763,6 +763,45 @@ struct BuildRailToolbarWindow : Window {
 };
 
 /**
+ * Selects RailType based on _last_built_railtype and global modifiers from RailToolbarWidgetModifiers
+ *
+ * If GHK_MOD_* modifiers were used hotkey replaced with last selected widget
+ * or WID_RAT_AUTORAIL (if toolbar was closed).
+ *
+ * Without wrapping, so if you're on RAILTYPE_RAIL you'll stay there. Same for upper boundary.
+ *
+ * @param [out] hotkey Replaced by last user selected widget or WID_RAT_AUTORAIL if prev/next railtype used
+ * @return selected RailType
+ */
+static RailType ChooseRailTypeOnGlobalHotkey(int &hotkey)
+{
+	extern RailType _last_built_railtype;
+	RailType rt = _last_built_railtype;
+	bool change_rt = false;
+	if (HasBit(hotkey, GHK_MOD_RAT_PREV_RAILTYPE)) {
+		ClrBit(hotkey, GHK_MOD_RAT_PREV_RAILTYPE);
+		change_rt = true;
+		do {
+			rt--;
+		} while (rt > RAILTYPE_BEGIN && !HasRailtypeAvail(_local_company, rt));
+	} else if (HasBit(hotkey, GHK_MOD_RAT_NEXT_RAILTYPE)) {
+		ClrBit(hotkey, GHK_MOD_RAT_NEXT_RAILTYPE);
+		change_rt = true;
+		do {
+			rt++;
+		} while (rt < RAILTYPE_END && !HasRailtypeAvail(_local_company, rt));
+		if (rt >= RAILTYPE_END) rt = _last_built_railtype;
+	}
+	if (change_rt) {
+		// get previous selected widget from current build toolbar if present
+		auto *w = dynamic_cast<BuildRailToolbarWindow *>(FindWindowById(WC_BUILD_TOOLBAR, TRANSPORT_RAIL));
+		hotkey = (w == nullptr || w->last_user_action < WID_RAT_BUILD_NS) ? WID_RAT_AUTORAIL : w->last_user_action;
+	}
+	_last_built_railtype = rt;
+	return rt;
+}
+
+/**
  * Handler for global hotkeys of the BuildRailToolbarWindow.
  * @param hotkey Hotkey
  * @return ES_HANDLED if hotkey was accepted.
@@ -770,8 +809,8 @@ struct BuildRailToolbarWindow : Window {
 static EventState RailToolbarGlobalHotkeys(int hotkey)
 {
 	if (_game_mode != GM_NORMAL) return ES_NOT_HANDLED;
-	extern RailType _last_built_railtype;
-	Window *w = ShowBuildRailToolbar(_last_built_railtype);
+	RailType railtype = ChooseRailTypeOnGlobalHotkey(hotkey);
+	Window *w = ShowBuildRailToolbar(railtype);
 	if (w == nullptr) return ES_NOT_HANDLED;
 	return w->OnHotkey(hotkey);
 }
@@ -793,6 +832,8 @@ static Hotkey railtoolbar_hotkeys[] = {
 	Hotkey('T', "tunnel", WID_RAT_BUILD_TUNNEL),
 	Hotkey('R', "remove", WID_RAT_REMOVE),
 	Hotkey('C', "convert", WID_RAT_CONVERT_RAIL),
+	Hotkey(WKC_L_BRACKET | WKC_GLOBAL_HOTKEY, "prev_railtype", GHK_MODB_RAT_PREV_RAILTYPE),
+	Hotkey(WKC_R_BRACKET | WKC_GLOBAL_HOTKEY, "next_railtype", GHK_MODB_RAT_NEXT_RAILTYPE),
 	HOTKEY_LIST_END
 };
 HotkeyList BuildRailToolbarWindow::hotkeys("railtoolbar", railtoolbar_hotkeys, RailToolbarGlobalHotkeys);

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -10,6 +10,15 @@
 #ifndef WIDGETS_RAIL_WIDGET_H
 #define WIDGETS_RAIL_WIDGET_H
 
+/** Global hotkeys modifiers for #RailToolbarWidgets */
+enum RailToolbarWidgetModifiers {
+	GHK_MOD_RAT_PREV_RAILTYPE = 9, ///< bit added to WID_RAT_AUTORAIL to select previous railtype
+	GHK_MOD_RAT_NEXT_RAILTYPE = 10, ///< bit added to WID_RAT_AUTORAIL to select next railtype
+
+	GHK_MODB_RAT_PREV_RAILTYPE = 1 << GHK_MOD_RAT_PREV_RAILTYPE, ///< bitmask for GHK_MOD_RAT_PREV_RAILTYPE
+	GHK_MODB_RAT_NEXT_RAILTYPE = 1 << GHK_MOD_RAT_NEXT_RAILTYPE, ///< bitmask for GHK_MOD_RAT_NEXT_RAILTYPE
+};
+
 /** Widgets of the #BuildRailToolbarWindow class. */
 enum RailToolbarWidgets {
 	/* Name starts with RA instead of R, because of collision with RoadToolbarWidgets */


### PR DESCRIPTION
This patch adds support for next/prev railtype global hotkeys which are basically autorail + special modifier which selects previous or next available railtype.

Such behaviour is useful for players who use PURR, Useless Tracks and similar NewGRFs for quick selection.

I use PURR with semantic tracks coloring (e.g. white purr for waiting bays, red purr for prio zones etc).

Current patch binds this feature to `GLOBAL+[` and `GLOBAL+]`.

*UPD* If user explicitly selected some widget in railway build toolbar it won't switch to autorail.

Signed-off-by: Konstantin Gribov <grossws@gmail.com>