### PR TITLE
Feature: NewGRF callback profiling

### DIFF
--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -71,6 +71,8 @@ The following is an explanation of the different statistics:
 - *World ticks* - Time spent on other world/landscape processing. This
   includes towns growing, building animations, updates of farmland and trees,
   and station rating updates.
+- *NewGRF callbacks* - Time spent executing NewGRF dynamic callbacks.
+  This is the sum of all callbacks across all NewGRFs active in the game.
 - *GS/AI total*, *Game script*, and *AI players* - Time spent running logic
   for game scripts and AI players. The total may show as less than the current
   sum of the individual scripts, this is because AI players at lower

--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -99,3 +99,40 @@ The following is an explanation of the different statistics:
 If the frame rate window is shaded, the title bar will instead show just the
 current simulation rate and the game speed factor.
 
+## 3.0) NewGRF callback profiling
+
+NewGRF developers can profile callback chains via the `newgrf_profile`
+console command. The command enables a profiling mode where every sprite
+request is measured and logged, and written to a CSV file in the end.
+
+Usage:
+
+- `newgrf_profile` - show a list of loaded GRFs and their index numbers.
+- `newgrf_profile <grf-num> <days>` - Begin profiling the GRF and run profiling
+  for that many in-game days. Automarically writes a CSV file to the screenshot
+  folder at the end.
+
+Only one GRF can be profiled at a time. Trying to start a second profiling
+session will abort the first.
+
+The CSV file contains one line per sprite request during the profiling. It can
+get very large, especially on large games with many objects from the GRF.
+Start profiling short periods such as 3 or 7 days, and watch the file sizes.
+
+The produced CSV file contains the following fields:
+
+- *Tick* - Game tick counter, this may wrap to zero during recording.
+  Mainly useful to distinguish events from separate ticks.
+- *Sprite* - Index of the root Action 2 sprite in the GRF file. This is
+  the sprite group being resolved.
+- *CallbackID* - The type of callback being resolved. ID 0 is regular graphics
+  lookup. See the `newgrf_callbacks.h` file in the OpenTTD source code for the
+  full list of callback IDs.
+- *Microseconds* - Total time spent to resolve the Action 2, in microseconds.
+- *Subs* - Number of recursive Action 2 lookups were made during resolution.
+  Value zero means the sprite group resolved directly.
+- *Result* - Result of the callback resolution. For lookups that result in
+  a sprite, this is the index of the base action 2 in the GRF file. For
+  callbacks that give a numeric result, this is the callback result value.
+  For lookups that result in an industry production or tilelayout, this
+  is the sprite index of the action 2 defining the production/tilelayout.

--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -125,11 +125,15 @@ The produced CSV file contains the following fields:
   Mainly useful to distinguish events from separate ticks.
 - *Sprite* - Index of the root Action 2 sprite in the GRF file. This is
   the sprite group being resolved.
+- *Feature* - NewGRF feature number the sprite group is being resolved for.
+  This will be 0xFF for AI purchase selection and ambient sound callbacks.
+- *Item* - The id of the item within the GRF. For cargotypes, railtypes,
+  roadtypes, and tramtypes, this is the integer representation of the label.
 - *CallbackID* - The type of callback being resolved. ID 0 is regular graphics
   lookup. See the `newgrf_callbacks.h` file in the OpenTTD source code for the
   full list of callback IDs.
 - *Microseconds* - Total time spent to resolve the Action 2, in microseconds.
-- *Subs* - Number of recursive Action 2 lookups were made during resolution.
+- *Depth* - Number of recursive Action 2 lookups were made during resolution.
   Value zero means the sprite group resolved directly.
 - *Result* - Result of the callback resolution. For lookups that result in
   a sprite, this is the index of the base action 2 in the GRF file. For

--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -109,7 +109,7 @@ Usage:
 
 - `newgrf_profile` - show a list of loaded GRFs and their index numbers.
 - `newgrf_profile <grf-num> <days>` - Begin profiling the GRF and run profiling
-  for that many in-game days. Automarically writes a CSV file to the screenshot
+  for that many in-game days. Automatically writes a CSV file to the screenshot
   folder at the end.
 
 Only one GRF can be profiled at a time. Trying to start a second profiling

--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -107,19 +107,8 @@ request is measured and logged, and written to a CSV file in the end.
 
 The NewGRF developer tools need to be enabled for the command to function.
 
-Usage:
-
-- `newgrf_profile` - show a list of loaded GRFs and their index numbers.
-- `newgrf_profile add <grf-num>...` - Select one or more GRFs for profiling.
-- `newgrf_profile rem <grf-num>...` - Remove one or more GRFs from profiling.
-- `newgrf_profile rem all` - Remove all GRFs from profiling.
-- `newgrf_profile start [<num-days>]` - Begin profiling the selected GRFs,
-  you can optionally specify a number of in-game days to automatically stop
-  profiling after.
-- `newgrf_profile stop` - Finish profiling and write the collected data to CSV
-  files in the screenshot folder.
-- `newgrf_profile abort` - Cancel active profiling and discard collected data.
-  Selected GRFs remain selected.
+View the syntax for the command in-game with the console command
+`help newgrf_profile`.
 
 Profiling only works during game or in the editor, it's not possible to
 profile across the main menu, world generation, or loading savegames.

--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -102,22 +102,32 @@ current simulation rate and the game speed factor.
 ## 3.0) NewGRF callback profiling
 
 NewGRF developers can profile callback chains via the `newgrf_profile`
-console command. The command enables a profiling mode where every sprite
+console command. The command controls a profiling mode where every sprite
 request is measured and logged, and written to a CSV file in the end.
+
+The NewGRF developer tools need to be enabled for the command to function.
 
 Usage:
 
 - `newgrf_profile` - show a list of loaded GRFs and their index numbers.
-- `newgrf_profile <grf-num> <days>` - Begin profiling the GRF and run profiling
-  for that many in-game days. Automatically writes a CSV file to the screenshot
-  folder at the end.
+- `newgrf_profile add <grf-num>...` - Select one or more GRFs for profiling.
+- `newgrf_profile rem <grf-num>...` - Remove one or more GRFs from profiling.
+- `newgrf_profile rem all` - Remove all GRFs from profiling.
+- `newgrf_profile start [<num-days>]` - Begin profiling the selected GRFs,
+  you can optionally specify a number of in-game days to automatically stop
+  profiling after.
+- `newgrf_profile stop` - Finish profiling and write the collected data to CSV
+  files in the screenshot folder.
+- `newgrf_profile abort` - Cancel active profiling and discard collected data.
+  Selected GRFs remain selected.
 
-Only one GRF can be profiled at a time. Trying to start a second profiling
-session will abort the first.
+Profiling only works during game or in the editor, it's not possible to
+profile across the main menu, world generation, or loading savegames.
 
-The CSV file contains one line per sprite request during the profiling. It can
-get very large, especially on large games with many objects from the GRF.
-Start profiling short periods such as 3 or 7 days, and watch the file sizes.
+The CSV files contain one line per sprite request during the profiling.
+They can get very large, especially on large games with many objects from
+the GRF. Start profiling short periods such as 3 or 7 days, and watch the
+file sizes.
 
 The produced CSV file contains the following fields:
 

--- a/docs/logging_and_performance_metrics.md
+++ b/docs/logging_and_performance_metrics.md
@@ -71,8 +71,6 @@ The following is an explanation of the different statistics:
 - *World ticks* - Time spent on other world/landscape processing. This
   includes towns growing, building animations, updates of farmland and trees,
   and station rating updates.
-- *NewGRF callbacks* - Time spent executing NewGRF dynamic callbacks.
-  This is the sum of all callbacks across all NewGRFs active in the game.
 - *GS/AI total*, *Game script*, and *AI players* - Time spent running logic
   for game scripts and AI players. The total may show as less than the current
   sum of the individual scripts, this is because AI players at lower

--- a/projects/openttd_vs140.vcxproj
+++ b/projects/openttd_vs140.vcxproj
@@ -582,6 +582,7 @@
     <ClInclude Include="..\src\newgrf_industries.h" />
     <ClInclude Include="..\src\newgrf_industrytiles.h" />
     <ClInclude Include="..\src\newgrf_object.h" />
+    <ClInclude Include="..\src\newgrf_profiling.h" />
     <ClInclude Include="..\src\newgrf_properties.h" />
     <ClInclude Include="..\src\newgrf_railtype.h" />
     <ClInclude Include="..\src\newgrf_roadtype.h" />
@@ -627,6 +628,7 @@
     <ClInclude Include="..\src\screenshot.h" />
     <ClInclude Include="..\src\sound\sdl_s.h" />
     <ClInclude Include="..\src\video\sdl_v.h" />
+    <ClInclude Include="..\src\video\sdl2_v.h" />
     <ClInclude Include="..\src\settings_func.h" />
     <ClInclude Include="..\src\settings_gui.h" />
     <ClInclude Include="..\src\settings_internal.h" />
@@ -1232,6 +1234,7 @@
     <ClCompile Include="..\src\newgrf_industries.cpp" />
     <ClCompile Include="..\src\newgrf_industrytiles.cpp" />
     <ClCompile Include="..\src\newgrf_object.cpp" />
+    <ClCompile Include="..\src\newgrf_profiling.cpp" />
     <ClCompile Include="..\src\newgrf_railtype.cpp" />
     <ClCompile Include="..\src\newgrf_roadtype.cpp" />
     <ClCompile Include="..\src\newgrf_sound.cpp" />
@@ -1326,6 +1329,7 @@
     <ClCompile Include="..\src\video\dedicated_v.cpp" />
     <ClCompile Include="..\src\video\null_v.cpp" />
     <ClCompile Include="..\src\video\sdl_v.cpp" />
+    <ClCompile Include="..\src\video\sdl2_v.cpp" />
     <ClCompile Include="..\src\video\win32_v.cpp" />
     <ClCompile Include="..\src\music\dmusic.cpp" />
     <ClCompile Include="..\src\music\null_m.cpp" />
@@ -1333,6 +1337,7 @@
     <ClCompile Include="..\src\music\win32_m.cpp" />
     <ClCompile Include="..\src\sound\null_s.cpp" />
     <ClCompile Include="..\src\sound\sdl_s.cpp" />
+    <ClCompile Include="..\src\sound\sdl2_s.cpp" />
     <ClCompile Include="..\src\sound\win32_s.cpp" />
     <ClCompile Include="..\src\sound\xaudio2_s.cpp" />
     <ClCompile Include="..\src\os\windows\crashlog_win.cpp" />

--- a/projects/openttd_vs140.vcxproj.filters
+++ b/projects/openttd_vs140.vcxproj.filters
@@ -834,6 +834,9 @@
     <ClInclude Include="..\src\newgrf_object.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\newgrf_profiling.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\newgrf_properties.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -967,6 +970,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\video\sdl_v.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\video\sdl2_v.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\settings_func.h">
@@ -2784,6 +2790,9 @@
     <ClCompile Include="..\src\newgrf_object.cpp">
       <Filter>NewGRF</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\newgrf_profiling.cpp">
+      <Filter>NewGRF</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\newgrf_railtype.cpp">
       <Filter>NewGRF</Filter>
     </ClCompile>
@@ -3066,6 +3075,9 @@
     <ClCompile Include="..\src\video\sdl_v.cpp">
       <Filter>Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\video\sdl2_v.cpp">
+      <Filter>Video</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\video\win32_v.cpp">
       <Filter>Video</Filter>
     </ClCompile>
@@ -3085,6 +3097,9 @@
       <Filter>Sound</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sound\sdl_s.cpp">
+      <Filter>Sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\sound\sdl2_s.cpp">
       <Filter>Sound</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sound\win32_s.cpp">

--- a/projects/openttd_vs141.vcxproj
+++ b/projects/openttd_vs141.vcxproj
@@ -582,6 +582,7 @@
     <ClInclude Include="..\src\newgrf_industries.h" />
     <ClInclude Include="..\src\newgrf_industrytiles.h" />
     <ClInclude Include="..\src\newgrf_object.h" />
+    <ClInclude Include="..\src\newgrf_profiling.h" />
     <ClInclude Include="..\src\newgrf_properties.h" />
     <ClInclude Include="..\src\newgrf_railtype.h" />
     <ClInclude Include="..\src\newgrf_roadtype.h" />
