### PR TITLE
Feature: add 'screenshot res <x> <y> [<filename>]' console command

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1407,17 +1407,21 @@ DEF_CONSOLE_CMD(ConAlias)
 DEF_CONSOLE_CMD(ConScreenShot)
 {
 	if (argc == 0) {
-		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [big | giant | no_con | minimap] [file name]'");
+		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [big | giant | no_con | minimap | res <x> <y>] [<filename>]'");
 		IConsoleHelp("'big' makes a zoomed-in screenshot of the visible area, 'giant' makes a screenshot of the "
 				"whole map, 'no_con' hides the console to create the screenshot. 'big' or 'giant' "
 				"screenshots are always drawn without console. "
-				"'minimap' makes a top-viewed minimap screenshot of whole world which represents one tile by one pixel.");
+				"'minimap' makes a top-viewed minimap screenshot of whole world which represents one tile by one pixel. "
+				"'res' makes a screenshot at the default zoom level, but with a custom screen resolution. "
+				"if either <x> or <y> is 0, a default zoom screenshot of the visible area is made instead.");
 		return true;
 	}
 
-	if (argc > 3) return false;
+	if ((argc > 3 && strcmp(argv[1], "res") != 0) || argc > 5) return false;
 
 	ScreenshotType type = SC_VIEWPORT;
+	uint32 res_x = 0;
+	uint32 res_y = 0;
 	const char *name = nullptr;
 
 	if (argc > 1) {
@@ -1437,6 +1441,13 @@ DEF_CONSOLE_CMD(ConScreenShot)
 			/* screenshot no_con [filename] */
 			IConsoleClose();
 			if (argc > 2) name = argv[2];
+		} else if (strcmp(argv[1], "res") == 0) {
+			/* screenshot res <x> <y> [filename] */
+			if (argc < 4) return false;
+			type = SC_DEFAULTZOOM;
+			GetArgumentInteger(&res_x, argv[2]);
+			GetArgumentInteger(&res_y, argv[3]);
+			if (argc > 4) name = argv[4];
 		} else if (argc == 2) {
 			/* screenshot filename */
 			name = argv[1];
@@ -1446,7 +1457,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 		}
 	}
 
-	MakeScreenshot(type, name);
+	MakeScreenshot(type, name, res_x, res_y);
 	return true;
 }
 

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -25,10 +25,10 @@ enum ScreenshotType {
 	SC_MINIMAP,     ///< Minimap screenshot.
 };
 
-void SetupScreenshotViewport(ScreenshotType t, struct Viewport *vp);
+void SetupScreenshotViewport(ScreenshotType t, struct Viewport *vp, uint32 res_x = 0, uint32 res_y = 0);
 bool MakeHeightmapScreenshot(const char *filename);
 void MakeScreenshotWithConfirm(ScreenshotType t);
-bool MakeScreenshot(ScreenshotType t, const char *name);
+bool MakeScreenshot(ScreenshotType t, const char *name, uint32 res_x = 0, uint32 res_y = 0);
 bool MakeMinimapWorldScreenshot();
 
 extern char _screenshot_format_name[8];


### PR DESCRIPTION
## Motivation / Problem

For title save contests, a way to automatically make screenshots of different resolutions independent from the screen resolution is needed
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

this PR adds a mode to the existing `screenshot` command to supply custom resolutions, and makes a screenshot with the default zoom level

usage: `screenshot res <x> <y> [<filename>]`

if either `<x>` or `<y>` are 0, it falls back to the "default zoom screenshot" of the current viewport

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

there is no range check on the resolutions, so giving ridiculously high numbers might go OOM

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
