### PR TITLE
Fix: for original terrain generator, keep a single gap of water at the borders

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -865,7 +865,8 @@ static void GenerateTerrain(int type, uint flag)
 	uint x = r & MapMaxX();
 	uint y = (r >> MapLogX()) & MapMaxY();
 
-	if (x < 2 || y < 2) return;
+	uint edge_distance = 1 + (_settings_game.construction.freeform_edges ? 1 : 0);
+	if (x <= edge_distance || y <= edge_distance) return;
 
 	DiagDirection direction = (DiagDirection)GB(r, 22, 2);
 	uint w = templ->width;
@@ -900,8 +901,8 @@ static void GenerateTerrain(int type, uint flag)
 		}
 	}
 
-	if (x + w >= MapMaxX() - 1) return;
-	if (y + h >= MapMaxY() - 1) return;
+	if (x + w >= MapMaxX()) return;
+	if (y + h >= MapMaxY()) return;
 
 	TileIndex tile = TileXY(x, y);
 


### PR DESCRIPTION
- When freeform_edges was on, NE and NW borders could have terrain adjacent to the void tiles
- SE and SW borders minimum gap was 2-tile wide instead of 1