### PR TITLE
Clang LTO

### DIFF
--- a/config.lib
+++ b/config.lib
@@ -1059,7 +1059,7 @@ check_params() {
 	else
 		log 1 "checking revision... no detection"
 		log 1 "WARNING: there is no means to determine the version."
-		log 1 "WARNING: please use a subversion, mercurial, or git checkout of OpenTTD."
+		log 1 "WARNING: please use a source tarball or a git checkout of OpenTTD."
 		log 1 "WARNING: you can only join game servers that have been compiled without"
 		log 1 "WARNING:   version detection."
 		log 1 "WARNING: there is a great chance you desync."

--- a/config.lib
+++ b/config.lib
@@ -2111,8 +2111,8 @@ check_osx_sdk() {
 			return 1
 		fi
 
-		# Set minimum version to 10.4 as that's when kCGBitmapByteOrder32Host was introduced
-		sysroot="-isysroot $osx_sdk_path -Wl,-syslibroot,$osx_sdk_path -mmacosx-version-min=10.4"
+		# Set minimum version to 10.9; minimum supported by OpenTTD
+		sysroot="-isysroot $osx_sdk_path -Wl,-syslibroot,$osx_sdk_path -mmacosx-version-min=10.9"
 	fi
 
 cat > tmp.osx.mm << EOF

--- a/config.lib
+++ b/config.lib
@@ -667,7 +667,8 @@ check_params() {
 
 	if [ "$enable_lto" != "0" ]; then
 		# GCC 4.5 outputs '%{flto}', GCC 4.6 outputs '%{flto*}'
-		has_lto=`($cxx_build -dumpspecs 2>&1 | grep '\%{flto') || ($cxx_build -help ipo 2>&1 | grep '\-ipo')`
+		# Clang outputs -flto=thin
+		has_lto=`($cxx_build -dumpspecs 2>&1 | grep '\%{flto') || ($cxx_build -help ipo 2>&1 | grep '\-ipo') || ($cxx_build --help 2>&1 | grep 'lto.*thin')`
 		if [ -n "$has_lto" ]; then
 			log 1 "using link time optimization... yes"
 		else
@@ -1335,6 +1336,12 @@ make_compiler_cflags() {
 
 		# rdynamic is used to get useful stack traces from crash reports.
 		ldflags="$ldflags -rdynamic"
+
+		if [ "$enable_lto" != "0" ]; then
+			flags="$flags -flto=thin"
+			features="$features lto"
+			features_host="$features_host lto"
+		fi
 
 	# Assume gcc, since it just uses argv[0] in its --version output
 	else


### PR DESCRIPTION
This adds support using LTO with Clang. I've tested it on my Mac, and it appears to work. I also removed a mention of Mercurial from the `configure` script — I happened to be using it when I got that error.