### PR TITLE
Fix #8129: Crash if a news message expires while viewing the endgame screen

### DIFF
--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -671,6 +671,11 @@ static bool ReadyForNextNewsItem()
 /** Move to the next ticker item */
 static void MoveToNextTickerItem()
 {
+	/* There is no status bar, so no reason to show news;
+	 * especially important with the end game screen when
+	 * there is no status bar but possible news. */
+	if (FindWindowById(WC_STATUS_BAR, 0) == nullptr) return;
+
 	InvalidateWindowData(WC_STATUS_BAR, 0, SBI_NEWS_DELETED); // invalidate the statusbar
 
 	/* if we're not at the last item, then move on */
@@ -702,6 +707,11 @@ static void MoveToNextTickerItem()
 /** Move to the next news item */
 static void MoveToNextNewsItem()
 {
+	/* There is no status bar, so no reason to show news;
+	 * especially important with the end game screen when
+	 * there is no status bar but possible news. */
+	if (FindWindowById(WC_STATUS_BAR, 0) == nullptr) return;
+
 	DeleteWindowById(WC_NEWS_WINDOW, 0); // close the newspapers window if shown
 	_forced_news = nullptr;
 
@@ -994,11 +1004,6 @@ void NewsLoop()
 {
 	/* no news item yet */
 	if (_total_news == 0) return;
-
-	/* There is no status bar, so no reason to show news;
-	 * especially important with the end game screen when
-	 * there is no status bar but possible news. */
-	if (FindWindowById(WC_STATUS_BAR, 0) == nullptr) return;
 
 	static byte _last_clean_month = 0;
 


### PR DESCRIPTION
https://github.com/OpenTTD/OpenTTD/blob/b84d61ef6ed5cb79273b752b6031d9574ed735ab/src/news_gui.cpp#L998-L1001

Move (and duplicate) the check to the MoveToNext*Item functions