### PR TITLE
Fix: VS 2019 16.6 doesn't like newlines in <SettingsCommandLine>

### DIFF
--- a/projects/generate
+++ b/projects/generate
@@ -263,19 +263,22 @@ generate() {
 	echo "Generating $2..."
 	# Everything above the !!FILTERS!! marker
 	cat "$ROOT_DIR/projects/$2".in | ${AWK} -v BINMODE=1 -v FILTERS="$3" -v FILES="$1" '
-		{ CR = (match($0, "\\r$") > 0 ? "\r" : "") }
 		/^$/ { next }
 		/!!FILTERS!!/ {
 			split(FILTERS, filters, "\n");
 			for (i = 1; filters[i] != ""; i++) {
-				print filters[i] CR;
+				line = $0
+				gsub(/!!FILTERS!!/, filters[i], line);
+				print line;
 			}
 			next;
 		}
 		/!!FILES!!/ {
 			split(FILES, files, "\n");
 			for (i = 1; files[i] != ""; i++) {
-				print files[i] CR;
+				line = $0
+				gsub(/!!FILES!!/, files[i], line);
+				print line;
 			}
 			next;
 		}

--- a/projects/generate
+++ b/projects/generate
@@ -69,6 +69,7 @@ fi
 # First, collect the list of Windows files
 allegro_config=""
 sdl_config="1"
+sdl2_config="1"
 png_config="1"
 os="MSVC"
 enable_dedicated="0"
@@ -123,6 +124,7 @@ load_main_data() {
 
 			if ($0 == "ALLEGRO"     && "'$allegro_config'" == "")      { next; }
 			if ($0 == "SDL"         && "'$sdl_config'" == "")          { next; }
+			if ($0 == "SDL2"        && "'$sdl2_config'" == "")         { next; }
 			if ($0 == "PNG"         && "'$png_config'" == "")          { next; }
 			if ($0 == "OSX"         && "'$os'" != "OSX")               { next; }
 			if ($0 == "OS2"         && "'$os'" != "OS2")               { next; }

--- a/projects/generate.vbs
+++ b/projects/generate.vbs
@@ -172,6 +172,7 @@ Sub load_main_data(filename, ByRef vcxproj, ByRef filters, ByRef files)
 					line = Replace(line, "#if ", "")
 					If deep = skip And ( _
 						line = "SDL" Or _
+						line = "SDL2" Or _
 						line = "PNG" Or _
 						line = "WIN32" Or _
 						line = "MSVC" Or _

--- a/projects/generate.vbs
+++ b/projects/generate.vbs
@@ -321,21 +321,26 @@ Sub load_baseset_data(dir, langdir, ByRef vcxproj, ByRef files, ByRef langs)
 End Sub
 
 Sub generate(data, dest, data2)
-	Dim srcfile, destfile, line
+	Dim srcfile, destfile, line, regexp
 	WScript.Echo "Generating " & FSO.GetFileName(dest) & "..."
 	Set srcfile = FSO.OpenTextFile(dest & ".in", 1, 0, 0)
 	Set destfile = FSO.CreateTextFile(dest, -1, 0)
 
 	If Not IsNull(data2) Then
 		' Everything above the !!FILTERS!! marker
+		Set regexp = New RegExp
+		regexp.Pattern = "!!FILTERS!!"
+		regexp.Global = True
+
 		line = srcfile.ReadLine()
-		While line <> "!!FILTERS!!"
+		While Not regexp.Test(line)
 			If len(line) > 0 Then destfile.WriteLine(line)
 			line = srcfile.ReadLine()
 		Wend
 
 		' Our generated content
-		destfile.WriteLine(data2)
+		line = regexp.Replace(line, data2)
+		destfile.WriteLine(line)
 	End If
 
 	' Everything above the !!FILES!! marker

--- a/projects/settings_vs140.vcxproj
+++ b/projects/settings_vs140.vcxproj
@@ -23,9 +23,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <SettingsCommandLine>
-..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble ..\src\table\company_settings.ini ..\src\table\currency_settings.ini ..\src\table\gameopt_settings.ini ..\src\table\misc_settings.ini ..\src\table\settings.ini ..\src\table\win32_settings.ini ..\src\table\window_settings.ini
-    </SettingsCommandLine>
+    <SettingsCommandLine>..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble ..\src\table\company_settings.ini ..\src\table\currency_settings.ini ..\src\table\gameopt_settings.ini ..\src\table\misc_settings.ini ..\src\table\settings.ini ..\src\table\win32_settings.ini ..\src\table\window_settings.ini</SettingsCommandLine>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\objs\settings\table\</OutDir>

--- a/projects/settings_vs140.vcxproj.in
+++ b/projects/settings_vs140.vcxproj.in
@@ -23,9 +23,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <SettingsCommandLine>
-!!FILTERS!!
-    </SettingsCommandLine>
+    <SettingsCommandLine>!!FILTERS!!</SettingsCommandLine>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\objs\settings\table\</OutDir>

--- a/projects/settings_vs141.vcxproj
+++ b/projects/settings_vs141.vcxproj
@@ -23,9 +23,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <SettingsCommandLine>
-..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble ..\src\table\company_settings.ini ..\src\table\currency_settings.ini ..\src\table\gameopt_settings.ini ..\src\table\misc_settings.ini ..\src\table\settings.ini ..\src\table\win32_settings.ini ..\src\table\window_settings.ini
-    </SettingsCommandLine>
+    <SettingsCommandLine>..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble ..\src\table\company_settings.ini ..\src\table\currency_settings.ini ..\src\table\gameopt_settings.ini ..\src\table\misc_settings.ini ..\src\table\settings.ini ..\src\table\win32_settings.ini ..\src\table\window_settings.ini</SettingsCommandLine>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\objs\settings\table\</OutDir>

--- a/projects/settings_vs141.vcxproj.in
+++ b/projects/settings_vs141.vcxproj.in
@@ -23,9 +23,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <SettingsCommandLine>
-!!FILTERS!!
-    </SettingsCommandLine>
+    <SettingsCommandLine>!!FILTERS!!</SettingsCommandLine>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\objs\settings\table\</OutDir>

--- a/projects/settings_vs142.vcxproj
+++ b/projects/settings_vs142.vcxproj
@@ -23,9 +23,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <SettingsCommandLine>
-..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble ..\src\table\company_settings.ini ..\src\table\currency_settings.ini ..\src\table\gameopt_settings.ini ..\src\table\misc_settings.ini ..\src\table\settings.ini ..\src\table\win32_settings.ini ..\src\table\window_settings.ini
-    </SettingsCommandLine>
+    <SettingsCommandLine>..\objs\settings\settings_gen.exe -o ..\objs\settings\table\settings.h -b ..\src\table\settings.h.preamble -a ..\src\table\settings.h.postamble ..\src\table\company_settings.ini ..\src\table\currency_settings.ini ..\src\table\gameopt_settings.ini ..\src\table\misc_settings.ini ..\src\table\settings.ini ..\src\table\win32_settings.ini ..\src\table\window_settings.ini</SettingsCommandLine>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\objs\settings\table\</OutDir>

--- a/projects/settings_vs142.vcxproj.in
+++ b/projects/settings_vs142.vcxproj.in
@@ -23,9 +23,7 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros">
-    <SettingsCommandLine>
-!!FILTERS!!
-    </SettingsCommandLine>
+    <SettingsCommandLine>!!FILTERS!!</SettingsCommandLine>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\objs\settings\table\</OutDir>


### PR DESCRIPTION
And while touching the generate scripts I also fixed the SDL2 inconsistency (files were included by `generate`, but not by `generate.vbs`)