### PR TITLE
Add: Buttons to select script profile in the AI/GS configuration window

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -690,6 +690,11 @@ static const NWidgetPart _nested_ai_config_widgets[] = {
 				NWidget(WWT_TEXT, COLOUR_MAUVE, WID_AIC_NUMBER), SetDataTip(STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS, STR_NULL), SetFill(1, 0), SetPadding(1, 0, 0, 0),
 			EndContainer(),
 			NWidget(NWID_HORIZONTAL, NC_EQUALSIZE), SetPIP(7, 0, 7),
+				NWidget(WWT_TEXTBTN, COLOUR_YELLOW, WID_AIC_PROFILE_EASY), SetDataTip(STR_AI_CONFIG_PROFILE_EASY, STR_AI_CONFIG_PROFILE_TOOLTIP), SetFill(1, 1),
+				NWidget(WWT_TEXTBTN, COLOUR_YELLOW, WID_AIC_PROFILE_MEDIUM), SetDataTip(STR_AI_CONFIG_PROFILE_MEDIUM, STR_AI_CONFIG_PROFILE_TOOLTIP), SetFill(1, 1),
+				NWidget(WWT_TEXTBTN, COLOUR_YELLOW, WID_AIC_PROFILE_HARD), SetDataTip(STR_AI_CONFIG_PROFILE_HARD, STR_AI_CONFIG_PROFILE_TOOLTIP), SetFill(1, 1),
+			EndContainer(),
+			NWidget(NWID_HORIZONTAL, NC_EQUALSIZE), SetPIP(7, 0, 7),
 				NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_AIC_MOVE_UP), SetResize(1, 0), SetFill(1, 0), SetDataTip(STR_AI_CONFIG_MOVE_UP, STR_AI_CONFIG_MOVE_UP_TOOLTIP),
 				NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_AIC_MOVE_DOWN), SetResize(1, 0), SetFill(1, 0), SetDataTip(STR_AI_CONFIG_MOVE_DOWN, STR_AI_CONFIG_MOVE_DOWN_TOOLTIP),
 			EndContainer(),
@@ -888,6 +893,14 @@ struct AIConfigWindow : public Window {
 				break;
 			}
 
+			case WID_AIC_PROFILE_EASY:
+			case WID_AIC_PROFILE_MEDIUM:
+			case WID_AIC_PROFILE_HARD: {
+				int new_value = widget - WID_AIC_PROFILE_EASY;
+				IConsoleSetSetting("script.settings_profile", new_value);
+				break;
+			}
+
 			case WID_AIC_GAMELIST: {
 				this->selected_slot = OWNER_DEITY;
 				this->InvalidateData();
@@ -964,6 +977,10 @@ struct AIConfigWindow : public Window {
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
 			this->SetWidgetDisabledState(WID_AIC_TEXTFILE + tft, this->selected_slot == INVALID_COMPANY || (GetConfig(this->selected_slot)->GetTextfile(tft, this->selected_slot) == nullptr));
+		}
+
+		for (SettingsProfile sp = SP_BEGIN; sp < SP_END; sp++) {
+			this->SetWidgetLoweredState(WID_AIC_PROFILE_EASY + sp, GetGameSettings().script.settings_profile == sp);
 		}
 	}
 };

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4154,6 +4154,10 @@ STR_AI_CONFIG_MOVE_UP                                           :{BLACK}Move Up
 STR_AI_CONFIG_MOVE_UP_TOOLTIP                                   :{BLACK}Move selected AI up in the list
 STR_AI_CONFIG_MOVE_DOWN                                         :{BLACK}Move Down
 STR_AI_CONFIG_MOVE_DOWN_TOOLTIP                                 :{BLACK}Move selected AI down in the list
+STR_AI_CONFIG_PROFILE_EASY                                      :{BLACK}Easy
+STR_AI_CONFIG_PROFILE_MEDIUM                                    :{BLACK}Medium
+STR_AI_CONFIG_PROFILE_HARD                                      :{BLACK}Hard
+STR_AI_CONFIG_PROFILE_TOOLTIP                                   :{BLACK}Choose which settings profile to use for random AIs or for initial values when adding a new AI or Game Script
 
 STR_AI_CONFIG_GAMESCRIPT                                        :{SILVER}Game Script
 STR_AI_CONFIG_AI                                                :{SILVER}AIs

--- a/src/script/api/game/game_window.hpp.sq
+++ b/src/script/api/game/game_window.hpp.sq
@@ -178,6 +178,9 @@ void SQGSWindow_Register(Squirrel *engine)
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_GAMELIST,                          "WID_AIC_GAMELIST");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_LIST,                              "WID_AIC_LIST");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_SCROLLBAR,                         "WID_AIC_SCROLLBAR");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_PROFILE_EASY,                      "WID_AIC_PROFILE_EASY");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_PROFILE_MEDIUM,                    "WID_AIC_PROFILE_MEDIUM");
+	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_PROFILE_HARD,                      "WID_AIC_PROFILE_HARD");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_MOVE_UP,                           "WID_AIC_MOVE_UP");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_MOVE_DOWN,                         "WID_AIC_MOVE_DOWN");
 	SQGSWindow.DefSQConst(engine, ScriptWindow::WID_AIC_CHANGE,                            "WID_AIC_CHANGE");

