### PR TITLE
Fix f1f281b31: [Win32] MinGW doesn't know timeapi.h

### DIFF
--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -20,8 +20,8 @@
 #include "../../video/video_driver.hpp"
 
 #include <windows.h>
+#include <mmsystem.h>
 #include <signal.h>
-#include <timeapi.h>
 
 #include "../../safeguards.h"
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -14,11 +14,11 @@
 #include "../../fileio_func.h"
 #include <windows.h>
 #include <fcntl.h>
+#include <mmsystem.h>
 #include <regstr.h>
 #define NO_SHOBJIDL_SORTDIRECTION // Avoid multiple definition of SORT_ASCENDING
 #include <shlobj.h> /* SHGetFolderPath */
 #include <shellapi.h>
-#include <timeapi.h>
 #include "win32.h"
 #include "../../fios.h"
 #include "../../core/alloc_func.hpp"


### PR DESCRIPTION
## Motivation / Problem
Following Microsoft documentation to set minimum timer resolution I included `timeapi.h`, but this file is not available with MinGW.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
As `timeapi.h` is included by `mmsystem.h` for VS, and `mmsystem.h` includes timer functions for MinGW, it's better to include `mmsystem.h` than `timeapi.h`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
