### PR TITLE
Fix 63ccb36ef3: Crash trying to load TTO/TTD savegames.

### DIFF
--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -445,7 +445,7 @@ static bool FixTTOEngines()
 		e->preview_company = INVALID_COMPANY;
 		e->preview_asked = (CompanyMask)-1;
 		e->preview_wait = 0;
-		e->name = nullptr;
+		e->name = std::string{};
 	}
 
 	return true;


### PR DESCRIPTION
Same deal as in #8353. Don't use `nullptr` to initialise `std::string`.