### PR TITLE
Fix f0f96e31: [OpenGL] warning: comparison of integer expressions of different signedness.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -887,7 +887,7 @@ template <class T>
 static void ClearPixelBuffer(size_t len, T data)
 {
 	T *buf = reinterpret_cast<T *>(_glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_READ_WRITE));
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		*buf++ = data;
 	}
 	_glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);


### PR DESCRIPTION
## Motivation / Problem
```
src/video/opengl.cpp: In instantiation of ‘void ClearPixelBuffer(size_t, T) [with T = unsigned int; size_t = long unsigned int]’:
src/video/opengl.cpp:930:50:   required from here
src/video/opengl.cpp:890:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  for (int i = 0; i < len; i++) {
                  ~~^~~~~
src/video/opengl.cpp: In instantiation of ‘void ClearPixelBuffer(size_t, T) [with T = unsigned char; size_t = long unsigned int]’:
src/video/opengl.cpp:937:39:   required from here
src/video/opengl.cpp:890:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
```

## Description

Moo.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
