### PR TITLE
Add: GUI option to select video driver.

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -197,6 +197,30 @@ char *DriverFactoryBase::GetDriversInfo(char *p, const char *last)
 }
 
 /**
+ * Get a list of available drivers for a driver type.
+ * @param type Driver types to return.
+ * @param user_only Only return drivers that are marked as user visible.
+ * @return List of matching drivers.
+ */
+std::vector<DriverFactoryBase *> DriverFactoryBase::GetAvailableDrivers(Driver::Type type, bool user_only)
+{
+	std::vector<DriverFactoryBase *> drivers;
+
+	/* Collect drivers for the requested type. */
+	for (auto &it : GetDrivers()) {
+		if (it.second->type != type) continue;
+		if (user_only && !it.second->IsUserVisible()) continue;
+
+		drivers.push_back(it.second);
+	}
+
+	/* Sort by name. */
+	std::sort(drivers.begin(), drivers.end(), [](DriverFactoryBase *a, DriverFactoryBase *b) { return a->GetGUIDescription() < b->GetGUIDescription(); });
+
+	return drivers;
+}
+
+/**
  * Construct a new DriverFactory.
  * @param type        The type of driver.
  * @param priority    The priority within the driver class.

--- a/src/driver.h
+++ b/src/driver.h
@@ -64,8 +64,9 @@ private:
 
 	Driver::Type type;       ///< The type of driver.
 	int priority;            ///< The priority of this factory.
-	const char *name;        ///< The name of the drivers of this factory.
-	const char *description; ///< The description of this driver.
+	std::string name;        ///< The name of the drivers of this factory.
+	std::string description; ///< The description of this driver.
+	std::string short_desc;  ///< Short GUI description of this driver.
 
 	typedef std::map<std::string, DriverFactoryBase *> Drivers; ///< Type for a map of drivers.
 
@@ -103,7 +104,7 @@ private:
 	static bool SelectDriverImpl(const std::string &name, Driver::Type type);
 
 protected:
-	DriverFactoryBase(Driver::Type type, int priority, const char *name, const char *description);
+	DriverFactoryBase(Driver::Type type, int priority, const char *name, const char *description, const char *short_desc = nullptr);
 
 	virtual ~DriverFactoryBase();
 
@@ -123,12 +124,30 @@ public:
 	static char *GetDriversInfo(char *p, const char *last);
 
 	/**
+	 * Get the short name of the driver-class.
+	 * @return The short name.
+	 */
+	const std::string &GetShortName() const
+	{
+		return this->name;
+	}
+
+	/**
 	 * Get a nice description of the driver-class.
 	 * @return The description.
 	 */
