### PR TITLE
Fix: [CMake] Restore 'games' as default install bindir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 
 # Use GNUInstallDirs to allow customisation
-# but set our own default data dir
+# but set our own default data and bin dir
 if(NOT CMAKE_INSTALL_DATADIR)
     set(CMAKE_INSTALL_DATADIR "share/games")
+endif()
+if(NOT CMAKE_INSTALL_BINDIR)
+    set(CMAKE_INSTALL_BINDIR "games")
 endif()
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Closes #8599
## Motivation / Problem
On Debian-based distributions, the executable should go to `<prefix>/games`, not `<prefix>/bin`.
Before switching to CMake, our old `configure` used to default to `<prefix>/games`.
Our CMake script uses `GNUInstallDirs`, which defaults to `<prefix>/bin`
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I restored `games` as default install bin dir, like it was in `configure`. We already set default data dir to `share/games` anyway.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Package maintainers will need to set `CMAKE_INSTALL_BINDIR` if default doesn't match their target OS, but they are already used to do similar with the old `configure`.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
