### PR TITLE
Add: [CMake] Source group definitions for MSVC project filters.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ include_directories(${CMAKE_SOURCE_DIR}/src)
 # Needed by everything that uses Squirrel
 include_directories(${CMAKE_SOURCE_DIR}/src/3rdparty/squirrel/include)
 
+include(MSVCFilters)
+
 include(CompileFlags)
 compile_flags()
 

--- a/cmake/MSVCFilters.cmake
+++ b/cmake/MSVCFilters.cmake
@@ -1,0 +1,37 @@
+# Add source group filters for use in generated projects.
+
+source_group("AI Core" REGULAR_EXPRESSION "src/ai/")
+source_group("Blitters" REGULAR_EXPRESSION "src/blitter/")
+source_group("Core Source Code" REGULAR_EXPRESSION "src/core/")
+source_group("Game Core" REGULAR_EXPRESSION "src/game/")
+source_group("MD5" REGULAR_EXPRESSION "src/3rdparty/md5/")
+source_group("Misc" REGULAR_EXPRESSION "src/misc/")
+source_group("Music" REGULAR_EXPRESSION "src/music/")
+source_group("Network Core" REGULAR_EXPRESSION "src/network/core/")
+source_group("Pathfinder" REGULAR_EXPRESSION "src/pathfinder/")
+source_group("Save/Load handlers" REGULAR_EXPRESSION "src/saveload/")
+source_group("Sound" REGULAR_EXPRESSION "src/sound/")
+source_group("Sprite loaders" REGULAR_EXPRESSION "src/spriteloader/")
+source_group("Squirrel" REGULAR_EXPRESSION "src/3rdparty/squirrel/squirrel/")
+source_group("Tables" REGULAR_EXPRESSION "src/table/")
+source_group("Video" REGULAR_EXPRESSION "src/video/")
+source_group("Widgets" REGULAR_EXPRESSION "src/widgets/")
+source_group("Windows files" REGULAR_EXPRESSION "src/os/windows/|\.rc$")
+
+# Last directive for each file wins, so make sure NPF/YAPF are after the generic pathfinder filter.
+source_group("NPF" REGULAR_EXPRESSION "src/pathfinder/npf/")
+source_group("YAPF" REGULAR_EXPRESSION "src/pathfinder/yapf/")
+
+source_group("Script" REGULAR_EXPRESSION "src/script/")
+source_group("Script API Implementation" REGULAR_EXPRESSION "src/script/api/")
+source_group("Script API" REGULAR_EXPRESSION "src/script/api/.*\.hpp$")
+source_group("AI API" REGULAR_EXPRESSION "src/script/api/ai_")
+source_group("Game API" REGULAR_EXPRESSION "src/script/api/game_")
+
+# Placed last to ensure any of the previous directory filters are overridden.
+source_group("Command handlers" REGULAR_EXPRESSION "_cmd\.cpp$")
+source_group("Drivers" REGULAR_EXPRESSION "_driver\.hpp$")
+source_group("GUI Source Code" REGULAR_EXPRESSION "_gui\.cpp$")
+source_group("Map Accessors" REGULAR_EXPRESSION "_map\.(cpp|h)$")
+source_group("NewGRF" REGULAR_EXPRESSION "newgrf.*cpp$")
+source_group("Squirrel headers" REGULAR_EXPRESSION "src/3rdparty/squirrel/squirrel/.*\.h$")


### PR DESCRIPTION
I kinda liked the logical grouping of the source files in the old MSVC project. This commit restores this grouping in the generated project files.

I tried adding the source_group definitions to the appropriate CMakeLists, but apparently this just doesn't work: https://stackoverflow.com/questions/31422680/how-to-set-visual-studio-filters-for-nested-sub-directory-using-cmake