### PR TITLE
Add display refresh rate game option

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1021,6 +1021,14 @@ STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_NORMAL                      :Normal
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_2X_ZOOM                     :Double size
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_4X_ZOOM                     :Quad size
 
+STR_GAME_OPTIONS_GRAPHICS                                       :{BLACK}Graphics
+
+STR_GAME_OPTIONS_REFRESH_RATE                                   :{BLACK}Display refresh rate
+STR_GAME_OPTIONS_REFRESH_RATE_TOOLTIP                           :{BLACK}Select the screen refresh rate to use
+STR_GAME_OPTIONS_REFRESH_RATE_OTHER                             :other
+STR_GAME_OPTIONS_REFRESH_RATE_ITEM                              :{NUM}Hz
+STR_GAME_OPTIONS_REFRESH_RATE_WARNING                           :{WHITE}Refresh rates higher than 60Hz might impact performance.
+
 STR_GAME_OPTIONS_BASE_GRF                                       :{BLACK}Base graphics set
 STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :{BLACK}Select the base graphics set to use
 STR_GAME_OPTIONS_BASE_GRF_STATUS                                :{RED}{NUM} missing/corrupted file{P "" s}

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -236,6 +236,16 @@ bool VideoDriver_Allegro::ClaimMousePointer()
 	return true;
 }
 
+std::vector<int> VideoDriver_Allegro::GetListOfMonitorRefreshRates()
+{
+	std::vector<int> rates = {};
+
+	int refresh_rate = get_refresh_rate();
+	if (refresh_rate != 0) rates.push_back(refresh_rate);
+
+	return rates;
+}
+
 struct AllegroVkMapping {
 	uint16 vk_from;
 	byte vk_count;

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -31,6 +31,8 @@ public:
 
 	bool ClaimMousePointer() override;
 
+	std::vector<int> GetListOfMonitorRefreshRates() override;
+
 	const char *GetName() const override { return "allegro"; }
 
 protected:

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -47,6 +47,8 @@ public:
 
 	void EditBoxLostFocus() override;
 
+	std::vector<int> GetListOfMonitorRefreshRates() override;
+
 	/* --- The following methods should be private, but can't be due to Obj-C limitations. --- */
 
 	void MainLoopReal();

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -43,6 +43,7 @@
 
 #import <sys/param.h> /* for MAXPATHLEN */
 #import <sys/time.h> /* gettimeofday */
+#include <array>
 
 /**
  * Important notice regarding all modifications!!!!!!!
@@ -226,6 +227,30 @@ void VideoDriver_Cocoa::EditBoxLostFocus()
 	[ [ this->cocoaview inputContext ] discardMarkedText ];
 	/* Clear any marked string from the current edit box. */
 	HandleTextInput(nullptr, true);
+}
+
+/**
+ * Get refresh rates of all connected monitors.
+ */
+std::vector<int> VideoDriver_Cocoa::GetListOfMonitorRefreshRates()
+{
+	std::vector<int> rates{};
+
+	if (MacOSVersionIsAtLeast(10, 6, 0)) {
+		std::array<CGDirectDisplayID, 16> displays;
+
+		uint32_t count = 0;
+		CGGetActiveDisplayList(displays.size(), displays.data(), &count);
+
+		for (uint32_t i = 0; i < count; i++) {
+			CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displays[i]);
+			int rate = (int)CGDisplayModeGetRefreshRate(mode);
+			if (rate > 0) rates.push_back(rate);
+			CGDisplayModeRelease(mode);
+		}
+	}
+
+	return rates;
 }
 
 /**

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -237,6 +237,17 @@ void VideoDriver_SDL_Base::EditBoxLostFocus()
 	}
 }
 
+std::vector<int> VideoDriver_SDL_Base::GetListOfMonitorRefreshRates()
+{
+	std::vector<int> rates = {};
+	for (int i = 0; i < SDL_GetNumVideoDisplays(); i++) {
+		SDL_DisplayMode mode = {};
+		if (SDL_GetDisplayMode(i, 0, &mode) != 0) continue;
+		if (mode.refresh_rate != 0) rates.push_back(mode.refresh_rate);
+	}
+	return rates;
+}
+
 
 struct SDLVkMapping {
 	SDL_Keycode vk_from;

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -39,6 +39,8 @@ public:
 
 	void EditBoxLostFocus() override;
 
+	std::vector<int> GetListOfMonitorRefreshRates() override;
+
 	const char *GetName() const override { return "sdl"; }
 
 protected:

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -150,6 +150,15 @@ public:
 	virtual void EditBoxGainedFocus() {}
 
 	/**
+	 * Get a list of refresh rates of each available monitor.
+	 * @return A vector of the refresh rates of all available monitors.
+	 */
+	virtual std::vector<int> GetListOfMonitorRefreshRates()
+	{
+		return {};
+	}
+
+	/**
 	 * Get a suggested default GUI zoom taking screen DPI into account.
 	 */
 	virtual ZoomLevel GetSuggestedUIZoom()

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -916,6 +916,27 @@ void VideoDriver_Win32Base::EditBoxLostFocus()
 	SetCandidatePos(this->main_wnd);
 }
 
