### PR TITLE
Fix: vehicle-cursor size-limit did not account for the interface zoom level.

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3151,7 +3151,7 @@ void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type)
 	_cursor.sprite_count = 0;
 	int total_width = 0;
 	for (; v != nullptr; v = v->HasArticulatedPart() ? v->GetNextArticulatedPart() : nullptr) {
-		if (total_width >= 2 * (int)VEHICLEINFO_FULL_VEHICLE_WIDTH) break;
+		if (total_width >= ScaleGUITrad(2 * (int)VEHICLEINFO_FULL_VEHICLE_WIDTH)) break;
 
 		PaletteID pal = (v->vehstatus & VS_CRASHED) ? PALETTE_CRASH : GetVehiclePalette(v);
 		VehicleSpriteSeq seq;


### PR DESCRIPTION
## Motivation / Problem

When dragging vehicles in depot, the vehicles being dragged are used as mouse cursor.
While this looks good for short and medium length vehicles, it becomes inconvenient for very long articulated vehicles. (some sets define 5-unit long vehicles).

Thus OpenTTD enforces a maximum length for vehicles as mouse cursor, and then cuts the vehicle.
However, this limit currently does not scale by GUI zoom level. With GUI zoom enabled, the cursor is smaller than expected.

## Description

This PR scales the cursor size limit by the interface zoom level.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
