### PR TITLE
Deduplicate tick-related code in video drivers

### DIFF
--- a/src/table/win32_settings.ini
+++ b/src/table/win32_settings.ini
@@ -7,8 +7,7 @@
 [pre-amble]
 /* win32_v.cpp only settings */
 #if defined(_WIN32) && !defined(DEDICATED)
-extern bool _force_full_redraw, _window_maximize;
-extern uint _display_hz;
+extern bool _window_maximize;
 
 static const SettingDescGlobVarList _win32_settings[] = {
 [post-amble]
@@ -34,22 +33,6 @@ cat      = SC_ADVANCED
 extra    = 0
 startup  = true
 
-
-
-[SDTG_VAR]
-name     = ""display_hz""
-type     = SLE_UINT
-var      = _display_hz
-def      = 0
-min      = 0
-max      = 120
-cat      = SC_EXPERT
-
-[SDTG_BOOL]
-name     = ""force_full_redraw""
-var      = _force_full_redraw
-def      = false
-cat      = SC_EXPERT
 
 [SDTG_BOOL]
 name     = ""window_maximize""

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -31,5 +31,6 @@ add_files(
     dedicated_v.h
     null_v.cpp
     null_v.h
+    video_driver.cpp
     video_driver.hpp
 )

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -56,7 +56,7 @@ void VideoDriver_Allegro::MakeDirty(int left, int top, int width, int height)
 	_num_dirty_rects++;
 }
 
-static void DrawSurfaceToScreen()
+void VideoDriver_Allegro::Paint()
 {
 	PerformanceMeasurer framerate(PFE_VIDEO);
 
@@ -524,7 +524,7 @@ void VideoDriver_Allegro::MainLoop()
 			UpdateWindows();
 			CheckPaletteAnim();
 
-			DrawSurfaceToScreen();
+			this->Paint();
 		}
 
 		/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -95,7 +95,7 @@ static void InitPalette()
 	UpdatePalette(0, 256);
 }
 
-static void CheckPaletteAnim()
+void VideoDriver_Allegro::CheckPaletteAnim()
 {
 	if (_cur_palette.count_dirty != 0) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
@@ -484,8 +484,6 @@ void VideoDriver_Allegro::MainLoop()
 	auto next_game_tick = cur_ticks;
 	auto next_draw_tick = cur_ticks;
 
-	CheckPaletteAnim();
-
 	for (;;) {
 		InteractiveRandom(); // randomness
 
@@ -522,7 +520,7 @@ void VideoDriver_Allegro::MainLoop()
 			this->InputLoop();
 			::InputLoop();
 			UpdateWindows();
-			CheckPaletteAnim();
+			this->CheckPaletteAnim();
 
 			this->Paint();
 		}

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -32,6 +32,9 @@ public:
 	bool ClaimMousePointer() override;
 
 	const char *GetName() const override { return "allegro"; }
+
+protected:
+	void InputLoop() override;
 };
 
 /** Factory for the allegro video driver. */

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -36,6 +36,7 @@ public:
 protected:
 	void InputLoop() override;
 	void Paint() override;
+	void CheckPaletteAnim() override;
 };
 
 /** Factory for the allegro video driver. */

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -35,6 +35,7 @@ public:
 
 protected:
 	void InputLoop() override;
+	void Paint() override;
 };
 
 /** Factory for the allegro video driver. */

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -75,6 +75,7 @@ protected:
 	Dimension GetScreenSize() const override;
 	float GetDPIScale() override;
 	void InputLoop() override;
+	void Paint() override;
 
 private:
 	bool PollEvent();
@@ -89,7 +90,6 @@ private:
 	void UpdatePalette(uint first_color, uint num_colors);
 	void CheckPaletteAnim();
 
-	void Draw(bool force_update = false);
 	void BlitIndexedToView32(int left, int top, int right, int bottom);
 };
 

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -74,6 +74,7 @@ public:
 protected:
 	Dimension GetScreenSize() const override;
 	float GetDPIScale() override;
+	void InputLoop() override;
 
 private:
 	bool PollEvent();

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -76,6 +76,7 @@ protected:
 	float GetDPIScale() override;
 	void InputLoop() override;
 	void Paint() override;
+	void CheckPaletteAnim() override;
 
 private:
 	bool PollEvent();
@@ -88,7 +89,6 @@ private:
 	bool MakeWindow(int width, int height);
 
 	void UpdatePalette(uint first_color, uint num_colors);
