### PR TITLE
Codechanges to SDL2 driver to increase readability (and make it more like Win32 driver)

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -282,7 +282,6 @@ static uint FindStartupDisplay(uint startup_display)
 bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 {
 	SDL_Surface *newscreen;
-	char caption[50];
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 
 	GetAvailableVideoMode(&w, &h);
@@ -291,8 +290,6 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 
 	/* Free any previously allocated shadow surface */
 	if (_sdl_surface != nullptr && _sdl_surface != _sdl_realscreen) SDL_FreeSurface(_sdl_surface);
-
-	seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
 
 	if (_sdl_window == nullptr) {
 		Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
@@ -307,6 +304,9 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 			x = r.x + std::max(0, r.w - static_cast<int>(w)) / 2;
 			y = r.y + std::max(0, r.h - static_cast<int>(h)) / 4; // decent desktops have taskbars at the bottom
 		}
+
+		char caption[50];
+		seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
 		_sdl_window = SDL_CreateWindow(
 			caption,
 			x, y,

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -7,8 +7,6 @@
 
 /** @file sdl2_v.cpp Implementation of the SDL2 video driver. */
 
-#ifdef WITH_SDL2
-
 #include "../stdafx.h"
 #include "../openttd.h"
 #include "../gfx_func.h"
@@ -962,5 +960,3 @@ Dimension VideoDriver_SDL::GetScreenSize() const
 
 	return { static_cast<uint>(mode.w), static_cast<uint>(mode.h) };
 }
-
-#endif /* WITH_SDL2 */

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -306,7 +306,7 @@ bool VideoDriver_SDL::CreateMainWindow(uint w, uint h)
 		flags);
 
 	if (_sdl_window == nullptr) {
-		DEBUG(driver, 0, "SDL2: Couldn't allocate a window to draw on");
+		DEBUG(driver, 0, "SDL2: Couldn't allocate a window to draw on: %s", SDL_GetError());
 		return false;
 	}
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -280,56 +280,61 @@ static uint FindStartupDisplay(uint startup_display)
 	return 0;
 }
 
