### PR TITLE
Fix: Don't allow towns to terraform certain floodable tiles

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -15,6 +15,7 @@
 #include "viewport_func.h"
 #include "core/random_func.hpp"
 #include "newgrf_generic.h"
+#include "town.h"
 #include "landscape_cmd.h"
 
 #include "table/strings.h"
@@ -351,8 +352,14 @@ static void ChangeTileOwner_Clear(TileIndex, Owner, Owner)
 	return;
 }
 
-static CommandCost TerraformTile_Clear(TileIndex tile, DoCommandFlag flags, int, Slope)
+static CommandCost TerraformTile_Clear(TileIndex tile, DoCommandFlag flags, int z_new, Slope tileh_new)
 {
+	if (flags & DC_NO_TERRAFORM_FLOOD) {
+		if (!CanTownTerraformTileWithoutFlooding(tile, z_new, tileh_new)) {
+			return CMD_ERROR;
+		}
+	}
+
 	return Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 }
 

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -377,7 +377,7 @@ enum DoCommandFlag {
 	DC_AUTO                  = 0x002, ///< don't allow building on structures
 	DC_QUERY_COST            = 0x004, ///< query cost only,  don't build.
 	DC_NO_WATER              = 0x008, ///< don't allow building on water
-	// 0x010 is unused
+	DC_NO_TERRAFORM_FLOOD    = 0x010, ///< don't allow terraforming on tiles with a flooding behaviour (used for town growth)
 	DC_NO_TEST_TOWN_RATING   = 0x020, ///< town rating does not disallow you from building
 	DC_BANKRUPT              = 0x040, ///< company bankrupts, skip money check, skip vehicle on tile check in some cases
 	DC_AUTOREPLACE           = 0x080, ///< autoreplace/autorenew is in progress, this shall disable vehicle limits when building, and ignore certain restrictions when undoing things (like vehicle attach callback)

--- a/src/town.h
+++ b/src/town.h
@@ -318,7 +318,7 @@ inline uint16_t TownTicksToGameTicks(uint16_t ticks)
 	return (std::min(ticks, MAX_TOWN_GROWTH_TICKS) + 1) * Ticks::TOWN_GROWTH_TICKS - 1;
 }
 
-
+bool CanTownTerraformTileWithoutFlooding(TileIndex tile, int z_new, Slope tileh_new);
 RoadType GetTownRoadType();
 bool CheckTownRoadTypes();
 std::span<const DrawBuildingsTileStruct> GetTownDrawTileData();

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -880,8 +880,14 @@ void InitializeTrees()
 	_trees_tick_ctr = 0;
 }
 
-static CommandCost TerraformTile_Trees(TileIndex tile, DoCommandFlag flags, int, Slope)
+static CommandCost TerraformTile_Trees(TileIndex tile, DoCommandFlag flags, int z_new, Slope tileh_new)
 {
+	if (flags & DC_NO_TERRAFORM_FLOOD) {
+		if (!CanTownTerraformTileWithoutFlooding(tile, z_new, tileh_new)) {
+			return CMD_ERROR;
+		}
+	}
+
 	return Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 }
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -37,6 +37,7 @@
 #include "company_gui.h"
 #include "newgrf_generic.h"
 #include "industry.h"
+#include "town.h"
 #include "water_cmd.h"
 #include "landscape_cmd.h"
 #include "pathfinder/water_regions.h"
@@ -1409,10 +1410,16 @@ static VehicleEnterTileStatus VehicleEnter_Water(Vehicle *, TileIndex, int, int)
 	return VETSB_CONTINUE;
 }
 
-static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlag flags, int, Slope)
+static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlag flags, int z_new, Slope tileh_new)
 {
 	/* Canals can't be terraformed */
 	if (IsWaterTile(tile) && IsCanal(tile)) return CommandCost(STR_ERROR_MUST_DEMOLISH_CANAL_FIRST);
+
+	if (flags & DC_NO_TERRAFORM_FLOOD) {
+		if (!CanTownTerraformTileWithoutFlooding(tile, z_new, tileh_new)) {
+			return CMD_ERROR;
+		}
+	}
 
 	return Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 }


### PR DESCRIPTION
## Motivation / Problem
![road and house flooded](https://user-images.githubusercontent.com/43006711/103466811-4c670e00-4d40-11eb-9169-a4ee78f89965.png)
During world generation, town growth algorithm is speed up, allowing the town to perform multiple sequential growth actions, like building houses, roads, and terraforming. If it happens to lower terrain adjacent to sea and then in one of those sequences it builds a road or a house there, it will end up flooded during the "run tile loop" phase of world generation.
The result could be similar to what the screenshot shows: disconnected roads and/or houses.

This happens very rarely. I tried 12k towns 4096x4096 map, and detected no more than 3 flooded road or house tiles.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Prevent rare occurrences of roads and houses being flooded, resulting in disconnected towns.

If the terraform command finds a certain floodable tile, the terraform fails. This works even for a sequence of commands during town generation. So far, the tests have not yet produced any flooded houses or roads.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Void tiles were a problem. Terraform command ignores them. If the town terraformed one of the tiles at the edges of the map, there was no checking happening for the void tiles, and it could result in a flood coming in the direction of the void tile. I added checks coming from the edge tiles. Terraform command shall fail if the resulting slope on an edge tile is flat and has a height of zero.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
