### PR TITLE
Fix: Vehicle list windows did not update when this year's profit changed

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -185,7 +185,7 @@ void BaseVehicleListWindow::BuildVehicleList()
 	if (this->grouping == GB_NONE) {
 		uint max_unitnumber = 0;
 		for (auto it = this->vehicles.begin(); it != this->vehicles.end(); ++it) {
-			this->vehgroups.emplace_back(it, it + 1, (*it)->GetDisplayProfitThisYear(), (*it)->GetDisplayProfitLastYear(), (*it)->age);
+			this->vehgroups.emplace_back(it, it + 1);
 
 			max_unitnumber = std::max<uint>(max_unitnumber, (*it)->unitnumber);
 		}
@@ -204,17 +204,7 @@ void BaseVehicleListWindow::BuildVehicleList()
 				return v->FirstShared() == first_shared;
 			});
 
-			Money display_profit_this_year = 0;
-			Money display_profit_last_year = 0;
-			Date age = 0;
-			for (auto it = begin; it != end; ++it) {
-				const Vehicle * const v = (*it);
-				display_profit_this_year += v->GetDisplayProfitThisYear();
-				display_profit_last_year += v->GetDisplayProfitLastYear();
-				age = std::max<Date>(age, v->age);
-			}
-
-			this->vehgroups.emplace_back(begin, end, display_profit_this_year, display_profit_last_year, age);
+			this->vehgroups.emplace_back(begin, end);
 
 			max_num_vehicles = std::max<uint>(max_num_vehicles, static_cast<uint>(end - begin));
 
