### PR TITLE
Remove undefined behaviour from save/load code

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -392,18 +392,13 @@ static_assert(SIZE_MAX >= UINT32_MAX);
  */
 #define lastof(x) (&x[lengthof(x) - 1])
 
-#define cpp_offsetof(s, m)   (((size_t)&reinterpret_cast<const volatile char&>((((s*)(char*)8)->m))) - 8)
-#if !defined(offsetof)
-#	define offsetof(s, m) cpp_offsetof(s, m)
-#endif /* offsetof */
-
 /**
  * Gets the size of a variable within a class.
  * @param base     The class the variable is in.
  * @param variable The variable to get the size of.
  * @return the size of the variable
  */
-#define cpp_sizeof(base, variable) (sizeof(((base*)8)->variable))
+#define cpp_sizeof(base, variable) (sizeof(std::declval<base>().variable))
 
 /**
  * Gets the length of an array variable within a class.

--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -16,8 +16,8 @@ static const SettingDesc _company_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat),
+SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDT_END  = SDT_END()
 
 [defaults]
@@ -32,6 +32,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -9,9 +9,9 @@ static const SettingDesc _currency_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR = SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDT_CHR = SDT_CHR($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat),
+SDT_VAR = SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_CHR = SDT_CHR($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDT_END = SDT_END()
 
 [defaults]
@@ -26,6 +26,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 

--- a/src/table/gameopt_settings.ini
+++ b/src/table/gameopt_settings.ini
@@ -37,13 +37,13 @@ static const SettingDesc _gameopt_settings[] = {
 [post-amble]
 };
 [templates]
-SDTG_GENERAL = SDTG_GENERAL($name, $sdt_cmd, $sle_cmd, $type, $flags, $guiflags, $var, $length, $def, $min, $max, $interval, $full, $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_VAR     =     SDTG_VAR($name,                     $type, $flags, $guiflags, $var,          $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat),
+SDTG_GENERAL = SDTG_GENERAL($name, $sdt_cmd, $sle_cmd, $type, $flags, $guiflags, $var, $length, $def, $min, $max, $interval, $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_VAR     =     SDTG_VAR($name,                     $type, $flags, $guiflags, $var,          $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDT_NULL     =   SDT_NULL($length, $from, $to),
-SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to, $load, $cat),
-SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat),
+SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra),
+SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
 SDT_END      = SDT_END()
 
 [defaults]
@@ -58,6 +58,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -13,13 +13,13 @@ static const SettingDescGlobVarList _misc_settings[] = {
 [post-amble]
 };
 [templates]
-SDTG_LIST  =  SDTG_LIST($name, $type, $length, $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_MMANY = SDTG_MMANY($name, $type,          $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_OMANY = SDTG_OMANY($name, $type,          $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat),
+SDTG_LIST  =  SDTG_LIST($name, $type, $length, $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_MMANY = SDTG_MMANY($name, $type,          $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_OMANY = SDTG_OMANY($name, $type,          $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_END   = SDTG_END()
 
 [defaults]
@@ -34,6 +34,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -12,11 +12,11 @@
 #include "../newgrf_roadtype.h"
 
 /* Helper for filling property tables */
-#define NIP(prop, base, variable, type, name) { name, (ptrdiff_t)cpp_offsetof(base, variable), cpp_sizeof(base, variable), prop, type }
+#define NIP(prop, base, variable, type, name) { name, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->variable); }, cpp_sizeof(base, variable), prop, type }
 #define NIP_END() { nullptr, 0, 0, 0, 0 }
 
 /* Helper for filling callback tables */
-#define NIC(cb_id, base, variable, bit) { #cb_id, (ptrdiff_t)cpp_offsetof(base, variable), cpp_sizeof(base, variable), bit, cb_id }
+#define NIC(cb_id, base, variable, bit) { #cb_id, [] (const void *b) -> const void * { return std::addressof(static_cast<const base *>(b)->variable); }, cpp_sizeof(base, variable), bit, cb_id }
 #define NIC_END() { nullptr, 0, 0, 0, 0 }
 
 /* Helper for filling variable tables */

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -61,29 +61,29 @@ static size_t ConvertLandscape(const char *value);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
-#define SDTG_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, var, length, def, min, max, interval, full, str, strhelp, strval, proc, from, to, cat)\
-	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, nullptr, cat), SLEG_GENERAL(sle_cmd, var, type | flags, length, from, to)}
+#define SDTG_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, var, length, def, min, max, interval, full, str, strhelp, strval, proc, from, to, cat, extra)\
+	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, nullptr, cat), SLEG_GENERAL(sle_cmd, var, type | flags, length, from, to, extra)}
 
