### PR TITLE
Change: send network error to the server before making an emergency save

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -217,10 +217,11 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 		SendError(errorno);
 	}
 
+	this->CloseConnection(res);
+
 	ClientNetworkEmergencySave();
 
 	_switch_mode = SM_MENU;
-	this->CloseConnection(res);
 	_networking = false;
 }
 


### PR DESCRIPTION
Doesn't matter for a client but in case of a desync it allows server to make a save that is much closer to the moment of desync and thus way more useful for debugging.

It's a bit hard to guarantee this change doesn't break anything but I checked as I could and also included it in the last release of cmclient and noone complained so far ;)