### PR TITLE
Fix f0f96e31: [OpenGL] Signed/unsigned warning.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -887,7 +887,7 @@ template <class T>
 static void ClearPixelBuffer(size_t len, T data)
 {
 	T *buf = reinterpret_cast<T *>(_glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_READ_WRITE));
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		*buf++ = data;
 	}
 	_glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);


### PR DESCRIPTION
## Motivation / Problem

`comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]`


## Description

Change integer signedness.



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
