### PR TITLE
Fix #8808: Crash on switching blitters due to double-mapping the video buffer

### DIFF
--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -265,7 +265,7 @@ void VideoDriver_CocoaOpenGL::AllocateBackingStore(bool force)
 	CGLSetCurrentContext(this->gl_context);
 	NSRect frame = [ this->cocoaview getRealRect:[ this->cocoaview frame ] ];
 	OpenGLBackend::Get()->Resize(frame.size.width, frame.size.height, force);
-	_screen.dst_ptr = this->GetVideoPointer();
+	if (this->buffer_locked) _screen.dst_ptr = this->GetVideoPointer();
 	this->dirty_rect = {};
 
 	/* Redraw screen */

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -213,7 +213,7 @@ bool VideoDriver_Cocoa::ToggleFullscreen(bool full_screen)
  */
 bool VideoDriver_Cocoa::AfterBlitterChange()
 {
-	this->ChangeResolution(_cur_resolution.width, _cur_resolution.height);
+	this->AllocateBackingStore(true);
 	return true;
 }
 
@@ -224,7 +224,7 @@ void VideoDriver_Cocoa::EditBoxLostFocus()
 {
 	[ [ this->cocoaview inputContext ] discardMarkedText ];
 	/* Clear any marked string from the current edit box. */
-	HandleTextInput(NULL, true);
+	HandleTextInput(nullptr, true);
 }
 
 /**

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -700,9 +700,9 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 		if (!EditBoxInGlobalFocus() || IsInsideMM(pressed_key & ~WKC_SPECIAL_KEYS, WKC_F1, WKC_PAUSE + 1)) {
 			HandleKeypress(pressed_key, unicode);
 		}
-		DEBUG(driver, 2, "cocoa_v: QZ_KeyEvent: %x (%x), down, mapping: %x", keycode, unicode, pressed_key);
+		DEBUG(driver, 3, "cocoa_v: QZ_KeyEvent: %x (%x), down, mapping: %x", keycode, unicode, pressed_key);
 	} else {
-		DEBUG(driver, 2, "cocoa_v: QZ_KeyEvent: %x (%x), up", keycode, unicode);
+		DEBUG(driver, 3, "cocoa_v: QZ_KeyEvent: %x (%x), up", keycode, unicode);
 	}
 
 	return interpret_keys;


### PR DESCRIPTION
## Motivation / Problem

Something broke and switching blitters would always map the video buffer, no matter if it was previously mapped or not, leading to a crash later on when trying to double-map the buffer.


## Description

Only map the video buffer after switching blitters if it was previously mapped.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
