### PR TITLE
Fix "exec" call depth and "exec" never returning to script

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -960,6 +960,11 @@ DEF_CONSOLE_CMD(ConExec)
 		return true;
 	}
 
+	if (_script_current_depth == 11) {
+		IConsoleError("Maximum 'exec' depth reached; script A is calling script B is calling script C ... more than 10 times.");
+		return true;
+	}
+
 	_script_current_depth++;
 	uint script_depth = _script_current_depth;
 


### PR DESCRIPTION
## Motivation / Problem

See #8851. Two problems are mentioned:

- "exec" doesn't have a max depth
- "exec" doesn't return

This PR fixes both problems at the same time.

## Description

"exec" uses a global `bool`, which limits what you can do. Making that a depth variable solves both issues nicely.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
