### PR TITLE
Fix road pathfinder behaviour with speed limits on roadtypes/bridges

### DIFF
--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -466,12 +466,17 @@ public:
 		if (!IsWaterTT() && IsBridgeTile(m_old_tile)) {
 			int spd = GetBridgeSpec(GetBridgeType(m_old_tile))->speed;
 			if (IsRoadTT()) spd *= 2;
-			if (max_speed > spd) max_speed = spd;
+			max_speed = std::min(max_speed, spd);
 		}
 		/* Check for speed limit imposed by railtype */
 		if (IsRailTT()) {
 			uint16 rail_speed = GetRailTypeInfo(GetRailType(m_old_tile))->max_speed;
 			if (rail_speed > 0) max_speed = std::min<int>(max_speed, rail_speed);
+		}
+		if (IsRoadTT()) {
+			/* max_speed is already in roadvehicle units, no need to further modify (divide by 2) */
+			uint16 road_speed = GetRoadTypeInfo(GetRoadType(m_old_tile, GetRoadTramType(RoadVehicle::From(m_veh)->roadtype)))->max_speed;
+			if (road_speed > 0) max_speed = std::min<int>(max_speed, road_speed);
 		}
 
 		/* if min speed was requested, return it */

--- a/src/pathfinder/yapf/yapf_road.cpp
+++ b/src/pathfinder/yapf/yapf_road.cpp
@@ -161,8 +161,8 @@ public:
 			int min_speed = 0;
 			int max_veh_speed = v->GetDisplayMaxSpeed();
 			int max_speed = F.GetSpeedLimit(&min_speed);
-			if (max_speed < max_veh_speed) segment_cost += 1 * (max_veh_speed - max_speed);
-			if (min_speed > max_veh_speed) segment_cost += 10 * (min_speed - max_veh_speed);
+			if (max_speed < max_veh_speed) segment_cost += YAPF_TILE_LENGTH * (max_veh_speed - max_speed) * (4 + F.m_tiles_skipped) / max_veh_speed;
+			if (min_speed > max_veh_speed) segment_cost += YAPF_TILE_LENGTH * (min_speed - max_veh_speed);
 
 			/* move to the next tile */
 			tile = F.m_new_tile;


### PR DESCRIPTION
## Motivation / Problem
#8594

Also noted that road vehicles were always picking wooden bridges over faster ones, regardless of whether the (slightly) longer route was better or not.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Get the speed limit from the roadtype if there is one, same as for railtypes.

Account for bridge length in path cost calculation, same as is done for rail
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Might change/break some existing setups? Possibly?

Path cache can take a few months to fully clear for some road vehicles.

I don't think it's perfect yet. Road vehicles still seem to pick the an unexpected path sometimes - the wooden bridge is still being chosen more often than I'd expect
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