@@ -1183,25 +1173,25 @@ static bool VehicleGroupLengthSorter(const GUIVehicleGroup &a, const GUIVehicleG
 /** Sort vehicle groups by the total profit this year */
 static bool VehicleGroupTotalProfitThisYearSorter(const GUIVehicleGroup &a, const GUIVehicleGroup &b)
 {
-	return a.display_profit_this_year < b.display_profit_this_year;
+	return a.GetDisplayProfitThisYear() < b.GetDisplayProfitThisYear();
 }
 
 /** Sort vehicle groups by the total profit last year */
 static bool VehicleGroupTotalProfitLastYearSorter(const GUIVehicleGroup &a, const GUIVehicleGroup &b)
 {
-	return a.display_profit_last_year < b.display_profit_last_year;
+	return a.GetDisplayProfitLastYear() < b.GetDisplayProfitLastYear();
 }
 
 /** Sort vehicle groups by the average profit this year */
 static bool VehicleGroupAverageProfitThisYearSorter(const GUIVehicleGroup &a, const GUIVehicleGroup &b)
 {
-	return a.display_profit_this_year * static_cast<uint>(b.NumVehicles()) < b.display_profit_this_year * static_cast<uint>(a.NumVehicles());
+	return a.GetDisplayProfitThisYear() * static_cast<uint>(b.NumVehicles()) < b.GetDisplayProfitThisYear() * static_cast<uint>(a.NumVehicles());
 }
 
 /** Sort vehicle groups by the average profit last year */
 static bool VehicleGroupAverageProfitLastYearSorter(const GUIVehicleGroup &a, const GUIVehicleGroup &b)
 {
-	return a.display_profit_last_year * static_cast<uint>(b.NumVehicles()) < b.display_profit_last_year * static_cast<uint>(a.NumVehicles());
+	return a.GetDisplayProfitLastYear() * static_cast<uint>(b.NumVehicles()) < b.GetDisplayProfitLastYear() * static_cast<uint>(a.NumVehicles());
 }
 
 /** Sort vehicles by their number */
@@ -1538,11 +1528,11 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 
 		const GUIVehicleGroup &vehgroup = this->vehgroups[i];
 
-		SetDParam(0, vehgroup.display_profit_this_year);
-		SetDParam(1, vehgroup.display_profit_last_year);
+		SetDParam(0, vehgroup.GetDisplayProfitThisYear());
+		SetDParam(1, vehgroup.GetDisplayProfitLastYear());
 		DrawString(text_left, text_right, y + line_height - FONT_HEIGHT_SMALL - WD_FRAMERECT_BOTTOM - 1, STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR);
 
-		DrawVehicleProfitButton(vehgroup.age, vehgroup.display_profit_last_year, vehgroup.NumVehicles(), vehicle_button_x, y + FONT_HEIGHT_NORMAL + 3);
+		DrawVehicleProfitButton(vehgroup.GetOldestVehicleAge(), vehgroup.GetDisplayProfitLastYear(), vehgroup.NumVehicles(), vehicle_button_x, y + FONT_HEIGHT_NORMAL + 3);
 
 		switch (this->grouping) {
 			case GB_NONE: {

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -14,32 +14,54 @@
 #include "date_type.h"
 #include "economy_type.h"
 #include "sortlist_type.h"
+#include "vehicle_base.h"
 #include "vehiclelist.h"
 #include "window_gui.h"
 #include "widgets/dropdown_type.h"
 
 #include <iterator>
+#include <numeric>
 
 typedef GUIList<const Vehicle*> GUIVehicleList;
 
 struct GUIVehicleGroup {
 	VehicleList::const_iterator vehicles_begin;    ///< Pointer to beginning element of this vehicle group.
 	VehicleList::const_iterator vehicles_end;      ///< Pointer to past-the-end element of this vehicle group.
-	Money display_profit_this_year;                ///< Total profit for the vehicle group this year.
-	Money display_profit_last_year;                ///< Total profit for the vehicle group laste year.
-	Date age;                                      ///< Age in days of oldest vehicle in the group.
 
-	GUIVehicleGroup(VehicleList::const_iterator vehicles_begin, VehicleList::const_iterator vehicles_end, Money display_profit_this_year, Money display_profit_last_year, Date age)
-		: vehicles_begin(vehicles_begin), vehicles_end(vehicles_end), display_profit_this_year(display_profit_this_year), display_profit_last_year(display_profit_last_year), age(age) {}
+	GUIVehicleGroup(VehicleList::const_iterator vehicles_begin, VehicleList::const_iterator vehicles_end)
+		: vehicles_begin(vehicles_begin), vehicles_end(vehicles_end) {}
 
 	std::ptrdiff_t NumVehicles() const
 	{
-		return std::distance(vehicles_begin, vehicles_end);
+		return std::distance(this->vehicles_begin, this->vehicles_end);
 	}
+
 	const Vehicle *GetSingleVehicle() const
 	{
-		assert(NumVehicles() == 1);
-		return vehicles_begin[0];
+		assert(this->NumVehicles() == 1);
+		return this->vehicles_begin[0];
+	}
+
+	Money GetDisplayProfitThisYear() const
+	{
+		return std::accumulate(this->vehicles_begin, this->vehicles_end, (Money)0, [](Money acc, const Vehicle *v) {
+			return acc + v->GetDisplayProfitThisYear();
+		});
+	}
+
+	Money GetDisplayProfitLastYear() const
+	{
+		return std::accumulate(this->vehicles_begin, this->vehicles_end, (Money)0, [](Money acc, const Vehicle *v) {
+			return acc + v->GetDisplayProfitLastYear();
+		});
+	}
+
+	Date GetOldestVehicleAge() const
+	{
+		const Vehicle *oldest = *std::max_element(this->vehicles_begin, this->vehicles_end, [](const Vehicle *v_a, const Vehicle *v_b) {
+			return v_a->age < v_b->age;
+		});
+		return oldest->age;
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem
#8575 (update commit message when merging)
584df54 introduced Vehicle groups, which cached age, this-year-profit & last-year-profit of the groups. These groups were not (and could not be) updated when the profit of the group changed, meaning that
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Remove caching from vehicle group object and recalculate it whenever required instead.

Was an awful lot less effort than finding all the places where vehicle profit changes and updating the relevant group object.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Might slow things down for group-heavy games. Needs further testing with a game with such properties. Perhaps @btzy would like to test?
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
