### PR TITLE
Fix: sdl2-config would always be detected as present

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -2434,7 +2434,7 @@ detect_sdl() {
 		detect_pkg_config "2" "sdl2" "sdl2_config" "2.0"
 	else
 		sdl2_config=""
-		if [ -x `which sdl2-config` ]; then
+		if [ -x "`which sdl2-config`" ]; then
 			detect_pkg_config "$with_sdl" "sdl2" "sdl2_config" "2.0"
 		fi
 		if [ -z "$sdl2_config" ]; then


### PR DESCRIPTION
The presence of sdl2-config is used go determine whether to look for
sdl2 first, or just sdl1. However, when sdl2-config is *not* present,
`which` returns an empty string. Due to lack of quoting, this produces
`[ -x ]`, rather than `[ -x "" ]` and it turns out the former actually
has a succesful exit status for some reason.

This was not a problem when just running configure, because it would
then just fail to detect sdl2 and fall back to sdl1. However, when
passing `--with-sdl` (without specifying a version), this would only
attempt to detect sdl2, even when sdl2-config was not present, but sdl1
is.

Adding quotes makes the check work as intended.