-#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_NUMX, SL_VAR, type, flags, guiflags, var, 0, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(name, SDT_NUMX, SL_VAR, type, flags, guiflags, var, 0, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, var, 0, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(name, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, var, 0, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTG_LIST(name, type, length, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_INTLIST, SL_ARR, type, flags, guiflags, var, length, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_LIST(name, type, length, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(name, SDT_INTLIST, SL_ARR, type, flags, guiflags, var, length, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTG_STR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_STR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTG_SSTR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat)\
-    SDTG_GENERAL(name, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_SSTR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
+    SDTG_GENERAL(name, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(name, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(name, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, 0, 0, full, str, strhelp, strval, proc, from, to, cat)
+#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(name, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, 0, 0, full, str, strhelp, strval, proc, from, to, cat, extra)
 
 #define SDTG_NULL(length, from, to)\
 	{{"", nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLEG_NULL(length, from, to)}
@@ -92,48 +92,48 @@ static size_t ConvertLandscape(const char *value);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
-#define SDT_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, base, var, length, def, min, max, interval, full, str, strhelp, strval, proc, load, from, to, cat)\
-	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, load, cat), SLE_GENERAL(sle_cmd, base, var, type | flags, length, from, to)}
+#define SDT_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, base, var, length, def, min, max, interval, full, str, strhelp, strval, proc, load, from, to, cat, extra)\
+	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, load, cat), SLE_GENERAL(sle_cmd, base, var, type | flags, length, from, to, extra)}
 
-#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat)\
-	SDT_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, base, var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat)
+#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDT_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, base, var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
 
-#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDT_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, base, var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat)
+#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDT_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, base, var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
 
-#define SDT_LIST(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDT_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat)
+#define SDT_LIST(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDT_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
 
-#define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat)
+#define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
 
-#define SDT_CHR(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDT_GENERAL(#var, SDT_STRING, SL_VAR, SLE_CHAR, flags, guiflags, base, var, 1, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat)
+#define SDT_CHR(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDT_GENERAL(#var, SDT_STRING, SL_VAR, SLE_CHAR, flags, guiflags, base, var, 1, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
 
-#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat)\
-	SDT_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, load, from, to, cat)
+#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra)\
+	SDT_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, load, from, to, cat, extra)
 
