### PR TITLE
Town, station and industry directory window sorting performance improvements

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -56,6 +56,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 
 	char *name;                     ///< Custom name
 	StringID string_id;             ///< Default name (town area) of station
+	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the station, if not using a custom name
 
 	Town *town;                     ///< The town this station is associated with
 	Owner owner;                    ///< The owner of this station
@@ -107,6 +108,13 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	 * Update the coordinated of the sign (as shown in the viewport).
 	 */
 	virtual void UpdateVirtCoord() = 0;
+
+	inline const char *GetCachedName() const
+	{
+		if (this->name != nullptr) return this->name;
+		if (this->cached_name.empty()) this->FillCachedName();
+		return this->cached_name.c_str();
+	}
 
 	virtual void MoveSign(TileIndex new_xy)
 	{
@@ -161,6 +169,9 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	}
 
 	static void PostDestructor(size_t index);
+
+private:
+	void FillCachedName() const;
 };
 
 /**

--- a/src/industry.h
+++ b/src/industry.h
@@ -62,6 +62,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 
 	PartOfSubsidy part_of_subsidy; ///< NOSAVE: is this industry a source/destination of a subsidy?
 	StationList stations_near;     ///< NOSAVE: List of nearby stations.
+	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the industry
 
 	Owner founder;                 ///< Founder of the industry
 	Date construction_date;        ///< Date of the construction of the industry
@@ -157,9 +158,20 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 		memset(&counts, 0, sizeof(counts));
 	}
 
+	inline const char *GetCachedName() const
+	{
+		if (this->cached_name.empty()) this->FillCachedName();
+		return this->cached_name.c_str();
+	}
+
+private:
+	void FillCachedName() const;
+
 protected:
 	static uint16 counts[NUM_INDUSTRYTYPES]; ///< Number of industries per type ingame
 };
+
+void ClearAllIndustryCachedNames();
 
 void PlantRandomFarmField(const Industry *i);
 

--- a/src/industry.h
+++ b/src/industry.h
@@ -197,4 +197,12 @@ struct IndustryBuildData {
 
 extern IndustryBuildData _industry_builder;
 
+
+/** Special values for the industry list window for the data parameter of #InvalidateWindowData. */
+enum IndustryDirectoryInvalidateWindowData {
+	IDIWD_FORCE_REBUILD,
+	IDIWD_PRODUCTION_CHANGE,
+	IDIWD_FORCE_RESORT,
+};
+
 #endif /* INDUSTRY_H */

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2319,6 +2319,21 @@ void Industry::RecomputeProductionMultipliers()
 	}
 }
 
+void Industry::FillCachedName() const
+{
+	char buf[256];
+	int64 args_array[] = { this->index };
+	StringParameters tmp_params(args_array);
+	char *end = GetStringWithArgs(buf, STR_INDUSTRY_NAME, &tmp_params, lastof(buf));
+	this->cached_name.assign(buf, end);
+}
+
+void ClearAllIndustryCachedNames()
+{
+	for (Industry *ind : Industry::Iterate()) {
+		ind->cached_name.clear();
+	}
+}
 
 /**
  * Set the #probability and #min_number fields for the industry type \a it for a running game.

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -204,7 +204,7 @@ Industry::~Industry()
  */
 void Industry::PostDestructor(size_t index)
 {
-	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, 0);
+	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, IDIWD_FORCE_REBUILD);
 }
 
 
@@ -1900,7 +1900,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	if (GetIndustrySpec(i->type)->behaviour & INDUSTRYBEH_PLANT_ON_BUILT) {
 		for (uint j = 0; j != 50; j++) PlantRandomFarmField(i);
 	}
-	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, 0);
+	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, IDIWD_FORCE_REBUILD);
 
 	if (!_generating_world) PopulateStationsNearby(i);
 }
@@ -2829,7 +2829,7 @@ void IndustryDailyLoop()
 	cur_company.Restore();
 
 	/* production-change */
-	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, 1);
+	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, IDIWD_PRODUCTION_CHANGE);
 }
 
 void IndustryMonthlyLoop()
