### PR TITLE
Fix: [CMake] Fix install paths using GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@ endif (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
+# Use GNUInstallDirs to allow customisation
+# but set our own default data dir
+if (NOT CMAKE_INSTALL_DATADIR)
+    set(CMAKE_INSTALL_DATADIR "share/games")
+endif (NOT CMAKE_INSTALL_DATADIR)
+include(GNUInstallDirs)
+
 include(Options)
 set_options()
 set_directory_options()

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -1,9 +1,11 @@
+include(GNUInstallDirs)
+
 # If requested, use FHS layout; otherwise fall back to a flat layout.
 if (OPTION_INSTALL_FHS)
-    set(BINARY_DESTINATION_DIR "bin")
-    set(DATA_DESTINATION_DIR "share/games/openttd")
-    set(DOCS_DESTINATION_DIR "share/doc/openttd")
-    set(MAN_DESTINATION_DIR "share/man/openttd")
+    set(BINARY_DESTINATION_DIR "${CMAKE_INSTALL_BINDIR}")
+    set(DATA_DESTINATION_DIR "${CMAKE_INSTALL_DATADIR}/openttd")
+    set(DOCS_DESTINATION_DIR "${CMAKE_INSTALL_DOCDIR}")
+    set(MAN_DESTINATION_DIR "${CMAKE_INSTALL_MANDIR}")
 else (OPTION_INSTALL_FHS)
     set(BINARY_DESTINATION_DIR ".")
     set(DATA_DESTINATION_DIR ".")
@@ -40,7 +42,7 @@ install(FILES
 if (OPTION_INSTALL_FHS)
     install(FILES
                     ${CMAKE_SOURCE_DIR}/docs/openttd.6
-            DESTINATION ${MAN_DESTINATION_DIR}
+            DESTINATION ${MAN_DESTINATION_DIR}/man6
             COMPONENT manual)
 endif (OPTION_INSTALL_FHS)
 

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,3 +1,5 @@
+include(GNUInstallDirs)
+
 # Set the options for the directories (personal, shared, global).
 #
 # set_directory_options()
@@ -14,7 +16,7 @@ function(set_directory_options)
     elseif (UNIX)
         set(DEFAULT_PERSONAL_DIR ".openttd")
         set(DEFAULT_SHARED_DIR "(not set)")
-        set(DEFAULT_GLOBAL_DIR "${CMAKE_INSTALL_PREFIX}/share/games/openttd")
+        set(DEFAULT_GLOBAL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/openttd")
     else ()
         message(FATAL_ERROR "Unknown OS found; please consider creating a Pull Request to add support for this OS.")
     endif ()


### PR DESCRIPTION
- Fix man page installation path `/usr/share/man/openttd.6` => `/usr/share/man/man6/openttd.6`.
- Adds, as a side effect, the ability to override install paths using `-DCMAKE_INSTALL_*`. See [`GNUInstallDirs`](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html).

(This is a simplified version of #8218 that changes as little as possible, in order to expedite the review process. Unfortunately some changes in #8218 are not compatible, but most of them are. There are further enhancements in #8218 that this doesn't cover.)