### PR TITLE
Add: Singapore Dollar Currency (#2)

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -68,6 +68,7 @@ static const CurrencySpec origin_currency_specs[CURRENCY_END] = {
 	{   90, "", CF_NOEURO, u8"\u20b9",     "",               0, STR_GAME_OPTIONS_CURRENCY_INR    }, ///< Indian Rupee
 	{   19, "", CF_NOEURO, "Rp",           "",               0, STR_GAME_OPTIONS_CURRENCY_IDR    }, ///< Indonesian Rupiah
 	{    5, "", CF_NOEURO, "RM",           "",               0, STR_GAME_OPTIONS_CURRENCY_MYR    }, ///< Malaysian Ringgit
+	{    2, "", CF_NOEURO, "S$",           "",               0, STR_GAME_OPTIONS_CURRENCY_SGD    }, ///< Singapore Dollar
 };
 
 /** Array of currencies used by the system */

--- a/src/currency.h
+++ b/src/currency.h
@@ -65,6 +65,7 @@ enum Currencies {
 	CURRENCY_INR,       ///< Indian Rupee
 	CURRENCY_IDR,       ///< Indonesian Rupiah
 	CURRENCY_MYR,       ///< Malaysian Ringgit
+	CURRENCY_SGD,       ///< Singapore Dollar
 	CURRENCY_END,       ///< always the last item
 };
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -948,6 +948,7 @@ STR_GAME_OPTIONS_CURRENCY_HKD                                   :Hong Kong Dolla
 STR_GAME_OPTIONS_CURRENCY_INR                                   :Indian Rupee (INR)
 STR_GAME_OPTIONS_CURRENCY_IDR                                   :Indonesian Rupiah (IDR)
 STR_GAME_OPTIONS_CURRENCY_MYR                                   :Malaysian Ringgit (MYR)
+STR_GAME_OPTIONS_CURRENCY_SGD                                   :Singapore Dollar (SGD)
 ############ end of currency region
 
 STR_GAME_OPTIONS_ROAD_VEHICLES_DROPDOWN_LEFT                    :Drive on left


### PR DESCRIPTION
Added Singapore Dollar to the list of currency with conversion rate of 2. 
Planned to add more currency.
Need advice from lead developers.