### PR TITLE
Add: [Script] ScriptCargo::GetName, to get the human readable name of a cargo

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -332,7 +332,8 @@ function Regression::Cargo()
 	for (local i = -1; i < 15; i++) {
 		print("  Cargo " + i);
 		print("    IsValidCargo():          " + AICargo.IsValidCargo(i));
-		print("    GetCargoLabel():         '" + AICargo.GetCargoLabel(i)+ "'");
+		print("    GetName():               '" + AICargo.GetName(i) + "'");
+		print("    GetCargoLabel():         '" + AICargo.GetCargoLabel(i) + "'");
 		print("    IsFreight():             " + AICargo.IsFreight(i));
 		print("    HasCargoClass():         " + AICargo.HasCargoClass(i, AICargo.CC_PASSENGERS));
 		print("    GetTownEffect():         " + AICargo.GetTownEffect(i));

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1109,6 +1109,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
 --AICargo--
   Cargo -1
     IsValidCargo():          false
+    GetName():               '(null : 0x00000000)'
     GetCargoLabel():         '(null : 0x00000000)'
     IsFreight():             false
     HasCargoClass():         false
@@ -1120,6 +1121,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 0
     IsValidCargo():          true
+    GetName():               'Passengers'
     GetCargoLabel():         'PASS'
     IsFreight():             false
     HasCargoClass():         true
@@ -1131,6 +1133,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 0
   Cargo 1
     IsValidCargo():          true
+    GetName():               'Coal'
     GetCargoLabel():         'COAL'
     IsFreight():             true
     HasCargoClass():         false
@@ -1142,6 +1145,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 2
     IsValidCargo():          true
+    GetName():               'Mail'
     GetCargoLabel():         'MAIL'
     IsFreight():             false
     HasCargoClass():         false
@@ -1153,6 +1157,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 3
     IsValidCargo():          true
+    GetName():               'Oil'
     GetCargoLabel():         'OIL_'
     IsFreight():             true
     HasCargoClass():         false
@@ -1164,6 +1169,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 4
     IsValidCargo():          true
+    GetName():               'Livestock'
     GetCargoLabel():         'LVST'
     IsFreight():             true
     HasCargoClass():         false
@@ -1175,6 +1181,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 5
     IsValidCargo():          true
+    GetName():               'Goods'
     GetCargoLabel():         'GOOD'
     IsFreight():             true
     HasCargoClass():         false
@@ -1186,6 +1193,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 6
     IsValidCargo():          true
+    GetName():               'Grain'
     GetCargoLabel():         'GRAI'
     IsFreight():             true
     HasCargoClass():         false
@@ -1197,6 +1205,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 7
     IsValidCargo():          true
+    GetName():               'Wood'
     GetCargoLabel():         'WOOD'
     IsFreight():             true
     HasCargoClass():         false
@@ -1208,6 +1217,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 8
     IsValidCargo():          true
+    GetName():               'Iron Ore'
     GetCargoLabel():         'IORE'
     IsFreight():             true
     HasCargoClass():         false
@@ -1219,6 +1229,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 9
     IsValidCargo():          true
+    GetName():               'Steel'
     GetCargoLabel():         'STEL'
     IsFreight():             true
     HasCargoClass():         false
@@ -1230,6 +1241,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 10
     IsValidCargo():          true
+    GetName():               'Valuables'
     GetCargoLabel():         'VALU'
     IsFreight():             true
     HasCargoClass():         false
@@ -1241,6 +1253,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 11
     IsValidCargo():          false
+    GetName():               '(null : 0x00000000)'
     GetCargoLabel():         '(null : 0x00000000)'
     IsFreight():             false
     HasCargoClass():         false
@@ -1252,6 +1265,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 12
     IsValidCargo():          false
+    GetName():               '(null : 0x00000000)'
     GetCargoLabel():         '(null : 0x00000000)'
     IsFreight():             false
     HasCargoClass():         false
@@ -1263,6 +1277,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 13
     IsValidCargo():          false
+    GetName():               '(null : 0x00000000)'
     GetCargoLabel():         '(null : 0x00000000)'
     IsFreight():             false
     HasCargoClass():         false
@@ -1274,6 +1289,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetRoadVehicleTypeForCargo(): 1
   Cargo 14
     IsValidCargo():          false
+    GetName():               '(null : 0x00000000)'
     GetCargoLabel():         '(null : 0x00000000)'
     IsFreight():             false
     HasCargoClass():         false

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -18,6 +18,7 @@
  * This version is not yet released. The following changes are not set in stone yet.
  *
  * API additions:
+ * \li AICargo::GetName
  * \li AIPriorityQueue
  *
  * \b 1.10.0

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -18,6 +18,7 @@
  * This version is not yet released. The following changes are not set in stone yet.
  *
  * API additions:
+ * \li GSCargo::GetName
  * \li GSEventStoryPageButtonClick
  * \li GSEventStoryPageTileSelect
  * \li GSEventStoryPageVehicleSelect

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -11,7 +11,9 @@
 #include "script_cargo.hpp"
 #include "../../economy_func.h"
 #include "../../core/bitmath_func.hpp"
+#include "../../strings_func.h"
 #include "../../settings_type.h"
+#include "table/strings.h"
 
 #include "../../safeguards.h"
 
@@ -23,6 +25,14 @@
 /* static */ bool ScriptCargo::IsValidTownEffect(TownEffect towneffect_type)
 {
 	return (towneffect_type >= (TownEffect)TE_BEGIN && towneffect_type < (TownEffect)TE_END);
+}
+
+/* static */ char *ScriptCargo::GetName(CargoID cargo_type)
+{
+	if (!IsValidCargo(cargo_type)) return nullptr;
+
+	::SetDParam(0, 1 << cargo_type);
+	return GetString(STR_JUST_CARGO_LIST);
 }
 
 /* static */ char *ScriptCargo::GetCargoLabel(CargoID cargo_type)

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -85,6 +85,14 @@ public:
 	static bool IsValidTownEffect(TownEffect towneffect_type);
 
 	/**
+	 * Get the name of the cargo type.
+	 * @param cargo_type The cargo type to get the name of.
+	 * @pre IsValidCargo(cargo_type).
+	 * @return The name of the cargo type.
+	 */
+	static char *GetName(CargoID cargo_type);
+
+	/**
 	 * Gets the string representation of the cargo label.
 	 * @param cargo_type The cargo to get the string representation of.
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).


### PR DESCRIPTION
Fixes #7869.

## Motivation / Problem

Most other things have a `GetName()`, like Industries, even Roads. Cargo did not have it yet.

`GetName()` of course uses local language for the translation, this means that, like with all the other `GetName()` it should not be used to present strings to players. But it is very useful for debugging etc, and more consistent overall in the API.

## Description

Of course this translates into AICargo.GetName() for AIs and
GSCargo.GetName() for GameScripts.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating. ** Done **
    * The compatibility wrappers (compat_*.nut) need updating. ** Not needed, new addition **
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
    * ~~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~~
