### PR TITLE
Codechange: On regression failure, output the result in a file

### DIFF
--- a/cmake/scripts/Regression.cmake
+++ b/cmake/scripts/Regression.cmake
@@ -74,23 +74,30 @@ list(LENGTH REGRESSION_EXPECTED REGRESSION_EXPECTED_LENGTH)
 
 # Compare the output
 foreach(RESULT IN LISTS REGRESSION_RESULT)
-    list(GET REGRESSION_EXPECTED ${ARGC} EXPECTED)
+    unset(EXPECTED)
+    if(ARGC LESS REGRESSION_EXPECTED_LENGTH)
+        list(GET REGRESSION_EXPECTED ${ARGC} EXPECTED)
+    endif()
+
+    math(EXPR ARGC "${ARGC} + 1")
 
     if(NOT RESULT STREQUAL EXPECTED)
         message("${ARGC}: - ${EXPECTED}")
         message("${ARGC}: + ${RESULT}'")
         set(ERROR YES)
     endif()
-
-    math(EXPR ARGC "${ARGC} + 1")
 endforeach()
 
 if(NOT REGRESSION_EXPECTED_LENGTH EQUAL ARGC)
-    math(EXPR MISSING "${REGRESSION_EXPECTED_LENGTH} - ${ARGC}")
-    message("(${MISSING} more lines were expected than found)")
+    message("(${REGRESSION_EXPECTED_LENGTH} lines were expected but ${ARGC} were found)")
     set(ERROR YES)
 endif()
 
 if(ERROR)
-    message(FATAL_ERROR "Regression failed")
+    # Ouput the regression result to a file
+    set(REGRESSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/regression_${REGRESSION_TEST}_output.txt")
+    string(REPLACE ";" "\n" REGRESSION_RESULT "${REGRESSION_RESULT}")
+    file(WRITE ${REGRESSION_FILE} "${REGRESSION_RESULT}")
+
+    message(FATAL_ERROR "Regression failed - Output in ${REGRESSION_FILE}")
 endif()


### PR DESCRIPTION
## Motivation / Problem
When regression test fails, sometimes our basic diff is not the most usable output. Especially when you are adding more checks to regression test. Having the output in a file can allow use of more avanced tools to compare it with expected output.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
On failure simply save the output to a file.
But first I needed to add support for more output lines than expected.
And while in the area I moved the counter increment before diff output, so lines are numbered from 1.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
