### PR TITLE
Codechange: Limit field width to avoid sscanf crash

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -917,7 +917,8 @@ void NetworkGameLoop()
 				if (*p == ' ') p++;
 				cp = CallocT<CommandPacket>(1);
 				int company;
-				int ret = sscanf(p, "%x; %x; %x; %x; %x; %x; %x; \"%[^\"]\"", &next_date, &next_date_fract, &company, &cp->tile, &cp->p1, &cp->p2, &cp->cmd, cp->text);
+				assert_compile(sizeof(cp->text) == 128);
+				int ret = sscanf(p, "%x; %x; %x; %x; %x; %x; %x; \"%127[^\"]\"", &next_date, &next_date_fract, &company, &cp->tile, &cp->p1, &cp->p2, &cp->cmd, cp->text);
 				/* There are 8 pieces of data to read, however the last is a
 				 * string that might or might not exist. Ignore it if that
 				 * string misses because in 99% of the time it's not used. */


### PR DESCRIPTION
According to Cppcheck, "sscanf() without field width limits can crash with huge input data."

I added a field width of 127 since `cp->text` is a buffer of size `32 * MAX_CHAR_LENGTH` ([src/command_type.h:483](https://github.com/OpenTTD/OpenTTD/blob/75031c9693ee0525c75e8e02ead345b1f8264735/src/command_type.h#L483)) where MAX_CHAR_LENGTH = 4 ([src/strings_type.h:18](https://github.com/OpenTTD/OpenTTD/blob/75031c9693ee0525c75e8e02ead345b1f8264735/src/strings_type.h#L18)), so a total length of 128. Cppcheck recommends to subtract one from the field width to leave room for the null byte at the end of the buffer.

Cppcheck error below:
```
[D:/Linux_home/nathan/src/OpenTTD/src/network/network.cpp:920] (warning) sscanf() without field width limits can crash with huge input data. Add a field width specifier to fix this problem.

Sample program that can crash:

#include <stdio.h>
int main()
{
    char c[5];
    scanf("%s", c);
    return 0;
}

Typing in 5 or more characters may make the program crash. The correct usage here is 'scanf("%4s", c);', as the maximum field width does not include the terminating null byte.
Source: http://linux.die.net/man/3/scanf
Source: http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/libkern/stdio/scanf.c [invalidscanf]```