### PR TITLE
Add: make modal windows update more smooth and fix "closing the app" issues closely related to this.

### DIFF
--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -338,6 +338,7 @@ void GenerateClearTile()
 				TileIndex tile_new;
 
 				SetClearGroundDensity(tile, CLEAR_ROCKS, 3);
+				MarkTileDirtyByTile(tile);
 				do {
 					if (--j == 0) goto get_out;
 					tile_new = tile + TileOffsByDiagDir((DiagDirection)GB(Random(), 0, 2));

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1340,7 +1340,7 @@ DEF_CONSOLE_CMD(ConRescanNewGRF)
 		return true;
 	}
 
-	ScanNewGRFFiles(nullptr);
+	RequestNewGRFScan();
 
 	return true;
 }

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -59,18 +59,10 @@ GenWorldInfo _gw;
 /** Whether we are generating the map or not. */
 bool _generating_world;
 
-/**
- * Tells if the world generation is done in a thread or not.
- * @return the 'threaded' status
- */
-bool IsGenerateWorldThreaded()
-{
-	return _gw.threaded && !_gw.quit_thread;
-}
+class AbortGenerateWorldSignal { };
 
 /**
- * Clean up the 'mess' of generation. That is, show windows again, reset
- * thread variables, and delete the progress window.
+ * Generation is done; show windows again and delete the progress window.
  */
 static void CleanupGeneration()
 {
@@ -78,11 +70,10 @@ static void CleanupGeneration()
 
 	SetMouseCursorBusy(false);
 	/* Show all vital windows again, because we have hidden them */
-	if (_gw.threaded && _game_mode != GM_MENU) ShowVitalWindows();
+	if (_game_mode != GM_MENU) ShowVitalWindows();
 	SetModalProgress(false);
 	_gw.proc     = nullptr;
 	_gw.abortp   = nullptr;
-	_gw.threaded = false;
 
 	DeleteWindowByClass(WC_MODAL_PROGRESS);
 	ShowFirstError();
@@ -97,10 +88,8 @@ static void _GenerateWorld()
 	/* Make sure everything is done via OWNER_NONE. */
 	Backup<CompanyID> _cur_company(_current_company, OWNER_NONE, FILE_LINE);
 
-	std::unique_lock<std::mutex> lock(_modal_progress_work_mutex, std::defer_lock);
 	try {
 		_generating_world = true;
-		lock.lock();
 		if (_network_dedicated) DEBUG(net, 1, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
@@ -136,14 +125,7 @@ static void _GenerateWorld()
 			/* Only generate towns, tree and industries in newgame mode. */
 			if (_game_mode != GM_EDITOR) {
 				if (!GenerateTowns(_settings_game.economy.town_layout)) {
-					_cur_company.Restore();
 					HandleGeneratingWorldAbortion();
-					BasePersistentStorageArray::SwitchMode(PSM_LEAVE_GAMELOOP);
-					if (_network_dedicated) {
-						/* Exit the game to prevent a return to main menu.  */
-						DEBUG(net, 0, "Generating map failed, aborting");
-						_exit_game = true;
-					}
 					return;
 				}
 				GenerateIndustries();
@@ -200,7 +182,6 @@ static void _GenerateWorld()
 		IncreaseGeneratingWorldProgress(GWP_GAME_START);
 
 		CleanupGeneration();
-		lock.unlock();
 
 		ShowNewGRFError();
 
@@ -212,11 +193,19 @@ static void _GenerateWorld()
 			seprintf(name, lastof(name), "dmp_cmds_%08x_%08x.sav", _settings_game.game_creation.generation_seed, _date);
 			SaveOrLoad(name, SLO_SAVE, DFT_GAME_FILE, AUTOSAVE_DIR, false);
 		}
-	} catch (...) {
+	} catch (AbortGenerateWorldSignal&) {
+		CleanupGeneration();
+
 		BasePersistentStorageArray::SwitchMode(PSM_LEAVE_GAMELOOP, true);
 		if (_cur_company.IsValid()) _cur_company.Restore();
-		_generating_world = false;
-		throw;
+
+		if (_network_dedicated) {
+			/* Exit the game to prevent a return to main menu.  */
+			DEBUG(net, 0, "Generating map failed, aborting");
+			_exit_game = true;
+		} else {
+			SwitchToMode(_switch_mode);
+		}
 	}
 }
 
@@ -238,23 +227,6 @@ void GenerateWorldSetCallback(GWDoneProc *proc)
 void GenerateWorldSetAbortCallback(GWAbortProc *proc)
 {
 	_gw.abortp = proc;
-}
-
-/**
- * This will wait for the thread to finish up his work. It will not continue
- * till the work is done.
- */
-void WaitTillGeneratedWorld()
-{
-	if (!_gw.thread.joinable()) return;
-
-	_modal_progress_work_mutex.unlock();
-	_modal_progress_paint_mutex.unlock();
-	_gw.quit_thread = true;
-	_gw.thread.join();
-	_gw.threaded = false;
-	_modal_progress_work_mutex.lock();
-	_modal_progress_paint_mutex.lock();
 }
 
 /**
@@ -284,11 +256,7 @@ void HandleGeneratingWorldAbortion()
 
 	if (_gw.abortp != nullptr) _gw.abortp();
 
-	CleanupGeneration();
-
-	if (_gw.thread.joinable() && _gw.thread.get_id() == std::this_thread::get_id()) throw OTTDThreadExitSignal();
-
-	SwitchToMode(_switch_mode);
+	throw AbortGenerateWorldSignal();
 }
 
 /**
@@ -308,8 +276,6 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 	_gw.abort  = false;
 	_gw.abortp = nullptr;
 	_gw.lc     = _local_company;
-	_gw.quit_thread   = false;
-	_gw.threaded      = true;
 
 	/* This disables some commands and stuff */
 	SetLocalCompany(COMPANY_SPECTATOR);
@@ -328,28 +294,16 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 	SetupColoursAndInitialWindow();
 	SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
 
-	if (_gw.thread.joinable()) _gw.thread.join();
-
-	if (!UseThreadedModelProgress() || !VideoDriver::GetInstance()->HasGUI() || !StartNewThread(&_gw.thread, "ottd:genworld", &_GenerateWorld)) {
-		DEBUG(misc, 1, "Cannot create genworld thread, reverting to single-threaded mode");
-		_gw.threaded = false;
-		_modal_progress_work_mutex.unlock();
-		_GenerateWorld();
-		_modal_progress_work_mutex.lock();
-		return;
-	}
-
 	UnshowCriticalError();
-	/* Remove any open window */
 	DeleteAllNonVitalWindows();
-	/* Hide vital windows, because we don't allow to use them */
 	HideVitalWindows();
 
-	/* Don't show the dialog if we don't have a thread */
 	ShowGenerateWorldProgress();
 
 	/* Centre the view on the map */
 	if (FindWindowById(WC_MAIN_WINDOW, 0) != nullptr) {
 		ScrollMainWindowToTile(TileXY(MapSizeX() / 2, MapSizeY() / 2), true);
 	}
+
+	_GenerateWorld();
 }

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -243,7 +243,7 @@ void AbortGeneratingWorld()
  */
 bool IsGeneratingWorldAborted()
 {
-	return _gw.abort;
+	return _gw.abort || _exit_game;
 }
 
 /**

--- a/src/genworld.h
+++ b/src/genworld.h
@@ -52,15 +52,12 @@ typedef void GWAbortProc(); ///< Called when genworld is aborted
 /** Properties of current genworld process */
 struct GenWorldInfo {
 	bool abort;            ///< Whether to abort the thread ASAP
-	bool quit_thread;      ///< Do we want to quit the active thread
-	bool threaded;         ///< Whether we run _GenerateWorld threaded
 	GenWorldMode mode;     ///< What mode are we making a world in
 	CompanyID lc;          ///< The local_company before generating
 	uint size_x;           ///< X-size of the map
 	uint size_y;           ///< Y-size of the map
 	GWDoneProc *proc;      ///< Proc that is called when done (can be nullptr)
 	GWAbortProc *abortp;   ///< Proc that is called when aborting (can be nullptr)
-	std::thread thread;    ///< The thread we are in (joinable if a thread was created)
 };
 
 /** Current stage of world generation process */
