### PR TITLE
Fix: [Emscripten] Pin Dockerfile to 2.0.10 to prevent patch failure

### DIFF
--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk
+FROM emscripten/emsdk:2.0.10
 
 COPY emsdk-liblzma.patch /
 RUN cd /emsdk/upstream/emscripten && patch -p1 < /emsdk-liblzma.patch


### PR DESCRIPTION
## Motivation / Problem

The provided emsdk patch for adding LZMA support to Emscripten is out of date and fails with the following error:

```
Step 3/3 : RUN cd /emsdk/upstream/emscripten && patch -p1 < /emsdk-liblzma.patch
 ---> Running in fc5f4dc7d2fc
patching file embuilder.py
Hunk #1 succeeded at 63 (offset 3 lines).
Hunk #2 FAILED at 198.
1 out of 2 hunks FAILED -- saving rejects to file embuilder.py.rej
patching file src/settings.js
Hunk #1 succeeded at 1212 (offset 15 lines).
patching file tools/ports/liblzma.py
The command '/bin/sh -c cd /emsdk/upstream/emscripten && patch -p1 < /emsdk-liblzma.patch' returned a non-zero code: 1
```



## Description

This PR fixes that by pinning the Emscripten version to 2.0.10, similarly to what is being done for CI. 
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

It would be preferable to upstream LZMA support instead of relying on patching, which is IMO a fragile process. However, that is out of the scope of this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
