### PR TITLE
GS methods to let company have exclusive access to the industry

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1042,6 +1042,8 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 		/* Check if industry temporarily refuses acceptance */
 		if (IndustryTemporarilyRefusesCargo(ind, cargo_type)) continue;
 
+		if (ind->exclusive_supplier != INVALID_OWNER && ind->exclusive_supplier != st->owner) continue;
+
 		/* Insert the industry into _cargo_delivery_destinations, if not yet contained */
 		include(_cargo_delivery_destinations, ind);
 

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -29,7 +29,7 @@ int UpdateCompanyRatingAndValue(Company *c, bool update);
 void StartupIndustryDailyChanges(bool init_counter);
 
 Money GetTransportedGoodsIncome(uint num_pieces, uint dist, byte transit_days, CargoID cargo_type);
-uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList *all_stations);
+uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList *all_stations, Owner exclusivity = INVALID_OWNER);
 
 void PrepareUnload(Vehicle *front_v);
 void LoadUnloadStation(Station *st);

--- a/src/industry.h
+++ b/src/industry.h
@@ -90,6 +90,8 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	uint8 construction_type;       ///< Way the industry was constructed (@see IndustryConstructionType)
 	Date last_cargo_accepted_at[INDUSTRY_NUM_INPUTS]; ///< Last day each cargo type was accepted by this industry
 	byte selected_layout;          ///< Which tile layout was used when creating the industry
+	Owner exclusive_supplier;      ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
+	Owner exclusive_consumer;      ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)
 
 	uint16 random;                 ///< Random value used for randomisation of all kinds of things
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3125,6 +3125,14 @@ bool AfterLoadGame()
 		}
 	}
 
