### PR TITLE
Feature: [Actions / CMake] support for generic linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,93 @@ jobs:
         retention-days: 5
 
   linux:
-    name: Linux
+    name: Linux (Generic)
+    needs: source
+
+    runs-on: ubuntu-20.04
+    container:
+      # manylinux2014 is based on CentOS 7, but already has a lot of things
+      # installed and preconfigured. It makes it easier to build OpenTTD.
+      image: quay.io/pypa/manylinux2014_x86_64
+
+    steps:
+    - name: Download source
+      uses: actions/download-artifact@v2
+      with:
+        name: internal-source
+
+    - name: Unpack source
+      run: |
+        tar -xf source.tar.gz --strip-components=1
+
+    - name: Install dependencies
+      run: |
+        echo "::group::Install dependencies"
+        yum install -y \
+          fontconfig-devel \
+          freetype-devel \
+          libicu-devel \
+          libpng-devel \
+          libpng-devel \
+          lzo-devel \
+          SDL2-devel \
+          wget \
+          xz-devel \
+          zlib-devel \
+          # EOF
+        echo "::endgroup::"
+
+        # The yum variant of fluidsynth depends on all possible audio drivers.
+        # This is not really useful for us, as that would require a user to
+        # have them all before he can start OpenTTD. Instead, compile a
+        # version that can only use SDL2. As OpenTTD does sound via SDL2,
+        # this simply means we either have sound and music, or have none.
+        echo "::group::Install fluidsynth"
+        wget https://github.com/FluidSynth/fluidsynth/archive/v2.1.6.tar.gz
+        tar xf v2.1.6.tar.gz
+        (
+          cd fluidsynth-2.1.6
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr
+          make -j$(nproc)
+          make install
+        )
+        echo "::endgroup::"
+
+    - name: Install GCC problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+
+    - name: Build
+      run: |
+        mkdir -p build
+        cd build
+
+        echo "::group::CMake"
+        cmake ${GITHUB_WORKSPACE} \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_PACKAGE_DEPENDENCIES=ON \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(nproc) cores"
+        make -j$(nproc) package
+        echo "::endgroup::"
+
+        # Remove the sha256 files CPack generates; we will do this ourself at
+        # the end of this workflow.
+        rm -f bundles/*.sha256
+
+    - name: Store bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: openttd-linux-generic
+        path: build/bundles
+        retention-days: 5
+
+  linux-distro:
+    name: Linux (Distros)
     needs: source
 
     if: needs.source.outputs.is_tag == 'true'
@@ -633,6 +719,7 @@ jobs:
     - source
     - docs
     - linux
+    - linux-distro
     - macos
     - windows
 
@@ -641,7 +728,7 @@ jobs:
     # "always()" is important here, it is the keyword to use to stop skipping
     # this job if any dependency is skipped. It looks a bit silly, but it is
     # how GitHub Actions work ;)
-    if: always() && needs.source.result == 'success' && needs.docs.result == 'success' && (needs.linux.result == 'success' || needs.linux.result == 'skipped') && needs.macos.result == 'success' && needs.windows.result == 'success'
+    if: always() && needs.source.result == 'success' && needs.docs.result == 'success' && needs.linux.result == 'success' && (needs.linux-distro.result == 'success' || needs.linux-distro.result == 'skipped') && needs.macos.result == 'success' && needs.windows.result == 'success'
 
     runs-on: ubuntu-20.04
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,27 @@ if(APPLE)
     endif()
 endif()
 
+if(OPTION_PACKAGE_DEPENDENCIES)
+    if(NOT UNIX)
+        message(FATAL_ERROR "Can only package dependencies on Linux")
+    endif()
+    if(OPTION_INSTALL_FHS)
+        message(FATAL_ERROR "Cannot install in FHS folders when we are packaging dependencies")
+    endif()
+    if(${CMAKE_VERSION} VERSION_LESS "3.16.0")
+        message(FATAL_ERROR "OPTION_PACKAGE_DEPENDENCIES can only work with CMake 3.16+; you are using ${CMAKE_VERSION}")
+    endif()
+
+    # If we are packaging dependencies, we do two things:
+    # 1) set the RPATH to include $ORIGIN/lib; $ORIGIN (that literal string)
+    #    is a Linux indicator for "path where application is". In CMake, we
+    #    have to do this before add_executable() is executed.
+    # 2) copy the libraries that we compile against to the "lib" folder.
+    #    This is done in InstallAndPackage.cmake.
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN/lib")
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+endif()
+
 include(SourceList)
 
 # Needed by rev.cpp

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -44,7 +44,9 @@ endfunction()
 # set_options()
 #
 function(set_options)
-    if(UNIX AND NOT APPLE)
+    option(OPTION_PACKAGE_DEPENDENCIES "Copy dependencies into lib/ for easy packaging (Linux only)" OFF)
+
+    if(UNIX AND NOT APPLE AND NOT OPTION_PACKAGE_DEPENDENCIES)
         set(DEFAULT_OPTION_INSTALL_FHS ON)
     else()
         set(DEFAULT_OPTION_INSTALL_FHS OFF)
@@ -76,6 +78,7 @@ endfunction()
 # show_options()
 #
 function(show_options)
+    message(STATUS "Option Package Dependencies - ${OPTION_PACKAGE_DEPENDENCIES}")
     message(STATUS "Option Dedicated - ${OPTION_DEDICATED}")
     message(STATUS "Option Install FHS - ${OPTION_INSTALL_FHS}")
     message(STATUS "Option Use assert - ${OPTION_USE_ASSERTS}")


### PR DESCRIPTION
## Motivation / Problem

For Steam we would like to have a Linux release too. As we didn't build a generic linux build yet, this was a bit of a challenge ;)

## Description

```
These bundles can be opened on any "modern" Linux machine with
a driver that SDL2 supports.

Machines needs at least glibc 2.15, which was released 10 years ago.
It is build with CentOS 7 as base, and only assumes the following
libraries are available on the system:
- libc
- libdl
- libgcc_s
- libpthread
- librt
- libstdc++

All other libraries the game depends on are bundled together with
the game, so users don't need any library installed to use this
bundle. The downside of course is that this increases the binary
size a bit: 30 MiB of libraries are in this bundle.

RPATH is used to make ld-linux find the folder libraries are
stored in; however, system libraries are always used before these,
in the assumption libraries on the user system are more up-to-date.

Using -DOPTION_PACKAGE_DEPENDENCIES=ON switches on packaging
of libraries in the "lib" folder. This requires CMake 3.16 to
be installed; otherwise it will fail.
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
