### PR TITLE
Fix: MacOS bundle creation

### DIFF
--- a/cmake/PackageBundle.cmake
+++ b/cmake/PackageBundle.cmake
@@ -18,6 +18,7 @@ install(
     CODE
     "
         include(BundleUtilities)
+        set(BU_CHMOD_BUNDLE_ITEMS TRUE)
         fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/openttd\"  \"\" \"\")
     "
     DESTINATION .


### PR DESCRIPTION
Nightlies currently fails to build because
```
error: /Applications/Xcode_11.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't open input file: /Users/runner/runners/2.169.1/work/1/s/build/_CPack_Packages/amd64/Bundle/openttd-20200605-master-g877d196ef5-macosx/OpenTTD.app/Contents/Frameworks/libfreetype.6.dylib for writing (Permission denied)
error: /Applications/Xcode_11.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't lseek to offset: 0 in file: /Users/runner/runners/2.169.1/work/1/s/build/_CPack_Packages/amd64/Bundle/openttd-20200605-master-g877d196ef5-macosx/OpenTTD.app/Contents/Frameworks/libfreetype.6.dylib for writing (Bad file descriptor)
error: /Applications/Xcode_11.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't write new headers in file: /Users/runner/runners/2.169.1/work/1/s/build/_CPack_Packages/amd64/Bundle/openttd-20200605-master-g877d196ef5-macosx/OpenTTD.app/Contents/Frameworks/libfreetype.6.dylib (Bad file descriptor)
error: /Applications/Xcode_11.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't close written on input file: /Users/runner/runners/2.169.1/work/1/s/build/_CPack_Packages/amd64/Bundle/openttd-20200605-master-g877d196ef5-macosx/OpenTTD.app/Contents/Frameworks/libfreetype.6.dylib (Bad file descriptor)
```
Based on https://gitlab.kitware.com/cmake/cmake/-/issues/19663 I think I have the right fix.