### PR TITLE
Change: always allow to click on the toolbar icons for road/rail/dock/airport

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -71,6 +71,7 @@ struct BuildAirToolbarWindow : Window {
 	BuildAirToolbarWindow(WindowDesc *desc, WindowNumber window_number) : Window(desc)
 	{
 		this->InitNested(window_number);
+		this->OnInvalidateData();
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 		this->last_user_action = WIDGET_LIST_END;
 	}
@@ -90,7 +91,13 @@ struct BuildAirToolbarWindow : Window {
 	{
 		if (!gui_scope) return;
 
-		if (!CanBuildVehicleInfrastructure(VEH_AIRCRAFT)) delete this;
+		bool can_build = CanBuildVehicleInfrastructure(VEH_AIRCRAFT);
+		this->SetWidgetsDisabledState(!can_build,
+			WID_AT_AIRPORT,
+			WIDGET_LIST_END);
+		if (!can_build) {
+			DeleteWindowById(WC_BUILD_STATION, TRANSPORT_AIR);
+		}
 	}
 
 	void OnClick(Point pt, int widget, int click_count) override
@@ -160,7 +167,6 @@ struct BuildAirToolbarWindow : Window {
  */
 static EventState AirportToolbarGlobalHotkeys(int hotkey)
 {
-	if (_game_mode != GM_NORMAL || !CanBuildVehicleInfrastructure(VEH_AIRCRAFT)) return ES_NOT_HANDLED;
 	Window *w = ShowBuildAirToolbar();
 	if (w == nullptr) return ES_NOT_HANDLED;
 	return w->OnHotkey(hotkey);

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -97,6 +97,11 @@ struct BuildAirToolbarWindow : Window {
 			WIDGET_LIST_END);
 		if (!can_build) {
 			DeleteWindowById(WC_BUILD_STATION, TRANSPORT_AIR);
+
+			/* Show in the tooltip why this button is disabled. */
+			this->GetWidget<NWidgetCore>(WID_AT_AIRPORT)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+		} else {
+			this->GetWidget<NWidgetCore>(WID_AT_AIRPORT)->SetToolTip(STR_TOOLBAR_AIRCRAFT_BUILD_AIRPORT_TOOLTIP);
 		}
 	}
 

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -125,6 +125,15 @@ struct BuildDocksToolbarWindow : Window {
 		if (!can_build) {
 			DeleteWindowById(WC_BUILD_STATION, TRANSPORT_WATER);
 			DeleteWindowById(WC_BUILD_DEPOT, TRANSPORT_WATER);
+
+			/* Show in the tooltip why this button is disabled. */
+			this->GetWidget<NWidgetCore>(WID_DT_DEPOT)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+			this->GetWidget<NWidgetCore>(WID_DT_STATION)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+			this->GetWidget<NWidgetCore>(WID_DT_BUOY)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+		} else {
+			this->GetWidget<NWidgetCore>(WID_DT_DEPOT)->SetToolTip(STR_WATERWAYS_TOOLBAR_BUILD_DEPOT_TOOLTIP);
+			this->GetWidget<NWidgetCore>(WID_DT_STATION)->SetToolTip(STR_WATERWAYS_TOOLBAR_BUILD_DOCK_TOOLTIP);
+			this->GetWidget<NWidgetCore>(WID_DT_BUOY)->SetToolTip(STR_WATERWAYS_TOOLBAR_BUOY_TOOLTIP);
 		}
 	}
 

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -144,17 +144,14 @@ struct BuildDocksToolbarWindow : Window {
 				break;
 
 			case WID_DT_DEPOT: // Build depot button
-				if (!CanBuildVehicleInfrastructure(VEH_SHIP)) return;
 				if (HandlePlacePushButton(this, WID_DT_DEPOT, SPR_CURSOR_SHIP_DEPOT, HT_RECT)) ShowBuildDocksDepotPicker(this);
 				break;
 
 			case WID_DT_STATION: // Build station button
-				if (!CanBuildVehicleInfrastructure(VEH_SHIP)) return;
 				if (HandlePlacePushButton(this, WID_DT_STATION, SPR_CURSOR_DOCK, HT_SPECIAL)) ShowBuildDockStationPicker(this);
 				break;
 
 			case WID_DT_BUOY: // Build buoy button
-				if (!CanBuildVehicleInfrastructure(VEH_SHIP)) return;
 				HandlePlacePushButton(this, WID_DT_BUOY, SPR_CURSOR_BUOY, HT_RECT);
 				break;
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2353,6 +2353,9 @@ STR_JOIN_STATION_CREATE_SPLITTED_STATION                        :{YELLOW}Build a
 STR_JOIN_WAYPOINT_CAPTION                                       :{WHITE}Join waypoint
 STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT                      :{YELLOW}Build a separate waypoint
 
+# Generic toolbar
+STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE                       :{BLACK}Disabled as currently no vehicles are available for this infrastructure
+
 # Rail construction toolbar
 STR_RAIL_TOOLBAR_RAILROAD_CONSTRUCTION_CAPTION                  :Railway Construction
 STR_RAIL_TOOLBAR_ELRAIL_CONSTRUCTION_CAPTION                    :Electrified Railway Construction

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -437,18 +437,6 @@ struct BuildRailToolbarWindow : Window {
 	}
 
 	/**
-	 * Some data on this window has become invalid.
-	 * @param data Information about the changed data.
-	 * @param gui_scope Whether the call is done from GUI scope. You may not do everything when not in GUI scope. See #InvalidateWindowData() for details.
-	 */
-	void OnInvalidateData(int data = 0, bool gui_scope = true) override
-	{
-		if (!gui_scope) return;
-
-		if (!CanBuildVehicleInfrastructure(VEH_TRAIN)) delete this;
-	}
-
-	/**
 	 * Configures the rail toolbar for railtype given
 	 * @param railtype the railtype to display
 	 */
@@ -781,7 +769,6 @@ struct BuildRailToolbarWindow : Window {
  */
 static EventState RailToolbarGlobalHotkeys(int hotkey)
 {
-	if (_game_mode != GM_NORMAL || !CanBuildVehicleInfrastructure(VEH_TRAIN)) return ES_NOT_HANDLED;
 	extern RailType _last_built_railtype;
 	Window *w = ShowBuildRailToolbar(_last_built_railtype);
 	if (w == nullptr) return ES_NOT_HANDLED;

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -295,39 +295,3 @@ RoadTypes ExistingRoadTypes(CompanyID c)
 
 	return known_roadtypes;
 }
-
-/**
- * Check whether we can build infrastructure for the given RoadType. This to disable building stations etc. when
- * you are not allowed/able to have the RoadType yet.
- * @param roadtype the roadtype to check this for
- * @param company the company id to check this for
- * @param any_date to check only existing vehicles or if it is possible to build them in the future
- * @return true if there is any reason why you may build the infrastructure for the given roadtype
- */
-bool CanBuildRoadTypeInfrastructure(RoadType roadtype, CompanyID company)
-{
-	if (_game_mode != GM_EDITOR && !Company::IsValidID(company)) return false;
-	if (!_settings_client.gui.disable_unsuitable_building) return true;
-	if (!HasAnyRoadTypesAvail(company, GetRoadTramType(roadtype))) return false;
-
-	RoadTypes roadtypes = ExistingRoadTypes(company);
-
-	/* Check if the filtered roadtypes does have the roadtype we are checking for
-	 * and if we can build new ones */
-	if (_settings_game.vehicle.max_roadveh > 0 && HasBit(roadtypes, roadtype)) {
-		/* Can we actually build the vehicle type? */
-		for (const Engine *e : Engine::IterateType(VEH_ROAD)) {
-			if (!HasBit(e->company_avail, company)) continue;
-			if (HasPowerOnRoad(e->u.road.roadtype, roadtype) || HasPowerOnRoad(roadtype, e->u.road.roadtype)) return true;
-		}
-		return false;
-	}
-
-	/* We should be able to build infrastructure when we have the actual vehicle type */
-	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->type == VEH_ROAD && (company == OWNER_DEITY || v->owner == company) &&
-			HasBit(roadtypes, RoadVehicle::From(v)->roadtype) && HasPowerOnRoad(RoadVehicle::From(v)->roadtype, roadtype)) return true;
-	}
-
-	return false;
-}

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -303,8 +303,9 @@ struct BuildRoadToolbarWindow : Window {
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
 		if (!gui_scope) return;
+		RoadTramType rtt = GetRoadTramType(this->roadtype);
 
-		bool can_build = CanBuildVehicleInfrastructure(VEH_ROAD, GetRoadTramType(this->roadtype));
+		bool can_build = CanBuildVehicleInfrastructure(VEH_ROAD, rtt);
 		this->SetWidgetsDisabledState(!can_build,
 			WID_ROT_DEPOT,
 			WID_ROT_BUS_STATION,
@@ -314,6 +315,15 @@ struct BuildRoadToolbarWindow : Window {
 			DeleteWindowById(WC_BUS_STATION, TRANSPORT_ROAD);
 			DeleteWindowById(WC_TRUCK_STATION, TRANSPORT_ROAD);
 			DeleteWindowById(WC_BUILD_DEPOT, TRANSPORT_ROAD);
+
+			/* Show in the tooltip why this button is disabled. */
+			this->GetWidget<NWidgetCore>(WID_ROT_DEPOT)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+			this->GetWidget<NWidgetCore>(WID_ROT_BUS_STATION)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+			this->GetWidget<NWidgetCore>(WID_ROT_TRUCK_STATION)->SetToolTip(STR_TOOLBAR_DISABLED_NO_VEHICLE_AVAILABLE);
+		} else {
+			this->GetWidget<NWidgetCore>(WID_ROT_DEPOT)->SetToolTip(rtt == RTT_ROAD ? STR_ROAD_TOOLBAR_TOOLTIP_BUILD_ROAD_VEHICLE_DEPOT : STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRAM_VEHICLE_DEPOT);
+			this->GetWidget<NWidgetCore>(WID_ROT_BUS_STATION)->SetToolTip(rtt == RTT_ROAD ? STR_ROAD_TOOLBAR_TOOLTIP_BUILD_BUS_STATION : STR_ROAD_TOOLBAR_TOOLTIP_BUILD_PASSENGER_TRAM_STATION);
+			this->GetWidget<NWidgetCore>(WID_ROT_TRUCK_STATION)->SetToolTip(rtt == RTT_ROAD ? STR_ROAD_TOOLBAR_TOOLTIP_BUILD_TRUCK_LOADING_BAY : STR_ROAD_TOOLBAR_TOOLTIP_BUILD_CARGO_TRAM_STATION);
 		}
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -304,7 +304,17 @@ struct BuildRoadToolbarWindow : Window {
 	{
 		if (!gui_scope) return;
 
-		if (_game_mode != GM_EDITOR && !CanBuildVehicleInfrastructure(VEH_ROAD, GetRoadTramType(this->roadtype))) delete this;
+		bool can_build = CanBuildVehicleInfrastructure(VEH_ROAD, GetRoadTramType(this->roadtype));
+		this->SetWidgetsDisabledState(!can_build,
+			WID_ROT_DEPOT,
+			WID_ROT_BUS_STATION,
+			WID_ROT_TRUCK_STATION,
+			WIDGET_LIST_END);
+		if (!can_build) {
+			DeleteWindowById(WC_BUS_STATION, TRANSPORT_ROAD);
+			DeleteWindowById(WC_TRUCK_STATION, TRANSPORT_ROAD);
+			DeleteWindowById(WC_BUILD_DEPOT, TRANSPORT_ROAD);
+		}
 	}
 
 	void Initialize(RoadType roadtype)
@@ -434,7 +444,6 @@ struct BuildRoadToolbarWindow : Window {
 				break;
 
 			case WID_ROT_DEPOT:
-				if (_game_mode == GM_EDITOR || !CanBuildVehicleInfrastructure(VEH_ROAD, GetRoadTramType(this->roadtype))) return;
 				if (HandlePlacePushButton(this, WID_ROT_DEPOT, this->rti->cursor.depot, HT_RECT)) {
 					ShowRoadDepotPicker(this);
 					this->last_started_action = widget;
@@ -442,7 +451,6 @@ struct BuildRoadToolbarWindow : Window {
 				break;
 
 			case WID_ROT_BUS_STATION:
-				if (_game_mode == GM_EDITOR || !CanBuildVehicleInfrastructure(VEH_ROAD, GetRoadTramType(this->roadtype))) return;
 				if (HandlePlacePushButton(this, WID_ROT_BUS_STATION, SPR_CURSOR_BUS_STATION, HT_RECT)) {
 					ShowRVStationPicker(this, ROADSTOP_BUS);
 					this->last_started_action = widget;
@@ -450,7 +458,6 @@ struct BuildRoadToolbarWindow : Window {
 				break;
 
 			case WID_ROT_TRUCK_STATION:
-				if (_game_mode == GM_EDITOR || !CanBuildVehicleInfrastructure(VEH_ROAD, GetRoadTramType(this->roadtype))) return;
 				if (HandlePlacePushButton(this, WID_ROT_TRUCK_STATION, SPR_CURSOR_TRUCK_STATION, HT_RECT)) {
 					ShowRVStationPicker(this, ROADSTOP_TRUCK);
 					this->last_started_action = widget;
@@ -711,7 +718,6 @@ static EventState RoadTramToolbarGlobalHotkeys(int hotkey, RoadType last_build, 
 	Window* w = nullptr;
 	switch (_game_mode) {
 		case GM_NORMAL:
-			if (!CanBuildVehicleInfrastructure(VEH_ROAD, rtt)) return ES_NOT_HANDLED;
 			w = ShowBuildRoadToolbar(last_build);
 			break;
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1555,7 +1555,6 @@ static SettingsContainer &GetSettingsTree()
 				construction->Add(new SettingEntry("gui.persistent_buildingtools"));
 				construction->Add(new SettingEntry("gui.quick_goto"));
 				construction->Add(new SettingEntry("gui.default_rail_type"));
-				construction->Add(new SettingEntry("gui.disable_unsuitable_building"));
 			}
 
 			interface->Add(new SettingEntry("gui.autosave"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -108,7 +108,6 @@ struct GUISettings {
 	uint8  window_soft_limit;                ///< soft limit of maximum number of non-stickied non-vital windows (0 = no limit)
 	ZoomLevel zoom_min;                      ///< minimum zoom out level
 	ZoomLevel zoom_max;                      ///< maximum zoom out level
-	bool   disable_unsuitable_building;      ///< disable infrastructure building when no suitable vehicles are available
 	byte   autosave;                         ///< how often should we do autosaves?
 	bool   threaded_saves;                   ///< should we do threaded saves?
 	bool   keep_all_autosave;                ///< name the autosave in a different way

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3049,15 +3049,6 @@ str      = STR_CONFIG_SETTING_WARN_LOST_VEHICLE
 strhelp  = STR_CONFIG_SETTING_WARN_LOST_VEHICLE_HELPTEXT
 
 [SDTC_BOOL]
-var      = gui.disable_unsuitable_building
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-def      = true
-str      = STR_CONFIG_SETTING_DISABLE_UNSUITABLE_BUILDING
-strhelp  = STR_CONFIG_SETTING_DISABLE_UNSUITABLE_BUILDING_HELPTEXT
-proc     = RedrawScreen
-cat      = SC_EXPERT
-
-[SDTC_BOOL]
 var      = gui.new_nonstop
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -2033,11 +2033,6 @@ struct MainToolbarWindow : Window {
 		this->SetWidgetDisabledState(WID_TN_GOAL, Goal::GetNumItems() == 0);
 		this->SetWidgetDisabledState(WID_TN_STORY, StoryPage::GetNumItems() == 0);
 
-		this->SetWidgetDisabledState(WID_TN_RAILS, !CanBuildVehicleInfrastructure(VEH_TRAIN));
-		this->SetWidgetDisabledState(WID_TN_ROADS, !CanBuildVehicleInfrastructure(VEH_ROAD, RTT_ROAD));
-		this->SetWidgetDisabledState(WID_TN_TRAMS, !CanBuildVehicleInfrastructure(VEH_ROAD, RTT_TRAM));
-		this->SetWidgetDisabledState(WID_TN_AIR, !CanBuildVehicleInfrastructure(VEH_AIRCRAFT));
-
 		this->DrawWidgets();
 	}
 
@@ -2078,11 +2073,11 @@ struct MainToolbarWindow : Window {
 			case MTHK_AIRCRAFT_LIST: ShowVehicleListWindow(_local_company, VEH_AIRCRAFT); break;
 			case MTHK_ZOOM_IN: ToolbarZoomInClick(this); break;
 			case MTHK_ZOOM_OUT: ToolbarZoomOutClick(this); break;
-			case MTHK_BUILD_RAIL: if (CanBuildVehicleInfrastructure(VEH_TRAIN)) ShowBuildRailToolbar(_last_built_railtype); break;
+			case MTHK_BUILD_RAIL: ShowBuildRailToolbar(_last_built_railtype); break;
 			case MTHK_BUILD_ROAD: ShowBuildRoadToolbar(_last_built_roadtype); break;
-			case MTHK_BUILD_TRAM: if (CanBuildVehicleInfrastructure(VEH_ROAD, RTT_TRAM)) ShowBuildRoadToolbar(_last_built_tramtype); break;
+			case MTHK_BUILD_TRAM: ShowBuildRoadToolbar(_last_built_tramtype); break;
 			case MTHK_BUILD_DOCKS: ShowBuildDocksToolbar(); break;
-			case MTHK_BUILD_AIRPORT: if (CanBuildVehicleInfrastructure(VEH_AIRCRAFT)) ShowBuildAirToolbar(); break;
+			case MTHK_BUILD_AIRPORT: ShowBuildAirToolbar(); break;
 			case MTHK_BUILD_TREES: ShowBuildTreesToolbar(); break;
 			case MTHK_MUSIC: ShowMusicWindow(); break;
 			case MTHK_AI_DEBUG: ShowAIDebugWindow(); break;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1792,7 +1792,6 @@ bool CanBuildVehicleInfrastructure(VehicleType type, byte subtype)
 	assert(IsCompanyBuildableVehicleType(type));
 
 	if (!Company::IsValidID(_local_company)) return false;
-	if (!_settings_client.gui.disable_unsuitable_building) return true;
 
 	UnitID max;
 	switch (type) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -895,6 +895,15 @@ void NWidgetCore::SetDataTip(uint32 widget_data, StringID tool_tip)
 	this->tool_tip = tool_tip;
 }
 
+/**
+ * Set the tool tip of the nested widget.
+ * @param tool_tip Tool tip string to use.
+ */
+void NWidgetCore::SetToolTip(StringID tool_tip)
+{
+	this->tool_tip = tool_tip;
+}
+
 void NWidgetCore::FillNestedArray(NWidgetBase **array, uint length)
 {
 	if (this->index >= 0 && (uint)(this->index) < length) array[this->index] = this;

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -285,6 +285,7 @@ public:
 
 	void SetIndex(int index);
 	void SetDataTip(uint32 widget_data, StringID tool_tip);
+	void SetToolTip(StringID tool_tip);
 
 	inline void SetLowered(bool lowered);
 	inline bool IsLowered() const;


### PR DESCRIPTION
Fixes #8055.
Closes #8063.

## Motivation / Problem

This is my take on #8055. I somewhat disagree with comments made in #8063, and I think not allowing people to build roads when the server has max-road-vehicles set to zero is silly. Expecting the user to change a GUI setting before he can, I do not see the point in that.

## Description

This change allows a user to see what is available and what will become
available before it is available, instead of only disabling the button
with no further explanation. It also always allows building roads and
canals, even if no vehicles are available for road / water.

For rail/road/tram, a dropdown with available types is shown. If
none are available, it reads "None". If the type is not yet available,
it is greyed out.

For dock/airport, this always open the toolbar, but building airports,
docks, and depots buttons are disabled till vehicles are available
for those.

Road is the only exception, with the primary road always being
available. Here too, stations and depots are disabled till vehicles
become available. It does mean you can now always build roads to
for example help towns grow.

Disabled buttons show on their tooltip why they are disabled.

Imported 2 commits from #8063. With the removing of `disable_unsuitable_building` setting, `CanBuildVehicleInfrastructure()` now does much more what the name suggest, and how it is, with this PR, used in the code.

![image](https://user-images.githubusercontent.com/1663690/103953881-4eb3d880-5143-11eb-8748-aa1a6eb32f61.png)



## Limitations

- I did make this consistent, which means that for airports this is slightly weird.
- Removing the `disable_unsuitable_building` setting means there is now no way to already start building rail before engines are available. This might result in some people complaining about that.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
