### PR TITLE
Fix c4df0f95: bootstrap was only showing a black screen

### DIFF
--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -41,7 +41,7 @@ bool VideoDriver::Tick()
 	}
 
 	/* Prevent drawing when switching mode, as windows can be removed when they should still appear. */
-	if (this->HasGUI() && cur_ticks >= this->next_draw_tick && (_switch_mode == SM_NONE || HasModalProgress())) {
+	if (this->HasGUI() && cur_ticks >= this->next_draw_tick && (_switch_mode == SM_NONE || _game_mode == GM_BOOTSTRAP || HasModalProgress())) {
 		this->next_draw_tick += this->GetDrawInterval();
 		/* Avoid next_draw_tick getting behind more and more if it cannot keep up. */
 		if (this->next_draw_tick < cur_ticks - ALLOWED_DRIFT * this->GetDrawInterval()) this->next_draw_tick = cur_ticks;


### PR DESCRIPTION
Fixes #8785

Tnx to @PeterN for triage.

## Motivation / Problem

Bootstrap wasn't working. Now it is.

## Description

```
The bootstrap has the _switch_mode to SM_MENU, and never leaves
this mode. Neither is it considered a modal window (while in some
sense it really is). So .. we need to add another "draw anyway"
exception, to make sure bootstrap is being drawn.
```

Over the years we collected various of ways of doing "modal" windows, where two use HasModalProgress (but are implemented differently) and one, as it turns out, uses a completely different method. This confused the new video-driver code.

This fix is just a quick-fix, as this non-sense should be resolved properly ;) Mostly, these exceptions are here as when you press "Exit to Main Menu" the window asking for confirmation is removed before your game-mode is switched, leave you in-game with a non-responsive interface, being confused. So this code in question keeps the confirmation dialog visible, while the game switched to a new mode.
The more proper fix is to show a dialog: "Exiting game ...", and let the drawing continue. This also, not now but in future iterations, would make it possible to keep the mouse responsive.

But, both solutions are not there yet, and require more refactoring of video-driver related code. I would consider that unlikely to hit 1.11, hence this fix to at least make bootstrap work again. A hack on a hack is still just a hack :D

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
