### PR TITLE
Change: don't encourage the use of LZO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ include(LinkPackage)
 link_package(PNG TARGET PNG::PNG ENCOURAGED)
 link_package(ZLIB TARGET ZLIB::ZLIB ENCOURAGED)
 link_package(LIBLZMA TARGET LibLZMA::LibLZMA ENCOURAGED)
-link_package(LZO ENCOURAGED)
+link_package(LZO)
 link_package(XDG_basedir)
 
 if(NOT OPTION_DEDICATED)


### PR DESCRIPTION
LZO was used before the first version we track in our version
control system, which dates back to Aug 2004. Somewhere before
that time a few savegames / scenarios exist which use LZO. No
other savegame / scenario does since then. Let's not encourage
people to install something that ancient.

There are no scenarios on BaNaNaS that require LZO.