### PR TITLE
Change: A company goal type will open the company overview window when clicked

### DIFF
--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -19,6 +19,7 @@
 #include "core/geometry_func.hpp"
 #include "company_func.h"
 #include "company_base.h"
+#include "company_gui.h"
 #include "story_base.h"
 #include "command_func.h"
 #include "string_func.h"
@@ -106,7 +107,12 @@ struct GoalListWindow : public Window {
 		TileIndex xy;
 		switch (s->type) {
 			case GT_NONE: return;
-			case GT_COMPANY: return;
+
+			case GT_COMPANY:
+				/* s->dst here is not a tile, but a CompanyID.
+				 * Show the window with the overview of the company instead. */
+				ShowCompany((CompanyID)s->dst);
+				return;
 
 			case GT_TILE:
 				if (!IsValidTile(s->dst)) return;


### PR DESCRIPTION
https://docs.openttd.org/gs-api/classGSGoal.html

I noticed goals of type GT_COMPANY were "unclickable" even when I set a proper company.
`GSGoal.New(GSCompany.COMPANY_INVALID, "random text", GSGoal.GT_COMPANY, GSCompany.COMPANY_FIRST);`