### PR TITLE
Fix #8774: Black screenshots when using 40bpp-blitter.

### DIFF
--- a/src/blitter/32bpp_optimized.hpp
+++ b/src/blitter/32bpp_optimized.hpp
@@ -26,9 +26,10 @@ public:
 
 	const char *GetName() override { return "32bpp-optimized"; }
 
-	template <BlitterMode mode> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
+	template <BlitterMode mode, bool Tpal_to_rgb = false> void Draw(const Blitter::BlitterParams *bp, ZoomLevel zoom);
 
 protected:
+	template <bool Tpal_to_rgb> void Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom);
 	template <bool Tpal_to_rgb> Sprite *EncodeInternal(const SpriteLoader::Sprite *sprite, AllocatorProc *allocator);
 };
 

--- a/src/blitter/40bpp_anim.cpp
+++ b/src/blitter/40bpp_anim.cpp
@@ -315,7 +315,7 @@ void Blitter_40bppAnim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomL
 
 	if (_screen_disable_anim || VideoDriver::GetInstance()->GetAnimBuffer() == nullptr) {
 		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent Draw() */
-		Blitter_32bppOptimized::Draw(bp, mode, zoom);
+		Blitter_32bppOptimized::Draw<true>(bp, mode, zoom);
 		return;
 	}
 


### PR DESCRIPTION
This affected all screenshot types that render to an off-screen
buffer and don't copy the actual screen contents.

## Motivation / Problem

Screenshot types that take their contents from an newly rendered off-screen buffer were black when using 8bpp graphics with the 40bpp-anim blitter.


## Description

The 40bpp-blitter does not resolve palette values when encoding a sprite as palette resolving is done by OpenGL in the end. Off-screen screenshots render using 32bpp-optimized though, which expects resolved RGB values.

We fix this by adding a special mode to the 32bpp drawing code that resolves the palette during blitting.

## Limitations

Rendering these screenshots will take longer with 40bpp-anim than with a 32bpp blitter, as it incurs an additional palette lookup for each pixel. The 40bpp-anim blitter also takes a slight performance hit during sprite encoding as it has to calculate the max brightness value just for the screenshots.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
