### PR TITLE
Fix #8064: Incorrect display of refit capacity

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -169,7 +169,7 @@ CargoArray GetCapacityOfArticulatedParts(EngineID engine)
  * @param cargo_type Selected refitted cargo type
  * @param cargo_capacity Capacity of selected refitted cargo type
  */
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint16 cargo_capacity)
+void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint cargo_capacity)
 {
 	cargoes->Clear();
 	*refits = 0;

--- a/src/engine_func.h
+++ b/src/engine_func.h
@@ -24,7 +24,7 @@ extern const uint8 _engine_offsets[4];
 
 bool IsEngineBuildable(EngineID engine, VehicleType type, CompanyID company);
 bool IsEngineRefittable(EngineID engine);
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint16 cargo_capacity);
+void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint cargo_capacity);
 void SetYearEngineAgingStops();
 void StartupOneEngine(Engine *e, Date aging_date);
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -82,7 +82,7 @@ static const uint GEN_HASHX_MASK =  (1 << GEN_HASHX_BITS) - 1;
 static const uint GEN_HASHY_MASK = ((1 << GEN_HASHY_BITS) - 1) << GEN_HASHX_BITS;
 
 VehicleID _new_vehicle_id;
-uint16 _returned_refit_capacity;      ///< Stores the capacity after a refit operation.
+uint _returned_refit_capacity;        ///< Stores the capacity after a refit operation.
 uint16 _returned_mail_refit_capacity; ///< Stores the mail capacity after a refit operation (Aircraft only).
 
 

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -165,7 +165,7 @@ CommandCost EnsureNoVehicleOnGround(TileIndex tile);
 CommandCost EnsureNoTrainOnTrackBits(TileIndex tile, TrackBits track_bits);
 
 extern VehicleID _new_vehicle_id;
-extern uint16 _returned_refit_capacity;
+extern uint _returned_refit_capacity;
 extern uint16 _returned_mail_refit_capacity;
 
 bool CanVehicleUseStation(EngineID engine_type, const struct Station *st);

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -39,7 +39,7 @@ enum VehicleInvalidateWindowData {
 struct TestedEngineDetails {
 	Money cost;           ///< Refit cost
 	CargoID cargo;        ///< Cargo type
-	uint16 capacity;      ///< Cargo capacity
+	uint capacity;        ///< Cargo capacity
 	uint16 mail_capacity; ///< Mail capacity if available
 };
 


### PR DESCRIPTION
_returned_refit_capacity was too small to contain the total capacity
https://github.com/OpenTTD/OpenTTD/blob/7fe291667fbe75f01b03980fa3654b1bf387117f/src/vehicle_cmd.cpp#L448

Also increased `TestedEngineDetails::capacity` for this reason
https://github.com/OpenTTD/OpenTTD/blob/7fe291667fbe75f01b03980fa3654b1bf387117f/src/build_vehicle_gui.cpp#L1222

Then `GetArticulatedVehicleCargoesAndRefits()` signature required an update too.