### PR TITLE
Build on competitor canal

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -991,13 +991,16 @@
        </tr>
       </table>
      </li>
+     <li>m6 bits 7..6: bits 3..2 of <a href="#OwnershipInfo">owner</a> of canal (see m6 bits 1..0)</li>
      <li>m6 bits 5..3: the station type (rail, airport, truck, bus, oilrig, dock, buoy, waypoint)</li>
      <li>m6 bit 2: pbs reservation state for railway stations/waypoints</li>
+     <li>m6 bits 1..0: <a href="#OwnershipInfo">owner</a> of canal (dock, buoy, oilrig) (plus m6 bits 7..6); OWNER_NONE (<tt>10</tt>) is stored as OWNER_TOWN (<tt>0F</tt>)</li>
 
      <li>m7 bits 4..0: <a href="#OwnershipInfo">owner</a> of road (road stops)</li>
      <li>m7: animation frame (railway stations/waypoints, airports)</li>
      <li>m8 bits 11..6: <a href="#TramType">Tramtype</a></li>
      <li>m8 bits 5..0: <a href="#TrackType">track type</a> for railway stations/waypoints</li>
+     <li>m8 bit 15: set if a river was originally present under water based station tiles when current water class is canal (dock, buoy, oilrig)</li>
     </ul>
    </td>
   </tr>
@@ -1108,6 +1111,9 @@
        </tr>
       </table>
      </li>
+     <li>m6 bits 7..6: bits 3..2 of <a href="#OwnershipInfo">owner</a> of canal (see m6 bits 1..0)</li>
+     <li>m6 bits 1..0: <a href="#OwnershipInfo">owner</a> of canal (canal, ship depot, lock) (plus m6 bits 7..6); OWNER_NONE (<tt>10</tt>) is stored as OWNER_TOWN (<tt>0F</tt>)</li>
+     <li>m8 bit 15: set if a river was originally present at the tile when current water class is canal (canal, ship depot, lock)</li>
     </ul>
    </td>
   </tr>
@@ -1447,9 +1453,12 @@
        </tr>
       </table>
      </li>
+     <li>m6 bits 7..6: bits 3..2 of <a href="#OwnershipInfo">owner</a> of canal (see m6 bits 1..0)</li>
      <li>m6 bits 5..3: random triggers (NewGRF)</li>
      <li>m6 bit 2: bit 8 of type (see m5)</li>
+     <li>m6 bits 1..0: <a href="#OwnershipInfo">owner</a> of canal (oilrig) (plus m6 bits 7..6); OWNER_NONE (<tt>10</tt>) is stored as OWNER_TOWN (<tt>0F</tt>)</li>
      <li>m7: animation frame</li>
+     <li>m8 bit 15: set if a river was originally present at the tile when current water class is canal (oilrig)
     </ul>
    </td>
   </tr>
@@ -1621,7 +1630,10 @@
      <li>m2: index into the array of objects, bits 0 to 15 (upper bits in m5)</li>
      <li>m3: random bits</li>
      <li>m5: index into the array of objects, bits 16 to 23 (lower bits in m2)</li>
+     <li>m6 bits 7..6: bits 3..2 of <a href="#OwnershipInfo">owner</a> of canal (see m6 bits 1..0)</li>
+     <li>m6 bits 1..0: <a href="#OwnershipInfo">owner</a> of canal (object) (plus m6 bits 7..6); OWNER_NONE (<tt>10</tt>) is stored as OWNER_TOWN (<tt>0F</tt>)</li>
      <li>m7: animation counter</li>
+     <li>m8 bit 15: set if a river was originally present at the tile when current water class is canal</li>
     </ul>
    </td>
   </tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -252,9 +252,9 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="option">~~~~ ~</span>XXX</td>
-      <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
+      <td class="bits">XXXX X<span class="free">O</span>XX</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">airport</td>
@@ -278,9 +278,9 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="option">~~~~ ~~~~</span></td>
-      <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
+      <td class="bits">XXXX X<span class="free">O</span>XX</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">oilrig</td>
@@ -291,12 +291,12 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="option">~~~~ ~~~~</span></td>
-      <td class="bits"><span class="free">OO</span>XX X<span class="free">OOO</span></td>
+      <td class="bits">XXXX X<span class="free">O</span>XX</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
-      <td rowspan=3>6</td>
+      <td rowspan=5>6</td>
       <td class="caption">sea, shore</td>
       <td class="bits">XXXX XXXX</td>
       <td class="bits">XXXX XXXX</td>
