### PR TITLE
Fix #6566: Fix signed integer overflow in viewport draw area chunking

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1728,7 +1728,7 @@ void ViewportDoDraw(const ViewPort *vp, int left, int top, int right, int bottom
  */
 static void ViewportDrawChk(const ViewPort *vp, int left, int top, int right, int bottom)
 {
-	if (ScaleByZoom(bottom - top, vp->zoom) * ScaleByZoom(right - left, vp->zoom) > (int)(180000 * ZOOM_LVL_BASE * ZOOM_LVL_BASE)) {
+	if ((int64)ScaleByZoom(bottom - top, vp->zoom) * (int64)ScaleByZoom(right - left, vp->zoom) > (int64)(180000 * ZOOM_LVL_BASE * ZOOM_LVL_BASE)) {
 		if ((bottom - top) > (right - left)) {
 			int t = (top + bottom) >> 1;
 			ViewportDrawChk(vp, left, top, right, t);


### PR DESCRIPTION
This caused drawing areas larger than 2097151 pixels at 8x zoom to
not be subdivided into smaller chunks as required.
This resulted in pathological performance issues in the sprite sorter.