### PR TITLE
Move GameLoop into a thread (and no longer run Paint in a thread)

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1480,9 +1480,7 @@ void DrawDirtyBlocks()
 		if (!IsFirstModalProgressLoop()) CSleep(MODAL_PROGRESS_REDRAW_TIMEOUT);
 
 		/* Modal progress thread may need blitter access while we are waiting for it. */
-		VideoDriver::GetInstance()->ReleaseBlitterLock();
 		_modal_progress_paint_mutex.lock();
-		VideoDriver::GetInstance()->AcquireBlitterLock();
 		_modal_progress_work_mutex.lock();
 
 		/* When we ended with the modal progress, do not draw the blocks.

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -295,8 +295,6 @@ static bool SwitchNewGRFBlitter()
 	const bool animation_wanted = HasBit(_display_opt, DO_FULL_ANIMATION);
 	const char *cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
 
-	VideoDriver::GetInstance()->AcquireBlitterLock();
-
 	for (uint i = 0; i < lengthof(replacement_blitters); i++) {
 		if (animation_wanted && (replacement_blitters[i].animation == 0)) continue;
 		if (!animation_wanted && (replacement_blitters[i].animation == 1)) continue;
@@ -306,7 +304,6 @@ static bool SwitchNewGRFBlitter()
 		const char *repl_blitter = replacement_blitters[i].name;
 
 		if (strcmp(repl_blitter, cur_blitter) == 0) {
-			VideoDriver::GetInstance()->ReleaseBlitterLock();
 			return false;
 		}
 		if (BlitterFactory::GetBlitterFactory(repl_blitter) == nullptr) continue;
@@ -322,8 +319,6 @@ static bool SwitchNewGRFBlitter()
 		/* Failed to switch blitter, let's hope we can return to the old one. */
 		if (BlitterFactory::SelectBlitter(cur_blitter) == nullptr || !VideoDriver::GetInstance()->AfterBlitterChange()) usererror("Failed to reinitialize video driver. Specify a fixed blitter in the config");
 	}
-
-	VideoDriver::GetInstance()->ReleaseBlitterLock();
 
 	return true;
 }

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -308,16 +308,9 @@ static bool SwitchNewGRFBlitter()
 		}
 		if (BlitterFactory::GetBlitterFactory(repl_blitter) == nullptr) continue;
 
-		DEBUG(misc, 1, "Switching blitter from '%s' to '%s'... ", cur_blitter, repl_blitter);
-		Blitter *new_blitter = BlitterFactory::SelectBlitter(repl_blitter);
-		if (new_blitter == nullptr) NOT_REACHED();
-		DEBUG(misc, 1, "Successfully switched to %s.", repl_blitter);
+		/* Inform the video driver we want to switch blitter as soon as possible. */
+		VideoDriver::GetInstance()->ChangeBlitter(repl_blitter);
 		break;
-	}
-
-	if (!VideoDriver::GetInstance()->AfterBlitterChange()) {
-		/* Failed to switch blitter, let's hope we can return to the old one. */
-		if (BlitterFactory::SelectBlitter(cur_blitter) == nullptr || !VideoDriver::GetInstance()->AfterBlitterChange()) usererror("Failed to reinitialize video driver. Specify a fixed blitter in the config");
 	}
 
 	return true;

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -412,7 +412,7 @@ bool VideoDriver_Allegro::PollEvent()
  */
 int _allegro_instance_count = 0;
 
-const char *VideoDriver_Allegro::Start(const StringList &parm)
+const char *VideoDriver_Allegro::Start(const StringList &param)
 {
 	if (_allegro_instance_count == 0 && install_allegro(SYSTEM_AUTODETECT, &errno, nullptr)) {
 		DEBUG(driver, 0, "allegro: install_allegro failed '%s'", allegro_error);
@@ -439,6 +439,8 @@ const char *VideoDriver_Allegro::Start(const StringList &parm)
 	}
 	MarkWholeScreenDirty();
 	set_close_button_callback(HandleExitGameRequest);
+
+	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
 	return nullptr;
 }
@@ -475,12 +477,16 @@ void VideoDriver_Allegro::InputLoop()
 
 void VideoDriver_Allegro::MainLoop()
 {
+	this->StartGameThread();
+
 	for (;;) {
-		if (_exit_game) return;
+		if (_exit_game) break;
 
 		this->Tick();
 		this->SleepTillNextTick();
 	}
+
+	this->StopGameThread();
 }
 
 bool VideoDriver_Allegro::ChangeResolution(int w, int h)

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -478,9 +478,7 @@ void VideoDriver_Allegro::MainLoop()
 	for (;;) {
 		if (_exit_game) return;
 
-		if (this->Tick()) {
-			this->Paint();
-		}
+		this->Tick();
 		this->SleepTillNextTick();
 	}
 }

--- a/src/video/cocoa/cocoa_ogl.h
+++ b/src/video/cocoa/cocoa_ogl.h
@@ -33,6 +33,8 @@ public:
 
 	void ClearSystemSprites() override;
 
