### PR TITLE
Feature: Show the name of the NewGRF in the build vehicle window.

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -928,6 +928,14 @@ int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, 
 	/* Additional text from NewGRF */
 	y = ShowAdditionalText(left, right, y, engine_number);
 
+	/* The NewGRF's name which the vehicle comes from */
+	const GRFConfig *config = GetGRFConfig(e->GetGRFID());
+	if (_settings_client.gui.show_newgrf_name && config != nullptr)
+	{
+		DrawString(left, right, y, config->GetName(), TC_BLACK);
+		y += FONT_HEIGHT_NORMAL;
+	}
+
 	return y;
 }
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1315,6 +1315,8 @@ STR_CONFIG_SETTING_POPULATION_IN_LABEL                          :Show town popul
 STR_CONFIG_SETTING_POPULATION_IN_LABEL_HELPTEXT                 :Display the population of towns in their label on the map
 STR_CONFIG_SETTING_GRAPH_LINE_THICKNESS                         :Thickness of lines in graphs: {STRING2}
 STR_CONFIG_SETTING_GRAPH_LINE_THICKNESS_HELPTEXT                :Width of the line in the graphs. A thin line is more precisely readable, a thicker line is easier to see and colours are easier to distinguish
+STR_CONFIG_SETTING_SHOW_NEWGRF_NAME                             :Show the NewGRF's name in the build vehicle window
+STR_CONFIG_SETTING_SHOW_NEWGRF_NAME_HELPTEXT                    :Add a line to the build vehicle window, showing which NewGRF the selected vehicle comes from.
 
 STR_CONFIG_SETTING_LANDSCAPE                                    :Landscape: {STRING2}
 STR_CONFIG_SETTING_LANDSCAPE_HELPTEXT                           :Landscapes define basic gameplay scenarios with different cargos and town growth requirements. NewGRF and Game Scripts allow finer control though

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1566,6 +1566,7 @@ static SettingsContainer &GetSettingsTree()
 			interface->Add(new SettingEntry("gui.timetable_in_ticks"));
 			interface->Add(new SettingEntry("gui.timetable_arrival_departure"));
 			interface->Add(new SettingEntry("gui.expenses_layout"));
+			interface->Add(new SettingEntry("gui.show_newgrf_name"));
 		}
 
 		SettingsPage *advisors = main->Add(new SettingsPage(STR_CONFIG_SETTING_ADVISORS));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -145,6 +145,7 @@ struct GUISettings {
 	uint8  graph_line_thickness;             ///< the thickness of the lines in the various graph guis
 	uint8  osk_activation;                   ///< Mouse gesture to trigger the OSK.
 	byte   starting_colour;                  ///< default color scheme for the company to start a new game with
+	bool   show_newgrf_name;                 ///< Show the name of the NewGRF in the build vehicle window
 
 	uint16 console_backlog_timeout;          ///< the minimum amount of time items should be in the console backlog before they will be removed in ~3 seconds granularity.
 	uint16 console_backlog_length;           ///< the minimum amount of items in the console backlog before items will be removed.

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3217,6 +3217,15 @@ strhelp  = STR_CONFIG_SETTING_GRAPH_LINE_THICKNESS_HELPTEXT
 strval   = STR_JUST_COMMA
 proc     = RedrawScreen
 
+[SDTC_BOOL]
+var      = gui.show_newgrf_name
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+def      = false
+str      = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME
+strhelp  = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME_HELPTEXT
+proc     = RedrawScreen
+cat      = SC_ADVANCED
+
 ; For the dedicated build we'll enable dates in logs by default.
 [SDTC_BOOL]
 ifdef    = DEDICATED


### PR DESCRIPTION
I am usually using couple of vehicle sets, mainly road vehicles, and I like to know which vehicle comes from which NewGRF. So I can use buses/truck from the same set in a town or region. Furthermore I can see which set's vehicles I am using frequently or rarely, so I can keep or remove it from my next game. You can enable or disable this feature in the settings. I put it among the advanced settings, because most players probably are not interested in this. But as you can see in the forum, at least one is interested. :)
![newgrf_name_1](https://user-images.githubusercontent.com/48624099/69994054-54f18180-154d-11ea-8d82-ee65be62767d.png)
![newgrf_name_2](https://user-images.githubusercontent.com/48624099/69994056-54f18180-154d-11ea-8913-54c8be53b162.png)
