### PR TITLE
Feature: "Remove all industries" button in scenario editor

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2605,12 +2605,18 @@ STR_FOUND_TOWN_SELECT_LAYOUT_RANDOM                             :{BLACK}Random
 # Fund new industry window
 STR_FUND_INDUSTRY_CAPTION                                       :{WHITE}Fund new industry
 STR_FUND_INDUSTRY_SELECTION_TOOLTIP                             :{BLACK}Choose the appropriate industry from this list
-STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES                        :Many random industries
+STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES                        :{BLACK}Create random industries
 STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES_TOOLTIP                :{BLACK}Cover the map with randomly placed industries
+STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES_CAPTION                :{WHITE}Create random industries
+STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES_QUERY                  :{YELLOW}Are you sure you want to create many random industries?
 STR_FUND_INDUSTRY_INDUSTRY_BUILD_COST                           :{BLACK}Cost: {YELLOW}{CURRENCY_LONG}
 STR_FUND_INDUSTRY_PROSPECT_NEW_INDUSTRY                         :{BLACK}Prospect
 STR_FUND_INDUSTRY_BUILD_NEW_INDUSTRY                            :{BLACK}Build
 STR_FUND_INDUSTRY_FUND_NEW_INDUSTRY                             :{BLACK}Fund
+STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES                         :{BLACK}Remove all industries
+STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES_TOOLTIP                 :{BLACK}Remove all industries currently present on the map
+STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES_CAPTION                 :{WHITE}Remove all industries
+STR_FUND_INDUSTRY_REMOVE_ALL_INDUSTRIES_QUERY                   :{YELLOW}Are you sure you want to remove all industries?
 
 # Industry cargoes window
 STR_INDUSTRY_CARGOES_INDUSTRY_CAPTION                           :{WHITE}Industry chain for {STRING} industry

--- a/src/widgets/industry_widget.h
+++ b/src/widgets/industry_widget.h
@@ -12,11 +12,14 @@
 
 /** Widgets of the #BuildIndustryWindow class. */
 enum DynamicPlaceIndustriesWidgets {
-	WID_DPI_MATRIX_WIDGET,  ///< Matrix of the industries.
-	WID_DPI_SCROLLBAR,      ///< Scrollbar of the matrix.
-	WID_DPI_INFOPANEL,      ///< Info panel about the industry.
-	WID_DPI_DISPLAY_WIDGET, ///< Display chain button.
-	WID_DPI_FUND_WIDGET,    ///< Fund button.
+	WID_DPI_SCENARIO_EDITOR_PANE,            ///< Pane containing SE-only widgets.
+	WID_DPI_REMOVE_ALL_INDUSTRIES_WIDGET,    ///< Remove all industries button.
+	WID_DPI_CREATE_RANDOM_INDUSTRIES_WIDGET, ///< Create random industries button.
+	WID_DPI_MATRIX_WIDGET,                   ///< Matrix of the industries.
+	WID_DPI_SCROLLBAR,                       ///< Scrollbar of the matrix.
+	WID_DPI_INFOPANEL,                       ///< Info panel about the industry.
+	WID_DPI_DISPLAY_WIDGET,                  ///< Display chain button.
+	WID_DPI_FUND_WIDGET,                     ///< Fund button.
 };
 
 /** Widgets of the #IndustryViewWindow class. */


### PR DESCRIPTION
## Motivation / Problem

Many scenarios found in on the online content server come with industries. This is unfortunate when you want to play that particular map with for instance the FIRS industry set, or if you want to start with a clean slate for a different reason. The current solution is to go over the entire map and remove each industry, which is tedious.

## Description

This feature is only available in the scenario editor. It removes all industries. It also turns removes residual farmland and replaces it with grass.

![wAc0puysLU](https://user-images.githubusercontent.com/68320206/104109093-94e77400-52ca-11eb-8be1-3500319c8ff8.gif)

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