-	void CheckPaletteAnim();
 
 	void BlitIndexedToView32(int left, int top, int right, int bottom);
 };

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -656,11 +656,6 @@ void VideoDriver_Cocoa::InputLoop()
 /** Main game loop. */
 void VideoDriver_Cocoa::GameLoop()
 {
-	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_realtime_tick = cur_ticks;
-	auto next_game_tick = cur_ticks;
-	auto next_draw_tick = cur_ticks;
-
 	for (;;) {
 		@autoreleasepool {
 
@@ -674,52 +669,10 @@ void VideoDriver_Cocoa::GameLoop()
 				break;
 			}
 
-
-			cur_ticks = std::chrono::steady_clock::now();
-
-			/* If more than a millisecond has passed, increase the _realtime_tick. */
-			if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
-				auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
-				_realtime_tick += delta.count();
-				last_realtime_tick += delta;
-			}
-
-			if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-				if (_fast_forward && !_pause_mode) {
-					next_game_tick = cur_ticks + this->GetGameInterval();
-				} else {
-					next_game_tick += this->GetGameInterval();
-					/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-					if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
-				}
-
-				::GameLoop();
-			}
-
-			/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
-			if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
-				next_draw_tick += this->GetDrawInterval();
-				/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-				if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
-
-				this->InputLoop();
-				::InputLoop();
-				UpdateWindows();
-				this->CheckPaletteAnim();
-
+			if (this->Tick()) {
 				this->Paint();
 			}
-
-			/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
-			if (!_fast_forward || _pause_mode) {
-				/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
-				auto next_tick = std::min(next_draw_tick, next_game_tick);
-				auto now = std::chrono::steady_clock::now();
-
-				if (next_tick > now) {
-					std::this_thread::sleep_for(next_tick - now);
-				}
-			}
+			this->SleepTillNextTick();
 		}
 	}
 }

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -465,10 +465,10 @@ void VideoDriver_Cocoa::BlitIndexedToView32(int left, int top, int right, int bo
 }
 
 /**
- * Draw window.
+ * Paint window.
  * @param force_update Whether to redraw unconditionally
  */
-void VideoDriver_Cocoa::Draw(bool force_update)
+void VideoDriver_Cocoa::Paint()
 {
 	PerformanceMeasurer framerate(PFE_VIDEO);
 
@@ -502,9 +502,8 @@ void VideoDriver_Cocoa::Draw(bool force_update)
 		dirtyrect.size.height = this->dirty_rects[i].bottom - this->dirty_rects[i].top;
 
 		/* Normally drawRect will be automatically called by Mac OS X during next update cycle,
-		 * and then blitting will occur. If force_update is true, it will be done right now. */
+		 * and then blitting will occur. */
 		[ this->cocoaview setNeedsDisplayInRect:[ this->cocoaview getVirtualRect:dirtyrect ] ];
-		if (force_update) [ this->cocoaview displayIfNeeded ];
 	}
 
 	this->num_dirty_rects = 0;
@@ -708,7 +707,7 @@ void VideoDriver_Cocoa::GameLoop()
 				UpdateWindows();
 				this->CheckPaletteAnim();
 
-				this->Draw();
+				this->Paint();
 			}
 
 			/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -786,42 +786,7 @@ void VideoDriver_SDL::LoopOnce()
 		return;
 	}
 
