### PR TITLE
Fix: Assert from towns looking outside map when trying to build tunnels

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1256,6 +1256,7 @@ static bool GrowTownWithTunnel(const Town* t, const TileIndex tile, const DiagDi
 		/* Only tunnel under a mountain if the slope is continuous for at least 4 tiles. We want tunneling to be a last resort for large hills. */
 		TileIndex slope_tile = tile;
 		for (uint8 tiles = 0; tiles < 4; tiles++) {
+			if (!IsValidTile(slope_tile)) return false;
 			slope = GetTileSlope(slope_tile);
 			if (slope != InclinedSlope(tunnel_dir) && !IsSteepSlope(slope) && !IsSlopeWithOneCornerRaised(slope)) return false;
 			slope_tile += delta;


### PR DESCRIPTION
## Motivation / Problem

@SamuXarick reported [an assertion error](https://pastebin.com/8ZLkirw8) during map generation related to GrowTownWithTunnel() checking the slope of a tile outside the map.

## Description

When looking up the slope to measure the height of the mountain, the town needs to check the validity of the tile before attempting to measure the slope. Checking a tile outside the map would produce an assertion error in TileHeight() via GetTileSlope(), as in the crash report linked above.

## Limitations

I cannot reliably reproduce the assertion error in Scenario Editor or during live gameplay, so testing is based on repeatedly running map generation with and without this change.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
