### PR TITLE
Fix #7904: Don't use a timer for hundredth tick determination

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -13,6 +13,7 @@
 #include "strings_type.h"
 #include "company_type.h"
 #include "core/geometry_type.hpp"
+#include "guitimer_func.h"
 
 struct GRFFile;
 
@@ -27,7 +28,7 @@ enum WarningLevel {
 /** The data of the error message. */
 class ErrorMessageData {
 protected:
-	uint duration;                  ///< Length of display of the message. 0 means forever,
+	GUITimer display_timer;         ///< Timer before closing the message.
 	uint64 decode_params[20];       ///< Parameters of the message strings.
 	const char *strings[20];        ///< Copies of raw strings that were used.
 	const GRFFile *textref_stack_grffile; ///< NewGRF that filled the #TextRefStack for the error message.

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -691,7 +691,9 @@ public:
 	virtual void OnGameTick() {}
 
 	/**
-	 * Called once every 100 (game) ticks.
+	 * Called once every 100 (game) ticks, or once every 3s, whichever comes last.
+	 * In normal game speed the frequency is 1 call every 100 ticks (can be more than 3s).
+	 * In fast-forward the frequency is 1 call every ~3s (can be more than 100 ticks).
 	 */
 	virtual void OnHundredthTick() {}
 


### PR DESCRIPTION
I'm not really sure about how to test this change. But in theory, now, OnHundredthTick() will be called every 100 ticks when a tick is 30 ms or more. Call frequency will be reduced in fast forward as a tick is less than 30 ms in this case, but I don't think it should be an issue.