### PR TITLE
Fix: framerate window showed a slightly higher rate than actually measured

### DIFF
--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -151,6 +151,10 @@ namespace {
 			/* Total duration covered by collected points */
 			TimingMeasurement total = 0;
 
+			/* We have nothing to compare the first point against */
+			point--;
+			if (point < 0) point = NUM_FRAMERATE_POINTS - 1;
+
 			while (point != last_point) {
 				/* Only record valid data points, but pretend the gaps in measurements aren't there */
 				if (this->durations[point] != INVALID_DURATION) {


### PR DESCRIPTION
## Motivation / Problem

Ever wondered why the simulation was always running at 34-ish fps, and not 33.33fps? How could it run faster than 30ms if we wait at least 30ms between ticks?

Now you know! The framerate window was (slightly) lying to you!

Off by one :D

With this PR, you can finally enjoy exactly 33.33fps! Isn't that lovely? I think it is!

![image](https://user-images.githubusercontent.com/1663690/108106346-1e3e5300-708e-11eb-9036-f0184d3ed7e9.png)



## Description

```
The first point was counted, but also initialized as "last". As
such, it didn't add to "total", but did add to "count", which made
the "count" 1 more than the total actually represents.
```



## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
