### PR TITLE
Fix: Issues with cursors consisting of multiple sprites

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3171,7 +3171,7 @@ void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type)
 		total_width += GetSingleVehicleWidth(v, image_type);
 	}
 
-	int offs = ((int)VEHICLEINFO_FULL_VEHICLE_WIDTH - total_width) / 2;
+	int offs = (ScaleGUITrad(VEHICLEINFO_FULL_VEHICLE_WIDTH) - total_width) / 2;
 	if (rtl) offs = -offs;
 	for (uint i = 0; i < _cursor.sprite_count; ++i) {
 		_cursor.sprite_pos[i].x += offs;

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1028,6 +1028,7 @@ void OpenGLBackend::DrawMouseCursor()
 	_cur_dpi = &_screen;
 	for (uint i = 0; i < _cursor.sprite_count; ++i) {
 		SpriteID sprite = _cursor.sprite_seq[i].sprite;
+		const Sprite *spr = GetSprite(sprite, ST_NORMAL);
 
 		if (!this->cursor_cache.Contains(sprite)) {
 			Sprite *old = this->cursor_cache.Insert(sprite, (Sprite *)GetRawSprite(sprite, ST_NORMAL, &SimpleSpriteAlloc, this));
@@ -1038,7 +1039,10 @@ void OpenGLBackend::DrawMouseCursor()
 			}
 		}
 
-		this->RenderOglSprite((OpenGLSprite *)this->cursor_cache.Get(sprite)->data, _cursor.sprite_seq[i].pal, _cursor.pos.x + _cursor.sprite_pos[i].x, _cursor.pos.y + _cursor.sprite_pos[i].y, ZOOM_LVL_GUI);
+		this->RenderOglSprite((OpenGLSprite *)this->cursor_cache.Get(sprite)->data, _cursor.sprite_seq[i].pal,
+				_cursor.pos.x + _cursor.sprite_pos[i].x + UnScaleByZoom(spr->x_offs, ZOOM_LVL_GUI),
+				_cursor.pos.y + _cursor.sprite_pos[i].y + UnScaleByZoom(spr->y_offs, ZOOM_LVL_GUI),
+				ZOOM_LVL_GUI);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

OpenGL video driver: when dragging multi-sprite vehicles in depot, they looked borked when attached to the cursor.

## Description

The OpenGL driver did not use sprite offset. For regular cursor sprites this does not matter, since the offset is usually (0,0), but for vehicle cursors it's important.

Also included is yet another fix, where the vehicle cursor did not account for the GUI zoom level.

## Limitations

None

## Checklist for review

N/A