### PR TITLE
Add: use our search-paths to find fonts based on relative filenames too

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -561,8 +561,19 @@ static void LoadFreeTypeFont(FontSize fs)
 	}
 
 	FT_Face face = nullptr;
+
+	/* If font is an absolute path to a ttf, try loading that first. */
 	FT_Error error = FT_New_Face(_library, settings->font, 0, &face);
 
+	if (error != FT_Err_Ok) {
+		/* Check if font is a relative filename in one of our search-paths. */
+		std::string full_font = FioFindFullPath(BASE_DIR, settings->font);
+		if (!full_font.empty()) {
+			error = FT_New_Face(_library, full_font.c_str(), 0, &face);
+		}
+	}
+
+	/* Try loading based on font face name (OS-wide fonts). */
 	if (error != FT_Err_Ok) error = GetFontByFaceName(settings->font, &face);
 
 	if (error == FT_Err_Ok) {
@@ -970,42 +981,55 @@ static void LoadWin32Font(FontSize fs)
 
 	if (settings->os_handle != nullptr) {
 		logfont = *(const LOGFONT *)settings->os_handle;
-	} else if (strchr(settings->font, '.') != nullptr && FileExists(settings->font)) {
+	} else if (strchr(settings->font, '.') != nullptr) {
 		/* Might be a font file name, try load it. */
-		TCHAR fontPath[MAX_PATH];
-		convert_to_fs(settings->font, fontPath, lengthof(fontPath), false);
 
-		if (AddFontResourceEx(fontPath, FR_PRIVATE, 0) != 0) {
-			/* Try a nice little undocumented function first for getting the internal font name.
-			 * Some documentation is found at: http://www.undocprint.org/winspool/getfontresourceinfo */
-			typedef BOOL(WINAPI * PFNGETFONTRESOURCEINFO)(LPCTSTR, LPDWORD, LPVOID, DWORD);
+		TCHAR fontPath[MAX_PATH] = {};
+
+		/* See if this is an absolute path. */
+		if (FileExists(settings->font)) {
+			convert_to_fs(settings->font, fontPath, lengthof(fontPath), false);
+		} else {
+			/* Scan the search-paths to see if it can be found. */
+			std::string full_font = FioFindFullPath(BASE_DIR, settings->font);
+			if (!full_font.empty()) {
+				convert_to_fs(full_font.c_str(), fontPath, lengthof(fontPath), false);
+			}
+		}
+
+		if (fontPath[0] != 0) {
+			if (AddFontResourceEx(fontPath, FR_PRIVATE, 0) != 0) {
+				/* Try a nice little undocumented function first for getting the internal font name.
+				* Some documentation is found at: http://www.undocprint.org/winspool/getfontresourceinfo */
+				typedef BOOL(WINAPI * PFNGETFONTRESOURCEINFO)(LPCTSTR, LPDWORD, LPVOID, DWORD);
 #ifdef UNICODE
-			static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(_T("Gdi32")), "GetFontResourceInfoW");
+				static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(_T("Gdi32")), "GetFontResourceInfoW");
 #else
-			static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(_T("Gdi32")), "GetFontResourceInfoA");
+				static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(_T("Gdi32")), "GetFontResourceInfoA");
 #endif
 
-			if (GetFontResourceInfo != nullptr) {
-				/* Try to query an array of LOGFONTs that describe the file. */
-				DWORD len = 0;
-				if (GetFontResourceInfo(fontPath, &len, nullptr, 2) && len >= sizeof(LOGFONT)) {
-					LOGFONT *buf = (LOGFONT *)AllocaM(byte, len);
-					if (GetFontResourceInfo(fontPath, &len, buf, 2)) {
-						logfont = *buf; // Just use first entry.
+				if (GetFontResourceInfo != nullptr) {
+					/* Try to query an array of LOGFONTs that describe the file. */
+					DWORD len = 0;
+					if (GetFontResourceInfo(fontPath, &len, nullptr, 2) && len >= sizeof(LOGFONT)) {
+						LOGFONT *buf = (LOGFONT *)AllocaM(byte, len);
+						if (GetFontResourceInfo(fontPath, &len, buf, 2)) {
+							logfont = *buf; // Just use first entry.
+						}
 					}
 				}
-			}
 
-			/* No dice yet. Use the file name as the font face name, hoping it matches. */
-			if (logfont.lfFaceName[0] == 0) {
-				TCHAR fname[_MAX_FNAME];
-				_tsplitpath(fontPath, nullptr, nullptr, fname, nullptr);
+				/* No dice yet. Use the file name as the font face name, hoping it matches. */
+				if (logfont.lfFaceName[0] == 0) {
+					TCHAR fname[_MAX_FNAME];
+					_tsplitpath(fontPath, nullptr, nullptr, fname, nullptr);
 
-				_tcsncpy_s(logfont.lfFaceName, lengthof(logfont.lfFaceName), fname, _TRUNCATE);
-				logfont.lfWeight = strcasestr(settings->font, " bold") != nullptr || strcasestr(settings->font, "-bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
+					_tcsncpy_s(logfont.lfFaceName, lengthof(logfont.lfFaceName), fname, _TRUNCATE);
+					logfont.lfWeight = strcasestr(settings->font, " bold") != nullptr || strcasestr(settings->font, "-bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
+				}
+			} else {
+				ShowInfoF("Unable to load file '%s' for %s font, using default windows font selection instead", settings->font, SIZE_TO_NAME[fs]);
 			}
-		} else {
-			ShowInfoF("Unable to load file '%s' for %s font, using default windows font selection instead", settings->font, SIZE_TO_NAME[fs]);
 		}
 	}
 


### PR DESCRIPTION
Fixes #7830

## Motivation / Problem

Given how OpenTTD works, you would expect that you can put `ttf` files in your `PERSONAL_DIR`, and that the game can find that. This was not the case, as we never looked in our search-paths for the `ttf`.
This PR addresses that issue.

## Description

This allows "small_font = ./myfont.ttf", with "myfont.ttf" located
in "~/.openttd".

Tested on both Linux and Windows.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
