### PR TITLE
Fix #8102: Update Windows installer strings to reference newer Windows version

### DIFF
--- a/os/windows/installer/install.nsi
+++ b/os/windows/installer/install.nsi
@@ -599,12 +599,12 @@ Function CheckWindowsVersion
 	StrCmp $R0 "win9x" 0 WinNT
 	ClearErrors
 	StrCmp ${APPARCH} "win9x" Done 0
-	MessageBox MB_YESNO|MB_ICONSTOP "You are trying to install the Windows XP SP3, Vista and 7 version on Windows 95, 98, ME, 2000 and XP without SP3. This is will not work. Please download the correct version. Do you really want to continue?" IDYES Done IDNO Abort
+	MessageBox MB_YESNO|MB_ICONSTOP "You are trying to install the Windows XP SP3 and newer version on Windows 95, 98, ME, 2000, or XP without SP3. This will not work - please download the correct version. Do you really want to continue?" IDYES Done IDNO Abort
 	GoTo Done
 WinNT:
 	ClearErrors
 	StrCmp ${APPARCH} "win9x" 0 Done
-	MessageBox MB_YESNO|MB_ICONEXCLAMATION "You are trying to install the Windows 95, 98, 2000 and XP without SP3 version on Windows XP SP3, Vista or 7. This is not advised, but will work with reduced capabilities. We suggest that you download the correct version. Do you really want to continue?" IDYES Done IDNO Abort
+	MessageBox MB_YESNO|MB_ICONEXCLAMATION "You are trying to install the Windows 95, 98, 2000 and XP without SP3 version on Windows XP SP3 or newer. This is not advised, but will work with reduced capabilities. We suggest that you download the correct version. Do you really want to continue?" IDYES Done IDNO Abort
 Abort:
 	Quit
 Done:

--- a/os/windows/installer/version_win32.txt
+++ b/os/windows/installer/version_win32.txt
@@ -1,5 +1,5 @@
 !define APPBITS 32          ; Define number of bits for the architecture
-!define EXTRA_VERSION "XP SP3 and Newer"
+!define EXTRA_VERSION "XP SP3 and newer"
 !define APPARCH "win32"     ; Define the application architecture
 !define BINARY_DIR "${PATH_ROOT}objs\win32\Release"
 InstallDir "$PROGRAMFILES32\OpenTTD\"

--- a/os/windows/installer/version_win32.txt
+++ b/os/windows/installer/version_win32.txt
@@ -1,5 +1,5 @@
 !define APPBITS 32          ; Define number of bits for the architecture
-!define EXTRA_VERSION "XP SP3, Vista and 7"
+!define EXTRA_VERSION "XP SP3 and Newer"
 !define APPARCH "win32"     ; Define the application architecture
 !define BINARY_DIR "${PATH_ROOT}objs\win32\Release"
 InstallDir "$PROGRAMFILES32\OpenTTD\"

--- a/os/windows/installer/version_win64.txt
+++ b/os/windows/installer/version_win64.txt
@@ -1,5 +1,5 @@
 !define APPBITS 64          ; Define number of bits for the architecture
-!define EXTRA_VERSION "XP and Newer"
+!define EXTRA_VERSION "XP and newer"
 !define APPARCH "win64"     ; Define the application architecture
 !define BINARY_DIR "${PATH_ROOT}objs\x64\Release"
 InstallDir "$PROGRAMFILES64\OpenTTD\"

--- a/os/windows/installer/version_win64.txt
+++ b/os/windows/installer/version_win64.txt
@@ -1,5 +1,5 @@
 !define APPBITS 64          ; Define number of bits for the architecture
-!define EXTRA_VERSION "XP, Vista and 7"
+!define EXTRA_VERSION "XP and Newer"
 !define APPARCH "win64"     ; Define the application architecture
 !define BINARY_DIR "${PATH_ROOT}objs\x64\Release"
 InstallDir "$PROGRAMFILES64\OpenTTD\"

--- a/os/windows/installer/version_win9x.txt
+++ b/os/windows/installer/version_win9x.txt
@@ -1,5 +1,5 @@
 !define APPBITS 32          ; Define number of bits for the architecture
-!define EXTRA_VERSION "95, 98, ME, 2000 and XP without SP3"
+!define EXTRA_VERSION "95, 98, ME, 2000 and XP SP2 or older"
 !define APPARCH "win9x"     ; Define the application architecture
 !define BINARY_DIR "${PATH_ROOT}objs\release"
 InstallDir "$PROGRAMFILES32\OpenTTD\"


### PR DESCRIPTION
The old strings didn't make it obvious that Windows versions newer than 7 were supported.

I've updated the Windows installer strings to make this more obvious, and also improved the grammar of some of the pre-install warnings.