### PR TITLE
Fix #8216: Don't show floating text on autoreplace if cost is 0

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1045,7 +1045,7 @@ void CallVehicleTicks()
 
 		if (!IsLocalCompany()) continue;
 
-		if (res.Succeeded()) {
+		if (res.Succeeded() && res.GetCost() != 0) {
 			ShowCostOrIncomeAnimation(x, y, z, res.GetCost());
 			continue;
 		}


### PR DESCRIPTION
Not actually tested, but it's the only use of the function that isn't already guarded by an "if != 0" check.