### PR TITLE
Fix: mention our websites with https:// (instead of http://)

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -510,7 +510,7 @@ struct AboutWindow : public Window {
 
 	void SetStringParameters(int widget) const override
 	{
-		if (widget == WID_A_WEBSITE) SetDParamStr(0, "Website: http://www.openttd.org");
+		if (widget == WID_A_WEBSITE) SetDParamStr(0, "Website: https://www.openttd.org");
 		if (widget == WID_A_COPYRIGHT) SetDParamStr(0, _openttd_revision_year);
 	}
 

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -325,7 +325,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		char url[1024];
 		const char *last = lastof(url);
 
-		char *pos = strecpy(url, "http://grfsearch.openttd.org/?", last);
+		char *pos = strecpy(url, "https://grfsearch.openttd.org/?", last);
 
 		if (this->auto_select) {
 			pos = strecpy(pos, "do=searchgrfid&q=", last);


### PR DESCRIPTION


## Motivation / Problem

It is 2021. Nobody should advertise http anymore. Not even us.


## Description

What the title says.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
