### PR TITLE
Fix #7925: Reset temporary saveload data at the start of loading.

### DIFF
--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -140,6 +140,11 @@ void CopyTempEngineData()
 		if (se->name != nullptr) e->name = stredup(se->name);
 	}
 
+	ResetTempEngineData();
+}
+
+void ResetTempEngineData()
+{
 	/* Get rid of temporary data */
 	for (std::vector<Engine*>::iterator it = _temp_engine.begin(); it != _temp_engine.end(); ++it) {
 		FreeEngine(*it);

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -12,6 +12,7 @@
 #include "../tunnelbridge_map.h"
 
 #include "saveload.h"
+#include "saveload_internal.h"
 
 #include "../safeguards.h"
 
@@ -79,6 +80,11 @@ void AfterLoadLabelMaps()
 		}
 	}
 
+	ResetLabelMaps();
+}
+
+void ResetLabelMaps()
+{
 	_railtype_list.clear();
 }
 
@@ -106,7 +112,7 @@ static void Save_RAIL()
 
 static void Load_RAIL()
 {
-	_railtype_list.clear();
+	ResetLabelMaps();
 
 	LabelObject lo;
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2378,6 +2378,16 @@ extern bool AfterLoadGame();
 extern bool LoadOldSaveGame(const char *file);
 
 /**
+ * Clear temporary data that is passed between various saveload phases.
+ */
+static void ResetSaveloadData()
+{
+	ResetTempEngineData();
+	ResetLabelMaps();
+	ResetOldWaypoints();
+}
+
+/**
  * Clear/free saveload state.
  */
 static inline void ClearSaveLoadState()
@@ -2623,6 +2633,8 @@ static SaveOrLoadResult DoLoad(LoadFilter *reader, bool load_check)
 	_next_offs = 0;
 
 	if (!load_check) {
+		ResetSaveloadData();
+
 		/* Old maps were hardcoded to 256x256 and thus did not contain
 		 * any mapsize information. Pre-initialize to 256x256 to not to
 		 * confuse old games */
@@ -2727,6 +2739,8 @@ SaveOrLoadResult SaveOrLoad(const char *filename, SaveLoadOperation fop, Detaile
 	try {
 		/* Load a TTDLX or TTDPatch game */
 		if (fop == SLO_LOAD && dft == DFT_OLD_GAME_FILE) {
+			ResetSaveloadData();
+
 			InitializeGame(256, 256, true, true); // set a mapsize of 256x256 for TTDPatch games or it might get confused
 
 			/* TTD/TTO savegames have no NewGRFs, TTDP savegame have them

--- a/src/saveload/saveload_internal.h
+++ b/src/saveload/saveload_internal.h
@@ -20,6 +20,7 @@ StringID RemapOldStringID(StringID s);
 char *CopyFromOldName(StringID id);
 void ResetOldNames();
 
+void ResetOldWaypoints();
 void MoveBuoysToWaypoints();
 void MoveWaypointsToBaseStations();
 const SaveLoad *GetBaseStationDescription();
@@ -28,6 +29,7 @@ void AfterLoadVehicles(bool part_of_load);
 void FixupTrainLengths();
 void AfterLoadStations();
 void AfterLoadRoadStops();
+void ResetLabelMaps();
 void AfterLoadLabelMaps();
 void AfterLoadStoryBook();
 void AfterLoadLinkGraphs();
@@ -42,6 +44,7 @@ void ResetViewportAfterLoadGame();
 void ConvertOldMultiheadToNew();
 void ConnectMultiheadedTrains();
 
+void ResetTempEngineData();
 Engine *GetTempDataEngine(EngineID index);
 void CopyTempEngineData();
 

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -155,6 +155,11 @@ void MoveWaypointsToBaseStations()
 		UpdateWaypointOrder(&v->current_order);
 	}
 
+	ResetOldWaypoints();
+}
+
+void ResetOldWaypoints()
+{
 	_old_waypoints.clear();
 	_old_waypoints.shrink_to_fit();
 }
@@ -182,7 +187,7 @@ static const SaveLoad _old_waypoint_desc[] = {
 static void Load_WAYP()
 {
 	/* Precaution for when loading failed and it didn't get cleared */
-	_old_waypoints.clear();
+	ResetOldWaypoints();
 
 	int index;
 


### PR DESCRIPTION
Bug #7925 caused this behaviour:
* Loading the savegame involved calling Load_RAIL, which filled _railtype_list.
* Loading was aborted before AfterLoadLabelMaps, so _railtype_list was not cleared.
* The titlegame is old and does not contain a RAIL chunk, and thus LOAD_RAIL was not called.
* Thus the titlegame's AfterLoadLabelMaps used the _railtype_list from the aborted savegame.

Funnily noone bothered to add the equivalent of AfterLoadLabelMaps for road types, so an alternative fix may be to just delete it.