### PR TITLE
[OSX] Fullscreen improvments

### DIFF
--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -140,7 +140,7 @@ public:
 	/** Toggle between fullscreen and windowed mode
 	 * @return whether switch was successful
 	 */
-	virtual bool ToggleFullscreen() { return false; };
+	virtual bool ToggleFullscreen(bool fullscreen) { return false; };
 
 	/** Return the width of the current view
 	 * @return width of the current view

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -11,10 +11,16 @@
 #define VIDEO_COCOA_H
 
 #include "../video_driver.hpp"
+#include "../../core/geometry_type.hpp"
+
 
 extern bool _cocoa_video_started;
 
 class VideoDriver_Cocoa : public VideoDriver {
+private:
+	bool fullscreen_on_mainloop; ///< Switch to fullscreen once the main loop is running?
+	Dimension orig_res;          ///< Saved window size for non-fullscreen mode.
+
 public:
 	const char *Start(const StringList &param) override;
 
@@ -59,6 +65,16 @@ public:
 	 * @return driver name
 	 */
 	const char *GetName() const override { return "cocoa"; }
+
+	/* --- The following methods should be private, but can't be due to Obj-C limitations. --- */
+
+	/** Main game loop. */
+	void GameLoop(); // In event.mm.
+
+private:
+	friend class WindowQuartzSubdriver;
+
+	void GameSizeChanged();
 };
 
 class FVideoDriver_Cocoa : public DriverFactoryBase {
@@ -189,10 +205,6 @@ public:
 extern CocoaSubdriver *_cocoa_subdriver;
 
 CocoaSubdriver *QZ_CreateWindowQuartzSubdriver(int width, int height, int bpp);
-
-void QZ_GameSizeChanged();
-
-void QZ_GameLoop();
 
 uint QZ_ListModes(OTTD_Point *modes, uint max_modes, CGDirectDisplayID display_id, int display_depth);
 

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -67,6 +67,7 @@ extern NSString *OTTDMainLaunchGameEngine;
 - (BOOL)windowShouldClose:(id)sender;
 - (void)windowDidEnterFullScreen:(NSNotification *)aNotification;
 - (void)windowDidChangeScreenProfile:(NSNotification *)aNotification;
+- (NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions;
 @end
 
 

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -73,7 +73,7 @@ static OTTDMain *_ottd_main;
 	[ _cocoa_subdriver->cocoaview resetCursorRects ];
 
 	/* Hand off to main application code. */
-	QZ_GameLoop();
+	static_cast<VideoDriver_Cocoa *>(VideoDriver::GetInstance())->GameLoop();
 
 	/* We are done, thank you for playing. */
 	[ self performSelectorOnMainThread:@selector(stopEngine) withObject:nil waitUntilDone:FALSE ];

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -860,5 +860,11 @@ static const char *Utf8AdvanceByUtf16Units(const char *str, NSUInteger count)
 	if (!driver->setup) driver->WindowResized();
 }
 
+/** Presentation options to use for fullsreen mode. */
+- (NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions
+{
+	return NSApplicationPresentationFullScreen | NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock;
+}
+
 @end
 #endif /* WITH_COCOA */

--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -617,7 +617,7 @@ static bool QZ_PollEvent()
 }
 
 
-void QZ_GameLoop()
+void VideoDriver_Cocoa::GameLoop()
 {
 	uint32 cur_ticks = GetTick();
 	uint32 last_cur_ticks = cur_ticks;
@@ -633,7 +633,7 @@ void QZ_GameLoop()
 	_cocoa_subdriver->Draw(true);
 	CSleep(1);
 
-	for (int i = 0; i < 2; i++) GameLoop();
+	for (int i = 0; i < 2; i++) ::GameLoop();
 
 	UpdateWindows();
 	QZ_CheckPaletteAnim();
@@ -652,7 +652,17 @@ void QZ_GameLoop()
 
 		while (QZ_PollEvent()) {}
 
-		if (_exit_game) break;
+		/* If we do that right after window creation, a grey bar will be left at the top. */
+		if (this->fullscreen_on_mainloop) {
+			this->fullscreen_on_mainloop = false;
+			_cocoa_subdriver->ToggleFullscreen(true);
+		}
+
+		if (_exit_game) {
+			/* Restore saved resolution if in fullscreen mode. */
+			if (_cocoa_subdriver->IsFullscreen()) _cur_resolution = this->orig_res;
+			break;
+		}
 
 #if defined(_DEBUG)
 		if (_current_mods & NSShiftKeyMask)
@@ -678,7 +688,7 @@ void QZ_GameLoop()
 
 			if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 
-			GameLoop();
+			::GameLoop();
 
 			UpdateWindows();
 			QZ_CheckPaletteAnim();


### PR DESCRIPTION
Fixes #8038

## Motivation / Problem

The menu bar gets in the way in OSX fullscreen mode.
Also, quitting while in fullscreen mode looses the original window size, unlike e.g. under Windows.


## Description

Hide Dock and menu bar in fullscreen mode and store the original windows size in the config, not the fullscreen size.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
