### PR TITLE
Fix: [Cygwin] Fix missing uint definition

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -306,8 +306,8 @@
 
 typedef unsigned char byte;
 
-/* This is already defined in unix, but not in QNX Neutrino (6.x)*/
-#if (!defined(UNIX) && !defined(__HAIKU__)) || defined(__QNXNTO__)
+/* This is already defined in unix, but not in QNX Neutrino (6.x) or Cygwin. */
+#if (!defined(UNIX) && !defined(__HAIKU__)) || defined(__QNXNTO__) || defined(__CYGWIN__)
 	typedef unsigned int uint;
 #endif
 


### PR DESCRIPTION
## Motivation / Problem

In some situations, I observe the following build issue on Cygwin/Mingw32:

```
In file included from src/settingsgen/../string_func.h:30,
                 from src/settingsgen/settingsgen.cpp:11:
src/settingsgen/../core/bitmath_func.hpp:34:15: error: ‘uint’ does not name a type; did you mean ‘uint8’?
   34 | static inline uint GB(const T x, const uint8 s, const uint8 n)
      |               ^~~~
      |               uint8
```

## Description

Fix it by defining the type.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
