### PR TITLE
Add: [Actions] Automatically upload releases to Steam

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -714,7 +714,7 @@ jobs:
         retention-days: 5
 
   upload:
-    name: Upload
+    name: Upload (AWS)
     needs:
     - source
     - docs
@@ -772,3 +772,80 @@ jobs:
         repository: OpenTTD/workflows
         event-type: ${{ needs.source.outputs.trigger_type }}
         client-payload: '{"version": "${{ needs.source.outputs.version }}", "folder": "${{ needs.source.outputs.folder }}"}'
+
+  upload-steam:
+    name: Upload (Steam)
+    needs:
+    - source
+    - linux
+    - macos
+    - windows
+
+    if: needs.source.outputs.trigger_type == 'new-master' || needs.source.outputs.trigger_type == 'new-tag'
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Download all bundles
+      uses: actions/download-artifact@v2
+
+    - name: Setup steamcmd
+      uses: CyberAndrii/setup-steamcmd@v1
+
+    - name: Generate Steam auth code
+      id: steam-totp
+      uses: CyberAndrii/steam-totp@v1
+      with:
+        shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
+
+    - name: Upload to Steam
+      run: |
+        echo "::group::Extracting source"
+        mkdir source
+        (
+          cd source
+          tar -xf ../internal-source/source.tar.gz --strip-components=1
+        )
+        echo "::endgroup::"
+
+        mkdir steam
+        (
+          cd steam
+
+          echo "::group::Prepare Win32"
+          unzip ../openttd-windows-x86/openttd-*-windows-win32.zip
+          mv openttd-*-windows-win32 steam-win32
+          echo "::endgroup::"
+
+          echo "::group::Prepare Win64"
+          unzip ../openttd-windows-x64/openttd-*-windows-win64.zip
+          mv openttd-*-windows-win64 steam-win64
+          echo "::endgroup::"
+
+          echo "::group::Prepare macOS"
+          mkdir steam-macos
+          (
+            cd steam-macos
+            unzip ../../openttd-macos-universal/openttd-*-macos-universal.zip
+          )
+          echo "::endgroup::"
+
+          echo "::group::Prepare Linux"
+          tar xvf ../openttd-linux-generic/openttd-*-linux-generic-amd64.tar.xz
+          mv openttd-*-linux-generic-amd64 steam-linux
+          echo "::endgroup::"
+
+          echo "::group::Preparing build file"
+          if [ "${{ needs.source.outputs.trigger_type }}" = "new-tag" ]; then
+            BRANCH="testing"
+          else
+            BRANCH="nightly"
+          fi
+          cat ../source/os/steam/release.vdf | sed 's/@@DESCRIPTION@@/openttd-${{ needs.source.outputs.version }}/;s/@@BRANCH@@/'${BRANCH}'/' > release.vdf
+          cat release.vdf
+          echo "::endgroup::"
+
+          echo "::group::Upload to Steam"
+          steamcmd +login ${{ secrets.STEAM_USERNAME }} ${{ secrets.STEAM_PASSWORD }} ${{ steps.steam-totp.outputs.code }} +run_app_build $(pwd)/release.vdf +quit
+          echo "::endgroup::"
+        )

--- a/os/steam/release.vdf
+++ b/os/steam/release.vdf
@@ -1,0 +1,57 @@
+"AppBuild"
+{
+	"AppID" "1536610"
+	"Desc" "@@DESCRIPTION@@"
+
+	"SetLive" "@@BRANCH@@"
+
+	"ContentRoot" "./"
+	"BuildOutput" "build/"
+
+	"Depots"
+	{
+		"1536613"
+		{
+			"ContentRoot" "./steam-win32"
+			"FileMapping"
+			{
+				"LocalPath" "*"
+				"DepotPath" "."
+				"recursive" "1"
+			}
+		}
+
+		"1536612"
+		{
+			"ContentRoot" "./steam-win64"
+			"FileMapping"
+			{
+				"LocalPath" "*"
+				"DepotPath" "."
+				"recursive" "1"
+			}
+		}
+
+		"1536614"
+		{
+			"ContentRoot" "./steam-macos"
+			"FileMapping"
+			{
+				"LocalPath" "*"
+				"DepotPath" "."
+				"recursive" "1"
+			}
+		}
+
+		"1536615"
+		{
+			"ContentRoot" "./steam-linux"
+			"FileMapping"
+			{
+				"LocalPath" "*"
+				"DepotPath" "."
+				"recursive" "1"
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Motivation / Problem

Why do things by hand if you can automate it?


## Description

The nightlies and all tags will now automatically be uploaded to Steam.

Nightlies will be pushed automatically to the "nightly" beta branch on Steam.
Tags will be pushed automatically to the "testing" beta branch on Steam.

This means that if someone selects the "nightly" beta branch, he will receive a new version of OpenTTD every night (given there was a chance that day).


## Limitations

- it is not possible to automatically push to the "default" branch on Steam; this means that non-beta / non-RC releases have to be pushed manually to "default" branch by logging in to Steam Partner and promoting the BuildID from "testing" to "default" branch. Given this happens, what, 4 times a year, I am sure we survive :) Just .. don't forget ;)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
