### PR TITLE
Feature: configurable refresh-rate and change default to 60fps

### DIFF
--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -189,7 +189,7 @@ namespace {
 		PerformanceData(1),                     // PFE_ACC_GL_AIRCRAFT
 		PerformanceData(1),                     // PFE_GL_LANDSCAPE
 		PerformanceData(1),                     // PFE_GL_LINKGRAPH
-		PerformanceData(GL_RATE),               // PFE_DRAWING
+		PerformanceData(1000.0 / 30),           // PFE_DRAWING
 		PerformanceData(1),                     // PFE_ACC_DRAWWORLD
 		PerformanceData(60.0),                  // PFE_VIDEO
 		PerformanceData(1000.0 * 8192 / 44100), // PFE_SOUND
@@ -468,7 +468,7 @@ struct FramerateWindow : Window {
 		this->speed_gameloop.SetRate(gl_rate / _pf_data[PFE_GAMELOOP].expected_rate, 1.0);
 		if (this->small) return; // in small mode, this is everything needed
 
-		this->rate_drawing.SetRate(_pf_data[PFE_DRAWING].GetRate(), _pf_data[PFE_DRAWING].expected_rate);
+		this->rate_drawing.SetRate(_pf_data[PFE_DRAWING].GetRate(), _settings_client.gui.refresh_rate);
 
 		int new_active = 0;
 		for (PerformanceElement e = PFE_FIRST; e < PFE_MAX; e++) {

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1188,7 +1188,7 @@ struct GenWorldStatus {
 	StringID cls;
 	uint current;
 	uint total;
-	int timer;
+	std::chrono::steady_clock::time_point timer;
 };
 
 static GenWorldStatus _gws;
@@ -1294,7 +1294,7 @@ void PrepareGenerateWorldProgress()
 	_gws.current = 0;
 	_gws.total   = 0;
 	_gws.percent = 0;
-	_gws.timer   = 0; // Forces to paint the progress window immediately
+	_gws.timer   = std::chrono::steady_clock::now() - std::chrono::milliseconds(MODAL_PROGRESS_REDRAW_TIMEOUT * 2); // Ensure we draw on first update
 }
 
 /**
@@ -1329,7 +1329,7 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 	}
 
 	/* Don't update the screen too often. So update it once in every once in a while... */
-	if (!_network_dedicated && _gws.timer != 0 && _realtime_tick - _gws.timer < MODAL_PROGRESS_REDRAW_TIMEOUT) return;
+	if (!_network_dedicated && std::chrono::steady_clock::now() - _gws.timer < std::chrono::milliseconds(MODAL_PROGRESS_REDRAW_TIMEOUT)) return;
 
 	/* Percentage is about the number of completed tasks, so 'current - 1' */
 	_gws.percent = percent_table[cls] + (percent_table[cls + 1] - percent_table[cls]) * (_gws.current == 0 ? 0 : _gws.current - 1) / _gws.total;
@@ -1365,7 +1365,7 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 	_modal_progress_work_mutex.lock();
 	_modal_progress_paint_mutex.unlock();
 
-	_gws.timer = _realtime_tick;
+	_gws.timer = std::chrono::steady_clock::now();
 }
 
 /**

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1470,9 +1470,8 @@ void DrawDirtyBlocks()
 		_modal_progress_paint_mutex.unlock();
 		_modal_progress_work_mutex.unlock();
 
-		/* Wait a while and update _realtime_tick so we are given the rights */
+		/* Wait a while and hope the modal gives us a bit of time to draw the GUI. */
 		if (!IsFirstModalProgressLoop()) CSleep(MODAL_PROGRESS_REDRAW_TIMEOUT);
-		_realtime_tick += MODAL_PROGRESS_REDRAW_TIMEOUT;
 
 		/* Modal progress thread may need blitter access while we are waiting for it. */
 		VideoDriver::GetInstance()->ReleaseBlitterLock();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1465,7 +1465,6 @@ void GameLoop()
 	if (_game_mode == GM_BOOTSTRAP) {
 		/* Check for UDP stuff */
 		if (_network_available) NetworkBackgroundLoop();
-		InputLoop();
 		return;
 	}
 
@@ -1504,8 +1503,6 @@ void GameLoop()
 	}
 
 	if (!_pause_mode && HasBit(_display_opt, DO_FULL_ANIMATION)) DoPaletteAnimations();
