### PR TITLE
Fix #8153: Report autoreplace failure when new vehicle cannot carry the cargo

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4473,6 +4473,8 @@ STR_ERROR_DEPOT_WRONG_DEPOT_TYPE                                :Wrong depot typ
 STR_ERROR_TRAIN_TOO_LONG_AFTER_REPLACEMENT                      :{WHITE}{VEHICLE} is too long after replacement
 STR_ERROR_AUTOREPLACE_NOTHING_TO_DO                             :{WHITE}No autoreplace/renew rules applied
 STR_ERROR_AUTOREPLACE_MONEY_LIMIT                               :(money limit)
+STR_ERROR_AUTOREPLACE_INCOMPATIBLE_CARGO                        :{WHITE}New vehicle can't carry {STRING}
+STR_ERROR_AUTOREPLACE_INCOMPATIBLE_REFIT                        :{WHITE}New vehicle can't do refit in order {NUM}
 
 # Rail construction errors
 STR_ERROR_IMPOSSIBLE_TRACK_COMBINATION                          :{WHITE}Impossible track combination


### PR DESCRIPTION
Fixes #8153

> For more information we'll have to modify the variables that are passed to the string template, I can see this is done here:
> 
> https://github.com/OpenTTD/OpenTTD/blob/c972a63c8cbee7fa8d6d5af2cbbecb8c75ee561a/src/vehicle.cpp#L1058-L1067
> 
> Should I be adding some extra logic here to set a third parameter (cargo type) if the error message is my new one? Seems like there's a couple of conditionals for building the message depending on the error here already.
> 
> Made a barebones save for easier testing too - [bugboats.zip](https://github.com/OpenTTD/OpenTTD/files/4678745/bugboats.zip)
