### PR TITLE
Fix: Minor changes in bundle generation

### DIFF
--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -91,7 +91,7 @@ jobs:
       VcpkgTargetTriplet: $(VcpkgTargetTriplet)
       BuildConfiguration: 'RelWithDebInfo'
       ${{ if eq(parameters.IsStableRelease, true) }}:
-        OptionUseNSIS: "YES"
+        OptionUseNSIS: "ON"
   - task: VSBuild@1
     displayName: 'Create bundles'
     inputs:

--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -101,6 +101,7 @@ jobs:
       set -ex
 
       cp build/RelWithDebInfo/openttd.pdb build/bundles/openttd-$(Build.BuildNumber)-windows-$(BundlePlatform).pdb
+      xz -9 build/bundles/openttd-$(Build.BuildNumber)-windows-$(BundlePlatform).pdb
     displayName: 'Copy PDB to bundles folder'
   - template: release-bundles.yml
 

--- a/azure-pipelines/templates/release.yml
+++ b/azure-pipelines/templates/release.yml
@@ -90,6 +90,8 @@ jobs:
       BuildArch: $(BuildArch)
       VcpkgTargetTriplet: $(VcpkgTargetTriplet)
       BuildConfiguration: 'RelWithDebInfo'
+      ${{ if eq(parameters.IsStableRelease, true) }}:
+        OptionUseNSIS: "YES"
   - task: VSBuild@1
     displayName: 'Create bundles'
     inputs:

--- a/azure-pipelines/templates/windows-build.yml
+++ b/azure-pipelines/templates/windows-build.yml
@@ -2,7 +2,7 @@ parameters:
   BuildArch: ''
   VcpkgTargetTriplet: ''
   BuildConfiguration: ''
-  OptionUseNSIS: 'NO'
+  OptionUseNSIS: 'OFF'
 
 steps:
 - task: CMake@1

--- a/azure-pipelines/templates/windows-build.yml
+++ b/azure-pipelines/templates/windows-build.yml
@@ -2,12 +2,13 @@ parameters:
   BuildArch: ''
   VcpkgTargetTriplet: ''
   BuildConfiguration: ''
+  OptionUseNSIS: 'NO'
 
 steps:
 - task: CMake@1
   displayName: 'Configure'
   inputs:
-    cmakeArgs: '.. -G "Visual Studio 15 2017" -A ${{ parameters.BuildArch }} -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="${{ parameters.VcpkgTargetTriplet }}"'
+    cmakeArgs: '.. -G "Visual Studio 15 2017" -A ${{ parameters.BuildArch }} -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="${{ parameters.VcpkgTargetTriplet }}" -DOPTION_USE_NSIS="${{ parameters.OptionUseNSIS }}"'
 - task: VSBuild@1
   displayName: 'Build'
   inputs:

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -81,7 +81,7 @@ set(CPACK_STRIP_FILES YES)
 set(CPACK_OUTPUT_FILE_PREFIX "bundles")
 
 if (APPLE)
-    set(CPACK_GENERATOR "Bundle")
+    set(CPACK_GENERATOR "ZIP;Bundle")
     include(PackageBundle)
 
     set(CPACK_PACKAGE_FILE_NAME "openttd-#CPACK_PACKAGE_VERSION#-macosx")

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -86,8 +86,11 @@ if (APPLE)
 
     set(CPACK_PACKAGE_FILE_NAME "openttd-#CPACK_PACKAGE_VERSION#-macosx")
 elseif (WIN32)
-    set(CPACK_GENERATOR "ZIP;NSIS")
-    include(PackageNSIS)
+    set(CPACK_GENERATOR "ZIP")
+    if (OPTION_USE_NSIS)
+        list(APPEND CPACK_GENERATOR "NSIS")
+        include(PackageNSIS)
+    endif (OPTION_USE_NSIS)
 
     set(CPACK_PACKAGE_FILE_NAME "openttd-#CPACK_PACKAGE_VERSION#-windows-${CPACK_SYSTEM_NAME}")
 elseif (UNIX)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -50,6 +50,7 @@ function(set_options)
     option(OPTION_INSTALL_FHS "Install with Filesstem Hierarchy Standard folders" ${DEFAULT_OPTION_INSTALL_FHS})
     option(OPTION_USE_ASSERTS "Use assertions; leave enabled for nightlies, betas, and RCs" YES)
     option(OPTION_USE_THREADS "Use threads" YES)
