### PR TITLE
[SDL2] Start OpenTTD on the display where the mouse cursor is

### DIFF
--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -64,6 +64,7 @@ private:
 	uint32 last_cur_ticks;
 	uint32 next_tick;
 
+	int startup_display;
 	std::thread draw_thread;
 	std::unique_lock<std::recursive_mutex> draw_lock;
 };


### PR DESCRIPTION
## Motivation / Problem

Regular programs start on the display where the mouse cursor is.
SDL2 is aware of multi-display setups, but seems to default to screen 0.

## Description

By default the SDL2 video driver will now create the window on the display where the mouse cursor is.
For control freaks and debugging there is a driver parameter to force a particular display.

## Limitations

No idea whether this applies to other OS as well, or whether other video drivers have similar issues.

## Checklist for review

N/A