### PR TITLE
Feature: [GS] Allow non-question type windows to have no buttons

### DIFF
--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -260,8 +260,9 @@ CommandCost CmdGoalQuestion(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 	} else {
 		if (company != INVALID_COMPANY && !Company::IsValidID(company)) return CMD_ERROR;
 	}
-	if (CountBits(button_mask) < 1 || CountBits(button_mask) > 3) return CMD_ERROR;
-	if (type >= GOAL_QUESTION_TYPE_COUNT) return CMD_ERROR;
+	uint min_buttons = (type == GQT_QUESTION ? 1 : 0);
+	if (CountBits(button_mask) < min_buttons || CountBits(button_mask) > 3) return CMD_ERROR;
+	if (type >= GQT_END) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
 		if (is_client) {

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -375,10 +375,16 @@ struct GoalQuestionWindow : public Window {
 			if (n == 3) break;
 		}
 		this->buttons = n;
-		assert(this->buttons > 0 && this->buttons < 4);
+		assert(this->buttons < 4);
 
 		this->CreateNestedTree();
-		this->GetWidget<NWidgetStacked>(WID_GQ_BUTTONS)->SetDisplayedPlane(this->buttons - 1);
+		if (this->buttons == 0) {
+			this->GetWidget<NWidgetStacked>(WID_GQ_BUTTONS)->SetDisplayedPlane(SZSP_HORIZONTAL);
+			this->GetWidget<NWidgetStacked>(WID_GQ_BUTTON_SPACER)->SetDisplayedPlane(SZSP_HORIZONTAL);
+		} else {
+			this->GetWidget<NWidgetStacked>(WID_GQ_BUTTONS)->SetDisplayedPlane(this->buttons - 1);
+			this->GetWidget<NWidgetStacked>(WID_GQ_BUTTON_SPACER)->SetDisplayedPlane(0);
+		}
 		this->FinishInitNested(window_number);
 	}
 
@@ -463,7 +469,9 @@ static const NWidgetPart _nested_goal_question_widgets_question[] = {
 				NWidget(WWT_PUSHTXTBTN, COLOUR_LIGHT_BLUE, WID_GQ_BUTTON_3), SetDataTip(STR_BLACK_STRING, STR_NULL), SetFill(1, 0),
 			EndContainer(),
 		EndContainer(),
-		NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GQ_BUTTON_SPACER),
+			NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		EndContainer(),
 	EndContainer(),
 };
 
@@ -488,7 +496,9 @@ static const NWidgetPart _nested_goal_question_widgets_info[] = {
 				NWidget(WWT_PUSHTXTBTN, COLOUR_LIGHT_BLUE, WID_GQ_BUTTON_3), SetDataTip(STR_BLACK_STRING, STR_NULL), SetFill(1, 0),
 			EndContainer(),
 		EndContainer(),
-		NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GQ_BUTTON_SPACER),
+			NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		EndContainer(),
 	EndContainer(),
 };
 
@@ -513,7 +523,9 @@ static const NWidgetPart _nested_goal_question_widgets_warning[] = {
 				NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_GQ_BUTTON_3), SetDataTip(STR_BLACK_STRING, STR_NULL), SetFill(1, 0),
 			EndContainer(),
 		EndContainer(),
-		NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GQ_BUTTON_SPACER),
+			NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		EndContainer(),
 	EndContainer(),
 };
 
@@ -538,7 +550,9 @@ static const NWidgetPart _nested_goal_question_widgets_error[] = {
 				NWidget(WWT_PUSHTXTBTN, COLOUR_YELLOW, WID_GQ_BUTTON_3), SetDataTip(STR_BLACK_STRING, STR_NULL), SetFill(1, 0),
 			EndContainer(),
 		EndContainer(),
-		NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GQ_BUTTON_SPACER),
+			NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+		EndContainer(),
 	EndContainer(),
 };
 
