### PR TITLE
Fix: Farms could be generated at sea level

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1295,7 +1295,7 @@ static CommandCost CheckNewIndustry_OilRig(TileIndex tile)
 static CommandCost CheckNewIndustry_Farm(TileIndex tile)
 {
 	if (_settings_game.game_creation.landscape == LT_ARCTIC) {
-		if (GetTileZ(tile) + 2 >= HighestSnowLine()) {
+		if (GetTileMaxZ(tile) + 2 >= HighestSnowLine()) {
 			return_cmd_error(STR_ERROR_SITE_UNSUITABLE);
 		}
 	}


### PR DESCRIPTION
An incorrect height check function was being used, which could result in leveled land with height lower than 1.


![lGBnGP7 - Imgur](https://user-images.githubusercontent.com/43006711/71481579-559cd100-27f6-11ea-96f4-390507a916e6.png)
![VYOHgMM - Imgur](https://user-images.githubusercontent.com/43006711/71481580-56356780-27f6-11ea-9791-64dac6b7313b.png)
