### PR TITLE
Feature: Add ARM64 build for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,6 +512,7 @@ jobs:
         include:
         - arch: x86
         - arch: x64
+        - arch: arm64
 
     runs-on: windows-latest
 
@@ -559,7 +560,7 @@ jobs:
       uses: ammaraskar/msvc-problem-matcher@master
 
     - name: Build (with installer)
-      if: needs.source.outputs.is_tag == 'true' && matrix.arch != 'arm64'
+      if: needs.source.outputs.is_tag == 'true'
       uses: lukka/run-cmake@v3
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
@@ -568,7 +569,7 @@ jobs:
         cmakeAppendedArgs: ' -GNinja -DOPTION_USE_NSIS=ON -DHOST_BINARY_DIR=${{ github.workspace }}/build-host -DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
     - name: Build (without installer)
-      if: needs.source.outputs.is_tag != 'true' || matrix.arch == 'arm64'
+      if: needs.source.outputs.is_tag != 'true'
       uses: lukka/run-cmake@v3
       with:
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -70,10 +70,15 @@ endif()
 # Windows is a bit more annoying to detect; using the size of void pointer
 # seems to be the most robust.
 if(WIN32)
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(ARCHITECTURE "win64")
+    # Check if the MSVC platform has been defined
+    if ("$ENV{Platform}" STREQUAL "arm64")
+        set(ARCHITECTURE "arm64")
     else()
-        set(ARCHITECTURE "win32")
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(ARCHITECTURE "win64")
+        else()
+            set(ARCHITECTURE "win32")
+        endif()
     endif()
 endif()
 if(APPLE AND CMAKE_OSX_ARCHITECTURES)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -16,11 +16,18 @@
 
 /* rdtsc for MSC_VER, uses simple inline assembly, or _rdtsc
  * from external win64.asm because VS2005 does not support inline assembly */
-#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64)) && !defined(RDTSC_AVAILABLE)
+#if defined(_MSC_VER) && !defined(RDTSC_AVAILABLE)
 #include <intrin.h>
+#include <windows.h>
 uint64 ottd_rdtsc()
 {
+#if defined(_M_ARM)
+	return __rdpmccntr64();
+#elif defined(_M_ARM64)
+	return _ReadStatusReg(ARM64_PMCCNTR_EL0);
+#else
 	return __rdtsc();
+#endif
 }
 #define RDTSC_AVAILABLE
 #endif


### PR DESCRIPTION
## Motivation / Problem

This adds a nightly (and release) ARM64 build for Windows. (While we could technically also support ARM32, I'm not sure there's enough of a user base for it to be worth supporting.)

This also enables support for NSIS arm64 builds (NSIS itself remains x86 but Windows for ARM does have x86 emulation support, and the installer works fine in my testing).