### PR TITLE
Fix #8676: Revert a2c3197f4 and unconditionally load settings "early"

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1722,8 +1722,10 @@ static void HandleSettingDescs(IniFile *ini, SettingDescProc *proc, SettingDescP
 #endif /* _WIN32 */
 	}
 
+	/* Always load settings. */
+	proc(ini, _settings, "patches", &_settings_newgame);
+
 	if (other_settings) {
-		proc(ini, _settings,         "patches",  &_settings_newgame);
 		proc(ini, _currency_settings,"currency", &_custom_currency);
 		proc(ini, _company_settings, "company",  &_settings_client.company);
 

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -5,8 +5,6 @@
 ;
 
 [pre-amble]
-static bool ZoomMinMaxChanged(int32 p1);
-
 extern std::string _config_language_file;
 
 static const char *_support8bppmodes = "no|system|hardware";
@@ -26,7 +24,6 @@ SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,   
 SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTC_VAR   =   SDTC_VAR($var,  $type,          $flags, $guiflags,       $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
 SDTG_END   = SDTG_END()
 
 [defaults]
@@ -305,32 +302,6 @@ def      = 100
 min      = 0
 max      = UINT32_MAX
 cat      = SC_EXPERT
-
-[SDTC_VAR]
-var      = gui.zoom_min
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = ZOOM_LVL_MIN
-min      = ZOOM_LVL_MIN
-max      = ZOOM_LVL_OUT_4X
-str      = STR_CONFIG_SETTING_ZOOM_MIN
-strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
-strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
-proc     = ZoomMinMaxChanged
-
-[SDTC_VAR]
-var      = gui.zoom_max
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = ZOOM_LVL_MAX
-min      = ZOOM_LVL_OUT_8X
-max      = ZOOM_LVL_MAX
-str      = STR_CONFIG_SETTING_ZOOM_MAX
-strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
-strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
-proc     = ZoomMinMaxChanged
 
 [SDTG_VAR]
 name     = ""gui_zoom""

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -38,6 +38,7 @@ static bool InvalidateAISettingsWindow(int32 p1);
 static bool RedrawTownAuthority(int32 p1);
 static bool InvalidateCompanyInfrastructureWindow(int32 p1);
 static bool InvalidateCompanyWindow(int32 p1);
+static bool ZoomMinMaxChanged(int32 p1);
 static bool MaxVehiclesChanged(int32 p1);
 static bool InvalidateShipPathCache(int32 p1);
 
@@ -2791,6 +2792,32 @@ str      = STR_CONFIG_SETTING_SOFT_LIMIT
 strhelp  = STR_CONFIG_SETTING_SOFT_LIMIT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SOFT_LIMIT_VALUE
 cat      = SC_EXPERT
+
+[SDTC_VAR]
+var      = gui.zoom_min
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = ZOOM_LVL_MIN
+min      = ZOOM_LVL_MIN
+max      = ZOOM_LVL_OUT_4X
+str      = STR_CONFIG_SETTING_ZOOM_MIN
+strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
+strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
+proc     = ZoomMinMaxChanged
+
+[SDTC_VAR]
+var      = gui.zoom_max
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = ZOOM_LVL_MAX
+min      = ZOOM_LVL_OUT_8X
+max      = ZOOM_LVL_MAX
+str      = STR_CONFIG_SETTING_ZOOM_MAX
+strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
+strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
+proc     = ZoomMinMaxChanged
 
 [SDTC_BOOL]
 var      = gui.population_in_label


### PR DESCRIPTION
## Motivation / Problem
`gui.zoom_min` and `gui.zoom_max` where moved to `_misc_settings` while settings windows was still expecting them in `_settings`.
The move was to have these settings available early, to update GUI zoom level before drawing anything.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Reverted the move, as it caused the issue.
Since settings are reloaded after each grf scan, it should not be an issue to always load them, even in the "early" load.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