--- a/src/script/api/script_window.hpp
+++ b/src/script/api/script_window.hpp
@@ -886,6 +886,9 @@ public:
 		WID_AIC_GAMELIST                             = ::WID_AIC_GAMELIST,                             ///< List with current selected GameScript.
 		WID_AIC_LIST                                 = ::WID_AIC_LIST,                                 ///< List with currently selected AIs.
 		WID_AIC_SCROLLBAR                            = ::WID_AIC_SCROLLBAR,                            ///< Scrollbar to scroll through the selected AIs.
+		WID_AIC_PROFILE_EASY                         = ::WID_AIC_PROFILE_EASY,                         ///< Easy profile button.
+		WID_AIC_PROFILE_MEDIUM                       = ::WID_AIC_PROFILE_MEDIUM,                       ///< Medium profile button.
+		WID_AIC_PROFILE_HARD                         = ::WID_AIC_PROFILE_HARD,                         ///< Hard profile button.
 		WID_AIC_MOVE_UP                              = ::WID_AIC_MOVE_UP,                              ///< Move up button.
 		WID_AIC_MOVE_DOWN                            = ::WID_AIC_MOVE_DOWN,                            ///< Move down button.
 		WID_AIC_CHANGE                               = ::WID_AIC_CHANGE,                               ///< Select another AI button.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1198,6 +1198,13 @@ static bool MaxNoAIsChange(int32 i)
 	return true;
 }
 
+static bool ScriptSettingsProfileChange(int32 i)
+{
+	InvalidateWindowClassesData(WC_GAME_OPTIONS, 0);
+	InvalidateWindowClassesData(WC_AI_SETTINGS, 0);
+	return true;
+}
+
 /**
  * Check whether the road side may be changed.
  * @param p1 unused

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -36,6 +36,7 @@ enum SettingsProfile {
 	SP_MULTIPLAYER = SP_SAVED_HIGHSCORE_END,  ///< Special "multiplayer" highscore. Not saved, always specific to the current game.
 	SP_HIGHSCORE_END,                         ///< End of highscore tables.
 };
+DECLARE_POSTFIX_INCREMENT(SettingsProfile)
 
 /** Available industry map generation densities. */
 enum IndustryDensity {

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -25,6 +25,7 @@ static bool DragSignalsDensityChanged(int32);
 static bool TownFoundingChanged(int32 p1);
 static bool DifficultyNoiseChange(int32 i);
 static bool MaxNoAIsChange(int32 i);
+static bool ScriptSettingsProfileChange(int32 i);
 static bool CheckRoadSide(int p1);
 static bool ChangeMaxHeightLevel(int32 p1);
 static bool CheckFreeformEdges(int32 p1);
@@ -1535,6 +1536,7 @@ def      = SP_EASY
 min      = SP_EASY
 max      = SP_HARD
 full     = _settings_profiles
+proc     = ScriptSettingsProfileChange
 str      = STR_CONFIG_SETTING_AI_PROFILE
 strhelp  = STR_CONFIG_SETTING_AI_PROFILE_HELPTEXT
 strval   = STR_CONFIG_SETTING_AI_PROFILE_EASY

--- a/src/widgets/ai_widget.h
+++ b/src/widgets/ai_widget.h
@@ -41,6 +41,9 @@ enum AIConfigWidgets {
 	WID_AIC_GAMELIST,         ///< List with current selected GameScript.
 	WID_AIC_LIST,             ///< List with currently selected AIs.
 	WID_AIC_SCROLLBAR,        ///< Scrollbar to scroll through the selected AIs.
+	WID_AIC_PROFILE_EASY,     ///< Easy profile button.
+	WID_AIC_PROFILE_MEDIUM,   ///< Medium profile button.
+	WID_AIC_PROFILE_HARD,     ///< Hard profile button.
 	WID_AIC_MOVE_UP,          ///< Move up button.
 	WID_AIC_MOVE_DOWN,        ///< Move down button.
 	WID_AIC_CHANGE,           ///< Select another AI button.


### PR DESCRIPTION
Adds 3 buttons with each profile on the AI/GS config window, and refreshes AI Parameters when changing to another profile.

![screenshot#1](https://user-images.githubusercontent.com/43006711/77694980-e5dbe500-6fa2-11ea-9f78-a48440095a2b.png)
![screenshot#2](https://user-images.githubusercontent.com/43006711/77694982-e6747b80-6fa2-11ea-81ee-5bea8c844b69.png)
![screenshot#3](https://user-images.githubusercontent.com/43006711/77694983-e70d1200-6fa2-11ea-9eed-011a11e65cba.png)
