### PR TITLE
Change: Don't display OS name when the user is exiting the game

### DIFF
--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -285,19 +285,6 @@ static void AskExitGameCallback(Window *w, bool confirmed)
 
 void AskExitGame()
 {
-#if defined(_WIN32)
-		SetDParam(0, STR_OSNAME_WINDOWS);
-#elif defined(__APPLE__)
-		SetDParam(0, STR_OSNAME_OSX);
-#elif defined(__HAIKU__)
-		SetDParam(0, STR_OSNAME_HAIKU);
-#elif defined(__OS2__)
-		SetDParam(0, STR_OSNAME_OS2);
-#elif defined(SUNOS)
-		SetDParam(0, STR_OSNAME_SUNOS);
-#else
-		SetDParam(0, STR_OSNAME_UNIX);
-#endif
 	ShowQuery(
 		STR_QUIT_CAPTION,
 		STR_QUIT_ARE_YOU_SURE_YOU_WANT_TO_EXIT_OPENTTD,

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1807,17 +1807,9 @@ STR_INTRO_TRANSLATION                                           :{BLACK}This tra
 
 # Quit window
 STR_QUIT_CAPTION                                                :{WHITE}Exit
-STR_QUIT_ARE_YOU_SURE_YOU_WANT_TO_EXIT_OPENTTD                  :{YELLOW}Are you sure you want to exit OpenTTD and return to {STRING}?
+STR_QUIT_ARE_YOU_SURE_YOU_WANT_TO_EXIT_OPENTTD                  :{YELLOW}Are you sure you want to exit OpenTTD?
 STR_QUIT_YES                                                    :{BLACK}Yes
 STR_QUIT_NO                                                     :{BLACK}No
-
-# Supported OSes
-STR_OSNAME_WINDOWS                                              :Windows
-STR_OSNAME_UNIX                                                 :Unix
-STR_OSNAME_OSX                                                  :OS{NBSP}X
-STR_OSNAME_HAIKU                                                :Haiku
-STR_OSNAME_OS2                                                  :OS/2
-STR_OSNAME_SUNOS                                                :SunOS
 
 # Abandon game
 STR_ABANDON_GAME_CAPTION                                        :{WHITE}Abandon Game


### PR DESCRIPTION
It's not 1995 any more, just prompt the user if they want to exit the game.

This does result in build warnings because of the un-updated string using {STRING} in all the translations (the game then falls back to the English string for those languages). I'm not sure what the correct process here, but if I need to amend the patch, let me know.