### PR TITLE
Cleanup: StationCargoList::AreMergable doxygen comment references Veh…

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -538,8 +538,8 @@ public:
 	uint Reroute(uint max_move, StationCargoList *dest, StationID avoid, StationID avoid2, const GoodsEntry *ge);
 
 	/**
-	 * Are two the two CargoPackets mergeable in the context of
-	 * a list of CargoPackets for a Vehicle?
+	 * Are the two CargoPackets mergeable in the context of
+	 * a list of CargoPackets for a Station?
 	 * @param cp1 First CargoPacket.
 	 * @param cp2 Second CargoPacket.
 	 * @return True if they are mergeable.


### PR DESCRIPTION
…icle instead of Station.

There is some contention about whether this function's comment should reference `Vehicle` or `Station`. Someone who is familiar with the cargodist codepaths should review this before merging it to trunk.