### PR TITLE
 Revert f51e66f: creating zip bundle fails for MacOS 

### DIFF
--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -81,7 +81,7 @@ set(CPACK_STRIP_FILES YES)
 set(CPACK_OUTPUT_FILE_PREFIX "bundles")
 
 if (APPLE)
-    set(CPACK_GENERATOR "ZIP;Bundle")
+    set(CPACK_GENERATOR "Bundle")
     include(PackageBundle)
 
     set(CPACK_PACKAGE_FILE_NAME "openttd-#CPACK_PACKAGE_VERSION#-macosx")


### PR DESCRIPTION
`make install` doesn't work on MacOS yet, so creating zip bundle is impossible.
I think #8189 should solve that