### PR TITLE
Fix: [AI/GS] AreWaterTilesConnected wasn't handling aqueducts properly

### DIFF
--- a/src/script/api/script_marine.cpp
+++ b/src/script/api/script_marine.cpp
@@ -62,11 +62,11 @@
 	DiagDirection to_other_tile = ::DiagdirBetweenTiles(t2, t1);
 
 	/* Determine the reachable tracks from the shared edge */
-	TrackBits gtts1 = ::TrackStatusToTrackBits(::GetTileTrackStatus(t1, TRANSPORT_WATER, 0, to_other_tile)) & ::DiagdirReachesTracks(to_other_tile);
+	TrackBits gtts1 = ::TrackStatusToTrackBits(::GetTileTrackStatus(t1, TRANSPORT_WATER, 0, ReverseDiagDir(to_other_tile))) & ::DiagdirReachesTracks(to_other_tile);
 	if (gtts1 == TRACK_BIT_NONE) return false;
 
 	to_other_tile = ReverseDiagDir(to_other_tile);
-	TrackBits gtts2 = ::TrackStatusToTrackBits(::GetTileTrackStatus(t2, TRANSPORT_WATER, 0, to_other_tile)) & ::DiagdirReachesTracks(to_other_tile);
+	TrackBits gtts2 = ::TrackStatusToTrackBits(::GetTileTrackStatus(t2, TRANSPORT_WATER, 0, ReverseDiagDir(to_other_tile))) & ::DiagdirReachesTracks(to_other_tile);
 
 	return gtts2 != TRACK_BIT_NONE;
 }


### PR DESCRIPTION
[PR 8074 test AI.zip](https://github.com/OpenTTD/OpenTTD/files/4462111/PR.8074.test.AI.zip)
[aqueduct scenario.zip](https://github.com/OpenTTD/OpenTTD/files/4462112/aqueduct.scenario.zip)

There are 2 bugs being fixed. I have attached a scenario and an AI that must run with each other.

Bug 1: As an example, tiles 1700 and 1764 are connected, but AreWaterTilesConnected reports that they're not. There are others similar tiles that fall into the same bug.
Bug 2: As an example, tiles 2032 and 2096 aren't connected, but AreWaterTilesConnected reports that they are.

This PR attempts to fix those cases while still maintaining the results the same for the other test cases. I'm sure I didn't handle all the possible cases, but I hope the fixes don't break anything.

![Donfingfield Transport, 2160-06-22](https://user-images.githubusercontent.com/43006711/79002086-9fac8700-7b47-11ea-9ee8-5c3aa59c85c9.png)