-
-	InputLoop();
 
 	SoundDriver::GetInstance()->MainLoop();
 	MusicLoop();

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -147,6 +147,7 @@ struct GUISettings {
 	byte   starting_colour;                  ///< default color scheme for the company to start a new game with
 	bool   show_newgrf_name;                 ///< Show the name of the NewGRF in the build vehicle window
 	bool   auto_remove_signals;              ///< automatically remove signals when in the way during rail construction
+	uint16 refresh_rate;                     ///< How often we refresh the screen (time between draw-ticks).
 
 	uint16 console_backlog_timeout;          ///< the minimum amount of time items should be in the console backlog before they will be removed in ~3 seconds granularity.
 	uint16 console_backlog_length;           ///< the minimum amount of items in the console backlog before items will be removed.

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3354,6 +3354,16 @@ def      = 100
 min      = 10
 max      = 65500
 
+[SDTC_VAR]
+var      = gui.refresh_rate
+type     = SLE_UINT16
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+def      = 60
+min      = 10
+max      = 1000
+cat      = SC_EXPERT
+startup  = true
+
 [SDTC_BOOL]
 var      = sound.news_ticker
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -495,7 +495,8 @@ void VideoDriver_Allegro::MainLoop()
 			GameLoop();
 		}
 
-		if (cur_ticks >= next_draw_tick) {
+		/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
+		if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
 			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -485,20 +485,20 @@ void VideoDriver_Allegro::MainLoop()
 
 		if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
 			if (_fast_forward && !_pause_mode) {
-				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick = cur_ticks + this->GetGameInterval();
 			} else {
-				next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick += this->GetGameInterval();
 				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-				if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+				if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 			}
 
 			GameLoop();
 		}
 
 		if (cur_ticks >= next_draw_tick) {
-			next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-			if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
+			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -484,13 +484,21 @@ void VideoDriver_Allegro::MainLoop()
 		}
 
 		if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-			next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			if (_fast_forward && !_pause_mode) {
+				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			} else {
+				next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
+				if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+			}
 
 			GameLoop();
 		}
 
 		if (cur_ticks >= next_draw_tick) {
-			next_draw_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
+			if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -521,8 +521,15 @@ void VideoDriver_Allegro::MainLoop()
 			DrawSurfaceToScreen();
 		}
 
+		/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
 		if (!_fast_forward || _pause_mode) {
-			CSleep(1);
+			/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
+			auto next_tick = std::min(next_draw_tick, next_game_tick);
+			auto now = std::chrono::steady_clock::now();
+
+			if (next_tick > now) {
+				std::this_thread::sleep_for(next_tick - now);
+			}
 		}
 	}
 }

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -448,7 +448,7 @@ void VideoDriver_Allegro::Stop()
 void VideoDriver_Allegro::MainLoop()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_cur_ticks = cur_ticks;
+	auto last_realtime_tick = cur_ticks;
 	auto next_tick = cur_ticks;
 
 	CheckPaletteAnim();
@@ -473,9 +473,15 @@ void VideoDriver_Allegro::MainLoop()
 		}
 
 		cur_ticks = std::chrono::steady_clock::now();
+
+		/* If more than a millisecond has passed, increase the _realtime_tick. */
+		if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
+			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
+			_realtime_tick += delta.count();
+			last_realtime_tick += delta;
+		}
+
 		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
-			_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
-			last_cur_ticks = cur_ticks;
 			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 			bool old_ctrl_pressed = _ctrl_pressed;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -704,8 +704,15 @@ void VideoDriver_Cocoa::GameLoop()
 				this->Draw();
 			}
 
+			/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
 			if (!_fast_forward || _pause_mode) {
-				CSleep(1);
+				/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
+				auto next_tick = std::min(next_draw_tick, next_game_tick);
+				auto now = std::chrono::steady_clock::now();
+
+				if (next_tick > now) {
+					std::this_thread::sleep_for(next_tick - now);
+				}
 			}
 		}
 	}

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -36,6 +36,7 @@
 #include "../../gfx_func.h"
 #include "../../thread.h"
 #include "../../core/random_func.hpp"
