### PR TITLE
Add: [NewGRF] Patch flag to test if inflation is on or off.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8389,7 +8389,8 @@ static void InitializeGRFSpecial()
 	                   |                                                      (1 << 0x1E)  // variablerunningcosts
 	                   |                                                      (1 << 0x1F); // any switch is on
 
-	_ttdpatch_flags[4] =                                                      (1 << 0x00); // larger persistent storage
+	_ttdpatch_flags[4] =                                                      (1 << 0x00)  // larger persistent storage
+	                   |             ((_settings_game.economy.inflation ? 1 : 0) << 0x01); // inflation is on
 }
 
 /** Reset and clear all NewGRF stations */

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1283,6 +1283,7 @@ proc     = DeleteSelectStationWindow
 [SDT_BOOL]
 base     = GameSettings
 var      = economy.inflation
+guiflags = SGF_NO_NETWORK
 def      = true
 str      = STR_CONFIG_SETTING_INFLATION
 strhelp  = STR_CONFIG_SETTING_INFLATION_HELPTEXT


### PR DESCRIPTION
## Motivation / Problem

NewGRFs don't know if their costs are affected by inflation or not.
## Description

The inflation setting is added to global var 0x85 (TTDPatch flags).
This is especially useful combined with e.g. #7589 to allow NewGRFs proper cost balance.

## Limitations

The TTDPatch flag variable is not updated if settings are changed during a running game, but the corresponding Action 7/9 is only run during NewGRF load anyway.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
