### PR TITLE
Feature #7735: Implement protocol handling

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -513,6 +513,14 @@ bool ParseNextQueryParameter(const char **fieldname, const char **value, char **
 				**query = '\0';
 				(*query)++;
 				return true;
+			case '%':
+				unsigned int ascii_code;
+				if (strlen(*query) < 3 || sscanf(*query, "%%%2x", &ascii_code) != 1) {
+					fprintf(stderr, "Malformed query string\n");
+					return false;
+				}
+				**query = (char)ascii_code;
+				memmove(*query, *query + 3, strlen(*query) - 3);
 		}
 	}
 	return true;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -487,17 +487,22 @@ void ParseConnectionString(const char **company, const char **port, char *connec
 }
 
 /**
- * Finds the first parameter and value in a query string
- *  Format: param0=val0&param1=val1&...
+ * Parses the first parameter found in a query string and moves query to the
+ * following parameter.
+ *  Format: fieldname0=value0&fieldname1=value1&...
  *
- * query will be moved to the start of the next query, and parameter name and
- * value will be set to the name and value strings given by the user, inside
- * the memory area originally occupied by connection_string.
+ * The fieldname and value variables will be set to the first fieldname and
+ * value substrings found in the query string. Query will point to the following
+ * parameter.
+ * @param query The query string
+ * @return fieldname The fieldname of the parameter
+ * @return value The value of the parameter
+ * @return query The query string updated to the next parameter
  */
