### PR TITLE
Fix: [Actions] Use vcpkg to provide libpng on macOS

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -161,7 +161,7 @@ jobs:
         vcpkgDirectory: '/usr/local/share/vcpkg'
         doNotUpdateVcpkg: false
         vcpkgGitCommitId: 2a42024b53ebb512fb5dd63c523338bf26c8489c
-        vcpkgArguments: 'liblzma lzo'
+        vcpkgArguments: 'liblzma libpng lzo'
         vcpkgTriplet: '${{ matrix.arch }}-osx'
 
     - name: Install OpenGFX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,7 +482,7 @@ jobs:
         vcpkgDirectory: '/usr/local/share/vcpkg'
         doNotUpdateVcpkg: false
         vcpkgGitCommitId: 2a42024b53ebb512fb5dd63c523338bf26c8489c
-        vcpkgArguments: 'liblzma:x64-osx lzo:x64-osx liblzma:arm64-osx lzo:arm64-osx'
+        vcpkgArguments: 'liblzma:x64-osx libpng:x64-osx lzo:x64-osx liblzma:arm64-osx libpng:arm64-osx lzo:arm64-osx'
 
     - name: Build tools
       run: |


### PR DESCRIPTION
## Motivation / Problem

The macOS builds are failing because libpng is missing on ARM64.

## Description

vcpkg previously installed libpng as a dependency of freetype. When freetype was removed, libpng was no longer installed. We should have had libpng specified explicitly, but didn't.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
