### PR TITLE
Fix: Display banlist's indexes correctly

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -606,6 +606,7 @@ DEF_CONSOLE_CMD(ConBanList)
 	uint i = 1;
 	for (const auto &entry : _network_ban_list) {
 		IConsolePrintF(CC_DEFAULT, "  %d) %s", i, entry.c_str());
+		i++;
 	}
 
 	return true;


### PR DESCRIPTION
Bug introduced via commit ab711e6942