### PR TITLE
Fix d84b67e5: Station rating effects affecting too large area

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3858,7 +3858,7 @@ void StationMonthlyLoop()
 void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint radius)
 {
 	ForAllStationsRadius(tile, radius, [&](Station *st) {
-		if (st->owner == owner) {
+		if (st->owner == owner && DistanceManhattan(tile, st->xy) <= radius) {
 			for (CargoID i = 0; i < NUM_CARGO; i++) {
 				GoodsEntry *ge = &st->goods[i];
 


### PR DESCRIPTION
Reported by @ldpl  who provided the following images.
This causes advertising in towns and vehicle crashes to affect stations they shouldn't.

Original effect radius:
![image](https://user-images.githubusercontent.com/1062071/73951535-ee4a6480-48fd-11ea-8af4-88e2f2ba38c1.png)

Current/wrong effect radius:
![image](https://user-images.githubusercontent.com/1062071/73951547-f4404580-48fd-11ea-8ac2-1d464841efc1.png)