+std::vector<int> VideoDriver_Win32Base::GetListOfMonitorRefreshRates()
+{
+	std::vector<int> rates = {};
+	EnumDisplayMonitors(nullptr, nullptr, [](HMONITOR hMonitor, HDC hDC, LPRECT rc, LPARAM data) -> BOOL {
+		auto &list = *reinterpret_cast<std::vector<int>*>(data);
+
+		MONITORINFOEX monitorInfo = {};
+		monitorInfo.cbSize = sizeof(MONITORINFOEX);
+		GetMonitorInfo(hMonitor, &monitorInfo);
+
+		DEVMODE devMode = {};
+		devMode.dmSize = sizeof(DEVMODE);
+		devMode.dmDriverExtra = 0;
+		EnumDisplaySettings(monitorInfo.szDevice, ENUM_CURRENT_SETTINGS, &devMode);
+
+		if (devMode.dmDisplayFrequency != 0) list.push_back(devMode.dmDisplayFrequency);
+		return true;
+	}, reinterpret_cast<LPARAM>(&rates));
+	return rates;
+}
+
 Dimension VideoDriver_Win32Base::GetScreenSize() const
 {
 	return { static_cast<uint>(GetSystemMetrics(SM_CXSCREEN)), static_cast<uint>(GetSystemMetrics(SM_CYSCREEN)) };

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -33,6 +33,8 @@ public:
 
 	void EditBoxLostFocus() override;
 
+	std::vector<int> GetListOfMonitorRefreshRates() override;
+
 protected:
 	HWND main_wnd;          ///< Handle to system window.
 	bool fullscreen;        ///< Whether to use (true) fullscreen mode.

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -33,6 +33,7 @@ enum GameOptionsWidgets {
 	WID_GO_BASE_MUSIC_DESCRIPTION = WID_GO_BASE_MUSIC_TEXTFILE + TFT_END, ///< Description of selected base music set.
 	WID_GO_FONT_ZOOM_DROPDOWN,     ///< Dropdown for the font zoom level.
 	WID_GO_VIDEO_ACCEL_BUTTON,     ///< Toggle for video acceleration.
+	WID_GO_REFRESH_RATE_DROPDOWN,  ///< Dropdown for all available refresh rates.
 };
 
 /** Widgets of the #GameSettingsWindow class. */


### PR DESCRIPTION
## Motivation / Problem

With the recent addition of the new OpenGL-based video drivers and detached render tick, I deemed it a good option to also include a option for display refresh rate. As personally I don't want to fiddle with `refresh_rate` inside the `openttd.cfg` file, like most other players, I thought this might be a good solution.

## Description

This adds a new option called `Display refresh rate` next to `Resolution` in the `Game Options` window. Players can selected from various different refresh rates and change their refresh rate.

![](https://cdn.discordapp.com/attachments/442748131898032138/817878643086458900/unknown.png)

## Limitations

Custom framerate configuration could be added in the future, but I think this is a very nieche use case.
Otherwise, only the drivers would be limiting us in any way, as some might not precisely give information about screens.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
