### PR TITLE
Fix #7974: Crash when CTRL+click to show a vehicle group that is coll…

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -1017,6 +1017,7 @@ public:
 				}
 				this->groups.ForceRebuild();
 				this->BuildGroupList(this->owner);
+				this->group_sb->SetCount((uint)this->groups.size());
 				id_g = find_index(this->groups, g);
 			}
 			this->group_sb->ScrollTowards(id_g);


### PR DESCRIPTION
…apsed

Maybe we should add `this->group_sb->SetCount((uint)this->groups.size());` to `BuildGroupList()`.