### PR TITLE
Fix: next 67 savegame versions are used in PatchPacks; skip them

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4254,6 +4254,7 @@ STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME                        :Savegame is mad
 STR_GAME_SAVELOAD_ERROR_FILE_NOT_READABLE                       :File not readable
 STR_GAME_SAVELOAD_ERROR_FILE_NOT_WRITEABLE                      :File not writeable
 STR_GAME_SAVELOAD_ERROR_DATA_INTEGRITY_CHECK_FAILED             :Data integrity check failed
+STR_GAME_SAVELOAD_ERROR_PATCHPACK                               :Savegame is made with a modified version
 STR_GAME_SAVELOAD_NOT_AVAILABLE                                 :<not available>
 STR_WARNING_LOADGAME_REMOVED_TRAMS                              :{WHITE}Game was saved in version without tram support. All trams have been removed
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2689,6 +2689,7 @@ static SaveOrLoadResult DoLoad(LoadFilter *reader, bool load_check)
 
 			/* Is the version higher than the current? */
 			if (_sl_version > SAVEGAME_VERSION) SlError(STR_GAME_SAVELOAD_ERROR_TOO_NEW_SAVEGAME);
+			if (_sl_version >= SLV_START_PATCHPACKS && _sl_version <= SLV_END_PATCHPACKS) SlError(STR_GAME_SAVELOAD_ERROR_PATCHPACK);
 			break;
 		}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -304,6 +304,22 @@ enum SaveLoadVersion : uint16 {
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10 Configurable ending year.
 	SLV_REMOVE_TOWN_CARGO_CACHE,            ///< 219  PR#8258 Remove town cargo acceptance and production caches.
 
+	/* Patchpacks for a while considered it a good idea to jump a few versions
+	 * above our version for their savegames. But as time continued, this gap
+	 * has been closing, up to the point we would start to reuse versions from
+	 * their patchpacks. This is not a problem from our perspective: the
+	 * savegame will simply fail to load because they all contain chunks we
+	 * cannot digest. But, this gives for ugly errors. As we have plenty of
+	 * versions anyway, we simply skip the versions we know belong to
+	 * patchpacks. This way we can present the user with a clean error
+	 * indicate he is loading a savegame from a patchpack.
+	 * For future patchpack creators: please follow a system like JGRPP, where
+	 * the version is masked with 0x8000, and the true version is stored in
+	 * its own chunk with feature toggles.
+	 */
+	SLV_START_PATCHPACKS,                   ///< 220  First known patchpack to use a version just above ours.
+	SLV_END_PATCHPACKS = 286,               ///< 286  Last known patchpack to use a version just above ours.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 


### PR DESCRIPTION
Various of PatchPacks (Spring 2013, Joker, ChillPP) used versions
slightly higher than ours. Of course, as time went by, this
caught up with us, and we are now almost pushing a new version
that would conflict with them. To avoid users creating unneeded
issues about "why can I not load my savegame", lets be ahead of
the curve and flat-out refuse to load them.

Version-wise, this is totally fine. We have ~32k versions to go
before we run out (0x8000 is masked by JGRPP; we should avoid
using that). At the rate we bump savegames, this is not going to
happen in any sane reality.

Fixes #8116 (well, rather, it prevents, but GitHub understands fixes :P)