### PR TITLE
Fix #8401: Drive-thru road stations can be connected at either end

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1112,6 +1112,7 @@ static bool GrowTownWithRoad(const Town *t, TileIndex tile, RoadBits rcmd)
  * Checks if a town road can be continued into the next tile.
  *  Road vehicle stations, bridges, and tunnels are fine, as long as they are facing the right direction.
  *
+ * @param t The current town
  * @param tile The tile where the road would be built
  * @param road_dir The direction of the road
  * @return true if the road can be continued, else false
@@ -1133,8 +1134,8 @@ static bool CanRoadContinueIntoNextTile(const Town* t, const TileIndex tile, con
 
 	/* If the next tile is a station, allow if it's a road station facing the proper direction. Otherwise return false. */
 	if (IsTileType(next_tile, MP_STATION)) {
-		/* If the next tile is a road station, allow if it's facing the same direction, otherwise disallow. */
-		return IsRoadStop(next_tile) && GetRoadStopDir(next_tile) == ReverseDiagDir(road_dir);
+		/* If the next tile is a road station, allow if it can be entered by the new tunnel/bridge, otherwise disallow. */
+		return IsRoadStop(next_tile) && (GetRoadStopDir(next_tile) == ReverseDiagDir(road_dir) || (IsDriveThroughStopTile(next_tile) && GetRoadStopDir(next_tile) == road_dir));
 	}
 
 	/* If the next tile is a road depot, allow if it's facing the right way. */


### PR DESCRIPTION
## Motivation / Problem

In #8401 introduced a bug when checking the direction of road stations. 

## Description

Standard dead-end road stations can only be entered from `ReverseDiagDir(road_dir)`, but drive-through stations can also be entered from `road_dir` itself.

Also, I added the town `t` parameter to the function description which I'd forgotten earlier.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
