### PR TITLE
Change #8325: Make engine reliability independent of introduction date

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -661,6 +661,8 @@ void StartupOneEngine(Engine *e, Date aging_date)
 		e->flags |= ENGINE_AVAILABLE;
 	}
 
+	RestoreRandomSeeds(saved_seeds);
+
 	e->reliability_start = GB(r, 16, 14) + 0x7AE0;
 	r = Random();
 	e->reliability_max   = GB(r,  0, 14) + 0xBFFF;
@@ -673,7 +675,6 @@ void StartupOneEngine(Engine *e, Date aging_date)
 
 	e->reliability_spd_dec = ei->decay_speed << 2;
 
-	RestoreRandomSeeds(saved_seeds);
 	CalcEngineReliability(e);
 
 	/* prevent certain engines from ever appearing. */


### PR DESCRIPTION
## Motivation / Problem
#8325 
Engines that are introduced in the same date also have the same reliability. While it is more desirable for engines to be introduced simultaneously for NewGRF vehicle sets, it seems it isn't as desirable for the reliability, especially for players that use breakdowns.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
The problem is solved by not using the same random seed that is used for engine introduction to also generate reliability.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
