### PR TITLE
Codechange: use more C++11 in script-related functions

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -87,8 +87,8 @@ struct AIListWindow : public Window {
 		if (GetConfig(slot)->HasScript()) {
 			ScriptInfo *info = GetConfig(slot)->GetInfo();
 			int i = 0;
-			for (ScriptInfoList::const_iterator it = this->info_list->begin(); it != this->info_list->end(); it++, i++) {
-				if ((*it).second == info) {
+			for (const auto &item : *this->info_list) {
+				if (item.second == info) {
 					this->selected = i;
 					break;
 				}
@@ -127,10 +127,11 @@ struct AIListWindow : public Window {
 					DrawString(r.left + WD_MATRIX_LEFT, r.right - WD_MATRIX_LEFT, y + WD_MATRIX_TOP, this->slot == OWNER_DEITY ? STR_AI_CONFIG_NONE : STR_AI_CONFIG_RANDOM_AI, this->selected == -1 ? TC_WHITE : TC_ORANGE);
 					y += this->line_height;
 				}
-				ScriptInfoList::const_iterator it = this->info_list->begin();
-				for (int i = 1; it != this->info_list->end(); i++, it++) {
+				int i = 1;
+				for (const auto &item : *this->info_list) {
+					i++;
 					if (this->vscroll->IsVisible(i)) {
-						DrawString(r.left + WD_MATRIX_LEFT, r.right - WD_MATRIX_RIGHT, y + WD_MATRIX_TOP, (*it).second->GetName(), (this->selected == i - 1) ? TC_WHITE : TC_ORANGE);
+						DrawString(r.left + WD_MATRIX_LEFT, r.right - WD_MATRIX_RIGHT, y + WD_MATRIX_TOP, item.second->GetName(), (this->selected == i - 1) ? TC_WHITE : TC_ORANGE);
 						y += this->line_height;
 					}
 				}
@@ -138,9 +139,10 @@ struct AIListWindow : public Window {
 			}
 			case WID_AIL_INFO_BG: {
 				AIInfo *selected_info = nullptr;
-				ScriptInfoList::const_iterator it = this->info_list->begin();
-				for (int i = 1; selected_info == nullptr && it != this->info_list->end(); i++, it++) {
-					if (this->selected == i - 1) selected_info = static_cast<AIInfo *>((*it).second);
+				int i = 1;
+				for (const auto &item : *this->info_list) {
+					i++;
+					if (this->selected == i - 1) selected_info = static_cast<AIInfo *>(item.second);
 				}
 				/* Some info about the currently selected AI. */
 				if (selected_info != nullptr) {
@@ -334,11 +336,10 @@ struct AISettingsWindow : public Window {
 	{
 		visible_settings.clear();
 
-		ScriptConfigItemList::const_iterator it = this->ai_config->GetConfigList()->begin();
-		for (; it != this->ai_config->GetConfigList()->end(); it++) {
-			bool no_hide = (it->flags & SCRIPTCONFIG_DEVELOPER) == 0;
+		for (const auto &item : *this->ai_config->GetConfigList()) {
+			bool no_hide = (item.flags & SCRIPTCONFIG_DEVELOPER) == 0;
 			if (no_hide || _settings_client.gui.ai_developer_tools) {
-				visible_settings.push_back(&(*it));
+				visible_settings.push_back(&item);
 			}
 		}
 

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -61,8 +61,8 @@ void AIScannerInfo::RegisterAPI(class Squirrel *engine)
 AIInfo *AIScannerInfo::SelectRandomAI() const
 {
 	uint num_random_ais = 0;
-	for (ScriptInfoList::const_iterator it = this->info_single_list.begin(); it != this->info_single_list.end(); it++) {
-		AIInfo *i = static_cast<AIInfo *>((*it).second);
+	for (const auto &item : info_single_list) {
+		AIInfo *i = static_cast<AIInfo *>(item.second);
 		if (i->UseAsRandomAI()) num_random_ais++;
 	}
 
@@ -121,11 +121,10 @@ AIInfo *AIScannerInfo::FindInfo(const char *nameParam, int versionParam, bool fo
 
 	/* See if there is a compatible AI which goes by that name, with the highest
 	 *  version which allows loading the requested version */
-	ScriptInfoList::iterator it = this->info_list.begin();
-	for (; it != this->info_list.end(); it++) {
-		AIInfo *i = static_cast<AIInfo *>((*it).second);
+	for (const auto &item : this->info_list) {
+		AIInfo *i = static_cast<AIInfo *>(item.second);
 		if (strcasecmp(ai_name, i->GetName()) == 0 && i->CanLoadFromVersion(versionParam) && (version == -1 || i->GetVersion() > version)) {
-			version = (*it).second->GetVersion();
+			version = item.second->GetVersion();
 			info = i;
 		}
 	}
@@ -158,8 +157,8 @@ AILibrary *AIScannerLibrary::FindLibrary(const char *library, int version)
 	strtolower(library_name);
 
 	/* Check if the library + version exists */
-	ScriptInfoList::iterator iter = this->info_list.find(library_name);
-	if (iter == this->info_list.end()) return nullptr;
+	ScriptInfoList::iterator it = this->info_list.find(library_name);
+	if (it == this->info_list.end()) return nullptr;
 
-	return static_cast<AILibrary *>((*iter).second);
+	return static_cast<AILibrary *>((*it).second);
 }

--- a/src/game/game_scanner.cpp
+++ b/src/game/game_scanner.cpp
@@ -60,11 +60,10 @@ GameInfo *GameScannerInfo::FindInfo(const char *nameParam, int versionParam, boo
 
 	/* See if there is a compatible Game script which goes by that name, with the highest
 	 *  version which allows loading the requested version */
-	ScriptInfoList::iterator it = this->info_list.begin();
-	for (; it != this->info_list.end(); it++) {
-		GameInfo *i = static_cast<GameInfo *>((*it).second);
+	for (const auto &item : this->info_list) {
+		GameInfo *i = static_cast<GameInfo *>(item.second);
 		if (strcasecmp(game_name, i->GetName()) == 0 && i->CanLoadFromVersion(versionParam) && (version == -1 || i->GetVersion() > version)) {
-			version = (*it).second->GetVersion();
+			version = item.second->GetVersion();
 			info = i;
 		}
 	}
@@ -97,8 +96,8 @@ GameLibrary *GameScannerLibrary::FindLibrary(const char *library, int version)
 	strtolower(library_name);
 
 	/* Check if the library + version exists */
-	ScriptInfoList::iterator iter = this->info_list.find(library_name);
-	if (iter == this->info_list.end()) return nullptr;
+	ScriptInfoList::iterator it = this->info_list.find(library_name);
+	if (it == this->info_list.end()) return nullptr;
 
-	return static_cast<GameLibrary *>((*iter).second);
+	return static_cast<GameLibrary *>((*it).second);
 }

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -77,9 +77,9 @@ ScriptController::ScriptController(CompanyID company) :
 
 ScriptController::~ScriptController()
 {
-	for (LoadedLibraryList::iterator iter = this->loaded_library.begin(); iter != this->loaded_library.end(); iter++) {
-		free((*iter).second);
-		free((*iter).first);
+	for (const auto &item : this->loaded_library) {
+		free(item.second);
+		free(item.first);
 	}
 
 	this->loaded_library.clear();
@@ -129,9 +129,9 @@ ScriptController::~ScriptController()
 
 	char fake_class[1024];
 
-	LoadedLibraryList::iterator iter = controller->loaded_library.find(library_name);
-	if (iter != controller->loaded_library.end()) {
-		strecpy(fake_class, (*iter).second, lastof(fake_class));
+	LoadedLibraryList::iterator it = controller->loaded_library.find(library_name);
+	if (it != controller->loaded_library.end()) {
+		strecpy(fake_class, (*it).second, lastof(fake_class));
 	} else {
 		int next_number = ++controller->loaded_library_count;
 

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -20,14 +20,14 @@
 ScriptInfo::~ScriptInfo()
 {
 	/* Free all allocated strings */
-	for (ScriptConfigItemList::iterator it = this->config_list.begin(); it != this->config_list.end(); it++) {
-		free((*it).name);
-		free((*it).description);
-		if (it->labels != nullptr) {
-			for (auto &lbl_map : *(*it).labels) {
+	for (const auto &item : this->config_list) {
+		free(item.name);
+		free(item.description);
+		if (item.labels != nullptr) {
+			for (auto &lbl_map : *item.labels) {
 				free(lbl_map.second);
 			}
-			delete it->labels;
+			delete item.labels;
 		}
 	}
 	this->config_list.clear();
@@ -232,8 +232,8 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 	ValidateString(setting_name);
 
 	ScriptConfigItem *config = nullptr;
-	for (ScriptConfigItemList::iterator it = this->config_list.begin(); it != this->config_list.end(); it++) {
-		if (strcmp((*it).name, setting_name) == 0) config = &(*it);
+	for (auto &item : this->config_list) {
+		if (strcmp(item.name, setting_name) == 0) config = &item;
 	}
 
 	if (config == nullptr) {
@@ -284,22 +284,22 @@ const ScriptConfigItemList *ScriptInfo::GetConfigList() const
 
 const ScriptConfigItem *ScriptInfo::GetConfigItem(const char *name) const
 {
-	for (ScriptConfigItemList::const_iterator it = this->config_list.begin(); it != this->config_list.end(); it++) {
-		if (strcmp((*it).name, name) == 0) return &(*it);
+	for (const auto &item : this->config_list) {
+		if (strcmp(item.name, name) == 0) return &item;
 	}
 	return nullptr;
 }
 
 int ScriptInfo::GetSettingDefaultValue(const char *name) const
 {
-	for (ScriptConfigItemList::const_iterator it = this->config_list.begin(); it != this->config_list.end(); it++) {
-		if (strcmp((*it).name, name) != 0) continue;
+	for (const auto &item : this->config_list) {
+		if (strcmp(item.name, name) != 0) continue;
 		/* The default value depends on the difficulty level */
 		switch (GetGameSettings().script.settings_profile) {
-			case SP_EASY:   return (*it).easy_value;
-			case SP_MEDIUM: return (*it).medium_value;
-			case SP_HARD:   return (*it).hard_value;
-			case SP_CUSTOM: return (*it).custom_value;
+			case SP_EASY:   return item.easy_value;
+			case SP_MEDIUM: return item.medium_value;
+			case SP_HARD:   return item.hard_value;
+			case SP_CUSTOM: return item.custom_value;
 			default: NOT_REACHED();
 		}
 	}

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -103,14 +103,12 @@ void ScriptScanner::RescanDir()
 
 void ScriptScanner::Reset()
 {
-	ScriptInfoList::iterator it = this->info_list.begin();
-	for (; it != this->info_list.end(); it++) {
-		free((*it).first);
-		delete (*it).second;
+	for (const auto &item : this->info_list) {
+		free(item.first);
+		delete item.second;
 	}
-	it = this->info_single_list.begin();
-	for (; it != this->info_single_list.end(); it++) {
-		free((*it).first);
+	for (const auto &item : this->info_single_list) {
+		free(item.first);
 	}
 
 	this->info_list.clear();
@@ -171,9 +169,8 @@ char *ScriptScanner::GetConsoleList(char *p, const char *last, bool newest_only)
 {
 	p += seprintf(p, last, "List of %s:\n", this->GetScannerName());
 	const ScriptInfoList &list = newest_only ? this->info_single_list : this->info_list;
-	ScriptInfoList::const_iterator it = list.begin();
-	for (; it != list.end(); it++) {
-		ScriptInfo *i = (*it).second;
+	for (const auto &item : list) {
+		ScriptInfo *i = item.second;
 		p += seprintf(p, last, "%10s (v%d): %s\n", i->GetName(), i->GetVersion(), i->GetDescription());
 	}
 	p += seprintf(p, last, "\n");
@@ -273,16 +270,16 @@ static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, S
 
 bool ScriptScanner::HasScript(const ContentInfo *ci, bool md5sum)
 {
-	for (ScriptInfoList::iterator it = this->info_list.begin(); it != this->info_list.end(); it++) {
-		if (IsSameScript(ci, md5sum, (*it).second, this->GetDirectory())) return true;
+	for (const auto &item : this->info_list) {
+		if (IsSameScript(ci, md5sum, item.second, this->GetDirectory())) return true;
 	}
 	return false;
 }
 
 const char *ScriptScanner::FindMainScript(const ContentInfo *ci, bool md5sum)
 {
-	for (ScriptInfoList::iterator it = this->info_list.begin(); it != this->info_list.end(); it++) {
-		if (IsSameScript(ci, md5sum, (*it).second, this->GetDirectory())) return (*it).second->GetMainScript();
+	for (const auto &item : this->info_list) {
+		if (IsSameScript(ci, md5sum, item.second, this->GetDirectory())) return item.second->GetMainScript();
 	}
 	return nullptr;
 }


### PR DESCRIPTION
## Motivation / Problem

When trying to read the AI code (emphasis on trying), I run into a lot of very hard to read statements that can be solved by using a bit of `auto` and `for (.. : ..)` constructions.

## Description

Well .. it uses C++11 now.

## Limitations

- Only did matches for `iter`  in `script`, `ai` and `game` folder.
