### PR TITLE
Feature: Close adjacent level crossings as if they were one large crossing

### DIFF
--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -105,8 +105,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 		case MP_ROAD:
 			if (IsLevelCrossing(tile) && !HasCrossingReservation(tile)) {
 				SetCrossingReservation(tile, true);
-				BarCrossing(tile);
-				MarkTileDirtyByTile(tile); // crossing barred, make tile dirty
+				UpdateLevelCrossing(tile, false);
 				return true;
 			}
 			break;

--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -105,7 +105,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 		case MP_ROAD:
 			if (IsLevelCrossing(tile) && !HasCrossingReservation(tile)) {
 				SetCrossingReservation(tile, true);
-				UpdateLevelCrossing(tile, false);
+				UpdateLevelCrossing(tile);
 				return true;
 			}
 			break;

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -551,7 +551,7 @@ CommandCost CmdBuildSingleRail(TileIndex tile, DoCommandFlag flags, uint32 p1, u
 
 					if (flags & DC_EXEC) {
 						MakeRoadCrossing(tile, road_owner, tram_owner, _current_company, (track == TRACK_X ? AXIS_Y : AXIS_X), railtype, roadtype_road, roadtype_tram, GetTownIndex(tile));
-						UpdateLevelCrossing(tile, false);
+						UpdateLevelCrossing(tile);
 						Company::Get(_current_company)->infrastructure.rail[railtype] += LEVELCROSSING_TRACKBIT_FACTOR;
 						DirtyCompanyInfrastructureWindows(_current_company);
 						if (num_new_road_pieces > 0 && Company::IsValidID(road_owner)) {

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2040,7 +2040,19 @@ static TrackStatus GetTileTrackStatus_Road(TileIndex tile, TransportType mode, u
 					if (side != INVALID_DIAGDIR && axis != DiagDirToAxis(side)) break;
 
 					trackdirbits = TrackBitsToTrackdirBits(AxisToTrackBits(axis));
+					/* Block entry if level crossing is closed */
 					if (IsCrossingBarred(tile)) red_signals = trackdirbits;
+					/* Allow continuing if coming from a closed crossing */
+					if (IsLevelCrossingTile(TileAddByDiagDir(tile, AxisToDiagDir(axis))) &&
+							IsCrossingBarred(TileAddByDiagDir(tile, AxisToDiagDir(axis)))) {
+						/* If coming from south, allow travelling north */
+						red_signals &= ~(TRACKDIR_BIT_Y_NW | TRACKDIR_BIT_X_NE);
+					}
+					if (IsLevelCrossingTile(TileAddByDiagDir(tile, ReverseDiagDir(AxisToDiagDir(axis)))) &&
+							IsCrossingBarred(TileAddByDiagDir(tile, ReverseDiagDir(AxisToDiagDir(axis))))) {
+						/* If coming from north, allow travelling south */
+						red_signals &= ~(TRACKDIR_BIT_Y_SE | TRACKDIR_BIT_X_SW);
+					}
 					break;
 				}
 

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -784,7 +784,7 @@ CommandCost CmdBuildRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 				bool reserved = HasBit(GetRailReservationTrackBits(tile), railtrack);
 				MakeRoadCrossing(tile, company, company, GetTileOwner(tile), roaddir, GetRailType(tile), rtt == RTT_ROAD ? rt : INVALID_ROADTYPE, (rtt == RTT_TRAM) ? rt : INVALID_ROADTYPE, p2);
 				SetCrossingReservation(tile, reserved);
-				UpdateLevelCrossing(tile, false);
+				UpdateLevelCrossing(tile);
 				MarkTileDirtyByTile(tile);
 			}
 			return CommandCost(EXPENSES_CONSTRUCTION, 2 * RoadBuildCost(rt));

--- a/src/road_func.h
+++ b/src/road_func.h
@@ -153,7 +153,7 @@ RoadTypes GetCompanyRoadTypes(CompanyID company, bool introduces = true);
 RoadTypes GetRoadTypes(bool introduces);
 RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, Date date);
 
-void UpdateLevelCrossing(TileIndex tile, bool sound = true);
+void UpdateLevelCrossing(TileIndex tile);
 void UpdateCompanyRoadInfrastructure(RoadType rt, Owner o, int count);
 
 struct TileInfo;

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -431,24 +431,6 @@ static inline void SetCrossingBarred(TileIndex t, bool barred)
 	SB(_m[t].m5, 5, 1, barred ? 1 : 0);
 }
 
-/**
- * Unbar a level crossing.
- * @param t The tile to change.
- */
-static inline void UnbarCrossing(TileIndex t)
-{
-	SetCrossingBarred(t, false);
-}
-
-/**
- * Bar a level crossing.
- * @param t The tile to change.
- */
-static inline void BarCrossing(TileIndex t)
-{
-	SetCrossingBarred(t, true);
-}
-
 /** Check if a road tile has snow/desert. */
 #define IsOnDesert IsOnSnow
 /**

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1989,7 +1989,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_102)) {
 		for (TileIndex t = 0; t < map_size; t++) {
 			/* Now all crossings should be in correct state */
-			if (IsLevelCrossingTile(t)) UpdateLevelCrossing(t, false);
+			if (IsLevelCrossingTile(t)) UpdateLevelCrossing(t);
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Level crossings on parallel tracks can be dangerous, especially for articulated road vehicles, or if multiple road vehicles follow each other. Often, a vehicle is waiting for a level crossing to open, when it suddenly gets struck in its "tail" by another train.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

Updated patch from https://www.tt-forums.net/viewtopic.php?f=33&t=46091

This patch tries to avoid the situation that a vehicle gets stuck inbetween two tracks by closing all level crossings simultaneously, and instead allowing road vehicles to leave a crossing they already entered. Best combined with a path signal some tiles ahead of a level crossing, to give vehicles time to leave if a train approaches.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

on loading an old savegame, road vehicles that were previously waiting for a crossing to open, may now immediately start up, causing them to run straight into a train. some savegame conversion update is needed.

~~also, a call to `SndPlayTileFx(SND_0E_LEVEL_CROSSING, tile);` fell off and i don't remember where it went, or why i removed it.~~
**Update:** level crossing sound is now changed to only appear when a train approaches the crossing, instead of sometimes when it is being closed.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
