### PR TITLE
Codechange: replace _realtime_tick with std::chrono

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -45,8 +45,6 @@ int _debug_console_level;
 int _debug_random_level;
 #endif
 
-uint32 _realtime_tick = 0;
-
 struct DebugLevel {
 	const char *name;
 	int *level;

--- a/src/debug.h
+++ b/src/debug.h
@@ -121,7 +121,4 @@ void CDECL ShowInfoF(const char *str, ...) WARN_FORMAT(1, 2);
 
 const char *GetLogPrefix();
 
-/** The real time in the game. */
-extern uint32 _realtime_tick;
-
 #endif /* DEBUG_H */

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -25,9 +25,10 @@
  * @param s The socket to connect with.
  */
 NetworkGameSocketHandler::NetworkGameSocketHandler(SOCKET s) : info(nullptr), client_id(INVALID_CLIENT_ID),
-		last_frame(_frame_counter), last_frame_server(_frame_counter), last_packet(_realtime_tick)
+		last_frame(_frame_counter), last_frame_server(_frame_counter)
 {
 	this->sock = s;
+	this->last_packet = std::chrono::steady_clock::now();
 }
 
 /**
@@ -63,7 +64,7 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet *p)
 {
 	PacketGameType type = (PacketGameType)p->Recv_uint8();
 
-	this->last_packet = _realtime_tick;
+	this->last_packet = std::chrono::steady_clock::now();
 
 	switch (this->HasClientQuit() ? PACKET_END : type) {
 		case PACKET_SERVER_FULL:                  return this->Receive_SERVER_FULL(p);

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -16,6 +16,7 @@
 #include "tcp.h"
 #include "../network_type.h"
 #include "../../core/pool_type.hpp"
+#include <chrono>
 
 /**
  * Enum with all types of TCP packets.
@@ -518,7 +519,7 @@ public:
 	uint32 last_frame;           ///< Last frame we have executed
 	uint32 last_frame_server;    ///< Last frame the server has executed
 	CommandQueue incoming_queue; ///< The command-queue awaiting handling
-	uint last_packet;            ///< Time we received the last frame.
+	std::chrono::steady_clock::time_point last_packet; ///< Time we received the last frame.
 
 	NetworkRecvStatus CloseConnection(bool error = true) override;
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -37,7 +37,7 @@ protected:
 	NetworkRecvStatus SendPong(uint32 d1);
 public:
 	AdminUpdateFrequency update_frequency[ADMIN_UPDATE_END]; ///< Admin requested update intervals.
-	uint32 realtime_connect;                                 ///< Time of connection.
+	std::chrono::steady_clock::time_point connect_time;      ///< Time of connection.
 	NetworkAddress address;                                  ///< Address of the admin.
 
 	ServerNetworkAdminSocketHandler(SOCKET s);

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -40,7 +40,7 @@ static const uint NETWORK_CHAT_LINE_SPACING = 3;
 struct ChatMessage {
 	char message[DRAW_STRING_BUFFER]; ///< The action message.
 	TextColour colour;  ///< The colour of the message.
-	uint32 remove_time; ///< The time to remove the message.
+	std::chrono::steady_clock::time_point remove_time; ///< The time to remove the message.
 };
 
 /* used for chat window */
@@ -97,7 +97,7 @@ void CDECL NetworkAddChatMessage(TextColour colour, uint duration, const char *m
 	ChatMessage *cmsg = &_chatmsg_list[msg_count++];
 	strecpy(cmsg->message, buf, lastof(cmsg->message));
 	cmsg->colour = (colour & TC_IS_PALETTE_COLOUR) ? colour : TC_WHITE;
-	cmsg->remove_time = _realtime_tick + duration * 1000;
+	cmsg->remove_time = std::chrono::steady_clock::now() + std::chrono::seconds(duration);
 
 	_chatmessage_dirty = true;
 }
@@ -180,7 +180,7 @@ void NetworkChatMessageLoop()
 		if (cmsg->message[0] == '\0') continue;
 
 		/* Message has expired, remove from the list */
-		if (cmsg->remove_time < _realtime_tick) {
+		if (std::chrono::steady_clock::now() > cmsg->remove_time) {
 			/* Move the remaining messages over the current message */
 			if (i != MAX_CHAT_MESSAGES - 1) memmove(cmsg, cmsg + 1, sizeof(*cmsg) * (MAX_CHAT_MESSAGES - i - 1));
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -711,9 +711,9 @@ ClientNetworkContentSocketHandler::ClientNetworkContentSocketHandler() :
 	http_response_index(-2),
 	curFile(nullptr),
 	curInfo(nullptr),
-	isConnecting(false),
-	lastActivity(_realtime_tick)
+	isConnecting(false)
 {
+	this->lastActivity = std::chrono::steady_clock::now();
 }
 
 /** Clear up the mess ;) */
@@ -743,7 +743,7 @@ public:
 	void OnConnect(SOCKET s) override
 	{
 		assert(_network_content_client.sock == INVALID_SOCKET);
-		_network_content_client.lastActivity = _realtime_tick;
+		_network_content_client.lastActivity = std::chrono::steady_clock::now();
 		_network_content_client.isConnecting = false;
 		_network_content_client.sock = s;
 		_network_content_client.Reopen();
@@ -780,7 +780,7 @@ void ClientNetworkContentSocketHandler::SendReceive()
 {
 	if (this->sock == INVALID_SOCKET || this->isConnecting) return;
 
-	if (this->lastActivity + IDLE_TIMEOUT < _realtime_tick) {
+	if (std::chrono::steady_clock::now() > this->lastActivity + IDLE_TIMEOUT) {
 		this->Close();
 		return;
 	}
@@ -788,7 +788,7 @@ void ClientNetworkContentSocketHandler::SendReceive()
 	if (this->CanSendReceive()) {
 		if (this->ReceivePackets()) {
 			/* Only update activity once a packet is received, instead of every time we try it. */
-			this->lastActivity = _realtime_tick;
+			this->lastActivity = std::chrono::steady_clock::now();
 		}
 	}
 

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -74,7 +74,7 @@ protected:
 	FILE *curFile;        ///< Currently downloaded file
 	ContentInfo *curInfo; ///< Information about the currently downloaded file
 	bool isConnecting;    ///< Whether we're connecting
-	uint32 lastActivity;  ///< The last time there was network activity
+	std::chrono::steady_clock::time_point lastActivity;  ///< The last time there was network activity
 
 	friend class NetworkContentConnecter;
 
@@ -100,7 +100,7 @@ protected:
 	void DownloadSelectedContentFallback(const ContentIDList &content);
 public:
 	/** The idle timeout; when to close the connection because it's idle. */
-	static const int IDLE_TIMEOUT = 60 * 1000;
+	static constexpr std::chrono::seconds IDLE_TIMEOUT = std::chrono::seconds(60);
 
 	ClientNetworkContentSocketHandler();
 	~ClientNetworkContentSocketHandler();

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1816,7 +1816,7 @@ void NetworkServer_Tick(bool send_frame)
 			case NetworkClientSocket::STATUS_ACTIVE:
 				if (lag > _settings_client.network.max_lag_time) {
 					/* Client did still not report in within the specified limit. */
-					IConsolePrintF(CC_ERROR, cs->last_packet + lag * MILLISECONDS_PER_TICK > _realtime_tick ?
+					IConsolePrintF(CC_ERROR, cs->last_packet + std::chrono::milliseconds(lag * MILLISECONDS_PER_TICK) > std::chrono::steady_clock::now() ?
 							/* A packet was received in the last three game days, so the client is likely lagging behind. */
 								"Client #%d is dropped because the client's game state is more than %d ticks behind" :
 							/* No packet was received in the last three game days; sounds like a lost connection. */
@@ -1827,11 +1827,11 @@ void NetworkServer_Tick(bool send_frame)
 				}
 
 				/* Report once per time we detect the lag, and only when we
-				 * received a packet in the last 2000 milliseconds. If we
+				 * received a packet in the last 2 seconds. If we
 				 * did not receive a packet, then the client is not just
 				 * slow, but the connection is likely severed. Mentioning
 				 * frame_freq is not useful in this case. */
-				if (lag > (uint)DAY_TICKS && cs->lag_test == 0 && cs->last_packet + 2000 > _realtime_tick) {
+				if (lag > (uint)DAY_TICKS && cs->lag_test == 0 && cs->last_packet + std::chrono::seconds(2) > std::chrono::steady_clock::now()) {
 					IConsolePrintF(CC_WARNING, "[%d] Client #%d is slow, try increasing [network.]frame_freq to a higher value!", _frame_counter, cs->client_id);
 					cs->lag_test = 1;
 				}

--- a/src/newgrf_debug.h
+++ b/src/newgrf_debug.h
@@ -26,7 +26,6 @@ enum NewGrfDebugSpritePickerMode {
 struct NewGrfDebugSpritePicker {
 	NewGrfDebugSpritePickerMode mode;   ///< Current state
 	void *clicked_pixel;                ///< Clicked pixel (pointer to blitter buffer)
-	uint32 click_time;                  ///< Realtime tick when clicked to detect next frame
 	std::vector<SpriteID> sprites;       ///< Sprites found
 };
 

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -45,7 +45,7 @@
 #include "safeguards.h"
 
 /** The sprite picker. */
-NewGrfDebugSpritePicker _newgrf_debug_sprite_picker = { SPM_NONE, nullptr, 0, std::vector<SpriteID>() };
+NewGrfDebugSpritePicker _newgrf_debug_sprite_picker = { SPM_NONE, nullptr, std::vector<SpriteID>() };
 
 /**
  * Get the feature index related to the window number.

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -20,17 +20,6 @@ bool VideoDriver::Tick()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();
 
-	/* If more than a millisecond has passed, increase the _realtime_tick. */
-	if (cur_ticks - this->last_realtime_tick > std::chrono::milliseconds(1)) {
-		auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(cur_ticks - this->last_realtime_tick);
-		_realtime_tick += delta.count();
-		this->last_realtime_tick += delta;
-
-		/* Keep the interactive randomizer a bit more random by requesting
-		 * new values when-ever we can. */
-		InteractiveRandom();
-	}
-
 	if (cur_ticks >= this->next_game_tick || (_fast_forward && !_pause_mode)) {
 		if (_fast_forward && !_pause_mode) {
 			this->next_game_tick = cur_ticks + this->GetGameInterval();
@@ -59,6 +48,10 @@ bool VideoDriver::Tick()
 		this->next_draw_tick += this->GetDrawInterval();
 		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 		if (this->next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) this->next_draw_tick = cur_ticks;
+
+		/* Keep the interactive randomizer a bit more random by requesting
+		 * new values when-ever we can. */
+		InteractiveRandom();
 
 		while (this->PollEvent()) {}
 		this->InputLoop();

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -276,7 +276,6 @@ protected:
 		return std::chrono::microseconds(1000000 / _settings_client.gui.refresh_rate);
 	}
 
-	std::chrono::steady_clock::time_point last_realtime_tick;
 	std::chrono::steady_clock::time_point next_game_tick;
 	std::chrono::steady_clock::time_point next_draw_tick;
 };

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2825,10 +2825,11 @@ enum MouseClick {
 	MC_HOVER,
 
 	MAX_OFFSET_DOUBLE_CLICK = 5,     ///< How much the mouse is allowed to move to call it a double click
-	TIME_BETWEEN_DOUBLE_CLICK = 500, ///< Time between 2 left clicks before it becoming a double click, in ms
 	MAX_OFFSET_HOVER = 5,            ///< Maximum mouse movement before stopping a hover event.
 };
 extern EventState VpHandlePlaceSizingDrag();
+
+const std::chrono::milliseconds TIME_BETWEEN_DOUBLE_CLICK(500); ///< Time between 2 left clicks before it becoming a double click.
 
 static void ScrollMainViewport(int x, int y)
 {
@@ -2991,19 +2992,27 @@ void HandleMouseEvents()
 	 * But there is no company related window open anyway, so _current_company is not used. */
 	assert(HasModalProgress() || IsLocalCompany());
 
-	static int double_click_time = 0;
+	/* Handle sprite picker before any GUI interaction */
+	if (_newgrf_debug_sprite_picker.mode == SPM_REDRAW && _input_events_this_tick == 0) {
+		/* We are done with the last draw-frame, so we know what sprites we
+		 * clicked on. Reset the picker mode and invalidate the window. */
+		_newgrf_debug_sprite_picker.mode = SPM_NONE;
+		InvalidateWindowData(WC_SPRITE_ALIGNER, 0, 1);
+	}
+
+	static std::chrono::steady_clock::time_point double_click_time = {};
 	static Point double_click_pos = {0, 0};
 
 	/* Mouse event? */
 	MouseClick click = MC_NONE;
 	if (_left_button_down && !_left_button_clicked) {
 		click = MC_LEFT;
-		if (double_click_time != 0 && _realtime_tick - double_click_time   < TIME_BETWEEN_DOUBLE_CLICK &&
+		if (std::chrono::steady_clock::now() <= double_click_time + TIME_BETWEEN_DOUBLE_CLICK &&
 				double_click_pos.x != 0 && abs(_cursor.pos.x - double_click_pos.x) < MAX_OFFSET_DOUBLE_CLICK  &&
 				double_click_pos.y != 0 && abs(_cursor.pos.y - double_click_pos.y) < MAX_OFFSET_DOUBLE_CLICK) {
 			click = MC_DOUBLE_LEFT;
 		}
-		double_click_time = _realtime_tick;
+		double_click_time = std::chrono::steady_clock::now();
 		double_click_pos = _cursor.pos;
 		_left_button_clicked = true;
 		_input_events_this_tick++;
@@ -3020,7 +3029,7 @@ void HandleMouseEvents()
 		_input_events_this_tick++;
 	}
 
-	static uint32 hover_time = 0;
+	static std::chrono::steady_clock::time_point hover_time = {};
 	static Point hover_pos = {0, 0};
 
 	if (_settings_client.gui.hover_delay_ms > 0) {
@@ -3028,10 +3037,10 @@ void HandleMouseEvents()
 				hover_pos.x == 0 || abs(_cursor.pos.x - hover_pos.x) >= MAX_OFFSET_HOVER  ||
 				hover_pos.y == 0 || abs(_cursor.pos.y - hover_pos.y) >= MAX_OFFSET_HOVER) {
 			hover_pos = _cursor.pos;
-			hover_time = _realtime_tick;
+			hover_time = std::chrono::steady_clock::now();
 			_mouse_hovering = false;
 		} else {
-			if (hover_time != 0 && _realtime_tick > hover_time + _settings_client.gui.hover_delay_ms) {
+			if (std::chrono::steady_clock::now() > hover_time + std::chrono::milliseconds(_settings_client.gui.hover_delay_ms)) {
 				click = MC_HOVER;
 				_input_events_this_tick++;
 				_mouse_hovering = true;
@@ -3039,18 +3048,10 @@ void HandleMouseEvents()
 		}
 	}
 
-	/* Handle sprite picker before any GUI interaction */
-	if (_newgrf_debug_sprite_picker.mode == SPM_REDRAW && _newgrf_debug_sprite_picker.click_time != _realtime_tick) {
-		/* Next realtime tick? Then redraw has finished */
-		_newgrf_debug_sprite_picker.mode = SPM_NONE;
-		InvalidateWindowData(WC_SPRITE_ALIGNER, 0, 1);
-	}
-
 	if (click == MC_LEFT && _newgrf_debug_sprite_picker.mode == SPM_WAIT_CLICK) {
 		/* Mark whole screen dirty, and wait for the next realtime tick, when drawing is finished. */
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 		_newgrf_debug_sprite_picker.clicked_pixel = blitter->MoveTo(_screen.dst_ptr, _cursor.pos.x, _cursor.pos.y);
-		_newgrf_debug_sprite_picker.click_time = _realtime_tick;
 		_newgrf_debug_sprite_picker.sprites.clear();
 		_newgrf_debug_sprite_picker.mode = SPM_REDRAW;
 		MarkWholeScreenDirty();
@@ -3138,11 +3139,12 @@ void CallWindowRealtimeTickEvent(uint delta_ms)
  */
 void UpdateWindows()
 {
-	static uint32 last_realtime_tick = _realtime_tick;
-	uint delta_ms = _realtime_tick - last_realtime_tick;
-	last_realtime_tick = _realtime_tick;
+	static std::chrono::steady_clock::time_point last_time = std::chrono::steady_clock::now();
+	uint delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - last_time).count();
 
 	if (delta_ms == 0) return;
+
+	last_time = std::chrono::steady_clock::now();
 
 	PerformanceMeasurer framerate(PFE_DRAWING);
 	PerformanceAccumulator::Reset(PFE_DRAWWORLD);


### PR DESCRIPTION
## Motivation / Problem

`_realtime_tick` is a global variable that counts time, driven by the video-drivers mainloop. In many cases there is no longer a need to do it this way, as we can just use `std::chrono` to get the time any moment we want in our code.

Additionally, because we have `std::chrono::seconds` etc, there is less bla about what unit a `const` has, making the code slightly more readable.


## Description

### For the first commit

Pretty straight-forward. I did rework some functions slightly to make them simpler. Mostly, wrapping no longer happens (well, every 250+ years (REAL LIFE YEARS @ldpl , not game years!), so .. yeah .. never), so that code can be removed.
Most noticeable change would be the advertisement; instead of keeping 2 variables for "next", just keep one "last" and check if the duration elapsed.

I tested all timeouts except one.
- Admin, `nc` connect and don't do anything. Works.
- Client timeout, `iptables` drop the TCP traffic after connect. client gets dialog counting up to 15 seconds.
- Server lag timeout, harder to test, but modified the code to trigger this path.
- Chat, by typing something and waiting for the timeout,
- Advertisement, both failed and success advertisement, by letting a server do that.
- Content service, clicking the button, waiting 60 boring seconds, checking `netstat -n` that the connection is gone.

All works as expected.

### For the second commit

Two cases were straight-forward. Double click and hover. Nothing special about it. Tested, works as expected.

The third case was a bit more odd, as it was abusing `_realtime_tick` to now if any draw-ticks happened. This is because every mouse interaction can cause a call to `HandleMouseEvents`. Luckily, we already have a counter to check if any call to that function has been done during the draw-tick, so instead of using `_realtime_tick` like that, use the variable that was intended for it.
To have it slightly more readable, this did mean the function had to be moved up a bit.

### For the third commit

Yes, `_realtime_tick` was in `debug.h` ... seems it was originally meant for debugging :D Super weird ..

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
