### PR TITLE
Fix: [Win32] now we are drawing on a tick, no longer use WM_PAINT

### DIFF
--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1165,8 +1165,9 @@ void VideoDriver_Win32::MainLoop()
 
 	CheckPaletteAnim();
 	for (;;) {
+		InteractiveRandom(); // randomness
+
 		while (PeekMessage(&mesg, nullptr, 0, 0, PM_REMOVE)) {
-			InteractiveRandom(); // randomness
 			/* Convert key messages to char messages if we want text input. */
 			if (EditBoxInGlobalFocus()) TranslateMessage(&mesg);
 			DispatchMessage(&mesg);

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -45,6 +45,9 @@ protected:
 	Dimension GetScreenSize() const override;
 
 	float GetDPIScale() override;
+
+private:
+	void CheckPaletteAnim();
 };
 
 /** The factory for Windows' video driver. */


### PR DESCRIPTION
## Motivation / Problem

With the 60fps patch, mouse movements should be silky smooth on Windows too. It was not. It turns out it is because I assumed `WM_PAINT` worked slightly different than it does.

## Description

In the old days, are drawing was driven by `WM_PAINT`, when ever Windows decided it was a good time to redraw the screen. This is based on when we send `InvalidateRect` to the window. This is a good system if you don't care about fps and just want to redraw when ever is best for the OS.

With the 60fps patch, we do care when we redraw. So depending on `WM_PAINT` gives a "lagging" effect, especially noticeable with mouse movements. When ever you move your mouse, we register it, tell Windows to redraw the window, which happens .. some time later. So you get this feeling you mouse is never where it should be.

So, instead, what is perfectly normal for games to do, is to drive the drawing yourself. As we already have a draw-tick, we can do this perfectly fine.

It does mean we can no longer depend on `InvalidateRect`, as `GetUpdateRect` does not return the same value you just set with `InvalidateRect` without yielding. Shocker, I know. So, instead, the Win32 video driver is now a lot more like all other drivers, and records its own dirty-rect, and redraws that screen.

`WM_PAINT` is still used if outside influences trigger an `GetUpdateRect`, to indicate an overlapping window moved etc. We will redraw that surface once it has done.

In a result, we will be redrawing more and too much in more cases (especially when the window is being overlapped by another). This is a consequence of wanting to hit 60fps :)

Result: silky smooth mouse movement on Windows too!

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
