### PR TITLE
Change: Default settings improved for new players

### DIFF
--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1181,7 +1181,7 @@ cat      = SC_EXPERT
 var      = gui.sg_new_nonstop
 from     = SLV_22
 to       = SLV_93
-def      = false
+def      = true
 
 ; station.nonuniform_stations
 [SDT_NULL]
@@ -1284,7 +1284,7 @@ proc     = DeleteSelectStationWindow
 base     = GameSettings
 var      = economy.inflation
 guiflags = SGF_NO_NETWORK
-def      = true
+def      = false
 str      = STR_CONFIG_SETTING_INFLATION
 strhelp  = STR_CONFIG_SETTING_INFLATION_HELPTEXT
 cat      = SC_BASIC
@@ -2622,7 +2622,7 @@ var      = gui.date_format_in_default_names
 type     = SLE_UINT8
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_MULTISTRING
-def      = 0
+def      = 2
 max      = 2
 full     = _savegame_date
 str      = STR_CONFIG_SETTING_DATE_FORMAT_IN_SAVE_NAMES
@@ -2932,7 +2932,7 @@ proc     = InvalidateVehTimetableWindow
 [SDTC_BOOL]
 var      = gui.quick_goto
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_QUICKGOTO
 strhelp  = STR_CONFIG_SETTING_QUICKGOTO_HELPTEXT
 cat      = SC_BASIC
@@ -3120,7 +3120,7 @@ max      = 255
 [SDTC_BOOL]
 var      = gui.show_track_reservation
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION
 strhelp  = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT
 proc     = RedrawScreen
@@ -3193,7 +3193,7 @@ cat      = SC_BASIC
 [SDTC_BOOL]
 var      = gui.expenses_layout
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_EXPENSES_LAYOUT
 strhelp  = STR_CONFIG_SETTING_EXPENSES_LAYOUT_HELPTEXT
 proc     = RedrawScreen


### PR DESCRIPTION
## Motivation / Problem

In #8393, nine community members discussed the best default settings for new players who have not yet waded into the settings menu we have all tweaked to our liking. We agreed on changing six settings which are currently unfriendly to new players.

## Description

Each of these received a unanimous agreement of at least 6 votes, and most received 8-10.

- Savegame date format (ISO)
- Group expenses in company finance window (on)
- Inflation (off)
- Quick creation of vehicle orders (on)
- New orders are non-stop by default (on)

Additionally, one issue received 10 upvotes and one downvote.
- Show path reservations for tracks (on)

## Limitations
Two settings received four upvotes and no downvotes, but I don't feel like this is enough to justify changing the default settings.
- Interface > Construction > Link landscape toolbar to rail/road/water/airport toolbars
- Environment > Industries > Allow multiple similar industries per town

There was also discussion about breakdowns and train/road vehicle collisions at level crossings, but the consensus seemed to be that these issues should be fixed separately rather than ignored by changing default settings.