### PR TITLE
Fix: don't link to OpenGL with SDL2 as backend; SDL2 dynamically loads it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,16 @@ if(NOT OPTION_DEDICATED)
     link_package(Fontconfig TARGET Fontconfig::Fontconfig)
     link_package(ICU_lx)
     link_package(ICU_i18n)
-    link_package(OpenGL TARGET OpenGL::GL)
+
+    if(SDL2_FOUND AND OPENGL_FOUND AND UNIX)
+        # SDL2 dynamically loads OpenGL if needed, so do not link to OpenGL when
+        # on Linux. For Windows, we need to link to OpenGL as we also have a win32
+        # driver using it.
+        add_definitions(-DWITH_OPENGL)
+        message(STATUS "OpenGL found -- -DWITH_OPENGL -- (via SDL2)")
+    else()
+        link_package(OpenGL TARGET OpenGL::GL)
+    endif()
 endif()
 
 if(APPLE)


### PR DESCRIPTION


## Motivation / Problem

Our `linux-generic` had many more dependencies than strictly needed, because we linked to OpenGL, which dragged in X11 libraries, and booommm.


## Description

```
Although for developers this doesn't change anything, for our
linux-generic binary it changes everything. Without this, the
OpenGL dynamic library is dragged in as dependency, and as it
depends on X11, that will be dragged in too. This is not
something we prefer to have, as that won't run on as many
machines as it could.

SDL2 doesn't depend on OpenGL directly, as it tries to load it
in on runtime. If found, it would work in exactly the same way
as if we would link to OpenGL ourselves. As such, this is
the best of both worlds: our linux-generics have less linked
dependencies, and developers won't notice any difference.

As a side-effect, if someone uses linux-generic on a machine
that does not have any OpenGL package installed, it will
gracefully fall back to the default backend of SDL instead.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
