### PR TITLE
Fix #8221: Subtitle - No Bridge Type Given Size

### DIFF
--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -426,7 +426,7 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 			default: break;
 		}
 
-		bool any_available = 0;
+		bool any_available = false;
 		CommandCost type_check;
 		/* loop for all bridgetypes */
 		for (BridgeType brd_type = 0; brd_type != MAX_BRIDGES; brd_type++) {
@@ -440,7 +440,7 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 				/* Add to terraforming & bulldozing costs the cost of the
 				 * bridge itself (not computed with DC_QUERY_COST) */
 				item.cost = ret.GetCost() + (((int64)tot_bridgedata_len * _price[PR_BUILD_BRIDGE] * item.spec->price) >> 8) + infra_cost;
-				any_available = 1;
+				any_available = true;
 			}
 		}
 		/* give error cause if no bridges available here*/

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -426,9 +426,12 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 			default: break;
 		}
 
+		bool any_available = 0;
+		CommandCost type_check;
 		/* loop for all bridgetypes */
 		for (BridgeType brd_type = 0; brd_type != MAX_BRIDGES; brd_type++) {
-			if (CheckBridgeAvailability(brd_type, bridge_len).Succeeded()) {
+			type_check = CheckBridgeAvailability(brd_type, bridge_len);
+			if (type_check.Succeeded()) {
 				/* bridge is accepted, add to list */
 				/*C++17: BuildBridgeData &item = */ bl->emplace_back();
 				BuildBridgeData &item = bl->back();
@@ -437,7 +440,13 @@ void ShowBuildBridgeWindow(TileIndex start, TileIndex end, TransportType transpo
 				/* Add to terraforming & bulldozing costs the cost of the
 				 * bridge itself (not computed with DC_QUERY_COST) */
 				item.cost = ret.GetCost() + (((int64)tot_bridgedata_len * _price[PR_BUILD_BRIDGE] * item.spec->price) >> 8) + infra_cost;
+				any_available = 1;
 			}
+		}
+		/* give error cause if no bridges available here*/
+		if (!any_available)
+		{
+			errmsg = type_check.GetErrorMessage();
 		}
 	}
 


### PR DESCRIPTION
The error box for going over max the lengths for each of the bridge types was given the "...bridge too long" subtitle.