### PR TITLE
Fix #8625: Wrong ending year was displayed in highscore table

### DIFF
--- a/known-bugs.txt
+++ b/known-bugs.txt
@@ -409,3 +409,12 @@ Involuntary cargo exchange with cargodist via neutral station [#6114]:
         shared station make the order "no unload" and if you're unloading make
         it "no load". Cargodist will then figure out that it should not create
         such a route.
+
+Incorrect ending year displayed in end of game newspaper [#8625]
+        The ending year of the game is configurable, but the date displayed in
+        the newspaper at the end of the game is part of the graphics, not text.
+        So to fix this would involve fixing the graphics in every baseset,
+        including the original. Additionally, basesets are free to put this
+        text in different positions (which they do), making a proper solution
+        to this infinitely more complex for a part of the game that fewer than
+        1% of players ever see.

--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -183,7 +183,7 @@ struct HighScoreWindow : EndGameHighScoreBaseWindow {
 		this->SetupHighScoreEndWindow();
 		Point pt = this->GetTopLeft(ScaleGUITrad(640), ScaleGUITrad(480));
 
-		SetDParam(0, ORIGINAL_END_YEAR);
+		SetDParam(0, _settings_game.game_creation.ending_year);
 		DrawStringMultiLine(pt.x + ScaleGUITrad(70), pt.x + ScaleGUITrad(570), pt.y, pt.y + ScaleGUITrad(140), !_networking ? STR_HIGHSCORE_TOP_COMPANIES_WHO_REACHED : STR_HIGHSCORE_TOP_COMPANIES_NETWORK_GAME, TC_FROMSTRING, SA_CENTER);
 
 		/* Draw Highscore peepz */


### PR DESCRIPTION
## Motivation / Problem
* Highscore table was using the default end year, not the configured one.
* Endgame newspaper displays only the default 2050 end year
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
* Make the highscore table use the setting.
* Endgame newspaper cannot be feasibly changed due to being embedded in the baseset graphics. Document it in known-bugs.txt
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
