### PR TITLE
Fix 0125892: Don't crash when towns upgrade road tiles during expansion

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2291,7 +2291,7 @@ static bool CanConvertUnownedRoadType(Owner owner, RoadTramType rtt)
 }
 
 /**
- * Convert the ownership of the RoadType of the tile if applyable
+ * Convert the ownership of the RoadType of the tile if applicable
  * @param tile the tile of which convert ownership
  * @param num_pieces the count of the roadbits to assign to the new owner
  * @param owner the current owner of the RoadType
@@ -2428,11 +2428,9 @@ CommandCost CmdConvertRoad(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 			cost.AddCost(num_pieces * RoadConvertCost(from_type, to_type));
 
 			if (flags & DC_EXEC) { // we can safely convert, too
-				/* Update the company infrastructure counters. */
+				/* Call ConvertRoadTypeOwner() to update the company infrastructure counters. */
 				if (owner == _current_company) {
-					Company * c = Company::Get(_current_company);
-					c->infrastructure.road[from_type] -= num_pieces;
-					c->infrastructure.road[to_type] += num_pieces;
+					ConvertRoadTypeOwner(tile, num_pieces, owner, from_type, to_type);
 				}
 
 				/* Perform the conversion */


### PR DESCRIPTION
## Motivation / Problem

0125892 introduced a fix for converting road types not updating infrastructure counters.

When a town expands in a game with multiple town-buildable road types introduced over time, it may result in a road tile being upgraded by the build road command. This causes an assert when the new code tries to get a company from the company pool using company ID 15.

Fixes #8650 

## Description

This fix checks that the current company ID is a valid company before attempting to get the company from the pool and update infrastructure counters.

## Limitations

There do not appear to be any other attempts to get companies from the pool introduced by the mentioned commit, so this should be sufficient to fix the observed bug. I haven't done an exhaustive search for other cases, although my experience is this bug has only occurred in versions build after December 28th so it's likely that is the sole cause.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
