### PR TITLE
Fix: reset roadtype/streetcartype info for non-road bridges

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3118,6 +3118,14 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionUntil(SLV_ENDING_YEAR)) {
+		for (TileIndex t = 0; t < map_size; t++) {
+			if (IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) != TRANSPORT_ROAD) {
+				SetRoadTypes(t, INVALID_ROADTYPE, INVALID_ROADTYPE);
+			}
+		}
+	}
+
 	/* Update station docking tiles. */
 	AfterLoadScanDockingTiles();
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -770,6 +770,19 @@ static inline bool IsSavegameVersionBefore(SaveLoadVersion major, byte minor = 0
 }
 
 /**
+ * Checks whether the savegame is below or at \a major. This should be used to repair data from existing
+ * savegames which is no longer corrupted in new savegames, but for which otherwise no savegame
+ * bump is required.
+ * @param major Major number of the version to check against.
+ * @return Savegame version is at most the specified version.
+ */
+static inline bool IsSavegameVersionUntil(SaveLoadVersion major)
+{
+	extern SaveLoadVersion _sl_version;
+	return _sl_version <= major;
+}
+
+/**
  * Checks if some version from/to combination falls within the range of the
  * active savegame version.
  * @param version_from Inclusive savegame version lower bound.


### PR DESCRIPTION
Roadtype information in m4/m8 is potentially wrong for all non-road bridges build before the introduction of NRT, even if they've been saved in a later version.

TTD savegames like the one from https://github.com/OpenTTD/OpenTTD/issues/8108 demonstrate this. If you use the land area information tile on a rail bridge, it shows road/streetcar type lines that should not be there.
Rail type...
rail speed limit...
Road type: Road
Streetcar type: Road

Not sure how to go about the current "apply fix for everything up to but including the current savegame level" bit. I could bump the savegame version, which is slightly cleaner. Or we could leave this as is and remove the extern/change the if the next time the savegame level gets bumped.