+	void PopulateSystemSprites() override;
+
 	bool HasAnimBuffer() override { return true; }
 	uint8 *GetAnimBuffer() override { return this->anim_buffer; }
 

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -214,6 +214,8 @@ const char *VideoDriver_CocoaOpenGL::Start(const StringList &param)
 	this->UpdateVideoModes();
 	MarkWholeScreenDirty();
 
+	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
+
 	return nullptr;
 
 }
@@ -225,6 +227,11 @@ void VideoDriver_CocoaOpenGL::Stop()
 	CGLSetCurrentContext(this->gl_context);
 	OpenGLBackend::Destroy();
 	CGLReleaseContext(this->gl_context);
+}
+
+void VideoDriver_CocoaOpenGL::PopulateSystemSprites()
+{
+	OpenGLBackend::Get()->PopulateCursorCache();
 }
 
 void VideoDriver_CocoaOpenGL::ClearSystemSprites()

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -435,6 +435,8 @@ void VideoDriver_Cocoa::InputLoop()
 /** Main game loop. */
 void VideoDriver_Cocoa::MainLoopReal()
 {
+	this->StartGameThread();
+
 	for (;;) {
 		@autoreleasepool {
 			if (_exit_game) {
@@ -447,6 +449,8 @@ void VideoDriver_Cocoa::MainLoopReal()
 			this->SleepTillNextTick();
 		}
 	}
+
+	this->StopGameThread();
 }
 
 
@@ -557,6 +561,8 @@ const char *VideoDriver_CocoaQuartz::Start(const StringList &param)
 
 	this->GameSizeChanged();
 	this->UpdateVideoModes();
+
+	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
 	return nullptr;
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -443,9 +443,7 @@ void VideoDriver_Cocoa::MainLoopReal()
 				break;
 			}
 
-			if (this->Tick()) {
-				this->Paint();
-			}
+			this->Tick();
 			this->SleepTillNextTick();
 		}
 	}

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -267,6 +267,8 @@ void VideoDriver_Dedicated::MainLoop()
 		}
 	}
 
+	this->is_game_threaded = false;
+
 	/* Done loading, start game! */
 
 	if (!_networking) {

--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -48,9 +48,9 @@ void VideoDriver_Null::MainLoop()
 	uint i;
 
 	for (i = 0; i < this->ticks; i++) {
-		GameLoop();
-		InputLoop();
-		UpdateWindows();
+		::GameLoop();
+		::InputLoop();
+		::UpdateWindows();
 	}
 }
 

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1036,7 +1036,23 @@ void OpenGLBackend::DrawMouseCursor()
 	_cur_dpi = &_screen;
 	for (uint i = 0; i < _cursor.sprite_count; ++i) {
 		SpriteID sprite = _cursor.sprite_seq[i].sprite;
-		const Sprite *spr = GetSprite(sprite, ST_NORMAL);
+
+		/* Sprites are cached by PopulateCursorCache(). */
+		if (this->cursor_cache.Contains(sprite)) {
+			const Sprite *spr = GetSprite(sprite, ST_NORMAL);
+
+			this->RenderOglSprite((OpenGLSprite *)this->cursor_cache.Get(sprite)->data, _cursor.sprite_seq[i].pal,
+					_cursor.pos.x + _cursor.sprite_pos[i].x + UnScaleByZoom(spr->x_offs, ZOOM_LVL_GUI),
+					_cursor.pos.y + _cursor.sprite_pos[i].y + UnScaleByZoom(spr->y_offs, ZOOM_LVL_GUI),
+					ZOOM_LVL_GUI);
+		}
+	}
+}
+
+void OpenGLBackend::PopulateCursorCache()
+{
+	for (uint i = 0; i < _cursor.sprite_count; ++i) {
+		SpriteID sprite = _cursor.sprite_seq[i].sprite;
 
 		if (!this->cursor_cache.Contains(sprite)) {
 			Sprite *old = this->cursor_cache.Insert(sprite, (Sprite *)GetRawSprite(sprite, ST_NORMAL, &SimpleSpriteAlloc, this));
@@ -1046,11 +1062,6 @@ void OpenGLBackend::DrawMouseCursor()
 				free(old);
 			}
 		}
-
-		this->RenderOglSprite((OpenGLSprite *)this->cursor_cache.Get(sprite)->data, _cursor.sprite_seq[i].pal,
-				_cursor.pos.x + _cursor.sprite_pos[i].x + UnScaleByZoom(spr->x_offs, ZOOM_LVL_GUI),
-				_cursor.pos.y + _cursor.sprite_pos[i].y + UnScaleByZoom(spr->y_offs, ZOOM_LVL_GUI),
-				ZOOM_LVL_GUI);
 	}
 }
 

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -88,6 +88,7 @@ public:
 	void Paint();
 
 	void DrawMouseCursor();
+	void PopulateCursorCache();
 	void ClearCursorCache();
 
 	void *GetVideoBuffer();

