### PR TITLE
Change: set the default setting for autorenew to on for new games

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -433,6 +433,7 @@ function Regression::Company()
 	print("  GetAutoRenewStatus();              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
 	print("  SetAutoRenewStatus(true);          " + AICompany.SetAutoRenewStatus(true));
 	print("  SetAutoRenewStatus(false);         " + AICompany.SetAutoRenewStatus(false));
+	print("  GetAutoRenewStatus();              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
 	print("  GetAutoRenewMonths();              " + AICompany.GetAutoRenewMonths(AICompany.COMPANY_SELF));
 	print("  SetAutoRenewMonths(-12);           " + AICompany.SetAutoRenewMonths(-12));
 	print("  GetAutoRenewMonths();              " + AICompany.GetAutoRenewMonths(AICompany.COMPANY_SELF));

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -615,11 +615,12 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetCompanyHQ():                    33153
   BuildCompanyHQ():                  false
   GetLastErrorString():              ERR_AREA_NOT_CLEAR
-  GetAutoRenewStatus();              false
+  GetAutoRenewStatus();              true
   SetAutoRenewStatus(true);          true
   GetAutoRenewStatus();              true
   SetAutoRenewStatus(true);          true
   SetAutoRenewStatus(false);         true
+  GetAutoRenewStatus();              false
   GetAutoRenewMonths();              6
   SetAutoRenewMonths(-12);           true
   GetAutoRenewMonths();              -12

--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -38,7 +38,7 @@ cat      = SC_ADVANCED
 [SDT_BOOL]
 base     = CompanySettings
 var      = engine_renew
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_AUTORENEW_VEHICLE
 strhelp  = STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT
 cat      = SC_BASIC


### PR DESCRIPTION
Andythenorth and I have both noticed an abundance of new players who are confused by Autorenew, both on Discord and [the](https://www.reddit.com/r/openttd/comments/k57j6a/how_to_replace_old_vehicles/) [r/OpenTTD](https://www.reddit.com/r/openttd/comments/ifio7v/how_to_replace_vehicles_with_one_of_the_same_type/) [subreddit](https://www.reddit.com/r/openttd/comments/gotory/why_is_my_replacement_vehicle_list_blank_also/).

I understand that #7729 addresses this to some degree, but in the meantime I'd like to make the case that Autorenew should be on by default.

No matter whether it's on or off by default, there will be players who will be frustrated. New players are often confused that Autoreplace can't replace with the same model, and if we change it to default on then some experienced players using difficult economic settings, NewGRFs, and/or GameScripts may be frustrated by unwanted expenses. Someone will always be inconvenienced.

That said, it's obvious to me that the experienced, hardcore players are the ones most suited to tweaking the settings to their liking. Autorenew is a company setting, so a player who wants it off should only have to disable it once for all new games. I think that settings should default to the recommended settings for new players, who can then change them as their knowledge grows.