### PR TITLE
Fix 52317bb7: [SDL2] ensure we don't try to blit out of bounds

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -351,6 +351,13 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 		_sdl_surface = _sdl_real_surface;
 	}
 
+	/* X11 doesn't appreciate it if we invalidate areas outside the window
+	 * if shared memory is enabled (read: it crashes). So, as we might have
+	 * gotten smaller, reset our dirty rects. GameSizeChanged() a bit lower
+	 * will mark the whole screen dirty again anyway, but this time with the
+	 * new dimensions. */
+	_num_dirty_rects = 0;
+
 	_screen.width = _sdl_surface->w;
 	_screen.height = _sdl_surface->h;
 	_screen.pitch = _sdl_surface->pitch / (bpp / 8);


### PR DESCRIPTION

## Motivation / Problem

@ldpl found a nice crash with SDL. We finally know why we had to reset the dirty-rects! :D

Left a proper comment for future-us, instead of a comment that nobody understood.

## Description

```
During resizing, there can still be dirty-rects ready to blit based
on the old dimensions. X11 with shared memory enabled crashes if
you try to do this. So, instead, if we resize, reset the dirty-rects.

This is fine, as moments later we mark the whole (new) screen as
dirty anyway.
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
