### PR TITLE
Add: PR templates.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+## Motivation / Problem
+
+<!--
+Describe here shortly
+* For bug fixes:
+    * What problem does this solve?
+    * If there is already an issue, link the issue, otherwise describe the problem here.
+* For features or gameplay changes:
+    * What was the motivation to develop this feature?
+    * Does this address any problem with the gameplay or interface?
+    * Which group of players do you think would enjoy this feature?
+-->
+
+
+## Description
+
+<!--
+Describe here shortly
+* For bug fixes:
+    * How is the problem solved?
+* For features or gameplay changes:
+    * What does this feature do?
+    * How does it improve/solve the situation described under 'motivation'.
+-->
+
+
+## Limitations
+
+<!--
+Describe here
+* Is the problem solved in all scenarios?
+* Is this feature complete? Are there things that could be added in the future?
+* Are there things that are intentionally left out?
+* Do you know of a bug or corner case that does not work?
+-->
+
+
+## Checklist for review
+
+Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
+* The bug fix is important enough to be backported? (label: 'backport requested')
+* This PR affects the save game format? (label 'savegame upgrade')
+* This PR affects the GS/AI API? (label 'needs review: Script API')
+    * ai_changelog.hpp, gs_changelog.hpp need updating.
+    * The compatibility wrappers (compat_*.nut) need updating.
+* This PR affects the NewGRF API? (label 'needs review: NewGRF')
+    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)


### PR DESCRIPTION
This adds a template for PRs.
* Github does not feature any PR template chooser as it does for issues, so we can only have one template.
* Please mind the `<!-- -->` in the text.