### PR TITLE
Fix #8067: [OSX] Calculate title bar height instead of assuming a fixed value

### DIFF
--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -18,7 +18,6 @@ extern bool _cocoa_video_started;
 
 class VideoDriver_Cocoa : public VideoDriver {
 private:
-	bool fullscreen_on_mainloop; ///< Switch to fullscreen once the main loop is running?
 	Dimension orig_res;          ///< Saved window size for non-fullscreen mode.
 
 public:

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -156,6 +156,7 @@ static void QZ_UpdateVideoModes()
 static CocoaSubdriver *QZ_CreateSubdriver(int width, int height, int bpp, bool fullscreen, bool fallback)
 {
 	CocoaSubdriver *ret = QZ_CreateWindowQuartzSubdriver(width, height, bpp);
+	if (ret != nullptr && fullscreen) ret->ToggleFullscreen(fullscreen);
 
 	if (ret != nullptr) return ret;
 	if (!fallback) return nullptr;
@@ -209,9 +210,6 @@ const char *VideoDriver_Cocoa::Start(const StringList &parm)
 		return "The cocoa quartz subdriver only supports 8 and 32 bpp.";
 	}
 
-	/* Defer fullscreen toggle until the main loop is running,
-	 * as otherwise a grey bar will be stuck on top of the window. */
-	this->fullscreen_on_mainloop = _fullscreen;
 	_cocoa_subdriver = QZ_CreateSubdriver(width, height, bpp, _fullscreen, true);
 	if (_cocoa_subdriver == NULL) {
 		Stop();

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -569,7 +569,8 @@ bool WindowQuartzSubdriver::SetVideoMode(int width, int height, int bpp)
 		[ this->window setContentSize:contentRect.size ];
 
 		/* Ensure frame height - title bar height >= view height */
-		contentRect.size.height = Clamp(height, 0, (int)[ this->window frame ].size.height - 22 /* 22 is the height of title bar of window*/);
+		float content_height = [ this->window contentRectForFrameRect:[ this->window frame ] ].size.height;
+		contentRect.size.height = Clamp(height, 0, (int)content_height);
 
 		if (this->cocoaview != nil) {
 			height = (int)contentRect.size.height;

--- a/src/video/cocoa/event.mm
+++ b/src/video/cocoa/event.mm
@@ -652,12 +652,6 @@ void VideoDriver_Cocoa::GameLoop()
 
 		while (QZ_PollEvent()) {}
 
-		/* If we do that right after window creation, a grey bar will be left at the top. */
-		if (this->fullscreen_on_mainloop) {
-			this->fullscreen_on_mainloop = false;
-			_cocoa_subdriver->ToggleFullscreen(true);
-		}
-
 		if (_exit_game) {
 			/* Restore saved resolution if in fullscreen mode. */
 			if (_cocoa_subdriver->IsFullscreen()) _cur_resolution = this->orig_res;


### PR DESCRIPTION
## Motivation / Problem

Title bar height is not 22 pixel in fullscreen mode.


## Description

Get the real title bar height instead.