-	const char *GetDescription() const
+	const std::string &GetDescription() const
 	{
 		return this->description;
+	}
+
+	/**
+	 * Get a short GUI description of the driver.
+	 * @return The description.
+	 */
+	const std::string &GetGUIDescription() const
+	{
+		return this->short_desc;
 	}
 
 	/**

--- a/src/driver.h
+++ b/src/driver.h
@@ -108,6 +108,9 @@ protected:
 
 	virtual ~DriverFactoryBase();
 
+	/** Indicates that this driver should be offered in user GUI contexts. */
+	virtual bool IsUserVisible() const { return true; }
+
 public:
 	/**
 	 * Shuts down all active drivers
@@ -122,6 +125,8 @@ public:
 
 	static void SelectDriver(const std::string &name, Driver::Type type);
 	static char *GetDriversInfo(char *p, const char *last);
+
+	static std::vector<DriverFactoryBase *> GetAvailableDrivers(Driver::Type type, bool user_only);
 
 	/**
 	 * Get the short name of the driver-class.

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1017,6 +1017,12 @@ STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_NORMAL                      :Normal
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_2X_ZOOM                     :Double size
 STR_GAME_OPTIONS_FONT_ZOOM_DROPDOWN_4X_ZOOM                     :Quad size
 
+STR_GAME_OPTIONS_VIDEO_DRIVER                                   :{BLACK}Video driver
+STR_GAME_OPTIONS_VIDEO_DRIVER_DROPDOWN_TOOLTIP                  :{BLACK}Select the video driver to use
+STR_GAME_OPTIONS_VIDEO_DRIVER_RESTART                           :{WHITE}The setting will only take effect after a game restart
+
+STR_GAME_OPTIONS_VIDEO_DRIVER_DROPDOWN_AUTO                     :(auto-select)
+
 STR_GAME_OPTIONS_BASE_GRF                                       :{BLACK}Base graphics set
 STR_GAME_OPTIONS_BASE_GRF_TOOLTIP                               :{BLACK}Select the base graphics set to use
 STR_GAME_OPTIONS_BASE_GRF_STATUS                                :{RED}{NUM} missing/corrupted file{P "" s}
@@ -5166,6 +5172,7 @@ STR_ORANGE_INT                                                  :{ORANGE}{NUM}
 STR_WHITE_SIGN                                                  :{WHITE}{SIGN}
 STR_TINY_BLACK_STATION                                          :{TINY_FONT}{BLACK}{STATION}
 STR_BLACK_STRING                                                :{BLACK}{STRING}
+STR_BLACK_STRING1                                               :{BLACK}{STRING1}
 STR_BLACK_RAW_STRING                                            :{BLACK}{RAW_STRING}
 STR_ORANGE_STRING                                               :{ORANGE}{STRING}
 STR_LTBLUE_STRING                                               :{LTBLUE}{STRING}

--- a/src/video/allegro_v.h
+++ b/src/video/allegro_v.h
@@ -43,7 +43,7 @@ protected:
 /** Factory for the allegro video driver. */
 class FVideoDriver_Allegro : public DriverFactoryBase {
 public:
-	FVideoDriver_Allegro() : DriverFactoryBase(Driver::DT_VIDEO, 4, "allegro", "Allegro Video Driver") {}
+	FVideoDriver_Allegro() : DriverFactoryBase(Driver::DT_VIDEO, 4, "allegro", "Allegro Video Driver", "Allegro") {}
 	Driver *CreateInstance() const override { return new VideoDriver_Allegro(); }
 };
 

--- a/src/video/cocoa/cocoa_ogl.h
+++ b/src/video/cocoa/cocoa_ogl.h
@@ -52,7 +52,7 @@ protected:
 
 class FVideoDriver_CocoaOpenGL : public DriverFactoryBase {
 public:
-	FVideoDriver_CocoaOpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 9, "cocoa-opengl", "Cocoa OpenGL Video Driver") {}
+	FVideoDriver_CocoaOpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 9, "cocoa-opengl", "Cocoa OpenGL Video Driver", "OpenGL") {}
 	Driver *CreateInstance() const override { return new VideoDriver_CocoaOpenGL(); }
 };
 

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -122,7 +122,7 @@ protected:
 
 class FVideoDriver_CocoaQuartz : public DriverFactoryBase {
 public:
-	FVideoDriver_CocoaQuartz() : DriverFactoryBase(Driver::DT_VIDEO, 10, "cocoa", "Cocoa Video Driver") {}
+	FVideoDriver_CocoaQuartz() : DriverFactoryBase(Driver::DT_VIDEO, 10, "cocoa", "Cocoa Video Driver", "Quartz") {}
 	Driver *CreateInstance() const override { return new VideoDriver_CocoaQuartz(); }
 };
 

--- a/src/video/dedicated_v.h
+++ b/src/video/dedicated_v.h
@@ -42,6 +42,9 @@ public:
 #endif
 	FVideoDriver_Dedicated() : DriverFactoryBase(Driver::DT_VIDEO, PRIORITY, "dedicated", "Dedicated Video Driver") {}
 	Driver *CreateInstance() const override { return new VideoDriver_Dedicated(); }
+
+protected:
+	bool IsUserVisible() const override { return false; }
 };
 
 #endif /* VIDEO_DEDICATED_H */

--- a/src/video/null_v.h
+++ b/src/video/null_v.h
@@ -38,6 +38,9 @@ class FVideoDriver_Null : public DriverFactoryBase {
 public:
 	FVideoDriver_Null() : DriverFactoryBase(Driver::DT_VIDEO, 0, "null", "Null Video Driver") {}
 	Driver *CreateInstance() const override { return new VideoDriver_Null(); }
+
+protected:
+	bool IsUserVisible() const override { return false; }
 };
 
 #endif /* VIDEO_NULL_H */

