### PR TITLE
Fix: [CMake] cross-compiling requires native tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,9 @@ add_custom_target(find_version
         BYPRODUCTS ${GENERATED_SOURCE_FILES}
 )
 
+# An empty target for the tools
+add_custom_target(tools)
+
 include(SourceList)
 include(Endian)
 add_endian_definition()

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -35,6 +35,8 @@ function(set_directory_options)
         set(GLOBAL_DIR "${DEFAULT_GLOBAL_DIR}" CACHE STRING "Global directory")
         message(STATUS "Detecting Global Data directory - ${GLOBAL_DIR}")
     endif()
+
+    set(HOST_BINARY_DIR "" CACHE PATH "Full path to native cmake build directory")
 endfunction()
 
 # Set some generic options that influence what is being build.

--- a/src/lang/CMakeLists.txt
+++ b/src/lang/CMakeLists.txt
@@ -59,6 +59,10 @@ set(LANG_SOURCE_FILES
 
 set(LANG_BINARY_DIR ${CMAKE_BINARY_DIR}/lang)
 
+if (HOST_BINARY_DIR)
+    include(${HOST_BINARY_DIR}/strgen.cmake)
+endif()
+
 # Walk over all the (finished) language files, and generate a command to compile them
 foreach(LANG_SOURCE_FILE IN LISTS LANG_SOURCE_FILES)
     get_filename_component(LANG_SOURCE_FILE_NAME_WE ${LANG_SOURCE_FILE} NAME_WE)

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -1,13 +1,18 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(settingsgen)
+if (NOT HOST_BINARY_DIR)
+    project(settingsgen)
 
-set(sourcefiles
-        settingsgen.cpp
-        ../core/alloc_func.cpp
-        ../misc/getoptdata.cpp
-        ../ini_load.cpp
-        ../string.cpp
-)
-add_definitions(-DSETTINGSGEN)
-add_executable(settingsgen ${sourcefiles})
+    set(sourcefiles
+            settingsgen.cpp
+            ../core/alloc_func.cpp
+            ../misc/getoptdata.cpp
+            ../ini_load.cpp
+            ../string.cpp
+    )
+    add_definitions(-DSETTINGSGEN)
+    add_executable(settingsgen ${sourcefiles})
+
+    export(TARGETS settingsgen FILE ${CMAKE_BINARY_DIR}/settingsgen.cmake)
+    add_dependencies(tools settingsgen)
+endif()

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -1,22 +1,26 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(strgen)
+if (NOT HOST_BINARY_DIR)
+    project(strgen)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
 
-set(sourcefiles
-        strgen.cpp
-        strgen_base.cpp
-        ../core/alloc_func.cpp
-        ../misc/getoptdata.cpp
-        ../string.cpp
-)
-add_definitions(-DSTRGEN)
-add_executable(strgen ${sourcefiles})
+    set(sourcefiles
+            strgen.cpp
+            strgen_base.cpp
+            ../core/alloc_func.cpp
+            ../misc/getoptdata.cpp
+            ../string.cpp
+    )
+    add_definitions(-DSTRGEN)
+    add_executable(strgen ${sourcefiles})
 
-include(Endian)
-add_endian_definition()
+    include(Endian)
+    add_endian_definition()
 
+    export(TARGETS strgen FILE ${CMAKE_BINARY_DIR}/strgen.cmake)
+    add_dependencies(tools strgen)
+endif()
 
 # Source Files
 add_files(strgen_base.cpp)

--- a/src/table/CMakeLists.txt
+++ b/src/table/CMakeLists.txt
@@ -11,6 +11,10 @@ set(TABLE_INI_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/window_settings.ini
 )
 
+if (HOST_BINARY_DIR)
+    include(${HOST_BINARY_DIR}/settingsgen.cmake)
+endif()
+
 # Generate a command and target to create the settings table
 add_custom_command_timestamp(OUTPUT ${TABLE_BINARY_DIR}/settings.h
         COMMAND ${CMAKE_COMMAND} -E make_directory ${TABLE_BINARY_DIR}


### PR DESCRIPTION
It requires some manual steps (and 2 build directories):
* create a directory for native
* run cmake for native
* build at least `tools` target
* create a directory for cross-compile
* run cmake for cross-compile, passing the full path to native directory in `HOST_BINARY_DIR`
* build cross-compile
