### PR TITLE
Fix #8676: GUI-visible settings may not be part of misc settings.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -86,7 +86,7 @@ typedef std::list<ErrorMessageData> ErrorList;
 static ErrorList _settings_error_list; ///< Errors while loading minimal settings.
 
 
-typedef void SettingDescProc(IniFile *ini, const SettingDesc *desc, const char *grpname, void *object);
+typedef void SettingDescProc(IniFile *ini, const SettingDesc *desc, const char *grpname, void *object, bool only_startup);
 typedef void SettingDescProcList(IniFile *ini, const char *grpname, StringList &list);
 
 static bool IsSignedVarMemType(VarType vt);
@@ -501,8 +501,9 @@ static void Write_ValidateSetting(void *ptr, const SettingDesc *sd, int32 val)
  *        be given values
  * @param grpname the group of the IniFile to search in for the new values
  * @param object pointer to the object been loaded
+ * @param only_startup load only the startup settings set
  */
-static void IniLoadSettings(IniFile *ini, const SettingDesc *sd, const char *grpname, void *object)
+static void IniLoadSettings(IniFile *ini, const SettingDesc *sd, const char *grpname, void *object, bool only_startup)
 {
 	IniGroup *group;
 	IniGroup *group_def = ini->GetGroup(grpname);
@@ -512,6 +513,7 @@ static void IniLoadSettings(IniFile *ini, const SettingDesc *sd, const char *grp
 		const SaveLoad        *sld = &sd->save;
 
 		if (!SlIsObjectCurrentlyValid(sld->version_from, sld->version_to)) continue;
+		if (sd->desc.startup != only_startup) continue;
 
 		/* For settings.xx.yy load the settings from [xx] yy = ? */
 		std::string s{ sdb->name };
@@ -612,7 +614,7 @@ static void IniLoadSettings(IniFile *ini, const SettingDesc *sd, const char *grp
  * values are reloaded when saving). If settings indeed have changed, we get
  * these and save them.
  */
-static void IniSaveSettings(IniFile *ini, const SettingDesc *sd, const char *grpname, void *object)
+static void IniSaveSettings(IniFile *ini, const SettingDesc *sd, const char *grpname, void *object, bool)
 {
 	IniGroup *group_def = nullptr, *group;
 	IniItem *item;
@@ -797,7 +799,7 @@ static void IniSaveSettingList(IniFile *ini, const char *grpname, StringList &li
  */
 void IniLoadWindowSettings(IniFile *ini, const char *grpname, void *desc)
 {
-	IniLoadSettings(ini, _window_settings, grpname, desc);
+	IniLoadSettings(ini, _window_settings, grpname, desc, false);
 }
 
 /**
@@ -808,7 +810,7 @@ void IniLoadWindowSettings(IniFile *ini, const char *grpname, void *desc)
  */
 void IniSaveWindowSettings(IniFile *ini, const char *grpname, void *desc)
 {
-	IniSaveSettings(ini, _window_settings, grpname, desc);
+	IniSaveSettings(ini, _window_settings, grpname, desc, false);
 }
 
 /**
@@ -1713,20 +1715,18 @@ static void GRFSaveConfig(IniFile *ini, const char *grpname, const GRFConfig *li
 }
 
 /* Common handler for saving/loading variables to the configuration file */
-static void HandleSettingDescs(IniFile *ini, SettingDescProc *proc, SettingDescProcList *proc_list, bool basic_settings = true, bool other_settings = true)
+static void HandleSettingDescs(IniFile *ini, SettingDescProc *proc, SettingDescProcList *proc_list, bool only_startup = false)
 {
-	if (basic_settings) {
-		proc(ini, (const SettingDesc*)_misc_settings,    "misc",  nullptr);
+	proc(ini, (const SettingDesc*)_misc_settings,    "misc",  nullptr, only_startup);
 #if defined(_WIN32) && !defined(DEDICATED)
-		proc(ini, (const SettingDesc*)_win32_settings,   "win32", nullptr);
+	proc(ini, (const SettingDesc*)_win32_settings,   "win32", nullptr, only_startup);
 #endif /* _WIN32 */
-	}
 
-	if (other_settings) {
-		proc(ini, _settings,         "patches",  &_settings_newgame);
-		proc(ini, _currency_settings,"currency", &_custom_currency);
-		proc(ini, _company_settings, "company",  &_settings_client.company);
+	proc(ini, _settings,         "patches",  &_settings_newgame, only_startup);
+	proc(ini, _currency_settings,"currency", &_custom_currency, only_startup);
+	proc(ini, _company_settings, "company",  &_settings_client.company, only_startup);
 
+	if (!only_startup) {
 		proc_list(ini, "server_bind_addresses", _network_bind_list);
 		proc_list(ini, "servers", _network_host_list);
 		proc_list(ini, "bans",    _network_ban_list);
@@ -1742,24 +1742,24 @@ static IniFile *IniLoadConfig()
 
 /**
  * Load the values from the configuration files
- * @param minimal Load the minimal amount of the configuration to "bootstrap" the blitter and such.
+ * @param startup Load the minimal amount of the configuration to "bootstrap" the blitter and such.
  */
-void LoadFromConfig(bool minimal)
+void LoadFromConfig(bool startup)
 {
 	IniFile *ini = IniLoadConfig();
-	if (!minimal) ResetCurrencies(false); // Initialize the array of currencies, without preserving the custom one
+	if (!startup) ResetCurrencies(false); // Initialize the array of currencies, without preserving the custom one
 
 	/* Load basic settings only during bootstrap, load other settings not during bootstrap */
-	HandleSettingDescs(ini, IniLoadSettings, IniLoadSettingList, minimal, !minimal);
+	HandleSettingDescs(ini, IniLoadSettings, IniLoadSettingList, startup);
 
-	if (!minimal) {
+	if (!startup) {
 		_grfconfig_newgame = GRFLoadConfig(ini, "newgrf", false);
 		_grfconfig_static  = GRFLoadConfig(ini, "newgrf-static", true);
 		AILoadConfig(ini, "ai_players");
 		GameLoadConfig(ini, "game_scripts");
 
 		PrepareOldDiffCustom();
-		IniLoadSettings(ini, _gameopt_settings, "gameopt", &_settings_newgame);
+		IniLoadSettings(ini, _gameopt_settings, "gameopt", &_settings_newgame, false);
 		HandleOldDiffCustom(false);
 
 		ValidateSettings();

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -103,6 +103,7 @@ struct SettingDescBase {
 	OnChange *proc;         ///< callback procedure for when the value is changed
 	OnConvert *proc_cnvt;   ///< callback procedure when loading value mechanism fails
 	SettingCategory cat;    ///< assigned categories of the setting
+	bool startup;           ///< setting has to be loaded directly at startup?
 };
 
 struct SettingDesc {

--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -16,8 +16,8 @@ static const SettingDesc _company_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END  = SDT_END()
 
 [defaults]
@@ -33,6 +33,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = false
 
 
 

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -9,9 +9,9 @@ static const SettingDesc _currency_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR = SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDT_CHR = SDT_CHR($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_VAR = SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_CHR = SDT_CHR($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END = SDT_END()
 
 [defaults]
@@ -27,6 +27,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = false
 
 
 

--- a/src/table/gameopt_settings.ini
+++ b/src/table/gameopt_settings.ini
@@ -37,13 +37,13 @@ static const SettingDesc _gameopt_settings[] = {
 [post-amble]
 };
 [templates]
-SDTG_GENERAL = SDTG_GENERAL($name, $sdt_cmd, $sle_cmd, $type, $flags, $guiflags, $var, $length, $def, $min, $max, $interval, $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_VAR     =     SDTG_VAR($name,                     $type, $flags, $guiflags, $var,          $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_GENERAL = SDTG_GENERAL($name, $sdt_cmd, $sle_cmd, $type, $flags, $guiflags, $var, $length, $def, $min, $max, $interval, $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_VAR     =     SDTG_VAR($name,                     $type, $flags, $guiflags, $var,          $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_NULL     =   SDT_NULL($length, $from, $to),
-SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra),
-SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_END      = SDT_END()
 
 [defaults]
@@ -59,6 +59,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = false
 
 
 

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -19,14 +19,14 @@ static const SettingDescGlobVarList _misc_settings[] = {
 [post-amble]
 };
 [templates]
-SDTG_LIST  =  SDTG_LIST($name, $type, $length, $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_MMANY = SDTG_MMANY($name, $type,          $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_OMANY = SDTG_OMANY($name, $type,          $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTC_VAR   =   SDTC_VAR($var,  $type,          $flags, $guiflags,       $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_LIST  =  SDTG_LIST($name, $type, $length, $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_MMANY = SDTG_MMANY($name, $type,          $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name, $type,          $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR($var,  $type,          $flags, $guiflags,       $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_END   = SDTG_END()
 
 [defaults]
@@ -42,6 +42,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = true
 
 
 

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -5,8 +5,6 @@
 ;
 
 [pre-amble]
-static bool ZoomMinMaxChanged(int32 p1);
-
 extern std::string _config_language_file;
 
 static const char *_support8bppmodes = "no|system|hardware";
@@ -26,7 +24,6 @@ SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,   
 SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR($var,  $type,          $flags, $guiflags,       $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_END   = SDTG_END()
 
 [defaults]
@@ -306,32 +303,6 @@ def      = 100
 min      = 0
 max      = UINT32_MAX
 cat      = SC_EXPERT
-
-[SDTC_VAR]
-var      = gui.zoom_min
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = ZOOM_LVL_MIN
-min      = ZOOM_LVL_MIN
-max      = ZOOM_LVL_OUT_4X
-str      = STR_CONFIG_SETTING_ZOOM_MIN
-strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
-strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
-proc     = ZoomMinMaxChanged
-
-[SDTC_VAR]
-var      = gui.zoom_max
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = ZOOM_LVL_MAX
-min      = ZOOM_LVL_OUT_8X
-max      = ZOOM_LVL_MAX
-str      = STR_CONFIG_SETTING_ZOOM_MAX
-strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
-strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
-proc     = ZoomMinMaxChanged
 
 [SDTG_VAR]
 name     = ""gui_zoom""

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -56,84 +56,84 @@ static size_t ConvertLandscape(const char *value);
  * on the appropriate macro.
  */
 
-#define NSD_GENERAL(name, def, cmd, guiflags, min, max, interval, many, str, strhelp, strval, proc, load, cat)\
-	{name, (const void*)(size_t)(def), cmd, guiflags, min, max, interval, many, str, strhelp, strval, proc, load, cat}
+#define NSD_GENERAL(name, def, cmd, guiflags, min, max, interval, many, str, strhelp, strval, proc, load, cat, startup)\
+	{name, (const void*)(size_t)(def), cmd, guiflags, min, max, interval, many, str, strhelp, strval, proc, load, cat, startup}
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
-#define SDTG_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, var, length, def, min, max, interval, full, str, strhelp, strval, proc, from, to, cat, extra)\
-	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, nullptr, cat), SLEG_GENERAL(sle_cmd, var, type | flags, length, from, to, extra)}
+#define SDTG_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, var, length, def, min, max, interval, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, nullptr, cat, startup), SLEG_GENERAL(sle_cmd, var, type | flags, length, from, to, extra)}
 
-#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(name, SDT_NUMX, SL_VAR, type, flags, guiflags, var, 0, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(name, SDT_NUMX, SL_VAR, type, flags, guiflags, var, 0, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(name, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, var, 0, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(name, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, var, 0, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_LIST(name, type, length, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(name, SDT_INTLIST, SL_ARR, type, flags, guiflags, var, length, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_LIST(name, type, length, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(name, SDT_INTLIST, SL_ARR, type, flags, guiflags, var, length, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_STR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_STR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_SSTR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra)\
-    SDTG_GENERAL(name, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_SSTR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+    SDTG_GENERAL(name, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(name, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(name, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(name, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, 0, 0, full, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(name, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, var, 0, def, 0, 0, 0, full, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
 #define SDTG_NULL(length, from, to)\
-	{{"", nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLEG_NULL(length, from, to)}
+	{{"", nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE, false}, SLEG_NULL(length, from, to)}
 
-#define SDTG_END() {{nullptr, nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLEG_END()}
+#define SDTG_END() {{nullptr, nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE, false}, SLEG_END()}
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
-#define SDT_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, base, var, length, def, min, max, interval, full, str, strhelp, strval, proc, load, from, to, cat, extra)\
-	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, load, cat), SLE_GENERAL(sle_cmd, base, var, type | flags, length, from, to, extra)}
+#define SDT_GENERAL(name, sdt_cmd, sle_cmd, type, flags, guiflags, base, var, length, def, min, max, interval, full, str, strhelp, strval, proc, load, from, to, cat, extra, startup)\
+	{NSD_GENERAL(name, def, sdt_cmd, guiflags, min, max, interval, full, str, strhelp, strval, proc, load, cat, startup), SLE_GENERAL(sle_cmd, base, var, type | flags, length, from, to, extra)}
 
-#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDT_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, base, var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
+#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, base, var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
-#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDT_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, base, var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
+#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, base, var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
-#define SDT_LIST(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDT_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
+#define SDT_LIST(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
-#define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
+#define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
-#define SDT_CHR(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDT_GENERAL(#var, SDT_STRING, SL_VAR, SLE_CHAR, flags, guiflags, base, var, 1, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
+#define SDT_CHR(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_STRING, SL_VAR, SLE_CHAR, flags, guiflags, base, var, 1, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
-#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra)\
-	SDT_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, load, from, to, cat, extra)
+#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, load, from, to, cat, extra, startup)
 
-#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, proc, strhelp, strval, from, to, cat, extra)\
-	SDT_GENERAL(#var, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, 0, 0, full, str, strhelp, strval, proc, nullptr, from, to, cat, extra)
+#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, proc, strhelp, strval, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_MANYOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, 0, 0, full, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
 #define SDT_NULL(length, from, to)\
-	{{"", nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLE_CONDNULL(length, from, to)}
+	{{"", nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE, false}, SLE_CONDNULL(length, from, to)}
 
 
-#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(#var, SDT_NUMX, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, min, max, interval, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, _settings_client.var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(#var, SDT_BOOLX, SL_VAR, SLE_BOOL, flags, guiflags, _settings_client.var, 1, def, 0, 1, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTC_LIST(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTC_LIST(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat, extra)\
-	SDTG_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra)
+#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDT_END() {{nullptr, nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE}, SLE_END()}
+#define SDT_END() {{nullptr, nullptr, SDT_NUMX, SGF_NONE, 0, 0, 0, nullptr, STR_NULL, STR_NULL, STR_NULL, nullptr, nullptr, SC_NONE, false}, SLE_END()}
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -61,18 +61,18 @@ const SettingDesc _settings[] = {
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTC_STR   =   SDTC_STR(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra),
-SDT_STR    =    SDT_STR($base, $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
-SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra),
+SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_STR   =   SDTC_STR(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra, $startup),
+SDT_STR    =    SDT_STR($base, $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_NULL   =   SDT_NULL($length, $from, $to),
 SDT_END    = SDT_END()
 
@@ -89,6 +89,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = false
 
 
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -38,6 +38,7 @@ static bool InvalidateAISettingsWindow(int32 p1);
 static bool RedrawTownAuthority(int32 p1);
 static bool InvalidateCompanyInfrastructureWindow(int32 p1);
 static bool InvalidateCompanyWindow(int32 p1);
+static bool ZoomMinMaxChanged(int32 p1);
 static bool MaxVehiclesChanged(int32 p1);
 static bool InvalidateShipPathCache(int32 p1);
 
@@ -2792,6 +2793,34 @@ str      = STR_CONFIG_SETTING_SOFT_LIMIT
 strhelp  = STR_CONFIG_SETTING_SOFT_LIMIT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SOFT_LIMIT_VALUE
 cat      = SC_EXPERT
+
+[SDTC_VAR]
+var      = gui.zoom_min
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = ZOOM_LVL_MIN
+min      = ZOOM_LVL_MIN
+max      = ZOOM_LVL_OUT_4X
+str      = STR_CONFIG_SETTING_ZOOM_MIN
+strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
+strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
+proc     = ZoomMinMaxChanged
+startup  = true
+
+[SDTC_VAR]
+var      = gui.zoom_max
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = ZOOM_LVL_MAX
+min      = ZOOM_LVL_OUT_8X
+max      = ZOOM_LVL_MAX
+str      = STR_CONFIG_SETTING_ZOOM_MAX
+strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
+strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
+proc     = ZoomMinMaxChanged
+startup  = true
 
 [SDTC_BOOL]
 var      = gui.population_in_label

--- a/src/table/win32_settings.ini
+++ b/src/table/win32_settings.ini
@@ -15,8 +15,8 @@ static const SettingDescGlobVarList _win32_settings[] = {
 };
 #endif /* _WIN32 */
 [templates]
-SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_END  = SDTG_END()
 
 [defaults]
@@ -32,6 +32,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = true
 
 
 

--- a/src/table/window_settings.ini
+++ b/src/table/window_settings.ini
@@ -10,8 +10,8 @@ static const SettingDesc _window_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra),
+SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END  = SDT_END()
 
 [defaults]
@@ -28,6 +28,7 @@ from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
 cat      = SC_ADVANCED
 extra    = 0
+startup  = false
 
 
 


### PR DESCRIPTION
## Motivation / Problem

`gui.zoom_min` and `gui.zoom_max` need to be early-loaded for GUI auto-zoom to work and were moved to `_misc_settings` for that. Unfortunately, GUI visible settings may no be there.


## Description

This introduces a per-settings flag to decide early-load and moves the two settings back to where they came from.


## Limitations

Alternative to #8677.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
