### PR TITLE
Fix #8045: [AI/GS] Estimate costs for failed commands

### DIFF
--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -330,6 +330,11 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	/* Try to perform the command. */
 	CommandCost res = ::DoCommandPInternal(tile, p1, p2, cmd, (_networking && !_generating_world) ? ScriptObject::GetActiveInstance()->GetDoCommandCallback() : nullptr, text, false, estimate_only);
 
+	/* Estimates, update the cost for the estimate */
+	if (estimate_only) {
+		IncreaseDoCommandCosts(res.GetCost());
+	}
+
 	/* We failed; set the error and bail out */
 	if (res.Failed()) {
 		SetLastError(ScriptError::StringToError(res.GetErrorMessage()));
@@ -339,9 +344,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	/* No error, then clear it. */
 	SetLastError(ScriptError::ERR_NONE);
 
-	/* Estimates, update the cost for the estimate and be done */
 	if (estimate_only) {
-		IncreaseDoCommandCosts(res.GetCost());
 		return true;
 	}
 


### PR DESCRIPTION
I'm not sure of this fix in a larger scale. I tested against my AI and it now gets the estimated costs correctly for `AIVehicle.CloneVehicle` even when it is returned as failed.

Maybe the alternative would be to change `CmdCloneVehicle` to return true to estimate costs, I'm unsure.

https://github.com/OpenTTD/OpenTTD/blob/55e81d39737ccf7d7bbcca92d997ac4db862176d/src/vehicle_cmd.cpp#L978-L986