### PR TITLE
Fix: Incorrect save/load array size of Town::cargo_accepted

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2830,7 +2830,7 @@ bool AfterLoadGame()
 	 * which is done by StartupEngines(). */
 	if (gcf_res != GLC_ALL_GOOD) StartupEngines();
 
-	if (IsSavegameVersionBefore(SLV_166)) {
+	if (IsSavegameVersionBefore(SLV_FIX_TOWN_ACCEPTANCE)) {
 		/* Update cargo acceptance map of towns. */
 		for (TileIndex t = 0; t < map_size; t++) {
 			if (!IsTileType(t, MP_HOUSE)) continue;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -467,16 +467,6 @@ static inline void SlWriteUint64(uint64 x)
 }
 
 /**
- * Read in bytes from the file/data structure but don't do
- * anything with them, discarding them in effect
- * @param length The amount of bytes that is being treated this way
- */
-static inline void SlSkipBytes(size_t length)
-{
-	for (; length != 0; length--) SlReadByte();
-}
-
-/**
  * Read in the header descriptor of an object or an array.
  * If the highest bit is set (7), then the index is bigger than 127
  * elements, so use the next byte to read in the real value.

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -302,6 +302,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_MULTITILE_DOCKS,                    ///< 216  PR#7380 Multiple docks per station.
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10 Configurable ending year.
+	SLV_FIX_TOWN_ACCEPTANCE,                ///< 219  PR#8157 Fix Town::cargo_accepted savegame format.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -865,6 +865,16 @@ void NORETURN SlErrorCorruptFmt(const char *format, ...);
 
 bool SaveloadCrashWithMissingNewGRFs();
 
+/**
+ * Read in bytes from the file/data structure but don't do
+ * anything with them, discarding them in effect
+ * @param length The amount of bytes that is being treated this way
+ */
+static inline void SlSkipBytes(size_t length)
+{
+	for (; length != 0; length--) SlReadByte();
+}
+
 extern char _savegame_format[8];
 extern bool _do_autosave;
 

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -256,7 +256,7 @@ static void RealSave_Town(Town *t)
 	SlObject(&t->cargo_accepted, GetTileMatrixDesc());
 	if (t->cargo_accepted.area.w != 0) {
 		uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
-		SlArray(t->cargo_accepted.data, arr_len, SLE_UINT32);
+		SlArray(t->cargo_accepted.data, arr_len, SLE_UINT64);
 	}
 }
 
@@ -288,16 +288,23 @@ static void Load_TOWN()
 			SlErrorCorrupt("Invalid town name generator");
 		}
 
-		if (IsSavegameVersionBefore(SLV_166)) continue;
+		if (!IsSavegameVersionBefore(SLV_FIX_TOWN_ACCEPTANCE)) {
+			SlObject(&t->cargo_accepted, GetTileMatrixDesc());
+			if (t->cargo_accepted.area.w != 0) {
+				uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
+				t->cargo_accepted.data = MallocT<CargoTypes>(arr_len);
+				SlArray(t->cargo_accepted.data, arr_len, SLE_UINT64);
 
-		SlObject(&t->cargo_accepted, GetTileMatrixDesc());
-		if (t->cargo_accepted.area.w != 0) {
-			uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
-			t->cargo_accepted.data = MallocT<CargoTypes>(arr_len);
-			SlArray(t->cargo_accepted.data, arr_len, SLE_UINT32);
-
-			/* Rebuild total cargo acceptance. */
-			UpdateTownCargoTotal(t);
+				/* Rebuild total cargo acceptance. */
+				UpdateTownCargoTotal(t);
+			}
+		} else if (!IsSavegameVersionBefore(SLV_166)) {
+			AcceptanceMatrix cargo_accepted;
+			SlObject(&cargo_accepted, GetTileMatrixDesc());
+			if (cargo_accepted.area.w != 0) {
+				uint arr_len = cargo_accepted.area.w / AcceptanceMatrix::GRID * cargo_accepted.area.h / AcceptanceMatrix::GRID;
+				SlSkipBytes(4 * arr_len);
+			}
 		}
 	}
 }


### PR DESCRIPTION
In 11ab3c4 the number of cargo types was changed from 32 to 64.
The save/load of Town::cargo_accepted was not updated, such that
only half of the data structure is saved/loaded in savegame versions
199 to 218.
Discard and regenerate data from all savegame versions prior to 219.