### PR TITLE
Add tile parameter for GSCompany.ChangeBankBalance to show text effect if needed

### DIFF
--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -6,3 +6,10 @@
  */
 
 GSLog.Info("1.10 API compatibility in effect.");
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -28,3 +28,10 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -28,3 +28,10 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -20,3 +20,11 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}
+

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -13,3 +13,10 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -13,3 +13,10 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -13,3 +13,10 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -13,3 +13,10 @@ GSBridge.GetName <- function(bridge_id)
 {
 	return GSBridge._GetName(bridge_id, GSVehicle.VT_RAIL);
 }
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -6,3 +6,10 @@
  */
 
 GSLog.Info("1.9 API compatibility in effect.");
+
+/* 1.11 adds a tile parameter. */
+GSCompany._ChangeBankBalance <- GSCompany.ChangeBankBalance;
+GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
+{
+	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
+}

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -19,6 +19,8 @@
 #include "company_func.h"
 #include "company_gui.h"
 #include "company_base.h"
+#include "tile_map.h"
+#include "texteff.hpp"
 #include "core/backup_type.hpp"
 
 #include "table/strings.h"
@@ -207,7 +209,7 @@ CommandCost CmdMoneyCheat(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 
 /**
  * Change the bank bank balance of a company by inserting or removing money without affecting the loan.
- * @param tile unused
+ * @param tile tile to show text effect on (if not 0)
  * @param flags operation to perform
  * @param p1 the amount of money to receive (if positive), or spend (if negative)
  * @param p2 (bit 0-7)  - the company ID.
@@ -230,6 +232,10 @@ CommandCost CmdChangeBankBalance(TileIndex tile, DoCommandFlag flags, uint32 p1,
 		Backup<CompanyID> cur_company(_current_company, company, FILE_LINE);
 		SubtractMoneyFromCompany(CommandCost(expenses_type, -delta));
 		cur_company.Restore();
+
+		if (tile != 0) {
+			ShowCostOrIncomeAnimation(TileX(tile) * TILE_SIZE, TileY(tile) * TILE_SIZE, GetTilePixelZ(tile), -delta);
+		}
 	}
 
 	/* This command doesn't cost anything for deity. */

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -35,6 +35,9 @@
  * \li GSStoryPage::MakeVehicleButtonReference
  * \li GSPriorityQueue
  *
+ * Other changes:
+ * \li GSCompany::ChangeBankBalance takes one extra parameter to refer to a location to show text effect on
+ *
  * \b 1.10.0
  *
  * API additions:

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -226,17 +226,19 @@
 	return GetLoanAmount() == loan;
 }
 
-/* static */ bool ScriptCompany::ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type)
+/* static */ bool ScriptCompany::ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
 	EnforcePrecondition(false, expenses_type < (ExpensesType)::EXPENSES_END);
 	EnforcePrecondition(false, (int64)delta >= INT32_MIN);
 	EnforcePrecondition(false, (int64)delta <= INT32_MAX);
+	EnforcePrecondition(false, tile == INVALID_TILE || ::IsValidTile(tile));
 
 	company = ResolveCompanyID(company);
 	EnforcePrecondition(false, company != COMPANY_INVALID);
 
-	return ScriptObject::DoCommand(0, (uint32)(delta), company | expenses_type << 8 , CMD_CHANGE_BANK_BALANCE);
+	/* Network commands only allow 0 to indicate invalid tiles, not INVALID_TILE */
+	return ScriptObject::DoCommand(tile == INVALID_TILE ? 0 : tile , (uint32)(delta), company | expenses_type << 8 , CMD_CHANGE_BANK_BALANCE);
 }
 
 /* static */ bool ScriptCompany::BuildCompanyHQ(TileIndex tile)

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -242,6 +242,7 @@ public:
 	 * @param company The company to change the bank balance of.
 	 * @param delta Amount of money to give or take from the bank balance. A positive value adds money to the bank balance.
 	 * @param expenses_type The account in the finances window that will register the cost.
+	 * @param tile The tile to show text effect on or ScriptMap::TILE_INVALID
 	 * @return True, if the bank balance was changed.
 	 * @game @pre No ScriptCompanyMode active in scope.
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
@@ -250,7 +251,7 @@ public:
 	 * @note You need to create your own news message to inform about costs/gifts that you create using this command.
 	 * @api -ai
 	 */
-	static bool ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type);
+	static bool ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile);
 
 	/**
 	 * Get the income of the company in the given quarter.


### PR DESCRIPTION
Add an extra tile parameter to GSCompany.ChangeBankBalance that if set to a valid tile triggers an income/cost text effect. Can be used to better communicate balance changes to a player when they can be related to a certain location. E.g. fees for using road of other company or passing a toll booth. 
![Screenshot from 2021-01-14 22-39-54](https://user-images.githubusercontent.com/413570/104654000-80d9b300-56cc-11eb-96cb-9f1d6e2206c4.png)

GS for testing: [money-spring.zip](https://github.com/OpenTTD/OpenTTD/files/5817210/money-spring.zip)


## Checklist for review
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.