### PR TITLE
Feature: Permanent rivers

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -998,6 +998,7 @@
      <li>m7: animation frame (railway stations/waypoints, airports)</li>
      <li>m8 bits 11..6: <a href="#TramType">Tramtype</a></li>
      <li>m8 bits 5..0: <a href="#TrackType">track type</a> for railway stations/waypoints</li>
+     <li>m8 bit 15: set if a river was originally present under water based station tiles when current water class is canal (dock, buoy, oilrig)</li>
     </ul>
    </td>
   </tr>
@@ -1108,6 +1109,7 @@
        </tr>
       </table>
      </li>
+     <li>m8 bit 15: set if a river was originally present at the tile when current water class is canal (canal, ship depot, lock)</li>
     </ul>
    </td>
   </tr>
@@ -1450,6 +1452,7 @@
      <li>m6 bits 5..3: random triggers (NewGRF)</li>
      <li>m6 bit 2: bit 8 of type (see m5)</li>
      <li>m7: animation frame</li>
+     <li>m8 bit 15: set if a river was originally present at the tile when current water class is canal (oilrig)
     </ul>
    </td>
   </tr>
@@ -1622,6 +1625,7 @@
      <li>m3: random bits</li>
      <li>m5: index into the array of objects, bits 16 to 23 (lower bits in m2)</li>
      <li>m7: animation counter</li>
+     <li>m8 bit 15: set if a river was originally present at the tile when current water class is canal</li>
     </ul>
    </td>
   </tr>

--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -79,8 +79,8 @@ the array so you can quickly see what is used and what is not.
     <tr>
       <td rowspan="2">0</td>
       <td class="caption">ground</td>
-      <td class="bits" rowspan=27><span class="used" title="Tile type">XXXX</span> <span class="used" title="Presence and direction of bridge above">XX</span> <span class="used" title="Tropic Zone: only meaningful in tropic climate. It contains the definition of the available zones">XX</span></td>
-      <td class="bits" rowspan=27><span class="used" title="Tile height">XXXX XXXX</span></td>
+      <td class="bits" rowspan=28><span class="used" title="Tile type">XXXX</span> <span class="used" title="Presence and direction of bridge above">XX</span> <span class="used" title="Tropic Zone: only meaningful in tropic climate. It contains the definition of the available zones">XX</span></td>
+      <td class="bits" rowspan=28><span class="used" title="Tile height">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOO</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Type of hedge on NE border">XXX</span> <span class="used" title="Snow presence">X</span><span class="free">OOOO</span></td>
@@ -211,7 +211,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Graphics index">XXXX XXXX</span></td>
       <td class="bits"><span class="used" title="Animation frame">XXXX XXXX</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">dock</td>
@@ -219,6 +219,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="usable" title="Graphics index">OOOO </span><span class="usable" title="Graphics index">O</span><span class="used" title="Graphics index">XXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
+      <td class="bits" rowspan=3><span class="used" title="Canal on river presence">X</span><span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">buoy</td>
@@ -235,21 +236,25 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="free">OOOO OOOO</span></td>
     </tr>
     <tr>
-      <td rowspan=4>6</td>
+      <td rowspan=5>6</td>
       <td class="caption">sea, shore</td>
