### PR TITLE
Fix #8784: using alt+enter didn't update the fullscreen toggle visibly

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -201,6 +201,7 @@ bool VideoDriver_Cocoa::ToggleFullscreen(bool full_screen)
 		[ NSMenu setMenuBarVisible:!full_screen ];
 
 		this->UpdateVideoModes();
+		InvalidateWindowClassesData(WC_GAME_OPTIONS, 3);
 		return true;
 	}
 

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -761,6 +761,7 @@ bool VideoDriver_SDL_Base::ToggleFullscreen(bool fullscreen)
 		DEBUG(driver, 0, "SDL_SetWindowFullscreen() failed: %s", SDL_GetError());
 	}
 
+	InvalidateWindowClassesData(WC_GAME_OPTIONS, 3);
 	return ret == 0;
 }
 

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -763,6 +763,7 @@ bool VideoDriver_SDL::ToggleFullscreen(bool fullscreen)
 		_fullscreen ^= true;
 	}
 
+	InvalidateWindowClassesData(WC_GAME_OPTIONS, 3);
 	return ret;
 }
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -967,7 +967,10 @@ bool VideoDriver_Win32Base::ToggleFullscreen(bool full_screen)
 	std::unique_lock<std::recursive_mutex> lock;
 	if (this->draw_mutex != nullptr) lock = std::unique_lock<std::recursive_mutex>(*this->draw_mutex);
 
-	return this->MakeWindow(full_screen);
+	bool res = this->MakeWindow(full_screen);
+
+	InvalidateWindowClassesData(WC_GAME_OPTIONS, 3);
+	return res;
 }
 
 void VideoDriver_Win32Base::AcquireBlitterLock()


### PR DESCRIPTION
## Motivation / Problem

Not all flows for changing fullscreen resulted in invalidating the game options window.

## Description

```
Basically, the window was not invalidated, so it was never redrawn.
This made it look like it wasn't working, but it really was.
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