@@ -627,6 +628,7 @@
     <ClInclude Include="..\src\screenshot.h" />
     <ClInclude Include="..\src\sound\sdl_s.h" />
     <ClInclude Include="..\src\video\sdl_v.h" />
+    <ClInclude Include="..\src\video\sdl2_v.h" />
     <ClInclude Include="..\src\settings_func.h" />
     <ClInclude Include="..\src\settings_gui.h" />
     <ClInclude Include="..\src\settings_internal.h" />
@@ -1232,6 +1234,7 @@
     <ClCompile Include="..\src\newgrf_industries.cpp" />
     <ClCompile Include="..\src\newgrf_industrytiles.cpp" />
     <ClCompile Include="..\src\newgrf_object.cpp" />
+    <ClCompile Include="..\src\newgrf_profiling.cpp" />
     <ClCompile Include="..\src\newgrf_railtype.cpp" />
     <ClCompile Include="..\src\newgrf_roadtype.cpp" />
     <ClCompile Include="..\src\newgrf_sound.cpp" />
@@ -1326,6 +1329,7 @@
     <ClCompile Include="..\src\video\dedicated_v.cpp" />
     <ClCompile Include="..\src\video\null_v.cpp" />
     <ClCompile Include="..\src\video\sdl_v.cpp" />
+    <ClCompile Include="..\src\video\sdl2_v.cpp" />
     <ClCompile Include="..\src\video\win32_v.cpp" />
     <ClCompile Include="..\src\music\dmusic.cpp" />
     <ClCompile Include="..\src\music\null_m.cpp" />
@@ -1333,6 +1337,7 @@
     <ClCompile Include="..\src\music\win32_m.cpp" />
     <ClCompile Include="..\src\sound\null_s.cpp" />
     <ClCompile Include="..\src\sound\sdl_s.cpp" />
+    <ClCompile Include="..\src\sound\sdl2_s.cpp" />
     <ClCompile Include="..\src\sound\win32_s.cpp" />
     <ClCompile Include="..\src\sound\xaudio2_s.cpp" />
     <ClCompile Include="..\src\os\windows\crashlog_win.cpp" />

--- a/projects/openttd_vs141.vcxproj.filters
+++ b/projects/openttd_vs141.vcxproj.filters
@@ -834,6 +834,9 @@
     <ClInclude Include="..\src\newgrf_object.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\newgrf_profiling.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\newgrf_properties.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -967,6 +970,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\video\sdl_v.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\video\sdl2_v.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\settings_func.h">
@@ -2784,6 +2790,9 @@
     <ClCompile Include="..\src\newgrf_object.cpp">
       <Filter>NewGRF</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\newgrf_profiling.cpp">
+      <Filter>NewGRF</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\newgrf_railtype.cpp">
       <Filter>NewGRF</Filter>
     </ClCompile>
@@ -3066,6 +3075,9 @@
     <ClCompile Include="..\src\video\sdl_v.cpp">
       <Filter>Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\video\sdl2_v.cpp">
+      <Filter>Video</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\video\win32_v.cpp">
       <Filter>Video</Filter>
     </ClCompile>
@@ -3085,6 +3097,9 @@
       <Filter>Sound</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sound\sdl_s.cpp">
+      <Filter>Sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\sound\sdl2_s.cpp">
       <Filter>Sound</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sound\win32_s.cpp">

--- a/projects/openttd_vs142.vcxproj
+++ b/projects/openttd_vs142.vcxproj
@@ -582,6 +582,7 @@
     <ClInclude Include="..\src\newgrf_industries.h" />
     <ClInclude Include="..\src\newgrf_industrytiles.h" />
     <ClInclude Include="..\src\newgrf_object.h" />
+    <ClInclude Include="..\src\newgrf_profiling.h" />
     <ClInclude Include="..\src\newgrf_properties.h" />
     <ClInclude Include="..\src\newgrf_railtype.h" />
     <ClInclude Include="..\src\newgrf_roadtype.h" />
@@ -627,6 +628,7 @@
     <ClInclude Include="..\src\screenshot.h" />
     <ClInclude Include="..\src\sound\sdl_s.h" />
     <ClInclude Include="..\src\video\sdl_v.h" />
+    <ClInclude Include="..\src\video\sdl2_v.h" />
     <ClInclude Include="..\src\settings_func.h" />
     <ClInclude Include="..\src\settings_gui.h" />
     <ClInclude Include="..\src\settings_internal.h" />
@@ -1232,6 +1234,7 @@
     <ClCompile Include="..\src\newgrf_industries.cpp" />
     <ClCompile Include="..\src\newgrf_industrytiles.cpp" />
     <ClCompile Include="..\src\newgrf_object.cpp" />
+    <ClCompile Include="..\src\newgrf_profiling.cpp" />
     <ClCompile Include="..\src\newgrf_railtype.cpp" />
     <ClCompile Include="..\src\newgrf_roadtype.cpp" />
     <ClCompile Include="..\src\newgrf_sound.cpp" />
@@ -1326,6 +1329,7 @@
     <ClCompile Include="..\src\video\dedicated_v.cpp" />
     <ClCompile Include="..\src\video\null_v.cpp" />
     <ClCompile Include="..\src\video\sdl_v.cpp" />
+    <ClCompile Include="..\src\video\sdl2_v.cpp" />
     <ClCompile Include="..\src\video\win32_v.cpp" />
     <ClCompile Include="..\src\music\dmusic.cpp" />
     <ClCompile Include="..\src\music\null_m.cpp" />
@@ -1333,6 +1337,7 @@
     <ClCompile Include="..\src\music\win32_m.cpp" />
     <ClCompile Include="..\src\sound\null_s.cpp" />
     <ClCompile Include="..\src\sound\sdl_s.cpp" />
+    <ClCompile Include="..\src\sound\sdl2_s.cpp" />
     <ClCompile Include="..\src\sound\win32_s.cpp" />
     <ClCompile Include="..\src\sound\xaudio2_s.cpp" />
     <ClCompile Include="..\src\os\windows\crashlog_win.cpp" />

--- a/projects/openttd_vs142.vcxproj.filters
+++ b/projects/openttd_vs142.vcxproj.filters
@@ -834,6 +834,9 @@
     <ClInclude Include="..\src\newgrf_object.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\newgrf_profiling.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\newgrf_properties.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -967,6 +970,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\video\sdl_v.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\video\sdl2_v.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\settings_func.h">
@@ -2784,6 +2790,9 @@
     <ClCompile Include="..\src\newgrf_object.cpp">
       <Filter>NewGRF</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\newgrf_profiling.cpp">
+      <Filter>NewGRF</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\newgrf_railtype.cpp">
       <Filter>NewGRF</Filter>
     </ClCompile>
@@ -3066,6 +3075,9 @@
     <ClCompile Include="..\src\video\sdl_v.cpp">
       <Filter>Video</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\video\sdl2_v.cpp">
+      <Filter>Video</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\video\win32_v.cpp">
       <Filter>Video</Filter>
     </ClCompile>
@@ -3085,6 +3097,9 @@
       <Filter>Sound</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sound\sdl_s.cpp">
+      <Filter>Sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\sound\sdl2_s.cpp">
       <Filter>Sound</Filter>
     </ClCompile>
     <ClCompile Include="..\src\sound\win32_s.cpp">

--- a/source.list
+++ b/source.list
@@ -269,6 +269,7 @@ newgrf_house.h
 newgrf_industries.h
 newgrf_industrytiles.h
 newgrf_object.h
+newgrf_profiling.h
 newgrf_properties.h
 newgrf_railtype.h
 newgrf_roadtype.h
@@ -983,6 +984,7 @@ newgrf_house.cpp
 newgrf_industries.cpp
 newgrf_industrytiles.cpp
 newgrf_object.cpp
+newgrf_profiling.cpp
 newgrf_railtype.cpp
 newgrf_roadtype.cpp
 newgrf_sound.cpp

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1876,13 +1876,13 @@ DEF_CONSOLE_CMD(ConNewGRFReload)
 DEF_CONSOLE_CMD(ConNewGRFProfile)
 {
 	if (argc == 0) {
-		IConsoleHelp("Collect a callback profiling session from a NewGRF for a number of in-game days.");
+		IConsoleHelp("Collect performance data about NewGRF sprite requests and callbacks.");
 		IConsoleHelp("Usage: newgrf_profile [list]");
 		IConsoleHelp("  List all NewGRFs that can be profiled, and their status.");
-		IConsoleHelp("Usage: newgrf_profile add <grf-num>...");
+		IConsoleHelp("Usage: newgrf_profile select <grf-num>...");
 		IConsoleHelp("  Select one or more GRFs for profiling.");
-		IConsoleHelp("Usage: newgrf_profile rem <grf-num>...");
-		IConsoleHelp("  Deselect one or more GRFs from profiling. Use the keyword \"all\" instead of a GRF number to remove all.");
+		IConsoleHelp("Usage: newgrf_profile unselect <grf-num>...");
+		IConsoleHelp("  Unselect one or more GRFs from profiling. Use the keyword \"all\" instead of a GRF number to unselect all. Removing an active profiler aborts data collection.");
 		IConsoleHelp("Usage: newgrf_profile start [<num-days>]");
 		IConsoleHelp("  Begin profiling all selected GRFs. If a number of days is provided, profiling stops after that many in-game days.");
 		IConsoleHelp("Usage: newgrf_profile stop");
@@ -1895,18 +1895,24 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	extern const std::vector<GRFFile *> &GetAllGRFFiles();
 	const std::vector<GRFFile *> &files = GetAllGRFFiles();
 
-	if (argc == 1 || strcasecmp(argv[1], "list") == 0) {
+	/* "list" sub-command */
+	if (argc == 1 || strncasecmp(argv[1], "lis", 3) == 0) {
 		IConsolePrint(TC_LIGHT_BROWN, "Active GRF files:");
 		int i = 1;
 		for (GRFFile *grf : files) {
-			bool active = std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; });
-			IConsolePrintF(active ? TC_LIGHT_BLUE : TC_LIGHT_BROWN, "%d: [%08X] %s%s", i, grf->grfid, grf->filename, active ? " (selected)" : "");
+			auto profiler = std::find_if(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; });
+			bool selected = profiler != _newgrf_profilers.end();
+			bool active = selected && profiler->active;
+			TextColour tc = active ? TC_GREEN : selected ? TC_LIGHT_BLUE : TC_LIGHT_BROWN;
+			const char *statustext = active ? " (active)" : selected ? " (selected)" : "";
+			IConsolePrintF(tc, "%d: [%08X] %s%s", i, grf->grfid, grf->filename, statustext);
 			i++;
 		}
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "add") == 0 && argc >= 3) {
+	/* "select" sub-command */
+	if (strncasecmp(argv[1], "sel", 3) == 0 && argc >= 3) {
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > files.size()) {
@@ -1915,7 +1921,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 			GRFFile *grf = files[grfnum - 1];
 			if (std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; })) {
-				IConsolePrintF(TC_YELLOW, "GRF number %d (GRFID %08X) is already selected for profiling.", grfnum, grf->grfid);
+				IConsolePrintF(TC_YELLOW, "GRF number %d [%08X] is already selected for profiling.", grfnum, grf->grfid);
 				continue;
 			}
 			_newgrf_profilers.emplace_back(grf);
@@ -1923,7 +1929,8 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		return true;
 	}
 
-	if (strncasecmp(argv[1], "rem", 3) == 0 && argc >= 3) {
+	/* "unselect" sub-command */
+	if (strncasecmp(argv[1], "uns", 3) == 0 && argc >= 3) {
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			if (strcasecmp(argv[argnum], "all") == 0) {
 				_newgrf_profilers.clear();
@@ -1941,7 +1948,8 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "start") == 0) {
+	/* "start" sub-command */
+	if (strncasecmp(argv[1], "sta", 3) == 0) {
 		std::string grfids;
 		size_t started = 0;
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
@@ -1950,8 +1958,8 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				started++;
 
 				if (!grfids.empty()) grfids += ", ";
-				char grfidstr[10]{ 0 };
-				seprintf(grfidstr, lastof(grfidstr), "%08X", pr.grffile->grfid);
+				char grfidstr[12]{ 0 };
+				seprintf(grfidstr, lastof(grfidstr), "[%08X]", pr.grffile->grfid);
 				grfids += grfidstr;
 			}
 		}
@@ -1976,14 +1984,16 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "stop") == 0) {
+	/* "stop" sub-command */
+	if (strncasecmp(argv[1], "sto", 3) == 0) {
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
 			if (pr.active) pr.Finish();
 		}
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "abort") == 0) {
+	/* "abort" sub-command */
+	if (strncasecmp(argv[1], "abo", 3) == 0) {
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
 			pr.Abort();
 		}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1905,7 +1905,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			bool active = selected && profiler->active;
 			TextColour tc = active ? TC_GREEN : selected ? TC_LIGHT_BLUE : TC_LIGHT_BROWN;
 			const char *statustext = active ? " (active)" : selected ? " (selected)" : "";
-			IConsolePrintF(tc, "%d: [%08X] %s%s", i, grf->grfid, grf->filename, statustext);
+			IConsolePrintF(tc, "%d: [%08X] %s%s", i, BSWAP32(grf->grfid), grf->filename, statustext);
 			i++;
 		}
 		return true;