@@ -81,10 +78,8 @@ enum GenWorldProgress {
 };
 
 /* genworld.cpp */
-bool IsGenerateWorldThreaded();
 void GenerateWorldSetCallback(GWDoneProc *proc);
 void GenerateWorldSetAbortCallback(GWAbortProc *proc);
-void WaitTillGeneratedWorld();
 void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_settings = true);
 void AbortGeneratingWorld();
 bool IsGeneratingWorldAborted();

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1470,26 +1470,6 @@ void DrawDirtyBlocks()
 	int x;
 	int y;
 
-	if (HasModalProgress()) {
-		/* We are generating the world, so release our rights to the map and
-		 * painting while we are waiting a bit. */
-		_modal_progress_paint_mutex.unlock();
-		_modal_progress_work_mutex.unlock();
-
-		/* Wait a while and hope the modal gives us a bit of time to draw the GUI. */
-		if (!IsFirstModalProgressLoop()) CSleep(MODAL_PROGRESS_REDRAW_TIMEOUT);
-
-		/* Modal progress thread may need blitter access while we are waiting for it. */
-		_modal_progress_paint_mutex.lock();
-		_modal_progress_work_mutex.lock();
-
-		/* When we ended with the modal progress, do not draw the blocks.
-		 * Simply let the next run do so, otherwise we would be loading
-		 * the new state (and possibly change the blitter) when we hold
-		 * the drawing lock, which we must not do. */
-		if (_switch_mode != SM_NONE && !HasModalProgress()) return;
-	}
-
 	y = 0;
 	do {
 		x = 0;

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1062,6 +1062,7 @@ static bool MakeLake(TileIndex tile, void *user_data)
 		TileIndex t2 = tile + TileOffsByDiagDir(d);
 		if (IsWaterTile(t2)) {
 			MakeRiver(tile, Random());
+			MarkTileDirtyByTile(tile);
 			/* Remove desert directly around the river tile. */
 			TileIndex t = tile;
 			CircularTileSearch(&t, RIVER_OFFSET_DESERT_DISTANCE, RiverModifyDesertZone, nullptr);
@@ -1135,6 +1136,7 @@ static void River_FoundEndNode(AyStar *aystar, OpenListNode *current)
 		TileIndex tile = path->node.tile;
 		if (!IsWaterTile(tile)) {
 			MakeRiver(tile, Random());
+			MarkTileDirtyByTile(tile);
 			/* Remove desert directly around the river tile. */
 			CircularTileSearch(&tile, RIVER_OFFSET_DESERT_DISTANCE, RiverModifyDesertZone, nullptr);
 		}
@@ -1247,6 +1249,7 @@ static bool FlowRiver(TileIndex spring, TileIndex begin)
 				DistanceManhattan(spring, lakeCenter) > _settings_game.game_creation.min_river_length) {
 			end = lakeCenter;
 			MakeRiver(lakeCenter, Random());
+			MarkTileDirtyByTile(lakeCenter);
 			/* Remove desert directly around the river tile. */
 			CircularTileSearch(&lakeCenter, RIVER_OFFSET_DESERT_DISTANCE, RiverModifyDesertZone, nullptr);
 			lakeCenter = end;
@@ -1368,8 +1371,11 @@ void GenerateLandscape(byte mode)
 	/* Do not call IncreaseGeneratingWorldProgress() before FixSlopes(),
 	 * it allows screen redraw. Drawing of broken slopes crashes the game */
 	FixSlopes();
+	MarkWholeScreenDirty();
 	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
+
 	ConvertGroundTilesIntoWaterTiles();
+	MarkWholeScreenDirty();
 	IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);
 
 	if (_settings_game.game_creation.landscape == LT_TROPIC) CreateDesertOrRainForest();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -15,6 +15,7 @@
 #include "../ai/ai.hpp"
 #include "../game/game.hpp"
 #include "../base_media_base.h"
+#include "../openttd.h"
 #include "../sortlist_type.h"
 #include "../stringfilter_type.h"
 #include "../querystring_gui.h"
@@ -236,7 +237,7 @@ public:
 					break;
 
 				case CONTENT_TYPE_NEWGRF:
-					ScanNewGRFFiles(nullptr);
+					RequestNewGRFScan();
 					break;
 
 				case CONTENT_TYPE_SCENARIO:

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -603,6 +603,9 @@ public:
 
 bool GRFFileScanner::AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename)
 {
+	/* Abort if the user stopped the game during a scan. */
+	if (_exit_game) return false;
+
 	GRFConfig *c = new GRFConfig(filename.c_str() + basepath_length);
 
 	bool added = true;
@@ -702,7 +705,7 @@ void DoScanNewGRFFiles(NewGRFScanCallback *callback)
 	/* Yes... these are the NewGRF windows */
 	InvalidateWindowClassesData(WC_SAVELOAD, 0, true);
 	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_NEWGRF_STATE, GOID_NEWGRF_RESCANNED, true);
