### PR TITLE
Fix 196d5868: Always apply filter on town directory rebuild

### DIFF
--- a/src/town.h
+++ b/src/town.h
@@ -161,7 +161,6 @@ enum TownRatingCheckType {
 /** Special values for town list window for the data parameter of #InvalidateWindowData. */
 enum TownDirectoryInvalidateWindowData {
 	TDIWD_FORCE_REBUILD,
-	TDIWD_FILTER_CHANGES,        ///< The filename filter has changed (via the editbox)
 	TDIWD_FORCE_RESORT,
 };
 


### PR DESCRIPTION
In scenario editor, when a town is created/deleted, the filter was ignored when rebuilding the town list.