### PR TITLE
Feature: Add news notifications for significantly delayed trains

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -853,6 +853,7 @@ STR_NEWS_VEHICLE_IS_GETTING_OLD                                 :{WHITE}{VEHICLE
 STR_NEWS_VEHICLE_IS_GETTING_VERY_OLD                            :{WHITE}{VEHICLE} is getting very old
 STR_NEWS_VEHICLE_IS_GETTING_VERY_OLD_AND                        :{WHITE}{VEHICLE} is getting very old and urgently needs replacing
 STR_NEWS_TRAIN_IS_STUCK                                         :{WHITE}{VEHICLE} can't find a path to continue
+STR_NEWS_TRAIN_IS_DELAYED                                       :{WHITE}{VEHICLE} is delayed for {STRING3}
 STR_NEWS_VEHICLE_IS_LOST                                        :{WHITE}{VEHICLE} is lost
 STR_NEWS_VEHICLE_IS_UNPROFITABLE                                :{WHITE}{VEHICLE}'s profit last year was {CURRENCY_LONG}
 STR_NEWS_AIRCRAFT_DEST_TOO_FAR                                  :{WHITE}{VEHICLE} can't get to the next destination because it is out of range
@@ -1281,6 +1282,8 @@ STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS_HELPTEXT               :Enabling this s
 
 STR_CONFIG_SETTING_WARN_LOST_VEHICLE                            :Warn if vehicle is lost: {STRING2}
 STR_CONFIG_SETTING_WARN_LOST_VEHICLE_HELPTEXT                   :Trigger messages about vehicles unable to find a path to their ordered destination
+STR_CONFIG_SETTING_WARN_DELAYED_VEHICLE                         :Warn if vehicle is delayed: {STRING2}
+STR_CONFIG_SETTING_WARN_DELAYED_VEHICLE_HELPTEXT                :Trigger messages about vehicles sitting idle due to delays on the line
 STR_CONFIG_SETTING_ORDER_REVIEW                                 :Review vehicles' orders: {STRING2}
 STR_CONFIG_SETTING_ORDER_REVIEW_HELPTEXT                        :When enabled, the orders of the vehicles are periodically checked, and some obvious issues are reported with a news message when detected
 STR_CONFIG_SETTING_ORDER_REVIEW_OFF                             :No

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1584,6 +1584,7 @@ static SettingsContainer &GetSettingsTree()
 			advisors->Add(new SettingEntry("gui.order_review_system"));
 			advisors->Add(new SettingEntry("gui.vehicle_income_warn"));
 			advisors->Add(new SettingEntry("gui.lost_vehicle_warn"));
+			advisors->Add(new SettingEntry("gui.delay_vehicle_warn"));
 			advisors->Add(new SettingEntry("gui.show_finances"));
 			advisors->Add(new SettingEntry("news_display.economy"));
 			advisors->Add(new SettingEntry("news_display.subsidies"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -82,6 +82,7 @@ enum ViewportScrollMode {
 struct GUISettings {
 	bool   sg_full_load_any;                 ///< new full load calculation, any cargo must be full read from pre v93 savegames
 	bool   lost_vehicle_warn;                ///< if a vehicle can't find its destination, show a warning
+	bool   delay_vehicle_warn;               ///< if a vehicle is unnecessarily delayed, show a warning
 	uint8  order_review_system;              ///< perform order reviews on vehicles
 	bool   vehicle_income_warn;              ///< if a vehicle isn't generating income, show a warning
 	bool   show_finances;                    ///< show finances at end of year

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3043,6 +3043,13 @@ str      = STR_CONFIG_SETTING_WARN_LOST_VEHICLE
 strhelp  = STR_CONFIG_SETTING_WARN_LOST_VEHICLE_HELPTEXT
 
 [SDTC_BOOL]
+var      = gui.delay_vehicle_warn
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+def      = true
+str      = STR_CONFIG_SETTING_WARN_DELAYED_VEHICLE
+strhelp  = STR_CONFIG_SETTING_WARN_DELAYED_VEHICLE_HELPTEXT
+
+[SDTC_BOOL]
 var      = gui.disable_unsuitable_building
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = true


### PR DESCRIPTION
Occasionally in single-player games, I get deeply engrossed in new construction projects only to find out hours later that I've inadvertently constructed the perfect deadlock; or I throw several new trains on a line which is nearing capacity and fail to realize that the newly introduced congestion is crowding out my profitable shared city stations.

Locating the source of these congestion points is quite easy. First, you wait until the end of the next full year.. then you observe the flood of notifications about unprofitable trains. Then you fix it. Easy, right?

But wait, if we can notify about unprofitable trains, and you can certainly notify about those ships with pathfinding issues... why can't the game tell you when your trains are deadlocking? Challenge accepted! Let me just put together a menu item...

![delay-option](https://user-images.githubusercontent.com/1243336/72869994-bc999280-3c9b-11ea-9f96-f5af87c28288.png)

Bit of digging around and hacking on the code...

![delay-train](https://user-images.githubusercontent.com/1243336/72872699-d38fb300-3ca2-11ea-9d6b-67c8ec47ce95.png)

et, voila! Stop a random train on one of your congested routes, and a short while later you'll see this message pop up. I recall the particular congestion point that caused me to write this patch, but what I didn't expect is that the first time I loaded up my game with this, it pointed out yet another highly congested track down at the bottom of my network! I hadn't looked down there for *years*!

I had to run a few variations on this patch to tweak the threshold, I found that path delay * 2 * `DAY_TICKS` was a reliable point where you don't receive false alerts, but it will still reliably detect deadlocks and highly congested paths. Moderate congestion does not trigger the alerts.

Let me know what you think!