### PR TITLE
Codechange: [AzurePipelines] Update MacOS image to 10.14

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -58,7 +58,7 @@ jobs:
 - job: macos
   displayName: 'MacOS'
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
 
   variables:
     MACOSX_DEPLOYMENT_TARGET: 10.9

--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -141,7 +141,7 @@ jobs:
 - job: macos
   displayName: 'MacOS'
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   dependsOn: source
 
   variables:


### PR DESCRIPTION
As per https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/, macOS-10.13 image will be removed from azure in the next month. So update to 10.14 to see what happens.

Could also update to 10.15 instead? Not sure if we want to do that for compatibility reasons or anything.

Will need to be backported to 1.10 branch so that the release can happen :)