### PR TITLE
Fix #8713: Change OTTD2FS and FS2OTTD to return string objects

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -133,7 +133,7 @@ static void debug_print(const char *dbg, const char *buf)
 		seprintf(buffer, lastof(buffer), "%sdbg: [%s] %s\n", GetLogPrefix(), dbg, buf);
 #if defined(_WIN32)
 		wchar_t system_buf[512];
-		convert_to_fs(buffer, system_buf, lengthof(system_buf), true);
+		convert_to_fs(buffer, system_buf, lengthof(system_buf));
 		fputws(system_buf, stderr);
 #else
 		fputs(buffer, stderr);

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -134,7 +134,7 @@ static void debug_print(const char *dbg, const char *buf)
 #if defined(_WIN32)
 		wchar_t system_buf[512];
 		convert_to_fs(buffer, system_buf, lengthof(system_buf), true);
-		_fputts(system_buf, stderr);
+		fputws(system_buf, stderr);
 #else
 		fputs(buffer, stderr);
 #endif

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -279,7 +279,7 @@ bool FioCheckFileExists(const std::string &filename, Subdirectory subdir)
  */
 bool FileExists(const std::string &filename)
 {
-	return access(OTTD2FS(filename.c_str()), 0) == 0;
+	return access(OTTD2FS(filename).c_str(), 0) == 0;
 }
 
 /**
@@ -358,7 +358,7 @@ static FILE *FioFOpenFileSp(const std::string &filename, const char *mode, Searc
 	}
 
 #if defined(_WIN32)
-	if (mode[0] == 'r' && GetFileAttributes(OTTD2FS(buf.c_str())) == INVALID_FILE_ATTRIBUTES) return nullptr;
+	if (mode[0] == 'r' && GetFileAttributes(OTTD2FS(buf).c_str()) == INVALID_FILE_ATTRIBUTES) return nullptr;
 #endif
 
 	f = fopen(buf.c_str(), mode);
@@ -506,11 +506,11 @@ void FioCreateDirectory(const std::string &name)
 	/* Ignore directory creation errors; they'll surface later on, and most
 	 * of the time they are 'directory already exists' errors anyhow. */
 #if defined(_WIN32)
-	CreateDirectory(OTTD2FS(name.c_str()), nullptr);
+	CreateDirectory(OTTD2FS(name).c_str(), nullptr);
 #elif defined(OS2) && !defined(__INNOTEK_LIBC__)
-	mkdir(OTTD2FS(name.c_str()));
+	mkdir(OTTD2FS(name).c_str());
 #else
-	mkdir(OTTD2FS(name.c_str()), 0755);
+	mkdir(OTTD2FS(name).c_str(), 0755);
 #endif
 }
 
