### PR TITLE
Dump info console commands

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -36,6 +36,8 @@
 #include "newgrf_profiling.h"
 #include "console_func.h"
 #include "engine_base.h"
+#include "road.h"
+#include "rail.h"
 #include "game/game.hpp"
 #include "table/strings.h"
 #include <time.h>
@@ -2095,6 +2097,163 @@ DEF_CONSOLE_CMD(ConFramerateWindow)
 	return true;
 }
 
+static void ConDumpRoadTypes()
+{
+	IConsolePrintF(CC_DEFAULT, "  Flags:");
+	IConsolePrintF(CC_DEFAULT, "    c = catenary");
+	IConsolePrintF(CC_DEFAULT, "    l = no level crossings");
+	IConsolePrintF(CC_DEFAULT, "    X = no houses");
+	IConsolePrintF(CC_DEFAULT, "    h = hidden");
+	IConsolePrintF(CC_DEFAULT, "    T = buildable by towns");
+
+	extern RoadTypeInfo _roadtypes[ROADTYPE_END];
+	std::set<uint32> grfids;
+	for (RoadType rt = ROADTYPE_BEGIN; rt < ROADTYPE_END; rt++) {
+		const RoadTypeInfo &rti = _roadtypes[rt];
+		if (rti.label == 0) continue;
+		uint32 grfid = 0;
+		if (rti.grffile[ROTSG_GROUND] != nullptr) {
+			grfid = rti.grffile[ROTSG_GROUND]->grfid;
+			grfids.insert(grfid);
+		}
+		IConsolePrintF(CC_DEFAULT, "  %02u %s %c%c%c%c, Flags: %c%c%c%c%c, GRF: %08X, %s",
+				(uint) rt,
+				RoadTypeIsTram(rt) ? "Tram" : "Road",
+				rti.label >> 24, rti.label >> 16, rti.label >> 8, rti.label,
+				HasBit(rti.flags, ROTF_CATENARY)          ? 'c' : '-',
+				HasBit(rti.flags, ROTF_NO_LEVEL_CROSSING) ? 'l' : '-',
+				HasBit(rti.flags, ROTF_NO_HOUSES)         ? 'X' : '-',
+				HasBit(rti.flags, ROTF_HIDDEN)            ? 'h' : '-',
+				HasBit(rti.flags, ROTF_TOWN_BUILD)        ? 'T' : '-',
+				BSWAP32(grfid),
+				GetStringPtr(rti.strings.name)
+		);
+	}
+	for (uint32 grfid : grfids) {
+		extern GRFFile *GetFileByGRFID(uint32 grfid);
+		const GRFFile *grffile = GetFileByGRFID(grfid);
+		IConsolePrintF(CC_DEFAULT, "  GRF: %08X = %s", BSWAP32(grfid), grffile ? grffile->filename : "????");
+	}
+}
+
+static void ConDumpRailTypes()
+{
+	IConsolePrintF(CC_DEFAULT, "  Flags:");
+	IConsolePrintF(CC_DEFAULT, "    c = catenary");
+	IConsolePrintF(CC_DEFAULT, "    l = no level crossings");
+	IConsolePrintF(CC_DEFAULT, "    h = hidden");
+	IConsolePrintF(CC_DEFAULT, "    s = no sprite combine");
+	IConsolePrintF(CC_DEFAULT, "    a = always allow 90 degree turns");
+	IConsolePrintF(CC_DEFAULT, "    d = always disallow 90 degree turns");
+
+	std::set<uint32> grfids;
+	for (RailType rt = RAILTYPE_BEGIN; rt < RAILTYPE_END; rt++) {
+		const RailtypeInfo *rti = GetRailTypeInfo(rt);
+		if (rti->label == 0) continue;
+		uint32 grfid = 0;
+		if (rti->grffile[ROTSG_GROUND] != nullptr) {
+			grfid = rti->grffile[ROTSG_GROUND]->grfid;
+			grfids.insert(grfid);
+		}
+		IConsolePrintF(CC_DEFAULT, "  %02u %c%c%c%c, Flags: %c%c%c%c%c%c, GRF: %08X, %s",
+				(uint) rt,
+				rti->label >> 24, rti->label >> 16, rti->label >> 8, rti->label,
+				HasBit(rti->flags, RTF_CATENARY)          ? 'c' : '-',
+				HasBit(rti->flags, RTF_NO_LEVEL_CROSSING) ? 'l' : '-',
+				HasBit(rti->flags, RTF_HIDDEN)            ? 'h' : '-',
+				HasBit(rti->flags, RTF_NO_SPRITE_COMBINE) ? 's' : '-',
+				HasBit(rti->flags, RTF_ALLOW_90DEG)       ? 'a' : '-',
+				HasBit(rti->flags, RTF_DISALLOW_90DEG)    ? 'd' : '-',
+				BSWAP32(grfid),
+				GetStringPtr(rti->strings.name)
+		);
+	}
+	for (uint32 grfid : grfids) {
+		extern GRFFile *GetFileByGRFID(uint32 grfid);
+		const GRFFile *grffile = GetFileByGRFID(grfid);
+		IConsolePrintF(CC_DEFAULT, "  GRF: %08X = %s", BSWAP32(grfid), grffile ? grffile->filename : "????");
+	}
+}
+
+static void ConDumpCargoTypes()
+{
+	IConsolePrintF(CC_DEFAULT, "  Cargo classes:");
+	IConsolePrintF(CC_DEFAULT, "    p = passenger");
+	IConsolePrintF(CC_DEFAULT, "    m = mail");
+	IConsolePrintF(CC_DEFAULT, "    x = express");
+	IConsolePrintF(CC_DEFAULT, "    a = armoured");
+	IConsolePrintF(CC_DEFAULT, "    b = bulk");
+	IConsolePrintF(CC_DEFAULT, "    g = piece goods");
+	IConsolePrintF(CC_DEFAULT, "    l = liquid");
+	IConsolePrintF(CC_DEFAULT, "    r = refrigerated");
+	IConsolePrintF(CC_DEFAULT, "    h = hazardous");
+	IConsolePrintF(CC_DEFAULT, "    c = covered/sheltered");
+	IConsolePrintF(CC_DEFAULT, "    S = special");
+
+	std::set<uint32> grfids;
+	for (CargoID i = 0; i < NUM_CARGO; i++) {
+		const CargoSpec *spec = CargoSpec::Get(i);
+		if (!spec->IsValid()) continue;
+		uint32 grfid = 0;
+		if (spec->grffile != nullptr) {
+			grfid = spec->grffile->grfid;
+			grfids.insert(grfid);
+		}
+		IConsolePrintF(CC_DEFAULT, "  %02u Bit: %2u, Label: %c%c%c%c, Callback mask: 0x%02X, Cargo class: %c%c%c%c%c%c%c%c%c%c%c, GRF: %08X, %s",
+				(uint) i,
+				spec->bitnum,
+				spec->label >> 24, spec->label >> 16, spec->label >> 8, spec->label,
+				spec->callback_mask,
+				(spec->classes & CC_PASSENGERS)   != 0 ? 'p' : '-',
+				(spec->classes & CC_MAIL)         != 0 ? 'm' : '-',
+				(spec->classes & CC_EXPRESS)      != 0 ? 'x' : '-',
+				(spec->classes & CC_ARMOURED)     != 0 ? 'a' : '-',
+				(spec->classes & CC_BULK)         != 0 ? 'b' : '-',
+				(spec->classes & CC_PIECE_GOODS)  != 0 ? 'g' : '-',
+				(spec->classes & CC_LIQUID)       != 0 ? 'l' : '-',
+				(spec->classes & CC_REFRIGERATED) != 0 ? 'r' : '-',
+				(spec->classes & CC_HAZARDOUS)    != 0 ? 'h' : '-',
+				(spec->classes & CC_COVERED)      != 0 ? 'c' : '-',
+				(spec->classes & CC_SPECIAL)      != 0 ? 'S' : '-',
+				BSWAP32(grfid),
+				GetStringPtr(spec->name)
+		);
+	}
+	for (uint32 grfid : grfids) {
+		extern GRFFile *GetFileByGRFID(uint32 grfid);
+		const GRFFile *grffile = GetFileByGRFID(grfid);
+		IConsolePrintF(CC_DEFAULT, "  GRF: %08X = %s", BSWAP32(grfid), grffile ? grffile->filename : "????");
+	}
+}
+
+
+DEF_CONSOLE_CMD(ConDumpInfo)
+{
+	if (argc != 2) {
+		IConsoleHelp("Dump debugging information.");
+		IConsoleHelp("Usage: dump_info roadtypes|railtypes|cargotypes");
+		IConsoleHelp("  Show information about road/tram types, rail types or cargo types.");
+		return true;
+	}
+
+	if (strcasecmp(argv[1], "roadtypes") == 0) {
+		ConDumpRoadTypes();
+		return true;
+	}
+
+	if (strcasecmp(argv[1], "railtypes") == 0) {
+		ConDumpRailTypes();
+		return true;
+	}
+
+	if (strcasecmp(argv[1], "cargotypes") == 0) {
+		ConDumpCargoTypes();
+		return true;
+	}
+
+	return false;
+}
+
 /*******************************
  * console command registration
  *******************************/
