### PR TITLE
Fix: [Emscripten] Only lock pointer on right click

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -1,4 +1,5 @@
 Module.arguments.push('-mnull', '-snull', '-vsdl:relative_mode');
+Module.elementPointerLock = false;
 Module['websocket'] = { url: function(host, port, proto) {
     /* openttd.org hosts a WebSocket proxy for the content service. */
     if (host == "content.openttd.org" && port == 3978 && proto == "tcp") {
@@ -11,6 +12,15 @@ Module['websocket'] = { url: function(host, port, proto) {
      * are best to add another "if" statement as above for this. */
     return null;
 } };
+Module.canvas = document.querySelector(".emscripten");
+Module.canvas.addEventListener("mousedown", (e) => {
+    if(e.button == 2)
+        Module.canvas.requestPointerLock();
+});
+Module.canvas.addEventListener("mouseup", (e) => {
+    if(e.button == 2)
+        Module.canvas.exitPointerLock();
+});
 
 Module.preRun.push(function() {
     personal_dir = '/home/web_user/.openttd';


### PR DESCRIPTION
## Problem and Description

Currently the Emscripten port forcefully locks the pointer (if not locked already) on the first click. I might just be picky, but I find this to be bad UX as I have to hit Escape whenever I wish to move to another tab or do something else.

This got me to think: why does the pointer need to be locked in the first place? After some experimentation I came to the conclusion that the pointer really only needs to be locked when dragging the viewport map using the mouse. As such, this PR adjusts pointer locking so that it only happens when the user is dragging the viewport, and automatically releases afterwards. The result is a smooth user experience with no locking/releasing visible to the player.

## Limitations

Releasing the pointer lock in a browser comes with a major caveat: the OS cursor will reappear at the same location where locking was requested, not the new location. As it turns out, OpenTTD freezes the pointer while dragging the map anyway, so this wasn't a problem. However, it is the reason why this locking mechanism cannot be enabled for left clicks, as those are used to build infrastructure, and the pointer does move while dragging to build those.

Another caveat is that I've assumed the only instance where dragging with the RMB held down is used is viewport movement. If that changes in a future OpenTTD release, this solution will need a rework.

I fully understand if the OpenTTD devs are not interested in this fix due to the limitations or would prefer a different solution. I'm suggesting this mainly because I think it's a net positive experience for players, compared to the current behavior.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