-	cur_ticks = std::chrono::steady_clock::now();
-
-	/* If more than a millisecond has passed, increase the _realtime_tick. */
-	if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
-		auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
-		_realtime_tick += delta.count();
-		last_realtime_tick += delta;
-	}
-
-	if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-		if (_fast_forward && !_pause_mode) {
-			next_game_tick = cur_ticks + this->GetGameInterval();
-		} else {
-			next_game_tick += this->GetGameInterval();
-			/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-			if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
-		}
-
-		/* The gameloop is the part that can run asynchronously. The rest
-		 * except sleeping can't. */
-		this->UnlockVideoBuffer();
-		GameLoop();
-		this->LockVideoBuffer();
-	}
-
-	/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
-	if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
-		next_draw_tick += this->GetDrawInterval();
-		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-		if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
-
-		this->InputLoop();
-		::InputLoop();
-		UpdateWindows();
-		this->CheckPaletteAnim();
-
+	if (VideoDriver::Tick()) {
 		if (_draw_mutex != nullptr && !HasModalProgress()) {
 			_draw_signal->notify_one();
 		} else {
@@ -832,27 +797,12 @@ void VideoDriver_SDL::LoopOnce()
 /* Emscripten is running an event-based mainloop; there is already some
  * downtime between each iteration, so no need to sleep. */
 #ifndef __EMSCRIPTEN__
-	/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
-	if (!_fast_forward || _pause_mode) {
-		/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
-		auto next_tick = std::min(next_draw_tick, next_game_tick);
-		auto now = std::chrono::steady_clock::now();
-
-		if (next_tick > now) {
-			this->UnlockVideoBuffer();
-			std::this_thread::sleep_for(next_tick - now);
-			this->LockVideoBuffer();
-		}
-	}
+	this->SleepTillNextTick();
 #endif
 }
 
 void VideoDriver_SDL::MainLoop()
 {
-	cur_ticks = std::chrono::steady_clock::now();
-	last_realtime_tick = cur_ticks;
-	next_game_tick = cur_ticks;
-
 	if (_draw_threaded) {
 		/* Initialise the mutex first, because that's the thing we *need*
 		 * directly in the newly created thread. */

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -729,11 +729,41 @@ void VideoDriver_SDL::Stop()
 	}
 }
 
+void VideoDriver_SDL::InputLoop()
+{
+	uint32 mod = SDL_GetModState();
+	const Uint8 *keys = SDL_GetKeyboardState(NULL);
+
+	bool old_ctrl_pressed = _ctrl_pressed;
+
+	_ctrl_pressed  = !!(mod & KMOD_CTRL);
+	_shift_pressed = !!(mod & KMOD_SHIFT);
+
+#if defined(_DEBUG)
+	if (_shift_pressed)
+#else
+	/* Speedup when pressing tab, except when using ALT+TAB
+	 * to switch to another application. */
+	if (keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0)
+#endif /* defined(_DEBUG) */
+	{
+		if (!_networking && _game_mode != GM_MENU) _fast_forward |= 2;
+	} else if (_fast_forward & 2) {
+		_fast_forward = 0;
+	}
+
+	/* Determine which directional keys are down. */
+	_dirkeys =
+		(keys[SDL_SCANCODE_LEFT]  ? 1 : 0) |
+		(keys[SDL_SCANCODE_UP]    ? 2 : 0) |
+		(keys[SDL_SCANCODE_RIGHT] ? 4 : 0) |
+		(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
+
+	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
+}
+
 void VideoDriver_SDL::LoopOnce()
 {
-	uint32 mod;
-	int numkeys;
-	const Uint8 *keys;
 	InteractiveRandom(); // randomness
 
 	while (PollEvent() == -1) {}
@@ -749,22 +779,6 @@ void VideoDriver_SDL::LoopOnce()
 		MainLoopCleanup();
 #endif
 		return;
-	}
-
-	mod = SDL_GetModState();
-	keys = SDL_GetKeyboardState(&numkeys);
-
-#if defined(_DEBUG)
-	if (_shift_pressed)
-#else
-	/* Speedup when pressing tab, except when using ALT+TAB
-	 * to switch to another application */
-	if (keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0)
-#endif /* defined(_DEBUG) */
-	{
-		if (!_networking && _game_mode != GM_MENU) _fast_forward |= 2;
-	} else if (_fast_forward & 2) {
-		_fast_forward = 0;
 	}
 
 	cur_ticks = std::chrono::steady_clock::now();
@@ -798,20 +812,8 @@ void VideoDriver_SDL::LoopOnce()
 		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 		if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
-		bool old_ctrl_pressed = _ctrl_pressed;
-
-		_ctrl_pressed  = !!(mod & KMOD_CTRL);
-		_shift_pressed = !!(mod & KMOD_SHIFT);
-
-		/* determine which directional keys are down */
-		_dirkeys =
-			(keys[SDL_SCANCODE_LEFT]  ? 1 : 0) |
-			(keys[SDL_SCANCODE_UP]    ? 2 : 0) |
-			(keys[SDL_SCANCODE_RIGHT] ? 4 : 0) |
-			(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
-		if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
-
-		InputLoop();
+		this->InputLoop();
+		::InputLoop();
 		UpdateWindows();
 		this->CheckPaletteAnim();
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -801,9 +801,9 @@ void VideoDriver_SDL::LoopOnce()
 
 		/* The gameloop is the part that can run asynchronously. The rest
 		 * except sleeping can't. */
-		if (_draw_mutex != nullptr) draw_lock.unlock();
+		this->UnlockVideoBuffer();
 		GameLoop();
-		if (_draw_mutex != nullptr) draw_lock.lock();
+		this->LockVideoBuffer();
 	}
 
 	/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
@@ -834,9 +834,9 @@ void VideoDriver_SDL::LoopOnce()
 		auto now = std::chrono::steady_clock::now();
 
 		if (next_tick > now) {
-			if (_draw_mutex != nullptr) draw_lock.unlock();
+			this->UnlockVideoBuffer();
 			std::this_thread::sleep_for(next_tick - now);
-			if (_draw_mutex != nullptr) draw_lock.lock();
+			this->LockVideoBuffer();
 		}
 	}
 #endif
@@ -985,4 +985,15 @@ Dimension VideoDriver_SDL::GetScreenSize() const
 	if (SDL_GetCurrentDisplayMode(this->startup_display, &mode) != 0) return VideoDriver::GetScreenSize();
 
 	return { static_cast<uint>(mode.w), static_cast<uint>(mode.h) };
+}
+
+bool VideoDriver_SDL::LockVideoBuffer()
+{
+	if (_draw_threaded) this->draw_lock.lock();
+	return true;
+}
+
+void VideoDriver_SDL::UnlockVideoBuffer()
+{
+	if (_draw_threaded) this->draw_lock.unlock();
 }

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -853,8 +853,6 @@ void VideoDriver_SDL::MainLoop()
 	last_realtime_tick = cur_ticks;
 	next_game_tick = cur_ticks;
 
