### PR TITLE
Cleanup 2db88953e7: Remove VL_FIRST_SORT as it's useless

### DIFF
--- a/src/sortlist_type.h
+++ b/src/sortlist_type.h
@@ -21,9 +21,8 @@ enum SortListFlags {
 	VL_DESC       = 1 << 0, ///< sort descending or ascending
 	VL_RESORT     = 1 << 1, ///< instruct the code to resort the list in the next loop
 	VL_REBUILD    = 1 << 2, ///< rebuild the sort list
-	VL_FIRST_SORT = 1 << 3, ///< sort with quick sort first
-	VL_FILTER     = 1 << 4, ///< filter disabled/enabled
-	VL_END        = 1 << 5,
+	VL_FILTER     = 1 << 3, ///< filter disabled/enabled
+	VL_END        = 1 << 4,
 };
 DECLARE_ENUM_AS_BIT_SET(SortListFlags)
 
@@ -80,7 +79,7 @@ public:
 	GUIList() :
 		sort_func_list(nullptr),
 		filter_func_list(nullptr),
-		flags(VL_FIRST_SORT),
+		flags(VL_NONE),
 		sort_type(0),
 		filter_type(0),
 		resort_timer(1)
@@ -104,7 +103,7 @@ public:
 	void SetSortType(uint8 n_type)
 	{
 		if (this->sort_type != n_type) {
-			SETBITS(this->flags, VL_RESORT | VL_FIRST_SORT);
+			SETBITS(this->flags, VL_RESORT);
 			this->sort_type = n_type;
 		}
 	}
@@ -136,8 +135,6 @@ public:
 			CLRBITS(this->flags, VL_DESC);
 		}
 		this->sort_type = l.criteria;
-
-		SETBITS(this->flags, VL_FIRST_SORT);
 	}
 
 	/**
@@ -242,10 +239,6 @@ public:
 
 	/**
 	 * Sort the list.
-	 *  For the first sorting we use quick sort since it is
-	 *  faster for irregular sorted data. After that we
-	 *  use gsort.
-	 *
 	 * @param compare The function to compare two list items
 	 * @return true if the list sequence has been altered
 	 *
@@ -264,13 +257,6 @@ public:
 		if (!this->IsSortable()) return false;
 
 		const bool desc = (this->flags & VL_DESC) != 0;
-
-		if (this->flags & VL_FIRST_SORT) {
-			CLRBITS(this->flags, VL_FIRST_SORT);
-
-			std::sort(std::vector<T>::begin(), std::vector<T>::end(), [&](const T &a, const T &b) { return desc ? compare(b, a) : compare(a, b); });
-			return true;
-		}
 
 		std::sort(std::vector<T>::begin(), std::vector<T>::end(), [&](const T &a, const T &b) { return desc ? compare(b, a) : compare(a, b); });
 		return true;
@@ -394,7 +380,7 @@ public:
 	void RebuildDone()
 	{
 		CLRBITS(this->flags, VL_REBUILD);
-		SETBITS(this->flags, VL_RESORT | VL_FIRST_SORT);
+		SETBITS(this->flags, VL_RESORT);
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem

`VL_FIRST_SORT` original use was to sort with quick sort first, then gsort.
In 2db88953e7, both qsort and gsort were replaced by std::sort, so `VL_FIRST_SORT` has no effect.  
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
