### PR TITLE
Codechange: [Actions] we no longer need xdg-basedir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,6 @@ jobs:
           liblzma-dev \
           liblzo2-dev \
           libsdl2-dev \
-          libxdg-basedir-dev \
           lsb-release \
           zlib1g-dev \
           # EOF


### PR DESCRIPTION


## Motivation / Problem

Open a file, read something I wasn't expected, think about it once, think about it twice, realise we really did a poor job, fix it, leave the commit in the wrong branch for a few days, get reminded by it again, finally manage to PR it. Pfft.


## Description

This was already removed from the "ci-build", but not yet from
"release".

Should have been done with https://github.com/OpenTTD/OpenTTD/commit/3dfee979a7e486b8d90f6398ea557d2889855059#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcd , but here we are :)


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