@@ -2231,4 +2390,6 @@ void IConsoleStdLibRegister()
 	/* NewGRF development stuff */
 	IConsoleCmdRegister("reload_newgrfs",  ConNewGRFReload, ConHookNewGRFDeveloperTool);
 	IConsoleCmdRegister("newgrf_profile",  ConNewGRFProfile, ConHookNewGRFDeveloperTool);
+
+	IConsoleCmdRegister("dump_info", ConDumpInfo);
 }

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -393,7 +393,7 @@ void CDECL grfmsg(int severity, const char *str, ...)
  * @param grfid The grfID to obtain the file for
  * @return The file.
  */
-static GRFFile *GetFileByGRFID(uint32 grfid)
+GRFFile *GetFileByGRFID(uint32 grfid)
 {
 	for (GRFFile * const file : _grf_files) {
 		if (file->grfid == grfid) return file;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -393,7 +393,7 @@ void CDECL grfmsg(int severity, const char *str, ...)
  * @param grfid The grfID to obtain the file for
  * @return The file.
  */
-GRFFile *GetFileByGRFID(uint32 grfid)
+static GRFFile *GetFileByGRFID(uint32 grfid)
 {
 	for (GRFFile * const file : _grf_files) {
 		if (file->grfid == grfid) return file;


### PR DESCRIPTION
## Motivation / Problem

This is a partial implementation of the suggested improvements for visibility of information useful for debugging such as road/tram/rail flags as described in #8545.


## Description

This adds a console command which dumps information on a named feature.
`dumpinfo roadtypes` dumps information on road/tram types
`dumpinfo railtypes` dumps information on rail types
`dumpinfo cargotypes` dumps information on cargo types

<details>
  <summary>Example console output:</summary>
  
  ```
‎] dumpinfo
- Dump debugging information.
- Usage: dump_info roadtypes|railtypes|cargotypes
-   Show information about road/tram types, rail types or cargo types.
‎] dumpinfo roadtypes
  Flags:
    c = catenary
    l = no level crossings
    X = no houses
    h = hidden
    T = buildable by towns
  00 Road ROAD, Flags: ----T, GRF: 55420101, Basic road
  01 Tram ELRL, Flags: c----, GRF: 55420101, Tram track no ballast (Electrified) 
  02 Road DIRT, Flags: -----, GRF: 55420101, Dirt road
  03 Road GRAV, Flags: -----, GRF: 55420101, Gravel road
  04 Road CONC, Flags: -----, GRF: 55420101, Concrete road
  05 Road ASPR, Flags: -----, GRF: 55420101, Asphalt road
  06 Road ASP1, Flags: -----, GRF: 55420101, Asphalt road w/ Stripes
  07 Road URBR, Flags: -----, GRF: 55420101, Urban asphalt road
  08 Road URB1, Flags: c----, GRF: 55420101, Urban asphalt road w/ Lights
  09 Road HWAY, Flags: -lX--, GRF: 55420101, Highway
  10 Road HWA0, Flags: clX--, GRF: 55420101, Highway w/ Lights (Both)
  11 Road HWA1, Flags: clX--, GRF: 55420101, Highway w/ Lights (Left)
  12 Road HWA2, Flags: clX--, GRF: 55420101, Highway w/ Lights (Right)
  13 Road ISRR, Flags: --X--, GRF: 55420101, ISR road
  14 Road FIED, Flags: -l---, GRF: 55420101, Fied road
  15 Tram ELR1, Flags: c----, GRF: 55420101, Tram track (Electrified)
  16 Tram ELR2, Flags: c----, GRF: 55420101, Modern tram track (Electrified) 
  17 Tram ELR3, Flags: c----, GRF: 55420101, Urban tram track (Electrified) 
  18 Tram ELR4, Flags: c----, GRF: 55420101, Urban tram track w/ Lights (Electrified) 
  19 Tram ELR5, Flags: c----, GRF: 55420101, ISR Tram track (Electrified) 
  20 Road WWAY, Flags: c----, GRF: 43530902, Water Way
  21 Road RWAY, Flags: c----, GRF: 43530902, River Way
  22 Road FRZN, Flags: --X--, GRF: 43530902, Frozen River Way
  GRF: 55420101 = v3grf/U_RaTT.grf
  GRF: 43530902 = water_way_road-0.3.1/waterway.grf
‎] dumpinfo railtypes
  Flags:
    c = catenary
    l = no level crossings
    h = hidden
    s = no sprite combine
    a = allow 90° turns
    d = disallow 90° turns
  00 RAIL, Flags: --h---, GRF: 00000000, Railway
  01 ELRL, Flags: --h---, GRF: 00000000, Electrified railway
  02 MONO, Flags: -l-s-d, GRF: 00000000, Monorail
  03 MGLV, Flags: -l-s-d, GRF: 00000000, Maglev
  04 LFTD, Flags: ------, GRF: FBFB0A01, Lifted Track
  05 PLAN, Flags: ------, GRF: FBFB0A01, Planning Track
  06 SAAN, Flags: ---s-d, GRF: 55464990, Branch line
  07 SABN, Flags: ---s-d, GRF: 55464990, Main line
  08 SABE, Flags: c--s-d, GRF: 55464990, Main line (Electrified)
  09 SBBN, Flags: ---s-d, GRF: 55464990, Modern main line
  10 SBBE, Flags: c--s-d, GRF: 55464990, Modern main line (Electrified)
  11 SCBN, Flags: ---s-d, GRF: 55464990, Highspeed line
  12 SCBE, Flags: c--s-d, GRF: 55464990, Highspeed line (Electrified)
  13 SDBE, Flags: cl-s-d, GRF: 55464990, Modern highspeed line (Electrified)
  14 SEBE, Flags: cl-s-d, GRF: 55464990, Very highspeed line (Electrified)
  15 SUBE, Flags: c--s-d, GRF: 55464990, Urban main line (Electrified)
  16 SAB3, Flags: ---s-d, GRF: 55464990, Metro line (3rd rail powered)
  17 SBB3, Flags: ---s-d, GRF: 55464990, Modern metro line (3rd rail powered)
  18 SUB3, Flags: ---s-d, GRF: 55464990, Urban metro line (3rd rail powered)
  19 dAAN, Flags: ---s-d, GRF: 55464990, Normal + narrow gauge line
  20 NAAN, Flags: ---s-d, GRF: 55464990, Narrow gauge line
  21 NAAE, Flags: c--s-d, GRF: 55464990, Narrow gauge line (Electrified)
  22 NBAN, Flags: ---s-d, GRF: 55464990, Modern narrow gauge line
  23 NBAE, Flags: c--s-d, GRF: 55464990, Modern narrow gauge line (Electrified)
  24 NCAN, Flags: ---s-d, GRF: 55464990, Highspeed narrow gauge line
  25 NCAE, Flags: c--s-d, GRF: 55464990, Highspeed narrow gauge line (Electrified)
  26 NDAE, Flags: c--s-d, GRF: 55464990, Modern highspeed narrow gauge line (Electrified)
  27 NUAE, Flags: c--s-d, GRF: 55464990, Urban narrow gauge line (Electrified)
  28 NAA3, Flags: ---s-d, GRF: 55464990, Narrow gauge line (3rd rail powered)
  29 NBA3, Flags: ---s-d, GRF: 55464990, Modern Narrow gauge line (3rd rail powered)
  30 PIPE, Flags: -l----, GRF: 41560102, Pipeline
  GRF: FBFB0A01 = useless_tracks-0.1.0/uselesstracks.grf
  GRF: 41560102 = pipe-6.40/pipe.grf
  GRF: 55464990 = u_rermm_2-1c/urermm2.grf
‎] dumpinfo cargotypes
  Cargo classes:
    p = passenger
    m = mail
    x = express
    a = armoured
    b = bulk
    g = piece goods
    l = liquid
    r = refrigerated
    h = hazardous
    c = covered/sheltered
    S = special
  00 Bit:  0, Label: PASS, Callback mask: 0x00, Cargo class: p----------, GRF: 00000000, Passengers
  01 Bit:  1, Label: ACID, Callback mask: 0x00, Cargo class: ------l-h--, GRF: 4A448807, Acid
  02 Bit:  2, Label: MAIL, Callback mask: 0x00, Cargo class: -m---------, GRF: 00000000, Mail
  03 Bit:  3, Label: BEER, Callback mask: 0x00, Cargo class: --x--gl----, GRF: 4A448807, Alcohol
  04 Bit:  4, Label: AORE, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Bauxite
  05 Bit:  5, Label: GOOD, Callback mask: 0x00, Cargo class: --x--------, GRF: 00000000, Goods
  06 Bit:  6, Label: BEAN, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Soy
  07 Bit:  7, Label: BDMT, Callback mask: 0x00, Cargo class: ----bg-----, GRF: 4A448807, Building Materials
  08 Bit:  8, Label: CMNT, Callback mask: 0x00, Cargo class: ----b----c-, GRF: 4A448807, Cement
  09 Bit:  9, Label: RFPR, Callback mask: 0x00, Cargo class: ------l----, GRF: 4A448807, Petrochemicals
  10 Bit: 10, Label: CHLO, Callback mask: 0x00, Cargo class: ------l-h--, GRF: 4A448807, Chlorine
  11 Bit: 11, Label: FOOD, Callback mask: 0x00, Cargo class: --x----r---, GRF: 00000000, Food
  12 Bit: 12, Label: CLAY, Callback mask: 0x00, Cargo class: ----b----c-, GRF: 4A448807, Clay
  13 Bit: 13, Label: COAL, Callback mask: 0x00, Cargo class: ----b------, GRF: 00000000, Coal
  14 Bit: 14, Label: COKE, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Coke
  15 Bit: 15, Label: COPR, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Copper
  16 Bit: 16, Label: CORE, Callback mask: 0x00, Cargo class: ----b------, GRF: 00000000, Copper Ore
  17 Bit: 17, Label: EOIL, Callback mask: 0x00, Cargo class: -----gl----, GRF: 4A448807, Edible Oil
  18 Bit: 18, Label: POWR, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Electrical Machines
  19 Bit: 19, Label: ENSP, Callback mask: 0x00, Cargo class: --x--g-----, GRF: 4A448807, Engineering Supplies
  20 Bit: 20, Label: BOOM, Callback mask: 0x00, Cargo class: --x--g-----, GRF: 4A448807, Explosives
  21 Bit: 21, Label: FMSP, Callback mask: 0x00, Cargo class: --x--g-----, GRF: 4A448807, Farm Supplies
  22 Bit: 22, Label: FERT, Callback mask: 0x00, Cargo class: ----bg---c-, GRF: 4A448807, Fertiliser
  23 Bit: 23, Label: FISH, Callback mask: 0x00, Cargo class: --x----r---, GRF: 4A448807, Fish
  24 Bit: 24, Label: FRUT, Callback mask: 0x00, Cargo class: --x--g-r---, GRF: 4A448807, Fruit
  25 Bit: 25, Label: GRAI, Callback mask: 0x00, Cargo class: ----b------, GRF: 00000000, Grain
  26 Bit: 26, Label: IORE, Callback mask: 0x00, Cargo class: ----b------, GRF: 00000000, Iron Ore
  27 Bit: 27, Label: KAOL, Callback mask: 0x00, Cargo class: ----b-l--c-, GRF: 4A448807, Lithium
  28 Bit: 28, Label: LIME, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Limestone
  29 Bit: 29, Label: LVST, Callback mask: 0x00, Cargo class: -----g-----, GRF: 00000000, Livestock
  30 Bit: 30, Label: WDPR, Callback mask: 0x00, Cargo class: ----bg-----, GRF: 4A448807, Timber
  31 Bit: 31, Label: MNO2, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Manganese
  32 Bit: 32, Label: METL, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Aluminium
  33 Bit: 33, Label: MILK, Callback mask: 0x00, Cargo class: --x---lr---, GRF: 4A448807, Milk
  34 Bit: 34, Label: NITR, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Nitrates
  35 Bit: 35, Label: OIL_, Callback mask: 0x00, Cargo class: ------l----, GRF: 00000000, Oil
  36 Bit: 36, Label: MNSP, Callback mask: 0x00, Cargo class: --x--g-----, GRF: 4A448807, Packaging
  37 Bit: 37, Label: PAPR, Callback mask: 0x00, Cargo class: -----g-----, GRF: 00000000, Paper
  38 Bit: 38, Label: PEAT, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Biomass
  39 Bit: 39, Label: PETR, Callback mask: 0x00, Cargo class: ------l----, GRF: 4A448807, Petroleum Fuels
  40 Bit: 40, Label: PHOS, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Oil Sands
  41 Bit: 41, Label: IRON, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Pig Iron
  42 Bit: 42, Label: PIPE, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Pipe
  43 Bit: 43, Label: FICR, Callback mask: 0x00, Cargo class: ----bg-----, GRF: 4A448807, Fibres
  44 Bit: 44, Label: PORE, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Zinc Ore
  45 Bit: 45, Label: QLME, Callback mask: 0x00, Cargo class: ----b----c-, GRF: 4A448807, Quicklime
  46 Bit: 46, Label: RCYC, Callback mask: 0x00, Cargo class: ----bg-----, GRF: 4A448807, Recyclables
  47 Bit: 47, Label: RUBR, Callback mask: 0x00, Cargo class: ------l----, GRF: 00000000, Rubber
  48 Bit: 48, Label: SALT, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Salt
  49 Bit: 49, Label: SAND, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Sand
  50 Bit: 50, Label: SCMT, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Scrap Metal
  51 Bit: 51, Label: SLAG, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Slag
  52 Bit: 52, Label: SASH, Callback mask: 0x00, Cargo class: ----b----c-, GRF: 4A448807, Soda Ash
  53 Bit: 53, Label: STEL, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Steel
  54 Bit: 54, Label: SGBT, Callback mask: 0x00, Cargo class: ----b------, GRF: 4A448807, Sugar Beet
  55 Bit: 55, Label: SULP, Callback mask: 0x00, Cargo class: ----b-l--c-, GRF: 4A448807, Sulphur
  56 Bit: 56, Label: VBOD, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Vehicle Bodies
  57 Bit: 57, Label: VPTS, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Parts
  58 Bit: 58, Label: VEHI, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Vehicles
  59 Bit: 59, Label: WOOD, Callback mask: 0x00, Cargo class: -----g-----, GRF: 00000000, Wood
  60 Bit: 60, Label: WOOL, Callback mask: 0x00, Cargo class: -----g---c-, GRF: 4A448807, Wool
  61 Bit: 61, Label: ZINC, Callback mask: 0x00, Cargo class: -----g-----, GRF: 4A448807, Zinc
  GRF: 4A448807 = extreme_industry_set-0.6.0/xis_0.6.0.grf
‎] script
file output complete

  ```
  
</details>

## Limitations

So far this only includes road/tram types, rail types and cargo types.
This only includes a subset of available fields (those which are not otherwise indicated in the UI and have debugging implications).

More features types and/or fields could be added later as required.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
