### PR TITLE
Change: Don't decrease vehicle reliability when stopped

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1254,8 +1254,9 @@ void CheckVehicleBreakdown(Vehicle *v)
 	int rel, rel_old;
 
 	/* decrease reliability */
-	if (!_settings_game.order.no_servicing_if_no_breakdowns ||
-			_settings_game.difficulty.vehicle_breakdowns != 0) {
+	if ((!_settings_game.order.no_servicing_if_no_breakdowns ||
+			_settings_game.difficulty.vehicle_breakdowns != 0)
+			&& v->cur_speed > 0) {
 		v->reliability = rel = std::max((rel_old = v->reliability) - v->reliability_spd_dec, 0);
 		if ((rel_old >> 8) != (rel >> 8)) SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 	}


### PR DESCRIPTION
## Motivation / Problem

I frequently see comments from players that breakdowns are "broken" and seem random to players. #8317 improves breakdowns by making each service in a depot prevent future breakdowns, but vehicles still degrade while waiting in a station for a full load, waiting for a station track to open up, or while stuck in traffic jams.

I typically service vehicles before they load in a station using a depot overflow, but by the time the vehicle achieves a full load and departs, its reliability has already decreased significantly, despite having only moved a few tiles from the depot to the station. I would expect my vehicle's reliability to only degrade when the vehicle is moving.

While real-world vehicles do degrade in reliability when parked for long periods of time, this is on the order of weeks and months and isn't really applicable to OpenTTD.

We discussed disabling breakdowns by default in #8393 but the consensus was that they should be fixed, not just avoided. This is an attempt to iteratively improve them by fixing what I consider to be an unexpected behavior. 

## Description

With this proposal, vehicles only decrease in reliability if their speed is greater than 0.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
