### PR TITLE
Feature: Prevent tunnels from being built under mines

### DIFF
--- a/src/industry.h
+++ b/src/industry.h
@@ -202,6 +202,8 @@ void ReleaseDisastersTargetingIndustry(IndustryID);
 
 bool IsTileForestIndustry(TileIndex tile);
 
+bool IsTileMineIndustry(TileIndex tile);
+
 /** Data for managing the number of industries of a single industry type. */
 struct IndustryTypeBuildData {
 	uint32 probability;  ///< Relative probability of building this industry.

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -976,6 +976,33 @@ bool IsTileForestIndustry(TileIndex tile)
 	return false;
 }
 
+/**
+ * Check whether the tile is a mine.
+ * @param tile the tile to investigate.
+ * @return true if and only if the tile is a mine
+ */
+bool IsTileMineIndustry(TileIndex tile)
+{
+	/* No industry */
+	if (!IsTileType(tile, MP_INDUSTRY)) return false;
+
+	const Industry* ind = Industry::GetByTile(tile);
+
+	/* No extractive industry */
+	if ((GetIndustrySpec(ind->type)->life_type & INDUSTRYLIFE_EXTRACTIVE) == 0) return false;
+
+	for (uint i = 0; i < lengthof(ind->produced_cargo); i++) {
+		/* The industry extracts something non-liquid, i.e. no oil or plastic, so it is a mine.
+		 * Also the production of passengers and mail is ignored. */
+		if (ind->produced_cargo[i] != CT_INVALID &&
+			(CargoSpec::Get(ind->produced_cargo[i])->classes & (CC_LIQUID | CC_PASSENGERS | CC_MAIL)) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static const byte _plantfarmfield_type[] = {1, 1, 1, 1, 1, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6};
 
 /**

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -79,6 +79,7 @@ static inline bool IsIndustryCompleted(TileIndex t)
 }
 
 IndustryType GetIndustryType(TileIndex tile);
+bool IsTileMineIndustry(TileIndex tile);
 
 /**
  * Set if the industry that owns the tile as under construction or not

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1228,6 +1228,8 @@ STR_CONFIG_SETTING_MAX_BRIDGE_HEIGHT                            :Maximum bridge 
 STR_CONFIG_SETTING_MAX_BRIDGE_HEIGHT_HELPTEXT                   :Maximum height for building bridges
 STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH                            :Maximum tunnel length: {STRING2}
 STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH_HELPTEXT                   :Maximum length for building tunnels
+STR_CONFIG_SETTING_MIN_TUNNEL_DEPTH_UNDER_MINE                  :Minimum tunnel depth under mines: {STRING2}
+STR_CONFIG_SETTING_MIN_TUNNEL_DEPTH_UNDER_MINE_HELPTEXT         :Minimum depth required for building tunnels under mines
 STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD             :Manual primary industry construction method: {STRING2}
 STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_HELPTEXT    :Method of funding a primary industry. 'none' means it is not possible to fund any, 'prospecting' means funding is possible, but construction occurs in a random spot on the map and may as well fail, 'as other industries' means raw industries can be constructed by companies like processing industries in any position they like
 STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_NONE        :None
@@ -4539,6 +4541,7 @@ STR_ERROR_CAN_T_BUILD_TUNNEL_HERE                               :{WHITE}Can't bu
 STR_ERROR_SITE_UNSUITABLE_FOR_TUNNEL                            :{WHITE}Site unsuitable for tunnel entrance
 STR_ERROR_MUST_DEMOLISH_TUNNEL_FIRST                            :{WHITE}Must demolish tunnel first
 STR_ERROR_ANOTHER_TUNNEL_IN_THE_WAY                             :{WHITE}Another tunnel in the way
+STR_ERROR_MINE_INDUSTRY_IN_THE_WAY                              :{WHITE}Unable to build tunnel under mine
 STR_ERROR_TUNNEL_THROUGH_MAP_BORDER                             :{WHITE}Tunnel would end out of the map
 STR_ERROR_UNABLE_TO_EXCAVATE_LAND                               :{WHITE}Unable to excavate land for other end of tunnel
 STR_ERROR_TUNNEL_TOO_LONG                                       :{WHITE}... tunnel too long

--- a/src/script/api/script_tunnel.hpp
+++ b/src/script/api/script_tunnel.hpp
@@ -35,6 +35,9 @@ public:
 		/** Another tunnel is in the way */
 		ERR_TUNNEL_ANOTHER_TUNNEL_IN_THE_WAY,        // [STR_ERROR_ANOTHER_TUNNEL_IN_THE_WAY]
 
+		/** Another tunnel is in the way */
+		ERR_TUNNEL_MINE_INDUSTRY_IN_THE_WAY,         // [STR_ERROR_MINE_INDUSTRY_IN_THE_WAY]
+
 		/** Unable to excavate land at the end to create the tunnel's exit */
 		ERR_TUNNEL_END_SITE_UNSUITABLE,              // [STR_ERROR_UNABLE_TO_EXCAVATE_LAND]
 	};
@@ -90,6 +93,7 @@ public:
 	 * @exception ScriptTunnel::ERR_TUNNEL_CANNOT_BUILD_ON_WATER
 	 * @exception ScriptTunnel::ERR_TUNNEL_START_SITE_UNSUITABLE
 	 * @exception ScriptTunnel::ERR_TUNNEL_ANOTHER_TUNNEL_IN_THE_WAY
+	 * @exception ScriptTunnel::ERR_TUNNEL_MINE_INDUSTRY_IN_THE_WAY
 	 * @exception ScriptTunnel::ERR_TUNNEL_END_SITE_UNSUITABLE
 	 * @return Whether the tunnel has been/can be build or not.
 	 * @note The slope of a tile can be determined by ScriptTile::GetSlope(TileIndex).

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1661,6 +1661,7 @@ static SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("construction.max_bridge_length"));
 			limitations->Add(new SettingEntry("construction.max_bridge_height"));
 			limitations->Add(new SettingEntry("construction.max_tunnel_length"));
+			limitations->Add(new SettingEntry("construction.min_tunnel_depth_under_mine"));
 			limitations->Add(new SettingEntry("station.never_expire_airports"));
 			limitations->Add(new SettingEntry("vehicle.never_expire_vehicles"));
 			limitations->Add(new SettingEntry("vehicle.max_trains"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -308,6 +308,7 @@ struct ConstructionSettings {
 	uint16 max_bridge_length;                ///< maximum length of bridges
 	byte   max_bridge_height;                ///< maximum height of bridges
 	uint16 max_tunnel_length;                ///< maximum length of tunnels
+	uint16 min_tunnel_depth_under_mine;      ///< minimum depth of tunnel under mine
 	byte   train_signal_side;                ///< show signals on left / driving / right side
 	bool   extra_dynamite;                   ///< extra dynamite
 	bool   road_stop_on_town_road;           ///< allow building of drive-through road stops on town owned roads

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -154,24 +154,7 @@ static int CountMapSquareAround(TileIndex tile, CMSAMatcher cmp)
  */
 static bool CMSAMine(TileIndex tile)
 {
-	/* No industry */
-	if (!IsTileType(tile, MP_INDUSTRY)) return false;
-
-	const Industry *ind = Industry::GetByTile(tile);
-
-	/* No extractive industry */
-	if ((GetIndustrySpec(ind->type)->life_type & INDUSTRYLIFE_EXTRACTIVE) == 0) return false;
-
-	for (uint i = 0; i < lengthof(ind->produced_cargo); i++) {
-		/* The industry extracts something non-liquid, i.e. no oil or plastic, so it is a mine.
-		 * Also the production of passengers and mail is ignored. */
-		if (ind->produced_cargo[i] != CT_INVALID &&
-				(CargoSpec::Get(ind->produced_cargo[i])->classes & (CC_LIQUID | CC_PASSENGERS | CC_MAIL)) == 0) {
-			return true;
-		}
-	}
-
-	return false;
+	return IsTileMineIndustry(tile);
 }
 
 /**

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -541,6 +541,19 @@ str      = STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH
 strhelp  = STR_CONFIG_SETTING_MAX_TUNNEL_LENGTH_HELPTEXT
 strval   = STR_CONFIG_SETTING_TILE_LENGTH
 
+[SDT_VAR]
+base     = GameSettings
+var      = construction.min_tunnel_depth_under_mine
+type     = SLE_UINT16
+guiflags = SGF_NO_NETWORK
+def      = 1
+min      = 1
+max      = MAX_MAX_HEIGHTLEVEL
+interval = 1
+str      = STR_CONFIG_SETTING_MIN_TUNNEL_DEPTH_UNDER_MINE
+strhelp  = STR_CONFIG_SETTING_MIN_TUNNEL_DEPTH_UNDER_MINE_HELPTEXT
+strval   = STR_JUST_COMMA
+
 # construction.longbridges
 [SDT_NULL]
 length   = 1

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -23,6 +23,7 @@
 #include "pathfinder/yapf/yapf_cache.h"
 #include "newgrf_sound.h"
 #include "autoslope.h"
+#include "industry_map.h"
 #include "tunnelbridge_map.h"
 #include "strings_func.h"
 #include "date_func.h"
@@ -676,6 +677,10 @@ CommandCost CmdBuildTunnel(TileIndex start_tile, DoCommandFlag flags, uint32 p1,
 
 		if (!_cheats.crossing_tunnels.value && IsTunnelInWayDir(end_tile, start_z, tunnel_in_way_dir)) {
 			return_cmd_error(STR_ERROR_ANOTHER_TUNNEL_IN_THE_WAY);
+		}
+
+		if (IsTileMineIndustry(end_tile) && end_z - start_z < _settings_game.construction.min_tunnel_depth_under_mine) {
+			return_cmd_error(STR_ERROR_MINE_INDUSTRY_IN_THE_WAY);
 		}
 
 		tiles++;


### PR DESCRIPTION
## Motivation / Problem

Currently, tunnels (road or rail) can be built under tiles with mines. The motivation is to make the game more realistic by preventing tunnels to be built where the raw material being extracted is supposed to come from: under ground.

## Description

Prevent tunnels from being built under mines. The code changes adds a constrain to the code path that makes a tunnel to check that every tile along the tunnel is not under a mine industry.

I assume some players should be OK with this restriction as it makes sense in real life and makes the game more challenging in a good way. However, I am making it as an opt-in, given that the default value is set to 1.

## Limitations

This code change does not prevent mines to be built on top of already existing tunnels.

## Checklist for review

There is no problem with existing tunnels in previously saved games.

## Testing

I have tested this change successfully with the original industry set as well as FIRS. Only mine industries prevent tunnels to be built under them.