### PR TITLE
Fix #8620: Scale spacing between date & news in history window according to font scaling

### DIFF
--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -34,6 +34,7 @@
 #include "settings_internal.h"
 #include "guitimer_func.h"
 #include "group_gui.h"
+#include "zoom_func.h"
 
 #include "widgets/news_widget.h"
 
@@ -1174,8 +1175,8 @@ struct MessageHistoryWindow : Window {
 		bool rtl = _current_text_dir == TD_RTL;
 		uint date_left  = rtl ? r.right - WD_FRAMERECT_RIGHT - this->date_width : r.left + WD_FRAMERECT_LEFT;
 		uint date_right = rtl ? r.right - WD_FRAMERECT_RIGHT : r.left + WD_FRAMERECT_LEFT + this->date_width;
-		uint news_left  = rtl ? r.left + WD_FRAMERECT_LEFT : r.left + WD_FRAMERECT_LEFT + this->date_width + WD_FRAMERECT_RIGHT;
-		uint news_right = rtl ? r.right - WD_FRAMERECT_RIGHT - this->date_width - WD_FRAMERECT_RIGHT : r.right - WD_FRAMERECT_RIGHT;
+		uint news_left  = rtl ? r.left + WD_FRAMERECT_LEFT : r.left + WD_FRAMERECT_LEFT + this->date_width + WD_FRAMERECT_RIGHT + ScaleFontTrad(5);
+		uint news_right = rtl ? r.right - WD_FRAMERECT_RIGHT - this->date_width - WD_FRAMERECT_RIGHT - ScaleFontTrad(5) : r.right - WD_FRAMERECT_RIGHT;
 		for (int n = this->vscroll->GetCapacity(); n > 0; n--) {
 			SetDParam(0, ni->date);
 			DrawString(date_left, date_right, y, STR_SHORT_DATE);


### PR DESCRIPTION
## Motivation / Problem
Before:
Normal:
![image](https://user-images.githubusercontent.com/4007992/107862050-f35fbf00-6e41-11eb-937a-2b1a19ae6b89.png)

Double:
![image](https://user-images.githubusercontent.com/4007992/107862053-fd81bd80-6e41-11eb-8bd7-e91887f8b275.png)

Quad:
![image](https://user-images.githubusercontent.com/4007992/107862058-05d9f880-6e42-11eb-8401-4317dc26cafc.png)

## Description
After:
Normal:
![image](https://user-images.githubusercontent.com/4007992/107861984-77657700-6e41-11eb-9003-0bd27f7e0fdf.png)

Double:
![image](https://user-images.githubusercontent.com/4007992/107861994-82b8a280-6e41-11eb-9c7a-d2c0644f46d7.png)

Quad:
![image](https://user-images.githubusercontent.com/4007992/107861999-93691880-6e41-11eb-8c38-958b49180e06.png)

Tested with RTL langs as well. Looks weird, but it looked weird before as well.
## Limitations
Arbitrary spacing of 5 (scaled) pixels.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
