### PR TITLE
Feature: Choose a sensible window size on a fresh OTTD config file.

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -708,14 +708,12 @@ int openttd_main(int argc, char *argv[])
 
 	if (resolution.width != 0) _cur_resolution = resolution;
 
-	/*
-	 * The width and height must be at least 1 pixel and width times
-	 * height times bytes per pixel must still fit within a 32 bits
-	 * integer, even for 32 bpp video modes. This way all internal
-	 * drawing routines work correctly.
-	 */
-	_cur_resolution.width  = ClampU(_cur_resolution.width,  1, UINT16_MAX / 2);
-	_cur_resolution.height = ClampU(_cur_resolution.height, 1, UINT16_MAX / 2);
+	/* Limit width times height times bytes per pixel to fit a 32 bit
+	 * integer, This way all internal drawing routines work correctly.
+	 * A resolution that has one component as 0 is treated as a marker to
+	 * auto-detect a good window size. */
+	_cur_resolution.width  = std::min(_cur_resolution.width, UINT16_MAX / 2u);
+	_cur_resolution.height = std::min(_cur_resolution.height, UINT16_MAX / 2u);
 
 	/* Assume the cursor starts within the game as not all video drivers
 	 * get an event that the cursor is within the window when it is opened.

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -120,7 +120,7 @@ name     = ""resolution""
 type     = SLE_INT
 length   = 2
 var      = _cur_resolution
-def      = ""640,480""
+def      = ""0,0""
 cat      = SC_BASIC
 
 [SDTG_STR]

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -417,6 +417,8 @@ const char *VideoDriver_Allegro::Start(const StringList &parm)
 	}
 	_allegro_instance_count++;
 
+	this->UpdateAutoResolution();
+
 	install_timer();
 	install_mouse();
 	install_keyboard();

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -70,6 +70,9 @@ public:
 	/** Main game loop. */
 	void GameLoop(); // In event.mm.
 
+protected:
+	Dimension GetScreenSize() const override;
+
 private:
 	friend class WindowQuartzSubdriver;
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -200,6 +200,8 @@ const char *VideoDriver_Cocoa::Start(const StringList &parm)
 	/* Don't create a window or enter fullscreen if we're just going to show a dialog. */
 	if (!CocoaSetupApplication()) return NULL;
 
+	this->UpdateAutoResolution();
+
 	this->orig_res = _cur_resolution;
 	int width  = _cur_resolution.width;
 	int height = _cur_resolution.height;
@@ -300,6 +302,15 @@ void VideoDriver_Cocoa::EditBoxLostFocus()
 	if (_cocoa_subdriver != NULL) [ [ _cocoa_subdriver->cocoaview inputContext ] discardMarkedText ];
 	/* Clear any marked string from the current edit box. */
 	HandleTextInput(NULL, true);
+}
+
+/**
+ * Get the resolution of the main screen.
+ */
+Dimension VideoDriver_Cocoa::GetScreenSize() const
+{
+	NSRect frame = [ [ NSScreen mainScreen ] frame ];
+	return { static_cast<uint>(NSWidth(frame)), static_cast<uint>(NSHeight(frame)) };
 }
 
 /**

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -135,6 +135,8 @@ static FVideoDriver_Dedicated iFVideoDriver_Dedicated;
 
 const char *VideoDriver_Dedicated::Start(const StringList &parm)
 {
+	this->UpdateAutoResolution();
+
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 	_dedicated_video_mem = (bpp == 0) ? nullptr : MallocT<byte>(_cur_resolution.width * _cur_resolution.height * (bpp / 8));
 

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -24,6 +24,8 @@ const char *VideoDriver_Null::Start(const StringList &parm)
 	_set_error_mode(_OUT_TO_STDERR);
 #endif
 
+	this->UpdateAutoResolution();
+
 	this->ticks = GetDriverParamInt(parm, "ticks", 1000);
 	_screen.width  = _screen.pitch = _cur_resolution.width;
 	_screen.height = _cur_resolution.height;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -674,6 +674,8 @@ const char *VideoDriver_SDL::Start(const StringList &parm)
 	}
 	if (ret_code < 0) return SDL_GetError();
 
+	this->UpdateAutoResolution();
+
 	GetVideoModes();
 	if (!CreateMainSurface(_cur_resolution.width, _cur_resolution.height, false)) {
 		return SDL_GetError();
@@ -928,6 +930,14 @@ void VideoDriver_SDL::AcquireBlitterLock()
 void VideoDriver_SDL::ReleaseBlitterLock()
 {
 	if (_draw_mutex != nullptr) _draw_mutex->unlock();
+}
+
+Dimension VideoDriver_SDL::GetScreenSize() const
+{
+	SDL_DisplayMode mode;
+	if (SDL_GetCurrentDisplayMode(0, &mode) != 0) return VideoDriver::GetScreenSize();
+
+	return { static_cast<uint>(mode.w), static_cast<uint>(mode.h) };
 }
 
 #endif /* WITH_SDL2 */

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -40,6 +40,10 @@ public:
 	void EditBoxLostFocus() override;
 
 	const char *GetName() const override { return "sdl"; }
+
+protected:
+	Dimension GetScreenSize() const override;
+
 private:
 	int PollEvent();
 	void LoopOnce();

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -614,6 +614,8 @@ const char *VideoDriver_SDL::Start(const StringList &parm)
 	}
 	if (ret_code < 0) return SDL_GetError();
 
+	this->UpdateAutoResolution();
+
 	GetVideoModes();
 	if (!CreateMainSurface(_cur_resolution.width, _cur_resolution.height)) {
 		return SDL_GetError();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1114,6 +1114,8 @@ static FVideoDriver_Win32 iFVideoDriver_Win32;
 
 const char *VideoDriver_Win32::Start(const StringList &parm)
 {
+	this->UpdateAutoResolution();
+
 	memset(&_wnd, 0, sizeof(_wnd));
 
 	RegisterWndClass();
@@ -1342,4 +1344,9 @@ void VideoDriver_Win32::EditBoxLostFocus()
 	CancelIMEComposition(_wnd.main_wnd);
 	SetCompositionPos(_wnd.main_wnd);
 	SetCandidatePos(_wnd.main_wnd);
+}
+
+Dimension VideoDriver_Win32::GetScreenSize() const
+{
+	return { static_cast<uint>(GetSystemMetrics(SM_CXSCREEN)), static_cast<uint>(GetSystemMetrics(SM_CYSCREEN)) };
 }

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -40,6 +40,9 @@ public:
 	const char *GetName() const override { return "win32"; }
 
 	bool MakeWindow(bool full_screen);
+
+protected:
+	Dimension GetScreenSize() const override;
 };
 
 /** The factory for Windows' video driver. */


### PR DESCRIPTION
## Motivation / Problem

Most screens today are bigger than 640x480. Assume the user actually
wants to see OpenTTD on screen and try to make the window sized
to 75% of the screen.


## Description

If the config file contains a resolution of 0x0 (which is also set as the default value), the video drivers will (where possible) set the actual resolution to 75% of the screen size.

The selected window size will be written to the config after the first start,
disabling this automatic on subsequent launches.

Each video driver must unfortunately duplicate the call to auto-resolution handling, as for example SDL functions can only be called after SDL_Init, which is only done on video driver load when we know SDL is going to be used.

If a video driver does not provide a screen resolution, the old default of 640x480 will be used.


## Limitations

Missing implementation for SDL1, as I couldn't see a proper function for it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~The bug fix is important enough to be backported? (label: 'backport requested')~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
