### PR TITLE
Codechange: Realign SDL driver with SDL2 driver to ease maintenance.

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -170,9 +170,7 @@ static void DrawSurfaceToScreen()
 	} else {
 		if (_sdl_surface != _sdl_realscreen) {
 			for (int i = 0; i < n; i++) {
-				SDL_BlitSurface(
-					_sdl_surface, &_dirty_rects[i],
-					_sdl_realscreen, &_dirty_rects[i]);
+				SDL_BlitSurface(_sdl_surface, &_dirty_rects[i], _sdl_realscreen, &_dirty_rects[i]);
 			}
 		}
 


### PR DESCRIPTION
Renamed _sdl_screen, reformatted sourcecode, and updated comments so as to allow the two versions of the SDL video driver to be more easily compared and maintained.