### PR TITLE
Fix: [Win32] Set minimum resolution for timers to 1ms.

### DIFF
--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -21,6 +21,7 @@
 
 #include <windows.h>
 #include <signal.h>
+#include <timeapi.h>
 
 #include "../../safeguards.h"
 
@@ -540,6 +541,9 @@ void *_safe_esp = nullptr;
 
 static LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS *ep)
 {
+	/* Restore system timer resolution. */
+	timeEndPeriod(1);
+
 	/* Disable our event loop. */
 	SetWindowLongPtr(GetActiveWindow(), GWLP_WNDPROC, (LONG_PTR)&DefWindowProc);
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -18,6 +18,7 @@
 #define NO_SHOBJIDL_SORTDIRECTION // Avoid multiple definition of SORT_ASCENDING
 #include <shlobj.h> /* SHGetFolderPath */
 #include <shellapi.h>
+#include <timeapi.h>
 #include "win32.h"
 #include "../../fios.h"
 #include "../../core/alloc_func.hpp"
@@ -413,6 +414,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	int argc;
 	char *argv[64]; // max 64 command line arguments
 
+	/* Set system timer resolution to 1ms. */
+	timeBeginPeriod(1);
+
 	CrashLog::InitialiseCrashLog();
 
 #if defined(UNICODE)
@@ -440,6 +444,10 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	for (int i = 0; i < argc; i++) ValidateString(argv[i]);
 
 	openttd_main(argc, argv);
+
+	/* Restore system timer resolution. */
+	timeEndPeriod(1);
+
 	free(cmdline);
 	return 0;
 }


### PR DESCRIPTION
Fixes #8658

## Motivation / Problem
Since Windows 10 2004, timer resolution is always ~15.625ms, unless higher resolution as been requested by the app.
Before this version of windows, any app could request higher resolution and affect other apps.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Request a 1ms resolution and don't rely on what any other app could have set.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
