### PR TITLE
Codechange: [OpenGL] Load all OpenGL functions dynamically.

### DIFF
--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1285,10 +1285,15 @@ static PFNWGLCREATECONTEXTATTRIBSARBPROC _wglCreateContextAttribsARB = nullptr;
 static PFNWGLSWAPINTERVALEXTPROC _wglSwapIntervalEXT = nullptr;
 static bool _hasWGLARBCreateContextProfile = false; ///< Is WGL_ARB_create_context_profile supported?
 
-/** Platform-specific callback to get an OpenGL funtion pointer. */
+/** Platform-specific callback to get an OpenGL function pointer. */
 static OGLProc GetOGLProcAddressCallback(const char *proc)
 {
-	return reinterpret_cast<OGLProc>(wglGetProcAddress(proc));
+	OGLProc ret = reinterpret_cast<OGLProc>(wglGetProcAddress(proc));
+	if (ret == nullptr) {
+		/* Non-extension GL function? Try normal loading. */
+		ret = reinterpret_cast<OGLProc>(GetProcAddress(GetModuleHandle(L"opengl32"), proc));
+	}
+	return ret;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Some Linux OpenGL drivers don't use the global system dispatch table.


## Description

Link all OpenGL functions dynamically to make sure we use the right one.


## Limitations

OpenGL headers are not uniform among systems, which might cause compile problems on more obscure systems.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