@@ -310,7 +310,33 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
-      <td class="caption">canal, river</td>
+      <td class="caption">lock</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits">-inherit-</td>
+      <td class="bits">XX<span class="free">OO OO</span>XX</td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
+    </tr>
+    <tr>
+      <td class="caption">canal</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits">XXXX XXXX</td>
+      <td class="bits">-inherit-</td>
+      <td class="bits">XX<span class="free">OO OO</span>XX</td>
+      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
+    </tr>
+    <tr>
+     <td class="caption">river</td>
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
       <td class="bits">-inherit-</td>
@@ -331,9 +357,9 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits">-inherit-</td>
+      <td class="bits">XX<span class="free">OO OO</span>XX</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOOO</span></td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td>8</td>
@@ -345,9 +371,9 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">XXXX XXXX</td>
       <td class="bits">XXXX XXXX</td>
       <td class="bits">XXXX XXXX</td>
-      <td class="bits"><span class="free">OO</span>XX XX<span class="free">OO</span></td>
       <td class="bits">XXXX XXXX</td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">XXXX XXXX</td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td rowspan=2>9</td>
@@ -386,9 +412,9 @@ the array so you can quickly see what is used and what is not.
       <td class="bits">XXXX XXXX</td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits">XXXX XXXX</td>
-      <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits">XX<span class="free">OO OO</span>XX</td>
       <td class="bits">XXXX XXXX</td>
-      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits">X<span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
   </tbody>
 </table>

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -7326,7 +7326,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         true
   IsLockTile():         true
   IsCanalTile():        true
-  GetBankBalance():     465070
+  GetBankBalance():     461290
 
 --AIWaypointList(BUOY)--
   Count():             1
@@ -7345,7 +7345,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   IsBuoyTile():         false
   IsLockTile():         false
   IsCanalTile():        false
-  GetBankBalance():     459675
+  GetBankBalance():     452145
   BuildWaterDepot():    true
   BuildDock():          true
 

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -270,12 +270,13 @@ static inline void SetIndustryTriggers(TileIndex tile, byte triggers)
 /**
  * Make the given tile an industry tile
  * @param t      the tile to make an industry tile
+ * @param oc     the owner of the canal (only set if it's placed on a canal).
  * @param index  the industry this tile belongs to
  * @param gfx    the graphics to use for the tile
  * @param random the random value
  * @param wc     the water class for this industry; only useful when build on water
  */