-	if (callback != nullptr) callback->OnNewGRFsScanned();
+	if (!_exit_game && callback != nullptr) callback->OnNewGRFsScanned();
 
 	DeleteWindowByClass(WC_MODAL_PROGRESS);
 	SetModalProgress(false);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1127,7 +1127,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 			case WID_NS_RESCAN_FILES:
 			case WID_NS_RESCAN_FILES2:
-				ScanNewGRFFiles(this);
+				RequestNewGRFScan(this);
 				break;
 		}
 	}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -663,7 +663,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		DeleteWindowByClass(WC_TEXTFILE);
 		DeleteWindowByClass(WC_SAVE_PRESET);
 
-		if (this->editable && !this->execute) {
+		if (this->editable && !this->execute && !_exit_game) {
 			CopyGRFConfigList(this->orig_list, this->actives, true);
 			ResetGRFConfig(false);
 			ReloadNewGRFData();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1469,6 +1469,8 @@ void GameLoop()
 		ScanNewGRFFiles(_request_newgrf_scan_callback);
 		_request_newgrf_scan = false;
 		_request_newgrf_scan_callback = nullptr;
+		/* In case someone closed the game during our scan, don't do anything else. */
+		if (_exit_game) return;
 	}
 
 	ProcessAsyncSaveFinish();

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1347,8 +1347,8 @@ void StateGameLoop()
 		StateGameLoop_LinkGraphPauseControl();
 	}
 
