### PR TITLE
Fix 937d60f2: Broken company colours for 40bpp-blitter.

### DIFF
--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -356,6 +356,10 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 							dst_px->r = colour.r;
 							dst_px->g = colour.g;
 							dst_px->b = colour.b;
+						} else {
+							dst_px->r = src->r;
+							dst_px->g = src->g;
+							dst_px->b = src->b;
 						}
 					} else {
 						dst_px->r = src->r;


### PR DESCRIPTION
## Motivation / Problem

Company colour remap is not properly applied to the screen when using 40bpp-anim blitter.


## Description

RGB channel needs to contain original colours for 40bpp-anim blitter. So make sure they are in fact stored.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
