### PR TITLE
Feature: Object class selection string filtering

### DIFF
--- a/src/widgets/object_widget.h
+++ b/src/widgets/object_widget.h
@@ -12,6 +12,7 @@
 
 /** Widgets of the #BuildObjectWindow class. */
 enum BuildObjectWidgets {
+	WID_BO_FILTER,         ///< The filter text box for the object list.
 	WID_BO_CLASS_LIST,     ///< The list with classes.
 	WID_BO_SCROLLBAR,      ///< The scrollbar associated with the list.
 	WID_BO_OBJECT_MATRIX,  ///< The matrix with preview sprites.


### PR DESCRIPTION
## Motivation / Problem

Players can use NewGRF in a new game, and some of them contain _objects_ than can be placed on the map. To make it easier for players to browse throughout the list of _object classes_, this pull request adds a text edit box to the _Object Selection_ window so _object classes_ can be filtered by.

## Description

Adding a filter for object classes in the _Object Selection_ window.

![filter](https://user-images.githubusercontent.com/2025406/105945661-8e6f3100-601a-11eb-884f-c687dc5dffed.png)

## Limitations

Note that object classes are filtered by objects themselves are not.

## Highlights

- Selection gets preserved when filtering
- Always a class selected if filter removes all
- Re-opening the window selects the previous object class and object
- Starting a new game too, but only if the corresponding NewGRF is still available.

I plan to do the same for stations next probably. Or vehicles?

## Checklist for review

N/A
