### PR TITLE
Fix: [NoAI] don't notify caught exceptions

### DIFF
--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -478,7 +478,7 @@ void Squirrel::Initialize()
 
 	/* Handle compile-errors ourself, so we can display it nicely */
 	sq_setcompilererrorhandler(this->vm, &Squirrel::CompileError);
-	sq_notifyallexceptions(this->vm, SQTrue);
+	sq_notifyallexceptions(this->vm, _debug_script_level > 5);
 	/* Set a good print-function */
 	sq_setprintfunc(this->vm, &Squirrel::PrintFunc);
 	/* Handle runtime-errors ourself, so we can display it nicely */


### PR DESCRIPTION
Make _notifyallexceptions and error raising behave as expected
(1 LOC backport from https://github.com/albertodemichelis/squirrel trunk)
Set _notifyallexceptions to false to only call Squirrel::_RunError on uncaught exceptions