### PR TITLE
Make subsidies scan for town cargo instead of wasting resources and risking desyncs by maintaining cargo caches

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2830,7 +2830,7 @@ bool AfterLoadGame()
 	 * which is done by StartupEngines(). */
 	if (gcf_res != GLC_ALL_GOOD) StartupEngines();
 
-	if (IsSavegameVersionBefore(SLV_FIX_TOWN_ACCEPTANCE)) {
+	if (IsSavegameVersionBefore(SLV_166)) {
 		/* Update cargo acceptance map of towns. */
 		for (TileIndex t = 0; t < map_size; t++) {
 			if (!IsTileType(t, MP_HOUSE)) continue;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2830,18 +2830,6 @@ bool AfterLoadGame()
 	 * which is done by StartupEngines(). */
 	if (gcf_res != GLC_ALL_GOOD) StartupEngines();
 
-	if (IsSavegameVersionBefore(SLV_166)) {
-		/* Update cargo acceptance map of towns. */
-		for (TileIndex t = 0; t < map_size; t++) {
-			if (!IsTileType(t, MP_HOUSE)) continue;
-			Town::Get(GetTownIndex(t))->cargo_accepted.Add(t);
-		}
-
-		for (Town *town : Town::Iterate()) {
-			UpdateTownCargoes(town);
-		}
-	}
-
 	/* The road owner of standard road stops was not properly accounted for. */
 	if (IsSavegameVersionBefore(SLV_172)) {
 		for (TileIndex t = 0; t < map_size; t++) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -302,7 +302,6 @@ enum SaveLoadVersion : uint16 {
 	SLV_MULTITILE_DOCKS,                    ///< 216  PR#7380 Multiple docks per station.
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10 Configurable ending year.
-	SLV_FIX_TOWN_ACCEPTANCE,                ///< 219  PR#8157 Fix Town::cargo_accepted savegame format.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -256,7 +256,7 @@ static void RealSave_Town(Town *t)
 	SlObject(&t->cargo_accepted, GetTileMatrixDesc());
 	if (t->cargo_accepted.area.w != 0) {
 		uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
-		SlArray(t->cargo_accepted.data, arr_len, SLE_UINT64);
+		SlArray(t->cargo_accepted.data, arr_len, SLE_UINT32);
 	}
 }
 
@@ -288,23 +288,16 @@ static void Load_TOWN()
 			SlErrorCorrupt("Invalid town name generator");
 		}
 
-		if (!IsSavegameVersionBefore(SLV_FIX_TOWN_ACCEPTANCE)) {
-			SlObject(&t->cargo_accepted, GetTileMatrixDesc());
-			if (t->cargo_accepted.area.w != 0) {
-				uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
-				t->cargo_accepted.data = MallocT<CargoTypes>(arr_len);
-				SlArray(t->cargo_accepted.data, arr_len, SLE_UINT64);
+		if (IsSavegameVersionBefore(SLV_166)) continue;
 
-				/* Rebuild total cargo acceptance. */
-				UpdateTownCargoTotal(t);
-			}
-		} else if (!IsSavegameVersionBefore(SLV_166)) {
-			AcceptanceMatrix cargo_accepted;
-			SlObject(&cargo_accepted, GetTileMatrixDesc());
-			if (cargo_accepted.area.w != 0) {
-				uint arr_len = cargo_accepted.area.w / AcceptanceMatrix::GRID * cargo_accepted.area.h / AcceptanceMatrix::GRID;
-				SlSkipBytes(4 * arr_len);
-			}
+		SlObject(&t->cargo_accepted, GetTileMatrixDesc());
+		if (t->cargo_accepted.area.w != 0) {
+			uint arr_len = t->cargo_accepted.area.w / AcceptanceMatrix::GRID * t->cargo_accepted.area.h / AcceptanceMatrix::GRID;
+			t->cargo_accepted.data = MallocT<CargoTypes>(arr_len);
+			SlArray(t->cargo_accepted.data, arr_len, SLE_UINT32);
+
+			/* Rebuild total cargo acceptance. */
+			UpdateTownCargoTotal(t);
 		}
 	}
 }

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -434,7 +434,7 @@ bool FindSubsidyCargoDestination(CargoID cid, SourceType src_type, SourceID src)
 			CargoArray town_cargo_accepted = GetAcceptanceAroundTiles(dst_town->xy, 1, 1, SUBSIDY_TOWN_CARGO_RADIUS);
 
 			/* Check if the town can accept this cargo. */
-			if (town_cargo_accepted[cid] >= 8) return false;
+			if (town_cargo_accepted[cid] < 8) return false;
 
 			dst = dst_town->index;
 			break;

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -328,20 +328,27 @@ bool FindSubsidyTownCargoRoute()
 	const Town *src_town = Town::GetRandom();
 	if (src_town->cache.population < SUBSIDY_CARGO_MIN_POPULATION) return false;
 
-	CargoTypes town_cargo_produced = src_town->cargo_produced;
+	CargoArray town_cargo_produced = GetProductionAroundTiles(src_town->xy, 1, 1, SUBSIDY_TOWN_CARGO_RADIUS);
 
 	/* Passenger subsidies are not handled here. */
-	ClrBit(town_cargo_produced, CT_PASSENGERS);
+	town_cargo_produced[CT_PASSENGERS] = 0;
+
+	uint8 cargo_count = 0;
+	for (CargoID i = 0; i < NUM_CARGO; i++) {
+		if (town_cargo_produced[i] > 0) cargo_count++;
+	}
 
 	/* No cargo produced at all? */
-	if (town_cargo_produced == 0) return false;
+	if (cargo_count == 0) return false;
 
 	/* Choose a random cargo that is produced in the town. */
-	uint8 cargo_number = RandomRange(CountBits(town_cargo_produced));
+	uint8 cargo_number = RandomRange(cargo_count);
 	CargoID cid;
-	FOR_EACH_SET_CARGO_ID(cid, town_cargo_produced) {
-		if (cargo_number == 0) break;
-		cargo_number--;
+	for (cid = 0; cid < NUM_CARGO; cid++) {
+		if (town_cargo_produced[cid] > 0) {
+			if (cargo_number == 0) break;
+			cargo_number--;
+		}
 	}
 
 	/* Avoid using invalid NewGRF cargoes. */
@@ -416,17 +423,18 @@ bool FindSubsidyIndustryCargoRoute()
  */
 bool FindSubsidyCargoDestination(CargoID cid, SourceType src_type, SourceID src)
 {
-	/* Choose a random destination. Only consider towns if they can accept the cargo. */
-	SourceType dst_type = (HasBit(_town_cargoes_accepted, cid) && Chance16(1, 2)) ? ST_TOWN : ST_INDUSTRY;
+	/* Choose a random destination. */
+	SourceType dst_type = Chance16(1, 2) ? ST_TOWN : ST_INDUSTRY;
 
 	SourceID dst;
 	switch (dst_type) {
 		case ST_TOWN: {
 			/* Select a random town. */
 			const Town *dst_town = Town::GetRandom();
+			CargoArray town_cargo_accepted = GetAcceptanceAroundTiles(dst_town->xy, 1, 1, SUBSIDY_TOWN_CARGO_RADIUS);
 
 			/* Check if the town can accept this cargo. */
-			if (!HasBit(dst_town->cargo_accepted_total, cid)) return false;
+			if (town_cargo_accepted[cid] >= 8) return false;
 
 			dst = dst_town->index;
 			break;

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -57,5 +57,6 @@ static const uint SUBSIDY_PAX_MIN_POPULATION   = 400; ///< Min. population of to
 static const uint SUBSIDY_CARGO_MIN_POPULATION = 900; ///< Min. population of destination town for cargo route
 static const uint SUBSIDY_MAX_PCT_TRANSPORTED  =  42; ///< Subsidy will be created only for towns/industries with less % transported
 static const uint SUBSIDY_MAX_DISTANCE         =  70; ///< Max. length of subsidised route (DistanceManhattan)
+static const uint SUBSIDY_TOWN_CARGO_RADIUS    =   6; ///< Extent of a tile area around town center when scanning for town cargo acceptance and production (6 ~= min catchmement + min station / 2)
 
 #endif /* SUBSIDY_BASE_H */

--- a/src/town.h
+++ b/src/town.h
@@ -15,7 +15,6 @@
 #include "subsidy_type.h"
 #include "newgrf_storage.h"
 #include "cargotype.h"
-#include "tilematrix_type.hpp"
 #include <list>
 
 template <typename T>
@@ -23,8 +22,6 @@ struct BuildingCounts {
 	T id_count[NUM_HOUSES];
 	T class_count[HOUSE_CLASS_MAX];
 };
-
-typedef TileMatrix<CargoTypes, 4> AcceptanceMatrix;
 
 static const uint CUSTOM_TOWN_NUMBER_DIFFICULTY  = 4; ///< value for custom town number in difficulty settings
 static const uint CUSTOM_TOWN_MAX_NUMBER = 5000;  ///< this is the maximum number of towns a user can specify in customisation
@@ -83,10 +80,6 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	inline byte GetPercentTransported(CargoID cid) const { return this->supplied[cid].old_act * 256 / (this->supplied[cid].old_max + 1); }
 
-	/* Cargo production and acceptance stats. */
-	CargoTypes cargo_produced;       ///< Bitmap of all cargoes produced by houses in this town.
-	AcceptanceMatrix cargo_accepted; ///< Bitmap of cargoes accepted by houses for each 4*4 map square of the town.
-	CargoTypes cargo_accepted_total; ///< NOSAVE: Bitmap of all cargoes accepted by houses in this town.
 	StationList stations_near;       ///< NOSAVE: List of nearby stations.
 
 	uint16 time_until_rebuild;       ///< time until we rebuild a house
@@ -203,9 +196,6 @@ void ResetHouses();
 void ClearTownHouse(Town *t, TileIndex tile);
 void UpdateTownMaxPass(Town *t);
 void UpdateTownRadius(Town *t);
-void UpdateTownCargoes(Town *t);
-void UpdateTownCargoTotal(Town *t);
-void UpdateTownCargoBitmap();
 CommandCost CheckIfAuthorityAllowsNewStation(TileIndex tile, DoCommandFlag flags);
 Town *ClosestTownFromTile(TileIndex tile, uint threshold);
 void ChangeTownRating(Town *t, int add, int max, DoCommandFlag flags);
@@ -312,8 +302,6 @@ static inline uint16 TownTicksToGameTicks(uint16 ticks) {
 	return (min(ticks, MAX_TOWN_GROWTH_TICKS) + 1) * TOWN_GROWTH_TICKS - 1;
 }
 
-
-extern CargoTypes _town_cargoes_accepted;
 
 RoadType GetTownRoadType(const Town *t);
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -55,7 +55,6 @@
 #include "safeguards.h"
 
 TownID _new_town_id;
-CargoTypes _town_cargoes_accepted; ///< Bitmap of all cargoes accepted by houses.
 
 /* Initialize the town-pool */
 TownPool _town_pool("Town");
@@ -780,85 +779,6 @@ static TrackStatus GetTileTrackStatus_Town(TileIndex tile, TransportType mode, u
 static void ChangeTileOwner_Town(TileIndex tile, Owner old_owner, Owner new_owner)
 {
 	/* not used */
-}
-
-/** Update the total cargo acceptance of the whole town.
- * @param t The town to update.
- */
-void UpdateTownCargoTotal(Town *t)
-{
-	t->cargo_accepted_total = 0;
-
-	const TileArea &area = t->cargo_accepted.GetArea();
-	TILE_AREA_LOOP(tile, area) {
-		if (TileX(tile) % AcceptanceMatrix::GRID == 0 && TileY(tile) % AcceptanceMatrix::GRID == 0) {
-			t->cargo_accepted_total |= t->cargo_accepted[tile];
-		}
-	}
-}
-
-/**
- * Update accepted town cargoes around a specific tile.
- * @param t The town to update.
- * @param start Update the values around this tile.
- * @param update_total Set to true if the total cargo acceptance should be updated.
- */
-static void UpdateTownCargoes(Town *t, TileIndex start, bool update_total = true)
-{
-	CargoArray accepted, produced;
-	CargoTypes dummy = 0;
-
-	/* Gather acceptance for all houses in an area around the start tile.
-	 * The area is composed of the square the tile is in, extended one square in all
-	 * directions as the coverage area of a single station is bigger than just one square. */
-	TileArea area = AcceptanceMatrix::GetAreaForTile(start, 1);
-	TILE_AREA_LOOP(tile, area) {
-		if (!IsTileType(tile, MP_HOUSE) || GetTownIndex(tile) != t->index) continue;
-
-		AddAcceptedCargo_Town(tile, accepted, &dummy);
-		AddProducedCargo_Town(tile, produced);
-	}
-
-	/* Create bitmap of produced and accepted cargoes. */
-	CargoTypes acc = 0;
-	for (uint cid = 0; cid < NUM_CARGO; cid++) {
-		if (accepted[cid] >= 8) SetBit(acc, cid);
-		if (produced[cid] > 0) SetBit(t->cargo_produced, cid);
-	}
-	t->cargo_accepted[start] = acc;
-
-	if (update_total) UpdateTownCargoTotal(t);
-}
-
-/** Update cargo acceptance for the complete town.
- * @param t The town to update.
- */
-void UpdateTownCargoes(Town *t)
-{
-	t->cargo_produced = 0;
-
-	const TileArea &area = t->cargo_accepted.GetArea();
-	if (area.tile == INVALID_TILE) return;
-
-	/* Update acceptance for each grid square. */
-	TILE_AREA_LOOP(tile, area) {
-		if (TileX(tile) % AcceptanceMatrix::GRID == 0 && TileY(tile) % AcceptanceMatrix::GRID == 0) {
-			UpdateTownCargoes(t, tile, false);
-		}
-	}
-
-	/* Update the total acceptance. */
-	UpdateTownCargoTotal(t);
-}
-
-/** Updates the bitmap of all cargoes accepted by houses. */
-void UpdateTownCargoBitmap()
-{
-	_town_cargoes_accepted = 0;
-
-	for (const Town *town : Town::Iterate()) {
-		_town_cargoes_accepted |= town->cargo_accepted_total;
-	}
 }
 
 static bool GrowTown(Town *t);
@@ -2588,7 +2508,6 @@ static bool BuildTownHouse(Town *t, TileIndex tile)
 		MakeTownHouse(tile, t, construction_counter, construction_stage, house, random_bits);
 		UpdateTownRadius(t);
 		UpdateTownGrowthRate(t);
-		UpdateTownCargoes(t, tile);
 
 		return true;
 	}
@@ -2673,9 +2592,6 @@ void ClearTownHouse(Town *t, TileIndex tile)
 	RemoveNearbyStations(t, tile, hs->building_flags);
 
 	UpdateTownRadius(t);
-
-	/* Update cargo acceptance. */
-	UpdateTownCargoes(t, tile);
 }
 
 /**
@@ -3698,10 +3614,8 @@ void TownsMonthlyLoop()
 		UpdateTownGrowth(t);
 		UpdateTownRating(t);
 		UpdateTownUnwanted(t);
-		UpdateTownCargoes(t);
 	}
 
-	UpdateTownCargoBitmap();
 }
 
 void TownsYearlyLoop()


### PR DESCRIPTION
As mentioned in #7603 and #8157 there are currently a number of problems with town cargo caches. I also roughly measured the performance of updating them and it contributes about 25%-100% of the total monthly tick lag. Considering they're only used by subsidy generation which only happens once per month with a small chance it makes absolutely no sense to waste so many resources maintaining these caches. 

I see 3 possible ways of removing caches:
1. Reimplement subsidy generation completely (more CPU intensive and needs savegame bump).
2. Break/alter subsidies a bit by reducing the probability of generating certain subsidy types.
3. Remove default subsidy generation completely in favor of GS solution.

This PR basically does 2 but is also a partway to 1 or 3 if either of them is chosen in the future. 

It's meant to be backported so savegame bump was avoided and a separate PR will be needed to remove the junk from the save in future. And there is almost no harm to zeroing it all as the only possible consequence I see is that there may be fewer subsidies if newer save is loaded in the old game version.
