### PR TITLE
Feature: Double-click to rename vehicle

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3737,6 +3737,7 @@ STR_REPLACE_REMOVE_WAGON_HELP                                   :{BLACK}Make aut
 # Vehicle view
 STR_VEHICLE_VIEW_CAPTION                                        :{WHITE}{VEHICLE}
 
+STR_VEHICLE_VIEW_CAPTION_TOOLTIP                                :{BLACK}Window title - drag this to move window{}Double click to name vehicle
 STR_VEHICLE_VIEW_TRAIN_LOCATION_TOOLTIP                         :{BLACK}Centre main view on train's location. Ctrl+Click will follow train in main view
 STR_VEHICLE_VIEW_ROAD_VEHICLE_LOCATION_TOOLTIP                  :{BLACK}Centre main view on vehicle's location. Ctrl+Click will follow vehicle in main view
 STR_VEHICLE_VIEW_SHIP_LOCATION_TOOLTIP                          :{BLACK}Centre main view on ship's location. Ctrl+Click will follow ship in main view

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -711,8 +711,12 @@ static void DispatchLeftClickEvent(Window *w, int x, int y, int click_count)
 			return;
 
 		case WWT_CAPTION: // 'Title bar'
-			StartWindowDrag(w);
-			return;
+			if (click_count == 1) {
+				StartWindowDrag(w);
+				return;
+			} else {
+				break;
+			}
 
 		case WWT_RESIZEBOX:
 			/* When the resize widget is on the left size of the window


### PR DESCRIPTION
Renaming vehicle is a bit complicated in current state, so renaming a number of vehicles takes long time. This patch allows double-click title bar of vehicle view window to rename vehicles.
![openttd_doubleclick](https://user-images.githubusercontent.com/24273113/74755289-4a29cb80-52b6-11ea-9679-31ca4746a777.PNG)
