### PR TITLE
Fix: Assertion failure when post road-works cleanup removes all road pieces

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1955,6 +1955,12 @@ static void TileLoop_Road(TileIndex tile)
 
 			if (old_rb != new_rb) {
 				RemoveRoad(tile, DC_EXEC | DC_AUTO | DC_NO_WATER, (old_rb ^ new_rb), RTT_ROAD, true);
+
+				/* If new_rb is 0, there are now no road pieces left and the tile is no longer a road tile */
+				if (new_rb == 0) {
+					MarkTileDirtyByTile(tile);
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
When road works have completed on a tile, if _settings_game.economy.mod_road_rebuild is true, CleanUpRoadBits() may remove all road bits currently on the tile.
In this case, after RemoveRoad() is called, the tile is no longer a road tile.
The subsequent call to GetRoadOwner() causes an assertion failure.

Once RemoveRoad() is called in this case, TileLoop_Road() should return early as the tile is no longer a road tile and all subsequent road tile checks/actions are no longer applicable.