### PR TITLE
Fix bootstrap with missing basesets

### DIFF
--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -262,6 +262,6 @@ bool HandleBootstrap()
 
 	/* Failure to get enough working to get a graphics set. */
 failure:
-	usererror("Failed to find a graphics set. Please acquire a graphics set for OpenTTD. See section 4.1 of README.md.");
+	usererror("Failed to find a graphics set. Please acquire a graphics set for OpenTTD. See section 1.4 of README.md.");
 	return false;
 }

--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -11,7 +11,7 @@
 #include "base_media_base.h"
 #include "blitter/factory.hpp"
 
-#if defined(WITH_FREETYPE)
+#if defined(WITH_FREETYPE) || defined(WITH_UNISCRIBE)
 
 #include "core/geometry_func.hpp"
 #include "fontcache.h"
@@ -218,7 +218,7 @@ bool HandleBootstrap()
 	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 0) goto failure;
 
 	/* If there is no network or no freetype, then there is nothing we can do. Go straight to failure. */
-#if defined(WITH_FREETYPE) && (defined(WITH_FONTCONFIG) || defined(_WIN32) || defined(__APPLE__))
+#if (defined(_WIN32) && defined(WITH_UNISCRIBE)) || (defined(WITH_FREETYPE) && (defined(WITH_FONTCONFIG) || defined(__APPLE__)))
 	if (!_network_available) goto failure;
 
 	/* First tell the game we're bootstrapping. */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -804,7 +804,7 @@ int openttd_main(int argc, char *argv[])
 	if (sounds_set == nullptr && BaseSounds::ini_set != nullptr) sounds_set = stredup(BaseSounds::ini_set);
 	if (!BaseSounds::SetSet(sounds_set)) {
 		if (StrEmpty(sounds_set) || !BaseSounds::SetSet(nullptr)) {
-			usererror("Failed to find a sounds set. Please acquire a sounds set for OpenTTD. See section 4.1 of README.md.");
+			usererror("Failed to find a sounds set. Please acquire a sounds set for OpenTTD. See section 1.4 of README.md.");
 		} else {
 			ErrorMessageData msg(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_BASE_SOUNDS_NOT_FOUND);
 			msg.SetDParamStr(0, sounds_set);
@@ -817,7 +817,7 @@ int openttd_main(int argc, char *argv[])
 	if (music_set == nullptr && BaseMusic::ini_set != nullptr) music_set = stredup(BaseMusic::ini_set);
 	if (!BaseMusic::SetSet(music_set)) {
 		if (StrEmpty(music_set) || !BaseMusic::SetSet(nullptr)) {
-			usererror("Failed to find a music set. Please acquire a music set for OpenTTD. See section 4.1 of README.md.");
+			usererror("Failed to find a music set. Please acquire a music set for OpenTTD. See section 1.4 of README.md.");
 		} else {
 			ErrorMessageData msg(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_BASE_MUSIC_NOT_FOUND);
 			msg.SetDParamStr(0, music_set);


### PR DESCRIPTION
The bootstrap GUI did not work on Windows builds made with Uniscribe but no Freetype.

Additionally, the section in the README referenced is wrong.