### PR TITLE
Fix #8066: Try another fallback colourspace if first one fails

### DIFF
--- a/src/video/cocoa/wnd_quartz.mm
+++ b/src/video/cocoa/wnd_quartz.mm
@@ -318,6 +318,8 @@ bool WindowQuartzSubdriver::SetVideoMode(int width, int height, int bpp)
 
 	[this->window setColorSpace:[NSColorSpace sRGBColorSpace]];
 	this->color_space = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+	if (this->color_space == nullptr) this->color_space = CGColorSpaceCreateDeviceRGB();
+	if (this->color_space == nullptr) error("Could not get a valid colour space for drawing.");
 
 	bool ret = WindowResized();
 	this->UpdatePalette(0, 256);


### PR DESCRIPTION
This is a "maybe" fix, I'm not sure of the actual cause but let's try the one point where we make an assumption about a pointer being non-null.