### PR TITLE
Change: Don't show global goals in company goal windows

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -120,6 +120,7 @@ void SetLocalCompany(CompanyID new_company)
 	/* ... and redraw the whole screen. */
 	MarkWholeScreenDirty();
 	InvalidateWindowClassesData(WC_SIGN_LIST, -1);
+	InvalidateWindowClassesData(WC_GOALS_LIST);
 }
 
 /**

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -46,6 +46,8 @@ struct GoalListWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_GOAL_SCROLLBAR);
 		this->FinishInitNested(window_number);
 		this->owner = (Owner)this->window_number;
+		NWidgetStacked *wi = this->GetWidget<NWidgetStacked>(WID_GOAL_SELECT_BUTTONS);
+		wi->SetDisplayedPlane(window_number == INVALID_COMPANY ? 1 : 0);
 		this->OnInvalidateData(0);
 	}
 
@@ -63,17 +65,31 @@ struct GoalListWindow : public Window {
 
 	void OnClick(Point pt, int widget, int click_count) override
 	{
-		if (widget != WID_GOAL_LIST) return;
+		switch (widget) {
+			case WID_GOAL_GLOBAL_BUTTON:
+				ShowGoalsList(INVALID_COMPANY);
+				break;
 
-		int y = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_GOAL_LIST, WD_FRAMERECT_TOP);
-		for (const Goal *s : Goal::Iterate()) {
-			if (s->company == this->window_number) {
-				if (y == 0) {
-					this->HandleClick(s);
-					return;
+			case WID_GOAL_COMPANY_BUTTON:
+				ShowGoalsList(_local_company);
+				break;
+
+			case WID_GOAL_LIST: {
+				int y = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_GOAL_LIST, WD_FRAMERECT_TOP);
+				for (const Goal *s : Goal::Iterate()) {
+					if (s->company == this->window_number) {
+						if (y == 0) {
+							this->HandleClick(s);
+							return;
+						}
+						y--;
+					}
 				}
-				y--;
+				break;
 			}
+
+			default:
+				break;
 		}
 	}
 
@@ -260,6 +276,8 @@ struct GoalListWindow : public Window {
 	{
 		if (!gui_scope) return;
 		this->vscroll->SetCount(this->CountLines());
+		this->SetWidgetDisabledState(WID_GOAL_COMPANY_BUTTON, _local_company == COMPANY_SPECTATOR);
+		this->SetWidgetDirty(WID_GOAL_COMPANY_BUTTON);
 		this->SetWidgetDirty(WID_GOAL_LIST);
 	}
 };
@@ -269,6 +287,10 @@ static const NWidgetPart _nested_goals_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_BROWN),
 		NWidget(WWT_CAPTION, COLOUR_BROWN, WID_GOAL_CAPTION), SetDataTip(STR_JUST_STRING, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GOAL_SELECT_BUTTONS),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_BROWN, WID_GOAL_GLOBAL_BUTTON), SetMinimalSize(50, 0), SetMinimalTextLines(1, WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM + 2), SetDataTip(STR_GOALS_GLOBAL_BUTTON, STR_GOALS_GLOBAL_BUTTON_HELPTEXT),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_BROWN, WID_GOAL_COMPANY_BUTTON), SetMinimalSize(50, 0), SetMinimalTextLines(1, WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM + 2), SetDataTip(STR_GOALS_COMPANY_BUTTON, STR_GOALS_COMPANY_BUTTON_HELPTEXT),
+		EndContainer(),
 		NWidget(WWT_SHADEBOX, COLOUR_BROWN),
 		NWidget(WWT_DEFSIZEBOX, COLOUR_BROWN),
 		NWidget(WWT_STICKYBOX, COLOUR_BROWN),

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3184,13 +3184,10 @@ STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{YELLOW}Bribe t
 STR_GOALS_CAPTION                                               :{WHITE}{COMPANY} Goals
 STR_GOALS_SPECTATOR_CAPTION                                     :{WHITE}Global Goals
 STR_GOALS_SPECTATOR                                             :Global Goals
-STR_GOALS_GLOBAL_TITLE                                          :{BLACK}Global goals:
 STR_GOALS_TEXT                                                  :{ORANGE}{RAW_STRING}
 STR_GOALS_NONE                                                  :{ORANGE}- None -
-STR_GOALS_SPECTATOR_NONE                                        :{ORANGE}- Not applicable -
 STR_GOALS_PROGRESS                                              :{ORANGE}{RAW_STRING}
 STR_GOALS_PROGRESS_COMPLETE                                     :{GREEN}{RAW_STRING}
-STR_GOALS_COMPANY_TITLE                                         :{BLACK}Company goals:
 STR_GOALS_TOOLTIP_CLICK_ON_SERVICE_TO_CENTER                    :{BLACK}Click on goal to centre main view on industry/town/tile. Ctrl+Click opens a new viewport on industry/town/tile location
 
 # Goal question window

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3184,6 +3184,10 @@ STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{YELLOW}Bribe t
 STR_GOALS_CAPTION                                               :{WHITE}{COMPANY} Goals
 STR_GOALS_SPECTATOR_CAPTION                                     :{WHITE}Global Goals
 STR_GOALS_SPECTATOR                                             :Global Goals
+STR_GOALS_GLOBAL_BUTTON                                         :{BLACK}Global
+STR_GOALS_GLOBAL_BUTTON_HELPTEXT                                :{BLACK}Show global goals
+STR_GOALS_COMPANY_BUTTON                                        :{BLACK}Company
+STR_GOALS_COMPANY_BUTTON_HELPTEXT                               :{BLACK}Show company goals
 STR_GOALS_TEXT                                                  :{ORANGE}{RAW_STRING}
 STR_GOALS_NONE                                                  :{ORANGE}- None -
 STR_GOALS_PROGRESS                                              :{ORANGE}{RAW_STRING}

--- a/src/widgets/goal_widget.h
+++ b/src/widgets/goal_widget.h
@@ -13,9 +13,12 @@
 
 /** Widgets of the #GoalListWindow class. */
 enum GoalListWidgets {
-	WID_GOAL_CAPTION,   ///< Caption of the window.
-	WID_GOAL_LIST,      ///< Goal list.
-	WID_GOAL_SCROLLBAR, ///< Scrollbar of the goal list.
+	WID_GOAL_CAPTION,         ///< Caption of the window.
+	WID_GOAL_SELECT_BUTTONS,  ///< Selection widget for the title bar button.
+	WID_GOAL_GLOBAL_BUTTON,   ///< Button to show global goals.
+	WID_GOAL_COMPANY_BUTTON,  ///< Button to show company goals.
+	WID_GOAL_LIST,            ///< Goal list.
+	WID_GOAL_SCROLLBAR,       ///< Scrollbar of the goal list.
 };
 
 /** Widgets of the #GoalQuestionWindow class. */


### PR DESCRIPTION
## Motivation / Problem

Despite having a dedicated window global goals are also shown in every company goal window distracting players from the important part or hiding it below the scrollbar (in 1.11). I see no reason for that as even in the rare case when the player needs both he can just open two windows.  It also simplifies the code a lot and removes the need for awkward global/company goal subheaders.

## Description

Before:
![Screenshot from 2021-02-21 01-11-52](https://user-images.githubusercontent.com/413570/108609854-dac34c00-73e1-11eb-90ff-f16b3feaddf5.png)

After (updated):
![Screenshot from 2021-02-21 02-34-21](https://user-images.githubusercontent.com/413570/108611208-5971b680-73ed-11eb-913d-3a3f59c5dafa.png)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
