### PR TITLE
Fix #6452: Reset only editable and visible settings from GUI

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -315,8 +315,6 @@ struct AISettingsWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_AIS_SCROLLBAR);
 		this->FinishInitNested(slot);  // Initializes 'this->line_height' as side effect.
 
-		this->SetWidgetDisabledState(WID_AIS_RESET, _game_mode != GM_MENU && Company::IsValidID(this->slot));
-
 		this->RebuildVisibleSettings();
 	}
 
@@ -524,10 +522,8 @@ struct AISettingsWindow : public Window {
 				break;
 
 			case WID_AIS_RESET:
-				if (_game_mode == GM_MENU || !Company::IsValidID(this->slot)) {
-					this->ai_config->ResetSettings();
-					this->SetDirty();
-				}
+				this->ai_config->ResetEditableSettings(_game_mode == GM_MENU || ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot)));
+				this->SetDirty();
 				break;
 		}
 	}

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -127,6 +127,26 @@ void ScriptConfig::ResetSettings()
 	this->settings.clear();
 }
 
+void ScriptConfig::ResetEditableSettings(bool yet_to_start)
+{
+	if (this->info == nullptr) return ResetSettings();
+
+	for (SettingValueList::iterator it = this->settings.begin(); it != this->settings.end();) {
+		const ScriptConfigItem *config_item = this->info->GetConfigItem(it->first);
+		assert(config_item != nullptr);
+
+		bool editable = yet_to_start || (config_item->flags & SCRIPTCONFIG_INGAME) != 0;
+		bool visible = _settings_client.gui.ai_developer_tools || (config_item->flags & SCRIPTCONFIG_DEVELOPER) == 0;
+
+		if (editable && visible) {
+			free(it->first);
+			it = this->settings.erase(it);
+		} else {
+			it++;
+		}
+	}
+}
+
 void ScriptConfig::AddRandomDeviation()
 {
 	for (const auto &item : *this->GetConfigList()) {

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -135,6 +135,11 @@ public:
 	void ResetSettings();
 
 	/**
+	 * Reset only editable and visible settings to their default value.
+	 */
+	void ResetEditableSettings(bool yet_to_start);
+
+	/**
 	 * Randomize all settings the Script requested to be randomized.
 	 */
 	virtual void AddRandomDeviation();


### PR DESCRIPTION
Also enables the Reset button while in-game for AI configs.