-#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, proc, strhelp, strval, from, to, cat)\
-	SDT_GENERAL(#var, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, 0, 0, full, str, strhelp, strval, proc, nullptr, from, to, cat)
+#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, proc, strhelp, strval, from, to, cat, extra)\
+	SDT_GENERAL(#var, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, 0, 0, full, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
 
 #define SDT_NULL(length, from, to)\
 	{{"", nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLE_CONDNULL(length, from, to)}
 
 
-#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, _settings_client.var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, _settings_client.var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTC_LIST(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTC_LIST(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat)
+#define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
 
-#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat)\
-	SDTG_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat)
+#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat, extra)\
+	SDTG_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra)
 
 #define SDT_END() {{nullptr, nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLE_END()}
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -62,18 +62,18 @@ const SettingDesc _settings[] = {
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTC_STR   =   SDTC_STR(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat),
-SDT_STR    =    SDT_STR($base, $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat),
-SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat),
+SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTC_STR   =   SDTC_STR(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra),
+SDT_STR    =    SDT_STR($base, $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
 SDT_NULL   =   SDT_NULL($length, $from, $to),
 SDT_END    = SDT_END()
 
@@ -89,6 +89,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 
@@ -644,6 +645,7 @@ interval = 2
 str      = STR_CONFIG_SETTING_LINKGRAPH_INTERVAL
 strval   = STR_JUST_COMMA
 strhelp  = STR_CONFIG_SETTING_LINKGRAPH_INTERVAL_HELPTEXT
+extra    = offsetof(LinkGraphSettings, recalc_interval)
 
 [SDT_VAR]
 base     = GameSettings
@@ -657,6 +659,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_LINKGRAPH_TIME
 strval   = STR_JUST_COMMA
 strhelp  = STR_CONFIG_SETTING_LINKGRAPH_TIME_HELPTEXT
+extra    = offsetof(LinkGraphSettings, recalc_time)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -671,6 +675,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_DISTRIBUTION_PAX
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_PAX_HELPTEXT
+extra    = offsetof(LinkGraphSettings, distribution_pax)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -685,6 +691,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_DISTRIBUTION_MAIL
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_MAIL_HELPTEXT
+extra    = offsetof(LinkGraphSettings, distribution_mail)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -699,6 +707,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_DISTRIBUTION_ARMOURED
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_ARMOURED_HELPTEXT
+extra    = offsetof(LinkGraphSettings, distribution_armoured)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -713,6 +723,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_DISTRIBUTION_DEFAULT
 strval   = STR_CONFIG_SETTING_DISTRIBUTION_MANUAL
 strhelp  = STR_CONFIG_SETTING_DISTRIBUTION_DEFAULT_HELPTEXT
+extra    = offsetof(LinkGraphSettings, distribution_default)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -726,6 +738,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_LINKGRAPH_ACCURACY
 strval   = STR_JUST_COMMA
 strhelp  = STR_CONFIG_SETTING_LINKGRAPH_ACCURACY_HELPTEXT
+extra    = offsetof(LinkGraphSettings, accuracy)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -739,6 +753,8 @@ interval = 5
 str      = STR_CONFIG_SETTING_DEMAND_DISTANCE
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 strhelp  = STR_CONFIG_SETTING_DEMAND_DISTANCE_HELPTEXT
+extra    = offsetof(LinkGraphSettings, demand_distance)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -752,6 +768,8 @@ interval = 5
 str      = STR_CONFIG_SETTING_DEMAND_SIZE
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 strhelp  = STR_CONFIG_SETTING_DEMAND_SIZE_HELPTEXT
+extra    = offsetof(LinkGraphSettings, demand_size)
+
 
 [SDT_VAR]
 base     = GameSettings
@@ -765,6 +783,8 @@ interval = 5
 str      = STR_CONFIG_SETTING_SHORT_PATH_SATURATION
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 strhelp  = STR_CONFIG_SETTING_SHORT_PATH_SATURATION_HELPTEXT
+extra    = offsetof(LinkGraphSettings, short_path_saturation)
+
 
 ; Vehicles
 

--- a/src/table/win32_settings.ini
+++ b/src/table/win32_settings.ini
@@ -15,8 +15,8 @@ static const SettingDescGlobVarList _win32_settings[] = {
 };
 #endif /* _WIN32 */
 [templates]
-SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat),
+SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_END  = SDTG_END()
 
 [defaults]
@@ -31,6 +31,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 

--- a/src/table/window_settings.ini
+++ b/src/table/window_settings.ini
@@ -10,8 +10,8 @@ static const SettingDesc _window_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat),
+SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDT_END  = SDT_END()
 
 [defaults]
@@ -27,6 +27,7 @@ load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
+extra    = 0
 
 
 


### PR DESCRIPTION
Our save/load code is totally depending on undefined behaviour via the
use of the `cpp_offsetof` macro.

This macro tries to get the address offset of member variables in a
non-portable way. Dereferencing a casted null pointer to get the member offset
can fail, as the value of the casted null pointer is not required to be numeric 0.
Tricks like the one used here by not using 0 and subtracting two pointers
are still undefined behaviour as you still might end up with a null pointer.

C++ has the `offsetof` function to work around this limitation. Unfortunatly,
it is only defined on types that are standard layout types and undefined behaviour
otherwise. Most types used during save/load are of course not standard
layout types. C++17 declares `offsetof` for other types as "conditionally
supported", which means that compilers may or may not implement it.
And even then using it for individual array elements is syntactically
not supported for the standard `offsetof` function.

Of course, undefined behaviour does not mean random behaviour, and all common
compilers that we use do define the behaviour in question, as evident by the
fact that the save/load system has been working fine for many years.

Still, this PR offers an alternative that does not rely on undefined behaviour
and only looks moderately offensive. Whether this is worth the effort is
left to the discretion of the reader.