-static inline void MakeIndustry(TileIndex t, IndustryID index, IndustryGfx gfx, uint8 random, WaterClass wc)
+static inline void MakeIndustry(TileIndex t, Owner oc, IndustryID index, IndustryGfx gfx, uint8 random, WaterClass wc)
 {
 	SetTileType(t, MP_INDUSTRY);
 	_m[t].m1 = 0;
@@ -285,6 +286,7 @@ static inline void MakeIndustry(TileIndex t, IndustryID index, IndustryGfx gfx, 
 	SetIndustryGfx(t, gfx); // m5, part of m6
 	SetIndustryTriggers(t, 0); // rest of m6
 	SetWaterClass(t, wc);
+	if (wc == WATER_CLASS_CANAL) SetCanalOwner(t, oc);
 	_me[t].m7 = 0;
 }
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1191,6 +1191,8 @@ STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES                     :Company station
 STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :When enabled, industries with attached stations (such as Oil Rigs) may also be served by company owned stations built nearby. When disabled, these industries may only be served by their attached stations. Any nearby company stations won't be able to serve them, nor will the attached station serve anything else other than the industry
 STR_CONFIG_SETTING_EXTRADYNAMITE                                :Allow removal of more town-owned roads, bridges and tunnels: {STRING2}
 STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT                       :Make it easier to remove town-owned infrastructure and buildings
+STR_CONFIG_SETTING_DYNAMITE_RIVER                               :Allow removal of rivers: {STRING2}
+STR_CONFIG_SETTING_DYNAMITE_RIVER_HELPTEXT                      :If disabled, rivers are indestructible and become a permanent part of the landscape
 STR_CONFIG_SETTING_TRAIN_LENGTH                                 :Maximum length of trains: {STRING2}
 STR_CONFIG_SETTING_TRAIN_LENGTH_HELPTEXT                        :Set the maximum length of trains
 STR_CONFIG_SETTING_TILE_LENGTH                                  :{COMMA} tile{P 0 "" s}
@@ -1270,6 +1272,8 @@ STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD                            :Allow drive-thr
 STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD_HELPTEXT                   :Allow construction of drive-through road stops on town-owned roads
 STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD                      :Allow drive-through road stops on roads owned by competitors: {STRING2}
 STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD_HELPTEXT             :Allow construction of drive-through road stops on roads owned by other companies
+STR_CONFIG_SETTING_BUILD_ON_COMPETITOR_CANAL                    :Allow water-based structures on canals owned by competitors: {STRING2}
+STR_CONFIG_SETTING_BUILD_ON_COMPETITOR_CANAL_HELPTEXT           :Allow construction of ship depots, docks and locks on canals owned by other companies. Also allow funding or prospecting water-based industries such as Oil Rigs on canals owned by other companies.
 STR_CONFIG_SETTING_DYNAMIC_ENGINES_EXISTING_VEHICLES            :{WHITE}Changing this setting is not possible when there are vehicles
 STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE                   :Infrastructure maintenance: {STRING2}
 STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE_HELPTEXT          :When enabled, infrastructure causes maintenance costs. The cost grows over-proportional with the network size, thus affecting bigger companies more than smaller ones
@@ -2623,6 +2627,7 @@ STR_LAND_AREA_INFORMATION_OWNER                                 :{BLACK}Owner: {
 STR_LAND_AREA_INFORMATION_ROAD_OWNER                            :{BLACK}Road owner: {LTBLUE}{STRING1}
 STR_LAND_AREA_INFORMATION_TRAM_OWNER                            :{BLACK}Tramway owner: {LTBLUE}{STRING1}
 STR_LAND_AREA_INFORMATION_RAIL_OWNER                            :{BLACK}Railway owner: {LTBLUE}{STRING1}
+STR_LAND_AREA_INFORMATION_CANAL_OWNER                           :{BLACK}Canal owner: {LTBLUE}{STRING1}
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY                       :{BLACK}Local authority: {LTBLUE}{STRING1}
 STR_LAND_AREA_INFORMATION_LOCAL_AUTHORITY_NONE                  :None
 STR_LAND_AREA_INFORMATION_LANDINFO_COORDS                       :{BLACK}Coordinates: {LTBLUE}{NUM} x {NUM} x {NUM} ({RAW_STRING})
@@ -2700,6 +2705,7 @@ STR_LAI_STATION_DESCRIPTION_WAYPOINT                            :Waypoint
 
 STR_LAI_WATER_DESCRIPTION_WATER                                 :Water
 STR_LAI_WATER_DESCRIPTION_CANAL                                 :Canal
+STR_LAI_WATER_DESCRIPTION_CANALISED_RIVER                       :Canalised river
 STR_LAI_WATER_DESCRIPTION_LOCK                                  :Lock
 STR_LAI_WATER_DESCRIPTION_RIVER                                 :River
 STR_LAI_WATER_DESCRIPTION_COAST_OR_RIVERBANK                    :Coast or riverbank
@@ -4499,6 +4505,7 @@ STR_ERROR_CAN_T_BUILD_ON_CANAL                                  :{WHITE}... can'
 STR_ERROR_CAN_T_BUILD_ON_RIVER                                  :{WHITE}... can't build on river
 STR_ERROR_MUST_DEMOLISH_CANAL_FIRST                             :{WHITE}Must demolish canal first
 STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE                             :{WHITE}Can't build aqueduct here...
+STR_ERROR_MUST_CLEAR_RIVER_FIRST                                :{WHITE}Must clear river first
 
 # Tree related errors
 STR_ERROR_TREE_ALREADY_HERE                                     :{WHITE}... tree already here

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -67,15 +67,17 @@ static inline byte GetObjectRandomBits(TileIndex t)
  * Make an Object tile.
  * @param t      The tile to make and object tile.
  * @param o      The new owner of the tile.
+ * @param oc     The owner of the canal (only set if it's placed on canal).
  * @param index  Index to the object.
  * @param wc     Water class for this object.
  * @param random Random data to store on the tile
  */
-static inline void MakeObject(TileIndex t, Owner o, ObjectID index, WaterClass wc, byte random)
+static inline void MakeObject(TileIndex t, Owner o, Owner oc, ObjectID index, WaterClass wc, byte random)
 {
 	SetTileType(t, MP_OBJECT);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
+	if (wc == WATER_CLASS_CANAL) SetCanalOwner(t, oc);
 	_m[t].m2 = index;
 	_m[t].m3 = random;
 	_m[t].m4 = 0;

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -140,7 +140,7 @@ void AfterLoadCompanyStats()
 
 			case MP_STATION:
 				c = Company::GetIfValid(GetTileOwner(tile));
-				if (c != nullptr && GetStationType(tile) != STATION_AIRPORT && !IsBuoy(tile)) c->infrastructure.station++;
+				if (c != nullptr && GetStationType(tile) != STATION_AIRPORT) c->infrastructure.station++;
 
 				switch (GetStationType(tile)) {
 					case STATION_RAIL:
@@ -161,8 +161,10 @@ void AfterLoadCompanyStats()
 					}
 
 					case STATION_DOCK:
+					case STATION_OILRIG:
 					case STATION_BUOY:
 						if (GetWaterClass(tile) == WATER_CLASS_CANAL) {
+							c = Company::GetIfValid(GetCanalOwner(tile));
 							if (c != nullptr) c->infrastructure.water++;
 						}
 						break;
@@ -175,20 +177,14 @@ void AfterLoadCompanyStats()
 			case MP_WATER:
 				if (IsShipDepot(tile) || IsLock(tile)) {
 					c = Company::GetIfValid(GetTileOwner(tile));
-					if (c != nullptr) {
-						if (IsShipDepot(tile)) c->infrastructure.water += LOCK_DEPOT_TILE_FACTOR;
-						if (IsLock(tile) && GetLockPart(tile) == LOCK_PART_MIDDLE) {
-							/* The middle tile specifies the owner of the lock. */
-							c->infrastructure.water += 3 * LOCK_DEPOT_TILE_FACTOR; // the middle tile specifies the owner of the
-							break; // do not count the middle tile as canal
-						}
-					}
+					if (c != nullptr) c->infrastructure.water += LOCK_DEPOT_TILE_FACTOR;
 				}
 				FALLTHROUGH;
 
+			case MP_INDUSTRY:
 			case MP_OBJECT:
 				if (GetWaterClass(tile) == WATER_CLASS_CANAL) {
-					c = Company::GetIfValid(GetTileOwner(tile));
+					c = Company::GetIfValid(GetCanalOwner(tile));
 					if (c != nullptr) c->infrastructure.water++;
 				}
 				break;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -302,6 +302,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_MULTITILE_DOCKS,                    ///< 216  PR#7380 Multiple docks per station.
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10 Configurable ending year.
+	SLV_BUILD_ON_COMPETITOR_CANAL,          ///< 219  PR#7937 Build on competitor canal.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1657,6 +1657,7 @@ static SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.command_pause_level"));
 			limitations->Add(new SettingEntry("construction.autoslope"));
 			limitations->Add(new SettingEntry("construction.extra_dynamite"));
+			limitations->Add(new SettingEntry("construction.dynamite_river"));
 			limitations->Add(new SettingEntry("construction.max_heightlevel"));
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));
@@ -1672,6 +1673,7 @@ static SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("station.distant_join_stations"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_town_road"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_competitor_road"));
+			limitations->Add(new SettingEntry("construction.build_on_competitor_canal"));
 			limitations->Add(new SettingEntry("vehicle.disable_elrails"));
 		}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -310,8 +310,10 @@ struct ConstructionSettings {
 	uint16 max_tunnel_length;                ///< maximum length of tunnels
 	byte   train_signal_side;                ///< show signals on left / driving / right side
 	bool   extra_dynamite;                   ///< extra dynamite
+	bool   dynamite_river;                   ///< allow removal of rivers
 	bool   road_stop_on_town_road;           ///< allow building of drive-through road stops on town owned roads
 	bool   road_stop_on_competitor_road;     ///< allow building of drive-through road stops on roads owned by competitors
+	bool   build_on_competitor_canal;        ///< allow building of water-based structures on canals owned by competitors
 	uint8  raw_industry_construction;        ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8  industry_platform;                ///< the amount of flat land around an industry
 	bool   freeform_edges;                   ///< allow terraforming the tiles at the map edges

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -561,6 +561,14 @@ static inline uint32 GetSmallMapOwnerPixels(TileIndex tile, TileType t)
 	switch (t) {
 		case MP_INDUSTRY: return MKCOLOUR_XXXX(PC_DARK_GREY);
 		case MP_HOUSE:    return MKCOLOUR_XXXX(PC_DARK_RED);
+		case MP_STATION:
+			if (IsBuoy(tile) && GetWaterClass(tile) == WATER_CLASS_CANAL) {
+				o = GetCanalOwner(tile);
+			} else {
+				o = GetTileOwner(tile);
+			}
+			break;
+
 		default:          o = GetTileOwner(tile); break;
 		/* FIXME: For MP_ROAD there are multiple owners.
 		 * GetTileOwner returns the rail owner (level crossing) resp. the owner of ROADTYPE_ROAD (normal road),

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2536,10 +2536,8 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
 
-	CommandCost cost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_STATION_DOCK]);
 	ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 	if (ret.Failed()) return ret;
-	cost.AddCost(ret);
 
 	TileIndex tile_cur = tile + TileOffsByDiagDir(direction);
 
@@ -2600,7 +2598,7 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 		st->AfterStationTileSetChange(true, STATION_DOCK);
 	}
 
-	return cost;
+	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_STATION_DOCK]);
 }
 
 void RemoveDockingTile(TileIndex t)

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2536,8 +2536,10 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
 
+	CommandCost cost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_STATION_DOCK]);
 	ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 	if (ret.Failed()) return ret;
+	cost.AddCost(ret);
 
 	TileIndex tile_cur = tile + TileOffsByDiagDir(direction);
 
@@ -2549,9 +2551,20 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 
 	/* Get the water class of the water tile before it is cleared.*/
 	WaterClass wc = GetWaterClass(tile_cur);
+	Owner oc = wc == WATER_CLASS_CANAL ? GetCanalOwner(tile_cur) : INVALID_OWNER;
 
-	ret = DoCommand(tile_cur, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
-	if (ret.Failed()) return ret;
+	/* At this point we got a tile_cur with no bridge over it. Check for ownership. */
+	if (IsCanal(tile_cur)) {
+		ret = EnsureNoVehicleOnGround(tile_cur);
+		if (ret.Failed()) return ret;
+		if (oc != OWNER_NONE) {
+			ret = CheckTileOwnership(tile_cur);
+			if (ret.Failed() && !_settings_game.construction.build_on_competitor_canal) return ret;
+		}
+	} else {
+		ret = DoCommand(tile_cur, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
+		if (ret.Failed()) return ret;
+	}
 
 	tile_cur += TileOffsByDiagDir(direction);
 	if (!IsTileType(tile_cur, MP_WATER) || !IsTileFlat(tile_cur)) {
@@ -2579,20 +2592,15 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 
 		st->rect.BeforeAddRect(dock_area.tile, dock_area.w, dock_area.h, StationRect::ADD_TRY);
 
-		/* If the water part of the dock is on a canal, update infrastructure counts.
-		 * This is needed as we've unconditionally cleared that tile before. */
-		if (wc == WATER_CLASS_CANAL) {
-			Company::Get(st->owner)->infrastructure.water++;
-		}
 		Company::Get(st->owner)->infrastructure.station += 2;
 
-		MakeDock(tile, st->owner, st->index, direction, wc);
+		MakeDock(tile, st->owner, oc, st->index, direction, wc);
 		UpdateStationDockingTiles(st);
 
 		st->AfterStationTileSetChange(true, STATION_DOCK);
 	}
 
-	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_STATION_DOCK]);
+	return cost;
 }
 
 void RemoveDockingTile(TileIndex t)
@@ -2697,11 +2705,12 @@ static CommandCost RemoveDock(TileIndex tile, DoCommandFlag flags)
 	ret = EnsureNoVehicleOnGround(tile1);
 	if (ret.Succeeded()) ret = EnsureNoVehicleOnGround(tile2);
 	if (ret.Failed()) return ret;
+	Owner oc = GetWaterClass(tile2) == WATER_CLASS_CANAL ? GetCanalOwner(tile2) : INVALID_OWNER;
 
 	if (flags & DC_EXEC) {
 		DoClearSquare(tile1);
 		MarkTileDirtyByTile(tile1);
-		MakeWaterKeepingClass(tile2, st->owner);
+		MakeWaterKeepingClass(tile2, oc);
 
 		st->rect.AfterRemoveTile(st, tile1);
 		st->rect.AfterRemoveTile(st, tile2);
@@ -3232,6 +3241,14 @@ static void GetTileDesc_Station(TileIndex tile, TileDesc *td)
 		case STATION_WAYPOINT: str = STR_LAI_STATION_DESCRIPTION_WAYPOINT; break;
 	}
 	td->str = str;
+
+	if (HasTileWaterGround(tile) && GetWaterClass(tile) == WATER_CLASS_CANAL) { // Dock, Buoy, Oil Rig station
+		Owner canal_owner = GetCanalOwner(tile);
+		if (canal_owner != td->owner[0]) {
+			td->owner_type[1] = STR_LAND_AREA_INFORMATION_CANAL_OWNER;
+			td->owner[1] = canal_owner;
+		}
+	}
 }
 
 
