### PR TITLE
Fix: Only center the window, when it is smaller than the screen.

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -275,8 +275,8 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 		int x = SDL_WINDOWPOS_UNDEFINED, y = SDL_WINDOWPOS_UNDEFINED;
 		SDL_Rect r;
 		if (SDL_GetDisplayBounds(this->startup_display, &r) == 0) {
-			x = r.x + (r.w - w) / 2;
-			y = r.y + (r.h - h) / 4; // decent desktops have taskbars at the bottom
+			x = r.x + std::max(0, r.w - static_cast<int>(w)) / 2;
+			y = r.y + std::max(0, r.h - static_cast<int>(h)) / 4; // decent desktops have taskbars at the bottom
 		}
 		_sdl_window = SDL_CreateWindow(
 			caption,


### PR DESCRIPTION
## Motivation / Problem

Subtracting unsigned from unsigned results in big unsigned. So, unless the window manager prevents it, the window is places off screen.
Probably only happens on windows.

## Description

Only center the window, when it is smaller than the screen.

## Limitations

N/A

## Checklist for review

N/A
