### PR TITLE
Change: Darken graph grid lines for legibility

### DIFF
--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -165,7 +165,8 @@ struct ValuesInterval {
 struct BaseGraphWindow : Window {
 protected:
 	static const int GRAPH_MAX_DATASETS     =  64;
-	static const int GRAPH_AXIS_LINE_COLOUR = PC_BLACK;
+	static const int GRAPH_AXIS_LINE_COLOUR =  GREY_SCALE(1);
+	static const int GRAPH_ZERO_LINE_COLOUR =  GREY_SCALE(8);
 	static const int GRAPH_NUM_MONTHS       =  24; ///< Number of months displayed in the graph.
 
 	static const int MIN_GRAPH_NUM_LINES_Y  =   9; ///< Minimal number of horizontal lines to draw.
@@ -292,7 +293,7 @@ protected:
 		static_assert(GRAPH_MAX_DATASETS >= (int)NUM_CARGO && GRAPH_MAX_DATASETS >= (int)MAX_COMPANIES);
 		assert(this->num_vert_lines > 0);
 
-		byte grid_colour = _colour_gradient[COLOUR_GREY][4];
+		byte grid_colour = GREY_SCALE(3);
 
 		/* Rect r will be adjusted to contain just the graph, with labels being
 		 * placed outside the area. */
@@ -352,7 +353,7 @@ protected:
 
 		/* Draw the x axis. */
 		y = x_axis_offset + r.top;
-		GfxFillRect(r.left, y, r.right, y, GRAPH_AXIS_LINE_COLOUR);
+		GfxFillRect(r.left, y, r.right, y, GRAPH_ZERO_LINE_COLOUR);
 
 		/* Find the largest value that will be drawn. */
 		if (this->num_on_x_axis == 0) return;


### PR DESCRIPTION
## Motivation / Problem

See #8630 for explanation of problem.

Closes #8630.

## Description

This darkens the grid lines to one shade lighter than the background, as suggested. It would be easy to go lighter, if desired.

It also changes the x-axis ($0) from black to a lighter grey than the other grid lines, for better readability.

Finally, it changes all greyscale color assignments to use the consistent GREY_SCALE() method.

Profit graph:

![profit_graph](https://user-images.githubusercontent.com/55058389/108311990-f9c4a280-7183-11eb-8e41-8cf0216f3e16.PNG)

Payment rates for vanilla cargos:

![vanilla_cargos](https://user-images.githubusercontent.com/55058389/108312019-034e0a80-7184-11eb-8564-cdcbd502409e.PNG)

## Limitations

This does not address the other issues raised by @LC-Zorg. I might tackle the period markings next, but one PR at a time.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