@@ -4130,6 +4147,9 @@ void BuildOilRig(TileIndex tile)
 		return;
 	}
 
+	WaterClass wc = GetWaterClass(tile);
+	Owner oc = wc == WATER_CLASS_CANAL ? GetCanalOwner(tile) : INVALID_OWNER;
+
 	Station *st = new Station(tile);
 	_station_kdtree.Insert(st->index);
 	st->town = ClosestTownFromTile(tile, UINT_MAX);
@@ -4141,7 +4161,7 @@ void BuildOilRig(TileIndex tile)
 	st->industry = Industry::GetByTile(tile);
 	st->industry->neutral_station = st;
 	DeleteAnimatedTile(tile);
-	MakeOilrig(tile, st->index, GetWaterClass(tile));
+	MakeOilrig(tile, oc, st->index, wc);
 
 	st->owner = OWNER_NONE;
 	st->airport.type = AT_OILRIG;
@@ -4162,7 +4182,9 @@ void DeleteOilRig(TileIndex tile)
 {
 	Station *st = Station::GetByTile(tile);
 
-	MakeWaterKeepingClass(tile, OWNER_NONE);
+	WaterClass wc = GetWaterClass(tile);
+	Owner oc = wc == WATER_CLASS_CANAL ? GetCanalOwner(tile) : INVALID_OWNER;
+	MakeWaterKeepingClass(tile, oc);
 
 	/* The oil rig station is not supposed to be shared with anything else */
 	assert(st->facilities == (FACIL_AIRPORT | FACIL_DOCK) && st->airport.type == AT_OILRIG);
@@ -4186,6 +4208,23 @@ static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_o
 					if (new_owner != INVALID_OWNER) Company::Get(new_owner)->infrastructure.road[rt] += 2;
 				}
 				SetRoadOwner(tile, rtt, new_owner == INVALID_OWNER ? OWNER_NONE : new_owner);
