### PR TITLE
Fix: [OSX] Register fonts loaded directly from disk for text layout

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -565,11 +565,19 @@ static void LoadFreeTypeFont(FontSize fs)
 	/* If font is an absolute path to a ttf, try loading that first. */
 	FT_Error error = FT_New_Face(_library, settings->font, 0, &face);
 
+#if defined(WITH_COCOA)
+	extern void MacOSRegisterExternalFont(const char *file_path);
+	if (error == FT_Err_Ok) MacOSRegisterExternalFont(settings->font);
+#endif
+
 	if (error != FT_Err_Ok) {
 		/* Check if font is a relative filename in one of our search-paths. */
 		std::string full_font = FioFindFullPath(BASE_DIR, settings->font);
 		if (!full_font.empty()) {
 			error = FT_New_Face(_library, full_font.c_str(), 0, &face);
+#if defined(WITH_COCOA)
+			if (error == FT_Err_Ok) MacOSRegisterExternalFont(full_font.c_str());
+#endif
 		}
 	}
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -289,6 +289,17 @@ void MacOSResetScriptCache(FontSize size)
 	_font_cache[size].reset();
 }
 
+/** Register an external font file with the CoreText system. */
+void MacOSRegisterExternalFont(const char *file_path)
+{
+	if (!MacOSVersionIsAtLeast(10, 6, 0)) return;
+
+	CFAutoRelease<CFStringRef> path(CFStringCreateWithCString(kCFAllocatorDefault, file_path, kCFStringEncodingUTF8));
+	CFAutoRelease<CFURLRef> url(CFURLCreateWithFileSystemPath(kCFAllocatorDefault, path.get(), kCFURLPOSIXPathStyle, false));
+
+	CTFontManagerRegisterFontsForURL(url.get(), kCTFontManagerScopeProcess, nullptr);
+}
+
 /** Store current language locale as a CoreFounation locale. */
 void MacOSSetCurrentLocaleName(const char *iso_code)
 {

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -85,4 +85,6 @@ void MacOSResetScriptCache(FontSize size);
 void MacOSSetCurrentLocaleName(const char *iso_code);
 int MacOSStringCompare(const char *s1, const char *s2);
 
+void MacOSRegisterExternalFont(const char *file_path);
+
 #endif /* STRING_OSX_H */


### PR DESCRIPTION
## Motivation / Problem

Unicode text layout on OSX is done by CoreText, which only uses font data registered with CoreText.

## Description

Register font that are loaded from file and not the OS store with CoreText.

## Limitations

~Interacts with #8482.~ FreeType and OSX CoreText might still not agree pixel-perfect.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
