### PR TITLE
Group management enhancements

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -193,6 +193,7 @@ CommandProc CmdDeleteGroup;
 CommandProc CmdAddVehicleGroup;
 CommandProc CmdAddSharedVehicleGroup;
 CommandProc CmdRemoveAllVehiclesGroup;
+CommandProc CmdAutoGroupVehicles;
 CommandProc CmdSetGroupReplaceProtection;
 CommandProc CmdSetGroupLivery;
 
@@ -358,6 +359,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdAddVehicleGroup,                                0, CMDT_ROUTE_MANAGEMENT      ), // CMD_ADD_VEHICLE_GROUP
 	DEF_CMD(CmdAddSharedVehicleGroup,                          0, CMDT_ROUTE_MANAGEMENT      ), // CMD_ADD_SHARE_VEHICLE_GROUP
 	DEF_CMD(CmdRemoveAllVehiclesGroup,                         0, CMDT_ROUTE_MANAGEMENT      ), // CMD_REMOVE_ALL_VEHICLES_GROUP
+	DEF_CMD(CmdAutoGroupVehicles,                              0, CMDT_ROUTE_MANAGEMENT      ), // CMD_AUTO_GROUP_VEHICLES
 	DEF_CMD(CmdSetGroupReplaceProtection,                      0, CMDT_ROUTE_MANAGEMENT      ), // CMD_SET_GROUP_REPLACE_PROTECTION
 	DEF_CMD(CmdSetGroupLivery,                                 0, CMDT_ROUTE_MANAGEMENT      ), // CMD_SET_GROUP_LIVERY
 	DEF_CMD(CmdMoveOrder,                                      0, CMDT_ROUTE_MANAGEMENT      ), // CMD_MOVE_ORDER

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -187,6 +187,7 @@ CommandProc CmdDepotSellAllVehicles;
 CommandProc CmdDepotMassAutoReplace;
 
 CommandProc CmdCreateGroup;
+CommandProc CmdCreateGroupAutogenName;
 CommandProc CmdAlterGroup;
 CommandProc CmdDeleteGroup;
 CommandProc CmdAddVehicleGroup;
@@ -351,6 +352,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdDepotSellAllVehicles,                           0, CMDT_VEHICLE_CONSTRUCTION  ), // CMD_DEPOT_SELL_ALL_VEHICLES
 	DEF_CMD(CmdDepotMassAutoReplace,                           0, CMDT_VEHICLE_CONSTRUCTION  ), // CMD_DEPOT_MASS_AUTOREPLACE
 	DEF_CMD(CmdCreateGroup,                                    0, CMDT_ROUTE_MANAGEMENT      ), // CMD_CREATE_GROUP
