### PR TITLE
Fix #8137: Rectangular industry area used for stations_near calculation

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1698,7 +1698,7 @@ static void PopulateStationsNearby(Industry *ind)
 	}
 
 	/* Get our list of nearby stations. */
-	FindStationsAroundTiles(ind->location, &ind->stations_near, false);
+	FindStationsAroundTiles(ind->location, &ind->stations_near, false, ind->index);
 
 	/* Test if industry can accept cargo */
 	uint cargo_index;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3971,8 +3971,9 @@ static void AddNearbyStationsByCatchment(TileIndex tile, StationList *stations, 
  * @param location The location/area of the producer
  * @param[out] stations The list to store the stations in
  * @param use_nearby Use nearby station list of industry/town associated with location.tile
+ * @param industry_filter Filter location parameter to only include industry tiles of the given industry ID, this may be INVALID_INDUSTRY to perform no filtering
  */
-void FindStationsAroundTiles(const TileArea &location, StationList * const stations, bool use_nearby)
+void FindStationsAroundTiles(const TileArea &location, StationList * const stations, bool use_nearby, const IndustryID industry_filter)
 {
 	if (use_nearby) {
 		/* Industries and towns maintain a list of nearby stations */
@@ -4008,6 +4009,7 @@ void FindStationsAroundTiles(const TileArea &location, StationList * const stati
 
 		/* Test if the tile is within the station's catchment */
 		TILE_AREA_LOOP(tile, location) {
+			if (industry_filter != INVALID_INDUSTRY && (!IsTileType(tile, MP_INDUSTRY) || GetIndustryIndex(tile) != industry_filter)) continue;
 			if (st->TileIsInCatchment(tile)) {
 				stations->insert(st);
 				break;

--- a/src/station_func.h
+++ b/src/station_func.h
@@ -22,7 +22,7 @@
 
 void ModifyStationRatingAround(TileIndex tile, Owner owner, int amount, uint radius);
 
-void FindStationsAroundTiles(const TileArea &location, StationList *stations, bool use_nearby = true);
+void FindStationsAroundTiles(const TileArea &location, StationList *stations, bool use_nearby = true, IndustryID industry_filter = INVALID_INDUSTRY);
 
 void ShowStationViewWindow(StationID station);
 void UpdateAllStationVirtCoords();


### PR DESCRIPTION
This could result in stations being incorrectly added in the case of
non-rectangular industries where the station's catchment only
intersected with a non-industry tile subset of the overall rectangular
industry area.

This could cause multiplayer desyncs.