### PR TITLE
Fix #8825: [OpenGL] Don't clear cursor cache from the game loop thread.

### DIFF
--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -63,6 +63,7 @@ private:
 
 	LRUCache<SpriteID, Sprite> cursor_cache;   ///< Cache of encoded cursor sprites.
 	PaletteID last_sprite_pal = (PaletteID)-1; ///< Last uploaded remap palette.
+	bool clear_cursor_cache = false;           ///< A clear of the cursor cache is pending.
 
 	OpenGLBackend();
 	~OpenGLBackend();


### PR DESCRIPTION
## Motivation / Problem

OpenGL functions may no be called from other threads except the main thread, which could happen when clearing the cursor cache.


## Description

Queue the pending clear until the next time the main thread prepares the cursor cache for drawing.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