@@ -2851,7 +2851,7 @@ void IndustryMonthlyLoop()
 	cur_company.Restore();
 
 	/* production-change */
-	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, 1);
+	InvalidateWindowData(WC_INDUSTRY_DIRECTORY, 0, IDIWD_PRODUCTION_CHANGE);
 }
 
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1708,11 +1708,19 @@ public:
 	 */
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
-		if (data == 0) {
-			/* This needs to be done in command-scope to enforce rebuilding before resorting invalid data */
-			this->industries.ForceRebuild();
-		} else {
-			this->industries.ForceResort();
+		switch (data) {
+			case IDIWD_FORCE_REBUILD:
+				/* This needs to be done in command-scope to enforce rebuilding before resorting invalid data */
+				this->industries.ForceRebuild();
+				break;
+
+			case IDIWD_PRODUCTION_CHANGE:
+				if (this->industries.SortType() == 2) this->industries.ForceResort();
+				break;
+
+			default:
+				this->industries.ForceResort();
+				break;
 		}
 	}
 };

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1251,7 +1251,6 @@ class IndustryDirectoryWindow : public Window {
 protected:
 	/* Runtime saved values */
 	static Listing last_sorting;
-	static const Industry *last_industry;
 
 	/* Constants for sorting stations */
 	static const StringID sorter_names[];
@@ -1350,8 +1349,6 @@ protected:
 			this->industries.RebuildDone();
 		}
 
-		IndustryDirectoryWindow::last_industry = nullptr; // Reset name sorter sort cache
-
 		auto filter = std::make_pair(this->cargo_filter[this->accepted_cargo_filter_criteria],
 		                             this->cargo_filter[this->produced_cargo_filter_criteria]);
 
@@ -1398,19 +1395,7 @@ protected:
 	/** Sort industries by name */
 	static bool IndustryNameSorter(const Industry * const &a, const Industry * const &b)
 	{
-		static char buf_cache[96];
-		static char buf[96];
-
-		SetDParam(0, a->index);
-		GetString(buf, STR_INDUSTRY_NAME, lastof(buf));
-
-		if (b != last_industry) {
-			last_industry = b;
-			SetDParam(0, b->index);
-			GetString(buf_cache, STR_INDUSTRY_NAME, lastof(buf_cache));
-		}
-
-		int r = strnatcmp(buf, buf_cache); // Sort by name (natural sorting).
+		int r = strnatcmp(a->GetCachedName(), b->GetCachedName()); // Sort by name (natural sorting).
 		if (r == 0) return a->index < b->index;
 		return r < 0;
 	}
@@ -1726,7 +1711,6 @@ public:
 };
 
 Listing IndustryDirectoryWindow::last_sorting = {false, 0};
-const Industry *IndustryDirectoryWindow::last_industry = nullptr;
 
 /* Available station sorting functions. */
 GUIIndustryList::SortFunction * const IndustryDirectoryWindow::sorter_funcs[] = {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -222,6 +222,13 @@ void UpdateAllVirtCoords()
 	RebuildViewportKdtree();
 }
 
+void ClearAllCachedNames()
+{
+	ClearAllStationCachedNames();
+	ClearAllTownCachedNames();
+	ClearAllIndustryCachedNames();
+}
+
 /**
  * Initialization of the windows and several kinds of caches.
  * This is not done directly in AfterLoadGame because these
@@ -238,6 +245,7 @@ static void InitializeWindowsAndCaches()
 	SetupColoursAndInitialWindow();
 
 	/* Update coordinates of the signs. */
+	ClearAllCachedNames();
 	UpdateAllVirtCoords();
 	ResetViewportAfterLoadGame();
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -526,6 +526,7 @@ struct GameOptionsWindow : Window {
 				ReadLanguagePack(&_languages[index]);
 				DeleteWindowByClass(WC_QUERY_STRING);
 				CheckForMissingGlyphs();
+				ClearAllCachedNames();
 				UpdateAllVirtCoords();
 				ReInitAllWindows();
 				break;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -453,6 +453,22 @@ void UpdateAllStationVirtCoords()
 	}
 }
 
