### PR TITLE
Change: [CMake] Bump minimal version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 if(NOT BINARY_NAME)
     set(BINARY_NAME openttd)
@@ -140,13 +140,8 @@ find_package(Xaudio2)
 
 find_package(Grfcodec)
 
-# IPO is only properly supported from CMake 3.9. Despite the fact we are
-# CMake 3.5, still enable IPO if we detect we are 3.9+.
-if(POLICY CMP0069)
-    cmake_policy(SET CMP0069 NEW)
-    include(CheckIPOSupported)
-    check_ipo_supported(RESULT IPO_FOUND)
-endif()
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IPO_FOUND)
 
 show_options()
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -57,6 +57,9 @@ To install both the x64 (64bit) and x86 (32bit) variants (though only one is nec
 ```
 
 You can open the folder (as a CMake project). CMake will be detected, and you can compile from there.
+If libraries are installed but not found, you need to set VCPKG_TARGET_TRIPLET in CMake parameters.
+For Visual Studio 2017 you also need to set CMAKE_TOOLCHAIN_FILE.
+(Typical values are shown in the MSVC project file command line example)
 
 Alternatively, you can create a MSVC project file via CMake. For this
 either download CMake from https://cmake.org/download/ or use the version
@@ -73,6 +76,7 @@ in the build folder are MSVC project files. MSVC can rebuild the project
 files himself via the `ZERO_CHECK` project.
 
 ## All other platforms
+Minimum required version of CMake is 3.9.
 
 ```bash
 mkdir build

--- a/cmake/FindICU.cmake
+++ b/cmake/FindICU.cmake
@@ -1,3 +1,8 @@
+# CMake provides a FindICU module since version 3.7.
+# But it doesn't use pkgconfig, doesn't set expected variables,
+# And it returns incomplete dependencies if only some modules are searched.
+
+
 #[=======================================================================[.rst:
 FindICU
 -------

--- a/src/settingsgen/CMakeLists.txt
+++ b/src/settingsgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 if (NOT HOST_BINARY_DIR)
     project(settingsgen)

--- a/src/strgen/CMakeLists.txt
+++ b/src/strgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
 if (NOT HOST_BINARY_DIR)
     project(strgen)


### PR DESCRIPTION
## Motivation / Problem
With CMake minimum version set to anything before 3.9, for some unknown reason (maybe vcpkg as it happens only for Windows and MacOS targets), CMP0069 policy is reset between CMake configuration and generation steps.
This triggers a CMake warning and cause INTERPROCEDURAL_OPTIMIZATION property to be ignored.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Since IPO support detection and CMP0069 policy were introduced in 3.9, it's simpler to set the minimum CMake version and get working interprocedural optimisation.
CMake 3.7 introduced a FindICU module, but our own module is better. So I kept our own, with a notice about why we don't use CMake provided module.
I also updated `COMPILING.md` to indicate minimum CMake version, and some hints for MSVC users when libraries are installed but not found.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Some linux distribution may only have older CMake version as standard, but I think on most there's a way to update it.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
