### PR TITLE
Fix #8731: Always use a 32bpp blitter if font anti-aliasing is enabled.

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -279,10 +279,10 @@ void TrueTypeFontCache::SetGlyphPtr(GlyphID key, const GlyphEntry *glyph, bool d
 
 
 /* Check if a glyph should be rendered with anti-aliasing. */
-static bool GetFontAAState(FontSize size)
+static bool GetFontAAState(FontSize size, bool check_blitter = true)
 {
 	/* AA is only supported for 32 bpp */
-	if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
+	if (check_blitter && BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
 
 	switch (size) {
 		default: NOT_REACHED();
@@ -714,6 +714,19 @@ void UninitFreeType()
 	FT_Done_FreeType(_library);
 	_library = nullptr;
 #endif /* WITH_FREETYPE */
+}
+
+/**
+ * Should any of the active fonts be anti-aliased?
+ * @return True if any of the loaded fonts want anti-aliased drawing.
+ */
+bool HasAntialiasedFonts()
+{
+	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
+		if (!FontCache::Get(fs)->IsBuiltInFont() && GetFontAAState(fs, false)) return true;
+	}
+
+	return false;
 }
 
 #if !defined(_WIN32) && !defined(__APPLE__) && !defined(WITH_FONTCONFIG) && !defined(WITH_COCOA)

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -233,5 +233,6 @@ extern FreeTypeSettings _freetype;
 
 void InitFreeType(bool monospace);
 void UninitFreeType();
+bool HasAntialiasedFonts();
 
 #endif /* FONTCACHE_H */

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -268,6 +268,8 @@ static bool SwitchNewGRFBlitter()
 		if (c->status == GCS_DISABLED || c->status == GCS_NOT_FOUND || HasBit(c->flags, GCF_INIT_ONLY)) continue;
 		if (c->palette & GRFP_BLT_32BPP) depth_wanted_by_grf = 32;
 	}
+	/* We need a 32bpp blitter for font anti-alias. */
+	if (HasAntialiasedFonts()) depth_wanted_by_grf = 32;
 
 	/* Search the best blitter. */
 	static const struct {

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -433,6 +433,7 @@ struct GameOptionsWindow : Window {
 				CheckForMissingGlyphs();
 				ClearAllCachedNames();
 				UpdateAllVirtCoords();
+				CheckBlitter();
 				ReInitAllWindows();
 				break;
 


### PR DESCRIPTION
## Motivation / Problem

OpenGL video drivers now sometimes cause an 8bpp blitter to be used. These can't do font anti-alias.


## Description

If any font should be anti-aliased, always use a 32bpp blitter.


## Limitations

Most video drivers result in a 32bpp anyway, so no real change for non-OpenGL video drivers.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