-	this->CheckPaletteAnim();
-
 	if (_draw_threaded) {
 		/* Initialise the mutex first, because that's the thing we *need*
 		 * directly in the newly created thread. */

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -67,11 +67,6 @@ private:
 	 */
 	bool edit_box_focused;
 
-	std::chrono::steady_clock::time_point cur_ticks;
-	std::chrono::steady_clock::time_point last_realtime_tick;
-	std::chrono::steady_clock::time_point next_game_tick;
-	std::chrono::steady_clock::time_point next_draw_tick;
-
 	int startup_display;
 	std::thread draw_thread;
 	std::unique_lock<std::recursive_mutex> draw_lock;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -46,6 +46,8 @@ protected:
 	void InputLoop() override;
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
+	void Paint() override;
+	void PaintThread() override;
 
 private:
 	int PollEvent();
@@ -73,6 +75,8 @@ private:
 	int startup_display;
 	std::thread draw_thread;
 	std::unique_lock<std::recursive_mutex> draw_lock;
+
+	static void PaintThreadThunk(VideoDriver_SDL *drv);
 };
 
 /** Factory for the SDL video driver. */

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -48,6 +48,7 @@ protected:
 	void UnlockVideoBuffer() override;
 	void Paint() override;
 	void PaintThread() override;
+	void CheckPaletteAnim();
 
 private:
 	int PollEvent();
@@ -55,7 +56,6 @@ private:
 	void MainLoopCleanup();
 	bool CreateMainSurface(uint w, uint h, bool resize);
 	bool CreateMainWindow(uint w, uint h);
-	void CheckPaletteAnim();
 
 #ifdef __EMSCRIPTEN__
 	/* Convert a constant pointer back to a non-constant pointer to a member function. */

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -43,6 +43,7 @@ public:
 
 protected:
 	Dimension GetScreenSize() const override;
+	void InputLoop() override;
 
 private:
 	int PollEvent();

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -44,6 +44,8 @@ public:
 protected:
 	Dimension GetScreenSize() const override;
 	void InputLoop() override;
+	bool LockVideoBuffer() override;
+	void UnlockVideoBuffer() override;
 
 private:
 	int PollEvent();

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -411,11 +411,7 @@ bool VideoDriver_SDL::ClaimMousePointer()
 }
 
 struct SDLVkMapping {
-#if SDL_VERSION_ATLEAST(1, 3, 0)
-	SDL_Keycode vk_from;
-#else
 	uint16 vk_from;
-#endif
 	byte vk_count;
 	byte map_to;
 };
