### PR TITLE
Change: Ability to convert between road types for town roads and bridges now indi…

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2388,22 +2388,20 @@ CommandCost CmdConvertRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 			}
 		}
 
-		bool is_owner_town = (owner == OWNER_TOWN);
-		Town *t = ClosestTownFromTile(tile, _settings_game.economy.dist_local_authority);
+		/* Base the ability to replace town roads and bridges on the town's
+		 * acceptance of destructive actions. */
+		if (owner == OWNER_TOWN) {
+			Town *t = ClosestTownFromTile(tile, _settings_game.economy.dist_local_authority);
+			CommandCost ret = CheckforTownRating(DC_NONE, t, tt == MP_TUNNELBRIDGE ? TUNNELBRIDGE_REMOVE : ROAD_REMOVE);
+			if (ret.Failed()) {
+				error = ret;
+				continue;
+			}
+		}
 
 		/* Vehicle on the tile when not converting normal <-> powered
 		 * Tunnels and bridges have special check later */
 		if (tt != MP_TUNNELBRIDGE) {
-			/* Base the ability to replace town roads on the town's acceptance
-			 * of road destruction. */
-			if (is_owner_town) {
-				CommandCost ret = CheckforTownRating(DC_NONE, t, ROAD_REMOVE);
-				if (ret.Failed()) {
-					error = ret;
-					continue;
-				}
-			}
-
 			if (!HasPowerOnRoad(from_type, to_type)) {
 				CommandCost ret = EnsureNoVehicleOnGround(tile);
 				if (ret.Failed()) {
@@ -2442,15 +2440,6 @@ CommandCost CmdConvertRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 				}
 			}
 		} else {
-			/* Base the ability to replace town road bridges on the town's acceptance
-			 * of bridge destruction. */
-			if (is_owner_town) {
-				CommandCost ret = CheckforTownRating(DC_NONE, t, TUNNELBRIDGE_REMOVE);
-				if (ret.Failed()) {
-					error = ret;
-					continue;
-				}
-			}
 			TileIndex endtile = GetOtherTunnelBridgeEnd(tile);
 
 			/* If both ends of tunnel/bridge are in the range, do not try to convert twice -


### PR DESCRIPTION
…rectly depends on town ratings.

## Motivation / Problem

Previously it was possible to convert town roads and bridges without restriction by the local authority.


## Description

With this change the ability to convert town roads and bridges depends on the players' companies' standing with the local authority, which is determined using CheckforTownRating() with the ROAD_REMOVE and the TUNNELBRIDGE_REMOVE TownRatingCheckTypes, respectively.

Basically the player is allowed to convert town roads if and only if the player would be allowed to destroy town roads, and the same goes for town bridges.