+#include "../../progress.h"
 #include "../../settings_type.h"
 #include "../../window_func.h"
 #include "../../window_gui.h"
@@ -685,7 +686,8 @@ void VideoDriver_Cocoa::GameLoop()
 				::GameLoop();
 			}
 
-			if (cur_ticks >= next_draw_tick) {
+			/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
+			if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
 				next_draw_tick += this->GetDrawInterval();
 				/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 				if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -635,7 +635,7 @@ bool VideoDriver_Cocoa::PollEvent()
 void VideoDriver_Cocoa::GameLoop()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_cur_ticks = cur_ticks;
+	auto last_realtime_tick = cur_ticks;
 	auto next_tick = cur_ticks;
 
 	for (;;) {
@@ -664,9 +664,15 @@ void VideoDriver_Cocoa::GameLoop()
 			}
 
 			cur_ticks = std::chrono::steady_clock::now();
+
+			/* If more than a millisecond has passed, increase the _realtime_tick. */
+			if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
+				auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
+				_realtime_tick += delta.count();
+				last_realtime_tick += delta;
+			}
+
 			if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
-				_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
-				last_cur_ticks = cur_ticks;
 				next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 				bool old_ctrl_pressed = _ctrl_pressed;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -675,20 +675,20 @@ void VideoDriver_Cocoa::GameLoop()
 
 			if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
 				if (_fast_forward && !_pause_mode) {
-					next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+					next_game_tick = cur_ticks + this->GetGameInterval();
 				} else {
-					next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+					next_game_tick += this->GetGameInterval();
 					/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-					if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+					if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 				}
 
 				::GameLoop();
 			}
 
 			if (cur_ticks >= next_draw_tick) {
-				next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_draw_tick += this->GetDrawInterval();
 				/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-				if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
+				if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
 				bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -674,13 +674,21 @@ void VideoDriver_Cocoa::GameLoop()
 			}
 
 			if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				if (_fast_forward && !_pause_mode) {
+					next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				} else {
+					next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+					/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
+					if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+				}
 
 				::GameLoop();
 			}
 
 			if (cur_ticks >= next_draw_tick) {
-				next_draw_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
+				if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
 
 				bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -294,11 +294,11 @@ void VideoDriver_Dedicated::MainLoop()
 
 		if (cur_ticks >= next_game_tick || _ddc_fastforward) {
 			if (_ddc_fastforward) {
-				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick = cur_ticks + this->GetGameInterval();
 			} else {
-				next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick += this->GetGameInterval();
 				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-				if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+				if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 			}
 
 			GameLoop();

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -236,7 +236,7 @@ static void DedicatedHandleKeyInput()
 void VideoDriver_Dedicated::MainLoop()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_cur_ticks = cur_ticks;
+	auto last_realtime_tick = cur_ticks;
 	auto next_tick = cur_ticks;
 
 	/* Signal handlers */
@@ -283,7 +283,14 @@ void VideoDriver_Dedicated::MainLoop()
 		if (!_dedicated_forks) DedicatedHandleKeyInput();
 
 		cur_ticks = std::chrono::steady_clock::now();
-		_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
+
+		/* If more than a millisecond has passed, increase the _realtime_tick. */
+		if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
+			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
+			_realtime_tick += delta.count();
+			last_realtime_tick += delta;
+		}
+
 		if (cur_ticks >= next_tick || _ddc_fastforward) {
 			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -21,6 +21,7 @@
 #include "../core/random_func.hpp"
 #include "../saveload/saveload.h"
 #include "../thread.h"
+#include "../window_func.h"
 #include "dedicated_v.h"
 
 #ifdef __OS2__
@@ -295,6 +296,7 @@ void VideoDriver_Dedicated::MainLoop()
 			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 			GameLoop();
+			InputLoop();
 			UpdateWindows();
 		}
 

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -311,9 +311,14 @@ void VideoDriver_Dedicated::MainLoop()
 			/* Sleep longer on a dedicated server, if the game is paused and no clients connected.
 			 * That can allow the CPU to better use deep sleep states. */
 			if (_pause_mode != 0 && !HasClients()) {
-				CSleep(100);
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
 			} else {
-				CSleep(1);
+				/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
+				auto now = std::chrono::steady_clock::now();
+
+				if (next_game_tick > now) {
+					std::this_thread::sleep_for(next_game_tick - now);
+				}
 			}
 		}
 	}

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../gfx_func.h"
 #include "../blitter/factory.hpp"
