### PR TITLE
Fix: sprite preview in sprite aligner is too small with scaled UI

### DIFF
--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -856,13 +856,17 @@ struct SpriteAlignerWindow : Window {
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
 	{
-		if (widget != WID_SA_LIST) return;
-
-		resize->height = max(11, FONT_HEIGHT_NORMAL + 1);
-		resize->width  = 1;
-
-		/* Resize to about 200 pixels (for the preview) */
-		size->height = (1 + 200 / resize->height) * resize->height;
+		switch (widget) {
+			case WID_SA_SPRITE:
+				size->height = ScaleGUITrad(200);
+				break;
+			case WID_SA_LIST:
+				resize->height = max(11, FONT_HEIGHT_NORMAL + 1);
+				resize->width  = 1;
+				break;
+			default:
+				break;
+		}
 	}
 
 	void DrawWidget(const Rect &r, int widget) const override


### PR DESCRIPTION
### Before:
![Screenshot from 2020-08-02 17-27-44](https://user-images.githubusercontent.com/413570/89125281-06cebc80-d4e6-11ea-9648-2f0f64c91bd5.png)

### After:
![Screenshot from 2020-08-02 17-28-27](https://user-images.githubusercontent.com/413570/89125233-ad668d80-d4e5-11ea-9dd4-03b131389c71.png)

Sprite selection list also looks meh by I couldn't figure out how to fix it.