### PR TITLE
Fix #8297: Infrastructure counters for road tunnels, bridges, depots …

### DIFF
--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -222,6 +222,10 @@ static const int INVALID_PRICE_MODIFIER = MIN_PRICE_MODIFIER - 1;
 static const uint TUNNELBRIDGE_TRACKBIT_FACTOR = 4;
 /** Multiplier for how many regular track bits a level crossing counts. */
 static const uint LEVELCROSSING_TRACKBIT_FACTOR = 2;
+/** Multiplier for how many regular track bits a road depot counts. */
+static const uint ROAD_DEPOT_TRACKBIT_FACTOR = 2;
+/** Multiplier for how many regular track bits a bay stop counts. */
+static const uint ROAD_STOP_TRACKBIT_FACTOR = 2;
 /** Multiplier for how many regular tiles a lock counts. */
 static const uint LOCK_DEPOT_TILE_FACTOR = 2;
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1933,8 +1933,8 @@ CommandCost CmdBuildRoadStop(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 				if (road_rt == INVALID_ROADTYPE && RoadTypeIsRoad(rt)) road_rt = rt;
 				if (tram_rt == INVALID_ROADTYPE && RoadTypeIsTram(rt)) tram_rt = rt;
 
-				UpdateCompanyRoadInfrastructure(road_rt, road_owner, 2);
-				UpdateCompanyRoadInfrastructure(tram_rt, tram_owner, 2);
+				UpdateCompanyRoadInfrastructure(road_rt, road_owner, ROAD_STOP_TRACKBIT_FACTOR);
+				UpdateCompanyRoadInfrastructure(tram_rt, tram_owner, ROAD_STOP_TRACKBIT_FACTOR);
 
 				MakeDriveThroughRoadStop(cur_tile, st->owner, road_owner, tram_owner, st->index, rs_type, road_rt, tram_rt, axis);
 				road_stop->MakeDriveThrough();
@@ -1942,7 +1942,7 @@ CommandCost CmdBuildRoadStop(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 				if (road_rt == INVALID_ROADTYPE && RoadTypeIsRoad(rt)) road_rt = rt;
 				if (tram_rt == INVALID_ROADTYPE && RoadTypeIsTram(rt)) tram_rt = rt;
 				/* Non-drive-through stop never overbuild and always count as two road bits. */
-				Company::Get(st->owner)->infrastructure.road[rt] += 2;
+				Company::Get(st->owner)->infrastructure.road[rt] += ROAD_STOP_TRACKBIT_FACTOR;
 				MakeRoadStop(cur_tile, st->owner, st->index, rs_type, road_rt, tram_rt, ddir);
 			}
 			Company::Get(st->owner)->infrastructure.station++;
@@ -2031,7 +2031,7 @@ static CommandCost RemoveRoadStop(TileIndex tile, DoCommandFlag flags)
 		/* Update company infrastructure counts. */
 		FOR_ALL_ROADTRAMTYPES(rtt) {
 			RoadType rt = GetRoadType(tile, rtt);
-			UpdateCompanyRoadInfrastructure(rt, GetRoadOwner(tile, rtt), -2);
+			UpdateCompanyRoadInfrastructure(rt, GetRoadOwner(tile, rtt), -ROAD_STOP_TRACKBIT_FACTOR);
 		}
 
 		Company::Get(st->owner)->infrastructure.station--;


### PR DESCRIPTION
…and bus and truck stops after road type conversion are now correct

The previous fix 887e9481ff0e70df6bf93ce15a3899a03f124c50 only worked for roads and failed to consider a multiplier used for the infrastructure totals for tunnels/bridges.
Also, depots and bus/truck stops are counted as 2 road pieces on creation but were only counted as 1 road piece on conversion because the function DiagDirToRoadBits() was used, which only ever returns single-piece road segments.

## Motivation / Problem

The code for converting between different road types available in NewGRFs such as RattRoads led to incorrect infrastructure totals for tunnels, bridges, depots and stops, enabling exploits such as described in #8297.


## Description
For tunnels and bridges their road piece numbers are now multiplied by TUNNELBRIDGE_TRACKBIT_FACTOR and the infrastructure total isn't updated twice as was the case before.
For stops a conditional was removed which meant that they weren't registered in the infrastructure counter at all.
For bay stops and depots the function DiagDirToRoadBits(), which incorrectly reported their number of road pieces on conversion, was replaced with DiagDirToStraightRoadBits().


## Limitations

The code was tested in-game as fixes were developed, and when I felt I met the goal of this issue I tested all types of road infrastructure again, so I think this issue is ultimately fixed.
It's not clear though when road type conversion should be possible, for example in towns with bad company ratings, and if road ownership should be changed when converting previously unowned roads.


## Checklist for review

The fix only affects in-game logic.
