### PR TITLE
Change: Service at depot resets breakdown chance

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -170,6 +170,7 @@ void VehicleServiceInDepot(Vehicle *v)
 		v->reliability = v->GetEngine()->reliability;
 		/* Prevent vehicles from breaking down directly after exiting the depot. */
 		v->breakdown_chance /= 4;
+		if (_settings_game.difficulty.vehicle_breakdowns == 1) v->breakdown_chance = 0; // on reduced breakdown
 		v = v->Next();
 	} while (v != nullptr && v->HasEngineType());
 }


### PR DESCRIPTION
I have so mush fun with this little change, that I really what to share it.
I have found the idea on Openttd forum.

Each time your vehicle go to service, then the breakdown chance is reset.
It allow to create large trains networks with simple tracks but carefully timed service and length to it.

Services on depot can work a bit like "predictive maintenance". If you do it well, everything goes well, if you start jamming your network sometime everything will go badly wrong after a while. Smoothness is require to operate an interconnection. Also a train waiting in depot for an route, still start raise there breakdown chance, so your buffers must be carefully crafted; but you don't have to do silly/made network with logic to handle breakdown, or disable breakdown.
It just make it playable.

Regards.

Peoples below are right.

@nielsmh 
 when you're playing with reduced breakdowns, vehicles will never break down right after receiving service (for a while).

@ldpl 
This is just the same as the vehicle breaking down, doesn't protect it from further breakdowns completely, only makes it less likely for a while. In some cases it makes it so much less likely that it's effectively 0.


This new PR, correct the #8286 for coding still and is made from the last OpenTTD master.