### PR TITLE
Fix: [AzurePipelines] the changelog-generation-script was mixing UTC and non-UTC

### DIFF
--- a/azure-pipelines/changelog.sh
+++ b/azure-pipelines/changelog.sh
@@ -12,5 +12,5 @@ fi
 
 # In all other cases, show the git log of the last 7 days
 revdate=$(git log -1 --pretty=format:"%ci")
-last_week=$(date -u -d "$revdate -7days" +"%Y-%m-%d %H:%M")
+last_week=$(date -d "$revdate -7days" +"%Y-%m-%d %H:%M")
 git log --after="${last_week}" --pretty=fuller


### PR DESCRIPTION
'date -u' returns the time in UTC. 'git log' uses local time. In
result, when a machine is on for example +0100, it would generate
the changelog of 7 days 1 hour, instead of 7 days. This is a silly
oversight.