### PR TITLE
Fix: several bugs related to joining a network server

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -822,13 +822,6 @@ CommandCost CmdCompanyCtrl(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 			ClientID client_id = (ClientID)p2;
 			NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
-#ifndef DEBUG_DUMP_COMMANDS
-			/* When replaying the client ID is not a valid client; there
-			 * are actually no clients at all. However, the company has to
-			 * be created, otherwise we cannot rerun the game properly.
-			 * So only allow a nullptr client info in that case. */
-			if (ci == nullptr) return CommandCost();
-#endif /* NOT DEBUG_DUMP_COMMANDS */
 
 			/* Delete multiplayer progress bar */
 			DeleteWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
@@ -837,7 +830,9 @@ CommandCost CmdCompanyCtrl(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 
 			/* A new company could not be created, revert to being a spectator */
 			if (c == nullptr) {
-				if (_network_server) {
+				/* We check for "ci != nullptr" as a client could have left by
+				 * the time we execute this command. */
+				if (_network_server && ci != nullptr) {
 					ci->client_playas = COMPANY_SPECTATOR;
 					NetworkUpdateClientInfo(ci->client_id);
 				}

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -256,7 +256,10 @@ CommandCost CmdGoalQuestion(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 	if (StrEmpty(text)) return CMD_ERROR;
 	if (is_client) {
-		if (NetworkClientInfo::GetByClientID(client) == nullptr) return CMD_ERROR;
+		/* Only check during pre-flight; the client might have left between
+		 * testing and executing. In that case it is fine to just ignore the
+		 * fact the client is no longer here. */
+		if (!(flags & DC_EXEC) && _network_server && NetworkClientInfo::GetByClientID(client) == nullptr) return CMD_ERROR;
 	} else {
 		if (company != INVALID_COMPANY && !Company::IsValidID(company)) return CMD_ERROR;
 	}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -550,7 +550,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendWelcome()
 /** Tell the client that its put in a waiting queue. */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendWait()
 {
-	int waiting = 0;
+	int waiting = 1; // current player getting the map counts as 1
 	Packet *p;
 
 	/* Count how many clients are waiting in the queue, in front of you! */

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -80,6 +80,8 @@ public:
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
 	void GetClientName(char *client_name, const char *last) const;
 
+	void CheckNextClientToSendMap(NetworkClientSocket *ignore_cs = nullptr);
+
 	NetworkRecvStatus SendMap();
 	NetworkRecvStatus SendErrorQuit(ClientID client_id, NetworkErrorCode errorno);
 	NetworkRecvStatus SendQuit(ClientID client_id);

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -43,7 +43,6 @@ protected:
 	NetworkRecvStatus SendCompanyInfo();
 	NetworkRecvStatus SendNewGRFCheck();
 	NetworkRecvStatus SendWelcome();
-	NetworkRecvStatus SendWait();
 	NetworkRecvStatus SendNeedGamePassword();
 	NetworkRecvStatus SendNeedCompanyPassword();
 
@@ -82,6 +81,7 @@ public:
 
 	void CheckNextClientToSendMap(NetworkClientSocket *ignore_cs = nullptr);
 
+	NetworkRecvStatus SendWait();
 	NetworkRecvStatus SendMap();
 	NetworkRecvStatus SendErrorQuit(ClientID client_id, NetworkErrorCode errorno);
 	NetworkRecvStatus SendQuit(ClientID client_id);


### PR DESCRIPTION
Fixes #8751

## Motivation / Problem

There are four bugs mentioned in the above ticket:
1) waiting queue seems off by 1
2) when client that is downloading disconnects, all others in queue will never start their download
3) while in queue, you get after 5 seconds that the server is not responding
4) if a client creates a new company and leaves while you are downloading a map, the client desyncs

## Description

1) is a linguistic issue. "1 person waiting" means 1 is being served while there is 1 more waiting. So when you are the next in line, there are 0 people waiting, so 0 people in front of you. But this just looks odd and weird. So let's ignore "strictly seen correct" and go with the more expected version: 1 people in front of you means that person is downloading the map.

2) the state machine was poorly designed around unhappy flows. Now, if for what-ever reason the client disconnects while downloading the map, the savegame process is stopped and the next person is getting the map.

3) every second all people in queue now receive a packet, letting them know the server is alive.

4) after the server approved the CmdCompanyCtrl, clients and server could still reject it depending if they received that the client left the server. This is latency depending, and can cause desync. Introduced in f8f7febe41311ff3562c57a10672e3a62174104b, which originally avoided this situation, but stricter validation created the possibility to desync (the check changed from an out-of-bound check to a "does this still exist" check).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
