### PR TITLE
Allow NewGRF vehicles to query the track-type NewGRF about the current track-type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,4 +44,5 @@ Some things are not automated, and forgotten often. This list is a reminder for 
     * ai_changelog.hpp, gs_changelog.hpp need updating.
     * The compatibility wrappers (compat_*.nut) need updating.
 * This PR affects the NewGRF API? (label 'needs review: NewGRF')
+    * newgrf_debug_data.h may need updating.
     * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -91,7 +91,10 @@ uint16 GetCargoCallback(CallbackID callback, uint32 param1, uint32 param2, const
 CargoID GetCargoTranslation(uint8 cargo, const GRFFile *grffile, bool usebit)
 {
 	/* Pre-version 7 uses the 'climate dependent' ID in callbacks and properties, i.e. cargo is the cargo ID */
-	if (grffile->grf_version < 7 && !usebit) return cargo;
+	if (grffile->grf_version < 7 && !usebit) {
+		if (cargo >= CargoSpec::GetArraySize() || !CargoSpec::Get(cargo)->IsValid()) return CT_INVALID;
+		return cargo;
+	}
 
 	/* Other cases use (possibly translated) cargobits */
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -702,6 +702,36 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 			return ret;
 		}
 
+		case 0x63:
+			/* Tile compatibility wrt. arbitrary track-type
+			 * Format:
+			 *  bit 0: Type 'parameter' is known.
+			 *  bit 1: Engines with type 'parameter' are compatible with this tile.
+			 *  bit 2: Engines with type 'parameter' are powered on this tile.
+			 *  bit 3: This tile has type 'parameter' or it is considered equivalent (alternate labels).
+			 */
+			switch (v->type) {
+				case VEH_TRAIN: {
+					RailType param_type = GetRailTypeTranslation(parameter, object->ro.grffile);
+					if (param_type == INVALID_RAILTYPE) return 0x00;
+					RailType tile_type = GetTileRailType(v->tile);
+					if (tile_type == param_type) return 0x0F;
+					return (HasPowerOnRail(param_type, tile_type) ? 0x04 : 0x00) |
+							(IsCompatibleRail(param_type, tile_type) ? 0x02 : 0x00) |
+							0x01;
+				}
+				case VEH_ROAD: {
+					RoadTramType rtt = GetRoadTramType(RoadVehicle::From(v)->roadtype);
+					RoadType param_type = GetRoadTypeTranslation(rtt, parameter, object->ro.grffile);
+					if (param_type == INVALID_ROADTYPE) return 0x00;
+					RoadType tile_type = GetRoadType(v->tile, rtt);
+					if (tile_type == param_type) return 0x0F;
+					return (HasPowerOnRoad(param_type, tile_type) ? 0x06 : 0x00) |
+							0x01;
+				}
+				default: return 0x00;
+			}
+
 		case 0xFE:
 		case 0xFF: {
 			uint16 modflags = 0;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -609,12 +609,18 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 			switch (v->type) {
 				case VEH_TRAIN: {
 					RailType rt = GetTileRailType(v->tile);
-					return (HasPowerOnRail(Train::From(v)->railtype, rt) ? 0x100 : 0) | GetReverseRailTypeTranslation(rt, object->ro.grffile);
+					const RailtypeInfo *rti = GetRailTypeInfo(rt);
+					return ((rti->flags & RTFB_CATENARY) ? 0x200 : 0) |
+						(HasPowerOnRail(Train::From(v)->railtype, rt) ? 0x100 : 0) |
+						GetReverseRailTypeTranslation(rt, object->ro.grffile);
 				}
 
 				case VEH_ROAD: {
 					RoadType rt = GetRoadType(v->tile, GetRoadTramType(RoadVehicle::From(v)->roadtype));
-					return 0x100 | GetReverseRoadTypeTranslation(rt, object->ro.grffile);
+					const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
+					return ((rti->flags & ROTFB_CATENARY) ? 0x200 : 0) |
+						0x100 |
+						GetReverseRoadTypeTranslation(rt, object->ro.grffile);
 				}
 
 				default:

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -311,6 +311,7 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 		case 0x70:
 		case 0x71: {
 			CargoID cargo = GetCargoTranslation(parameter, this->ro.grffile);
+			if (cargo == CT_INVALID) return 0;
 			int index = this->industry->GetCargoProducedIndex(cargo);
 			if (index < 0) return 0; // invalid cargo
 			switch (variable) {
@@ -329,6 +330,7 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 		case 0x6E:
 		case 0x6F: {
 			CargoID cargo = GetCargoTranslation(parameter, this->ro.grffile);
+			if (cargo == CT_INVALID) return 0;
 			int index = this->industry->GetCargoAcceptedIndex(cargo);
 			if (index < 0) return 0; // invalid cargo
 			if (variable == 0x6E) return this->industry->last_cargo_accepted_at[index];

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -139,6 +139,28 @@ SpriteID GetCustomSignalSprite(const RailtypeInfo *rti, TileIndex tile, SignalTy
 }
 
 /**
+ * Translate an index to the GRF-local railtype-translation table into a RailType.
+ * @param railtype  Index into GRF-local translation table.
+ * @param grffile   Originating GRF file.
+ * @return RailType or INVALID_RAILTYPE if the railtype is unknown.
+ */
+RailType GetRailTypeTranslation(uint8 railtype, const GRFFile *grffile)
+{
+	if (grffile == nullptr || grffile->railtype_list.size() == 0) {
+		/* No railtype table present. Return railtype as-is (if valid), so it works for original railtypes. */
+		if (railtype >= RAILTYPE_END || GetRailTypeInfo(static_cast<RailType>(railtype))->label == 0) return INVALID_RAILTYPE;
+
+		return static_cast<RailType>(railtype);
+	} else {
+		/* Railtype table present, but invalid index, return invalid type. */
+		if (railtype >= grffile->railtype_list.size()) return INVALID_RAILTYPE;
+
+		/* Look up railtype including alternate labels. */
+		return GetRailTypeByLabel(grffile->railtype_list[railtype]);
+	}
+}
+
+/**
  * Perform a reverse railtype lookup to get the GRF internal ID.
  * @param railtype The global (OpenTTD) railtype.
  * @param grffile The GRF to do the lookup for.

--- a/src/newgrf_railtype.h
+++ b/src/newgrf_railtype.h
@@ -58,6 +58,7 @@ struct RailTypeResolverObject : public ResolverObject {
 SpriteID GetCustomRailSprite(const RailtypeInfo *rti, TileIndex tile, RailTypeSpriteGroup rtsg, TileContext context = TCX_NORMAL, uint *num_results = nullptr);
 SpriteID GetCustomSignalSprite(const RailtypeInfo *rti, TileIndex tile, SignalType type, SignalVariant var, SignalState state, bool gui = false);
 
+RailType GetRailTypeTranslation(uint8 railtype, const GRFFile *grffile);
 uint8 GetReverseRailTypeTranslation(RailType railtype, const GRFFile *grffile);
 
 #endif /* NEWGRF_RAILTYPE_H */

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -48,6 +48,7 @@ struct RoadTypeResolverObject : public ResolverObject {
 
 SpriteID GetCustomRoadSprite(const RoadTypeInfo *rti, TileIndex tile, RoadTypeSpriteGroup rtsg, TileContext context = TCX_NORMAL, uint *num_results = nullptr);
 
+RoadType GetRoadTypeTranslation(RoadTramType rtt, uint8 tracktype, const GRFFile *grffile);
 uint8 GetReverseRoadTypeTranslation(RoadType roadtype, const GRFFile *grffile);
 
 #endif /* NEWGRF_ROADTYPE_H */

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -343,6 +343,15 @@ static const NIVariable _niv_industries[] = {
 	NIV(0x66, "get square of Euclidean distance of closes town"),
 	NIV(0x67, "count of industry and distance of closest instance"),
 	NIV(0x68, "count of industry and distance of closest instance with layout filter"),
+	NIV(0x69, "produced cargo waiting"),
+	NIV(0x6A, "cargo produced this month"),
+	NIV(0x6B, "cargo transported this month"),
+	NIV(0x6C, "cargo produced last month"),
+	NIV(0x6D, "cargo transported last month"),
+	NIV(0x6E, "date since cargo was delivered"),
+	NIV(0x6F, "waiting input cargo"),
+	NIV(0x70, "production rate"),
+	NIV(0x71, "percentage of cargo transported last month"),
 	NIV_END()
 };
 

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -63,7 +63,8 @@ static const NIVariable _niv_vehicles[] = {
 	NIV(0x4D, "position in articulated vehicle"),
 	NIV(0x60, "count vehicle id occurrences"),
 	// 0x61 not useful, since it requires register 0x10F
-	NIV(0x62, "Curvature/position difference to other vehicle"),
+	NIV(0x62, "curvature/position difference to other vehicle"),
+	NIV(0x63, "tile compatibility wrt. track-type"),
 	NIV_END()
 };
 


### PR DESCRIPTION
**This description uses "track-type" to refer to all 3 of "rail-type", "road-type" and "tram-type".**

## Motivation / Problem

Currently NewGRF vehicles can define a single track-type for their vehicles, which then decides what track-type they can drive on, and whether they are powered.

However, things are not always that binary. Dual-powered vehicles are compatible to multiple track-types and have different poweredness on them.
This extends from simple things like raising a pantograph when there is catenary, to changing vehicle power depending on whether there is electrification or whether the vehicle uses a secondary diesel engine.

Currently vehicle NewGRF can query the track-type of the current tile via var 4A. But this information is only usable when the NewGRF knows every track-type in existence.
This PR adds some variables to query some properties about the track-type on the current tile, so the vehicle NewGRF can essentially query the knowledge of the track-type NewGRF about track-type compatibility and poweredness.

## Description

This PR adds two methods to solve above problems. A simple one for simple NewGRF, and a complex one for NewGRF which want to deal with the full complexity of track-type compatibility.

* Variable 4A is extended with a flag, that reports whether there is catenary on the current tile. This is usable in simple visual effects, like raising a pantograph, when the vehicle NewGRF is not interested in dabbling in complex track-types with different AC/DC voltages, i.e. whether the catenary actually provides usable power.
* A new variable 63 is added, that allows the NewGRF to query the track-type NewGRF about compatibility and poweredness wrt. track-types they both know about.
    * The parameter is an index into the vehicle NewGRF's track-type translation table. I.e. specifies a track-type that the vehicle NewGRF knows.
    * The result value reports everything the track-type NewGRF knows about this track-type in relation to the track-type on the current tile.
    * Bit 0: Set if the track-type NewGRF also knows the queried track-type.
    * Bit 1: Set if vehicles of the queried track-type are compatible to the track on the current tile.
    * Bit 2: Set if vehicles of the queried track-type are powered on the current tile.
    * Bit 3: Set if the queried track-type is equivalent to the track-type on the current tile.

Notes:
* If the queried track-type in unknown to the track-type NewGRF, the variables return 0. All flags unset.
* Bit 2 is the major use-case. Bit 1 is added for completeness sake, and is usable for exotic multi-gauge-compatible vehicles (?!), who knows... I am sure someone wants that.
* Road vehicles do not distinguish compatibility and poweredness, so bit 1 and 2 always have the same value. This is consistent with other variables.
* Bit 3 is different to comparing the track-type from variable 4A with a fixed track-type, since it also considers alternate labels of equivalent track-types.
* I did consider changing variable 4A to also check alternate labels, and return an equivalent track-type, when the vehicle NewGRF does not know the actual track-type. But I decided against it, since the vehicle NewGRF may know multiple track-types that are considered equivalent. Picking any one of them would mislead the vehicle NewGRF in believing those track-types were distinct, and would probably result in unintentional behavior, that would be hard to fix by the vehicle NewGRF.

## Limitations

See description.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
    * ~~ai_changelog.hpp, gs_changelog.hpp need updating.~~
    * ~~The compatibility wrappers (compat_*.nut) need updating.~~
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
