### PR TITLE
MSYS XAudio build fix

### DIFF
--- a/cmake/FindXaudio2.cmake
+++ b/cmake/FindXaudio2.cmake
@@ -4,6 +4,7 @@ include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_FLAGS "")
 
 check_cxx_source_compiles("
+    #include <cstdio>
     #include <windows.h>
 
     #undef NTDDI_VERSION
@@ -13,6 +14,6 @@ check_cxx_source_compiles("
     #define _WIN32_WINNT     _WIN32_WINNT_WIN8
 
     #include <xaudio2.h>
-    int main() { return 0; }"
+    int main() { printf(\"%s\\\\n\", XAUDIO2_DLL_A); return 0; }"
     XAUDIO2_FOUND
 )

--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -130,7 +130,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 
 	if (FAILED(hr))
 	{
-		DEBUG(driver, 0, "xaudio2_s: CoInitializeEx failed (%08x)", hr);
+		DEBUG(driver, 0, "xaudio2_s: CoInitializeEx failed (%08x)", (uint)hr);
 		return "Failed to initialise COM";
 	}
 
@@ -164,7 +164,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		DEBUG(driver, 0, "xaudio2_s: XAudio2Create failed (%08x)", hr);
+		DEBUG(driver, 0, "xaudio2_s: XAudio2Create failed (%08x)", (uint)hr);
 		return "Failed to inititialise the XAudio2 engine";
 	}
 
@@ -177,7 +177,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		DEBUG(driver, 0, "xaudio2_s: CreateMasteringVoice failed (%08x)", hr);
+		DEBUG(driver, 0, "xaudio2_s: CreateMasteringVoice failed (%08x)", (uint)hr);
 		return "Failed to create a mastering voice";
 	}
 
@@ -216,7 +216,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 		FreeLibrary(_xaudio_dll_handle);
 		CoUninitialize();
 
-		DEBUG(driver, 0, "xaudio2_s: CreateSourceVoice failed (%08x)", hr);
+		DEBUG(driver, 0, "xaudio2_s: CreateSourceVoice failed (%08x)", (uint)hr);
 		return "Failed to create a source voice";
 	}
 
@@ -225,7 +225,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 
 	if (FAILED(hr))
 	{
-		DEBUG(driver, 0, "xaudio2_s: _source_voice->Start failed (%08x)", hr);
+		DEBUG(driver, 0, "xaudio2_s: _source_voice->Start failed (%08x)", (uint)hr);
 
 		Stop();
 		return "Failed to start the source voice";
@@ -238,7 +238,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 
 	if (FAILED(hr))
 	{
-		DEBUG(driver, 0, "xaudio2_s: _voice_context->SubmitBuffer failed (%08x)", hr);
+		DEBUG(driver, 0, "xaudio2_s: _voice_context->SubmitBuffer failed (%08x)", (uint)hr);
 
 		Stop();
 		return "Failed to submit the first audio buffer";


### PR DESCRIPTION
Seems that recent MSYS2 packages have added an xaudio2.h header... which doesn't contain things that OTTD expects to exist.

I'm not sure of the differences between them, but since XAudio isn't intended for MSYS anyway, just add some extra stuff to the cmake check.

Also some compiler warning fixes found before I just excluded the file entirely.