+#include "../window_func.h"
 #include "null_v.h"
 
 #include "../safeguards.h"
@@ -48,6 +49,7 @@ void VideoDriver_Null::MainLoop()
 
 	for (i = 0; i < this->ticks; i++) {
 		GameLoop();
+		InputLoop();
 		UpdateWindows();
 	}
 }

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -792,7 +792,8 @@ void VideoDriver_SDL::LoopOnce()
 		if (_draw_mutex != nullptr) draw_lock.lock();
 	}
 
-	if (cur_ticks >= next_draw_tick) {
+	/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
+	if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
 		next_draw_tick += this->GetDrawInterval();
 		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 		if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -777,7 +777,13 @@ void VideoDriver_SDL::LoopOnce()
 	}
 
 	if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-		next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+		if (_fast_forward && !_pause_mode) {
+			next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+		} else {
+			next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
+			if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+		}
 
 		/* The gameloop is the part that can run asynchronously. The rest
 		 * except sleeping can't. */
@@ -787,7 +793,9 @@ void VideoDriver_SDL::LoopOnce()
 	}
 
 	if (cur_ticks >= next_draw_tick) {
-		next_draw_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+		next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
+		if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
 
 		bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -793,9 +793,9 @@ void VideoDriver_SDL::LoopOnce()
 	}
 
 	if (cur_ticks >= next_draw_tick) {
-		next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+		next_draw_tick += this->GetDrawInterval();
 		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-		if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
+		if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
 		bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -824,10 +824,17 @@ void VideoDriver_SDL::LoopOnce()
 /* Emscripten is running an event-based mainloop; there is already some
  * downtime between each iteration, so no need to sleep. */
 #ifndef __EMSCRIPTEN__
+	/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
 	if (!_fast_forward || _pause_mode) {
-		if (_draw_mutex != nullptr) draw_lock.unlock();
-		CSleep(1);
-		if (_draw_mutex != nullptr) draw_lock.lock();
+		/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
+		auto next_tick = std::min(next_draw_tick, next_game_tick);
+		auto now = std::chrono::steady_clock::now();
+
+		if (next_tick > now) {
+			if (_draw_mutex != nullptr) draw_lock.unlock();
+			std::this_thread::sleep_for(next_tick - now);
+			if (_draw_mutex != nullptr) draw_lock.lock();
+		}
 	}
 #endif
 }

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -768,9 +768,15 @@ void VideoDriver_SDL::LoopOnce()
 	}
 
 	cur_ticks = std::chrono::steady_clock::now();
+
+	/* If more than a millisecond has passed, increase the _realtime_tick. */
+	if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
+		auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
+		_realtime_tick += delta.count();
+		last_realtime_tick += delta;
+	}
+
 	if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
-		_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
-		last_cur_ticks = cur_ticks;
 		next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 		bool old_ctrl_pressed = _ctrl_pressed;
