### PR TITLE
Feature: Show rail/road/tram NewGRF name in Land Area Information window

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2697,6 +2697,7 @@ STR_LAND_AREA_INFORMATION_LANDINFO_COORDS                       :{BLACK}Coordina
 STR_LAND_AREA_INFORMATION_BUILD_DATE                            :{BLACK}Built: {LTBLUE}{DATE_LONG}
 STR_LAND_AREA_INFORMATION_STATION_CLASS                         :{BLACK}Station class: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_STATION_TYPE                          :{BLACK}Station type: {LTBLUE}{STRING}
+STR_LAND_AREA_INFORMATION_STATION_NEWGRF_NAME                   :{BLACK}Station NewGRF: {LTBLUE}{RAW_STRING}
 STR_LAND_AREA_INFORMATION_AIRPORT_CLASS                         :{BLACK}Airport class: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORT_NAME                          :{BLACK}Airport name: {LTBLUE}{STRING}
 STR_LAND_AREA_INFORMATION_AIRPORTTILE_NAME                      :{BLACK}Airport tile name: {LTBLUE}{STRING}
@@ -2709,6 +2710,9 @@ STR_LANG_AREA_INFORMATION_TRAM_TYPE                             :{BLACK}Tram typ
 STR_LANG_AREA_INFORMATION_RAIL_SPEED_LIMIT                      :{BLACK}Rail speed limit: {LTBLUE}{VELOCITY}
 STR_LANG_AREA_INFORMATION_ROAD_SPEED_LIMIT                      :{BLACK}Road speed limit: {LTBLUE}{VELOCITY}
 STR_LANG_AREA_INFORMATION_TRAM_SPEED_LIMIT                      :{BLACK}Tram speed limit: {LTBLUE}{VELOCITY}
+STR_LANG_AREA_INFORMATION_RAIL_NEWGRF_NAME                      :{BLACK}Rail NewGRF: {LTBLUE}{RAW_STRING}
+STR_LANG_AREA_INFORMATION_ROAD_NEWGRF_NAME                      :{BLACK}Road NewGRF: {LTBLUE}{RAW_STRING}
+STR_LANG_AREA_INFORMATION_TRAM_NEWGRF_NAME                      :{BLACK}Tram NewGRF: {LTBLUE}{RAW_STRING}
 
 # Description of land area of different tiles
 STR_LAI_CLEAR_DESCRIPTION_ROCKS                                 :Rocks

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -162,15 +162,10 @@ public:
 
 		td.station_class = STR_NULL;
 		td.station_name = STR_NULL;
+		td.station_grf = nullptr;
 		td.airport_class = STR_NULL;
 		td.airport_name = STR_NULL;
 		td.airport_tile_name = STR_NULL;
-		td.railtype = STR_NULL;
-		td.rail_speed = 0;
-		td.roadtype = STR_NULL;
-		td.road_speed = 0;
-		td.tramtype = STR_NULL;
-		td.tram_speed = 0;
 
 		td.grf = nullptr;
 
@@ -255,6 +250,13 @@ public:
 			line_nr++;
 		}
 
+		/* Station NewGRF name */
+		if (td.station_grf != nullptr) {
+			SetDParamStr(0, td.station_grf);
+			GetString(this->landinfo_data[line_nr], STR_LAND_AREA_INFORMATION_STATION_NEWGRF_NAME, lastof(this->landinfo_data[line_nr]));
+			line_nr++;
+		}
+
 		/* Airport class */
 		if (td.airport_class != STR_NULL) {
 			SetDParam(0, td.airport_class);
@@ -277,44 +279,65 @@ public:
 		}
 
 		/* Rail type name */
-		if (td.railtype != STR_NULL) {
-			SetDParam(0, td.railtype);
+		if (td.rail_desc.type != STR_NULL) {
+			SetDParam(0, td.rail_desc.type);
 			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_RAIL_TYPE, lastof(this->landinfo_data[line_nr]));
 			line_nr++;
 		}
 
 		/* Rail speed limit */
-		if (td.rail_speed != 0) {
-			SetDParam(0, td.rail_speed);
+		if (td.rail_desc.speed != 0) {
+			SetDParam(0, td.rail_desc.speed);
 			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_RAIL_SPEED_LIMIT, lastof(this->landinfo_data[line_nr]));
 			line_nr++;
 		}
 