--- a/src/video/sdl2_default_v.cpp
+++ b/src/video/sdl2_default_v.cpp
@@ -136,22 +136,6 @@ void VideoDriver_SDL_Default::Paint()
 	this->dirty_rect = {};
 }
 
-void VideoDriver_SDL_Default::PaintThread()
-{
-	/* First tell the main thread we're started */
-	std::unique_lock<std::recursive_mutex> lock(*this->draw_mutex);
-	this->draw_signal->notify_one();
-
-	/* Now wait for the first thing to draw! */
-	this->draw_signal->wait(*this->draw_mutex);
-
-	while (this->draw_continue) {
-		/* Then just draw and wait till we stop */
-		this->Paint();
-		this->draw_signal->wait(lock);
-	}
-}
-
 bool VideoDriver_SDL_Default::AllocateBackingStore(int w, int h, bool force)
 {
 	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();

--- a/src/video/sdl2_default_v.cpp
+++ b/src/video/sdl2_default_v.cpp
@@ -107,13 +107,7 @@ void VideoDriver_SDL_Default::Paint()
 				break;
 
 			case Blitter::PALETTE_ANIMATION_BLITTER: {
-				bool need_buf = _screen.dst_ptr == nullptr;
-				if (need_buf) _screen.dst_ptr = this->GetVideoPointer();
 				blitter->PaletteAnimate(this->local_palette);
-				if (need_buf) {
-					this->ReleaseVideoPointer();
-					_screen.dst_ptr = nullptr;
-				}
 				break;
 			}
 

--- a/src/video/sdl2_default_v.h
+++ b/src/video/sdl2_default_v.h
@@ -21,7 +21,6 @@ protected:
 	bool AllocateBackingStore(int w, int h, bool force = false) override;
 	void *GetVideoPointer() override;
 	void Paint() override;
-	void PaintThread() override;
 
 	void ReleaseVideoPointer() override {}
 

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -110,6 +110,11 @@ const char *VideoDriver_SDL_OpenGL::AllocateContext()
 	return OpenGLBackend::Create(&GetOGLProcAddressCallback);
 }
 
+void VideoDriver_SDL_OpenGL::PopulateSystemSprites()
+{
+	OpenGLBackend::Get()->PopulateCursorCache();
+}
+
 void VideoDriver_SDL_OpenGL::ClearSystemSprites()
 {
 	OpenGLBackend::Get()->ClearCursorCache();

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -71,7 +71,6 @@ const char *VideoDriver_SDL_OpenGL::Start(const StringList &param)
 	this->ClientSizeChanged(w, h, true);
 
 	SDL_GL_SetSwapInterval(GetDriverParamBool(param, "vsync") ? 1 : 0);
-	this->draw_threaded = false;
 
 	return nullptr;
 }

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -36,8 +36,6 @@ protected:
 	void Paint() override;
 	bool CreateMainWindow(uint w, uint h, uint flags) override;
 
-	void PaintThread() override {}
-
 private:
 	void  *gl_context;  ///< OpenGL context.
 	uint8 *anim_buffer; ///< Animation buffer from OpenGL back-end.

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -24,6 +24,8 @@ public:
 
 	void ClearSystemSprites() override;
 
+	void PopulateSystemSprites() override;
+
 	bool HasAnimBuffer() override { return true; }
 	uint8 *GetAnimBuffer() override { return this->anim_buffer; }
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -23,7 +23,6 @@
 #include "../window_func.h"
 #include "sdl2_v.h"
 #include <SDL.h>
-#include <mutex>
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>
 #	include <emscripten/html5.h>
@@ -48,11 +47,6 @@ void VideoDriver_SDL_Base::CheckPaletteAnim()
 
 	this->local_palette = _cur_palette;
 	this->MakeDirty(0, 0, _screen.width, _screen.height);
-}
-
-/* static */ void VideoDriver_SDL_Base::PaintThreadThunk(VideoDriver_SDL_Base *drv)
-{
-	drv->PaintThread();
 }
 
 static const Dimension default_resolutions[] = {
@@ -565,19 +559,6 @@ const char *VideoDriver_SDL_Base::Start(const StringList &parm)
 
 	MarkWholeScreenDirty();
 
-	this->draw_threaded = !GetDriverParamBool(parm, "no_threads") && !GetDriverParamBool(parm, "no_thread");
-	/* Wayland SDL video driver uses EGL to render the game. SDL created the
-	 * EGL context from the main-thread, and with EGL you are not allowed to
-	 * draw in another thread than the context was created. The function of
-	 * draw_threaded is to do exactly this: draw in another thread than the
-	 * window was created, and as such, this fails on Wayland SDL video
-	 * driver. So, we disable threading by default if Wayland SDL video
-	 * driver is detected.
-	 */
-	if (strcmp(dname, "wayland") == 0) {
-		this->draw_threaded = false;
-	}
-
 	SDL_StopTextInput();
 	this->edit_box_focused = false;
 
@@ -631,18 +612,17 @@ void VideoDriver_SDL_Base::LoopOnce()
 		 * After that, Emscripten just halts, and the HTML shows a nice
 		 * "bye, see you next time" message. */
 		emscripten_cancel_main_loop();
-		MainLoopCleanup();
+		emscripten_exit_pointerlock();
+		/* In effect, the game ends here. As emscripten_set_main_loop() caused
+		 * the stack to be unwound, the code after MainLoop() in
+		 * openttd_main() is never executed. */
+		EM_ASM(if (window["openttd_syncfs"]) openttd_syncfs());
+		EM_ASM(if (window["openttd_exit"]) openttd_exit());
 #endif
 		return;
 	}
 
