### PR TITLE
Fix #8813: Misleading function name for selecting refresh rate

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -144,7 +144,7 @@ std::set<int> _refresh_rates = { 30, 60, 75, 90, 100, 120, 144, 240 };
  * Add the refresh rate from the config and the refresh rates from all the monitors to
  * our list of refresh rates shown in the GUI.
  */
-static void AddRefreshRatesAndSelect()
+static void AddCustomRefreshRates()
 {
 	/* Add the refresh rate as selected in the config. */
 	_refresh_rates.insert(_settings_client.gui.refresh_rate);
@@ -163,7 +163,7 @@ struct GameOptionsWindow : Window {
 		this->opt = &GetGameSettings();
 		this->reload = false;
 
-		AddRefreshRatesAndSelect();
+		AddCustomRefreshRates();
 
 		this->InitNested(WN_GAME_OPTIONS_GAME_OPTIONS);
 		this->OnInvalidateData(0);


### PR DESCRIPTION
## Motivation / Problem
After the code review on #8813, the function does not select any refresh rate anymore.

## Description
Simply renames the function to actually show what it does. Though there might be a better name for it?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
