### PR TITLE
Add: New disaster mode that enables all disaster types regardless of era

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -902,7 +902,7 @@ static void DoDisaster()
 
 	byte j = 0;
 	for (size_t i = 0; i != lengthof(_disasters); i++) {
-		if (_cur_year >= _disasters[i].min_year && _cur_year < _disasters[i].max_year) buf[j++] = (byte)i;
+		if (_settings_game.difficulty.disasters == DM_ON_ALL_TIME || (_cur_year >= _disasters[i].min_year && _cur_year < _disasters[i].max_year)) buf[j++] = (byte)i;
 	}
 
 	if (j == 0) return;
@@ -922,7 +922,7 @@ void DisasterDailyLoop()
 
 	ResetDisasterDelay();
 
-	if (_settings_game.difficulty.disasters != 0) DoDisaster();
+	if (_settings_game.difficulty.disasters != DM_OFF) DoDisaster();
 }
 
 void StartupDisasters()

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1105,6 +1105,10 @@ STR_CITY_APPROVAL_PERMISSIVE                                    :Permissive
 STR_CITY_APPROVAL_TOLERANT                                      :Tolerant
 STR_CITY_APPROVAL_HOSTILE                                       :Hostile
 
+STR_DISASTERS_OFF                                               :Disabled
+STR_DISASTERS_ON_ERA_SPECIFIC                                   :Era specific disasters
+STR_DISASTERS_ON_ALL_TIME                                       :All disasters types at any time
+
 STR_WARNING_NO_SUITABLE_AI                                      :{WHITE}No suitable AIs available...{}You can download several AIs via the 'Online Content' system
 
 # Settings tree window
@@ -1177,7 +1181,7 @@ STR_CONFIG_SETTING_RECESSIONS_HELPTEXT                          :If enabled, rec
 STR_CONFIG_SETTING_TRAIN_REVERSING                              :Disallow train reversing in stations: {STRING2}
 STR_CONFIG_SETTING_TRAIN_REVERSING_HELPTEXT                     :If enabled, trains will not reverse in non-terminus stations, even if there is a shorter path to their next destination when reversing
 STR_CONFIG_SETTING_DISASTERS                                    :Disasters: {STRING2}
-STR_CONFIG_SETTING_DISASTERS_HELPTEXT                           :Toggle disasters which may occasionally block or destroy vehicles or infrastructure
+STR_CONFIG_SETTING_DISASTERS_HELPTEXT                           :Toggle disasters which may occasionally block or destroy vehicles or infrastructure. Era specific disasters are disasters that are themathic to an era, they only happen in a certain period of time. All disaster types means any disaster theme from any era can happen regardless of date
 STR_CONFIG_SETTING_CITY_APPROVAL                                :Town council's attitude towards area restructuring: {STRING2}
 STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT                       :Choose how much noise and environmental damage by companies affect their town rating and further construction actions in their area
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -50,6 +50,15 @@ enum IndustryDensity {
 	ID_END,       ///< Number of industry density settings.
 };
 
+/** Disaster modes. */
+enum DisasterMode : uint8 {
+	DM_OFF,              ///< Disabled.
+	DM_ON_ERA_SPECIFIC,  ///< Era specific disasters.
+	DM_ON_ALL_TIME,      ///< All disasters types at any time.
+
+	DM_END,              ///< Number of disaster modes.
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	byte   max_no_competitors;               ///< the number of competitors (AIs)
@@ -66,7 +75,7 @@ struct DifficultySettings {
 	byte   quantity_sea_lakes;               ///< the amount of seas/lakes
 	bool   economy;                          ///< how volatile is the economy
 	bool   line_reverse_mode;                ///< reversing at stations or not
-	bool   disasters;                        ///< are disasters enabled
+	uint8  disasters;                        ///< disaster mode
 	byte   town_council_tolerance;           ///< minimum required town ratings to be allowed to demolish stuff
 };
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -293,13 +293,19 @@ def      = false
 str      = STR_CONFIG_SETTING_TRAIN_REVERSING
 strhelp  = STR_CONFIG_SETTING_TRAIN_REVERSING_HELPTEXT
 
-[SDT_BOOL]
+[SDT_VAR]
 base     = GameSettings
 var      = difficulty.disasters
+type     = SLE_UINT8
 from     = SLV_97
-def      = false
+guiflags = SGF_MULTISTRING
+def      = DM_OFF
+min      = DM_OFF
+max      = DM_END - 1
+interval = 1
 str      = STR_CONFIG_SETTING_DISASTERS
 strhelp  = STR_CONFIG_SETTING_DISASTERS_HELPTEXT
+strval   = STR_DISASTERS_OFF
 cat      = SC_BASIC
 
 [SDT_VAR]


### PR DESCRIPTION
This mode allows all disaster types to happen regardless of game year.

There is a small problem when loading the old openttd.cfg file. Not sure how to go about it.
![screenshot](https://user-images.githubusercontent.com/43006711/102717745-1fe0da00-42dc-11eb-96a9-accb32a333ec.png)

The workaround is to manually re-set the disaster setting and exit openttd to update the .cfg file.