### PR TITLE
Fix: [AI/GS] CanBuildConnectedRoadPartsHere neighbours tiles were at times incorrect

### DIFF
--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -401,7 +401,7 @@ static bool NormaliseTileOffset(int32 *tile)
 	if (::DistanceManhattan(tile, start) != 1 || ::DistanceManhattan(tile, end) != 1) return -1;
 
 	/*                                           ROAD_NW              ROAD_SW             ROAD_SE             ROAD_NE */
-	static const TileIndexDiff neighbours[] = {::TileDiffXY(0, -1), ::TileDiffXY(1, 0), ::TileDiffXY(0, 1), ::TileDiffXY(-1, 0)};
+	const TileIndexDiff neighbours[] = {::TileDiffXY(0, -1), ::TileDiffXY(1, 0), ::TileDiffXY(0, 1), ::TileDiffXY(-1, 0)};
 	Array *existing = (Array*)alloca(sizeof(Array) + lengthof(neighbours) * sizeof(int32));
 	existing->size = 0;
 


### PR DESCRIPTION
This bug was very difficult to reproduce.
Seems to happen when the map size changes between a save and another. In the first map that has an AI calling this function for the first time, the neighbours diffs are calculated. The next calls, no longer recomputes the neighbour diffs. If I now load a save of a different map size, the neighbours are still of the previous map.

PS: I request backport, if that is still possible. My AI makes heavy use of this function with the pathfinder routine.