### PR TITLE
Codechange: Remove std::function from Pool iteration wrapper

### DIFF
--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -142,15 +142,21 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 
 	uint32 GetGRFID() const;
 
+	struct EngineTypeFilter {
+		VehicleType vt;
+
+		bool operator() (size_t index) { return Engine::Get(index)->type == this->vt; }
+	};
+
 	/**
 	 * Returns an iterable ensemble of all valid engines of the given type
 	 * @param vt the VehicleType for engines to be valid
 	 * @param from index of the first engine to consider
 	 * @return an iterable ensemble of all valid engines of the given type
 	 */
-	static Pool::IterateWrapper<Engine> IterateType(VehicleType vt, size_t from = 0)
+	static Pool::IterateWrapperFiltered<Engine, EngineTypeFilter> IterateType(VehicleType vt, size_t from = 0)
 	{
-		return Pool::IterateWrapper<Engine>(from, [vt](size_t index) { return Engine::Get(index)->type == vt; });
+		return Pool::IterateWrapperFiltered<Engine, EngineTypeFilter>(from, EngineTypeFilter{ vt });
 	}
 };
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -83,15 +83,18 @@ public:
 		return "admin";
 	}
 
+	struct ServerNetworkAdminSocketHandlerFilter {
+		bool operator() (size_t index) { return ServerNetworkAdminSocketHandler::Get(index)->GetAdminStatus() == ADMIN_STATUS_ACTIVE; }
+	};
+
 	/**
 	 * Returns an iterable ensemble of all active admin sockets
 	 * @param from index of the first socket to consider
 	 * @return an iterable ensemble of all active admin sockets
 	 */
-	static Pool::IterateWrapper<ServerNetworkAdminSocketHandler> IterateActive(size_t from = 0)
+	static Pool::IterateWrapperFiltered<ServerNetworkAdminSocketHandler, ServerNetworkAdminSocketHandlerFilter> IterateActive(size_t from = 0)
 	{
-		return Pool::IterateWrapper<ServerNetworkAdminSocketHandler>(from,
-			[](size_t index) { return ServerNetworkAdminSocketHandler::Get(index)->GetAdminStatus() == ADMIN_STATUS_ACTIVE; });
+		return Pool::IterateWrapperFiltered<ServerNetworkAdminSocketHandler, ServerNetworkAdminSocketHandlerFilter>(from, ServerNetworkAdminSocketHandlerFilter{});
 	}
 };
 


### PR DESCRIPTION
Remove std::function from Pool iteration wrapper.
Add a separate functor templated wrapper for filtered Pool iteration.

Using std::function results in very poor code generation, and significantly increased code size.
It requires the use of expensive indirect calls, prevents optimisations and inlining, requires various exception and storage overheads, etc.
Trivial functions such as ResetVehicleColourMap() are more than 10x larger in code size than before the change to using PoolIterator instead of macros.
The use of a filter functor even in the unfiltered case creates a significant penalty relative to just checking if the filter is null/empty.

std::function can be removed entirely in the case of non-filtered iteration (the vast majority of cases), and replaced with zero-overhead template functors for filtered iteration, this results in comparable code size and performance to before the change to using PoolIterator.