### PR TITLE
Fix: Compilation warnings in story_gui and script_story_page

### DIFF
--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -83,6 +83,10 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		case SPET_BUTTON_VEHICLE:
 			refid = reference;
 			break;
+		case SPET_TEXT:
+			break;
+		default:
+			NOT_REACHED();
 	}
 
 	if (!ScriptObject::DoCommand(reftile,
@@ -124,6 +128,10 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		case SPET_BUTTON_VEHICLE:
 			refid = reference;
 			break;
+		case SPET_TEXT:
+			break;
+		default:
+			NOT_REACHED();
 	}
 
 	return ScriptObject::DoCommand(reftile,

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -459,7 +459,7 @@ protected:
 					}
 				}
 				/* Position element in main column */
-				LayoutCacheElement ce{ pe };
+				LayoutCacheElement ce{ pe, {} };
 				ce.bounds.left = left_offset;
 				ce.bounds.right = max_width - right_offset;
 				ce.bounds.top = main_y;
@@ -479,7 +479,7 @@ protected:
 				std::vector<size_t> &cur_floats = (fl == ElementFloat::Left) ? left_floats : right_floats;
 				/* Position element */
 				cur_width = max(cur_width, this->GetPageElementFloatWidth(*pe));
-				LayoutCacheElement ce{ pe };
+				LayoutCacheElement ce{ pe, {} };
 				ce.bounds.left = (fl == ElementFloat::Left) ? 0 : (max_width - cur_width);
 				ce.bounds.right = (fl == ElementFloat::Left) ? cur_width : max_width;
 				ce.bounds.top = cur_y;
@@ -745,11 +745,7 @@ public:
 				case SPET_BUTTON_PUSH:
 				case SPET_BUTTON_TILE:
 				case SPET_BUTTON_VEHICLE: {
-					const int height = FONT_HEIGHT_NORMAL;
 					const int tmargin = WD_BEVEL_TOP + WD_FRAMETEXT_TOP;
-					const int bmargin = WD_BEVEL_BOTTOM + WD_FRAMETEXT_BOTTOM;
-					const int width = ce.bounds.right - ce.bounds.left;
-					const int hmargin = width / 5;
 					const FrameFlags frame = this->active_button_id == ce.pe->index ? FR_LOWERED : FR_NONE;
 					const Colours bgcolour = StoryPageButtonData{ ce.pe->referenced_id }.GetColour();
 


### PR DESCRIPTION
Fix compilation warnings in story_gui.cpp and script/api/script_story_page.cpp

See: #7896

Warnings as output by gcc 9.2:
```
/home/jgr/openttd/trunk/src/script/api/script_story_page.cpp: In static member function ‘static ScriptStoryPage::StoryPageElementID ScriptStoryPage::NewElement(ScriptStoryPage::StoryPageID, ScriptStoryPage::StoryPageElementType, uint32, Text*)’:
/home/jgr/openttd/trunk/src/script/api/script_story_page.cpp:76:9: warning: enumeration value ‘SPET_TEXT’ not handled in switch [-Wswitch]
   76 |  switch (type) {
      |         ^
/home/jgr/openttd/trunk/src/script/api/script_story_page.cpp: In static member function ‘static bool ScriptStoryPage::UpdateElement(ScriptStoryPage::StoryPageElementID, uint32, Text*)’:
/home/jgr/openttd/trunk/src/script/api/script_story_page.cpp:117:9: warning: enumeration value ‘SPET_TEXT’ not handled in switch [-Wswitch]
  117 |  switch (type) {
      |         ^
/home/jgr/openttd/trunk/src/script/api/script_story_page.cpp:117:9: warning: enumeration value ‘SPET_END’ not handled in switch [-Wswitch]
/home/jgr/openttd/trunk/src/script/api/script_story_page.cpp:117:9: warning: enumeration value ‘INVALID_SPET’ not handled in switch [-Wswitch]
/home/jgr/openttd/trunk/src/story_gui.cpp: In member function ‘void StoryBookWindow::EnsureStoryPageElementLayout() const’:
/home/jgr/openttd/trunk/src/story_gui.cpp:462:31: warning: missing initializer for member ‘StoryBookWindow::LayoutCacheElement::bounds’ [-Wmissing-field-initializers]
  462 |     LayoutCacheElement ce{ pe };
      |                               ^
/home/jgr/openttd/trunk/src/story_gui.cpp:482:31: warning: missing initializer for member ‘StoryBookWindow::LayoutCacheElement::bounds’ [-Wmissing-field-initializers]
  482 |     LayoutCacheElement ce{ pe };
      |                               ^
/home/jgr/openttd/trunk/src/story_gui.cpp: In member function ‘virtual void StoryBookWindow::DrawWidget(const Rect&, int) const’:
/home/jgr/openttd/trunk/src/story_gui.cpp:748:16: warning: unused variable ‘height’ [-Wunused-variable]
  748 |      const int height = FONT_HEIGHT_NORMAL;
      |                ^~~~~~
/home/jgr/openttd/trunk/src/story_gui.cpp:750:16: warning: unused variable ‘bmargin’ [-Wunused-variable]
  750 |      const int bmargin = WD_BEVEL_BOTTOM + WD_FRAMETEXT_BOTTOM;
      |                ^~~~~~~
/home/jgr/openttd/trunk/src/story_gui.cpp:752:16: warning: unused variable ‘hmargin’ [-Wunused-variable]
  752 |      const int hmargin = width / 5;
      |
```