### PR TITLE
Fix: [Win32] Fullscreen OpenTTD cannot be alt-tabbed back into

### DIFF
--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -137,7 +137,7 @@ bool VideoDriver_Win32Base::MakeWindow(bool full_screen)
 	_fullscreen = full_screen;
 
 	/* recreate window? */
-	if ((full_screen || this->fullscreen) && this->main_wnd) {
+	if ((full_screen != this->fullscreen) && this->main_wnd) {
 		DestroyWindow(this->main_wnd);
 		this->main_wnd = 0;
 	}

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -715,7 +715,9 @@ LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			if (video_driver->fullscreen) {
 				if (active && minimized) {
 					/* Restore the game window */
+					Dimension d = _bck_resolution; // Save current non-fullscreen window size as it will be overwritten by ShowWindow.
 					ShowWindow(hwnd, SW_RESTORE);
+					_bck_resolution = d;
 					video_driver->MakeWindow(true);
 				} else if (!active && !minimized) {
 					/* Minimise the window and restore desktop */


### PR DESCRIPTION
## Motivation / Problem

Alt-tabbing in and out of fullscreen when using the `win32-opengl` video driver resulted in a invisible window.


## Description

When alt-tabbing back into fullscreen, the main window was unnecessarily recreated, losing the OpenGL context. The game would also loose the original non-fullscreen window size, which is also fixed.


## Limitations

Please test thoroughly.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
