### PR TITLE
Fix: TerraGenesis was not generating maps at the requested maximum height

### DIFF
--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -235,7 +235,7 @@ static height_t TGPGetMaxHeight()
 	};
 
 	int max_height_from_table = max_height[_settings_game.difficulty.terrain_type][min(MapLogX(), MapLogY()) - MIN_MAP_SIZE_BITS];
-	return I2H(min(max_height_from_table, _settings_game.construction.max_heightlevel));
+	return I2H(min(max_height_from_table, _settings_game.construction.max_heightlevel + 1));
 }
 
 /**


### PR DESCRIPTION
- Maps were being generated with a maximum height one level lower than intended


I used a game script to check max height that was being generated.
[Minimal GS-v2.zip](https://github.com/OpenTTD/OpenTTD/files/3996337/Minimal.GS-v2.zip)

On Original generator, setting a max height of 15, generates a map with max height of 15.
![mdOEDVP - Imgur](https://user-images.githubusercontent.com/43006711/71381399-4f76dc80-25cb-11ea-89e4-faab03e7ccbe.png)

On TerraGenesis generator, setting a max height of 15, generates a map with max height of 14.
![E4VjbWC - Imgur](https://user-images.githubusercontent.com/43006711/71381434-703f3200-25cb-11ea-94ce-4cb925777100.png)
