### PR TITLE
Fix recent NewGRF spec addition to make it less surprising/arbitrary

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2754,8 +2754,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 
 				/* Prevent production to overflow or Oil Rig passengers to be over-"produced" */
 				new_prod = Clamp(new_prod, 1, 255);
-
-				if (((indspec->behaviour & INDUSTRYBEH_BUILT_ONWATER) != 0) && j == 1 && !(indspec->behaviour & INDUSTRYBEH_WATER_NO_CLAMP_PROD)) {
+				if (i->produced_cargo[j] == CT_PASSENGERS && !(indspec->behaviour & INDUSTRYBEH_NO_PAX_PROD_CLAMP)) {
 					new_prod = Clamp(new_prod, 0, 16);
 				}
 

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -80,7 +80,7 @@ enum IndustryBehaviour {
 	INDUSTRYBEH_NOBUILT_MAPCREATION   = 1 << 16, ///< Do not force one instance of this type to appear on map generation
 	INDUSTRYBEH_CANCLOSE_LASTINSTANCE = 1 << 17, ///< Allow closing down the last instance of this type
 	INDUSTRYBEH_CARGOTYPES_UNLIMITED  = 1 << 18, ///< Allow produced/accepted cargoes callbacks to supply more than 2 and 3 types
-	INDUSTRYBEH_WATER_NO_CLAMP_PROD   = 1 << 19, ///< Do not clamp production of second cargo for water industries
+	INDUSTRYBEH_NO_PAX_PROD_CLAMP     = 1 << 19, ///< Do not clamp production of passengers. (smooth economy only)
 };
 DECLARE_ENUM_AS_BIT_SET(IndustryBehaviour)
 


### PR DESCRIPTION
## Motivation / Problem

While adding recent NewGRF features to NML, I came across #8079.
To translate NewGRF jargon into English, it adds this footnote to the API:
> When smooth economy is enabled in OpenTTD and the NewGRF provides no custom production-change mechanics, there is a special case:
> * If the industry is built on water, then the second output cargo is clamped to produce at most 16 units per production cycle.
> * This only applies to water-based industries, and only to the second output cargo.
> * If this behaviour is unwanted, NewGRFs have to disable it explicitly.

As a NewGRF author I would not expect the "second output cargo" to behave any different from other output cargos, just because my industry happens to be built on water.

From a NML perspective this flag could be considered as "enable work-around for OpenTTD bug", so NML could enable it silently by default.
However, it's both easier and likely better to give the flag some intention, and implement it with less arbitrary conditions.

## Description

The original intention of the special case in OpenTTD seems to be the original oil rig.
The oil rig features passengers as "support cargo", which are not supposed to be produced en-mass.

This PR changes the behavior of the flag added in #8079:
* The condition "second output cargo" is replaced with "passenger production".
* The condition "water-based industry" is removed.

This behavior is easier to explain, and likely also fits better what a NewGRF industry may want to achieve.

The "passenger" condition only triggers for real passenger, not for "tourists" or other cargos with "passenger" cargo class.
Though industry sets that feature "worker mechanics" always have custom production mechanics, so that smooth economy and this flag does not apply anyway.

In summary:
* The flag does no longer trigger for arbitrary NewGRF industries, that happen to be built on water.
* The flag does not trigger for NewGRF with distinct worker or tourist mechanics.
* The flag only triggers for NewGRF industries that behave similar to the original oil rig: when producing passengers "just like that", with no further production mechanics involved.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
