### PR TITLE
More code cleanups in video drivers

### DIFF
--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -329,7 +329,7 @@ static uint32 ConvertAllegroKeyIntoMy(WChar *character)
 static const uint LEFT_BUTTON  = 0;
 static const uint RIGHT_BUTTON = 1;
 
-static void PollEvent()
+bool VideoDriver_Allegro::PollEvent()
 {
 	poll_mouse();
 
@@ -403,6 +403,8 @@ static void PollEvent()
 		uint keycode = ConvertAllegroKeyIntoMy(&character);
 		HandleKeypress(keycode, character);
 	}
+
+	return false;
 }
 
 /**
@@ -482,7 +484,6 @@ void VideoDriver_Allegro::MainLoop()
 	for (;;) {
 		InteractiveRandom(); // randomness
 
-		PollEvent();
 		if (_exit_game) return;
 
 		if (this->Tick()) {

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -482,8 +482,6 @@ void VideoDriver_Allegro::InputLoop()
 void VideoDriver_Allegro::MainLoop()
 {
 	for (;;) {
-		InteractiveRandom(); // randomness
-
 		if (_exit_game) return;
 
 		if (this->Tick()) {

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -37,6 +37,7 @@ protected:
 	void InputLoop() override;
 	void Paint() override;
 	void CheckPaletteAnim() override;
+	bool PollEvent() override;
 };
 
 /** Factory for the allegro video driver. */

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -49,7 +49,7 @@ public:
 
 	/* --- The following methods should be private, but can't be due to Obj-C limitations. --- */
 
-	void GameLoop();
+	void MainLoopReal();
 
 	virtual void AllocateBackingStore(bool force = false) = 0;
 

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -62,6 +62,7 @@ protected:
 	void InputLoop() override;
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
+	bool PollEvent() override;
 
 	void GameSizeChanged();
 
@@ -79,8 +80,6 @@ protected:
 	virtual void ReleaseVideoPointer() {}
 
 private:
-	bool PollEvent();
-
 	bool IsFullscreen();
 };
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -440,8 +440,6 @@ void VideoDriver_Cocoa::GameLoop()
 
 			InteractiveRandom(); // randomness
 
-			while (this->PollEvent()) {}
-
 			if (_exit_game) {
 				/* Restore saved resolution if in fullscreen mode. */
 				if (this->IsFullscreen()) _cur_resolution = this->orig_res;

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -433,7 +433,7 @@ void VideoDriver_Cocoa::InputLoop()
 }
 
 /** Main game loop. */
