### PR TITLE
Fix: Remove semicolons from regression output

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -429,29 +429,29 @@ function Regression::Company()
 	print("  GetCompanyHQ():                    " + AICompany.GetCompanyHQ(AICompany.COMPANY_SELF));
 	print("  BuildCompanyHQ():                  " + AICompany.BuildCompanyHQ(AIMap.GetTileIndex(239, 76)));
 	print("  GetLastErrorString():              " + AIError.GetLastErrorString());
-	print("  GetAutoRenewStatus();              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
-	print("  SetAutoRenewStatus(true);          " + AICompany.SetAutoRenewStatus(true));
-	print("  GetAutoRenewStatus();              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
-	print("  SetAutoRenewStatus(true);          " + AICompany.SetAutoRenewStatus(true));
-	print("  SetAutoRenewStatus(false);         " + AICompany.SetAutoRenewStatus(false));
-	print("  GetAutoRenewStatus();              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
-	print("  GetAutoRenewMonths();              " + AICompany.GetAutoRenewMonths(AICompany.COMPANY_SELF));
-	print("  SetAutoRenewMonths(-12);           " + AICompany.SetAutoRenewMonths(-12));
-	print("  GetAutoRenewMonths();              " + AICompany.GetAutoRenewMonths(AICompany.COMPANY_SELF));
-	print("  SetAutoRenewMonths(-12);           " + AICompany.SetAutoRenewMonths(-12));
-	print("  SetAutoRenewMonths(6);             " + AICompany.SetAutoRenewMonths(6));
-	print("  GetAutoRenewMoney();               " + AICompany.GetAutoRenewMoney(AICompany.COMPANY_SELF));
-	print("  SetAutoRenewMoney(200000);         " + AICompany.SetAutoRenewMoney(200000));
-	print("  GetAutoRenewMoney();               " + AICompany.GetAutoRenewMoney(AICompany.COMPANY_SELF));
-	print("  SetAutoRenewMoney(200000);         " + AICompany.SetAutoRenewMoney(200000));
-	print("  SetAutoRenewMoney(100000);         " + AICompany.SetAutoRenewMoney(100000));
+	print("  GetAutoRenewStatus():              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
+	print("  SetAutoRenewStatus(true):          " + AICompany.SetAutoRenewStatus(true));
+	print("  GetAutoRenewStatus():              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
+	print("  SetAutoRenewStatus(true):          " + AICompany.SetAutoRenewStatus(true));
+	print("  SetAutoRenewStatus(false):         " + AICompany.SetAutoRenewStatus(false));
+	print("  GetAutoRenewStatus():              " + AICompany.GetAutoRenewStatus(AICompany.COMPANY_SELF));
+	print("  GetAutoRenewMonths():              " + AICompany.GetAutoRenewMonths(AICompany.COMPANY_SELF));
+	print("  SetAutoRenewMonths(-12):           " + AICompany.SetAutoRenewMonths(-12));
+	print("  GetAutoRenewMonths():              " + AICompany.GetAutoRenewMonths(AICompany.COMPANY_SELF));
+	print("  SetAutoRenewMonths(-12):           " + AICompany.SetAutoRenewMonths(-12));
+	print("  SetAutoRenewMonths(6):             " + AICompany.SetAutoRenewMonths(6));
+	print("  GetAutoRenewMoney():               " + AICompany.GetAutoRenewMoney(AICompany.COMPANY_SELF));
+	print("  SetAutoRenewMoney(200000):         " + AICompany.SetAutoRenewMoney(200000));
+	print("  GetAutoRenewMoney():               " + AICompany.GetAutoRenewMoney(AICompany.COMPANY_SELF));
+	print("  SetAutoRenewMoney(200000):         " + AICompany.SetAutoRenewMoney(200000));
+	print("  SetAutoRenewMoney(100000):         " + AICompany.SetAutoRenewMoney(100000));
 	for (local i = -1; i <= AICompany.EARLIEST_QUARTER; i++) {
 		print("  Quarter: " + i);
-		print("    GetQuarterlyIncome();            " + AICompany.GetQuarterlyIncome(AICompany.COMPANY_SELF, i));
-		print("    GetQuarterlyExpenses();          " + AICompany.GetQuarterlyExpenses(AICompany.COMPANY_SELF, i));
-		print("    GetQuarterlyCargoDelivered();    " + AICompany.GetQuarterlyCargoDelivered(AICompany.COMPANY_SELF, i));
-		print("    GetQuarterlyPerformanceRating(); " + AICompany.GetQuarterlyPerformanceRating(AICompany.COMPANY_SELF, i));
-		print("    GetQuarterlyCompanyValue();      " + AICompany.GetQuarterlyCompanyValue(AICompany.COMPANY_SELF, i));
+		print("    GetQuarterlyIncome():            " + AICompany.GetQuarterlyIncome(AICompany.COMPANY_SELF, i));
+		print("    GetQuarterlyExpenses():          " + AICompany.GetQuarterlyExpenses(AICompany.COMPANY_SELF, i));
+		print("    GetQuarterlyCargoDelivered():    " + AICompany.GetQuarterlyCargoDelivered(AICompany.COMPANY_SELF, i));
+		print("    GetQuarterlyPerformanceRating(): " + AICompany.GetQuarterlyPerformanceRating(AICompany.COMPANY_SELF, i));
+		print("    GetQuarterlyCompanyValue():      " + AICompany.GetQuarterlyCompanyValue(AICompany.COMPANY_SELF, i));
 	}
 }
 

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -615,178 +615,178 @@ ERROR: IsEnd() is invalid as Begin() is never called
   GetCompanyHQ():                    33153
   BuildCompanyHQ():                  false
   GetLastErrorString():              ERR_AREA_NOT_CLEAR
-  GetAutoRenewStatus();              true
-  SetAutoRenewStatus(true);          true
-  GetAutoRenewStatus();              true
-  SetAutoRenewStatus(true);          true
-  SetAutoRenewStatus(false);         true
-  GetAutoRenewStatus();              false
-  GetAutoRenewMonths();              6
-  SetAutoRenewMonths(-12);           true
-  GetAutoRenewMonths();              -12
-  SetAutoRenewMonths(-12);           true
-  SetAutoRenewMonths(6);             true
-  GetAutoRenewMoney();               100000
-  SetAutoRenewMoney(200000);         true
-  GetAutoRenewMoney();               200000
-  SetAutoRenewMoney(200000);         true
-  SetAutoRenewMoney(100000);         true
+  GetAutoRenewStatus():              true
+  SetAutoRenewStatus(true):          true
+  GetAutoRenewStatus():              true
+  SetAutoRenewStatus(true):          true
+  SetAutoRenewStatus(false):         true
+  GetAutoRenewStatus():              false
+  GetAutoRenewMonths():              6
+  SetAutoRenewMonths(-12):           true
+  GetAutoRenewMonths():              -12
+  SetAutoRenewMonths(-12):           true
+  SetAutoRenewMonths(6):             true
+  GetAutoRenewMoney():               100000
+  SetAutoRenewMoney(200000):         true
+  GetAutoRenewMoney():               200000
+  SetAutoRenewMoney(200000):         true
+  SetAutoRenewMoney(100000):         true
   Quarter: -1
-    GetQuarterlyIncome();            -1
-    GetQuarterlyExpenses();          -1
-    GetQuarterlyCargoDelivered();    -1
-    GetQuarterlyPerformanceRating(); -1
-    GetQuarterlyCompanyValue();      -1
+    GetQuarterlyIncome():            -1
+    GetQuarterlyExpenses():          -1
+    GetQuarterlyCargoDelivered():    -1
+    GetQuarterlyPerformanceRating(): -1
+    GetQuarterlyCompanyValue():      -1
   Quarter: 0
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          -210
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); -1
-    GetQuarterlyCompanyValue();      1
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          -210
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): -1
+    GetQuarterlyCompanyValue():      1
   Quarter: 1
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 2
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 3
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 4
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 5
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 6
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 7
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 8
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 9
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 10
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 11
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 12
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 13
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 14
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 15
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 16
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 17
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 18
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 19
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 20
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 21
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 22
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 23
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
   Quarter: 24
-    GetQuarterlyIncome();            0
-    GetQuarterlyExpenses();          0
-    GetQuarterlyCargoDelivered();    0
-    GetQuarterlyPerformanceRating(); 0
-    GetQuarterlyCompanyValue();      0
+    GetQuarterlyIncome():            0
+    GetQuarterlyExpenses():          0
+    GetQuarterlyCargoDelivered():    0
+    GetQuarterlyPerformanceRating(): 0
+    GetQuarterlyCompanyValue():      0
 
 --AIAirport--
   IsHangarTile():       false


### PR DESCRIPTION
## Motivation / Problem
When outputing regression log into a file, CMake uses semicolon to create a new line, but it shouldn't.
![KwYcWCX - Imgur](https://user-images.githubusercontent.com/43006711/104121916-c6e3ef00-5339-11eb-942e-72e6047dde2e.png)

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This PR removes the semicolons from regression AI and its result.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
