### PR TITLE
Feature: Make town bridge max length a function of its population

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1159,10 +1159,15 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 
 	const int delta = TileOffsByDiagDir(bridge_dir);
 
+	/* To prevent really small towns from building disproportionately
+	 * long bridges, make the max a function of its population. */
+	int base_bridge_length = 4;
+	int max_bridge_length = t->cache.population / 1000 + base_bridge_length;
+
 	if (slope == SLOPE_FLAT) {
 		/* Bridges starting on flat tiles are only allowed when crossing rivers, rails or one-way roads. */
 		do {
-			if (bridge_length++ >= 4) {
+			if (bridge_length++ >= base_bridge_length) {
 				/* Allow to cross rivers, not big lakes, nor large amounts of rails or one-way roads. */
 				return false;
 			}
@@ -1170,8 +1175,8 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 		} while (IsValidTile(bridge_tile) && ((IsWaterTile(bridge_tile) && !IsSea(bridge_tile)) || IsPlainRailTile(bridge_tile) || (IsNormalRoadTile(bridge_tile) && GetDisallowedRoadDirections(bridge_tile) != DRD_NONE)));
 	} else {
 		do {
-			if (bridge_length++ >= 11) {
-				/* Max 11 tile long bridges */
+			if (bridge_length++ >= max_bridge_length) {
+				/* Ensure the bridge is not longer than the max allowed length. */
 				return false;
 			}
 			bridge_tile += delta;

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1161,7 +1161,7 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 
 	/* To prevent really small towns from building disproportionately
 	 * long bridges, make the max a function of its population. */
-	int base_bridge_length = 4;
+	int base_bridge_length = 5;
 	int max_bridge_length = t->cache.population / 1000 + base_bridge_length;
 
 	if (slope == SLOPE_FLAT) {


### PR DESCRIPTION
Make new town bridge max length a function of its population.

## Motivation / Problem

Really small towns can build disproportionately long bridges, all the way up to 11 tiles. To make it more realistic, the max number of tiles for a built bridge should be a function of its population.

## Description

In order to prevent small towns from building disproportionately long bridges, this change makes the max allowed bridge length a function of its population, while letting every town build at least a town as long as 4 tiles. The max length is defined as a min of 4 plus 1 for each 1000 population, rounded down.

- town of 200 population -> max bridge length of 4
- town of 2000 population -> max bridge length of 6
- town of 10000 population -> max bridge length of 14
- town of 20000 population -> max bridge length of 24

## Limitations

None.

## Checklist for review

This PR is safe, and backwards compatible, since saved games won't be affected other than towns will build bridges with a variable max length as opposed as the current fixed hard coded max length.
