### PR TITLE
Fix: Trees disappear completely after a few years when they're not allowed to spread

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -632,6 +632,13 @@ static void TileLoopTreesAlps(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
+static bool CanPlantExtraTrees(TileIndex tile)
+{
+	return ((_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) == TROPICZONE_RAINFOREST) ?
+		_settings_game.construction.extra_tree_placement != ETP_NONE :
+		_settings_game.construction.extra_tree_placement == ETP_ALL);
+}
+
 static void TileLoop_Trees(TileIndex tile)
 {
 	if (GetTreeGround(tile) == TREE_GROUND_SHORE) {
@@ -682,12 +689,7 @@ static void TileLoop_Trees(TileIndex tile)
 						FALLTHROUGH;
 
 					case 2: { // add a neighbouring tree
-						/* Don't plant extra trees if that's not allowed. */
-						if ((_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) == TROPICZONE_RAINFOREST) ?
-								_settings_game.construction.extra_tree_placement == ETP_NONE :
-								_settings_game.construction.extra_tree_placement != ETP_ALL) {
-							break;
-						}
+						if (!CanPlantExtraTrees(tile)) break;
 
 						TreeType treetype = GetTreeType(tile);
 
@@ -715,6 +717,9 @@ static void TileLoop_Trees(TileIndex tile)
 				/* more than one tree, delete it */
 				AddTreeCount(tile, -1);
 				SetTreeGrowth(tile, 3);
+			} else if (!CanPlantExtraTrees(tile)) {
+				/* if trees can't spread just plant a new one to prevent deforestation */
+				SetTreeGrowth(tile, 0);
 			} else {
 				/* just one tree, change type into MP_CLEAR */
 				switch (GetTreeGround(tile)) {


### PR DESCRIPTION
Disabling tree spread shouldn't mean imminent deforestation, there is "None" tree placement for that.

This simple patch replants the same tree in place when it dies so forests just stay where they are indefinitely.