### PR TITLE
Fix #8860: [Win32] Crashlog window wasn't reliably shown for crashes.

### DIFF
--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -114,6 +114,12 @@ public:
 	 */
 	static void InitialiseCrashLog();
 
+	/**
+	 * Prepare crash log handler for a newly started thread.
+	 * @note must be implemented by all implementers of CrashLog.
+	 */
+	static void InitThread();
+
 	static void SetErrorMessage(const char *message);
 	static void AfterCrashLogCleanup();
 };

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -257,3 +257,7 @@ void CDECL HandleCrash(int signum)
 		signal(*i, HandleCrash);
 	}
 }
+
+/* static */ void CrashLog::InitThread()
+{
+}

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -181,3 +181,7 @@ static void CDECL HandleCrash(int signum)
 		signal(*i, HandleCrash);
 	}
 }
+
+/* static */ void CrashLog::InitThread()
+{
+}

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -537,7 +537,7 @@ static void ShowCrashlogWindow();
  * Stack pointer for use when 'starting' the crash handler.
  * Not static as gcc's inline assembly needs it that way.
  */
-void *_safe_esp = nullptr;
+thread_local void *_safe_esp = nullptr;
 
 static LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS *ep)
 {
@@ -605,28 +605,7 @@ static void CDECL CustomAbort(int signal)
 
 /* static */ void CrashLog::InitialiseCrashLog()
 {
-#if defined(_M_AMD64) || defined(_M_ARM64)
-	CONTEXT ctx;
-	RtlCaptureContext(&ctx);
-
-	/* The stack pointer for AMD64 must always be 16-byte aligned inside a
-	 * function. As we are simulating a function call with the safe ESP value,
-	 * we need to subtract 8 for the imaginary return address otherwise stack
-	 * alignment would be wrong in the called function. */
-#if defined(_M_ARM64)
-	_safe_esp = (void *)(ctx.Sp - 8);
-#else
-	_safe_esp = (void *)(ctx.Rsp - 8);
-#endif
-#else
-#if defined(_MSC_VER)
-	_asm {
-		mov _safe_esp, esp
-	}
-#else
-	asm("movl %esp, __safe_esp");
-#endif
-#endif
+	CrashLog::InitThread();
 
 	/* SIGABRT is not an unhandled exception, so we need to intercept it. */
 	signal(SIGABRT, CustomAbort);
@@ -635,6 +614,34 @@ static void CDECL CustomAbort(int signal)
 	_set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif
 	SetUnhandledExceptionFilter(ExceptionHandler);
+}
+
+/* static */ void CrashLog::InitThread()
+{
+#if defined(_M_AMD64) || defined(_M_ARM64)
+	CONTEXT ctx;
+	RtlCaptureContext(&ctx);
+
+	/* The stack pointer for AMD64 must always be 16-byte aligned inside a
+	 * function. As we are simulating a function call with the safe ESP value,
+	 * we need to subtract 8 for the imaginary return address otherwise stack
+	 * alignment would be wrong in the called function. */
+#	if defined(_M_ARM64)
+	_safe_esp = (void *)(ctx.Sp - 8);
+#	else
+	_safe_esp = (void *)(ctx.Rsp - 8);
+#	endif
+#else
+	void *safe_esp;
+#	if defined(_MSC_VER)
+	_asm {
+		mov safe_esp, esp
+	}
+#	else
+	asm("movl %esp, _safe_esp");
+#	endif
+	_safe_esp = safe_esp;
+#endif
 }
 
 /* The crash log GUI */

--- a/src/thread.h
+++ b/src/thread.h
@@ -11,6 +11,7 @@
 #define THREAD_H
 
 #include "debug.h"
+#include "crashlog.h"
 #include <system_error>
 #include <thread>
 
@@ -47,6 +48,7 @@ inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&
 	try {
 		std::thread t([] (const char *name, TFn&& F, TArgs&&... A) {
 				SetCurrentThreadName(name);
+				CrashLog::InitThread();
 				try {
 					/* Call user function with the given arguments. */
 					F(A...);


### PR DESCRIPTION
## Motivation / Problem

If a crash occurs on a different thread to the main thread, the crashlog window wasn't reliably shown on windows.


## Description

Crashlog on windows relies on a captured stack pointer to always have a safe stack area. We only captured the stack pointer on the main thread, which doesn't work when calling the crashlog handler from a different thread.

To solve this, we make the stack pointer a thread local var and capture it on thread init.


## Limitations

@JGRennison has an alternate suggestion in #8860, which, as far as I can see, would be enough for Windows (expect ARM64). This PR implements a solution that is more general, which in the future could be used to support thread specific things also on other platforms.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
