### PR TITLE
Feature: rail station class name filtering

### DIFF
--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -62,6 +62,8 @@ enum BuildRailStationWidgets {
 	WID_BRAS_IMAGE,                ///< Panel used at each cell of the matrix.
 	WID_BRAS_MATRIX_SCROLL,        ///< Scrollbar of the matrix widget.
 
+	WID_BRAS_FILTER_CONTAINER,     ///< Container for the filter text box for the station class list.
+	WID_BRAS_FILTER_EDITBOX,       ///< Filter text box for the station class list.
 	WID_BRAS_SHOW_NEWST_DEFSIZE,   ///< Selection for default-size button for newstation.
 	WID_BRAS_SHOW_NEWST_ADDITIONS, ///< Selection for newstation class selection list.
 	WID_BRAS_SHOW_NEWST_MATRIX,    ///< Selection for newstation image matrix.


### PR DESCRIPTION
## Motivation / Problem

Players with many NewGRF enabled for train stations sometimes struggle at finding the right one to place in every situation. This PR introduces a filter edit box for quicker access when train station NewGRF are enabled in the game. This is especially helpful for those that care about station design and eye candy looking terminals.

## Description

Add a text box to the Build Rail Station window for filtering train station classes. This is similar to the previous feature implemented in the Object Selection window here: https://github.com/OpenTTD/OpenTTD/pull/8603.

This is what it looks like:

![image](https://user-images.githubusercontent.com/2025406/108612731-294ff680-73a0-11eb-97e8-60fd7b694637.png)

Note that the sorting logic is based on the added NewGRF order given the concerns in https://github.com/OpenTTD/OpenTTD/issues/8817:

![image](https://user-images.githubusercontent.com/2025406/110250628-23761b80-7f31-11eb-98fd-82651e119d76.png)

## Limitations

No limitations.

## Testing

The following test cases have been tested:

- Re-opening the build train station window within the same game keeps the previously selected station class and station type.
- Starting/Loading a new game resets the selected station to the default one.
- Starting/Loading a new game with different NewGRFs.
- Default station always at the top.

All seems to work perfectly.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
