### PR TITLE
Add: Option for a new transfer feeder payment algorithm

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1216,10 +1216,11 @@ void CargoPayment::PayFinalDelivery(const CargoPacket *cp, uint count)
  */
 Money CargoPayment::PayTransfer(const CargoPacket *cp, uint count)
 {
-	Money profit = GetTransportedGoodsIncome(
+	Money profit = -cp->FeederShare(count) + GetTransportedGoodsIncome(
 			count,
-			/* pay transfer vehicle for only the part of transfer it has done: ie. cargo_loaded_at_xy to here */
-			DistanceManhattan(cp->LoadedAtXY(), Station::Get(this->current_station)->xy),
+			/* pay transfer vehicle the difference between the payment for the journey from
+			 * the source to the current point, and the sum of the previous transfer payments */
+			DistanceManhattan(cp->SourceStationXY(), Station::Get(this->current_station)->xy),
 			cp->DaysInTransit(),
 			this->ct);
 


### PR DESCRIPTION
The original algorithm pays intermediate legs in feeder systems based
on the start and end stations of that particular leg.
This tends to result in large negative payments on the final leg for
journeys with many feeder legs, as the overall feeder payment increases
with the number of legs, and the final leg is penalised for discrepancies
between the previous leg payments and the actual payment for delivery
from the source to the destination.
The feeder share setting is a partial mitigation, however it is difficult
to tune as a suitable value depends on the number of legs and the network
topology, which are often not the same for all vehicles.

The new incremental algorithm pays the cargo payment from the source
station to the end station of the current leg, minus any previous
transfer feeder payments for each leg.
This prevents unbounded increase of feeder payments and therefore avoids
the issue of excessive negative payments on the final leg.
Feeder payments may be negative, e.g. in the case of poorly performing
or highly indirect legs. This is better than penalising the final leg.
This mode reduces the need to tune the feeder shares setting to the
current network.

The feeder share setting applies in the existing way for both modes.