### PR TITLE
Feature: Hide block signals in GUI by default

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1814,22 +1814,17 @@ STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE_HELPTEXT         :Select the beha
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE                  :Automatically build semaphores before: {STRING2}
 STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT         :Set the year when electric signals will be used for tracks. Before this year, non-electric signals will be used (which have the exact same function, but different looks)
 
-STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI                            :Enable the signal GUI: {STRING2}
-STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI_HELPTEXT                   :Display a window for choosing signal types to build, instead of only window-less signal-type rotation with Ctrl+clicking on built signals
-
-STR_CONFIG_SETTING_DEFAULT_SIGNAL_TYPE                          :Signal type to build by default: {STRING2}
-STR_CONFIG_SETTING_DEFAULT_SIGNAL_TYPE_HELPTEXT                 :Default signal type to use
-###length 3
-STR_CONFIG_SETTING_DEFAULT_SIGNAL_NORMAL                        :Block signals
-STR_CONFIG_SETTING_DEFAULT_SIGNAL_PBS                           :Path signals
-STR_CONFIG_SETTING_DEFAULT_SIGNAL_PBSOWAY                       :One-way path signals
-
 STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES                           :Cycle through signal types: {STRING2}
-STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT                  :Select which signal types to cycle through, when Ctrl+clicking on a build signal with the signal tool
-###length 3
-STR_CONFIG_SETTING_CYCLE_SIGNAL_NORMAL                          :Block signals only
+STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT                  :Select which signal types to cycle through when Ctrl+clicking on a built signal with the signal tool
+###length 2
 STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS                             :Path signals only
-STR_CONFIG_SETTING_CYCLE_SIGNAL_ALL                             :All
+STR_CONFIG_SETTING_CYCLE_SIGNAL_ALL                             :All visible
+
+STR_CONFIG_SETTING_SIGNAL_GUI_MODE                              :Show signal types: {STRING2}
+STR_CONFIG_SETTING_SIGNAL_GUI_MODE_HELPTEXT                     :Choose which signal types are shown in the signal toolbar
+###length 2
+STR_CONFIG_SETTING_SIGNAL_GUI_MODE_PATH                         :Path signals only
+STR_CONFIG_SETTING_SIGNAL_GUI_MODE_ALL_CYCLE_PATH               :All signals
 
 STR_CONFIG_SETTING_TOWN_LAYOUT                                  :Road layout for new towns: {STRING2}
 STR_CONFIG_SETTING_TOWN_LAYOUT_HELPTEXT                         :Layout for the road network of towns

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -19,4 +19,16 @@ void ResetSignalVariant(int32 = 0);
 void InitializeRailGUI();
 DropDownList GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
 
