### PR TITLE
Change: Sort cargo payment rates legend in order of (initial) cost instead of alphabetically

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -130,6 +130,7 @@ private:
 
 extern CargoTypes _cargo_mask;
 extern CargoTypes _standard_cargo_mask;
+extern CargoTypes _cost_cargo_mask;
 
 void SetupCargoForClimate(LandscapeID l);
 CargoID GetCargoIDByLabel(CargoLabel cl);
@@ -137,6 +138,7 @@ CargoID GetCargoIDByBitnum(uint8 bitnum);
 
 void InitializeSortedCargoSpecs();
 extern std::vector<const CargoSpec *> _sorted_cargo_specs;
+extern std::vector<const CargoSpec *> _cost_sorted_cargo_specs;
 extern uint8 _sorted_standard_cargo_specs_size;
 
 /**
@@ -169,5 +171,19 @@ static inline bool IsCargoInClass(CargoID c, CargoClass cc)
  * @see CargoSpec
  */
 #define FOR_ALL_SORTED_STANDARD_CARGOSPECS(var) for (uint8 index = 0; index < _sorted_standard_cargo_specs_size && (var = _sorted_cargo_specs[index], true); index++)
+
+/**
+ * As above but sorted by cost.
+ * @param var Reference getting the cargospec.
+ * @see CargoSpec
+ */
+#define FOR_ALL_COST_SORTED_CARGOSPECS(var) for (uint8 index = 0; index < _cost_sorted_cargo_specs.size() && (var = _cost_sorted_cargo_specs[index], true) ; index++)
+
+/**
+ * As above but sorted by cost.
+ * @param var Reference getting the cargospec.
+ * @see CargoSpec
+ */
+#define FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(var) for (uint8 index = 0; index < _sorted_standard_cargo_specs_size && (var = _cost_sorted_cargo_specs[index], true); index++)
 
 #endif /* CARGOTYPE_H */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -894,7 +894,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 
 		int i = 0;
 		const CargoSpec *cs;
-		FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
+		FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(cs) {
 			if (HasBit(_legend_excluded_cargo, cs->Index())) SetBit(this->excluded_data, i);
 			i++;
 		}
@@ -908,7 +908,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 		}
 
 		const CargoSpec *cs;
-		FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
+		FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(cs) {
 			SetDParam(0, cs->name);
 			Dimension d = GetStringBoundingBox(STR_GRAPH_CARGO_PAYMENT_CARGO);
 			d.width += 14; // colour field
@@ -939,7 +939,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 		int max = pos + this->vscroll->GetCapacity();
 
 		const CargoSpec *cs;
-		FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
+		FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(cs) {
 			if (pos-- > 0) continue;
 			if (--max < 0) break;
 
@@ -974,7 +974,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 				/* Add all cargoes to the excluded lists. */
 				int i = 0;
 				const CargoSpec *cs;
-				FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
+				FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(cs) {
 					SetBit(_legend_excluded_cargo, cs->Index());
 					SetBit(this->excluded_data, i);
 					i++;
@@ -988,7 +988,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 				if (row >= this->vscroll->GetCount()) return;
 
 				const CargoSpec *cs;
-				FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
+				FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(cs) {
 					if (row-- > 0) continue;
 
 					ToggleBit(_legend_excluded_cargo, cs->Index());
@@ -1028,7 +1028,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 
 		int i = 0;
 		const CargoSpec *cs;
-		FOR_ALL_SORTED_STANDARD_CARGOSPECS(cs) {
+		FOR_ALL_COST_SORTED_STANDARD_CARGOSPECS(cs) {
 			this->colours[i] = cs->legend_colour;
 			for (uint j = 0; j != 20; j++) {
 				this->cost[i][j] = GetTransportedGoodsIncome(10, 20, j * 4 + 4, cs->Index());


### PR DESCRIPTION
Cargo payment rates are normally hard to read, as with more cargos, the different colours become harder to distinguish.
I believe that ordering the chart legend by cost will make it easier for the user to associate each line with the correct cargo.

Pic: chart with OpenGFX cargos
![Cargo payment rates chart with OpenGFX cargos](https://i.imgur.com/9WWoCxI.png)

Pic: chart with FIRS3 Extreme cargos
![Cargo payment rates chart with FIRS3 Extreme cargos](https://i.imgur.com/7NN7de9.png)