### PR TITLE
Feature: Configurable rainforest line height

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -111,7 +111,10 @@ static const NWidgetPart _nested_generate_landscape_widgets[] = {
 				NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 					NWidget(NWID_VERTICAL, NC_EQUALSIZE), SetPIP(0, 4, 0),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_MAX_HEIGHTLEVEL, STR_NULL), SetFill(1, 1),
-						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_SNOW_LINE_HEIGHT, STR_NULL), SetFill(1, 1),
+						NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_LEVEL_SEL_1),
+							NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_SNOW_LINE_HEIGHT, STR_NULL), SetFill(1, 1),
+							NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_RAINFOREST_LINE_HEIGHT, STR_NULL), SetFill(1, 1),
+						EndContainer(),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_DATE, STR_NULL), SetFill(1, 1),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_SMOOTHNESS, STR_NULL), SetFill(1, 1),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_QUANTITY_OF_RIVERS, STR_NULL), SetFill(1, 1),
@@ -124,11 +127,19 @@ static const NWidgetPart _nested_generate_landscape_widgets[] = {
 							NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_MAX_HEIGHTLEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_MAX_HEIGHTLEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_MAX_HEIGHTLEVEL_UP), SetFill(0, 1),
 						EndContainer(),
+						NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_LEVEL_SEL_2),
 						/* Snow line. */
 						NWidget(NWID_HORIZONTAL),
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_LINE_DOWN), SetFill(0, 1),
 							NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_LINE_UP), SetFill(0, 1),
+						EndContainer(),
+						/* Rainforest line. */
+						NWidget(NWID_HORIZONTAL),
+							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_RAINFOREST_LEVEL_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_MAPGEN_RAINFOREST_LINE_DOWN), SetFill(0, 1),
+							NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_RAINFOREST_LEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
+							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_RAINFOREST_LEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_RAINFOREST_LINE_UP), SetFill(0, 1),
+						EndContainer(),
 						EndContainer(),
 						/* Starting date. */
 						NWidget(NWID_HORIZONTAL),
@@ -228,7 +239,10 @@ static const NWidgetPart _nested_heightmap_load_widgets[] = {
 						NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 							NWidget(NWID_VERTICAL, NC_EQUALSIZE), SetPIP(0, 4, 0),
 								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_MAX_HEIGHTLEVEL, STR_NULL), SetFill(1, 1),
-								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_SNOW_LINE_HEIGHT, STR_NULL), SetFill(1, 1),
+								NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_LEVEL_SEL_1),
+									NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_SNOW_LINE_HEIGHT, STR_NULL), SetFill(1, 1),
+									NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_RAINFOREST_LINE_HEIGHT, STR_NULL), SetFill(1, 1),
+								EndContainer(),
 								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_DATE, STR_NULL), SetFill(1, 1),
 								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_GAME_OPTIONS_TOWN_NAMES_FRAME, STR_NULL), SetFill(1, 1),
 							EndContainer(),
@@ -238,10 +252,19 @@ static const NWidgetPart _nested_heightmap_load_widgets[] = {
 									NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_MAX_HEIGHTLEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_MAX_HEIGHTLEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_MAX_HEIGHTLEVEL_UP), SetFill(0, 1),
 								EndContainer(),
+								NWidget(NWID_SELECTION, INVALID_COLOUR, WID_GL_LEVEL_SEL_2),
+								/* Snow line. */
 								NWidget(NWID_HORIZONTAL),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_MAPGEN_SNOW_LINE_DOWN), SetFill(0, 1),
 									NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_SNOW_LEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_SNOW_LINE_UP), SetFill(0, 1),
+								EndContainer(),
+								/* Rainforest line. */
+								NWidget(NWID_HORIZONTAL),
+									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_RAINFOREST_LEVEL_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_MAPGEN_RAINFOREST_LINE_DOWN), SetFill(0, 1),
+									NWidget(WWT_TEXTBTN, COLOUR_ORANGE, WID_GL_RAINFOREST_LEVEL_TEXT), SetDataTip(STR_BLACK_INT, STR_NULL), SetFill(1, 0),
+									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_RAINFOREST_LEVEL_UP), SetDataTip(SPR_ARROW_UP, STR_MAPGEN_RAINFOREST_LINE_UP), SetFill(0, 1),
+								EndContainer(),
 								EndContainer(),
 								NWidget(NWID_HORIZONTAL),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_START_DATE_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_BACKWARD), SetFill(0, 1),