+			}
+		}
+	}
+
+	if (HasTileWaterGround(tile) && GetWaterClass(tile) == WATER_CLASS_CANAL) {
+		if (IsDockTile(tile) || IsBuoyTile(tile) || IsOilRig(tile)) {
+			if (GetCanalOwner(tile) == old_owner) {
+				Company::Get(old_owner)->infrastructure.water--;
+				if (new_owner != INVALID_OWNER) {
+					Company::Get(new_owner)->infrastructure.water++;
+				} else if (IsBuoyTile(tile)) {
+					/* Remove unused buoys. */
+					DoCommand(tile, 0, 0, DC_EXEC | DC_BANKRUPT, CMD_LANDSCAPE_CLEAR);
+					/* Set tile owner of canal under (now removed) buoy to OWNER_NONE. */
+					if (IsTileType(tile, MP_WATER) && IsCanal(tile) && IsTileOwner(tile, old_owner)) SetTileOwner(tile, OWNER_NONE);
+				}
+				SetCanalOwner(tile, new_owner == INVALID_OWNER ? OWNER_NONE : new_owner);
 			}
 		}
 	}
@@ -4215,12 +4254,10 @@ static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_o
 				/* Road stops were already handled above. */
 				break;
 
+			case STATION_OILRIG:
 			case STATION_BUOY:
 			case STATION_DOCK:
