### PR TITLE
Fix: Silence all notes when stopping song in fluidsynth

### DIFF
--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -136,6 +136,7 @@ void MusicDriver_FluidSynth::StopSong()
 	}
 	delete_fluid_player(_midi.player);
 	fluid_synth_system_reset(_midi.synth);
+	fluid_synth_all_sounds_off(_midi.synth, -1);
 	_midi.player = nullptr;
 }
 


### PR DESCRIPTION
Without it, there is small quirk:
-music is playing
-click stop, music immediately stops
-click play, before song starts playing again you can hear release of notes that were active before