### PR TITLE
Codechange: Format unsigned integers with %u instead of %i or %d.

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -697,7 +697,7 @@ public:
 		if (f == nullptr) return false;
 
 		ScenarioIdentifier id;
-		int fret = fscanf(f, "%i", &id.scenid);
+		int fret = fscanf(f, "%u", &id.scenid);
 		FioFCloseFile(f);
 		if (fret != 1) return false;
 		strecpy(id.filename, filename, lastof(id.filename));

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -109,7 +109,7 @@ uint32 NewGRFProfiler::Finish()
 
 	fputs("Tick,Sprite,Feature,Item,CallbackID,Microseconds,Depth,Result\n", f);
 	for (const Call &c : this->calls) {
-		fprintf(f, "%u,%u,0x%X,%d,0x%X,%u,%u,%u\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
+		fprintf(f, "%u,%u,0x%X,%u,0x%X,%u,%u,%u\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
 		total_microseconds += c.time;
 	}
 

--- a/src/pathfinder/npf/queue.cpp
+++ b/src/pathfinder/npf/queue.cpp
@@ -305,16 +305,16 @@ void Hash::PrintStatistics() const
 	}
 	printf(
 		"---\n"
-		"Hash size: %d\n"
-		"Nodes used: %d\n"
-		"Non empty buckets: %d\n"
-		"Max collision: %d\n",
+		"Hash size: %u\n"
+		"Nodes used: %u\n"
+		"Non empty buckets: %u\n"
+		"Max collision: %u\n",
 		this->num_buckets, this->size, used_buckets, max_collision
 	);
 	printf("{ ");
 	for (i = 0; i <= max_collision; i++) {
 		if (usage[i] > 0) {
-			printf("%d:%d ", i, usage[i]);
+			printf("%u:%u ", i, usage[i]);
 #if 0
 			if (i > 0) {
 				uint j;

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -310,7 +310,7 @@ struct HeaderFileWriter : HeaderWriter, FileWriter {
 		fprintf(this->fh,
 			"\n"
 			"static const uint LANGUAGE_PACK_VERSION     = 0x%X;\n"
-			"static const uint LANGUAGE_MAX_PLURAL       = %d;\n"
+			"static const uint LANGUAGE_MAX_PLURAL       = %u;\n"
 			"static const uint LANGUAGE_MAX_PLURAL_FORMS = %d;\n\n",
 			(uint)data.Version(), (uint)lengthof(_plural_forms), max_plural_forms
 		);


### PR DESCRIPTION
This pull request fixes some of the following [Cppcheck](https://github.com/danmar/cppcheck) warnings about %i and %d with `unsigned int`. I didn't fix the warnings about using %x with `signed int *`, because I wasn't sure how to fix them.
Cppcheck output:
```
[src\fios.cpp:700]: (warning) %i in format string (no. 1) requires 'int *' but the argument type is 'unsigned int *'.
[src\newgrf_profiling.cpp:112]: (warning) %d in format string (no. 4) requires 'int' but the argument type is 'unsigned int'.
[src\network\network.cpp:920]: (warning) %x in format string (no. 1) requires 'unsigned int *' but the argument type is 'signed int *'.
[src\network\network.cpp:920]: (warning) %x in format string (no. 3) requires 'unsigned int *' but the argument type is 'signed int *'.
[src\network\network.cpp:928]: (warning) %x in format string (no. 1) requires 'unsigned int *' but the argument type is 'signed int *'.
[src\network\network.cpp:938]: (warning) %x in format string (no. 1) requires 'unsigned int *' but the argument type is 'signed int *'.
[src\pathfinder\npf\queue.cpp:306]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\pathfinder\npf\queue.cpp:306]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[src\pathfinder\npf\queue.cpp:306]: (warning) %d in format string (no. 3) requires 'int' but the argument type is 'unsigned int'.
[src\pathfinder\npf\queue.cpp:306]: (warning) %d in format string (no. 4) requires 'int' but the argument type is 'unsigned int'.
[src\pathfinder\npf\queue.cpp:317]: (warning) %d in format string (no. 1) requires 'int' but the argument type is 'unsigned int'.
[src\pathfinder\npf\queue.cpp:317]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
[src\strgen\strgen.cpp:310]: (warning) %d in format string (no. 2) requires 'int' but the argument type is 'unsigned int'.
```