-void VideoDriver_Cocoa::GameLoop()
+void VideoDriver_Cocoa::MainLoopReal()
 {
 	for (;;) {
 		@autoreleasepool {

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -437,9 +437,6 @@ void VideoDriver_Cocoa::GameLoop()
 {
 	for (;;) {
 		@autoreleasepool {
-
-			InteractiveRandom(); // randomness
-
 			if (_exit_game) {
 				/* Restore saved resolution if in fullscreen mode. */
 				if (this->IsFullscreen()) _cur_resolution = this->orig_res;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -152,7 +152,7 @@ static std::vector<WChar> NSStringToUTF32(NSString *s)
 	[ e release ];
 
 	/* Hand off to main application code. */
-	drv->GameLoop();
+	drv->MainLoopReal();
 
 	/* We are done, thank you for playing. */
 	[ self performSelectorOnMainThread:@selector(stopEngine) withObject:nil waitUntilDone:FALSE ];

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -275,8 +275,6 @@ void VideoDriver_Dedicated::MainLoop()
 	}
 
 	while (!_exit_game) {
-		InteractiveRandom(); // randomness
-
 		if (!_dedicated_forks) DedicatedHandleKeyInput();
 
 		_fast_forward = _ddc_fastforward;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -370,11 +370,11 @@ static uint ConvertSdlKeycodeIntoMy(SDL_Keycode kc)
 	return key;
 }
 
-int VideoDriver_SDL_Base::PollEvent()
+bool VideoDriver_SDL_Base::PollEvent()
 {
 	SDL_Event ev;
 
-	if (!SDL_PollEvent(&ev)) return -2;
+	if (!SDL_PollEvent(&ev)) return false;
 
 	switch (ev.type) {
 		case SDL_MOUSEMOTION:
@@ -516,7 +516,8 @@ int VideoDriver_SDL_Base::PollEvent()
 			break;
 		}
 	}
-	return -1;
+
+	return true;
 }
 
 static const char *InitializeSDL()
@@ -629,7 +630,6 @@ void VideoDriver_SDL_Base::LoopOnce()
 {
 	InteractiveRandom(); // randomness
 
-	while (PollEvent() == -1) {}
 	if (_exit_game) {
 #ifdef __EMSCRIPTEN__
 		/* Emscripten is event-driven, and as such the main loop is inside

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -628,8 +628,6 @@ void VideoDriver_SDL_Base::InputLoop()
 
 void VideoDriver_SDL_Base::LoopOnce()
 {
-	InteractiveRandom(); // randomness
-
 	if (_exit_game) {
 #ifdef __EMSCRIPTEN__
 		/* Emscripten is event-driven, and as such the main loop is inside

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -60,6 +60,7 @@ protected:
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
 	void CheckPaletteAnim() override;
+	bool PollEvent() override;
 
 	/** Indicate to the driver the client-side might have changed. */
 	void ClientSizeChanged(int w, int h, bool force);
@@ -74,7 +75,6 @@ protected:
 	virtual bool CreateMainWindow(uint w, uint h, uint flags = 0);
 
 private:
-	int PollEvent();
 	void LoopOnce();
 	void MainLoopCleanup();
 	bool CreateMainSurface(uint w, uint h, bool resize);

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -718,8 +718,6 @@ void VideoDriver_SDL::MainLoop()
 	DEBUG(driver, 1, "SDL: using %sthreads", _draw_threaded ? "" : "no ");
 
 	for (;;) {
-		InteractiveRandom(); // randomness
-
 		if (_exit_game) break;
 
 		if (this->Tick()) {

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -507,11 +507,11 @@ static uint ConvertSdlKeyIntoMy(SDL_keysym *sym, WChar *character)
 	return key;
 }
 
-int VideoDriver_SDL::PollEvent()
+bool VideoDriver_SDL::PollEvent()
 {
 	SDL_Event ev;
 
-	if (!SDL_PollEvent(&ev)) return -2;
+	if (!SDL_PollEvent(&ev)) return false;
 
 	switch (ev.type) {
 		case SDL_MOUSEMOTION:
@@ -598,7 +598,8 @@ int VideoDriver_SDL::PollEvent()
 			break;
 		}
 	}
-	return -1;
+
+	return true;
 }
 
 const char *VideoDriver_SDL::Start(const StringList &parm)
@@ -719,7 +720,6 @@ void VideoDriver_SDL::MainLoop()
 	for (;;) {
 		InteractiveRandom(); // randomness
 
-		while (PollEvent() == -1) {}
 		if (_exit_game) break;
 
 		if (this->Tick()) {

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -43,12 +43,12 @@ protected:
 	void UnlockVideoBuffer() override;
 	void Paint() override;
 	void PaintThread() override;
-	void CheckPaletteAnim();
+	void CheckPaletteAnim() override;
+	bool PollEvent() override;
 
 private:
 	std::unique_lock<std::recursive_mutex> draw_lock;
 
-	int PollEvent();
 	bool CreateMainSurface(uint w, uint h);
 	void SetupKeyboard();
 

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -55,6 +55,7 @@ bool VideoDriver::Tick()
 		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 		if (this->next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) this->next_draw_tick = cur_ticks;
 
+		while (this->PollEvent()) {}
 		this->InputLoop();
 		::InputLoop();
 		UpdateWindows();

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -9,6 +9,7 @@
 
 #include "../stdafx.h"
 #include "../debug.h"
+#include "../core/random_func.hpp"
 #include "../gfx_func.h"
 #include "../progress.h"
 #include "../thread.h"
@@ -24,6 +25,10 @@ bool VideoDriver::Tick()
 		auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - this->last_realtime_tick);
 		_realtime_tick += delta.count();
 		this->last_realtime_tick += delta;
+
+		/* Keep the interactive randomizer a bit more random by requesting
+		 * new values when-ever we can. */
+		InteractiveRandom();
 	}
 
 	if (cur_ticks >= this->next_game_tick || (_fast_forward && !_pause_mode)) {

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -250,6 +250,12 @@ protected:
 	virtual void CheckPaletteAnim() {}
 
 	/**
+	 * Process a single system event.
+	 * @returns False if there are no more events to process.
+	 */
+	virtual bool PollEvent() { return false; };
+
+	/**
 	 * Run the game for a single tick, processing boththe game-tick and draw-tick.
 	 * @returns True if the driver should redraw the screen.
 	 */

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -857,10 +857,21 @@ void VideoDriver_Win32Base::InputLoop()
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 }
 
-void VideoDriver_Win32Base::MainLoop()
+bool VideoDriver_Win32Base::PollEvent()
 {
 	MSG mesg;
 
+	if (!PeekMessage(&mesg, nullptr, 0, 0, PM_REMOVE)) return false;
+
+	/* Convert key messages to char messages if we want text input. */
+	if (EditBoxInGlobalFocus()) TranslateMessage(&mesg);
+	DispatchMessage(&mesg);
+
+	return true;
+}
+
+void VideoDriver_Win32Base::MainLoop()
+{
 	std::thread draw_thread;
 
 	if (this->draw_threaded) {
@@ -898,11 +909,6 @@ void VideoDriver_Win32Base::MainLoop()
 	for (;;) {
 		InteractiveRandom(); // randomness
 
-		while (PeekMessage(&mesg, nullptr, 0, 0, PM_REMOVE)) {
-			/* Convert key messages to char messages if we want text input. */
-			if (EditBoxInGlobalFocus()) TranslateMessage(&mesg);
-			DispatchMessage(&mesg);
-		}
 		if (_exit_game) break;
 
 		/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -907,8 +907,6 @@ void VideoDriver_Win32Base::MainLoop()
 	}
 
 	for (;;) {
-		InteractiveRandom(); // randomness
-
 		if (_exit_game) break;
 
 		/* Flush GDI buffer to ensure we don't conflict with the drawing thread. */

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -60,6 +60,7 @@ protected:
 	bool LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
 	void CheckPaletteAnim() override;
+	bool PollEvent() override;
 
 	void Initialize();
 	bool MakeWindow(bool full_screen);


### PR DESCRIPTION
## Motivation / Problem

While working on another PR, I had to synchronize a few more things between the different video drivers. Without that PR, these are already helping to make the video drivers a bit more the same.

## Description

- `PollEvent` was doing nearly the same on different drivers, but with different return values.
- `InteractiveRandom` was called in the `MainLoop` but can be done from `Tick` too (deduplication)
- OSX has a weird quirk

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
