### PR TITLE
Fix: [Actions] cmakeBuildType is only used with CMakeListsTxtBasic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -479,8 +479,7 @@ jobs:
         useVcpkgToolchainFile: false
         buildDirectory: '${{ github.workspace }}/build-host'
         buildWithCMakeArgs: '--target tools'
-        cmakeBuildType: RelWithDebInfo
-        cmakeAppendedArgs: ' -GNinja -DOPTION_TOOLS_ONLY=ON'
+        cmakeAppendedArgs: ' -GNinja -DOPTION_TOOLS_ONLY=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
     - name: Install MSVC problem matcher
       uses: ammaraskar/msvc-problem-matcher@master
@@ -492,8 +491,7 @@ jobs:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         useVcpkgToolchainFile: true
         buildDirectory: '${{ github.workspace }}/build'
-        cmakeBuildType: RelWithDebInfo
-        cmakeAppendedArgs: ' -GNinja -DOPTION_USE_NSIS=ON -DHOST_BINARY_DIR=${{ github.workspace }}/build-host'
+        cmakeAppendedArgs: ' -GNinja -DOPTION_USE_NSIS=ON -DHOST_BINARY_DIR=${{ github.workspace }}/build-host -DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
     - name: Build (without installer)
       if: needs.source.outputs.is_tag != 'true' || matrix.arch == 'arm64'
@@ -502,8 +500,7 @@ jobs:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         useVcpkgToolchainFile: true
         buildDirectory: '${{ github.workspace }}/build'
-        cmakeBuildType: RelWithDebInfo
-        cmakeAppendedArgs: ' -GNinja -DHOST_BINARY_DIR=${{ github.workspace }}/build-host'
+        cmakeAppendedArgs: ' -GNinja -DHOST_BINARY_DIR=${{ github.workspace }}/build-host -DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
     - name: Create bundles
       shell: bash


### PR DESCRIPTION
## Motivation / Problem

Windows nightlies are a debug build, and not the intended release build.

## Description

    We use CMakeListsTxtAdvanced, and as such, we have to do this our
    self via "-DCMAKE_BUILD_TYPE=RelWithDebInfo". Otherwise we are
    producing Debug builds instead of Release builds. Oops.
