### PR TITLE
Feature: Snow line height can be autodetermined upon world generation

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -124,7 +124,7 @@ static const NWidgetPart _nested_generate_landscape_widgets[] = {
 						/* Snow line. */
 						NWidget(NWID_HORIZONTAL),
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_LINE_DOWN), SetFill(0, 1),
-							NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
+							NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_TEXT), SetDataTip(STR_JUST_STRING, STR_NULL), SetFill(1, 0),
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_LINE_UP), SetFill(0, 1),
 						EndContainer(),
 						/* Starting date. */
@@ -233,7 +233,7 @@ static const NWidgetPart _nested_heightmap_load_widgets[] = {
 								NWidget(WWT_TEXT, COLOUR_ORANGE, WID_GL_HEIGHTMAP_SIZE_TEXT), SetDataTip(STR_MAPGEN_HEIGHTMAP_SIZE, STR_NULL), SetFill(1, 0),
 								NWidget(NWID_HORIZONTAL),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_LINE_DOWN), SetFill(0, 1),
-									NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
+									NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_TEXT), SetDataTip(STR_JUST_STRING, STR_NULL), SetFill(1, 0),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_LINE_UP), SetFill(0, 1),
 								EndContainer(),
 								NWidget(NWID_HORIZONTAL),
@@ -337,7 +337,15 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_MAPSIZE_X_PULLDOWN:   SetDParam(0, 1LL << _settings_newgame.game_creation.map_x); break;
 			case WID_GL_MAPSIZE_Y_PULLDOWN:   SetDParam(0, 1LL << _settings_newgame.game_creation.map_y); break;
 			case WID_GL_MAX_HEIGHTLEVEL_TEXT: SetDParam(0, _settings_newgame.construction.max_heightlevel); break;