-      <td class="bits" rowspan=4><span class="used" title="Ship docking tile status">X</span> <span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
-      <td class="bits" rowspan=3><span class="free">OOOO OOOO OOOO OOOO</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="used" title="Ship docking tile status">X</span> <span class="used" title="Water class">XX</span> <span class="used" title="Owner">XXXXX</span></td>
+      <td class="bits" rowspan=4><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>O</span> <span class="free">OOO</span><span class="used" title="Sea shore flag">X</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</span></td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO</td>
-      <td class="bits" rowspan=4><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO</span></td>
+      <td class="bits" rowspan=5><span class="free">OOOO OOOO</td>
+      <td class="bits" rowspan=2><span class="free">OOOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
-      <td class="caption">canal, river</td>
-      <td class="bits"><span class="used" title="Canal/river random bits">XXXX XXXX</span></td>
-      <td class="bits"><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>O</span> <span class="free">OOOO</span></td>
+      <td class="caption">river</td>
+      <td class="bits" rowspan=2><span class="used" title="Canal/river random bits">XXXX XXXX</span></td>
+      <td class="bits" rowspan=2><span class="used" title="Water tile type: coast, clear, lock, depot">O<span class="usable">OO</span>O</span> <span class="free">OOOO</span></td>
+    </tr>
+    <tr>
+      <td class="caption">canal</td>
+      <td class="bits" rowspan=3><span class="used" title="Canal on river presence">X</span><span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">lock</td>
@@ -272,7 +277,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits" rowspan=2><span class="used" title="Industry graphics ID (m5 + m6[2])">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OO</span><span class="used" title="Random triggers (NewGRF)">XXX</span> <span class="used" title="Industry graphics ID (m5 + m6[2])">X</span><span class="free">OO</span></td>
       <td class="bits" rowspan=2><span class="used" title="Animation frame">XXXX XXXX</span></td>
-      <td class="bits" rowspan=2><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits" rowspan=2><span class="used" title="Canal on river presence">X</span><span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td class="caption">industry under construction</td>
@@ -305,7 +310,7 @@ the array so you can quickly see what is used and what is not.
       <td class="bits"><span class="pool" title="Object index on pool (m2 + m5)">XXXX XXXX</span></td>
       <td class="bits"><span class="free">OOOO OOOO</span></td>
       <td class="bits"><span class="used" title="Animation counter">XXXX XXXX</span></td>
-      <td class="bits" rowspan=1><span class="free">OOOO OOOO OOOO OOOO</span></td>
+      <td class="bits"><span class="used" title="Canal on river presence">X</span><span class="free">OOO OOOO OOOO OOOO</span></td>
     </tr>
     <tr>
       <td colspan=2 class="caption">bits</td>

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1884,10 +1884,12 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 			i->location.Add(cur_tile);
 
 			WaterClass wc = (IsWaterTile(cur_tile) ? GetWaterClass(cur_tile) : WATER_CLASS_INVALID);
+			bool river = HasTileCanalOnRiver(cur_tile);
 
 			Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC | DC_NO_TEST_TOWN_RATING | DC_NO_MODIFY_TOWN_RATING, cur_tile);
 
 			MakeIndustry(cur_tile, i->index, it.gfx, Random(), wc);