+void BaseStation::FillCachedName() const
+{
+	char buf[MAX_LENGTH_STATION_NAME_CHARS * MAX_CHAR_LENGTH];
+	int64 args_array[] = { this->index };
+	StringParameters tmp_params(args_array);
+	char *end = GetStringWithArgs(buf, Waypoint::IsExpected(this) ? STR_WAYPOINT_NAME : STR_STATION_NAME, &tmp_params, lastof(buf));
+	this->cached_name.assign(buf, end);
+}
+
+void ClearAllStationCachedNames()
+{
+	for (BaseStation *st : BaseStation::Iterate()) {
+		st->cached_name.clear();
+	}
+}
+
 /**
  * Get a mask of the cargo types that the station accepts.
  * @param st Station to query
@@ -3933,6 +3949,7 @@ CommandCost CmdRenameStation(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 	}
 
 	if (flags & DC_EXEC) {
+		st->cached_name.clear();
 		free(st->name);
 		st->name = reset ? nullptr : stredup(text);
 

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -26,6 +26,7 @@ void FindStationsAroundTiles(const TileArea &location, StationList *stations, bo
 
 void ShowStationViewWindow(StationID station);
 void UpdateAllStationVirtCoords();
+void ClearAllStationCachedNames();
 
 CargoArray GetProductionAroundTiles(TileIndex tile, int w, int h, int rad);
 CargoArray GetAcceptanceAroundTiles(TileIndex tile, int w, int h, int rad, CargoTypes *always_accepted = nullptr);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -207,7 +207,6 @@ protected:
 	static bool include_empty;            // whether we should include stations without waiting cargo
 	static const CargoTypes cargo_filter_max;
 	static CargoTypes cargo_filter;           // bitmap of cargo types to include
-	static const Station *last_station;
 
 	/* Constants for sorting stations */
 	static const StringID sorter_names[];
@@ -259,19 +258,7 @@ protected:
 	/** Sort stations by their name */
 	static bool StationNameSorter(const Station * const &a, const Station * const &b)
 	{
-		static char buf_cache[64];
-		char buf[64];
-
-		SetDParam(0, a->index);
-		GetString(buf, STR_STATION_NAME, lastof(buf));
-
-		if (b != last_station) {
-			last_station = b;
-			SetDParam(0, b->index);
-			GetString(buf_cache, STR_STATION_NAME, lastof(buf_cache));
-		}
-
-		int r = strnatcmp(buf, buf_cache); // Sort by name (natural sorting).
+		int r = strnatcmp(a->GetCachedName(), b->GetCachedName()); // Sort by name (natural sorting).
 		if (r == 0) return a->index < b->index;
 		return r < 0;
 	}
