### PR TITLE
Fix: change the bounding boxes of tram catenaries to fit with current sets

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1423,8 +1423,8 @@ void DrawRoadTypeCatenary(const TileInfo *ti, RoadType rt, RoadBits rb)
 	 * For tiles with OWNER_TOWN or OWNER_NONE, recolour CC to grey as a neutral colour. */
 	Owner owner = GetRoadOwner(ti->tile, GetRoadTramType(rt));
 	PaletteID pal = (owner == OWNER_NONE || owner == OWNER_TOWN ? GENERAL_SPRITE_COLOUR(COLOUR_GREY) : COMPANY_SPRITE_COLOUR(owner));
-	if (back != 0) AddSortableSpriteToDraw(back,  pal, ti->x, ti->y, 16, 16, TILE_HEIGHT + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
-	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 16, 16, TILE_HEIGHT + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
+	if (back != 0) AddSortableSpriteToDraw(back,  pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
+	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 1, 1, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
 }
 
 /**


### PR DESCRIPTION
Fixes #8647. Well ... it "mitigates" it.

## Motivation / Problem

WARNING: I know nothing about all this; I just applied my knowledge of isometric game engine sorters to OpenTTD .. so be careful :D

Catenaries for tram doesn't appear to have any specs for the bounding box used. This makes it a bit difficult to get them right. I compared the current two I could found: a 8bpp and a 32bpp variant, and checked if they match. I tried to make it look better for those two. This of course is a bullshit approach for the problem, so I am perfectly fine for being called names while this PR is closed :)

## Description

### Wrong height

Observations: catenaries are set to be `TILE_HEIGHT + BB_HEIGHT_UNDER_BRIDGE`, but clearly they are larger:
![image](https://user-images.githubusercontent.com/1663690/110639457-08650f00-81b0-11eb-94c1-aafe149427f2.png)

This causes catenaries to not been drawn when they should like in the image above.

Similar, this is true for the OpenGFX variant:
![image](https://user-images.githubusercontent.com/1663690/110639533-1dda3900-81b0-11eb-901b-2f75bb4da0ba.png)

Solution: `TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE`. This matches a lot better, but not perfectly between the two sets. There is no correct answer; this one is just better (but still wrong).

### Wrong dimension

Because the "front" sprite is considered 16x16, it captures the whole tile. This means sorting goes a bit weird, as these "front" sprites are supposed to be behind the vehicles (the name "front" is really misleading to me, but what-ever). There is here too not a correct answer, just one that might be slightly better: make them 1 by 1 (instead of 16 by 16). This is true for MOST sprites. Some sprites, however, draw both the front and back catenary in the same sprite. This is an impossible situation to solve in terms of sorting.

![image](https://user-images.githubusercontent.com/1663690/110639849-7a3d5880-81b0-11eb-8526-cc9c3053e3f7.png)
They are off by 1 for the OpenGFX set.

![image](https://user-images.githubusercontent.com/1663690/110639891-86291a80-81b0-11eb-880a-7172183ce6f5.png)
They are pretty correct with CZRT.

![image](https://user-images.githubusercontent.com/1663690/110639979-9c36db00-81b0-11eb-8f9c-22114afd117a.png)
This is zBase; those are even higher, but otherwise also "good enough".


Again, I want to stress, none of this is exact science, and all of this is wrong either way. This PR only appears to make it slightly less wrong in the current most common cases.


The result:

![image](https://user-images.githubusercontent.com/1663690/110640544-35fe8800-81b1-11eb-891a-655521736c0d.png)
Correctly sorted

![image](https://user-images.githubusercontent.com/1663690/110640644-562e4700-81b1-11eb-9dbd-4194338f9806.png)
Now breaks; both poles are in the same sprite, so there is no correct way here.

![image](https://user-images.githubusercontent.com/1663690/110640670-621a0900-81b1-11eb-9d39-b78f9a6d6979.png)
Correctly sorted


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
