### PR TITLE
Change: Do not disallow persistent buffer mapping on AMD GPUs, as it is actually faster.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -13,8 +13,6 @@
 
 /* Define to disable buffer syncing. Will increase max fast forward FPS but produces artifacts. Mainly useful for performance testing. */
 // #define NO_GL_BUFFER_SYNC
-/* Define to enable persistent buffer mapping on AMD GPUs. */
-// #define GL_MAP_PERSISTENT_AMD
 /* Define to allow software rendering backends. */
 // #define GL_ALLOW_SOFTWARE_RENDERER
 
@@ -575,14 +573,6 @@ const char *OpenGLBackend::Init()
 	this->persistent_mapping_supported = IsOpenGLVersionAtLeast(3, 0) && (IsOpenGLVersionAtLeast(4, 4) || IsOpenGLExtensionSupported("GL_ARB_buffer_storage"));
 #ifndef NO_GL_BUFFER_SYNC
 	this->persistent_mapping_supported = this->persistent_mapping_supported && (IsOpenGLVersionAtLeast(3, 2) || IsOpenGLExtensionSupported("GL_ARB_sync"));
-#endif
-
-#ifndef GL_MAP_PERSISTENT_AMD
-	if (this->persistent_mapping_supported && (strstr(vend, "AMD") != nullptr || strstr(renderer, "Radeon") != nullptr)) {
-		/* AMD GPUs seem to perform badly with persistent buffer mapping, disable it for them. */
-		DEBUG(driver, 3, "OpenGL: Detected AMD GPU, not using persistent buffer mapping due to performance problems");
-		this->persistent_mapping_supported = false;
-	}
 #endif
 
 	if (this->persistent_mapping_supported && !BindPersistentBufferExtensions()) {


### PR DESCRIPTION
Closes #8790 

## Motivation / Problem
At beginning, persistent buffer mapping was horribly slow on AMD GPUs (initally discovered on Linux Mesa drivers, but I now checked that same thing happened on Windows). As such, that workaround was added to disable persistent mapping when AMD is detected. This made performance on Mesa driver fine, but on propertiary driver on Windows it was better but still meh.
However, this was fixing the wrong problem. Meanwhile it was discovered that mapping was missing GL_CLIENT_STORAGE_BIT. With that bit set, performance is fine both on Mesa driver and Windows propertiary driver.

## Description

Do not disallow persistent buffer mapping on AMD GPUs.

## Limitations

Probably needs testing on Windows driver with dedicated GPU. I tested on Linux with dedicated GPU, and on Windows but on APU.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested'))
