### PR TITLE
Fix: Remove some redundant steps during world generation

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -127,7 +127,9 @@ static void _GenerateWorld()
 			/* Make the map the height of the setting */
 			if (_game_mode != GM_MENU) FlatEmptyWorld(_settings_game.game_creation.se_flat_world_height);
 
-			ConvertGroundTilesIntoWaterTiles();
+			if (!_settings_game.construction.freeform_edges || _settings_game.game_creation.se_flat_world_height == 0) {
+				ConvertGroundTilesIntoWaterTiles();
+			}
 			IncreaseGeneratingWorldProgress(GWP_OBJECT);
 		} else {
 			GenerateLandscape(_gw.mode);

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -498,9 +498,6 @@ void LoadHeightmap(DetailedFileType dft, const char *filename)
 
 	GrayscaleToMapHeights(x, y, map);
 	free(map);
-
-	FixSlopes();
-	MarkWholeScreenDirty();
 }
 
 /**
@@ -516,6 +513,5 @@ void FlatEmptyWorld(byte tile_height)
 		}
 	}
 
-	FixSlopes();
-	MarkWholeScreenDirty();
+	if (edge_distance != 0 && tile_height > 1) FixSlopes();
 }

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1294,8 +1294,8 @@ void GenerateLandscape(byte mode)
 {
 	/** Number of steps of landscape generation */
 	enum GenLandscapeSteps {
-		GLS_HEIGHTMAP    =  3, ///< Loading a heightmap
-		GLS_TERRAGENESIS =  5, ///< Terragenesis generator
+		GLS_HEIGHTMAP    =  2, ///< Loading a heightmap
+		GLS_TERRAGENESIS =  4, ///< Terragenesis generator
 		GLS_ORIGINAL     =  2, ///< Original generator
 		GLS_TROPIC       = 12, ///< Extra steps needed for tropic landscape
 		GLS_OTHER        =  0, ///< Extra steps for other landscapes
@@ -1305,7 +1305,6 @@ void GenerateLandscape(byte mode)
 	if (mode == GWM_HEIGHTMAP) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_HEIGHTMAP);
 		LoadHeightmap(_file_to_saveload.detail_ftype, _file_to_saveload.name);
-		IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
 	} else if (_settings_game.game_creation.land_generator == LG_TERRAGENESIS) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_TERRAGENESIS);
 		GenerateTerrainPerlin();
@@ -1364,10 +1363,12 @@ void GenerateLandscape(byte mode)
 		}
 	}
 
-	/* Do not call IncreaseGeneratingWorldProgress() before FixSlopes(),
-	 * it allows screen redraw. Drawing of broken slopes crashes the game */
-	FixSlopes();
-	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+	if (mode == GWM_HEIGHTMAP || _settings_game.game_creation.land_generator == LG_ORIGINAL) {
+		/* Do not call IncreaseGeneratingWorldProgress() before FixSlopes(),
+		 * it allows screen redraw. Drawing of broken slopes crashes the game */
+		FixSlopes();
+		IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+	}
 	ConvertGroundTilesIntoWaterTiles();
 	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
 


### PR DESCRIPTION
- FixSlopes was being done twice on heightmaps when one suffice. This reduces one step for loading a heightmap. Also removes redundant call to MarkWholeScreenDirty.
- FixSlopes doesn't need to be run on flat empty world, except when freeform_edges is off and tile_height is higher than 1. Also removes redundant call to MarkWholeScreenDirty.
- FixSlopes apparently isn't required for TerraGenesis. This reduces one step for TerraGenesis generator.
- ConvertGroundTilesIntoWaterTiles is only required when freeform_edges is off or when se_flat_world_height is zero.