### PR TITLE
Fixed translation error in Swedish

### DIFF
--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -624,7 +624,7 @@ STR_PERFORMANCE_DETAIL_AMOUNT_INT                               :{BLACK}({COMMA}
 STR_PERFORMANCE_DETAIL_PERCENT                                  :{WHITE}{NUM}%
 STR_PERFORMANCE_DETAIL_SELECT_COMPANY_TOOLTIP                   :{BLACK}Visa detaljer om detta företag
 ############ Those following lines need to be in this order!!
-STR_PERFORMANCE_DETAIL_VEHICLES                                 :{BLACK}Vägfordon:
+STR_PERFORMANCE_DETAIL_VEHICLES                                 :{BLACK}Fordon:
 STR_PERFORMANCE_DETAIL_STATIONS                                 :{BLACK}Stationer:
 STR_PERFORMANCE_DETAIL_MIN_PROFIT                               :{BLACK}Min. vinst:
 STR_PERFORMANCE_DETAIL_MIN_INCOME                               :{BLACK}Min. inkomst:


### PR DESCRIPTION
"Vehicles" is just "fordon", "vägfordon" means "road vehicles"

## Motivation / Problem

In the performance dropdown in Swedish, it says "vägfordon" (which means "road vehicles") when in fact it's referring to all vehicles, not just road vehicles.


## Description

I simply changed the word "vägfordon" to "fordon" in the translation file.


## Limitations

This is a very simple fix so there shouldn't be any limitations.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