+		/* Rail NewGRF name */
+		if (td.rail_desc.grf != nullptr) {
+			SetDParamStr(0, td.rail_desc.grf);
+			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_RAIL_NEWGRF_NAME, lastof(this->landinfo_data[line_nr]));
+			line_nr++;
+		}
+
 		/* Road type name */
-		if (td.roadtype != STR_NULL) {
-			SetDParam(0, td.roadtype);
+		if (td.road_desc.type != STR_NULL) {
+			SetDParam(0, td.road_desc.type);
 			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_ROAD_TYPE, lastof(this->landinfo_data[line_nr]));
 			line_nr++;
 		}
 
 		/* Road speed limit */
-		if (td.road_speed != 0) {
-			SetDParam(0, td.road_speed);
+		if (td.road_desc.speed != 0) {
+			SetDParam(0, td.road_desc.speed);
 			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_ROAD_SPEED_LIMIT, lastof(this->landinfo_data[line_nr]));
 			line_nr++;
 		}
 
+		/* Road NewGRF name */
+		if (td.road_desc.grf != nullptr) {
+			SetDParamStr(0, td.road_desc.grf);
+			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_ROAD_NEWGRF_NAME, lastof(this->landinfo_data[line_nr]));
+			line_nr++;
+		}
+
 		/* Tram type name */
-		if (td.tramtype != STR_NULL) {
-			SetDParam(0, td.tramtype);
+		if (td.tram_desc.type != STR_NULL) {
+			SetDParam(0, td.tram_desc.type);
 			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_TRAM_TYPE, lastof(this->landinfo_data[line_nr]));
 			line_nr++;
 		}
 
 		/* Tram speed limit */
-		if (td.tram_speed != 0) {
-			SetDParam(0, td.tram_speed);
+		if (td.tram_desc.speed != 0) {
+			SetDParam(0, td.tram_desc.speed);
 			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_TRAM_SPEED_LIMIT, lastof(this->landinfo_data[line_nr]));
+			line_nr++;
+		}
+
+		/* Tram NewGRF name */
+		if (td.tram_desc.grf != nullptr) {
+			SetDParamStr(0, td.tram_desc.grf);
+			GetString(this->landinfo_data[line_nr], STR_LANG_AREA_INFORMATION_TRAM_NEWGRF_NAME, lastof(this->landinfo_data[line_nr]));
 			line_nr++;
 		}
 

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2808,8 +2808,7 @@ static bool ClickTile_Track(TileIndex tile)
 static void GetTileDesc_Track(TileIndex tile, TileDesc *td)
 {
 	const RailtypeInfo *rti = GetRailTypeInfo(GetRailType(tile));
-	td->rail_speed = rti->max_speed;
-	td->railtype = rti->strings.name;
+	td->rail_desc = TrackDesc(rti->strings.name, rti->max_speed, rti->grffile[0]);
 	td->owner[0] = GetTileOwner(tile);
 	switch (GetRailTileType(tile)) {
 		case RAIL_TILE_NORMAL:
@@ -2884,10 +2883,10 @@ static void GetTileDesc_Track(TileIndex tile, TileDesc *td)
 		case RAIL_TILE_DEPOT:
 			td->str = STR_LAI_RAIL_DESCRIPTION_TRAIN_DEPOT;
 			if (_settings_game.vehicle.train_acceleration_model != AM_ORIGINAL) {
-				if (td->rail_speed > 0) {
-					td->rail_speed = std::min<uint16>(td->rail_speed, 61);
+				if (td->rail_desc.speed > 0) {
+					td->rail_desc.speed = std::min<uint16>(td->rail_desc.speed, 61);
 				} else {
-					td->rail_speed = 61;
+					td->rail_desc.speed = 61;
 				}
 			}
 			td->build_date = Depot::GetByTile(tile)->build_date;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2098,14 +2098,12 @@ static void GetTileDesc_Road(TileIndex tile, TileDesc *td)
 	RoadType tram_rt = GetRoadTypeTram(tile);
 	if (road_rt != INVALID_ROADTYPE) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(road_rt);
-		td->roadtype = rti->strings.name;
-		td->road_speed = rti->max_speed / 2;
+		td->road_desc = TrackDesc(rti->strings.name, rti->max_speed / 2, rti->grffile[0]);
 		road_owner = GetRoadOwner(tile, RTT_ROAD);
 	}
 	if (tram_rt != INVALID_ROADTYPE) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(tram_rt);
-		td->tramtype = rti->strings.name;
-		td->tram_speed = rti->max_speed / 2;
+		td->tram_desc = TrackDesc(rti->strings.name, rti->max_speed / 2, rti->grffile[0]);
 		tram_owner = GetRoadOwner(tile, RTT_TRAM);
 	}
 
@@ -2115,9 +2113,7 @@ static void GetTileDesc_Road(TileIndex tile, TileDesc *td)
 			rail_owner = GetTileOwner(tile);
 
 			const RailtypeInfo *rti = GetRailTypeInfo(GetRailType(tile));
-			td->railtype = rti->strings.name;
-			td->rail_speed = rti->max_speed;
-
+			td->rail_desc = TrackDesc(rti->strings.name, rti->max_speed, rti->grffile[0]);
 			break;
 		}
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3144,15 +3144,13 @@ static void GetTileDesc_Station(TileIndex tile, TileDesc *td)
 		Owner tram_owner = INVALID_OWNER;
 		if (road_rt != INVALID_ROADTYPE) {
 			const RoadTypeInfo *rti = GetRoadTypeInfo(road_rt);
-			td->roadtype = rti->strings.name;
-			td->road_speed = rti->max_speed / 2;
+			td->road_desc = TrackDesc(rti->strings.name, rti->max_speed / 2, rti->grffile[0]);
 			road_owner = GetRoadOwner(tile, RTT_ROAD);
 		}
 
 		if (tram_rt != INVALID_ROADTYPE) {
 			const RoadTypeInfo *rti = GetRoadTypeInfo(tram_rt);
-			td->tramtype = rti->strings.name;
-			td->tram_speed = rti->max_speed / 2;
+			td->tram_desc = TrackDesc(rti->strings.name, rti->max_speed / 2, rti->grffile[0]);
 			tram_owner = GetRoadOwner(tile, RTT_TRAM);
 		}
 
