### PR TITLE
Feature: Water tiles have a depth

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -1014,6 +1014,7 @@
      <li>m1 bits 6..5 : Water class (sea, canal or river)
      <li>m1 bits 4..0: <a href="#OwnershipInfo">owner</a> (for sea, rivers, and coasts normally <tt>11</tt>)</li>
      <li>m2: Depot index (for depots only)</li>
+     <li>m3: bits 3..0: depth (not required to be continuous between tiles)</li>
      <li>m4: Random data for canal or river tiles</li>
      <li>m5: tile type:
       <table>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -239,7 +239,7 @@ the array so you can quickly see what is used and what is not.
       <td class="caption">sea, shore</td>
       <td class="bits" rowspan=4><span class="used" title="Ship docking tile status">X</span> <span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
       <td class="bits" rowspan=3><span class="free">OOOO OOOO OOOO OOOO</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</span></td>
+      <td class="bits" rowspan=4><span class="free">OOOO</span> <span class="used" title="Water depth">XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>O</span> <span class="free">OOO</span><span class="used" title="Sea shore flag">X</span></td>
       <td class="bits" rowspan=4><span class="free">OOOO OOOO</span></td>

--- a/src/industry.h
+++ b/src/industry.h
@@ -211,6 +211,8 @@ void ReleaseDisastersTargetingIndustry(IndustryID);
 
 bool IsTileForestIndustry(TileIndex tile);
 
+WaterDepth GetIndustryTileWaterDepth(TileIndex tile);
+
 /** Data for managing the number of industries of a single industry type. */
 struct IndustryTypeBuildData {
 	uint32 probability;  ///< Relative probability of building this industry.

--- a/src/industry.h
+++ b/src/industry.h
@@ -96,6 +96,8 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	uint8 construction_type;       ///< Way the industry was constructed (@see IndustryConstructionType)
 	Date last_cargo_accepted_at[INDUSTRY_NUM_INPUTS]; ///< Last day each cargo type was accepted by this industry
 	byte selected_layout;          ///< Which tile layout was used when creating the industry
+	WaterDepth water_depth_min;    ///< Shallowest water depth the industry was constructed over
+	WaterDepth water_depth_max;    ///< Deepest water depth the industry was constructed over
 	Owner exclusive_supplier;      ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
 	Owner exclusive_consumer;      ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)
 	std::string text;              ///< General text with additional information.

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -955,6 +955,18 @@ static void ChangeTileOwner_Industry(TileIndex tile, Owner old_owner, Owner new_
 }
 
 /**
+ * Get the (pretend) water depth for an industry tile.
+ * @param tile  Which tile to check
+ * @return      Water depth of the industry on the tile.
+ * @pre IsTileType(tile, MP_INDUSTRY)
+ */
+WaterDepth GetIndustryTileWaterDepth(TileIndex tile)
+{
+	assert(IsTileType(tile, MP_INDUSTRY));
+	return Industry::GetByTile(tile)->water_depth_min;
+}
+
+/**
  * Check whether the tile is a forest.
  * @param tile the tile to investigate.
  * @return true if and only if the tile is a forest

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <vector>
 #include "map_type.h"
+#include "water_map.h"
 #include "slope_type.h"
 #include "industry_type.h"
 #include "landscape_type.h"
@@ -176,6 +177,7 @@ struct IndustryTileSpec {
 const IndustrySpec *GetIndustrySpec(IndustryType thistype);    ///< Array of industries data
 const IndustryTileSpec *GetIndustryTileSpec(IndustryGfx gfx);  ///< Array of industry tiles data
 void ResetIndustries();
+bool GetIndustryLayoutWaterDepthMinMax(const IndustryTileLayout &layout, TileIndex base_tile, WaterDepth &min_depth, WaterDepth &max_depth);
 
 /* writable arrays of specs */
 extern IndustrySpec _industry_specs[NUM_INDUSTRYTYPES];

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1487,6 +1487,8 @@ void GenerateLandscape(byte mode)
 	};
 	uint steps = (_settings_game.game_creation.landscape == LT_TROPIC) ? GLS_TROPIC : GLS_OTHER;
 
+	bool need_depth_erosion = true;
+
 	if (mode == GWM_HEIGHTMAP) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_HEIGHTMAP);
 		LoadHeightmap(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str());
@@ -1494,6 +1496,7 @@ void GenerateLandscape(byte mode)
 	} else if (_settings_game.game_creation.land_generator == LG_TERRAGENESIS) {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_TERRAGENESIS);
 		GenerateTerrainPerlin();