-	/* don't execute the state loop during pause */
-	if (_pause_mode != PM_UNPAUSED) {
+	/* Don't execute the state loop during pause or when modal windows are open. */
+	if (_pause_mode != PM_UNPAUSED || HasModalProgress()) {
 		PerformanceMeasurer::Paused(PFE_GAMELOOP);
 		PerformanceMeasurer::Paused(PFE_GL_ECONOMY);
 		PerformanceMeasurer::Paused(PFE_GL_TRAINS);
@@ -1357,7 +1357,7 @@ void StateGameLoop()
 		PerformanceMeasurer::Paused(PFE_GL_AIRCRAFT);
 		PerformanceMeasurer::Paused(PFE_GL_LANDSCAPE);
 
-		UpdateLandscapingLimits();
+		if (!HasModalProgress()) UpdateLandscapingLimits();
 #ifndef DEBUG_DUMP_COMMANDS
 		Game::GameLoop();
 #endif
@@ -1366,7 +1366,6 @@ void StateGameLoop()
 
 	PerformanceMeasurer framerate(PFE_GAMELOOP);
 	PerformanceAccumulator::Reset(PFE_GL_LANDSCAPE);
-	if (HasModalProgress()) return;
 
 	Layouter::ReduceLineCache();
 

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -81,4 +81,6 @@ void HandleExitGameRequest();
 
 void SwitchToMode(SwitchMode new_mode);
 
+void RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
+
 #endif /* OPENTTD_H */

--- a/src/progress.cpp
+++ b/src/progress.cpp
@@ -14,33 +14,12 @@
 
 /** Are we in a modal progress or not? */
 bool _in_modal_progress = false;
-bool _first_in_modal_loop = false;
-/** Threading usable for modal progress? */
-bool _use_threaded_modal_progress = true;
-/** Rights for the performing work. */
-std::mutex _modal_progress_work_mutex;
-/** Rights for the painting. */
-std::mutex _modal_progress_paint_mutex;
 
 /**
  * Set the modal progress state.
- * @note Makes IsFirstModalProgressLoop return true for the next call.
  * @param state The new state; are we modal or not?
  */
 void SetModalProgress(bool state)
 {
 	_in_modal_progress = state;
-	_first_in_modal_loop = true;
-}
-
-/**
- * Check whether this is the first modal progress loop.
- * @note Set by SetModalProgress, unset by calling this method.
- * @return True if this is the first loop.
- */
-bool IsFirstModalProgressLoop()
-{
-	bool ret = _first_in_modal_loop;
-	_first_in_modal_loop = false;
-	return ret;
 }

--- a/src/progress.h
+++ b/src/progress.h
@@ -10,10 +10,6 @@
 #ifndef PROGRESS_H
 #define PROGRESS_H
 
-#include <mutex>
-
-static const uint MODAL_PROGRESS_REDRAW_TIMEOUT = 200; ///< Timeout between redraws
-
 /**
  * Check if we are currently in a modal progress state.
  * @return Are we in the modal state?
@@ -24,20 +20,6 @@ static inline bool HasModalProgress()
 	return _in_modal_progress;
 }
 
-/**
- * Check if we can use a thread for modal progress.
- * @return Threading usable?
- */
-static inline bool UseThreadedModelProgress()
-{
-	extern bool _use_threaded_modal_progress;
-	return _use_threaded_modal_progress;
-}
-
-bool IsFirstModalProgressLoop();
 void SetModalProgress(bool state);
-
-extern std::mutex _modal_progress_work_mutex;
-extern std::mutex _modal_progress_paint_mutex;
 
 #endif /* PROGRESS_H */

--- a/src/thread.h
+++ b/src/thread.h
@@ -14,10 +14,6 @@
 #include <system_error>
 #include <thread>
 
-/** Signal used for signalling we knowingly want to end the thread. */
-class OTTDThreadExitSignal { };
-
-
 /**
  * Sleep on the current thread for a defined time.
  * @param milliseconds Time to sleep for in milliseconds.
@@ -54,7 +50,6 @@ inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&
 				try {
 					/* Call user function with the given arguments. */
 					F(A...);
-				} catch (OTTDThreadExitSignal&) {
 				} catch (...) {
 					NOT_REACHED();
 				}

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -164,6 +164,7 @@ static void PlaceTree(TileIndex tile, uint32 r)
 
 	if (tree != TREE_INVALID) {
 		PlantTreesOnTile(tile, tree, GB(r, 22, 2), std::min<byte>(GB(r, 16, 3), 6));
+		MarkTileDirtyByTile(tile);
 
 		/* Rerandomize ground, if neither snow nor shore */
 		TreeGround ground = GetTreeGround(tile);

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -251,30 +251,22 @@ void VideoDriver_Dedicated::MainLoop()
 	/* If SwitchMode is SM_LOAD_GAME, it means that the user used the '-g' options */
 	if (_switch_mode != SM_LOAD_GAME) {
 		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
-		SwitchToMode(_switch_mode);
-		_switch_mode = SM_NONE;
 	} else {
-		_switch_mode = SM_NONE;
 		/* First we need to test if the savegame can be loaded, else we will end up playing the
 		 *  intro game... */
-		if (!SafeLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.detail_ftype, GM_NORMAL, BASE_DIR)) {
+		if (SaveOrLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.detail_ftype, BASE_DIR) == SL_ERROR) {
 			/* Loading failed, pop out.. */
 			DEBUG(net, 0, "Loading requested map failed, aborting");
-			_networking = false;
+			return;
 		} else {
 			/* We can load this game, so go ahead */
-			SwitchToMode(SM_LOAD_GAME);
+			_switch_mode = SM_LOAD_GAME;
 		}
 	}
 
 	this->is_game_threaded = false;
 
 	/* Done loading, start game! */
-
-	if (!_networking) {
-		DEBUG(net, 0, "Dedicated server could not be started, aborting");
-		return;
-	}
 
 	while (!_exit_game) {
 		if (!_dedicated_forks) DedicatedHandleKeyInput();

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -56,6 +56,25 @@ void VideoDriver::GameThread()
 	}
 }
 