+/** Settings for which signals are shown by the signal GUI. */
+enum SignalGUISettings : uint8 {
+	SIGNAL_GUI_PATH = 0, ///< Show path signals only.
+	SIGNAL_GUI_ALL = 1,  ///< Show all signals, including block and presignals.
+};
+
+/** Settings for which signals are cycled through by control-clicking on the signal with the signal tool. */
+enum SignalCycleSettings : uint8 {
+	SIGNAL_CYCLE_PATH = 0, ///< Cycle through path signals only.
+	SIGNAL_CYCLE_ALL = 1,  ///< Cycle through all signals visible.
+};
+
 #endif /* RAIL_GUI_H */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1622,7 +1622,6 @@ static SettingsContainer &GetSettingsTree()
 			SettingsPage *construction = interface->Add(new SettingsPage(STR_CONFIG_SETTING_INTERFACE_CONSTRUCTION));
 			{
 				construction->Add(new SettingEntry("gui.link_terraform_toolbar"));
-				construction->Add(new SettingEntry("gui.enable_signal_gui"));
 				construction->Add(new SettingEntry("gui.persistent_buildingtools"));
 				construction->Add(new SettingEntry("gui.quick_goto"));
 				construction->Add(new SettingEntry("gui.default_rail_type"));
@@ -1667,8 +1666,8 @@ static SettingsContainer &GetSettingsTree()
 		SettingsPage *company = main->Add(new SettingsPage(STR_CONFIG_SETTING_COMPANY));
 		{
 			company->Add(new SettingEntry("gui.semaphore_build_before"));
-			company->Add(new SettingEntry("gui.default_signal_type"));
 			company->Add(new SettingEntry("gui.cycle_signal_types"));
+			company->Add(new SettingEntry("gui.signal_gui_mode"));
 			company->Add(new SettingEntry("gui.drag_signals_fixed_distance"));
 			company->Add(new SettingEntry("gui.auto_remove_signals"));
 			company->Add(new SettingEntry("gui.new_nonstop"));

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -109,13 +109,6 @@ static void StationSpreadChanged(int32 p1)
 	InvalidateWindowData(WC_BUILD_STATION, 0);
 }
 
-static void CloseSignalGUI(int32 new_value)
-{
-	if (new_value == 0) {
-		CloseWindowByClass(WC_BUILD_SIGNAL);
-	}
-}
-
 static void UpdateConsists(int32 new_value)
 {
 	for (Train *t : Train::Iterate()) {

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -20,6 +20,7 @@
 #include "linkgraph/linkgraph_type.h"
 #include "zoom_type.h"
 #include "openttd.h"
+#include "rail_gui.h"
 
 /* Used to validate sizes of "max" value in settings. */
 const size_t MAX_SLE_UINT8 = UINT8_MAX;
@@ -143,7 +144,8 @@ struct GUISettings {
 	bool   timetable_arrival_departure;      ///< show arrivals and departures in vehicle timetables
 	bool   right_mouse_wnd_close;            ///< close window with right click
 	bool   pause_on_newgame;                 ///< whether to start new games paused or not
-	bool   enable_signal_gui;                ///< show the signal GUI when the signal button is pressed
+	SignalGUISettings signal_gui_mode;       ///< select which signal types are shown in the signal GUI
+	SignalCycleSettings cycle_signal_types;  ///< Which signal types to cycle with the build signal tool.
 	Year   coloured_news_year;               ///< when does newspaper become coloured?
 	bool   timetable_in_ticks;               ///< whether to show the timetable in ticks rather than days
 	bool   quick_goto;                       ///< Allow quick access to 'goto button' in vehicle orders window
@@ -153,8 +155,6 @@ struct GUISettings {
 	Year   semaphore_build_before;           ///< build semaphore signals automatically before this year
 	byte   news_message_timeout;             ///< how much longer than the news message "age" should we keep the message in the history
 	bool   show_track_reservation;           ///< highlight reserved tracks.
-	uint8  default_signal_type;              ///< the signal type to build by default.
-	uint8  cycle_signal_types;               ///< what signal types to cycle with the build signal tool.
 	byte   station_numtracks;                ///< the number of platforms to default on for rail stations
 	byte   station_platlength;               ///< the platform length, in tiles, for rail stations
 	bool   station_dragdrop;                 ///< whether drag and drop is enabled for stations

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -10,7 +10,6 @@
 static void v_PositionMainToolbar(int32 new_value);
 static void v_PositionStatusbar(int32 new_value);
 static void RedrawSmallmap(int32 new_value);
-static void CloseSignalGUI(int32 new_value);
 static void InvalidateCompanyLiveryWindow(int32 new_value);
 static void InvalidateNewGRFChangeWindows(int32 new_value);
 static void ZoomMinMaxChanged(int32 new_value);
@@ -446,14 +445,18 @@ strhelp  = STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_HELPTEXT
 strval   = STR_CONFIG_SETTING_DEFAULT_RAIL_TYPE_FIRST
 cat      = SC_BASIC
 
-[SDTC_BOOL]
-var      = gui.enable_signal_gui
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = true
-str      = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI
-strhelp  = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI_HELPTEXT
-post_cb  = CloseSignalGUI
-cat      = SC_EXPERT
+[SDTC_VAR]
+var      = gui.signal_gui_mode
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = 0
+min      = 0
+max      = 1
+str      = STR_CONFIG_SETTING_SIGNAL_GUI_MODE
+strhelp  = STR_CONFIG_SETTING_SIGNAL_GUI_MODE_HELPTEXT
+strval   = STR_CONFIG_SETTING_SIGNAL_GUI_MODE_PATH
+post_cb  = [](auto) { CloseWindowByClass(WC_BUILD_SIGNAL); }
+cat      = SC_ADVANCED
 
 [SDTC_VAR]
 var      = gui.coloured_news_year
@@ -467,6 +470,19 @@ str      = STR_CONFIG_SETTING_COLOURED_NEWS_YEAR
 strhelp  = STR_CONFIG_SETTING_COLOURED_NEWS_YEAR_HELPTEXT
 strval   = STR_JUST_INT
 cat      = SC_EXPERT
+
+[SDTC_VAR]
+var      = gui.cycle_signal_types
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = 0
+min      = 0
+max      = 1
+interval = 1
+str      = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES
+strhelp  = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT
+strval   = STR_CONFIG_SETTING_CYCLE_SIGNAL_PBS
+cat      = SC_ADVANCED
 
 [SDTC_VAR]
 var      = gui.drag_signals_density
@@ -596,31 +612,6 @@ str      = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION
 strhelp  = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
-
-[SDTC_VAR]
-var      = gui.default_signal_type
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
-def      = 1
-min      = 0
-max      = 2
-interval = 1
-str      = STR_CONFIG_SETTING_DEFAULT_SIGNAL_TYPE
-strhelp  = STR_CONFIG_SETTING_DEFAULT_SIGNAL_TYPE_HELPTEXT
-strval   = STR_CONFIG_SETTING_DEFAULT_SIGNAL_NORMAL
-cat      = SC_BASIC
-
-[SDTC_VAR]
-var      = gui.cycle_signal_types
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
-def      = 2
-min      = 0
-max      = 2
-interval = 1
-str      = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES
-strhelp  = STR_CONFIG_SETTING_CYCLE_SIGNAL_TYPES_HELPTEXT
-strval   = STR_CONFIG_SETTING_CYCLE_SIGNAL_NORMAL
 
 [SDTC_VAR]
 var      = gui.station_numtracks

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -78,22 +78,31 @@ enum BuildRailStationWidgets {
 
 /** Widgets of the #BuildSignalWindow class. */
 enum BuildSignalWidgets {
-	WID_BS_SEMAPHORE_NORM,     ///< Build a semaphore normal block signal
-	WID_BS_SEMAPHORE_ENTRY,    ///< Build a semaphore entry block signal
-	WID_BS_SEMAPHORE_EXIT,     ///< Build a semaphore exit block signal
-	WID_BS_SEMAPHORE_COMBO,    ///< Build a semaphore combo block signal
+	WID_BS_CAPTION,            ///< Caption for the Signal Selection window.
+	WID_BS_SEMAPHORE_NORM,     ///< Build a semaphore normal block signal.
+	WID_BS_SEMAPHORE_ENTRY,    ///< Build a semaphore entry block signal.
+	WID_BS_SEMAPHORE_EXIT,     ///< Build a semaphore exit block signal.
+	WID_BS_SEMAPHORE_COMBO,    ///< Build a semaphore combo block signal.
 	WID_BS_SEMAPHORE_PBS,      ///< Build a semaphore path signal.
 	WID_BS_SEMAPHORE_PBS_OWAY, ///< Build a semaphore one way path signal.
-	WID_BS_ELECTRIC_NORM,      ///< Build an electric normal block signal
-	WID_BS_ELECTRIC_ENTRY,     ///< Build an electric entry block signal
-	WID_BS_ELECTRIC_EXIT,      ///< Build an electric exit block signal
-	WID_BS_ELECTRIC_COMBO,     ///< Build an electric combo block signal
+	WID_BS_ELECTRIC_NORM,      ///< Build an electric normal block signal.
+	WID_BS_ELECTRIC_ENTRY,     ///< Build an electric entry block signal.
+	WID_BS_ELECTRIC_EXIT,      ///< Build an electric exit block signal.
+	WID_BS_ELECTRIC_COMBO,     ///< Build an electric combo block signal.
 	WID_BS_ELECTRIC_PBS,       ///< Build an electric path signal.
 	WID_BS_ELECTRIC_PBS_OWAY,  ///< Build an electric one way path signal.
 	WID_BS_CONVERT,            ///< Convert the signal.
 	WID_BS_DRAG_SIGNALS_DENSITY_LABEL,    ///< The current signal density.
 	WID_BS_DRAG_SIGNALS_DENSITY_DECREASE, ///< Decrease the signal density.
 	WID_BS_DRAG_SIGNALS_DENSITY_INCREASE, ///< Increase the signal density.
+	WID_BS_SEMAPHORE_NORM_SEL,  ///< NWID_SELECTION for WID_BS_SEMAPHORE_NORM.
+	WID_BS_ELECTRIC_NORM_SEL,   ///< NWID_SELECTION for WID_BS_ELECTRIC_NORM.
+	WID_BS_SEMAPHORE_ENTRY_SEL, ///< NWID_SELECTION for WID_BS_SEMAPHORE_ENTRY.
+	WID_BS_ELECTRIC_ENTRY_SEL,  ///< NWID_SELECTION for WID_BS_ELECTRIC_ENTRY.
+	WID_BS_SEMAPHORE_EXIT_SEL,  ///< NWID_SELECTION for WID_BS_SEMAPHORE_EXIT.
+	WID_BS_ELECTRIC_EXIT_SEL,   ///< NWID_SELECTION for WID_BS_ELECTRIC_EXIT.
+	WID_BS_SEMAPHORE_COMBO_SEL, ///< NWID_SELECTION for WID_BS_SEMAPHORE_COMBO.
+	WID_BS_ELECTRIC_COMBO_SEL,  ///< NWID_SELECTION for WID_BS_ELECTRIC_COMBO.
 };
 
 /** Widgets of the #BuildRailDepotWindow class. */


### PR DESCRIPTION
## Motivation / Problem

New players to OpenTTD are confused by signals, partly because there are so many choices available. 

## Description

![signal_toolbar](https://user-images.githubusercontent.com/55058389/113487151-5f46c700-9484-11eb-8b5d-445c0ee0c84d.png)

Path signals are the only signals needed by the majority of players, so this PR hides all non-path signals from the signal GUI by default. For the players who use them for signal logic, priority merges, or stubborn habits, they can be enabled via an Advanced-level setting, `Show signal types`.

In an attempt to simplify the confusing combination of settings affecting signals, I have made additional changes:
- `Settings > Company > Signal type to build by default: Path signals` has been removed and hard-coded to one-way path signals. Note that players only see this when they first open a game -- after that, the toolbar opens with the last signal used selected.
- `Settings > Company > Cycle through signal types` now defaults to Path signals only, and the option for Block signals only has been removed.
- `Settings > Construction > Enable the signal GUI` has been removed. You can still control-click the signal button in the Rail construction menu to build signals without creating a toolbar.

I am open to debate on any of these changes.

This PR was inspired by #7504 but mostly builds on @JGRennison's work [hiding pre-signals for his Realistic Braking feature](https://github.com/JGRennison/OpenTTD-patches/commit/ed0ffb622070c21412b804c1cd9ef2690a0771a8).

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
