### PR TITLE
Fix eeb88e8: Trains reversed while paused do not correctly update sprite bounds

### DIFF
--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -470,6 +470,7 @@ void AfterLoadVehicles(bool part_of_load)
 
 		v->UpdateDeltaXY();
 		v->coord.left = INVALID_COORD;
+		v->sprite_cache.old_coord.left = INVALID_COORD;
 		v->UpdatePosition();
 		v->UpdateViewport(false);
 	}

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -646,6 +646,8 @@ static void ShipController(Ship *v)
 		if ((v->tick_counter & 7) == 0) {
 			DirDiff diff = DirDifference(v->direction, v->rotation);
 			v->rotation = ChangeDir(v->rotation, diff > DIRDIFF_REVERSE ? DIRDIFF_45LEFT : DIRDIFF_45RIGHT);
+			/* Invalidate the sprite cache direction to force recalculation of viewport */
+			v->sprite_cache.last_direction = INVALID_DIR;
 			v->UpdateViewport(true, true);
 		}
 		return;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -189,8 +189,7 @@ struct MutableSpriteCache {
 	Direction last_direction;     ///< Last direction we obtained sprites for
 	bool revalidate_before_draw;  ///< We need to do a GetImage() and check bounds before drawing this sprite
 	Rect old_coord;               ///< Co-ordinates from the last valid bounding box
-	int x_variance;               ///< How much the width of the sprite can vary within a single direction
-	int y_variance;               ///< How much the height of the sprite can vary within a single direction
+	bool is_viewport_candidate;   ///< This vehicle can potentially be drawn on a viewport
 	VehicleSpriteSeq sprite_seq;  ///< Vehicle appearance.
 };
 
@@ -772,7 +771,7 @@ public:
 	void UpdateViewport(bool dirty);
 	void UpdateBoundingBoxCoordinates(bool update_cache) const;
 	void UpdatePositionAndViewport();
-	void MarkAllViewportsDirty() const;
+	bool MarkAllViewportsDirty() const;
 
 	inline uint16 GetServiceInterval() const { return this->service_interval; }
 
