### PR TITLE
Feature: Automatic UI and font zoom levels.

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -59,6 +59,10 @@ static ReusableBuffer<uint8> _cursor_backup;
 ZoomLevel _gui_zoom; ///< GUI Zoom level
 ZoomLevel _font_zoom; ///< Font Zoom level
 
+int8 _gui_zoom_cfg;  ///< GUI zoom level in config.
+int8 _font_zoom_cfg; ///< Font zoom level in config.
+
+
 /**
  * The rect for repaint.
  *
@@ -1875,4 +1879,24 @@ bool ToggleFullScreen(bool fs)
 void SortResolutions()
 {
 	std::sort(_resolutions.begin(), _resolutions.end());
+}
+
+/**
+ * Resolve GUI zoom level, if auto-suggestion is requested.
+ */
+void UpdateGUIZoom()
+{
+	/* Determine real GUI zoom to use. */
+	if (_gui_zoom_cfg == ZOOM_LVL_CFG_AUTO) {
+		_gui_zoom = static_cast<ZoomLevel>(Clamp(VideoDriver::GetInstance()->GetSuggestedUIZoom(), _settings_client.gui.zoom_min, _settings_client.gui.zoom_max));
+	} else {
+		_gui_zoom = static_cast<ZoomLevel>(_gui_zoom_cfg);
+	}
+
+	/* Determine real font zoom to use. */
+	if (_font_zoom_cfg == ZOOM_LVL_CFG_AUTO) {
+		_font_zoom = static_cast<ZoomLevel>(VideoDriver::GetInstance()->GetSuggestedUIZoom());
+	} else {
+		_font_zoom = static_cast<ZoomLevel>(_font_zoom_cfg);
+	}
 }

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -77,6 +77,7 @@ void UpdateWindows();
 void DrawMouseCursor();
 void ScreenSizeChanged();
 void GameSizeChanged();
+void UpdateGUIZoom();
 void UndrawMouseCursor();
 
 /** Size of the buffer used for drawing strings. */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1004,6 +1004,7 @@ STR_GAME_OPTIONS_RESOLUTION_OTHER                               :other
 STR_GAME_OPTIONS_GUI_ZOOM_FRAME                                 :{BLACK}Interface size
 STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_TOOLTIP                      :{BLACK}Select the interface element size to use
 
+STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_AUTO                         :(auto-detect)
 STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_NORMAL                       :Normal
 STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_2X_ZOOM                      :Double size
 STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_4X_ZOOM                      :Quad size
@@ -1011,6 +1012,7 @@ STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_4X_ZOOM                      :Quad size
 STR_GAME_OPTIONS_FONT_ZOOM                                      :{BLACK}Font size
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_TOOLTIP                     :{BLACK}Select the interface font size to use
 
+STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_AUTO                        :(auto-detect)
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_NORMAL                      :Normal
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_2X_ZOOM                     :Double size
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_4X_ZOOM                     :Quad size

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -771,6 +771,7 @@ int openttd_main(int argc, char *argv[])
 
 	/* Initialize the zoom level of the screen to normal */
 	_screen.zoom = ZOOM_LVL_NORMAL;
+	UpdateGUIZoom();
 
 	NetworkStartUp(); // initialize network-core
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -538,24 +538,32 @@ struct GameOptionsWindow : Window {
 				}
 				break;
 
-			case WID_GO_GUI_ZOOM_DROPDOWN:
-				GfxClearSpriteCache();
-				_gui_zoom_cfg = index > 0 ? ZOOM_LVL_OUT_4X - index + 1 : ZOOM_LVL_CFG_AUTO;
-				UpdateGUIZoom();
-				UpdateCursorSize();
-				UpdateAllVirtCoords();
-				FixTitleGameZoom();
-				ReInitAllWindows();
+			case WID_GO_GUI_ZOOM_DROPDOWN: {
+				int8 new_zoom = index > 0 ? ZOOM_LVL_OUT_4X - index + 1 : ZOOM_LVL_CFG_AUTO;
+				if (new_zoom != _gui_zoom_cfg) {
+					GfxClearSpriteCache();
+					_gui_zoom_cfg = new_zoom;
+					UpdateGUIZoom();
+					UpdateCursorSize();
+					UpdateAllVirtCoords();
+					FixTitleGameZoom();
+					ReInitAllWindows();
+				}
 				break;
+			}
 