@@ -578,6 +592,6 @@ static WindowDesc _goal_question_list_desc[] = {
  */
 void ShowGoalQuestion(uint16 id, byte type, uint32 button_mask, const char *question)
 {
-	assert(type < GOAL_QUESTION_TYPE_COUNT);
+	assert(type < GQT_END);
 	new GoalQuestionWindow(&_goal_question_list_desc[type], id, type == 3 ? TC_WHITE : TC_BLACK, button_mask, question);
 }

--- a/src/goal_type.h
+++ b/src/goal_type.h
@@ -13,7 +13,14 @@
 #include "core/enum_type.hpp"
 
 static const uint32 GOAL_QUESTION_BUTTON_COUNT = 18; ///< Amount of buttons available.
-static const byte   GOAL_QUESTION_TYPE_COUNT   =  4; ///< Amount of question types.
+
+enum GoalQuestionType : byte {
+	GQT_QUESTION = 0,
+	GQT_INFORMATION = 1,
+	GQT_WARNING = 2,
+	GQT_ERROR = 3,
+	GQT_END = 4,
+};
 
 /** Types of goal destinations */
 enum GoalType : byte {

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -38,6 +38,7 @@
  *
  * Other changes:
  * \li GSCompany::ChangeBankBalance takes one extra parameter to refer to a location to show text effect on
+ * \li GSGoal::Question and GSGoal::QuestionClient no longer require to have any buttons except for the window type GSGoal.QT_QUESTION
  *
  * \b 1.10.0
  *

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -115,9 +115,10 @@
 	EnforcePrecondition(false, question != nullptr);
 	const char *text = question->GetEncodedText();
 	EnforcePreconditionEncodedText(false, text);
-	EnforcePrecondition(false, CountBits(buttons) >= 1 && CountBits(buttons) <= 3);
+	uint min_buttons = (type == QT_QUESTION ? 1 : 0);
+	EnforcePrecondition(false, CountBits(buttons) >= min_buttons && CountBits(buttons) <= 3);
 	EnforcePrecondition(false, buttons < (1 << ::GOAL_QUESTION_BUTTON_COUNT));
-	EnforcePrecondition(false, (int)type < ::GOAL_QUESTION_TYPE_COUNT);
+	EnforcePrecondition(false, (int)type < ::GQT_END);
 
 	return ScriptObject::DoCommand(0, uniqueid | (target << 16), buttons | (type << 29) | (is_client ? (1 << 31) : 0), CMD_GOAL_QUESTION, text);
 }

--- a/src/widgets/goal_widget.h
+++ b/src/widgets/goal_widget.h
@@ -20,12 +20,13 @@ enum GoalListWidgets {
 
 /** Widgets of the #GoalQuestionWindow class. */
 enum GoalQuestionWidgets {
-	WID_GQ_CAPTION,  ///< Caption of the window.
-	WID_GQ_QUESTION, ///< Question text.
-	WID_GQ_BUTTONS,  ///< Buttons selection (between 1, 2 or 3).
-	WID_GQ_BUTTON_1, ///< First button.
-	WID_GQ_BUTTON_2, ///< Second button.
-	WID_GQ_BUTTON_3, ///< Third button.
+	WID_GQ_CAPTION,        ///< Caption of the window.
+	WID_GQ_QUESTION,       ///< Question text.
+	WID_GQ_BUTTONS,        ///< Buttons selection (between 1, 2 or 3).
+	WID_GQ_BUTTON_1,       ///< First button.
+	WID_GQ_BUTTON_2,       ///< Second button.
+	WID_GQ_BUTTON_3,       ///< Third button.
+	WID_GQ_BUTTON_SPACER,  ///< Selection to hide extra padding if there are no buttons
 };
 
 #endif /* WIDGETS_GOAL_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

3 out of 4 gs "question" window types (info, warning and error) aren't really questions and likely don't need any buttons but are forced by gs api to have at least one.

## Description

![Screenshot from 2021-02-02 18-29-00](https://user-images.githubusercontent.com/413570/106628547-f5489900-658a-11eb-91c6-a25973e83e67.png)

GS for testing: [test-question-no-buttons.zip](https://github.com/OpenTTD/OpenTTD/files/5912664/test-question-no-buttons.zip)


## Limitations

It still looks somewhat different from the regular error because of how paddings are calculated but I decided to address it in a separate pr later.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* **This PR affects the GS/AI API? (label 'needs review: Script API')**
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
