### PR TITLE
[OSX] Draw immediately instead of waiting for the event loop.

### DIFF
--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -32,10 +32,8 @@ private:
 	void *pixel_buffer;   ///< used for direct pixel access
 	void *window_buffer;  ///< Colour translation from palette to screen
 
-	static const int MAX_DIRTY_RECTS = 100;
+	Rect dirty_rect;      ///< Region of the screen that needs redrawing.
 
-	Rect dirty_rects[MAX_DIRTY_RECTS]; ///< dirty rectangles
-	uint num_dirty_rects;  ///< Number of dirty rectangles
 	uint32 palette[256];  ///< Colour Palette
 
 public:

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -21,6 +21,7 @@
 #define Rect  OTTDRect
 #define Point OTTDPoint
 #import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
 #undef Rect
 #undef Point
 
@@ -486,9 +487,11 @@ void VideoDriver_Cocoa::Paint()
 	dirtyrect.size.width = this->dirty_rect.right - this->dirty_rect.left;
 	dirtyrect.size.height = this->dirty_rect.bottom - this->dirty_rect.top;
 
-	/* Normally drawRect will be automatically called by Mac OS X during next update cycle,
-	 * and then blitting will occur. */
+	/* Notify OS X that we have new content to show. */
 	[ this->cocoaview setNeedsDisplayInRect:[ this->cocoaview getVirtualRect:dirtyrect ] ];
+
+	/* Tell the OS to get our contents to screen as soon as possible. */
+	[ CATransaction flush ];
 
 	this->dirty_rect = {};
 }
@@ -674,6 +677,7 @@ void VideoDriver_Cocoa::GameLoop()
 		self.wantsLayer = YES;
 
 		self.layer.magnificationFilter = kCAFilterNearest;
+		self.layer.opaque = YES;
 	}
 	return self;
 }

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -158,7 +158,7 @@ void VideoDriver_SDL::Paint()
 	}
 	SDL_UpdateWindowSurfaceRects(_sdl_window, &r, 1);
 
-	MemSetT(&_dirty_rect, 0);
+	_dirty_rect = {};
 }
 
 void VideoDriver_SDL::PaintThread()
@@ -347,7 +347,7 @@ bool VideoDriver_SDL::CreateMainSurface(uint w, uint h, bool resize)
 	 * gotten smaller, reset our dirty rects. GameSizeChanged() a bit lower
 	 * will mark the whole screen dirty again anyway, but this time with the
 	 * new dimensions. */
-	MemSetT(&_dirty_rect, 0);
+	_dirty_rect = {};
 
 	_screen.width = _sdl_surface->w;
 	_screen.height = _sdl_surface->h;

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -378,7 +378,7 @@ void VideoDriver_Win32::Paint()
 
 	ReleaseDC(_wnd.main_wnd, dc);
 
-	MemSetT(&_dirty_rect, 0);
+	_dirty_rect = {};
 }
 
 void VideoDriver_Win32::PaintThread()


### PR DESCRIPTION
## Motivation / Problem

Using the event loop for displaying introduces an indeterminate delay. As we have now have a draw-tick, we can draw immediately.


## Description

#8702 for OSX basically.


## Limitations

The whole window compositor is still somewhat coupled to screen refresh, so it might not actually cause any visible change.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
