### PR TITLE
Fix f66baa44: index was off by one

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -127,7 +127,7 @@ struct AIListWindow : public Window {
 					DrawString(r.left + WD_MATRIX_LEFT, r.right - WD_MATRIX_LEFT, y + WD_MATRIX_TOP, this->slot == OWNER_DEITY ? STR_AI_CONFIG_NONE : STR_AI_CONFIG_RANDOM_AI, this->selected == -1 ? TC_WHITE : TC_ORANGE);
 					y += this->line_height;
 				}
-				int i = 1;
+				int i = 0;
 				for (const auto &item : *this->info_list) {
 					i++;
 					if (this->vscroll->IsVisible(i)) {
@@ -139,7 +139,7 @@ struct AIListWindow : public Window {
 			}
 			case WID_AIL_INFO_BG: {
 				AIInfo *selected_info = nullptr;
-				int i = 1;
+				int i = 0;
 				for (const auto &item : *this->info_list) {
 					i++;
 					if (this->selected == i - 1) selected_info = static_cast<AIInfo *>(item.second);


### PR DESCRIPTION
## Motivation / Problem

Broke master. You could not select an AI from the GUI anymore.

## Description

    i++ in the 3rd part of a for() is post, not pre. Oops.

See https://github.com/OpenTTD/OpenTTD/commit/f66baa444ff5575b2b40e3bfd514cdb463f6f560#diff-65e506358d200c3adbd2679e9f04fdb017459a79f08852173dd9fc5964859dbeL131 for the original code.