### PR TITLE
Fix #7972: show invalid orders to stations that don't accept your vehicle

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4021,6 +4021,7 @@ STR_ORDER_REFIT_STOP_ORDER                                      :(Refit to {STRI
 STR_ORDER_STOP_ORDER                                            :(Stop)
 
 STR_ORDER_GO_TO_STATION                                         :{STRING} {STATION} {STRING1}
+STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION                       :{PUSH_COLOUR}{RED}(Can't use station){POP_COLOUR} {STRING} {STATION} {STRING1}
 
 STR_ORDER_IMPLICIT                                              :(Implicit)
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -28,6 +28,7 @@
 #include "hotkeys.h"
 #include "aircraft.h"
 #include "engine_func.h"
+#include "vehicle_func.h"
 
 #include "widgets/order_widget.h"
 
@@ -258,8 +259,9 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 		case OT_GOTO_STATION: {
 			OrderLoadFlags load = order->GetLoadType();
 			OrderUnloadFlags unload = order->GetUnloadType();
+			bool valid_station = CanVehicleUseStation(v, Station::Get(order->GetDestination()));
 
-			SetDParam(0, STR_ORDER_GO_TO_STATION);
+			SetDParam(0, valid_station ? STR_ORDER_GO_TO_STATION : STR_ORDER_GO_TO_STATION_CAN_T_USE_STATION);
 			SetDParam(1, STR_ORDER_GO_TO + (v->IsGroundVehicle() ? order->GetNonStopType() : 0));
 			SetDParam(2, order->GetDestination());
 


### PR DESCRIPTION
Fixes #7972

## Motivation / Problem

Having invalid orders that are shown as regular orders heavily confuses any user. So we have to do something to make it more .. clear what is going on. See #7972 for more detail.

## Description

Before it was shown as a normal order, but the vehicle was skipping
it. This was rather unclear to the user. Now it is red and contains
text with some hints what is going on.

The text is prefixed rather than post-fixed, as we have many
post-fixes already.

For a train it looks like this:
![image](https://user-images.githubusercontent.com/1663690/103911646-91a38b00-5106-11eb-8552-5e8bd8823455.png)

For a bus it looks like this:
![image](https://user-images.githubusercontent.com/1663690/103911680-99fbc600-5106-11eb-906e-bccdd7693982.png)

And in a very extreme case it looks like this:
![image](https://user-images.githubusercontent.com/1663690/103911715-a41dc480-5106-11eb-9b3e-858e19f937fa.png)

## Limitations

- Order GUI already makes for way too long of a lines; this is adding to that problem. But I currently see no other way except to completely overhaul the GUI, which is just ever so slightly out of scope (sarcasm implied ;)).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
