### PR TITLE
Add: Cheat menu under land information menu and 'cheat' console command

### DIFF
--- a/src/cheat_func.h
+++ b/src/cheat_func.h
@@ -14,7 +14,7 @@
 
 extern Cheats _cheats;
 
-void ShowCheatWindow();
+bool ShowCheatWindow();
 
 bool CheatHasBeenUsed();
 

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -13,6 +13,7 @@
 #include "company_base.h"
 #include "company_func.h"
 #include "date_func.h"
+#include "openttd.h"
 #include "saveload/saveload.h"
 #include "textbuf_gui.h"
 #include "window_gui.h"
@@ -23,6 +24,7 @@
 #include "settings_gui.h"
 #include "company_gui.h"
 #include "linkgraph/linkgraphschedule.h"
+#include "network/network.h"
 #include "map_func.h"
 #include "tile_map.h"
 #include "newgrf.h"
@@ -413,8 +415,16 @@ static WindowDesc _cheats_desc(
 );
 
 /** Open cheat window. */
-void ShowCheatWindow()
+bool ShowCheatWindow()
 {
+	/* Not to open in multiplayer or intro game. */
+	if (_networking || _game_mode == GM_MENU)
+	{
+		ShowErrorMessage(STR_ERROR_CAN_T_OPEN_CHEAT, INVALID_STRING_ID, WL_ERROR);
+		return false;
+	}
+
 	DeleteWindowById(WC_CHEATS, 0);
 	new CheatWindow(&_cheats_desc);
+	return true;
 }

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1072,6 +1072,19 @@ DEF_CONSOLE_CMD(ConRestart)
 	return true;
 }
 
+DEF_CONSOLE_CMD(ConOpenCheats)
+{
+	if (argc == 0) {
+		IConsoleHelp("Just open the cheat window. Usage: 'cheat'");
+		return true;
+	}
+
+	extern bool ShowCheatWindow();
+	ShowCheatWindow();
+
+	return true;
+}
+
 /**
  * Print a text buffer line by line to the console. Lines are separated by '\n'.
  * @param buf The buffer to print.
@@ -2097,6 +2110,7 @@ void IConsoleStdLibRegister()
 	IConsoleCmdRegister("reset_enginepool", ConResetEnginePool, ConHookNoNetwork);
 	IConsoleCmdRegister("return",       ConReturn);
 	IConsoleCmdRegister("screenshot",   ConScreenShot);
+	IConsoleCmdRegister("cheat",        ConOpenCheats, ConHookNoNetwork);
 	IConsoleCmdRegister("script",       ConScript);
 	IConsoleCmdRegister("scrollto",     ConScrollToTile);
 	IConsoleCmdRegister("alias",        ConAlias);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -476,6 +476,7 @@ STR_NEWS_MENU_DELETE_ALL_MESSAGES                               :Delete all mess
 STR_ABOUT_MENU_LAND_BLOCK_INFO                                  :Land area information
 STR_ABOUT_MENU_SEPARATOR                                        :
 STR_ABOUT_MENU_TOGGLE_CONSOLE                                   :Toggle console
+STR_ABOUT_MENU_SHOW_CHEAT                                       :Cheat
 STR_ABOUT_MENU_AI_DEBUG                                         :AI/Game script debug
 STR_ABOUT_MENU_SCREENSHOT                                       :Screenshot
 STR_ABOUT_MENU_SHOW_FRAMERATE                                   :Show frame rate
@@ -4639,6 +4640,9 @@ STR_ERROR_TOO_MANY_SIGNS                                        :{WHITE}... too 
 STR_ERROR_CAN_T_PLACE_SIGN_HERE                                 :{WHITE}Can't place sign here...
 STR_ERROR_CAN_T_CHANGE_SIGN_NAME                                :{WHITE}Can't change sign name...
 STR_ERROR_CAN_T_DELETE_SIGN                                     :{WHITE}Can't delete sign...
+
+# Misc. errors
+STR_ERROR_CAN_T_OPEN_CHEAT                                      :{WHITE}Can't open cheat window in title screen or multiplayer game.
 
 # Translatable comment for OpenTTD's desktop shortcut
 STR_DESKTOP_SHORTCUT_COMMENT                                    :A simulation game based on Transport Tycoon Deluxe

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1067,7 +1067,7 @@ static CallBackFunction PlaceLandBlockInfo()
 
 static CallBackFunction ToolbarHelpClick(Window *w)
 {
-	PopupMainToolbMenu(w, _game_mode == GM_EDITOR ? (int)WID_TE_HELP : (int)WID_TN_HELP, STR_ABOUT_MENU_LAND_BLOCK_INFO, _settings_client.gui.newgrf_developer_tools ? 10 : 7);
+	PopupMainToolbMenu(w, _game_mode == GM_EDITOR ? (int)WID_TE_HELP : (int)WID_TN_HELP, STR_ABOUT_MENU_LAND_BLOCK_INFO, _settings_client.gui.newgrf_developer_tools ? 11 : 8);
 	return CBF_NONE;
 }
 
@@ -1157,15 +1157,16 @@ void SetStartingYear(Year year)
 static CallBackFunction MenuClickHelp(int index)
 {
 	switch (index) {
-		case  0: return PlaceLandBlockInfo();
-		case  2: IConsoleSwitch();                 break;
-		case  3: ShowAIDebugWindow();              break;
-		case  4: ShowScreenshotWindow();           break;
-		case  5: ShowFramerateWindow();            break;
-		case  6: ShowAboutWindow();                break;
-		case  7: ShowSpriteAlignerWindow();        break;
-		case  8: ToggleBoundingBoxes();            break;
-		case  9: ToggleDirtyBlocks();              break;
+		case  0:  return PlaceLandBlockInfo();
+		case  2:  IConsoleSwitch();                 break;
+		case  3:  ShowCheatWindow();                break;
+		case  4:  ShowAIDebugWindow();              break;
+		case  5:  ShowScreenshotWindow();           break;
+		case  6:  ShowFramerateWindow();            break;
+		case  7:  ShowAboutWindow();                break;
+		case  8:  ShowSpriteAlignerWindow();        break;
+		case  9:  ToggleBoundingBoxes();            break;
+		case  10: ToggleDirtyBlocks();              break;
 	}
 	return CBF_NONE;
 }


### PR DESCRIPTION
This ``cheat`` command just opens the cheat window.
It might be used in the situation which users ard hard to push Ctrl+Alt+C, such as mobile.
This codes is based on [pelya's openttd-android repo.](https://github.com/pelya/openttd-android/blob/master/src/console_cmds.cpp#L411)

Of course I know that OpenTTD is not currently supporting android officially.
So I have no idea if this seems okay to you or fits with current OpenTTD's developing directions.

Please comment if any opinions or problems.
Thanks :)