### PR TITLE
Fix a49fdb7ebb: bootstrap crash when trying to load new baseset

### DIFF
--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -253,7 +253,7 @@ bool HandleBootstrap()
 	if (_exit_game) return false;
 
 	/* Try to probe the graphics. Should work this time. */
-	if (!BaseGraphics::SetSet(nullptr)) goto failure;
+	if (!BaseGraphics::SetSet({})) goto failure;
 
 	/* Finally we can continue heading for the menu. */
 	_game_mode = GM_MENU;


### PR DESCRIPTION
Using nullptr as "name" crashes on "name.empty()". Use an empty
string instead.