### PR TITLE
Fix: Don't terraform during town generation

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -954,6 +954,7 @@ static bool TerraformTownTile(TileIndex tile, int edges, int dir)
 
 static void LevelTownLand(TileIndex tile)
 {
+	if (_generating_world) return;
 	assert(tile < MapSize());
 
 	/* Don't terraform if land is plain or if there's a house there. */


### PR DESCRIPTION
Prevent rare occurrences of roads and houses being flooded, resulting in disconnected towns.

## Motivation / Problem
![road and house flooded](https://user-images.githubusercontent.com/43006711/103466811-4c670e00-4d40-11eb-9169-a4ee78f89965.png)
During world generation, town growth algorithm is speed up, allowing the town to perform multiple sequential growth actions, like building houses, roads, and terraforming. If it happens to lower terrain adjacent to sea and then in one of those sequences it builds a road or a house there, it will end up flooded during the "run tile loop" phase of world generation.
The result could be similar to what the screenshot shows: disconnected roads and/or houses.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Bug is solved by preventing towns to terraform during world generation. There is already code preventing town terraforming during world generation like shown below, but this one went missing.
Line 930:
https://github.com/OpenTTD/OpenTTD/blob/126f40e0123d2585c7311c037be659503056e79d/src/town_cmd.cpp#L930-L934
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This happens very rarely. I tried 12k towns 4096x4096 map, and detected no more than 3 flooded road or house tiles.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
