### PR TITLE
Add: Option to (dis-)allow accelerated video drivers.

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -111,6 +111,8 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 				if (d->type != type) continue;
 				if (d->priority != priority) continue;
 
+				if (!d->IsUsable()) continue;
+
 				Driver *oldd = *GetActiveDriver(type);
 				Driver *newd = d->CreateInstance();
 				*GetActiveDriver(type) = newd;

--- a/src/driver.h
+++ b/src/driver.h
@@ -107,6 +107,15 @@ protected:
 
 	virtual ~DriverFactoryBase();
 
+	/**
+	 * Is the driver usable?
+	 * @return True if the driver can be instantiated.
+	 */
+	virtual bool IsUsable() const
+	{
+		return true;
+	}
+
 public:
 	/**
 	 * Shuts down all active drivers

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1001,6 +1001,10 @@ STR_GAME_OPTIONS_RESOLUTION                                     :{BLACK}Screen r
 STR_GAME_OPTIONS_RESOLUTION_TOOLTIP                             :{BLACK}Select the screen resolution to use
 STR_GAME_OPTIONS_RESOLUTION_OTHER                               :other
 
+STR_GAME_OPTIONS_VIDEO_ACCELERATION                             :{BLACK}Accelerated drawing
+STR_GAME_OPTIONS_VIDEO_ACCELERATION_TOOLTIP                     :{BLACK}Check this box to allow OpenTTD to try to use GPU acceleration for drawing. A changed setting will only be applied upon game restart
+STR_GAME_OPTIONS_VIDEO_ACCELERATION_RESTART                     :{WHITE}The setting will only take effect after a game restart
+
 STR_GAME_OPTIONS_GUI_ZOOM_FRAME                                 :{BLACK}Interface size
 STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_TOOLTIP                      :{BLACK}Select the interface element size to use
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -35,6 +35,7 @@
 #include "querystring_gui.h"
 #include "fontcache.h"
 #include "zoom_func.h"
+#include "video/video_driver.hpp"
 
 #include <vector>
 
@@ -381,6 +382,13 @@ struct GameOptionsWindow : Window {
 				this->SetDirty();
 				break;
 
+			case WID_GO_VIDEO_ACCEL_BUTTON:
+				_video_hw_accel = !_video_hw_accel;
+				ShowErrorMessage(STR_GAME_OPTIONS_VIDEO_ACCELERATION_RESTART, INVALID_STRING_ID, WL_INFO);
+				this->SetWidgetLoweredState(WID_GO_VIDEO_ACCEL_BUTTON, _video_hw_accel);
+				this->SetDirty();
+				break;
+
 			default: {
 				int selected;
 				DropDownList list = this->BuildDropDownList(widget, &selected);
@@ -493,6 +501,7 @@ struct GameOptionsWindow : Window {
 	{
 		if (!gui_scope) return;
 		this->SetWidgetLoweredState(WID_GO_FULLSCREEN_BUTTON, _fullscreen);
+		this->SetWidgetLoweredState(WID_GO_VIDEO_ACCEL_BUTTON, _video_hw_accel);
 
 		bool missing_files = BaseGraphics::GetUsedSet()->GetNumMissing() == 0;
 		this->GetWidget<NWidgetCore>(WID_GO_BASE_GRF_STATUS)->SetDataTip(missing_files ? STR_EMPTY : STR_GAME_OPTIONS_BASE_GRF_STATUS, STR_NULL);
@@ -521,14 +530,16 @@ static const NWidgetPart _nested_game_options_widgets[] = {
 				EndContainer(),
 				NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_GAME_OPTIONS_RESOLUTION, STR_NULL),
 					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_GO_RESOLUTION_DROPDOWN), SetMinimalSize(150, 12), SetDataTip(STR_BLACK_STRING, STR_GAME_OPTIONS_RESOLUTION_TOOLTIP), SetFill(1, 0), SetPadding(0, 0, 3, 0),
-					NWidget(NWID_HORIZONTAL),
+					NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0), SetPadding(0, 0, 3, 0),
 						NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalSize(0, 12), SetFill(1, 0), SetDataTip(STR_GAME_OPTIONS_FULLSCREEN, STR_NULL),
 						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_GO_FULLSCREEN_BUTTON), SetMinimalSize(21, 9), SetDataTip(STR_EMPTY, STR_GAME_OPTIONS_FULLSCREEN_TOOLTIP),
 					EndContainer(),
+					NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
+						NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalSize(0, 12), SetFill(1, 0), SetDataTip(STR_GAME_OPTIONS_VIDEO_ACCELERATION, STR_NULL),
+						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_GO_VIDEO_ACCEL_BUTTON),  SetMinimalSize(21, 9), SetDataTip(STR_EMPTY, STR_GAME_OPTIONS_VIDEO_ACCELERATION_TOOLTIP),
+					EndContainer(),
 				EndContainer(),
-				NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_GAME_OPTIONS_GUI_ZOOM_FRAME, STR_NULL),
-					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_GO_GUI_ZOOM_DROPDOWN), SetMinimalSize(150, 12), SetDataTip(STR_BLACK_STRING, STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_TOOLTIP), SetFill(1, 0),
-				EndContainer(),
+				NWidget(NWID_SPACER), SetMinimalSize(0, 0), SetFill(0, 1),
 			EndContainer(),
 
 			NWidget(NWID_VERTICAL), SetPIP(0, 6, 0),
@@ -538,7 +549,9 @@ static const NWidgetPart _nested_game_options_widgets[] = {
 				NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_GAME_OPTIONS_CURRENCY_UNITS_FRAME, STR_NULL),
 					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_GO_CURRENCY_DROPDOWN), SetMinimalSize(150, 12), SetDataTip(STR_BLACK_STRING, STR_GAME_OPTIONS_CURRENCY_UNITS_DROPDOWN_TOOLTIP), SetFill(1, 0),
 				EndContainer(),
-				NWidget(NWID_SPACER), SetMinimalSize(0, 0), SetFill(0, 1),
+				NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_GAME_OPTIONS_GUI_ZOOM_FRAME, STR_NULL),
+					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_GO_GUI_ZOOM_DROPDOWN), SetMinimalSize(150, 12), SetDataTip(STR_BLACK_STRING, STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_TOOLTIP), SetFill(1, 0),
+				EndContainer(),
 				NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_GAME_OPTIONS_FONT_ZOOM, STR_NULL),
 					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_GO_FONT_ZOOM_DROPDOWN), SetMinimalSize(150, 12), SetDataTip(STR_BLACK_STRING, STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_TOOLTIP), SetFill(1, 0),
 				EndContainer(),

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -12,6 +12,9 @@ static const char *_support8bppmodes = "no|system|hardware";
 #ifdef WITH_COCOA
 extern bool _allow_hidpi_window;
 #endif
+#ifndef WITH_COCOA
+#define WITHOUT_COCOA
+#endif
 
 static const SettingDescGlobVarList _misc_settings[] = {
 [post-amble]
@@ -58,6 +61,20 @@ full     = ""SHOW_TOWN_NAMES|SHOW_STATION_NAMES|SHOW_SIGNS|FULL_ANIMATION||FULL_
 name     = ""fullscreen""
 var      = _fullscreen
 def      = false
+cat      = SC_BASIC
+
+[SDTG_BOOL]
+ifdef    = WITH_COCOA
+name     = ""video_hw_accel""
+var      = _video_hw_accel
+def      = false
+cat      = SC_BASIC
+
+[SDTG_BOOL]
+ifdef    = WITHOUT_COCOA
+name     = ""video_hw_accel""
+var      = _video_hw_accel
+def      = true
 cat      = SC_BASIC
 
 [SDTG_OMANY]

--- a/src/video/cocoa/cocoa_ogl.h
+++ b/src/video/cocoa/cocoa_ogl.h
@@ -54,6 +54,9 @@ class FVideoDriver_CocoaOpenGL : public DriverFactoryBase {
 public:
 	FVideoDriver_CocoaOpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 9, "cocoa-opengl", "Cocoa OpenGL Video Driver") {}
 	Driver *CreateInstance() const override { return new VideoDriver_CocoaOpenGL(); }
+
+protected:
+	bool IsUsable() const override { return _video_hw_accel; }
 };
 
 #endif /* VIDEO_COCOA_OGL_H */

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -122,7 +122,7 @@ protected:
 
 class FVideoDriver_CocoaQuartz : public DriverFactoryBase {
 public:
-	FVideoDriver_CocoaQuartz() : DriverFactoryBase(Driver::DT_VIDEO, 10, "cocoa", "Cocoa Video Driver") {}
+	FVideoDriver_CocoaQuartz() : DriverFactoryBase(Driver::DT_VIDEO, 8, "cocoa", "Cocoa Video Driver") {}
 	Driver *CreateInstance() const override { return new VideoDriver_CocoaQuartz(); }
 };
 

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -51,4 +51,7 @@ class FVideoDriver_SDL_OpenGL : public DriverFactoryBase {
 public:
 	FVideoDriver_SDL_OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 8, "sdl-opengl", "SDL OpenGL Video Driver") {}
 	/* virtual */ Driver *CreateInstance() const override { return new VideoDriver_SDL_OpenGL(); }