@@ -1199,7 +1198,7 @@ struct SpecializedVehicle : public Vehicle {
 		 * there won't be enough change in bounding box or offsets to need
 		 * to resolve a new sprite.
 		 */
-		if (this->direction != this->sprite_cache.last_direction) {
+		if (this->direction != this->sprite_cache.last_direction || this->sprite_cache.is_viewport_candidate) {
 			VehicleSpriteSeq seq;
 
 			((T*)this)->T::GetImage(this->direction, EIT_ON_MAP, &seq);

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -189,6 +189,8 @@ struct MutableSpriteCache {
 	Direction last_direction;     ///< Last direction we obtained sprites for
 	bool revalidate_before_draw;  ///< We need to do a GetImage() and check bounds before drawing this sprite
 	Rect old_coord;               ///< Co-ordinates from the last valid bounding box
+	int x_variance;               ///< How much the width of the sprite can vary within a single direction
+	int y_variance;               ///< How much the height of the sprite can vary within a single direction
 	VehicleSpriteSeq sprite_seq;  ///< Vehicle appearance.
 };
 
@@ -251,7 +253,7 @@ public:
 
 	CargoPayment *cargo_payment;        ///< The cargo payment we're currently in
 
-	Rect coord;                         ///< NOSAVE: Graphical bounding box of the vehicle, i.e. what to redraw on moves.
+	mutable Rect coord;                 ///< NOSAVE: Graphical bounding box of the vehicle, i.e. what to redraw on moves.
 
 	Vehicle *hash_viewport_next;        ///< NOSAVE: Next vehicle in the visual location hash.
 	Vehicle **hash_viewport_prev;       ///< NOSAVE: Previous vehicle in the visual location hash.
@@ -768,7 +770,7 @@ public:
 
 	void UpdatePosition();
 	void UpdateViewport(bool dirty);
-	void UpdateBoundingBoxCoordinates(bool update_cache);
+	void UpdateBoundingBoxCoordinates(bool update_cache) const;
 	void UpdatePositionAndViewport();
 	void MarkAllViewportsDirty() const;
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -186,9 +186,10 @@ struct VehicleSpriteSeq {
  * or calculating the viewport.
  */
 struct MutableSpriteCache {
-	Direction last_direction;         ///< Last direction we obtained sprites for
-	bool revalidate_before_draw;      ///< We need to do a GetImage() and check bounds before drawing this sprite
-	VehicleSpriteSeq sprite_seq;      ///< Vehicle appearance.
+	Direction last_direction;     ///< Last direction we obtained sprites for
+	bool revalidate_before_draw;  ///< We need to do a GetImage() and check bounds before drawing this sprite
+	Rect old_coord;               ///< Co-ordinates from the last valid bounding box
+	VehicleSpriteSeq sprite_seq;  ///< Vehicle appearance.
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
@@ -767,7 +768,7 @@ public:
 
 	void UpdatePosition();
 	void UpdateViewport(bool dirty);
-	void UpdateBoundingBoxCoordinates();
+	void UpdateBoundingBoxCoordinates(bool update_cache);
 	void UpdatePositionAndViewport();
 	void MarkAllViewportsDirty() const;
 

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -27,7 +27,7 @@ Point TranslateXYToTileCoord(const Viewport *vp, int x, int y, bool clamp_to_map
 Point GetTileBelowCursor();
 void UpdateViewportPosition(Window *w);
 
-void MarkAllViewportsDirty(int left, int top, int right, int bottom);
+bool MarkAllViewportsDirty(int left, int top, int right, int bottom);
 
 bool DoZoomInOutWindow(ZoomStateChange how, Window *w);
 void ZoomInOrOutToCursorWindow(bool in, Window * w);


### PR DESCRIPTION
## Motivation / Problem

I found a bug in the code for resolving vehicle sprites only on direction change. Initially this was a flicker briefly observed when vehicles reversed at end of line, but I found a reproducible case:

* Create a game using Timberwolf's Trains (or other set with articulated rail vehicles that change sprites in relation to curvature information - while this feels like a vehicle length issue I couldn't reproduce it with sets that only have variable vehicle lengths)
* Build a train with a long vehicle such as a Class 55 or Mk3 carriage.
* Position the train on a length of straight track.
* Pause the game.
* Reverse the train.
* Scroll the display or drag a dialogue box over the train.

All conditions need to be true (game paused, train reversed, display region dirty). It is possible to notice single-frame sprite flickering in some circumstances when a vehicle reverses, but not as consistently reproducible.

The result is this:

![image](https://user-images.githubusercontent.com/13691859/104079297-4084bb80-521a-11eb-98da-417fbac34a14.png)

This is caused because `AdvanceWagonsBeforeSwap()` calls `TrainController()`, which in turn calls `UpdateViewport()` with the new direction. However, the correct configuration and location of sprites will not be known until after `AdvanceWagonsAfterSwap()` has been called, at which point the incorrect sprite information has already been cached.

## Description

My proposed fix is to make `ReverseTrainDirection()` invalidate the sprite cache before it requests a viewport update. This means the sprite is correctly set again once all of the vehicles are in their final direction, position and relative orientation.

An alternative would be to force updating the viewport information in `DoDrawVehicle()` but that felt less clean as it would force updating bounds even for vehicles where this is not necessary.

There are additional `GetImage()` calls introduced by this change. It is expected the number of vehicles reversing is negligible compared to the number that are transitioning through turn states in a typical game.

## Limitations

* This fixes a single situation. I don't think there are any others that I've observed from playing games in nightly builds, although the player base for Nightly+Timberwolf's Trains is small.
* There may be a better or more holistic solution available, this seeks to patch the observed bug without too much effect elsewhere.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