+			if (river) SetCanalOnRiver(cur_tile);
 
 			if (_generating_world) {
 				SetIndustryConstructionCounter(cur_tile, 3);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1280,6 +1280,9 @@ STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT            :When enabled, i
 STR_CONFIG_SETTING_EXTRADYNAMITE                                :Allow removal of more town-owned roads, bridges and tunnels: {STRING2}
 STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT                       :Make it easier to remove town-owned infrastructure and buildings
 
+STR_CONFIG_SETTING_DYNAMITE_RIVER                               :Allow removal of rivers: {STRING2}
+STR_CONFIG_SETTING_DYNAMITE_RIVER_HELPTEXT                      :If disabled, rivers are indestructible and become a permanent part of the landscape
+
 STR_CONFIG_SETTING_TRAIN_LENGTH                                 :Maximum length of trains: {STRING2}
 STR_CONFIG_SETTING_TRAIN_LENGTH_HELPTEXT                        :Set the maximum length of trains
 STR_CONFIG_SETTING_TILE_LENGTH                                  :{COMMA} tile{P 0 "" s}
@@ -3005,6 +3008,7 @@ STR_LAI_STATION_DESCRIPTION_WAYPOINT                            :Waypoint
 
 STR_LAI_WATER_DESCRIPTION_WATER                                 :Water
 STR_LAI_WATER_DESCRIPTION_CANAL                                 :Canal
+STR_LAI_WATER_DESCRIPTION_CANALISED_RIVER                       :Canalised river
 STR_LAI_WATER_DESCRIPTION_LOCK                                  :Lock
 STR_LAI_WATER_DESCRIPTION_RIVER                                 :River
 STR_LAI_WATER_DESCRIPTION_COAST_OR_RIVERBANK                    :Coast or riverbank
@@ -4890,6 +4894,7 @@ STR_ERROR_CAN_T_BUILD_ON_CANAL                                  :{WHITE}... can'
 STR_ERROR_CAN_T_BUILD_ON_RIVER                                  :{WHITE}... can't build on river
 STR_ERROR_MUST_DEMOLISH_CANAL_FIRST                             :{WHITE}Must demolish canal first
 STR_ERROR_CAN_T_BUILD_AQUEDUCT_HERE                             :{WHITE}Can't build aqueduct here...
+STR_ERROR_MUST_CLEAR_RIVER_FIRST                                :{WHITE}Must clear river first
 
 # Tree related errors
 STR_ERROR_TREE_ALREADY_HERE                                     :{WHITE}... tree already here

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3148,6 +3148,11 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_PERMANENT_RIVERS)) {
+		/* When loading an older savegame version, treat 'dynamite river' as enabled. */
+		_settings_game.construction.dynamite_river = true;
+	}
+
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -341,6 +341,8 @@ enum SaveLoadVersion : uint16 {
 	SLV_DOCK_DOCKINGTILES,                  ///< 298  PR#9578 All tiles around docks may be docking tiles.
 	SLV_REPAIR_OBJECT_DOCKING_TILES,        ///< 299  PR#9594 v12.0  Fixing issue with docking tiles overlapping objects.
 
+	SLV_PERMANENT_RIVERS,                   ///< 300  PR#8461 Permanent rivers.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1737,6 +1737,7 @@ static SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.command_pause_level"));
 			limitations->Add(new SettingEntry("construction.autoslope"));
 			limitations->Add(new SettingEntry("construction.extra_dynamite"));
+			limitations->Add(new SettingEntry("construction.dynamite_river"));
 			limitations->Add(new SettingEntry("construction.map_height_limit"));
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -343,6 +343,7 @@ struct ConstructionSettings {
 	bool   extra_dynamite;                   ///< extra dynamite
 	bool   road_stop_on_town_road;           ///< allow building of drive-through road stops on town owned roads
 	bool   road_stop_on_competitor_road;     ///< allow building of drive-through road stops on roads owned by competitors
+	bool   dynamite_river;                   ///< allow removal of rivers
 	uint8  raw_industry_construction;        ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8  industry_platform;                ///< the amount of flat land around an industry
 	bool   freeform_edges;                   ///< allow terraforming the tiles at the map edges

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2511,6 +2511,7 @@ CommandCost CmdBuildDock(DoCommandFlag flags, TileIndex tile, StationID station_
 
 	/* Get the water class of the water tile before it is cleared.*/
 	WaterClass wc = GetWaterClass(tile_cur);
+	bool river = HasTileCanalOnRiver(tile_cur);
 
 	ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile_cur);
 	if (ret.Failed()) return ret;
@@ -2549,6 +2550,7 @@ CommandCost CmdBuildDock(DoCommandFlag flags, TileIndex tile, StationID station_
 		Company::Get(st->owner)->infrastructure.station += 2;
 
 		MakeDock(tile, st->owner, st->index, direction, wc);
+		if (river) SetCanalOnRiver(tile + TileOffsByDiagDir(direction));
 		UpdateStationDockingTiles(st);
 
 		st->AfterStationTileSetChange(true, STATION_DOCK);

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -542,7 +542,7 @@ static inline void MakeStation(TileIndex t, Owner o, StationID sid, StationType 
 	SB(_me[t].m6, 2, 1, 0);
 	SB(_me[t].m6, 3, 3, st);
 	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	SB(_me[t].m8, 0, 15, 0);
 }
 
 /**

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -429,6 +429,14 @@ def      = true
 str      = STR_CONFIG_SETTING_EXTRADYNAMITE
 strhelp  = STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT
 
+[SDT_BOOL]
+var      = construction.dynamite_river
+from     = SLV_PERMANENT_RIVERS
+def      = true
+str      = STR_CONFIG_SETTING_DYNAMITE_RIVER
+strhelp  = STR_CONFIG_SETTING_DYNAMITE_RIVER_HELPTEXT
+cat      = SC_BASIC
+
 [SDT_VAR]
 var      = construction.max_bridge_length
 type     = SLE_UINT16

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -64,6 +64,12 @@ static inline bool IsValidWaterClass(WaterClass wc)
 	return wc < WATER_CLASS_INVALID;
 }
 
+/** Bases of a canal (for #WATER_CLASS_CANAL class of water). */
+enum CanalBase {
+	WCC_WITHOUT_RIVER = 0, ///< Without a river under it
+	WCC_WITH_RIVER    = 1, ///< With a river under it
+};
+
 /** Sections of the water depot. */
 enum DepotPart {
 	DEPOT_PART_NORTH = 0, ///< Northern part of a depot.
@@ -130,6 +136,40 @@ static inline void SetWaterClass(TileIndex t, WaterClass wc)
 {
 	assert(HasTileWaterClass(t));
 	SB(_m[t].m1, 5, 2, wc);
+}
+
+/**
+ * Get the base of the canal at a tile.
+ * @param t Water tile to query.
+ * @pre GetWaterClass(t) == WATER_CLASS_CANAL
+ * @return Base of the canal at the tile.
+ */
+static inline CanalBase GetCanalBase(TileIndex t)
+{
+	assert(GetWaterClass(t) == WATER_CLASS_CANAL);
+	return (CanalBase)HasBit(_me[t].m8, 15) ? WCC_WITH_RIVER : WCC_WITHOUT_RIVER;
+}
+
+/**
+ * Set the base of the canal to indicate there is a river under a tile.
+ * @param t Water tile of water class canal to query.
+ * @pre GetWaterClass(t) == WATER_CLASS_CANAL
+ */
+static inline void SetCanalOnRiver(TileIndex t)
+{
+	assert(GetWaterClass(t) == WATER_CLASS_CANAL);
+	SB(_me[t].m8, 15, 1, WCC_WITH_RIVER);
+}
+
+/**
+ * Checks whether the canal at a tile has a river under it.
+ * @param t Water tile of water class canal to query.
+ * @pre GetWaterClass(t) == WATER_CLASS_CANAL
+ * @return true if the canal has a river under it.
+ */
+static inline bool HasTileCanalOnRiver(TileIndex t)
+{
+	return HasTileWaterClass(t) && GetWaterClass(t) == WATER_CLASS_CANAL && GetCanalBase(t) == WCC_WITH_RIVER;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem
Players that make use of rivers for their ships can have another player come in and easily destroy the river just to lay their rail tracks or terraforming terrain without caring if there was any river there. The current solution is to build canals over the river to make them unclearable.

Accidental or not, terraforming rivers clears them. When it's not intentional, there's no way to bring the river back.

Some servers like citybuilders create an area that is exclusive to a player, and whenever another player tries to build something there, the server undoes it immediately. If it happens to be a canal being placed on a river, this would result in the canal being demolished and leave bare land instead of restoring the river.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Rivers are indestructible, unless cheating or in the scenario editor.
- Added a game setting that can turn on or off this feature.
- Savegame conversion.

Other changes:
- Demolishing a canal that was built on rivers will restore the river, regardless of setting value.
- Can no longer use terraform tool to remove rivers, must demolish them first, regardless of setting value.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I intentionally made terraforming rivers to come up with an error, warning the player that the river must be demolished first, assuming the setting allows demolishion of rivers.

* Is this feature complete? Are there things that could be added in the future?
Probably not complete, as there are things that could be added in the future. I suppose there could be added graphics for canalized river, extended to NewGRF support.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
