### PR TITLE
Fixes for modal progress and NewGRF scan issues

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1471,13 +1471,14 @@ void DrawDirtyBlocks()
 	int y;
 
 	if (HasModalProgress()) {
+		bool is_first_modal_progress_loop = IsFirstModalProgressLoop();
 		/* We are generating the world, so release our rights to the map and
 		 * painting while we are waiting a bit. */
 		_modal_progress_paint_mutex.unlock();
 		_modal_progress_work_mutex.unlock();
 
 		/* Wait a while and hope the modal gives us a bit of time to draw the GUI. */
-		if (!IsFirstModalProgressLoop()) CSleep(MODAL_PROGRESS_REDRAW_TIMEOUT);
+		if (!is_first_modal_progress_loop) CSleep(MODAL_PROGRESS_REDRAW_TIMEOUT);
 
 		/* Modal progress thread may need blitter access while we are waiting for it. */
 		_modal_progress_paint_mutex.lock();

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1478,7 +1478,7 @@ void DrawDirtyBlocks()
 		_modal_progress_work_mutex.unlock();
 
 		/* Wait a while and hope the modal gives us a bit of time to draw the GUI. */
-		if (!is_first_modal_progress_loop) CSleep(MODAL_PROGRESS_REDRAW_TIMEOUT);
+		if (!is_first_modal_progress_loop) SleepWhileModalProgress(MODAL_PROGRESS_REDRAW_TIMEOUT);
 
 		/* Modal progress thread may need blitter access while we are waiting for it. */
 		_modal_progress_paint_mutex.lock();

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -321,6 +321,8 @@ size_t GRFGetSizeOfDataSection(FILE *f)
 	return SIZE_MAX;
 }
 
+static std::atomic<bool> _abort_grf_scan;
+
 /**
  * Calculate the MD5 sum for a GRF, and store it in the config.
  * @param config GRF to compute.
@@ -603,6 +605,8 @@ public:
 
 bool GRFFileScanner::AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename)
 {
+	if (_abort_grf_scan.load(std::memory_order_relaxed)) return false;
+
 	GRFConfig *c = new GRFConfig(filename.c_str() + basepath_length);
 
 	bool added = true;
@@ -742,6 +746,11 @@ void ScanNewGRFFiles(NewGRFScanCallback *callback)
 	} else {
 		UpdateNewGRFScanStatus(0, nullptr);
 	}
+}
+
+void AbortScanNewGRFFiles()
+{
+	_abort_grf_scan.store(true, std::memory_order_relaxed);
 }
 
 /**

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -214,6 +214,7 @@ struct NewGRFScanCallback {
 size_t GRFGetSizeOfDataSection(FILE *f);
 
 void ScanNewGRFFiles(NewGRFScanCallback *callback);
+void AbortScanNewGRFFiles();
 const GRFConfig *FindGRFConfig(uint32 grfid, FindGRFConfigMode mode, const uint8 *md5sum = nullptr, uint32 desired_version = 0);
 GRFConfig *GetGRFConfig(uint32 grfid, uint32 mask = 0xFFFFFFFF);
 GRFConfig **CopyGRFConfigList(GRFConfig **dst, const GRFConfig *src, bool init_only);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -850,8 +850,10 @@ int openttd_main(int argc, char *argv[])
 
 	VideoDriver::GetInstance()->MainLoop();
 
+	AbortScanNewGRFFiles();
 	WaitTillSaved();
 	WaitTillGeneratedWorld(); // Make sure any generate world threads have been joined.
+	WaitUntilModalProgressCompleted();
 
 	/* only save config if we have to */
 	if (_save_config) {

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "progress.h"
 
+#include <chrono>
 #include <mutex>
 #include <condition_variable>
 
@@ -52,4 +53,15 @@ bool IsFirstModalProgressLoop()
 	bool ret = _first_in_modal_loop;
 	_first_in_modal_loop = false;
 	return ret;
+}
+
+/**
+ * Sleep until the first of: the specified time duration in milliseconds elapses, the modal progress state is false.
+ * The modal progress paint and work mutexes MUST NOT be held by the caller.
+ * @param milliseconds Time duration in milliseconds
+ */
+void SleepWhileModalProgress(int milliseconds)
+{
+	std::unique_lock<std::mutex> lk(_modal_progress_cv_mutex);
+	_modal_progress_cv.wait_for(lk, std::chrono::milliseconds(milliseconds), []{ return !_in_modal_progress; });
 }

--- a/src/progress.h
+++ b/src/progress.h
@@ -36,6 +36,7 @@ static inline bool UseThreadedModelProgress()
 
 bool IsFirstModalProgressLoop();
 void SetModalProgress(bool state);
+void SleepWhileModalProgress(int milliseconds);
 
 extern std::mutex _modal_progress_work_mutex;
 extern std::mutex _modal_progress_paint_mutex;

--- a/src/progress.h
+++ b/src/progress.h
@@ -37,6 +37,7 @@ static inline bool UseThreadedModelProgress()
 bool IsFirstModalProgressLoop();
 void SetModalProgress(bool state);
 void SleepWhileModalProgress(int milliseconds);
+void WaitUntilModalProgressCompleted();
 
 extern std::mutex _modal_progress_work_mutex;
 extern std::mutex _modal_progress_paint_mutex;


### PR DESCRIPTION
## Motivation / Problem

Fix: #8760 
Fix the 3rd data race in: #8712

## Description

* Add a mutex/CV pair for changes to the modal progress state.
* Use the mutex/CV pair to wait for the modal progress state to become false before exiting.
* Use the mutex/CV pair for MODAL_PROGRESS_REDRAW_TIMEOUT timed waits instead of CSleep.
* Add an abort flag for earlier conclusion of the NewGRF scan thread when exiting.

## Limitations

The abort flag could conceivably be made more forceful, but that would require more invasive changes and head into the realm of diminishing returns.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
