### PR TITLE
Fix #8024: make online content gui more responsive while loading

### DIFF
--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -951,7 +951,7 @@ public:
 	{
 		if (this->auto_select && !rci->IsSelected()) _network_content_client.ToggleSelectedState(rci);
 		this->content.ForceRebuild();
-		this->InvalidateData();
+		this->InvalidateData(0, false);
 	}
 
 	void OnDownloadComplete(ContentID cid) override


### PR DESCRIPTION
Previously the internal content list was invalidated and sorted for
every new item added. Now the sorting is delayed until the GUI is
drawn, which means we only sort once per GUI tick.

Since the amount of incoming items per GUI tick is not controlled by
the GUI but rather by network speed, we were previously doing a lot
of duplicate work per tick, causing the mouse cursor to lag while
the list was initialized.