@@ -3185,13 +3183,12 @@ static void GetTileDesc_Station(TileIndex tile, TileDesc *td)
 
 			if (spec->grf_prop.grffile != nullptr) {
 				const GRFConfig *gc = GetGRFConfig(spec->grf_prop.grffile->grfid);
-				td->grf = gc->GetName();
+				td->station_grf = gc->GetName();
 			}
 		}
 
 		const RailtypeInfo *rti = GetRailTypeInfo(GetRailType(tile));
-		td->rail_speed = rti->max_speed;
-		td->railtype = rti->strings.name;
+		td->rail_desc = TrackDesc(rti->strings.name, rti->max_speed, rti->grffile[0]);
 	}
 
 	if (IsAirport(tile)) {
@@ -3204,10 +3201,10 @@ static void GetTileDesc_Station(TileIndex tile, TileDesc *td)
 
 		if (as->grf_prop.grffile != nullptr) {
 			const GRFConfig *gc = GetGRFConfig(as->grf_prop.grffile->grfid);
-			td->grf = gc->GetName();
+			td->station_grf = gc->GetName();
 		} else if (ats->grf_prop.grffile != nullptr) {
 			const GRFConfig *gc = GetGRFConfig(ats->grf_prop.grffile->grfid);
-			td->grf = gc->GetName();
+			td->station_grf = gc->GetName();
 		}
 	}
 

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -15,6 +15,8 @@
 #include "cargo_type.h"
 #include "track_type.h"
 #include "tile_map.h"
