### PR TITLE
Fix #8029: [SDL2] disable draw-thread on wayland SDL video driver

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -715,6 +715,17 @@ const char *VideoDriver_SDL::Start(const StringList &parm)
 	MarkWholeScreenDirty();
 
 	_draw_threaded = !GetDriverParamBool(parm, "no_threads") && !GetDriverParamBool(parm, "no_thread");
+	/* Wayland SDL video driver uses EGL to render the game. SDL created the
+	 * EGL context from the main-thread, and with EGL you are not allowed to
+	 * draw in another thread than the context was created. The function of
+	 * _draw_threaded is to do exactly this: draw in another thread than the
+	 * window was created, and as such, this fails on Wayland SDL video
+	 * driver. So, we disable threading by default if Wayland SDL video
+	 * driver is detected.
+	 */
+	if (strcmp(dname, "wayland") == 0) {
+		_draw_threaded = false;
+	}
 
 	SDL_StopTextInput();
 	this->edit_box_focused = false;


### PR DESCRIPTION
## Motivation / Problem

Forcing SDL2 to use wayland as video driver renders a black screen.

## Description

```
When the wayland SDL video driver is used, an EGL context is
created in the main thread. It is not allowed to update this
context from another thread, which is exactly what our draw-thread
is trying.

The other solution would be to move all of SDL into the
draw-thread, but that would introduce a whole scala of different
problems.

The wayland SDL backend is significantly faster than the
X11 SDL backend, but there is a performance hit nevertheless.
```


## Limitations

There are more issues with using wayland as video driver, but these are all with SDL. It is the reason they don't have it enabled by default yet. See #8029 for more details.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
