### PR TITLE
Fix: [CMake] SDL2 Sound was not included

### DIFF
--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -12,6 +12,12 @@ if (NOT OPTION_DEDICATED)
     )
 
     add_files(
+        sdl2_s.cpp
+        sdl_s.h
+        CONDITION SDL2_FOUND
+    )
+
+    add_files(
         cocoa_s.cpp
         cocoa_s.h
         CONDITION APPLE


### PR DESCRIPTION
Problem: no sound effects when compiling with SDL2
Cause: If CMake detected SDL2, SDL2 Video was included, but SDL Sound was not.
This pull requests includes SDL2 Sound to the CMakeLists for sound.