### PR TITLE
Fix #7592: Limit road vehicle caching near destination

### DIFF
--- a/src/pathfinder/pathfinder_type.h
+++ b/src/pathfinder/pathfinder_type.h
@@ -44,6 +44,9 @@ static const int YAPF_SHIP_PATH_CACHE_LENGTH = 32;
 /** Maximum segments of road vehicle path cache */
 static const int YAPF_ROADVEH_PATH_CACHE_SEGMENTS = 8;
 
+/** Distance from destination road stops to not cache any further */
+static const int YAPF_ROADVEH_PATH_CACHE_DESTINATION_LIMIT = 8;
+
 /**
  * Helper container to find a depot
  */

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -251,6 +251,11 @@ public:
 		}
 	}
 
+	const Station *GetDestinationStation() const
+	{
+		return m_dest_station != INVALID_STATION ? Station::GetIfValid(m_dest_station) : nullptr;
+	}
+
 protected:
 	/** to access inherited path finder */
 	Tpf& Yapf()
@@ -401,6 +406,22 @@ public:
 			if (path_found && !path_cache.empty() && tile == v->dest_tile) {
 				path_cache.td.pop_back();
 				path_cache.tile.pop_back();
+			}
+
+			/* Check if target is a station, and cached path ends within 8 tiles of the dest tile */
+			const Station *st = Yapf().GetDestinationStation();
+			if (st) {
+				const RoadStop *stop = st->GetPrimaryRoadStop(v);
+				if (stop != nullptr && (IsDriveThroughStopTile(stop->xy) || stop->GetNextRoadStop(v) != nullptr)) {
+					/* Destination station has at least 2 usable road stops, or first is a drive-through stop,
+					 * trim end of path cache within a number of tiles of road stop tile area */
+					TileArea non_cached_area = v->IsBus() ? st->bus_station : st->truck_station;
+					non_cached_area.Expand(YAPF_ROADVEH_PATH_CACHE_DESTINATION_LIMIT);
+					while (!path_cache.empty() && non_cached_area.Contains(path_cache.tile.back())) {
+						path_cache.td.pop_back();
+						path_cache.tile.pop_back();
+					}
+				}
 			}
 		}
 		return next_trackdir;


### PR DESCRIPTION
Ported from https://github.com/JGRennison/OpenTTD-patches/commit/79d5be7e265df3be8b73d484f0c7261b3c23229d as suggested in https://github.com/OpenTTD/OpenTTD/issues/7592#issuecomment-546629800

Seems to work from my preliminary testing, although I haven't verified that the caching is still efficient when not near the destination.