@@ -342,9 +329,6 @@ protected:
 	void SortStationsList()
 	{
 		if (!this->stations.Sort()) return;
-
-		/* Reset name sorter sort cache */
-		this->last_station = nullptr;
 
 		/* Set the modified widget dirty */
 		this->SetWidgetDirty(WID_STL_LIST);
@@ -703,7 +687,6 @@ byte CompanyStationsWindow::facilities = FACIL_TRAIN | FACIL_TRUCK_STOP | FACIL_
 bool CompanyStationsWindow::include_empty = true;
 const CargoTypes CompanyStationsWindow::cargo_filter_max = ALL_CARGOTYPES;
 CargoTypes CompanyStationsWindow::cargo_filter = ALL_CARGOTYPES;
-const Station *CompanyStationsWindow::last_station = nullptr;
 
 /* Available station sorting functions */
 GUIStationList::SortFunction * const CompanyStationsWindow::sorter_funcs[] = {
@@ -1222,21 +1205,13 @@ bool CargoSorter::SortCount(const CargoDataEntry *cd1, const CargoDataEntry *cd2
 
 bool CargoSorter::SortStation(StationID st1, StationID st2) const
 {
-	static char buf1[MAX_LENGTH_STATION_NAME_CHARS];
-	static char buf2[MAX_LENGTH_STATION_NAME_CHARS];
-
 	if (!Station::IsValidID(st1)) {
 		return Station::IsValidID(st2) ? this->order == SO_ASCENDING : this->SortId(st1, st2);
 	} else if (!Station::IsValidID(st2)) {
 		return order == SO_DESCENDING;
 	}
 
-	SetDParam(0, st1);
-	GetString(buf1, STR_STATION_NAME, lastof(buf1));
-	SetDParam(0, st2);
-	GetString(buf2, STR_STATION_NAME, lastof(buf2));
-
-	int res = strnatcmp(buf1, buf2); // Sort by name (natural sorting).
+	int res = strnatcmp(Station::Get(st1)->GetCachedName(), Station::Get(st2)->GetCachedName()); // Sort by name (natural sorting).
 	if (res == 0) {
 		return this->SortId(st1, st2);
 	} else {

--- a/src/town.h
+++ b/src/town.h
@@ -161,6 +161,7 @@ enum TownRatingCheckType {
 /** Special values for town list window for the data parameter of #InvalidateWindowData. */
 enum TownDirectoryInvalidateWindowData {
 	TDIWD_FORCE_REBUILD,
+	TDIWD_POPULATION_CHANGE,
 	TDIWD_FORCE_RESORT,
 };
 

--- a/src/town.h
+++ b/src/town.h
@@ -60,6 +60,7 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 	uint16 townnametype;
 	uint32 townnameparts;
 	char *name;                    ///< Custom town name. If nullptr, the town was not renamed and uses the generated name.
+	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the town, if not using a custom town name
 
 	byte flags;                    ///< See #TownFlags.
 
@@ -130,6 +131,13 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	void UpdateVirtCoord();
 
+	inline const char *GetCachedName() const
+	{
+		if (this->name != nullptr) return this->name;
+		if (this->cached_name.empty()) this->FillCachedName();
+		return this->cached_name.c_str();
+	}
+
 	static inline Town *GetByTile(TileIndex tile)
 	{
 		return Town::Get(GetTownIndex(tile));
@@ -137,11 +145,15 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	static Town *GetRandom();
 	static void PostDestructor(size_t index);
+
+private:
+	void FillCachedName() const;
 };
 
 uint32 GetWorldPopulation();
 
 void UpdateAllTownVirtCoords();
+void ClearAllTownCachedNames();
 void ShowTownViewWindow(TownID town);
 void ExpandTown(Town *t);
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -199,6 +199,13 @@ void Town::InitializeLayout(TownLayout layout)
 	return Town::Get(index);
 }
 
+void Town::FillCachedName() const
+{
+	char buf[MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH];
+	char *end = GetTownName(buf, this, lastof(buf));
+	this->cached_name.assign(buf, end);
+}
+
 /**
  * Get the cost for removing this house
  * @return the cost (inflation corrected etc)
@@ -409,6 +416,13 @@ void UpdateAllTownVirtCoords()
 {
 	for (Town *t : Town::Iterate()) {
 		t->UpdateVirtCoord();
+	}
+}
+
+void ClearAllTownCachedNames()
+{
+	for (Town *t : Town::Iterate()) {
+		t->cached_name.clear();
 	}
 }
 
@@ -2681,11 +2695,14 @@ CommandCost CmdRenameTown(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 	}
 
 	if (flags & DC_EXEC) {
+		t->cached_name.clear();
 		free(t->name);
 		t->name = reset ? nullptr : stredup(text);
 
 		t->UpdateVirtCoord();
 		InvalidateWindowData(WC_TOWN_DIRECTORY, 0, TDIWD_FORCE_RESORT);
+		ClearAllStationCachedNames();
+		ClearAllIndustryCachedNames();
 		UpdateAllStationVirtCoords();
 	}
 	return CommandCost();

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -423,7 +423,7 @@ static void ChangePopulation(Town *t, int mod)
 	InvalidateWindowData(WC_TOWN_VIEW, t->index); // Cargo requirements may appear/vanish for small populations
 	if (_settings_client.gui.population_in_label) t->UpdateVirtCoord();
 
-	InvalidateWindowData(WC_TOWN_DIRECTORY, 0, TDIWD_FORCE_RESORT);
+	InvalidateWindowData(WC_TOWN_DIRECTORY, 0, TDIWD_POPULATION_CHANGE);
 }
 
 /**

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -994,6 +994,10 @@ public:
 				this->towns.ForceRebuild();
 				break;
 
+			case TDIWD_POPULATION_CHANGE:
+				if (this->towns.SortType() == 1) this->towns.ForceResort();
+				break;
+
 			default:
 				this->towns.ForceResort();
 		}

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -671,7 +671,6 @@ struct TownDirectoryWindow : public Window {
 private:
 	/* Runtime saved values */
 	static Listing last_sorting;
-	static const Town *last_town;
 
 	/* Constants for sorting towns */
 	static const StringID sorter_names[];
@@ -710,7 +709,6 @@ private:
 			this->vscroll->SetCount((uint)this->towns.size()); // Update scrollbar as well.
 		}
 		/* Always sort the towns. */
-		this->last_town = nullptr;
 		this->towns.Sort();
 		this->SetWidgetDirty(WID_TD_LIST); // Force repaint of the displayed towns.
 	}
@@ -718,22 +716,7 @@ private:
 	/** Sort by town name */
 	static bool TownNameSorter(const Town * const &a, const Town * const &b)
 	{
-		static char buf_cache[MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH];
-		char buf[MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH];
-
-		SetDParam(0, a->index);
-		GetString(buf, STR_TOWN_NAME, lastof(buf));
-
-		/* If 'b' is the same town as in the last round, use the cached value
-		 * We do this to speed stuff up ('b' is called with the same value a lot of
-		 * times after each other) */
-		if (b != last_town) {
-			last_town = b;
-			SetDParam(0, b->index);
-			GetString(buf_cache, STR_TOWN_NAME, lastof(buf_cache));
-		}
-
-		return strnatcmp(buf, buf_cache) < 0; // Sort by name (natural sorting).
+		return strnatcmp(a->GetCachedName(), b->GetCachedName()) < 0; // Sort by name (natural sorting).
 	}
 
 	/** Sort by population (default descending, as big towns are of the most interest). */
@@ -1005,7 +988,6 @@ public:
 };
 
 Listing TownDirectoryWindow::last_sorting = {false, 0};
-const Town *TownDirectoryWindow::last_town = nullptr;
 
 /** Names of the sorting functions. */
 const StringID TownDirectoryWindow::sorter_names[] = {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -686,8 +686,6 @@ private:
 	void BuildSortTownList()
 	{
 		if (this->towns.NeedRebuild()) {
-			char buf[MAX_LENGTH_TOWN_NAME_CHARS * MAX_CHAR_LENGTH];
-
 			this->towns.clear();
 
 			for (const Town *t : Town::Iterate()) {
@@ -696,11 +694,7 @@ private:
 					continue;
 				}
 				this->string_filter.ResetState();
-
-				SetDParam(0, t->index);
-				GetString(buf, STR_TOWN_NAME, lastof(buf));
-
-				this->string_filter.AddLine(buf);
+				this->string_filter.AddLine(t->GetCachedName());
 				if (this->string_filter.GetState()) this->towns.push_back(t);
 			}
 

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -74,6 +74,7 @@ bool ScrollMainWindowToTile(TileIndex tile, bool instant = false);
 bool ScrollMainWindowTo(int x, int y, int z = -1, bool instant = false);
 
 void UpdateAllVirtCoords();
+void ClearAllCachedNames();
 
 extern Point _tile_fract_coords;
 


### PR DESCRIPTION
Avoid unnecessary resorts of the town and industry directory windows due to population and production changes respectively, when the current sort mode does not depend on the town population or industry production.

Avoid regenerating town, station and industry name strings on every sort comparison and on every town name filter.
Measurements of the time taken to sort the town directory window on a 4k x 4k map indicated a reduction in sort time of between 7.5x and 11x.