### PR TITLE
Change: darken the background of all graph to increase contrast

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -593,7 +593,7 @@ public:
 		for (CompanyID k = COMPANY_FIRST; k < MAX_COMPANIES; k++) {
 			const Company *c = Company::GetIfValid(k);
 			if (c != nullptr) {
-				this->colours[numd] = _colour_gradient[c->colour][6];
+				this->colours[numd] = _colour_gradient[c->colour][4];
 				for (int j = this->num_on_x_axis, i = 0; --j >= 0;) {
 					this->cost[numd][i] = (j >= c->num_valid_stat_ent) ? INVALID_DATAPOINT : GetGraphData(c, j);
 					i++;


### PR DESCRIPTION
Fixes #8539.

## Motivation / Problem

Some company graph colours are very hard to read, making you want to change your company colour.

See #8539 for a detailed explanation.


## Description

For the current choice, colours like Mauve, Dark Green and Purple
are nearly invisible in the graphs. Using a darker background
resolves that issue.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
