### PR TITLE
Fix: Non-deterministic name sorting in industry directory window

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1410,7 +1410,9 @@ protected:
 			GetString(buf_cache, STR_INDUSTRY_NAME, lastof(buf_cache));
 		}
 
-		return strnatcmp(buf, buf_cache) < 0; // Sort by name (natural sorting).
+		int r = strnatcmp(buf, buf_cache); // Sort by name (natural sorting).
+		if (r == 0) return a->index < b->index;
+		return r < 0;
 	}
 
 	/** Sort industries by type and name */


### PR DESCRIPTION
In the case where multiple industries have the same name, sorting
in the industry directory window is non-deterministic.
This results in the order changing on each re-sort, and is noticeable
when the industries have different production or transported values.