### PR TITLE
Fix #7644: (Cocoa) Manually set colorspace to sRGB

### DIFF
--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -84,6 +84,7 @@ public:
 	int buffer_depth;     ///< Colour depth of used frame buffer
 	void *pixel_buffer;   ///< used for direct pixel access
 	void *window_buffer;  ///< Colour translation from palette to screen
+	CGColorSpaceRef color_space; //< Window color space
 	id window;            ///< Pointer to window object
 
 #	define MAX_DIRTY_RECTS 100


### PR DESCRIPTION
This commit manually sets the colorspace for the window to sRGB, as suggested in #7644 by @SoothedTau, to fix performance issues on OSX when using devices that use the P3 colorspace by default. This makes the game run smoothly on my laptop, with the full 33fps rate.

<img width="1380" alt="Screen Shot 2020-02-26 at 3 49 03 pm" src="https://user-images.githubusercontent.com/635580/75312950-8ad5a600-58af-11ea-94e4-3d05b6db03bd.png">
