### PR TITLE
Fix: [Emscripten] open links in browser

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -71,6 +71,34 @@ Module.preRun.push(function() {
          *  add_server("localhost", 3979); */
     }
 
+    var leftButtonDown = false;
+    document.addEventListener("mousedown", e => {
+        if (e.button == 0) {
+            leftButtonDown = true;
+        }
+    });
+    document.addEventListener("mouseup", e => {
+        if (e.button == 0) {
+            leftButtonDown = false;
+        }
+    });
+    window.openttd_open_url = function(url, url_len) {
+        const url_string = UTF8ToString(url, url_len);
+        function openWindow() {
+            document.removeEventListener("mouseup", openWindow);
+            window.open(url_string, '_blank');
+        }
+        /* Trying to open the URL while the mouse is down results in the button getting stuck, so wait for the
+         * mouse to be released before opening it. However, when OpenTTD is lagging, the mouse can get released
+         * before the button click even registers, so check for that, and open the URL immediately if that's the
+         * case. */
+        if (leftButtonDown) {
+            document.addEventListener("mouseup", openWindow);
+        } else {
+            openWindow();
+        }
+    }
+
     /* https://github.com/emscripten-core/emscripten/pull/12995 implements this
     * properly. Till that time, we use a polyfill. */
    SOCKFS.websocket_sock_ops.createPeer_ = SOCKFS.websocket_sock_ops.createPeer;

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -28,6 +28,10 @@
 #include <SDL.h>
 #endif
 
+#ifdef __EMSCRIPTEN__
+#	include <emscripten.h>
+#endif
+
 #ifdef __APPLE__
 #	include <sys/mount.h>
 #elif (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L) || defined(__GLIBC__)
@@ -288,7 +292,13 @@ bool GetClipboardContents(char *buffer, const char *last)
 #endif
 
 
-#ifndef __APPLE__
+#if defined(__EMSCRIPTEN__)
+void OSOpenBrowser(const char *url)
+{
+	/* Implementation in pre.js */
+	EM_ASM({ if(window["openttd_open_url"]) window.openttd_open_url($0, $1) }, url, strlen(url));
+}
+#elif !defined( __APPLE__)
 void OSOpenBrowser(const char *url)
 {
 	pid_t child_pid = fork();


### PR DESCRIPTION
## Problem

The "Visit website" buttons were not functional on Emscripten since it doesn't support `xdg-open`.

## Description

This PR adds Emscripten-specific logic that opens the website using standard JS APIs. 

## Limitations

None that I can really think of.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
