### PR TITLE
Doc: provide a visual representation of the company colour ranges

### DIFF
--- a/docs/company_colour_indexes.html
+++ b/docs/company_colour_indexes.html
@@ -1,0 +1,2159 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+    <title >OpenTTD Company Colour Indexes</title>
+</head>
+
+<!-- derived from Iron Horse branch at https://github.com/andythenorth/iron-horse/tree/company_colour_indexes -->
+
+<body>
+    <h1>Company Colour Indexes</h1>
+    <p>Hex / dec indexes into the DOS palette</p>
+    <p>
+        Visual representation of values derived from <a href="https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186">https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186</a>
+    </p>
+    <table style="margin-top:30px;">
+        <tbody>
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_DARK_BLUE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(8, 24, 88);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(12, 36, 104);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(20, 52, 124);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(28, 68, 140);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(40, 92, 164);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(56, 120, 188);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(72, 152, 216);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(100, 172, 224);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0xc6</td>
+
+                    <td style="text-align:right;">0xc7</td>
+
+                    <td style="text-align:right;">0xc8</td>
+
+                    <td style="text-align:right;">0xc9</td>
+
+                    <td style="text-align:right;">0xca</td>
+
+                    <td style="text-align:right;">0xcb</td>
+
+                    <td style="text-align:right;">0xcc</td>
+
+                    <td style="text-align:right;">0xcd</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">198</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">199</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">200</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">201</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">202</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">203</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">204</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">205</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_PALE_GREEN
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(16, 52, 24);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(32, 72, 44);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(56, 96, 72);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(76, 116, 88);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(96, 136, 108);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(120, 164, 136);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(152, 192, 168);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 220, 200);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x60</td>
+
+                    <td style="text-align:right;">0x61</td>
+
+                    <td style="text-align:right;">0x62</td>
+
+                    <td style="text-align:right;">0x63</td>
+
+                    <td style="text-align:right;">0x64</td>
+
+                    <td style="text-align:right;">0x65</td>
+
+                    <td style="text-align:right;">0x66</td>
+
+                    <td style="text-align:right;">0x67</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">96</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">97</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">98</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">99</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">100</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">101</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">102</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">103</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_PINK
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(112, 16, 32);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(136, 32, 52);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(160, 56, 76);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(188, 84, 108);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(204, 104, 124);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(220, 132, 144);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(236, 156, 164);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 188, 192);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x2a</td>
+
+                    <td style="text-align:right;">0x2b</td>
+
+                    <td style="text-align:right;">0x2c</td>
+
+                    <td style="text-align:right;">0x2d</td>
+
+                    <td style="text-align:right;">0x2e</td>
+
+                    <td style="text-align:right;">0x2f</td>
+
+                    <td style="text-align:right;">0x30</td>
+
+                    <td style="text-align:right;">0x31</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">42</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">43</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">44</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">45</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">46</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">47</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">48</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">49</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_YELLOW
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(128, 68, 8);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(156, 96, 16);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 120, 24);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(212, 156, 32);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(232, 184, 16);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 212, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 248, 128);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 252, 192);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x3e</td>
+
+                    <td style="text-align:right;">0x3f</td>
+
+                    <td style="text-align:right;">0x40</td>
+
+                    <td style="text-align:right;">0x41</td>
+
+                    <td style="text-align:right;">0x42</td>
+
+                    <td style="text-align:right;">0x43</td>
+
+                    <td style="text-align:right;">0x44</td>
+
+                    <td style="text-align:right;">0x45</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">62</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">63</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">64</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">65</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">66</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">67</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">68</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">69</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_RED
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(92, 0, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(128, 0, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(160, 0, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(196, 0, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(224, 0, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 52, 52);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 100, 88);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 144, 124);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0xb3</td>
+
+                    <td style="text-align:right;">0xb4</td>
+
+                    <td style="text-align:right;">0xb5</td>
+
+                    <td style="text-align:right;">0xb6</td>
+
+                    <td style="text-align:right;">0xb7</td>
+
+                    <td style="text-align:right;">0xa4</td>
+
+                    <td style="text-align:right;">0xa5</td>
+
+                    <td style="text-align:right;">0xa6</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">179</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">180</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">181</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">182</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">183</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">164</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">165</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">166</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_LIGHT_BLUE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(16, 64, 96);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(24, 80, 108);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(40, 96, 120);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(52, 112, 132);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(80, 140, 160);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(116, 172, 192);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(156, 204, 220);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(204, 240, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x9a</td>
+
+                    <td style="text-align:right;">0x9b</td>
+
+                    <td style="text-align:right;">0x9c</td>
+
+                    <td style="text-align:right;">0x9d</td>
+
+                    <td style="text-align:right;">0x9e</td>
+
+                    <td style="text-align:right;">0x9f</td>
+
+                    <td style="text-align:right;">0xa0</td>
+
+                    <td style="text-align:right;">0xa1</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">154</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">155</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">156</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">157</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">158</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">159</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">160</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">161</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_GREEN
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(32, 80, 4);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(48, 96, 4);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(64, 112, 12);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(84, 132, 20);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(92, 156, 52);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(108, 176, 64);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(124, 200, 76);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(144, 224, 92);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x52</td>
+
+                    <td style="text-align:right;">0x53</td>
+
+                    <td style="text-align:right;">0x54</td>
+
+                    <td style="text-align:right;">0x55</td>
+
+                    <td style="text-align:right;">0xce</td>
+
+                    <td style="text-align:right;">0xcf</td>
+
+                    <td style="text-align:right;">0xd0</td>
+
+                    <td style="text-align:right;">0xd1</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">82</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">83</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">84</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">85</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">206</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">207</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">208</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">209</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_DARK_GREEN
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(28, 52, 24);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(44, 68, 32);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(60, 88, 48);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(80, 104, 60);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(104, 124, 76);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(128, 148, 92);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(152, 176, 108);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(180, 204, 124);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x58</td>
+
+                    <td style="text-align:right;">0x59</td>
+
+                    <td style="text-align:right;">0x5a</td>
+
+                    <td style="text-align:right;">0x5b</td>
+
+                    <td style="text-align:right;">0x5c</td>
+
+                    <td style="text-align:right;">0x5d</td>
+
+                    <td style="text-align:right;">0x5e</td>
+
+                    <td style="text-align:right;">0x5f</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">88</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">89</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">90</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">91</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">92</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">93</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">94</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">95</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_BLUE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(0, 52, 160);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(0, 72, 184);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(0, 96, 212);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(24, 120, 220);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(56, 144, 232);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(88, 168, 240);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(128, 196, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(188, 224, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x92</td>
+
+                    <td style="text-align:right;">0x93</td>
+
+                    <td style="text-align:right;">0x94</td>
+
+                    <td style="text-align:right;">0x95</td>
+
+                    <td style="text-align:right;">0x96</td>
+
+                    <td style="text-align:right;">0x97</td>
+
+                    <td style="text-align:right;">0x98</td>
+
+                    <td style="text-align:right;">0x99</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">146</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">147</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">148</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">149</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">150</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">151</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">152</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">153</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_CREAM
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(116, 68, 40);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(136, 84, 56);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(164, 96, 64);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 112, 80);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(204, 128, 96);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(212, 148, 112);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(224, 168, 128);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(236, 188, 148);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x72</td>
+
+                    <td style="text-align:right;">0x73</td>
+
+                    <td style="text-align:right;">0x74</td>
+
+                    <td style="text-align:right;">0x75</td>
+
+                    <td style="text-align:right;">0x76</td>
+
+                    <td style="text-align:right;">0x77</td>
+
+                    <td style="text-align:right;">0x78</td>
+
+                    <td style="text-align:right;">0x79</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">114</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">115</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">116</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">117</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">118</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">119</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">120</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">121</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_MAUVE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(36, 40, 68);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(48, 52, 84);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(64, 64, 100);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(80, 80, 116);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(100, 100, 136);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(132, 132, 164);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(172, 172, 192);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(212, 212, 224);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x80</td>
+
+                    <td style="text-align:right;">0x81</td>
+
+                    <td style="text-align:right;">0x82</td>
+
+                    <td style="text-align:right;">0x83</td>
+
+                    <td style="text-align:right;">0x84</td>
+
+                    <td style="text-align:right;">0x85</td>
+
+                    <td style="text-align:right;">0x86</td>
+
+                    <td style="text-align:right;">0x87</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">128</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">129</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">130</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">131</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">132</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">133</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">134</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">135</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_PURPLE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(40, 20, 112);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(64, 44, 144);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(88, 64, 172);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(104, 76, 196);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(120, 88, 224);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(140, 104, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(160, 136, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(188, 168, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x88</td>
+
+                    <td style="text-align:right;">0x89</td>
+
+                    <td style="text-align:right;">0x8a</td>
+
+                    <td style="text-align:right;">0x8b</td>
+
+                    <td style="text-align:right;">0x8c</td>
+
+                    <td style="text-align:right;">0x8d</td>
+
+                    <td style="text-align:right;">0x8e</td>
+
+                    <td style="text-align:right;">0x8f</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">136</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">137</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">138</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">139</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">140</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">141</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">142</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">143</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_ORANGE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 120, 24);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(204, 136, 8);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(228, 144, 4);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 156, 0);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 176, 48);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 196, 100);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 216, 152);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(244, 220, 176);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x40</td>
+
+                    <td style="text-align:right;">0xc0</td>
+
+                    <td style="text-align:right;">0xc1</td>
+
+                    <td style="text-align:right;">0xc2</td>
+
+                    <td style="text-align:right;">0xc3</td>
+
+                    <td style="text-align:right;">0xc4</td>
+
+                    <td style="text-align:right;">0xc5</td>
+
+                    <td style="text-align:right;">0x27</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">64</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">192</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">193</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">194</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">195</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">196</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">197</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">39</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_BROWN
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(72, 44, 4);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(88, 60, 20);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(104, 80, 44);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(124, 104, 72);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(152, 132, 92);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 160, 120);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(212, 188, 148);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(244, 220, 176);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x20</td>
+
+                    <td style="text-align:right;">0x21</td>
+
+                    <td style="text-align:right;">0x22</td>
+
+                    <td style="text-align:right;">0x23</td>
+
+                    <td style="text-align:right;">0x24</td>
+
+                    <td style="text-align:right;">0x25</td>
+
+                    <td style="text-align:right;">0x26</td>
+
+                    <td style="text-align:right;">0x27</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">32</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">33</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">34</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">35</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">36</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">37</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">38</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">39</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_GREY
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(64, 64, 64);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(80, 80, 80);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(100, 100, 100);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(116, 116, 116);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(132, 132, 132);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(148, 148, 148);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(168, 168, 168);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 184, 184);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x4</td>
+
+                    <td style="text-align:right;">0x5</td>
+
+                    <td style="text-align:right;">0x6</td>
+
+                    <td style="text-align:right;">0x7</td>
+
+                    <td style="text-align:right;">0x8</td>
+
+                    <td style="text-align:right;">0x9</td>
+
+                    <td style="text-align:right;">0xa</td>
+
+                    <td style="text-align:right;">0xb</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">4</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">5</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">6</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">7</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">8</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">9</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">10</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">11</td>
+
+            </tr>
+
+            <tr>
+                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
+                    COLOUR_WHITE
+                </th>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(132, 132, 132);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(148, 148, 148);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(168, 168, 168);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(184, 184, 184);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(200, 200, 200);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(216, 216, 216);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(232, 232, 232);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+                    <td style="padding-top:20px;">
+                        <span style="background-color:rgb(252, 252, 252);
+                                     border:solid 1px #000;
+                                     width:32px;
+                                     height:32px;
+                                     display:inline-block;
+                                     vertical-align:top;
+                                     margin-left:0px;">
+                        </span>
+                    </td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right;">0x8</td>
+
+                    <td style="text-align:right;">0x9</td>
+
+                    <td style="text-align:right;">0xa</td>
+
+                    <td style="text-align:right;">0xb</td>
+
+                    <td style="text-align:right;">0xc</td>
+
+                    <td style="text-align:right;">0xd</td>
+
+                    <td style="text-align:right;">0xe</td>
+
+                    <td style="text-align:right;">0xf</td>
+
+            </tr>
+            <tr>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">8</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">9</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">10</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">11</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">12</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">13</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">14</td>
+
+                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">15</td>
+
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/company_colour_indexes.html
+++ b/docs/company_colour_indexes.html
@@ -1,2159 +1,557 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-<head>
-    <title >OpenTTD Company Colour Indexes</title>
-</head>
-
 <!-- derived from Iron Horse branch at https://github.com/andythenorth/iron-horse/tree/company_colour_indexes -->
