### PR TITLE
Fix: GetCurveSpeedLimit needs railtype from current tile

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -349,8 +349,8 @@ int Train::GetCurveSpeedLimit() const
 	}
 
 	if (max_speed != absolute_max_speed) {
-		/* Apply the engine's rail type curve speed advantage, if it slowed by curves */
-		const RailtypeInfo *rti = GetRailTypeInfo(this->railtype);
+		/* Apply the current railtype's curve speed advantage */
+		const RailtypeInfo *rti = GetRailTypeInfo(GetRailType(this->tile));
 		max_speed += (max_speed / 2) * rti->curve_speed;
 
 		if (this->tcache.cached_tilt) {


### PR DESCRIPTION
## Motivation / Problem

This is a fix to make railtype prop 11 work as described in the newgrf spec https://newgrf-specs.tt-wiki.net/wiki/Action0/Railtypes#Curve_Speed_advantage_multiplier_.2811.29

"This property sets the multiplier to the curve speed advantage which all trains running on this track type get."

GetCurveSpeedLimit was using the railtype from train prop 05, not the current railtype on the tile.  Seems plausible that it was just missed when NewGRF railtypes were added.

I noticed this (some time ago) when I created a railtype grf setting a higher value for prop 11 and could see no difference in game.

Additionally for Jan/Feb 2021 there is a tt-forums contest running for 'make a High Speed grf' which motivated me to look into this again, as contestants may encounter this bug.

## Description

GetCurveSpeedLimit now checks current railtype on the tile.

Test grf and savegame attached.  Behaves as expected in the test case.

[8466-railtype-prop-11-test-case.zip](https://github.com/OpenTTD/OpenTTD/files/5753460/8466-railtype-prop-11-test-case.zip)

## Limitations

I tried a test case where the railtype changes mid-curve.  It's not in the savegame, but it does appear to work.

GetAccelerationType in train.h (railtype prop 15) may have the same issue, but the NewGRF spec is less definitive there and is likely to trigger a debate, so I would like to stick to just fixing prop 11 as a single issue.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
    * possibly; see the contest running here https://www.tt-forums.net/viewtopic.php?f=26&t=88258
* This PR affects the save game format? (label 'savegame upgrade')
    * not as I understand it, although it will affect behaviour of any games with grfs that implement prop 11 (they will start working correctly which might mess with network performance in complex networks)
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * not as I understand it
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * yes, but as it's a bug fix to match NewGRF spec this doesn't need any changes.  NMLC and GRFCodec already support railtype prop 11 correctly
