### PR TITLE
remove unused src/3rdparty/optional licensing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,6 @@ See the comments in the source files in `src/3rdparty/md5` for the complete lice
 The implementations of Posix `getaddrinfo` and `getnameinfo` for OS/2 in `src/3rdparty/os2` are distributed partly under the GNU Lesser General Public License 2.1, and partly under the (3-clause) BSD license.
 The exact licensing terms can be found in `src/3rdparty/os2/getaddrinfo.c` resp. `src/3rdparty/os2/getnameinfo.c`.
 
-The implementation of C++17 `std::optional` in `src/3rdparty/optional` is licensed under the Boost Software License - Version 1.0.
-See `src/3rdparty/optional/LICENSE_1_0.txt` for the complete license text.
-
 
 ## 4.0 Credits
 


### PR DESCRIPTION
## Motivation / Problem

just saw it when looking through the readme, src/3rdparty/optional does not exist.

## Description

remove the license clause as it doesnt exist

## Limitations

uh i removed it

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