@@ -367,6 +390,7 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_MAPSIZE_Y_PULLDOWN:   SetDParam(0, 1LL << _settings_newgame.game_creation.map_y); break;
 			case WID_GL_MAX_HEIGHTLEVEL_TEXT: SetDParam(0, _settings_newgame.construction.max_heightlevel); break;
 			case WID_GL_SNOW_LEVEL_TEXT:      SetDParam(0, _settings_newgame.game_creation.snow_line_height); break;
+			case WID_GL_RAINFOREST_LEVEL_TEXT:SetDParam(0, _settings_newgame.game_creation.rainforest_line_height); break;
 
 			case WID_GL_TOWN_PULLDOWN:
 				if (_game_mode == GM_EDITOR) {
@@ -458,6 +482,13 @@ struct GenerateLandscapeWindow : public Window {
 
 		/* Disable snowline if not arctic */
 		this->SetWidgetDisabledState(WID_GL_SNOW_LEVEL_TEXT, _settings_newgame.game_creation.landscape != LT_ARCTIC);
+		/* Disable rainforest line if not tropic */
+		this->SetWidgetDisabledState(WID_GL_RAINFOREST_LEVEL_TEXT, _settings_newgame.game_creation.landscape != LT_TROPIC);
+
+		/* Set snow/rainforest selections */
+		int snow_rainforest_plane = _settings_newgame.game_creation.landscape == LT_TROPIC ? 1 : 0;
+		this->GetWidget<NWidgetStacked>(WID_GL_LEVEL_SEL_1)->SetDisplayedPlane(snow_rainforest_plane);
+		this->GetWidget<NWidgetStacked>(WID_GL_LEVEL_SEL_2)->SetDisplayedPlane(snow_rainforest_plane);
 
 		/* Update availability of decreasing / increasing start date and snow level */
 		this->SetWidgetDisabledState(WID_GL_MAX_HEIGHTLEVEL_DOWN, _settings_newgame.construction.max_heightlevel <= MIN_MAX_HEIGHTLEVEL);
@@ -466,6 +497,8 @@ struct GenerateLandscapeWindow : public Window {
 		this->SetWidgetDisabledState(WID_GL_START_DATE_UP,   _settings_newgame.game_creation.starting_year >= MAX_YEAR);
 		this->SetWidgetDisabledState(WID_GL_SNOW_LEVEL_DOWN, _settings_newgame.game_creation.snow_line_height <= MIN_SNOWLINE_HEIGHT || _settings_newgame.game_creation.landscape != LT_ARCTIC);
 		this->SetWidgetDisabledState(WID_GL_SNOW_LEVEL_UP,   _settings_newgame.game_creation.snow_line_height >= MAX_SNOWLINE_HEIGHT || _settings_newgame.game_creation.landscape != LT_ARCTIC);
+		this->SetWidgetDisabledState(WID_GL_RAINFOREST_LEVEL_DOWN, _settings_newgame.game_creation.rainforest_line_height <= MIN_RAINFOREST_HEIGHT || _settings_newgame.game_creation.landscape != LT_TROPIC);
+		this->SetWidgetDisabledState(WID_GL_RAINFOREST_LEVEL_UP, _settings_newgame.game_creation.rainforest_line_height >= MAX_RAINFOREST_HEIGHT || _settings_newgame.game_creation.landscape != LT_TROPIC);
 
 		/* Do not allow a custom sea level with the original land generator. */
 		if (_settings_newgame.game_creation.land_generator == LG_ORIGINAL &&
@@ -497,6 +530,11 @@ struct GenerateLandscapeWindow : public Window {
 
 			case WID_GL_SNOW_LEVEL_TEXT:
 				SetDParamMaxValue(0, MAX_TILE_HEIGHT);
+				*size = maxdim(*size, GetStringBoundingBox(STR_JUST_INT));
+				break;
+
+			case WID_GL_RAINFOREST_LEVEL_TEXT:
+				SetDParamMaxValue(0, MAX_RAINFOREST_HEIGHT);
 				*size = maxdim(*size, GetStringBoundingBox(STR_JUST_INT));
 				break;
 
@@ -674,6 +712,24 @@ struct GenerateLandscapeWindow : public Window {
 				ShowQueryString(STR_JUST_INT, STR_MAPGEN_SNOW_LINE_QUERY_CAPT, 4, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
 				break;
 
+				case WID_GL_RAINFOREST_LEVEL_DOWN:
+			case WID_GL_RAINFOREST_LEVEL_UP: // Rainforest line buttons
+				/* Don't allow too fast scrolling */
+				if (!(this->flags & WF_TIMEOUT) || this->timeout_timer <= 1) {
+					this->HandleButtonClick(widget);
+
+					_settings_newgame.game_creation.rainforest_line_height = Clamp(_settings_newgame.game_creation.rainforest_line_height + widget - WID_GL_RAINFOREST_LEVEL_TEXT, MIN_RAINFOREST_HEIGHT, MAX_RAINFOREST_HEIGHT);
+					this->InvalidateData();
+				}
+				_left_button_clicked = false;
+				break;
+
+			case WID_GL_RAINFOREST_LEVEL_TEXT: // Rainforest line text
+				this->widget_id = WID_GL_RAINFOREST_LEVEL_TEXT;
+				SetDParam(0, _settings_newgame.game_creation.rainforest_line_height);
+				ShowQueryString(STR_JUST_INT, STR_MAPGEN_RAINFOREST_LINE_QUERY_CAPT, 4, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
+				break;
+
 			case WID_GL_LANDSCAPE_PULLDOWN: // Landscape generator
 				ShowDropDownMenu(this, _landscape, _settings_newgame.game_creation.land_generator, WID_GL_LANDSCAPE_PULLDOWN, 0, 0);
 				break;
@@ -739,7 +795,7 @@ struct GenerateLandscapeWindow : public Window {
 
 	void OnTimeout() override
 	{
-		static const int raise_widgets[] = {WID_GL_MAX_HEIGHTLEVEL_DOWN, WID_GL_MAX_HEIGHTLEVEL_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_LEVEL_UP, WID_GL_SNOW_LEVEL_DOWN, WIDGET_LIST_END};
+		static const int raise_widgets[] = {WID_GL_MAX_HEIGHTLEVEL_DOWN, WID_GL_MAX_HEIGHTLEVEL_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_LEVEL_UP, WID_GL_SNOW_LEVEL_DOWN, WID_GL_RAINFOREST_LEVEL_UP, WID_GL_RAINFOREST_LEVEL_DOWN, WIDGET_LIST_END };
 		for (const int *widget = raise_widgets; *widget != WIDGET_LIST_END; widget++) {
 			if (this->IsWidgetLowered(*widget)) {
 				this->RaiseWidget(*widget);
@@ -812,6 +868,7 @@ struct GenerateLandscapeWindow : public Window {
 				case WID_GL_MAX_HEIGHTLEVEL_TEXT: value = DEF_MAX_HEIGHTLEVEL; break;
 				case WID_GL_START_DATE_TEXT: value = DEF_START_YEAR; break;
 				case WID_GL_SNOW_LEVEL_TEXT: value = DEF_SNOWLINE_HEIGHT; break;
+				case WID_GL_RAINFOREST_LEVEL_TEXT: value = DEF_RAINFOREST_HEIGHT; break;
 				case WID_GL_TOWN_PULLDOWN:   value = 1; break;
 				case WID_GL_WATER_PULLDOWN:  value = CUSTOM_SEA_LEVEL_MIN_PERCENTAGE; break;
 				default: NOT_REACHED();
@@ -832,6 +889,11 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_SNOW_LEVEL_TEXT:
 				this->SetWidgetDirty(WID_GL_SNOW_LEVEL_TEXT);
 				_settings_newgame.game_creation.snow_line_height = Clamp(value, MIN_SNOWLINE_HEIGHT, MAX_SNOWLINE_HEIGHT);
+				break;
+
+			case WID_GL_RAINFOREST_LEVEL_TEXT:
+				this->SetWidgetDirty(WID_GL_RAINFOREST_LEVEL_TEXT);
+				_settings_newgame.game_creation.rainforest_line_height = Clamp(value, MIN_RAINFOREST_HEIGHT, MAX_RAINFOREST_HEIGHT);
 				break;
 
 			case WID_GL_TOWN_PULLDOWN:

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -971,7 +971,7 @@ static void CreateDesertOrRainForest()
 {
 	TileIndex update_freq = MapSize() / 4;
 	const TileIndexDiffC *data;
-	uint max_desert_height = CeilDiv(_settings_game.construction.max_heightlevel, 4);
+	uint max_desert_height = _settings_game.game_creation.rainforest_line_height;
 
 	for (TileIndex tile = 0; tile != MapSize(); ++tile) {
 		if ((tile % update_freq) == 0) IncreaseGeneratingWorldProgress(GWP_LANDSCAPE);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1352,6 +1352,8 @@ STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Maximum distanc
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limit for how far from the map border oil refineries and oil rigs can be constructed. On island maps this ensures they are near the coast. On maps larger than 256 tiles, this value is scaled up.
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT                              :Snow line height: {STRING2}
 STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT                     :Control at what height snow starts in sub-arctic landscape. Snow also affects industry generation and town growth requirements
+STR_CONFIG_SETTING_RAINFORESTLINE_HEIGHT                        :Rainforest line height: {STRING}
+STR_CONFIG_SETTING_RAINFORESTLINE_HEIGHT_HELPTEXT               :Control at what height rainforest starts in sub-tropic landscape. Rainforests also affect industry generation and town growth requirements
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN                         :Roughness of terrain: {STRING2}
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_HELPTEXT                :(TerraGenesis only) Choose the frequency of hills: Smooth landscapes have fewer, more wide-spread hills. Rough landscapes have many hills, which may look repetitive
 STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_VERY_SMOOTH             :Very Smooth
@@ -2898,6 +2900,9 @@ STR_MAPGEN_MAX_HEIGHTLEVEL_DOWN                                 :{BLACK}Decrease
 STR_MAPGEN_SNOW_LINE_HEIGHT                                     :{BLACK}Snow line height:
 STR_MAPGEN_SNOW_LINE_UP                                         :{BLACK}Move the snow line height one up
 STR_MAPGEN_SNOW_LINE_DOWN                                       :{BLACK}Move the snow line height one down
+STR_MAPGEN_RAINFOREST_LINE_HEIGHT                               :{BLACK}Rainforest line height:
+STR_MAPGEN_RAINFOREST_LINE_UP                                   :{BLACK}Move the rainforest line height one up
+STR_MAPGEN_RAINFOREST_LINE_DOWN                                 :{BLACK}Move the rainforest line height one down
 STR_MAPGEN_LAND_GENERATOR                                       :{BLACK}Land generator:
 STR_MAPGEN_TERRAIN_TYPE                                         :{BLACK}Terrain type:
 STR_MAPGEN_QUANTITY_OF_SEA_LAKES                                :{BLACK}Sea level:
@@ -2925,6 +2930,7 @@ STR_MAPGEN_HEIGHTMAP_SIZE                                       :{ORANGE}{NUM} x
 
 STR_MAPGEN_MAX_HEIGHTLEVEL_QUERY_CAPT                           :{WHITE}Change maximum map height
 STR_MAPGEN_SNOW_LINE_QUERY_CAPT                                 :{WHITE}Change snow line height
+STR_MAPGEN_RAINFOREST_LINE_QUERY_CAPT                           :{WHITE}Change rainforest line height
 STR_MAPGEN_START_DATE_QUERY_CAPT                                :{WHITE}Change starting year
 
 # SE Map generation

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -324,6 +324,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GS_INDUSTRY_CONTROL,                ///< 287  PR#7912 and PR#8115 GS industry control.
 	SLV_VEH_MOTION_COUNTER,                 ///< 288  PR#8591 Desync safe motion counter
 	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 v1.11 Additional GS text for industries.
+	SLV_RAINFOREST_HEIGHT_SETTING,          ///< 290  PR#8879 Setting for rainforest line height.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1690,6 +1690,7 @@ static SettingsContainer &GetSettingsTree()
 			genworld->Add(new SettingEntry("game_creation.tgen_smoothness"));
 			genworld->Add(new SettingEntry("game_creation.variety"));
 			genworld->Add(new SettingEntry("game_creation.snow_line_height"));
+			genworld->Add(new SettingEntry("game_creation.rainforest_line_height"));
 			genworld->Add(new SettingEntry("game_creation.amount_of_rivers"));
 			genworld->Add(new SettingEntry("game_creation.tree_placer"));
 			genworld->Add(new SettingEntry("vehicle.road_side"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -297,6 +297,7 @@ struct GameCreationSettings {
 	byte   land_generator;                   ///< the landscape generator
 	byte   oil_refinery_limit;               ///< distance oil refineries allowed from map edge
 	byte   snow_line_height;                 ///< the configured snow line height
+	byte   rainforest_line_height;           ///< the configured rainforest line height
 	byte   tgen_smoothness;                  ///< how rough is the terrain from 0-3
 	byte   tree_placer;                      ///< the tree placer algorithm
 	byte   heightmap_rotation;               ///< rotation director for the heightmap

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -1418,6 +1418,21 @@ strhelp  = STR_CONFIG_SETTING_SNOWLINE_HEIGHT_HELPTEXT
 strval   = STR_JUST_COMMA
 cat      = SC_BASIC
 
+[SDT_VAR]
+base     = GameSettings
+var      = game_creation.rainforest_line_height
+type     = SLE_UINT8
+from     = SLV_RAINFOREST_HEIGHT_SETTING
+guiflags = SGF_NEWGAME_ONLY | SGF_SCENEDIT_TOO
+def      = DEF_RAINFOREST_HEIGHT
+min      = MIN_RAINFOREST_HEIGHT
+max      = MAX_RAINFOREST_HEIGHT
+interval = 1
+str      = STR_CONFIG_SETTING_RAINFORESTLINE_HEIGHT
+strhelp  = STR_CONFIG_SETTING_RAINFORESTLINE_HEIGHT_HELPTEXT
+strval   = STR_JUST_COMMA
+cat      = SC_BASIC
+
 [SDT_NULL]
 length   = 4
 to       = SLV_144

--- a/src/tile_type.h
+++ b/src/tile_type.h
@@ -29,6 +29,10 @@ static const uint MIN_SNOWLINE_HEIGHT = 2;                     ///< Minimum snow
 static const uint DEF_SNOWLINE_HEIGHT = 10;                    ///< Default snowline height
 static const uint MAX_SNOWLINE_HEIGHT = (MAX_TILE_HEIGHT - 2); ///< Maximum allowed snowline height
 
+static const uint MIN_RAINFOREST_HEIGHT = 1;                   ///< Minimum rainforest height
+static const uint DEF_RAINFOREST_HEIGHT = 8;                   ///< Default rainforest height
+static const uint MAX_RAINFOREST_HEIGHT = 255;                 ///< Maximum rainforest height
+
 
 /**
  * The different types of tiles.

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -38,6 +38,10 @@ enum GenerateLandscapeWidgets {
 	WID_GL_SNOW_LEVEL_TEXT,             ///< Snow level.
 	WID_GL_SNOW_LEVEL_UP,               ///< Increase snow level.
 
+	WID_GL_RAINFOREST_LEVEL_DOWN,       ///< Decrease rainforest level.
+	WID_GL_RAINFOREST_LEVEL_TEXT,       ///< Rainforest level.
+	WID_GL_RAINFOREST_LEVEL_UP,         ///< Increase rainforest level.
+
 	WID_GL_LANDSCAPE_PULLDOWN,          ///< Dropdown 'Land generator'.
 
 	WID_GL_HEIGHTMAP_NAME_TEXT,         ///< Heightmap name.
@@ -55,6 +59,9 @@ enum GenerateLandscapeWidgets {
 	WID_GL_WATER_NE,                    ///< NE 'Water'/'Freeform'.
 	WID_GL_WATER_SE,                    ///< SE 'Water'/'Freeform'.
 	WID_GL_WATER_SW,                    ///< SW 'Water'/'Freeform'.
+
+	WID_GL_LEVEL_SEL_1,                 ///< NWID_SELECTION for snow or rainforest level label
+	WID_GL_LEVEL_SEL_2,                 ///< NWID_SELECTION for snow or rainforest level selector
 };
 
 /** Widgets of the #CreateScenarioWindow class. */


### PR DESCRIPTION
## Motivation / Problem

This is a patch created by @reldred and @JGRennison. I am simply upstreaming their work from JGRPP, with their consent.

Currently, rainforest height is 1/4 of the chosen `Maximum map height`. This is not intuitive nor is it explained anywhere. 

More importantly, it also does not allow all-green sub-tropic maps, since the minimum maximum height is 15. This is true even for heightmaps — the only workaround is to bulldoze all the desert in Scenario Editor, then replant rainforests by hand (rainforests are defined by rainforest trees, which spawn only in rainforest land, so you need to plant them manually to create rainforest land).

## Description

This changes the rainforest line height to be controlled the same way as the snow line height, both in Settings and during map generation.

From reldred's [PR to JGRPP](https://github.com/JGRennison/OpenTTD-patches/pull/227): 
> Default setting is 8 which matches and should provide default behavior in new map creation.

![world_generation](https://user-images.githubusercontent.com/55058389/111910245-f3ea0780-8a36-11eb-99c2-ebadc947e0a6.png)

If you set the rainforest line height to 1, you get all rainforest! Water towers don't spawn, but the same is true for farms and forests for certain snow line settings, so I don't think we need to worry about players breaking this.

![green](https://user-images.githubusercontent.com/55058389/111910320-44616500-8a37-11eb-8b41-1a337902e724.png)

## Limitations

I have not done a savegame bump before, so please check to ensure I've done this correctly.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)