### PR TITLE
Fix: VkMapping declarations violated C++ ODR rule.

### DIFF
--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -235,7 +235,7 @@ bool VideoDriver_Allegro::ClaimMousePointer()
 	return true;
 }
 
-struct VkMapping {
+struct AllegroVkMapping {
 	uint16 vk_from;
 	byte vk_count;
 	byte map_to;
@@ -244,7 +244,7 @@ struct VkMapping {
 #define AS(x, z) {x, 0, z}
 #define AM(x, y, z, w) {x, y - x, z}
 
-static const VkMapping _vk_mapping[] = {
+static const AllegroVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
 	AM(KEY_PGUP, KEY_PGDN, WKC_PAGEUP, WKC_PAGEDOWN),
 	AS(KEY_UP,     WKC_UP),
@@ -302,7 +302,7 @@ static uint32 ConvertAllegroKeyIntoMy(WChar *character)
 	int scancode;
 	int unicode = ureadkey(&scancode);
 
-	const VkMapping *map;
+	const AllegroVkMapping *map;
 	uint key = 0;
 
 	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {

--- a/src/video/cocoa/cocoa_keys.h
+++ b/src/video/cocoa/cocoa_keys.h
@@ -132,14 +132,14 @@
 #define QZ_IBOOK_UP     0x3E
 
 
-struct VkMapping {
+struct CocoaVkMapping {
 	unsigned short vk_from;
 	byte map_to;
 };
 
 #define AS(x, z) {x, z}
 
-static const VkMapping _vk_mapping[] = {
+static const CocoaVkMapping _vk_mapping[] = {
 	AS(QZ_BACKQUOTE,  WKC_BACKQUOTE), // key left of '1'
 	AS(QZ_BACKQUOTE2, WKC_BACKQUOTE), // some keyboards have it on another scancode
 

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -673,7 +673,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 	BOOL interpret_keys = YES;
 	if (down) {
 		/* Map keycode to OTTD code. */
-		auto vk = std::find_if(std::begin(_vk_mapping), std::end(_vk_mapping), [=](const VkMapping &m) { return m.vk_from == keycode; });
+		auto vk = std::find_if(std::begin(_vk_mapping), std::end(_vk_mapping), [=](const CocoaVkMapping &m) { return m.vk_from == keycode; });
 		uint32 pressed_key = vk != std::end(_vk_mapping) ? vk->map_to : 0;
 
 		if (modifiers & NSShiftKeyMask)     pressed_key |= WKC_SHIFT;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -401,7 +401,7 @@ void VideoDriver_SDL::EditBoxLostFocus()
 }
 
 
-struct VkMapping {
+struct SDLVkMapping {
 	SDL_Keycode vk_from;
 	byte vk_count;
 	byte map_to;
@@ -413,7 +413,7 @@ struct VkMapping {
 #define AS_UP(x, z) {x, 0, z, true}
 #define AM_UP(x, y, z, w) {x, (byte)(y - x), z, true}
 
-static const VkMapping _vk_mapping[] = {
+static const SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
 	AS_UP(SDLK_PAGEUP,   WKC_PAGEUP),
 	AS_UP(SDLK_PAGEDOWN, WKC_PAGEDOWN),
@@ -468,7 +468,7 @@ static const VkMapping _vk_mapping[] = {
 
 static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, WChar *character)
 {
-	const VkMapping *map;
+	const SDLVkMapping *map;
 	uint key = 0;
 	bool unprintable = false;
 
@@ -508,7 +508,7 @@ static uint ConvertSdlKeyIntoMy(SDL_Keysym *sym, WChar *character)
  */
 static uint ConvertSdlKeycodeIntoMy(SDL_Keycode kc)
 {
-	const VkMapping *map;
+	const SDLVkMapping *map;
 	uint key = 0;
 
 	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -403,7 +403,7 @@ bool VideoDriver_SDL::ClaimMousePointer()
 	return true;
 }
 
-struct VkMapping {
+struct SDLVkMapping {
 #if SDL_VERSION_ATLEAST(1, 3, 0)
 	SDL_Keycode vk_from;
 #else
@@ -416,7 +416,7 @@ struct VkMapping {
 #define AS(x, z) {x, 0, z}
 #define AM(x, y, z, w) {x, (byte)(y - x), z}
 
-static const VkMapping _vk_mapping[] = {
+static const SDLVkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
 	AM(SDLK_PAGEUP, SDLK_PAGEDOWN, WKC_PAGEUP, WKC_PAGEDOWN),
 	AS(SDLK_UP,     WKC_UP),
@@ -470,7 +470,7 @@ static const VkMapping _vk_mapping[] = {
 
 static uint ConvertSdlKeyIntoMy(SDL_keysym *sym, WChar *character)
 {
-	const VkMapping *map;
+	const SDLVkMapping *map;
 	uint key = 0;
 
 	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -114,7 +114,7 @@ bool VideoDriver_Win32::ClaimMousePointer()
 	return true;
 }
 
-struct VkMapping {
+struct Win32VkMapping {
 	byte vk_from;
 	byte vk_count;
 	byte map_to;
@@ -123,7 +123,7 @@ struct VkMapping {
 #define AS(x, z) {x, 0, z}
 #define AM(x, y, z, w) {x, y - x, z}
 
-static const VkMapping _vk_mapping[] = {
+static const Win32VkMapping _vk_mapping[] = {
 	/* Pageup stuff + up/down */
 	AM(VK_PRIOR, VK_DOWN, WKC_PAGEUP, WKC_DOWN),
 	/* Map letters & digits */
@@ -166,7 +166,7 @@ static const VkMapping _vk_mapping[] = {
 
 static uint MapWindowsKey(uint sym)
 {
-	const VkMapping *map;
+	const Win32VkMapping *map;
 	uint key = 0;
 
 	for (map = _vk_mapping; map != endof(_vk_mapping); ++map) {


### PR DESCRIPTION
## Motivation / Problem
```

[100%] Linking CXX executable openttd
/home/milek7/OpenTTD/src/video/allegro_v.cpp:238:8: warning: type ‘struct VkMapping’ violates the C++ One Definition Rule [-Wodr]
  238 | struct VkMapping {
      |        ^
/home/milek7/OpenTTD/src/video/sdl2_v.cpp:404:8: note: a different type is defined in another translation unit
  404 | struct VkMapping {
      |        ^
/home/milek7/OpenTTD/src/video/allegro_v.cpp:239:16: note: the first difference of corresponding definitions is field ‘vk_from’
  239 |         uint16 vk_from;
      |                ^
/home/milek7/OpenTTD/src/video/sdl2_v.cpp:405:21: note: a field of same name but different type is defined in another translation unit
  405 |         SDL_Keycode vk_from;
      |                     ^
/home/milek7/OpenTTD/src/video/allegro_v.cpp:238:8: note: type ‘uint16’ should match type ‘SDL_Keycode’
  238 | struct VkMapping {
      |        ^
```
## Description

Prefix VkMapping names with driver name.


## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
