### PR TITLE
Fix: [Actions] circumvent Windows tar warning about read-only files

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -220,6 +220,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    # "restore-cache" which is done by "run-vcpkg" uses Windows tar.
+    # A git clone on windows marks a few files as read-only; when Windows tar
+    # tries to extract the cache over this folder, it fails, despite the files
+    # being identical. This failure shows up as an warning in the logs. We
+    # avoid this by simply removing the read-only mark from the git folder.
+    # In other words: this is a hack!
+    # See: https://github.com/lukka/run-vcpkg/issues/61
+    - name: Remove read-only flag from vcpkg git folder
+      shell: powershell
+      run: |
+        attrib -r "c:\vcpkg\.git\*.*" /s
+
     - name: Prepare vcpkg (with cache)
       uses: lukka/run-vcpkg@v6
       with:


### PR DESCRIPTION
## Motivation / Problem

Our CI is almost completely clean of any warnings, except for something that is not in our own code base: "restore-cache" step on Windows for "run-vcpkg". This resolves that issue, by introducing a small hack.

## Description

Windows tar returns "Can't unlink already-existing object" when
restoring a git clone with "restore-cache" operations. GNU tar
doesn't have this issue.

## Limitations

- This is clearly a hack, and upstream should fix this. But it has been months now, and no official reply .. so .. yeah ..

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
