### PR TITLE
Fix: The time-out for connecting to the content-server was shorter th…

### DIFF
--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -743,6 +743,7 @@ public:
 	void OnConnect(SOCKET s) override
 	{
 		assert(_network_content_client.sock == INVALID_SOCKET);
+		_network_content_client.lastActivity = _realtime_tick;
 		_network_content_client.isConnecting = false;
 		_network_content_client.sock = s;
 		_network_content_client.Reopen();
@@ -755,8 +756,6 @@ public:
  */
 void ClientNetworkContentSocketHandler::Connect()
 {
-	this->lastActivity = _realtime_tick;
-
 	if (this->sock != INVALID_SOCKET || this->isConnecting) return;
 	this->isConnecting = true;
 	new NetworkContentConnecter(NetworkAddress(NETWORK_CONTENT_SERVER_HOST, NETWORK_CONTENT_SERVER_PORT, AF_UNSPEC));


### PR DESCRIPTION
…an the combined timeouts for connecting to all resolve-addresses. So if connecting to the first N addresses timed out, OpenTTD would time-out the overall connection, even if one address finally succeeded.

## Motivation / Problem

When OpenTTD starts a TCP connection, it tries all resolved addresses sequentially.
If network is broken, connecing can take quite some time.

The content client is intended to close its connection after 60s of no packets sent/received (inactivity). However, the timeout is started when starting the connection, not when finishing it.
So when connecting takes longer than 60s, the connection is closed immediately, without any packets sent at all.

## Description

The timeout is reset, when a connection is established successfully.

## Limitations

No parallel-connection pony for you.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