+		need_depth_erosion = false;
 	} else {
 		SetGeneratingWorldProgress(GWP_LANDSCAPE, steps + GLS_ORIGINAL);
 		if (_settings_game.construction.freeform_edges) {
@@ -1575,7 +1578,7 @@ void GenerateLandscape(byte mode)
 	}
 
 	CreateRivers();
-	ErodeAllWaterTiles();
+	if (need_depth_erosion) ErodeAllWaterTiles();
 }
 
 void OnTick_Town();

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -702,8 +702,8 @@ bool HaveWaterDepthSprites()
 void SetWaterDepthSprites(SpriteID *table)
 {
 	ClearWaterDepthSprites();
-	_water_depth_sprites = CallocT<SpriteID>(WATER_DEPTH_MAX);
-	MemCpyT(_water_depth_sprites, table, WATER_DEPTH_MAX);
+	_water_depth_sprites = CallocT<SpriteID>(FLAT_WATER_DEPTH_SPRITE_COUNT);
+	MemCpyT(_water_depth_sprites, table, FLAT_WATER_DEPTH_SPRITE_COUNT);
 }
 
 /**
@@ -711,7 +711,7 @@ void SetWaterDepthSprites(SpriteID *table)
  */
 SpriteID GetWaterBaseSprite(WaterDepth depth)
 {
-	assert(depth < WATER_DEPTH_MAX);
+	assert(depth < FLAT_WATER_DEPTH_SPRITE_COUNT);
 	if (_water_depth_sprites != nullptr) return _water_depth_sprites[depth];
 	return SPR_FLAT_WATER_TILE;
 }

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1388,7 +1388,7 @@ bool ErodeWaterTileDepth(TileIndex tile)
 	} else if (num_water_tiles == required_water_tiles) {
 		WaterDepth new_depth = current_depth + 1;
 		new_depth = std::min<WaterDepth>(min_water_depth + 1, new_depth);
-		new_depth = std::min<WaterDepth>(max_water_depth + 1, new_depth);
+		if (current_depth > WATER_DEPTH_MIN) new_depth = (WaterDepth)std::max<int>(new_depth, current_depth - 1);
 		SetWaterDepth(tile, Clamp(new_depth, WATER_DEPTH_MIN, WATER_DEPTH_MAX));
 		return new_depth != current_depth;
 	}

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -89,6 +89,14 @@ extern const byte _slope_to_sprite_offset[32] = {
 static SnowLine *_snow_line = nullptr;
 
 /**
+ * Ground sprites to use for water of different depths.
+ *
+ * If this is \c nullptr, the default water sprite from the baseset is used.
+ * Otherwise it must point to an array of WATER_DEPTH_MAX SpriteID values.
+ */
+static SpriteID *_water_depth_sprites = nullptr;
+
+/**
  * Map 2D viewport or smallmap coordinate to 3D world or tile coordinate.
  * Function takes into account height of tiles and foundations.
  *
@@ -680,6 +688,41 @@ void ClearSnowLine()
 	free(_snow_line);
 	_snow_line = nullptr;
 }
+
+/** Return whether water depth sprites have been configured. */
+bool HaveWaterDepthSprites()
+{
+	return _water_depth_sprites != nullptr;
+}
+
+/**
+ * Change the water depth sprite mapping.
+ * @param table  Array with WATER_DEPTH_MAX SpriteID values to use for each depth level.
+ */
+void SetWaterDepthSprites(SpriteID *table)
+{
+	ClearWaterDepthSprites();
+	_water_depth_sprites = CallocT<SpriteID>(WATER_DEPTH_MAX);
+	MemCpyT(_water_depth_sprites, table, WATER_DEPTH_MAX);
+}
+
+/**
+ * Get the tile to use for flat water at a specific depth.
+ */
+SpriteID GetWaterBaseSprite(WaterDepth depth)
+{
+	assert(depth < WATER_DEPTH_MAX);
+	if (_water_depth_sprites != nullptr) return _water_depth_sprites[depth];
+	return SPR_FLAT_WATER_TILE;
+}
+
+/** Reset the water depth sprite mapping to no depth mapping. */
+void ClearWaterDepthSprites()
+{
+	free(_water_depth_sprites);
+	_water_depth_sprites = nullptr;
+}
+
 
 /**
  * Clear a piece of landscape

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1295,6 +1295,65 @@ static void CreateRivers()
 }
 
 /**
+ * Perform "erosion" of a single water tile, adjusting its depth closer to neighbours
+ * @param tile The tile to erode
+ * @return True if the tile was modified
+ * @pre IsTileType(tile, MP_WATER)
+ */
+bool ErodeWaterTileDepth(TileIndex tile)
+{
+	assert(IsTileType(tile, MP_WATER));
+	assert(GetWaterClass(tile) != WATER_CLASS_INVALID); // real, open water tiles can't be WATER_CLASS_INVALID
+
+	/* Coast tiles don't erode */
+	if (!IsWaterTile(tile)) return false;
+	/* Canals are artificial and don't erode */
+	if (GetWaterClass(tile) == WATER_CLASS_CANAL) return false;
+
+	/* Count number of water tiles around this tile.
+	 * If there are any non-water tiles next by, fill the tile to be shallower, else maybe make deeper. */
+	uint8 num_water_tiles = 0;
+	uint8 required_water_tiles = DIR_END;
+	WaterDepth min_water_depth = WATER_DEPTH_MAX;
+	WaterDepth max_water_depth = WATER_DEPTH_MIN;
+
+	for (Direction dir = DIR_BEGIN; dir < DIR_END; dir++) {
+		TileIndex dest = tile + TileOffsByDir(dir);
+		if (!IsValidTile(dest)) {
+			/* Map edges don't count for requirements */
+			required_water_tiles--;
+			continue;
+		}
+		if (!HasTileWaterClass(dest)) continue;
+		if (!IsTileOnWater(dest)) continue;
+		if (IsTileType(dest, MP_WATER) && GetWaterTileType(dest) == WATER_TILE_COAST) continue;
+		num_water_tiles++;
+
+		if (IsTileType(dest, MP_WATER)) {
+			const WaterDepth depth = GetWaterDepth(dest);
+			min_water_depth = std::min(min_water_depth, depth);
+			max_water_depth = std::max(max_water_depth, depth);
+		}
+	}
+
+	if (GetWaterClass(tile) != WATER_CLASS_SEA) max_water_depth = 2;
+
+	const uint8 current_depth = GetWaterDepth(tile);
+	if (num_water_tiles < required_water_tiles && current_depth > WATER_DEPTH_MIN) {
+		SetWaterDepth(tile, current_depth - 1);
+		return true;
+	} else if (num_water_tiles == required_water_tiles) {
+		WaterDepth new_depth = current_depth + 1;
+		new_depth = std::min<WaterDepth>(min_water_depth + 1, new_depth);
+		new_depth = std::min<WaterDepth>(max_water_depth + 1, new_depth);
+		SetWaterDepth(tile, Clamp(new_depth, WATER_DEPTH_MIN, WATER_DEPTH_MAX));
+		return new_depth != current_depth;
+	}
+
+	return false;
+}
+
+/**
  * Calculate what height would be needed to cover N% of the landmass.
  *
  * The function allows both snow and desert/tropic line to be calculated. It

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1353,6 +1353,19 @@ bool ErodeWaterTileDepth(TileIndex tile)
 	return false;
 }
 
+/** Run erosion over all water tiles on map repeatedly, until no more changes */
+void ErodeAllWaterTiles()
+{
+	for (int iteration = 0; iteration < WATER_DEPTH_MAX; iteration++) {
+		bool changed = false;
+		const TileIndex map_size = MapSize();
+		for (TileIndex tile = 0; tile < map_size; tile++) {
+			if (IsTileType(tile, MP_WATER)) changed |= ErodeWaterTileDepth(tile);
+		}
+		if (!changed) break;
+	}
+}
+
 /**
  * Calculate what height would be needed to cover N% of the landmass.
  *
@@ -1562,6 +1575,7 @@ void GenerateLandscape(byte mode)
 	}
 
 	CreateRivers();
+	ErodeAllWaterTiles();
 }
 
 void OnTick_Town();

--- a/src/landscape.h
+++ b/src/landscape.h
@@ -33,6 +33,11 @@ byte HighestSnowLine();
 byte LowestSnowLine();
 void ClearSnowLine();
 
+bool HaveWaterDepthSprites();
+void SetWaterDepthSprites(SpriteID *table);
+SpriteID GetWaterBaseSprite(uint8 depth);
+void ClearWaterDepthSprites();
+
 int GetSlopeZInCorner(Slope tileh, Corner corner);
 Slope GetFoundationSlope(TileIndex tile, int *z = nullptr);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2769,10 +2769,10 @@ STR_LAI_STATION_DESCRIPTION_SHIP_DOCK                           :Ship dock
 STR_LAI_STATION_DESCRIPTION_BUOY                                :Buoy
 STR_LAI_STATION_DESCRIPTION_WAYPOINT                            :Waypoint
 
-STR_LAI_WATER_DESCRIPTION_WATER                                 :Water
-STR_LAI_WATER_DESCRIPTION_CANAL                                 :Canal
+STR_LAI_WATER_DESCRIPTION_WATER                                 :Water (depth {HEIGHT})
+STR_LAI_WATER_DESCRIPTION_CANAL                                 :Canal (depth {HEIGHT})
 STR_LAI_WATER_DESCRIPTION_LOCK                                  :Lock
-STR_LAI_WATER_DESCRIPTION_RIVER                                 :River
+STR_LAI_WATER_DESCRIPTION_RIVER                                 :River (depth {HEIGHT})
 STR_LAI_WATER_DESCRIPTION_COAST_OR_RIVERBANK                    :Coast or riverbank
 STR_LAI_WATER_DESCRIPTION_SHIP_DEPOT                            :Ship depot
 
@@ -4391,6 +4391,8 @@ STR_ERROR_TREE_PLANT_LIMIT_REACHED                              :{WHITE}... tree
 STR_ERROR_NAME_MUST_BE_UNIQUE                                   :{WHITE}Name must be unique
 STR_ERROR_GENERIC_OBJECT_IN_THE_WAY                             :{WHITE}{1:STRING} in the way
 STR_ERROR_NOT_ALLOWED_WHILE_PAUSED                              :{WHITE}Not allowed while paused
+STR_ERROR_WATER_TOO_DEEP                                        :{WHITE}... water too deep
+STR_ERROR_WATER_TOO_SHALLOW                                     :{WHITE}... water too shallow
 
 # Local authority errors
 STR_ERROR_LOCAL_AUTHORITY_REFUSES_TO_ALLOW_THIS                 :{WHITE}{TOWN} local authority refuses to allow this

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1134,6 +1134,10 @@ STR_CITY_APPROVAL_PERMISSIVE                                    :Permissive
 STR_CITY_APPROVAL_TOLERANT                                      :Tolerant
 STR_CITY_APPROVAL_HOSTILE                                       :Hostile
 
+STR_WATER_CLEARING_COST_ORIGINAL                                :None
+STR_WATER_CLEARING_COST_LINEAR                                  :Linear
+STR_WATER_CLEARING_COST_QUADRATIC                               :Quadratic
+
 STR_WARNING_NO_SUITABLE_AI                                      :{WHITE}No suitable AIs available...{}You can download several AIs via the 'Online Content' system
 
 # Settings tree window
@@ -1212,6 +1216,8 @@ STR_CONFIG_SETTING_DISASTERS                                    :Disasters: {STR
 STR_CONFIG_SETTING_DISASTERS_HELPTEXT                           :Toggle disasters which may occasionally block or destroy vehicles or infrastructure
 STR_CONFIG_SETTING_CITY_APPROVAL                                :Town council's attitude towards area restructuring: {STRING2}
 STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT                       :Choose how much noise and environmental damage by companies affect their town rating and further construction actions in their area
+STR_CONFIG_SETTING_WATER_CLEARING_COST                          :Influence of water depths on modification cost: {STRING2}
+STR_CONFIG_SETTING_WATER_CLEARING_COST_HELPTEXT                 :Choose how expensive modifying/clearing deep water tiles is.{}None means all water tiles cost the same to clear regardless of depth. Linear means the regular cost must be paid for every depth level, makes modifying ocean expensive. Quadratic means the depth level is squared and multiplied by cost, makes modifying ocean extremely expensive.
 
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT                             :Map height limit: {STRING2}
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_HELPTEXT                    :Set the maximum height of the map terrain. With "(auto)" a good value will be picked after terrain generation

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3605,8 +3605,8 @@ STR_PURCHASE_INFO_COST_WEIGHT                                   :{BLACK}Cost: {G
 STR_PURCHASE_INFO_COST_REFIT_WEIGHT                             :{BLACK}Cost: {GOLD}{CURRENCY_LONG}{BLACK} (Refit Cost: {GOLD}{CURRENCY_LONG}{BLACK}) Weight: {GOLD}{WEIGHT_SHORT}
 STR_PURCHASE_INFO_SPEED_POWER                                   :{BLACK}Speed: {GOLD}{VELOCITY}{BLACK} Power: {GOLD}{POWER}
 STR_PURCHASE_INFO_SPEED                                         :{BLACK}Speed: {GOLD}{VELOCITY}
-STR_PURCHASE_INFO_SPEED_OCEAN                                   :{BLACK}Speed on ocean: {GOLD}{VELOCITY}
-STR_PURCHASE_INFO_SPEED_CANAL                                   :{BLACK}Speed on canal/river: {GOLD}{VELOCITY}
+STR_PURCHASE_INFO_SPEED_OCEAN                                   :{BLACK}Deep water speed: {GOLD}{VELOCITY}
+STR_PURCHASE_INFO_SPEED_CANAL                                   :{BLACK}Shallow water speed: {GOLD}{VELOCITY}
 STR_PURCHASE_INFO_RUNNINGCOST                                   :{BLACK}Running Cost: {GOLD}{CURRENCY_LONG}/yr
 STR_PURCHASE_INFO_CAPACITY                                      :{BLACK}Capacity: {GOLD}{CARGO_LONG} {STRING}
 STR_PURCHASE_INFO_REFITTABLE                                    :(refittable)

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1138,6 +1138,11 @@ STR_WATER_CLEARING_COST_ORIGINAL                                :None
 STR_WATER_CLEARING_COST_LINEAR                                  :Linear
 STR_WATER_CLEARING_COST_QUADRATIC                               :Quadratic
 
+STR_WATER_DEPTH_EROSION_SPEED_NONE                              :No erosion
+STR_WATER_DEPTH_EROSION_SPEED_SLOW                              :Slow
+STR_WATER_DEPTH_EROSION_SPEED_MEDIUM                            :Medium
+STR_WATER_DEPTH_EROSION_SPEED_FAST                              :Fast
+
 STR_WARNING_NO_SUITABLE_AI                                      :{WHITE}No suitable AIs available...{}You can download several AIs via the 'Online Content' system
 
 # Settings tree window
@@ -1218,6 +1223,8 @@ STR_CONFIG_SETTING_CITY_APPROVAL                                :Town council's 
 STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT                       :Choose how much noise and environmental damage by companies affect their town rating and further construction actions in their area
 STR_CONFIG_SETTING_WATER_CLEARING_COST                          :Influence of water depths on modification cost: {STRING2}
 STR_CONFIG_SETTING_WATER_CLEARING_COST_HELPTEXT                 :Choose how expensive modifying/clearing deep water tiles is.{}None means all water tiles cost the same to clear regardless of depth. Linear means the regular cost must be paid for every depth level, makes modifying ocean expensive. Quadratic means the depth level is squared and multiplied by cost, makes modifying ocean extremely expensive.
+STR_CONFIG_SETTING_WATER_DEPTH_EROSION_SPEED                    :Sea floor erosion speed: {STRING2}
+STR_CONFIG_SETTING_WATER_DEPTH_EROSION_SPEED_HELPTEXT           :Control how fast the depth of water tiles normalises toward a smooth gradient from the coast.{}Slow erosion takes place over centuries. Medium over decades. Fast erosion over a few years.
 
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT                             :Map height limit: {STRING2}
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_HELPTEXT                    :Set the maximum height of the map terrain. With "(auto)" a good value will be picked after terrain generation

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -6217,10 +6217,10 @@ static void GraphicsNew(ByteReader *buf)
 
 	if (type == 0x19) {
 		/* Read table of depth-sprite maping */
-		if (!buf->HasData(WATER_DEPTH_MAX)) {
+		if (!buf->HasData(FLAT_WATER_DEPTH_SPRITE_COUNT)) {
 			grfmsg(1, "GraphicsNew: %s (type 0x%02X) requires a %d byte table following the sprite count for depth sprite map. Skipping.", action5_type->name, type, WATER_DEPTH_MAX);
 		}
-		SpriteID water_tiles[WATER_DEPTH_MAX];
+		SpriteID water_tiles[FLAT_WATER_DEPTH_SPRITE_COUNT];
 		for (int i = 0; i < lengthof(water_tiles); i++) {
 			byte b = buf->ReadByte();
 			if (b == 0xFF) {

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -100,6 +100,9 @@ struct CanalResolverObject : public ResolverObject {
 
 		/* Random data for river or canal tiles, otherwise zero */
 		case 0x83: return IsTileType(this->tile, MP_WATER) ? GetWaterTileRandomBits(this->tile) : 0;
+
+		/* Water depth range 0 to 15 */
+		case 0x84: return IsTileType(this->tile, MP_WATER) ? GetWaterDepth(this->tile) : 0;
 	}
 
 	DEBUG(grf, 1, "Unhandled canal variable 0x%02X", variable);

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -497,6 +497,8 @@ CommandCost GetErrorMessageFromLocationCallbackResult(uint16 cb_res, const GRFFi
 			case 0x406: res = CommandCost(STR_ERROR_CAN_T_BUILD_ON_SEA); break;
 			case 0x407: res = CommandCost(STR_ERROR_CAN_T_BUILD_ON_CANAL); break;
 			case 0x408: res = CommandCost(STR_ERROR_CAN_T_BUILD_ON_RIVER); break;
+			case 0x409: res = CommandCost(STR_ERROR_WATER_TOO_DEEP); break;
+			case 0x40A: res = CommandCost(STR_ERROR_WATER_TOO_SHALLOW); break;
 		}
 	}
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -962,6 +962,7 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 			Ship *s = Ship::From(v);
 			switch (variable - 0x80) {
 				case 0x62: return s->state;
+				case 0x66: return GetEffectiveWaterDepth(s->tile);
 			}
 			break;
 		}

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -962,7 +962,7 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 			Ship *s = Ship::From(v);
 			switch (variable - 0x80) {
 				case 0x62: return s->state;
-				case 0x66: return GetEffectiveWaterDepth(s->tile);
+				case 0x66: return s->tile_depth;
 			}
 			break;
 		}

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -326,13 +326,6 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 			}
 		}
 
