### PR TITLE
Feature: Allow GameScripts to add additional text to Industry view window

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -266,7 +266,7 @@ static const Command _command_proc_table[] = {
 	DEF_CMD(CmdChangeServiceInt,                               0, CMDT_VEHICLE_MANAGEMENT    ), // CMD_CHANGE_SERVICE_INT
 
 	DEF_CMD(CmdBuildIndustry,                          CMD_DEITY, CMDT_LANDSCAPE_CONSTRUCTION), // CMD_BUILD_INDUSTRY
-	DEF_CMD(CmdIndustryCtrl,                           CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_INDUSTRY_CTRL
+	DEF_CMD(CmdIndustryCtrl,            CMD_STR_CTRL | CMD_DEITY, CMDT_OTHER_MANAGEMENT      ), // CMD_INDUSTRY_CTRL
 
 	DEF_CMD(CmdSetCompanyManagerFace,                          0, CMDT_OTHER_MANAGEMENT      ), // CMD_SET_COMPANY_MANAGER_FACE
 	DEF_CMD(CmdSetCompanyColour,                               0, CMDT_OTHER_MANAGEMENT      ), // CMD_SET_COMPANY_COLOUR

--- a/src/industry.h
+++ b/src/industry.h
@@ -33,6 +33,13 @@ enum ProductionLevels {
 	PRODLEVEL_MAXIMUM = 0x80,  ///< the industry is running at full speed
 };
 
+enum class IndustryAction : byte {
+	SetControlFlags = 0,       ///< Set IndustryControlFlags
+	SetExclusiveSupplier = 1,  ///< Set exclusive supplier
+	SetExclusiveConsumer = 2,  ///< Set exclusive consumer
+	SetText = 3,               ///< Set additional text
+};
+
 /**
  * Flags to control/override the behaviour of an industry.
  * These flags are controlled by game scripts.
@@ -91,6 +98,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	byte selected_layout;          ///< Which tile layout was used when creating the industry
 	Owner exclusive_supplier;      ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
 	Owner exclusive_consumer;      ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)
+	std::string text;              ///< General text with additional information.
 
 	uint16 random;                 ///< Random value used for randomisation of all kinds of things
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -913,6 +913,13 @@ public:
 				}
 			}
 		}
+
+		if (!i->text.empty()) {
+			SetDParamStr(0, i->text.c_str());
+			y += WD_PAR_VSEP_WIDE;
+			y = DrawStringMultiLine(left + WD_FRAMERECT_LEFT, right - WD_FRAMERECT_RIGHT, y, UINT16_MAX, STR_JUST_RAW_STRING, TC_BLACK);
+		}
+
 		return y + WD_FRAMERECT_BOTTOM;
 	}
 

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -72,6 +72,7 @@ static const SaveLoad _industry_desc[] = {
 
 	SLE_CONDNULL(1, SLV_82, SLV_197), // random_triggers
 	SLE_CONDVAR(Industry, random,                     SLE_UINT16,                SLV_82, SL_MAX_VERSION),
+	SLE_CONDSSTR(Industry, text,     SLE_STR | SLF_ALLOW_CONTROL,     SLV_INDUSTRY_TEXT, SL_MAX_VERSION),
 
 	SLE_CONDNULL(32, SLV_2, SLV_144), // old reserved space
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -323,6 +323,7 @@ enum SaveLoadVersion : uint16 {
 
 	SLV_GS_INDUSTRY_CONTROL,                ///< 287  PR#7912 and PR#8115 GS industry control.
 	SLV_VEH_MOTION_COUNTER,                 ///< 288  PR#8591 Desync safe motion counter
+	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 Additional GS text for industries.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -30,6 +30,7 @@
  * \li GSIndustry::SetControlFlags
  * \li GSIndustry::SetExclusiveConsumer
  * \li GSIndustry::SetExclusiveSupplier
+ * \li GSIndustry::SetText
  * \li GSStoryPage::MakePushButtonReference
  * \li GSStoryPage::MakeTileButtonReference
  * \li GSStoryPage::MakeVehicleButtonReference

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -15,6 +15,7 @@
 #include "script_map.hpp"
 #include "../../company_base.h"
 #include "../../industry.h"
+#include "../../string_func.h"
 #include "../../strings_func.h"
 #include "../../station_base.h"
 #include "../../newgrf_industries.h"
@@ -45,6 +46,20 @@
 
 	::SetDParam(0, industry_id);
 	return GetString(STR_INDUSTRY_NAME);
+}
+
+/* static */ bool ScriptIndustry::SetText(IndustryID industry_id, Text *text)
+{
+	CCountedPtr<Text> counter(text);
+
+	const char *encoded_text = nullptr;
+	if (text != nullptr) {
+		encoded_text = text->GetEncodedText();
+		EnforcePreconditionEncodedText(false, encoded_text);
+	}
+	EnforcePrecondition(false, IsValidIndustry(industry_id));
+
+	return ScriptObject::DoCommand(0, industry_id, static_cast<uint32>(IndustryAction::SetText), CMD_INDUSTRY_CTRL, encoded_text);
 }
 
 /* static */ ScriptIndustry::CargoAcceptState ScriptIndustry::IsCargoAccepted(IndustryID industry_id, CargoID cargo_id)

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -82,6 +82,16 @@ public:
 	static char *GetName(IndustryID industry_id);
 
 	/**
+	 * Set the custom text of an industry, shown in the GUI.
+	 * @param industry_id The industry to set the custom text of.
+	 * @param text The text to set it to (can be either a raw string, or a ScriptText object). If null is passed, the text will be removed.
+	 * @pre IsValidIndustry(industry_id).
+	 * @return True if the action succeeded.
+	 * @api -ai
+	 */
+	static bool SetText(IndustryID industry_id, Text *text);
+
+	/**
 	 * See whether an industry currently accepts a certain cargo.
 	 * @param industry_id The index of the industry.
 	 * @param cargo_id The index of the cargo.


### PR DESCRIPTION
## Motivation / Problem

With #8115 and #7912 been merged it becomes quite important for GameScripts to have the ability to communicate some extra info about specific industries to the player. This PR adds an additional text field to the industry that is shown at the bottom of the industry view window, much like it's already done for towns.

GS for testing: 
[industry-text-test.zip](https://github.com/OpenTTD/OpenTTD/files/5821228/industry-text-test.zip)


## Checklist for review

* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.