+	/* Make sure all industries exclusive supplier/consumer set correctly. */
+	if (IsSavegameVersionBefore(SLV_GS_INDUSTRY_CONTROL)) {
+		for (Industry *i : Industry::Iterate()) {
+			i->exclusive_supplier = INVALID_OWNER;
+			i->exclusive_consumer = INVALID_OWNER;
+		}
+	}
+
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();
 

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -64,6 +64,8 @@ static const SaveLoad _industry_desc[] = {
 	SLE_CONDVAR(Industry, last_cargo_accepted_at[0],  SLE_INT32,                 SLV_70, SLV_EXTEND_INDUSTRY_CARGO_SLOTS),
 	SLE_CONDARR(Industry, last_cargo_accepted_at,     SLE_INT32, 16,            SLV_EXTEND_INDUSTRY_CARGO_SLOTS, SL_MAX_VERSION),
 	SLE_CONDVAR(Industry, selected_layout,            SLE_UINT8,                 SLV_73, SL_MAX_VERSION),
+	SLE_CONDVAR(Industry, exclusive_supplier,         SLE_UINT8,                 SLV_GS_INDUSTRY_CONTROL, SL_MAX_VERSION),
+	SLE_CONDVAR(Industry, exclusive_consumer,         SLE_UINT8,                 SLV_GS_INDUSTRY_CONTROL, SL_MAX_VERSION),
 
 	SLEG_CONDARR(_old_ind_persistent_storage.storage, SLE_UINT32, 16,            SLV_76, SLV_161),
 	SLE_CONDREF(Industry, psa,                        REF_STORAGE,              SLV_161, SL_MAX_VERSION),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -320,7 +320,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_START_PATCHPACKS,                   ///< 220  First known patchpack to use a version just above ours.
 	SLV_END_PATCHPACKS = 286,               ///< 286  Last known patchpack to use a version just above ours.
 
-	SLV_GS_INDUSTRY_CONTROL,                ///< 287  PR#7912 GS industry control.
+	SLV_GS_INDUSTRY_CONTROL,                ///< 287  PR#7912 and PR#8115 GS industry control.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -23,8 +23,12 @@
  * \li GSEventStoryPageVehicleSelect
  * \li GSIndustry::GetCargoLastAcceptedDate
  * \li GSIndustry::GetControlFlags
+ * \li GSIndustry::GetExclusiveConsumer
+ * \li GSIndustry::GetExclusiveSupplier
  * \li GSIndustry::GetLastProductionYear
  * \li GSIndustry::SetControlFlags
+ * \li GSIndustry::SetExclusiveConsumer
+ * \li GSIndustry::SetExclusiveSupplier
  * \li GSStoryPage::MakePushButtonReference
  * \li GSStoryPage::MakeTileButtonReference
  * \li GSStoryPage::MakeVehicleButtonReference

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -10,7 +10,10 @@
 #include "../../stdafx.h"
 #include "script_industry.hpp"
 #include "script_cargo.hpp"
+#include "script_company.hpp"
+#include "script_error.hpp"
 #include "script_map.hpp"
+#include "../../company_base.h"
 #include "../../industry.h"
 #include "../../strings_func.h"
 #include "../../station_base.h"
@@ -240,4 +243,42 @@ bool ScriptIndustry::SetControlFlags(IndustryID industry_id, uint32 control_flag
 	if (!IsValidIndustry(industry_id)) return false;
 
 	return ScriptObject::DoCommand(0, industry_id, 0 | ((control_flags & ::INDCTL_MASK) << 8), CMD_INDUSTRY_CTRL);
+}
+
+/* static */ ScriptCompany::CompanyID ScriptIndustry::GetExclusiveSupplier(IndustryID industry_id)
+{
+	if (!IsValidIndustry(industry_id)) return ScriptCompany::COMPANY_INVALID;
+
+	auto company_id = ::Industry::Get(industry_id)->exclusive_supplier;
+	if (!::Company::IsValidID(company_id)) return ScriptCompany::COMPANY_INVALID;
+
+	return (ScriptCompany::CompanyID)((byte)company_id);
+}
+
+/* static */ bool ScriptIndustry::SetExclusiveSupplier(IndustryID industry_id, ScriptCompany::CompanyID company_id)
+{
+	EnforcePrecondition(false, IsValidIndustry(industry_id));
+
+	auto company = ScriptCompany::ResolveCompanyID(company_id);
+	::Owner owner = (company == ScriptCompany::COMPANY_INVALID ? ::INVALID_OWNER : (::Owner)company);
+	return ScriptObject::DoCommand(0, industry_id, 1 | (((uint8)owner) << 16), CMD_INDUSTRY_CTRL);
+}
+
+/* static */ ScriptCompany::CompanyID ScriptIndustry::GetExclusiveConsumer(IndustryID industry_id)
+{
+	if (!IsValidIndustry(industry_id)) return ScriptCompany::COMPANY_INVALID;
+
+	auto company_id = ::Industry::Get(industry_id)->exclusive_consumer;
+	if (!::Company::IsValidID(company_id)) return ScriptCompany::COMPANY_INVALID;
+
+	return (ScriptCompany::CompanyID)((byte)company_id);
+}
+
+/* static */ bool ScriptIndustry::SetExclusiveConsumer(IndustryID industry_id, ScriptCompany::CompanyID company_id)
+{
+	EnforcePrecondition(false, IsValidIndustry(industry_id));
+
+	auto company = ScriptCompany::ResolveCompanyID(company_id);
+	::Owner owner = (company == ScriptCompany::COMPANY_INVALID ? ::INVALID_OWNER : (::Owner)company);
+	return ScriptObject::DoCommand(0, industry_id, 2 | (((uint8)owner) << 16), CMD_INDUSTRY_CTRL);
 }

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -10,8 +10,9 @@
 #ifndef SCRIPT_INDUSTRY_HPP
 #define SCRIPT_INDUSTRY_HPP
 
-#include "script_object.hpp"
+#include "script_company.hpp"
 #include "script_date.hpp"
+#include "script_object.hpp"
 #include "../../industry.h"
 
 /**
@@ -259,6 +260,47 @@ public:
 	 * @api -ai
 	 */
 	static bool SetControlFlags(IndustryID industry_id, uint32 control_flags);
+
+	/**
+	 * Find out which company currently has the exclusive rights to deliver cargo to the industry.
+	 * @param industry_id The index of the industry.
+	 * @pre IsValidIndustry(industry_id).
+	 * @return The company that has the exclusive rights. The value
+	 *         ScriptCompany::COMPANY_INVALID means that there are currently no
+	 *         exclusive rights given out to anyone.
+	 */
+	static ScriptCompany::CompanyID GetExclusiveSupplier(IndustryID industry_id);
+
+	/**
+	 * Sets or resets the company that has exclusive right to deliver cargo to the industry.
+	 * @param industry_id The index of the industry.
+	 * @param company_id The company to set (ScriptCompany::COMPANY_INVALID to reset).
+	 * @pre IsValidIndustry(industry_id).
+	 * @return True if the action succeeded.
+	 * @api -ai
+	 */
+	static bool SetExclusiveSupplier(IndustryID industry_id, ScriptCompany::CompanyID company_id);
+
+	/**
+	 * Find out which company currently has the exclusive rights to take cargo from the industry.
+	 * @param industry_id The index of the industry.
+	 * @pre IsValidIndustry(industry_id).
+	 * @return The company that has the exclusive rights. The value
+	 *         ScriptCompany::COMPANY_SPECTATOR means that there are currently no
+	 *         exclusive rights given out to anyone.
+	 */
+	static ScriptCompany::CompanyID GetExclusiveConsumer(IndustryID industry_id);
+
+	/**
+	 * Sets or resets the company that has exclusive right to take cargo from the industry.
+	 * @param industry_id The index of the industry.
+	 * @param company_id The company to set (ScriptCompany::COMPANY_INVALID to reset).
+	 * @pre IsValidIndustry(industry_id).
+	 * @return True if the action succeeded.
+	 * @api -ai
+	 */
+	static bool SetExclusiveConsumer(IndustryID industry_id, ScriptCompany::CompanyID company_id);
+
 };
 
 #endif /* SCRIPT_INDUSTRY_HPP */

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4013,7 +4013,7 @@ static bool CanMoveGoodsToStation(const Station *st, CargoID type)
 	return true;
 }
 
-uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList *all_stations)
+uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, SourceID source_id, const StationList *all_stations, Owner exclusivity)
 {
 	/* Return if nothing to do. Also the rounding below fails for 0. */
 	if (all_stations->empty()) return 0;
@@ -4024,6 +4024,7 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 	std::vector<StationInfo> used_stations;
 
 	for (Station *st : *all_stations) {
+		if (exclusivity != INVALID_OWNER && exclusivity != st->owner) continue;
 		if (!CanMoveGoodsToStation(st, type)) continue;
 
 		/* Avoid allocating a vector if there is only one station to significantly


### PR DESCRIPTION
This is now build on top of #7912, which is included in the commits. Merge #7912 before this!

----

This allows GS to set/reset some company as an exclusive consumer or supplier for the industry. Meaning only that company would be able to take from / deliver to this industry.

This will allow multiplayer servers to cover most of the industry sharing scenarios that atm have to be enforced by rules and moderation. For example:
- Make the company "own" funded industry. (set both consumer/supplier to the founder company).
- Only allow sharing on primary industries (set exclusive consumer to the first company delivering cargo to the non-primary industry).
- On competitive servers stop companies from helping each other by delivering cargo to the secondary industry (set the first company as exclusive supplier).

I also decided to remove the unused owner field in the industry structure as it's somewhat related.

GS to test stuff (sets both consumer/supplier to the first company delivering or taking cargo):
[ownit.zip](https://github.com/OpenTTD/OpenTTD/files/4583379/ownit.zip)

It can probably be better to somehow merge this with #7912 to save on network commands and savegame versions but I've no idea what's the proper way to do that.