### PR TITLE
Fix: refresh coverage on option switch

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -485,6 +485,7 @@ public:
 				this->SetDirty();
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->UpdateSelectSize();
+				SetViewportCatchmentStation(nullptr, true);
 				break;
 
 			case WID_AP_LAYOUT_DECREASE:

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -448,6 +448,7 @@ public:
 				this->LowerWidget(_settings_client.gui.station_show_coverage + BDSW_LT_OFF);
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();
+				SetViewportCatchmentStation(nullptr, true);
 				break;
 		}
 	}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1319,6 +1319,7 @@ public:
 				this->SetWidgetLoweredState(WID_BRAS_HIGHLIGHT_ON, _settings_client.gui.station_show_coverage);
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();
+				SetViewportCatchmentStation(nullptr, true);
 				break;
 
 			case WID_BRAS_NEWST_LIST: {

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1147,6 +1147,7 @@ struct BuildRoadStationWindow : public PickerWindowBase {
 				this->LowerWidget(_settings_client.gui.station_show_coverage + WID_BROS_LT_OFF);
 				if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 				this->SetDirty();
+				SetViewportCatchmentStation(nullptr, true);
 				break;
 
 			default:


### PR DESCRIPTION
Fix #7980. Select station after switching "Coverage area hightlight" option to mark it dirty and redraw hightlighting in the viewport.