### PR TITLE
Fix clang-cl build on Windows

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -23,8 +23,10 @@ macro(compile_flags)
         # C++11 standard". We need C++11 for the way we use threads.
         add_compile_options(/Zc:rvalueCast)
 
-        # Enable multi-threaded compilation.
-        add_compile_options(/MP)
+        if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            # Enable multi-threaded compilation.
+            add_compile_options(/MP)
+        endif(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
         # Add DPI manifest to project; other WIN32 targets get this via ottdres.rc
         list(APPEND GENERATED_SOURCE_FILES "${CMAKE_SOURCE_DIR}/os/windows/openttd.manifest")

--- a/cmake/FindEditbin.cmake
+++ b/cmake/FindEditbin.cmake
@@ -1,10 +1,27 @@
 # Autodetect editbin. Only useful for MSVC.
 
-get_filename_component(MSVC_COMPILE_DIRECTORY ${CMAKE_CXX_COMPILER} DIRECTORY)
+if (NOT EDITBIN_DIRECTORY)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        get_filename_component(MSVC_COMPILE_DIRECTORY ${CMAKE_CXX_COMPILER} DIRECTORY)
+        set(EDITBIN_DIRECTORY ${MSVC_COMPILE_DIRECTORY})
+    else (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # For clang-cl build
+        # find editbin.exe from environmental variable VCToolsInstallDir
+        set(EDITBIN_DIRECTORY "$ENV{VCToolsInstallDir}/bin/Hostx64/x64")
+    endif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+endif (NOT EDITBIN_DIRECTORY)
+
+message(CHECK_START "Finding editbin.exe")
 find_program(
     EDITBIN_EXECUTABLE editbin.exe
-    HINTS ${MSVC_COMPILE_DIRECTORY}
+    HINTS ${EDITBIN_DIRECTORY}
 )
+
+if (EDITBIN_EXECUTABLE)
+    message(CHECK_PASS "found")
+else (EDITBIN_EXECUTABLE)
+    message(CHECK_FAIL "not found , please manually specify EDITBIN_DIRECTORY")
+endif (EDITBIN_EXECUTABLE)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Editbin


### PR DESCRIPTION
llvm on Windows does not come with `Editbin` (In general, I avoid using MSVC tools for clang build on Windows, except a few libraries and headers.), and `clang-cl` does not take the `/MP` flag.

Would it cause any problem without the `Editbin`? It seems like it is only used in `cmake/scripts/Regression.cmake`