### PR TITLE
Fix #8161, e31def197: Lang files may have LF EOL

### DIFF
--- a/media/baseset/translations.vbs
+++ b/media/baseset/translations.vbs
@@ -65,11 +65,12 @@ Sub Lookup(ini_key, str_id, outfile)
 			Dim f
 			Set f = CreateObject("ADODB.Stream")
 			f.Charset = "utf-8"
+			f.LineSeparator = 10 ' Assume lines end with \n even for \r\n files
 			f.Open
 			f.LoadFromFile(file.Path)
 
 			Do Until f.EOS
-				line = f.ReadText(-2)
+				line = Replace(f.ReadText(-2), Chr(13), "") ' Read a line and remove any \r
 
 				If InStr(1, line, "##isocode ") = 1 Then
 					p = Split(line)


### PR DESCRIPTION
Nightly binaries are built from a source archive made on linux, so using LF EOL. As `translations.vbs` expects CRLF in lang files, it silently fails to parse them and skip the `description` lines, generating incomplete, and unusable, `ob[gms]` files.