### PR TITLE
[OSX] Render screen in full native resolution on HiDPI displays.

### DIFF
--- a/os/macosx/Info.plist.in
+++ b/os/macosx/Info.plist.in
@@ -29,5 +29,7 @@
         <string>Copyright 2004-${CURRENT_YEAR} The OpenTTD team</string>
         <key>NSPrincipalClass</key>
         <string>NSApplication</string>
+        <key>NSHighResolutionCapable</key>
+        <string>True</string>
 </dict>
 </plist>

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -9,6 +9,10 @@ extern std::string _config_language_file;
 
 static const char *_support8bppmodes = "no|system|hardware";
 
+#ifdef WITH_COCOA
+extern bool _allow_hidpi_window;
+#endif
+
 static const SettingDescGlobVarList _misc_settings[] = {
 [post-amble]
 };
@@ -316,6 +320,12 @@ def      = ZOOM_LVL_OUT_4X
 min      = ZOOM_LVL_MIN
 max      = ZOOM_LVL_OUT_4X
 cat      = SC_BASIC
+
+[SDTG_BOOL]
+ifdef    = WITH_COCOA
+name     = ""allow_hidpi""
+var      = _allow_hidpi_window
+def      = true
 
 [SDTG_END]
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -270,7 +270,7 @@ bool VideoDriver_Cocoa::ToggleFullscreen(bool full_screen)
  */
 bool VideoDriver_Cocoa::AfterBlitterChange()
 {
-	this->ChangeResolution(_screen.width, _screen.height);
+	this->ChangeResolution(_cur_resolution.width, _cur_resolution.height);
 	this->UpdatePalette(0, 256);
 	return true;
 }

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -38,6 +38,9 @@ extern NSString *OTTDMainLaunchGameEngine;
 
 /** Subclass of NSView to support mouse awareness and text input. */
 @interface OTTD_CocoaView : NSView <NSTextInputClient>
+- (NSRect)getRealRect:(NSRect)rect;
+- (NSRect)getVirtualRect:(NSRect)rect;
+- (CGFloat)getContentsScale;
 - (NSPoint)mousePositionFromEvent:(NSEvent *)e;
 @end
 

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -46,6 +46,8 @@
  * Read http://developer.apple.com/releasenotes/Cocoa/Objective-C++.html for more information.
  */
 
+bool _allow_hidpi_window = true; // Referenced from table/misc_settings.ini
+
 @interface OTTDMain : NSObject <NSApplicationDelegate>
 @end
 
@@ -417,13 +419,13 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 	float _current_magnification;
 	NSUInteger _current_mods;
 	bool _emulated_down;
-	bool _use_hidpi;
+	bool _use_hidpi; ///< Render content in native resolution?
 }
 
 - (instancetype)initWithFrame:(NSRect)frameRect
 {
 	if (self = [ super initWithFrame:frameRect ]) {
-		self->_use_hidpi = [ self respondsToSelector:@selector(convertRectToBacking:) ] && [ self respondsToSelector:@selector(convertRectFromBacking:) ];
+		self->_use_hidpi = _allow_hidpi_window && [ self respondsToSelector:@selector(convertRectToBacking:) ] && [ self respondsToSelector:@selector(convertRectFromBacking:) ];
 	}
 	return self;
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2158,8 +2158,8 @@ void ResizeWindow(Window *w, int delta_x, int delta_y, bool clamp_to_screen)
 			 * the resolution clamp it in such a manner that it stays within the bounds. */
 			int new_right  = w->left + w->width  + delta_x;
 			int new_bottom = w->top  + w->height + delta_y;
-			if (new_right  >= (int)_cur_resolution.width)  delta_x -= Ceil(new_right  - _cur_resolution.width,  std::max(1U, w->nested_root->resize_x));
-			if (new_bottom >= (int)_cur_resolution.height) delta_y -= Ceil(new_bottom - _cur_resolution.height, std::max(1U, w->nested_root->resize_y));
+			if (new_right  >= (int)_screen.width)  delta_x -= Ceil(new_right  - _screen.width,  std::max(1U, w->nested_root->resize_x));
+			if (new_bottom >= (int)_screen.height) delta_y -= Ceil(new_bottom - _screen.height, std::max(1U, w->nested_root->resize_y));
 		}
 
 		w->SetDirty();
@@ -3468,7 +3468,7 @@ void ReInitAllWindows()
 	NetworkReInitChatBoxSize();
 
 	/* Make sure essential parts of all windows are visible */
-	RelocateAllWindows(_cur_resolution.width, _cur_resolution.height);
+	RelocateAllWindows(_screen.width, _screen.height);
 	MarkWholeScreenDirty();
 }
 


### PR DESCRIPTION
## Motivation / Problem

On HiDPI displays, OTTD renders in virtual resolution, giving a permanent x2 scaling effect. This makes it impossible to e.g. get crisp text on HiDPI displays. OSX is the only platform that does this.


## Description

Always use native resolution for rendering. x2 scaling can be achieved by using font/UI scaling and in-game zoom.


## Limitations

Rendering in full native resolution can affect performance, there are more pixels after all. This PR adds an OSX only (non-GUI) setting to restore the old behaviour for cases where OTTD struggles to render in native resolution.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
