### PR TITLE
Several fixes related to merging 60fps PR

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -88,6 +88,7 @@ jobs:
 
         echo "::group::Install dependencies"
         sudo apt-get install -y --no-install-recommends \
+          liballegro4-dev \
           libfontconfig-dev \
           libicu-dev \
           liblzma-dev \

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -93,7 +93,6 @@ jobs:
           libicu-dev \
           liblzma-dev \
           liblzo2-dev \
-          libsdl1.2-dev \
           libsdl2-dev \
           zlib1g-dev \
           # EOF

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -23,6 +23,7 @@
 #include "../core/random_func.hpp"
 #include "../core/math_func.hpp"
 #include "../framerate_type.h"
+#include "../progress.h"
 #include "../thread.h"
 #include "../window_func.h"
 #include "allegro_v.h"

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -778,11 +778,11 @@ void VideoDriver_SDL::LoopOnce()
 
 	if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
 		if (_fast_forward && !_pause_mode) {
-			next_game_tick = cur_ticks + std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_game_tick = cur_ticks + this->GetGameInterval();
 		} else {
-			next_game_tick += std::chrono::milliseconds(MILLISECONDS_PER_TICK);
+			next_game_tick += this->GetGameInterval();
 			/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-			if (next_game_tick < cur_ticks - std::chrono::milliseconds(ALLOWED_DRIFT * MILLISECONDS_PER_TICK)) next_game_tick = cur_ticks;
+			if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 		}
 
 		/* The gameloop is the part that can run asynchronously. The rest


### PR DESCRIPTION
## Motivation / Problem

Basically, I had fixes locally that I did for some stupid reason not to remote, so I merged the wrong code-base. It only contained two fixes, so not the worst problem in the world.

## Description

The missing include in the allegro driver should have been picked up by our CI, but as there was no allegro library installed, it did not. This also corrects that problem, to prevent this in the future.

It now reads: `Found Allegro: /usr/lib/x86_64-linux-gnu/liballeg.so (found version "4.4.3") ` \o/

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
