### PR TITLE
Fix #8332: aborting group drag&drop could cause crashes with vehicle drag&drop

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -981,6 +981,7 @@ public:
 		/* abort drag & drop */
 		this->vehicle_sel = INVALID_VEHICLE;
 		this->DirtyHighlightedGroupWidget();
+		this->group_sel = INVALID_GROUP;
 		this->group_over = INVALID_GROUP;
 		this->SetWidgetDirty(WID_GL_LIST_VEHICLE);
 	}


### PR DESCRIPTION
## Motivation / Problem

You could easily crash the game when aborting group drag&drop.

This is a partial backport of downstream patch:
https://github.com/JGRennison/OpenTTD-patches/commit/66630ef8dfb9652695e81959c3284b5f9fbe60b2

The other part of this patch seems somewhat pedantic, and mostly partial. There are more places in the GUI where `::Get` is done, which is not safeguarded either. See limitations how I think this could be abused. I kept this out of scope of this PR, as it would require much more changes for very unlikely edge-cases (in my opinion).

## Description

The selected group was not reset when drag&drop was aborted. When
after that vehicle drag&drop was successful, group drag&drop code
was still executed, causing weird behaviour or even crashes.


## Limitations

- In a coop-multiplayer game, when you do a group drag&drop, and your coop player removes your group during that time, releasing your drag&drop on another group crashes your game.
- Related, in a coop-multiplayer game, when you do a vehicle drag&drop, and your coop player removes your vehicle during that time, dragging the vehicle over a group can crash the game
- There are a few more of these: if someone in a coop-multiplayer game ....

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
