### PR TITLE
Fix: Recompute road/railtype availability after disabling the engine

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -747,8 +747,14 @@ static void EnableEngineForCompany(EngineID eid, CompanyID company)
 static void DisableEngineForCompany(EngineID eid, CompanyID company)
 {
 	Engine *e = Engine::Get(eid);
+	Company *c = Company::Get(company);
 
 	ClrBit(e->company_avail, company);
+	if (e->type == VEH_TRAIN) {
+		c->avail_railtypes = GetCompanyRailtypes(c->index);
+	} else if (e->type == VEH_ROAD) {
+		c->avail_roadtypes = GetCompanyRoadTypes(c->index);
+	}
 
 	if (company == _local_company) {
 		AddRemoveEngineFromAutoreplaceAndBuildWindows(e->type);


### PR DESCRIPTION
## Motivation / Problem

After disabling engines with GS road/railtype availability is not recomputed. Not only it can confuse players allowing to build types that have no vehicles but can also cause desyncs in multiplayer as availability is not stored in the save.

## Steps to reproduce

* Start default 1950 game with this GS [monoblink.zip](https://github.com/OpenTTD/OpenTTD/files/6159237/monoblink.zip)
* Check monorail availability 
* For desync connect client and build monorail station on server.

## Description

Recomputes availability when disabling the engine.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* **The bug fix is important enough to be backported? (label: 'backport requested')**
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
