### PR TITLE
Fix: [Actions] cleanup ci-build workflow to be up-to-date

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,29 +6,38 @@ on:
     branches:
     - master
 
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
 jobs:
   linux:
     name: Linux
 
-    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang, gcc]
         include:
           - compiler: clang
             cxxcompiler: clang++
           - compiler: gcc
             cxxcompiler: g++
+
+    runs-on: ubuntu-20.04
     env:
-      CTEST_OUTPUT_ON_FAILURE: 1
       CC: ${{ matrix.compiler }}
       CXX: ${{ matrix.cxxcompiler }}
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Install dependencies
       run: |
+        echo "::group::Update apt"
         sudo apt-get update
+        echo "::endgroup::"
+
+        echo "::group::Install dependencies"
         sudo apt-get install -y --no-install-recommends \
           libfontconfig-dev \
           libicu-dev \
@@ -39,104 +48,167 @@ jobs:
           libxdg-basedir-dev \
           zlib1g-dev \
           # EOF
-
-    - name: Checkout
-      uses: actions/checkout@v2
+        echo "::endgroup::"
+      env:
+        DEBIAN_FRONTEND: noninteractive
 
     - name: Get OpenGFX
       run: |
         mkdir -p ~/.local/share/openttd/baseset
         cd ~/.local/share/openttd/baseset
+
+        echo "::group::Download OpenGFX"
         curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
         unzip opengfx-all.zip
+        echo "::endgroup::"
+
         rm -f opengfx-all.zip
 
-    - name: CMake
-      run: mkdir build && cd build && cmake ..
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
 
-    - uses: ammaraskar/gcc-problem-matcher@master
     - name: Build
-      run: cd build && make -j2
-
-    - name: Test
-      run: cd build && make -j2 test
-
-  windows:
-    name: Windows
-
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x86, x64]
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Prepare vcpkg (with cache)
-      uses: lukka/run-vcpkg@v4
-      with:
-        vcpkgDirectory: 'c:/vcpkg'
-        doNotUpdateVcpkg: true
-        vcpkgArguments: 'liblzma libpng lzo zlib'
-        vcpkgTriplet: '${{ matrix.arch }}-windows-static'
-
-    - uses: ammaraskar/msvc-problem-matcher@master
-    - name: 'Build'
-      uses: lukka/run-cmake@v3
-      with:
-        cmakeListsOrSettingsJson: CMakeListsTxtBasic
-        useVcpkgToolchainFile: true
-        buildDirectory: '${{ runner.workspace }}/build'
-
-    - name: Install OpenGFX
       run: |
-        mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
-        cd "C:/Users/Public/Documents/OpenTTD/baseset"
-        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
-        unzip opengfx-all.zip
-        rm -f opengfx-all.zip
-      shell: bash
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake ..
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(nproc) cores"
+        make -j$(nproc)
+        echo "::endgroup::"
 
     - name: Test
       run: |
-        cd ${{ runner.workspace }}/build
-        ctest -C Debug
+        cd build
+        make -j$(nproc) test
 
   macos:
     name: Mac OS
 
-    runs-on: macos-latest
     strategy:
       fail-fast: false
+      matrix:
+        include:
+        - arch: x64
+          full_arch: x86_64
+
+    runs-on: macos-latest
     env:
-      CTEST_OUTPUT_ON_FAILURE: 1
       MACOSX_DEPLOYMENT_TARGET: 10.9
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: brew install pkg-config lzo xz libpng freetype
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
+    - name: Prepare vcpkg (with cache)
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgDirectory: '/usr/local/share/vcpkg'
+        doNotUpdateVcpkg: true
+        vcpkgArguments: 'freetype liblzma lzo'
+        vcpkgTriplet: '${{ matrix.arch }}-osx'
 
     - name: Install OpenGFX
       run: |
         mkdir -p ~/Documents/OpenTTD/baseset
         cd ~/Documents//OpenTTD/baseset
+
+        echo "::group::Download OpenGFX"
         curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
         unzip opengfx-all.zip
+        echo "::endgroup::"
+
         rm -f opengfx-all.zip
 
-    - name: CMake
-      run: mkdir build && cd build && cmake ..
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
 
-    - uses: ammaraskar/gcc-problem-matcher@master
     - name: Build
-      run: cd build && make -j2
+      run: |
+        mkdir build
+        cd build
+
+        echo "::group::CMake"
+        cmake ${GITHUB_WORKSPACE} \
+          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.full_arch }} \
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-osx \
+          -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(sysctl -n hw.logicalcpu) cores"
+        make -j$(sysctl -n hw.logicalcpu)
+        echo "::endgroup::"
 
     - name: Test
-      run: cd build && make -j2 test
+      run: |
+        cd build
+        make -j$(sysctl -n hw.logicalcpu) test
+
+  windows:
+    name: Windows
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: x86
+        - arch: x64
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Prepare vcpkg (with cache)
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgDirectory: 'c:/vcpkg'
+        doNotUpdateVcpkg: true
+        vcpkgArguments: 'liblzma libpng lzo zlib'
+        vcpkgTriplet: '${{ matrix.arch }}-windows-static'
+
+    - name: Install OpenGFX
+      shell: bash
+      run: |
+        mkdir -p "C:/Users/Public/Documents/OpenTTD/baseset"
+        cd "C:/Users/Public/Documents/OpenTTD/baseset"
+
+        echo "::group::Download OpenGFX"
+        curl -L https://cdn.openttd.org/opengfx-releases/0.6.0/opengfx-0.6.0-all.zip -o opengfx-all.zip
+        echo "::endgroup::"
+
+        echo "::group::Unpack OpenGFX"
+        unzip opengfx-all.zip
+        echo "::endgroup::"
+
+        rm -f opengfx-all.zip
+
+    - name: Install MSVC problem matcher
+      uses: ammaraskar/msvc-problem-matcher@master
+
+    - name: Build
+      uses: lukka/run-cmake@v3
+      with:
+        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+        useVcpkgToolchainFile: true
+        buildDirectory: '${{ github.workspace }}/build'
+        cmakeAppendedArgs: ' -GNinja'
+
+    - name: Test
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}/build
+        ctest -C Debug


### PR DESCRIPTION
Also, while at it, make it more like the upcoming release-workflow,
so they look a lot more similar.

Functional it should be the same, except that Windows should
now also output when a test fails.