-
+<head>
+	<title>OpenTTD Company Colour Indexes</title>
+	<meta charset="UTF-8" />
+<style>
+th { 
+	vertical-align: top; 
+	border-bottom:  solid 1px #ddd; 
+	padding-top:    30px; 
+	padding-right:  15px; 
+	text-align:     right;
+}
+tr.top td {
+	padding-top:    20px;
+}
+tr.bottom td {
+	border-bottom:  solid 1px #ddd; 
+	padding-bottom: 10px;
+}
+td {
+	text-align:     right;
+}
+span {
+	border:         solid 1px #000;
+	width:          32px;
+	height:         32px;
+	display:        inline-block;
+	vertical-align: top;
+	margin-left:    0px;
+}
+</style>
+</head>
 <body>
-    <h1>Company Colour Indexes</h1>
-    <p>Hex / dec indexes into the DOS palette</p>
-    <p>
-        Visual representation of values derived from <a href="https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186">https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186</a>
-    </p>
-    <table style="margin-top:30px;">
-        <tbody>
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_DARK_BLUE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(8, 24, 88);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(12, 36, 104);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(20, 52, 124);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(28, 68, 140);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(40, 92, 164);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(56, 120, 188);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(72, 152, 216);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(100, 172, 224);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0xc6</td>
-
-                    <td style="text-align:right;">0xc7</td>
-
-                    <td style="text-align:right;">0xc8</td>
-
-                    <td style="text-align:right;">0xc9</td>
-
-                    <td style="text-align:right;">0xca</td>
-
-                    <td style="text-align:right;">0xcb</td>
-
-                    <td style="text-align:right;">0xcc</td>
-
-                    <td style="text-align:right;">0xcd</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">198</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">199</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">200</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">201</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">202</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">203</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">204</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">205</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_PALE_GREEN
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(16, 52, 24);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(32, 72, 44);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(56, 96, 72);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(76, 116, 88);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(96, 136, 108);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(120, 164, 136);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(152, 192, 168);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 220, 200);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x60</td>
-
-                    <td style="text-align:right;">0x61</td>
-
-                    <td style="text-align:right;">0x62</td>
-
-                    <td style="text-align:right;">0x63</td>
-
-                    <td style="text-align:right;">0x64</td>
-
-                    <td style="text-align:right;">0x65</td>
-
-                    <td style="text-align:right;">0x66</td>
-
-                    <td style="text-align:right;">0x67</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">96</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">97</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">98</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">99</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">100</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">101</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">102</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">103</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_PINK
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(112, 16, 32);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(136, 32, 52);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(160, 56, 76);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(188, 84, 108);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(204, 104, 124);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(220, 132, 144);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(236, 156, 164);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 188, 192);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x2a</td>
-
-                    <td style="text-align:right;">0x2b</td>
-
-                    <td style="text-align:right;">0x2c</td>
-
-                    <td style="text-align:right;">0x2d</td>
-
-                    <td style="text-align:right;">0x2e</td>
-
-                    <td style="text-align:right;">0x2f</td>
-
-                    <td style="text-align:right;">0x30</td>
-
-                    <td style="text-align:right;">0x31</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">42</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">43</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">44</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">45</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">46</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">47</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">48</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">49</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_YELLOW
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(128, 68, 8);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(156, 96, 16);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 120, 24);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(212, 156, 32);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(232, 184, 16);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 212, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 248, 128);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 252, 192);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x3e</td>
-
-                    <td style="text-align:right;">0x3f</td>
-
-                    <td style="text-align:right;">0x40</td>
-
-                    <td style="text-align:right;">0x41</td>
-
-                    <td style="text-align:right;">0x42</td>
-
-                    <td style="text-align:right;">0x43</td>
-
-                    <td style="text-align:right;">0x44</td>
-
-                    <td style="text-align:right;">0x45</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">62</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">63</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">64</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">65</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">66</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">67</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">68</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">69</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_RED
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(92, 0, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(128, 0, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(160, 0, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(196, 0, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(224, 0, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 52, 52);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 100, 88);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 144, 124);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0xb3</td>
-
-                    <td style="text-align:right;">0xb4</td>
-
-                    <td style="text-align:right;">0xb5</td>
-
-                    <td style="text-align:right;">0xb6</td>
-
-                    <td style="text-align:right;">0xb7</td>
-
-                    <td style="text-align:right;">0xa4</td>
-
-                    <td style="text-align:right;">0xa5</td>
-
-                    <td style="text-align:right;">0xa6</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">179</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">180</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">181</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">182</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">183</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">164</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">165</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">166</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_LIGHT_BLUE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(16, 64, 96);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(24, 80, 108);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(40, 96, 120);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(52, 112, 132);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(80, 140, 160);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(116, 172, 192);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(156, 204, 220);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(204, 240, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x9a</td>
-
-                    <td style="text-align:right;">0x9b</td>
-
-                    <td style="text-align:right;">0x9c</td>
-
-                    <td style="text-align:right;">0x9d</td>
-
-                    <td style="text-align:right;">0x9e</td>
-
-                    <td style="text-align:right;">0x9f</td>
-
-                    <td style="text-align:right;">0xa0</td>
-
-                    <td style="text-align:right;">0xa1</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">154</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">155</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">156</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">157</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">158</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">159</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">160</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">161</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_GREEN
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(32, 80, 4);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(48, 96, 4);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(64, 112, 12);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(84, 132, 20);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(92, 156, 52);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(108, 176, 64);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(124, 200, 76);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(144, 224, 92);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x52</td>
-
-                    <td style="text-align:right;">0x53</td>
-
-                    <td style="text-align:right;">0x54</td>
-
-                    <td style="text-align:right;">0x55</td>
-
-                    <td style="text-align:right;">0xce</td>
-
-                    <td style="text-align:right;">0xcf</td>
-
-                    <td style="text-align:right;">0xd0</td>
-
-                    <td style="text-align:right;">0xd1</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">82</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">83</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">84</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">85</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">206</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">207</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">208</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">209</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_DARK_GREEN
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(28, 52, 24);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(44, 68, 32);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(60, 88, 48);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(80, 104, 60);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(104, 124, 76);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(128, 148, 92);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(152, 176, 108);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(180, 204, 124);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x58</td>
-
-                    <td style="text-align:right;">0x59</td>
-
-                    <td style="text-align:right;">0x5a</td>
-
-                    <td style="text-align:right;">0x5b</td>
-
-                    <td style="text-align:right;">0x5c</td>
-
-                    <td style="text-align:right;">0x5d</td>
-
-                    <td style="text-align:right;">0x5e</td>
-
-                    <td style="text-align:right;">0x5f</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">88</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">89</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">90</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">91</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">92</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">93</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">94</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">95</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_BLUE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(0, 52, 160);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(0, 72, 184);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(0, 96, 212);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(24, 120, 220);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(56, 144, 232);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(88, 168, 240);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(128, 196, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(188, 224, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x92</td>
-
-                    <td style="text-align:right;">0x93</td>
-
-                    <td style="text-align:right;">0x94</td>
-
-                    <td style="text-align:right;">0x95</td>
-
-                    <td style="text-align:right;">0x96</td>
-
-                    <td style="text-align:right;">0x97</td>
-
-                    <td style="text-align:right;">0x98</td>
-
-                    <td style="text-align:right;">0x99</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">146</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">147</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">148</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">149</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">150</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">151</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">152</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">153</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_CREAM
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(116, 68, 40);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(136, 84, 56);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(164, 96, 64);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 112, 80);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(204, 128, 96);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(212, 148, 112);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(224, 168, 128);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(236, 188, 148);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x72</td>
-
-                    <td style="text-align:right;">0x73</td>
-
-                    <td style="text-align:right;">0x74</td>
-
-                    <td style="text-align:right;">0x75</td>
-
-                    <td style="text-align:right;">0x76</td>
-
-                    <td style="text-align:right;">0x77</td>
-
-                    <td style="text-align:right;">0x78</td>
-
-                    <td style="text-align:right;">0x79</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">114</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">115</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">116</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">117</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">118</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">119</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">120</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">121</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_MAUVE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(36, 40, 68);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(48, 52, 84);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(64, 64, 100);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(80, 80, 116);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(100, 100, 136);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(132, 132, 164);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(172, 172, 192);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(212, 212, 224);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x80</td>
-
-                    <td style="text-align:right;">0x81</td>
-
-                    <td style="text-align:right;">0x82</td>
-
-                    <td style="text-align:right;">0x83</td>
-
-                    <td style="text-align:right;">0x84</td>
-
-                    <td style="text-align:right;">0x85</td>
-
-                    <td style="text-align:right;">0x86</td>
-
-                    <td style="text-align:right;">0x87</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">128</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">129</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">130</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">131</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">132</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">133</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">134</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">135</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_PURPLE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(40, 20, 112);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(64, 44, 144);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(88, 64, 172);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(104, 76, 196);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(120, 88, 224);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(140, 104, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(160, 136, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(188, 168, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x88</td>
-
-                    <td style="text-align:right;">0x89</td>
-
-                    <td style="text-align:right;">0x8a</td>
-
-                    <td style="text-align:right;">0x8b</td>
-
-                    <td style="text-align:right;">0x8c</td>
-
-                    <td style="text-align:right;">0x8d</td>
-
-                    <td style="text-align:right;">0x8e</td>
-
-                    <td style="text-align:right;">0x8f</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">136</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">137</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">138</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">139</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">140</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">141</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">142</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">143</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_ORANGE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 120, 24);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(204, 136, 8);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(228, 144, 4);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 156, 0);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 176, 48);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 196, 100);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 216, 152);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(244, 220, 176);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x40</td>
-
-                    <td style="text-align:right;">0xc0</td>
-
-                    <td style="text-align:right;">0xc1</td>
-
-                    <td style="text-align:right;">0xc2</td>
-
-                    <td style="text-align:right;">0xc3</td>
-
-                    <td style="text-align:right;">0xc4</td>
-
-                    <td style="text-align:right;">0xc5</td>
-
-                    <td style="text-align:right;">0x27</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">64</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">192</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">193</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">194</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">195</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">196</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">197</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">39</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_BROWN
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(72, 44, 4);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(88, 60, 20);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(104, 80, 44);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(124, 104, 72);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(152, 132, 92);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 160, 120);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(212, 188, 148);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(244, 220, 176);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x20</td>
-
-                    <td style="text-align:right;">0x21</td>
-
-                    <td style="text-align:right;">0x22</td>
-
-                    <td style="text-align:right;">0x23</td>
-
-                    <td style="text-align:right;">0x24</td>
-
-                    <td style="text-align:right;">0x25</td>
-
-                    <td style="text-align:right;">0x26</td>
-
-                    <td style="text-align:right;">0x27</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">32</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">33</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">34</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">35</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">36</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">37</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">38</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">39</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_GREY
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(64, 64, 64);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(80, 80, 80);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(100, 100, 100);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(116, 116, 116);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(132, 132, 132);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(148, 148, 148);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(168, 168, 168);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 184, 184);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x4</td>
-
-                    <td style="text-align:right;">0x5</td>
-
-                    <td style="text-align:right;">0x6</td>
-
-                    <td style="text-align:right;">0x7</td>
-
-                    <td style="text-align:right;">0x8</td>
-
-                    <td style="text-align:right;">0x9</td>
-
-                    <td style="text-align:right;">0xa</td>
-
-                    <td style="text-align:right;">0xb</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">4</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">5</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">6</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">7</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">8</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">9</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">10</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">11</td>
-
-            </tr>
-
-            <tr>
-                <th rowspan="3" style="vertical-align:top; border-bottom:solid 1px #ddd; padding-top:30px; padding-right:15px; text-align:right;">
-                    COLOUR_WHITE
-                </th>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(132, 132, 132);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(148, 148, 148);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(168, 168, 168);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(184, 184, 184);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(200, 200, 200);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(216, 216, 216);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(232, 232, 232);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-                    <td style="padding-top:20px;">
-                        <span style="background-color:rgb(252, 252, 252);
-                                     border:solid 1px #000;
-                                     width:32px;
-                                     height:32px;
-                                     display:inline-block;
-                                     vertical-align:top;
-                                     margin-left:0px;">
-                        </span>
-                    </td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right;">0x8</td>
-
-                    <td style="text-align:right;">0x9</td>
-
-                    <td style="text-align:right;">0xa</td>
-
-                    <td style="text-align:right;">0xb</td>
-
-                    <td style="text-align:right;">0xc</td>
-
-                    <td style="text-align:right;">0xd</td>
-
-                    <td style="text-align:right;">0xe</td>
-
-                    <td style="text-align:right;">0xf</td>
-
-            </tr>
-            <tr>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">8</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">9</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">10</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">11</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">12</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">13</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">14</td>
-
-                    <td style="text-align:right; border-bottom:solid 1px #ddd; padding-bottom:10px;">15</td>
-
-            </tr>
-        </tbody>
-    </table>
+	<h1>Company Colour Indexes</h1>
+	<p>Hex / dec indexes into the DOS palette</p>
+	<p>
+		Visual representation of values derived from <a href="https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186">https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186</a>
+	</p>
+	<table style="margin-top:30px;">
+		<tbody>
+			<tr class="top">
+				<th rowspan="3">COLOUR_DARK_BLUE</th>
+				<td><span style="background-color:rgb(  8,  24,  88)"></span></td>
+				<td><span style="background-color:rgb( 12,  36, 104)"></span></td>
+				<td><span style="background-color:rgb( 20,  52, 124)"></span></td>
+				<td><span style="background-color:rgb( 28,  68, 140)"></span></td>
+				<td><span style="background-color:rgb( 40,  92, 164)"></span></td>
+				<td><span style="background-color:rgb( 56, 120, 188)"></span></td>
+				<td><span style="background-color:rgb( 72, 152, 216)"></span></td>
+				<td><span style="background-color:rgb(100, 172, 224)"></span></td>
+			</tr>
+			<tr>
+				<td>0xc6</td>
+				<td>0xc7</td>
+				<td>0xc8</td>
+				<td>0xc9</td>
+				<td>0xca</td>
+				<td>0xcb</td>
+				<td>0xcc</td>
+				<td>0xcd</td>
+			</tr>
+			<tr class="bottom">
+				<td>198</td>
+				<td>199</td>
+				<td>200</td>
+				<td>201</td>
+				<td>202</td>
+				<td>203</td>
+				<td>204</td>
+				<td>205</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_PALE_GREEN</th>
+				<td><span style="background-color:rgb( 16,  52,  24)"></span></td>
+				<td><span style="background-color:rgb( 32,  72,  44)"></span></td>
+				<td><span style="background-color:rgb( 56,  96,  72)"></span></td>
+				<td><span style="background-color:rgb( 76, 116,  88)"></span></td>
+				<td><span style="background-color:rgb( 96, 136, 108)"></span></td>
+				<td><span style="background-color:rgb(120, 164, 136)"></span></td>
+				<td><span style="background-color:rgb(152, 192, 168)"></span></td>
+				<td><span style="background-color:rgb(184, 220, 200)"></span></td>
+			</tr>
+			<tr>
+				<td>0x60</td>
+				<td>0x61</td>
+				<td>0x62</td>
+				<td>0x63</td>
+				<td>0x64</td>
+				<td>0x65</td>
+				<td>0x66</td>
+				<td>0x67</td>
+			</tr>
+			<tr class="bottom">
+				<td>96</td>
+				<td>97</td>
+				<td>98</td>
+				<td>99</td>
+				<td>100</td>
+				<td>101</td>
+				<td>102</td>
+				<td>103</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_PINK</th>
+				<td><span style="background-color:rgb(112,  16,  32)"></span></td>
+				<td><span style="background-color:rgb(136,  32,  52)"></span></td>
+				<td><span style="background-color:rgb(160,  56,  76)"></span></td>
+				<td><span style="background-color:rgb(188,  84, 108)"></span></td>
+				<td><span style="background-color:rgb(204, 104, 124)"></span></td>
+				<td><span style="background-color:rgb(220, 132, 144)"></span></td>
+				<td><span style="background-color:rgb(236, 156, 164)"></span></td>
+				<td><span style="background-color:rgb(252, 188, 192)"></span></td>
+			</tr>
+			<tr>
+				<td>0x2a</td>
+				<td>0x2b</td>
+				<td>0x2c</td>
+				<td>0x2d</td>
+				<td>0x2e</td>
+				<td>0x2f</td>
+				<td>0x30</td>
+				<td>0x31</td>
+			</tr>
+			<tr class="bottom">
+				<td>42</td>
+				<td>43</td>
+				<td>44</td>
+				<td>45</td>
+				<td>46</td>
+				<td>47</td>
+				<td>48</td>
+				<td>49</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_YELLOW</th>
+				<td><span style="background-color:rgb(128,  68,   8)"></span></td>
+				<td><span style="background-color:rgb(156,  96,  16)"></span></td>
+				<td><span style="background-color:rgb(184, 120,  24)"></span></td>
+				<td><span style="background-color:rgb(212, 156,  32)"></span></td>
+				<td><span style="background-color:rgb(232, 184,  16)"></span></td>
+				<td><span style="background-color:rgb(252, 212,   0)"></span></td>
+				<td><span style="background-color:rgb(252, 248, 128)"></span></td>
+				<td><span style="background-color:rgb(252, 252, 192)"></span></td>
+			</tr>
+			<tr>
+				<td>0x3e</td>
+				<td>0x3f</td>
+				<td>0x40</td>
+				<td>0x41</td>
+				<td>0x42</td>
+				<td>0x43</td>
+				<td>0x44</td>
+				<td>0x45</td>
+			</tr>
+			<tr class="bottom">
+				<td>62</td>
+				<td>63</td>
+				<td>64</td>
+				<td>65</td>
+				<td>66</td>
+				<td>67</td>
+				<td>68</td>
+				<td>69</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_RED</th>
+				<td><span style="background-color:rgb( 92,   0,   0)"></span></td>
+				<td><span style="background-color:rgb(128,   0,   0)"></span></td>
+				<td><span style="background-color:rgb(160,   0,   0)"></span></td>
+				<td><span style="background-color:rgb(196,   0,   0)"></span></td>
+				<td><span style="background-color:rgb(224,   0,   0)"></span></td>
+				<td><span style="background-color:rgb(252,  52,  52)"></span></td>
+				<td><span style="background-color:rgb(252, 100,  88)"></span></td>
+				<td><span style="background-color:rgb(252, 144, 124)"></span></td>
+			</tr>
+			<tr>
+				<td>0xb3</td>
+				<td>0xb4</td>
+				<td>0xb5</td>
+				<td>0xb6</td>
+				<td>0xb7</td>
+				<td>0xa4</td>
+				<td>0xa5</td>
+				<td>0xa6</td>
+			</tr>
+			<tr class="bottom">
+				<td>179</td>
+				<td>180</td>
+				<td>181</td>
+				<td>182</td>
+				<td>183</td>
+				<td>164</td>
+				<td>165</td>
+				<td>166</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_LIGHT_BLUE</th>
+				<td><span style="background-color:rgb( 16,  64,  96)"></span></td>
+				<td><span style="background-color:rgb( 24,  80, 108)"></span></td>
+				<td><span style="background-color:rgb( 40,  96, 120)"></span></td>
+				<td><span style="background-color:rgb( 52, 112, 132)"></span></td>
+				<td><span style="background-color:rgb( 80, 140, 160)"></span></td>
+				<td><span style="background-color:rgb(116, 172, 192)"></span></td>
+				<td><span style="background-color:rgb(156, 204, 220)"></span></td>
+				<td><span style="background-color:rgb(204, 240, 252)"></span></td>
+			</tr>
+			<tr>
+				<td>0x9a</td>
+				<td>0x9b</td>
+				<td>0x9c</td>
+				<td>0x9d</td>
+				<td>0x9e</td>
+				<td>0x9f</td>
+				<td>0xa0</td>
+				<td>0xa1</td>
+			</tr>
+			<tr class="bottom">
+				<td>154</td>
+				<td>155</td>
+				<td>156</td>
+				<td>157</td>
+				<td>158</td>
+				<td>159</td>
+				<td>160</td>
+				<td>161</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_GREEN</th>
+				<td><span style="background-color:rgb( 32,  80,   4)"></span></td>
+				<td><span style="background-color:rgb( 48,  96,   4)"></span></td>
+				<td><span style="background-color:rgb( 64, 112,  12)"></span></td>
+				<td><span style="background-color:rgb( 84, 132,  20)"></span></td>
+				<td><span style="background-color:rgb( 92, 156,  52)"></span></td>
+				<td><span style="background-color:rgb(108, 176,  64)"></span></td>
+				<td><span style="background-color:rgb(124, 200,  76)"></span></td>
+				<td><span style="background-color:rgb(144, 224,  92)"></span></td>
+			</tr>
+			<tr>
+				<td>0x52</td>
+				<td>0x53</td>
+				<td>0x54</td>
+				<td>0x55</td>
+				<td>0xce</td>
+				<td>0xcf</td>
+				<td>0xd0</td>
+				<td>0xd1</td>
+			</tr>
+			<tr class="bottom">
+				<td>82</td>
+				<td>83</td>
+				<td>84</td>
+				<td>85</td>
+				<td>206</td>
+				<td>207</td>
+				<td>208</td>
+				<td>209</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_DARK_GREEN</th>
+				<td><span style="background-color:rgb( 28,  52,  24)"></span></td>
+				<td><span style="background-color:rgb( 44,  68,  32)"></span></td>
+				<td><span style="background-color:rgb( 60,  88,  48)"></span></td>
+				<td><span style="background-color:rgb( 80, 104,  60)"></span></td>
+				<td><span style="background-color:rgb(104, 124,  76)"></span></td>
+				<td><span style="background-color:rgb(128, 148,  92)"></span></td>
+				<td><span style="background-color:rgb(152, 176, 108)"></span></td>
+				<td><span style="background-color:rgb(180, 204, 124)"></span></td>
+			</tr>
+			<tr>
+				<td>0x58</td>
+				<td>0x59</td>
+				<td>0x5a</td>
+				<td>0x5b</td>
+				<td>0x5c</td>
+				<td>0x5d</td>
+				<td>0x5e</td>
+				<td>0x5f</td>
+			</tr>
+			<tr class="bottom">
+				<td>88</td>
+				<td>89</td>
+				<td>90</td>
+				<td>91</td>
+				<td>92</td>
+				<td>93</td>
+				<td>94</td>
+				<td>95</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_BLUE</th>
+				<td><span style="background-color:rgb(  0,  52, 160)"></span></td>
+				<td><span style="background-color:rgb(  0,  72, 184)"></span></td>
+				<td><span style="background-color:rgb(  0,  96, 212)"></span></td>
+				<td><span style="background-color:rgb( 24, 120, 220)"></span></td>
+				<td><span style="background-color:rgb( 56, 144, 232)"></span></td>
+				<td><span style="background-color:rgb( 88, 168, 240)"></span></td>
+				<td><span style="background-color:rgb(128, 196, 252)"></span></td>
+				<td><span style="background-color:rgb(188, 224, 252)"></span></td>
+			</tr>
+			<tr>
+				<td>0x92</td>
+				<td>0x93</td>
+				<td>0x94</td>
+				<td>0x95</td>
+				<td>0x96</td>
+				<td>0x97</td>
+				<td>0x98</td>
+				<td>0x99</td>
+			</tr>
+			<tr class="bottom">
+				<td>146</td>
+				<td>147</td>
+				<td>148</td>
+				<td>149</td>
+				<td>150</td>
+				<td>151</td>
+				<td>152</td>
+				<td>153</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_CREAM</th>
+				<td><span style="background-color:rgb(116,  68,  40)"></span></td>
+				<td><span style="background-color:rgb(136,  84,  56)"></span></td>
+				<td><span style="background-color:rgb(164,  96,  64)"></span></td>
+				<td><span style="background-color:rgb(184, 112,  80)"></span></td>
+				<td><span style="background-color:rgb(204, 128,  96)"></span></td>
+				<td><span style="background-color:rgb(212, 148, 112)"></span></td>
+				<td><span style="background-color:rgb(224, 168, 128)"></span></td>
+				<td><span style="background-color:rgb(236, 188, 148)"></span></td>
+			</tr>
+			<tr>
+				<td>0x72</td>
+				<td>0x73</td>
+				<td>0x74</td>
+				<td>0x75</td>
+				<td>0x76</td>
+				<td>0x77</td>
+				<td>0x78</td>
+				<td>0x79</td>
+			</tr>
+			<tr class="bottom">
+				<td>114</td>
+				<td>115</td>
+				<td>116</td>
+				<td>117</td>
+				<td>118</td>
+				<td>119</td>
+				<td>120</td>
+				<td>121</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_MAUVE</th>
+				<td><span style="background-color:rgb( 36,  40,  68)"></span></td>
+				<td><span style="background-color:rgb( 48,  52,  84)"></span></td>
+				<td><span style="background-color:rgb( 64,  64, 100)"></span></td>
+				<td><span style="background-color:rgb( 80,  80, 116)"></span></td>
+				<td><span style="background-color:rgb(100, 100, 136)"></span></td>
+				<td><span style="background-color:rgb(132, 132, 164)"></span></td>
+				<td><span style="background-color:rgb(172, 172, 192)"></span></td>
+				<td><span style="background-color:rgb(212, 212, 224)"></span></td>
+			</tr>
+			<tr>
+				<td>0x80</td>
+				<td>0x81</td>
+				<td>0x82</td>
+				<td>0x83</td>
+				<td>0x84</td>
+				<td>0x85</td>
+				<td>0x86</td>
+				<td>0x87</td>
+			</tr>
+			<tr class="bottom">
+				<td>128</td>
+				<td>129</td>
+				<td>130</td>
+				<td>131</td>
+				<td>132</td>
+				<td>133</td>
+				<td>134</td>
+				<td>135</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_PURPLE</th>
+				<td><span style="background-color:rgb( 40,  20, 112)"></span></td>
+				<td><span style="background-color:rgb( 64,  44, 144)"></span></td>
+				<td><span style="background-color:rgb( 88,  64, 172)"></span></td>
+				<td><span style="background-color:rgb(104,  76, 196)"></span></td>
+				<td><span style="background-color:rgb(120,  88, 224)"></span></td>
+				<td><span style="background-color:rgb(140, 104, 252)"></span></td>
+				<td><span style="background-color:rgb(160, 136, 252)"></span></td>
+				<td><span style="background-color:rgb(188, 168, 252)"></span></td>
+			</tr>
+			<tr>
+				<td>0x88</td>
+				<td>0x89</td>
+				<td>0x8a</td>
+				<td>0x8b</td>
+				<td>0x8c</td>
+				<td>0x8d</td>
+				<td>0x8e</td>
+				<td>0x8f</td>
+			</tr>
+			<tr class="bottom">
+				<td>136</td>
+				<td>137</td>
+				<td>138</td>
+				<td>139</td>
+				<td>140</td>
+				<td>141</td>
+				<td>142</td>
+				<td>143</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_ORANGE</th>
+				<td><span style="background-color:rgb(184, 120,  24)"></span></td>
+				<td><span style="background-color:rgb(204, 136,   8)"></span></td>
+				<td><span style="background-color:rgb(228, 144,   4)"></span></td>
+				<td><span style="background-color:rgb(252, 156,   0)"></span></td>
+				<td><span style="background-color:rgb(252, 176,  48)"></span></td>
+				<td><span style="background-color:rgb(252, 196, 100)"></span></td>
+				<td><span style="background-color:rgb(252, 216, 152)"></span></td>
+				<td><span style="background-color:rgb(244, 220, 176)"></span></td>
+			</tr>
+			<tr>
+				<td>0x40</td>
+				<td>0xc0</td>
+				<td>0xc1</td>
+				<td>0xc2</td>
+				<td>0xc3</td>
+				<td>0xc4</td>
+				<td>0xc5</td>
+				<td>0x27</td>
+			</tr>
+			<tr class="bottom">
+				<td>64</td>
+				<td>192</td>
+				<td>193</td>
+				<td>194</td>
+				<td>195</td>
+				<td>196</td>
+				<td>197</td>
+				<td>39</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_BROWN</th>
+				<td><span style="background-color:rgb( 72,  44,   4)"></span></td>
+				<td><span style="background-color:rgb( 88,  60,  20)"></span></td>
+				<td><span style="background-color:rgb(104,  80,  44)"></span></td>
+				<td><span style="background-color:rgb(124, 104,  72)"></span></td>
+				<td><span style="background-color:rgb(152, 132,  92)"></span></td>
+				<td><span style="background-color:rgb(184, 160, 120)"></span></td>
+				<td><span style="background-color:rgb(212, 188, 148)"></span></td>
+				<td><span style="background-color:rgb(244, 220, 176)"></span></td>
+			</tr>
+			<tr>
+				<td>0x20</td>
+				<td>0x21</td>
+				<td>0x22</td>
+				<td>0x23</td>
+				<td>0x24</td>
+				<td>0x25</td>
+				<td>0x26</td>
+				<td>0x27</td>
+			</tr>
+			<tr class="bottom">
+				<td>32</td>
+				<td>33</td>
+				<td>34</td>
+				<td>35</td>
+				<td>36</td>
+				<td>37</td>
+				<td>38</td>
+				<td>39</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_GREY</th>
+				<td><span style="background-color:rgb( 64,  64,  64)"></span></td>
+				<td><span style="background-color:rgb( 80,  80,  80)"></span></td>
+				<td><span style="background-color:rgb(100, 100, 100)"></span></td>
+				<td><span style="background-color:rgb(116, 116, 116)"></span></td>
+				<td><span style="background-color:rgb(132, 132, 132)"></span></td>
+				<td><span style="background-color:rgb(148, 148, 148)"></span></td>
+				<td><span style="background-color:rgb(168, 168, 168)"></span></td>
+				<td><span style="background-color:rgb(184, 184, 184)"></span></td>
+			</tr>
+			<tr>
+				<td>0x4</td>
+				<td>0x5</td>
+				<td>0x6</td>
+				<td>0x7</td>
+				<td>0x8</td>
+				<td>0x9</td>
+				<td>0xa</td>
+				<td>0xb</td>
+			</tr>
+			<tr class="bottom">
+				<td>4</td>
+				<td>5</td>
+				<td>6</td>
+				<td>7</td>
+				<td>8</td>
+				<td>9</td>
+				<td>10</td>
+				<td>11</td>
+			</tr>
+			
+			<tr class="top">
+				<th rowspan="3">COLOUR_WHITE</th>
+				<td><span style="background-color:rgb(132, 132, 132)"></span></td>
+				<td><span style="background-color:rgb(148, 148, 148)"></span></td>
+				<td><span style="background-color:rgb(168, 168, 168)"></span></td>
+				<td><span style="background-color:rgb(184, 184, 184)"></span></td>
+				<td><span style="background-color:rgb(200, 200, 200)"></span></td>
+				<td><span style="background-color:rgb(216, 216, 216)"></span></td>
+				<td><span style="background-color:rgb(232, 232, 232)"></span></td>
+				<td><span style="background-color:rgb(252, 252, 252)"></span></td>
+			</tr>
+			<tr>
+				<td>0x8</td>
+				<td>0x9</td>
+				<td>0xa</td>
+				<td>0xb</td>
+				<td>0xc</td>
+				<td>0xd</td>
+				<td>0xe</td>
+				<td>0xf</td>
+			</tr>
+			<tr class="bottom">
+				<td>8</td>
+				<td>9</td>
+				<td>10</td>
+				<td>11</td>
+				<td>12</td>
+				<td>13</td>
+				<td>14</td>
+				<td>15</td>
+			</tr>
+		</tbody>
+	</table>
 </body>
 </html>
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Motivation / Problem

As part of #8539 Truebrain sought a representation of the company colours.  

## Description

Per https://github.com/OpenTTD/OpenTTD/issues/8539#issuecomment-757325059

It was quite trivial to generate html from the Iron Horse compile as it already has in scope the company colours and a method for rgb values from palette indexes.

I've put it online at https://grf.farm/misc/company_colour_indexes.html _but_ I don't guarantee that's stable, so we _might_ want it in /docs for future travellers. 

## Limitations

* derived from the values from https://github.com/frosch123/TTDViewer/blob/master/src/recolor.xml#L186 so only as accurate as those (but frosch is generally infallible yes?)
* won't render nicely in Github, but eh, .md won't work for this case
* I didn't validate the html 🤣 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
