### PR TITLE
Fix #7587: Crash when loading saves with waypoints with invalid locations

### DIFF
--- a/src/order_base.h
+++ b/src/order_base.h
@@ -281,6 +281,8 @@ public:
 
 	void Initialize(Order *chain, Vehicle *v);
 
+	void RecalculateTimetableDuration();
+
 	/**
 	 * Get the first order of the order chain.
 	 * @return the first order of the chain.

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -296,14 +296,14 @@ void OrderList::Initialize(Order *chain, Vehicle *v)
 	this->num_manual_orders = 0;
 	this->num_vehicles = 1;
 	this->timetable_duration = 0;
-	this->total_duration = 0;
 
 	for (Order *o = this->first; o != nullptr; o = o->next) {
 		++this->num_orders;
 		if (!o->IsType(OT_IMPLICIT)) ++this->num_manual_orders;
-		this->timetable_duration += o->GetTimetabledWait() + o->GetTimetabledTravel();
 		this->total_duration += o->GetWaitTime() + o->GetTravelTime();
 	}
+
+	this->RecalculateTimetableDuration();
 
 	for (Vehicle *u = this->first_shared->PreviousShared(); u != nullptr; u = u->PreviousShared()) {
 		++this->num_vehicles;
@@ -311,6 +311,18 @@ void OrderList::Initialize(Order *chain, Vehicle *v)
 	}
 
 	for (const Vehicle *u = v->NextShared(); u != nullptr; u = u->NextShared()) ++this->num_vehicles;
+}
+
+/**
+ * Recomputes Timetable duration.
+ * Split out into a separate function so it can be used by afterload.
+ */
+void OrderList::RecalculateTimetableDuration()
+{
+	this->timetable_duration = 0;
+	for (Order *o = this->first; o != nullptr; o = o->next) {
+		this->timetable_duration += o->GetTimetabledWait() + o->GetTimetabledTravel();
+	}
 }
 
 /**

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2963,6 +2963,16 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_190)) {
+		for (Order *order : Order::Iterate()) {
+			order->SetTravelTimetabled(order->GetTravelTime() > 0);
+			order->SetWaitTimetabled(order->GetWaitTime() > 0);
+		}
+		for (OrderList *orderlist : OrderList::Iterate()) {
+			orderlist->RecalculateTimetableDuration();
+		}
+	}
+
 	/*
 	 * Only keep order-backups for network clients (and when replaying).
 	 * If we are a network server or not networking, then we just loaded a previously

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -182,10 +182,6 @@ static void Load_ORDR()
 		while ((index = SlIterateArray()) != -1) {
 			Order *order = new (index) Order();
 			SlObject(order, GetOrderDescription());
-			if (IsSavegameVersionBefore(SLV_190)) {
-				order->SetTravelTimetabled(order->GetTravelTime() > 0);
-				order->SetWaitTimetabled(order->GetWaitTime() > 0);
-			}
 		}
 	}
 }


### PR DESCRIPTION
Now successfully loads save from #1131, and runs for a couple of years