### PR TITLE
Fix #8313: use correct capitalization for TTO / DOS base-music

### DIFF
--- a/media/baseset/orig_dos.obm
+++ b/media/baseset/orig_dos.obm
@@ -8,40 +8,40 @@ version           = 1
 @description_STR_BASEMUSIC_DOS_DESCRIPTION@
 
 [files]
-theme = gm.cat
-old_0 = gm.cat
-old_1 = gm.cat
-old_2 = gm.cat
-old_3 = gm.cat
-old_4 = gm.cat
-old_5 = gm.cat
-old_6 = gm.cat
-old_7 = gm.cat
+theme = GM.CAT
+old_0 = GM.CAT
+old_1 = GM.CAT
+old_2 = GM.CAT
+old_3 = GM.CAT
+old_4 = GM.CAT
+old_5 = GM.CAT
+old_6 = GM.CAT
+old_7 = GM.CAT
 old_8 =
 old_9 =
-new_0 = gm.cat
-new_1 = gm.cat
-new_2 = gm.cat
-new_3 = gm.cat
-new_4 = gm.cat
-new_5 = gm.cat
-new_6 = gm.cat
+new_0 = GM.CAT
+new_1 = GM.CAT
+new_2 = GM.CAT
+new_3 = GM.CAT
+new_4 = GM.CAT
+new_5 = GM.CAT
+new_6 = GM.CAT
 new_7 =
 new_8 =
 new_9 =
-ezy_0 = gm.cat
-ezy_1 = gm.cat
-ezy_2 = gm.cat
-ezy_3 = gm.cat
-ezy_4 = gm.cat
-ezy_5 = gm.cat
+ezy_0 = GM.CAT
+ezy_1 = GM.CAT
+ezy_2 = GM.CAT
+ezy_3 = GM.CAT
+ezy_4 = GM.CAT
+ezy_5 = GM.CAT
 ezy_6 =
 ezy_7 =
 ezy_8 =
 ezy_9 =
 
 [md5s]
-gm.cat = 7a29d2d0c4f7d2e03091ffa9b2bdfffb
+GM.CAT = 7a29d2d0c4f7d2e03091ffa9b2bdfffb
 
 [catindex]
 theme = 0

--- a/media/baseset/orig_tto.obm
+++ b/media/baseset/orig_tto.obm
@@ -8,25 +8,25 @@ version           = 1
 @description_STR_BASEMUSIC_TTO_DESCRIPTION@
 
 [files]
-theme = gm-tto.cat
-old_0 = gm-tto.cat
-old_1 = gm-tto.cat
-old_2 = gm-tto.cat
-old_3 = gm-tto.cat
-old_4 = gm-tto.cat
-old_5 = gm-tto.cat
-old_6 = gm-tto.cat
-old_7 = gm-tto.cat
+theme = GM-TTO.CAT
+old_0 = GM-TTO.CAT
+old_1 = GM-TTO.CAT
+old_2 = GM-TTO.CAT
+old_3 = GM-TTO.CAT
+old_4 = GM-TTO.CAT
+old_5 = GM-TTO.CAT
+old_6 = GM-TTO.CAT
+old_7 = GM-TTO.CAT
 old_8 =
 old_9 =
-new_0 = gm-tto.cat
-new_1 = gm-tto.cat
-new_2 = gm-tto.cat
-new_3 = gm-tto.cat
-new_4 = gm-tto.cat
-new_5 = gm-tto.cat
-new_6 = gm-tto.cat
-new_7 = gm-tto.cat
+new_0 = GM-TTO.CAT
+new_1 = GM-TTO.CAT
+new_2 = GM-TTO.CAT
+new_3 = GM-TTO.CAT
+new_4 = GM-TTO.CAT
+new_5 = GM-TTO.CAT
+new_6 = GM-TTO.CAT
+new_7 = GM-TTO.CAT
 new_8 =
 new_9 =
 ezy_0 =
@@ -60,7 +60,7 @@ new_6 = 14
 new_7 = 3
 
 [md5s]
-gm-tto.cat = 26e85ff84b0063aa5da05dd4698fc76e
+GM-TTO.CAT = 26e85ff84b0063aa5da05dd4698fc76e
 
 [names]
 ; Names get read from the CAT file


### PR DESCRIPTION
DOS did not have cases in filenames. Different OS interpret
them as either all-lowercase or all-uppercase. So we try both.
All-uppercase is done by the obg/obm/obs files, and if opening
fails, OpenTTD will automatically retry the all-lowercase variant.

So for those who already have the files lowercase, nothing
changes. For those that install fresh from TTO, it should now
work out-of-the-box.

---

This is an alternative to #8322, which also changed a lot of entries to lowercase. This seems to be the wrong move: in the way OpenTTD works, lowercase is always checked anyway.