### PR TITLE
Fix: Whole status bar instead of money widget refreshed on money change

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -182,7 +182,7 @@ void InvalidateCompanyWindows(const Company *company)
 {
 	CompanyID cid = company->index;
 
-	if (cid == _local_company) SetWindowDirty(WC_STATUS_BAR, 0);
+	if (cid == _local_company) SetWindowWidgetDirty(WC_STATUS_BAR, 0, 2);
 	SetWindowDirty(WC_FINANCES, cid);
 }
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -35,6 +35,7 @@
 #include "game/game.hpp"
 #include "goal_base.h"
 #include "story_base.h"
+#include "widgets/statusbar_widget.h"
 
 #include "table/strings.h"
 
@@ -182,7 +183,7 @@ void InvalidateCompanyWindows(const Company *company)
 {
 	CompanyID cid = company->index;
 
-	if (cid == _local_company) SetWindowWidgetDirty(WC_STATUS_BAR, 0, 2);
+	if (cid == _local_company) SetWindowWidgetDirty(WC_STATUS_BAR, 0, WID_S_RIGHT);
 	SetWindowDirty(WC_FINANCES, cid);
 }
 

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -19,6 +19,7 @@
 #include "linkgraph/linkgraph.h"
 #include "saveload/saveload.h"
 #include "newgrf_profiling.h"
+#include "widgets/statusbar_widget.h"
 
 #include "safeguards.h"
 
@@ -255,7 +256,7 @@ static void OnNewDay()
 	DisasterDailyLoop();
 	IndustryDailyLoop();
 
-	SetWindowWidgetDirty(WC_STATUS_BAR, 0, 0);
+	SetWindowWidgetDirty(WC_STATUS_BAR, 0, WID_S_LEFT);
 	EnginesDailyLoop();
 
 	/* Refresh after possible snowline change */


### PR DESCRIPTION
## Motivation / Problem

Local company money changes resulted in the whole status bar being refreshed, instead of just the money widget.
This could result in the rest of the status bar being redrawn unnecessarily frequently.


## Description

Only refresh the status bar money widget on local company money changes.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
