### PR TITLE
Build AppImage

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,50 @@
+name: AppImage CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  pack:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libfontconfig-dev \
+            libicu-dev \
+            liblzma-dev \
+            liblzo2-dev \
+            libsdl1.2-dev \
+            libsdl2-dev \
+            libxdg-basedir-dev \
+            zlib1g-dev \
+            # EOF
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          mkdir -p build && cd build
+          cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+          make -j`nproc`
+          make install -j$(nproc) DESTDIR=AppDir
+
+      - name: Create AppImage
+        uses: AppImageCrafters/build-appimage-action@master
+        env:
+            BUILDER_WORKDIR: build
+            BUILDER_VERSION: 0.7.3
+        with:
+          recipe: ../os/linux/appimage-builder.yml
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: AppImage
+          path: ./build/*.AppImage

--- a/os/linux/appimage-builder.yml
+++ b/os/linux/appimage-builder.yml
@@ -5,12 +5,6 @@ script: |
     which unzip || apt-get update ; apt-get install wget unzip -y
     mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps
     cp ../media/openttd.svg AppDir/usr/share/icons/hicolor/scalable/apps
-    wget -qcO opengfx.zip https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip
-    unzip opengfx.zip -d AppDir/usr/share/games/openttd/baseset
-    wget -qcO openmsx.zip https://cdn.openttd.org/openmsx-releases/0.3.1/openmsx-0.3.1-all.zip
-    unzip openmsx.zip -d AppDir/usr/share/games/openttd/baseset
-    wget -qcO opensfx.zip https://cdn.openttd.org/opensfx-releases/0.2.3/opensfx-0.2.3-all.zip
-    unzip opensfx.zip -d AppDir/usr/share/games/openttd/baseset
 
 AppDir:
   path: ./AppDir

--- a/os/linux/appimage-builder.yml
+++ b/os/linux/appimage-builder.yml
@@ -33,28 +33,28 @@ AppDir:
 
     include:
       - freepats
-      - timidity
       - libicu66
       - liblzma5
       - liblzo2-2
       - libpng16-16
       - libsdl1.2debian
-      - libxdg-basedir1
       - libsdl2-2.0-0
+      - libxdg-basedir1
+      - timidity
       - zlib1g
     exclude:
-      - humanity-icon-theme
       - adwaita-icon-theme
-      - python3
-      - python3.6
-      - python3-minimal
-      - python3.6-minimal
+      - dpkg-dev
+      - humanity-icon-theme
+      - make
+      - patch
       - perl
       - perl-base
       - pkg-config
-      - patch
-      - make
-      - dpkg-dev
+      - python3
+      - python3-minimal
+      - python3.6
+      - python3.6-minimal
 
   after_bundle: |
     echo "source /etc/timidity/freepats.cfg" | tee AppDir/etc/timidity/timidity.cfg

--- a/os/linux/appimage-builder.yml
+++ b/os/linux/appimage-builder.yml
@@ -2,7 +2,6 @@
 version: 1
 
 script: |
-    which unzip || apt-get update ; apt-get install wget unzip -y
     mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps
     cp ../media/openttd.svg AppDir/usr/share/icons/hicolor/scalable/apps
 

--- a/os/linux/appimage-builder.yml
+++ b/os/linux/appimage-builder.yml
@@ -21,7 +21,6 @@ AppDir:
     sources:
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse'
-      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse'
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse'
         key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
 

--- a/os/linux/appimage-builder.yml
+++ b/os/linux/appimage-builder.yml
@@ -1,0 +1,94 @@
+# appimage-builder recipe, see https://appimage-builder.readthedocs.io
+version: 1
+
+script: |
+    which unzip || apt-get update ; apt-get install wget unzip -y
+    mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps
+    cp ../media/openttd.svg AppDir/usr/share/icons/hicolor/scalable/apps
+    wget -qcO opengfx.zip https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip
+    unzip opengfx.zip -d AppDir/usr/share/games/openttd/baseset
+    wget -qcO openmsx.zip https://cdn.openttd.org/openmsx-releases/0.3.1/openmsx-0.3.1-all.zip
+    unzip openmsx.zip -d AppDir/usr/share/games/openttd/baseset
+    wget -qcO opensfx.zip https://cdn.openttd.org/opensfx-releases/0.2.3/opensfx-0.2.3-all.zip
+    unzip opensfx.zip -d AppDir/usr/share/games/openttd/baseset
+
+AppDir:
+  path: ./AppDir
+
+  app_info:
+    id: org.openttd.openttd
+    name: openttd
+    icon: openttd
+    version: latest
+    exec: usr/bin/openttd
+
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+
+    include:
+      - freepats
+      - timidity
+      - libicu66
+      - liblzma5
+      - liblzo2-2
+      - libpng16-16
+      - libsdl1.2debian
+      - libxdg-basedir1
+      - libsdl2-2.0-0
+      - zlib1g
+    exclude:
+      - humanity-icon-theme
+      - adwaita-icon-theme
+      - python3
+      - python3.6
+      - python3-minimal
+      - python3.6-minimal
+      - perl
+      - perl-base
+      - pkg-config
+      - patch
+      - make
+      - dpkg-dev
+
+  after_bundle: |
+    echo "source /etc/timidity/freepats.cfg" | tee AppDir/etc/timidity/timidity.cfg
+
+  runtime:
+    path_mappings:
+      - /usr/share/games/openttd:$APPDIR/usr/share/games/openttd
+      - /etc/timidity:$APPDIR/etc/timidity
+      - /usr/lib/timidity:$APPDIR/usr/lib/timidity
+
+  test:
+    fedora:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+      use_host_x: true
+    debian:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: true
+    arch:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: true
+    centos:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+      use_host_x: true
+    ubuntu:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: true
+
+AppImage:
+  update-information: "gh-releases-zsync|OpenTTD|OpenTTD|latest|*x86_64.AppImage.zsync"
+  sign-key: None
+  arch: x86_64
+


### PR DESCRIPTION
This PR adds a Github workflow to pack OpenTDD using the AppImage format from commits and PR to master.
The resulting binary is published as an artifact. 

appimage-builder is ran twice in order to patch the timidity configuration to use freepaths. This could be fixed once the feature gets added into appimage-builder https://github.com/AppImageCrafters/appimage-builder/issues/50

Closes #8019