@@ -1921,7 +1921,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 			GRFFile *grf = files[grfnum - 1];
 			if (std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; })) {
-				IConsolePrintF(TC_YELLOW, "GRF number %d [%08X] is already selected for profiling.", grfnum, grf->grfid);
+				IConsolePrintF(TC_YELLOW, "GRF number %d [%08X] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
 				continue;
 			}
 			_newgrf_profilers.emplace_back(grf);
@@ -1959,7 +1959,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 
 				if (!grfids.empty()) grfids += ", ";
 				char grfidstr[12]{ 0 };
-				seprintf(grfidstr, lastof(grfidstr), "[%08X]", pr.grffile->grfid);
+				seprintf(grfidstr, lastof(grfidstr), "[%08X]", BSWAP32(pr.grffile->grfid));
 				grfids += grfidstr;
 			}
 		}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1897,13 +1897,13 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 
 	/* "list" sub-command */
 	if (argc == 1 || strncasecmp(argv[1], "lis", 3) == 0) {
-		IConsolePrint(TC_LIGHT_BROWN, "Loaded GRF files:");
+		IConsolePrint(CC_INFO, "Loaded GRF files:");
 		int i = 1;
 		for (GRFFile *grf : files) {
 			auto profiler = std::find_if(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; });
 			bool selected = profiler != _newgrf_profilers.end();
 			bool active = selected && profiler->active;
-			TextColour tc = active ? TC_GREEN : selected ? TC_LIGHT_BLUE : TC_LIGHT_BROWN;
+			TextColour tc = active ? TC_LIGHT_BLUE : selected ? TC_GREEN : CC_INFO;
 			const char *statustext = active ? " (active)" : selected ? " (selected)" : "";
 			IConsolePrintF(tc, "%d: [%08X] %s%s", i, BSWAP32(grf->grfid), grf->filename, statustext);
 			i++;
@@ -1916,12 +1916,12 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) { // safe cast, files.size() should not be larger than a few hundred in the most extreme cases
-				IConsolePrintF(TC_YELLOW, "GRF number %d out of range, not added.", grfnum);
+				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not added.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];
 			if (std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; })) {
-				IConsolePrintF(TC_YELLOW, "GRF number %d [%08X] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
+				IConsolePrintF(CC_WARNING, "GRF number %d [%08X] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
 				continue;
 			}
 			_newgrf_profilers.emplace_back(grf);
@@ -1938,7 +1938,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) {
-				IConsolePrintF(TC_YELLOW, "GRF number %d out of range, not removing.", grfnum);
+				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not removing.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];
@@ -1964,7 +1964,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 		}
 		if (started > 0) {
-			IConsolePrintF(TC_LIGHT_BROWN, "Started profiling for GRFID%s %s", (started > 1) ? "s" : "", grfids.c_str());
+			IConsolePrintF(CC_DEBUG, "Started profiling for GRFID%s %s", (started > 1) ? "s" : "", grfids.c_str());
 			if (argc >= 3) {
 				int days = max(atoi(argv[2]), 1);
 				_newgrf_profile_end_date = _date + days;
@@ -1972,14 +1972,14 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				char datestrbuf[32]{ 0 };
 				SetDParam(0, _newgrf_profile_end_date);
 				GetString(datestrbuf, STR_JUST_DATE_ISO, lastof(datestrbuf));
-				IConsolePrintF(TC_LIGHT_BROWN, "Profiling will automatically stop on game date %s", datestrbuf);
+				IConsolePrintF(CC_DEBUG, "Profiling will automatically stop on game date %s", datestrbuf);
 			} else {
 				_newgrf_profile_end_date = MAX_DAY;
 			}
 		} else if (_newgrf_profilers.empty()) {
-			IConsolePrintF(TC_YELLOW, "No GRFs selected for profiling, did not start.");
+			IConsolePrintF(CC_WARNING, "No GRFs selected for profiling, did not start.");
 		} else {
-			IConsolePrintF(TC_YELLOW, "Did not start profiling for any GRFs, all selected GRFs are already profiling.");
+			IConsolePrintF(CC_WARNING, "Did not start profiling for any GRFs, all selected GRFs are already profiling.");
 		}
 		return true;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1882,8 +1882,8 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		return true;
 	}
 
