### PR TITLE
Feature: Show group name as part of the default vehicle name.

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -9075,7 +9075,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   --Accounting--
     GetCosts():         -5947
     Should be:          -5947
-  GetName():            Road Vehicle 1
+  GetName():            Road Vehicle #1
   SetName():            true
   GetName():            MyVehicleName
   CloneVehicle():       13

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -456,6 +456,8 @@ CommandCost CmdAlterGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 		InvalidateWindowData(WC_REPLACE_VEHICLE, g->vehicle_type, 1);
 		InvalidateWindowData(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).Pack());
 		InvalidateWindowData(WC_COMPANY_COLOUR, g->owner, g->vehicle_type);
+		InvalidateWindowClassesData(WC_VEHICLE_VIEW);
+		InvalidateWindowClassesData(WC_VEHICLE_DETAILS);
 	}
 
 	return CommandCost();
@@ -545,6 +547,8 @@ CommandCost CmdAddVehicleGroup(TileIndex tile, DoCommandFlag flags, uint32 p1, u
 		SetWindowDirty(WC_VEHICLE_VIEW, v->index);
 		SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 		InvalidateWindowData(GetWindowClassForVehicleType(v->type), VehicleListIdentifier(VL_GROUP_LIST, v->type, _current_company).Pack());
+		InvalidateWindowData(WC_VEHICLE_VIEW, v->index);
+		InvalidateWindowData(WC_VEHICLE_DETAILS, v->index);
 	}
 
 	return CommandCost();

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5037,6 +5037,7 @@ STR_FORMAT_BUOY_NAME                                            :{TOWN} Buoy
 STR_FORMAT_BUOY_NAME_SERIAL                                     :{TOWN} Buoy #{COMMA}
 STR_FORMAT_COMPANY_NUM                                          :(Company {COMMA})
 STR_FORMAT_GROUP_NAME                                           :Group {COMMA}
+STR_FORMAT_GROUP_VEHICLE_NAME                                   :{GROUP} #{COMMA}
 STR_FORMAT_INDUSTRY_NAME                                        :{TOWN} {STRING}
 STR_FORMAT_WAYPOINT_NAME                                        :{TOWN} Waypoint
 STR_FORMAT_WAYPOINT_NAME_SERIAL                                 :{TOWN} Waypoint #{COMMA}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4732,10 +4732,10 @@ STR_INDUSTRY_NAME_SUGAR_MINE                                    :Sugar Mine
 ##id 0x6000
 STR_SV_EMPTY                                                    :
 STR_SV_UNNAMED                                                  :Unnamed
-STR_SV_TRAIN_NAME                                               :Train {COMMA}
-STR_SV_ROAD_VEHICLE_NAME                                        :Road Vehicle {COMMA}
-STR_SV_SHIP_NAME                                                :Ship {COMMA}
-STR_SV_AIRCRAFT_NAME                                            :Aircraft {COMMA}
+STR_SV_TRAIN_NAME                                               :Train #{COMMA}
+STR_SV_ROAD_VEHICLE_NAME                                        :Road Vehicle #{COMMA}
+STR_SV_SHIP_NAME                                                :Ship #{COMMA}
+STR_SV_AIRCRAFT_NAME                                            :Aircraft #{COMMA}
 
 STR_SV_STNAME                                                   :{STRING1}
 STR_SV_STNAME_NORTH                                             :{STRING1} North

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1467,6 +1467,11 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 					int64 args_array[] = {(int64)(size_t)v->name.c_str()};
 					StringParameters tmp_params(args_array);
 					buff = GetStringWithArgs(buff, STR_JUST_RAW_STRING, &tmp_params, last);
+				} else if (v->group_id != DEFAULT_GROUP) {
+					/* The vehicle has no name, but is member of a group, so print group name */
+					int64 args_array[] = {v->group_id, v->unitnumber};
+					StringParameters tmp_params(args_array);
+					buff = GetStringWithArgs(buff, STR_FORMAT_GROUP_VEHICLE_NAME, &tmp_params, last);
 				} else {
 					int64 args_array[] = {v->unitnumber};
 					StringParameters tmp_params(args_array);


### PR DESCRIPTION
Only if the vehicle is member of a group and does not have a user defined name.

This patch is based on @KeldorKatarn's commit:
KeldorKatarn/OpenTTD_PatchPack@3f03ec47

![group_name](https://user-images.githubusercontent.com/48624099/93125693-cb6e0300-f6cb-11ea-9d98-73ac06c5e482.png)
