### PR TITLE
Fix: for arctic and tropic, make sure we have at least a few hills

### DIFF
--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -234,7 +234,27 @@ static height_t TGPGetMaxHeight()
 		{  12,  19,  25,  31,  67,  75,  87 }, ///< Alpinist
 	};
 
-	int max_height_from_table = max_height[_settings_game.difficulty.terrain_type][std::min(MapLogX(), MapLogY()) - MIN_MAP_SIZE_BITS];
+	int map_size_bucket = std::min(MapLogX(), MapLogY()) - MIN_MAP_SIZE_BITS;
+	int max_height_from_table = max_height[_settings_game.difficulty.terrain_type][map_size_bucket];
+
+	/* Arctic needs snow to have all industries, so make sure we allow TGP to generate this high. */
+	if (_settings_game.game_creation.landscape == LT_ARCTIC) {
+		max_height_from_table += _settings_newgame.game_creation.snow_line_height;
+		/* Make flat a bit more flat by removing "very flat" from it, to somewhat compensate for the increase we just did. */
+		if (_settings_game.difficulty.terrain_type > 0) {
+			max_height_from_table -= max_height[_settings_game.difficulty.terrain_type - 1][map_size_bucket];
+		}
+	}
+	/* Tropic needs tropical forest to have all industries, so make sure we allow TGP to generate this high.
+	 * Tropic forest always starts at 1/4th of the max height. */
+	if (_settings_game.game_creation.landscape == LT_TROPIC) {
+		max_height_from_table += CeilDiv(_settings_game.construction.max_heightlevel, 4);
+		/* Make flat a bit more flat by removing "very flat" from it, to somewhat compensate for the increase we just did. */
+		if (_settings_game.difficulty.terrain_type > 0) {
+			max_height_from_table -= max_height[_settings_game.difficulty.terrain_type - 1][map_size_bucket];
+		}
+	}
+
 	return I2H(std::min<uint>(max_height_from_table, _settings_game.construction.max_heightlevel));
 }
 

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -26,7 +26,7 @@ static const uint DEF_MAX_HEIGHTLEVEL = 30;                    ///< Default maxi
 static const uint MAX_MAX_HEIGHTLEVEL = MAX_TILE_HEIGHT;       ///< Upper bound of maximum allowed heightlevel (in the construction settings)
 
 static const uint MIN_SNOWLINE_HEIGHT = 2;                     ///< Minimum snowline height
-static const uint DEF_SNOWLINE_HEIGHT = 15;                    ///< Default snowline height
+static const uint DEF_SNOWLINE_HEIGHT = 10;                    ///< Default snowline height
 static const uint MAX_SNOWLINE_HEIGHT = (MAX_TILE_HEIGHT - 2); ///< Maximum allowed snowline height
 
 


### PR DESCRIPTION
Fixes #6337

## Motivation / Problem

With the default configuration, creating arctic and tropic maps are not working as intended: on flat there are no hills to generate any of the hill-only industries. In the case of arctic this generate an error; one a new user would have no idea how to solve.

In general, on these two landscapes hills are .. not really hilly with the default height-level and snow-line level. If you drop them by 50% (15 / 7), it becomes more like what we were used to before 2014 (before the higher max-height-level was introduced).

## Description

Solving this is far from easy, as the TGP became a patch on a patch on a patch on a patch, often by people who did not understand the full scope. For example, the `max_height` table is now just terrible, as it is not a fluent increase of values (sometimes `+ 7`, next step `+ 2`); this makes no sense.

While solving this problem I got told multiple times that a rewrite of the map generator is the only true solution, but that is not helpful to anyone, especially new players. So I have been looking for a stopgap solution, that is not perfect, but gets the job done. This is the result.

In essence, it boils down that TGP uses a max-height based on map-size and "hilliness", which is clamped to "max-height-level" of the settings. By default, a 256x256 map can never generate any hill above 25 (this is independent of the "max-height-level"!). For "Very flat", "Flat", and "Hilly" it doesn't even come above the default snow-level, in arctic. This is pretty bad, and is the reason industries cannot be placed.

For tropic, the solution is picked is this:
- Make sure the allowed height-level for TGP is at least the level required to generate tropical forest. This is hardcoded to `max-height-level / 4`. To compensate for the additional increase in height-level, we reduce it with the hilliness of the setting lower, just to dampen the effect of increasing the height-level.

For arctic, I went for a 2-part solution:
- Similar to tropic, increase the height-level TGP works with with the snow-line-height. This means there is at least some hill somewhere above the snow-level. Also here we reduce the height-level again with the hilliness of the setting lower, to dampen the effect again.
- Reduce the default snow-line-height to 10, to make sure "flat" can still be flat-ish. With the default on 15, it becomes extremely hilly, even for "flat". This is a bit of a compromise between still allowing somewhat flat landscapes and making sure maps generate properly.

## Limitations

- For arctic and tropic, "Very flat" is not so flat again. Because of some other non-sense I am not going into, on tropic this is not that bad. On arctic this is more noticeable. But from my perspective, this is not a bad thing. I do not expect a full flat map on arctic, as that would make the landscape hard to play (you are missing industries). And it is called arctic .. would you expect a full flat map there? :D But, this is simply a compromise between two evils.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
