### PR TITLE
Codechange: Avoid copying function parameters by using const references

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -589,7 +589,7 @@ struct AISettingsWindow : public Window {
 	}
 
 private:
-	bool IsEditableItem(const ScriptConfigItem config_item) const
+	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
 		return _game_mode == GM_MENU || ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot)) || (config_item.flags & SCRIPTCONFIG_INGAME) != 0;
 	}

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -208,7 +208,7 @@ bool CheckCompanyHasMoney(CommandCost &cost)
  * @param c Company to pay the bill.
  * @param cost Money to pay.
  */
-static void SubtractMoneyFromAnyCompany(Company *c, CommandCost cost)
+static void SubtractMoneyFromAnyCompany(Company *c, const CommandCost &cost)
 {
 	if (cost.GetCost() == 0) return;
 	assert(cost.GetExpensesType() != INVALID_EXPENSES);
@@ -237,7 +237,7 @@ static void SubtractMoneyFromAnyCompany(Company *c, CommandCost cost)
  * Subtract money from the #_current_company, if the company is valid.
  * @param cost Money to pay.
  */
-void SubtractMoneyFromCompany(CommandCost cost)
+void SubtractMoneyFromCompany(const CommandCost &cost)
 {
 	Company *c = Company::GetIfValid(_current_company);
 	if (c != nullptr) SubtractMoneyFromAnyCompany(c, cost);
@@ -248,7 +248,7 @@ void SubtractMoneyFromCompany(CommandCost cost)
  * @param company Company paying the bill.
  * @param cst     Cost of a command.
  */
-void SubtractMoneyFromCompanyFract(CompanyID company, CommandCost cst)
+void SubtractMoneyFromCompanyFract(CompanyID company, const CommandCost &cst)
 {
 	Company *c = Company::Get(company);
 	byte m = c->money_fraction;

--- a/src/company_func.h
+++ b/src/company_func.h
@@ -25,8 +25,8 @@ void CompanyAdminBankrupt(CompanyID company_id);
 void UpdateLandscapingLimits();
 
 bool CheckCompanyHasMoney(CommandCost &cost);
-void SubtractMoneyFromCompany(CommandCost cost);
-void SubtractMoneyFromCompanyFract(CompanyID company, CommandCost cost);
+void SubtractMoneyFromCompany(const CommandCost& cost);
+void SubtractMoneyFromCompanyFract(CompanyID company, const CommandCost& cost);
 CommandCost CheckOwnership(Owner owner, TileIndex tile = 0);
 CommandCost CheckTileOwnership(TileIndex tile);
 


### PR DESCRIPTION
This fixes some more Cppcheck warnings. Although these warnings are reported as "performance" category warnings, I'm not sure this will speed the game up that much. At least this prevents the class instances passed as arguments from being copied.

```
[company_cmd.cpp:211]: (performance) Function parameter 'cost' should be passed by const reference.
[company_cmd.cpp:240]: (performance) Function parameter 'cost' should be passed by const reference.
[company_cmd.cpp:251]: (performance) Function parameter 'cst' should be passed by const reference.
[ai\ai_gui.cpp:592]: (performance) Function parameter 'config_item' should be passed by const reference. 
```
