### PR TITLE
Cmake fixes

### DIFF
--- a/cmake/CreateRegression.cmake
+++ b/cmake/CreateRegression.cmake
@@ -10,8 +10,8 @@ macro(create_regression)
     # build folder before we can run the regression
     file(GLOB_RECURSE REGRESSION_SOURCE_FILES ${CMAKE_SOURCE_DIR}/regression/*)
     foreach(REGRESSION_SOURCE_FILE IN LISTS REGRESSION_SOURCE_FILES)
-        string(REGEX REPLACE "^${CMAKE_SOURCE_DIR}/regression/" "${CMAKE_BINARY_DIR}/ai/" REGRESSION_BINARY_FILE "${REGRESSION_SOURCE_FILE}")
-        string(REGEX REPLACE "^${CMAKE_SOURCE_DIR}/regression/" "" REGRESSION_SOURCE_FILE_NAME "${REGRESSION_SOURCE_FILE}")
+        string(REPLACE "${CMAKE_SOURCE_DIR}/regression/" "" REGRESSION_SOURCE_FILE_NAME "${REGRESSION_SOURCE_FILE}")
+        string(CONCAT REGRESSION_BINARY_FILE "${CMAKE_BINARY_DIR}/ai/" "${REGRESSION_SOURCE_FILE_NAME}")
 
         if("${REGRESSION_SOURCE_FILE_NAME}" STREQUAL "regression.cfg")
             continue()

--- a/cmake/scripts/SquirrelIncludes.cmake
+++ b/cmake/scripts/SquirrelIncludes.cmake
@@ -16,10 +16,17 @@ endif()
 set(ARGC 1)
 set(ARG_READ NO)
 
+# For MSVC CMake runs this script from a batch file using || to detect errors,
+# depending on source path it may quote args, and cause cmd to not understand ||
+# and pass it as argument to ourself.
 # Read all the arguments given to CMake; we are looking for -- and everything
-# that follows. Those are our api files.
+# that follows, until ||. Those are our api files.
 while(ARGC LESS CMAKE_ARGC)
     set(ARG ${CMAKE_ARGV${ARGC}})
+
+    if(ARG STREQUAL "||")
+        set(ARG_READ NO)
+    endif()
 
     if(ARG_READ)
         list(APPEND SCRIPT_API_BINARY_FILES "${ARG}")


### PR DESCRIPTION
Fixes #8687

## Motivation / Problem
If path to openttd source contains special characters, CMake may fail to generate the build files.
If build files generation works, build may still fail later.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I solved an issue if path contains some regexp commands (example "Openttd(2++)").
Also solved the issue reported in #8687 (using "OpenTTD - cmake error" as source dir)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Compilation fails for "Openttd(2++)" but not for "Openttd (2++)", seems to depend on how ADD_CUSTOM_COMMAND decides to quote commands, and we can't do much about that.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
