### PR TITLE
Add: allow using SDL2 in "relative mouse mode"

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1785,6 +1785,30 @@ void SetAnimatedMouseCursor(const AnimCursor *table)
 }
 
 /**
+ * Update cursor position on mouse movement for relative modes.
+ * @param delta_x How much change in the X position.
+ * @param delta_y How much change in the Y position.
+ */
+void CursorVars::UpdateCursorPositionRelative(int delta_x, int delta_y)
+{
+	if (this->fix_at) {
+		this->delta.x = delta_x;
+		this->delta.y = delta_y;
+	} else {
+		int last_position_x = this->pos.x;
+		int last_position_y = this->pos.y;
+
+		this->pos.x = Clamp(this->pos.x + delta_x, 0, _cur_resolution.width - 1);
+		this->pos.y = Clamp(this->pos.y + delta_y, 0, _cur_resolution.height - 1);
+
+		this->delta.x = last_position_x - this->pos.x;
+		this->delta.y = last_position_y - this->pos.y;
+
+		this->dirty = true;
+	}
+}
+
+/**
  * Update cursor position on mouse movement.
  * @param x New X position.
  * @param y New Y position.

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -143,6 +143,7 @@ struct CursorVars {
 	/* Drag data */
 	bool vehchain;                ///< vehicle chain is dragged
 
+	void UpdateCursorPositionRelative(int delta_x, int delta_y);
 	bool UpdateCursorPosition(int x, int y, bool queued_warp);
 
 private:


### PR DESCRIPTION
This mode doesn't wrap the mouse constantly, but requests SDL / OS
to lock the mouse pointer. This solves mouse problems on a few
OSes, like GUI Linux via WSL2, where the X11-server is not allowed
to change the mouse position in Windows (as it isn't capturing it).

This also is needed for other OSes that by design can never
capture the mouse, like with Emscripten, as it runs in a browser.

You can enable this moude via "-vsdl:relative_mode".