### PR TITLE
Feature: Allow automatically separating vehicles in shared orders

### DIFF
--- a/src/base_consist.cpp
+++ b/src/base_consist.cpp
@@ -42,3 +42,12 @@ void BaseConsist::CopyConsistPropertiesFrom(const BaseConsist *src)
 	}
 	if (HasBit(src->vehicle_flags, VF_SERVINT_IS_CUSTOM)) SetBit(this->vehicle_flags, VF_SERVINT_IS_CUSTOM);
 }
+
+/**
+ * Resets all the data used for automatic separation
+ */
+void BaseConsist::ResetAutomaticSeparation()
+{
+	this->first_order_last_departure = 0;
+	this->first_order_round_trip_time = 0;
+}

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -22,8 +22,8 @@ struct BaseConsist {
 	TimerGameTick::Ticks lateness_counter;      ///< How many ticks late (or early if negative) this vehicle is.
 	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
-	TimerGameTick::Ticks first_order_last_departure;  ///< When the vehicle last left the first order.
-	TimerGameTick::Ticks first_order_round_trip_time; ///< How many ticks for a single circumnavigation of the orders.
+	TimerGameTick::TickCounter first_order_last_departure; ///< When the vehicle last left the first order.
+	TimerGameTick::Ticks first_order_round_trip_time;      ///< How many ticks for a single circumnavigation of the orders.
 
 	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.
 

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -22,6 +22,9 @@ struct BaseConsist {
 	TimerGameTick::Ticks lateness_counter;      ///< How many ticks late (or early if negative) this vehicle is.
 	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
+	TimerGameTick::Ticks first_order_last_departure;  ///< When the vehicle last left the first order.
+	TimerGameTick::Ticks first_order_round_trip_time; ///< How many ticks for a single circumnavigation of the orders.
+
 	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.
 
 	VehicleOrderID cur_real_order_index;///< The index to the current real (non-implicit) order
@@ -32,6 +35,7 @@ struct BaseConsist {
 	virtual ~BaseConsist() = default;
 
 	void CopyConsistPropertiesFrom(const BaseConsist *src);
+	void ResetAutomaticSeparation();
 };
 
 #endif /* BASE_CONSIST_H */

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -239,6 +239,7 @@ enum Commands : uint16_t {
 	CMD_SKIP_TO_ORDER,                ///< skip an order to the next of specific one
 	CMD_DELETE_ORDER,                 ///< delete an order
 	CMD_INSERT_ORDER,                 ///< insert a new order
+	CMD_ORDER_AUTOMATIC_SEPARATION,   ///< set automatic separation
 
 	CMD_CHANGE_SERVICE_INT,           ///< change the server interval of a vehicle
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4486,7 +4486,7 @@ STR_ORDERS_STOP_SHARING_BUTTON                                  :{BLACK}Stop sha
 STR_ORDERS_STOP_SHARING_TOOLTIP                                 :{BLACK}Stop sharing the order list. Ctrl+Click additionally deletes all orders for this vehicle
 
 STR_ORDERS_AUTOMATIC_SEPARATION                                 :{BLACK}Automatic separation
-STR_ORDERS_AUTOMATIC_SEPARATION_TOOLTIP                         :{BLACK}Automatically separate all vehicles sharing this order
+STR_ORDERS_AUTOMATIC_SEPARATION_TOOLTIP                         :{BLACK}Automatically separate all vehicles sharing these orders
 
 STR_ORDERS_GO_TO_BUTTON                                         :{BLACK}Go To
 STR_ORDER_GO_TO_NEAREST_DEPOT                                   :Go to nearest depot

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4485,6 +4485,9 @@ STR_ORDERS_DELETE_ALL_TOOLTIP                                   :{BLACK}Delete a
 STR_ORDERS_STOP_SHARING_BUTTON                                  :{BLACK}Stop sharing
 STR_ORDERS_STOP_SHARING_TOOLTIP                                 :{BLACK}Stop sharing the order list. Ctrl+Click additionally deletes all orders for this vehicle
 
+STR_ORDERS_AUTOMATIC_SEPARATION                                 :{BLACK}Automatic separation
+STR_ORDERS_AUTOMATIC_SEPARATION_TOOLTIP                         :{BLACK}Automatically separate all vehicles sharing this order
+
 STR_ORDERS_GO_TO_BUTTON                                         :{BLACK}Go To
 STR_ORDER_GO_TO_NEAREST_DEPOT                                   :Go to nearest depot
 STR_ORDER_GO_TO_NEAREST_HANGAR                                  :Go to nearest hangar

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -271,6 +271,8 @@ private:
 	TimerGameTick::Ticks timetable_duration;         ///< NOSAVE: Total timetabled duration of the order list.
 	TimerGameTick::Ticks total_duration;             ///< NOSAVE: Total (timetabled or not) duration of the order list.
 
+	bool automatic_separation;        ///< Is automatic separation enabled?
+
 public:
 	/** Default constructor producing an invalid order list. */
 	OrderList(VehicleOrderID num_orders = INVALID_VEH_ORDER_ID)
@@ -391,6 +393,18 @@ public:
 	 * @param delta By how many ticks has the total duration changed
 	 */
 	void UpdateTotalDuration(TimerGameTick::Ticks delta) { this->total_duration += delta; }
+
+	/**
+	 * Is this order list using automatic separation?
+	 * @return whether automatic separation is enabled
+	 */
+	inline bool AutomaticSeparationIsEnabled() const { return this->automatic_separation; }
+
+	/**
+	 * Enables or disables automatic separation for this order list
+	 * @param enabled whether to enable (true) or disable (false) automatic separation
+	 */
+	void SetAutomaticSeparationIsEnabled(bool enabled) { this->automatic_separation = enabled; }
 
 	void FreeChain(bool keep_orderlist = false);
 

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1470,7 +1470,7 @@ static bool CheckAircraftOrderDistance(const Aircraft *v_new, const Vehicle *v_o
 /**
  * Enable or disable automatic separation for a vehicle's order list
  * @param flags operation to perform
- * @param veh vehicle who's order list is being modified
+ * @param veh vehicle whose order list is being modified
  * @param enabled value indicating whether to enable (true) or disable (false) automatic separation
  * @return the cost of this operation or an error
  */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1096,6 +1096,7 @@ CommandCost CmdSkipToOrder(DoCommandFlag flags, VehicleID veh_id, VehicleOrderID
 
 		v->cur_implicit_order_index = v->cur_real_order_index = sel_ord;
 		v->UpdateRealOrderIndex();
+		v->ResetAutomaticSeparation();
 
 		InvalidateVehicleOrder(v, VIWD_MODIFY_ORDERS);
 

--- a/src/order_cmd.h
+++ b/src/order_cmd.h
@@ -18,6 +18,7 @@ CommandCost CmdModifyOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID se
 CommandCost CmdSkipToOrder(DoCommandFlag flags, VehicleID veh_id, VehicleOrderID sel_ord);
 CommandCost CmdDeleteOrder(DoCommandFlag flags, VehicleID veh_id, VehicleOrderID sel_ord);
 CommandCost CmdInsertOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID sel_ord, const Order &new_order);
+CommandCost CmdOrderAutomaticSeparation(DoCommandFlag flags, VehicleID veh, bool enabled);
 CommandCost CmdOrderRefit(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, CargoID cargo);
 CommandCost CmdCloneOrder(DoCommandFlag flags, CloneOptions action, VehicleID veh_dst, VehicleID veh_src);
 CommandCost CmdMoveOrder(DoCommandFlag flags, VehicleID veh, VehicleOrderID moving_order, VehicleOrderID target_order);
@@ -27,6 +28,7 @@ DEF_CMD_TRAIT(CMD_MODIFY_ORDER,       CmdModifyOrder,       CMD_LOCATION,  CMDT_
 DEF_CMD_TRAIT(CMD_SKIP_TO_ORDER,      CmdSkipToOrder,       CMD_LOCATION,  CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_DELETE_ORDER,       CmdDeleteOrder,       CMD_LOCATION,  CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_INSERT_ORDER,       CmdInsertOrder,       CMD_LOCATION,  CMDT_ROUTE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_ORDER_AUTOMATIC_SEPARATION, CmdOrderAutomaticSeparation, 0, CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_ORDER_REFIT,        CmdOrderRefit,        CMD_LOCATION,  CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_CLONE_ORDER,        CmdCloneOrder,        CMD_LOCATION,  CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_MOVE_ORDER,         CmdMoveOrder,         CMD_LOCATION,  CMDT_ROUTE_MANAGEMENT)

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -490,9 +490,9 @@ enum {
  * \section bottom-row Bottom row
  * The second row (the bottom row) is for manipulating the list of orders:
  * \verbatim
- * +-----------------+-----------------+-----------------+
- * |      SKIP       |     DELETE      |      GOTO       |
- * +-----------------+-----------------+-----------------+
+ * +-----------------+-----------------+-----------------+-----------------+
+ * |      SKIP       |     DELETE      | AUTO SEPARATION |      GOTO       |
+ * +-----------------+-----------------+-----------------+-----------------+
  * \endverbatim
  *
  * For vehicles of other companies, both button rows are not displayed.
@@ -570,6 +570,16 @@ private:
 		/* One past the orders is the 'End of Orders' line. */
 		assert(IsInsideBS(sel, 0, vehicle->GetNumOrders() + 1));
 		return sel;
+	}
+
+	/**
+	 * Handle the click on the automatic separation button
+	 */
+	void OrderClick_AutomaticSeparation()
+	{
+		if (Command<CMD_ORDER_AUTOMATIC_SEPARATION>::Post(this->vehicle->index, !this->vehicle->AutomaticSeparationIsEnabled())) {
+			this->UpdateButtonState();
+		}
 	}
 
 	/**
@@ -941,6 +951,10 @@ public:
 			}
 		}
 
+		/* automatic separation */
+		this->SetWidgetDisabledState(WID_O_AUTOMATIC_SEPARATION, this->vehicle->GetNumOrders() == 0);
+		this->SetWidgetLoweredState(WID_O_AUTOMATIC_SEPARATION, this->vehicle->AutomaticSeparationIsEnabled());
+
 		/* First row. */
 		this->RaiseWidget(WID_O_FULL_LOAD);
 		this->RaiseWidget(WID_O_UNLOAD);
@@ -1234,6 +1248,10 @@ public:
 					ShowDropDownMenu(this, _order_non_stop_drowdown, o->GetNonStopType(), WID_O_NON_STOP, 0,
 													o->IsType(OT_GOTO_STATION) ? 0 : (o->IsType(OT_GOTO_WAYPOINT) ? 3 : 12));
 				}
+				break;
+
+			case WID_O_AUTOMATIC_SEPARATION:
+				this->OrderClick_AutomaticSeparation();
 				break;
 
 			case WID_O_GOTO:
@@ -1629,6 +1647,8 @@ static const NWidgetPart _nested_orders_train_widgets[] = {
 				NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_O_STOP_SHARING), SetMinimalSize(124, 12), SetFill(1, 0),
 														SetDataTip(STR_ORDERS_STOP_SHARING_BUTTON, STR_ORDERS_STOP_SHARING_TOOLTIP), SetResize(1, 0),
 			EndContainer(),
+			NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_O_AUTOMATIC_SEPARATION), SetMinimalSize(124, 12), SetFill(1, 0),
+													SetDataTip(STR_ORDERS_AUTOMATIC_SEPARATION, STR_ORDERS_AUTOMATIC_SEPARATION_TOOLTIP), SetResize(1, 0),
 			NWidget(NWID_BUTTON_DROPDOWN, COLOUR_GREY, WID_O_GOTO), SetMinimalSize(124, 12), SetFill(1, 0),
 													SetDataTip(STR_ORDERS_GO_TO_BUTTON, STR_ORDERS_GO_TO_TOOLTIP), SetResize(1, 0),
 		EndContainer(),
@@ -1703,6 +1723,8 @@ static const NWidgetPart _nested_orders_widgets[] = {
 			NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_O_STOP_SHARING), SetMinimalSize(124, 12), SetFill(1, 0),
 													SetDataTip(STR_ORDERS_STOP_SHARING_BUTTON, STR_ORDERS_STOP_SHARING_TOOLTIP), SetResize(1, 0),
 		EndContainer(),
+		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_O_AUTOMATIC_SEPARATION), SetMinimalSize(124, 12), SetFill(1, 0),
+											SetDataTip(STR_ORDERS_AUTOMATIC_SEPARATION, STR_ORDERS_AUTOMATIC_SEPARATION_TOOLTIP), SetResize(1, 0),
 		NWidget(NWID_BUTTON_DROPDOWN, COLOUR_GREY, WID_O_GOTO), SetMinimalSize(124, 12), SetFill(1, 0),
 											SetDataTip(STR_ORDERS_GO_TO_BUTTON, STR_ORDERS_GO_TO_TOOLTIP), SetResize(1, 0),
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -202,6 +202,7 @@ SaveLoadTable GetOrderListDescription()
 {
 	static const SaveLoad _orderlist_desc[] = {
 		SLE_REF(OrderList, first,              REF_ORDER),
+		SLE_CONDVAR(OrderList, automatic_separation, SLE_BOOL, SLV_AUTOMATIC_SEPARATION, SL_MAX_VERSION),
 	};
 
 	return _orderlist_desc;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -331,6 +331,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_CUSTOM_SUBSIDY_DURATION,            ///< 292  PR#9081 Configurable subsidy duration.
 	SLV_SAVELOAD_LIST_LENGTH,               ///< 293  PR#9374 Consistency in list length with SL_STRUCT / SL_STRUCTLIST / SL_DEQUE / SL_REFLIST.
 	SLV_RIFF_TO_ARRAY,                      ///< 294  PR#9375 Changed many CH_RIFF chunks to CH_ARRAY chunks.
+	SLV_AUTOMATIC_SEPARATION,               ///< 295  PR#8342 Allow automatically separating vehicles in shared orders.
 
 	SLV_TABLE_CHUNKS,                       ///< 295  PR#9322 Introduction of CH_TABLE and CH_SPARSE_TABLE.
 	SLV_SCRIPT_INT64,                       ///< 296  PR#9415 SQInteger is 64bit but was saved as 32bit.

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -331,7 +331,6 @@ enum SaveLoadVersion : uint16_t {
 	SLV_CUSTOM_SUBSIDY_DURATION,            ///< 292  PR#9081 Configurable subsidy duration.
 	SLV_SAVELOAD_LIST_LENGTH,               ///< 293  PR#9374 Consistency in list length with SL_STRUCT / SL_STRUCTLIST / SL_DEQUE / SL_REFLIST.
 	SLV_RIFF_TO_ARRAY,                      ///< 294  PR#9375 Changed many CH_RIFF chunks to CH_ARRAY chunks.
-	SLV_AUTOMATIC_SEPARATION,               ///< 295  PR#8342 Allow automatically separating vehicles in shared orders.
 
 	SLV_TABLE_CHUNKS,                       ///< 295  PR#9322 Introduction of CH_TABLE and CH_SPARSE_TABLE.
 	SLV_SCRIPT_INT64,                       ///< 296  PR#9415 SQInteger is 64bit but was saved as 32bit.
@@ -367,6 +366,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_TIMETABLE_START_TICKS,              ///< 321  PR#11468 Convert timetable start from a date to ticks.
 	SLV_TIMETABLE_START_TICKS_FIX,          ///< 322  PR#11557 Fix for missing convert timetable start from a date to ticks.
 	SLV_TIMETABLE_TICKS_TYPE,               ///< 323  PR#11435 Convert timetable current order time to ticks.
+	SLV_AUTOMATIC_SEPARATION,               ///< 324  PR#8342 Allow automatically separating vehicles in shared orders.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -724,6 +724,9 @@ public:
 		SLE_CONDVAR(Vehicle, current_order_time,    SLE_INT32,                   SLV_TIMETABLE_TICKS_TYPE, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, last_loading_tick,     SLE_UINT64,                   SLV_LAST_LOADING_TICK, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
+
+		SLE_CONDVAR(Vehicle, first_order_last_departure, SLE_INT32,              SLV_AUTOMATIC_SEPARATION, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, first_order_round_trip_time, SLE_INT32,             SLV_AUTOMATIC_SEPARATION, SL_MAX_VERSION),
 	};
 #if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)
 		return description;

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -725,7 +725,7 @@ public:
 		SLE_CONDVAR(Vehicle, last_loading_tick,     SLE_UINT64,                   SLV_LAST_LOADING_TICK, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
 
-		SLE_CONDVAR(Vehicle, first_order_last_departure, SLE_INT32,              SLV_AUTOMATIC_SEPARATION, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, first_order_last_departure, SLE_UINT64,             SLV_AUTOMATIC_SEPARATION, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, first_order_round_trip_time, SLE_INT32,             SLV_AUTOMATIC_SEPARATION, SL_MAX_VERSION),
 	};
 #if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2449,7 +2449,7 @@ void Vehicle::UpdateAutomaticSeparation()
 	/* Debug logging can be quite spammy as it prints a line every time a vehicle departs the first manual order */
 	if (_debug_misc_level >= 4) {
 		SetDParam(0, this->index);
-		Debug(misc, 4, "Orders for {}: RTT = {} [{:.2f} days, {} veh], separation = {} [{:.2f} days, {} veh, {} queuing] / gap = {} [{:.2f} days], wait = {} [{:.2f} days]", GetString(STR_VEHICLE_NAME), round_trip_time, (float)round_trip_time / Ticks::DAY_TICKS, round_trip_count, separation, (float)separation / Ticks::DAY_TICKS, vehicles, vehicles_queuing, TimerGameTick::counter - last_departure, (float)(TimerGameTick::counter - last_departure) / Ticks::DAY_TICKS, this->first_order_last_departure - TimerGameTick::counter, (float)(this->first_order_last_departure - TimerGameTick::counter) / Ticks::DAY_TICKS);
+		Debug(misc, 4, "Orders for {}: RTT = {} [{:.2f} days, {} veh], separation = {} [{:.2f} days, {} veh, {} queuing] / gap = {} [{:.2f} days], wait = {} [{:.2f} days]", GetString(STR_VEHICLE_NAME), round_trip_time, (float)round_trip_time / Ticks::DAY_TICKS, round_trip_count, separation, (float)separation / Ticks::DAY_TICKS, vehicles, vehicles_queuing, (int64_t)(TimerGameTick::counter - last_departure), (float)(int64_t)(TimerGameTick::counter - last_departure) / Ticks::DAY_TICKS, this->first_order_last_departure - TimerGameTick::counter, (float)(this->first_order_last_departure - TimerGameTick::counter) / Ticks::DAY_TICKS);
 	}
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1537,6 +1537,7 @@ void VehicleEnterDepot(Vehicle *v)
 
 	v->vehstatus |= VS_HIDDEN;
 	v->cur_speed = 0;
+	v->ResetAutomaticSeparation();
 
 	VehicleServiceInDepot(v);
 
@@ -2338,6 +2339,10 @@ void Vehicle::HandleLoading(bool mode)
 			/* Not the first call for this tick, or still loading */
 			if (mode || !HasBit(this->vehicle_flags, VF_LOADING_FINISHED) || this->current_order_time < wait_time) return;
 
+			this->UpdateAutomaticSeparation();
+
+			if (this->IsWaitingForAutomaticSeparation()) return;
+
 			this->PlayLeaveStationSound();
 
 			this->LeaveStation();
@@ -2358,6 +2363,96 @@ void Vehicle::HandleLoading(bool mode)
 	}
 
 	this->IncrementImplicitOrderIndex();
+}
+
+/**
+ * Checks whether a vehicle is waiting for automatic separation (if not,
+ * it is ready to depart)
+ */
+bool Vehicle::IsWaitingForAutomaticSeparation() const {
+	TimerGameTick::Ticks now = TimerGameCalendar::date.base() * Ticks::DAY_TICKS + TimerGameCalendar::date_fract;
+	return this->AutomaticSeparationIsEnabled() && this->first_order_last_departure > now;
+};
+
+/**
+ * If enabled, calculates the departure time for this vehicle based on the
+ * automatic separation feature.
+ */
+void Vehicle::UpdateAutomaticSeparation()
+{
+	/* Check this feature is enabled on the vehicle's orders */
+	if (!this->AutomaticSeparationIsEnabled()) return;
+
+	/* Only perform the separation at the first manual order (saves on storage) */
+	VehicleOrderID first_manual_order = 0;
+	for (Order *o = this->GetFirstOrder(); o != nullptr && o->IsType(OT_IMPLICIT); o = o->next) {
+		++first_manual_order;
+	}
+	if (this->cur_implicit_order_index != first_manual_order) return;
+
+	/* A "last departure" >= now means we've already calculated the separation */
+	TimerGameTick::Ticks now = TimerGameCalendar::date.base() * Ticks::DAY_TICKS + TimerGameCalendar::date_fract;
+	if (this->first_order_last_departure >= now) return;
+
+	/* Calculate round trip time from last departure and now - automatic separation waiting time is not included */
+	if (this->first_order_last_departure > 0) {
+		this->first_order_round_trip_time = now - this->first_order_last_departure;
+	}
+
+	/* To work out the automatic separation waiting time we need to know:
+	 *   - When the last vehicle departed or will depart
+	 *   - Average time to perform the order list (as sum/count)
+	 *   - How many vehicles are currently operating the order list
+	 *   - How many vehicles are currently queuing for the first manual order
+	 */
+	TimerGameTick::Ticks last_departure = 0;
+	TimerGameTick::Ticks round_trip_sum = 0;
+	int round_trip_count = 0;
+	int vehicles = 0;
+	int vehicles_queuing = 0;
+	Vehicle *v = this->FirstShared();
+	while (v != nullptr) {
+		last_departure = std::max(last_departure, v->first_order_last_departure);
+		if (v->first_order_round_trip_time > 0) {
+			round_trip_sum += v->first_order_round_trip_time;
+			round_trip_count++;
+		}
+		/* A stopped vehicle is not included; it might be stopped by player or parked in a depot */
+		if (!(v->vehstatus & VS_STOPPED)) {
+			vehicles++;
+			/* Count vehicles queing for the first manual order but not currently in the station */
+			if (v != this && v->cur_speed == 0 && v->cur_implicit_order_index == first_manual_order && !v->current_order.IsType(OT_LOADING)) {
+				vehicles_queuing++;
+			}
+		}
+		v = v->NextShared();
+	}
+
+	/* Calculate the mean round trip time and separation. The time spent queuing for stations is included in vehicle
+	 * round trip times.
+	 *
+	 * For a single shared order into a single station, this will increase and decrease the separation as needed.
+	 * However, for multiple shared orders into the same station, each shared order can back up the others and all
+	 * the routes will slowly increase their separation until every available vehicle is in the same queue.
+	 *
+	 * To counter this, we need to reduce the round trip time when vehicles are queuing. The scaling here reduces it
+	 * by twice the proportion of queuing vehicles, e.g. if 1/N vehicles are queuing, the RTT is reduced by 2/N.
+	 *
+	 * This is based on the idea that if only M/N vehicles are progressing, the non-queuing RTT is approximately M/N
+	 * of the measured RTT, because (N-M)/N of the RTT is spent in the queue, with the 'twice' coming from the need
+	 * to over-compensate rather than aim exactly for the ideal (which is very approximate here). */
+	TimerGameTick::Ticks round_trip_time = round_trip_count > 0 ? round_trip_sum / round_trip_count : 0;
+	int vehicles_moving_ratio = std::max(1, vehicles - 2 * vehicles_queuing);
+	TimerGameTick::Ticks separation = std::max(1, vehicles > 0 ? round_trip_time * vehicles_moving_ratio / vehicles / vehicles : 1);
+
+	/* Finally we can calculate when this vehicle should depart; if that's in the past, it'll depart right now */
+	this->first_order_last_departure = std::max(last_departure + separation, now);
+
+	/* Debug logging can be quite spammy as it prints a line every time a vehicle departs the first manual order */
+	if (_debug_misc_level >= 4) {
+		SetDParam(0, this->index);
+		Debug(misc, 4, "Orders for {}: RTT = {} [{:.2f} days, {} veh], separation = {} [{:.2f} days, {} veh, {} queuing] / gap = {} [{:.2f} days], wait = {} [{:.2f} days]", GetString(STR_VEHICLE_NAME), round_trip_time, (float)round_trip_time / Ticks::DAY_TICKS, round_trip_count, separation, (float)separation / Ticks::DAY_TICKS, vehicles, vehicles_queuing, now - last_departure, (float)(now - last_departure) / Ticks::DAY_TICKS, this->first_order_last_departure - now, (float)(this->first_order_last_departure - now) / Ticks::DAY_TICKS);
+	}
 }
 
 /**

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -771,6 +771,7 @@ void Vehicle::ShiftDates(TimerGameCalendar::Date interval)
 	this->date_of_last_service = std::max(this->date_of_last_service + interval, TimerGameCalendar::Date(0));
 	/* date_of_last_service_newgrf is not updated here as it must stay stable
 	 * for vehicles outside of a depot. */
+	this->first_order_last_departure += interval.base() * Ticks::DAY_TICKS;
 }
 
 /**

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2444,7 +2444,12 @@ void Vehicle::UpdateAutomaticSeparation()
 	TimerGameTick::Ticks separation = std::max(1, vehicles > 0 ? round_trip_time * vehicles_moving_ratio / vehicles / vehicles : 1);
 
 	/* Finally we can calculate when this vehicle should depart; if that's in the past, it'll depart right now */
-	this->first_order_last_departure = std::max(last_departure + separation, TimerGameTick::counter);
+	TimerGameTick::TickCounter next_departure = last_departure + separation;
+	this->first_order_last_departure = std::max(next_departure, TimerGameTick::counter);
+
+	/* Update vehicle lateness based on the automatic separation, overriding the timetable */
+	this->lateness_counter = TimerGameTick::counter - next_departure;
+	SetWindowDirty(WC_VEHICLE_TIMETABLE, this->index);
 
 	/* Debug logging can be quite spammy as it prints a line every time a vehicle departs the first manual order */
 	if (_debug_misc_level >= 4) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2383,9 +2383,9 @@ void Vehicle::UpdateAutomaticSeparation()
 	/* Check this feature is enabled on the vehicle's orders */
 	if (!this->AutomaticSeparationIsEnabled()) return;
 
-	/* Only perform the separation at the first manual order (saves on storage) */
+	/* Only perform the separation at the first manual order which can load/unload (saves on storage) */
 	VehicleOrderID first_manual_order = 0;
-	for (Order *o = this->GetFirstOrder(); o != nullptr && o->IsType(OT_IMPLICIT); o = o->next) {
+	for (Order *o = this->GetFirstOrder(); o != nullptr && (o->IsType(OT_IMPLICIT) || !o->CanLoadOrUnload()); o = o->next) {
 		++first_manual_order;
 	}
 	if (this->cur_implicit_order_index != first_manual_order) return;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2371,7 +2371,7 @@ void Vehicle::HandleLoading(bool mode)
  * it is ready to depart)
  */
 bool Vehicle::IsWaitingForAutomaticSeparation() const {
-	TimerGameTick::Ticks now = TimerGameCalendar::date.base() * Ticks::DAY_TICKS + TimerGameCalendar::date_fract;
+	TimerGameTick::Ticks now = (TimerGameCalendar::date.base() * Ticks::DAY_TICKS) + TimerGameCalendar::date_fract;
 	return this->AutomaticSeparationIsEnabled() && this->first_order_last_departure > now;
 };
 
@@ -2421,7 +2421,7 @@ void Vehicle::UpdateAutomaticSeparation()
 		/* A stopped vehicle is not included; it might be stopped by player or parked in a depot */
 		if (!(v->vehstatus & VS_STOPPED)) {
 			vehicles++;
-			/* Count vehicles queing for the first manual order but not currently in the station */
+			/* Count vehicles queuing for the first manual order but not currently in the station */
 			if (v != this && v->cur_speed == 0 && v->cur_implicit_order_index == first_manual_order && !v->current_order.IsType(OT_LOADING)) {
 				vehicles_queuing++;
 			}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -812,6 +812,13 @@ public:
 
 	inline void SetServiceIntervalIsPercent(bool on) { SB(this->vehicle_flags, VF_SERVINT_IS_PERCENT, 1, on); }
 
+	inline bool AutomaticSeparationIsEnabled() const { return (this->orders == nullptr) ? false : this->orders->AutomaticSeparationIsEnabled(); }
+
+	inline void SetAutomaticSeparationIsEnabled(bool enabled) const { if (this->orders != nullptr) this->orders->SetAutomaticSeparationIsEnabled(enabled); }
+
+	bool IsWaitingForAutomaticSeparation() const;
+	void UpdateAutomaticSeparation();
+
 private:
 	/**
 	 * Advance cur_real_order_index to the next real order.

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -628,6 +628,7 @@ CommandCost CmdStartStopVehicle(DoCommandFlag flags, VehicleID veh_id, bool eval
 		if (v->IsStoppedInDepot() && (flags & DC_AUTOREPLACE) == 0) DeleteVehicleNews(veh_id, STR_NEWS_TRAIN_IS_WAITING + v->type);
 
 		v->vehstatus ^= VS_STOPPED;
+		if (v->vehstatus & VS_STOPPED) v->ResetAutomaticSeparation();
 		if (v->type != VEH_TRAIN) v->cur_speed = 0; // trains can stop 'slowly'
 		v->MarkDirty();
 		SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);

--- a/src/widgets/order_widget.h
+++ b/src/widgets/order_widget.h
@@ -20,6 +20,7 @@ enum OrderWidgets {
 	WID_O_DELETE,                    ///< Delete selected order.
 	WID_O_STOP_SHARING,              ///< Stop sharing orders.
 	WID_O_NON_STOP,                  ///< Goto non-stop to destination.
+	WID_O_AUTOMATIC_SEPARATION,      ///< Toggle automatic separation.
 	WID_O_GOTO,                      ///< Goto destination.
 	WID_O_FULL_LOAD,                 ///< Select full load.
 	WID_O_UNLOAD,                    ///< Select unload.


### PR DESCRIPTION
This is my proposed code for allowing vehicles (of all types) to be automatically separated amongst their shared orders with the click of a single button (once for each shared order), to massively reduce the micromanagement needed for optimal passenger journeys.

I filed issue #8095 initially to check that the feature was acceptable, and it was suggested I go forward with a PR.

As this is my first-time contributing code to OpenTTD, even though I have read the contributing guidelines and linked materials, I will also probably have missed/misunderstood something so please let me know where and how I might have messed up.

As part of that, I have tried to document the algorithm itself and surrounding code with comments but if anything isn't clear, or the details would be better served elsewhere, let me know.

### Outstanding issues - https://github.com/OpenTTD/OpenTTD/pull/8342#issuecomment-1867818309

- [ ] When should automatic separation be unavailable?
- [x] Integration with timetables
- [ ] Queuing detection and behaviour