### PR TITLE
Fix: Prevent showing company is in trouble again after about 260 months due to overflow

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -609,6 +609,7 @@ static void CompanyCheckBankrupt(Company *c)
 				 * is no THE-END, otherwise mark the client as spectator to make sure
 				 * he/she is no long in control of this company. However... when you
 				 * join another company (cheat) the "unowned" company can bankrupt. */
+				c->months_of_bankruptcy--;
 				c->bankrupt_asked = MAX_UVALUE(CompanyMask);
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem
When in single player, the company the player is in cannot bankrupt, but c->months_of_bankruptcy counter keeps going up every month the company is in red. It overflows once it reaches 255, restarting at 0. So, at aproximatelly 260 months, (case 4), the newspaper displays again that the company is in trouble.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Bug is fixed by decreasing months_of_bankruptcy counter by 1 inside the check where it maintains the company playing.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
