### PR TITLE
-Fix: [OSX] Don't show a crash/assertion message box for a GUI-less video driver.

### DIFF
--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -12,6 +12,7 @@
 #include "../../string_func.h"
 #include "../../gamelog.h"
 #include "../../saveload/saveload.h"
+#include "../../video/video_driver.hpp"
 #include "macos.h"
 
 #include <errno.h>
@@ -240,7 +241,9 @@ void CDECL HandleCrash(int signum)
 
 	CrashLogOSX log(signum);
 	log.MakeCrashLog();
-	log.DisplayCrashDialog();
+	if (VideoDriver::GetInstance() == nullptr || VideoDriver::GetInstance()->HasGUI()) {
+		log.DisplayCrashDialog();
+	}
 
 	CrashLog::AfterCrashLogCleanup();
 	abort();


### PR DESCRIPTION
Untested, but I applied a fix similar to 6a2735d24. I think it should work.