-				if (GetWaterClass(tile) == WATER_CLASS_CANAL) {
-					old_company->infrastructure.water--;
-					new_company->infrastructure.water++;
-				}
+				/* Docks were already handled above. */
 				break;
 
 			default:
@@ -4228,12 +4265,11 @@ static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_o
 		}
 
 		/* Update station tile count. */
-		if (!IsBuoy(tile) && !IsAirport(tile)) {
+		if (!IsAirport(tile)) {
 			old_company->infrastructure.station--;
 			new_company->infrastructure.station++;
 		}
 
-		/* for buoys, owner of tile is owner of water, st->owner == OWNER_NONE */
 		SetTileOwner(tile, new_owner);
 		InvalidateWindowClassesData(WC_STATION_LIST, 0);
 	} else {
@@ -4245,10 +4281,6 @@ static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_o
 			ChangeTileOwner(tile, old_owner, new_owner);
 		} else {
 			DoCommand(tile, 0, 0, DC_EXEC | DC_BANKRUPT, CMD_LANDSCAPE_CLEAR);
-			/* Set tile owner of water under (now removed) buoy and dock to OWNER_NONE.
-			 * Update owner of buoy if it was not removed (was in orders).
-			 * Do not update when owned by OWNER_WATER (sea and rivers). */
-			if ((IsTileType(tile, MP_WATER) || IsBuoyTile(tile)) && IsTileOwner(tile, old_owner)) SetTileOwner(tile, OWNER_NONE);
 		}
 	}
 }

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2536,8 +2536,10 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 
 	if (IsBridgeAbove(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
 
+	CommandCost cost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_STATION_DOCK]);
 	ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 	if (ret.Failed()) return ret;