--- a/src/video/sdl2_default_v.h
+++ b/src/video/sdl2_default_v.h
@@ -33,7 +33,7 @@ private:
 /** Factory for the SDL video driver. */
 class FVideoDriver_SDL_Default : public DriverFactoryBase {
 public:
-	FVideoDriver_SDL_Default() : DriverFactoryBase(Driver::DT_VIDEO, 5, "sdl", "SDL Video Driver") {}
+	FVideoDriver_SDL_Default() : DriverFactoryBase(Driver::DT_VIDEO, 5, "sdl", "SDL Video Driver", "SDL") {}
 	Driver *CreateInstance() const override { return new VideoDriver_SDL_Default(); }
 };
 

--- a/src/video/sdl2_opengl_v.h
+++ b/src/video/sdl2_opengl_v.h
@@ -49,6 +49,6 @@ private:
 /** The factory for SDL' OpenGL video driver. */
 class FVideoDriver_SDL_OpenGL : public DriverFactoryBase {
 public:
-	FVideoDriver_SDL_OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 8, "sdl-opengl", "SDL OpenGL Video Driver") {}
+	FVideoDriver_SDL_OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 8, "sdl-opengl", "SDL OpenGL Video Driver", "OpenGL (SDL)") {}
 	/* virtual */ Driver *CreateInstance() const override { return new VideoDriver_SDL_OpenGL(); }
 };

--- a/src/video/sdl_v.h
+++ b/src/video/sdl_v.h
@@ -58,7 +58,7 @@ private:
 /** Factory for the SDL video driver. */
 class FVideoDriver_SDL : public DriverFactoryBase {
 public:
-	FVideoDriver_SDL() : DriverFactoryBase(Driver::DT_VIDEO, 5, "sdl", "SDL Video Driver") {}
+	FVideoDriver_SDL() : DriverFactoryBase(Driver::DT_VIDEO, 5, "sdl", "SDL Video Driver", "SDL 1") {}
 	Driver *CreateInstance() const override { return new VideoDriver_SDL(); }
 };
 

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -120,7 +120,7 @@ public:
 /** The factory for Windows' video driver. */
 class FVideoDriver_Win32GDI : public DriverFactoryBase {
 public:
-	FVideoDriver_Win32GDI() : DriverFactoryBase(Driver::DT_VIDEO, 9, "win32", "Win32 GDI Video Driver") {}
+	FVideoDriver_Win32GDI() : DriverFactoryBase(Driver::DT_VIDEO, 9, "win32", "Win32 GDI Video Driver", "GDI") {}
 	Driver *CreateInstance() const override { return new VideoDriver_Win32GDI(); }
 };
 
@@ -173,7 +173,7 @@ protected:
 /** The factory for Windows' OpenGL video driver. */
 class FVideoDriver_Win32OpenGL : public DriverFactoryBase {
 public:
-	FVideoDriver_Win32OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 10, "win32-opengl", "Win32 OpenGL Video Driver") {}
+	FVideoDriver_Win32OpenGL() : DriverFactoryBase(Driver::DT_VIDEO, 10, "win32-opengl", "Win32 OpenGL Video Driver", "OpenGL (Win32)") {}
 	/* virtual */ Driver *CreateInstance() const override { return new VideoDriver_Win32OpenGL(); }
 };
 

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -32,6 +32,7 @@ enum GameOptionsWidgets {
 	WID_GO_BASE_MUSIC_TEXTFILE,    ///< Open base music readme, changelog (+1) or license (+2).
 	WID_GO_BASE_MUSIC_DESCRIPTION = WID_GO_BASE_MUSIC_TEXTFILE + TFT_END, ///< Description of selected base music set.
 	WID_GO_FONT_ZOOM_DROPDOWN,     ///< Dropdown for the font zoom level.
+	WID_GO_VIDEO_DRIVER_DROPDOWN,  ///< Dropdown for video driver selection.
 };
 
 /** Widgets of the #GameSettingsWindow class. */


### PR DESCRIPTION
## Motivation / Problem

Hardware GPU acceleration doesn't always behave as expected and performance results may vary.


## Description

As we will never be able to test any possible GPU/driver/OS combination, expose the video driver setting to the GUI.

## Limitations

It is not possible to modify driver parameters via the GUI. Also, selecting an entry on the drop-down will silently drop all driver parameters from the config file.

It takes the cheap way and makes the user do the game restart.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
Also use this opportunity to store driver factory strings as std::string.