### PR TITLE
Fix: [OSX] Hide dock when entering fullscreen

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -196,6 +196,10 @@ bool VideoDriver_Cocoa::ToggleFullscreen(bool full_screen)
 
 	if ([ this->window respondsToSelector:@selector(toggleFullScreen:) ]) {
 		[ this->window performSelector:@selector(toggleFullScreen:) withObject:this->window ];
+
+		/* Hide the menu bar and the dock */
+		[ NSMenu setMenuBarVisible:!full_screen ];
+
 		this->UpdateVideoModes();
 		return true;
 	}


### PR DESCRIPTION
## Motivation / Problem

As per the last comment in #8038, the dock still appears if you hover over the bottom of the screen when in fullscreen mode.

## Description

When switching into fullscreen mode, we hide both the menu and the dock programmatically. They are unhidden again when exiting full screen.

## Limitations

None that I'm aware of.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