-			case WID_GO_FONT_ZOOM_DROPDOWN:
-				GfxClearSpriteCache();
-				_font_zoom_cfg = index > 0 ? ZOOM_LVL_OUT_4X - index + 1 : ZOOM_LVL_CFG_AUTO;
-				UpdateGUIZoom();
-				ClearFontCache();
-				LoadStringWidthTable();
-				UpdateAllVirtCoords();
+			case WID_GO_FONT_ZOOM_DROPDOWN: {
+				int8 new_zoom = index > 0 ? ZOOM_LVL_OUT_4X - index + 1 : ZOOM_LVL_CFG_AUTO;
+				if (new_zoom != _font_zoom_cfg) {
+					GfxClearSpriteCache();
+					_font_zoom_cfg = new_zoom;
+					UpdateGUIZoom();
+					ClearFontCache();
+					LoadStringWidthTable();
+					UpdateAllVirtCoords();
+				}
 				break;
+			}
 
 			case WID_GO_BASE_GRF_DROPDOWN:
 				this->SetMediaSet<BaseGraphics>(index);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -58,6 +58,7 @@ static const StringID _autosave_dropdown[] = {
 };
 
 static const StringID _gui_zoom_dropdown[] = {
+	STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_AUTO,
 	STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_NORMAL,
 	STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_2X_ZOOM,
 	STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_4X_ZOOM,
@@ -65,6 +66,7 @@ static const StringID _gui_zoom_dropdown[] = {
 };
 
 static const StringID _font_zoom_dropdown[] = {
+	STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_AUTO,
 	STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_NORMAL,
 	STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_2X_ZOOM,
 	STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_4X_ZOOM,
@@ -291,16 +293,16 @@ struct GameOptionsWindow : Window {
 				break;
 
 			case WID_GO_GUI_ZOOM_DROPDOWN: {
-				*selected_index = ZOOM_LVL_OUT_4X - _gui_zoom;
+				*selected_index = _gui_zoom_cfg != ZOOM_LVL_CFG_AUTO ? ZOOM_LVL_OUT_4X - _gui_zoom + 1 : 0;
 				const StringID *items = _gui_zoom_dropdown;
 				for (int i = 0; *items != INVALID_STRING_ID; items++, i++) {
-					list.emplace_back(new DropDownListStringItem(*items, i, _settings_client.gui.zoom_min > ZOOM_LVL_OUT_4X - i));
+					list.emplace_back(new DropDownListStringItem(*items, i, i != 0 && _settings_client.gui.zoom_min > ZOOM_LVL_OUT_4X - i + 1));
 				}
 				break;
 			}
 
 			case WID_GO_FONT_ZOOM_DROPDOWN: {
-				*selected_index = ZOOM_LVL_OUT_4X - _font_zoom;
+				*selected_index = _font_zoom_cfg != ZOOM_LVL_CFG_AUTO ? ZOOM_LVL_OUT_4X - _font_zoom + 1 : 0;
 				const StringID *items = _font_zoom_dropdown;
 				for (int i = 0; *items != INVALID_STRING_ID; items++, i++) {
 					list.emplace_back(new DropDownListStringItem(*items, i, false));
@@ -333,8 +335,8 @@ struct GameOptionsWindow : Window {
 			case WID_GO_AUTOSAVE_DROPDOWN:   SetDParam(0, _autosave_dropdown[_settings_client.gui.autosave]); break;
 			case WID_GO_LANG_DROPDOWN:       SetDParamStr(0, _current_language->own_name); break;
 			case WID_GO_RESOLUTION_DROPDOWN: SetDParam(0, GetCurRes() == _resolutions.size() ? STR_GAME_OPTIONS_RESOLUTION_OTHER : SPECSTR_RESOLUTION_START + GetCurRes()); break;
-			case WID_GO_GUI_ZOOM_DROPDOWN:   SetDParam(0, _gui_zoom_dropdown[ZOOM_LVL_OUT_4X - _gui_zoom]); break;
-			case WID_GO_FONT_ZOOM_DROPDOWN:  SetDParam(0, _font_zoom_dropdown[ZOOM_LVL_OUT_4X - _font_zoom]); break;
+			case WID_GO_GUI_ZOOM_DROPDOWN:   SetDParam(0, _gui_zoom_dropdown[_gui_zoom_cfg != ZOOM_LVL_CFG_AUTO ? ZOOM_LVL_OUT_4X - _gui_zoom_cfg + 1 : 0]); break;
+			case WID_GO_FONT_ZOOM_DROPDOWN:  SetDParam(0, _font_zoom_dropdown[_font_zoom_cfg != ZOOM_LVL_CFG_AUTO ? ZOOM_LVL_OUT_4X - _font_zoom_cfg + 1 : 0]); break;
 			case WID_GO_BASE_GRF_DROPDOWN:   SetDParamStr(0, BaseGraphics::GetUsedSet()->name.c_str()); break;
 			case WID_GO_BASE_GRF_STATUS:     SetDParam(0, BaseGraphics::GetUsedSet()->GetNumInvalid()); break;
 			case WID_GO_BASE_SFX_DROPDOWN:   SetDParamStr(0, BaseSounds::GetUsedSet()->name.c_str()); break;
@@ -538,7 +540,8 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_GUI_ZOOM_DROPDOWN:
 				GfxClearSpriteCache();
-				_gui_zoom = (ZoomLevel)(ZOOM_LVL_OUT_4X - index);
+				_gui_zoom_cfg = index > 0 ? ZOOM_LVL_OUT_4X - index + 1 : ZOOM_LVL_CFG_AUTO;
+				UpdateGUIZoom();
 				UpdateCursorSize();
 				UpdateAllVirtCoords();
 				FixTitleGameZoom();
@@ -547,7 +550,8 @@ struct GameOptionsWindow : Window {
 
 			case WID_GO_FONT_ZOOM_DROPDOWN:
 				GfxClearSpriteCache();
-				_font_zoom = (ZoomLevel)(ZOOM_LVL_OUT_4X - index);
+				_font_zoom_cfg = index > 0 ? ZOOM_LVL_OUT_4X - index + 1 : ZOOM_LVL_CFG_AUTO;
+				UpdateGUIZoom();
 				ClearFontCache();
 				LoadStringWidthTable();
 				UpdateAllVirtCoords();

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -157,22 +157,12 @@
 /* Stuff for MSVC */
 #if defined(_MSC_VER)
 #	pragma once
-#	ifdef _WIN64
-		/* No 64-bit Windows below XP, so we can safely assume it as the target platform. */
-#		define NTDDI_VERSION NTDDI_WINXP // Windows XP
-#		define _WIN32_WINNT 0x501        // Windows XP
-#		define _WIN32_WINDOWS 0x501      // Windows XP
-#		define WINVER 0x0501             // Windows XP
-#		define _WIN32_IE_ 0x0600         // 6.0 (XP+)
-#	else
-		/* Define a win32 target platform, to override defaults of the SDK
-		 * We need to define NTDDI version for Vista SDK, but win2k is minimum */
-#		define NTDDI_VERSION NTDDI_WIN2K // Windows 2000
-#		define _WIN32_WINNT 0x0500       // Windows 2000
-#		define _WIN32_WINDOWS 0x400      // Windows 95
-#		define WINVER 0x0400             // Windows NT 4.0 / Windows 95
-#		define _WIN32_IE_ 0x0401         // 4.01 (win98 and NT4SP5+)
-#	endif
+#	define NTDDI_VERSION NTDDI_WINXP // Windows XP
+#	define _WIN32_WINNT 0x501        // Windows XP
+#	define _WIN32_WINDOWS 0x501      // Windows XP
+#	define WINVER 0x0501             // Windows XP
+#	define _WIN32_IE_ 0x0600         // 6.0 (XP+)
+
 #	define NOMINMAX                // Disable min/max macros in windows.h.
 
 #	pragma warning(disable: 4244)  // 'conversion' conversion from 'type1' to 'type2', possible loss of data

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -5,6 +5,8 @@
 ;
 
 [pre-amble]
+static bool ZoomMinMaxChanged(int32 p1);
+
 extern std::string _config_language_file;
 
 static const char *_support8bppmodes = "no|system|hardware";
@@ -24,6 +26,7 @@ SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,   
 SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTC_VAR   =   SDTC_VAR($var,  $type,          $flags, $guiflags,       $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_END   = SDTG_END()
 
 [defaults]
@@ -302,6 +305,32 @@ def      = 100
 min      = 0
 max      = UINT32_MAX
 cat      = SC_EXPERT
+
+[SDTC_VAR]
+var      = gui.zoom_min
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = ZOOM_LVL_MIN
+min      = ZOOM_LVL_MIN
+max      = ZOOM_LVL_OUT_4X
+str      = STR_CONFIG_SETTING_ZOOM_MIN
+strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
+strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
+proc     = ZoomMinMaxChanged
+
+[SDTC_VAR]
+var      = gui.zoom_max
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = ZOOM_LVL_MAX
+min      = ZOOM_LVL_OUT_8X
+max      = ZOOM_LVL_MAX
+str      = STR_CONFIG_SETTING_ZOOM_MAX
+strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
+strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
+proc     = ZoomMinMaxChanged
 
 [SDTG_VAR]
 name     = ""gui_zoom""

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -334,19 +334,19 @@ proc     = ZoomMinMaxChanged
 
 [SDTG_VAR]
 name     = ""gui_zoom""
-type     = SLE_UINT8
-var      = _gui_zoom
-def      = ZOOM_LVL_OUT_4X
-min      = ZOOM_LVL_MIN
+type     = SLE_INT8
+var      = _gui_zoom_cfg
+def      = ZOOM_LVL_CFG_AUTO
+min      = ZOOM_LVL_CFG_AUTO
 max      = ZOOM_LVL_OUT_4X
 cat      = SC_BASIC
 
 [SDTG_VAR]
 name     = ""font_zoom""
-type     = SLE_UINT8
-var      = _font_zoom
-def      = ZOOM_LVL_OUT_4X
-min      = ZOOM_LVL_MIN
+type     = SLE_INT8
+var      = _font_zoom_cfg
+def      = ZOOM_LVL_CFG_AUTO
+min      = ZOOM_LVL_CFG_AUTO
 max      = ZOOM_LVL_OUT_4X
 cat      = SC_BASIC
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -38,7 +38,6 @@ static bool InvalidateAISettingsWindow(int32 p1);
 static bool RedrawTownAuthority(int32 p1);
 static bool InvalidateCompanyInfrastructureWindow(int32 p1);
 static bool InvalidateCompanyWindow(int32 p1);
-static bool ZoomMinMaxChanged(int32 p1);
 static bool MaxVehiclesChanged(int32 p1);
 static bool InvalidateShipPathCache(int32 p1);
 
@@ -2790,32 +2789,6 @@ str      = STR_CONFIG_SETTING_SOFT_LIMIT
 strhelp  = STR_CONFIG_SETTING_SOFT_LIMIT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SOFT_LIMIT_VALUE
 cat      = SC_EXPERT
-
-[SDTC_VAR]
-var      = gui.zoom_min
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = ZOOM_LVL_MIN
-min      = ZOOM_LVL_MIN
-max      = ZOOM_LVL_OUT_4X
-str      = STR_CONFIG_SETTING_ZOOM_MIN
-strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
-strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
-proc     = ZoomMinMaxChanged
-
-[SDTC_VAR]
-var      = gui.zoom_max
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = ZOOM_LVL_MAX
-min      = ZOOM_LVL_OUT_8X
-max      = ZOOM_LVL_MAX
-str      = STR_CONFIG_SETTING_ZOOM_MAX
-strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
-strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
-proc     = ZoomMinMaxChanged
 
 [SDTC_BOOL]
 var      = gui.population_in_label

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -73,6 +73,7 @@ public:
 
 protected:
 	Dimension GetScreenSize() const override;
+	float GetDPIScale() override;
 
 private:
 	bool PollEvent();

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -294,6 +294,12 @@ Dimension VideoDriver_Cocoa::GetScreenSize() const
 	return { static_cast<uint>(NSWidth(frame)), static_cast<uint>(NSHeight(frame)) };
 }
 
+/** Get DPI scale of our window. */
+float VideoDriver_Cocoa::GetDPIScale()
+{
+	return this->cocoaview != nil ? [ this->cocoaview getContentsScale ] : 1.0f;
+}
+
 /**
  * Are we in fullscreen mode?
  * @return whether fullscreen mode is currently used

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -13,6 +13,7 @@
 #include "../driver.h"
 #include "../core/geometry_type.hpp"
 #include "../core/math_func.hpp"
+#include "../zoom_type.h"
 #include <vector>
 
 extern std::string _ini_videodriver;
@@ -106,6 +107,18 @@ public:
 	virtual void EditBoxGainedFocus() {}
 
 	/**
+	 * Get a suggested default GUI zoom taking screen DPI into account.
+	 */
+	virtual ZoomLevel GetSuggestedUIZoom()
+	{
+		float dpi_scale = this->GetDPIScale();
+
+		if (dpi_scale >= 3.0f) return ZOOM_LVL_NORMAL;
+		if (dpi_scale >= 1.5f) return ZOOM_LVL_OUT_2X;
+		return ZOOM_LVL_OUT_4X;
+	}
+
+	/**
 	 * Get the currently active instance of the video driver.
 	 */
 	static VideoDriver *GetInstance() {
@@ -113,10 +126,16 @@ public:
 	}
 
 protected:
-	/*
+	/**
 	 * Get the resolution of the main screen.
 	 */
 	virtual Dimension GetScreenSize() const { return { DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT }; }
+
+	/**
+	 * Get DPI scaling factor of the screen OTTD is displayed on.
+	 * @return 1.0 for default platform DPI, > 1.0 for higher DPI values, and < 1.0 for smaller DPI values.
+	 */
+	virtual float GetDPIScale() { return 1.0f; }
 
 	/**
 	 * Apply resolution auto-detection and clamp to sensible defaults.

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -43,6 +43,8 @@ public:
 
 protected:
 	Dimension GetScreenSize() const override;
+
+	float GetDPIScale() override;
 };
 
 /** The factory for Windows' video driver. */

--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -15,6 +15,8 @@
 static uint const ZOOM_LVL_SHIFT = 2;
 static uint const ZOOM_LVL_BASE  = 1 << ZOOM_LVL_SHIFT;
 
+static const int8 ZOOM_LVL_CFG_AUTO = -1;
+
 /** All zoom levels we know. */
 enum ZoomLevel : byte {
 	/* Our possible zoom-levels */
@@ -47,6 +49,9 @@ enum ZoomLevel : byte {
 
 };
 DECLARE_POSTFIX_INCREMENT(ZoomLevel)
+
+extern int8 _gui_zoom_cfg;
+extern int8 _font_zoom_cfg;
 
 extern ZoomLevel _gui_zoom;
 extern ZoomLevel _font_zoom;


### PR DESCRIPTION
## Motivation / Problem

On HiDPI screens, the default GUI and font zoom might be too small to read.


## Description

An additional (and default) "auto" value for the zoom settings is added, that will get the current DPI value/scaling from the video driver and choose a zoom value accordingly.

For Win32 and OSX, the set thresholds are 2X zoom at a DPI scale > 150% and 4X zoom at a scale > 300%. Current OSX version will only report 100% or 200% for the scale factor, but the implementation still checks for 300% to allow for future OSX updates.


## Limitations

I've marked this as a draft, as the OSX zoom level suggestion as implemented in this PR right now only makes sense together with #8519. It is it's own commit, so it could easily be stripped off for now.

It is also missing a SDL implementation, at least if HiDPI is a thing with SDL.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~The bug fix is important enough to be backported? (label: 'backport requested')~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
