### PR TITLE
Feature: Prevent vehicles to unload cargo in implicit stops in cargodist mode if the cargo is not accepted in such station

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3794,6 +3794,8 @@ void IncreaseStats(Station *st, CargoID cargo, StationID next_station_id, uint c
  */
 void IncreaseStats(Station *st, const Vehicle *front, StationID next_station_id)
 {
+	bool current_order_is_implicit = front->current_order.IsType(OT_IMPLICIT);
+
 	for (const Vehicle *v = front; v != nullptr; v = v->Next()) {
 		if (v->refit_cap > 0) {
 			/* The cargo count can indeed be higher than the refit_cap if
@@ -3802,6 +3804,13 @@ void IncreaseStats(Station *st, const Vehicle *front, StationID next_station_id)
 			 * among the wagons in that case.
 			 * As usage is not such an important figure anyway we just
 			 * ignore the additional cargo then.*/
+			Station *next_station = Station::Get(next_station_id);
+			if (current_order_is_implicit && !HasBit(GetAcceptanceMask(next_station), v->cargo_type)) {
+				/* Prevent node links to be created for implicit stops
+				 * whose stations do not accept the provided cargo. */
+				break;
+			}
+
 			IncreaseStats(st, v->cargo_type, next_station_id, v->refit_cap,
 					std::min<uint>(v->refit_cap, v->cargo.StoredCount()), EUM_INCREASE);
 		}


### PR DESCRIPTION
## Motivation / Problem

When using cargodist, there can be situations where vehicles set to load cargo at A and unload at B can potentially go through a third station C that is not in the order list. If that's the case, the extra station C gets added as an implicit stop, which is a correct behavior. However, in cargodist that station will be added as a node and will make the vehicle unload its cargo even if that type of cargo is not accepted.

While some players use non-stop orders to explicitly prevent this from happening, other players can play simpler by setting just two stops, A to load and B as destination, without worrying about intermediate stops since they assume the cargo won't be unloaded if the cargo is not accepted in those. As an example, this happens if coal trains go through common train paths with passenger stations in towns/cities.

### Repro steps

- Start a game with cargodist enabled.
- Create a train line with 3 stations A--->C--->B making sure A is placed in a location where it can load any cargo.
- Create a depot before A so the train starts at A towards B through C.
- Create 2 train to load that cargo.
- Set 2 orders: load at A and stop/unload at B.
- Start the trains and observe loading at A.
- Observe second train unloads cargo at C rather than keeping the cargo to be unloaded at B.

## Description

This code change prevent vehicles to unload cargo in implicit stops in cargodist mode if the cargo is not accepted in such station.

## Limitations

This code change is only solving the above mentioned situation and not meant to fix any other one. I am not aware of potential edge cases and I would appreciate suggestions. This topic got raised over the Discord chat.

## Checklist for review

This code change has the potential of breaking players who have vehicles transferring cargo at implicit stops. While this is unlikely, it is possible that players have gotten used to this situation and proceeded with it. I still believe this code change clarifies the behavior of vehicles in cargodist given that we expect transfers to be explicit stops.