+	cost.AddCost(ret);
 
 	TileIndex tile_cur = tile + TileOffsByDiagDir(direction);
 
@@ -2598,7 +2600,7 @@ CommandCost CmdBuildDock(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 		st->AfterStationTileSetChange(true, STATION_DOCK);
 	}
 
-	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_STATION_DOCK]);
+	return cost;
 }
 
 void RemoveDockingTile(TileIndex t)

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -542,7 +542,7 @@ static inline void MakeStation(TileIndex t, Owner o, StationID sid, StationType 
 	SB(_me[t].m6, 2, 1, 0);
 	SB(_me[t].m6, 3, 3, st);
 	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	SB(_me[t].m8, 0, 14, 0);
 }
 
 /**
@@ -631,40 +631,44 @@ static inline void MakeAirport(TileIndex t, Owner o, StationID sid, byte section
 /**
  * Make the given tile a buoy tile.
  * @param t the tile to make a buoy
+ * @param oc the owner of the canal (only set if it's placed on a canal).
  * @param sid the station to which this tile belongs
  * @param wc the type of water on this tile
  */
-static inline void MakeBuoy(TileIndex t, StationID sid, WaterClass wc)
+static inline void MakeBuoy(TileIndex t, Owner oc, StationID sid, WaterClass wc)
 {
-	/* Make the owner of the buoy tile the same as the current owner of the
-	 * water tile. In this way, we can reset the owner of the water to its
-	 * original state when the buoy gets removed. */
-	MakeStation(t, GetTileOwner(t), sid, STATION_BUOY, 0, wc);
+	/* Make the owner of the buoy tile OWNER_NONE. */
+	MakeStation(t, OWNER_NONE, sid, STATION_BUOY, 0, wc);
+	if (wc == WATER_CLASS_CANAL) SetCanalOwner(t, oc);
 }
 
 /**
  * Make the given tile a dock tile.
  * @param t the tile to make a dock
  * @param o the owner of the dock
+ * @param oc the owner of the canal under the dock (only set if it's placed on a canal).
  * @param sid the station to which this tile belongs
  * @param d the direction of the dock
  * @param wc the type of water on this tile
  */
-static inline void MakeDock(TileIndex t, Owner o, StationID sid, DiagDirection d, WaterClass wc)
+static inline void MakeDock(TileIndex t, Owner o, Owner oc, StationID sid, DiagDirection d, WaterClass wc)
 {
 	MakeStation(t, o, sid, STATION_DOCK, d);
 	MakeStation(t + TileOffsByDiagDir(d), o, sid, STATION_DOCK, GFX_DOCK_BASE_WATER_PART + DiagDirToAxis(d), wc);
+	if (wc == WATER_CLASS_CANAL) SetCanalOwner(t + TileOffsByDiagDir(d), oc);
 }
 
 /**
  * Make the given tile an oilrig tile.
  * @param t the tile to make an oilrig
+ * @param oc the owner of the canal (only set if it's placed on a canal).
  * @param sid the station to which this tile belongs
  * @param wc the type of water on this tile
  */
-static inline void MakeOilrig(TileIndex t, StationID sid, WaterClass wc)
+static inline void MakeOilrig(TileIndex t, Owner oc, StationID sid, WaterClass wc)
 {
 	MakeStation(t, OWNER_NONE, sid, STATION_OILRIG, 0, wc);
+	if (wc == WATER_CLASS_CANAL) SetCanalOwner(t, oc);
 }
 
 #endif /* STATION_MAP_H */

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -498,6 +498,15 @@ def      = true
 str      = STR_CONFIG_SETTING_EXTRADYNAMITE
 strhelp  = STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT
 