-	if (VideoDriver::Tick()) {
-		if (this->draw_mutex != nullptr && !HasModalProgress()) {
-			this->draw_signal->notify_one();
-		} else {
-			this->Paint();
-		}
-	}
+	this->Tick();
 
 /* Emscripten is running an event-based mainloop; there is already some
  * downtime between each iteration, so no need to sleep. */
@@ -653,36 +633,6 @@ void VideoDriver_SDL_Base::LoopOnce()
 
 void VideoDriver_SDL_Base::MainLoop()
 {
-	if (this->draw_threaded) {
-		/* Initialise the mutex first, because that's the thing we *need*
-		 * directly in the newly created thread. */
-		this->draw_mutex = new std::recursive_mutex();
-		if (this->draw_mutex == nullptr) {
-			this->draw_threaded = false;
-		} else {
-			draw_lock = std::unique_lock<std::recursive_mutex>(*this->draw_mutex);
-			this->draw_signal = new std::condition_variable_any();
-			this->draw_continue = true;
-
-			this->draw_threaded = StartNewThread(&draw_thread, "ottd:draw-sdl", &VideoDriver_SDL_Base::PaintThreadThunk, this);
-
-			/* Free the mutex if we won't be able to use it. */
-			if (!this->draw_threaded) {
-				draw_lock.unlock();
-				draw_lock.release();
-				delete this->draw_mutex;
-				delete this->draw_signal;
-				this->draw_mutex = nullptr;
-				this->draw_signal = nullptr;
-			} else {
-				/* Wait till the draw mutex has started itself. */
-				this->draw_signal->wait(*this->draw_mutex);
-			}
-		}
-	}
-
-	DEBUG(driver, 1, "SDL2: using %sthreads", this->draw_threaded ? "" : "no ");
-
 #ifdef __EMSCRIPTEN__
 	/* Run the main loop event-driven, based on RequestAnimationFrame. */
 	emscripten_set_main_loop_arg(&this->EmscriptenLoop, this, 0, 1);
@@ -690,52 +640,16 @@ void VideoDriver_SDL_Base::MainLoop()
 	while (!_exit_game) {
 		LoopOnce();
 	}
-
-	MainLoopCleanup();
-#endif
-}
-
-void VideoDriver_SDL_Base::MainLoopCleanup()
-{
-	if (this->draw_mutex != nullptr) {
-		this->draw_continue = false;
-		/* Sending signal if there is no thread blocked
-		 * is very valid and results in noop */
-		this->draw_signal->notify_one();
-		if (draw_lock.owns_lock()) draw_lock.unlock();
-		draw_lock.release();
-		draw_thread.join();
-
-		delete this->draw_mutex;
-		delete this->draw_signal;
-
-		this->draw_mutex = nullptr;
-		this->draw_signal = nullptr;
-	}
-
-#ifdef __EMSCRIPTEN__
-	emscripten_exit_pointerlock();
-	/* In effect, the game ends here. As emscripten_set_main_loop() caused
-	 * the stack to be unwound, the code after MainLoop() in
-	 * openttd_main() is never executed. */
-	EM_ASM(if (window["openttd_syncfs"]) openttd_syncfs());
-	EM_ASM(if (window["openttd_exit"]) openttd_exit());
 #endif
 }
 
 bool VideoDriver_SDL_Base::ChangeResolution(int w, int h)
 {
-	std::unique_lock<std::recursive_mutex> lock;
-	if (this->draw_mutex != nullptr) lock = std::unique_lock<std::recursive_mutex>(*this->draw_mutex);
-
 	return CreateMainSurface(w, h, true);
 }
 
 bool VideoDriver_SDL_Base::ToggleFullscreen(bool fullscreen)
 {
-	std::unique_lock<std::recursive_mutex> lock;
-	if (this->draw_mutex != nullptr) lock = std::unique_lock<std::recursive_mutex>(*this->draw_mutex);
-
 	int w, h;
 
 	/* Remember current window size */
@@ -773,16 +687,6 @@ bool VideoDriver_SDL_Base::AfterBlitterChange()
 	return CreateMainSurface(w, h, false);
 }
 
