### PR TITLE
Fix: if bootstrap failed, it could end with an empty screen instead of error

### DIFF
--- a/src/bootstrap_gui.cpp
+++ b/src/bootstrap_gui.cpp
@@ -120,7 +120,7 @@ public:
 };
 
 /** Nested widgets for the download window. */
-static const NWidgetPart _nested_boostrap_download_status_window_widgets[] = {
+static const NWidgetPart _nested_bootstrap_download_status_window_widgets[] = {
 	NWidget(WWT_CAPTION, COLOUR_GREY), SetDataTip(STR_CONTENT_DOWNLOAD_TITLE, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
 	NWidget(WWT_PANEL, COLOUR_GREY, WID_NCDS_BACKGROUND),
 		NWidget(NWID_SPACER), SetMinimalSize(350, 0), SetMinimalTextLines(3, WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM + 30),
@@ -132,7 +132,7 @@ static WindowDesc _bootstrap_download_status_window_desc(
 	WDP_CENTER, nullptr, 0, 0,
 	WC_NETWORK_STATUS_WINDOW, WC_NONE,
 	WDF_MODAL,
-	_nested_boostrap_download_status_window_widgets, lengthof(_nested_boostrap_download_status_window_widgets)
+	_nested_bootstrap_download_status_window_widgets, lengthof(_nested_bootstrap_download_status_window_widgets)
 );
 
 

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -396,6 +396,7 @@ void ShowErrorMessage(StringID summary_msg, StringID detailed_msg, WarningLevel 
 
 	bool no_timeout = wl == WL_CRITICAL;
 
+	if (_game_mode == GM_BOOTSTRAP) return;
 	if (_settings_client.gui.errmsg_duration == 0 && !no_timeout) return;
 
 	ErrorMessageData data(summary_msg, detailed_msg, no_timeout ? 0 : _settings_client.gui.errmsg_duration, x, y, textref_stack_grffile, textref_stack_size, textref_stack);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2339,6 +2339,10 @@ STR_MISSING_GRAPHICS_SET_MESSAGE                                :{BLACK}OpenTTD 
 STR_MISSING_GRAPHICS_YES_DOWNLOAD                               :{BLACK}Yes, download the graphics
 STR_MISSING_GRAPHICS_NO_QUIT                                    :{BLACK}No, exit OpenTTD
 
+STR_MISSING_GRAPHICS_ERROR_TITLE                                :{WHITE}Downloading failed
+STR_MISSING_GRAPHICS_ERROR                                      :{BLACK}Downloading graphics failed.{}Please download graphics manually.
+STR_MISSING_GRAPHICS_ERROR_QUIT                                 :{BLACK}Exit OpenTTD
+
 # Transparency settings window
 STR_TRANSPARENCY_CAPTION                                        :{WHITE}Transparency Options
 STR_TRANSPARENT_SIGNS_TOOLTIP                                   :{BLACK}Toggle transparency for signs. Ctrl+Click to lock

--- a/src/widgets/bootstrap_widget.h
+++ b/src/widgets/bootstrap_widget.h
@@ -15,6 +15,13 @@ enum BootstrapBackgroundWidgets {
 	WID_BB_BACKGROUND, ///< Background of the window.
 };
 
+/** Widgets of the #BootstrapErrmsgWindow class. */
+enum BootstrapErrorMessageWidgets {
+	WID_BEM_CAPTION, ///< Caption of the window.
+	WID_BEM_MESSAGE, ///< Error message.
+	WID_BEM_QUIT,    ///< Quit button.
+};
+
 /** Widgets of the #BootstrapContentDownloadStatusWindow class. */
 enum BootstrapAskForDownloadWidgets {
 	WID_BAFD_QUESTION, ///< The question whether to download.


### PR DESCRIPTION
Fixes #8855

## Motivation / Problem

Bootstrap had a flow where it could leave the screen with no open window. This is rather confusing for any human. Show an error instead, with next steps.

## Description

```
There are various of ways bootstrap can fail:
- Failing network connection
- Incomplete download
- No write permissions
- Disk full
- (others I forgot)

They all result in a screen with no windows. To ensure we at least
always show something when anything bad happens, if the bootstrap
is not successful, show a screen what the next step for the human
should be.
```

![image](https://user-images.githubusercontent.com/1663690/111028722-a8ad7480-83f8-11eb-9124-cf831507bd33.png)


## Limitations

This does not show the real error that happened. Some flows do have some snippets of information (like "write to file failed"), but most just close the download window. Additionally, showing real errors is rather difficult without hacking or rewriting the error window. Both felt a bit excessive for something that shouldn't happen in most cases.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
