### PR TITLE
Fix: Remove .sha256 files from macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,6 +452,10 @@ jobs:
         make -j$(sysctl -n hw.logicalcpu) package
         echo "::endgroup::"
 
+        # Remove the sha256 files CPack generates; we will do this ourself at
+        # the end of this workflow.
+        rm -f bundles/*.sha256
+
     - name: Install gon
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
I accidentally removed this from the release.yml in my previous PR, resulting in spurious "unknown filetype"s showing up on the nightly download page. (Plus a unit I've never seen before, "biB"!)