### PR TITLE
Fix #6468: don't store version of AIs-started-via-console in name

### DIFF
--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -101,20 +101,10 @@ AIInfo *AIScannerInfo::FindInfo(const char *nameParam, int versionParam, bool fo
 	strecpy(ai_name, nameParam, lastof(ai_name));
 	strtolower(ai_name);
 
-	AIInfo *info = nullptr;
-	int version = -1;
-
 	if (versionParam == -1) {
 		/* We want to load the latest version of this AI; so find it */
 		if (this->info_single_list.find(ai_name) != this->info_single_list.end()) return static_cast<AIInfo *>(this->info_single_list[ai_name]);
-
-		/* If we didn't find a match AI, maybe the user included a version */
-		char *e = strrchr(ai_name, '.');
-		if (e == nullptr) return nullptr;
-		*e = '\0';
-		e++;
-		versionParam = atoi(e);
-		/* Continue, like we were calling this function with a version. */
+		return nullptr;
 	}
 
 	if (force_exact_match) {
@@ -123,7 +113,11 @@ AIInfo *AIScannerInfo::FindInfo(const char *nameParam, int versionParam, bool fo
 		seprintf(ai_name_tmp, lastof(ai_name_tmp), "%s.%d", ai_name, versionParam);
 		strtolower(ai_name_tmp);
 		if (this->info_list.find(ai_name_tmp) != this->info_list.end()) return static_cast<AIInfo *>(this->info_list[ai_name_tmp]);
+		return nullptr;
 	}
+
+	AIInfo *info = nullptr;
+	int version = -1;
 
 	/* See if there is a compatible AI which goes by that name, with the highest
 	 *  version which allows loading the requested version */

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1172,7 +1172,24 @@ DEF_CONSOLE_CMD(ConStartAI)
 
 	AIConfig *config = AIConfig::GetConfig((CompanyID)n);
 	if (argc >= 2) {
-		config->Change(argv[1], -1, true);
+		config->Change(argv[1], -1, false);
+
+		/* If the name is not found, and there is a dot in the name,
+		 * try again with the assumption everything right of the dot is
+		 * the version the user wants to load. */
+		if (!config->HasScript()) {
+			char *name = stredup(argv[1]);
+			char *e = strrchr(name, '.');
+			if (e != nullptr) {
+				*e = '\0';
+				e++;
+
+				int version = atoi(e);
+				config->Change(name, version, true);
+			}
+			free(name);
+		}
+
 		if (!config->HasScript()) {
 			IConsoleWarning("Failed to load the specified AI");
 			return true;

--- a/src/game/game_scanner.cpp
+++ b/src/game/game_scanner.cpp
@@ -40,20 +40,10 @@ GameInfo *GameScannerInfo::FindInfo(const char *nameParam, int versionParam, boo
 	strecpy(game_name, nameParam, lastof(game_name));
 	strtolower(game_name);
 
-	GameInfo *info = nullptr;
-	int version = -1;
-
 	if (versionParam == -1) {
 		/* We want to load the latest version of this Game script; so find it */
 		if (this->info_single_list.find(game_name) != this->info_single_list.end()) return static_cast<GameInfo *>(this->info_single_list[game_name]);
-
-		/* If we didn't find a match Game script, maybe the user included a version */
-		char *e = strrchr(game_name, '.');
-		if (e == nullptr) return nullptr;
-		*e = '\0';
-		e++;
-		versionParam = atoi(e);
-		/* Continue like we were calling this function with a version. */
+		return nullptr;
 	}
 
 	if (force_exact_match) {
@@ -62,7 +52,11 @@ GameInfo *GameScannerInfo::FindInfo(const char *nameParam, int versionParam, boo
 		seprintf(game_name_tmp, lastof(game_name_tmp), "%s.%d", game_name, versionParam);
 		strtolower(game_name_tmp);
 		if (this->info_list.find(game_name_tmp) != this->info_list.end()) return static_cast<GameInfo *>(this->info_list[game_name_tmp]);
+		return nullptr;
 	}
+
+	GameInfo *info = nullptr;
+	int version = -1;
 
 	/* See if there is a compatible Game script which goes by that name, with the highest
 	 *  version which allows loading the requested version */

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -111,17 +111,17 @@ ScriptController::~ScriptController()
 	Squirrel *engine = ScriptObject::GetActiveInstance()->engine;
 	HSQUIRRELVM vm = engine->GetVM();
 
-	/* Internally we store libraries as 'library.version' */
-	char library_name[1024];
-	seprintf(library_name, lastof(library_name), "%s.%d", library, version);
-	strtolower(library_name);
-
 	ScriptInfo *lib = ScriptObject::GetActiveInstance()->FindLibrary(library, version);
 	if (lib == nullptr) {
 		char error[1024];
 		seprintf(error, lastof(error), "couldn't find library '%s' with version %d", library, version);
 		throw sq_throwerror(vm, error);
 	}
+
+	/* Internally we store libraries as 'library.version' */
+	char library_name[1024];
+	seprintf(library_name, lastof(library_name), "%s.%d", library, version);
+	strtolower(library_name);
 
 	/* Get the current table/class we belong to */
 	HSQOBJECT parent;


### PR DESCRIPTION
## Motivation / Problem

AI started from the console with an exact version behaved strangely. This is a long outstanding issue. #7193 tries to solve it, but the solution felt rather complicated. So I dived in to find the root-cause .. turns out it is a 10 year old bug :D

I wrote out my full analysis here:
https://github.com/OpenTTD/OpenTTD/pull/7193#issuecomment-751258576

Fixes #6468

## Description

    Fix #6468: don't store version of AIs started via console in name
    
    You can do: "startai myai.3", which starts version 3 of "myai".
    This is very useful for testing save/load code between different
    versions of your AI.
    
    However, when using this syntax, the AI got saved as "myai.3" as
    name of the AI, instead of "myai". This caused several problems,
    like indicating to the user the AI could not be found, but still
    load the AI. But in all cases, the AI never got the chance to
    load the saved data, making the whole reason this exists pointless.
    
    By splitting the name and version already in the console command,
    the code becomes simpler and AIs started this way now follow the
    normal flow after initialization.

## Limitations

- Save/load loads the latest compatible AI; one could think that when started with the exact version, it should retain that. This makes no sense to me, as the only real reason I can think of that you want to load an older version, is to check if your save/load code still works. If other use-cases present themself, we can always store the `force_exact_match` variable next to the AI. But as I currently do not see the use-case, I left that out.
- This does not fix old savegames; in fact, one could argue it breaks old savegames more, as it doesn't even try to load the AI anymore with any version (which it did use to do, despite telling in the console it did not).