### PR TITLE
Fix: Make goal question ID use 16 bits again

### DIFF
--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -244,7 +244,7 @@ CommandCost CmdSetGoalCompleted(TileIndex tile, DoCommandFlag flags, uint32 p1, 
  */
 CommandCost CmdGoalQuestion(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const char *text)
 {
-	uint16 uniqueid = (GoalType)GB(p1, 0, 16);
+	uint16 uniqueid = (uint16)GB(p1, 0, 16);
 	CompanyID company = (CompanyID)GB(p1, 16, 8);
 	ClientID client = (ClientID)GB(p1, 16, 16);
 


### PR DESCRIPTION
In 1.10.0 GoalType became 8-bit and so did question id that was for some reason using it.

#regression, #backport-requested ;)