@@ -826,7 +832,7 @@ void VideoDriver_SDL::LoopOnce()
 void VideoDriver_SDL::MainLoop()
 {
 	cur_ticks = std::chrono::steady_clock::now();
-	last_cur_ticks = cur_ticks;
+	last_realtime_tick = cur_ticks;
 	next_tick = cur_ticks;
 
 	this->CheckPaletteAnim();

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -63,7 +63,7 @@ private:
 	bool edit_box_focused;
 
 	std::chrono::steady_clock::time_point cur_ticks;
-	std::chrono::steady_clock::time_point last_cur_ticks;
+	std::chrono::steady_clock::time_point last_realtime_tick;
 	std::chrono::steady_clock::time_point next_tick;
 
 	int startup_display;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -64,7 +64,8 @@ private:
 
 	std::chrono::steady_clock::time_point cur_ticks;
 	std::chrono::steady_clock::time_point last_realtime_tick;
-	std::chrono::steady_clock::time_point next_tick;
+	std::chrono::steady_clock::time_point next_game_tick;
+	std::chrono::steady_clock::time_point next_draw_tick;
 
 	int startup_display;
 	std::thread draw_thread;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -62,9 +62,9 @@ private:
 	 */
 	bool edit_box_focused;
 
-	uint32 cur_ticks;
-	uint32 last_cur_ticks;
-	uint32 next_tick;
+	std::chrono::steady_clock::time_point cur_ticks;
+	std::chrono::steady_clock::time_point last_cur_ticks;
+	std::chrono::steady_clock::time_point next_tick;
 
 	int startup_display;
 	std::thread draw_thread;

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -649,7 +649,7 @@ void VideoDriver_SDL::Stop()
 void VideoDriver_SDL::MainLoop()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_cur_ticks = cur_ticks;
+	auto last_realtime_tick = cur_ticks;
 	auto next_tick = cur_ticks;
 	uint32 mod;
 	int numkeys;
@@ -719,9 +719,15 @@ void VideoDriver_SDL::MainLoop()
 		}
 
 		cur_ticks = std::chrono::steady_clock::now();
+
+		/* If more than a millisecond has passed, increase the _realtime_tick. */
+		if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
+			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
+			_realtime_tick += delta.count();
+			last_realtime_tick += delta;
+		}
+
 		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
-			_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
-			last_cur_ticks = cur_ticks;
 			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 			bool old_ctrl_pressed = _ctrl_pressed;

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -648,9 +648,9 @@ void VideoDriver_SDL::Stop()
 
 void VideoDriver_SDL::MainLoop()
 {
-	uint32 cur_ticks = SDL_GetTicks();
-	uint32 last_cur_ticks = cur_ticks;
-	uint32 next_tick = cur_ticks + MILLISECONDS_PER_TICK;
+	auto cur_ticks = std::chrono::steady_clock::now();
+	auto last_cur_ticks = cur_ticks;
+	auto next_tick = cur_ticks;
 	uint32 mod;
 	int numkeys;
 	Uint8 *keys;
@@ -690,7 +690,6 @@ void VideoDriver_SDL::MainLoop()
 	DEBUG(driver, 1, "SDL: using %sthreads", _draw_threaded ? "" : "no ");
 
 	for (;;) {
-		uint32 prev_cur_ticks = cur_ticks; // to check for wrapping
 		InteractiveRandom(); // randomness
 
 		while (PollEvent() == -1) {}
@@ -719,11 +718,11 @@ void VideoDriver_SDL::MainLoop()
 			_fast_forward = 0;
 		}
 
-		cur_ticks = SDL_GetTicks();
-		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
-			_realtime_tick += cur_ticks - last_cur_ticks;
+		cur_ticks = std::chrono::steady_clock::now();
+		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
+			_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
 			last_cur_ticks = cur_ticks;
-			next_tick = cur_ticks + MILLISECONDS_PER_TICK;
+			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -730,7 +730,13 @@ void VideoDriver_SDL::MainLoop()
 		}
 
 		if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-			next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			if (_fast_forward && !_pause_mode) {
+				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			} else {
+				next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
+				if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+			}
 
 			/* The gameloop is the part that can run asynchronously. The rest
 			 * except sleeping can't. */