-		/* Water depth (byte) at nearby tile, if it's water, otherwise 0 */
-		case 0x72: {
-			if (this->tile == INVALID_TILE) break;
-			TileIndex tile = GetNearbyTile(parameter, this->tile);
-			return IsWaterTile(this->tile) ? GetWaterDepth(this->tile) : 0;
-		}
-
 
 		case 0x6E:
 		case 0x6F: {

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -395,6 +395,8 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 		case 0xAA: return this->industry->counter;
 		case 0xAB: return GB(this->industry->counter, 8, 8);
 		case 0xAC: return this->industry->was_cargo_delivered;
+		case 0xAD: return this->industry->water_depth_min;
+		case 0xAE: return this->industry->water_depth_max;
 
 		case 0xB0: return Clamp(this->industry->construction_date - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 65535); // Date when built since 1920 (in days)
 		case 0xB3: return this->industry->construction_type; // Construction type
@@ -545,6 +547,7 @@ CommandCost CheckIfCallBackAllowsCreation(TileIndex tile, IndustryType type, siz
 	ind.random = initial_random_bits;
 	ind.founder = founder;
 	ind.psa = nullptr;
+	GetIndustryLayoutWaterDepthMinMax(indspec->layouts[layout], tile, ind.water_depth_min, ind.water_depth_max);
 
 	IndustriesResolverObject object(tile, &ind, type, seed, CBID_INDUSTRY_LOCATION, 0, creation_type);
 	uint16 result = object.ResolveCallback();

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -326,6 +326,13 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 			}
 		}
 
