### PR TITLE
Codechange: [OSX] Prevent the compiler from using SSE4 instructions unless we want to.

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -127,6 +127,18 @@ macro(compile_flags)
                 "$<$<BOOL:${LIFETIME_DSE_FOUND}>:-flifetime-dse=1>"
             )
         endif()
+
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+            include(CheckCXXCompilerFlag)
+            check_cxx_compiler_flag("-mno-sse4" NO_SSE4_FOUND)
+
+            if(NO_SSE4_FOUND)
+                add_compile_options(
+                    # Don't use SSE4 for general sources to increase compatibility.
+                    -mno-sse4
+                )
+            endif()
+        endif()
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
         add_compile_options(
             -Wall


### PR DESCRIPTION
## Motivation / Problem

Apple clang might default to use SSE4 instructions in the optimizer that don't work on old systems.

## Description

Tell the compiler to not use SSE4 in general, except for those files where we specifically want it.

## Limitations

We might loose a tiny fraction of performance on newer systems.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
