### PR TITLE
Fix 63ccb36e: Incorrect string type for OrderBackup::name save/load

### DIFF
--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -241,7 +241,7 @@ const SaveLoad *GetOrderBackupDescription()
 		     SLE_VAR(OrderBackup, group,                    SLE_UINT16),
 		 SLE_CONDVAR(OrderBackup, service_interval,         SLE_FILE_U32 | SLE_VAR_U16,  SL_MIN_VERSION, SLV_192),
 		 SLE_CONDVAR(OrderBackup, service_interval,         SLE_UINT16,                SLV_192, SL_MAX_VERSION),
-		     SLE_STR(OrderBackup, name,                     SLE_STR, 0),
+		    SLE_SSTR(OrderBackup, name,                     SLE_STR),
 		SLE_CONDNULL(2,                                                                  SL_MIN_VERSION, SLV_192), // clone (2 bytes of pointer, i.e. garbage)
 		 SLE_CONDREF(OrderBackup, clone,                    REF_VEHICLE,               SLV_192, SL_MAX_VERSION),
 		     SLE_VAR(OrderBackup, cur_real_order_index,     SLE_UINT8),


### PR DESCRIPTION
In 63ccb36e BaseConsist::name was changed from a malloced char* to a std::string.
OrderBackup inherits from BaseConsist.
The saveload of OrderBackup::name was not updated.
Loading a savegame with an order backup triggers the IsVariableSizeRight assertion.

This savegame contains an order backup: http://www.openttdcoop.org/files/publicserver_archive/PublicServerGame_201_Final.sav