### PR TITLE
Fix: placing random trees in SE crashes the game

### DIFF
--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1313,6 +1313,12 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 	static_assert(lengthof(percent_table) == GWP_CLASS_COUNT + 1);
 	assert(cls < GWP_CLASS_COUNT);
 
+	/* Check if we really are generating the world.
+	 * For example, placing trees via the SE also calls this function, but
+	 * shouldn't try to update the progress.
+	 */
+	if (!HasModalProgress()) return;
+
 	if (IsGeneratingWorldAborted()) {
 		HandleGeneratingWorldAbortion();
 		return;


### PR DESCRIPTION
## Motivation / Problem

Go to SE, try to place random trees. KABOOM.


## Description

```
This used to work by accident: originally the code checked if
GenerateWorld was threaded. If not, it would abort the function.
This worked for placing trees, because it was also returning false
when it was not active.

With the recent changes, that check got removed, and this crash
started to happen. So now check if we have a modal window, which
is a very solid indication we are generating the world.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
