### PR TITLE
Fix: do not add an offset to a nullptr

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1619,7 +1619,7 @@ void SlObject(void *object, const SaveLoad *sld)
 	}
 
 	for (; sld->cmd != SL_END; sld++) {
-		void *ptr = sld->global ? sld->address : GetVariableAddress(object, sld);
+		void *ptr = GetVariableAddress(object, sld);
 		SlObjectMember(ptr, sld);
 	}
 }

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -873,7 +873,18 @@ static inline bool IsNumericType(VarType conv)
  */
 static inline void *GetVariableAddress(const void *object, const SaveLoad *sld)
 {
-	return const_cast<byte *>((const byte*)(sld->global ? nullptr : object) + (ptrdiff_t)sld->address);
+	/* Entry is a global address. */
+	if (sld->global) return sld->address;
+
+	/* Entry is a null-variable, mostly used to read old savegames etc. */
+	if (GetVarMemType(sld->conv) == SLE_VAR_NULL) {
+		assert(sld->address == nullptr);
+		return nullptr;
+	}
+
+	/* Everything else should be a non-null pointer. */
+	assert(object != nullptr);
+	return const_cast<byte *>((const byte *)object + (ptrdiff_t)sld->address);
 }
 
 int64 ReadValue(const void *ptr, VarType conv);


### PR DESCRIPTION
While at it, prevent a potential cases where an offset would be added to a `nullptr` (which would be horrible wrong for completely different reasons).

Tnx to milek7 for tracing the root cause.