### PR TITLE
Fix: OSK layout not scaled for 2x or 4x GUI scale.

### DIFF
--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -15,6 +15,7 @@
 #include "gfx_func.h"
 #include "querystring_gui.h"
 #include "video/video_driver.hpp"
+#include "zoom_func.h"
 
 #include "widgets/osk_widget.h"
 
@@ -103,8 +104,8 @@ struct OskWindow : public Window {
 
 		widget -= WID_OSK_LETTERS;
 		DrawCharCentered(_keyboard[this->shift][widget],
-			r.left + 8,
-			r.top + 3,
+			r.left + (r.right - r.left) / 2,
+			r.top + (r.bottom - r.top - FONT_HEIGHT_NORMAL) / 2,
 			TC_BLACK);
 	}
 
@@ -231,15 +232,15 @@ static void AddKey(NWidgetHorizontal *hor, int height, int num_half, WidgetType 
 
 	if (widtype == NWID_SPACER) {
 		if (!hor->IsEmpty()) key_width += INTER_KEY_SPACE;
-		NWidgetSpacer *spc = new NWidgetSpacer(key_width, height);
+		NWidgetSpacer *spc = new NWidgetSpacer(ScaleGUITrad(key_width), height);
 		hor->Add(spc);
 	} else {
 		if (!hor->IsEmpty()) {
-			NWidgetSpacer *spc = new NWidgetSpacer(INTER_KEY_SPACE, height);
+			NWidgetSpacer *spc = new NWidgetSpacer(ScaleGUITrad(INTER_KEY_SPACE), height);
 			hor->Add(spc);
 		}
 		NWidgetLeaf *leaf = new NWidgetLeaf(widtype, COLOUR_GREY, widnum, widdata, STR_NULL);
-		leaf->SetMinimalSize(key_width, height);
+		leaf->SetMinimalSize(ScaleGUITrad(key_width), height);
 		hor->Add(leaf);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

OSK key buttons are squished into the left side of the OSK window when GUI scaling is 2x or 4x.

## Description

This is solved by using scaling horizontal dimensions when creating the widgets. Vertical scaling is already correct due to use of FONT_HEIGHT_NORMAL. Additionally when drawing, the text is centered instead of using a fixed offset.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
