### PR TITLE
Fix: Autorenew failure advice due to bad refit being shown to all companies

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -319,6 +319,8 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 	/* Does it need to be refitted */
 	CargoID refit_cargo = GetNewCargoTypeForReplace(old_veh, e, part_of_chain);
 	if (refit_cargo == CT_INVALID) {
+		if (!IsLocalCompany()) return CommandCost();
+
 		SetDParam(0, old_veh->index);
 
 		int order_id = GetIncompatibleRefitOrderIdForAutoreplace(old_veh, e);


### PR DESCRIPTION
## Motivation / Problem

Autorenew failure advice messages due to refit failures as introduced in a6aec252b1987d11e09f2778e481ae3d6fb916fa (#8169) should only be shown to the company owning the vehicle, not to players currently operating other companies or to spectators.
Other autorenew failure advice messages are only shown to the company owning the vehicle.

The following savegame can be used to generate large quantities of such advice messages for testing purposes.
[Autorefit test, 1980-02-09.sav.zip](https://github.com/OpenTTD/OpenTTD/files/5990869/Autorefit.test.1980-02-09.sav.zip)

## Description

Do not shown the advice message if the vehicle owner is not the local company.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
