### PR TITLE
Fix: [OpenGL] Don't use OpenGL on MESA software renderers.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -15,6 +15,8 @@
 // #define NO_GL_BUFFER_SYNC
 /* Define to enable persistent buffer mapping on AMD GPUs. */
 // #define GL_MAP_PERSISTENT_AMD
+/* Define to allow software rendering backends. */
+// #define GL_ALLOW_SOFTWARE_RENDERER
 
 #if defined(_WIN32)
 #	include <windows.h>
@@ -535,6 +537,12 @@ const char *OpenGLBackend::Init()
 	if (ver == nullptr || vend == nullptr || renderer == nullptr) return "OpenGL not supported";
 
 	DEBUG(driver, 1, "OpenGL driver: %s - %s (%s)", vend, renderer, ver);
+
+#ifndef GL_ALLOW_SOFTWARE_RENDERER
+	/* Don't use MESA software rendering backends as they are slower than
+	 * just using a non-OpenGL video driver. */
+	if (strncmp(renderer, "llvmpipe", 8) == 0 || strncmp(renderer, "softpipe", 8) == 0) return "Software renderer detected, not using OpenGL";
+#endif
 
 	const char *minor = strchr(ver, '.');
 	_gl_major_ver = atoi(ver);


### PR DESCRIPTION
## Motivation / Problem

MESA software OpenGL is slower than not using it.


## Description

Just block it and let OpenTTD fallback to another video dirver.


## Limitations

If the reported renderer string changes, the test might fail in the future.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
