### PR TITLE
Fix #8871: [OpenGL] Initialize all buffers after resize and clear back buffer.

### DIFF
--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -131,6 +131,7 @@ bool VideoDriver_SDL_OpenGL::AllocateBackingStore(int w, int h, bool force)
 	MemSetT(&this->dirty_rect, 0);
 
 	bool res = OpenGLBackend::Get()->Resize(w, h, force);
+	SDL_GL_SwapWindow(this->sdl_window);
 	_screen.dst_ptr = this->GetVideoPointer();
 
 	_cur_palette.first_dirty = 0;

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1417,6 +1417,7 @@ bool VideoDriver_Win32OpenGL::AllocateBackingStore(int w, int h, bool force)
 
 	this->dirty_rect = {};
 	bool res = OpenGLBackend::Get()->Resize(w, h, force);
+	SwapBuffers(this->dc);
 	_screen.dst_ptr = this->GetVideoPointer();
 
 	return res;


### PR DESCRIPTION
## Motivation / Problem

On some driver/OS/GPU combinations, the back buffer (and maybe textures) get created with random contents, leading to an ugly display until the first proper full draw.


## Description

Explicitly clear all texture buffers/back buffer and do a swap right after resize.


## Limitations

I don't really see the reported behaviour on a Windows/nVidia system, so this fix is mostly speculation and needs (just like all 3D driver related things) testing on as many different systems as possible.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
