### PR TITLE
Feature: Switch to bzip2 compression for DMG files (supported by OS X 10.4+)

### DIFF
--- a/cmake/PackageBundle.cmake
+++ b/cmake/PackageBundle.cmake
@@ -5,6 +5,7 @@ set(CPACK_BUNDLE_ICON "${CMAKE_SOURCE_DIR}/os/macosx/openttd.icns")
 set(CPACK_BUNDLE_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info.plist")
 set(CPACK_BUNDLE_STARTUP_COMMAND "${CMAKE_SOURCE_DIR}/os/macosx/launch.sh")
 set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/os/macosx/splash.png")
+set(CPACK_DMG_FORMAT "UDBZ")
 
 # Create a temporary Info.plist.in, where we will fill in the version via
 # CPackProperties.cmake.in. This because at this point in time the version


### PR DESCRIPTION
bzip2 compression for the DMG should shave maybe 1MB off the output image size.