### PR TITLE
Fix: Remove unnessary reference to suppress warning

### DIFF
--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -903,7 +903,7 @@ void ClientNetworkContentSocketHandler::ToggleSelectedState(const ContentInfo *c
  */
 void ClientNetworkContentSocketHandler::ReverseLookupDependency(ConstContentVector &parents, const ContentInfo *child) const
 {
-	for (const ContentInfo * const &ci : this->infos) {
+	for (const ContentInfo *ci : this->infos) {
 		if (ci == child) continue;
 
 		for (uint i = 0; i < ci->dependency_count; i++) {


### PR DESCRIPTION
Apple Clang version 12 (bundled with Xcode 12) complaints about copying
small objects in range loop (-Wrange-loop-analysis introduced by -Wall).
This warning can be easily avoided by removing the reference from
the const pointer type.
