### PR TITLE
Revert: access_mode "none" is only available on GCC 11.1 and later

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -137,16 +137,6 @@
 #	endif
 #endif /* __GNUC__ || __clang__ */
 
-#if defined __has_attribute
-#	if __has_attribute (access)
-#		define NOACCESS(args) __attribute__ ((access (none, args)))
-#	else
-#		define NOACCESS(args)
-#	endif
-#else
-#	define NOACCESS(args)
-#endif
-
 #if defined(__WATCOMC__)
 #	define NORETURN
 #	define CDECL

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -30,25 +30,25 @@
 #include "core/bitmath_func.hpp"
 #include "string_type.h"
 
-char *strecat(char *dst, const char *src, const char *last) NOACCESS(3);
-char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
-char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
+char *strecat(char *dst, const char *src, const char *last);
+char *strecpy(char *dst, const char *src, const char *last);
+char *stredup(const char *src, const char *last = nullptr);
 
-int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4) NOACCESS(2);
-int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0) NOACCESS(2);
+int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4);
+int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0);
 
 char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 
-void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
+void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 std::string str_validate(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void ValidateString(const char *str);
 
-void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
+void str_fix_scc_encoded(char *str, const char *last);
 void str_strip_colours(char *str);
 bool strtolower(char *str);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
-bool StrValid(const char *str, const char *last) NOACCESS(2);
+bool StrValid(const char *str, const char *last);
 
 /**
  * Check if a string buffer is empty.


### PR DESCRIPTION
## Motivation / Problem

GCC 11 and later only have "none" as `access_mode`. There is no sane alternative for this problem.


## Description

GCC 10 people complained; it broke stuff :D


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
