### PR TITLE
Fix #7525: Move autorenew setting to Basic category

### DIFF
--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -41,6 +41,7 @@ var      = engine_renew
 def      = false
 str      = STR_CONFIG_SETTING_AUTORENEW_VEHICLE
 strhelp  = STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT
+cat      = SC_BASIC
 
 [SDT_VAR]
 base     = CompanySettings


### PR DESCRIPTION
Alternative to #7729

Autorenew still needs some better GUI that's closer to the rest of the vehicle management things, but this might at least make it easier to find.