### PR TITLE
Fix #7998: Crash when scripts tried to access companies with invalid IDs.

### DIFF
--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -27,11 +27,11 @@
 /* static */ ScriptCompany::CompanyID ScriptCompany::ResolveCompanyID(ScriptCompany::CompanyID company)
 {
 	if (company == COMPANY_SELF) {
-		if (!::Company::IsValidID((::CompanyID)_current_company)) return COMPANY_INVALID;
+		if (!::Company::IsValidID(_current_company)) return COMPANY_INVALID;
 		return (CompanyID)((byte)_current_company);
 	}
 
-	return ::Company::IsValidID((::CompanyID)company) ? company : COMPANY_INVALID;
+	return ::Company::IsValidID(company) ? company : COMPANY_INVALID;
 }
 
 /* static */ bool ScriptCompany::IsMine(ScriptCompany::CompanyID company)
@@ -116,9 +116,9 @@
 	if (quarter > EARLIEST_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get((::CompanyID)company)->cur_economy.income;
+		return ::Company::Get(company)->cur_economy.income;
 	}
-	return ::Company::Get((::CompanyID)company)->old_economy[quarter - 1].income;
+	return ::Company::Get(company)->old_economy[quarter - 1].income;
 }
 
 /* static */ Money ScriptCompany::GetQuarterlyExpenses(ScriptCompany::CompanyID company, uint32 quarter)
@@ -128,9 +128,9 @@
 	if (quarter > EARLIEST_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get((::CompanyID)company)->cur_economy.expenses;
+		return ::Company::Get(company)->cur_economy.expenses;
 	}
-	return ::Company::Get((::CompanyID)company)->old_economy[quarter - 1].expenses;
+	return ::Company::Get(company)->old_economy[quarter - 1].expenses;
 }
 
 /* static */ int32 ScriptCompany::GetQuarterlyCargoDelivered(ScriptCompany::CompanyID company, uint32 quarter)
@@ -140,9 +140,9 @@
 	if (quarter > EARLIEST_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get((::CompanyID)company)->cur_economy.delivered_cargo.GetSum<OverflowSafeInt<int32, INT32_MAX, INT32_MIN> >();
+		return ::Company::Get(company)->cur_economy.delivered_cargo.GetSum<OverflowSafeInt<int32, INT32_MAX, INT32_MIN> >();
 	}
-	return ::Company::Get((::CompanyID)company)->old_economy[quarter - 1].delivered_cargo.GetSum<OverflowSafeInt<int32, INT32_MAX, INT32_MIN> >();
+	return ::Company::Get(company)->old_economy[quarter - 1].delivered_cargo.GetSum<OverflowSafeInt<int32, INT32_MAX, INT32_MIN> >();
 }
 
 /* static */ int32 ScriptCompany::GetQuarterlyPerformanceRating(ScriptCompany::CompanyID company, uint32 quarter)
@@ -152,7 +152,7 @@
 	if (quarter > EARLIEST_QUARTER) return -1;
 	if (quarter == CURRENT_QUARTER) return -1;
 
-	return ::Company::Get((::CompanyID)company)->old_economy[quarter - 1].performance_history;
+	return ::Company::Get(company)->old_economy[quarter - 1].performance_history;
 }
 
 /* static */ Money ScriptCompany::GetQuarterlyCompanyValue(ScriptCompany::CompanyID company, uint32 quarter)
@@ -162,9 +162,9 @@
 	if (quarter > EARLIEST_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::CalculateCompanyValue(::Company::Get((::CompanyID)company));
+		return ::CalculateCompanyValue(::Company::Get(company));
 	}
-	return ::Company::Get((::CompanyID)company)->old_economy[quarter - 1].company_value;
+	return ::Company::Get(company)->old_economy[quarter - 1].company_value;
 }
 
 
@@ -173,7 +173,7 @@
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
 
-	return ::Company::Get((CompanyID)company)->money;
+	return ::Company::Get(company)->money;
 }
 
 /* static */ Money ScriptCompany::GetLoanAmount()
@@ -250,7 +250,7 @@
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return INVALID_TILE;
 
-	TileIndex loc = ::Company::Get((CompanyID)company)->location_of_HQ;
+	TileIndex loc = ::Company::Get(company)->location_of_HQ;
 	return (loc == 0) ? INVALID_TILE : loc;
 }
 
@@ -264,7 +264,7 @@
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return false;
 
-	return ::Company::Get((CompanyID)company)->settings.engine_renew;
+	return ::Company::Get(company)->settings.engine_renew;
 }
 
 /* static */ bool ScriptCompany::SetAutoRenewMonths(int16 months)
@@ -277,7 +277,7 @@
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return 0;
 
-	return ::Company::Get((CompanyID)company)->settings.engine_renew_months;
+	return ::Company::Get(company)->settings.engine_renew_months;
 }
 
 /* static */ bool ScriptCompany::SetAutoRenewMoney(Money money)
@@ -292,7 +292,7 @@
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return 0;
 
-	return ::Company::Get((CompanyID)company)->settings.engine_renew_money;
+	return ::Company::Get(company)->settings.engine_renew_money;
 }
 
 /* static */ bool ScriptCompany::SetPrimaryLiveryColour(LiveryScheme scheme, Colours colour)


### PR DESCRIPTION
ResolveCompany reported ID 256 as valid, if ID 0 is valid, etc...

Actually, all casts are wrong in that file. Company::Get and Company::IsValidID both accept a size_t, so it is best to never cast anything, so there is always only one conversion from ScriptCompany::CompanyID to size_t.