### PR TITLE
Fix 3c047b1: AIGroup.GetProfitLastYear could get values different than those displayed in gui

### DIFF
--- a/src/group.h
+++ b/src/group.h
@@ -24,13 +24,14 @@ extern GroupPool _group_pool; ///< Pool of groups.
 /** Statistics and caches on the vehicles in a group. */
 struct GroupStatistics {
 	uint16 num_vehicle;                     ///< Number of vehicles.
+	Money profit_last_year;                 ///< Sum of profits for all vehicles.
 	uint16 *num_engines;                    ///< Caches the number of engines of each type the company owns.
 
 	bool autoreplace_defined;               ///< Are any autoreplace rules set?
 	bool autoreplace_finished;              ///< Have all autoreplacement finished?
 
 	uint16 num_profit_vehicle;              ///< Number of vehicles considered for profit statistics;
-	Money profit_last_year;                 ///< Sum of profits for all vehicles.
+	Money profit_last_year_min_age;         ///< Sum of profits for considered vehicles.
 
 	GroupStatistics();
 	~GroupStatistics();
@@ -41,6 +42,7 @@ struct GroupStatistics {
 	{
 		this->num_profit_vehicle = 0;
 		this->profit_last_year = 0;
+		this->profit_last_year_min_age = 0;
 	}
 
 	void ClearAutoreplace()
@@ -105,7 +107,7 @@ static inline bool IsAllGroupID(GroupID id_g)
 uint GetGroupNumEngines(CompanyID company, GroupID id_g, EngineID id_e);
 uint GetGroupNumVehicle(CompanyID company, GroupID id_g, VehicleType type);
 uint GetGroupNumProfitVehicle(CompanyID company, GroupID id_g, VehicleType type);
-Money GetGroupProfitLastYear(CompanyID company, GroupID id_g, VehicleType type);
+Money GetGroupProfitLastYearMinAge(CompanyID company, GroupID id_g, VehicleType type);
 
 void SetTrainGroupID(Train *v, GroupID grp);
 void UpdateTrainGroupID(Train *v);

--- a/src/group.h
+++ b/src/group.h
@@ -57,6 +57,7 @@ struct GroupStatistics {
 
 	static void CountVehicle(const Vehicle *v, int delta);
 	static void CountEngine(const Vehicle *v, int delta);
+	static void AddProfitLastYear(const Vehicle *v);
 	static void VehicleReachedProfitAge(const Vehicle *v);
 
 	static void UpdateProfits();

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -162,6 +162,18 @@ void GroupStatistics::Clear()
 }
 
 /**
+ * Add a vehicle's last year profit to the profit sum of its group.
+ */
+/* static */ void GroupStatistics::AddProfitLastYear(const Vehicle *v)
+{
+	GroupStatistics &stats_all = GroupStatistics::GetAllGroup(v);
+	GroupStatistics &stats = GroupStatistics::Get(v);
+
+	stats_all.profit_last_year += v->GetDisplayProfitLastYear();
+	stats.profit_last_year += v->GetDisplayProfitLastYear();
+}
+
+/**
  * Add a vehicle to the profit sum of its group.
  */
 /* static */ void GroupStatistics::VehicleReachedProfitAge(const Vehicle *v)
@@ -195,12 +207,7 @@ void GroupStatistics::Clear()
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
 		if (v->IsPrimaryVehicle()) {
-			GroupStatistics &stats_all = GroupStatistics::GetAllGroup(v);
-			GroupStatistics &stats = GroupStatistics::Get(v);
-
-			stats_all.profit_last_year += v->GetDisplayProfitLastYear();
-			stats.profit_last_year += v->GetDisplayProfitLastYear();
-
+			GroupStatistics::AddProfitLastYear(v);
 			if (v->age > VEHICLE_PROFIT_MIN_AGE) GroupStatistics::VehicleReachedProfitAge(v);
 		}
 	}

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -298,7 +298,7 @@ private:
 		x = rtl ? x - 2 - this->column_size[VGC_PROFIT].width : x + 2 + this->column_size[VGC_AUTOREPLACE].width;
 		SpriteID spr;
 		uint num_profit_vehicle = GetGroupNumProfitVehicle(this->vli.company, g_id, this->vli.vtype);
-		Money profit_last_year = GetGroupProfitLastYear(this->vli.company, g_id, this->vli.vtype);
+		Money profit_last_year = GetGroupProfitLastYearMinAge(this->vli.company, g_id, this->vli.vtype);
 		if (num_profit_vehicle == 0) {
 			spr = SPR_PROFIT_NA;
 		} else if (profit_last_year < 0) {

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -739,10 +739,7 @@ public:
 		this->profit_this_year = src->profit_this_year;
 		this->profit_last_year = src->profit_last_year;
 
-		GroupStatistics &stats_all = GroupStatistics::GetAllGroup(this);
-		GroupStatistics &stats = GroupStatistics::Get(this);
-		stats_all.profit_last_year += this->GetDisplayProfitLastYear();
-		stats.profit_last_year += this->GetDisplayProfitLastYear();
+		GroupStatistics::AddProfitLastYear(this);
 	}
 
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -738,6 +738,11 @@ public:
 
 		this->profit_this_year = src->profit_this_year;
 		this->profit_last_year = src->profit_last_year;
+
+		GroupStatistics &stats_all = GroupStatistics::GetAllGroup(this);
+		GroupStatistics &stats = GroupStatistics::Get(this);
+		stats_all.profit_last_year += this->GetDisplayProfitLastYear();
+		stats.profit_last_year += this->GetDisplayProfitLastYear();
 	}
 
 


### PR DESCRIPTION
AIGroup.GetProfitLastYear was only accounting profits of vehicles which had an age higher than VEHICLE_PROFIT_MIN_AGE, which is different than what is displayed on group_gui widget WID_GL_INFO

EDIT (31 Aug 2021):
After long deliberation, I went with the solution of: store 2 values, the "all time" and the "since minimum age". For that I had to rename some functions and objects, to reflect what they are actually doing, because the documentation wasn't clear about it. For example, `GroupStatistics::profit_last_year` becomes `GroupStatistics::profit_last_year_min_age` because that's what it reflects, vehicles above the minimum age for considered profits. Another one is `GetGroupProfitLastYear` which becomes `GetGroupProfitLastYearMinAge`. These are being used for displaying the colour of the profit icons in the vehicle list window.

Then I added `GroupStatistics::profit_last_year`, the one that is intended to be used by the AI script function `GetProfitLastYear`. This profit reflects exactly the profit last year value that is displayed in GUI for a selected group. While the implementation was somewhat easy to do, there was an issue that was causing a discrepancy of values between what's shown in GUI and what the script command was getting, and it was caused by Autoreplace code.

The issue happens when trying to copy group and vehicle statistics from the old vehicle to the new vehicle. The group was getting the last year profit of the new vehicle which was still 0, before the profit was updated over from the old vehicle. The end result after autoreplace was completed, was that the group statistics didn't account for the missing profit. It was only copied between vehicles, but not when updating the group.

I solved by cirurgically updating the last year profits of the affected groups in `CopyVehicleConfigAndStatistics`.