### PR TITLE
Fix: Stop any gamelog action when recovering from SlError()

### DIFF
--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -87,6 +87,11 @@ void GamelogStopAction()
 	if (print) GamelogPrintDebug(5);
 }
 
+void GamelogStopAnyAction()
+{
+	if (_gamelog_action_type != GLAT_NONE) GamelogStopAction();
+}
+
 /**
  * Frees the memory allocated by a gamelog
  */

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -27,6 +27,7 @@ enum GamelogActionType {
 
 void GamelogStartAction(GamelogActionType at);
 void GamelogStopAction();
+void GamelogStopAnyAction();
 
 void GamelogFree(struct LoggedAction *gamelog_action, uint gamelog_actions);
 void GamelogReset();

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -341,6 +341,10 @@ void NORETURN SlError(StringID string, const char *extra_msg)
 	 * when we access them during cleaning the pool dereferences of
 	 * those indices will be made with segmentation faults as result. */
 	if (_sl.action == SLA_LOAD || _sl.action == SLA_PTRS) SlNullPointers();
+
+	/* Logging could be active. */
+	GamelogStopAnyAction();
+
 	throw std::exception();
 }
 


### PR DESCRIPTION
I noticed the issue when trying to load [MC Transport.sav.zip](https://github.com/OpenTTD/OpenTTD/files/4605762/MC.Transport.sav.zip) from #4524