### PR TITLE
Add: [NewGRF] Industry behaviour flag to override second cargo produc…

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2685,7 +2685,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 				/* Prevent production to overflow or Oil Rig passengers to be over-"produced" */
 				new_prod = Clamp(new_prod, 1, 255);
 
-				if (((indspec->behaviour & INDUSTRYBEH_BUILT_ONWATER) != 0) && j == 1) {
+				if (((indspec->behaviour & INDUSTRYBEH_BUILT_ONWATER) != 0) && j == 1 && !(indspec->behaviour & INDUSTRYBEH_WATER_NO_CLAMP_PROD)) {
 					new_prod = Clamp(new_prod, 0, 16);
 				}
 

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -80,6 +80,7 @@ enum IndustryBehaviour {
 	INDUSTRYBEH_NOBUILT_MAPCREATION   = 1 << 16, ///< Do not force one instance of this type to appear on map generation
 	INDUSTRYBEH_CANCLOSE_LASTINSTANCE = 1 << 17, ///< Allow closing down the last instance of this type
 	INDUSTRYBEH_CARGOTYPES_UNLIMITED  = 1 << 18, ///< Allow produced/accepted cargoes callbacks to supply more than 2 and 3 types
+	INDUSTRYBEH_WATER_NO_CLAMP_PROD   = 1 << 19, ///< Do not clamp production of second cargo for water industries
 };
 DECLARE_ENUM_AS_BIT_SET(IndustryBehaviour)
 


### PR DESCRIPTION
…tion clamping for water industries when using smooth economy.

Smooth economy is only used when the corresponding setting is enabled and the industries does not use the production callback.