### PR TITLE
Fix: useless warning with -snull and no BaseSounds available

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1111,7 +1111,7 @@ void SwitchToMode(SwitchMode new_mode)
 
 		case SM_MENU: // Switch to game intro menu
 			LoadIntroGame();
-			if (BaseSounds::ini_set.empty() && BaseSounds::GetUsedSet()->fallback) {
+			if (BaseSounds::ini_set.empty() && BaseSounds::GetUsedSet()->fallback && SoundDriver::GetInstance()->HasOutput()) {
 				ShowErrorMessage(STR_WARNING_FALLBACK_SOUNDSET, INVALID_STRING_ID, WL_CRITICAL);
 				BaseSounds::ini_set = BaseSounds::GetUsedSet()->name;
 			}

--- a/src/sound/null_s.h
+++ b/src/sound/null_s.h
@@ -19,6 +19,7 @@ public:
 
 	void Stop() override { }
 	const char *GetName() const override { return "null"; }
+	bool HasOutput() const override { return false; }
 };
 
 /** Factory for the null sound driver. */

--- a/src/sound/sound_driver.hpp
+++ b/src/sound/sound_driver.hpp
@@ -19,6 +19,17 @@ public:
 	virtual void MainLoop() {}
 
 	/**
+	 * Whether the driver has an output from which the user can hear sound.
+	 * Or in other words, whether we should warn the user if no soundset is
+	 * loaded and that loading one would fix the sound problems.
+	 * @return True for all drivers except null.
+	 */
+	virtual bool HasOutput() const
+	{
+		return true;
+	}
+
+	/**
 	 * Get the currently active instance of the sound driver.
 	 */
 	static SoundDriver *GetInstance() {


### PR DESCRIPTION
If I explicitly tell the system I do not want sound, I still get
presented a nice message I do not have any BaseSounds available
on my system, and that I should download one to enjoy sound. Well,
let me tell you, with "-snull" that is really really not going to
help. So please, be quiet, and let me enjoy the game without
"boooooo" and "DING DING DING".

Thank you.