### PR TITLE
Codechange: Implement a constructor for CurrencySpec (fixes VS2017 compile failure)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -210,11 +210,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - arch: x86
-        - arch: x64
+        os: [windows-latest, windows-2016]
+        arch: [x86, x64]
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout

--- a/src/currency.h
+++ b/src/currency.h
@@ -11,6 +11,7 @@
 #define CURRENCY_H
 
 #include "date_type.h"
+#include "string_func.h"
 #include "strings_type.h"
 
 static const int CF_NOEURO = 0; ///< Currency never switches to the Euro (as far as known).
@@ -83,6 +84,15 @@ struct CurrencySpec {
 	 */
 	byte symbol_pos;
 	StringID name;
+
+	CurrencySpec() = default;
+
+	CurrencySpec(uint16 rate, const char *separator, Year to_euro, const char *prefix, const char *suffix, byte symbol_pos, StringID name) : rate(rate), to_euro(to_euro), symbol_pos(symbol_pos), name(name)
+	{
+		strecpy(this->separator, separator, lastof(this->separator));
+		strecpy(this->prefix, prefix, lastof(this->prefix));
+		strecpy(this->suffix, suffix, lastof(this->suffix));
+	}
 };
 
 extern CurrencySpec _currency_specs[CURRENCY_END];


### PR DESCRIPTION
## Motivation / Problem
VS2017 [fails to compile](https://github.com/glx22/OpenTTD/actions/runs/507639860) our current code with 
```
  Error: ..\src\currency.cpp(69): error C2440: 'initializing': cannot convert from 'const char [3]' to 'char'
  ..\src\currency.cpp(69): note: There is no context in which this conversion is possible
```
While the error is weird (and probably incorrect as VS2019 has no issue with our code), I think implicit copy from `const char[]` (string literal) to `char[]` is not fully legit.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I added a constructor to do the copy without implicit casting.
Of course that removed the default constructor, so I re-added it.
And with that VS2017 [succeeds to build](https://github.com/glx22/OpenTTD/runs/1762162432)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
None I can think of.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
