### PR TITLE
Fix some tram catenary sorting issues

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1424,7 +1424,7 @@ void DrawRoadTypeCatenary(const TileInfo *ti, RoadType rt, RoadBits rb)
 	Owner owner = GetRoadOwner(ti->tile, GetRoadTramType(rt));
 	PaletteID pal = (owner == OWNER_NONE || owner == OWNER_TOWN ? GENERAL_SPRITE_COLOUR(COLOUR_GREY) : COMPANY_SPRITE_COLOUR(owner));
 	if (back != 0) AddSortableSpriteToDraw(back,  pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
-	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
+	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 1, 1, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
 }
 
 /**

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1423,8 +1423,8 @@ void DrawRoadTypeCatenary(const TileInfo *ti, RoadType rt, RoadBits rb)
 	 * For tiles with OWNER_TOWN or OWNER_NONE, recolour CC to grey as a neutral colour. */
 	Owner owner = GetRoadOwner(ti->tile, GetRoadTramType(rt));
 	PaletteID pal = (owner == OWNER_NONE || owner == OWNER_TOWN ? GENERAL_SPRITE_COLOUR(COLOUR_GREY) : COMPANY_SPRITE_COLOUR(owner));
-	if (back != 0) AddSortableSpriteToDraw(back,  pal, ti->x, ti->y, 16, 16, TILE_HEIGHT + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
-	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 16, 16, TILE_HEIGHT + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
+	if (back != 0) AddSortableSpriteToDraw(back,  pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
+	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
 }
 
 /**

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1423,7 +1423,7 @@ void DrawRoadTypeCatenary(const TileInfo *ti, RoadType rt, RoadBits rb)
 	 * For tiles with OWNER_TOWN or OWNER_NONE, recolour CC to grey as a neutral colour. */
 	Owner owner = GetRoadOwner(ti->tile, GetRoadTramType(rt));
 	PaletteID pal = (owner == OWNER_NONE || owner == OWNER_TOWN ? GENERAL_SPRITE_COLOUR(COLOUR_GREY) : COMPANY_SPRITE_COLOUR(owner));
-	if (back != 0) AddSortableSpriteToDraw(back,  pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
+	if (back != 0) AddSortableSpriteToDraw(back, pal, ti->x, ti->y, 16, 16, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
 	if (front != 0) AddSortableSpriteToDraw(front, pal, ti->x, ti->y, 1, 1, TILE_HEIGHT * 2 + BB_HEIGHT_UNDER_BRIDGE, ti->z, IsTransparencySet(TO_CATENARY));
 }
 


### PR DESCRIPTION
Fixes #8647
Breaks OpenGFX.

## Motivation / Problem

Attempt #<!-- -->2, after @glx22 explained a few things to me about catenaries :D Tnx for that!

Basically, there appears to be some weirdness around tram catenaries. So far I collected the following list:

- In the code, `front` is the back sprite, and `back` is the front sprite.

- OpenGFX has many front sprites that do not redraw the front pylon, or the east/west. This currently "works", because front/back sprites have the same order. After this fix, you get glitches like this:
![image](https://user-images.githubusercontent.com/1663690/110658351-e96f7880-81c1-11eb-9eed-92fd708714a1.png)

- Front/back sprites are ordered exactly the same, so a vehicle is either before both or behind both. This currently works out (most of the time) as most vehicles are lower than the start of the pylons in most sets.

- The pylons in most sets are visibly higher than the bounding box. This causes glitches, like:
![image](https://user-images.githubusercontent.com/1663690/110658301-dc528980-81c1-11eb-90bd-14f418737048.png)
![image](https://user-images.githubusercontent.com/1663690/110658482-0310c000-81c2-11eb-8544-d6faf77f588f.png)

- zbase is in a league of its own. No clue what is going on there, but it aint right.

## Description

After a bit of discussion on IRC, and as we all know nobody really understand NewGRF (besides @frosch123 ; so he might be laughing reading this, as I got this all wrong), I come to this solution with the following arguments:

- Height is a bit weird, but increasing it makes it less often wrong. Ideally a set can indicate how high pylons are, but this is currently not possible. Maybe it should be part of the spec that it should be N pixels, but that is a different discussion.
- Back sprites should be sorted behind the vehicle. Front sprites before vehicles. It is up to the NewGRF author to make this look pretty. So the back sprite is now sorted as if it is on the north corner, where the front sprite is not sorted as if it is on the south corner. With this, bounding boxes look a bit crap.

Funny enough, elrail has a completely different implementation for catenaries, where pylons and wires are separated. That for sure feels a bit more natural. Now NewGRF authors need to understand tram catenaries a lot more where things are drawn; OpenGFX shows this is not trivial.

Either way, with this PR, OpenGFX really needs fixing, as it visually glitches a lot more.

The result, a bit better looking catenaries:
![image](https://user-images.githubusercontent.com/1663690/110659214-a9f55c00-81c2-11eb-9cdc-389f23897e58.png)
![image](https://user-images.githubusercontent.com/1663690/110659232-acf04c80-81c2-11eb-8f38-789468878842.png)

zBase still looks weird though: 
![image](https://user-images.githubusercontent.com/1663690/110659338-c7c2c100-81c2-11eb-8618-61bdbd5d7e4a.png)
Seems front pylons are wrong or something. Dunno exactly, but there are double pylons everywhere (already the case before this PR too).

## Limitations

- I might be completely wrong with this fix
- OpenGFX has poor tram sprites (how I and @glx22 understand it) and requires fixing!
- Height is an estimate, and can still be wrong. It is just less likely, and most vehicles are smaller than `(TILE_HEIGHT + BB_HEIGHT_UNDER_BRIDGE) / 2`, as otherwise they would look crap under bridges. This is also the minimum height needed to be sorted wrong with the new approach.
- I did not fix the back/front mixup in the code, as it is just really confusing to me if I am reading it wrong, or that the code is wrong, or the specs, or the examples, or ....

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
