### PR TITLE
Codechange: Check if access __attribute__ is supported before trying to use it.

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -136,8 +136,12 @@
 #	endif
 #endif /* __GNUC__ || __clang__ */
 
-#if defined(__GNUC__)
-#	define NOACCESS(args) __attribute__ ((access (none, args)))
+#if defined __has_attribute
+#	if __has_attribute (access)
+#		define NOACCESS(args) __attribute__ ((access (none, args)))
+#	else
+#		define NOACCESS(args)
+#	endif
 #else
 #	define NOACCESS(args)
 #endif


### PR DESCRIPTION
## Motivation / Problem

639cfa43d23 introduced warnings about using unknown access `__attribute__` in older compilers.


## Description

Use __has_attribute check as recommended on https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
