### PR TITLE
Add: always set PERSONAL_DIR "/content_download" in search path

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1009,17 +1009,24 @@ void DetermineBasePaths(const char *exe)
 		tmp += PATHSEP;
 		tmp += PERSONAL_DIR[0] == '.' ? &PERSONAL_DIR[1] : PERSONAL_DIR;
 		AppendPathSeparator(tmp);
-
 		_searchpaths[SP_PERSONAL_DIR_XDG] = tmp;
+
+		tmp += "content_download";
+		AppendPathSeparator(tmp);
+		_searchpaths[SP_AUTODOWNLOAD_PERSONAL_DIR_XDG] = tmp;
 	} else if (!homedir.empty()) {
 		tmp = homedir;
 		tmp += PATHSEP ".local" PATHSEP "share" PATHSEP;
 		tmp += PERSONAL_DIR[0] == '.' ? &PERSONAL_DIR[1] : PERSONAL_DIR;
 		AppendPathSeparator(tmp);
-
 		_searchpaths[SP_PERSONAL_DIR_XDG] = tmp;
+
+		tmp += "content_download";
+		AppendPathSeparator(tmp);
+		_searchpaths[SP_AUTODOWNLOAD_PERSONAL_DIR_XDG] = tmp;
 	} else {
 		_searchpaths[SP_PERSONAL_DIR_XDG].clear();
+		_searchpaths[SP_AUTODOWNLOAD_PERSONAL_DIR_XDG].clear();
 	}
 #endif
 
@@ -1031,10 +1038,14 @@ void DetermineBasePaths(const char *exe)
 		tmp += PATHSEP;
 		tmp += PERSONAL_DIR;
 		AppendPathSeparator(tmp);
-
 		_searchpaths[SP_PERSONAL_DIR] = tmp;
+
+		tmp += "content_download";
+		AppendPathSeparator(tmp);
+		_searchpaths[SP_AUTODOWNLOAD_PERSONAL_DIR] = tmp;
 	} else {
 		_searchpaths[SP_PERSONAL_DIR].clear();
+		_searchpaths[SP_AUTODOWNLOAD_PERSONAL_DIR].clear();
 	}
 #endif
 

--- a/src/fileio_type.h
+++ b/src/fileio_type.h
@@ -140,6 +140,8 @@ enum Searchpath : unsigned {
 	SP_INSTALLATION_DIR,           ///< Search in the installation directory
 	SP_APPLICATION_BUNDLE_DIR,     ///< Search within the application bundle
 	SP_AUTODOWNLOAD_DIR,           ///< Search within the autodownload directory
+	SP_AUTODOWNLOAD_PERSONAL_DIR,  ///< Search within the autodownload directory located in the personal directory
+	SP_AUTODOWNLOAD_PERSONAL_DIR_XDG, ///< Search within the autodownload directory located in the personal directory (XDG variant)
 	NUM_SEARCHPATHS
 };
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -466,6 +466,10 @@ void DetermineBasePaths(const char *exe)
 		tmp += PERSONAL_DIR;
 		AppendPathSeparator(tmp);
 		_searchpaths[SP_PERSONAL_DIR] = tmp;
+
+		tmp += "content_download";
+		AppendPathSeparator(tmp);
+		_searchpaths[SP_AUTODOWNLOAD_PERSONAL_DIR] = tmp;
 	} else {
 		_searchpaths[SP_PERSONAL_DIR].clear();
 	}


### PR DESCRIPTION
Fixes #7311.

## Motivation / Problem

I am often annoyed during development that the `content_download` folder is only on the search-path once, and this is for the location it found `openttd.cfg` (or with XDG, this can be `~/.local/share/openttd/content_download`. This means that from time to time I get the popup it cannot find my OpenGFX, as I downloaded it via the content service. I have to move it to `baseset` folder in my `PERSONAL_DIR` to not have this happening.

When does this popup happen? When using `-c` or when running the regression, mostly. I can imagine server-owners have similar experience.

There have been bugs reported about this, in all forms. The one that I could find that was still open is #7311.


## Description

This means that if you start OpenTTD with "-c" to indicate another
location to store files, it can still read the content you already
downloaded from your PERSONAL_DIR. This folder is, however,
read-only.

This is useful for situations where you downloaded OpenGFX via
the content-service, but want to run the regression or want to
run with a clean configuration. With this change, you no longer
need to download OpenGFX again.


## Limitations

- This is a bit of a dirty solution, just adding additional search-paths, but it appears to be the most clean. All other search-paths (shared, binary, installation, application-bundle) cannot contain `content_download`. So the `PERSONAL_DIR` really was the only one missing here.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
