### PR TITLE
Fix: Compiler warnings about memsetting non-trivial classes

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -31,7 +31,7 @@ macro(compile_flags)
     # it does not appear to support the $<> tags.
     add_compile_options(
         "$<$<CONFIG:Debug>:-D_DEBUG>"
-        "$<$<CONFIG:Debug>:-D_FORTIFY_SOURCE=2>"
+        "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>" # FORTIFY_SOURCE should only be used in non-debug builds (requires -O1+)
     )
 
     # Prepare a generator that checks if we are not a debug, and don't have asserts

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -65,9 +65,9 @@ public:
 	}
 	NORETURN static void ThrowError(void *ud, const SQChar *s) {
 		SQCompiler *c = (SQCompiler *)ud;
-		c->Error(s);
+		c->Error("%s", s);
 	}
-	NORETURN void Error(const SQChar *s, ...)
+	NORETURN void Error(const SQChar *s, ...) WARN_FORMAT(2, 3)
 	{
 		static SQChar temp[256];
 		va_list vl;
@@ -122,7 +122,7 @@ public:
 					}
 					Error("expected '%s'", etypename);
 				}
-				Error("expected '%c'", tok);
+				Error("expected '%c'", (char)tok);
 			}
 		}
 		SQObjectPtr ret;

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -94,7 +94,7 @@ bool SQVM::ARITH_OP(SQUnsignedInteger op,SQObjectPtr &trg,const SQObjectPtr &o1,
 					if(!StringCat(o1, o2, trg)) return false;
 			}
 			else if(!ArithMetaMethod(op,o1,o2,trg)) {
-				Raise_Error("arith op %c on between '%s' and '%s'",op,GetTypeName(o1),GetTypeName(o2)); return false;
+				Raise_Error("arith op %c on between '%s' and '%s'",(char)op,GetTypeName(o1),GetTypeName(o2)); return false;
 			}
 		}
 		return true;

--- a/src/3rdparty/squirrel/squirrel/sqvm.h
+++ b/src/3rdparty/squirrel/squirrel/sqvm.h
@@ -81,7 +81,7 @@ public:
 	SQString *PrintObjVal(const SQObject &o);
 
 
-	void Raise_Error(const SQChar *s, ...);
+	void Raise_Error(const SQChar *s, ...) WARN_FORMAT(2, 3);
 	void Raise_Error(SQObjectPtr &desc);
 	void Raise_IdxError(const SQObject &o);
 	void Raise_CompareError(const SQObject &o1, const SQObject &o2);

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -42,8 +42,8 @@ void SetupCargoForClimate(LandscapeID l)
 	assert(l < lengthof(_default_climate_cargo));
 
 	/* Reset and disable all cargo types */
-	memset(CargoSpec::array, 0, sizeof(CargoSpec::array));
 	for (CargoID i = 0; i < lengthof(CargoSpec::array); i++) {
+		*CargoSpec::Get(i) = {};
 		CargoSpec::Get(i)->bitnum = INVALID_CARGO;
 
 		/* Set defaults for newer properties, which old GRFs do not know */

--- a/src/misc/str.hpp
+++ b/src/misc/str.hpp
@@ -90,7 +90,7 @@ struct CStrA : public CBlobT<char>
 	}
 
 	/** Add formatted string (like vsprintf) at the end of existing contents. */
-	int AddFormatL(const char *format, va_list args)
+	int AddFormatL(const char *format, va_list args) WARN_FORMAT(2, 0)
 	{
 		size_t addSize = max<size_t>(strlen(format), 16);
 		addSize += addSize / 2;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1580,7 +1580,7 @@ struct NetworkLobbyWindow : public Window {
 				NetworkTCPQueryServer(NetworkAddress(_settings_client.network.last_host, _settings_client.network.last_port)); // company info
 				NetworkUDPQueryServer(NetworkAddress(_settings_client.network.last_host, _settings_client.network.last_port)); // general data
 				/* Clear the information so removed companies don't remain */
-				memset(this->company_info, 0, sizeof(this->company_info));
+				for (auto &company : this->company_info) company = {};
 				break;
 		}
 	}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -896,7 +896,7 @@ void SlObject(void *object, const SaveLoad *sld);
 bool SlObjectMember(void *object, const SaveLoad *sld);
 void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
 void NORETURN SlErrorCorrupt(const char *msg);
-void NORETURN SlErrorCorruptFmt(const char *format, ...);
+void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);
 
 bool SaveloadCrashWithMissingNewGRFs();
 

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -99,7 +99,7 @@ public:
 	 * Types of expenses.
 	 * @api -ai
 	 */
