### PR TITLE
Fix: [CMake] our allegro drivers use v4, so skip v5 if found

### DIFF
--- a/cmake/FindAllegro.cmake
+++ b/cmake/FindAllegro.cmake
@@ -31,7 +31,7 @@ The following cache variables may also be set:
 #]=======================================================================]
 
 find_package(PkgConfig QUIET)
-pkg_check_modules(PC_Allegro QUIET allegro)
+pkg_check_modules(PC_Allegro QUIET allegro<5)
 
 find_path(Allegro_INCLUDE_DIR
     NAMES allegro.h


### PR DESCRIPTION


## Motivation / Problem

User on IRC reported problems compiling on Linux where the allegro driver was failing. Turns out, v5 was installed, where we only work with v4.

## Description

```
On some distros allegro v5 is called allegro-5, but on some others
it is not. So this should fix for all distros that allegro v5 is
not being picked up, and only v4 is.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
