### PR TITLE
Fix 65f65ad2: Don't try to construct a std::string from nullptr

### DIFF
--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -92,7 +92,7 @@ public:
 		ALL      = BASESET | NEWGRF | AI | SCENARIO | GAME, ///< Scan for everything.
 	};
 
-	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename = nullptr) override;
+	bool AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename = {}) override;
 
 	bool AddFile(Subdirectory sd, const std::string &filename);
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -539,7 +539,7 @@ void ClientNetworkContentSocketHandler::AfterDownload()
 
 		TarScanner ts;
 		std::string fname = GetFullFilename(this->curInfo, false);
-		ts.AddFile(sd, fname.c_str());
+		ts.AddFile(sd, fname);
 
 		if (this->curInfo->type == CONTENT_TYPE_BASE_MUSIC) {
 			/* Music can't be in a tar. So extract the tar! */


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Downloading online content caused a crash

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
Crash caused by trying to construct a std::string from a nullptr
Also remove an unnecessary conversion.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
