### PR TITLE
Unlimit framerate window and fix pause behaviour

### DIFF
--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -399,7 +399,6 @@ struct FramerateWindow : Window {
 		{
 			const double threshold_good = target * 0.95;
 			const double threshold_bad = target * 2 / 3;
-			value = std::min(9999.99, value);
 			this->value = (uint32)(value * 100);
 			this->strid = (value > threshold_good) ? STR_FRAMERATE_FPS_GOOD : (value < threshold_bad) ? STR_FRAMERATE_FPS_BAD : STR_FRAMERATE_FPS_WARN;
 		}
@@ -408,7 +407,6 @@ struct FramerateWindow : Window {
 		{
 			const double threshold_good = target / 3;
 			const double threshold_bad = target;
-			value = std::min(9999.99, value);
 			this->value = (uint32)(value * 100);
 			this->strid = (value < threshold_good) ? STR_FRAMERATE_MS_GOOD : (value > threshold_bad) ? STR_FRAMERATE_MS_BAD : STR_FRAMERATE_MS_WARN;
 		}

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -274,6 +274,7 @@ void PerformanceMeasurer::SetExpectedRate(double rate)
  */
 /* static */ void PerformanceMeasurer::Paused(PerformanceElement elem)
 {
+	PerformanceMeasurer::SetInactive(elem);
 	_pf_data[elem].AddPause(GetPerformanceTimer());
 }
 


### PR DESCRIPTION
## Motivation / Problem
Framerate window maxes out at 9999 fps. Game can (fairly trivially) exceed that now. Useful/fun to display the actual framerate
While paused, framerate window would display the last (stale) data, rather than zero-values
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Removes limit on framerate window
![](https://i.imgur.com/4McHu2K.png)

Changes behaviour of window while game is paused:
Before:
![](https://i.imgur.com/xLzLjO4.png)
After:
![](https://i.imgur.com/3YxQOOh.png)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Might consider adding `SetInactive` to `Paused` to be a hack.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
