### PR TITLE
Fix #8875: Filter string in station window breaks flow in user interface

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1018,8 +1018,6 @@ public:
 			matrix->SetClicked(_railstation.station_type);
 
 			EnsureSelectedStationClassIsVisible();
-
-			this->SetFocusedWidget(WID_BRAS_FILTER_EDITBOX);
 		}
 
 		this->InvalidateData();


### PR DESCRIPTION
## Motivation / Problem

Fix for https://github.com/OpenTTD/OpenTTD/issues/8875

The newly added filter string textbox in the create station window automatically gets the focus when NewGRFs with custom stations are used. This "steals" hotkeys like A and DEL because you suddenly are typing text in that textbox.

## Description

The auto focus on the text box was added as a suggestion here https://github.com/OpenTTD/OpenTTD/pull/8706 . I removed it again.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
