### PR TITLE
Change: Use key names instead of characters in hotkey.cfg

### DIFF
--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -67,17 +67,25 @@ static const KeycodeNames _keycode_to_name[] = {
 	{"NUM_PLUS", WKC_NUM_PLUS},
 	{"NUM_ENTER", WKC_NUM_ENTER},
 	{"NUM_DOT", WKC_NUM_DECIMAL},
-	{"/", WKC_SLASH},
-	{";", WKC_SEMICOLON},
-	{"=", WKC_EQUALS},
-	{"[", WKC_L_BRACKET},
-	{"\\", WKC_BACKSLASH},
-	{"]", WKC_R_BRACKET},
-	{"'", WKC_SINGLEQUOTE},
-	{",", WKC_COMMA},
-	{"COMMA", WKC_COMMA}, // legacy variant, should be below ","
-	{".", WKC_PERIOD},
-	{"-", WKC_MINUS},
+	{"SLASH", WKC_SLASH},
+	{"/", WKC_SLASH}, /* deprecated, use SLASH */
+	{"SEMICOLON", WKC_SEMICOLON},
+	{";", WKC_SEMICOLON}, /* deprecated, use SEMICOLON */
+	{"EQUALS", WKC_EQUALS},
+	{"=", WKC_EQUALS}, /* deprecated, use EQUALS */
+	{"L_BRACKET", WKC_L_BRACKET},
+	{"[", WKC_L_BRACKET}, /* deprecated, use L_BRACKET */
+	{"BACKSLASH", WKC_BACKSLASH},
+	{"\\", WKC_BACKSLASH}, /* deprecated, use BACKSLASH */
+	{"R_BRACKET", WKC_R_BRACKET},
+	{"]", WKC_R_BRACKET}, /* deprecated, use R_BRACKET */
+	{"SINGLEQUOTE", WKC_SINGLEQUOTE},
+	{"'", WKC_SINGLEQUOTE}, /* deprecated, use SINGLEQUOTE */
+	{"COMMA", WKC_COMMA},
+	{"PERIOD", WKC_PERIOD},
+	{".", WKC_PERIOD}, /* deprecated, use PERIOD */
+	{"MINUS", WKC_MINUS},
+	{"-", WKC_MINUS}, /* deprecated, use MINUS */
 };
 
 /**


### PR DESCRIPTION
Because using .cfg special characters as values is a terrible idea:
- `=` doesn't work as a single hotkey
- `,` never works at all, it's a hotkey list separator
- `+` and `"` would've never worked as well but were strategically avoided even though there are `-` and `'`
- some other chars like `\` only work by the miracle of a weird ini parser
- `COMMA` and `"="` only work once before it rewrites config with broken variants
- there is `BACKQUOTE`
- there is `NUM_MINUS` as well as `-` even though they're the same character (because they are supposed to be key codes, not characters).

So, IMO, the only way out of this mess is to use key names everywhere. Unfortunately, characters will also have to be kept, at least for a while, to convert old configs.