### PR TITLE
Fix 2db88953: default Network Server List sorter put compatible servers in wrong order

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -330,10 +330,9 @@ protected:
 		if (r == 0) r = b->info.compatible - a->info.compatible;
 		/* Passworded servers should be below unpassworded servers */
 		if (r == 0) r = a->info.use_password - b->info.use_password;
-		/* Finally sort on the number of clients of the server */
-		if (r == 0) return NGameClientSorter(a, b);
 
-		return r < 0;
+		/* Finally sort on the number of clients of the server in reverse order. */
+		return (r != 0) ? r < 0: !NGameClientSorter(a, b);
 	}
 
 	/** Sort the server list */


### PR DESCRIPTION
## Motivation / Problem

A user on IRC reported a very vague problem (as in, it was not understandable), but luckily is triggered @ldpl .. turns out that the whole 1.10 series had the default sorter sorting wrong. Honest mistake in a codechange commit, simple fix. For some reason nobody had done so, so here we are.

## Description

If a server is compatible, it falls back to sorting by clients.
This used to be in reverse, so full servers are on top. With
the codechange commit, this was removed by accident, and as
such empty servers were on top. This is silly.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