-	extern std::vector<GRFFile *> GetAllGRFFiles();
-	std::vector<GRFFile *> files = GetAllGRFFiles();
+	extern const std::vector<GRFFile *> &GetAllGRFFiles();
+	const std::vector<GRFFile *> &files = GetAllGRFFiles();
 
 	if (argc == 1) {
 		IConsolePrint(TC_LIGHT_BROWN, "Active GRF files:");

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1907,11 +1907,10 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 
 		if (_newgrf_profiler != nullptr) {
 			IConsoleWarning("NewGRF profiling already active, aborting current session.");
-			delete _newgrf_profiler;
-			_newgrf_profiler = nullptr;
+			_newgrf_profiler.reset();
 		}
 
-		_newgrf_profiler = new NewGRFProfiler(files[grfnum - 1], _date + numdays);
+		_newgrf_profiler.reset(new NewGRFProfiler(files[grfnum - 1], _date + numdays));
 		return true;
 	} else {
 		return false;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1897,7 +1897,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 
 	/* "list" sub-command */
 	if (argc == 1 || strncasecmp(argv[1], "lis", 3) == 0) {
-		IConsolePrint(TC_LIGHT_BROWN, "Active GRF files:");
+		IConsolePrint(TC_LIGHT_BROWN, "Loaded GRF files:");
 		int i = 1;
 		for (GRFFile *grf : files) {
 			auto profiler = std::find_if(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; });
@@ -1986,9 +1986,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 
 	/* "stop" sub-command */
 	if (strncasecmp(argv[1], "sto", 3) == 0) {
-		for (NewGRFProfiler &pr : _newgrf_profilers) {
-			if (pr.active) pr.Finish();
-		}
+		NewGRFProfiler::FinishAll();
 		return true;
 	}
 
@@ -1997,6 +1995,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
 			pr.Abort();
 		}
+		_newgrf_profile_end_date = MAX_DAY;
 		return true;
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1915,7 +1915,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	if (strncasecmp(argv[1], "sel", 3) == 0 && argc >= 3) {
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			int grfnum = atoi(argv[argnum]);
-			if (grfnum < 1 || grfnum > files.size()) {
+			if (grfnum < 1 || grfnum > (int)files.size()) { // safe cast, files.size() should not be larger than a few hundred in the most extreme cases
 				IConsolePrintF(TC_YELLOW, "GRF number %d out of range, not added.", grfnum);
 				continue;
 			}
@@ -1937,7 +1937,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				break;
 			}
 			int grfnum = atoi(argv[argnum]);
-			if (grfnum < 1 || grfnum > files.size()) {
+			if (grfnum < 1 || grfnum > (int)files.size()) {
 				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not removing.", grfnum);
 				continue;
 			}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1876,7 +1876,7 @@ DEF_CONSOLE_CMD(ConNewGRFReload)
 DEF_CONSOLE_CMD(ConNewGRFProfile)
 {
 	if (argc == 0) {
-		IConsoleHelp("Collect performance data about NewGRF sprite requests and callbacks.");
+		IConsoleHelp("Collect performance data about NewGRF sprite requests and callbacks. Sub-commands can be abbreviated.");
 		IConsoleHelp("Usage: newgrf_profile [list]");
 		IConsoleHelp("  List all NewGRFs that can be profiled, and their status.");
 		IConsoleHelp("Usage: newgrf_profile select <grf-num>...");
@@ -1938,7 +1938,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) {
-				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not removing.", grfnum);
+				IConsolePrintF(TC_YELLOW, "GRF number %d out of range, not removing.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -245,8 +245,7 @@ static void OnNewMonth()
 static void OnNewDay()
 {
 	if (_newgrf_profiler != nullptr && _newgrf_profiler->profile_end_date <= _date) {
-		delete _newgrf_profiler;
-		_newgrf_profiler = nullptr;
+		_newgrf_profiler.reset();
 	}
 
 	if (_network_server) NetworkServerDailyLoop();

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -18,6 +18,7 @@
 #include "rail_gui.h"
 #include "linkgraph/linkgraph.h"
 #include "saveload/saveload.h"
+#include "newgrf_profiling.h"
 
 #include "safeguards.h"
 
@@ -243,6 +244,11 @@ static void OnNewMonth()
  */
 static void OnNewDay()
 {
+	if (_newgrf_profiler != nullptr && _newgrf_profiler->profile_end_date <= _date) {
+		delete _newgrf_profiler;
+		_newgrf_profiler = nullptr;
+	}
+
 	if (_network_server) NetworkServerDailyLoop();
 
 	DisasterDailyLoop();

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -244,8 +244,11 @@ static void OnNewMonth()
  */
 static void OnNewDay()
 {
-	if (_newgrf_profiler != nullptr && _newgrf_profiler->profile_end_date <= _date) {
-		_newgrf_profiler.reset();
+	if (!_newgrf_profilers.empty() && _newgrf_profile_end_date <= _date) {
+		for (NewGRFProfiler &pr : _newgrf_profilers) {
+			if (pr.active) pr.Finish();
+		}
+		_newgrf_profile_end_date = MAX_DAY;
 	}
 
 	if (_network_server) NetworkServerDailyLoop();

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -245,10 +245,7 @@ static void OnNewMonth()
 static void OnNewDay()
 {
 	if (!_newgrf_profilers.empty() && _newgrf_profile_end_date <= _date) {
-		for (NewGRFProfiler &pr : _newgrf_profilers) {
-			if (pr.active) pr.Finish();
-		}
-		_newgrf_profile_end_date = MAX_DAY;
+		NewGRFProfiler::FinishAll();
 	}
 
 	if (_network_server) NetworkServerDailyLoop();

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -184,6 +184,7 @@ namespace {
 		PerformanceData(1),                     // PFE_ACC_GL_SHIPS
 		PerformanceData(1),                     // PFE_ACC_GL_AIRCRAFT
 		PerformanceData(1),                     // PFE_GL_LANDSCAPE
+		PerformanceData(1),                     // PFE_GL_NEWGRFCB
 		PerformanceData(1),                     // PFE_GL_LINKGRAPH
 		PerformanceData(GL_RATE),               // PFE_DRAWING
 		PerformanceData(1),                     // PFE_ACC_DRAWWORLD
@@ -314,6 +315,7 @@ static const PerformanceElement DISPLAY_ORDER_PFE[PFE_MAX] = {
 	PFE_GL_SHIPS,
 	PFE_GL_AIRCRAFT,
 	PFE_GL_LANDSCAPE,
+	PFE_GL_NEWGRFCB,
 	PFE_ALLSCRIPTS,
 	PFE_GAMESCRIPT,
 	PFE_AI0,
@@ -1030,6 +1032,7 @@ void ConPrintFramerate()
 		"  GL ship ticks",
 		"  GL aircraft ticks",
 		"  GL landscape ticks",
+		"  GL NewGRF callbacks",
 		"  GL link graph delays",
 		"Drawing",
 		"  Viewport drawing",

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -184,7 +184,6 @@ namespace {
 		PerformanceData(1),                     // PFE_ACC_GL_SHIPS
 		PerformanceData(1),                     // PFE_ACC_GL_AIRCRAFT
 		PerformanceData(1),                     // PFE_GL_LANDSCAPE
-		PerformanceData(1),                     // PFE_GL_NEWGRFCB
 		PerformanceData(1),                     // PFE_GL_LINKGRAPH
 		PerformanceData(GL_RATE),               // PFE_DRAWING
 		PerformanceData(1),                     // PFE_ACC_DRAWWORLD
@@ -315,7 +314,6 @@ static const PerformanceElement DISPLAY_ORDER_PFE[PFE_MAX] = {
 	PFE_GL_SHIPS,
 	PFE_GL_AIRCRAFT,
 	PFE_GL_LANDSCAPE,
-	PFE_GL_NEWGRFCB,
 	PFE_ALLSCRIPTS,
 	PFE_GAMESCRIPT,
 	PFE_AI0,
@@ -1032,7 +1030,6 @@ void ConPrintFramerate()
 		"  GL ship ticks",
 		"  GL aircraft ticks",
 		"  GL landscape ticks",
-		"  GL NewGRF callbacks",
 		"  GL link graph delays",
 		"Drawing",
 		"  Viewport drawing",

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -53,6 +53,7 @@ enum PerformanceElement {
 	PFE_GL_SHIPS,      ///< Time spent processing ships
 	PFE_GL_AIRCRAFT,   ///< Time spent processing aircraft
 	PFE_GL_LANDSCAPE,  ///< Time spent processing other world features
+	PFE_GL_NEWGRFCB,   ///< Time spent resolving NewGRF callbacks
 	PFE_GL_LINKGRAPH,  ///< Time spent waiting for link graph background jobs
 	PFE_DRAWING,       ///< Speed of drawing world and GUI.
 	PFE_DRAWWORLD,     ///< Time spent drawing world viewports in GUI

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -53,7 +53,6 @@ enum PerformanceElement {
 	PFE_GL_SHIPS,      ///< Time spent processing ships
 	PFE_GL_AIRCRAFT,   ///< Time spent processing aircraft
 	PFE_GL_LANDSCAPE,  ///< Time spent processing other world features
-	PFE_GL_NEWGRFCB,   ///< Time spent resolving NewGRF callbacks
 	PFE_GL_LINKGRAPH,  ///< Time spent waiting for link graph background jobs
 	PFE_DRAWING,       ///< Speed of drawing world and GUI.
 	PFE_DRAWWORLD,     ///< Time spent drawing world viewports in GUI

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2768,6 +2768,7 @@ STR_FRAMERATE_GL_ROADVEHS                                       :{BLACK}  Road v
 STR_FRAMERATE_GL_SHIPS                                          :{BLACK}  Ship ticks:
 STR_FRAMERATE_GL_AIRCRAFT                                       :{BLACK}  Aircraft ticks:
 STR_FRAMERATE_GL_LANDSCAPE                                      :{BLACK}  World ticks:
+STR_FRAMERATE_GL_NEWGRFCB                                       :{BLACK}  NewGRF callbacks:
 STR_FRAMERATE_GL_LINKGRAPH                                      :{BLACK}  Link graph delay:
 STR_FRAMERATE_DRAWING                                           :{BLACK}Graphics rendering:
 STR_FRAMERATE_DRAWING_VIEWPORTS                                 :{BLACK}  World viewports:
@@ -2785,6 +2786,7 @@ STR_FRAMETIME_CAPTION_GL_ROADVEHS                               :Road vehicle ti
 STR_FRAMETIME_CAPTION_GL_SHIPS                                  :Ship ticks
 STR_FRAMETIME_CAPTION_GL_AIRCRAFT                               :Aircraft ticks
 STR_FRAMETIME_CAPTION_GL_LANDSCAPE                              :World ticks
+STR_FRAMETIME_CAPTION_GL_NEWGRFCB                               :NewGRF callbacks
 STR_FRAMETIME_CAPTION_GL_LINKGRAPH                              :Link graph delay
 STR_FRAMETIME_CAPTION_DRAWING                                   :Graphics rendering
 STR_FRAMETIME_CAPTION_DRAWING_VIEWPORTS                         :World viewport rendering

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2768,7 +2768,6 @@ STR_FRAMERATE_GL_ROADVEHS                                       :{BLACK}  Road v
 STR_FRAMERATE_GL_SHIPS                                          :{BLACK}  Ship ticks:
 STR_FRAMERATE_GL_AIRCRAFT                                       :{BLACK}  Aircraft ticks:
 STR_FRAMERATE_GL_LANDSCAPE                                      :{BLACK}  World ticks:
-STR_FRAMERATE_GL_NEWGRFCB                                       :{BLACK}  NewGRF callbacks:
 STR_FRAMERATE_GL_LINKGRAPH                                      :{BLACK}  Link graph delay:
 STR_FRAMERATE_DRAWING                                           :{BLACK}Graphics rendering:
 STR_FRAMERATE_DRAWING_VIEWPORTS                                 :{BLACK}  World viewports:
@@ -2786,7 +2785,6 @@ STR_FRAMETIME_CAPTION_GL_ROADVEHS                               :Road vehicle ti
 STR_FRAMETIME_CAPTION_GL_SHIPS                                  :Ship ticks
 STR_FRAMETIME_CAPTION_GL_AIRCRAFT                               :Aircraft ticks
 STR_FRAMETIME_CAPTION_GL_LANDSCAPE                              :World ticks
-STR_FRAMETIME_CAPTION_GL_NEWGRFCB                               :NewGRF callbacks
 STR_FRAMETIME_CAPTION_GL_LINKGRAPH                              :Link graph delay
 STR_FRAMETIME_CAPTION_DRAWING                                   :Graphics rendering
 STR_FRAMETIME_CAPTION_DRAWING_VIEWPORTS                         :World viewport rendering

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -70,7 +70,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_thd.redsq = INVALID_TILE;
 	if (reset_settings) MakeNewgameSettingsLive();
 
-	_newgrf_profiler.reset();
+	_newgrf_profilers.clear();
 
 	if (reset_date) {
 		SetDate(ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1), 0);

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -70,10 +70,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_thd.redsq = INVALID_TILE;
 	if (reset_settings) MakeNewgameSettingsLive();
 
-	if (_newgrf_profiler != nullptr) {
-		delete _newgrf_profiler;
-		_newgrf_profiler = nullptr;
-	}
+	_newgrf_profiler.reset();
 
 	if (reset_date) {
 		SetDate(ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1), 0);

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -29,6 +29,7 @@
 #include "station_kdtree.h"
 #include "town_kdtree.h"
 #include "viewport_kdtree.h"
+#include "newgrf_profiling.h"
 
 #include "safeguards.h"
 
@@ -68,6 +69,11 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_cur_tileloop_tile = 1;
 	_thd.redsq = INVALID_TILE;
 	if (reset_settings) MakeNewgameSettingsLive();
+
+	if (_newgrf_profiler != nullptr) {
+		delete _newgrf_profiler;
+		_newgrf_profiler = nullptr;
+	}
 
 	if (reset_date) {
 		SetDate(ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1), 0);

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -66,7 +66,7 @@
 /** List of all loaded GRF files */
 static std::vector<GRFFile *> _grf_files;
 
-std::vector<GRFFile *> GetAllGRFFiles()
+const std::vector<GRFFile *> &GetAllGRFFiles()
 {
 	return _grf_files;
 }

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -66,6 +66,11 @@
 /** List of all loaded GRF files */
 static std::vector<GRFFile *> _grf_files;
 
+std::vector<GRFFile *> GetAllGRFFiles()
+{
+	return _grf_files;
+}
+
 /** Miscellaneous GRF features, set by Action 0x0D, parameter 0x9E */
 byte _misc_grf_features = 0;
 
@@ -5000,6 +5005,7 @@ static void NewSpriteGroup(ByteReader *buf)
 
 			assert(DeterministicSpriteGroup::CanAllocateItem());
 			DeterministicSpriteGroup *group = new DeterministicSpriteGroup();
+			group->nfo_line = _cur.nfo_line;
 			act_group = group;
 			group->var_scope = HasBit(type, 1) ? VSG_SCOPE_PARENT : VSG_SCOPE_SELF;
 
@@ -5116,6 +5122,7 @@ static void NewSpriteGroup(ByteReader *buf)
 		{
 			assert(RandomizedSpriteGroup::CanAllocateItem());
 			RandomizedSpriteGroup *group = new RandomizedSpriteGroup();
+			group->nfo_line = _cur.nfo_line;
 			act_group = group;
 			group->var_scope = HasBit(type, 1) ? VSG_SCOPE_PARENT : VSG_SCOPE_SELF;
 
@@ -5164,6 +5171,7 @@ static void NewSpriteGroup(ByteReader *buf)
 
 					assert(RealSpriteGroup::CanAllocateItem());
 					RealSpriteGroup *group = new RealSpriteGroup();
+					group->nfo_line = _cur.nfo_line;
 					act_group = group;
 
 					group->num_loaded  = num_loaded;
@@ -5197,6 +5205,7 @@ static void NewSpriteGroup(ByteReader *buf)
 
 					assert(TileLayoutSpriteGroup::CanAllocateItem());
 					TileLayoutSpriteGroup *group = new TileLayoutSpriteGroup();
+					group->nfo_line = _cur.nfo_line;
 					act_group = group;
 
 					/* On error, bail out immediately. Temporary GRF data was already freed */
@@ -5212,6 +5221,7 @@ static void NewSpriteGroup(ByteReader *buf)
 
 					assert(IndustryProductionSpriteGroup::CanAllocateItem());
 					IndustryProductionSpriteGroup *group = new IndustryProductionSpriteGroup();
+					group->nfo_line = _cur.nfo_line;
 					act_group = group;
 					group->version = type;
 					if (type == 0) {

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -60,7 +60,7 @@ struct AirportResolverObject : public ResolverObject {
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 /**
@@ -234,7 +234,7 @@ GrfSpecFeature AirportResolverObject::GetFeature() const
 	return GSF_AIRPORTS;
 }
 
-uint32 AirportResolverObject::GetLocalID() const
+uint32 AirportResolverObject::GetDebugID() const
 {
 	return AirportSpec::Get(this->airport_scope.airport_id)->grf_prop.local_id;
 }

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -58,6 +58,9 @@ struct AirportResolverObject : public ResolverObject {
 	}
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 /**
@@ -224,6 +227,16 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 	if (group->num_loading > 0) return group->loading[0];
 
 	return nullptr;
+}
+
+GrfSpecFeature AirportResolverObject::GetFeature() const
+{
+	return GSF_AIRPORTS;
+}
+
+uint32 AirportResolverObject::GetLocalID() const
+{
+	return AirportSpec::Get(this->airport_scope.airport_id)->grf_prop.local_id;
 }
 
 /* virtual */ uint32 AirportScopeResolver::GetRandomBits() const

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -220,6 +220,16 @@ AirportTileResolverObject::AirportTileResolverObject(const AirportTileSpec *ats,
 	this->root_spritegroup = ats->grf_prop.spritegroup[0];
 }
 
+GrfSpecFeature AirportTileResolverObject::GetFeature() const
+{
+	return GSF_AIRPORTTILES;
+}
+
+uint32 AirportTileResolverObject::GetLocalID() const
+{
+	return this->tiles_scope.ats->grf_prop.local_id;
+}
+
 uint16 GetAirportTileCallback(CallbackID callback, uint32 param1, uint32 param2, const AirportTileSpec *ats, Station *st, TileIndex tile, int extra_data = 0)
 {
 	AirportTileResolverObject object(ats, tile, st, callback, param1, param2);

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -225,7 +225,7 @@ GrfSpecFeature AirportTileResolverObject::GetFeature() const
 	return GSF_AIRPORTTILES;
 }
 
-uint32 AirportTileResolverObject::GetLocalID() const
+uint32 AirportTileResolverObject::GetDebugID() const
 {
 	return this->tiles_scope.ats->grf_prop.local_id;
 }

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -57,7 +57,7 @@ struct AirportTileResolverObject : public ResolverObject {
 	}
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 /**

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -22,6 +22,7 @@ struct AirportTileScopeResolver : public ScopeResolver {
 	struct Station *st;  ///< %Station of the airport for which the callback is run, or \c nullptr for build gui.
 	byte airport_id;     ///< Type of airport for which the callback is run.
 	TileIndex tile;      ///< Tile for the callback, only valid for airporttile callbacks.
+	const AirportTileSpec *ats;
 
 	/**
 	 * Constructor of the scope resolver specific for airport tiles.
@@ -30,7 +31,7 @@ struct AirportTileScopeResolver : public ScopeResolver {
 	 * @param st Station of the airport for which the callback is run, or \c nullptr for build gui.
 	 */
 	AirportTileScopeResolver(ResolverObject &ro, const AirportTileSpec *ats, TileIndex tile, Station *st)
-		: ScopeResolver(ro), st(st), tile(tile)
+		: ScopeResolver(ro), st(st), tile(tile), ats(ats)
 	{
 		assert(st != nullptr);
 		this->airport_id = st->airport.type;
@@ -54,6 +55,9 @@ struct AirportTileResolverObject : public ResolverObject {
 			default: return ResolverObject::GetScope(scope, relative);
 		}
 	}
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 /**

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -52,7 +52,7 @@ struct CanalResolverObject : public ResolverObject {
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 /* virtual */ uint32 CanalScopeResolver::GetRandomBits() const
@@ -121,9 +121,9 @@ GrfSpecFeature CanalResolverObject::GetFeature() const
 	return GSF_CANALS;
 }
 
-uint32 CanalResolverObject::GetLocalID() const
+uint32 CanalResolverObject::GetDebugID() const
 {
-	return 0; // TODO? not sure there is one/this is possible
+	return this->feature;
 }
 
 /**

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -13,6 +13,7 @@
 #include "newgrf_canal.h"
 #include "water.h"
 #include "water_map.h"
+#include "spritecache.h"
 
 #include "safeguards.h"
 
@@ -35,6 +36,7 @@ struct CanalScopeResolver : public ScopeResolver {
 /** Resolver object for canals. */
 struct CanalResolverObject : public ResolverObject {
 	CanalScopeResolver canal_scope;
+	CanalFeature feature;
 
 	CanalResolverObject(CanalFeature feature, TileIndex tile,
 			CallbackID callback = CBID_NO_CALLBACK, uint32 callback_param1 = 0, uint32 callback_param2 = 0);
@@ -48,6 +50,9 @@ struct CanalResolverObject : public ResolverObject {
 	}
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 /* virtual */ uint32 CanalScopeResolver::GetRandomBits() const
@@ -111,6 +116,16 @@ struct CanalResolverObject : public ResolverObject {
 	return group->loaded[0];
 }
 
+GrfSpecFeature CanalResolverObject::GetFeature() const
+{
+	return GSF_CANALS;
+}
+
+uint32 CanalResolverObject::GetLocalID() const
+{
+	return 0; // TODO? not sure there is one/this is possible
+}
+
 /**
  * Canal resolver constructor.
  * @param feature Which canal feature we want.
@@ -121,7 +136,7 @@ struct CanalResolverObject : public ResolverObject {
  */
 CanalResolverObject::CanalResolverObject(CanalFeature feature, TileIndex tile,
 		CallbackID callback, uint32 callback_param1, uint32 callback_param2)
-		: ResolverObject(_water_feature[feature].grffile, callback, callback_param1, callback_param2), canal_scope(*this, tile)
+		: ResolverObject(_water_feature[feature].grffile, callback, callback_param1, callback_param2), canal_scope(*this, tile), feature(feature)
 {
 	this->root_spritegroup = _water_feature[feature].group;
 }

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -15,9 +15,14 @@
 
 /** Resolver of cargo. */
 struct CargoResolverObject : public ResolverObject {
+	const CargoSpec *cargospec;
+
 	CargoResolverObject(const CargoSpec *cs, CallbackID callback = CBID_NO_CALLBACK, uint32 callback_param1 = 0, uint32 callback_param2 = 0);
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 /* virtual */ const SpriteGroup *CargoResolverObject::ResolveReal(const RealSpriteGroup *group) const
@@ -30,6 +35,16 @@ struct CargoResolverObject : public ResolverObject {
 	return nullptr;
 }
 
+GrfSpecFeature CargoResolverObject::GetFeature() const
+{
+	return GSF_CARGOES;
+}
+
+uint32 CargoResolverObject::GetLocalID() const
+{
+	return this->cargospec->label; // Not quite the same as ID, but should work
+}
+
 /**
  * Constructor of the cargo resolver.
  * @param cs Cargo being resolved.
@@ -38,7 +53,7 @@ struct CargoResolverObject : public ResolverObject {
  * @param callback_param2 Second parameter (var 18) of the callback.
  */
 CargoResolverObject::CargoResolverObject(const CargoSpec *cs, CallbackID callback, uint32 callback_param1, uint32 callback_param2)
-		: ResolverObject(cs->grffile, callback, callback_param1, callback_param2)
+		: ResolverObject(cs->grffile, callback, callback_param1, callback_param2), cargospec(cs)
 {
 	this->root_spritegroup = cs->group;
 }

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -22,7 +22,7 @@ struct CargoResolverObject : public ResolverObject {
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 /* virtual */ const SpriteGroup *CargoResolverObject::ResolveReal(const RealSpriteGroup *group) const
@@ -40,9 +40,9 @@ GrfSpecFeature CargoResolverObject::GetFeature() const
 	return GSF_CARGOES;
 }
 
-uint32 CargoResolverObject::GetLocalID() const
+uint32 CargoResolverObject::GetDebugID() const
 {
-	return this->cargospec->label; // Not quite the same as ID, but should work
+	return this->cargospec->label;
 }
 
 /**

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -946,6 +946,22 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 	return in_motion ? group->loaded[set] : group->loading[set];
 }
 
+GrfSpecFeature VehicleResolverObject::GetFeature() const
+{
+	switch (Engine::Get(this->self_scope.self_type)->type) {
+		case VEH_TRAIN: return GSF_TRAINS;
+		case VEH_ROAD: return GSF_ROADVEHICLES;
+		case VEH_SHIP: return GSF_SHIPS;
+		case VEH_AIRCRAFT: return GSF_AIRCRAFT;
+		default: return GSF_INVALID;
+	}
+}
+
+uint32 VehicleResolverObject::GetLocalID() const
+{
+	return Engine::Get(this->self_scope.self_type)->grf_prop.local_id;
+}
+
 /**
  * Get the grf file associated with an engine type.
  * @param engine_type Engine to query.

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -957,7 +957,7 @@ GrfSpecFeature VehicleResolverObject::GetFeature() const
 	}
 }
 
-uint32 VehicleResolverObject::GetLocalID() const
+uint32 VehicleResolverObject::GetDebugID() const
 {
 	return Engine::Get(this->self_scope.self_type)->grf_prop.local_id;
 }

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -65,6 +65,9 @@ struct VehicleResolverObject : public ResolverObject {
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override;
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 static const uint TRAININFO_DEFAULT_VEHICLE_WIDTH   = 29;

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -67,7 +67,7 @@ struct VehicleResolverObject : public ResolverObject {
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 static const uint TRAININFO_DEFAULT_VEHICLE_WIDTH   = 29;

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -29,6 +29,8 @@ struct GenericScopeResolver : public ScopeResolver {
 	uint8 count;
 	uint8 station_size;
 
+	uint8 feature;
+
 	/**
 	 * Generic scope resolver.
 	 * @param ro Surrounding resolver.
@@ -36,7 +38,7 @@ struct GenericScopeResolver : public ScopeResolver {
 	 */
 	GenericScopeResolver(ResolverObject &ro, bool ai_callback)
 		: ScopeResolver(ro), cargo_type(0), default_selection(0), src_industry(0), dst_industry(0), distance(0),
-		event(), count(0), station_size(0), ai_callback(ai_callback)
+		event(), count(0), station_size(0), feature(GSF_INVALID), ai_callback(ai_callback)
 	{
 	}
 
@@ -62,6 +64,16 @@ struct GenericResolverObject : public ResolverObject {
 	}
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override
+	{
+		return (GrfSpecFeature)this->generic_scope.feature;
+	}
+
+	uint32 GetDebugID() const override
+	{
+		return 0;
+	}
 };
 
 struct GenericCallback {
@@ -226,6 +238,7 @@ uint16 GetAiPurchaseCallbackResult(uint8 feature, CargoID cargo_type, uint8 defa
 	object.generic_scope.event             = event;
 	object.generic_scope.count             = count;
 	object.generic_scope.station_size      = station_size;
+	object.generic_scope.feature           = feature;
 
 	uint16 callback = GetGenericCallbackResult(feature, object, 0, 0, file);
 	if (callback != CALLBACK_FAILED) callback = GB(callback, 0, 8);
@@ -247,6 +260,7 @@ void AmbientSoundEffectCallback(TileIndex tile)
 
 	/* Prepare resolver object. */
 	GenericResolverObject object(false, CBID_SOUNDS_AMBIENT_EFFECT);
+	object.generic_scope.feature = GSF_SOUNDFX;
 
 	uint32 param1_v7 = GetTileType(tile) << 28 | Clamp(TileHeight(tile), 0, 15) << 24 | GB(r, 16, 8) << 16 | GetTerrainType(tile);
 	uint32 param1_v8 = GetTileType(tile) << 24 | GetTileZ(tile) << 16 | GB(r, 16, 8) << 8 | (HasTileWaterClass(tile) ? GetWaterClass(tile) : 0) << 3 | GetTerrainType(tile);

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -62,6 +62,16 @@ HouseResolverObject::HouseResolverObject(HouseID house_id, TileIndex tile, Town 
 	this->root_spritegroup = HouseSpec::Get(house_id)->grf_prop.spritegroup[0];
 }
 
+GrfSpecFeature HouseResolverObject::GetFeature() const
+{
+	return GSF_HOUSES;
+}
+
+uint32 HouseResolverObject::GetLocalID() const
+{
+	return HouseSpec::Get(this->house_scope.house_id)->grf_prop.local_id;
+}
+
 HouseClassID AllocateHouseClassID(byte grf_class_id, uint32 grfid)
 {
 	/* Start from 1 because 0 means that no class has been assigned. */

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -67,7 +67,7 @@ GrfSpecFeature HouseResolverObject::GetFeature() const
 	return GSF_HOUSES;
 }
 
-uint32 HouseResolverObject::GetLocalID() const
+uint32 HouseResolverObject::GetDebugID() const
 {
 	return HouseSpec::Get(this->house_scope.house_id)->grf_prop.local_id;
 }

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -64,6 +64,9 @@ struct HouseResolverObject : public ResolverObject {
 			default: return ResolverObject::GetScope(scope, relative);
 		}
 	}
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 /**

--- a/src/newgrf_house.h
+++ b/src/newgrf_house.h
@@ -66,7 +66,7 @@ struct HouseResolverObject : public ResolverObject {
 	}
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 /**

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -494,7 +494,7 @@ GrfSpecFeature IndustriesResolverObject::GetFeature() const
 	return GSF_INDUSTRIES;
 }
 
-uint32 IndustriesResolverObject::GetLocalID() const
+uint32 IndustriesResolverObject::GetDebugID() const
 {
 	return GetIndustrySpec(this->industries_scope.type)->grf_prop.local_id;
 }

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -489,6 +489,16 @@ TownScopeResolver *IndustriesResolverObject::GetTown()
 	return this->town_scope;
 }
 
+GrfSpecFeature IndustriesResolverObject::GetFeature() const
+{
+	return GSF_INDUSTRIES;
+}
+
+uint32 IndustriesResolverObject::GetLocalID() const
+{
+	return GetIndustrySpec(this->industries_scope.type)->grf_prop.local_id;
+}
+
 /**
  * Perform an industry callback.
  * @param callback The callback to perform.

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -63,6 +63,9 @@ struct IndustriesResolverObject : public ResolverObject {
 				return ResolverObject::GetScope(scope, relative);
 		}
 	}
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 /** When should the industry(tile) be triggered for random bits? */

--- a/src/newgrf_industries.h
+++ b/src/newgrf_industries.h
@@ -65,7 +65,7 @@ struct IndustriesResolverObject : public ResolverObject {
 	}
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 /** When should the industry(tile) be triggered for random bits? */

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -139,9 +139,20 @@ IndustryTileResolverObject::IndustryTileResolverObject(IndustryGfx gfx, TileInde
 			CallbackID callback, uint32 callback_param1, uint32 callback_param2)
 	: ResolverObject(GetIndTileGrffile(gfx), callback, callback_param1, callback_param2),
 	indtile_scope(*this, indus, tile),
-	ind_scope(*this, tile, indus, indus->type)
+	ind_scope(*this, tile, indus, indus->type),
+	gfx(gfx)
 {
 	this->root_spritegroup = GetIndustryTileSpec(gfx)->grf_prop.spritegroup[0];
+}
+
+GrfSpecFeature IndustryTileResolverObject::GetFeature() const
+{
+	return GSF_INDUSTRYTILES;
+}
+
+uint32 IndustryTileResolverObject::GetLocalID() const
+{
+	return GetIndustryTileSpec(gfx)->grf_prop.local_id;
 }
 
 static void IndustryDrawTileLayout(const TileInfo *ti, const TileLayoutSpriteGroup *group, byte rnd_colour, byte stage, IndustryGfx gfx)

--- a/src/newgrf_industrytiles.cpp
+++ b/src/newgrf_industrytiles.cpp
@@ -150,7 +150,7 @@ GrfSpecFeature IndustryTileResolverObject::GetFeature() const
 	return GSF_INDUSTRYTILES;
 }
 
-uint32 IndustryTileResolverObject::GetLocalID() const
+uint32 IndustryTileResolverObject::GetDebugID() const
 {
 	return GetIndustryTileSpec(gfx)->grf_prop.local_id;
 }

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -54,7 +54,7 @@ struct IndustryTileResolverObject : public ResolverObject {
 	}
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const IndustryTileSpec *inds);

--- a/src/newgrf_industrytiles.h
+++ b/src/newgrf_industrytiles.h
@@ -39,6 +39,7 @@ struct IndustryTileScopeResolver : public ScopeResolver {
 struct IndustryTileResolverObject : public ResolverObject {
 	IndustryTileScopeResolver indtile_scope; ///< Scope resolver for the industry tile.
 	IndustriesScopeResolver ind_scope;       ///< Scope resolver for the industry owning the tile.
+	IndustryGfx gfx;
 
 	IndustryTileResolverObject(IndustryGfx gfx, TileIndex tile, Industry *indus,
 			CallbackID callback = CBID_NO_CALLBACK, uint32 callback_param1 = 0, uint32 callback_param2 = 0);
@@ -51,6 +52,9 @@ struct IndustryTileResolverObject : public ResolverObject {
 			default: return ResolverObject::GetScope(scope, relative);
 		}
 	}
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 bool DrawNewIndustryTile(TileInfo *ti, Industry *i, IndustryGfx gfx, const IndustryTileSpec *inds);

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -389,7 +389,7 @@ GrfSpecFeature ObjectResolverObject::GetFeature() const
 	return GSF_OBJECTS;
 }
 
-uint32 ObjectResolverObject::GetLocalID() const
+uint32 ObjectResolverObject::GetDebugID() const
 {
 	return this->object_scope.spec->grf_prop.local_id;
 }

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -352,7 +352,7 @@ unhandled:
  */
 ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, TileIndex tile, uint8 view,
 		CallbackID callback, uint32 param1, uint32 param2)
-	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, tile, view)
+	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
 	this->town_scope = nullptr;
 	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[CT_PURCHASE_OBJECT] != nullptr) ?
@@ -382,6 +382,16 @@ TownScopeResolver *ObjectResolverObject::GetTown()
 		this->town_scope = new TownScopeResolver(*this, t, this->object_scope.obj == nullptr);
 	}
 	return this->town_scope;
+}
+
+GrfSpecFeature ObjectResolverObject::GetFeature() const
+{
+	return GSF_OBJECTS;
+}
+
+uint32 ObjectResolverObject::GetLocalID() const
+{
+	return this->object_scope.spec->grf_prop.local_id;
 }
 
 /**

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -146,7 +146,7 @@ struct ObjectResolverObject : public ResolverObject {
 	}
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 
 private:
 	TownScopeResolver *GetTown();

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -98,9 +98,10 @@ struct ObjectSpec {
 
 /** Object scope resolver. */
 struct ObjectScopeResolver : public ScopeResolver {
-	struct Object *obj; ///< The object the callback is ran for.
-	TileIndex tile;     ///< The tile related to the object.
-	uint8 view;         ///< The view of the object.
+	struct Object *obj;     ///< The object the callback is ran for.
+	const ObjectSpec *spec; ///< Specification of the object type.
+	TileIndex tile;         ///< The tile related to the object.
+	uint8 view;             ///< The view of the object.
 
 	/**
 	 * Constructor of an object scope resolver.
@@ -109,8 +110,8 @@ struct ObjectScopeResolver : public ScopeResolver {
 	 * @param tile %Tile of the object.
 	 * @param view View of the object.
 	 */
-	ObjectScopeResolver(ResolverObject &ro, Object *obj, TileIndex tile, uint8 view = 0)
-		: ScopeResolver(ro), obj(obj), tile(tile), view(view)
+	ObjectScopeResolver(ResolverObject &ro, Object *obj, const ObjectSpec *spec, TileIndex tile, uint8 view = 0)
+		: ScopeResolver(ro), obj(obj), spec(spec), tile(tile), view(view)
 	{
 	}
 
@@ -143,6 +144,9 @@ struct ObjectResolverObject : public ResolverObject {
 				return ResolverObject::GetScope(scope, relative);
 		}
 	}
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 
 private:
 	TownScopeResolver *GetTown();

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -1,0 +1,97 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file newgrf_profiling.cpp Profiling of NewGRF action 2 handling. */
+
+#include "newgrf_profiling.h"
+#include "date_func.h"
+#include "fileio_func.h"
+#include "string_func.h"
+#include "console_func.h"
+
+#include <chrono>
+#include <time.h>
+
+
+NewGRFProfiler *_newgrf_profiler;
+
+
+/**
+ * Create profiler object and begin profiling session.
+ * @param grffile   The GRF file to collect profiling data on
+ * @param end_date  Game date to end profiling on
+ */
+NewGRFProfiler::NewGRFProfiler(const GRFFile *grffile, Date end_date) : grffile(grffile), profile_end_date(end_date)
+{
+	IConsolePrintF(TC_LIGHT_BROWN, "Beginning profile of NewGRF %s", grffile->filename);
+}
+
+/**
+ * Complete profiling session and write data to file
+ */
+NewGRFProfiler::~NewGRFProfiler()
+{
+	std::string filename = this->GetOutputFilename();
+	IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF, writing %u events to %s", (uint)this->calls.size(), filename.c_str());
+
+	FILE *f = FioFOpenFile(filename.c_str(), "wt", Subdirectory::NO_DIRECTORY);
+	FileCloser fcloser(f);
+
+	fputs("Tick,Sprite,CallbackID,Microseconds,Subs\n", f);
+	for (const Call &c : this->calls) {
+		fprintf(f, "%u,%u,%u,%u,%u\n", c.tick, c.nfo_line, (uint)c.cb, c.time, c.subs);
+	}
+}
+
+/**
+ * Capture the start of a sprite group resolution.
+ * @param resolver  Data about sprite group being resolved
+ */
+void NewGRFProfiler::BeginResolve(const ResolverObject &resolver)
+{
+	using namespace std::chrono;
+	this->cur_call.nfo_line = resolver.root_spritegroup->nfo_line;
+	this->cur_call.subs = 0;
+	this->cur_call.time = (uint32)time_point_cast<microseconds>(high_resolution_clock::now()).time_since_epoch().count();
+	this->cur_call.tick = _tick_counter;
+	this->cur_call.cb = resolver.callback;
+}
+
+/**
+ * Capture the completion of a sprite group resolution.
+ */
+void NewGRFProfiler::EndResolve()
+{
+	using namespace std::chrono;
+	this->cur_call.time = (uint32)time_point_cast<microseconds>(high_resolution_clock::now()).time_since_epoch().count() - this->cur_call.time;
+	this->calls.push_back(this->cur_call);
+}
+
+/**
+ * Capture a recursive sprite group resolution.
+ */
+void NewGRFProfiler::RecursiveResolve()
+{
+	this->cur_call.subs += 1;
+}
+
+/**
+ * Get name of the file that will be written.
+ * @return File name of profiling output file.
+ */
+std::string NewGRFProfiler::GetOutputFilename() const
+{
+	time_t write_time = time(nullptr);
+
+	char timestamp[16] = {};
+	strftime(timestamp, lengthof(timestamp), "%Y%m%d-%H%M", localtime(&write_time));
+
+	char filepath[MAX_PATH] = {};
+	seprintf(filepath, lastof(filepath), "%sgrfprofile-%s.csv", FiosGetScreenshotDir(), timestamp);
+
+	return std::string(filepath);
+}

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -95,12 +95,12 @@ uint32 NewGRFProfiler::Finish()
 	if (!this->active) return 0;
 
 	if (this->calls.empty()) {
-		IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], no events collected, not writing a file", this->grffile->grfid);
+		IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], no events collected, not writing a file", BSWAP32(this->grffile->grfid));
 		return 0;
 	}
 
 	std::string filename = this->GetOutputFilename();
-	IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], writing %u events to %s", this->grffile->grfid, (uint)this->calls.size(), filename.c_str());
+	IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], writing %u events to %s", BSWAP32(this->grffile->grfid), (uint)this->calls.size(), filename.c_str());
 
 	FILE *f = FioFOpenFile(filename.c_str(), "wt", Subdirectory::NO_DIRECTORY);
 	FileCloser fcloser(f);
@@ -136,7 +136,7 @@ std::string NewGRFProfiler::GetOutputFilename() const
 	strftime(timestamp, lengthof(timestamp), "%Y%m%d-%H%M", localtime(&write_time));
 
 	char filepath[MAX_PATH] = {};
-	seprintf(filepath, lastof(filepath), "%sgrfprofile-%s-%08X.csv", FiosGetScreenshotDir(), timestamp, this->grffile->grfid);
+	seprintf(filepath, lastof(filepath), "%sgrfprofile-%s-%08X.csv", FiosGetScreenshotDir(), timestamp, BSWAP32(this->grffile->grfid));
 
 	return std::string(filepath);
 }

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -95,12 +95,12 @@ uint32 NewGRFProfiler::Finish()
 	if (!this->active) return 0;
 
 	if (this->calls.empty()) {
-		IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], no events collected, not writing a file", BSWAP32(this->grffile->grfid));
+		IConsolePrintF(CC_DEBUG, "Finished profile of NewGRF [%08X], no events collected, not writing a file", BSWAP32(this->grffile->grfid));
 		return 0;
 	}
 
 	std::string filename = this->GetOutputFilename();
-	IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], writing %u events to %s", BSWAP32(this->grffile->grfid), (uint)this->calls.size(), filename.c_str());
+	IConsolePrintF(CC_DEBUG, "Finished profile of NewGRF [%08X], writing %u events to %s", BSWAP32(this->grffile->grfid), (uint)this->calls.size(), filename.c_str());
 
 	FILE *f = FioFOpenFile(filename.c_str(), "wt", Subdirectory::NO_DIRECTORY);
 	FileCloser fcloser(f);
@@ -153,7 +153,7 @@ uint32 NewGRFProfiler::FinishAll()
 	}
 
 	if (total_microseconds > 0 && max_ticks > 0) {
-		IConsolePrintF(TC_LIGHT_BROWN, "Total NewGRF callback processing: %u microseconds over %d ticks", total_microseconds, max_ticks);
+		IConsolePrintF(CC_DEBUG, "Total NewGRF callback processing: %u microseconds over %d ticks", total_microseconds, max_ticks);
 	}
 
 	_newgrf_profile_end_date = MAX_DAY;

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -94,7 +94,7 @@ void NewGRFProfiler::Finish()
 	if (!this->active) return;
 
 	std::string filename = this->GetOutputFilename();
-	IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF %08X, writing %u events to %s", this->grffile->grfid, (uint)this->calls.size(), filename.c_str());
+	IConsolePrintF(TC_LIGHT_BROWN, "Finished profile of NewGRF [%08X], writing %u events to %s", this->grffile->grfid, (uint)this->calls.size(), filename.c_str());
 
 	FILE *f = FioFOpenFile(filename.c_str(), "wt", Subdirectory::NO_DIRECTORY);
 	FileCloser fcloser(f);

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -42,7 +42,7 @@ NewGRFProfiler::~NewGRFProfiler()
 	FILE *f = FioFOpenFile(filename.c_str(), "wt", Subdirectory::NO_DIRECTORY);
 	FileCloser fcloser(f);
 
-	fputs("Tick,Sprite,Feature,Item,CallbackID,Microseconds,Subs,Result\n", f);
+	fputs("Tick,Sprite,Feature,Item,CallbackID,Microseconds,Depth,Result\n", f);
 	for (const Call &c : this->calls) {
 		fprintf(f, "%u,%u,0x%X,%d,0x%X,%u,%u,%u\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
 	}
@@ -61,7 +61,7 @@ void NewGRFProfiler::BeginResolve(const ResolverObject &resolver)
 	this->cur_call.tick = _tick_counter;
 	this->cur_call.cb = resolver.callback;
 	this->cur_call.feat = resolver.GetFeature();
-	this->cur_call.item = resolver.GetLocalID();
+	this->cur_call.item = resolver.GetDebugID();
 }
 
 /**

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -24,13 +24,16 @@
  * Callback profiler for NewGRF development
  */
 struct NewGRFProfiler {
-	NewGRFProfiler(const GRFFile *grffile, Date end_date);
+	NewGRFProfiler(const GRFFile *grffile);
 	~NewGRFProfiler();
 
 	void BeginResolve(const ResolverObject &resolver);
 	void EndResolve(const SpriteGroup *result);
 	void RecursiveResolve();
 
+	void Start();
+	void Finish();
+	void Abort();
 	std::string GetOutputFilename() const;
 
 	/** Measurement of a single sprite group resolution */
@@ -46,11 +49,12 @@ struct NewGRFProfiler {
 	};
 
 	const GRFFile *grffile;  ///< Which GRF is being profiled
-	Date profile_end_date;   ///< Game date to end this profiling session
+	bool active;             ///< Is this profiler collecting data
 	Call cur_call;           ///< Data for current call in progress
 	std::vector<Call> calls; ///< All calls collected so far
 };
 
-extern std::unique_ptr<NewGRFProfiler> _newgrf_profiler;
+extern std::vector<NewGRFProfiler> _newgrf_profilers;
+extern Date _newgrf_profile_end_date;
 
 #endif /* NEWGRF_PROFILING_H */

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -32,9 +32,11 @@ struct NewGRFProfiler {
 	void RecursiveResolve();
 
 	void Start();
-	void Finish();
+	uint32 Finish();
 	void Abort();
 	std::string GetOutputFilename() const;
+
+	static uint32 FinishAll();
 
 	/** Measurement of a single sprite group resolution */
 	struct Call {
@@ -50,6 +52,7 @@ struct NewGRFProfiler {
 
 	const GRFFile *grffile;  ///< Which GRF is being profiled
 	bool active;             ///< Is this profiler collecting data
+	uint16 start_tick;       ///< Tick number this profiler was started on
 	Call cur_call;           ///< Data for current call in progress
 	std::vector<Call> calls; ///< All calls collected so far
 };

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <string>
+#include <memory>
 
 /**
  * Callback profiler for NewGRF development
@@ -34,13 +35,14 @@ struct NewGRFProfiler {
 
 	/** Measurement of a single sprite group resolution */
 	struct Call {
-		uint32 root_sprite; ///< Pseudo-sprite index in GRF file
-		uint32 result;      ///< Result of callback
-		uint32 subs;        ///< Sub-calls to other sprite groups
-		uint32 time;        ///< Time taken for resolution (microseconds)
-		uint16 tick;        ///< Game tick
-		CallbackID cb;      ///< Callback ID
-
+		uint32 root_sprite;  ///< Pseudo-sprite index in GRF file
+		uint32 item;         ///< Local ID of item being resolved for
+		uint32 result;       ///< Result of callback
+		uint32 subs;         ///< Sub-calls to other sprite groups
+		uint32 time;         ///< Time taken for resolution (microseconds)
+		uint16 tick;         ///< Game tick
+		CallbackID cb;       ///< Callback ID
+		GrfSpecFeature feat; ///< GRF feature being resolved for
 	};
 
 	const GRFFile *grffile;  ///< Which GRF is being profiled
@@ -49,6 +51,6 @@ struct NewGRFProfiler {
 	std::vector<Call> calls; ///< All calls collected so far
 };
 
-extern NewGRFProfiler *_newgrf_profiler;
+extern std::unique_ptr<NewGRFProfiler> _newgrf_profiler;
 
 #endif /* NEWGRF_PROFILING_H */

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -27,18 +27,19 @@ struct NewGRFProfiler {
 	~NewGRFProfiler();
 
 	void BeginResolve(const ResolverObject &resolver);
-	void EndResolve();
+	void EndResolve(const SpriteGroup *result);
 	void RecursiveResolve();
 
 	std::string GetOutputFilename() const;
 
 	/** Measurement of a single sprite group resolution */
 	struct Call {
-		uint32 nfo_line; ///< Pseudo-sprite index in GRF file
-		uint32 subs;     ///< Sub-calls to other sprite groups
-		uint32 time;     ///< Time taken for resolution (microseconds)
-		uint16 tick;     ///< Game tick
-		CallbackID cb;   ///< Callback ID
+		uint32 root_sprite; ///< Pseudo-sprite index in GRF file
+		uint32 result;      ///< Result of callback
+		uint32 subs;        ///< Sub-calls to other sprite groups
+		uint32 time;        ///< Time taken for resolution (microseconds)
+		uint16 tick;        ///< Game tick
+		CallbackID cb;      ///< Callback ID
 
 	};
 

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file newgrf_profiling.h Profiling of NewGRF action 2 handling. */
+
+#ifndef NEWGRF_PROFILING_H
+#define NEWGRF_PROFILING_H
+
+#include "stdafx.h"
+#include "date_type.h"
+#include "newgrf.h"
+#include "newgrf_callbacks.h"
+#include "newgrf_spritegroup.h"
+
+#include <vector>
+#include <string>
+
+/**
+ * Callback profiler for NewGRF development
+ */
+struct NewGRFProfiler {
+	NewGRFProfiler(const GRFFile *grffile, Date end_date);
+	~NewGRFProfiler();
+
+	void BeginResolve(const ResolverObject &resolver);
+	void EndResolve();
+	void RecursiveResolve();
+
+	std::string GetOutputFilename() const;
+
+	/** Measurement of a single sprite group resolution */
+	struct Call {
+		uint32 nfo_line; ///< Pseudo-sprite index in GRF file
+		uint32 subs;     ///< Sub-calls to other sprite groups
+		uint32 time;     ///< Time taken for resolution (microseconds)
+		uint16 tick;     ///< Game tick
+		CallbackID cb;   ///< Callback ID
+
+	};
+
+	const GRFFile *grffile;  ///< Which GRF is being profiled
+	Date profile_end_date;   ///< Game date to end this profiling session
+	Call cur_call;           ///< Data for current call in progress
+	std::vector<Call> calls; ///< All calls collected so far
+};
+
+extern NewGRFProfiler *_newgrf_profiler;
+
+#endif /* NEWGRF_PROFILING_H */

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -65,6 +65,16 @@
 	return nullptr;
 }
 
+GrfSpecFeature RailTypeResolverObject::GetFeature() const
+{
+	return GSF_RAILTYPES;
+}
+
+uint32 RailTypeResolverObject::GetLocalID() const
+{
+	return this->railtype_scope.rti->label;
+}
+
 /**
  * Resolver object for rail types.
  * @param rti Railtype. nullptr in NewGRF Inspect window.
@@ -75,7 +85,7 @@
  * @param param2 Extra parameter (second parameter of the callback, except railtypes do not have callbacks).
  */
 RailTypeResolverObject::RailTypeResolverObject(const RailtypeInfo *rti, TileIndex tile, TileContext context, RailTypeSpriteGroup rtsg, uint32 param1, uint32 param2)
-	: ResolverObject(rti != nullptr ? rti->grffile[rtsg] : nullptr, CBID_NO_CALLBACK, param1, param2), railtype_scope(*this, tile, context)
+	: ResolverObject(rti != nullptr ? rti->grffile[rtsg] : nullptr, CBID_NO_CALLBACK, param1, param2), railtype_scope(*this, rti, tile, context)
 {
 	this->root_spritegroup = rti != nullptr ? rti->group[rtsg] : nullptr;
 }

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -70,7 +70,7 @@ GrfSpecFeature RailTypeResolverObject::GetFeature() const
 	return GSF_RAILTYPES;
 }
 
-uint32 RailTypeResolverObject::GetLocalID() const
+uint32 RailTypeResolverObject::GetDebugID() const
 {
 	return this->railtype_scope.rti->label;
 }

--- a/src/newgrf_railtype.h
+++ b/src/newgrf_railtype.h
@@ -18,6 +18,7 @@
 struct RailTypeScopeResolver : public ScopeResolver {
 	TileIndex tile;      ///< Tracktile. For track on a bridge this is the southern bridgehead.
 	TileContext context; ///< Are we resolving sprites for the upper halftile, or on a bridge?
+	const RailtypeInfo *rti;
 
 	/**
 	 * Constructor of the railtype scope resolvers.
@@ -25,8 +26,8 @@ struct RailTypeScopeResolver : public ScopeResolver {
 	 * @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
 	 * @param context Are we resolving sprites for the upper halftile, or on a bridge?
 	 */
-	RailTypeScopeResolver(ResolverObject &ro, TileIndex tile, TileContext context)
-		: ScopeResolver(ro), tile(tile), context(context)
+	RailTypeScopeResolver(ResolverObject &ro, const RailtypeInfo *rti, TileIndex tile, TileContext context)
+		: ScopeResolver(ro), tile(tile), context(context), rti(rti)
 	{
 	}
 
@@ -49,6 +50,9 @@ struct RailTypeResolverObject : public ResolverObject {
 	}
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 SpriteID GetCustomRailSprite(const RailtypeInfo *rti, TileIndex tile, RailTypeSpriteGroup rtsg, TileContext context = TCX_NORMAL, uint *num_results = nullptr);

--- a/src/newgrf_railtype.h
+++ b/src/newgrf_railtype.h
@@ -52,7 +52,7 @@ struct RailTypeResolverObject : public ResolverObject {
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 SpriteID GetCustomRailSprite(const RailtypeInfo *rti, TileIndex tile, RailTypeSpriteGroup rtsg, TileContext context = TCX_NORMAL, uint *num_results = nullptr);

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -65,16 +65,27 @@
 	return nullptr;
 }
 
+GrfSpecFeature RoadTypeResolverObject::GetFeature() const
+{
+	return GSF_ROADTYPES; // FIXME: when is this GSF_TRAMTYPES instead?
+}
+
+uint32 RoadTypeResolverObject::GetLocalID() const
+{
+	return this->roadtype_scope.rti->label;
+}
+
 /**
  * Constructor of the roadtype scope resolvers.
  * @param ro Surrounding resolver.
  * @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
  * @param context Are we resolving sprites for the upper halftile, or on a bridge?
  */
-RoadTypeScopeResolver::RoadTypeScopeResolver(ResolverObject &ro, TileIndex tile, TileContext context) : ScopeResolver(ro)
+RoadTypeScopeResolver::RoadTypeScopeResolver(ResolverObject &ro, const RoadTypeInfo *rti, TileIndex tile, TileContext context) : ScopeResolver(ro)
 {
 	this->tile = tile;
 	this->context = context;
+	this->rti = rti;
 }
 
 /**
@@ -87,7 +98,7 @@ RoadTypeScopeResolver::RoadTypeScopeResolver(ResolverObject &ro, TileIndex tile,
  * @param param2 Extra parameter (second parameter of the callback, except roadtypes do not have callbacks).
  */
 RoadTypeResolverObject::RoadTypeResolverObject(const RoadTypeInfo *rti, TileIndex tile, TileContext context, RoadTypeSpriteGroup rtsg, uint32 param1, uint32 param2)
-	: ResolverObject(rti != nullptr ? rti->grffile[rtsg] : nullptr, CBID_NO_CALLBACK, param1, param2), roadtype_scope(*this, tile, context)
+	: ResolverObject(rti != nullptr ? rti->grffile[rtsg] : nullptr, CBID_NO_CALLBACK, param1, param2), roadtype_scope(*this, rti, tile, context)
 {
 	this->root_spritegroup = rti != nullptr ? rti->group[rtsg] : nullptr;
 }

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -67,10 +67,15 @@
 
 GrfSpecFeature RoadTypeResolverObject::GetFeature() const
 {
-	return GSF_ROADTYPES; // FIXME: when is this GSF_TRAMTYPES instead?
+	RoadType rt = GetRoadTypeByLabel(this->roadtype_scope.rti->label, false);
+	switch (GetRoadTramType(rt)) {
+		case RTT_ROAD: return GSF_ROADTYPES;
+		case RTT_TRAM: return GSF_TRAMTYPES;
+		default: return GSF_INVALID;
+	}
 }
 
-uint32 RoadTypeResolverObject::GetLocalID() const
+uint32 RoadTypeResolverObject::GetDebugID() const
 {
 	return this->roadtype_scope.rti->label;
 }

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -43,7 +43,7 @@ struct RoadTypeResolverObject : public ResolverObject {
 	/* virtual */ const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 SpriteID GetCustomRoadSprite(const RoadTypeInfo *rti, TileIndex tile, RoadTypeSpriteGroup rtsg, TileContext context = TCX_NORMAL, uint *num_results = nullptr);

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -18,8 +18,9 @@
 struct RoadTypeScopeResolver : public ScopeResolver {
 	TileIndex tile;      ///< Tracktile. For track on a bridge this is the southern bridgehead.
 	TileContext context; ///< Are we resolving sprites for the upper halftile, or on a bridge?
+	const RoadTypeInfo *rti;
 
-	RoadTypeScopeResolver(ResolverObject &ro, TileIndex tile, TileContext context);
+	RoadTypeScopeResolver(ResolverObject &ro, const RoadTypeInfo *rti, TileIndex tile, TileContext context);
 
 	/* virtual */ uint32 GetRandomBits() const;
 	/* virtual */ uint32 GetVariable(byte variable, uint32 parameter, bool *available) const;
@@ -40,6 +41,9 @@ struct RoadTypeResolverObject : public ResolverObject {
 	}
 
 	/* virtual */ const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 SpriteID GetCustomRoadSprite(const RoadTypeInfo *rti, TileIndex tile, RoadTypeSpriteGroup rtsg, TileContext context = TCX_NORMAL, uint *num_results = nullptr);

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -36,17 +36,20 @@ TemporaryStorageArray<int32, 0x110> _temp_store;
 {
 	if (group == nullptr) return nullptr;
 
-	if (_newgrf_profiler == nullptr || _newgrf_profiler->grffile != object.grffile) {
+	const GRFFile *grf = object.grffile;
+	auto profiler = std::find_if(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](const NewGRFProfiler &pr) { return pr.grffile == grf; });
+
+	if (profiler == _newgrf_profilers.end() || !profiler->active) {
 		if (top_level) _temp_store.ClearChanges();
 		return group->Resolve(object);
 	} else if (top_level) {
-		_newgrf_profiler->BeginResolve(object);
+		profiler->BeginResolve(object);
 		_temp_store.ClearChanges();
 		const SpriteGroup *result = group->Resolve(object);
-		_newgrf_profiler->EndResolve(result);
+		profiler->EndResolve(result);
 		return result;
 	} else {
-		_newgrf_profiler->RecursiveResolve();
+		profiler->RecursiveResolve();
 		return group->Resolve(object);
 	}
 }

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -12,6 +12,7 @@
 #include "debug.h"
 #include "newgrf_spritegroup.h"
 #include "core/pool_func.hpp"
+#include "framerate_type.h"
 
 #include "safeguards.h"
 
@@ -35,9 +36,12 @@ TemporaryStorageArray<int32, 0x110> _temp_store;
 {
 	if (group == nullptr) return nullptr;
 	if (top_level) {
+		PerformanceAccumulator pfe(PFE_GL_NEWGRFCB); // only measure top-level calls, to avoid double measurements
 		_temp_store.ClearChanges();
+		return group->Resolve(object);
+	} else {
+		return group->Resolve(object);
 	}
-	return group->Resolve(object);
 }
 
 RealSpriteGroup::~RealSpriteGroup()

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -43,7 +43,7 @@ TemporaryStorageArray<int32, 0x110> _temp_store;
 		_newgrf_profiler->BeginResolve(object);
 		_temp_store.ClearChanges();
 		const SpriteGroup *result = group->Resolve(object);
-		_newgrf_profiler->EndResolve();
+		_newgrf_profiler->EndResolve(result);
 		return result;
 	} else {
 		_newgrf_profiler->RecursiveResolve();

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -12,7 +12,6 @@
 #include "debug.h"
 #include "newgrf_spritegroup.h"
 #include "core/pool_func.hpp"
-#include "framerate_type.h"
 
 #include "safeguards.h"
 
@@ -36,12 +35,9 @@ TemporaryStorageArray<int32, 0x110> _temp_store;
 {
 	if (group == nullptr) return nullptr;
 	if (top_level) {
-		PerformanceAccumulator pfe(PFE_GL_NEWGRFCB); // only measure top-level calls, to avoid double measurements
 		_temp_store.ClearChanges();
-		return group->Resolve(object);
-	} else {
-		return group->Resolve(object);
 	}
+	return group->Resolve(object);
 }
 
 RealSpriteGroup::~RealSpriteGroup()

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include "debug.h"
 #include "newgrf_spritegroup.h"
+#include "newgrf_profiling.h"
 #include "core/pool_func.hpp"
 
 #include "safeguards.h"
@@ -34,10 +35,20 @@ TemporaryStorageArray<int32, 0x110> _temp_store;
 /* static */ const SpriteGroup *SpriteGroup::Resolve(const SpriteGroup *group, ResolverObject &object, bool top_level)
 {
 	if (group == nullptr) return nullptr;
-	if (top_level) {
+
+	if (_newgrf_profiler == nullptr || _newgrf_profiler->grffile != object.grffile) {
+		if (top_level) _temp_store.ClearChanges();
+		return group->Resolve(object);
+	} else if (top_level) {
+		_newgrf_profiler->BeginResolve(object);
 		_temp_store.ClearChanges();
+		const SpriteGroup *result = group->Resolve(object);
+		_newgrf_profiler->EndResolve();
+		return result;
+	} else {
+		_newgrf_profiler->RecursiveResolve();
+		return group->Resolve(object);
 	}
-	return group->Resolve(object);
 }
 
 RealSpriteGroup::~RealSpriteGroup()

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -400,10 +400,17 @@ struct ResolverObject {
 		memset(this->reseed, 0, sizeof(this->reseed));
 	}
 
-	/** Get the feature number being resolved for. */
+	/**
+	 * Get the feature number being resolved for.
+	 * This function is mainly intended for the callback profiling feature.
+	 */
 	virtual GrfSpecFeature GetFeature() const { return GSF_INVALID; }
-	/** Get the GRF local id of the item being resolved for. */
-	virtual uint32 GetLocalID() const { return 0; }
+	/**
+	 * Get an identifier for the item being resolved.
+	 * This function is mainly intended for the callback profiling feature,
+	 * and should return an identifier recognisable by the NewGRF developer.
+	 */
+	virtual uint32 GetDebugID() const { return 0; }
 };
 
 #endif /* NEWGRF_SPRITEGROUP_H */

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -399,6 +399,11 @@ struct ResolverObject {
 		this->used_triggers = 0;
 		memset(this->reseed, 0, sizeof(this->reseed));
 	}
+
+	/** Get the feature number being resolved for. */
+	virtual GrfSpecFeature GetFeature() const { return GSF_INVALID; }
+	/** Get the GRF local id of the item being resolved for. */
+	virtual uint32 GetLocalID() const { return 0; }
 };
 
 #endif /* NEWGRF_SPRITEGROUP_H */

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -56,13 +56,14 @@ extern SpriteGroupPool _spritegroup_pool;
 /* Common wrapper for all the different sprite group types */
 struct SpriteGroup : SpriteGroupPool::PoolItem<&_spritegroup_pool> {
 protected:
-	SpriteGroup(SpriteGroupType type) : type(type) {}
+	SpriteGroup(SpriteGroupType type) : nfo_line(0), type(type) {}
 	/** Base sprite group resolver */
 	virtual const SpriteGroup *Resolve(ResolverObject &object) const { return this; };
 
 public:
 	virtual ~SpriteGroup() {}
 
+	uint32 nfo_line;
 	SpriteGroupType type;
 
 	virtual SpriteID GetResult() const { return 0; }

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -532,7 +532,7 @@ GrfSpecFeature StationResolverObject::GetFeature() const
 	return GSF_STATIONS;
 }
 
-uint32 StationResolverObject::GetLocalID() const
+uint32 StationResolverObject::GetDebugID() const
 {
 	return this->station_scope.statspec->grf_prop.local_id;
 }

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -527,6 +527,16 @@ uint32 Waypoint::GetNewGRFVariable(const ResolverObject &object, byte variable, 
 	return group->loading[0];
 }
 
+GrfSpecFeature StationResolverObject::GetFeature() const
+{
+	return GSF_STATIONS;
+}
+
+uint32 StationResolverObject::GetLocalID() const
+{
+	return this->station_scope.statspec->grf_prop.local_id;
+}
+
 /**
  * Resolver for stations.
  * @param statspec Station (type) specification.

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -75,6 +75,9 @@ struct StationResolverObject : public ResolverObject {
 	}
 
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
+
+	GrfSpecFeature GetFeature() const override;
+	uint32 GetLocalID() const override;
 };
 
 enum StationClassID : byte {

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -77,7 +77,7 @@ struct StationResolverObject : public ResolverObject {
 	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
 
 	GrfSpecFeature GetFeature() const override;
-	uint32 GetLocalID() const override;
+	uint32 GetDebugID() const override;
 };
 
 enum StationClassID : byte {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1336,6 +1336,7 @@ void StateGameLoop()
 		PerformanceMeasurer::Paused(PFE_GL_SHIPS);
 		PerformanceMeasurer::Paused(PFE_GL_AIRCRAFT);
 		PerformanceMeasurer::Paused(PFE_GL_LANDSCAPE);
+		PerformanceMeasurer::Paused(PFE_GL_NEWGRFCB);
 
 		UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS
@@ -1346,6 +1347,7 @@ void StateGameLoop()
 
 	PerformanceMeasurer framerate(PFE_GAMELOOP);
 	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
+	PerformanceAccumulator::Reset(PFE_GL_NEWGRFCB);
 	if (HasModalProgress()) return;
 
 	Layouter::ReduceLineCache();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1336,7 +1336,6 @@ void StateGameLoop()
 		PerformanceMeasurer::Paused(PFE_GL_SHIPS);
 		PerformanceMeasurer::Paused(PFE_GL_AIRCRAFT);
 		PerformanceMeasurer::Paused(PFE_GL_LANDSCAPE);
-		PerformanceMeasurer::Paused(PFE_GL_NEWGRFCB);
 
 		UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS
@@ -1347,7 +1346,6 @@ void StateGameLoop()
 
 	PerformanceMeasurer framerate(PFE_GAMELOOP);
 	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
-	PerformanceAccumulator::Reset(PFE_GL_NEWGRFCB);
 	if (HasModalProgress()) return;
 
 	Layouter::ReduceLineCache();

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -146,6 +146,17 @@ uint GetOriginFileSlot(SpriteID sprite)
 }
 
 /**
+ * Get the GRF-local sprite id of a given sprite.
+ * @param sprite The sprite to look at.
+ * @return The GRF-local sprite id.
+ */
+uint32 GetSpriteLocalID(SpriteID sprite)
+{
+	if (!SpriteExists(sprite)) return 0;
+	return GetSpriteCache(sprite)->id;
+}
+
+/**
  * Count the sprites which originate from a specific file slot in a range of SpriteIDs.
  * @param file_slot FIOS file slot.
  * @param begin First sprite in range.

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -30,6 +30,7 @@ bool SpriteExists(SpriteID sprite);
 
 SpriteType GetSpriteType(SpriteID sprite);
 uint GetOriginFileSlot(SpriteID sprite);
+uint32 GetSpriteLocalID(SpriteID sprite);
 uint GetSpriteCountForSlot(uint file_slot, SpriteID begin, SpriteID end);
 uint GetMaxSpriteID();
 


### PR DESCRIPTION
Adds a console command `newgrf_profile` to collect some profiling data about NewGRF action 2 callbacks and produce a CSV file.

I'm not entirely sure if this is useful or not, hopefully someone can try it out and decide. It should have almost no impact on performance when not in use. The console command requires developer tools to be enabled.

Careful, the CSV files can get very large very fast :) One small-ish test game with (a beta of) Iron Horse being profiled made a CSV file of 8 MB with more than 460k events recorded across 7 in-game days.