### PR TITLE
Fix ec1dd0bf: missing override causing compiler warnings

### DIFF
--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -48,7 +48,7 @@ protected:
 	void UnlockVideoBuffer() override;
 	void Paint() override;
 	void PaintThread() override;
-	void CheckPaletteAnim();
+	void CheckPaletteAnim() override;
 
 private:
 	int PollEvent();


### PR DESCRIPTION
## Motivation / Problem

I was sure I fixed this ....

## Description

The realisation you are getting old .. it is horrible!

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
