### PR TITLE
Fix build with icu-68.1

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -116,7 +116,7 @@ void Font::getGlyphAdvance(LEGlyphID glyph, LEPoint &advance) const
 
 le_bool Font::getGlyphPoint(LEGlyphID glyph, le_int32 pointNumber, LEPoint &point) const
 {
-	return FALSE;
+	return false;
 }
 
 /**


### PR DESCRIPTION
icu-68.1 removed public macro definitions for TRUE and FALSE

See icu upstream commit: https://github.com/unicode-org/icu/commit/a18df7ba2834afc2b577a1d5a7d906868ade6fa9