-	enum ExpensesType {
+	enum ExpensesType : byte {
 		EXPENSES_CONSTRUCTION = ::EXPENSES_CONSTRUCTION, ///< Construction costs.
 		EXPENSES_NEW_VEHICLES = ::EXPENSES_NEW_VEHICLES, ///< New vehicles.
 		EXPENSES_TRAIN_RUN    = ::EXPENSES_TRAIN_RUN,    ///< Running costs trains.

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -36,7 +36,7 @@ public:
 	/**
 	 * Goal types that can be given to a goal.
 	 */
-	enum GoalType {
+	enum GoalType : byte {
 		/* Note: these values represent part of the in-game GoalType enum */
 		GT_NONE     = ::GT_NONE,     ///< Destination is not linked.
 		GT_TILE     = ::GT_TILE,     ///< Destination is a tile.

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -40,7 +40,7 @@ public:
 	/**
 	 * Types of rail known to the game.
 	 */
-	enum RailType {
+	enum RailType : byte {
 		/* Note: these values represent part of the in-game static values */
 		RAILTYPE_INVALID  = ::INVALID_RAILTYPE, ///< Invalid RailType.
 	};

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -60,7 +60,7 @@ public:
 	/**
 	 * Road/tram types
 	 */
-	enum RoadTramTypes {
+	enum RoadTramTypes : uint8 {
 		ROADTRAMTYPES_ROAD = ::RTTB_ROAD, ///< Road road types.
 		ROADTRAMTYPES_TRAM = ::RTTB_TRAM, ///< Tram road types.
 	};

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -119,16 +119,16 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	uint32 refid = 0;
 	TileIndex reftile = 0;
 	switch (type) {
-		case SPET_LOCATION:
+		case ::SPET_LOCATION:
 			reftile = reference;
 			break;
-		case SPET_GOAL:
-		case SPET_BUTTON_PUSH:
-		case SPET_BUTTON_TILE:
-		case SPET_BUTTON_VEHICLE:
+		case ::SPET_GOAL:
+		case ::SPET_BUTTON_PUSH:
+		case ::SPET_BUTTON_TILE:
+		case ::SPET_BUTTON_VEHICLE:
 			refid = reference;
 			break;
-		case SPET_TEXT:
+		case ::SPET_TEXT:
 			break;
 		default:
 			NOT_REACHED();

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -57,7 +57,7 @@ public:
 	/**
 	 * Story page element types.
 	 */
-	enum StoryPageElementType {
+	enum StoryPageElementType : byte {
 		SPET_TEXT = ::SPET_TEXT,                     ///< An element that displays a block of text.
 		SPET_LOCATION = ::SPET_LOCATION,             ///< An element that displays a single line of text along with a button to view the referenced location.
 		SPET_GOAL = ::SPET_GOAL,                     ///< An element that displays a goal.
@@ -75,7 +75,7 @@ public:
 	 * Formatting and layout flags for story page buttons.
 	 * The SPBF_FLOAT_LEFT and SPBF_FLOAT_RIGHT flags can not be combined.
 	 */
-	enum StoryPageButtonFlags {
+	enum StoryPageButtonFlags : byte {
 		SPBF_NONE        = ::SPBF_NONE,        ///< No special formatting for button.
 		SPBF_FLOAT_LEFT  = ::SPBF_FLOAT_LEFT,  ///< Button is placed to the left of the following paragraph.
 		SPBF_FLOAT_RIGHT = ::SPBF_FLOAT_RIGHT, ///< Button is placed to the right of the following paragraph.
@@ -84,7 +84,7 @@ public:
 	/**
 	 * Mouse cursors usable by story page buttons.
 	 */
-	enum StoryPageButtonCursor {
+	enum StoryPageButtonCursor : byte {
 		SPBC_MOUSE          = ::SPBC_MOUSE,
 		SPBC_ZZZ            = ::SPBC_ZZZ,
 		SPBC_BUOY           = ::SPBC_BUOY,

--- a/src/script/squirrel.hpp
+++ b/src/script/squirrel.hpp
@@ -63,12 +63,12 @@ protected:
 	/**
 	 * If a user runs 'print' inside a script, this function gets the params.
 	 */
-	static void PrintFunc(HSQUIRRELVM vm, const SQChar *s, ...);
+	static void PrintFunc(HSQUIRRELVM vm, const SQChar *s, ...) WARN_FORMAT(2, 3);
 
 	/**
 	 * If an error has to be print, this function is called.
 	 */
-	static void ErrorPrintFunc(HSQUIRRELVM vm, const SQChar *s, ...);
+	static void ErrorPrintFunc(HSQUIRRELVM vm, const SQChar *s, ...) WARN_FORMAT(2, 3);
 
 public:
 	Squirrel(const char *APIName);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -35,7 +35,7 @@ char *strecpy(char *dst, const char *src, const char *last);
 char *stredup(const char *src, const char *last = nullptr);
 
 int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4);
-int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap);
+int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0);
 
 char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 


### PR DESCRIPTION
Noticed a couple of warnings with GCC 10:

```
/home/lordaro/dev/openttd/src/network/network_gui.cpp: In member function ‘virtual void NetworkLobbyWindow::OnClick(Point, int, int)’:
/home/lordaro/dev/openttd/src/network/network_gui.cpp:1583:61: warning: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct NetworkCompanyInfo’ with no trivial copy-assignment; use assignment or value-initialization instead [-Wclass-memaccess]
 1583 |     memset(this->company_info, 0, sizeof(this->company_info));
      |                                                             ^
In file included from /home/lordaro/dev/openttd/src/network/network_gui.cpp:15:
/home/lordaro/dev/openttd/src/network/network_gui.h:28:8: note: ‘struct NetworkCompanyInfo’ declared here
   28 | struct NetworkCompanyInfo : NetworkCompanyStats {
      |        ^~~~~~~~~~~~~~~~~~
/home/lordaro/dev/openttd/src/cargotype.cpp: In function ‘void SetupCargoForClimate(LandscapeID)’:
/home/lordaro/dev/openttd/src/cargotype.cpp:45:54: warning: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct CargoSpec’ with no trivial copy-assignment; use assignment or value-initialization instead [-Wclass-memaccess]
   45 |  memset(CargoSpec::array, 0, sizeof(CargoSpec::array));
      |                                                      ^
In file included from /home/lordaro/dev/openttd/src/cargotype.cpp:11:
/home/lordaro/dev/openttd/src/cargotype.h:55:8: note: ‘struct CargoSpec’ declared here
   55 | struct CargoSpec {
      |        ^~~~~~~~~
```