### PR TITLE
Fix #8711: having gui_zoom lower than zoom_min causes crashes

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1893,7 +1893,9 @@ void UpdateGUIZoom()
 	if (_gui_zoom_cfg == ZOOM_LVL_CFG_AUTO) {
 		_gui_zoom = static_cast<ZoomLevel>(Clamp(VideoDriver::GetInstance()->GetSuggestedUIZoom(), _settings_client.gui.zoom_min, _settings_client.gui.zoom_max));
 	} else {
-		_gui_zoom = static_cast<ZoomLevel>(_gui_zoom_cfg);
+		_gui_zoom = static_cast<ZoomLevel>(Clamp(_gui_zoom_cfg, _settings_client.gui.zoom_min, _settings_client.gui.zoom_max));
+		/* Write the value back in case it was not between min/max. */
+		_gui_zoom_cfg = _gui_zoom;
 	}
 
 	/* Determine real font zoom to use. */


### PR DESCRIPTION
Fixes #8711.

## Motivation / Problem

Manually changing your config makes the game go boom!

Specially: set `gui_zoom` to 0 and `zoom_min` to 1. This brings `gui_zoom` out of the valid range, creating really weird effects.


## Description

```
gui_zoom was never clamp'd between zoom_min/zoom_max.

zoom_min controls how zoomed-in we load sprites. For a value of 1,
no quad-sizes sprites are loaded. If gui_zoom would be 0, meaning
it wants quad-sized sprites to display, it was printing random
stuff to the screen, which could or could not result in crashes.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