+    option(OPTION_USE_NSIS "Use NSIS to create windows installer; enable only for stable releases" NO)
 endfunction()
 
 # Show the values of the generic options.
@@ -61,6 +62,7 @@ function(show_options)
     message(STATUS "Option Install FHS - ${OPTION_INSTALL_FHS}")
     message(STATUS "Option Use assert - ${OPTION_USE_ASSERTS}")
     message(STATUS "Option Use threads - ${OPTION_USE_THREADS}")
+    message(STATUS "Option Use NSIS - ${OPTION_USE_NSIS}")
 endfunction()
 
 # Add the definitions for the options that are selected.

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -41,16 +41,16 @@ endfunction()
 #
 function(set_options)
     if (UNIX AND NOT APPLE)
-        set(DEFAULT_OPTION_INSTALL_FHS YES)
+        set(DEFAULT_OPTION_INSTALL_FHS ON)
     else (UNIX AND NOT APPLE)
-        set(DEFAULT_OPTION_INSTALL_FHS NO)
+        set(DEFAULT_OPTION_INSTALL_FHS OFF)
     endif (UNIX AND NOT APPLE)
 
-    option(OPTION_DEDICATED "Build dedicated server only (no GUI)" NO)
+    option(OPTION_DEDICATED "Build dedicated server only (no GUI)" OFF)
     option(OPTION_INSTALL_FHS "Install with Filesstem Hierarchy Standard folders" ${DEFAULT_OPTION_INSTALL_FHS})
-    option(OPTION_USE_ASSERTS "Use assertions; leave enabled for nightlies, betas, and RCs" YES)
-    option(OPTION_USE_THREADS "Use threads" YES)
-    option(OPTION_USE_NSIS "Use NSIS to create windows installer; enable only for stable releases" NO)
+    option(OPTION_USE_ASSERTS "Use assertions; leave enabled for nightlies, betas, and RCs" ON)
+    option(OPTION_USE_THREADS "Use threads" ON)
+    option(OPTION_USE_NSIS "Use NSIS to create windows installer; enable only for stable releases" OFF)
 endfunction()
 
 # Show the values of the generic options.


### PR DESCRIPTION
With cmake merge, and the first successful nightly build run, I noticed some differences in the generated packages.
Before cmake
```
changelog.txt
openttd-20200604-master-gcdd2892c49-docs-ai.tar.xz
openttd-20200604-master-gcdd2892c49-docs-gs.tar.xz
openttd-20200604-master-gcdd2892c49-docs.tar.xz
openttd-20200604-master-gcdd2892c49-macosx.dmg
openttd-20200604-master-gcdd2892c49-macosx.zip
openttd-20200604-master-gcdd2892c49-source.tar.xz
openttd-20200604-master-gcdd2892c49-source.zip
openttd-20200604-master-gcdd2892c49-windows-win32.pdb.xz
openttd-20200604-master-gcdd2892c49-windows-win32.zip
openttd-20200604-master-gcdd2892c49-windows-win64.pdb.xz
openttd-20200604-master-gcdd2892c49-windows-win64.zip
README.md
released.txt
manifest.yaml
```
After cmake
```
changelog.txt
openttd-20200606-master-gb145ee310c-docs-ai.tar.xz
openttd-20200606-master-gb145ee310c-docs-gs.tar.xz
openttd-20200606-master-gb145ee310c-docs.tar.xz
openttd-20200606-master-gb145ee310c-macosx.dmg
openttd-20200606-master-gb145ee310c-source.tar.xz
openttd-20200606-master-gb145ee310c-source.zip
openttd-20200606-master-gb145ee310c-windows-win32.exe
openttd-20200606-master-gb145ee310c-windows-win32.pdb
openttd-20200606-master-gb145ee310c-windows-win32.zip
openttd-20200606-master-gb145ee310c-windows-win64.exe
openttd-20200606-master-gb145ee310c-windows-win64.pdb
openttd-20200606-master-gb145ee310c-windows-win64.zip
README.md
released.txt
manifest.yaml
```
This PR should generate the same packages as before cmake merge.