### PR TITLE
Fix: Assert fail when using restart command after opening save/load GUI

### DIFF
--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -929,7 +929,5 @@ void ShowSaveLoadDialog(AbstractFileType abstract_filetype, SaveLoadOperation fo
 		sld = (abstract_filetype == FT_HEIGHTMAP) ? &_load_heightmap_dialog_desc : &_load_dialog_desc;
 	}
 
-	_file_to_saveload.abstract_ftype = abstract_filetype;
-
 	new SaveLoadWindow(sld, abstract_filetype, fop);
 }


### PR DESCRIPTION
## Motivation / Problem

Use of the `restart` console command and network auto-restarting (`NetworkCheckRestartMap`) after opening the save/load window triggers an assertion failure.

Example reproduction steps:
1. Start a new game
2. Open the load game window (but don't actually load anything)
3. Run `restart` in the console

## Description

`ShowSaveLoadDialog` incorrectly overwrites the value of `_file_to_saveload.abstract_ftype`.
This value is used by the `restart` console command and by `NetworkCheckRestartMap`.

The value of the `_file_to_saveload.abstract_ftype` must be consistent with the other members of `_file_to_saveload`.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
