### PR TITLE
Codechange: Use access __attribute__ to silence warnings in GCC

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -136,6 +136,12 @@
 #	endif
 #endif /* __GNUC__ || __clang__ */
 
+#if defined(__GNUC__)
+#	define NOACCESS(args) __attribute__ ((access (none, args)))
+#else
+#	define NOACCESS(args)
+#endif
+
 #if defined(__WATCOMC__)
 #	define NORETURN
 #	define CDECL

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -30,25 +30,25 @@
 #include "core/bitmath_func.hpp"
 #include "string_type.h"
 
-char *strecat(char *dst, const char *src, const char *last);
-char *strecpy(char *dst, const char *src, const char *last);
-char *stredup(const char *src, const char *last = nullptr);
+char *strecat(char *dst, const char *src, const char *last) NOACCESS(3);
+char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
+char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
 
-int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4);
-int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0);
+int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4) NOACCESS(2);
+int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0) NOACCESS(2);
 
 char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 
-void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
 std::string str_validate(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void ValidateString(const char *str);
 
-void str_fix_scc_encoded(char *str, const char *last);
+void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
 void str_strip_colours(char *str);
 bool strtolower(char *str);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
-bool StrValid(const char *str, const char *last);
+bool StrValid(const char *str, const char *last) NOACCESS(2);
 
 /**
  * Check if a string buffer is empty.


### PR DESCRIPTION
## Motivation / Problem

GCC in some cases warns about uninitialized uses where in fact pointer is not dereferenced at all, such as `last` pointer in safe string functions.

```
/home/milek7/OpenTTD/src/network/network_content_gui.cpp: In member function ‘void NetworkContentListWindow::OpenExternalSearch()’:
/home/milek7/OpenTTD/src/network/network_content_gui.cpp:328:36: warning: ‘last’ may be used uninitialized [-Wmaybe-uninitialized]
  328 |                 char *pos = strecpy(url, "http://grfsearch.openttd.org/?", last);
      |                             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/milek7/OpenTTD/src/network/core/address.h:15,
                 from /home/milek7/OpenTTD/src/network/core/tcp.h:15,
                 from /home/milek7/OpenTTD/src/network/core/tcp_content.h:16,
                 from /home/milek7/OpenTTD/src/network/network_content.h:13,
                 from /home/milek7/OpenTTD/src/network/network_content_gui.h:13,
                 from /home/milek7/OpenTTD/src/network/network_content_gui.cpp:23:
/home/milek7/OpenTTD/src/network/core/../../string_func.h:34:7: note: by argument 3 of type ‘const char*’ to ‘char* strecpy(char*, const char*, const char*)’ declared here
   34 | char *strecpy(char *dst, const char *src, const char *last);
      |       ^~~~~~~
/home/milek7/OpenTTD/src/network/network_content_gui.cpp:325:22: note: ‘url’ declared here
  325 |                 char url[1024];
      |                      ^~~
```


## Description

Add `NOACCESS` macro that uses access `__attribute__` to tell compiler that pointer is not dereferenced at all. https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html


## Limitations

None (except ugly macro).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