+/**
+ * Pause the game-loop for a bit, releasing the game-state lock. This allows,
+ * if the draw-tick requested this, the drawing to happen.
+ */
+void VideoDriver::GameLoopPause()
+{
+	/* If we are not called from the game-thread, ignore this request. */
+	if (std::this_thread::get_id() != this->game_thread.get_id()) return;
+
+	this->game_state_mutex.unlock();
+
+	{
+		/* See GameThread() for more details on this lock. */
+		std::lock_guard<std::mutex> lock(this->game_thread_wait_mutex);
+	}
+
+	this->game_state_mutex.lock();
+}
+
 /* static */ void VideoDriver::GameThreadThunk(VideoDriver *drv)
 {
 	drv->GameThread();

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -179,6 +179,8 @@ public:
 		this->change_blitter = new_blitter;
 	}
 
+	void GameLoopPause();
+
 	/**
 	 * Get the currently active instance of the video driver.
 	 */


### PR DESCRIPTION
- This invalidates the first three commits in #8828, but not the fourth. That is, this also fixes the bug mentioned, but not in the way you think: it simply continues the NewGRF scan till it is finished, while the window is closed.
- EXTRA EXTRA EXTRA: the second commit in this PR also fixes #8760, and stops the NewGRF scan as soon as possible, similar to #8828 (but without all the complex thread-stuff, as it is now running in the game-thread anyway).
- And while at it, fixed similar issue for world-gen: that is now also aborted when you close the game.
- #8833 was closely related to all this, and now also part of this PR

