### PR TITLE
Fix #8734: [OpenGL] Apply palette remap to cursor sprites.

### DIFF
--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -344,6 +344,7 @@ void GfxLoadSprites()
 	DEBUG(sprite, 2, "Loading sprite set %d", _settings_game.game_creation.landscape);
 
 	SwitchNewGRFBlitter();
+	VideoDriver::GetInstance()->ClearSystemSprites();
 	ClearFontCache();
 	GfxInitSpriteMem();
 	LoadSpriteTables();

--- a/src/table/opengl_shader.h
+++ b/src/table/opengl_shader.h
@@ -146,3 +146,58 @@ static const char *_frag_shader_rgb_mask_blend_150[] = {
 	"  colour.rgb = idx > 0.0 ? adj_brightness(remap_col.rgb, max3(rgb_col.rgb)) : rgb_col.rgb;",
 	"}",
 };
+
+/** Fragment shader that performs a palette lookup to read the colour from a sprite texture. */
+static const char *_frag_shader_sprite_blend[] = {
+	"#version 110\n",
+	"#extension GL_ATI_shader_texture_lod: enable\n",
+	"#extension GL_ARB_shader_texture_lod: enable\n",
+	"uniform sampler2D colour_tex;",
+	"uniform sampler1D palette;",
+	"uniform sampler2D remap_tex;",
+	"uniform sampler1D pal;",
+	"uniform float zoom;",
+	"uniform bool rgb;",
+	"uniform bool crash;",
+	"varying vec2 colour_tex_uv;",
+	"",
+	_frag_shader_remap_func,
+	"",
+	"void main() {",
+	"  float idx = texture2DLod(remap_tex, colour_tex_uv, zoom).r;",
+	"  float r = texture1D(pal, idx).r;",
+	"  vec4 remap_col = texture1D(palette, idx);",
+	"  vec4 rgb_col = texture2DLod(colour_tex, colour_tex_uv, zoom);",
+	"",
+	"  if (crash && idx == 0.0) rgb_col.rgb = vec2(dot(rgb_col.rgb, vec3(0.199325561523, 0.391342163085, 0.076004028320)), 0.0).rrr;"
+	"  gl_FragData[0].a = rgb && (r > 0.0 || idx == 0.0) ? rgb_col.a : remap_col.a;",
+	"  gl_FragData[0].rgb = idx > 0.0 ? adj_brightness(remap_col.rgb, max3(rgb_col.rgb)) : rgb_col.rgb;",
+	"}",
+};
+
+/** GLSL 1.50 fragment shader that performs a palette lookup to read the colour from a sprite texture. */
+static const char *_frag_shader_sprite_blend_150[] = {
+	"#version 150\n",
+	"uniform sampler2D colour_tex;",
+	"uniform sampler1D palette;",
+	"uniform sampler2D remap_tex;",
+	"uniform sampler1D pal;",
+	"uniform float zoom;",
+	"uniform bool rgb;",
+	"uniform bool crash;",
+	"in vec2 colour_tex_uv;",
+	"out vec4 colour;",
+	"",
+	_frag_shader_remap_func,
+	"",
+	"void main() {",
+	"  float idx =  textureLod(remap_tex, colour_tex_uv, zoom).r;"
+	"  float r = texture(pal, idx).r;",
+	"  vec4 remap_col = texture(palette, r);",
+	"  vec4 rgb_col = textureLod(colour_tex, colour_tex_uv, zoom);",
+	"",
+	"  if (crash && idx == 0.0) rgb_col.rgb = vec2(dot(rgb_col.rgb, vec3(0.199325561523, 0.391342163085, 0.076004028320)), 0.0).rrr;"
+	"  colour.a = rgb && (r > 0.0 || idx == 0.0) ? rgb_col.a : remap_col.a;",
+	"  colour.rgb = idx > 0.0 ? adj_brightness(remap_col.rgb, max3(rgb_col.rgb)) : rgb_col.rgb;",
+	"}",
+};

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -54,7 +54,15 @@ private:
 	GLint  remap_zoom_loc;   ///< Uniform location for sprite zoom;
 	GLint  remap_rgb_loc;    ///< Uniform location for RGB mode flag;
 
-	LRUCache<SpriteID, Sprite> cursor_cache; ///< Cache of encoded cursor sprites.
+	GLuint sprite_program;    ///< Shader program for blending and rendering a sprite to the video buffer.
+	GLint  sprite_sprite_loc; ///< Uniform location for sprite parameters.
+	GLint  sprite_screen_loc; ///< Uniform location for screen size;
+	GLint  sprite_zoom_loc;   ///< Uniform location for sprite zoom;
+	GLint  sprite_rgb_loc;    ///< Uniform location for RGB mode flag;
+	GLint  sprite_crash_loc;  ///< Uniform location for crash remap mode flag;
+
+	LRUCache<SpriteID, Sprite> cursor_cache;   ///< Cache of encoded cursor sprites.
+	PaletteID last_sprite_pal = (PaletteID)-1; ///< Last uploaded remap palette.
 
 	OpenGLBackend();
 	~OpenGLBackend();
@@ -62,7 +70,7 @@ private:
 	const char *Init();
 	bool InitShaders();
 
-	void RenderOglSprite(OpenGLSprite *gl_sprite, uint x, uint y, ZoomLevel zoom);
+	void RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, uint x, uint y, ZoomLevel zoom);
 
 public:
 	/** Get singleton instance of this class. */
@@ -109,6 +117,10 @@ private:
 	GLuint tex[NUM_TEX]; ///< The texture objects.
 
 	static GLuint dummy_tex[NUM_TEX]; ///< 1x1 dummy textures to substitute for unused sprite components.
+
+	static GLuint pal_identity; ///< Identity texture mapping.
+	static GLuint pal_tex;      ///< Texture for palette remap.
+	static GLuint pal_pbo;      ///< Pixel buffer object for remap upload.
 
 	static bool Create();
 	static void Destroy();


### PR DESCRIPTION
## Motivation / Problem

Palette remap was not applied to cursor sprites when using OpenGL.


## Description

Change shader code to apply palette remap.


## Limitations

Transparent palette remap is not implemented, but not used for cursor sprites. The shader code is also not very optimised, which should not pose a problem for the average pixel amount in a cursor sprite.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