-void VideoDriver_SDL_Base::AcquireBlitterLock()
-{
-	if (this->draw_mutex != nullptr) this->draw_mutex->lock();
-}
-
-void VideoDriver_SDL_Base::ReleaseBlitterLock()
-{
-	if (this->draw_mutex != nullptr) this->draw_mutex->unlock();
-}
-
 Dimension VideoDriver_SDL_Base::GetScreenSize() const
 {
 	SDL_DisplayMode mode;
@@ -795,8 +699,6 @@ bool VideoDriver_SDL_Base::LockVideoBuffer()
 {
 	if (this->buffer_locked) return false;
 	this->buffer_locked = true;
-
-	if (this->draw_threaded) this->draw_lock.lock();
 
 	_screen.dst_ptr = this->GetVideoPointer();
 	assert(_screen.dst_ptr != nullptr);
@@ -812,6 +714,5 @@ void VideoDriver_SDL_Base::UnlockVideoBuffer()
 		_screen.dst_ptr = nullptr;
 	}
 
-	if (this->draw_threaded) this->draw_lock.unlock();
 	this->buffer_locked = false;
 }

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -33,10 +33,6 @@ public:
 
 	bool AfterBlitterChange() override;
 
-	void AcquireBlitterLock() override;
-
-	void ReleaseBlitterLock() override;
-
 	bool ClaimMousePointer() override;
 
 	void EditBoxGainedFocus() override;
@@ -48,10 +44,6 @@ public:
 protected:
 	struct SDL_Window *sdl_window; ///< Main SDL window.
 	Palette local_palette; ///< Copy of _cur_palette.
-	bool draw_threaded; ///< Whether the drawing is/may be done in a separate thread.
-	std::recursive_mutex *draw_mutex = nullptr; ///< Mutex to keep the access to the shared memory controlled.
-	std::condition_variable_any *draw_signal = nullptr; ///< Signal to draw the next frame.
-	volatile bool draw_continue; ///< Should we keep continue drawing?
 	bool buffer_locked; ///< Video buffer was locked by the main thread.
 	Rect dirty_rect; ///< Rectangle encompassing the dirty area of the video buffer.
 
@@ -91,10 +83,6 @@ private:
 	bool edit_box_focused;
 
 	int startup_display;
-	std::thread draw_thread;
-	std::unique_lock<std::recursive_mutex> draw_lock;
-
-	static void PaintThreadThunk(VideoDriver_SDL_Base *drv);
 };
 
 #endif /* VIDEO_SDL_H */

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -23,8 +23,6 @@
 #include "../window_func.h"
 #include "sdl_v.h"
 #include <SDL.h>
-#include <mutex>
-#include <condition_variable>
 
 #include "../safeguards.h"
 
@@ -34,14 +32,6 @@ static SDL_Surface *_sdl_surface;
 static SDL_Surface *_sdl_realscreen;
 static bool _all_modes;
 
-/** Whether the drawing is/may be done in a separate thread. */
-static bool _draw_threaded;
-/** Mutex to keep the access to the shared memory controlled. */
-static std::recursive_mutex *_draw_mutex = nullptr;
-/** Signal to draw the next frame. */
-static std::condition_variable_any *_draw_signal = nullptr;
-/** Should we keep continue drawing? */
-static volatile bool _draw_continue;
 static Palette _local_palette;
 
 #define MAX_DIRTY_RECTS 100
@@ -172,27 +162,6 @@ void VideoDriver_SDL::Paint()
 
 		SDL_UpdateRects(_sdl_realscreen, n, _dirty_rects);
 	}
-}
-
-void VideoDriver_SDL::PaintThread()
-{
-	/* First tell the main thread we're started */
-	std::unique_lock<std::recursive_mutex> lock(*_draw_mutex);
-	_draw_signal->notify_one();
-
-	/* Now wait for the first thing to draw! */
-	_draw_signal->wait(*_draw_mutex);
-
-	while (_draw_continue) {
-		/* Then just draw and wait till we stop */
-		this->Paint();
-		_draw_signal->wait(lock);
-	}
-}
-
-/* static */ void VideoDriver_SDL::PaintThreadThunk(VideoDriver_SDL *drv)
-{
-	drv->PaintThread();
 }
 
 static const Dimension _default_resolutions[] = {
@@ -630,8 +599,6 @@ const char *VideoDriver_SDL::Start(const StringList &parm)
 	MarkWholeScreenDirty();
 	SetupKeyboard();
 
-	_draw_threaded = !GetDriverParamBool(parm, "no_threads") && !GetDriverParamBool(parm, "no_thread");
-
 	return nullptr;
 }
 
