### PR TITLE
Validate that "max" values in settings fit in their storage container

### DIFF
--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -21,6 +21,15 @@
 #include "zoom_type.h"
 #include "openttd.h"
 
+/* Used to validate sizes of "max" value in settings. */
+const size_t MAX_SLE_UINT8 = UINT8_MAX;
+const size_t MAX_SLE_UINT16 = UINT16_MAX;
+const size_t MAX_SLE_UINT32 = UINT32_MAX;
+const size_t MAX_SLE_UINT = UINT_MAX;
+const size_t MAX_SLE_INT8 = INT8_MAX;
+const size_t MAX_SLE_INT16 = INT16_MAX;
+const size_t MAX_SLE_INT32 = INT32_MAX;
+const size_t MAX_SLE_INT = INT_MAX;
 
 /** Settings profiles and highscore tables. */
 enum SettingsProfile {

--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -20,6 +20,9 @@ SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                
 SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END  = SDT_END()
 
+[validation]
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+
 [defaults]
 flags    = 0
 guiflags = SGF_PER_COMPANY

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -14,6 +14,9 @@ SDT_CHR = SDT_CHR($base, $var,        $flags, $guiflags, $def,                  
 SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END = SDT_END()
 
+[validation]
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+
 [defaults]
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NONE

--- a/src/table/gameopt_settings.ini
+++ b/src/table/gameopt_settings.ini
@@ -149,7 +149,8 @@ var      = game_creation.snow_line_height
 type     = SLE_UINT8
 def      = DEF_SNOWLINE_HEIGHT * TILE_HEIGHT
 min      = MIN_SNOWLINE_HEIGHT * TILE_HEIGHT
-max      = MAX_SNOWLINE_HEIGHT * TILE_HEIGHT
+# "max" used to be MAX_SNOWLINE_HEIGHT * TILE_HEIGHT, but this would overflow the storage.
+max      = UINT8_MAX
 to       = SLV_22
 
 [SDT_NULL]

--- a/src/table/gameopt_settings.ini
+++ b/src/table/gameopt_settings.ini
@@ -46,6 +46,13 @@ SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $ma
 SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_END      = SDT_END()
 
+[validation]
+SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+
 [defaults]
 flags    = 0
 guiflags = SGF_NONE

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -26,6 +26,10 @@ SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,   
 SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_END   = SDTG_END()
 
+[validation]
+SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+
 [defaults]
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NONE

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -435,7 +435,7 @@ type     = SLE_UINT16
 from     = SLV_156
 def      = 4096
 min      = 0
-max      = 1 << 30
+max      = 1 << 15
 interval = 1
 cat      = SC_EXPERT
 
@@ -457,7 +457,7 @@ type     = SLE_UINT16
 from     = SLV_156
 def      = 4096
 min      = 0
-max      = 1 << 30
+max      = 1 << 15
 interval = 1
 cat      = SC_EXPERT
 
@@ -479,7 +479,7 @@ type     = SLE_UINT16
 from     = SLV_175
 def      = 4096
 min      = 0
-max      = 1 << 30
+max      = 1 << 15
 interval = 1
 cat      = SC_EXPERT
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -77,6 +77,14 @@ SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min,
 SDT_NULL   =   SDT_NULL($length, $from, $to),
 SDT_END    = SDT_END()
 
+[validation]
+SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTC_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+
 [defaults]
 flags    = 0
 guiflags = SGF_NONE

--- a/src/table/win32_settings.ini
+++ b/src/table/win32_settings.ini
@@ -18,6 +18,9 @@ SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,              
 SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_END  = SDTG_END()
 
+[validation]
+SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+
 [defaults]
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NONE

--- a/src/table/window_settings.ini
+++ b/src/table/window_settings.ini
@@ -14,6 +14,9 @@ SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                
 SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END  = SDT_END()
 
+[validation]
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+
 [defaults]
 base     = WindowDesc
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC


### PR DESCRIPTION
Fixes #8610.

## Motivation / Problem

Yesterday I added a setting where the maximum value exceeded the storage size. I was not aware of this, and nothing told me it was wrong. The reviewer missed it too.

To prevent this simple mistake from ever happening again, we should simply validate this.

Found 4 current instances that already were out-of-bounds. By accident this fixes an issue :D


## Description

Make `settingsgen` generate a post-amble that does a ton of `static_assert` to validate `max` is within the storage size assigned to the setting. This means that if you add a new setting, the compiler will tell you you suck at cookie, euh, coding.

It required moving some code in `settingsgen` to its own function, to avoid code duplication.

This could not be done by `settingsgen` btw, as `settingsgen` doesn't understand the values it is reading/writing .. it just copies them byte-by-byte. This makes sense, as you can use constants, additions, etc etc.

Fixed the four issues found too.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
