### PR TITLE
Fix d437445c: also use std::chrono for the GRFFileScanner modal window

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -66,10 +66,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - compiler: clang
-            cxxcompiler: clang++
-          - compiler: gcc
-            cxxcompiler: g++
+        - compiler: clang
+          cxxcompiler: clang++
+          libsdl: libsdl2-dev
+        - compiler: gcc
+          cxxcompiler: g++
+          libsdl: libsdl2-dev
+        - compiler: gcc
+          cxxcompiler: g++
+          libsdl: libsdl1.2-dev
 
     runs-on: ubuntu-20.04
     env:
@@ -93,7 +98,7 @@ jobs:
           libicu-dev \
           liblzma-dev \
           liblzo2-dev \
-          libsdl2-dev \
+          ${{ matrix.libsdl }} \
           zlib1g-dev \
           # EOF
         echo "::endgroup::"

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1188,7 +1188,7 @@ struct GenWorldStatus {
 	StringID cls;
 	uint current;
 	uint total;
-	std::chrono::steady_clock::time_point timer;
+	std::chrono::steady_clock::time_point next_update;
 };
 
 static GenWorldStatus _gws;
@@ -1290,11 +1290,11 @@ struct GenerateProgressWindow : public Window {
  */
 void PrepareGenerateWorldProgress()
 {
-	_gws.cls     = STR_GENERATION_WORLD_GENERATION;
+	_gws.cls = STR_GENERATION_WORLD_GENERATION;
 	_gws.current = 0;
-	_gws.total   = 0;
+	_gws.total = 0;
 	_gws.percent = 0;
-	_gws.timer   = std::chrono::steady_clock::now() - std::chrono::milliseconds(MODAL_PROGRESS_REDRAW_TIMEOUT * 2); // Ensure we draw on first update
+	_gws.next_update = std::chrono::steady_clock::now();
 }
 
 /**
@@ -1329,7 +1329,8 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 	}
 
 	/* Don't update the screen too often. So update it once in every once in a while... */
-	if (!_network_dedicated && std::chrono::steady_clock::now() - _gws.timer < std::chrono::milliseconds(MODAL_PROGRESS_REDRAW_TIMEOUT)) return;
+	if (!_network_dedicated && std::chrono::steady_clock::now() < _gws.next_update) return;
+	_gws.next_update = std::chrono::steady_clock::now() + std::chrono::milliseconds(MODAL_PROGRESS_REDRAW_TIMEOUT);
 
 	/* Percentage is about the number of completed tasks, so 'current - 1' */
 	_gws.percent = percent_table[cls] + (percent_table[cls + 1] - percent_table[cls]) * (_gws.current == 0 ? 0 : _gws.current - 1) / _gws.total;
@@ -1364,8 +1365,6 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 	_modal_progress_paint_mutex.lock();
 	_modal_progress_work_mutex.lock();
 	_modal_progress_paint_mutex.unlock();
-
-	_gws.timer = std::chrono::steady_clock::now();
 }
 
 /**


### PR DESCRIPTION
Fixes #8697

## Motivation / Problem

In some weird moment of insanity, I converted one of the two modal windows to use `std::chrono`, but forgot to convert the other. No clue where the brainfart came from, but here we are.


## Description

Fixes hanging screen during NewGRF Scans.

As bonus, made the code look more similar between those two windows .. for some reason someone decided to go the completely different direction for the second :P

Additionally, just because I am too lazy to make an extra PR out of it, run the CI against LibSDL2 and LibSDL1.2.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
