### PR TITLE
OpenBSD: fix endianness detection

### DIFF
--- a/src/core/endian_type.hpp
+++ b/src/core/endian_type.hpp
@@ -33,6 +33,13 @@
 #	else
 #		define TTD_ENDIAN TTD_BIG_ENDIAN
 #	endif
+#elif defined(__OpenBSD__)
+#	include <endian.h>
+#	if BYTE_ORDER == LITTLE_ENDIAN
+#		define TTD_ENDIAN TTD_LITTLE_ENDIAN
+#	else
+#		define TTD_ENDIAN TTD_BIG_ENDIAN
+#	endif
 #elif !defined(TESTING)
 #	include <sys/param.h>
 #	if __BYTE_ORDER == __LITTLE_ENDIAN


### PR DESCRIPTION
Hi!

@rapenne-s reported to me that OpenTTD colors are off on OpenBSD/macppc (32-bit powerpc). I've found out it's because we don't implement endianness reporting like the rest; `__*_ENDIAN` and `__BYTE_ORDER` don't exist out of the box.

This PR adds the appropriate code to fix the issue.

(cc @bentley)