### PR TITLE
Fix: allow input of numbers greater than INT32_MAX for GiveMoney

### DIFF
--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -73,7 +73,7 @@ void HandleOnEditText(const char *str)
 		case 3: { // Give money, you can only give money in excess of loan
 			const Company *c = Company::GetIfValid(_local_company);
 			if (c == nullptr) break;
-			Money money = min(c->money - c->current_loan, (Money)(atoi(str) / _currency->rate));
+			Money money = min(c->money - c->current_loan, (Money)(strtoull(str, nullptr, 10) / _currency->rate));
 
 			uint32 money_c = Clamp(ClampToI32(money), 0, 20000000); // Clamp between 20 million and 0
 


### PR DESCRIPTION
Fixes #7750.

## Motivation / Problem

You could wire `INT32_MAX+1` to another player, which resulted in `-1`, which is clamped to `0`. The expectation of course is to wire the upper-bound, `20,000,000`.

## Description

Based on [patch by JGR](https://github.com/JGRennison/OpenTTD-patches/commit/b132272fb1da66234a3549f1d936ec1d8113ee0f). Basically, use `strtoull` to parse string to int, instead of `atoi`.

Now no matter what you input, it is converted to an unsigned long, and casted into `Money`, meaning it will max-out (instead of bottom-out). Which is much more in line with what a player would expect.

## Limitations

- You can still wire 0 to another player. This was already the case, and this still is the case after this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
