### PR TITLE
Change: Move toolbar button for cargo payment graph under industries

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -429,7 +429,6 @@ STR_GRAPH_MENU_INCOME_GRAPH                                     :Income graph
 STR_GRAPH_MENU_DELIVERED_CARGO_GRAPH                            :Delivered cargo graph
 STR_GRAPH_MENU_PERFORMANCE_HISTORY_GRAPH                        :Performance history graph
 STR_GRAPH_MENU_COMPANY_VALUE_GRAPH                              :Company value graph
-STR_GRAPH_MENU_CARGO_PAYMENT_RATES                              :Cargo payment rates
 ############ range ends here
 
 ############ range for company league menu starts
@@ -441,6 +440,7 @@ STR_GRAPH_MENU_HIGHSCORE                                        :Highscore table
 ############ range for industry menu starts
 STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY                            :Industry directory
 STR_INDUSTRY_MENU_INDUSTRY_CHAIN                                :Industry chains
+STR_GRAPH_MENU_CARGO_PAYMENT_RATES                              :Cargo payment rates
 STR_INDUSTRY_MENU_FUND_NEW_INDUSTRY                             :Fund new industry
 ############ range ends here
 

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -677,7 +677,7 @@ static CallBackFunction MenuClickGoal(int index)
 
 static CallBackFunction ToolbarGraphsClick(Window *w)
 {
-	PopupMainToolbMenu(w, WID_TN_GRAPHS, STR_GRAPH_MENU_OPERATING_PROFIT_GRAPH, (_toolbar_mode == TB_NORMAL) ? 6 : 8);
+	PopupMainToolbMenu(w, WID_TN_GRAPHS, STR_GRAPH_MENU_OPERATING_PROFIT_GRAPH, (_toolbar_mode == TB_NORMAL) ? 5 : 7);
 	return CBF_NONE;
 }
 
@@ -695,10 +695,9 @@ static CallBackFunction MenuClickGraphs(int index)
 		case 2: ShowDeliveredCargoGraph();     break;
 		case 3: ShowPerformanceHistoryGraph(); break;
 		case 4: ShowCompanyValueGraph();       break;
-		case 5: ShowCargoPaymentRates();       break;
 		/* functions for combined graphs/league button */
-		case 6: ShowCompanyLeagueTable();      break;
-		case 7: ShowPerformanceRatingDetail(); break;
+		case 5: ShowCompanyLeagueTable();      break;
+		case 6: ShowPerformanceRatingDetail(); break;
 	}
 	return CBF_NONE;
 }
@@ -732,7 +731,7 @@ static CallBackFunction MenuClickLeague(int index)
 static CallBackFunction ToolbarIndustryClick(Window *w)
 {
 	/* Disable build-industry menu if we are a spectator */
-	PopupMainToolbMenu(w, WID_TN_INDUSTRIES, STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, (_local_company == COMPANY_SPECTATOR) ? 2 : 3);
+	PopupMainToolbMenu(w, WID_TN_INDUSTRIES, STR_INDUSTRY_MENU_INDUSTRY_DIRECTORY, (_local_company == COMPANY_SPECTATOR) ? 3 : 4);
 	return CBF_NONE;
 }
 
@@ -747,7 +746,8 @@ static CallBackFunction MenuClickIndustry(int index)
 	switch (index) {
 		case 0: ShowIndustryDirectory();     break;
 		case 1: ShowIndustryCargoesWindow(); break;
-		case 2: ShowBuildIndustryWindow();   break;
+		case 2: ShowCargoPaymentRates();     break;
+		case 3: ShowBuildIndustryWindow();   break;
 	}
 	return CBF_NONE;
 }


### PR DESCRIPTION
## Motivation / Problem

The "Display graphs" button in the main toolbar contains five graphs comparing company performance...and one graph about cargo payments rates. I think cargo payment rates should be under the Industries button, next to Industry Chains.

My motivation was to organize the GUI in a logical manner so that players who don't already know where to look (new and inexperienced players, but I am trying to improve things for all players) can find things where they expect them to be.

The cargo payment chart has only one thing in common with the other graphs in its current menu: it is a point and line graph. Everything else is different:
- The player might look at the graph to determine what to do in the future; others are used to look at past performance
- The points and lines represent cargos; others are companies
- The data is global and unchanging; others show data over time relating to each company
- The period is days in transit; others are quarters and years

In my mind, this graph is a sister to the industry chains chart and belongs with it. The only reason it's with graphs is because is is visually — but not functionally — similar.

## Description

Current:
![original](https://user-images.githubusercontent.com/55058389/108600019-7f05ae00-7362-11eb-89cf-d5c2a39770e0.png)

Moved:
![moved](https://user-images.githubusercontent.com/55058389/108600021-82993500-7362-11eb-8902-07a6f9464a69.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