+	DEF_CMD(CmdCreateGroupAutogenName,                         0, CMDT_ROUTE_MANAGEMENT      ), // CMD_CREATE_GROUP_AUTOGEN_NAME
 	DEF_CMD(CmdDeleteGroup,                                    0, CMDT_ROUTE_MANAGEMENT      ), // CMD_DELETE_GROUP
 	DEF_CMD(CmdAlterGroup,                                     0, CMDT_OTHER_MANAGEMENT      ), // CMD_ALTER_GROUP
 	DEF_CMD(CmdAddVehicleGroup,                                0, CMDT_ROUTE_MANAGEMENT      ), // CMD_ADD_VEHICLE_GROUP

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -318,6 +318,7 @@ enum Commands {
 	CMD_DEPOT_MASS_AUTOREPLACE,       ///< force the autoreplace to take action in a given depot
 
 	CMD_CREATE_GROUP,                 ///< create a new group
+	CMD_CREATE_GROUP_AUTOGEN_NAME,    ///< create a new group with an automatically generated name
 	CMD_DELETE_GROUP,                 ///< delete a group
 	CMD_ALTER_GROUP,                  ///< alter a group
 	CMD_ADD_VEHICLE_GROUP,            ///< add a vehicle to a group

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -324,6 +324,7 @@ enum Commands {
 	CMD_ADD_VEHICLE_GROUP,            ///< add a vehicle to a group
 	CMD_ADD_SHARED_VEHICLE_GROUP,     ///< add all other shared vehicles to a group which are missing
 	CMD_REMOVE_ALL_VEHICLES_GROUP,    ///< remove all vehicles from a group
+	CMD_AUTO_GROUP_VEHICLES,          ///< create groups for all vehicles of a certain type that are not yet in any group
 	CMD_SET_GROUP_REPLACE_PROTECTION, ///< set the autoreplace-protection for a group
 	CMD_SET_GROUP_LIVERY,             ///< set the livery for a group
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -10,17 +10,24 @@
 #include "stdafx.h"
 #include "cmd_helper.h"
 #include "command_func.h"
+#include "town.h"
 #include "train.h"
+#include "station_base.h"
 #include "vehiclelist.h"
 #include "vehicle_func.h"
 #include "autoreplace_base.h"
 #include "autoreplace_func.h"
+#include "strings_func.h"
 #include "string_func.h"
 #include "company_func.h"
 #include "core/pool_func.hpp"
 #include "order_backup.h"
+#include "strings_func.h"
 
 #include "table/strings.h"
+
+#include <algorithm>
+#include <vector>
 
 #include "safeguards.h"
 
@@ -493,6 +500,139 @@ static void AddVehicleToGroup(Vehicle *v, GroupID new_g)
 	}
 
 	GroupStatistics::CountVehicle(v, 1);
+}
+
+/**
+ * Create a new group, rename it with an automatically generated name and add vehicle to this group
+ * @param tile unused
+ * @param flags type of operation
+ * @param p1   vehicle to add to a group
+ *   - p1 bit 0-19 : VehicleID
+ *   - p1 bit   31 : Add shared vehicles as well.
+ * @param p2   parent groupid
+ * @param text unused
+ * @return the cost of this operation or an error
+ */
+CommandCost CmdCreateGroupAutogenName(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
+{
+	Vehicle *v = Vehicle::GetIfValid(GB(p1, 0, 20));
+
+	if (v == nullptr) return CMD_ERROR;
+
+	if (v->owner != _current_company || !v->IsPrimaryVehicle()) return CMD_ERROR;
+
+	/* Get the essential orders */
+	std::vector<Order *> unique_orders;
+
+	Order *order;
+	FOR_VEHICLE_ORDERS(v, order) {
+		if (order->IsType(OT_GOTO_STATION)) {
+			if (std::find_if(unique_orders.begin(), unique_orders.end(), [order](Order *o) { return o->GetDestination() == order->GetDestination(); }) == unique_orders.end()) {
+				unique_orders.push_back(order);
+			}
+		}
+	}
+
+	if (unique_orders.empty()) return_cmd_error(STR_ERROR_GROUP_CAN_T_CREATE_NAME);
+
+	/* Create the name */
+
+	static char str[71] = { "" };  // 5 + 31 + 3 + 31 + 1: ["cargo abbreviation"] "town/station name max. length" - "town/station name max. length""\0"
+
+	StringID cargo_abbreviation_si = INVALID_STRING_ID;
+
+	for (Vehicle *u = v; u != nullptr; u = u->Next()) {
+		if (u->cargo_cap == 0) continue;
+
+		const CargoSpec *cs = CargoSpec::Get(u->cargo_type);
+		cargo_abbreviation_si = cs->abbrev;
+		break;
+	}
+
+	if (cargo_abbreviation_si == INVALID_STRING_ID) return_cmd_error(STR_ERROR_GROUP_CAN_T_CREATE_NAME);
+
+	// Remove the 'tiny font' formatting
+	static char buf[7] = { "" }; // 3 + 2 + 2 : TINYFONT + cargo abbreviation + "\0\0"
+	SetDParam(0, cargo_abbreviation_si);
+	GetString(buf, STR_JUST_STRING, lastof(buf));
+	const char *cargo_abbreviation = SkipGarbage(buf);
+
+	if (_settings_client.gui.autogen_group_name == 1) { // Use station names
+
+		static char stationname_first[MAX_LENGTH_STATION_NAME_CHARS] = { "" };
+		static char stationname_last[MAX_LENGTH_STATION_NAME_CHARS] = { "" };
+
+		SetDParam(0, unique_orders.front()->GetDestination());
+		GetString(stationname_first, STR_STATION_NAME, lastof(stationname_first));
+
+		SetDParam(0, unique_orders.back()->GetDestination());
+		GetString(stationname_last, STR_STATION_NAME, lastof(stationname_last));
+
+		SetDParamStr(0, cargo_abbreviation);
+		SetDParam(1, unique_orders.front()->GetDestination());
+		SetDParam(2, unique_orders.back()->GetDestination());
+		GetString(str, STR_GROUP_AUTOGEN_NAME_STATION, lastof(str));
+
+	} else { //Use town names
+
+		Station *station_first = Station::GetIfValid(unique_orders.front()->GetDestination());
+		Station *station_last = Station::GetIfValid(unique_orders.back()->GetDestination());
+
+		if (station_last == nullptr || station_first == nullptr) return_cmd_error(STR_ERROR_GROUP_CAN_T_CREATE_NAME);
+
+		Town *town_first = station_first->town;
+		Town *town_last = station_last->town;
+
+		if (town_first->index == town_last->index) { // First and last station belong to the same town
+			SetDParamStr(0, cargo_abbreviation);
+			SetDParam(1, town_first->index);
+			GetString(str, STR_GROUP_AUTOGEN_NAME_TOWN_LOCAL, lastof(str));
+		} else {
+			static char townname_first[MAX_LENGTH_TOWN_NAME_CHARS] = { "" };
+			static char townname_last[MAX_LENGTH_TOWN_NAME_CHARS] = { "" };
+
+			SetDParam(0, town_first->index);
+			GetString(townname_first, STR_TOWN_NAME, lastof(townname_first));
+
+			SetDParam(0, town_last->index);
+			GetString(townname_last, STR_TOWN_NAME, lastof(townname_last));
+
+			SetDParamStr(0, cargo_abbreviation);
+			SetDParam(1, town_first->index);
+			SetDParam(2, town_last->index );
+			GetString(str, STR_GROUP_AUTOGEN_NAME_TOWN, lastof(str));
+		}
+	}
+
+	if (Utf8StringLength(str) >= MAX_LENGTH_GROUP_NAME_CHARS) return CMD_ERROR;
+
+	CommandCost ret = CmdCreateGroup(0, flags, v->type, p2, nullptr);
+
+	if (ret.Failed()) return ret;
+
+	GroupID new_g = _new_group_id;
+	CmdAlterGroup(0, flags, new_g, 0, str);
+
+	if (flags & DC_EXEC) {
+		AddVehicleToGroup(v, new_g);
+
+		if (HasBit(p1, 31)) {
+			/* Add vehicles in the shared order list as well. */
+			for (Vehicle *u = v->FirstShared(); u != nullptr; u = u->NextShared()) {
+				if (u->group_id != new_g) {
+					AddVehicleToGroup(u, new_g);
+				}
+			}
+		}
+
+		GroupStatistics::UpdateAutoreplace(v->owner);
+
+		/* Update the Replace Vehicle Windows */
+		SetWindowDirty(WC_REPLACE_VEHICLE, v->type);
+		InvalidateWindowData(GetWindowClassForVehicleType(v->type), VehicleListIdentifier(VL_GROUP_LIST, v->type, _current_company).Pack());
+	}
+
+	return CommandCost();
 }
 
 /**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -64,6 +64,10 @@ static const NWidgetPart _nested_group_widgets[] = {
 						SetDataTip(SPR_GROUP_RENAME_TRAIN, STR_GROUP_RENAME_TOOLTIP),
 				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_LIVERY_GROUP), SetFill(0, 1),
 						SetDataTip(SPR_GROUP_LIVERY_TRAIN, STR_GROUP_LIVERY_TOOLTIP),
+				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_COLLAPSE_ALL_GROUPS), SetFill(0, 1),
+						SetDataTip(SPR_IMG_ZOOMOUT, STR_GROUP_COLLAPSE_ALL),
+				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_EXPAND_ALL_GROUPS), SetFill(0, 1),
+						SetDataTip(SPR_IMG_ZOOMIN, STR_GROUP_EXPAND_ALL),
 				NWidget(WWT_PANEL, COLOUR_GREY), SetFill(1, 1), EndContainer(),
 				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_REPLACE_PROTECTION), SetFill(0, 1),
 						SetDataTip(SPR_GROUP_REPLACE_OFF_TRAIN, STR_GROUP_REPLACE_PROTECTION_TOOLTIP),
@@ -155,11 +159,24 @@ private:
 
 		GUIGroupList list;
 
+		bool enable_expand_all = false;
+		bool enable_collapse_all = false;
+
 		for (const Group *g : Group::Iterate()) {
 			if (g->owner == owner && g->vehicle_type == this->vli.vtype) {
 				list.push_back(g);
+				if (g->parent != INVALID_GROUP) {
+					if (Group::Get(g->parent)->folded) {
+						enable_expand_all = true;
+					} else {
+						enable_collapse_all = true;
+					}
+				}
 			}
 		}
+
+		this->SetWidgetDisabledState(WID_GL_EXPAND_ALL_GROUPS, !enable_expand_all);
+		this->SetWidgetDisabledState(WID_GL_COLLAPSE_ALL_GROUPS, !enable_collapse_all);
 
 		list.ForceResort();
 
@@ -331,6 +348,19 @@ private:
 		} else {
 			this->SetWidgetDirty(WID_GL_LIST_GROUP);
 		}
+	}
+
+	void SetAllGroupsFoldState(bool folded)
+	{
+		for (const Group *g : Group::Iterate()) {
+			if (g->owner == this->owner && g->vehicle_type == this->vli.vtype) {
+				if (g->parent != INVALID_GROUP) {
+					Group::Get(g->parent)->folded = folded;
+				}
+			}
+		}
+		this->groups.ForceRebuild();
+		this->SetDirty();
 	}
 
 public:
@@ -760,6 +790,14 @@ public:
 
 			case WID_GL_LIVERY_GROUP: // Set group livery
 				ShowCompanyLiveryWindow(this->owner, this->vli.index);
+				break;
+
+			case WID_GL_COLLAPSE_ALL_GROUPS:
+				this->SetAllGroupsFoldState(true);
+				break;
+
+			case WID_GL_EXPAND_ALL_GROUPS:
+				this->SetAllGroupsFoldState(false);
 				break;
 
 			case WID_GL_AVAILABLE_VEHICLES:

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -897,6 +897,16 @@ public:
 				}
 				break;
 			}
+			case WID_GL_CREATE_GROUP: {
+				const VehicleID vindex = this->vehicle_sel;
+				this->vehicle_sel = INVALID_VEHICLE;
+				this->group_over = INVALID_GROUP;
+				this->SetDirty();
+
+				DoCommandP(0, vindex | (_ctrl_pressed ? 1 << 31 : 0), this->vli.index, CMD_CREATE_GROUP_AUTOGEN_NAME | CMD_MSG(STR_ERROR_GROUP_CAN_T_CREATE_AUTOGEN_NAME),  nullptr);
+
+				break;
+			}
 		}
 	}
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -68,6 +68,8 @@ static const NWidgetPart _nested_group_widgets[] = {
 						SetDataTip(SPR_IMG_ZOOMOUT, STR_GROUP_COLLAPSE_ALL),
 				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_EXPAND_ALL_GROUPS), SetFill(0, 1),
 						SetDataTip(SPR_IMG_ZOOMIN, STR_GROUP_EXPAND_ALL),
+				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_AUTO_GROUP), SetFill(0, 1),
+						SetDataTip(SPR_CLONE_TRAIN, STR_AUTO_GROUP_TOOLTIP),
 				NWidget(WWT_PANEL, COLOUR_GREY), SetFill(1, 1), EndContainer(),
 				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_GL_REPLACE_PROTECTION), SetFill(0, 1),
 						SetDataTip(SPR_GROUP_REPLACE_OFF_TRAIN, STR_GROUP_REPLACE_PROTECTION_TOOLTIP),
@@ -404,6 +406,7 @@ public:
 		this->GetWidget<NWidgetCore>(WID_GL_RENAME_GROUP)->widget_data += this->vli.vtype;
 		this->GetWidget<NWidgetCore>(WID_GL_DELETE_GROUP)->widget_data += this->vli.vtype;
 		this->GetWidget<NWidgetCore>(WID_GL_LIVERY_GROUP)->widget_data += this->vli.vtype;
+		this->GetWidget<NWidgetCore>(WID_GL_AUTO_GROUP)->widget_data += this->vli.vtype;
 		this->GetWidget<NWidgetCore>(WID_GL_REPLACE_PROTECTION)->widget_data += this->vli.vtype;
 
 		this->FinishInitNested(window_number);
@@ -550,6 +553,7 @@ public:
 
 		/* Disable all lists management button when the list is empty */
 		this->SetWidgetsDisabledState(this->vehicles.size() == 0 || _local_company != this->vli.company,
+				WID_GL_AUTO_GROUP,
 				WID_GL_STOP_ALL,
 				WID_GL_START_ALL,
 				WID_GL_MANAGE_VEHICLES_DROPDOWN,
@@ -799,6 +803,15 @@ public:
 			case WID_GL_EXPAND_ALL_GROUPS:
 				this->SetAllGroupsFoldState(false);
 				break;
+
+			case WID_GL_AUTO_GROUP: {
+				DoCommandP(0, vli.company, vli.vtype, CMD_AUTO_GROUP_VEHICLES, nullptr);
+
+				this->vehicle_sel = INVALID_VEHICLE;
+				this->group_over = INVALID_GROUP;
+				this->SetDirty();
+				break;
+			}
 
 			case WID_GL_AVAILABLE_VEHICLES:
 				ShowBuildVehicleWindow(INVALID_TILE, this->vli.vtype);

--- a/src/group_type.h
+++ b/src/group_type.h
@@ -17,7 +17,7 @@ static const GroupID ALL_GROUP     = 0xFFFD; ///< All vehicles are in this group
 static const GroupID DEFAULT_GROUP = 0xFFFE; ///< Ungrouped vehicles are in this group.
 static const GroupID INVALID_GROUP = 0xFFFF; ///< Sentinel for invalid groups.
 
-static const uint MAX_LENGTH_GROUP_NAME_CHARS = 32; ///< The maximum length of a group name in characters including '\0'
+static const uint MAX_LENGTH_GROUP_NAME_CHARS = 128; ///< The maximum length of a group name in characters including '\0'
 
 struct Group;
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3477,6 +3477,8 @@ STR_GROUP_CREATE_TOOLTIP                                        :{BLACK}Click to
 STR_GROUP_DELETE_TOOLTIP                                        :{BLACK}Delete the selected group
 STR_GROUP_RENAME_TOOLTIP                                        :{BLACK}Rename the selected group
 STR_GROUP_LIVERY_TOOLTIP                                        :{BLACK}Change livery of the selected group
+STR_GROUP_EXPAND_ALL                                            :{BLACK}Expand all
+STR_GROUP_COLLAPSE_ALL                                          :{BLACK}Collapse all
 STR_GROUP_REPLACE_PROTECTION_TOOLTIP                            :{BLACK}Click to protect this group from global autoreplace
 
 STR_QUERY_GROUP_DELETE_CAPTION                                  :{WHITE}Delete Group

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1234,6 +1234,10 @@ STR_CONFIG_SETTING_SIGNALSIDE_DRIVING_SIDE                      :On the driving 
 STR_CONFIG_SETTING_SIGNALSIDE_RIGHT                             :On the right
 STR_CONFIG_SETTING_SHOWFINANCES                                 :Show finances window at the end of the year: {STRING2}
 STR_CONFIG_SETTING_SHOWFINANCES_HELPTEXT                        :If enabled, the finances window pops up at the end of each year to allow easy inspection of the financial status of the company
+STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME                           :Use {STRING2} names for automatically generated group name
+STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME_HELPTEXT                  :Uses the selected name from the first and last order of a vehicle to create an autmatically generated group name
+STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME_TOWN                      :town
+STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME_STATION                   :station
 STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT                           :New orders are 'non-stop' by default: {STRING2}
 STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT_HELPTEXT                  :Normally, a vehicle will stop at every station it passes. By enabling this setting, it will drive through all station on the way to its final destination without stopping. Note, that this setting only defines a default value for new orders. Individual orders can be set explicitly to either behaviour nevertheless
 STR_CONFIG_SETTING_STOP_LOCATION                                :New train orders stop by default at the {STRING2} of the platform
@@ -3473,7 +3477,7 @@ STR_GROUP_DEFAULT_AIRCRAFTS                                     :Ungrouped aircr
 STR_GROUP_COUNT_WITH_SUBGROUP                                   :{TINY_FONT}{COMMA} (+{COMMA})
 
 STR_GROUPS_CLICK_ON_GROUP_FOR_TOOLTIP                           :{BLACK}Groups - click on a group to list all vehicles of this group. Drag and drop groups to arrange hierarchy.
-STR_GROUP_CREATE_TOOLTIP                                        :{BLACK}Click to create a group
+STR_GROUP_CREATE_TOOLTIP                                        :{BLACK}Click to create a group. Drag and drop a vehicle to create a group for it with an automatic name. Ctrl+Drag to add vehicles with shared orders.
 STR_GROUP_DELETE_TOOLTIP                                        :{BLACK}Delete the selected group
 STR_GROUP_RENAME_TOOLTIP                                        :{BLACK}Rename the selected group
 STR_GROUP_LIVERY_TOOLTIP                                        :{BLACK}Change livery of the selected group
@@ -3488,6 +3492,9 @@ STR_GROUP_ADD_SHARED_VEHICLE                                    :Add shared vehi
 STR_GROUP_REMOVE_ALL_VEHICLES                                   :Remove all vehicles
 
 STR_GROUP_RENAME_CAPTION                                        :{BLACK}Rename a group
+STR_GROUP_AUTOGEN_NAME_STATION                                  :[{RAW_STRING}] {STATION} - {STATION}
+STR_GROUP_AUTOGEN_NAME_TOWN                                     :[{RAW_STRING}] {TOWN} - {TOWN}
+STR_GROUP_AUTOGEN_NAME_TOWN_LOCAL                               :[{RAW_STRING}] Local {TOWN}
 
 STR_GROUP_PROFIT_THIS_YEAR                                      :Profit this year:
 STR_GROUP_PROFIT_LAST_YEAR                                      :Profit last year:
@@ -4542,6 +4549,8 @@ STR_ERROR_GROUP_CAN_T_SET_PARENT_RECURSION                      :{WHITE}... loop
 STR_ERROR_GROUP_CAN_T_REMOVE_ALL_VEHICLES                       :{WHITE}Can't remove all vehicles from this group...
 STR_ERROR_GROUP_CAN_T_ADD_VEHICLE                               :{WHITE}Can't add the vehicle to this group...
 STR_ERROR_GROUP_CAN_T_ADD_SHARED_VEHICLE                        :{WHITE}Can't add shared vehicles to group...
+STR_ERROR_GROUP_CAN_T_CREATE_AUTOGEN_NAME                       :{WHITE}Can't create group with automatically generated name...
+STR_ERROR_GROUP_CAN_T_CREATE_NAME                               :{WHITE}Can't create group name...
 
 # Generic vehicle errors
 STR_ERROR_TRAIN_IN_THE_WAY                                      :{WHITE}Train in the way

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3483,6 +3483,7 @@ STR_GROUP_RENAME_TOOLTIP                                        :{BLACK}Rename t
 STR_GROUP_LIVERY_TOOLTIP                                        :{BLACK}Change livery of the selected group
 STR_GROUP_EXPAND_ALL                                            :{BLACK}Expand all
 STR_GROUP_COLLAPSE_ALL                                          :{BLACK}Collapse all
+STR_AUTO_GROUP_TOOLTIP                                          :{BLACK}Automatically group all otherwise ungrouped vehicles.
 STR_GROUP_REPLACE_PROTECTION_TOOLTIP                            :{BLACK}Click to protect this group from global autoreplace
 
 STR_QUERY_GROUP_DELETE_CAPTION                                  :{WHITE}Delete Group

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -19,6 +19,8 @@
  *
  * API additions:
  * \li AIPriorityQueue
+ * \li AIGroup::CreateGroupAutogenName
+ * \li AIGroup::AutoGroupVehicles
  *
  * \b 1.10.0
  *

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -34,6 +34,21 @@
 	return (ScriptGroup::GroupID)0;
 }
 
+/* static */ ScriptGroup::GroupID ScriptGroup::CreateGroupAutogenName(VehicleID vehicle_id, GroupID parent_group_id, bool add_shared_vehicles)
+{
+	EnforcePrecondition(ScriptGroup::GROUP_INVALID, ScriptVehicle::IsValidVehicle(vehicle_id));
+	if (!ScriptObject::DoCommand(0, vehicle_id | (add_shared_vehicles << 31), parent_group_id, CMD_CREATE_GROUP_AUTOGEN_NAME, nullptr, &ScriptInstance::DoCommandReturnGroupID)) return GROUP_INVALID;
+
+	/* In case of test-mode, we return GroupID 0 */
+	return (ScriptGroup::GroupID)0;
+}
+
+/* static */ void ScriptGroup::AutoGroupVehicles(ScriptVehicle::VehicleType vehicle_type)
+{
+	ScriptObject::DoCommand(0, ScriptObject::GetCompany(), (::VehicleType)vehicle_type, CMD_AUTO_GROUP_VEHICLES, nullptr);
+}
+
+
 /* static */ bool ScriptGroup::DeleteGroup(GroupID group_id)
 {
 	EnforcePrecondition(false, IsValidGroup(group_id));

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -48,6 +48,26 @@ public:
 	static GroupID CreateGroup(ScriptVehicle::VehicleType vehicle_type, GroupID parent_group_id);
 
 	/**
+	 * Create a new group, rename it with specific name and add vehicle to this group
+	 *
+	 * @param vehicle_id vehicle to add to a group
+	 * @param parent_group_id parent groupid
+	 * @param add_shared_vehicles whether to add shared vehicles as well
+	 * @return The GroupID of the new group, or an invalid GroupID when
+	 *  it failed. Check the return value using IsValidGroup(). In test-mode
+	 *  0 is returned if it was successful; any other value indicates failure.
+	 */
+	static GroupID CreateGroupAutogenName(VehicleID vehicle_id, GroupID parent_group_id, bool add_shared_vehicles = false);
+
+	/**
+	 * Create groups for all vehicles of a certain type that are not yet in any group.
+	 *
+	 * @param vehicle_type The VehicleType of the vehicles that should be auto-grouped.
+	 * @return False if the groups was not successfully created.
+	 */
+	static void AutoGroupVehicles(ScriptVehicle::VehicleType vehicle_type);
+
+	/**
 	 * Delete the given group. When the deletion succeeds all vehicles in the
 	 *  given group will move to the GROUP_DEFAULT.
 	 * @param group_id The group to delete.

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1650,6 +1650,7 @@ static SettingsContainer &GetSettingsTree()
 
 			vehicles->Add(new SettingEntry("order.no_servicing_if_no_breakdowns"));
 			vehicles->Add(new SettingEntry("order.serviceathelipad"));
+			vehicles->Add(new SettingEntry("gui.autogen_group_name"));
 		}
 
 		SettingsPage *limitations = main->Add(new SettingsPage(STR_CONFIG_SETTING_LIMITATIONS));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -86,6 +86,7 @@ struct GUISettings {
 	uint8  order_review_system;              ///< perform order reviews on vehicles
 	bool   vehicle_income_warn;              ///< if a vehicle isn't generating income, show a warning
 	bool   show_finances;                    ///< show finances at end of year
+	uint8  autogen_group_name;               ///< use station or town names for automatically generated group names
 	bool   sg_new_nonstop;                   ///< ttdpatch compatible nonstop handling read from pre v93 savegames
 	bool   new_nonstop;                      ///< ttdpatch compatible nonstop handling
 	uint8  stop_location;                    ///< what is the default stop location of trains?

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -597,7 +597,7 @@ char *strcasestr(const char *haystack, const char *needle)
  * @param str The string to skip the initial garbage of.
  * @return The string with the garbage skipped.
  */
-static const char *SkipGarbage(const char *str)
+const char *SkipGarbage(const char *str)
 {
 	while (*str != '\0' && (*str < '0' || IsInsideMM(*str, ';', '@' + 1) || IsInsideMM(*str, '[', '`' + 1) || IsInsideMM(*str, '{', '~' + 1))) str++;
 	return str;

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -266,6 +266,7 @@ static inline bool IsWhitespace(WChar c)
 char *strcasestr(const char *haystack, const char *needle);
 #endif /* strcasestr is available */
 
+const char *SkipGarbage(const char *str);
 int strnatcmp(const char *s1, const char *s2, bool ignore_garbage_at_front = false);
 
 #endif /* STRING_FUNC_H */

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3254,6 +3254,20 @@ strhelp  = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME_HELPTEXT
 proc     = RedrawScreen
 cat      = SC_ADVANCED
 
+[SDTC_VAR]
+var      = gui.autogen_group_name
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = 0
+min      = 0
+max      = 1
+interval = 1
+str      = STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME
+strhelp  = STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME_HELPTEXT
+strval   = STR_CONFIG_SETTING_AUTOGEN_GROUP_NAME_TOWN
+cat      = SC_BASIC
+
 ; For the dedicated build we'll enable dates in logs by default.
 [SDTC_BOOL]
 ifdef    = DEDICATED

--- a/src/widgets/group_widget.h
+++ b/src/widgets/group_widget.h
@@ -30,6 +30,8 @@ enum GroupListWidgets {
 	WID_GL_DELETE_GROUP,             ///< Delete group button.
 	WID_GL_RENAME_GROUP,             ///< Rename group button.
 	WID_GL_LIVERY_GROUP,             ///< Group livery button.
+	WID_GL_COLLAPSE_ALL_GROUPS,      ///< Collapse all groups button.
+	WID_GL_EXPAND_ALL_GROUPS,        ///< Expand all groups button.
 	WID_GL_REPLACE_PROTECTION,       ///< Replace protection button.
 	WID_GL_INFO,                     ///< Group info.
 };

--- a/src/widgets/group_widget.h
+++ b/src/widgets/group_widget.h
@@ -32,6 +32,7 @@ enum GroupListWidgets {
 	WID_GL_LIVERY_GROUP,             ///< Group livery button.
 	WID_GL_COLLAPSE_ALL_GROUPS,      ///< Collapse all groups button.
 	WID_GL_EXPAND_ALL_GROUPS,        ///< Expand all groups button.
+	WID_GL_AUTO_GROUP,               ///< Auto group all ungrouped vehicles.
 	WID_GL_REPLACE_PROTECTION,       ///< Replace protection button.
 	WID_GL_INFO,                     ///< Group info.
 };

--- a/src/widgets/group_widget.h
+++ b/src/widgets/group_widget.h
@@ -26,7 +26,7 @@ enum GroupListWidgets {
 	WID_GL_DEFAULT_VEHICLES,         ///< Default vehicles entry.
 	WID_GL_LIST_GROUP,               ///< List of the groups.
 	WID_GL_LIST_GROUP_SCROLLBAR,     ///< Scrollbar for the list.
-	WID_GL_CREATE_GROUP,             ///< Create group button.
+	WID_GL_CREATE_GROUP,             ///< Create group button. In the case of drag and drop create a group with vehicle specific name and add the vehicle to it.
 	WID_GL_DELETE_GROUP,             ///< Delete group button.
 	WID_GL_RENAME_GROUP,             ///< Rename group button.
 	WID_GL_LIVERY_GROUP,             ///< Group livery button.


### PR DESCRIPTION
The first commit is based on @JGRennison's patch: JGRennison/OpenTTD-patches@91c5dee.
I replaced the text buttons with image buttons.

The second commit is from @KeldorKatarn's patch pack: KeldorKatarn/OpenTTD_PatchPack@3f03ec4.
I modified the loop which finds the unique orders.

The third one is also based on @KeldorKatarn's patches: KeldorKatarn/OpenTTD_PatchPack@49082fb and KeldorKatarn/OpenTTD_PatchPack@bdabd04.
I also modified it a little and added parent groups by cargo for the new groups.

![group](https://user-images.githubusercontent.com/48624099/71632940-83788000-2c11-11ea-8e45-35eb2710433d.png)
