### PR TITLE
Make openttd reproducible by not embedding timestamps in gzip

### DIFF
--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -45,7 +45,7 @@ if(OPTION_INSTALL_FHS)
     install(CODE
             "
                 execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${MAN_SOURCE_FILE} ${MAN_BINARY_FILE})
-                execute_process(COMMAND gzip -9 -f ${MAN_BINARY_FILE})
+                execute_process(COMMAND gzip -9 -n -f ${MAN_BINARY_FILE})
             "
             COMPONENT manual)
     install(FILES


### PR DESCRIPTION
By default gzip embeds a timestamps which makes building it twice
not reproducible, passing -n skips this embedding behaviour.

Motivation: https://reproducible-builds.org