### PR TITLE
Fix #8506: Towns shouldn't add junctions to NewGRF roads they cannot build

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1349,6 +1349,9 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 	assert(tile < MapSize());
 
+	/* Don't allow junctions on roadtypes which can't be built by towns. */
+	if (IsTileType(tile, MP_ROAD) && !HasBit(GetRoadTypeInfo(GetRoadTypeRoad(tile))->flags, ROTF_TOWN_BUILD)) return;
+
 	if (cur_rb == ROAD_NONE) {
 		/* Tile has no road. First reset the status counter
 		 * to say that this is the last iteration. */


### PR DESCRIPTION
Fixes #8506

## Motivation / Problem

Per #8506, towns add junctions to NewGRF roads which have the `TOWN_BUILD` flag disabled.

If a town cannot build a road type, I would assume that it should not be able to add junctions to roads of that type.

## Description

I have created a savegame to test. You will need the RattRoads NewGRF, available from Bananas.
[HighwayRoadTest.zip](https://github.com/OpenTTD/OpenTTD/files/5789609/HighwayRoadTest.zip)

While the town is not able to build junctions on the highway, the town growth algorithm can still walk down the highway to build houses past the highway.

Note that while the RattRoads Highway also has the `NO_HOUSES` flag set, this is not checked as I think it is irrelevant to towns building said road.

## Limitations

There could be side effects I'm not aware of. Please help test this!

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
