### PR TITLE
Fix: [CMake] Language files should depend on english.txt

### DIFF
--- a/src/lang/CMakeLists.txt
+++ b/src/lang/CMakeLists.txt
@@ -1,4 +1,9 @@
+set(MASTER_LANG_FILE
+        ${CMAKE_CURRENT_SOURCE_DIR}/english.txt
+)
+
 set(LANG_SOURCE_FILES
+        ${MASTER_LANG_FILE}
         ${CMAKE_CURRENT_SOURCE_DIR}/afrikaans.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/arabic_egypt.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/basque.txt
@@ -10,7 +15,6 @@ set(LANG_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/czech.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/danish.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/dutch.txt
-        ${CMAKE_CURRENT_SOURCE_DIR}/english.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/english_AU.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/english_US.txt
         ${CMAKE_CURRENT_SOURCE_DIR}/esperanto.txt
@@ -75,7 +79,7 @@ foreach(LANG_SOURCE_FILE IN LISTS LANG_SOURCE_FILES)
                     -s ${CMAKE_CURRENT_SOURCE_DIR}
                     -d ${LANG_BINARY_DIR}
                     ${LANG_SOURCE_FILE}
-            DEPENDS strgen
+            DEPENDS strgen ${MASTER_LANG_FILE}
             MAIN_DEPENDENCY ${LANG_SOURCE_FILE}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Compiling language ${LANG_SOURCE_FILE_NAME_WE}"
@@ -103,7 +107,7 @@ add_custom_command_timestamp(OUTPUT ${TABLE_BINARY_DIR}/strings.h
         COMMAND strgen
                 -s ${CMAKE_CURRENT_SOURCE_DIR}
                 -d ${TABLE_BINARY_DIR}
-        DEPENDS strgen ${LANG_SOURCE_FILES}
+        DEPENDS strgen ${MASTER_LANG_FILE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating table/strings.h"
 )


### PR DESCRIPTION
## Motivation / Problem
When trying something implying a modification in `english.txt`, I noticed other languages were not recompiled, and consequently were not available in game.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I added `english.txt` as dependency for all lang files.
While at it I simplified `table/strings.h` to depend only on `english.txt`
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
