### PR TITLE
Fix: [Emscripten] compile with exceptions enabled, as our AIs depend on it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,8 @@ if(EMSCRIPTEN)
     # Allow heap-growth, and start with a bigger memory size.
     target_link_libraries(WASM::WASM INTERFACE "-s ALLOW_MEMORY_GROWTH=1")
     target_link_libraries(WASM::WASM INTERFACE "-s INITIAL_MEMORY=33554432")
+    target_link_libraries(WASM::WASM INTERFACE "-s DISABLE_EXCEPTION_CATCHING=0")
+    add_definitions(-s DISABLE_EXCEPTION_CATCHING=0)
 
     # Export functions to Javascript.
     target_link_libraries(WASM::WASM INTERFACE "-s EXPORTED_FUNCTIONS='[\"_main\", \"_em_openttd_add_server\"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='[\"cwrap\"]'")

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -66,6 +66,12 @@ uint64 ottd_rdtsc()
 # define RDTSC_AVAILABLE
 #endif
 
+#if defined(__EMSCRIPTEN__) && !defined(RDTSC_AVAILABLE)
+/* On emscripten doing TIC/TOC would be ill-advised */
+uint64 ottd_rdtsc() {return 0;}
+# define RDTSC_AVAILABLE
+#endif
+
 /* In all other cases we have no support for rdtsc. No major issue,
  * you just won't be able to profile your code with TIC()/TOC() */
 #if !defined(RDTSC_AVAILABLE)


### PR DESCRIPTION
## Motivation / Problem

Emscripten by default disables exceptions, as it is pretty expensive (it is not implemented in WASM yet, so they have to construct around it).
Our script framework heavily uses exceptions to work, but also our saveload code uses it. This means both were not always functioning as expected, and could crash the game completely.

## Description

    Compile with exceptions enabled, as our AIs depend on it

    Also parts of the saveload code does, and some other places. This
    does slow down builds, but for most computers this will not be
    measurable. At least, the ones I had access to I could not find
    a difference in FPS, mainly as that is heavily limited by the Hz
    of the screens of the computer.
    
    Either way, it is better to have a full functional game than a
    fast one in my opinion

Additionally, muted the TIC/TOC warning the Emscripten build was throwing.

## Limitations

- Binary is slightly bigger (< 5% bigger)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