+		/* Water depth (byte) at nearby tile, if it's water, otherwise 0 */
+		case 0x72: {
+			if (this->tile == INVALID_TILE) break;
+			TileIndex tile = GetNearbyTile(parameter, this->tile);
+			return IsWaterTile(this->tile) ? GetWaterDepth(this->tile) : 0;
+		}
+
 
 		case 0x6E:
 		case 0x6F: {

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -297,7 +297,7 @@ public:
 
 		/* Ocean/canal speed penalty. */
 		const ShipVehicleInfo *svi = ShipVehInfo(Yapf().GetVehicle()->engine_type);
-		byte speed_frac = (GetEffectiveWaterClass(n.GetTile()) == WATER_CLASS_SEA) ? svi->ocean_speed_frac : svi->canal_speed_frac;
+		byte speed_frac = (GetEffectiveWaterDepth(n.GetTile()) >= WATER_DEPTH_DEEP) ? svi->ocean_speed_frac : svi->canal_speed_frac;
 		if (speed_frac > 0) c += YAPF_TILE_LENGTH * (1 + tf->m_tiles_skipped) * speed_frac / (256 - speed_frac);
 
 		/* apply it */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3082,6 +3082,8 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_WATER_DEPTH)) {
+		/* Set difficulty to "original" */
+		_settings_game.difficulty.water_clearing_cost_exponent = 0;
 		/* Make sure water tiles have an appropriate depth */
 		for (TileIndex t = 0; t < map_size; t++) {
 			if (IsTileType(t, MP_WATER)) SetWaterDepth(t, 0);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3081,6 +3081,25 @@ bool AfterLoadGame()
 		for (Industry *ind : Industry::Iterate()) if (ind->neutral_station != nullptr) ind->neutral_station->industry = ind;
 	}
 
+	if (IsSavegameVersionBefore(SLV_WATER_DEPTH)) {
+		/* Make sure water tiles have an appropriate depth */
+		for (TileIndex t = 0; t < map_size; t++) {
+			if (IsWaterTile(t)) {
+				switch (GetWaterClass(t)) {
+					case WATER_CLASS_SEA:
+					case WATER_CLASS_RIVER:
+						SetWaterDepth(t, 1);
+						break;
+					default:
+						SetWaterDepth(t, 0);
+						break;
+				}
+			} else if (IsTileType(t, MP_WATER)) {
+				SetWaterDepth(t, 0);
+			}
+		}
+	}
+
 	if (IsSavegameVersionBefore(SLV_TREES_WATER_CLASS)) {
 		/* Update water class for trees. */
 		for (TileIndex t = 0; t < map_size; t++) {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3084,20 +3084,10 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_WATER_DEPTH)) {
 		/* Make sure water tiles have an appropriate depth */
 		for (TileIndex t = 0; t < map_size; t++) {
-			if (IsWaterTile(t)) {
-				switch (GetWaterClass(t)) {
-					case WATER_CLASS_SEA:
-					case WATER_CLASS_RIVER:
-						SetWaterDepth(t, 1);
-						break;
-					default:
-						SetWaterDepth(t, 0);
-						break;
-				}
-			} else if (IsTileType(t, MP_WATER)) {
-				SetWaterDepth(t, 0);
-			}
+			if (IsTileType(t, MP_WATER)) SetWaterDepth(t, 0);
 		}
+		extern void ErodeAllWaterTiles(); // landscape.cpp
+		ErodeAllWaterTiles();
 	}
 
 	if (IsSavegameVersionBefore(SLV_TREES_WATER_CLASS)) {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3090,6 +3090,17 @@ bool AfterLoadGame()
 		}
 		extern void ErodeAllWaterTiles(); // landscape.cpp
 		ErodeAllWaterTiles();
+		/* Synthesize water depth min/max on all industries */
+		for (Industry *ind : Industry::Iterate()) {
+			const IndustrySpec *spec = GetIndustrySpec(ind->type);
+			ind->water_depth_min = ind->water_depth_max = 0;
+			if (spec == nullptr || !(spec->behaviour & INDUSTRYBEH_BUILT_ONWATER)) continue;
+			/* This industry type builds on water, try to find nearby water tiles for synthetic depth */
+			TileIndex tile = INVALID_TILE;
+			if (CircularTileSearch(&tile, 5, [](TileIndex t, void *) { return IsWaterTile(t); }, nullptr)) {
+				ind->water_depth_min = ind->water_depth_max = GetWaterDepth(tile);
+			}
+		}
 	}
 
 	if (IsSavegameVersionBefore(SLV_TREES_WATER_CLASS)) {

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -66,6 +66,8 @@ static const SaveLoad _industry_desc[] = {
 	SLE_CONDVAR(Industry, selected_layout,            SLE_UINT8,                 SLV_73, SL_MAX_VERSION),
 	SLE_CONDVAR(Industry, exclusive_supplier,         SLE_UINT8,                 SLV_GS_INDUSTRY_CONTROL, SL_MAX_VERSION),
 	SLE_CONDVAR(Industry, exclusive_consumer,         SLE_UINT8,                 SLV_GS_INDUSTRY_CONTROL, SL_MAX_VERSION),
+	SLE_CONDVAR(Industry, water_depth_min,            SLE_UINT8,                SLV_WATER_DEPTH, SL_MAX_VERSION),
+	SLE_CONDVAR(Industry, water_depth_max,            SLE_UINT8,                SLV_WATER_DEPTH, SL_MAX_VERSION),
 
 	SLEG_CONDARR(_old_ind_persistent_storage.storage, SLE_UINT32, 16,            SLV_76, SLV_161),
 	SLE_CONDREF(Industry, psa,                        REF_STORAGE,              SLV_161, SL_MAX_VERSION),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -326,6 +326,8 @@ enum SaveLoadVersion : uint16 {
 	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 v1.11.0-RC1  Additional GS text for industries.
 	SLV_MAPGEN_SETTINGS_REVAMP,             ///< 290  PR#8891 v1.11  Revamp of some mapgen settings (snow coverage, desert coverage, heightmap height, custom terrain type).
 
+	SLV_WATER_DEPTH,                        ///< 220  PR#7924 Water depth in map array.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -766,6 +766,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		      SLE_VAR(Ship, state,                     SLE_UINT8),
 		SLE_CONDDEQUE(Ship, path,                      SLE_UINT8,                  SLV_SHIP_PATH_CACHE, SL_MAX_VERSION),
 		  SLE_CONDVAR(Ship, rotation,                  SLE_UINT8,                  SLV_SHIP_ROTATION, SL_MAX_VERSION),
+		  SLE_CONDVAR(Ship, tile_depth,                SLE_UINT8,                  SLV_WATER_DEPTH, SL_MAX_VERSION),
 
 		SLE_CONDNULL(16, SLV_2, SLV_144), // old reserved space
 

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -22,6 +22,7 @@
  * API additions:
  * \li AICargo::GetName
  * \li AIPriorityQueue
+ * \li AITile::GetWaterDepth
  *
  * Other changes:
  * \li AIVehicle::CloneVehicle now correctly returns estimate when short on cash

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -37,6 +37,7 @@
  * \li GSStoryPage::MakeTileButtonReference
  * \li GSStoryPage::MakeVehicleButtonReference
  * \li GSPriorityQueue
+ * \li GSTile::GetWaterDepth
  *
  * Other changes:
  * \li GSCompany::ChangeBankBalance takes one extra parameter to refer to a location to show text effect on

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -186,6 +186,14 @@
 	return (z + ::GetSlopeZInCorner(slope, (::Corner)corner));
 }
 
+int32 ScriptTile::GetWaterDepth(TileIndex tile)
+{
+	if (!::IsValidTile(tile)) return -1;
+	if (!::IsWaterTile(tile)) return 0;
+
+	return ::GetWaterDepth(tile);
+}
+
 /* static */ ScriptCompany::CompanyID ScriptTile::GetOwner(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return ScriptCompany::COMPANY_INVALID;

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -312,6 +312,14 @@ public:
 	static int32 GetCornerHeight(TileIndex tile, Corner corner);
 
 	/**
+	 * Get the water depth of a tile.
+	 * @param tile The tile to check on.
+	 * @pre ScriptMap::IsValidTile(tile).
+	 * @return Water depth, range 0 (shallow) to 15 (deepest).
+	 */
+	static int32 GetWaterDepth(TileIndex tile);
+
+	/**
 	 * Get the owner of the tile.
 	 * @param tile The tile to get the owner from.
 	 * @pre ScriptMap::IsValidTile(tile).

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1711,6 +1711,7 @@ static SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("economy.infrastructure_maintenance"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs"));
 			accounting->Add(new SettingEntry("difficulty.construction_cost"));
+			accounting->Add(new SettingEntry("difficulty.water_clearing_cost_exponent"));
 		}
 
 		SettingsPage *vehicles = main->Add(new SettingsPage(STR_CONFIG_SETTING_VEHICLES));

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1841,6 +1841,7 @@ static SettingsContainer &GetSettingsTree()
 
 			environment->Add(new SettingEntry("station.modified_catchment"));
 			environment->Add(new SettingEntry("construction.extra_tree_placement"));
+			environment->Add(new SettingEntry("difficulty.water_depth_erosion_speed"));
 		}
 
 		SettingsPage *ai = main->Add(new SettingsPage(STR_CONFIG_SETTING_AI));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -77,6 +77,7 @@ struct DifficultySettings {
 	bool   line_reverse_mode;                ///< reversing at stations or not
 	bool   disasters;                        ///< are disasters enabled
 	byte   town_council_tolerance;           ///< minimum required town ratings to be allowed to demolish stuff
+	byte   water_clearing_cost_exponent;     ///< how the cost of clearing water tiles grows depending on depth
 };
 
 /** Settings relating to viewport/smallmap scrolling. */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -78,6 +78,7 @@ struct DifficultySettings {
 	bool   disasters;                        ///< are disasters enabled
 	byte   town_council_tolerance;           ///< minimum required town ratings to be allowed to demolish stuff
 	byte   water_clearing_cost_exponent;     ///< how the cost of clearing water tiles grows depending on depth
+	byte   water_depth_erosion_speed;        ///< how fast water depth smoothing happens
 };
 
 /** Settings relating to viewport/smallmap scrolling. */

--- a/src/ship.h
+++ b/src/ship.h
@@ -16,7 +16,7 @@
 #include "water_map.h"
 
 void GetShipSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
-WaterClass GetEffectiveWaterClass(TileIndex tile);
+WaterDepth GetEffectiveWaterDepth(TileIndex tile);
 
 typedef std::deque<Trackdir> ShipPathCache;
 

--- a/src/ship.h
+++ b/src/ship.h
@@ -24,11 +24,12 @@ typedef std::deque<Trackdir> ShipPathCache;
  * All ships have this type.
  */
 struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
-	TrackBits state;      ///< The "track" the ship is following.
-	ShipPathCache path;   ///< Cached path.
-	Direction rotation;   ///< Visible direction.
-	int16 rotation_x_pos; ///< NOSAVE: X Position before rotation.
-	int16 rotation_y_pos; ///< NOSAVE: Y Position before rotation.
+	TrackBits state;       ///< The "track" the ship is following.
+	ShipPathCache path;    ///< Cached path.
+	Direction rotation;    ///< Visible direction.
+	WaterDepth tile_depth; ///< Cached depth of current tile.
+	int16 rotation_x_pos;  ///< NOSAVE: X Position before rotation.
+	int16 rotation_y_pos;  ///< NOSAVE: Y Position before rotation.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Ship() : SpecializedVehicleBase() {}

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -221,8 +221,11 @@ void Ship::UpdateCache()
 {
 	const ShipVehicleInfo *svi = ShipVehInfo(this->engine_type);
 
+	/* Update current water depth */
+	this->tile_depth = GetEffectiveWaterDepth(this->tile);
+
 	/* Get speed fraction for the current water type. Aqueducts are always canals. */
-	bool is_ocean = GetEffectiveWaterDepth(this->tile) >= WATER_DEPTH_DEEP;
+	bool is_ocean = this->tile_depth >= WATER_DEPTH_DEEP;
 	uint raw_speed = GetVehicleProperty(this, PROP_SHIP_SPEED, svi->max_speed);
 	this->vcache.cached_max_speed = svi->ApplyWaterClassSpeedFrac(raw_speed, is_ocean);
 
@@ -756,7 +759,7 @@ static void ShipController(Ship *v)
 				v->state = TrackToTrackBits(track);
 
 				/* Update ship cache when the water depth changes. */
-				WaterDepth old_depth = GetEffectiveWaterDepth(gp.old_tile);
+				WaterDepth old_depth = v->tile_depth;
 				WaterDepth new_depth = GetEffectiveWaterDepth(gp.new_tile);
 				if (old_depth != new_depth) v->UpdateCache();
 			}

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -48,7 +48,8 @@ WaterDepth GetEffectiveWaterDepth(TileIndex tile)
 {
 	switch (GetTileType(tile)) {
 		case MP_WATER:
-			/* Real water tile */
+		case MP_INDUSTRY:
+			/* Tile types that can be queried directly */
 			return GetWaterDepth(tile);
 		case MP_TUNNELBRIDGE:
 			/* Aqueduct, assume it's always shallow */
@@ -60,7 +61,6 @@ WaterDepth GetEffectiveWaterDepth(TileIndex tile)
 			assert(GetRailGroundType(tile) == RAIL_GROUND_WATER);
 			return WATER_DEPTH_MIN;
 		case MP_STATION:
-		case MP_INDUSTRY:
 		case MP_OBJECT:
 			/* Thing in the water - search for a real water tile nearby and use that */
 			if (CircularTileSearch(&tile, 5, [](TileIndex tile, void *) { return IsTileType(tile, MP_WATER); }, nullptr)) {

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -46,14 +46,23 @@
  */
 WaterClass GetEffectiveWaterClass(TileIndex tile)
 {
+	if (IsTileType(tile, MP_WATER)) {
+		/* If the tile is real water (i.e. has depth) then depth over 0 always counts as sea,
+		 * and depth equal to zero always counts as river or canal. */
+		if (GetWaterDepth(tile) > 0) return WATER_CLASS_SEA;
+		if (GetWaterClass(tile) == WATER_CLASS_SEA) return WATER_CLASS_RIVER;
+		return GetWaterClass(tile);
+	}
 	if (HasTileWaterClass(tile)) return GetWaterClass(tile);
 	if (IsTileType(tile, MP_TUNNELBRIDGE)) {
 		assert(GetTunnelBridgeTransportType(tile) == TRANSPORT_WATER);
 		return WATER_CLASS_CANAL;
 	}
 	if (IsTileType(tile, MP_RAILWAY)) {
+		/* Halftile with railway on foundation, and water on lower part.
+		 * Counts as shallow river as it's next by coast. */
 		assert(GetRailGroundType(tile) == RAIL_GROUND_WATER);
-		return WATER_CLASS_SEA;
+		return WATER_CLASS_RIVER;
 	}
 	NOT_REACHED();
 }

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -326,6 +326,21 @@ strhelp  = STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT
 strval   = STR_CITY_APPROVAL_PERMISSIVE
 proc     = DifficultyNoiseChange
 
+[SDT_VAR]
+base     = GameSettings
+var      = difficulty.water_clearing_cost_exponent
+type     = SLE_UINT8
+from     = SLV_WATER_DEPTH
+guiflags = SGF_MULTISTRING
+def      = 2
+min      = 0
+max      = 2
+interval = 1
+str      = STR_CONFIG_SETTING_WATER_CLEARING_COST
+strhelp  = STR_CONFIG_SETTING_WATER_CLEARING_COST_HELPTEXT
+strval   = STR_WATER_CLEARING_COST_ORIGINAL
+cat      = SC_BASIC
+
 [SDTG_VAR]
 name     = ""diff_level""
 var      = _old_diff_level

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -341,6 +341,21 @@ strhelp  = STR_CONFIG_SETTING_WATER_CLEARING_COST_HELPTEXT
 strval   = STR_WATER_CLEARING_COST_ORIGINAL
 cat      = SC_BASIC
 
+[SDT_VAR]
+base     = GameSettings
+var      = difficulty.water_depth_erosion_speed
+type     = SLE_UINT8
+from     = SLV_WATER_DEPTH
+guiflags = SGF_MULTISTRING
+def      = 2
+min      = 0
+max      = 3
+interval = 1
+str      = STR_CONFIG_SETTING_WATER_DEPTH_EROSION_SPEED
+strhelp  = STR_CONFIG_SETTING_WATER_DEPTH_EROSION_SPEED_HELPTEXT
+strval   = STR_WATER_DEPTH_EROSION_SPEED_NONE
+cat      = SC_ADVANCED
+
 [SDTG_VAR]
 name     = ""diff_level""
 var      = _old_diff_level

--- a/src/table/sprites.h
+++ b/src/table/sprites.h
@@ -303,8 +303,12 @@ static const uint16 EMPTY_BOUNDING_BOX_SPRITE_COUNT = 1;
 static const SpriteID SPR_PALETTE_BASE = SPR_EMPTY_BOUNDING_BOX + EMPTY_BOUNDING_BOX_SPRITE_COUNT;
 static const uint16 PALETTE_SPRITE_COUNT = 1;
 
+/* Sprites for flat water with depth */
+static const SpriteID SPR_FLAT_WATER_DEPTH_BASE = SPR_PALETTE_BASE + PALETTE_SPRITE_COUNT;
+static const uint16 FLAT_WATER_DEPTH_SPRITE_COUNT = 16;
+
 /* From where can we start putting NewGRFs? */
-static const SpriteID SPR_NEWGRFS_BASE = SPR_PALETTE_BASE + PALETTE_SPRITE_COUNT;
+static const SpriteID SPR_NEWGRFS_BASE = SPR_FLAT_WATER_DEPTH_BASE + PALETTE_SPRITE_COUNT;
 
 /* Manager face sprites */
 static const SpriteID SPR_GRADIENT = 874; // background gradient behind manager face

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1293,7 +1293,7 @@ void TileLoop_Water(TileIndex tile)
 	if (_settings_game.difficulty.water_depth_erosion_speed == 0) do_erosion = false;
 
 	if (do_erosion) {
-		ErodeWaterTileDepth(tile);
+		if (ErodeWaterTileDepth(tile)) MarkTileDirtyByTile(tile);
 	}
 
 	switch (GetFloodingBehaviour(tile)) {

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -722,6 +722,9 @@ static void DrawWaterSprite(SpriteID base, uint offset, CanalFeature feature, Ti
 	if (base != SPR_FLAT_WATER_TILE) {
 		/* Only call offset callback if the sprite is NewGRF-provided. */
 		offset = GetCanalSpriteOffset(feature, tile, offset);
+	} else {
+		/* Use the regular base sprite for the depth */
+		base = GetWaterBaseSprite(GetWaterDepth(tile));
 	}
 	DrawGroundSprite(base + offset, PAL_NONE);
 }
@@ -787,7 +790,8 @@ static void DrawWaterEdges(bool canal, uint offset, TileIndex tile)
 /** Draw a plain sea water tile with no edges */
 static void DrawSeaWater(TileIndex tile)
 {
-	DrawGroundSprite(SPR_FLAT_WATER_TILE, PAL_NONE);
+	const WaterDepth depth = IsWaterTile(tile) ? GetWaterDepth(tile) : 0;
+	DrawGroundSprite(GetWaterBaseSprite(depth), PAL_NONE);
 }
 
 /** draw a canal styled water tile with dikes around */
@@ -909,6 +913,9 @@ static void DrawRiverWater(const TileInfo *ti)
 		}
 	}
 
+	/* If the plain flat tile was selected, use a depth indicating sprite instead. */
+	if (image == SPR_FLAT_WATER_TILE && offset == 0) image = GetWaterBaseSprite(GetWaterDepth(ti->tile));
+
 	DrawGroundSprite(image + offset, PAL_NONE);
 
 	/* Draw river edges if available. */
@@ -948,7 +955,7 @@ static void DrawTile_Water(TileInfo *ti)
 		case WATER_TILE_CLEAR:
 			DrawWaterClassGround(ti);
 #ifdef _DEBUG
-			if (_cur_dpi->zoom <= ZOOM_LVL_VIEWPORT) {
+			if (_cur_dpi->zoom <= ZOOM_LVL_VIEWPORT && !HaveWaterDepthSprites()) {
 				WaterDepth depth = GetWaterDepth(ti->tile);
 				SpriteID spr = SPR_ASCII_SPACE_SMALL + (depth > 9 ? depth + 'A' - 10 : depth + '0') - ' ';
 				DrawGroundSprite(spr, TC_GOLD | (1 << PALETTE_TEXT_RECOLOUR));

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -260,6 +260,14 @@ void MakeWaterKeepingClass(TileIndex tile, Owner o)
 		default: break;
 	}
 
+	/* Restore the water depth from surrounding tiles */
+	uint8 min_water_depth = WATER_DEPTH_MAX + 1;
+	for (Direction dir = DIR_BEGIN; dir < DIR_END; dir++) {
+		const TileIndex dest = tile + TileOffsByDir(dir);
+		if (IsValidTile(dest) && IsTileType(dest, MP_WATER)) min_water_depth = std::min(min_water_depth, GetWaterDepth(dest));
+	}
+	if (min_water_depth <= WATER_DEPTH_MAX) SetWaterDepth(tile, min_water_depth);
+
 	if (wc != WATER_CLASS_INVALID) CheckForDockingTile(tile);
 	MarkTileDirtyByTile(tile);
 }

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -64,8 +64,8 @@ static const uint8 _flood_from_dirs[] = {
 	(1 << DIR_W ) | (1 << DIR_SW) | (1 << DIR_NW),                 // SLOPE_SEN, SLOPE_STEEP_E
 };
 
-const uint8 SHIP_DEPOT_MAX_WATER_DEPTH = 2; ///< Maximum depth ship depots can be built at
-const uint8 CANAL_MAX_WATER_DEPTH      = 2; ///< Maximum depth canals can be built over
+const WaterDepth SHIP_DEPOT_MAX_WATER_DEPTH = 2; ///< Maximum depth ship depots can be built at
+const WaterDepth CANAL_MAX_WATER_DEPTH      = 2; ///< Maximum depth canals can be built over
 
 const int WATER_DEPTH_METRES_PER_UNIT = 20; ///< How many metres of depth one unit represents
 const int WATER_DEPTH_METRES_ZERO     = 10; ///< Depth in metres for water depth zero
@@ -262,7 +262,7 @@ void MakeWaterKeepingClass(TileIndex tile, Owner o)
 	}
 
 	/* Restore the water depth from surrounding tiles */
-	uint8 min_water_depth = WATER_DEPTH_MAX + 1;
+	WaterDepth min_water_depth = WATER_DEPTH_MAX + 1;
 	for (Direction dir = DIR_BEGIN; dir < DIR_END; dir++) {
 		const TileIndex dest = tile + TileOffsByDir(dir);
 		if (IsValidTile(dest) && IsTileType(dest, MP_WATER)) min_water_depth = std::min(min_water_depth, GetWaterDepth(dest));
@@ -497,7 +497,7 @@ CommandCost CmdBuildCanal(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 		if (IsTileType(tile, MP_WATER) && (!IsTileOwner(tile, OWNER_WATER) || wc == WATER_CLASS_SEA)) continue;
 
 		bool water = IsWaterTile(tile);
-		uint8 depth = water ? GetWaterDepth(tile) : WATER_DEPTH_MIN;
+		WaterDepth depth = water ? GetWaterDepth(tile) : WATER_DEPTH_MIN;
 		if (depth > CANAL_MAX_WATER_DEPTH) {
 			/* Too deep to convert to canal, pretend the tile has to be demolished and rebuilt */
 			water = false;
@@ -997,7 +997,7 @@ static void GetTileDesc_Water(TileIndex tile, TileDesc *td)
 				case WATER_CLASS_RIVER: td->str = STR_LAI_WATER_DESCRIPTION_RIVER; break;
 				default: NOT_REACHED();
 			}
-			const uint8 depth = GetWaterDepth(tile);
+			const WaterDepth depth = GetWaterDepth(tile);
 			td->dparam[0] = (depth == 0) ? WATER_DEPTH_METRES_ZERO : depth * WATER_DEPTH_METRES_PER_UNIT;
 			break;
 		}
@@ -1269,8 +1269,8 @@ void TileLoop_Water(TileIndex tile)
 
 		uint8 num_water_tiles = 0;
 		uint8 required_water_tiles = DIR_END;
-		uint8 min_water_depth = WATER_DEPTH_MAX;
-		uint8 max_water_depth = WATER_DEPTH_MIN;
+		WaterDepth min_water_depth = WATER_DEPTH_MAX;
+		WaterDepth max_water_depth = WATER_DEPTH_MIN;
 
 		for (Direction dir = DIR_BEGIN; dir < DIR_END; dir++) {
 			TileIndex dest = tile + TileOffsByDir(dir);
@@ -1285,7 +1285,7 @@ void TileLoop_Water(TileIndex tile)
 			num_water_tiles++;
 
 			if (IsTileType(dest, MP_WATER)) {
-				const uint8 depth = GetWaterDepth(dest);
+				const WaterDepth depth = GetWaterDepth(dest);
 				min_water_depth = std::min(min_water_depth, depth);
 				max_water_depth = std::max(max_water_depth, depth);
 			}
@@ -1297,9 +1297,9 @@ void TileLoop_Water(TileIndex tile)
 		if (num_water_tiles < required_water_tiles && current_depth > WATER_DEPTH_MIN) {
 			SetWaterDepth(tile, current_depth - 1);
 		} else if (num_water_tiles == required_water_tiles) {
-			uint8 new_depth = current_depth + 1;
-			new_depth = std::min<uint8>(min_water_depth + 1, new_depth);
-			new_depth = std::min<uint8>(max_water_depth + 1, new_depth);
+			WaterDepth new_depth = current_depth + 1;
+			new_depth = std::min<WaterDepth>(min_water_depth + 1, new_depth);
+			new_depth = std::min<WaterDepth>(max_water_depth + 1, new_depth);
 			SetWaterDepth(tile, Clamp(new_depth, WATER_DEPTH_MIN, WATER_DEPTH_MAX));
 		}
 	}

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1284,9 +1284,13 @@ void TileLoop_Water(TileIndex tile)
 {
 	if (IsTileType(tile, MP_WATER)) AmbientSoundEffect(tile);
 
-	/* Only do depth erosion on rare occasions.
+	/* Only do depth erosion on rare occasions (at maximum erosion speed).
 	 * 6 bits matched means once every 16384 ticks, or about 221 days between erosion. */
 	bool do_erosion = IsTileType(tile, MP_WATER) && (TileHash2Bit(TileX(tile), TileY(tile)) << 4 | GB(GetWaterTileRandomBits(tile), 0, 4)) == GB(_tick_counter, 8, 6);
+	/* Slower erosion is achieved by a chance roll (probability is further decreased by the effect of neighbour tiles changing slowly too) */
+	if (_settings_game.difficulty.water_depth_erosion_speed == 2) do_erosion = do_erosion && Chance16(1, 3);
+	if (_settings_game.difficulty.water_depth_erosion_speed == 1) do_erosion = do_erosion && Chance16(1, 30);
+	if (_settings_game.difficulty.water_depth_erosion_speed == 0) do_erosion = false;
 
 	if (do_erosion) {
 		ErodeWaterTileDepth(tile);

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -948,6 +948,13 @@ static void DrawTile_Water(TileInfo *ti)
 	switch (GetWaterTileType(ti->tile)) {
 		case WATER_TILE_CLEAR:
 			DrawWaterClassGround(ti);
+#ifdef _DEBUG
+			if (_cur_dpi->zoom <= ZOOM_LVL_VIEWPORT) {
+				WaterDepth depth = GetWaterDepth(ti->tile);
+				SpriteID spr = SPR_ASCII_SPACE_SMALL + (depth > 9 ? depth + 'A' - 10 : depth + '0') - ' ';
+				DrawGroundSprite(spr, TC_GOLD | (1 << PALETTE_TEXT_RECOLOUR));
+			}
+#endif
 			DrawBridgeMiddle(ti);
 			break;
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -127,14 +127,14 @@ CommandCost CmdBuildShipDepot(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 	CommandCost cost = CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_DEPOT_SHIP]);
 
 	bool add_cost = !IsWaterTile(tile);
-	WaterDepth depth1 = IsWaterTile(tile) ? GetWaterDepth(tile) : WATER_DEPTH_MIN;
+	WaterDepth depth1 = HasWaterDepth(tile) ? GetWaterDepth(tile) : WATER_DEPTH_MIN;
 	CommandCost ret = DoCommand(tile, 0, 0, flags | DC_AUTO, CMD_LANDSCAPE_CLEAR);
 	if (ret.Failed()) return ret;
 	if (add_cost) {
 		cost.AddCost(ret);
 	}
 	add_cost = !IsWaterTile(tile2);
-	WaterDepth depth2 = IsWaterTile(tile2) ? GetWaterDepth(tile2) : WATER_DEPTH_MIN;
+	WaterDepth depth2 = HasWaterDepth(tile2) ? GetWaterDepth(tile2) : WATER_DEPTH_MIN;
 	ret = DoCommand(tile2, 0, 0, flags | DC_AUTO, CMD_LANDSCAPE_CLEAR);
 	if (ret.Failed()) return ret;
 	if (add_cost) {
@@ -800,7 +800,7 @@ static void DrawWaterEdges(bool canal, uint offset, TileIndex tile)
 /** Draw a plain sea water tile with no edges */
 static void DrawSeaWater(TileIndex tile)
 {
-	const WaterDepth depth = IsWaterTile(tile) ? GetWaterDepth(tile) : 0;
+	const WaterDepth depth = HasWaterDepth(tile) ? GetWaterDepth(tile) : 0;
 	DrawGroundSprite(GetWaterBaseSprite(depth), PAL_NONE);
 }
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -556,8 +556,9 @@ static CommandCost ClearTile_Water(TileIndex tile, DoCommandFlag flags)
 				if (ret.Failed()) return ret;
 			}
 
-			/* Deeper water is more expensive to clear */
-			const int cost_multiplier = GetWaterDepth(tile) + 1;
+			/* Deeper water is much more expensive to clear */
+			const int real_depth = std::max<int>(GetWaterDepth(tile), 1);
+			const int cost_multiplier = real_depth * real_depth;
 
 			if (flags & DC_EXEC) {
 				if (IsCanal(tile) && Company::IsValidID(owner)) {

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -262,12 +262,14 @@ void MakeWaterKeepingClass(TileIndex tile, Owner o)
 	}
 
 	/* Restore the water depth from surrounding tiles */
-	WaterDepth min_water_depth = WATER_DEPTH_MAX + 1;
-	for (Direction dir = DIR_BEGIN; dir < DIR_END; dir++) {
-		const TileIndex dest = tile + TileOffsByDir(dir);
-		if (IsValidTile(dest) && IsTileType(dest, MP_WATER)) min_water_depth = std::min(min_water_depth, GetWaterDepth(dest));
+	if (wc != WATER_CLASS_INVALID) {
+		WaterDepth min_water_depth = WATER_DEPTH_MAX + 1;
+		for (Direction dir = DIR_BEGIN; dir < DIR_END; dir++) {
+			const TileIndex dest = tile + TileOffsByDir(dir);
+			if (IsValidTile(dest) && IsTileType(dest, MP_WATER)) min_water_depth = std::min(min_water_depth, GetWaterDepth(dest));
+		}
+		if (min_water_depth <= WATER_DEPTH_MAX) SetWaterDepth(tile, min_water_depth);
 	}
-	if (min_water_depth <= WATER_DEPTH_MAX) SetWaterDepth(tile, min_water_depth);
 
 	if (wc != WATER_CLASS_INVALID) CheckForDockingTile(tile);
 	MarkTileDirtyByTile(tile);

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1259,7 +1259,11 @@ void TileLoop_Water(TileIndex tile)
 {
 	if (IsTileType(tile, MP_WATER)) AmbientSoundEffect(tile);
 
-	if (IsWaterTile(tile) && GetWaterClass(tile) != WATER_CLASS_CANAL) {
+	/* Only do depth checks on rare occasions */
+	bool do_depth_check = IsWaterTile(tile) && GetWaterClass(tile) != WATER_CLASS_CANAL;
+	do_depth_check = do_depth_check && (TileHash2Bit(TileX(tile), TileY(tile)) << 4 | GB(GetWaterTileRandomBits(tile), 0, 4)) == GB(_tick_counter, 8, 6);
+
+	if (do_depth_check) {
 		/* Check depth of water */
 		assert(GetWaterClass(tile) != WATER_CLASS_INVALID); // real, open water tiles can't be WATER_CLASS_INVALID
 

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -436,7 +436,7 @@ static inline void MakeWater(TileIndex t, Owner o, WaterClass wc, uint8 random_b
  */
 static inline void MakeSea(TileIndex t)
 {
-	MakeWater(t, OWNER_WATER, WATER_CLASS_SEA, 0, 1);
+	MakeWater(t, OWNER_WATER, WATER_CLASS_SEA, 0, 0);
 }
 
 /**

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -53,8 +53,10 @@ enum WaterClass {
 /** Helper information for extract tool. */
 template <> struct EnumPropsT<WaterClass> : MakeEnumPropsT<WaterClass, byte, WATER_CLASS_SEA, WATER_CLASS_INVALID, WATER_CLASS_INVALID, 2> {};
 
-const uint8 WATER_DEPTH_MIN = 0;  ///< Smallest permitted water depth level
-const uint8 WATER_DEPTH_MAX = 15; ///< Largest permitted water depth level (4 bits)
+typedef uint8 WaterDepth;
+const WaterDepth WATER_DEPTH_MIN  = 0;  ///< Smallest permitted water depth level
+const WaterDepth WATER_DEPTH_DEEP = 1;  ///< Smallest depth value that counts as "deep" water (not shallow)
+const WaterDepth WATER_DEPTH_MAX  = 15; ///< Largest permitted water depth level (4 bits)
 
 /** Sections of the water depot. */
 enum DepotPart {
@@ -195,13 +197,13 @@ static inline bool IsWaterTile(TileIndex t)
  * @return Depth of water (range 0 to 15)
  * @pre IsTileType(t, MP_WATER)
  */
-static inline uint8 GetWaterDepth(TileIndex t)
+static inline WaterDepth GetWaterDepth(TileIndex t)
 {
 	assert(IsTileType(t, MP_WATER));
 	return GB(_m[t].m3, 0, 4);
 }
 
-static inline void SetWaterDepth(TileIndex t, uint8 depth)
+static inline void SetWaterDepth(TileIndex t, WaterDepth depth)
 {
 	assert(IsTileType(t, MP_WATER));
 	assert(depth <= WATER_DEPTH_MAX);
@@ -416,7 +418,7 @@ static inline void MakeShore(TileIndex t)
  * @param random_bits Eventual random bits to be set for this tile
  * @param depth Depth of water at tile
  */
-static inline void MakeWater(TileIndex t, Owner o, WaterClass wc, uint8 random_bits, uint8 depth)
+static inline void MakeWater(TileIndex t, Owner o, WaterClass wc, uint8 random_bits, WaterDepth depth)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -192,16 +192,34 @@ static inline bool IsWaterTile(TileIndex t)
 	return IsTileType(t, MP_WATER) && IsWater(t);
 }
 
+static inline bool HasWaterDepth(TileIndex t)
+{
+	switch (GetTileType(t)) {
+		case MP_WATER:
+		case MP_INDUSTRY:
+			return true;
+		default:
+			return false;
+	}
+}
+
 /**
  * Get the depth of water on a water tile.
  * @param t Tile to query.
  * @return Depth of water (range 0 to 15)
- * @pre IsTileType(t, MP_WATER)
+ * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_INDUSTRY)
  */
 static inline WaterDepth GetWaterDepth(TileIndex t)
 {
-	assert(IsTileType(t, MP_WATER));
-	return GB(_m[t].m3, 0, 4);
+	extern WaterDepth GetIndustryTileWaterDepth(TileIndex tile);
+	switch (GetTileType(t)) {
+		case MP_WATER:
+			return GB(_m[t].m3, 0, 4);
+		case MP_INDUSTRY:
+			return GetIndustryTileWaterDepth(t);
+		default:
+			NOT_REACHED();
+	}
 }
 
 static inline void SetWaterDepth(TileIndex t, WaterDepth depth)

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -73,6 +73,7 @@ enum LockPart {
 };
 
 bool IsPossibleDockingTile(TileIndex t);
+bool ErodeWaterTileDepth(TileIndex tile);
 
 /**
  * Get the water tile type at a tile.


### PR DESCRIPTION
Allocate 4 bits in M3 to store the depth of MP_WATER tiles.

In the base game, depth affects the cost of clearing (and otherwise modifying) water tiles, and the meaning of "river" versus "sea" speed for ships has changed to "shallow" versus "deep" water.
There is support for NewGRFs to supply a table of water surface sprites for different depth levels, via action 5. Maybe this should be added to the baseset.
Additionally, NewGRF industries will be able to check the water depth, so e.g. dredging sites in FIRS could be limited to construction on shallow water.

Water depth 0 and 1 have the original cost to clear, higher depths have the cost to clear multiplied by the square of depth, so clearing the max depth of 15 (represented in land area information window as 300 m) has a cost of around £1.7 million at default 'low' construction costs, while clearing a water tile at the coast costs £7,524.
Rivers are soft limited to a depth of 3 (60 m), and canals are always built at depth 0 (10 m).

Water tiles can "erode" over time to even out the depth gradient from the shore. This is an option that can be disabled, or the frequency can be selected.

## Not in scope
- Depth-aware bridges. Doing an overhaul of bridges is a large project in itself and is probably best tackled in a later patch.
- Multiple variations of water tiles. Having more than one tile graphics for each depth level could reduce visual repetition, but is a large project in itself.
- Adding deep water tiles to the original baseset, although it should probably be done before a release is made with this patch included.

## To do
- [x] Canals built over rivers should probably inherit the depth of the river.
- [x] Evening out of depth and depth gradient should be more controlled and slower -- maybe a game setting to control the speed or entirely disable it.
- [x] Need a way for GS and AI to query depth.
- [x] Need a way for NewGRF to query depth, especially for industries constructing on water.
- [x] Perhaps change the ship "on river/canal" speed limit to count as "on shallow water" instead.
- [x] Would be neat to have different water tiles for different depths (perhaps darker blue).
- [x] Configurable cost of modifying deep water tiles.
- [ ] Need a test case of rivers/canals GRF using new variable for depth.
- [x] Find a way to make ground sprites below oil rig be depth aware.

## Unresolved questions
- Should industry tiles and station tiles also have space to store water depth? Right now, industry tiles do not store water depth, instead the industry itself stores the min and max water depths it was on when it was constructed. Stations (docks, buoys, oil rig stations) store nothing and instead search for a nearby water tile whose depth is assumed.
- What should the default setting for `difficulty.water_clearing_cost_exponent` be? Is the "basic" category appropriate?
- What should the default setting for `difficulty.water_depth_erosion_speed` be? Is the "advanced" category appropriate?
- What values should those settings be given when savegames are converted?

## NewGRF docs that need to be updated with this PR
- Action 5 adds feature 0x19 to define deep water terrain sprites. Requires an array of sprite offsets as "other data" mapping depth levels to sprites.
- Canal/river feature callbacks add variable 0x84 to query the water depth of the current tile.
- Industry placement callback has two new error returns available, 0x409 and 0x40A for respectively "water too deep" and "water too shallow".
- Industry callbacks add two new variables, 0xAD and 0xAE, to get the minimum and maximum water depth on the site the industry was/is going to be constructed.
- Ships feature callbacks add variable 0xE6 to get water depth of current tile.
