### PR TITLE
Fix #8750: [OpenGL] Line drawing did not set proper RGB/mask colours.

### DIFF
--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -23,6 +23,7 @@ public:
 	// void *MoveTo(void *video, int x, int y) override;
 	void SetPixel(void *video, int x, int y, uint8 colour) override;
 	void DrawRect(void *video, int width, int height, uint8 colour) override;
+	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8 colour, int width, int dash) override;
 	void CopyFromBuffer(void *video, const void *src, int width, int height) override;
 	void CopyToBuffer(const void *video, void *dst, int width, int height) override;
 	void CopyImageToBuffer(const void *video, void *dst, int width, int height, int dst_pitch) override;


### PR DESCRIPTION
## Motivation / Problem

Lines look wrong with 40bpp-anim blitter.


## Description

Line drawing needs to set both the RGB and the mask part of the screen buffer.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
