### PR TITLE
Cleanup: More code comment and doxygen fixes.

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -423,7 +423,7 @@ public:
 	uint Reroute(uint max_move, VehicleCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge);
 
 	/**
-	 * Are two the two CargoPackets mergeable in the context of
+	 * Are the two CargoPackets mergeable in the context of
 	 * a list of CargoPackets for a Vehicle?
 	 * @param cp1 First CargoPacket.
 	 * @param cp2 Second CargoPacket.
@@ -486,7 +486,7 @@ public:
 		while (!next.IsEmpty()) {
 			if (this->packets.find(next.Pop()) != this->packets.end()) return true;
 		}
-		/* Packets for INVALID_STTION can go anywhere. */
+		/* Packets for INVALID_STATION can go anywhere. */
 		return this->packets.find(INVALID_STATION) != this->packets.end();
 	}
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -902,6 +902,7 @@ void DrawCharCentered(WChar c, int x, int y, TextColour colour)
  * Get the size of a sprite.
  * @param sprid Sprite to examine.
  * @param[out] offset Optionally returns the sprite position offset.
+ * @param zoom The zoom level applicable to the sprite.
  * @return Sprite size in pixels.
  * @note The size assumes (0, 0) as top-left coordinate and ignores any part of the sprite drawn at the left or above that position.
  */

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file null_v.cpp The videio driver that doesn't blit. */
+/** @file null_v.cpp The video driver that doesn't blit. */
 
 #include "../stdafx.h"
 #include "../gfx_func.h"


### PR DESCRIPTION
Some aspects of `gfx.cpp` and the blitter subsystem can certainly use better documentation; however, I am not yet in a position to do this in any meaningful way.

`Blitter::DrawLineGeneric()` in `blitter/common.hpp`, in particular, is a real brain bender; I spent a good half hour there and am still not 100% certain how it works.