### PR TITLE
WIP Feature: Setting to loop the same year forever

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -108,6 +108,7 @@ static int32 ClickChangeDateCheat(int32 p1, int32 p2)
 	Date new_date = ConvertYMDToDate(p1, ymd.month, ymd.day);
 	LinkGraphSchedule::instance.ShiftDates(new_date - _date);
 	SetDate(new_date, _date_fract);
+	_year_is_looping = false;
 	EnginesMonthlyLoop();
 	SetWindowDirty(WC_STATUS_BAR, 0);
 	InvalidateWindowClassesData(WC_BUILD_STATION, 0);

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -76,7 +76,8 @@ struct CompanyProperties {
 
 	Owner share_owners[4];           ///< Owners of the 4 shares of the company. #INVALID_OWNER if nobody has bought them yet.
 
-	Year inaugurated_year;           ///< Year of starting the company.
+	Year inaugurated_year;           ///< Year of starting the company, n .
+	GameYear inaugurated_game_year;   ///< Game year when the company was started
 
 	byte months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?
@@ -102,7 +103,7 @@ struct CompanyProperties {
 	CompanyProperties()
 		: name_2(0), name_1(0), president_name_1(0), president_name_2(0),
 		  face(0), money(0), money_fraction(0), current_loan(0), colour(0), block_preview(0),
-		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0),
+		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0), inaugurated_game_year(0),
 		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
 		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false) {}
 };

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -76,8 +76,8 @@ struct CompanyProperties {
 
 	Owner share_owners[4];           ///< Owners of the 4 shares of the company. #INVALID_OWNER if nobody has bought them yet.
 
-	Year inaugurated_year;           ///< Year of starting the company, n .
-	GameYear inaugurated_game_year;   ///< Game year when the company was started
+	Year inaugurated_year;           ///< Actual year the company was started.
+	GameYear inaugurated_game_year;  ///< Game year when the company was started.
 
 	byte months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -563,6 +563,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 	c->avail_railtypes = GetCompanyRailtypes(c->index);
 	c->avail_roadtypes = GetCompanyRoadTypes(c->index);
 	c->inaugurated_year = _cur_year;
+	c->inaugurated_game_year = _game_year;
 	RandomCompanyManagerFaceBits(c->face, (GenderEthnicity)Random(), false, false); // create a random company manager face
 
 	SetDefaultCompanySettings(c->index);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -342,7 +342,7 @@ struct CompanyFinancesWindow : Window {
 			case WID_CF_EXPS_PRICE2:
 			case WID_CF_EXPS_PRICE3: {
 				const Company *c = Company::Get((CompanyID)this->window_number);
-				int age = std::min(_cur_year - c->inaugurated_year, 2);
+				int age = std::min(_game_year - c->inaugurated_game_year, 2);
 				int wid_offset = widget - WID_CF_EXPS_PRICE1;
 				if (wid_offset <= age) {
 					DrawYearColumn(r, _cur_year - (age - wid_offset), c->yearly_expenses + (age - wid_offset));

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -30,7 +30,7 @@ DateFract _date_fract; ///< Fractional part of the day.
 uint16    _tick_counter;  ///< Ever incrementing (and sometimes wrapping) tick counter for setting off various events
 GameYear  _game_year;  ///< Number of years since the game began.
 
-bool _year_is_looping; ///< Is the current year repeating? (and has looped at least once)
+bool _year_is_looping; ///< True if the current year is selected to loop and has done so at least once.
 
 /**
  * Checks if the current year is looping, and has occurred at least once.

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -27,7 +27,8 @@ Year      _cur_year;   ///< Current year, starting at 0
 Month     _cur_month;  ///< Current month (0..11)
 Date      _date;       ///< Current date in days (day counter)
 DateFract _date_fract; ///< Fractional part of the day.
-uint16 _tick_counter;  ///< Ever incrementing (and sometimes wrapping) tick counter for setting off various events
+uint16    _tick_counter;  ///< Ever incrementing (and sometimes wrapping) tick counter for setting off various events
+GameYear  _game_year;  ///< Number of years since the game began.
 
 bool _year_is_looping; ///< Is the current year repeating? (and has looped at least once)
 
@@ -207,6 +208,9 @@ static void OnNewYear()
 	TownsYearlyLoop();
 	InvalidateWindowClassesData(WC_BUILD_STATION);
 	if (_network_server) NetworkServerYearlyLoop();
+
+	/* Always increment _game_year, even if the year is looping. */
+	_game_year++;
 
 	/* If we have reached the end of the maximum year or the end of the loop year, decrement dates by a year and skip the checks in else {} */
 	if ((_cur_year > MAX_YEAR) || (_cur_year == _settings_game.game_creation.loop_year + 1)) {

--- a/src/date_func.h
+++ b/src/date_func.h
@@ -17,6 +17,7 @@ extern Month     _cur_month;
 extern Date      _date;
 extern DateFract _date_fract;
 extern uint16    _tick_counter;
+extern GameYear  _game_year;
 extern bool      _year_is_looping;
 
 bool YearIsLooping();

--- a/src/date_func.h
+++ b/src/date_func.h
@@ -16,8 +16,10 @@ extern Year      _cur_year;
 extern Month     _cur_month;
 extern Date      _date;
 extern DateFract _date_fract;
-extern uint16 _tick_counter;
+extern uint16    _tick_counter;
+extern bool      _year_is_looping;
 
+bool YearIsLooping();
 void SetDate(Date date, DateFract fract);
 void ConvertDateToYMD(Date date, YearMonthDay *ymd);
 Date ConvertYMDToDate(Year year, Month month, Day day);

--- a/src/date_type.h
+++ b/src/date_type.h
@@ -15,9 +15,10 @@ typedef int32  Date;      ///< The type to store our dates in
 typedef uint16 DateFract; ///< The fraction of a date we're in, i.e. the number of ticks since the last date changeover
 typedef int32  Ticks;     ///< The type to store ticks in
 
-typedef int32  Year;  ///< Type for the year, note: 0 based, i.e. starts at the year 0.
-typedef uint8  Month; ///< Type for the month, note: 0 based, i.e. 0 = January, 11 = December.
-typedef uint8  Day;   ///< Type for the day of the month, note: 1 based, first day of a month is 1.
+typedef int32  GameYear;  ///< The number of years since the current game started, note: begins with 0.
+typedef int32  Year;       ///< Type for the year, note: 0 based, i.e. starts at the year 0.
+typedef uint8  Month;      ///< Type for the month, note: 0 based, i.e. 0 = January, 11 = December.
+typedef uint8  Day;        ///< Type for the day of the month, note: 1 based, first day of a month is 1.
 
 /**
  * 1 day is 74 ticks; _date_fract used to be uint16 and incremented by 885. On

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -703,7 +703,7 @@ static void CompaniesGenStatistics()
 /**
  * Add monthly inflation
  * @param check_year Shall the inflation get stopped after 170 years?
- * @return true if inflation is maxed and nothing was changed
+ * @return true if inflation is not changed, else false.
  */
 bool AddInflation(bool check_year)
 {
@@ -725,6 +725,9 @@ bool AddInflation(bool check_year)
 	if (check_year && (_cur_year < ORIGINAL_BASE_YEAR || _cur_year >= ORIGINAL_MAX_YEAR)) return true;
 
 	if (_economy.inflation_prices == MAX_INFLATION || _economy.inflation_payment == MAX_INFLATION) return true;
+
+	/* Don't increase inflation during gameplay if the year is looping. */
+	if (check_year && YearIsLooping()) return true;
 
 	/* Approximation for (100 + infl_amount)% ** (1 / 12) - 100%
 	 * scaled by 65536

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -2026,7 +2026,7 @@ CommandCost CmdBuyShareInCompany(TileIndex tile, DoCommandFlag flags, uint32 p1,
 	if (c == nullptr || !_settings_game.economy.allow_shares || _current_company == target_company) return CMD_ERROR;
 
 	/* Protect new companies from hostile takeovers */
-	if (_cur_year - c->inaugurated_year < _settings_game.economy.min_years_for_shares) return_cmd_error(STR_ERROR_PROTECTED);
+	if (_game_year - c->inaugurated_game_year < _settings_game.economy.min_years_for_shares) return_cmd_error(STR_ERROR_PROTECTED);
 
 	/* Those lines are here for network-protection (clients can be slow) */
 	if (GetAmountOwnedBy(c, COMPANY_SPECTATOR) == 0) return cost;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1757,7 +1757,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 
 		/* if last speed is 0, we treat that as if no vehicle has ever visited the station. */
 		ge->last_speed = std::min(t, 255);
-		ge->last_age = std::min(_cur_year - front->build_year, 255);
+		ge->last_age = std::min(front->age / DAYS_IN_LEAP_YEAR, 255);
 
 		assert(v->cargo_cap >= v->cargo.StoredCount());
 		/* Capacity available for loading more cargo. */

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -845,6 +845,9 @@ void EnginesDailyLoop()
 
 	if (_cur_year >= _year_engine_aging_stops) return;
 
+	/* Don't age engines if the year is looping */
+	if (YearIsLooping()) return;
+
 	for (Engine *e : Engine::Iterate()) {
 		EngineID i = e->index;
 		if (e->flags & ENGINE_EXCLUSIVE_PREVIEW) {
@@ -1034,7 +1037,7 @@ static void NewVehicleAvailable(Engine *e)
 /** Monthly update of the availability, reliability, and preview offers of the engines. */
 void EnginesMonthlyLoop()
 {
-	if (_cur_year < _year_engine_aging_stops) {
+	if (_cur_year < _year_engine_aging_stops && !YearIsLooping()) {
 		for (Engine *e : Engine::Iterate()) {
 			/* Age the vehicle */
 			if ((e->flags & ENGINE_AVAILABLE) && e->age != MAX_DAY) {

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1757,7 +1757,7 @@ static void DoCreateNewIndustry(Industry *i, TileIndex tile, IndustryType type, 
 	i->counter = GB(r, 4, 12);
 	i->random = initial_random_bits;
 	i->was_cargo_delivered = false;
-	i->last_prod_year = _cur_year;
+	i->last_prod_year = _game_year;
 	i->founder = founder;
 	i->ctlflags = INDCTL_NONE;
 
@@ -2358,7 +2358,7 @@ static void UpdateIndustryStatistics(Industry *i)
 		if (i->produced_cargo[j] != CT_INVALID) {
 			byte pct = 0;
 			if (i->this_month_production[j] != 0) {
-				i->last_prod_year = _cur_year;
+				i->last_prod_year = _game_year;
 				pct = std::min(i->this_month_transported[j] * 256 / i->this_month_production[j], 255);
 			}
 			i->last_month_pct_transported[j] = pct;
@@ -2793,7 +2793,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 	if ((i->ctlflags & INDCTL_NO_PRODUCTION_INCREASE) && (mul > 0 || increment > 0)) return;
 
 	if (!callback_enabled && (indspec->life_type & INDUSTRYLIFE_PROCESSING)) {
-		if ( (byte)(_cur_year - i->last_prod_year) >= 5 && Chance16(1, original_economy ? 2 : 180)) {
+		if ( (byte)(_game_year - i->last_prod_year) >= 5 && Chance16(1, original_economy ? 2 : 180)) {
 			closeit = true;
 		}
 	}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1600,6 +1600,10 @@ STR_CONFIG_SETTING_ENDING_YEAR                                  :Scoring end yea
 STR_CONFIG_SETTING_ENDING_YEAR_HELPTEXT                         :Year the game ends for scoring purposes. At the end of this year, the company's score is recorded and the high-score screen is displayed, but the players can continue playing after that.{}If this is before the starting year, the high-score screen is never displayed.
 STR_CONFIG_SETTING_ENDING_YEAR_VALUE                            :{NUM}
 STR_CONFIG_SETTING_ENDING_YEAR_ZERO                             :Never
+STR_CONFIG_SETTING_LOOP_YEAR                                    :Loop year: {STRING2}
+STR_CONFIG_SETTING_LOOP_YEAR_HELPTEXT                           :Repeat this year forever. Days and months pass as normal, but the year does not advance. Set to 0 to disable.
+STR_CONFIG_SETTING_LOOP_YEAR_VALUE                              :{NUM}
+STR_CONFIG_SETTING_LOOP_YEAR_ZERO                               :Never
 STR_CONFIG_SETTING_ECONOMY_TYPE                                 :Economy type: {STRING2}
 STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT                        :Smooth economy makes production changes more often, and in smaller steps. Frozen economy stops production changes and industry closures. This setting may have no effect if industry types are provided by a NewGRF.
 STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL                        :Original

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1618,7 +1618,8 @@ void NetworkUpdateClientInfo(ClientID client_id)
 /** Check if we want to restart the map */
 static void NetworkCheckRestartMap()
 {
-	if (_settings_client.network.restart_game_year != 0 && _cur_year >= _settings_client.network.restart_game_year) {
+	if ((_settings_client.network.restart_game_length != 0 && _game_year >= _settings_client.network.restart_game_length) ||
+		(_settings_client.network.restart_game_year != 0 && _cur_year >= _settings_client.network.restart_game_year)) {
 		DEBUG(net, 0, "Auto-restarting map. Year %d reached", _cur_year);
 
 		_settings_newgame.game_creation.generation_seed = GENERATE_NEW_SEED;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -304,7 +304,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10  Configurable ending year.
 	SLV_REMOVE_TOWN_CARGO_CACHE,            ///< 219  PR#8258 Remove town cargo acceptance and production caches.
-	SLV_LOOP_YEAR,							///< 220  FIXME: Add PR# Configurable loop year.
+	SLV_LOOP_YEAR,                          ///< 220  PR#8749 Configurable loop year.
 
 	/* Patchpacks for a while considered it a good idea to jump a few versions
 	 * above our version for their savegames. But as time continued, this gap

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -304,6 +304,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_TRADING_AGE,                        ///< 217  PR#7780 Configurable company trading age.
 	SLV_ENDING_YEAR,                        ///< 218  PR#7747 v1.10  Configurable ending year.
 	SLV_REMOVE_TOWN_CARGO_CACHE,            ///< 219  PR#8258 Remove town cargo acceptance and production caches.
+	SLV_LOOP_YEAR,							///< 220  FIXME: Add PR# Configurable loop year.
 
 	/* Patchpacks for a while considered it a good idea to jump a few versions
 	 * above our version for their savegames. But as time continued, this gap

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1791,6 +1791,7 @@ static SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("difficulty.industry_density"));
 			genworld->Add(new SettingEntry("gui.pause_on_newgame"));
 			genworld->Add(new SettingEntry("game_creation.ending_year"));
+			genworld->Add(new SettingEntry("game_creation.loop_year"));
 		}
 
 		SettingsPage *environment = main->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -292,6 +292,7 @@ struct GameCreationSettings {
 	uint32 generation_seed;                  ///< noise seed for world generation
 	Year   starting_year;                    ///< starting date
 	Year   ending_year;                      ///< scoring end date
+	Year   loop_year;                        ///< groundhog year
 	uint8  map_x;                            ///< X size of map
 	uint8  map_y;                            ///< Y size of map
 	byte   land_generator;                   ///< the landscape generator

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -279,6 +279,7 @@ struct NetworkSettings {
 	uint8  max_clients;                                   ///< maximum amount of clients
 	uint8  max_spectators;                                ///< maximum amount of spectators
 	Year   restart_game_year;                             ///< year the server restarts
+	GameYear restart_game_length;                         ///< number of years to play (including loop years) before restarting the server
 	uint8  min_active_clients;                            ///< minimum amount of active clients to unpause the game
 	uint8  server_lang;                                   ///< language of the server
 	bool   reload_cfg;                                    ///< reload the config file before restarting

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1496,6 +1496,21 @@ cat      = SC_ADVANCED
 
 [SDT_VAR]
 base     = GameSettings
+var      = game_creation.loop_year
+type     = SLE_INT32
+from     = SLV_LOOP_YEAR
+guiflags = SGF_0ISDISABLED
+def      = MIN_YEAR
+min      = MIN_YEAR
+max      = MAX_YEAR
+interval = 1
+str      = STR_CONFIG_SETTING_LOOP_YEAR
+strhelp  = STR_CONFIG_SETTING_LOOP_YEAR_HELPTEXT
+strval   = STR_CONFIG_SETTING_LOOP_YEAR_VALUE
+cat      = SC_ADVANCED
+
+[SDT_VAR]
+base     = GameSettings
 var      = economy.type
 type     = SLE_UINT8
 guiflags = SGF_MULTISTRING

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -4062,8 +4062,19 @@ var      = network.restart_game_year
 type     = SLE_INT32
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_0ISDISABLED | SGF_NETWORK_ONLY
+to       = SLV_LOOP_YEAR
 def      = 0
 min      = MIN_YEAR
+max      = MAX_YEAR
+interval = 1
+
+[SDTC_VAR]
+var      = network.restart_game_length
+type     = SLE_INT32
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_0ISDISABLED | SGF_NETWORK_ONLY
+def      = 0
+min      = 0
 max      = MAX_YEAR
 interval = 1
 


### PR DESCRIPTION
## Motivation / Problem

The goal of this PR is to add an option to freeze technological progress in a chosen year, by failing to advance the year after December 31st. While this can be faked using the cheat menu or “Vehicles never expire,” both are tedious and the latter doesn’t affect the introduction of new houses, towns building newer roadtypes, and other NewGRFs which progress through time.

The ability to remain in a certain year (really a period of time, but commonly a year) is often requested by players who want to explore a certain period in history without the frustration or immersion-breaking of the aforementioned hacks. Transport Fever 2 includes a setting to repeat a certain year forever, to support this style of play. I see several new opportunities in offering this game mode:
- Early-year games such as the American Wild West can actually reach a late-game network size and bank account without cheating time and money — without this, by the time a large network can be built, the era is long past.
- Industry sets can be designed for this mode without regard to supporting realistic technological progression, and can offer industry chains which were phased out long ago. Imagine sending ships to hunt whales, delivering coal to gasworks for town gas production, and harvesting ice from frozen lakes to ship around the world. Currently, the NewGRF author can either choose to force these industries to close, frustrating the player, or keep them around forever, which feels silly.
- Players who want to build in one time period and not have to worry about vehicle and tech upgrades can do so, without having to start their game in the future or use the aforementioned hacks. Many transport simulator games, like Cities in Motion, Cities: Skylines, Mini Metro, and Airport CEO; train simulators like Trainz, Derail Valley, Train Sim World, and MSTS; and logistics games like Factorio, Satisfactory, and Rise of Industry do not have history progression and let the player focus on other things.

## Description

#7938 proposed a “groundhog year” but did not consider the many potential side effects of looping a gameplay year. This PR is my attempt to address these and either make the necessary changes or confirm that no change is required. Thanks to those who participated in #8384 (especially @andythenorth) to suggest potential issues.

This also adds a "game year" which functions like the repeating years in Transport Fever 2, displaying a counter of how many years have passed since the game started. This means graphs, the company finance window, etc., still provide useful information.

There is plenty yet to be done, but I figure it's good to start the conversation before I get too far down rabbitholes like changing how time is measured. 🙂 This change to `_game_year` is the area where I'm least confident in my work. Please see the "Help needed" section in Limitations.

For the sake of reviews, I’ve tried to organize my changes into logical commits. We can squash later before merging.

### Modified to work with looped years:
- Implemented #7938 to add a game setting, loop the year, and add a boolean which tells if the current year is looping. Note that the first time through the looped year is not considered a loop.
- Reorganized OnNewYear() to prevent calling:
  - Semaphore signal introduction date
  - End game chart
  - Switch to Euro
- Changing the year using cheats resets `year_is_looping` to false
- Inflation is not applied during looped years
- Don’t age engines (life cycle of vehicle types, not individual vehicles), introduce new engines, or show vehicle previews in looped years

### Modified to use _game_year:
`_game_year` is a counter which measures how many years have passed in the current game.
- Company inaugurated year and age, including requirements to purchase shares and send money
- Secondary industry closure mechanic (1/16 chance of closing after 5 years of no production)
- Added restart_game_length to network config, to restart game after some number of years (including looped years)

### Tested, no change needed:
- Attempting to pass MAX_YEAR by changing the date in the cheat menu is not possible, since this doesn’t touch MAX_YEAR at all (unlike the original PR).
- Vehicle age is counted in days and calculated to years, so years don’t affect:
  - Vehicle aging, reliability, breakdowns
  - Vehicle autorenew
- Newspapers, disasters, vanilla industries with date restrictions (Oil Wells, Oil Rigs), NewGRF airport availability, bridge availability, and house availability simply check the current year and have no issues with a looped year.
- Subsidies and town funded growth use counters which are decremented each month (note: subsidies display the wrong end date, but work fine)
- Loan interest isn’t affected by time, not even when inflation is enabled
- Town rating is updated in the monthly loop, which doesn’t touch years.

## Limitations

### Help needed:
- Did I add the savegame upgrade properly?
- How does LoadNewGRF (in newgrf.cpp) use the year? I don’t understand this.
- Does the new company `inaugurated_game_year` need to be sent to network clients, along with the old `inaugurated_year`?
- What other considerations are required for `_game_year` in network games?

### Testing needed:
- Vehicles don’t seem to disappear from the purchase menu, even when they become available mid-year (you can test with the Class ET in Danish Trains, which becomes available 2000/07/02), unless I use the console commands `resetengines` or `reload_newgrfs`. This needs more testing to confirm.
- NewGRF and Game Script can both check the year. This opens up potential side effects but can’t possibly be in scope for this PR. I suggest making the game_year_counter variable visible to them as an alternative way to measure time. Can anyone thing of specific examples where this could break things?

### To Do:
- Switch to showing the game_year instead of the actual year when the year is looping (all are functional, but display the wrong date):
  - Graphs
  - Company finance window
  - Timetable dates
  - Date in status bar
  - Subsidy expiration date

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
