### PR TITLE
Doc: Clarify comment that SND_05_TRAIN_THROUGH_TUNNEL is only for ste…

### DIFF
--- a/src/sound_type.h
+++ b/src/sound_type.h
@@ -39,7 +39,7 @@ enum SoundFx {
 	SND_02_CONSTRUCTION_WATER = 0,         ///<  0 == 0x00  Construction: water infrastructure
 	SND_03_FACTORY,                        ///<  1 == 0x01  Industry producing: factory: whistle
 	SND_04_DEPARTURE_STEAM,                ///<  2 == 0x02  Station departure: steam engine
-	SND_05_TRAIN_THROUGH_TUNNEL,           ///<  3 == 0x03  Train enters tunnel
+	SND_05_TRAIN_THROUGH_TUNNEL,           ///<  3 == 0x03  Train enters tunnel: steam engine
 	SND_06_DEPARTURE_CARGO_SHIP,           ///<  4 == 0x04  Station departure: cargo ships
 	SND_07_DEPARTURE_FERRY,                ///<  5 == 0x05  Station departure: passenger ships
 	SND_08_TAKEOFF_PROPELLER,              ///<  6 == 0x06  Takeoff: propeller plane (non-toyland)


### PR DESCRIPTION
…am engines

## Motivation / Problem

Per #8857:

> In the file src/sound_type.h, there is this sound ID:
> `SND_05_TRAIN_THROUGH_TUNNEL,           ///<  3 == 0x03  Train enters tunnel`
> This is slightly misleading. I know this sound is ONLY played for steam trains. Any other train type entering a tunnel remains silent. So the description should reflect that.

## Description

Change the comment to reflect this fact.

Closes #8857.

## Limitations

Long commit title; feel free to change.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