-bool ParseQueryString(const char **name, const char **value, char **query)
+bool ParseNextQueryParameter(const char **fieldname, const char **value, char **query)
 {
 	if (**query == '\0') return false;
-	*name = *query;
+	*fieldname = *query;
 	for (; **query != '\0'; (*query)++) {
 		switch (**query) {
 			case '=':

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -487,6 +487,33 @@ void ParseConnectionString(const char **company, const char **port, char *connec
 }
 
 /**
+ * Finds the first parameter and value in a query string
+ *  Format: param0=val0&param1=val1&...
+ *
+ * query will be moved to the start of the next query, and parameter name and
+ * value will be set to the name and value strings given by the user, inside
+ * the memory area originally occupied by connection_string.
+ */
+bool ParseQueryString(const char **name, const char **value, char **query)
+{
+	if (**query == '\0') return false;
+	*name = *query;
+	for (; **query != '\0'; (*query)++) {
+		switch (**query) {
+			case '=':
+				**query = '\0';
+				*value = *query + 1;
+				break;
+			case '&':
+				**query = '\0';
+				(*query)++;
+				return true;
+		}
+	}
+	return true;
+}
+
+/**
  * Handle the accepting of a connection to the server.
  * @param s The socket of the new connection.
  * @param address The address of the peer.

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -44,7 +44,7 @@ void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 void ParseConnectionString(const char **company, const char **port, char *connection_string);
-bool ParseQueryString(const char **name, const char **value, char **query);
+bool ParseNextQueryParameter(const char **fieldname, const char **value, char **query);
 void NetworkStartDebugLog(NetworkAddress address);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -44,6 +44,7 @@ void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 void ParseConnectionString(const char **company, const char **port, char *connection_string);
+bool ParseQueryString(const char **name, const char **value, char **query);
 void NetworkStartDebugLog(NetworkAddress address);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -633,7 +633,7 @@ int openttd_main(int argc, char *argv[])
 
 			const char* name = nullptr;
 			const char* value = nullptr;
-			while (ParseQueryString(&name, &value, &p)) {
+			while (ParseNextQueryParameter(&name, &value, &p)) {
 				if (strcmp(name, "password") == 0) {
 					scanner->join_server_password = value;
 				} else if (strcmp(name, "join") == 0) {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -393,6 +393,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 	uint16 dedicated_port;             ///< Port for the dedicated server.
 	char *network_conn;                ///< Information about the server to connect to, or nullptr.
 	const char *join_server_password;  ///< The password to join the server with.
+	const char *join_company;          ///< The company to join.
 	const char *join_company_password; ///< The password to join the company with.
 	bool *save_config_ptr;             ///< The pointer to the save config setting.
 	bool save_config;                  ///< The save config setting.
@@ -405,8 +406,9 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 	AfterNewGRFScan(bool *save_config_ptr) :
 			startyear(INVALID_YEAR), generation_seed(GENERATE_NEW_SEED),
 			dedicated_host(nullptr), dedicated_port(0), network_conn(nullptr),
-			join_server_password(nullptr), join_company_password(nullptr),
-			save_config_ptr(save_config_ptr), save_config(true)
+			join_server_password(nullptr), join_company(nullptr),
+			join_company_password(nullptr), save_config_ptr(save_config_ptr),
+			save_config(true)
 	{
 		/* Visual C++ 2015 fails compiling this line (AfterNewGRFScan::generation_seed undefined symbol)
 		 * if it's placed outside a member function, directly in the struct body. */
@@ -467,10 +469,18 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 
 			ParseConnectionString(&company, &port, network_conn);
 
-			if (company != nullptr) {
-				join_as = (CompanyID)atoi(company);
+			if (company == nullptr) company = join_company;
 
-				if (join_as != COMPANY_SPECTATOR) {
+			if (company != nullptr) {
+				if (strcmp(company, "") == 0) {
+					join_as = COMPANY_SPECTATOR;
+				} else if (strcmp(company, "new") == 0) {
+					join_as = COMPANY_NEW_COMPANY;
+				} else {
+					join_as = (CompanyID)atoi(company);
+				}
+
+				if (join_as != COMPANY_SPECTATOR && join_as != COMPANY_NEW_COMPANY) {
 					join_as--;
 					if (join_as >= MAX_COMPANIES) {
 						delete this;
@@ -508,6 +518,7 @@ static const OptionData _options[] = {
 	 GETOPT_SHORT_VALUE('l'),
 	 GETOPT_SHORT_VALUE('p'),
 	 GETOPT_SHORT_VALUE('P'),
+	 GETOPT_SHORT_VALUE('U'),
 #if !defined(_WIN32)
 	 GETOPT_SHORT_NOVAL('f'),
 #endif
@@ -603,6 +614,42 @@ int openttd_main(int argc, char *argv[])
 		case 'P':
 			scanner->join_company_password = mgo.opt;
 			break;
+		case 'U': {
+			char* p = mgo.opt;
+
+			const char* protocol = "openttd://";
+			if (strncmp(p, protocol, strlen(protocol)) != 0) {
+				fprintf(stderr, "Unknown protocol\n");
+				break;
+			}
+
+			p += strlen(protocol);
+
+			char* network_conn = p;
+			p = strchr(p, '?');
+			*p = '\0';
+			p++;
+			scanner->network_conn = network_conn;
+
+			const char* name = nullptr;
+			const char* value = nullptr;
+			while (ParseQueryString(&name, &value, &p)) {
+				if (strcmp(name, "password") == 0) {
+					scanner->join_server_password = value;
+				} else if (strcmp(name, "join") == 0) {
+					scanner->join_company = value;
+				} else if (strcmp(name, "companypassword") == 0) {
+					scanner->join_company_password = value;
+				} else if (strcmp(name, "version") == 0) {
+					/* Nothing for now */
+				} else {
+					fprintf(stderr, "Unknown parameter: ");
+					fprintf(stderr, name);
+					fprintf(stderr, "\n");
+				}
+			}
+			break;
+		}
 		case 'r': ParseResolution(&resolution, mgo.opt); break;
 		case 't': scanner->startyear = atoi(mgo.opt); break;
 		case 'd': {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -615,9 +615,9 @@ int openttd_main(int argc, char *argv[])
 			scanner->join_company_password = mgo.opt;
 			break;
 		case 'U': {
-			char* p = mgo.opt;
+			char *p = mgo.opt;
 
-			const char* protocol = "openttd://";
+			const char *protocol = "openttd://";
 			if (strncmp(p, protocol, strlen(protocol)) != 0) {
 				fprintf(stderr, "Unknown protocol\n");
 				break;
@@ -625,14 +625,14 @@ int openttd_main(int argc, char *argv[])
 
 			p += strlen(protocol);
 
-			char* network_conn = p;
+			char *network_conn = p;
 			p = strchr(p, '?');
 			*p = '\0';
 			p++;
 			scanner->network_conn = network_conn;
 
-			const char* name = nullptr;
-			const char* value = nullptr;
+			const char *name = nullptr;
+			const char *value = nullptr;
 			while (ParseNextQueryParameter(&name, &value, &p)) {
 				if (strcmp(name, "password") == 0) {
 					scanner->join_server_password = value;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -643,9 +643,7 @@ int openttd_main(int argc, char *argv[])
 				} else if (strcmp(name, "version") == 0) {
 					/* Nothing for now */
 				} else {
-					fprintf(stderr, "Unknown parameter: ");
-					fprintf(stderr, name);
-					fprintf(stderr, "\n");
+					fprintf(stderr, "Unknown parameter: %s\n", name);
 				}
 			}
 			break;


### PR DESCRIPTION
Basically does what #7735 asks for.

In [openttd.cpp](https://github.com/JMcKiern/OpenTTD/blob/278477d97055aa05033424c6c53478d164eeec38/src/openttd.cpp#L475) L475-483, I added cases for joining as a new company ("new") and joining as a spectator (""). These changes will affect the way a command line connection string (-n host:post#company) is parse but I think that would be ideal.

Let me know what you think.

