### PR TITLE
Fix #8132: Corrupted savegame crashing OpenTTD on load

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -898,6 +898,9 @@ bool AfterLoadGame()
 			case MP_STATION: {
 				BaseStation *bst = BaseStation::GetByTile(t);
 
+				/* Sanity check */
+				if (bst->owner != GetTileOwner(t)) SlErrorCorrupt("Wrong owner for station tile");
+
 				/* Set up station spread */
 				bst->rect.BeforeAddTile(t, StationRect::ADD_FORCE);
 


### PR DESCRIPTION
OpenTTD still crashes but #8133 solves that.