### PR TITLE
Fix 9c872192: [OSX] Clear mouse button emulation flag.

### DIFF
--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -564,6 +564,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 - (void)mouseUp:(NSEvent *)event
 {
 	if (self->_emulated_down) {
+		self->_emulated_down = false;
 		[ self rightMouseUp:event ];
 	} else {
 		_left_button_down = false;


### PR DESCRIPTION
## Motivation / Problem

Stuck mouse when using RMB emulation on OSX.


## Description

Reset emulation state on mouse up.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
