### PR TITLE
Change: [Linkgraph] Allow job threads to be aborted early when clearing schedule

### DIFF
--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -38,7 +38,8 @@ LinkGraphJob::LinkGraphJob(const LinkGraph &orig) :
 		link_graph(orig),
 		settings(_settings_game.linkgraph),
 		join_date(_date + _settings_game.linkgraph.recalc_time),
-		job_completed(false)
+		job_completed(false),
+		job_aborted(false)
 {
 }
 
@@ -91,6 +92,11 @@ LinkGraphJob::~LinkGraphJob()
 	/* Don't update stuff from other pools, when everything is being removed.
 	 * Accessing other pools may be invalid. */
 	if (CleaningPool()) return;
+
+	/* If the job has been aborted, the job state is invalid.
+	 * This should never be reached, as once the job has been marked as aborted
+	 * the only valid job operation is to clear the LinkGraphJob pool. */
+	assert(!this->IsJobAborted());
 
 	/* Link graph has been merged into another one. */
 	if (!LinkGraph::IsValidID(this->link_graph.index)) return;

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -86,6 +86,7 @@ void LinkGraphSchedule::JoinNext()
 /* static */ void LinkGraphSchedule::Run(LinkGraphJob *job)
 {
 	for (uint i = 0; i < lengthof(instance.handlers); ++i) {
+		if (job->IsJobAborted()) return;
 		instance.handlers[i]->Run(*job);
 	}
 
@@ -119,7 +120,7 @@ void LinkGraphSchedule::SpawnAll()
 /* static */ void LinkGraphSchedule::Clear()
 {
 	for (JobList::iterator i(instance.running.begin()); i != instance.running.end(); ++i) {
-		(*i)->JoinThread();
+		(*i)->AbortJob();
 	}
 	instance.running.clear();
 	instance.schedule.clear();

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -528,7 +528,7 @@ MCF1stPass::MCF1stPass(LinkGraphJob &job) : MultiCommodityFlow(job)
 			finished_sources[source] = !source_demand_left;
 			this->CleanupPaths(source, paths);
 		}
-	} while (more_loops || this->EliminateCycles());
+	} while ((more_loops || this->EliminateCycles()) && !job.IsJobAborted());
 }
 
 /**
@@ -544,7 +544,7 @@ MCF2ndPass::MCF2ndPass(LinkGraphJob &job) : MultiCommodityFlow(job)
 	uint accuracy = job.Settings().accuracy;
 	bool demand_left = true;
 	std::vector<bool> finished_sources(size);
-	while (demand_left) {
+	while (demand_left && !job.IsJobAborted()) {
 		demand_left = false;
 		for (NodeID source = 0; source < size; ++source) {
 			if (finished_sources[source]) continue;


### PR DESCRIPTION
## Motivation / Problem

Long running link graph jobs running in separate threads continue running until completion when the game state is cleared due to one of: abandoning game, loading replacement game, exiting game.

This causes the game and user interface to be unnecessarily blocked by joining the job thread when the result will be discarded.

## Description

When link graph jobs are cleared due to abandoning the game or exiting, flag the job as aborted.

The link graph job running in a separate thread checks the aborted flag periodically and terminates processing early if set.

This reduces the delay at game abandon or exit if a long-running job would otherwise still be running.

## Limitations

N/A

## Checklist for review

PR justification: https://github.com/OpenTTD/OpenTTD/pull/7081#pullrequestreview-557094105
