### PR TITLE
Feature: Contextual actions for vehicles grouped by shared orders

### DIFF
--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -24,8 +24,10 @@
 #include "tilehighlight_func.h"
 #include "window_gui.h"
 #include "vehiclelist.h"
+#include "vehicle_func.h"
 #include "order_backup.h"
 #include "zoom_func.h"
+#include "error.h"
 #include "depot_cmd.h"
 #include "train_cmd.h"
 #include "vehicle_cmd.h"
@@ -910,6 +912,49 @@ struct DepotWindow : Window {
 			/* Copy-clone, open viewport for new vehicle, and deselect the tool (assume player wants to change things on new vehicle) */
 			if (Command<CMD_CLONE_VEHICLE>::Post(STR_ERROR_CAN_T_BUY_TRAIN + v->type, CcCloneVehicle, this->window_number, v->index, false)) {
 				ResetObjectToPlace();
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Clones a vehicle from a vehicle list.  If this doesn't make sense (because not all vehicles in the list have the same orders), then it displays an error.
+	 * @return This always returns true, which indicates that the contextual action handled the mouse click.
+	 *         Note that it's correct behaviour to always handle the click even though an error is displayed,
+	 *         because users aren't going to expect the default action to be performed just because they overlooked that cloning doesn't make sense.
+	 */
+	bool OnVehicleSelect(VehicleList::const_iterator begin, VehicleList::const_iterator end) override
+	{
+		if (!_ctrl_pressed) {
+			/* If CTRL is not pressed: If all the vehicles in this list have the same orders, then copy orders */
+			if (AllEqual(begin, end, [](const Vehicle *v1, const Vehicle *v2) {
+				return VehiclesHaveSameEngineList(v1, v2);
+			})) {
+				if (AllEqual(begin, end, [](const Vehicle *v1, const Vehicle *v2) {
+					return VehiclesHaveSameOrderList(v1, v2);
+				})) {
+					OnVehicleSelect(*begin);
+				} else {
+					ShowErrorMessage(STR_ERROR_CAN_T_BUY_TRAIN + (*begin)->type, STR_ERROR_CAN_T_COPY_ORDER_VEHICLE_LIST, WL_INFO);
+				}
+			} else {
+				ShowErrorMessage(STR_ERROR_CAN_T_BUY_TRAIN + (*begin)->type, STR_ERROR_CAN_T_CLONE_VEHICLE_LIST, WL_INFO);
+			}
+		} else {
+			/* If CTRL is pressed: If all the vehicles in this list share orders, then copy orders */
+			if (AllEqual(begin, end, [](const Vehicle *v1, const Vehicle *v2) {
+				return VehiclesHaveSameEngineList(v1, v2);
+			})) {
+				if (AllEqual(begin, end, [](const Vehicle *v1, const Vehicle *v2) {
+					return v1->FirstShared() == v2->FirstShared();
+				})) {
+					OnVehicleSelect(*begin);
+				} else {
+					ShowErrorMessage(STR_ERROR_CAN_T_BUY_TRAIN + (*begin)->type, STR_ERROR_CAN_T_SHARE_ORDER_VEHICLE_LIST, WL_INFO);
+				}
+			} else {
+				ShowErrorMessage(STR_ERROR_CAN_T_BUY_TRAIN + (*begin)->type, STR_ERROR_CAN_T_CLONE_VEHICLE_LIST, WL_INFO);
 			}
 		}
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -888,14 +888,14 @@ public:
 					}
 
 					case GB_SHARED_ORDERS: {
-						const Vehicle *v = vehgroup.vehicles_begin[0];
-						/* We do not support VehicleClicked() here since the contextual action may only make sense for individual vehicles */
-
-						if (vindex == v->index) {
-							if (vehgroup.NumVehicles() == 1) {
-								ShowVehicleViewWindow(v);
-							} else {
-								ShowVehicleListWindow(v);
+						if (!VehicleClicked(vehgroup)) {
+							const Vehicle* v = vehgroup.vehicles_begin[0];
+							if (vindex == v->index) {
+								if (vehgroup.NumVehicles() == 1) {
+									ShowVehicleViewWindow(v);
+								} else {
+									ShowVehicleListWindow(v);
+								}
 							}
 						}
 						break;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5025,6 +5025,8 @@ STR_ERROR_CAN_T_CHANGE_SERVICING                                :{WHITE}Can't ch
 
 STR_ERROR_VEHICLE_IS_DESTROYED                                  :{WHITE}... vehicle is destroyed
 
+STR_ERROR_CAN_T_CLONE_VEHICLE_LIST                              :{WHITE}... not all vehicles are identical
+
 STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL                          :{WHITE}No vehicles will be available at all
 STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL_EXPLANATION              :{WHITE}Change your NewGRF configuration
 STR_ERROR_NO_VEHICLES_AVAILABLE_YET                             :{WHITE}No vehicles are available yet
@@ -5051,6 +5053,8 @@ STR_ERROR_CAN_T_SKIP_TO_ORDER                                   :{WHITE}Can't sk
 STR_ERROR_CAN_T_COPY_SHARE_ORDER                                :{WHITE}... vehicle can't go to all stations
 STR_ERROR_CAN_T_ADD_ORDER                                       :{WHITE}... vehicle can't go to that station
 STR_ERROR_CAN_T_ADD_ORDER_SHARED                                :{WHITE}... a vehicle sharing this order can't go to that station
+STR_ERROR_CAN_T_COPY_ORDER_VEHICLE_LIST                         :{WHITE}... not all vehicles have the same orders
+STR_ERROR_CAN_T_SHARE_ORDER_VEHICLE_LIST                        :{WHITE}... not all vehicles are sharing orders
 
 STR_ERROR_CAN_T_SHARE_ORDER_LIST                                :{WHITE}Can't share order list...
 STR_ERROR_CAN_T_STOP_SHARING_ORDER_LIST                         :{WHITE}Can't stop sharing order list...

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -29,6 +29,9 @@
 #include "aircraft.h"
 #include "engine_func.h"
 #include "vehicle_func.h"
+#include "vehiclelist.h"
+#include "vehicle_func.h"
+#include "error.h"
 #include "order_cmd.h"
 #include "company_cmd.h"
 
@@ -1462,6 +1465,40 @@ public:
 			this->selected_order = -1;
 			ResetObjectToPlace();
 		}
+		return true;
+	}
+
+	/**
+	 * Clones an order list from a vehicle list.  If this doesn't make sense (because not all vehicles in the list have the same orders), then it displays an error.
+	 * @return This always returns true, which indicates that the contextual action handled the mouse click.
+	 *         Note that it's correct behaviour to always handle the click even though an error is displayed,
+	 *         because users aren't going to expect the default action to be performed just because they overlooked that cloning doesn't make sense.
+	 */
+	bool OnVehicleSelect(VehicleList::const_iterator begin, VehicleList::const_iterator end) override
+	{
+		bool share_order = _ctrl_pressed || this->goto_type == OPOS_SHARE;
+		if (this->vehicle->GetNumOrders() != 0 && !share_order) return false;
+
+		if (!share_order) {
+			/* If CTRL is not pressed: If all the vehicles in this list have the same orders, then copy orders */
+			if (AllEqual(begin, end, [](const Vehicle *v1, const Vehicle *v2) {
+				return VehiclesHaveSameOrderList(v1, v2);
+			})) {
+				OnVehicleSelect(*begin);
+			} else {
+				ShowErrorMessage(STR_ERROR_CAN_T_COPY_ORDER_LIST, STR_ERROR_CAN_T_COPY_ORDER_VEHICLE_LIST, WL_INFO);
+			}
+		} else {
+			/* If CTRL is pressed: If all the vehicles in this list share orders, then copy orders */
+			if (AllEqual(begin, end, [](const Vehicle *v1, const Vehicle *v2) {
+				return v1->FirstShared() == v2->FirstShared();
+			})) {
+				OnVehicleSelect(*begin);
+			} else {
+				ShowErrorMessage(STR_ERROR_CAN_T_SHARE_ORDER_LIST, STR_ERROR_CAN_T_SHARE_ORDER_VEHICLE_LIST, WL_INFO);
+			}
+		}
+
 		return true;
 	}
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3013,3 +3013,39 @@ uint32 Vehicle::GetDisplayMinPowerToWeight() const
 	if (max_weight == 0) return 0;
 	return GetGroundVehicleCache()->cached_power * 10u / max_weight;
 }
+
+/**
+ * Checks if two vehicle chains have the same list of engines.
+ * @param v1 First vehicle chain.
+ * @param v1 Second vehicle chain.
+ * @return True if same, false if different.
+ */
+bool VehiclesHaveSameEngineList(const Vehicle *v1, const Vehicle *v2)
+{
+	while (true) {
+		if (v1 == nullptr && v2 == nullptr) return true;
+		if (v1 == nullptr || v2 == nullptr) return false;
+		if (v1->GetEngine() != v2->GetEngine()) return false;
+		v1 = v1->GetNextVehicle();
+		v2 = v2->GetNextVehicle();
+	}
+}
+
+/**
+ * Checks if two vehicles have the same list of orders.
+ * @param v1 First vehicles.
+ * @param v1 Second vehicles.
+ * @return True if same, false if different.
+ */
+bool VehiclesHaveSameOrderList(const Vehicle *v1, const Vehicle *v2)
+{
+	const Order *o1 = v1->GetFirstOrder();
+	const Order *o2 = v2->GetFirstOrder();
+	while (true) {
+		if (o1 == nullptr && o2 == nullptr) return true;
+		if (o1 == nullptr || o2 == nullptr) return false;
+		if (!o1->Equals(*o2)) return false;
+		o1 = o1->next;
+		o2 = o2->next;
+	}
+}

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -174,4 +174,7 @@ void GetVehicleSet(VehicleSet &set, Vehicle *v, uint8 num_vehicles);
 
 void CheckCargoCapacity(Vehicle *v);
 
+bool VehiclesHaveSameEngineList(const Vehicle *v1, const Vehicle *v2);
+bool VehiclesHaveSameOrderList(const Vehicle *v1, const Vehicle *v2);
+
 #endif /* VEHICLE_FUNC_H */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1997,16 +1997,16 @@ public:
 
 					case GB_SHARED_ORDERS: {
 						assert(vehgroup.NumVehicles() > 0);
-						const Vehicle *v = vehgroup.vehicles_begin[0];
-						/* We do not support VehicleClicked() here since the contextual action may only make sense for individual vehicles */
-
-						if (_ctrl_pressed) {
-							ShowOrdersWindow(v);
-						} else {
-							if (vehgroup.NumVehicles() == 1) {
-								ShowVehicleViewWindow(v);
+						if (!VehicleClicked(vehgroup)) {
+							const Vehicle *v = vehgroup.vehicles_begin[0];
+							if (_ctrl_pressed) {
+								ShowOrdersWindow(v);
 							} else {
-								ShowVehicleListWindow(v);
+								if (vehgroup.NumVehicles() == 1) {
+									ShowVehicleViewWindow(v);
+								} else {
+									ShowVehicleListWindow(v);
+								}
 							}
 						}
 						break;
@@ -3271,6 +3271,33 @@ bool VehicleClicked(const Vehicle *v)
 	if (!v->IsPrimaryVehicle()) return false;
 
 	return _thd.GetCallbackWnd()->OnVehicleSelect(v);
+}
+
+/**
+ * Dispatch a "vehicle group selected" event if any window waits for it.
+ * @param begin iterator to the start of the range of vehicles
+ * @param end iterator to the end of the range of vehicles
+ * @return did any window accept vehicle group selection?
+ */
+bool VehicleClicked(VehicleList::const_iterator begin, VehicleList::const_iterator end)
+{
+	assert(begin != end);
+	if (!(_thd.place_mode & HT_VEHICLE)) return false;
+
+	/* If there is only one vehicle in the group, act as if we clicked a single vehicle */
+	if (begin + 1 == end) return _thd.GetCallbackWnd()->OnVehicleSelect(*begin);
+
+	return _thd.GetCallbackWnd()->OnVehicleSelect(begin, end);
+}
+
+/**
+ * Dispatch a "vehicle group selected" event if any window waits for it.
+ * @param vehgroup the GUIVehicleGroup representing the vehicle group
+ * @return did any window accept vehicle group selection?
+ */
+bool VehicleClicked(const GUIVehicleGroup &vehgroup)
+{
+	return VehicleClicked(vehgroup.vehicles_begin, vehgroup.vehicles_end);
 }
 
 void StopGlobalFollowVehicle(const Vehicle *v)

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -12,6 +12,8 @@
 
 #include "window_type.h"
 #include "vehicle_type.h"
+#include "vehicle_gui_base.h"
+#include "vehiclelist.h"
 #include "order_type.h"
 #include "station_type.h"
 #include "engine_type.h"
@@ -102,6 +104,8 @@ static inline WindowClass GetWindowClassForVehicleType(VehicleType vt)
 /* Unified window procedure */
 void ShowVehicleViewWindow(const Vehicle *v);
 bool VehicleClicked(const Vehicle *v);
+bool VehicleClicked(VehicleList::const_iterator begin, VehicleList::const_iterator end);
+bool VehicleClicked(const GUIVehicleGroup &vehgroup);
 void StartStopVehicle(const Vehicle *v, bool texteffect);
 
 Vehicle *CheckClickOnVehicle(const struct Viewport *vp, int x, int y);

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -11,7 +11,10 @@
 #define WINDOW_GUI_H
 
 #include <list>
+#include <algorithm>
+#include <functional>
 
+#include "vehiclelist.h"
 #include "vehicle_type.h"
 #include "viewport_type.h"
 #include "company_type.h"
@@ -750,10 +753,19 @@ public:
 
 	/**
 	 * The user clicked on a vehicle while HT_VEHICLE has been set.
-	 * @param v clicked vehicle. It is guaranteed to be v->IsPrimaryVehicle() == true
-	 * @return True if the click is handled, false if it is ignored.
+	 * @param v clicked vehicle
+	 * @return true if the click is handled, false if it is ignored
+	 * @pre v->IsPrimaryVehicle() == true
 	 */
 	virtual bool OnVehicleSelect(const struct Vehicle *v) { return false; }
+
+	/**
+	 * The user clicked on a vehicle while HT_VEHICLE has been set.
+	 * @param v clicked vehicle
+	 * @return True if the click is handled, false if it is ignored
+	 * @pre v->IsPrimaryVehicle() == true
+	 */
+	virtual bool OnVehicleSelect(VehicleList::const_iterator begin, VehicleList::const_iterator end) { return false; }
 
 	/**
 	 * The user cancelled a tile highlight mode that has been set.
@@ -874,6 +886,19 @@ public:
 	using IterateFromBack = AllWindows<false>; //!< Iterate all windows in Z order from back to front.
 	using IterateFromFront = AllWindows<true>; //!< Iterate all windows in Z order from front to back.
 };
+
+/**
+ * Generic helper function that checks if all elements of the range are equal with respect to the given predicate.
+ * @param begin The start of the range.
+ * @param end The end of the range.
+ * @param pred The predicate to use.
+ * @return True if all elements are equal, false otherwise.
+ */
+template <class It, class Pred>
+inline bool AllEqual(It begin, It end, Pred pred)
+{
+	return std::adjacent_find(begin, end, std::not_fn(pred)) == end;
+}
 
 /**
  * Get the nested widget with number \a widnum from the nested widget tree.


### PR DESCRIPTION
## Motivation

This is a possible addition to #7028 to allow (some) contextual actions when vehicle lists are grouped by shared orders.  Contextual actions are clicks on a vehicle in the vehicle list that complete some other ongoing action, such as to clone a vehicle or to copy/share orders.

This brings the option with grouping enabled to "parity" with the non-grouped option, by supporting contextual actions wherever it is unambiguous.

## Description

The main addition of this PR is the contextual callback (`VehicleClicked()`) overload for multiple vehicles.  This PR is implemented as a generic mechanism for contextual actions on sets containing multiple vehicles, instead of just a single vehicle.  It hence does not rely on anything specific to grouping by _shared orders_, so it will still work even if in the future we have other ways to group vehicles.

I've implemented this whole feature outside of the `DoCommand` system.  I'm not sure if this is the best way, but since vehicle grouping is a purely UI feature (kind of a "view" over the real list of vehicles), it might be arguable that this resolution of contextual actions should also happen outside of the command system too.  Also I'm not sure if there's a simpler way to implement this.

## How to test

1. Load a game, open the vehicle list of some station with many routes passing through it, and set the vehicle list to group by shared orders.
2. Create a new vehicle, open the order list, click "Go to", then click any row in the vehicle list from step 1.  Observe that the order list is copied to the new vehicle.
3. Same as step 2, but hold down CTRL when clicking the row in the vehicle list.  Observe that the new vehicle is now sharing orders.
4. Create a depot, click "Clone Vehicle", then click any row in the vehicle list from step 1.  If all vehicles in the vehicle list have the same sequence of engines, then the vehicle will be cloned.  Otherwise an error will be displayed.
5. Same as step 4, but hold down CTRL when clicking the row in the vehicle list.  You should observe the same thing as step 4, but the new vehicle is now sharing orders.

Note:  I'm not sure if checking that two vehicles have the same sequence of engines is the correct way to check if two vehicles are "equal" (for steps 4 and 5).  Please correct me if it isn't!