### PR TITLE
Fix: tell the user if a font fails to load and fallback is about to be used

### DIFF
--- a/src/fontdetection.cpp
+++ b/src/fontdetection.cpp
@@ -347,7 +347,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	PLOGFONT os_data = MallocT<LOGFONT>(1);
 	*os_data = logfont->elfLogFont;
 	info->callback->SetFontNames(info->settings, font_name, os_data);
-	if (info->callback->FindMissingGlyphs(nullptr)) return 1;
+	if (info->callback->FindMissingGlyphs()) return 1;
 	DEBUG(freetype, 1, "Fallback font: %s (%s)", font_name, english_name);
 	return 0; // stop enumerating
 }
@@ -477,7 +477,7 @@ bool SetFallbackFont(FreeTypeSettings *settings, const char *language_isocode, i
 
 		/* Save result. */
 		callback->SetFontNames(settings, name);
-		if (!callback->FindMissingGlyphs(nullptr)) {
+		if (!callback->FindMissingGlyphs()) {
 			DEBUG(freetype, 2, "CT-Font for %s: %s", language_isocode, name);
 			result = true;
 			break;
@@ -488,10 +488,10 @@ bool SetFallbackFont(FreeTypeSettings *settings, const char *language_isocode, i
 		/* For some OS versions, the font 'Arial Unicode MS' does not report all languages it
 		 * supports. If we didn't find any other font, just try it, maybe we get lucky. */
 		callback->SetFontNames(settings, "Arial Unicode MS");
-		result = !callback->FindMissingGlyphs(nullptr);
+		result = !callback->FindMissingGlyphs();
 	}
 
-	callback->FindMissingGlyphs(nullptr);
+	callback->FindMissingGlyphs();
 	return result;
 }
 
@@ -623,7 +623,7 @@ bool SetFallbackFont(FreeTypeSettings *settings, const char *language_isocode, i
 
 			callback->SetFontNames(settings, (const char*)file);
 
-			bool missing = callback->FindMissingGlyphs(nullptr);
+			bool missing = callback->FindMissingGlyphs();
 			DEBUG(freetype, 1, "Font \"%s\" misses%s glyphs", file, missing ? "" : " no");
 
 			if (!missing) {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2017,6 +2017,17 @@ bool MissingGlyphSearcher::FindMissingGlyphs()
 				size = (FontSize)(c - SCC_FIRST_FONT);
 			} else if (!IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END) && IsPrintable(c) && !IsTextDirectionChar(c) && c != '?' && GetGlyph(size, c) == question_mark[size]) {
 				/* The character is printable, but not in the normal font. This is the case we were testing for. */
+				std::string size_name;
+
+				switch (size) {
+					case 0: size_name = "medium"; break;
+					case 1: size_name = "small"; break;
+					case 2: size_name = "large"; break;
+					case 3: size_name = "mono"; break;
+					default: NOT_REACHED();
+				}
+
+				DEBUG(freetype, 0, "Font is missing glyphs to display char 0x%X in %s font size", c, size_name.c_str());
 				return true;
 			}
 		}
@@ -2109,6 +2120,19 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 		free(_freetype.medium.os_handle);
 
 		memcpy(&_freetype, &backup, sizeof(backup));
+
+		if (!bad_font) {
+			/* Show that we loaded fallback font. To do this properly we have
+			 * to set the colour of the string, otherwise we end up with a lot
+			 * of artifacts.* The colour 'character' might change in the
+			 * future, so for safety we just Utf8 Encode it into the string,
+			 * which takes exactly three characters, so it replaces the "XXX"
+			 * with the colour marker. */
+			static char *err_str = stredup("XXXThe current font is missing some of the characters used in the texts for this language. Using system fallback font instead.");
+			Utf8Encode(err_str, SCC_YELLOW);
+			SetDParamStr(0, err_str);
+			ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_WARNING);
+		}
 
 		if (bad_font && base_font) {
 			/* Our fallback font does miss characters too, so keep the

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1998,11 +1998,9 @@ const char *GetCurrentLanguageIsoCode()
 
 /**
  * Check whether there are glyphs missing in the current language.
- * @param[out] str Pointer to an address for storing the text pointer.
  * @return If glyphs are missing, return \c true, else return \c false.
- * @post If \c true is returned and str is not nullptr, *str points to a string that is found to contain at least one missing glyph.
  */
-bool MissingGlyphSearcher::FindMissingGlyphs(const char **str)
+bool MissingGlyphSearcher::FindMissingGlyphs()
 {
 	InitFreeType(this->Monospace());
 	const Sprite *question_mark[FS_END];
@@ -2014,7 +2012,6 @@ bool MissingGlyphSearcher::FindMissingGlyphs(const char **str)
 	this->Reset();
 	for (const char *text = this->NextString(); text != nullptr; text = this->NextString()) {
 		FontSize size = this->DefaultSize();
-		if (str != nullptr) *str = text;
 		for (WChar c = Utf8Consume(&text); c != '\0'; c = Utf8Consume(&text)) {
 			if (c >= SCC_FIRST_FONT && c <= SCC_LAST_FONT) {
 				size = (FontSize)(c - SCC_FIRST_FONT);
@@ -2095,7 +2092,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 {
 	static LanguagePackGlyphSearcher pack_searcher;
 	if (searcher == nullptr) searcher = &pack_searcher;
-	bool bad_font = !base_font || searcher->FindMissingGlyphs(nullptr);
+	bool bad_font = !base_font || searcher->FindMissingGlyphs();
 #if defined(WITH_FREETYPE) || defined(_WIN32)
 	if (bad_font) {
 		/* We found an unprintable character... lets try whether we can find

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -277,7 +277,7 @@ public:
 	 */
 	virtual void SetFontNames(struct FreeTypeSettings *settings, const char *font_name, const void *os_data = nullptr) = 0;
 
-	bool FindMissingGlyphs(const char **str);
+	bool FindMissingGlyphs();
 };
 
 void CheckForMissingGlyphs(bool base_font = true, MissingGlyphSearcher *search = nullptr);


### PR DESCRIPTION
Fixes #7615 (well, not really fixes, but informs the user better).

## Motivation / Problem

When fonts fail to load, the user is not informed why and that it failed. Instead, system fallback is loaded, and that is all she wrote. Really frustrating for the user, as he would think he did the path wrong or something. None of that .. if only a single glyph is missing, all the fonts are rejected and the system fallback is used.

## Description

So instead of doing stuff in silence, be a bit more talkative:

- Report in console what character failed to render
- Show a GUI error that the font failed, and that the system fallback is used

Hopefully that makes it a bit easier to debug font issues :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
