### PR TITLE
Fix #8763: [OpenGL] Cursor sprite origin can be negative.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1217,7 +1217,7 @@ void OpenGLBackend::ReleaseAnimBuffer(const Rect &update_rect)
  * @param y Y position of the sprite.
  * @param zoom Zoom level to use.
  */
-void OpenGLBackend::RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, uint x, uint y, ZoomLevel zoom)
+void OpenGLBackend::RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom)
 {
 	/* Set textures. */
 	bool rgb = gl_sprite->BindTextures();

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -70,7 +70,7 @@ private:
 	const char *Init();
 	bool InitShaders();
 
-	void RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, uint x, uint y, ZoomLevel zoom);
+	void RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom);
 
 public:
 	/** Get singleton instance of this class. */


### PR DESCRIPTION
## Motivation / Problem

Cursor sprite can disapper near the top/left border.


## Description

While dragging, the cursor origin can get negative. Allow negative values and it will magically work.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
