### PR TITLE
Feature: Ships yield when passing through one another

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1239,6 +1239,8 @@ STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS                 :Slope steepness
 STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS_HELPTEXT        :Steepness of a sloped tile for a road vehicle. Higher values make it more difficult to climb a hill
 STR_CONFIG_SETTING_FORBID_90_DEG                                :Forbid trains from making 90° turns: {STRING2}
 STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT                       :90 degree turns occur when a horizontal track is directly followed by a vertical track piece on the adjacent tile, thus making the train turn by 90 degree when traversing the tile edge instead of the usual 45 degrees for other track combinations.
+STR_CONFIG_SETTING_SHIPS_YIELD                                  :Ships yield when passing through each other
+STR_CONFIG_SETTING_SHIPS_YIELD_HELPTEXT                         :Select if ships yield when passing through each other. The fastest ship on the tile takes priority, then the ship carrying the most cargo
 STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS                        :Allow to join stations not directly adjacent: {STRING2}
 STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS_HELPTEXT               :Allow adding parts to a station without directly touching the existing parts. Needs Ctrl+Click while placing the new parts
 STR_CONFIG_SETTING_INFLATION                                    :Inflation: {STRING2}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -325,6 +325,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_VEH_MOTION_COUNTER,                 ///< 288  PR#8591 Desync safe motion counter
 	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 v1.11.0-RC1  Additional GS text for industries.
 	SLV_MAPGEN_SETTINGS_REVAMP,             ///< 290  PR#8891 v1.11  Revamp of some mapgen settings (snow coverage, desert coverage, heightmap height, custom terrain type).
+	SLV_SHIP_YIELD,                         ///< 291  PR#8574 Ships yield when passing through one another
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1669,6 +1669,7 @@ static SettingsContainer &GetSettingsTree()
 				routing->Add(new SettingEntry("difficulty.line_reverse_mode"));
 				routing->Add(new SettingEntry("pf.reverse_at_signals"));
 				routing->Add(new SettingEntry("pf.forbid_90_deg"));
+				routing->Add(new SettingEntry("vehicle.ships_yield"));
 				routing->Add(new SettingEntry("pf.pathfinder_for_roadvehs"));
 				routing->Add(new SettingEntry("pf.pathfinder_for_ships"));
 			}

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -480,6 +480,7 @@ struct VehicleSettings {
 	byte   extend_vehicle_life;              ///< extend vehicle life by this many years
 	byte   road_side;                        ///< the side of the road vehicles drive on
 	uint8  plane_crashes;                    ///< number of plane crashes, 0 = none, 1 = reduced, 2 = normal
+	bool   ships_yield;                      ///< whether ships yield when passing through each other
 };
 
 /** Settings related to the economy. */

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -878,6 +878,15 @@ strhelp  = STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT
 proc     = InvalidateShipPathCache
 cat      = SC_EXPERT
 
+[SDT_BOOL]
+base     = GameSettings
+var      = vehicle.ships_yield
+from     = SLV_SHIP_YIELD
+def      = true
+str      = STR_CONFIG_SETTING_SHIPS_YIELD
+strhelp  = STR_CONFIG_SETTING_SHIPS_YIELD_HELPTEXT
+cat      = SC_ADVANCED
+
 [SDT_VAR]
 base     = GameSettings
 var      = vehicle.max_train_length


### PR DESCRIPTION
## Motivation / Problem

Because ships have no collisions, they have infinite capacity with minimal infrastructure. This does not match the rest of the game, where designing and upgrading infrastructure is a large part of the gameplay.

## Description

Various ideas have been floated to solve this, but most have to do with pathfinding. JGR’s patchpack includes such a patch, but it’s possible to create gridlock in tight areas.

This PR takes a more permissive approach, allowing ships to clip through each other, but only allowing one ship on each tile to move while stopping the rest. Railroad Tycoon 3 used this to allow trains to pass on single track or overtake slower trains (thanks to andythenorth for suggesting this).

In this implementation, the priority goes to the fastest ship, with a primary tiebreaker of the ship carrying the most cargo and a fallback of the ship index. I chose speed because it allows fast ships to overtake slow ships traveling in the same direction, and because speed is a reasonably accurate surrogate for priority. I initially tried prioritizing cargo for ships traveling in opposite directions, but it allowed a feedback loop in locks where three ships would take turns moving one tick at a time.

With this change, players are not required to change their gameplay, however with moderate to heavy traffic, docks, locks, and single-tile bidirectional canals become clogged and inefficient. This gives players an incentive to build multiple docks in busy harbors, construct two-tile canals and docks, and use buoys to route ships in multiple sea lanes. This is more in line with gameplay for trains, road vehicles, and aircraft (and is also fun, I think!).

There is an additional visual improvement, since ships traveling in the same direction are often unbunched by disruptions in harbors and locks, and even when traveling a single tile apart, don’t clip nearly as much.

I have created a savegame which demonstrates how this change affects old designs, and how they can be fixed with more interesting and realistic infrastructure: [ShipDemo.zip](https://github.com/OpenTTD/OpenTTD/files/5817571/ShipDemo.zip)

This feature is controlled by a setting, so players can choose to disable it.

## Limitations

When many ships overlap, there has always been some flickering of the sprites. This seems to be slightly increased in this PR, mostly at docks which many ships are trying to reach at once. I suspect it’s because the ship sprite is being marked dirty each time it is stopped.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
