### PR TITLE
Fix 65f65ad2: Missing path separator that fell over a cliff.

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -219,7 +219,7 @@ static std::string FiosMakeFilename(const std::string *path, const char *name, c
 	const char *period = strrchr(name, '.');
 	if (period != nullptr && strcasecmp(period, ext) == 0) ext = "";
 
-	return buf + name + ext;
+	return buf + PATHSEP + name + ext;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

PATHSEP removed by oversight.