### PR TITLE
Fix: Custom sea level default value is now equal to minimum value, not lower

### DIFF
--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2373,9 +2373,9 @@ base     = GameSettings
 var      = game_creation.custom_sea_level
 type     = SLE_UINT8
 from     = SLV_149
-def      = 1
-min      = 2
-max      = 90
+def      = CUSTOM_SEA_LEVEL_MIN_PERCENTAGE
+min      = CUSTOM_SEA_LEVEL_MIN_PERCENTAGE
+max      = CUSTOM_SEA_LEVEL_MAX_PERCENTAGE
 cat      = SC_BASIC
 
 [SDT_VAR]


### PR DESCRIPTION
Custom sea level default value was lower than the minimum