### PR TITLE
Add: new economy "frozen" that stops production changes and industry closures

### DIFF
--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -15,6 +15,15 @@
 
 typedef OverflowSafeInt64 Money;
 
+/** Type of the game economy. */
+enum EconomyType : uint8 {
+	ET_BEGIN = 0,
+	ET_ORIGINAL = 0,
+	ET_SMOOTH = 1,
+	ET_FROZEN = 2,
+	ET_END = 3,
+};
+
 /** Data of the economy. */
 struct Economy {
 	Money max_loan;                       ///< NOSAVE: Maximum possible loan

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1080,7 +1080,7 @@ public:
 		const Industry *i = Industry::Get(this->window_number);
 		if (IsProductionAlterable(i)) {
 			const IndustrySpec *ind = GetIndustrySpec(i->type);
-			this->editable = ind->UsesSmoothEconomy() ? EA_RATE : EA_MULTIPLIER;
+			this->editable = ind->UsesOriginalEconomy() ? EA_MULTIPLIER : EA_RATE;
 		} else {
 			this->editable = EA_NONE;
 		}
@@ -1100,7 +1100,7 @@ public:
 static void UpdateIndustryProduction(Industry *i)
 {
 	const IndustrySpec *indspec = GetIndustrySpec(i->type);
-	if (!indspec->UsesSmoothEconomy()) i->RecomputeProductionMultipliers();
+	if (indspec->UsesOriginalEconomy()) i->RecomputeProductionMultipliers();
 
 	for (byte j = 0; j < lengthof(i->produced_cargo); j++) {
 		if (i->produced_cargo[j] != CT_INVALID) {

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -144,7 +144,7 @@ struct IndustrySpec {
 	bool IsProcessingIndustry() const;
 	Money GetConstructionCost() const;
 	Money GetRemovalCost() const;
-	bool UsesSmoothEconomy() const;
+	bool UsesOriginalEconomy() const;
 
 	~IndustrySpec();
 };

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1553,8 +1553,11 @@ STR_CONFIG_SETTING_ENDING_YEAR                                  :Scoring end yea
 STR_CONFIG_SETTING_ENDING_YEAR_HELPTEXT                         :Year the game ends for scoring purposes. At the end of this year, the company's score is recorded and the high-score screen is displayed, but the players can continue playing after that.{}If this is before the starting year, the high-score screen is never displayed.
 STR_CONFIG_SETTING_ENDING_YEAR_VALUE                            :{NUM}
 STR_CONFIG_SETTING_ENDING_YEAR_ZERO                             :Never
-STR_CONFIG_SETTING_SMOOTH_ECONOMY                               :Enable smooth economy (more, smaller changes): {STRING2}
-STR_CONFIG_SETTING_SMOOTH_ECONOMY_HELPTEXT                      :When enabled, industry production changes more often, and in smaller steps. This setting has usually no effect, if industry types are provided by a NewGRF
+STR_CONFIG_SETTING_ECONOMY_TYPE                                 :Economy type: {STRING2}
+STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT                        :Smooth economy makes production changes more often, and in smaller steps. Frozen economy stops production changes and industry closures. This setting may have no effect if industry types are provided by a NewGRF.
+STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL                        :Original
+STR_CONFIG_SETTING_ECONOMY_TYPE_SMOOTH                          :Smooth
+STR_CONFIG_SETTING_ECONOMY_TYPE_FROZEN                          :Frozen
 STR_CONFIG_SETTING_ALLOW_SHARES                                 :Allow buying shares from other companies: {STRING2}
 STR_CONFIG_SETTING_ALLOW_SHARES_HELPTEXT                        :When enabled, allow buying and selling of company shares. Shares will only be available for companies reaching a certain age
 STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES                         :Minimum company age to trade shares: {STRING2}

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1729,7 +1729,7 @@ static SettingsContainer &GetSettingsTree()
 				industries->Add(new SettingEntry("construction.industry_platform"));
 				industries->Add(new SettingEntry("economy.multiple_industry_per_town"));
 				industries->Add(new SettingEntry("game_creation.oil_refinery_limit"));
-				industries->Add(new SettingEntry("economy.smooth_economy"));
+				industries->Add(new SettingEntry("economy.type"));
 				industries->Add(new SettingEntry("station.serve_neutral_industries"));
 			}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -11,6 +11,7 @@
 #define SETTINGS_TYPE_H
 
 #include "date_type.h"
+#include "economy_type.h"
 #include "town_type.h"
 #include "transport_type.h"
 #include "network/core/config.h"
@@ -470,7 +471,7 @@ struct VehicleSettings {
 struct EconomySettings {
 	bool   inflation;                        ///< disable inflation
 	bool   bribe;                            ///< enable bribing the local authority
-	bool   smooth_economy;                   ///< smooth economy
+	EconomyType type;                        ///< economy type (original/smooth/frozen)
 	bool   allow_shares;                     ///< allow the buying/selling of shares
 	uint8  min_years_for_shares;             ///< minimum age of a company for it to trade shares
 	uint8  feeder_payment_share;             ///< percentage of leg payment to virtually pay in feeder systems

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1429,12 +1429,17 @@ strhelp  = STR_CONFIG_SETTING_ENDING_YEAR_HELPTEXT
 strval   = STR_CONFIG_SETTING_ENDING_YEAR_VALUE
 cat      = SC_ADVANCED
 
-[SDT_BOOL]
+[SDT_VAR]
 base     = GameSettings
-var      = economy.smooth_economy
-def      = true
-str      = STR_CONFIG_SETTING_SMOOTH_ECONOMY
-strhelp  = STR_CONFIG_SETTING_SMOOTH_ECONOMY_HELPTEXT
+var      = economy.type
+type     = SLE_UINT8
+guiflags = SGF_MULTISTRING
+def      = ET_SMOOTH
+min      = ET_BEGIN
+max      = ET_END - 1
+str      = STR_CONFIG_SETTING_ECONOMY_TYPE
+strhelp  = STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT
+strval   = STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL
 proc     = InvalidateIndustryViewWindow
 cat      = SC_BASIC
 


### PR DESCRIPTION
OpenTTD production changing and industry closing scheme only supports default evenly-spread random industry generation. Even if scenario does some custom one it will be destroyed as the game goes. And while this issue can be somewhat worked around by using kluge industry sets like "manual industries" it's incompatible with other industry sets (including kluges) and can't be changed if player noticed the issue mid-game. 

Doesn't need a savgame upgrade as it's just a bool->uint8 conversion.