### PR TITLE
Remove remaining Windows 95 support

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -134,7 +134,7 @@ static void debug_print(const char *dbg, const char *buf)
 		char buffer[512];
 		seprintf(buffer, lastof(buffer), "%sdbg: [%s] %s\n", GetLogPrefix(), dbg, buf);
 #if defined(_WIN32)
-		TCHAR system_buf[512];
+		wchar_t system_buf[512];
 		convert_to_fs(buffer, system_buf, lengthof(system_buf), true);
 		_fputts(system_buf, stderr);
 #else

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -340,7 +340,7 @@ std::string FioFindDirectory(Subdirectory subdir)
 
 static FILE *FioFOpenFileSp(const std::string &filename, const char *mode, Searchpath sp, Subdirectory subdir, size_t *filesize)
 {
-#if defined(_WIN32) && defined(UNICODE)
+#if defined(_WIN32)
 	/* fopen is implemented as a define with ellipses for
 	 * Unicode support (prepend an L). As we are not sending
 	 * a string, but a variable, it 'renames' the variable,

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -107,14 +107,14 @@ DECLARE_ENUM_AS_BIT_SET(TarScanner::Mode)
 struct DIR;
 
 struct dirent { // XXX - only d_name implemented
-	TCHAR *d_name; // name of found file
+	wchar_t *d_name; // name of found file
 	/* little hack which will point to parent DIR struct which will
 	 * save us a call to GetFileAttributes if we want information
 	 * about the file (for example in function fio_bla) */
 	DIR *dir;
 };
 
-DIR *opendir(const TCHAR *path);
+DIR *opendir(const wchar_t *path);
 struct dirent *readdir(DIR *d);
 int closedir(DIR *d);
 #else

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -92,17 +92,15 @@ bool IniFile::SaveToDisk(const std::string &filename)
 #endif
 
 #if defined(_WIN32)
-	/* _tcsncpy = strcpy is TCHAR is char, but isn't when TCHAR is wchar. */
-#	undef strncpy
 	/* Allocate space for one more \0 character. */
-	TCHAR tfilename[MAX_PATH + 1], tfile_new[MAX_PATH + 1];
-	_tcsncpy(tfilename, OTTD2FS(filename.c_str()), MAX_PATH);
-	_tcsncpy(tfile_new, OTTD2FS(file_new.c_str()), MAX_PATH);
+	wchar_t tfilename[MAX_PATH + 1], tfile_new[MAX_PATH + 1];
+	wcsncpy(tfilename, OTTD2FS(filename.c_str()), MAX_PATH);
+	wcsncpy(tfile_new, OTTD2FS(file_new.c_str()), MAX_PATH);
 	/* SHFileOperation wants a double '\0' terminated string. */
 	tfilename[MAX_PATH - 1] = '\0';
 	tfile_new[MAX_PATH - 1] = '\0';
-	tfilename[_tcslen(tfilename) + 1] = '\0';
-	tfile_new[_tcslen(tfile_new) + 1] = '\0';
+	tfilename[wcslen(tfilename) + 1] = '\0';
+	tfile_new[wcslen(tfile_new) + 1] = '\0';
 
 	/* Rename file without any user confirmation. */
 	SHFILEOPSTRUCT shfopt;

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -81,7 +81,7 @@ struct DLSFile {
 	std::vector<DLSWave> waves;
 
 	/** Try loading a DLS file into memory. */
-	bool LoadFile(const TCHAR *file);
+	bool LoadFile(const wchar_t *file);
 
 private:
 	/** Load an articulation structure from a DLS file. */
@@ -428,11 +428,11 @@ bool DLSFile::ReadDLSWaveList(FILE *f, DWORD list_length)
 	return true;
 }
 