+
+protected:
+	bool IsUsable() const override { return _video_hw_accel; }
 };

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -17,6 +17,8 @@
 #include "../window_func.h"
 #include "video_driver.hpp"
 
+bool _video_hw_accel; ///< Whether to consider hardware accelerated video drivers.
+
 bool VideoDriver::Tick()
 {
 	auto cur_ticks = std::chrono::steady_clock::now();

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -23,6 +23,7 @@ extern std::string _ini_videodriver;
 extern std::vector<Dimension> _resolutions;
 extern Dimension _cur_resolution;
 extern bool _rightclick_emulate;
+extern bool _video_hw_accel;
 
 /** The base of all video drivers. */
 class VideoDriver : public Driver {

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -175,6 +175,9 @@ class FVideoDriver_Win32OpenGL : public DriverFactoryBase {
 public:
 	FVideoDriver_Win32OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 10, "win32-opengl", "Win32 OpenGL Video Driver") {}
 	/* virtual */ Driver *CreateInstance() const override { return new VideoDriver_Win32OpenGL(); }
+
+protected:
+	bool IsUsable() const override { return _video_hw_accel; }
 };
 
 #endif /* WITH_OPENGL */

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -32,6 +32,7 @@ enum GameOptionsWidgets {
 	WID_GO_BASE_MUSIC_TEXTFILE,    ///< Open base music readme, changelog (+1) or license (+2).
 	WID_GO_BASE_MUSIC_DESCRIPTION = WID_GO_BASE_MUSIC_TEXTFILE + TFT_END, ///< Description of selected base music set.
 	WID_GO_FONT_ZOOM_DROPDOWN,     ///< Dropdown for the font zoom level.
+	WID_GO_VIDEO_ACCEL_BUTTON,     ///< Toggle for video acceleration.
 };
 
 /** Widgets of the #GameSettingsWindow class. */


### PR DESCRIPTION
## Motivation / Problem

Hardware GPU acceleration doesn't always behave as expected and performance results may vary.


## Description

As we will never be able to test any possible GPU/driver/OS combination, allow users the option to allow or disallow an accelerated video driver. The video drivers using the OpenGL backend are currently our only accelerated drivers.

The options defaults to off for macOS builds and to on everywhere else.


## Limitations

Default value is open to discussion. GUI could look better. It takes the cheap way and makes the user do the game restart.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