@@ -1315,7 +1315,7 @@ static uint ScanPath(FileScanner *fs, const char *extension, const char *path, s
 	if (path == nullptr || (dir = ttd_opendir(path)) == nullptr) return 0;
 
 	while ((dirent = readdir(dir)) != nullptr) {
-		const char *d_name = FS2OTTD(dirent->d_name);
+		std::string d_name = FS2OTTD(dirent->d_name);
 
 		if (!FiosIsValidFile(path, dirent, &sb)) continue;
 
@@ -1325,7 +1325,7 @@ static uint ScanPath(FileScanner *fs, const char *extension, const char *path, s
 		if (S_ISDIR(sb.st_mode)) {
 			/* Directory */
 			if (!recursive) continue;
-			if (strcmp(d_name, ".") == 0 || strcmp(d_name, "..") == 0) continue;
+			if (d_name == "." || d_name == "..") continue;
 			AppendPathSeparator(filename);
 			num += ScanPath(fs, extension, filename.c_str(), basepath_length, recursive);
 		} else if (S_ISREG(sb.st_mode)) {

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -132,7 +132,7 @@ int closedir(DIR *d);
  */
 static inline DIR *ttd_opendir(const char *path)
 {
-	return opendir(OTTD2FS(path));
+	return opendir(OTTD2FS(path).c_str());
 }
 
 

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -309,7 +309,7 @@ bool FiosFileScanner::AddFile(const std::string &filename, size_t basepath_lengt
 	FiosItem *fios = file_list.Append();
 #ifdef _WIN32
 	// Retrieve the file modified date using GetFileTime rather than stat to work around an obscure MSVC bug that affects Windows XP
-	HANDLE fh = CreateFile(OTTD2FS(filename.c_str()), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+	HANDLE fh = CreateFile(OTTD2FS(filename).c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
 
 	if (fh != INVALID_HANDLE_VALUE) {
 		FILETIME ft;
@@ -384,7 +384,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 	/* Show subdirectories */
 	if ((dir = ttd_opendir(_fios_path->c_str())) != nullptr) {
 		while ((dirent = readdir(dir)) != nullptr) {
-			strecpy(d_name, FS2OTTD(dirent->d_name), lastof(d_name));
+			strecpy(d_name, FS2OTTD(dirent->d_name).c_str(), lastof(d_name));
 
 			/* found file must be directory, but not '.' or '..' */
 			if (FiosIsValidFile(_fios_path->c_str(), dirent, &sb) && S_ISDIR(sb.st_mode) &&

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -53,7 +53,7 @@ bool IniFile::SaveToDisk(const std::string &filename)
 	std::string file_new{ filename };
 	file_new.append(".new");
 
-	std::ofstream os(OTTD2FS(file_new.c_str()));
+	std::ofstream os(OTTD2FS(file_new));
 	if (os.fail()) return false;
 
 	for (const IniGroup *group = this->group; group != nullptr; group = group->next) {
@@ -94,8 +94,8 @@ bool IniFile::SaveToDisk(const std::string &filename)
 #if defined(_WIN32)
 	/* Allocate space for one more \0 character. */
 	wchar_t tfilename[MAX_PATH + 1], tfile_new[MAX_PATH + 1];
-	wcsncpy(tfilename, OTTD2FS(filename.c_str()), MAX_PATH);
-	wcsncpy(tfile_new, OTTD2FS(file_new.c_str()), MAX_PATH);
+	wcsncpy(tfilename, OTTD2FS(filename).c_str(), MAX_PATH);
+	wcsncpy(tfile_new, OTTD2FS(file_new).c_str(), MAX_PATH);
 	/* SHFileOperation wants a double '\0' terminated string. */
 	tfilename[MAX_PATH - 1] = '\0';
 	tfile_new[MAX_PATH - 1] = '\0';

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -134,8 +134,8 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 		return;
 	}
 
-	const char *os_file = OTTD2FS(filename.c_str());
-	CFAutoRelease<CFURLRef> url(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file, strlen(os_file), false));
+	std::string os_file = OTTD2FS(filename);
+	CFAutoRelease<CFURLRef> url(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)os_file.c_str(), os_file.length(), false));
 
 	if (MusicSequenceFileLoad(_sequence, url.get(), kMusicSequenceFile_AnyType, 0) != noErr) {
 		DEBUG(driver, 0, "cocoa_m: Failed to load MIDI file");

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -430,7 +430,7 @@ bool DLSFile::ReadDLSWaveList(FILE *f, DWORD list_length)
 
 bool DLSFile::LoadFile(const wchar_t *file)
 {
-	DEBUG(driver, 2, "DMusic: Try to load DLS file %s", FS2OTTD(file));
+	DEBUG(driver, 2, "DMusic: Try to load DLS file %s", FS2OTTD(file).c_str());
 
 	FILE *f = _wfopen(file, L"rb");
 	if (f == nullptr) return false;
@@ -881,7 +881,7 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 				if (!dls_file.LoadFile(path)) return "Can't load GM DLS collection";
 			}
 		} else {
-			if (!dls_file.LoadFile(OTTD2FS(user_dls))) return "Can't load GM DLS collection";
+			if (!dls_file.LoadFile(OTTD2FS(user_dls).c_str())) return "Can't load GM DLS collection";
 		}
 
 		/* Get download port and allocate download IDs. */

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -246,7 +246,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 	if (e != 0) {
 		if (func != ResolveLoopProc) {
 			DEBUG(net, 0, "getaddrinfo for hostname \"%s\", port %s, address family %s and socket type %s failed: %s",
-				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), FS2OTTD(gai_strerror(e)));
+				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), FS2OTTD(gai_strerror(e)).c_str());
 		}
 		return INVALID_SOCKET;
 	}

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -203,9 +203,6 @@ bool GetClipboardContents(char *buffer, const char *last)
 }
 
 
-const char *FS2OTTD(const char *name) {return name;}
-const char *OTTD2FS(const char *name) {return name;}
-
 void OSOpenBrowser(const char *url)
 {
 	// stub only

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -146,9 +146,8 @@ static const char *GetLocalCode()
  * Convert between locales, which from and which to is set in the calling
  * functions OTTD2FS() and FS2OTTD().
  */
-static const char *convert_tofrom_fs(iconv_t convd, const char *name)
+static const char *convert_tofrom_fs(iconv_t convd, const char *name, char *outbuf, size_t outlen)
 {
-	static char buf[1024];
 	/* There are different implementations of iconv. The older ones,
 	 * e.g. SUSv2, pass a const pointer, whereas the newer ones, e.g.
 	 * IEEE 1003.1 (2004), pass a non-const pointer. */
@@ -158,9 +157,8 @@ static const char *convert_tofrom_fs(iconv_t convd, const char *name)
 	const char *inbuf = name;
 #endif
 
-	char *outbuf  = buf;
-	size_t outlen = sizeof(buf) - 1;
 	size_t inlen  = strlen(name);
+	char *buf = outbuf;
 
 	strecpy(outbuf, name, outbuf + outlen);
 
@@ -179,9 +177,10 @@ static const char *convert_tofrom_fs(iconv_t convd, const char *name)
  * @param name pointer to a valid string that will be converted
  * @return pointer to a new stringbuffer that contains the converted string
  */
-const char *OTTD2FS(const char *name)
+std::string OTTD2FS(const std::string &name)
 {
 	static iconv_t convd = (iconv_t)(-1);
+	char buf[1024] = {};
 
 	if (convd == (iconv_t)(-1)) {
 		const char *env = GetLocalCode();
@@ -192,17 +191,18 @@ const char *OTTD2FS(const char *name)
 		}
 	}
 
-	return convert_tofrom_fs(convd, name);
+	return convert_tofrom_fs(convd, name.c_str(), buf, lengthof(buf));
 }
 
 /**
  * Convert to OpenTTD's encoding from that of the local environment
- * @param name pointer to a valid string that will be converted
+ * @param name valid string that will be converted
  * @return pointer to a new stringbuffer that contains the converted string
  */
-const char *FS2OTTD(const char *name)
+std::string FS2OTTD(const std::string &name)
 {
 	static iconv_t convd = (iconv_t)(-1);
+	char buf[1024] = {};
 
 	if (convd == (iconv_t)(-1)) {
 		const char *env = GetLocalCode();
@@ -213,12 +213,9 @@ const char *FS2OTTD(const char *name)
 		}
 	}
 
-	return convert_tofrom_fs(convd, name);
+	return convert_tofrom_fs(convd, name.c_str(), buf, lengthof(buf));
 }
 
-#else
-const char *FS2OTTD(const char *name) {return name;}
-const char *OTTD2FS(const char *name) {return name;}
 #endif /* WITH_ICONV */
 
 void ShowInfo(const char *str)

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -705,21 +705,21 @@ static INT_PTR CALLBACK CrashDialogFunc(HWND wnd, UINT msg, WPARAM wParam, LPARA
 
 			/* Add path to crash.log and crash.dmp (if any) to the crash window text */
 			size_t len = wcslen(_crash_desc) + 2;
-			len += wcslen(convert_to_fs(CrashLogWindows::current->crashlog_filename, filenamebuf, lengthof(filenamebuf), false)) + 2;
-			len += wcslen(convert_to_fs(CrashLogWindows::current->crashdump_filename, filenamebuf, lengthof(filenamebuf), false)) + 2;
-			len += wcslen(convert_to_fs(CrashLogWindows::current->screenshot_filename, filenamebuf, lengthof(filenamebuf), false)) + 1;
+			len += wcslen(convert_to_fs(CrashLogWindows::current->crashlog_filename, filenamebuf, lengthof(filenamebuf))) + 2;
+			len += wcslen(convert_to_fs(CrashLogWindows::current->crashdump_filename, filenamebuf, lengthof(filenamebuf))) + 2;
+			len += wcslen(convert_to_fs(CrashLogWindows::current->screenshot_filename, filenamebuf, lengthof(filenamebuf))) + 1;
 
 			wchar_t *text = AllocaM(wchar_t, len);
-			int printed = _snwprintf(text, len, _crash_desc, convert_to_fs(CrashLogWindows::current->crashlog_filename, filenamebuf, lengthof(filenamebuf), false));
+			int printed = _snwprintf(text, len, _crash_desc, convert_to_fs(CrashLogWindows::current->crashlog_filename, filenamebuf, lengthof(filenamebuf)));
 			if (printed < 0 || (size_t)printed > len) {
 				MessageBox(wnd, L"Catastrophic failure trying to display crash message. Could not perform text formatting.", L"OpenTTD", MB_ICONERROR);
 				return FALSE;
 			}
-			if (convert_to_fs(CrashLogWindows::current->crashdump_filename, filenamebuf, lengthof(filenamebuf), false)[0] != L'\0') {
+			if (convert_to_fs(CrashLogWindows::current->crashdump_filename, filenamebuf, lengthof(filenamebuf))[0] != L'\0') {
 				wcscat(text, L"\n");
 				wcscat(text, filenamebuf);
 			}
-			if (convert_to_fs(CrashLogWindows::current->screenshot_filename, filenamebuf, lengthof(filenamebuf), false)[0] != L'\0') {
+			if (convert_to_fs(CrashLogWindows::current->screenshot_filename, filenamebuf, lengthof(filenamebuf))[0] != L'\0') {
 				wcscat(text, L"\n");
 				wcscat(text, filenamebuf);
 			}
@@ -738,7 +738,7 @@ static INT_PTR CALLBACK CrashDialogFunc(HWND wnd, UINT msg, WPARAM wParam, LPARA
 					wchar_t filenamebuf[MAX_PATH * 2];
 					char filename[MAX_PATH];
 					if (CrashLogWindows::current->WriteSavegame(filename, lastof(filename))) {
-						convert_to_fs(filename, filenamebuf, lengthof(filenamebuf), false);
+						convert_to_fs(filename, filenamebuf, lengthof(filenamebuf));
 						size_t len = lengthof(_save_succeeded) + wcslen(filenamebuf) + 1;
 						wchar_t *text = AllocaM(wchar_t, len);
 						_snwprintf(text, len, _save_succeeded, filenamebuf);

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -606,12 +606,12 @@ void LoadWin32Font(FontSize fs)
 
 		/* See if this is an absolute path. */
 		if (FileExists(settings->font)) {
-			convert_to_fs(settings->font, fontPath, lengthof(fontPath), false);
+			convert_to_fs(settings->font, fontPath, lengthof(fontPath));
 		} else {
 			/* Scan the search-paths to see if it can be found. */
 			std::string full_font = FioFindFullPath(BASE_DIR, settings->font);
 			if (!full_font.empty()) {
-				convert_to_fs(full_font.c_str(), fontPath, lengthof(fontPath), false);
+				convert_to_fs(full_font.c_str(), fontPath, lengthof(fontPath));
 			}
 		}
 
@@ -649,7 +649,7 @@ void LoadWin32Font(FontSize fs)
 
 	if (logfont.lfFaceName[0] == 0) {
 		logfont.lfWeight = strcasestr(settings->font, " bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
-		convert_to_fs(settings->font, logfont.lfFaceName, lengthof(logfont.lfFaceName), false);
+		convert_to_fs(settings->font, logfont.lfFaceName, lengthof(logfont.lfFaceName));
 	}
 
 	HFONT font = CreateFontIndirect(&logfont);

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -83,7 +83,7 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 	}
 
 	/* Convert font name to file system encoding. */
-	wchar_t *font_namep = wcsdup(OTTD2FS(font_name));
+	wchar_t *font_namep = wcsdup(OTTD2FS(font_name).c_str());
 
 	for (index = 0;; index++) {
 		wchar_t *s;
@@ -377,6 +377,7 @@ Win32FontCache::Win32FontCache(FontSize fs, const LOGFONT &logfont, int pixels) 
 {
 	this->dc = CreateCompatibleDC(nullptr);
 	this->SetFontSize(fs, pixels);
+	this->fontname = FS2OTTD(this->logfont.lfFaceName);
 }
 
 Win32FontCache::~Win32FontCache()
@@ -438,7 +439,7 @@ void Win32FontCache::SetFontSize(FontSize fs, int pixels)
 	this->glyph_size.cx = otm->otmTextMetrics.tmMaxCharWidth;
 	this->glyph_size.cy = otm->otmTextMetrics.tmHeight;
 
-	DEBUG(freetype, 2, "Loaded font '%s' with size %d", FS2OTTD((LPTSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFullName)), pixels);
+	DEBUG(freetype, 2, "Loaded font '%s' with size %d", FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFullName)).c_str(), pixels);
 }
 
 /**
@@ -541,10 +542,10 @@ void Win32FontCache::ClearFontCache()
 	/* Convert characters outside of the BMP into surrogate pairs. */
 	WCHAR chars[2];
 	if (key >= 0x010000U) {
-		chars[0] = (WCHAR)(((key - 0x010000U) >> 10) + 0xD800);
-		chars[1] = (WCHAR)(((key - 0x010000U) & 0x3FF) + 0xDC00);
+		chars[0] = (wchar_t)(((key - 0x010000U) >> 10) + 0xD800);
+		chars[1] = (wchar_t)(((key - 0x010000U) & 0x3FF) + 0xDC00);
 	} else {
-		chars[0] = (WCHAR)(key & 0xFFFF);
+		chars[0] = (wchar_t)(key & 0xFFFF);
 	}
 
 	WORD glyphs[2] = { 0, 0 };

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -21,6 +21,7 @@ private:
 	HDC dc = nullptr;     ///< Cached GDI device context.
 	HGDIOBJ old_font;     ///< Old font selected into the GDI context.
 	SIZE glyph_size;      ///< Maximum size of regular glyphs.
+	std::string fontname; ///< Cached copy of this->logfont.lfFaceName
 
 	void SetFontSize(FontSize fs, int pixels);
 
@@ -33,7 +34,7 @@ public:
 	~Win32FontCache();
 	void ClearFontCache() override;
 	GlyphID MapCharToGlyph(WChar key) override;
-	const char *GetFontName() override { return FS2OTTD(this->logfont.lfFaceName); }
+	const char *GetFontName() override { return this->fontname.c_str(); }
 	const void *GetOSHandle() override { return &this->logfont; }
 };
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -578,7 +578,7 @@ std::string FS2OTTD(const std::wstring &name)
  * @param console_cp convert to the console encoding instead of the normal system encoding.
  * @return converted string; if failed string is of zero-length
  */
-std::wstring OTTD2FS(const std::string &name, bool console_cp)
+std::wstring OTTD2FS(const std::string &name)
 {
 	int name_len = (name.length() >= INT_MAX) ? INT_MAX : (int)name.length();
 	int len = MultiByteToWideChar(CP_UTF8, 0, name.c_str(), name_len, nullptr, 0);
@@ -618,7 +618,7 @@ char *convert_from_fs(const wchar_t *name, char *utf8_buf, size_t buflen)
  * @param console_cp convert to the console encoding instead of the normal system encoding.
  * @return pointer to system_buf. If conversion fails the string is of zero-length
  */
-wchar_t *convert_to_fs(const char *name, wchar_t *system_buf, size_t buflen, bool console_cp)
+wchar_t *convert_to_fs(const char *name, wchar_t *system_buf, size_t buflen)
 {
 	int len = MultiByteToWideChar(CP_UTF8, 0, name, -1, system_buf, (int)buflen);
 	if (len == 0) system_buf[0] = '\0';

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -17,7 +17,7 @@ typedef void (*Function)(int);
 bool LoadLibraryList(Function proc[], const char *dll);
 
 char *convert_from_fs(const wchar_t *name, char *utf8_buf, size_t buflen);
-wchar_t *convert_to_fs(const char *name, wchar_t *utf16_buf, size_t buflen, bool console_cp = false);
+wchar_t *convert_to_fs(const char *name, wchar_t *utf16_buf, size_t buflen);
 
 #if defined(__MINGW32__) && !defined(__MINGW64__)
 #define SHGFP_TYPE_CURRENT 0

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -263,7 +263,7 @@
 #		define unlink(file) _wunlink(OTTD2FS(file).c_str())
 
 		std::string FS2OTTD(const std::wstring &name);
-		std::wstring OTTD2FS(const std::string &name, bool console_cp = false);
+		std::wstring OTTD2FS(const std::string &name);
 #	elif defined(WITH_ICONV)
 #		define fopen(file, mode) fopen(OTTD2FS(file).c_str(), mode)
 		std::string FS2OTTD(const std::string &name);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1910,14 +1910,14 @@ static void GetLanguageList(const char *path)
 	if (dir != nullptr) {
 		struct dirent *dirent;
 		while ((dirent = readdir(dir)) != nullptr) {
-			const char *d_name    = FS2OTTD(dirent->d_name);
-			const char *extension = strrchr(d_name, '.');
+			std::string d_name = FS2OTTD(dirent->d_name);
+			const char *extension = strrchr(d_name.c_str(), '.');
 
 			/* Not a language file */
 			if (extension == nullptr || strcmp(extension, ".lng") != 0) continue;
 
 			LanguageMetadata lmd;
-			seprintf(lmd.file, lastof(lmd.file), "%s%s", path, d_name);
+			seprintf(lmd.file, lastof(lmd.file), "%s%s", path, d_name.c_str());
 
 			/* Check whether the file is of the correct version */
 			if (!GetLanguageFileHeader(lmd.file, &lmd)) {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -214,7 +214,7 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen, bool resize)
 			char window_title[64];
 			seprintf(window_title, lastof(window_title), "OpenTTD %s", _openttd_revision);
 
-			this->main_wnd = CreateWindow(L"OTTD", OTTD2FS(window_title), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);
+			this->main_wnd = CreateWindow(L"OTTD", OTTD2FS(window_title).c_str(), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);
 			if (this->main_wnd == nullptr) usererror("CreateWindow failed");
 			ShowWindow(this->main_wnd, showstyle);
 		}
@@ -331,7 +331,7 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 			/* Transmit text to windowing system. */
 			if (len > 0) {
 				HandleTextInput(nullptr, true); // Clear marked string.
-				HandleTextInput(FS2OTTD(str));
+				HandleTextInput(FS2OTTD(str).c_str());
 			}
 			SetCompositionPos(hwnd);
 


### PR DESCRIPTION
## Motivation / Problem

The `OTTD2FS` and `FS2OTTD` functions are not thread safe, they use static (global) buffers to hold the returned string data and require the caller to copy the data to somewhere better, and pray there isn't any race condition.

## Description

Change the functions to return `std::string` and `std::wstring` objects instead, to get automatic lifetime management of the data, and avoid data sharing between threads.

Additionally, this removes mostly any pretense that we can still build Windows 95 versions of the game.

## Limitations

Several of these changes are done blind, so far. Only tested in a single configuration on Windows, the changes for other OS may not compile.

There are unrelated changes here that should probably be split off.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
