### PR TITLE
Fix: typo in Australian English translation of tooltip setting.

### DIFF
--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -1253,7 +1253,7 @@ STR_CONFIG_SETTING_ERRMSG_DURATION_HELPTEXT                     :Duration for di
 STR_CONFIG_SETTING_ERRMSG_DURATION_VALUE                        :{COMMA} second{P 0 "" s}
 STR_CONFIG_SETTING_HOVER_DELAY                                  :Show tooltips: {STRING}
 STR_CONFIG_SETTING_HOVER_DELAY_HELPTEXT                         :Delay before tooltips are displayed when hovering the mouse over some interface element. Alternatively tooltips can be bound to the right mouse button
-STR_CONFIG_SETTING_HOVER_DELAY_VALUE                            :Hover for {COMMA} second{P 0 "" s}
+STR_CONFIG_SETTING_HOVER_DELAY_VALUE                            :Hover for {COMMA} millisecond{P 0 "" s}
 STR_CONFIG_SETTING_HOVER_DELAY_DISABLED                         :Right click
 STR_CONFIG_SETTING_POPULATION_IN_LABEL                          :Show town population in the town name label: {STRING}
 STR_CONFIG_SETTING_POPULATION_IN_LABEL_HELPTEXT                 :Display the population of towns in their label on the map


### PR DESCRIPTION
English (AU) language shows this one setting incorrectly (should be milliseconds instead of seconds) - this commit fixes that.