### PR TITLE
Fix: Infrastructure total update when removing tram road stop

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2126,7 +2126,7 @@ CommandCost CmdRemoveRoadStop(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 			/* Update company infrastructure counts. */
 			int count = CountBits(road_bits);
 			UpdateCompanyRoadInfrastructure(road_type[RTT_ROAD], road_owner[RTT_ROAD], count);
-			UpdateCompanyRoadInfrastructure(road_type[RTT_TRAM], road_owner[RTT_ROAD], count);
+			UpdateCompanyRoadInfrastructure(road_type[RTT_TRAM], road_owner[RTT_TRAM], count);
 		}
 	}
 


### PR DESCRIPTION
The wrong road owner was used when updating the tram infrastructure total.
This could result in desyncs, negative infrastructure totals, etc.

Reproduction steps:
1. Build a tram stop
2. Remove the tram stop
3. Demolish the tram tracks
You now have -2 tram tracks