@@ -740,7 +746,9 @@ void VideoDriver_SDL::MainLoop()
 		}
 
 		if (cur_ticks >= next_draw_tick) {
-			next_draw_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
+			if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -731,11 +731,11 @@ void VideoDriver_SDL::MainLoop()
 
 		if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
 			if (_fast_forward && !_pause_mode) {
-				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick = cur_ticks + this->GetGameInterval();
 			} else {
-				next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick += this->GetGameInterval();
 				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-				if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+				if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 			}
 
 			/* The gameloop is the part that can run asynchronously. The rest
@@ -746,9 +746,9 @@ void VideoDriver_SDL::MainLoop()
 		}
 
 		if (cur_ticks >= next_draw_tick) {
-			next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-			if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
+			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -745,7 +745,8 @@ void VideoDriver_SDL::MainLoop()
 			if (_draw_mutex != nullptr) draw_lock.lock();
 		}
 
-		if (cur_ticks >= next_draw_tick) {
+		/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
+		if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
 			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -782,10 +782,17 @@ void VideoDriver_SDL::MainLoop()
 			}
 		}
 
+		/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
 		if (!_fast_forward || _pause_mode) {
-			if (_draw_mutex != nullptr) draw_lock.unlock();
-			CSleep(1);
-			if (_draw_mutex != nullptr) draw_lock.lock();
+			/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
+			auto next_tick = std::min(next_draw_tick, next_game_tick);
+			auto now = std::chrono::steady_clock::now();
+
+			if (next_tick > now) {
+				if (_draw_mutex != nullptr) draw_lock.unlock();
+				std::this_thread::sleep_for(next_tick - now);
+				if (_draw_mutex != nullptr) draw_lock.lock();
+			}
 		}
 	}
 

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -126,6 +126,8 @@ public:
 	}
 
 protected:
+	const uint ALLOWED_DRIFT = 5; ///< How many times videodriver can miss deadlines without it being overly compensated.
+
 	/**
 	 * Get the resolution of the main screen.
 	 */

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -13,7 +13,9 @@
 #include "../driver.h"
 #include "../core/geometry_type.hpp"
 #include "../core/math_func.hpp"
+#include "../settings_type.h"
 #include "../zoom_type.h"
+#include <chrono>
 #include <vector>
 
 extern std::string _ini_videodriver;
@@ -152,6 +154,16 @@ protected:
 			_cur_resolution.width  = ClampU(res.width  * 3 / 4, DEFAULT_WINDOW_WIDTH, UINT16_MAX / 2);
 			_cur_resolution.height = ClampU(res.height * 3 / 4, DEFAULT_WINDOW_HEIGHT, UINT16_MAX / 2);
 		}
+	}
+
+	std::chrono::steady_clock::duration GetGameInterval()
+	{
+		return std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+	}
+
+	std::chrono::steady_clock::duration GetDrawInterval()
+	{
+		return std::chrono::microseconds(1000000 / _settings_client.gui.refresh_rate);
 	}
 };
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1134,7 +1134,7 @@ void VideoDriver_Win32::MainLoop()
 {
 	MSG mesg;
 	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_cur_ticks = cur_ticks;
+	auto last_realtime_tick = cur_ticks;
 	auto next_tick = cur_ticks;
 
 	std::thread draw_thread;
@@ -1197,9 +1197,15 @@ void VideoDriver_Win32::MainLoop()
 		}
 
 		cur_ticks = std::chrono::steady_clock::now();
+
+		/* If more than a millisecond has passed, increase the _realtime_tick. */
+		if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
+			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
+			_realtime_tick += delta.count();
+			last_realtime_tick += delta;
+		}
+
 		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
-			_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
-			last_cur_ticks = cur_ticks;
 			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 			bool old_ctrl_pressed = _ctrl_pressed;

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1208,11 +1208,11 @@ void VideoDriver_Win32::MainLoop()
 
 		if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
 			if (_fast_forward && !_pause_mode) {
-				next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick = cur_ticks + this->GetGameInterval();
 			} else {
-				next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+				next_game_tick += this->GetGameInterval();
 				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-				if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+				if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 			}
 
 			/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */
