### PR TITLE
Set invalid road and tram types for rail tunnel ends

### DIFF
--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -10,6 +10,7 @@
 #ifndef TUNNEL_MAP_H
 #define TUNNEL_MAP_H
 
+#include "rail_map.h"
 #include "road_map.h"
 
 
@@ -79,7 +80,9 @@ static inline void MakeRailTunnel(TileIndex t, Owner o, DiagDirection d, RailTyp
 	_m[t].m5 = TRANSPORT_RAIL << 2 | d;
 	SB(_me[t].m6, 2, 4, 0);
 	_me[t].m7 = 0;
-	_me[t].m8 = r;
+	_me[t].m8 = 0;
+	SetRailType(t, r);
+	SetRoadTypes(t, INVALID_ROADTYPE, INVALID_ROADTYPE);
 }
 
 #endif /* TUNNEL_MAP_H */


### PR DESCRIPTION
Set invalid road/tram types for rail tunnels that were seemingly forgotten in c671dcea0e0532d1ce1924a097c7262035960829 and somehow #8111 that did a savegame fix for it.

Not sure if that actually affects the game in any way except showing up in land info but I came across it while debugging desyc of android players even though it probably wasn't the cause.
![Screenshot from 2020-07-12 00-44-47](https://user-images.githubusercontent.com/413570/87247748-4dd50f00-c45e-11ea-89d1-b4040e92ef82.png)
