### PR TITLE
Fix: [Actions] Use same vcpkg commit for CI on macOS as release builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -159,7 +159,8 @@ jobs:
       uses: lukka/run-vcpkg@v6
       with:
         vcpkgDirectory: '/usr/local/share/vcpkg'
-        doNotUpdateVcpkg: true
+        doNotUpdateVcpkg: false
+        vcpkgGitCommitId: 2a42024b53ebb512fb5dd63c523338bf26c8489c
         vcpkgArguments: 'freetype liblzma lzo'
         vcpkgTriplet: '${{ matrix.arch }}-osx'
 


### PR DESCRIPTION
## Motivation / Problem

The CI job is failing on macOS.

## Description

It looks like there has been an update to the macOS 10.15 environment for GitHub Actions, and the version of vcpkg included in the current build of the environment appears to be failing to compile. I don't think there's anything wrong with the way we're using it, but this change pins the version to a known good version.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
