### PR TITLE
Update known-bugs.txt

### DIFF
--- a/known-bugs.txt
+++ b/known-bugs.txt
@@ -364,35 +364,6 @@ Trains might not stop at platforms that are currently being changed [#5553]:
         list multiple times in a row or if there is only one station
         in theorder list (see #5684).
 
-Inconsistent catchment areas [#5661]:
-        Due to performance decisions the catchment area for cargo accepted by a
-        station for delivery to houses or industries differs from the catchment
-        area for cargo that is delivered to stations from houses or industries.
-
-        Conceptually they work the same, but the effect in game differs. They
-        work by finding the closest destination "around" the source which is
-        within a certain distance. This distance depends on the type of station,
-        e.g. road stops have a smaller catchment area than large airports.
-        In both cases the bounding box, the smallest rectangle that contains
-        all tiles of something, is searched for the target of the cargo,
-        and then spiraling outwards finding the closest tile of the target.
-
-        In the case of a station with two tiles spread far apart with a house
-        that is within the station's bounding box, it would be possible that
-        the spiraling search from the house does not reach one of the station
-        tiles before the search ends, i.e. all tiles within that distance
-        are searched. So the house does not deliver cargo to the station.
-        On the other hand, the station will deliver cargo because the house
-        falls within the bounding box, and thus search area.
-
-        It is possible to make these consistent, but then cargo from a house
-        to a station needs to search up to 32 tiles around itself, i.e. 64
-        by 64 tiles, to find all possible stations it could deliver to
-        instead of 10 by 10 tiles (40 times more tiles). Alternatively the
-        search from a station could be changed to use the actual tiles, but
-        that would require considering checking 10 by 10 tiles for each of
-        the tiles of a station, instead of just once.
-
 Some houses and industries are not affected by transparency [#5817]:
         Some of the default houses and industries (f.e. the iron ore mine) are
         not affected by the transparency options. This is because the graphics


### PR DESCRIPTION
## Motivation / Problem

Sometimes we forget to update `known-bugs.txt` when a bug is actually resolved.
Some items in the list are may not even be testable any longer.

## Description

- #7235 implemented in version 1.10 actually resolved #5661

## Limitations

Possible driver issues that may no longer be relevant but I'm not sure anyone can test for:
- #3294 (I don't remember any issues when running SDL + PulseAudio though)
- #3305 (possibly different for SDL 1 and 2?)
- #3447 (does anyone even attempt to make SDL builds for macOS any longer?)
- #4003 (anyone have a copy of Parallels Desktop on hand?)
- #4511 (I think 32 bpp blitter is default now, so only custom configs would possibly experience this)
- #4587 (anyone use MSYS and can retest this?)
- #4997 (possible SDL 1/2 difference? also recent changes to all video drivers may affect this)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