(okay, this might be growing a bit too much; if it is easier if I PR them separately (a few depend on each other, but I can deal with that), just let me know!)

Closes #8828
Fixes #8760
Fixes #8833

## Motivation / Problem

With the gameloop now threaded, we can get ride of the ugliness that the NewGRFScan and GenerateWorld threads are. They are a huge hack dating back when threads were still scary and not many people had more than one core. Pretty sure those days are over :P

By removing the special code for those two modal windows, the code becomes a lot simpler. Having such massive chunks of code not running in different threads makes things easier to debug and understand.

Purely by accident, this solves most issues mentioned in #8712, with the exception of the palette.

But mostly ... it now looks so much more smooth to generate a world ...

https://user-images.githubusercontent.com/1663690/110473423-cb7d1780-80de-11eb-947c-d22d4344ea0c.mp4


## Description

```
Basically, modal windows had their own thread-locking for what
drawing was possible. This is a bit nonsense now we have a
game-thread. And it makes much more sense to do things like
NewGRFScan and GenerateWorld in the game-thread, and not in a
thread next to the game-thread.

This commit changes that: it removes the threads for NewGRFScan
and GenerateWorld, and just runs the code in the game-thread.
On regular intervals it allows the draw-thread to do a tick,
which gives a much smoother look and feel.

It does slow down NewGRFScan and GenerateWorld ever so slightly
as it spends more time on drawing. But the slowdown is not
measureable on my machines (with 700+ NewGRFs / 4kx4k map and
a Debug build).

Running without a game-thread means NewGRFScan and GenerateWorld
are now blocking.
```

All the extra `MarkDirty` calls are because formally it just made the whole screen dirty every time, but that is very expensive. So now only that what changed is marked dirty, which is a lot nicer on the CPU.

## Limitations

- Slightly slower NewGRF scanning and map generation, because time is spend on drawing (and not on scanning). On my machine it is so small, I could not measure this outside the noise. I would estimate it at: 0.05ms per frame, 60 frames per second, 3ms per 1000ms, so 0.3% speed loss.
- Running with `-vwin32-opengl:no_threads` means you don't see those two modals; similar to running without threads before this commit. I think this is reasonable, to make it work this way.
- The game used to mark the whole screen dirty during map generation; but doing that now would be dreadfully slow. So instead I tried to find all the places that modify the map, and mark the files dirty. To me it seems I found them all, but I might have missed some. Nothing we can't fix over time. (Basically, the old implementation was lazy and just did EVERYTHING, instead of what is needed).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
