### PR TITLE
Fix: change the working-dir searchpath when using '-c'

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1234,7 +1234,6 @@ void DeterminePaths(const char *exe)
 		/* We are using the XDG configuration home for the config file,
 		 * then store the rest in the XDG data home folder. */
 		_personal_dir = _searchpaths[SP_PERSONAL_DIR_XDG];
-		FioCreateDirectory(_personal_dir);
 	} else
 #endif
 	{
@@ -1242,9 +1241,9 @@ void DeterminePaths(const char *exe)
 	}
 
 	/* Make the necessary folders */
-#if defined(WITH_PERSONAL_DIR)
 	FioCreateDirectory(config_dir);
-	if (config_dir != _personal_dir) FioCreateDirectory(_personal_dir);
+#if defined(WITH_PERSONAL_DIR)
+	FioCreateDirectory(_personal_dir);
 #endif
 
 	DEBUG(misc, 3, "%s found as personal directory", _personal_dir);

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1192,6 +1192,15 @@ void DeterminePaths(const char *exe)
 		} else {
 			end[1] = '\0';
 		}
+
+		/* When using '-c', which sets _config_file, change the first search
+		 * path to the folder the configuration file is in. This folder is
+		 * also prepared to store autosaves and content you download. This
+		 * means that by using '-c', you create an sandboxed OpenTTD
+		 * installation as far as writing goes. For reading it still uses the
+		 * other search paths to find files, except for content_download.
+		 * Anything else in your personal-dir will be used if possible. */
+		_searchpaths[SP_WORKING_DIR] = config_dir;
 	} else {
 		char personal_dir[MAX_PATH];
 		if (FioFindFullPath(personal_dir, lastof(personal_dir), BASE_DIR, "openttd.cfg") != nullptr) {


### PR DESCRIPTION
Basically, with '-c' you now create a sandbox. It will still use
your personal-dir and global-dir to find files you installed there,
but all new files are stored with a base folder identical to the
folder the configuration is in.
    
This is a bit of an old bug, that we many have tried to solve in
various of different ways. The code has grown sufficiently complex
that it is hard to see what consequences of actions are. This is
in my opinion the most harmless solution, while increasing the
usefulness of the '-c' flag.
    
In essence, the problem was that empty folders were always created
in the directory where the configuration was, but as that directory
wasn't added to any searchpath, files weren't stored there, unless
by accident it was a folder already on the searchpath. For example,
if you do './openttd -c local.cfg', it did work as expected. But
in the more generic variant, it did not.
    
With this patch, you can run './openttd -c /new/folder/local.cfg',
and it will create and prepare that folder to receive new files.
    
'content_download' is also stored in the directory the
configuration is in; this was already the case. Important to
note that there is only one search-path for 'content_download'.
In other words, when using '-c', it will not look in '~/.openttd'
inside the 'content_download' folder.