### PR TITLE
Fix: Don't lower tree density if spreading is not enabled

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -681,7 +681,7 @@ static void TileLoop_Trees(TileIndex tile)
 						break;
 
 					case 1: // add a tree
-						if (GetTreeCount(tile) < 4) {
+						if (GetTreeCount(tile) < 4 && CanPlantExtraTrees(tile)) {
 							AddTreeCount(tile, 1);
 							SetTreeGrowth(tile, 0);
 							break;
@@ -713,13 +713,13 @@ static void TileLoop_Trees(TileIndex tile)
 			break;
 
 		case 6: // final stage of tree destruction
-			if (GetTreeCount(tile) > 1) {
+			 if (!CanPlantExtraTrees(tile)) {
+				/* if trees can't spread just plant a new one to prevent deforestation */
+				SetTreeGrowth(tile, 0);
+			} else if (GetTreeCount(tile) > 1) {
 				/* more than one tree, delete it */
 				AddTreeCount(tile, -1);
 				SetTreeGrowth(tile, 3);
-			} else if (!CanPlantExtraTrees(tile)) {
-				/* if trees can't spread just plant a new one to prevent deforestation */
-				SetTreeGrowth(tile, 0);
 			} else {
 				/* just one tree, change type into MP_CLEAR */
 				switch (GetTreeGround(tile)) {


### PR DESCRIPTION
I started this in #8160 but apparently, it wasn't good enough as even though it prevented forests from disappearing completely they still thin out after a while which is undesirable, especially in realistic scenarios with custom tree density.

It may not be the best example (aka worst case) but still enough to illustrate the issue:
After map generation:
![Screenshot from 2020-12-22 16-46-34](https://user-images.githubusercontent.com/413570/102895173-46864880-4475-11eb-9d66-069b113b7c78.png)
Current behaviour:
![Screenshot from 2020-12-22 15-58-28](https://user-images.githubusercontent.com/413570/102895187-51d97400-4475-11eb-87be-e1c7018070c5.png)
With this PR:
![Screenshot from 2020-12-22 16-38-51](https://user-images.githubusercontent.com/413570/102895213-5dc53600-4475-11eb-99fe-e43b8981f134.png)

Savegame used for testing: 
[tree-test.tar.gz](https://github.com/OpenTTD/OpenTTD/files/5730143/tree-test.tar.gz)
 