### PR TITLE
Codechange: Make void tiles flood edge tiles, instead of edge tiles flooding themselves

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -13,7 +13,6 @@
 #include "landscape.h"
 #include "genworld.h"
 #include "viewport_func.h"
-#include "water.h"
 #include "core/random_func.hpp"
 #include "newgrf_generic.h"
 #include "landscape_cmd.h"
@@ -248,15 +247,6 @@ static void TileLoopClearDesert(TileIndex tile)
 
 static void TileLoop_Clear(TileIndex tile)
 {
-	/* If the tile is at any edge flood it to prevent maps without water. */
-	if (_settings_game.construction.freeform_edges && DistanceFromEdge(tile) == 1) {
-		int z;
-		if (IsTileFlat(tile, &z) && z == 0) {
-			DoFloodTile(tile);
-			MarkTileDirtyByTile(tile);
-			return;
-		}
-	}
 	AmbientSoundEffect(tile);
 
 	switch (_settings_game.game_creation.landscape) {

--- a/src/void_cmd.cpp
+++ b/src/void_cmd.cpp
@@ -12,6 +12,7 @@
 #include "command_func.h"
 #include "viewport_func.h"
 #include "slope_func.h"
+#include "water.h"
 
 #include "table/strings.h"
 #include "table/sprites.h"
@@ -53,7 +54,8 @@ static void GetTileDesc_Void(TileIndex tile, TileDesc *td)
 
 static void TileLoop_Void(TileIndex tile)
 {
-	/* not used */
+	/* Floods adjacent edge tile to prevent maps without water. */
+	TileLoop_Water(tile);
 }
 
 static void ChangeTileOwner_Void(TileIndex tile, Owner old_owner, Owner new_owner)

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1089,6 +1089,9 @@ FloodingBehaviour GetFloodingBehaviour(TileIndex tile)
 		case MP_TREES:
 			return (GetTreeGround(tile) == TREE_GROUND_SHORE ? FLOOD_DRYUP : FLOOD_NONE);
 
+		case MP_VOID:
+			return FLOOD_ACTIVE;
+
 		default:
 			return FLOOD_NONE;
 	}
@@ -1240,7 +1243,7 @@ void TileLoop_Water(TileIndex tile)
 			Slope slope_here = GetFoundationSlope(tile) & ~SLOPE_HALFTILE_MASK & ~SLOPE_STEEP;
 			for (uint dir : SetBitIterator(_flood_from_dirs[slope_here])) {
 				TileIndex dest = tile + TileOffsByDir((Direction)dir);
-				if (!IsValidTile(dest)) continue;
+				if (dest >= Map::Size()) continue;
 
 				FloodingBehaviour dest_behaviour = GetFloodingBehaviour(dest);
 				if ((dest_behaviour == FLOOD_ACTIVE) || (dest_behaviour == FLOOD_PASSIVE)) return;
@@ -1279,7 +1282,7 @@ void ConvertGroundTilesIntoWaterTiles()
 					for (uint dir : SetBitIterator(_flood_from_dirs[slope & ~SLOPE_STEEP])) {
 						TileIndex dest = TileAddByDir(tile, (Direction)dir);
 						Slope slope_dest = GetTileSlope(dest) & ~SLOPE_STEEP;
-						if (slope_dest == SLOPE_FLAT || IsSlopeWithOneCornerRaised(slope_dest)) {
+						if (slope_dest == SLOPE_FLAT || IsSlopeWithOneCornerRaised(slope_dest) || IsTileType(dest, MP_VOID)) {
 							MakeShore(tile);
 							break;
 						}


### PR DESCRIPTION
## Motivation / Problem
Tiles at the edges of the map only start to be flooded if they are of type Clear. If they are of any other type, there is no flood. It also requires the tile to be flat, a setting and at height 0. And visually, the shores of tiles adjacent to void don't look like they're watered.
![Unnamed, 1950-01-01#10](https://user-images.githubusercontent.com/43006711/103912860-b7796180-50ff-11eb-8d80-92e6042d2a2f.png)



<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
All problems are solved by allowing Void tiles to have an active flood behaviour. The rest of the code already handles how to draw nearby tiles, what tile types to flood. The flooding mechanics are all done from TileLoop_Water now.
![Unnamed, 1950-01-01#11](https://user-images.githubusercontent.com/43006711/103913662-b5fc6900-5100-11eb-83ea-58aa273bcddd.png)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
