### PR TITLE
Fix #8453: [Script] Don't truncate loan variation to 32bit

### DIFF
--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -204,8 +204,10 @@
 
 	if (loan == GetLoanAmount()) return true;
 
+	Money amount = abs(loan - GetLoanAmount());
+
 	return ScriptObject::DoCommand(0,
-			abs(loan - GetLoanAmount()), 2,
+			amount >> 32, (amount & 0xFFFFFFFC) | 2,
 			(loan > GetLoanAmount()) ? CMD_INCREASE_LOAN : CMD_DECREASE_LOAN);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Difference between requested new loan and current loan may not fit in 32 bits.

## Description

Replaced p1 with higher half of loan variation.
Used free bits in p2 to pass 30 highest bits of lower half of loan variation (assuming lower 2 bits are always 0)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
