### PR TITLE
Change #8001: Don't add docking tile cost when ships are still too far from their destination

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -328,10 +328,16 @@ static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *par
 	}
 
 	if (IsDockingTile(current->tile)) {
-		/* Check docking tile for occupancy */
-		uint count = 1;
-		HasVehicleOnPos(current->tile, &count, &CountShipProc);
-		cost += count * 3 * _trackdir_length[trackdir];
+		NPFFindStationOrTileData *fstd = (NPFFindStationOrTileData*)as->user_target;
+		if (IsShipDestinationTile(current->tile, fstd->station_index)) {
+			/* Check docking tile for occupancy */
+			uint count = 0;
+			if (DistanceManhattan(fstd->dest_coords, fstd->v->tile) < 16) {
+				count++;
+				HasVehicleOnPos(current->tile, &count, &CountShipProc);
+			}
+			cost += count * 3 * _trackdir_length[trackdir];
+		}
 	}
 
 	/* @todo More penalties? */

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -604,6 +604,7 @@ static bool ShipMoveUpDownOnLock(Ship *v)
 bool IsShipDestinationTile(TileIndex tile, StationID station)
 {
 	assert(IsDockingTile(tile));
+	if (!Station::IsValidID(station)) return false;
 	/* Check each tile adjacent to docking tile. */
 	for (DiagDirection d = DIAGDIR_BEGIN; d != DIAGDIR_END; d++) {
 		TileIndex t = tile + TileOffsByDiagDir(d);


### PR DESCRIPTION
I noticed the problem with #8001 was mainly due to the added cost of docking tile penalty, though it could also be related with ship curve penalties as well, but I decided to mess with docking tile. I know it's used to separate the ships heading to docking tiles of a single station multi-dock.

So I thought of not adding this penalty too early in the search as an effort to reduce the number of pathfinding search nodes. It is only added when the distance to the destination is less than 16 Manhattan tiles.