### PR TITLE
Fix potential bug in SDL2 driver introduced in last cleanup, and cleanup some more

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -351,9 +351,6 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 		_sdl_surface = _sdl_real_surface;
 	}
 
-	/* Delay drawing for this cycle; the next cycle will redraw the whole screen */
-	_num_dirty_rects = 0;
-
 	_screen.width = _sdl_surface->w;
 	_screen.height = _sdl_surface->h;
 	_screen.pitch = _sdl_surface->pitch / (bpp / 8);

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -95,6 +95,8 @@ static void MakePalette()
 		if (_sdl_palette == nullptr) usererror("SDL2: Couldn't allocate palette: %s", SDL_GetError());
 	}
 
+	_cur_palette.first_dirty = 0;
+	_cur_palette.count_dirty = 256;
 	_local_palette = _cur_palette;
 	UpdatePalette();
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -58,10 +58,6 @@ static bool _cursor_new_in_window = false;
 static SDL_Rect _dirty_rects[MAX_DIRTY_RECTS];
 static int _num_dirty_rects;
 
-/* Size of window */
-static int _window_size_w;
-static int _window_size_h;
-
 void VideoDriver_SDL::MakeDirty(int left, int top, int width, int height)
 {
 	if (_num_dirty_rects < MAX_DIRTY_RECTS) {
@@ -929,9 +925,11 @@ bool VideoDriver_SDL::ToggleFullscreen(bool fullscreen)
 	std::unique_lock<std::recursive_mutex> lock;
 	if (_draw_mutex != nullptr) lock = std::unique_lock<std::recursive_mutex>(*_draw_mutex);
 
+	int w, h;
+
 	/* Remember current window size */
 	if (fullscreen) {
-		SDL_GetWindowSize(_sdl_window, &_window_size_w, &_window_size_h);
+		SDL_GetWindowSize(_sdl_window, &w, &h);
 
 		/* Find fullscreen window size */
 		SDL_DisplayMode dm;
@@ -947,7 +945,7 @@ bool VideoDriver_SDL::ToggleFullscreen(bool fullscreen)
 	if (ret == 0) {
 		/* Switching resolution succeeded, set fullscreen value of window. */
 		_fullscreen = fullscreen;
-		if (!fullscreen) SDL_SetWindowSize(_sdl_window, _window_size_w, _window_size_h);
+		if (!fullscreen) SDL_SetWindowSize(_sdl_window, w, h);
 	} else {
 		DEBUG(driver, 0, "SDL_SetWindowFullscreen() failed: %s", SDL_GetError());
 	}


### PR DESCRIPTION
## Motivation / Problem

During final preparations for SDL OpenGL, I found that I jumped the gun on the last cleanup, and already removed some lines that should not have been removed.

Additionally, I had a few more minor cleanups that might as well hit master.


## Description

`_local_palette` was not reset before making a new palette, potentially not sending the full palette to SDL.
Otherwise, a few cleanups (rather minor).
Lastly, removal of a line that is absolutely unclear to me as to why it is there. I cannot find any issue with removing it, so yeah .. there we go.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