+bool VideoDriver_SDL::CreateMainWindow(uint w, uint h)
+{
+	if (_sdl_window != nullptr) return true;
+
+	Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
+
+	if (_fullscreen) {
+		flags |= SDL_WINDOW_FULLSCREEN;
+	}
+
+	int x = SDL_WINDOWPOS_UNDEFINED, y = SDL_WINDOWPOS_UNDEFINED;
+	SDL_Rect r;
+	if (SDL_GetDisplayBounds(this->startup_display, &r) == 0) {
+		x = r.x + std::max(0, r.w - static_cast<int>(w)) / 2;
+		y = r.y + std::max(0, r.h - static_cast<int>(h)) / 4; // decent desktops have taskbars at the bottom
+	}
+
+	char caption[50];
+	seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
+	_sdl_window = SDL_CreateWindow(
+		caption,
+		x, y,
+		w, h,
+		flags);
+
+	if (_sdl_window == nullptr) {
+		DEBUG(driver, 0, "SDL2: Couldn't allocate a window to draw on");
+		return false;
+	}
+
+	std::string icon_path = FioFindFullPath(BASESET_DIR, "openttd.32.bmp");
+	if (!icon_path.empty()) {
+		/* Give the application an icon */
+		SDL_Surface *icon = SDL_LoadBMP(icon_path.c_str());
+		if (icon != nullptr) {
+			/* Get the colourkey, which will be magenta */
+			uint32 rgbmap = SDL_MapRGB(icon->format, 255, 0, 255);
+
+			SDL_SetColorKey(icon, SDL_TRUE, rgbmap);
+			SDL_SetWindowIcon(_sdl_window, icon);
+			SDL_FreeSurface(icon);
+		}
+	}
+
+	return true;
+}
+
 bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 {
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 
 	GetAvailableVideoMode(&w, &h);
-
 	DEBUG(driver, 1, "SDL2: using mode %ux%ux%d", w, h, bpp);
 
-	if (_sdl_window == nullptr) {
-		Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
-
-		if (_fullscreen) {
-			flags |= SDL_WINDOW_FULLSCREEN;
-		}
-
-		int x = SDL_WINDOWPOS_UNDEFINED, y = SDL_WINDOWPOS_UNDEFINED;
-		SDL_Rect r;
-		if (SDL_GetDisplayBounds(this->startup_display, &r) == 0) {
-			x = r.x + std::max(0, r.w - static_cast<int>(w)) / 2;
-			y = r.y + std::max(0, r.h - static_cast<int>(h)) / 4; // decent desktops have taskbars at the bottom
-		}
-
-		char caption[50];
-		seprintf(caption, lastof(caption), "OpenTTD %s", _openttd_revision);
-		_sdl_window = SDL_CreateWindow(
-			caption,
-			x, y,
-			w, h,
-			flags);
-
-		if (_sdl_window == nullptr) {
-			DEBUG(driver, 0, "SDL2: Couldn't allocate a window to draw on");
-			return false;
-		}
-
-		std::string icon_path = FioFindFullPath(BASESET_DIR, "openttd.32.bmp");
-		if (!icon_path.empty()) {
-			/* Give the application an icon */
-			SDL_Surface *icon = SDL_LoadBMP(icon_path.c_str());
-			if (icon != nullptr) {
-				/* Get the colourkey, which will be magenta */
-				uint32 rgbmap = SDL_MapRGB(icon->format, 255, 0, 255);
-
-				SDL_SetColorKey(icon, SDL_TRUE, rgbmap);
-				SDL_SetWindowIcon(_sdl_window, icon);
-				SDL_FreeSurface(icon);
-			}
-		}
-	}
-
+	if (!this->CreateMainWindow(w, h)) return false;
 	if (resize) SDL_SetWindowSize(_sdl_window, w, h);
 
 	_sdl_real_surface = SDL_GetWindowSurface(_sdl_window);

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -655,7 +655,7 @@ int VideoDriver_SDL::PollEvent()
 		case SDL_WINDOWEVENT: {
 			if (ev.window.event == SDL_WINDOWEVENT_EXPOSED) {
 				// Force a redraw of the entire screen.
-				_num_dirty_rects = MAX_DIRTY_RECTS + 1;
+				this->MakeDirty(0, 0, _screen.width, _screen.height);
 			} else if (ev.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
 				int w = std::max(ev.window.data1, 64);
 				int h = std::max(ev.window.data2, 64);

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -128,9 +128,9 @@ static void UpdatePalette(bool init = false)
 
 static void InitPalette()
 {
+	_cur_palette.first_dirty = 0;
+	_cur_palette.count_dirty = 256;
 	_local_palette = _cur_palette;
-	_local_palette.first_dirty = 0;
-	_local_palette.count_dirty = 256;
 	UpdatePalette(true);
 }
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -375,13 +375,10 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 	 * appropriate event to know this. */
 	if (_fullscreen) _cursor.in_window = true;
 
-	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
-	blitter->PostResize();
+	BlitterFactory::GetCurrentBlitter()->PostResize();
 
 	InitPalette();
-
 	GameSizeChanged();
-
 	return true;
 }
 

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -50,6 +50,7 @@ private:
 	void MainLoopCleanup();
 	bool CreateMainSurface(uint w, uint h, bool resize);
 	bool CreateMainWindow(uint w, uint h);
+	void CheckPaletteAnim();
 
 #ifdef __EMSCRIPTEN__
 	/* Convert a constant pointer back to a non-constant pointer to a member function. */

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -49,6 +49,7 @@ private:
 	void LoopOnce();
 	void MainLoopCleanup();
 	bool CreateMainSurface(uint w, uint h, bool resize);
+	bool CreateMainWindow(uint w, uint h);
 
 #ifdef __EMSCRIPTEN__
 	/* Convert a constant pointer back to a non-constant pointer to a member function. */


### PR DESCRIPTION
## Motivation / Problem

While working on adding OpenGL support to SDL2, I found various of things in the SDL2 code that were either hard to read, made the control-flow difficult to understand, or was just a pile of "lets add this and this and this and this" in a single function.

Additionally, for OpenGL we plan to unify the naming and flow of Win32 and SDL2 driver a bit more, so when you read one or the other, you have better grasp of what is going on.


## Description

This PR should make absolute zero change to what SDL2 is actually doing. That is, I did my best to not make any real change, but only move code, make it more readable, make it more like Win32, etc. If there is any change, this is most likely not intended.

Few exceptions (as always):

- SDL2 was the only driver without fallback resolutions. This might be "strictly correct" but makes the code very special in contrast to other drivers. In fact, after OpenGL merges, I hope we can unify the drivers a bit more, as they all have near identical resolution detection code.
- The way SDL2 did Palette animation was just .. weird. It redraws the screen twice, it follows a very odd flow (especially when looking at other drivers). So I took some freedom to rework how the flow is; it is now very similar to Win32, doesn't do unneeded redraws, and only has a single huge-blob-of-comments about the RGB surface used.

Tip for reviewer: review this commit by commit, they are all fixing a single problem, and they do not depend on each other. It could as well have been 11 separate PRs.

## Limitations

- I tested this on Windows, where we strictly seen don't support SDL on. This needs testing on Linux by people to confirm my statement: this makes 0 change, holds.
- SDL1 driver has similar issues. I don't mind backporting this to SDL1 too, but before I do I would rather know if we are going to keep SDL1 driver in, or if we are going to drop it soon (tm).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