+#include "newgrf.h"
+#include "newgrf_config.h"
 
 /** The returned bits of VehicleEnterTile. */
 enum VehicleEnterTileStatus {
@@ -47,6 +49,19 @@ struct TileInfo {
 	int z;          ///< Height
 };
 
+/** Track extended description for the 'land area information' tool */
+struct TrackDesc {
+	StringID type;   ///< Type of track on the tile
+	uint16 speed;    ///< Speed limit (bridges and track)
+	const char *grf; ///< NewGRF used for the track
+
+	TrackDesc() : TrackDesc(0x0, 0, nullptr) {}
+	TrackDesc(StringID type, uint16 speed_limit, const GRFFile *grffile) :
+		type(type),
+		speed(speed_limit),
+		grf(grffile != nullptr ? GetGRFConfig(grffile->grfid)->GetName() : nullptr) {}
+};
+
 /** Tile description for the 'land area information' tool */
 struct TileDesc {
 	StringID str;               ///< Description of the tile
@@ -55,17 +70,15 @@ struct TileDesc {
 	Date build_date;            ///< Date of construction of tile contents
 	StringID station_class;     ///< Class of station
 	StringID station_name;      ///< Type of station within the class
+	const char *station_grf;    ///< NewGRF used for the station
 	StringID airport_class;     ///< Name of the airport class
 	StringID airport_name;      ///< Name of the airport
 	StringID airport_tile_name; ///< Name of the airport tile
-	const char *grf;            ///< newGRF used for the tile contents
+	const char *grf;            ///< NewGRF used for the tile contents
 	uint64 dparam[2];           ///< Parameters of the \a str string
-	StringID railtype;          ///< Type of rail on the tile.
-	uint16 rail_speed;          ///< Speed limit of rail (bridges and track)
-	StringID roadtype;          ///< Type of road on the tile.
-	uint16 road_speed;          ///< Speed limit of road (bridges and track)
-	StringID tramtype;          ///< Type of tram on the tile.
-	uint16 tram_speed;          ///< Speed limit of tram (bridges and track)
+	TrackDesc rail_desc;        ///< Tile rail description
+	TrackDesc road_desc;        ///< Tile road description
+	TrackDesc tram_desc;        ///< Tile tram description
 };
 
 /**

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1721,14 +1721,12 @@ static void GetTileDesc_TunnelBridge(TileIndex tile, TileDesc *td)
 	RoadType tram_rt = GetRoadTypeTram(tile);
 	if (road_rt != INVALID_ROADTYPE) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(road_rt);
-		td->roadtype = rti->strings.name;
-		td->road_speed = rti->max_speed / 2;
+		td->road_desc = TrackDesc(rti->strings.name, rti->max_speed / 2, rti->grffile[0]);
 		road_owner = GetRoadOwner(tile, RTT_ROAD);
 	}
 	if (tram_rt != INVALID_ROADTYPE) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(tram_rt);
-		td->tramtype = rti->strings.name;
-		td->tram_speed = rti->max_speed / 2;
+		td->tram_desc = TrackDesc(rti->strings.name, rti->max_speed / 2, rti->grffile[0]);
 		tram_owner = GetRoadOwner(tile, RTT_TRAM);
 	}
 
@@ -1749,19 +1747,18 @@ static void GetTileDesc_TunnelBridge(TileIndex tile, TileDesc *td)
 
 	if (tt == TRANSPORT_RAIL) {
 		const RailtypeInfo *rti = GetRailTypeInfo(GetRailType(tile));
-		td->rail_speed = rti->max_speed;
-		td->railtype = rti->strings.name;
+		td->rail_desc = TrackDesc(rti->strings.name, rti->max_speed, rti->grffile[0]);
 
 		if (!IsTunnel(tile)) {
 			uint16 spd = GetBridgeSpec(GetBridgeType(tile))->speed;
-			if (td->rail_speed == 0 || spd < td->rail_speed) {
-				td->rail_speed = spd;
+			if (td->rail_desc.speed == 0 || spd < td->rail_desc.speed) {
+				td->rail_desc.speed = spd;
 			}
 		}
 	} else if (tt == TRANSPORT_ROAD && !IsTunnel(tile)) {
 		uint16 spd = GetBridgeSpec(GetBridgeType(tile))->speed;
-		if (road_rt != INVALID_ROADTYPE && (td->road_speed == 0 || spd < td->road_speed)) td->road_speed = spd;
-		if (tram_rt != INVALID_ROADTYPE && (td->tram_speed == 0 || spd < td->tram_speed)) td->tram_speed = spd;
+		if (road_rt != INVALID_ROADTYPE && (td->road_desc.speed == 0 || spd < td->road_desc.speed)) td->road_desc.speed = spd;
+		if (tram_rt != INVALID_ROADTYPE && (td->tram_desc.speed == 0 || spd < td->tram_desc.speed)) td->tram_desc.speed = spd;
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Currently there is no way of retrieving NewGRF name for a rail, road or tram track.

Closes https://github.com/OpenTTD/OpenTTD/issues/8779

## Description

This code change introduces extra fields in the Land Area Information window to display the NewGRF names for rail, road and tram tracks, as well as for stations. It works for railroad crossings and overlapping road and tram tracks.

![image](https://user-images.githubusercontent.com/2025406/109575768-52ab0980-7aa7-11eb-81e3-ce35e472fcfd.png)

## Limitations

Not that I am aware of.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
