### PR TITLE
Codechange: Add fast path to catenary drawing in MaskWireBits

### DIFF
--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -124,6 +124,9 @@ static TrackBits GetRailTrackBitsUniversal(TileIndex t, byte *override)
  */
 static TrackBits MaskWireBits(TileIndex t, TrackBits tracks)
 {
+	/* Single track bits are never masked out. */
+	if (likely(HasAtMostOneBit(tracks))) return tracks;
+
 	if (!IsPlainRailTile(t)) return tracks;
 
 	TrackdirBits neighbour_tdb = TRACKDIR_BIT_NONE;


### PR DESCRIPTION
## Motivation / Problem

MaskWireBits always returns its input unchanged if the input has only 0 or 1 track bits set.
Having only 0 or 1 track bits sets (i.e. non junction tiles) is by far the most common case.
Examining the state of neighbouring tiles and the subsequent masking logic is relatively expensive and can be omitted in this case.

## Description

Return immediately in the common/trivial case of only 0 or 1 set track bits in the input.
This produces a measurable improvement in catenary drawing performance. (Measured previously in my branch using valgrind/callgrind/FPS window).

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
