### PR TITLE
Feature: allow custom width/height of screenshot via console

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1409,11 +1409,12 @@ DEF_CONSOLE_CMD(ConAlias)
 DEF_CONSOLE_CMD(ConScreenShot)
 {
 	if (argc == 0) {
-		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [viewport | normal | big | giant | minimap] [no_con] [size <width> <height>] [<filename>]'");
+		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [viewport | normal | big | giant | heightmap | minimap] [no_con] [size <width> <height>] [<filename>]'");
 		IConsoleHelp("'viewport' (default) makes a screenshot of the current viewport (including menus, windows, ..), "
 				"'normal' makes a screenshot of the visible area, "
 				"'big' makes a zoomed-in screenshot of the visible area, "
 				"'giant' makes a screenshot of the whole map, "
+				"'heightmap' makes a heightmap screenshot of the map that can be loaded in as heightmap, "
 				"'minimap' makes a top-viewed minimap screenshot of the whole world which represents one tile by one pixel. "
 				"'no_con' hides the console to create the screenshot (only useful in combination with 'viewport'). "
 				"'size' sets the width and height of the viewport to make a screenshot of (only useful in combination with 'normal' or 'big').");
@@ -1440,6 +1441,9 @@ DEF_CONSOLE_CMD(ConScreenShot)
 			arg_index += 1;
 		} else if (strcmp(argv[arg_index], "giant") == 0) {
 			type = SC_WORLD;
+			arg_index += 1;
+		} else if (strcmp(argv[arg_index], "heightmap") == 0) {
+			type = SC_HEIGHTMAP;
 			arg_index += 1;
 		} else if (strcmp(argv[arg_index], "minimap") == 0) {
 			type = SC_MINIMAP;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1868,7 +1868,7 @@ DEF_CONSOLE_CMD(ConContent)
 			 * to download every available package on BaNaNaS. This is not in
 			 * the spirit of this service. Additionally, these few people were
 			 * good for 70% of the consumed bandwidth of BaNaNaS. */
-			IConsolePrintF(CC_ERROR, "'select all' is no longer supported since 1.11");
+			IConsoleError("'select all' is no longer supported since 1.11");
 		} else {
 			_network_content_client.Select((ContentID)atoi(argv[2]));
 		}

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -25,10 +25,10 @@ enum ScreenshotType {
 	SC_MINIMAP,     ///< Minimap screenshot.
 };
 
-void SetupScreenshotViewport(ScreenshotType t, struct Viewport *vp);
+void SetupScreenshotViewport(ScreenshotType t, struct Viewport *vp, uint32 width = 0, uint32 height = 0);
 bool MakeHeightmapScreenshot(const char *filename);
 void MakeScreenshotWithConfirm(ScreenshotType t);
-bool MakeScreenshot(ScreenshotType t, const char *name);
+bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width = 0, uint32 height = 0);
 bool MakeMinimapWorldScreenshot();
 
 extern char _screenshot_format_name[8];


### PR DESCRIPTION
Used #8598 for inspiration and this PR is meant as alternative to that PR.

Fixes #8798
Yes, I sneaked that in this PR, I am sorry .. I could make a new PR out of it if you like.

## Motivation / Problem

For the titlegame competition I was looking for a good way to make screenshots of different resolutions in a single run in an automated way. #8598 allows this, but I noticed we could do better. It started out as renaming `res_x` to `width`, adding docstrings, and more of these things, but I soon figured out the console parsing code was just a bit too stiff for me. For example, you could only set the size of the screenshot for normal zoom, not for big zoom, without there really being a reason not to allow that.

So I rewrote how screenshot command is parsed, and made it into a token-system. You can now mix and match different modes. Also, rewrote most of the implementation to be a bit more robust and future-proof, in my opinion of course.


## Description

```
Reworked how the screenshot command works while keeping it backwards
compatible. It can now more freely understand arguments, and has
the ability to make SC_DEFAULTZOOM screenshots.
```

**BONUS** you can now also make heightmap screenshots!

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
