### PR TITLE
Fix cc39fa9: New orders are non-stop by default

### DIFF
--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1201,7 +1201,7 @@ cat      = SC_EXPERT
 var      = gui.sg_new_nonstop
 from     = SLV_22
 to       = SLV_93
-def      = true
+def      = false
 
 ; station.nonuniform_stations
 [SDT_NULL]
@@ -3076,7 +3076,7 @@ strhelp  = STR_CONFIG_SETTING_WARN_LOST_VEHICLE_HELPTEXT
 [SDTC_BOOL]
 var      = gui.new_nonstop
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-def      = false
+def      = true
 str      = STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT
 strhelp  = STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT_HELPTEXT
 cat      = SC_BASIC


### PR DESCRIPTION
## Motivation / Problem

In cc39fa9, I changed a legacy setting for non-stop orders instead of the setting currently used. It didn't work and could potentially break old savegames.

## Description

This PR reverts the change to the legacy setting, and changes the correct setting instead.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