-bool DLSFile::LoadFile(const TCHAR *file)
+bool DLSFile::LoadFile(const wchar_t *file)
 {
 	DEBUG(driver, 2, "DMusic: Try to load DLS file %s", FS2OTTD(file));
 
-	FILE *f = _tfopen(file, _T("rb"));
+	FILE *f = _wfopen(file, L"rb");
 	if (f == nullptr) return false;
 
 	FileCloser f_scope(f);
@@ -861,11 +861,11 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 		if (user_dls == nullptr) {
 			/* Try loading the default GM DLS file stored in the registry. */
 			HKEY hkDM;
-			if (SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("Software\\Microsoft\\DirectMusic"), 0, KEY_READ, &hkDM))) {
-				TCHAR dls_path[MAX_PATH];
+			if (SUCCEEDED(RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\Microsoft\\DirectMusic", 0, KEY_READ, &hkDM))) {
+				wchar_t dls_path[MAX_PATH];
 				DWORD buf_size = sizeof(dls_path); // Buffer size as to be given in bytes!
-				if (SUCCEEDED(RegQueryValueEx(hkDM, _T("GMFilePath"), nullptr, nullptr, (LPBYTE)dls_path, &buf_size))) {
-					TCHAR expand_path[MAX_PATH * 2];
+				if (SUCCEEDED(RegQueryValueEx(hkDM, L"GMFilePath", nullptr, nullptr, (LPBYTE)dls_path, &buf_size))) {
+					wchar_t expand_path[MAX_PATH * 2];
 					ExpandEnvironmentStrings(dls_path, expand_path, lengthof(expand_path));
 					if (!dls_file.LoadFile(expand_path)) DEBUG(driver, 1, "Failed to load default GM DLS file from registry");
 				}
@@ -874,8 +874,8 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 
 			/* If we couldn't load the file from the registry, try again at the default install path of the GM DLS file. */
 			if (dls_file.instruments.size() == 0) {
-				static const TCHAR *DLS_GM_FILE = _T("%windir%\\System32\\drivers\\gm.dls");
-				TCHAR path[MAX_PATH];
+				static const wchar_t *DLS_GM_FILE = L"%windir%\\System32\\drivers\\gm.dls";
+				wchar_t path[MAX_PATH];
 				ExpandEnvironmentStrings(DLS_GM_FILE, path, lengthof(path));
 
 				if (!dls_file.LoadFile(path)) return "Can't load GM DLS collection";

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -1103,7 +1103,6 @@ const char *MusicDriver_DMusic::Start(const StringList &parm)
 		DEBUG(driver, 1, "Detected DirectMusic ports:");
 		for (int i = 0; _music->EnumPort(i, &caps) == S_OK; i++) {
 			if (caps.dwClass == DMUS_PC_OUTPUTCLASS) {
-				/* Description is UNICODE even for ANSI build. */
 				DEBUG(driver, 1, " %d: %s%s", i, convert_from_fs(caps.wszDescription, desc, lengthof(desc)), i == pIdx ? " (selected)" : "");
 			}
 		}

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -46,10 +46,10 @@ extern FT_Library _library;
  * @param long_path the path in system encoding.
  * @return the short path in ANSI (ASCII).
  */
-static const char *GetShortPath(const TCHAR *long_path)
+static const char *GetShortPath(const wchar_t *long_path)
 {
 	static char short_path[MAX_PATH];
-	WCHAR short_path_w[MAX_PATH];
+	wchar_t short_path_w[MAX_PATH];
 	GetShortPathName(long_path, short_path_w, lengthof(short_path_w));
 	WideCharToMultiByte(CP_ACP, 0, short_path_w, -1, short_path, lengthof(short_path), nullptr, nullptr);
 	return short_path;
@@ -69,8 +69,8 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 	FT_Error err = FT_Err_Cannot_Open_Resource;
 	HKEY hKey;
 	LONG ret;
-	TCHAR vbuffer[MAX_PATH], dbuffer[256];
-	TCHAR *pathbuf;
+	wchar_t vbuffer[MAX_PATH], dbuffer[256];
+	wchar_t *pathbuf;
 	const char *font_path;
 	uint index;
 	size_t path_len;
@@ -83,10 +83,10 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 	}
 
 	/* Convert font name to file system encoding. */
-	TCHAR *font_namep = _tcsdup(OTTD2FS(font_name));
+	wchar_t *font_namep = wcsdup(OTTD2FS(font_name));
 
 	for (index = 0;; index++) {
-		TCHAR *s;
+		wchar_t *s;
 		DWORD vbuflen = lengthof(vbuffer);
 		DWORD dbuflen = lengthof(dbuffer);
 
@@ -102,13 +102,13 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 		 * TTC files, font files which contain more than one font are separated
 		 * by '&'. Our best bet will be to do substr match for the fontname
 		 * and then let FreeType figure out which index to load */
-		s = _tcschr(vbuffer, _T('('));
+		s = wcschr(vbuffer, L'(');
 		if (s != nullptr) s[-1] = '\0';
 
-		if (_tcschr(vbuffer, _T('&')) == nullptr) {
-			if (_tcsicmp(vbuffer, font_namep) == 0) break;
+		if (wcschr(vbuffer, L'&') == nullptr) {
+			if (wcsicmp(vbuffer, font_namep) == 0) break;
 		} else {
-			if (_tcsstr(vbuffer, font_namep) != nullptr) break;
+			if (wcsstr(vbuffer, font_namep) != nullptr) break;
 		}
 	}
 
@@ -121,9 +121,9 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 	 * contain multiple fonts inside this single file. GetFontData however
 	 * returns the whole file, so we need to check each font inside to get the
 	 * proper font. */
-	path_len = _tcslen(vbuffer) + _tcslen(dbuffer) + 2; // '\' and terminating nul.
-	pathbuf = AllocaM(TCHAR, path_len);
-	_sntprintf(pathbuf, path_len, _T("%s\\%s"), vbuffer, dbuffer);
+	path_len = wcslen(vbuffer) + wcslen(dbuffer) + 2; // '\' and terminating nul.
+	pathbuf = AllocaM(wchar_t, path_len);
+	_snwprintf(pathbuf, path_len, L"%s\\%s", vbuffer, dbuffer);
 
 	/* Convert the path into something that FreeType understands. */
 	font_path = GetShortPath(pathbuf);
@@ -228,13 +228,13 @@ err2:
 	ReleaseDC(nullptr, dc);
 	DeleteObject(font);
 err1:
-	return ret_font_name == nullptr ? WIDE_TO_MB((const TCHAR *)logfont->elfFullName) : ret_font_name;
+	return ret_font_name == nullptr ? FS2OTTD((const wchar_t *)logfont->elfFullName) : ret_font_name;
 }
 #endif /* WITH_FREETYPE */
 
 class FontList {
 protected:
-	TCHAR **fonts;
+	wchar_t **fonts;
 	uint items;
 	uint capacity;
 
@@ -251,9 +251,9 @@ public:
 		free(this->fonts);
 	}
 
-	bool Add(const TCHAR *font) {
+	bool Add(const wchar_t *font) {
 		for (uint i = 0; i < this->items; i++) {
-			if (_tcscmp(this->fonts[i], font) == 0) return false;
+			if (wcscmp(this->fonts[i], font) == 0) return false;
 		}
 
 		if (this->items == this->capacity) {
@@ -261,7 +261,7 @@ public:
 			this->fonts = ReallocT(this->fonts, this->capacity);
 		}
 
-		this->fonts[this->items++] = _tcsdup(font);
+		this->fonts[this->items++] = wcsdup(font);
 
 		return true;
 	}
@@ -279,7 +279,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	EFCParam *info = (EFCParam *)lParam;
 
 	/* Skip duplicates */
-	if (!info->fonts.Add((const TCHAR *)logfont->elfFullName)) return 1;
+	if (!info->fonts.Add((const wchar_t *)logfont->elfFullName)) return 1;
 	/* Only use TrueType fonts */
 	if (!(type & TRUETYPE_FONTTYPE)) return 1;
 	/* Don't use SYMBOL fonts */
@@ -305,7 +305,7 @@ static int CALLBACK EnumFontCallback(const ENUMLOGFONTEX *logfont, const NEWTEXT
 	}
 
 	char font_name[MAX_PATH];
-	convert_from_fs((const TCHAR *)logfont->elfFullName, font_name, lengthof(font_name));
+	convert_from_fs((const wchar_t *)logfont->elfFullName, font_name, lengthof(font_name));
 
 #ifdef WITH_FREETYPE
 	/* Add english name after font name */
@@ -342,7 +342,7 @@ bool SetFallbackFont(FreeTypeSettings *settings, const char *language_isocode, i
 {
 	DEBUG(freetype, 1, "Trying fallback fonts");
 	EFCParam langInfo;
-	if (GetLocaleInfo(MAKELCID(winlangid, SORT_DEFAULT), LOCALE_FONTSIGNATURE, (LPTSTR)&langInfo.locale, sizeof(langInfo.locale) / sizeof(TCHAR)) == 0) {
+	if (GetLocaleInfo(MAKELCID(winlangid, SORT_DEFAULT), LOCALE_FONTSIGNATURE, (LPTSTR)&langInfo.locale, sizeof(langInfo.locale) / sizeof(wchar_t)) == 0) {
 		/* Invalid langid or some other mysterious error, can't determine fallback font. */
 		DEBUG(freetype, 1, "Can't get locale info for fallback font (langid=0x%x)", winlangid);
 		return false;
@@ -601,7 +601,7 @@ void LoadWin32Font(FontSize fs)
 	} else if (strchr(settings->font, '.') != nullptr) {
 		/* Might be a font file name, try load it. */
 
-		TCHAR fontPath[MAX_PATH] = {};
+		wchar_t fontPath[MAX_PATH] = {};
 
 		/* See if this is an absolute path. */
 		if (FileExists(settings->font)) {
@@ -619,7 +619,7 @@ void LoadWin32Font(FontSize fs)
 				/* Try a nice little undocumented function first for getting the internal font name.
 				 * Some documentation is found at: http://www.undocprint.org/winspool/getfontresourceinfo */
 				typedef BOOL(WINAPI *PFNGETFONTRESOURCEINFO)(LPCTSTR, LPDWORD, LPVOID, DWORD);
-				static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(_T("Gdi32")), "GetFontResourceInfoW");
+				static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(L"Gdi32"), "GetFontResourceInfoW");
 
 				if (GetFontResourceInfo != nullptr) {
 					/* Try to query an array of LOGFONTs that describe the file. */
@@ -634,10 +634,10 @@ void LoadWin32Font(FontSize fs)
 
 				/* No dice yet. Use the file name as the font face name, hoping it matches. */
 				if (logfont.lfFaceName[0] == 0) {
-					TCHAR fname[_MAX_FNAME];
-					_tsplitpath(fontPath, nullptr, nullptr, fname, nullptr);
+					wchar_t fname[_MAX_FNAME];
+					_wsplitpath(fontPath, nullptr, nullptr, fname, nullptr);
 
-					_tcsncpy_s(logfont.lfFaceName, lengthof(logfont.lfFaceName), fname, _TRUNCATE);
+					wcsncpy_s(logfont.lfFaceName, lengthof(logfont.lfFaceName), fname, _TRUNCATE);
 					logfont.lfWeight = strcasestr(settings->font, " bold") != nullptr || strcasestr(settings->font, "-bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
 				}
 			} else {

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -33,7 +33,7 @@ public:
 	~Win32FontCache();
 	void ClearFontCache() override;
 	GlyphID MapCharToGlyph(WChar key) override;
-	const char *GetFontName() override { return WIDE_TO_MB(this->logfont.lfFaceName); }
+	const char *GetFontName() override { return FS2OTTD(this->logfont.lfFaceName); }
 	const void *GetOSHandle() override { return &this->logfont; }
 };
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -244,15 +244,10 @@ bool FiosIsHiddenFile(const struct dirent *ent)
 bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
 {
 	UINT sem = SetErrorMode(SEM_FAILCRITICALERRORS);  // disable 'no-disk' message box
-	bool retval = false;
-	wchar_t root[4];
-	DWORD spc, bps, nfc, tnc;
 
-	_snwprintf(root, lengthof(root), L"%c:" PATHSEP, path[0]);
-	if (tot != nullptr && GetDiskFreeSpace(root, &spc, &bps, &nfc, &tnc)) {
-		*tot = ((spc * bps) * (uint64)nfc);
-		retval = true;
-	}
+	ULARGE_INTEGER bytes_free;
+	bool retval = GetDiskFreeSpaceEx(OTTD2FS(path), &bytes_free, nullptr, nullptr);
+	if (retval) *tot = bytes_free.QuadPart;
 
 	SetErrorMode(sem); // reset previous setting
 	return retval;

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -16,13 +16,8 @@ bool MyShowCursor(bool show, bool toggle = false);
 typedef void (*Function)(int);
 bool LoadLibraryList(Function proc[], const char *dll);
 
-char *convert_from_fs(const TCHAR *name, char *utf8_buf, size_t buflen);
-TCHAR *convert_to_fs(const char *name, TCHAR *utf16_buf, size_t buflen, bool console_cp = false);
-
-/* Function shortcuts for UTF-8 <> UNICODE conversion. These functions use an
- * internal buffer of max 512 characters. */
-# define MB_TO_WIDE(str) OTTD2FS(str)
-# define WIDE_TO_MB(str) FS2OTTD(str)
+char *convert_from_fs(const wchar_t *name, char *utf8_buf, size_t buflen);
+wchar_t *convert_to_fs(const char *name, wchar_t *utf16_buf, size_t buflen, bool console_cp = false);
 
 #if defined(__MINGW32__) && !defined(__MINGW64__)
 #define SHGFP_TYPE_CURRENT 0

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -19,19 +19,10 @@ bool LoadLibraryList(Function proc[], const char *dll);
 char *convert_from_fs(const TCHAR *name, char *utf8_buf, size_t buflen);
 TCHAR *convert_to_fs(const char *name, TCHAR *utf16_buf, size_t buflen, bool console_cp = false);
 
-/* Function shortcuts for UTF-8 <> UNICODE conversion. When unicode is not
- * defined these macros return the string passed to them, with UNICODE
- * they return a pointer to the converted string. These functions use an
+/* Function shortcuts for UTF-8 <> UNICODE conversion. These functions use an
  * internal buffer of max 512 characters. */
-#if defined(UNICODE)
 # define MB_TO_WIDE(str) OTTD2FS(str)
 # define WIDE_TO_MB(str) FS2OTTD(str)
-#else
-# define MB_TO_WIDE(str) (str)
-# define WIDE_TO_MB(str) (str)
-#endif
-
-HRESULT OTTDSHGetFolderPath(HWND, int, HANDLE, DWORD, LPTSTR);
 
 #if defined(__MINGW32__) && !defined(__MINGW64__)
 #define SHGFP_TYPE_CURRENT 0

--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -48,7 +48,7 @@ static DWORD WINAPI SoundThread(LPVOID arg)
 			if ((hdr->dwFlags & WHDR_INQUEUE) != 0) continue;
 			MxMixSamples(hdr->lpData, hdr->dwBufferLength / 4);
 			if (waveOutWrite(_waveout, hdr, sizeof(WAVEHDR)) != MMSYSERR_NOERROR) {
-				MessageBox(nullptr, _T("Sounds are disabled until restart."), _T("waveOutWrite failed"), MB_ICONINFORMATION);
+				MessageBox(nullptr, L"Sounds are disabled until restart.", L"waveOutWrite failed", MB_ICONINFORMATION);
 				return 0;
 			}
 		}

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -260,12 +260,12 @@
 #		include <tchar.h>
 #		include <io.h>
 
-		namespace std { using ::_tfopen; }
-#		define fopen(file, mode) _tfopen(OTTD2FS(file), _T(mode))
-#		define unlink(file) _tunlink(OTTD2FS(file))
+		namespace std { using ::_wfopen; }
+#		define fopen(file, mode) _wfopen(OTTD2FS(file), _T(mode))
+#		define unlink(file) _wunlink(OTTD2FS(file))
 
-		const char *FS2OTTD(const TCHAR *name);
-		const TCHAR *OTTD2FS(const char *name, bool console_cp = false);
+		const char *FS2OTTD(const wchar_t *name);
+		const wchar_t *OTTD2FS(const char *name, bool console_cp = false);
 #	else
 #		define fopen(file, mode) fopen(OTTD2FS(file), mode)
 		const char *FS2OTTD(const char *name);

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -151,7 +151,7 @@ const char *VideoDriver_Dedicated::Start(const StringList &parm)
 	/* For win32 we need to allocate a console (debug mode does the same) */
 	CreateConsole();
 	CreateWindowsConsoleThread();
-	SetConsoleTitle(_T("OpenTTD Dedicated Server"));
+	SetConsoleTitle(L"OpenTTD Dedicated Server");
 #endif
 
 #ifdef _MSC_VER

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -214,7 +214,7 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen)
 			char window_title[64];
 			seprintf(window_title, lastof(window_title), "OpenTTD %s", _openttd_revision);
 
-			this->main_wnd = CreateWindow(_T("OTTD"), MB_TO_WIDE(window_title), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);
+			this->main_wnd = CreateWindow(L"OTTD", OTTD2FS(window_title), style, x, y, w, h, 0, 0, GetModuleHandle(nullptr), this);
 			if (this->main_wnd == nullptr) usererror("CreateWindow failed");
 			ShowWindow(this->main_wnd, showstyle);
 		}
@@ -329,9 +329,9 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 		if (lParam & GCS_RESULTSTR) {
 			/* Read result string from the IME. */
 			LONG len = ImmGetCompositionString(hIMC, GCS_RESULTSTR, nullptr, 0); // Length is always in bytes, even in UNICODE build.
-			TCHAR *str = (TCHAR *)_alloca(len + sizeof(TCHAR));
+			wchar_t *str = (wchar_t *)_alloca(len + sizeof(wchar_t));
 			len = ImmGetCompositionString(hIMC, GCS_RESULTSTR, str, len);
-			str[len / sizeof(TCHAR)] = '\0';
+			str[len / sizeof(wchar_t)] = '\0';
 
 			/* Transmit text to windowing system. */
 			if (len > 0) {
@@ -347,9 +347,9 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 		if ((lParam & GCS_COMPSTR) && DrawIMECompositionString()) {
 			/* Read composition string from the IME. */
 			LONG len = ImmGetCompositionString(hIMC, GCS_COMPSTR, nullptr, 0); // Length is always in bytes, even in UNICODE build.
-			TCHAR *str = (TCHAR *)_alloca(len + sizeof(TCHAR));
+			wchar_t *str = (wchar_t *)_alloca(len + sizeof(wchar_t));
 			len = ImmGetCompositionString(hIMC, GCS_COMPSTR, str, len);
-			str[len / sizeof(TCHAR)] = '\0';
+			str[len / sizeof(wchar_t)] = '\0';
 
 			if (len > 0) {
 				static char utf8_buf[1024];
@@ -358,7 +358,7 @@ static LRESULT HandleIMEComposition(HWND hwnd, WPARAM wParam, LPARAM lParam)
 				/* Convert caret position from bytes in the input string to a position in the UTF-8 encoded string. */
 				LONG caret_bytes = ImmGetCompositionString(hIMC, GCS_CURSORPOS, nullptr, 0);
 				const char *caret = utf8_buf;
-				for (const TCHAR *c = str; *c != '\0' && *caret != '\0' && caret_bytes > 0; c++, caret_bytes--) {
+				for (const wchar_t *c = str; *c != '\0' && *caret != '\0' && caret_bytes > 0; c++, caret_bytes--) {
 					/* Skip DBCS lead bytes or leading surrogates. */
 					if (Utf16IsLeadSurrogate(*c)) {
 						c++;
@@ -748,7 +748,7 @@ static void RegisterWndClass()
 		LoadCursor(nullptr, IDC_ARROW),
 		0,
 		0,
-		_T("OTTD")
+		L"OTTD"
 	};
 
 	registered = true;
@@ -1009,9 +1009,9 @@ float VideoDriver_Win32Base::GetDPIScale()
 	if (!init_done) {
 		init_done = true;
 
-		_GetDpiForWindow = (PFNGETDPIFORWINDOW)GetProcAddress(GetModuleHandle(_T("User32")), "GetDpiForWindow");
-		_GetDpiForSystem = (PFNGETDPIFORSYSTEM)GetProcAddress(GetModuleHandle(_T("User32")), "GetDpiForSystem");
-		_GetDpiForMonitor = (PFNGETDPIFORMONITOR)GetProcAddress(LoadLibrary(_T("Shcore.dll")), "GetDpiForMonitor");
+		_GetDpiForWindow = (PFNGETDPIFORWINDOW)GetProcAddress(GetModuleHandle(L"User32"), "GetDpiForWindow");
+		_GetDpiForSystem = (PFNGETDPIFORSYSTEM)GetProcAddress(GetModuleHandle(L"User32"), "GetDpiForSystem");
+		_GetDpiForMonitor = (PFNGETDPIFORMONITOR)GetProcAddress(LoadLibrary(L"Shcore.dll"), "GetDpiForMonitor");
 	}
 
 	UINT cur_dpi = 0;


### PR DESCRIPTION
## Motivation / Problem

By attempting to support compiling both with and without `UNICODE` defined, it makes the code more complex to read and write. There probably aren't any compilers available that target Windows 95/98/ME and also support the languages features we want any more regardless, so may as well clean it up.

## Description

More or less a search first for uses of the `UNICODE` define, and simplify the code there.
Then various other simplifications by cleaning up code that only supports special cases/downlevel OS.
Finally some cleanup by more searching for terms like `_T(`, `TCHAR`, and `_tcs` and replacing them with plain `wchar_t` code.

## Limitations

Definitely no longer builds a binary that works on 25 year old Windows systems.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
