### PR TITLE
Fix a bug in "restart" and introduce "reload" console command

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1073,6 +1073,23 @@ DEF_CONSOLE_CMD(ConRestart)
 	return true;
 }
 
+DEF_CONSOLE_CMD(ConReload)
+{
+	if (argc == 0) {
+		IConsoleHelp("Reload game. Usage: 'reload'");
+		IConsoleHelp("Reloads a game.");
+		IConsoleHelp(" * if you started from a savegame / scenario / heightmap, that exact same savegame / scenario / heightmap will be loaded.");
+		IConsoleHelp(" * if you started from a new game, this acts the same as 'restart'.");
+		return true;
+	}
+
+	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
+	_settings_game.game_creation.map_x = MapLogX();
+	_settings_game.game_creation.map_y = FindFirstBit(MapSizeY());
+	_switch_mode = SM_RELOADGAME;
+	return true;
+}
+
 /**
  * Print a text buffer line by line to the console. Lines are separated by '\n'.
  * @param buf The buffer to print.
@@ -2113,6 +2130,7 @@ void IConsoleStdLibRegister()
 	IConsoleCmdRegister("list_aliases", ConListAliases);
 	IConsoleCmdRegister("newgame",      ConNewGame);
 	IConsoleCmdRegister("restart",      ConRestart);
+	IConsoleCmdRegister("reload",       ConReload);
 	IConsoleCmdRegister("getseed",      ConGetSeed);
 	IConsoleCmdRegister("getdate",      ConGetDate);
 	IConsoleCmdRegister("getsysdate",   ConGetSysDate);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -928,6 +928,10 @@ static void MakeNewGameDone()
 static void MakeNewGame(bool from_heightmap, bool reset_settings)
 {
 	_game_mode = GM_NORMAL;
+	if (!from_heightmap) {
+		/* "reload" command needs to know what mode we were in. */
+		_file_to_saveload.SetMode(SLO_INVALID, FT_INVALID, DFT_INVALID);
+	}
 
 	ResetGRFConfig(true);
 
@@ -943,6 +947,8 @@ static void MakeNewEditorWorldDone()
 static void MakeNewEditorWorld()
 {
 	_game_mode = GM_EDITOR;
+	/* "reload" command needs to know what mode we were in. */
+	_file_to_saveload.SetMode(SLO_INVALID, FT_INVALID, DFT_INVALID);
 
 	ResetGRFConfig(true);
 
@@ -1052,9 +1058,9 @@ void SwitchToMode(SwitchMode new_mode)
 				SwitchToMode(_switch_mode);
 				break;
 			}
-			/* No break here, to enter the next case:
-			 * Restart --> 'Random game' with current settings */
-			FALLTHROUGH;
+
+			MakeNewGame(false, new_mode == SM_NEWGAME);
+			break;
 
 		case SM_NEWGAME: // New Game --> 'Random game'
 			if (_network_server) {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1046,9 +1046,9 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewEditorWorld();
 			break;
 
-		case SM_RESTARTGAME: // Restart --> Current settings preserved
+		case SM_RELOADGAME: // Reload with what-ever started the game
 			if (_file_to_saveload.abstract_ftype == FT_SAVEGAME || _file_to_saveload.abstract_ftype == FT_SCENARIO) {
-				/* Restart current savegame/scenario */
+				/* Reload current savegame/scenario */
 				_switch_mode = _game_mode == GM_EDITOR ? SM_LOAD_SCENARIO : SM_LOAD_GAME;
 				SwitchToMode(_switch_mode);
 				break;
@@ -1062,6 +1062,7 @@ void SwitchToMode(SwitchMode new_mode)
 			MakeNewGame(false, new_mode == SM_NEWGAME);
 			break;
 
+		case SM_RESTARTGAME: // Restart --> 'Random game' with current settings
 		case SM_NEWGAME: // New Game --> 'Random game'
 			if (_network_server) {
 				seprintf(_network_game_info.map_name, lastof(_network_game_info.map_name), "Random Map");

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -25,6 +25,7 @@ enum SwitchMode {
 	SM_NONE,
 	SM_NEWGAME,           ///< New Game --> 'Random game'.
 	SM_RESTARTGAME,       ///< Restart --> 'Random game' with current settings.
+	SM_RELOADGAME,        ///< Reload the savegame / scenario / heightmap you started the game with.
 	SM_EDITOR,            ///< Switch to scenario editor.
 	SM_LOAD_GAME,         ///< Load game, Play Scenario.
 	SM_MENU,              ///< Switch to game intro menu.


### PR DESCRIPTION
## Motivation / Problem

#7328 missed a case where a new game doesn't reset `_file_to_saveload.abstract_ftype`. This could make `restart` behave rather weird and unpredictable.

#8469, despite the way of wording, does have a point, which was already brought up in [a comment in the original PR](https://github.com/OpenTTD/OpenTTD/pull/7328#issuecomment-469626976). Basically, "restart" and "reload" really are two different words, with different meaning. The new "restart" as accepted by #7328 acted in a way many people would not expect, especially as you are already used to the old one.

To top it off, the console command help-text was never changed, making it even more confusing.


## Description

In this PR I opted to revert the change to "restart" from #7328, and reintroduce it as "reload". As we haven't had a release since the introduction of that PR, this should be fine. Now people who are used to the way the old command worked, can keep using it that way. Those who fancy the new way, can use that to.

In my world, the naming makes more sense this way:

- If you want to restart a map, I expect it to be clean of trains, companies, etc.
- If I want to reload a map, I expect to have exactly that: a reload of what I last loaded the game with.

This was echo'd by several comments in #7328.

I went through these use-case:
- If I am an AI developer, I would like to use "restart", as that gives me the same map, clean slate, and the AI can go nuts.
- If I am an NewGRF developer, I would like to use "reload", as I would want to see the buildings I put down, the vehicles, etc.
- If I am a server owner, I would like to use "restart": a competitive game that repeats on the same map, can use "restart". If he has to upgrade or reboot his machine, he might have loaded the savegame from the reboot, but he still expects "restart" to begin from zero.

But most of all, I find it very weird to so drastically change an existing console command between 2 releases, without having a good argument not to name the new way different. The ones given in #7328 were not convincing to me, at all. But, truth be told, this is a personal itch, as I was mostly annoyed the help text was not updated to reflect reality :)

## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)


## Things to not forget after merge

* Update https://wiki.openttd.org/en/Manual/Console
