### PR TITLE
Fix 02e770ff: allow estimating CloneVehicle if short on money

### DIFF
--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -21,6 +21,9 @@
  * \li AICargo::GetName
  * \li AIPriorityQueue
  *
+ * Other changes:
+ * \li AIVehicle::CloneVehicle now correctly returns estimate when short on cash
+ *
  * \b 1.10.0
  *
  * API additions:

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -987,16 +987,14 @@ CommandCost CmdCloneVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 
 		/* Now clone the vehicle's name, if it has one. */
 		if (!v_front->name.empty()) CloneVehicleName(v_front, w_front);
-	}
 
-	/* Since we can't estimate the cost of cloning a vehicle accurately we must
-	 * check whether the company has enough money manually. */
-	if (!CheckCompanyHasMoney(total_cost)) {
-		if (flags & DC_EXEC) {
+		/* Since we can't estimate the cost of cloning a vehicle accurately we must
+		 * check whether the company has enough money manually. */
+		if (!CheckCompanyHasMoney(total_cost)) {
 			/* The vehicle has already been bought, so now it must be sold again. */
 			DoCommand(w_front->tile, w_front->index | 1 << 20, 0, flags, GetCmdSellVeh(w_front));
+			return total_cost;
 		}
-		return total_cost;
 	}
 
 	return total_cost;


### PR DESCRIPTION
Fixes #8045

## Motivation / Problem

See https://github.com/OpenTTD/OpenTTD/issues/8045#issuecomment-786678532 for the analysis.

## Description

```
CheckCompanyHasMoney() was also executed when not using DC_EXEC,
resulting in an error about shortage of money instead of the
estimation.
This mostly is a problem for AI players, as they will have no
way to know how much it would have cost.
```

PS: this bug is 14 years old :D

## Limitations

- This mostly affects AI writers .. should we mention this in the changelog of AIs?
- The other 5 `CMD_NO_TEST` functions use `_additional_cash_required`, but this approach seems pretty much worse than using `CheckCompanyHasMoney`. This makes me think it would be better to change these 5 to using `CheckCompanyHasMoney` too. But, if it ain't broken, don't fix it.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
