### PR TITLE
Fix: [CMake]  libpng header/library mismatch for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ if(OPTION_TOOLS_ONLY)
     return()
 endif()
 
+if(APPLE)
+	# Avoid searching for headers in Frameworks, and libraries in LIBDIR.
+	set(CMAKE_FIND_FRAMEWORK LAST)
+endif()
+
 # Prefer -pthread over -lpthread, which is often the better option of the two.
 set(CMAKE_THREAD_PREFER_PTHREAD YES)
 # Make sure we have Threads available.


### PR DESCRIPTION
## Motivation / Problem
On macos, CMake find modules first search in `Framework`.
From CI `vcpkg install`
```
    libpng[core]:x64-osx -> 1.6.37#14
```
From CI `cmake build`
```
-- Found PNG: optimized;/usr/local/share/vcpkg/installed/x64-osx/debug/lib/libpng.a;debug;/usr/local/share/vcpkg/installed/x64-osx/debug/lib/libpng16d.a (found version "1.4.12") 
```
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Simply change search order so `Framework` are tested after user installed packages.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

[result](https://github.com/OpenTTD/OpenTTD/pull/8754/checks?check_run_id=1991753350#step:8:59)
## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