+[SDT_BOOL]
+base     = GameSettings
+var      = construction.dynamite_river
+from     = SLV_BUILD_ON_COMPETITOR_CANAL
+def      = true
+str      = STR_CONFIG_SETTING_DYNAMITE_RIVER
+strhelp  = STR_CONFIG_SETTING_DYNAMITE_RIVER_HELPTEXT
+cat      = SC_BASIC
+
 [SDT_VAR]
 base     = GameSettings
 var      = construction.max_bridge_length
@@ -1251,6 +1260,15 @@ from     = SLV_114
 def      = true
 str      = STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD
 strhelp  = STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD_HELPTEXT
+cat      = SC_BASIC
+
+[SDT_BOOL]
+base     = GameSettings
+var      = construction.build_on_competitor_canal
+from     = SLV_BUILD_ON_COMPETITOR_CANAL
+def      = true
+str      = STR_CONFIG_SETTING_BUILD_ON_COMPETITOR_CANAL
+strhelp  = STR_CONFIG_SETTING_BUILD_ON_COMPETITOR_CANAL_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_BOOL]

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -346,13 +346,9 @@ static CommandCost DoBuildLock(TileIndex tile, DiagDirection dir, DoCommandFlag 
 
 	/* middle tile */
 	WaterClass wc_middle = HasTileWaterGround(tile) ? GetWaterClass(tile) : WATER_CLASS_CANAL;
-	if (!IsWaterTile(tile)) {
-		ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
-		if (ret.Failed()) return ret;
-		cost.AddCost(ret);
-		/* Add an extra cost only if not building on a river. */
-		if (wc_middle == WATER_CLASS_CANAL) cost.AddCost(_price[PR_BUILD_CANAL]);
-	}
+	ret = DoCommand(tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
+	if (ret.Failed()) return ret;
+	cost.AddCost(ret);
 
 	/* lower tile */
 	bool is_already_canal_lower = HasTileWaterGround(tile - delta) && GetWaterClass(tile - delta) == WATER_CLASS_CANAL;
@@ -469,10 +465,6 @@ static CommandCost RemoveLock(TileIndex tile, DoCommandFlag flags)
 	Owner oc_lower = GetWaterClass(tile - delta) == WATER_CLASS_CANAL ? GetCanalOwner(tile - delta) : INVALID_OWNER;
 	Owner oc_upper = GetWaterClass(tile + delta) == WATER_CLASS_CANAL ? GetCanalOwner(tile + delta) : INVALID_OWNER;
 
-	CommandCost cost(EXPENSES_CONSTRUCTION, _price[PR_CLEAR_LOCK]);
-	/* Add an extra cost only if it was not built on a river. */
-	if (GetWaterClass(tile) != WATER_CLASS_RIVER) cost.AddCost(_price[PR_CLEAR_CANAL]);
-
 	if (flags & DC_EXEC) {
 		/* Remove middle part from company infrastructure count. */
 		Company *c = Company::GetIfValid(GetTileOwner(tile));
@@ -494,7 +486,7 @@ static CommandCost RemoveLock(TileIndex tile, DoCommandFlag flags)
 		MarkCanalsAndRiversAroundDirty(tile + delta);
 	}
 
-	return cost;
+	return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_CLEAR_LOCK]);
 }
 
 /**


### PR DESCRIPTION
Feature: Build on competitor canal

1) Major feature: Canal Owners, it allows everything that is a canal or was built over a canal to have a 'canal owner'. Stuff like Canal, Ship Depot, Dock, Buoy, Lock, Oil Rig, Object, if built on a
canal or if it is a canal, will have a 'canal owner'.
- Querying these tiles will display 'Canal owner:' to retrieve the respective owner of that canal.
- Added a game setting allowing or disallowing building over canals of competitors.
- Savegame conversion.

2) Another semi-major feature: Permanent rivers, which mean, rivers are indestructible, unless cheating or in the scenario editor.
- Demolishing a canal that was built on rivers will restore the river.
- Added a game setting that can turn on or off this feature.
- Savegame conversion.

3) Less relevant stuff:
- Improved Lock pricing and infrastructure counting, to achieve better consistency.