### PR TITLE
Fix #8166: don't crash on loading an invalid roadtype newgrf

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8718,18 +8718,18 @@ GRFFile::GRFFile(const GRFConfig *config)
 	}
 
 	/* Initialise rail type map with default rail types */
-	memset(this->railtype_map, INVALID_RAILTYPE, sizeof(this->railtype_map));
+	std::fill(std::begin(this->railtype_map), std::end(this->railtype_map), INVALID_RAILTYPE);
 	this->railtype_map[0] = RAILTYPE_RAIL;
 	this->railtype_map[1] = RAILTYPE_ELECTRIC;
 	this->railtype_map[2] = RAILTYPE_MONO;
 	this->railtype_map[3] = RAILTYPE_MAGLEV;
 
 	/* Initialise road type map with default road types */
-	memset(this->roadtype_map, INVALID_ROADTYPE, sizeof(this->roadtype_map));
+	std::fill(std::begin(this->roadtype_map), std::end(this->roadtype_map), INVALID_ROADTYPE);
 	this->roadtype_map[0] = ROADTYPE_ROAD;
 
 	/* Initialise tram type map with default tram types */
-	memset(this->tramtype_map, INVALID_ROADTYPE, sizeof(this->tramtype_map));
+	std::fill(std::begin(this->tramtype_map), std::end(this->tramtype_map), INVALID_ROADTYPE);
 	this->tramtype_map[0] = ROADTYPE_TRAM;
 
 	/* Copy the initial parameter list

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -132,7 +132,7 @@ struct GRFFile : ZeroedMemoryAllocator {
 	std::vector<RoadTypeLabel> roadtype_list;       ///< Roadtype translation table (road)
 	RoadType roadtype_map[ROADTYPE_END];
 
-	std::vector<RoadTypeLabel> tramtype_list;       ///, Roadtype translation table (tram)
+	std::vector<RoadTypeLabel> tramtype_list;       ///< Roadtype translation table (tram)
 	RoadType tramtype_map[ROADTYPE_END];
 
 	CanalProperties canal_local_properties[CF_END]; ///< Canal properties as set by this NewGRF


### PR DESCRIPTION
Initialization code for GRFFile::roadtype_map was copied from
railtype_map. But while RailType is a byte-sized enum and could thus
be initialized via memset, RoadType doesn't have a defined size.