### PR TITLE
Revert 78f92130: "Fix #8506: Towns shouldn't add junctions to NewGRF roads they cannot build"

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1349,9 +1349,6 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 
 	assert(tile < MapSize());
 
-	/* Don't allow junctions on roadtypes which can't be built by towns. */
-	if (IsTileType(tile, MP_ROAD) && !HasBit(GetRoadTypeInfo(GetRoadTypeRoad(tile))->flags, ROTF_TOWN_BUILD)) return;
-
 	if (cur_rb == ROAD_NONE) {
 		/* Tile has no road. First reset the status counter
 		 * to say that this is the last iteration. */


### PR DESCRIPTION
Reverts OpenTTD/OpenTTD#8535

As per https://github.com/OpenTTD/OpenTTD/pull/8535#issuecomment-757122918, jumped the gun here.