@@ -1226,9 +1226,9 @@ void VideoDriver_Win32::MainLoop()
 		}
 
 		if (cur_ticks >= next_draw_tick) {
-			next_draw_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-			if (next_draw_tick < cur_ticks - std::chrono::microseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_draw_tick = cur_ticks;
+			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1225,7 +1225,8 @@ void VideoDriver_Win32::MainLoop()
 			if (_draw_threaded) draw_lock.lock();
 		}
 
-		if (cur_ticks >= next_draw_tick) {
+		/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
+		if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
 			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1133,9 +1133,9 @@ static void CheckPaletteAnim()
 void VideoDriver_Win32::MainLoop()
 {
 	MSG mesg;
-	uint32 cur_ticks = GetTickCount();
-	uint32 last_cur_ticks = cur_ticks;
-	uint32 next_tick = cur_ticks + MILLISECONDS_PER_TICK;
+	auto cur_ticks = std::chrono::steady_clock::now();
+	auto last_cur_ticks = cur_ticks;
+	auto next_tick = cur_ticks;
 
 	std::thread draw_thread;
 	std::unique_lock<std::recursive_mutex> draw_lock;
@@ -1176,8 +1176,6 @@ void VideoDriver_Win32::MainLoop()
 
 	CheckPaletteAnim();
 	for (;;) {
-		uint32 prev_cur_ticks = cur_ticks; // to check for wrapping
-
 		while (PeekMessage(&mesg, nullptr, 0, 0, PM_REMOVE)) {
 			InteractiveRandom(); // randomness
 			/* Convert key messages to char messages if we want text input. */
@@ -1198,11 +1196,11 @@ void VideoDriver_Win32::MainLoop()
 			_fast_forward = 0;
 		}
 
-		cur_ticks = GetTickCount();
-		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode) || cur_ticks < prev_cur_ticks) {
-			_realtime_tick += cur_ticks - last_cur_ticks;
+		cur_ticks = std::chrono::steady_clock::now();
+		if (cur_ticks >= next_tick || (_fast_forward && !_pause_mode)) {
+			_realtime_tick += std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_cur_ticks).count();
 			last_cur_ticks = cur_ticks;
-			next_tick = cur_ticks + MILLISECONDS_PER_TICK;
+			next_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
 
 			bool old_ctrl_pressed = _ctrl_pressed;
 


### PR DESCRIPTION
## Motivation / Problem

While working on OpenGL for SDL, I noticed a few things with the video driver that stood out. It made me wonder if they could be changed .. and so I tried them out. These combined with OpenGL give to me a much better experience with SDL.

While doing SDL, I found that doing all drivers is pretty easy if (and this is a big if) `std::chrono::steady_clock` has a high enough resolution on all our targets. Turns out, they do!

## Description

There are several, rather unrelated, changes in this PR, but combined gives a good total experience.

1) draw-ticks and game-ticks are separated. This means that during fast-forward, the speed of drawing is no longer influenced. This leaves more time for the game-ticks, making fast-foward a lot faster. Additionally, draw-ticks demand time, making it hit its mark a lot better.

2) make refresh-rate configurable, and 60 by default. Our 33.33 was always a bit weird, and most modern monitors do 60Hz. 60 fps is a lot smoother for the eye. Users can change it to 30, or, in my case, to 144 if they like. The higher the number, the less time there is available for simulation!

3) switched all video-drivers to `std::chrono`, and applied many fixes to smooth out how often we (nearly) hit our deadline. This makes the fps counter a lot more stable.

There is one TODO in the code, as it depends on another PR to be merged first (startup-configuration-entries).

And as you can see in the diff, there is a lot of duplication between the drivers now. We could abstract this, but I was unsure we should go that route. They are the same now, as we worked a lot on them lately, but there is no guarantee that works in the future. So I left that out for now .. but creating a "base" driver with the mainloop in there is very much possible.

Tested it on SDL2, SDL1, Allegro, Cocoa, Win32, dedicated server and emscripten; they all work as I would expect.

## Limitations

- Drawing at 60fps or 144fps has an impact on performance. Mostly, on SDL it takes 5ms to draw a frame. This means that if we run at 60fps, 30% of the time is needed to draw. OpenGL PR mostly fixes this, as that reduces this time to almost nothing.
- Things like "new game" and "abandon game" now sometimes have their window disappear before the command is executed, giving for a few frames the illusion nothing happened. During those times, the mouse hangs, so it is not like they can do anything anyway.

## What issues does this solve?

- Sluggish mouse behaviour (and window behaviour); mostly we have reports from macOS users about this, and it drove me crazy personally.
- When the game is taking more than 30ms to run (mostly, the `GameLoop`), it would still sleep (which takes ~6ms). This is time we could have spend trying to play the game.
- Fast-forward is much faster, as it doesn't waste time on drawing frames nobody is going to see anyway.
- More decoupling of game-state from GUI.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