@@ -656,12 +652,8 @@ void VideoDriver_SDL::Stop()
 void VideoDriver_SDL::InputLoop()
 {
 	uint32 mod = SDL_GetModState();
-#if SDL_VERSION_ATLEAST(1, 3, 0)
-	Uint8 *keys = SDL_GetKeyboardState(&numkeys);
-#else
 	int numkeys;
 	Uint8 *keys = SDL_GetKeyState(&numkeys);
-#endif
 
 	bool old_ctrl_pressed = _ctrl_pressed;
 
@@ -673,11 +665,7 @@ void VideoDriver_SDL::InputLoop()
 #else
 	/* Speedup when pressing tab, except when using ALT+TAB
 	 * to switch to another application. */
-#if SDL_VERSION_ATLEAST(1, 3, 0)
-	if (keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0)
-#else
 	if (keys[SDLK_TAB] && (mod & KMOD_ALT) == 0)
-#endif /* SDL_VERSION_ATLEAST(1, 3, 0) */
 #endif /* defined(_DEBUG) */
 	{
 		if (!_networking && _game_mode != GM_MENU) _fast_forward |= 2;
@@ -687,17 +675,10 @@ void VideoDriver_SDL::InputLoop()
 
 	/* Determine which directional keys are down. */
 	_dirkeys =
-#if SDL_VERSION_ATLEAST(1, 3, 0)
-		(keys[SDL_SCANCODE_LEFT]  ? 1 : 0) |
-		(keys[SDL_SCANCODE_UP]    ? 2 : 0) |
-		(keys[SDL_SCANCODE_RIGHT] ? 4 : 0) |
-		(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
-#else
 		(keys[SDLK_LEFT]  ? 1 : 0) |
 		(keys[SDLK_UP]    ? 2 : 0) |
 		(keys[SDLK_RIGHT] ? 4 : 0) |
 		(keys[SDLK_DOWN]  ? 8 : 0);
-#endif
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 }

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -704,11 +704,6 @@ void VideoDriver_SDL::InputLoop()
 
 void VideoDriver_SDL::MainLoop()
 {
-	auto cur_ticks = std::chrono::steady_clock::now();
-	auto last_realtime_tick = cur_ticks;
-	auto next_game_tick = cur_ticks;
-	auto next_draw_tick = cur_ticks;
-
 	std::thread draw_thread;
 	if (_draw_threaded) {
 		/* Initialise the mutex first, because that's the thing we *need*
@@ -746,61 +741,14 @@ void VideoDriver_SDL::MainLoop()
 		while (PollEvent() == -1) {}
 		if (_exit_game) break;
 
-		cur_ticks = std::chrono::steady_clock::now();
-
-		/* If more than a millisecond has passed, increase the _realtime_tick. */
-		if (cur_ticks - last_realtime_tick > std::chrono::milliseconds(1)) {
-			auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - last_realtime_tick);
-			_realtime_tick += delta.count();
-			last_realtime_tick += delta;
-		}
-
-		if (cur_ticks >= next_game_tick || (_fast_forward && !_pause_mode)) {
-			if (_fast_forward && !_pause_mode) {
-				next_game_tick = cur_ticks + this->GetGameInterval();
-			} else {
-				next_game_tick += this->GetGameInterval();
-				/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
-				if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
-			}
-
-			/* The gameloop is the part that can run asynchronously. The rest
-			 * except sleeping can't. */
-			this->UnlockVideoBuffer();
-			GameLoop();
-			this->LockVideoBuffer();
-		}
-
-		/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
-		if (cur_ticks >= next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
-			next_draw_tick += this->GetDrawInterval();
-			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
-			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
-
-			this->InputLoop();
-			::InputLoop();
-			UpdateWindows();
-			this->CheckPaletteAnim();
-
+		if (this->Tick()) {
 			if (_draw_mutex != nullptr && !HasModalProgress()) {
 				_draw_signal->notify_one();
 			} else {
 				this->Paint();
 			}
 		}
-
-		/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
-		if (!_fast_forward || _pause_mode) {
-			/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
-			auto next_tick = std::min(next_draw_tick, next_game_tick);
-			auto now = std::chrono::steady_clock::now();
-
-			if (next_tick > now) {
-				this->UnlockVideoBuffer();
-				std::this_thread::sleep_for(next_tick - now);
-				this->LockVideoBuffer();
-			}
-		}
+		this->SleepTillNextTick();
 	}
 
 	if (_draw_mutex != nullptr) {

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -41,6 +41,8 @@ protected:
 	void InputLoop() override;
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
+	void Paint() override;
+	void PaintThread() override;
 
 private:
 	std::unique_lock<std::recursive_mutex> draw_lock;
@@ -48,6 +50,8 @@ private:
 	int PollEvent();
 	bool CreateMainSurface(uint w, uint h);
 	void SetupKeyboard();
+
+	static void PaintThreadThunk(VideoDriver_SDL *drv);
 };
 
 /** Factory for the SDL video driver. */

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -36,6 +36,10 @@ public:
 	bool ClaimMousePointer() override;
 
 	const char *GetName() const override { return "sdl"; }
+
+protected:
+	void InputLoop() override;
+
 private:
 	int PollEvent();
 	bool CreateMainSurface(uint w, uint h);

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -43,6 +43,7 @@ protected:
 	void UnlockVideoBuffer() override;
 	void Paint() override;
 	void PaintThread() override;
+	void CheckPaletteAnim();
 
 private:
 	std::unique_lock<std::recursive_mutex> draw_lock;

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -39,8 +39,12 @@ public:
 
 protected:
 	void InputLoop() override;
+	bool LockVideoBuffer() override;
+	void UnlockVideoBuffer() override;
 
 private:
+	std::unique_lock<std::recursive_mutex> draw_lock;
+
 	int PollEvent();
 	bool CreateMainSurface(uint w, uint h);
 	void SetupKeyboard();

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -1,0 +1,83 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file video_driver.cpp Common code between video driver implementations. */
+
+#include "../stdafx.h"
+#include "../debug.h"
+#include "../gfx_func.h"
+#include "../progress.h"
+#include "../thread.h"
+#include "../window_func.h"
+#include "video_driver.hpp"
+
+bool VideoDriver::Tick()
+{
+	auto cur_ticks = std::chrono::steady_clock::now();
+
+	/* If more than a millisecond has passed, increase the _realtime_tick. */
+	if (cur_ticks - this->last_realtime_tick > std::chrono::milliseconds(1)) {
+		auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - this->last_realtime_tick);
+		_realtime_tick += delta.count();
+		this->last_realtime_tick += delta;
+	}
+
+	if (cur_ticks >= this->next_game_tick || (_fast_forward && !_pause_mode)) {
+		if (_fast_forward && !_pause_mode) {
+			this->next_game_tick = cur_ticks + this->GetGameInterval();
+		} else {
+			this->next_game_tick += this->GetGameInterval();
+			/* Avoid next_game_tick getting behind more and more if it cannot keep up. */
+			if (this->next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) this->next_game_tick = cur_ticks;
+		}
+
+		/* The game loop is the part that can run asynchronously.
+		 * The rest except sleeping can't. */
+		this->UnlockVideoBuffer();
+		::GameLoop();
+		this->LockVideoBuffer();
+
+		/* For things like dedicated server, don't run a separate draw-tick. */
+		if (!this->HasGUI()) {
+			::InputLoop();
+			UpdateWindows();
+			this->next_draw_tick = this->next_game_tick;
+		}
+	}
+
+	/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
+	if (this->HasGUI() && cur_ticks >= this->next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
+		this->next_draw_tick += this->GetDrawInterval();
+		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
+		if (this->next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) this->next_draw_tick = cur_ticks;
+
+		this->InputLoop();
+		::InputLoop();
+		UpdateWindows();
+		this->CheckPaletteAnim();
+
+		return true;
+	}
+
+	return false;
+}
+
+void VideoDriver::SleepTillNextTick()
+{
+	/* If we are not in fast-forward, create some time between calls to ease up CPU usage. */
+	if (!_fast_forward || _pause_mode) {
+		/* See how much time there is till we have to process the next event, and try to hit that as close as possible. */
+		auto next_tick = std::min(this->next_draw_tick, this->next_game_tick);
+		auto now = std::chrono::steady_clock::now();
+
+		if (next_tick > now) {
+			this->UnlockVideoBuffer();
+			std::this_thread::sleep_for(next_tick - now);
+			this->LockVideoBuffer();
+		}
+	}
+}

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -189,6 +189,17 @@ protected:
 	 */
 	virtual void CheckPaletteAnim() {}
 
+	/**
+	 * Run the game for a single tick, processing boththe game-tick and draw-tick.
+	 * @returns True if the driver should redraw the screen.
+	 */
+	bool Tick();
+
+	/**
+	 * Sleep till the next tick is about to happen.
+	 */
+	void SleepTillNextTick();
+
 	std::chrono::steady_clock::duration GetGameInterval()
 	{
 		return std::chrono::milliseconds(MILLISECONDS_PER_TICK);
@@ -198,6 +209,10 @@ protected:
 	{
 		return std::chrono::microseconds(1000000 / _settings_client.gui.refresh_rate);
 	}
+
+	std::chrono::steady_clock::time_point last_realtime_tick;
+	std::chrono::steady_clock::time_point next_game_tick;
+	std::chrono::steady_clock::time_point next_draw_tick;
 };
 
 #endif /* VIDEO_VIDEO_DRIVER_HPP */

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -174,6 +174,16 @@ protected:
 	 */
 	virtual void UnlockVideoBuffer() {}
 
+	/**
+	 * Paint the window.
+	 */
+	virtual void Paint() {}
+
+	/**
+	 * Thread function for threaded drawing.
+	 */
+	virtual void PaintThread() {}
+
 	std::chrono::steady_clock::duration GetGameInterval()
 	{
 		return std::chrono::milliseconds(MILLISECONDS_PER_TICK);

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -161,6 +161,19 @@ protected:
 	 */
 	virtual void InputLoop() {}
 
+	/**
+	 * Make sure the video buffer is ready for drawing.
+	 * @returns True if the video buffer has to be unlocked.
+	 */
+	virtual bool LockVideoBuffer() {
+		return false;
+	}
+
+	/**
+	 * Unlock a previously locked video buffer.
+	 */
+	virtual void UnlockVideoBuffer() {}
+
 	std::chrono::steady_clock::duration GetGameInterval()
 	{
 		return std::chrono::milliseconds(MILLISECONDS_PER_TICK);

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -184,6 +184,11 @@ protected:
 	 */
 	virtual void PaintThread() {}
 
+	/**
+	 * Process any pending palette animation.
+	 */
+	virtual void CheckPaletteAnim() {}
+
 	std::chrono::steady_clock::duration GetGameInterval()
 	{
 		return std::chrono::milliseconds(MILLISECONDS_PER_TICK);

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -156,6 +156,11 @@ protected:
 		}
 	}
 
+	/**
+	 * Handle input logic, is CTRL pressed, should we fast-forward, etc.
+	 */
+	virtual void InputLoop() {}
+
 	std::chrono::steady_clock::duration GetGameInterval()
 	{
 		return std::chrono::milliseconds(MILLISECONDS_PER_TICK);

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1211,6 +1211,9 @@ void VideoDriver_Win32::MainLoop()
 		}
 		if (_exit_game) break;
 
+		/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */
+		GdiFlush();
+
 		cur_ticks = std::chrono::steady_clock::now();
 
 		/* If more than a millisecond has passed, increase the _realtime_tick. */
@@ -1229,9 +1232,6 @@ void VideoDriver_Win32::MainLoop()
 				if (next_game_tick < cur_ticks - ALLOWED_DRIFT * this->GetGameInterval()) next_game_tick = cur_ticks;
 			}
 
-			/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */
-			GdiFlush();
-
 			/* The game loop is the part that can run asynchronously.
 			 * The rest except sleeping can't. */
 			this->UnlockVideoBuffer();
@@ -1246,9 +1246,6 @@ void VideoDriver_Win32::MainLoop()
 			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
 
 			if (_force_full_redraw) MarkWholeScreenDirty();
-
-			/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */
-			GdiFlush();
 
 			this->InputLoop();
 			::InputLoop();
@@ -1269,9 +1266,6 @@ void VideoDriver_Win32::MainLoop()
 			auto now = std::chrono::steady_clock::now();
 
 			if (next_tick > now) {
-				/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */
-				GdiFlush();
-
 				this->UnlockVideoBuffer();
 				std::this_thread::sleep_for(next_tick - now);
 				this->LockVideoBuffer();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -54,9 +54,7 @@ static struct {
 	bool running;         ///< Is the main loop running?
 } _wnd;
 
-bool _force_full_redraw;
 bool _window_maximize;
-uint _display_hz;
 static Dimension _bck_resolution;
 DWORD _imm_props;
 
@@ -253,12 +251,10 @@ bool VideoDriver_Win32::MakeWindow(bool full_screen)
 		settings.dmFields =
 			DM_BITSPERPEL |
 			DM_PELSWIDTH |
-			DM_PELSHEIGHT |
-			(_display_hz != 0 ? DM_DISPLAYFREQUENCY : 0);
+			DM_PELSHEIGHT;
 		settings.dmBitsPerPel = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
 		settings.dmPelsWidth  = _wnd.width_org;
 		settings.dmPelsHeight = _wnd.height_org;
-		settings.dmDisplayFrequency = _display_hz;
 
 		/* Check for 8 bpp support. */
 		if (settings.dmBitsPerPel == 8 &&
@@ -1244,8 +1240,6 @@ void VideoDriver_Win32::MainLoop()
 			next_draw_tick += this->GetDrawInterval();
 			/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 			if (next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) next_draw_tick = cur_ticks;
-
-			if (_force_full_redraw) MarkWholeScreenDirty();
 
 			this->InputLoop();
 			::InputLoop();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1175,13 +1175,13 @@ void VideoDriver_Win32::MainLoop()
 		if (_exit_game) break;
 
 #if defined(_DEBUG)
-		if (_wnd.has_focus && GetAsyncKeyState(VK_SHIFT) < 0 &&
+		if (_wnd.has_focus && GetAsyncKeyState(VK_SHIFT) < 0)
 #else
 		/* Speed up using TAB, but disable for ALT+TAB of course */
-		if (_wnd.has_focus && GetAsyncKeyState(VK_TAB) < 0 && GetAsyncKeyState(VK_MENU) >= 0 &&
+		if (_wnd.has_focus && GetAsyncKeyState(VK_TAB) < 0 && GetAsyncKeyState(VK_MENU) >= 0)
 #endif
-			  !_networking && _game_mode != GM_MENU) {
-			_fast_forward |= 2;
+		{
+			if (!_networking && _game_mode != GM_MENU) _fast_forward |= 2;
 		} else if (_fast_forward & 2) {
 			_fast_forward = 0;
 		}

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1201,7 +1201,6 @@ void VideoDriver_Win32::MainLoop()
 
 	_wnd.running = true;
 
-	CheckPaletteAnim();
 	for (;;) {
 		InteractiveRandom(); // randomness
 

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -49,11 +49,10 @@ protected:
 	void UnlockVideoBuffer() override;
 	void Paint() override;
 	void PaintThread() override;
+	void CheckPaletteAnim() override;
 
 private:
 	std::unique_lock<std::recursive_mutex> draw_lock;
-
-	void CheckPaletteAnim();
 
 	static void PaintThreadThunk(VideoDriver_Win32 *drv);
 };

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -45,9 +45,15 @@ protected:
 	Dimension GetScreenSize() const override;
 	float GetDPIScale() override;
 	void InputLoop() override;
+	bool LockVideoBuffer() override;
+	void UnlockVideoBuffer() override;
 
 private:
+	std::unique_lock<std::recursive_mutex> draw_lock;
+
 	void CheckPaletteAnim();
+
+	static void PaintThreadThunk(VideoDriver_Win32 *drv);
 };
 
 /** The factory for Windows' video driver. */

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -47,6 +47,8 @@ protected:
 	void InputLoop() override;
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
+	void Paint() override;
+	void PaintThread() override;
 
 private:
 	std::unique_lock<std::recursive_mutex> draw_lock;

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -43,8 +43,8 @@ public:
 
 protected:
 	Dimension GetScreenSize() const override;
-
 	float GetDPIScale() override;
+	void InputLoop() override;
 
 private:
 	void CheckPaletteAnim();


### PR DESCRIPTION
Contains #8702, as I was too lazy to do this work twice.

## Motivation / Problem

During the 60fps it was found that all (!) video drivers have nearly the same GameLoop code, with some minor naming differences and some minor workflow differences.

This PR sets out to unify them further, and deduplicate the tick-related code.

Future extensions are helped by this, because now they can change in a single place how the game-ticks and draw-ticks behave. For example, if the game-tick takes too long, there would be a single place to make a choice what suffers: simulation time or draw-fps.


## Description

This is mostly moving around code and making sure drivers do the same into the highest amount of detail.

Drivers I have tested and on what platform:

- [x] SDL (WSL2, X11)
- [x] SDL (Ubuntu 20.04, X11)
- [x] SDL (Ubuntu 20.04, Wayland)
- [x] Allegro (WSL2)
- [x] Dedicated server (WSL2)
- [x] Win32 (Windows 10)
- [x] Cocoa (macOS 10.15)

To me, they all behave identical. More testing is of course appreciated :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
