### PR TITLE
Fix #8131: small bridges also have pillars drawn

### DIFF
--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1623,22 +1623,7 @@ void DrawBridgeMiddle(const TileInfo *ti)
 	if (IsInvisibilitySet(TO_BRIDGES)) return;
 
 	psid++;
-	if (ti->z + 5 == z) {
-		/* draw poles below for small bridges */
-		if (psid->sprite != 0) {
-			SpriteID image = psid->sprite;
-			SpriteID pal   = psid->pal;
-			if (IsTransparencySet(TO_BRIDGES)) {
-				SetBit(image, PALETTE_MODIFIER_TRANSPARENT);
-				pal = PALETTE_TO_TRANSPARENT;
-			}
-
-			DrawGroundSpriteAt(image, pal, x - ti->x, y - ti->y, z - ti->z);
-		}
-	} else {
-		/* draw pillars below for high bridges */
-		DrawBridgePillars(psid, ti, axis, drawfarpillar, x, y, z);
-	}
+	DrawBridgePillars(psid, ti, axis, drawfarpillar, x, y, z);
 }
 
 


### PR DESCRIPTION
Fixes issue #8131 
I have basically removed the code to draw poles below for small bridges as a ground sprite using `DrawGroundSpriteAt()`.

Instead all pillions of bridges will be drawn by `DrawBridgePillars()`

I am unsure of what all this will break. Please give me some scenarios to test with. I have played around with this and doesn't break the game for me.

![Screenshot from 2020-05-15 11-48-08](https://user-images.githubusercontent.com/16652000/82018043-10444780-96a2-11ea-9690-c56addb50e01.png)
