### PR TITLE
Doc: for over 10 years, we do not load the exact AI version first

### DIFF
--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -23,7 +23,6 @@
  *  script that matches to the specified version as close as possible. It tries
  *  (from first to last, stopping as soon as the attempt succeeds)
  *
- *  - load the exact same version of the same script,
  *  - load the latest version of the same script that supports loading data from
  *    the saved version (the version of saved data must be equal or greater
  *    than ScriptInfo::MinVersionToLoad),


### PR DESCRIPTION
## Motivation / Problem

Documentation suggests a savegame with an AI of a specific version first tries to load the AI with that exact same version. This hasn't been the case for 10 years now, and could be confusing to users.

## Description

See commit fae34ee7 and #3232 for details. The documentation simply never got updated.

## Limitations

(None)
