### PR TITLE
Change: Default to a 32bpp blitter.

### DIFF
--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -263,7 +263,7 @@ static bool SwitchNewGRFBlitter()
 	 * between multiple 32bpp blitters, which perform differently with 8bpp sprites.
 	 */
 	uint depth_wanted_by_base = BaseGraphics::GetUsedSet()->blitter == BLT_32BPP ? 32 : 8;
-	uint depth_wanted_by_grf = _support8bpp != S8BPP_NONE || VideoDriver::GetInstance()->HasEfficient8Bpp() ? 8 : 32;
+	uint depth_wanted_by_grf = _support8bpp != S8BPP_NONE ? 8 : 32;
 	for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
 		if (c->status == GCS_DISABLED || c->status == GCS_NOT_FOUND || HasBit(c->flags, GCF_INIT_ONLY)) continue;
 		if (c->palette & GRFP_BLT_32BPP) depth_wanted_by_grf = 32;


### PR DESCRIPTION
## Motivation / Problem

Most video drivers cause an 32bpp blitter to be used. OpenGL video drivers currently do not, as they have efficient 8bpp display.

Apparently, the looks of 32bpp blitters are superior.


## Description

Only choose an 8bpp blitter if the `support8bpp` tells us to. Otherwise, use an 32bpp one.


## Limitations

The 8bpp blitter together with the OpenGL backend is slightly faster than 32bpp bliters.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
