### PR TITLE
Fix: Don't rerandomise a script's settings when loading from a save

### DIFF
--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -35,11 +35,6 @@ ScriptConfigItem _start_date_config = {
 
 AIConfig::AIConfig(const AIConfig *config) : ScriptConfig(config)
 {
-	/* Override start_date as per AIConfig::AddRandomDeviation().
-	 * This is necessary because the ScriptConfig constructor will instead call
-	 * ScriptConfig::AddRandomDeviation(). */
-	int start_date = config->GetSetting("start_date");
-	this->SetSetting("start_date", start_date != 0 ? max(1, this->GetSetting("start_date")) : 0);
 }
 
 /* static */ AIConfig *AIConfig::GetConfig(CompanyID company, ScriptSettingSource source)

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -52,7 +52,6 @@ ScriptConfig::ScriptConfig(const ScriptConfig *config)
 	for (SettingValueList::const_iterator it = config->settings.begin(); it != config->settings.end(); it++) {
 		this->settings[stredup((*it).first)] = (*it).second;
 	}
-	this->AddRandomDeviation();
 }
 
 ScriptConfig::~ScriptConfig()

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -29,7 +29,7 @@ void ScriptConfig::Change(const char *name, int version, bool force_exact_match,
 
 	this->ClearConfigList();
 
-	if (_game_mode == GM_NORMAL && this->info != nullptr) {
+	if (_game_mode == GM_NORMAL && _switch_mode != SM_LOAD_GAME && this->info != nullptr) {
 		/* If we're in an existing game and the Script is changed, set all settings
 		 *  for the Script that have the random flag to a random value. */
 		for (ScriptConfigItemList::const_iterator it = this->info->GetConfigList()->begin(); it != this->info->GetConfigList()->end(); it++) {


### PR DESCRIPTION
ScriptConfig stuff is all pretty hairy, but I'm pretty sure this is what's wanted. Besides, Samu's AfterFix AI is literally the only one on BaNaNaS that makes use of the random settings anyway.

Closes #7486 