### PR TITLE
Fix #8886: Don't try to resolve folders within tars named '.'

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -429,6 +429,9 @@ FILE *FioFOpenFile(const std::string &filename, const char *mode, Subdirectory s
 			if (token == "..") {
 				if (tokens.size() < 2) return nullptr;
 				tokens.pop_back();
+			} else if (token == ".") {
+				/* Do nothing. "." means current folder, but you can create tar files with "." in the path.
+				 * This confuses our file resolver. So, act like this folder doesn't exist. */
 			} else {
 				tokens.push_back(token);
 			}


### PR DESCRIPTION
## Motivation / Problem
Through mildly nefarious means, you can create a tar that has a "root folder" named `.`. In standard file systems, this is the current directory. But OTTD (without the tar filename to realise it's supposed to be within a tarfile, falls back to the standard directory resolving, which includes the the current directory, and can cause OTTD to try to load text files from that directory, rather than from within the tar
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
#8006 is beneficial here too, though no longer required for #8886


## Description
Resolve the `.` (by ignoring it). This causes OTTD to not be able to find the grf/content item, which means it can't try to access textfiles in the wrong directory.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Might want to add some sort of debug output for when this occurs? It's currently very unclear why a GRF has been silently rejected.
It should be noted that this cannot be "exploited" by bananas-downloaded content, as it would be rejected at that level.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
