### PR TITLE
Fix: [OSX] don't show top OS menu bar when in full screen

### DIFF
--- a/os/macosx/Info.plist.in
+++ b/os/macosx/Info.plist.in
@@ -29,5 +29,7 @@
         <string>Copyright 2004-${CURRENT_YEAR} The OpenTTD team</string>
         <key>NSPrincipalClass</key>
         <string>NSApplication</string>
+        <key>LSUIPresentationMode</key>
+        <integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #8038.

## Motivation / Problem

#8038 has a good movie showing the issue.


## Description

Solution given by https://github.com/OpenTTD/OpenTTD/issues/8038#issuecomment-643012480 and confirmed by https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-113616 .


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
