### PR TITLE
Codechange #8258: Remove unused town cargo caches from the savegame

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -302,6 +302,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_MULTITILE_DOCKS,                    ///< 216  PR#7380 Multiple docks per station.
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10 Configurable ending year.
+	SLV_REMOVE_TOWN_CARGO_CACHE,            ///< 219  PR#8258 Remove town cargo acceptance and production caches.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };


### PR DESCRIPTION
Remove from the savegame Town::cargo_accepted and Town::cargo_produced that were made obsolete by #8159. Also while at it I removed 30 reserved bytes for each town that somehow survived the dff871b40d56e05e58636396b74ad4468e11f6a4 purge.

I considered also removing TileMatrix/AcceptanceMatrix but decided to leave it be for now even though atm it's only used to read matrix dimensions as it's still a nice structure that can be useful in the future.