### PR TITLE
Fix: [SDL2] simplify what to redraw to prevent tearing

### DIFF
--- a/src/core/geometry_func.cpp
+++ b/src/core/geometry_func.cpp
@@ -26,3 +26,25 @@ Dimension maxdim(const Dimension &d1, const Dimension &d2)
 	d.height = std::max(d1.height, d2.height);
 	return d;
 }
+
+/**
+ * Compute the bounding rectangle around two rectangles.
+ * @param r1 First rectangle.
+ * @param r2 Second rectangle.
+ * @return The bounding rectangle, the smallest rectangle that contains both arguments.
+ */
+Rect BoundingRect(const Rect &r1, const Rect &r2)
+{
+	/* If either the first or the second is empty, return the other. */
+	if (IsEmptyRect(r1)) return r2;
+	if (IsEmptyRect(r2)) return r1;
+
+	Rect r;
+
+	r.top    = std::min(r1.top,    r2.top);
+	r.bottom = std::max(r1.bottom, r2.bottom);
+	r.left   = std::min(r1.left,   r2.left);
+	r.right  = std::max(r1.right,  r2.right);
+
+	return r;
+}

--- a/src/core/geometry_func.hpp
+++ b/src/core/geometry_func.hpp
@@ -14,4 +14,16 @@
 
 Dimension maxdim(const Dimension &d1, const Dimension &d2);
 
+/**
+ * Check if a rectangle is empty.
+ * @param r Rectangle to check.
+ * @return True if and only if the rectangle doesn't define space.
+ */
+static inline bool IsEmptyRect(const Rect &r)
+{
+	return (r.left | r.top | r.right | r.bottom) == 0;
+}
+
+Rect BoundingRect(const Rect &r1, const Rect &r2);
+
 #endif /* GEOMETRY_FUNC_HPP */


### PR DESCRIPTION
## Motivation / Problem

When scrolling around on the map, on SDL2 there often is some vertical tearing going on, mostly on the right side of the screen. If you move the map slowly, this is very visible on for example my system, but others reported it too.

JGRPP solves this problem with this: https://github.com/JGRennison/OpenTTD-patches/commit/51477334be06e2a91541f397b7cbc227ab392bfa

With the eye on the OpenGL branch, I went for a slightly different approach but with a similar effect.

## Description

```
When there are a lot of rects to redraw, of which one of the last
ones is almost the full screen, visual tearing happens over the
vertical axis. This is most visible when scrolling the map.

This can be prevented by using less rects. To simplify the situation,
and as solutions like OpenGL need this anyway, keep a single rect
that shows the biggest size that updates everything correctly.

Although this means it needs a bit more time redrawing where it
is strictly seen not needed, it also means less commands have
to be executed in the backend. In the end, this is a trade-off,
and from experiments it seems the approach of this commit gives
a better result.
```

## Limitations

- I need a few people testing this out on their hardware, to see if there is any regression because of this.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
