### PR TITLE
Fix f0f96e31: [OpenGL] Broken window resizing.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -909,6 +909,8 @@ bool OpenGLBackend::Resize(int w, int h, bool force)
 
 	_glViewport(0, 0, w, h);
 
+	_glPixelStorei(GL_UNPACK_ROW_LENGTH, pitch);
+
 	this->vid_buffer = nullptr;
 	if (this->persistent_mapping_supported) {
 		_glDeleteBuffers(1, &this->vid_pbo);


### PR DESCRIPTION
## Motivation / Problem

Resizing the game windows is broken if the new size is smaller than the old size.


## Description

Texture (re-)creation failed due to invalid value for row pitch, leading to an invalid OpenGL operation.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
