### PR TITLE
Change: Service depot also reset breakdown chance.

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -170,6 +170,8 @@ void VehicleServiceInDepot(Vehicle *v)
 		v->reliability = v->GetEngine()->reliability;
 		/* Prevent vehicles from breaking down directly after exiting the depot. */
 		v->breakdown_chance /= 4;
+		if (_settings_game.difficulty.vehicle_breakdowns == 1) // reduced breakdown.
+			v->breakdown_chance = 0;
 		v = v->Next();
 	} while (v != nullptr && v->HasEngineType());
 }


### PR DESCRIPTION
I have so mush fun with this little change, that I really what to share it.
I have found the idea on Openttd forum.

Each time your vehicle go to service, then the breakdown chance is reset.
It allow to create large trains networks with simple tracks but carefully timed service and length to it.

Regards.