@@ -680,80 +647,21 @@ void VideoDriver_SDL::InputLoop()
 
 void VideoDriver_SDL::MainLoop()
 {
-	std::thread draw_thread;
-	if (_draw_threaded) {
-		/* Initialise the mutex first, because that's the thing we *need*
-		 * directly in the newly created thread. */
-		_draw_mutex = new std::recursive_mutex();
-		if (_draw_mutex == nullptr) {
-			_draw_threaded = false;
-		} else {
-			this->draw_lock = std::unique_lock<std::recursive_mutex>(*_draw_mutex);
-			_draw_signal = new std::condition_variable_any();
-			_draw_continue = true;
-
-			_draw_threaded = StartNewThread(&draw_thread, "ottd:draw-sdl", &VideoDriver_SDL::PaintThreadThunk, this);
-
-			/* Free the mutex if we won't be able to use it. */
-			if (!_draw_threaded) {
-				this->draw_lock.unlock();
-				this->draw_lock.release();
-				delete _draw_mutex;
-				delete _draw_signal;
-				_draw_mutex = nullptr;
-				_draw_signal = nullptr;
-			} else {
-				/* Wait till the draw mutex has started itself. */
-				_draw_signal->wait(*_draw_mutex);
-			}
-		}
-	}
-
-	DEBUG(driver, 1, "SDL: using %sthreads", _draw_threaded ? "" : "no ");
-
 	for (;;) {
 		if (_exit_game) break;
 
-		if (this->Tick()) {
-			if (_draw_mutex != nullptr && !HasModalProgress()) {
-				_draw_signal->notify_one();
-			} else {
-				this->Paint();
-			}
-		}
+		this->Tick();
 		this->SleepTillNextTick();
-	}
-
-	if (_draw_mutex != nullptr) {
-		_draw_continue = false;
-		/* Sending signal if there is no thread blocked
-		 * is very valid and results in noop */
-		_draw_signal->notify_one();
-		if (this->draw_lock.owns_lock()) this->draw_lock.unlock();
-		this->draw_lock.release();
-		draw_thread.join();
-
-		delete _draw_mutex;
-		delete _draw_signal;
-
-		_draw_mutex = nullptr;
-		_draw_signal = nullptr;
 	}
 }
 
 bool VideoDriver_SDL::ChangeResolution(int w, int h)
 {
-	std::unique_lock<std::recursive_mutex> lock;
-	if (_draw_mutex != nullptr) lock = std::unique_lock<std::recursive_mutex>(*_draw_mutex);
-
 	return CreateMainSurface(w, h);
 }
 
 bool VideoDriver_SDL::ToggleFullscreen(bool fullscreen)
 {
-	std::unique_lock<std::recursive_mutex> lock;
-	if (_draw_mutex != nullptr) lock = std::unique_lock<std::recursive_mutex>(*_draw_mutex);
-
 	_fullscreen = fullscreen;
 	GetVideoModes(); // get the list of available video modes
 	bool ret = !_resolutions.empty() && CreateMainSurface(_cur_resolution.width, _cur_resolution.height);
@@ -770,27 +678,6 @@ bool VideoDriver_SDL::ToggleFullscreen(bool fullscreen)
 bool VideoDriver_SDL::AfterBlitterChange()
 {
 	return CreateMainSurface(_screen.width, _screen.height);
-}
-
-void VideoDriver_SDL::AcquireBlitterLock()
-{
-	if (_draw_mutex != nullptr) _draw_mutex->lock();
-}
-
-void VideoDriver_SDL::ReleaseBlitterLock()
-{
-	if (_draw_mutex != nullptr) _draw_mutex->unlock();
-}
-
-bool VideoDriver_SDL::LockVideoBuffer()
-{
-	if (_draw_threaded) this->draw_lock.lock();
-	return true;
-}
-
-void VideoDriver_SDL::UnlockVideoBuffer()
-{
-	if (_draw_threaded) this->draw_lock.unlock();
 }
 
 #endif /* WITH_SDL */

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -570,10 +570,10 @@ bool VideoDriver_SDL::PollEvent()
 	return true;
 }
 
-const char *VideoDriver_SDL::Start(const StringList &parm)
+const char *VideoDriver_SDL::Start(const StringList &param)
 {
 	char buf[30];
-	_use_hwpalette = GetDriverParamInt(parm, "hw_palette", 2);
+	_use_hwpalette = GetDriverParamInt(param, "hw_palette", 2);
 
 	/* Just on the offchance the audio subsystem started before the video system,
 	 * check whether any part of SDL has been initialised before getting here.
@@ -598,6 +598,8 @@ const char *VideoDriver_SDL::Start(const StringList &parm)
 
 	MarkWholeScreenDirty();
 	SetupKeyboard();
+
+	this->is_game_threaded = !GetDriverParamBool(param, "no_threads") && !GetDriverParamBool(param, "no_thread");
 
 	return nullptr;
 }
@@ -647,12 +649,16 @@ void VideoDriver_SDL::InputLoop()
 
 void VideoDriver_SDL::MainLoop()
 {
+	this->StartGameThread();
+
 	for (;;) {
 		if (_exit_game) break;
 
 		this->Tick();
 		this->SleepTillNextTick();
 	}
+
+	this->StopGameThread();
 }
 
 bool VideoDriver_SDL::ChangeResolution(int w, int h)

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -29,30 +29,19 @@ public:
 
 	bool AfterBlitterChange() override;
 
-	void AcquireBlitterLock() override;
-
-	void ReleaseBlitterLock() override;
-
 	bool ClaimMousePointer() override;
 
 	const char *GetName() const override { return "sdl"; }
 
 protected:
 	void InputLoop() override;
-	bool LockVideoBuffer() override;
-	void UnlockVideoBuffer() override;
 	void Paint() override;
-	void PaintThread() override;
 	void CheckPaletteAnim() override;
 	bool PollEvent() override;
 
 private:
-	std::unique_lock<std::recursive_mutex> draw_lock;
-
 	bool CreateMainSurface(uint w, uint h);
 	void SetupKeyboard();
-
-	static void PaintThreadThunk(VideoDriver_SDL *drv);
 };
 
 /** Factory for the SDL video driver. */

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -19,7 +19,7 @@
 
 bool _video_hw_accel; ///< Whether to consider hardware accelerated video drivers.
 
-bool VideoDriver::Tick()
+void VideoDriver::Tick()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();
 
@@ -66,12 +66,10 @@ bool VideoDriver::Tick()
 
 		::InputLoop();
 		UpdateWindows();
+
 		this->CheckPaletteAnim();
-
-		return true;
+		this->Paint();
 	}
