### PR TITLE
Fix: [SDL2] sdl driver debug log

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -647,7 +647,7 @@ const char *VideoDriver_SDL::Start(const char * const *parm)
 		return SDL_GetError();
 	}
 
-	const char *dname = SDL_GetVideoDriver(0);
+	const char *dname = SDL_GetCurrentVideoDriver();
 	DEBUG(driver, 1, "SDL2: using driver '%s'", dname);
 
 	MarkWholeScreenDirty();


### PR DESCRIPTION
SDL_GetVideoDriver(0) returns name of first video driver included in
the library, not the driver currently used.
SDL_GetCurrentVideoDriver() does what we want here.