### PR TITLE
Fix 805ecd32be64e14d8555ebc06eadf673bdf401ee: Incorrect length specifier

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -529,7 +529,7 @@ DEF_CONSOLE_CMD(ConKick)
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
 	if (kick_message_length >= 255) {
-		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered %d characters.", kick_message_length);
+		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered %zu characters.", kick_message_length);
 		return false;
 	} else {
 		return ConKickOrBan(argv[1], false, argv[2]);
@@ -553,7 +553,7 @@ DEF_CONSOLE_CMD(ConBan)
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
 	if (kick_message_length >= 255) {
-		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered %d characters.", kick_message_length);
+		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered %zu characters.", kick_message_length);
 		return false;
 	} else {
 		return ConKickOrBan(argv[1], true, argv[2]);


### PR DESCRIPTION
`g++ (Debian 8.3.0-6) 8.3.0` complains:
```
warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
   IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered %d characters.", kick_message_length);
```
In 805ecd32be64e14d8555ebc06eadf673bdf401ee, variable type got changed, but not the `printf` length specifier.