### PR TITLE
Feature: Create .zip for macOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,6 +496,29 @@ jobs:
         cd build-x64
         ../os/macosx/notarize.sh
 
+    - name: Build zip
+      run: |
+        cd build-x64
+
+        pushd _CPack_Packages/*/Bundle/openttd-*/
+
+        # Remove the Applications symlink from the staging folder
+        rm -f Applications
+
+        # Remove the original dmg built by CPack to avoid a conflict when resolving
+        # the zip_filename variable below
+        rm -f ../*.dmg
+
+        zip_filename=(../openttd-*)
+
+        # Package up the existing, notarised .app into a zip file
+        zip -r -9 ${zip_filename}.zip OpenTTD.app
+
+        popd
+
+        # Now move it into place to be uploaded
+        mv _CPack_Packages/*/Bundle/openttd-*.zip bundles/
+
     - name: Store bundles
       uses: actions/upload-artifact@v2
       with:

--- a/os/macosx/notarize.sh
+++ b/os/macosx/notarize.sh
@@ -56,3 +56,13 @@ cat <<EOF > notarize.json
 EOF
 
 gon notarize.json
+
+app_filename=(_CPack_Packages/*/Bundle/openttd-*/OpenTTD.app)
+
+if [ "${app_filename}" = "_CPack_Packages/*/Bundle/openttd-*/OpenTTD.app" ]; then
+    echo "No .app found in the _CPack_Packages directory, skipping stapling."
+    exit 0
+fi;
+
+# Now staple the ticket to the .app
+xcrun stapler staple "${app_filename[0]}"


### PR DESCRIPTION
## Motivation / Problem

Offers a .zip option for macOS users who prefer that to .dmg.

## Description

The app is already notarised as part of the dmg by gon. We now manually staple the notarisation token to the .app in the CPack build directory, then zip up the .app (rather than trying to run a separate CPack process with a zip generator).

## Limitations

The .zip file itself can’t be stapled to, but this is a file format/macOS limitation, and shouldn’t affect the user.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
