### PR TITLE
Fix f66baa44: for-loop is no longer increasing "i"

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -92,6 +92,8 @@ struct AIListWindow : public Window {
 					this->selected = i;
 					break;
 				}
+
+				i++;
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

When you go to the AI list, the first AI was always selected instead of the current selected on.

## Description

    During conversion it was overlooked that the for-loop used to do
    this. Oops.

See https://github.com/OpenTTD/OpenTTD/commit/f66baa444ff5575b2b40e3bfd514cdb463f6f560#diff-65e506358d200c3adbd2679e9f04fdb017459a79f08852173dd9fc5964859dbeL90 for the original code. See how sneaky the `i++` was hiding there? Bah :P