-
-	return false;
 }
 
 void VideoDriver::SleepTillNextTick()

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -62,25 +62,12 @@ public:
 
 	/**
 	 * Callback invoked after the blitter was changed.
-	 * This may only be called between AcquireBlitterLock and ReleaseBlitterLock.
 	 * @return True if no error.
 	 */
 	virtual bool AfterBlitterChange()
 	{
 		return true;
 	}
-
-	/**
-	 * Acquire any lock(s) required to be held when changing blitters.
-	 * These lock(s) may not be acquired recursively.
-	 */
-	virtual void AcquireBlitterLock() { }
-
-	/**
-	 * Release any lock(s) required to be held when changing blitters.
-	 * These lock(s) may not be acquired recursively.
-	 */
-	virtual void ReleaseBlitterLock() { }
 
 	virtual bool ClaimMousePointer()
 	{

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -242,11 +242,6 @@ protected:
 	virtual void Paint() {}
 
 	/**
-	 * Thread function for threaded drawing.
-	 */
-	virtual void PaintThread() {}
-
-	/**
 	 * Process any pending palette animation.
 	 */
 	virtual void CheckPaletteAnim() {}
@@ -258,10 +253,11 @@ protected:
 	virtual bool PollEvent() { return false; };
 
 	/**
-	 * Run the game for a single tick, processing boththe game-tick and draw-tick.
-	 * @returns True if the driver should redraw the screen.
+	 * Give the video-driver a tick.
+	 * It will process any potential game-tick and/or draw-tick, and/or any
+	 * other video-driver related event.
 	 */
-	bool Tick();
+	void Tick();
 
 	/**
 	 * Sleep till the next tick is about to happen.

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -35,7 +35,7 @@ class VideoDriver : public Driver {
 	const uint DEFAULT_WINDOW_HEIGHT = 480u; ///< Default window height.
 
 public:
-	VideoDriver() : is_game_threaded(true) {}
+	VideoDriver() : is_game_threaded(true), change_blitter(nullptr) {}
 
 	/**
 	 * Mark a particular area dirty.
@@ -159,6 +159,15 @@ public:
 		if (dpi_scale >= 3.0f) return ZOOM_LVL_NORMAL;
 		if (dpi_scale >= 1.5f) return ZOOM_LVL_OUT_2X;
 		return ZOOM_LVL_OUT_4X;
+	}
+
+	/**
+	 * Queue a request to change the blitter. This is not executed immediately,
+	 * but instead on the next draw-tick.
+	 */
+	void ChangeBlitter(const char *new_blitter)
+	{
+		this->change_blitter = new_blitter;
 	}
 
 	/**
@@ -303,6 +312,9 @@ protected:
 private:
 	void GameLoop();
 	void GameThread();
+	void RealChangeBlitter(const char *repl_blitter);
+
+	const char *change_blitter; ///< Request to change the blitter. nullptr if no pending request.
 };
 
 #endif /* VIDEO_VIDEO_DRIVER_HPP */

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -128,9 +128,10 @@ uint8 VideoDriver_Win32Base::GetFullscreenBpp()
 /**
  * Instantiate a new window.
  * @param full_screen Whether to make a full screen window or not.
+ * @param resize Whether to change window size.
  * @return True if the window could be created.
  */
-bool VideoDriver_Win32Base::MakeWindow(bool full_screen)
+bool VideoDriver_Win32Base::MakeWindow(bool full_screen, bool resize)
 {
 	/* full_screen is whether the new window should be fullscreen,
 	 * _wnd.fullscreen is whether the current window is. */
@@ -172,7 +173,7 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen)
 		}
 
 		if (ChangeDisplaySettings(&settings, CDS_FULLSCREEN) != DISP_CHANGE_SUCCESSFUL) {
-			this->MakeWindow(false);  // don't care about the result
+			this->MakeWindow(false, resize);  // don't care about the result
 			return false;  // the request failed
 		}
 	} else if (this->fullscreen) {
@@ -205,7 +206,7 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen)
 		h = r.bottom - r.top;
 
 		if (this->main_wnd != nullptr) {
-			if (!_window_maximize) SetWindowPos(this->main_wnd, 0, 0, 0, w, h, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOMOVE);
+			if (!_window_maximize && resize) SetWindowPos(this->main_wnd, 0, 0, 0, w, h, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER | SWP_NOMOVE);
 		} else {
 			int x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
 			int y = (GetSystemMetrics(SM_CYSCREEN) - h) / 2;
@@ -1043,7 +1044,7 @@ bool VideoDriver_Win32GDI::AllocateBackingStore(int w, int h, bool force)
 bool VideoDriver_Win32GDI::AfterBlitterChange()
 {
 	assert(BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 0);
-	return this->AllocateBackingStore(_screen.width, _screen.height, true) && this->MakeWindow(_fullscreen);
+	return this->AllocateBackingStore(_screen.width, _screen.height, true) && this->MakeWindow(_fullscreen, false);
 }
 
 void VideoDriver_Win32GDI::MakePalette()

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -54,7 +54,7 @@ protected:
 	bool PollEvent() override;
 
 	void Initialize();
-	bool MakeWindow(bool full_screen);
+	bool MakeWindow(bool full_screen, bool resize = true);
 	void ClientSizeChanged(int w, int h, bool force = false);
 
 	/** Get screen depth to use for fullscreen mode. */

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -129,6 +129,8 @@ public:
 
 	bool UseSystemCursor() override { return true; }
 
+	void PopulateSystemSprites() override;
+
 	void ClearSystemSprites() override;
 
 	bool HasAnimBuffer() override { return true; }


### PR DESCRIPTION
Requires #8747 to be merged first.

## Motivation / Problem

During work on the video drivers, I noticed a few (SDL1, SDL2 and Win32) had a "draw thread" implementation, where drawing was moved to a thread. This to me is odd, as normally you want to do drawing in the main thread, and everything else in other threads.

This was also showing, as with OpenGL, "draw thread" could not be used. The thread the context is created in, has to be the thread that is updating it. And given this was done in the main thread, it could not be done in the "draw thread".

This PR introduced an alternative: do `GameLoop` in a thread. It works for all video drivers.

## Description

```
This allows drawing to happen while the GameLoop is doing an
iteration too.
    
Sadly, not much drawing currently can be done while the GameLoop
is running, as for example PollEvent() or UpdateWindows() can
influence the game-state. As such, they first need to acquire a
lock on the game-state before they can be called.
    
Currently, the main advantage is the time spend in Paint(), which
for non-OpenGL drivers can be a few milliseconds. For OpenGL this
is more like 0.05 milliseconds; in these instances this change
doesn't add any benefits for now.
    
This is an alternative to the former "draw-thread", which moved
the drawing in a thread for some OSes. It has similar performance
gain as this does, although this implementation allows for more
finer control over what suffers when the GameLoop takes too
long: drawing or the next GameLoop. For now they both suffer
equally.
```

This is the inverse of draw_thread, where drawing was done in a thread. Now the `GameLoop` is instead.

There is currently very little benefit from doing this with OpenGL. The time spend in `Paint`, the only function that is allowed to run in parallel with the `GameLoop` for now, takes on my machine ~0.05ms. That won't change anything, really.
For non-OpenGL, it is a bit different. `Paint` can easily take 5ms, so that means the simulation speed can go slightly higher.

If I load complex games, like ProGame5 or a game with many Timberwolf's trains, using threads does indeed increase the simulation speed (with something between 10% and 20%, so noticeable), when using non-OpenGL. With OpenGL, again, no difference is to be spotted (or expected).

This PR is mainly meant to allow future work. Things to think about:

- `UpdateWindows` now does everything while the game-state is locked. This is not required. Half-way through the viewport functions it can release the game-state lock, as it no longer will change the game-state. Sadly, this is not trivial to implement, but doing so would mean more time could be spend during the `GameLoop`, further improving the gameplay for complex games.
- During resource starvation, currently both the simulation and draw fps suffer. But this doesn't have to be that way. I experimented a bit with this, but it is trivial to let one or the other suffer more. In the end, if `GameLoop` goes over 30ms, draw fps will always suffer, but till that time simulation can suffer. Or, if we like, we can always prioritize simulation over draw fps, and for example have drawing being done at 10fps so the simulation can run at 1x. I have fiddled a bit with this, but it is really hard to find a good compromise. So l left it at equal starvation for now.
- The mouse is now non-responsive during `GameLoop`, but that is not needed. We can just keep the mouse reactive. This would also change how Modal windows work, for example. Already with this PR the `AcquireBlitterLock` doesn't do anything, and it is a small step to just remove it, and have a more reactive GUI.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
