### PR TITLE
Feature: Build train locomotive filter

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3561,6 +3561,7 @@ STR_PURCHASE_INFO_PWAGPOWER_PWAGWEIGHT                          :{BLACK}Powered 
 STR_PURCHASE_INFO_REFITTABLE_TO                                 :{BLACK}Refittable to: {GOLD}{STRING2}
 STR_PURCHASE_INFO_ALL_TYPES                                     :All cargo types
 STR_PURCHASE_INFO_NONE                                          :None
+STR_PURCHASE_INFO_ENGINES_ONLY                                  :Engines only
 STR_PURCHASE_INFO_ALL_BUT                                       :All but {CARGO_LIST}
 STR_PURCHASE_INFO_MAX_TE                                        :{BLACK}Max. Tractive Effort: {GOLD}{FORCE}
 STR_PURCHASE_INFO_AIRCRAFT_RANGE                                :{BLACK}Range: {GOLD}{COMMA} tiles


### PR DESCRIPTION
## Motivation / Problem

When creating a train, there is no way of filtering by engines, given that the 'None' cargo filter removes all engines that also carry cargo, typically passengers and mail. As a player, I want to be able to see all the available engines regardless of whether they can carry cargo or not. This is especially helpful when creating passenger trains.

## Description

This PR adds a new filter in the train vehicle window drop down menu so in addition to (1) any cargo, (2) no cargo, and (3) a specific cargo, players can also filter by engines only, regardless of whether they carry cargo or not.

This is how it looks, observe that some of the engines can carry passengers, like the selected one:

![image](https://user-images.githubusercontent.com/2025406/108806089-96f15380-7555-11eb-8454-dc1785aed06b.png)

Note that

```
static const CargoID CF_ANY     = CT_NO_REFIT;   ///< Show all vehicles independent of carried cargo (i.e. no filtering)
static const CargoID CF_NONE    = CT_INVALID;    ///< Show only vehicles which do not carry cargo (e.g. train engines)
static const CargoID CF_ENGINES = CT_AUTO_REFIT; ///< Show only engines (for rail vehicles only)
```

seems a little hacky to me, so I just reused the same pattern using CT_AUTO_REFIT as there wasn't a better option.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
