### PR TITLE
Fix: GCC warns about possibly uninitialized data in signal.cpp

### DIFF
--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -268,10 +268,10 @@ static SigFlags ExploreSegment(Owner owner)
 {
 	SigFlags flags = SF_NONE;
 
-	TileIndex tile;
-	DiagDirection enterdir;
+	TileIndex tile = INVALID_TILE; // Stop GCC from complaining about a possibly uninitialized variable (issue #8280).
+	DiagDirection enterdir = INVALID_DIAGDIR;
 
-	while (_tbdset.Get(&tile, &enterdir)) {
+	while (_tbdset.Get(&tile, &enterdir)) { // tile and enterdir are initialized here, unless I'm mistaken.
 		TileIndex oldtile = tile; // tile we are leaving
 		DiagDirection exitdir = enterdir == INVALID_DIAGDIR ? INVALID_DIAGDIR : ReverseDiagDir(enterdir); // expected new exit direction (for straight line)
 
@@ -407,8 +407,8 @@ static SigFlags ExploreSegment(Owner owner)
  */
 static void UpdateSignalsAroundSegment(SigFlags flags)
 {
-	TileIndex tile;
-	Trackdir trackdir;
+	TileIndex tile = INVALID_TILE; // Stop GCC from complaining about a possibly uninitialized variable (issue #8280).
+	Trackdir trackdir = INVALID_TRACKDIR;
 
 	while (_tbuset.Get(&tile, &trackdir)) {
 		assert(HasSignalOnTrackdir(tile, trackdir));
@@ -474,8 +474,8 @@ static SigSegState UpdateSignalsInBuffer(Owner owner)
 	bool first = true;  // first block?
 	SigSegState state = SIGSEG_FREE; // value to return
 
-	TileIndex tile;
-	DiagDirection dir;
+	TileIndex tile = INVALID_TILE; // Stop GCC from complaining about a possibly uninitialized variable (issue #8280).
+	DiagDirection dir = INVALID_DIAGDIR;
 
 	while (_globset.Get(&tile, &dir)) {
 		assert(_tbuset.IsEmpty());


### PR DESCRIPTION
When compiling with `-Og`, GCC warns about variables that are initialized by reference in the condition of a `while` loop.

This commit silences the warning by explicitly initializing the variables in question to their respective 'invalid value' markers, which will most likely be optimized out when the compiler realizes the values are never used.

As near as I can tell, the compiler complains because there is a path through `SmallSet::Get` that does not assign to its parameters (i.e. the case of an empty set); and the optimization level in question does not perform the static analysis that would be necessary to determine that the results (or lack thereof) are not actually used in that case.

Fixes https://github.com/OpenTTD/OpenTTD/issues/8280