### PR TITLE
Fix c02ef3e4: [NewGRF] Variable 0x44 is always HZB_TOWN_EDGE for roadstops

### DIFF
--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -45,7 +45,7 @@
 			const Town *t = nullptr;
 			if (IsRoadDepotTile(this->tile)) {
 				t = Depot::GetByTile(this->tile)->town;
-			} else if (IsTileType(this->tile, MP_ROAD)) {
+			} else {
 				t = ClosestTownFromTile(this->tile, UINT_MAX);
 			}
 			return t != nullptr ? GetTownRadiusGroup(t, this->tile) : HZB_TOWN_EDGE;


### PR DESCRIPTION
When inspecting roadtype variable 0x44 in a newgrf, it would always return HZB_TOWN_EDGE no matter where the roadstop is located. This causes inconsistent behaviour for NewGRFs which use the town zone to select different road underlays.

I _think_ this is because the road stops have tile type MP_STATION and the check is only for MP_ROAD. This fixes the test to also try to find the closest town when the tile has type MP_STATION. Works well in testing and doesn't seem to introduce any unexpected side effects. (Although my set of GRF files to test with is limited, to my knowledge only Timberwolf's Roads inspects 0x44 to decide which type of road underlay and roadstop to display)