-			case WID_GL_SNOW_LEVEL_TEXT:      SetDParam(0, _settings_newgame.game_creation.snow_line_height); break;
+
+			case WID_GL_SNOW_LEVEL_TEXT:
+				if (_settings_client.gui.determine_snowline_height) {
+					SetDParam(0, STR_MAPGEN_SNOW_LINE_AUTOFILL);
+				} else {
+					SetDParam(0, STR_BLACK_INT);
+					SetDParam(1, _settings_newgame.game_creation.snow_line_height);
+				}
+				break;
 
 			case WID_GL_TOWN_PULLDOWN:
 				if (_game_mode == GM_EDITOR) {
@@ -623,6 +631,7 @@ struct GenerateLandscapeWindow : public Window {
 					this->HandleButtonClick(widget);
 
 					_settings_newgame.game_creation.snow_line_height = Clamp(_settings_newgame.game_creation.snow_line_height + widget - WID_GL_SNOW_LEVEL_TEXT, MIN_SNOWLINE_HEIGHT, MAX_SNOWLINE_HEIGHT);
+					_settings_client.gui.determine_snowline_height = false;
 					this->InvalidateData();
 				}
 				_left_button_clicked = false;
@@ -762,6 +771,7 @@ struct GenerateLandscapeWindow : public Window {
 		if (str == nullptr) return;
 
 		int32 value;
+		bool autofill_snowline = false;
 		if (!StrEmpty(str)) {
 			value = atoi(str);
 		} else {
@@ -769,7 +779,7 @@ struct GenerateLandscapeWindow : public Window {
 			switch (this->widget_id) {
 				case WID_GL_MAX_HEIGHTLEVEL_TEXT: value = DEF_MAX_HEIGHTLEVEL; break;
 				case WID_GL_START_DATE_TEXT: value = DEF_START_YEAR; break;
-				case WID_GL_SNOW_LEVEL_TEXT: value = DEF_SNOWLINE_HEIGHT; break;
+				case WID_GL_SNOW_LEVEL_TEXT: value = DEF_SNOWLINE_HEIGHT; autofill_snowline = true; break;
 				case WID_GL_TOWN_PULLDOWN:   value = 1; break;
 				case WID_GL_WATER_PULLDOWN:  value = CUSTOM_SEA_LEVEL_MIN_PERCENTAGE; break;
 				default: NOT_REACHED();
@@ -790,6 +800,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_SNOW_LEVEL_TEXT:
 				this->SetWidgetDirty(WID_GL_SNOW_LEVEL_TEXT);
 				_settings_newgame.game_creation.snow_line_height = Clamp(value, MIN_SNOWLINE_HEIGHT, MAX_SNOWLINE_HEIGHT);
+				_settings_client.gui.determine_snowline_height = autofill_snowline;
 				break;
 
 			case WID_GL_TOWN_PULLDOWN:

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -517,5 +517,6 @@ void FlatEmptyWorld(byte tile_height)
 	}
 
 	FixSlopes();
+	if (_settings_game.game_creation.landscape == LT_ARCTIC) DetermineSnowLineHeight(tile_height);
 	MarkWholeScreenDirty();
 }

--- a/src/heightmap.h
+++ b/src/heightmap.h
@@ -25,5 +25,6 @@ bool GetHeightmapDimensions(DetailedFileType dft, const char *filename, uint *x,
 void LoadHeightmap(DetailedFileType dft, const char *filename);
 void FlatEmptyWorld(byte tile_height);
 void FixSlopes();
+void DetermineSnowLineHeight(int flat_world_height = -1);
 
 #endif /* HEIGHTMAP_H */

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -971,6 +971,8 @@ static void GenerateTerrain(int type, uint flag)
  */
 void DetermineSnowLineHeight(int flat_world_height)
 {
+	if (!_settings_client.gui.determine_snowline_height) return;
+
 	if (flat_world_height >= 0) { // generating a flat world
 		/* This doesn't require the extensive computations below */
 		int max_value = std::min(MAX_SNOWLINE_HEIGHT, std::max(MIN_SNOWLINE_HEIGHT, (uint)(flat_world_height - 2)));

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1336,8 +1336,10 @@ STR_CONFIG_SETTING_INDUSTRY_DENSITY                             :Industry densit
 STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Set how many industries should be generated and what level should be maintained during the game
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Maximum distance from edge for Oil industries: {STRING2}
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limit for how far from the map border oil refineries and oil rigs can be constructed. On island maps this ensures they are near the coast. On maps larger than 256 tiles, this value is scaled up.
+STR_CONFIG_SETTING_DETERMINE_SNOWLINE_HEIGHT                    :Autofill snow line height: {STRING2}
+STR_CONFIG_SETTING_DETERMINE_SNOWLINE_HEIGHT_HELPTEXT           :Automatically determine and set at what height snow starts in sub-arctic landscape upon world generation.
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT                              :Snow line height: {STRING2}
-STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Control at what height snow starts in sub-arctic landscape. Snow also affects industry generation and town growth requirements
+STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Manually control at what height snow starts in sub-arctic landscape. Snow also affects industry generation and town growth requirements
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN                         :Roughness of terrain: {STRING2}
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_HELPTEXT                :(TerraGenesis only) Choose the frequency of hills: Smooth landscapes have fewer, more wide-spread hills. Rough landscapes have many hills, which may look repetitive
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_VERY_SMOOTH             :Very Smooth

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2860,6 +2860,7 @@ STR_MAPGEN_MAX_HEIGHTLEVEL_DOWN                                 :{BLACK}Decrease
 STR_MAPGEN_SNOW_LINE_HEIGHT                                     :{BLACK}Snow line height:
 STR_MAPGEN_SNOW_LINE_UP                                         :{BLACK}Move the snow line height one up
 STR_MAPGEN_SNOW_LINE_DOWN                                       :{BLACK}Move the snow line height one down
+STR_MAPGEN_SNOW_LINE_AUTOFILL                                   :{BLACK}Autofill
 STR_MAPGEN_LAND_GENERATOR                                       :{BLACK}Land generator:
 STR_MAPGEN_TREE_PLACER                                          :{BLACK}Tree algorithm:
 STR_MAPGEN_TERRAIN_TYPE                                         :{BLACK}Terrain type:

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1690,6 +1690,7 @@ static SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("difficulty.terrain_type"));
 			genworld->Add(new SettingEntry("game_creation.tgen_smoothness"));
 			genworld->Add(new SettingEntry("game_creation.variety"));
+			genworld->Add(new SettingEntry("gui.determine_snowline_height"));
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));
 			genworld->Add(new SettingEntry("game_creation.tree_placer"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -122,6 +122,7 @@ struct GUISettings {
 	bool   timetable_arrival_departure;      ///< show arrivals and departures in vehicle timetables
 	bool   right_mouse_wnd_close;            ///< close window with right click
 	bool   pause_on_newgame;                 ///< whether to start new games paused or not
+	bool   determine_snowline_height;        ///< whether to automatically determine and set snow line height upon map generation
 	bool   enable_signal_gui;                ///< show the signal GUI when the signal button is pressed
 	Year   coloured_news_year;               ///< when does newspaper become coloured?
 	bool   timetable_in_ticks;               ///< whether to show the timetable in ticks rather than days

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -2900,6 +2900,14 @@ str      = STR_CONFIG_SETTING_PAUSE_ON_NEW_GAME
 strhelp  = STR_CONFIG_SETTING_PAUSE_ON_NEW_GAME_HELPTEXT
 cat      = SC_BASIC
 
+[SDTC_BOOL]
+var      = gui.determine_snowline_height
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+def      = true
+str      = STR_CONFIG_SETTING_DETERMINE_SNOWLINE_HEIGHT
+strhelp  = STR_CONFIG_SETTING_DETERMINE_SNOWLINE_HEIGHT_HELPTEXT
+cat      = SC_BASIC
+
 [SDTC_VAR]
 var      = gui.advanced_vehicle_list
 type     = SLE_UINT8

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -244,6 +244,10 @@ static height_t TGPGetMaxHeight()
 		if (_settings_game.difficulty.terrain_type > 0) {
 			max_height_from_table -= max_height[_settings_game.difficulty.terrain_type - 1][map_size_bucket];
 		}
+		/* Farms can only generate below 'snow_line_height - 2', and Forests can only generate at a minimum of 'snow_line_height + 2'.
+		 * Ensuring a minimum value of 6 solves this (0 -> Farm, 3 -> snow line height, 5 -> Forest). Since the value is not inclusive,
+		 * it becomes 6. */
+		max_height_from_table = std::max<uint>(6, max_height_from_table);
 	}
 	/* Tropic needs tropical forest to have all industries, so make sure we allow TGP to generate this high.
 	 * Tropic forest always starts at 1/4th of the max height. */


### PR DESCRIPTION
Adds an autofill snow line height option for World Generation GUI

First, it counts the land mass in number of tiles, excluding those that are at sea level.
Then, starting with a snow line height of 1, it runs multiple passes on the map and counts the number of tiles that are of that height.
While the number of tiles counted don't reach 50% of the land mass, it keeps adding +1 to the snow line height each pass.
Once the number of tiles surpass 50%, the snow line height is whichever value it stopped at.
The resulting value is checked against some industry restraints, like farms, which can't be placed on snow, and forests which can only be placed on snow. Should the result need adjusting, it is clamped accordingly.

Due to these industry constraints, the lowest value for the maximum height for generating Sub-Arctic terrain with TerraGenesis has been increased to 6, which affect the 'Very Flat' and, to a minor extent, the 'Flat' presets.