### PR TITLE
Fix #8104: always add WINDOW_RESIZABLE flag to SDL2

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -258,12 +258,10 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 	seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
 
 	if (_sdl_window == nullptr) {
-		Uint32 flags = SDL_WINDOW_SHOWN;
+		Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
 
 		if (_fullscreen) {
 			flags |= SDL_WINDOW_FULLSCREEN;
-		} else {
-			flags |= SDL_WINDOW_RESIZABLE;
 		}
 
 		_sdl_window = SDL_CreateWindow(


### PR DESCRIPTION
This fixes a bug that can reproduced with these steps:
1. Start openttd in fullscreen mode
2. Turn off fullscreen mode
3. Try to resize the window. The window can't be resized.