### PR TITLE
Fix: [SDL2] support pasting from clipboard on Linux

### DIFF
--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -24,6 +24,10 @@
 #include <time.h>
 #include <signal.h>
 
+#ifdef WITH_SDL2
+#include <SDL.h>
+#endif
+
 #ifdef __APPLE__
 	#include <sys/mount.h>
 #elif (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L) || defined(__GLIBC__)
@@ -266,7 +270,17 @@ int CDECL main(int argc, char *argv[])
 #ifndef WITH_COCOA
 bool GetClipboardContents(char *buffer, const char *last)
 {
+#ifdef WITH_SDL2
+	char *clip;
+
+	if (SDL_HasClipboardText() == SDL_TRUE && (clip = SDL_GetClipboardText()) != NULL) {
+		strecpy(buffer, clip, last);
+		return true;
+	}
+	else return false;
+#else
 	return false;
+#endif
 }
 #endif
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -271,16 +271,18 @@ int CDECL main(int argc, char *argv[])
 bool GetClipboardContents(char *buffer, const char *last)
 {
 #ifdef WITH_SDL2
-	char *clip;
+	if (SDL_HasClipboardText() == SDL_FALSE) {
+		return false;
+	}
 
-	if (SDL_HasClipboardText() == SDL_TRUE && (clip = SDL_GetClipboardText()) != NULL) {
+	char *clip = SDL_GetClipboardText();
+	if (clip != NULL) {
 		strecpy(buffer, clip, last);
 		return true;
 	}
-	else return false;
-#else
-	return false;
 #endif
+
+	return false;
 }
 #endif
 


### PR DESCRIPTION
Pasting from clipboard in text fields was not possible on Linux.  This became possible with the addition of the SDL2 backend.