### PR TITLE
Codechange: [OSX] remove final bits of old debugging code

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -64,10 +64,6 @@ bool _cocoa_video_started = false;
 
 extern bool _tab_is_down;
 
-#ifdef _DEBUG
-static uint32 _tEvent;
-#endif
-
 
 /** List of common display/window sizes. */
 static const Dimension _default_resolutions[] = {
@@ -86,19 +82,6 @@ static const Dimension _default_resolutions[] = {
 };
 
 static FVideoDriver_Cocoa iFVideoDriver_Cocoa;
-
-
-/**
- * Get current realtime.
- * @return Tick time in milliseconds.
- */
-static uint32 GetTick()
-{
-	struct timeval tim;
-
-	gettimeofday(&tim, NULL);
-	return tim.tv_usec / 1000 + tim.tv_sec * 1000;
-}
 
 
 /** Subclass of NSView for drawing to screen. */
@@ -603,13 +586,7 @@ void VideoDriver_Cocoa::CheckPaletteAnim()
  */
 bool VideoDriver_Cocoa::PollEvent()
 {
-#ifdef _DEBUG
-	uint32 et0 = GetTick();
-#endif
 	NSEvent *event = [ NSApp nextEventMatchingMask:NSAnyEventMask untilDate:[ NSDate distantPast ] inMode:NSDefaultRunLoopMode dequeue:YES ];
-#ifdef _DEBUG
-	_tEvent += GetTick() - et0;
-#endif
 
 	if (event == nil) return false;
 


### PR DESCRIPTION
## Motivation / Problem

I forgot to clean up properly ...


## Description

OSX driver used to have debug statements to show timings etc. This is rather silly with the new framerate window.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
