### PR TITLE
Replace IConsolePrint*(F)( calls with specific console level calls

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -497,7 +497,7 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 	for (cmdptr = cmdstr; *cmdptr != '\0'; cmdptr++) {
 		if (!IsValidChar(*cmdptr, CS_ALPHANUMERAL)) {
 			IConsoleError("command contains malformed characters, aborting");
-			IConsolePrintF(CC_ERROR, "ERROR: command was: '%s'", cmdstr);
+			IConsoleErrorF("ERROR: command was: '%s'", cmdstr);
 			return;
 		}
 	}

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -117,6 +117,16 @@ void IConsolePrint(TextColour colour_code, const char *string)
 	IConsoleGUIPrint(colour_code, str);
 }
 
+void CDECL WARN_FORMAT(2, 0) IConsolePrintV(TextColour colour_code, const char *format, va_list args)
+{
+	assert(IsValidConsoleColour(colour_code));
+
+	char buf[ICON_MAX_STREAMSIZE];
+	vseprintf(buf, lastof(buf), format, args);
+
+	IConsolePrint(colour_code, buf);
+}
+
 /**
  * Handle the printing of text entered into the console or redirected there
  * by any other means. Uses printf() style format, for more information look
@@ -124,16 +134,11 @@ void IConsolePrint(TextColour colour_code, const char *string)
  */
 void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
 {
-	assert(IsValidConsoleColour(colour_code));
-
 	va_list va;
-	char buf[ICON_MAX_STREAMSIZE];
 
 	va_start(va, format);
-	vseprintf(buf, lastof(buf), format, va);
+	IConsolePrintV(colour_code, format, va);
 	va_end(va);
-
-	IConsolePrint(colour_code, buf);
 }
 
 /**
@@ -142,34 +147,28 @@ void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
  * level 2 (developer) for debugging messages to show up.
  * Uses printf() style format, for more information look at IConsolePrint()
  */
-void CDECL IConsoleDebugF(const char* format, ...)
+void CDECL IConsoleDebugF(const char *format, ...)
 {
 	if (_settings_client.gui.developer <= 1) return;
 
 	va_list va;
-	char buf[ICON_MAX_STREAMSIZE];
 
 	va_start(va, format);
-	vseprintf(buf, lastof(buf), format, va);
+	IConsolePrintV(CC_DEBUG, format, va);
 	va_end(va);
-
-	IConsolePrint(CC_DEBUG, buf);
 }
 
 /**
  * It is possible to print informational messages to the console.
  * Uses printf() style format, for more information look at IConsolePrint()
  */
-void CDECL IConsoleInfoF(const char* format, ...)
+void CDECL IConsoleInfoF(const char *format, ...)
 {
 	va_list va;
-	char buf[ICON_MAX_STREAMSIZE];
 
 	va_start(va, format);
-	vseprintf(buf, lastof(buf), format, va);
+	IConsolePrintV(CC_INFO, format, va);
 	va_end(va);
-
-	IConsolePrint(CC_INFO, buf);
 }
 
 /**
@@ -178,18 +177,15 @@ void CDECL IConsoleInfoF(const char* format, ...)
  * debugging messages to show up.
  * Uses printf() style format, for more information look at IConsolePrint()
  */
-void CDECL IConsoleWarningF(const char* format, ...)
+void CDECL IConsoleWarningF(const char *format, ...)
 {
 	if (_settings_client.gui.developer == 0) return;
 
 	va_list va;
-	char buf[ICON_MAX_STREAMSIZE];
 
 	va_start(va, format);
-	vseprintf(buf, lastof(buf), format, va);
+	IConsolePrintV(CC_WARNING, format, va);
 	va_end(va);
-
-	IConsolePrint(CC_WARNING, buf);
 }
 
 /**
@@ -197,56 +193,13 @@ void CDECL IConsoleWarningF(const char* format, ...)
  * game errors, or errors in general you would want the user to notice.
  * Uses printf() style format, for more information look at IConsolePrint()
  */
-void CDECL IConsoleErrorF(const char* format, ...)
+void CDECL IConsoleErrorF(const char *format, ...)
 {
 	va_list va;
-	char buf[ICON_MAX_STREAMSIZE];
 
 	va_start(va, format);
-	vseprintf(buf, lastof(buf), format, va);
+	IConsolePrintV(CC_ERROR, format, va);
 	va_end(va);
-
-	IConsolePrint(CC_ERROR, buf);
-}
-
-/**
- * It is possible to print debugging information to the console,
- * which is achieved by using this function. Can only be used by
- * debug() in debug.cpp. You need at least a level 2 (developer) for debugging
- * messages to show up
- * @param dbg debugging category
- * @param string debugging message
- */
-void IConsoleDebug(const char *dbg, const char *string)
-{
-	IConsoleDebugF("dbg: [%s] %s", dbg, string);
-}
-
-/**
- * It is possible to print informational messages to the console
- */
-void IConsoleInfo(const char* string)
-{
-	IConsoleInfoF("INFO: %s", string);
-}
-
-/**
- * It is possible to print warnings to the console. These are mostly
- * errors or mishaps, but non-fatal. You need at least a level 1 (developer) for
- * debugging messages to show up
- */
-void IConsoleWarning(const char *string)
-{
-	IConsoleWarningF("WARNING: %s", string);
-}
-
-/**
- * It is possible to print error information to the console. This can include
- * game errors, or errors in general you would want the user to notice
- */
-void IConsoleError(const char *string)
-{
-	IConsoleErrorF("ERROR: %s", string);
 }
 
 /**

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -451,7 +451,7 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 
 						if (param < 0 || param >= tokencount) {
 							IConsoleError("too many or wrong amount of parameters passed to alias, aborting");
-							IConsolePrintF(CC_WARNING, "Usage of alias '%s': %s", alias->name, alias->cmdline);
+							IConsoleWarningF("Usage of alias '%s': %s", alias->name, alias->cmdline);
 							return;
 						}
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -138,6 +138,79 @@ void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
 
 /**
  * It is possible to print debugging information to the console,
+ * which is achieved by using this function. You need at least a
+ * level 2 (developer) for debugging messages to show up.
+ * Uses printf() style format, for more information look at IConsolePrint()
+ */
+void CDECL IConsoleDebugF(const char* format, ...)
+{
+	if (_settings_client.gui.developer <= 1) return;
+
+	va_list va;
+	char buf[ICON_MAX_STREAMSIZE];
+
+	va_start(va, format);
+	vseprintf(buf, lastof(buf), format, va);
+	va_end(va);
+
+	IConsolePrint(CC_DEBUG, buf);
+}
+
+/**
+ * It is possible to print informational messages to the console.
+ * Uses printf() style format, for more information look at IConsolePrint()
+ */
+void CDECL IConsoleInfoF(const char* format, ...)
+{
+	va_list va;
+	char buf[ICON_MAX_STREAMSIZE];
+
+	va_start(va, format);
+	vseprintf(buf, lastof(buf), format, va);
+	va_end(va);
+
+	IConsolePrint(CC_INFO, buf);
+}
+
+/**
+ * It is possible to print warnings to the console. These are mostly
+ * errors or mishaps, but non-fatal. You need at least a level 1 (developer) for
+ * debugging messages to show up.
+ * Uses printf() style format, for more information look at IConsolePrint()
+ */
+void CDECL IConsoleWarningF(const char* format, ...)
+{
+	if (_settings_client.gui.developer == 0) return;
+
+	va_list va;
+	char buf[ICON_MAX_STREAMSIZE];
+
+	va_start(va, format);
+	vseprintf(buf, lastof(buf), format, va);
+	va_end(va);
+
+	IConsolePrint(CC_WARNING, buf);
+}
+
+/**
+ * It is possible to print error information to the console. This can include
+ * game errors, or errors in general you would want the user to notice.
+ * Uses printf() style format, for more information look at IConsolePrint()
+ */
+void CDECL IConsoleErrorF(const char* format, ...)
+{
+	va_list va;
+	char buf[ICON_MAX_STREAMSIZE];
+
+	va_start(va, format);
+	vseprintf(buf, lastof(buf), format, va);
+	va_end(va);
+
+	IConsolePrint(CC_ERROR, buf);
+}
+
+/**
+ * It is possible to print debugging information to the console,
  * which is achieved by using this function. Can only be used by
  * debug() in debug.cpp. You need at least a level 2 (developer) for debugging
  * messages to show up
@@ -146,8 +219,15 @@ void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
  */
 void IConsoleDebug(const char *dbg, const char *string)
 {
-	if (_settings_client.gui.developer <= 1) return;
-	IConsolePrintF(CC_DEBUG, "dbg: [%s] %s", dbg, string);
+	IConsoleDebugF("dbg: [%s] %s", dbg, string);
+}
+
+/**
+ * It is possible to print informational messages to the console
+ */
+void IConsoleInfo(const char* string)
+{
+	IConsoleInfoF("INFO: %s", string);
 }
 
 /**
@@ -157,8 +237,7 @@ void IConsoleDebug(const char *dbg, const char *string)
  */
 void IConsoleWarning(const char *string)
 {
-	if (_settings_client.gui.developer == 0) return;
-	IConsolePrintF(CC_WARNING, "WARNING: %s", string);
+	IConsoleWarningF("WARNING: %s", string);
 }
 
 /**
@@ -167,7 +246,7 @@ void IConsoleWarning(const char *string)
  */
 void IConsoleError(const char *string)
 {
-	IConsolePrintF(CC_ERROR, "ERROR: %s", string);
+	IConsoleErrorF("ERROR: %s", string);
 }
 
 /**

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -358,10 +358,10 @@ DEF_CONSOLE_CMD(ConLoad)
 			_file_to_saveload.SetName(FiosBrowseTo(item));
 			_file_to_saveload.SetTitle(item->title);
 		} else {
-			IConsolePrintF(CC_ERROR, "%s: Not a savegame.", file);
+			IConsoleErrorF("%s: Not a savegame.", file);
 		}
 	} else {
-		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		IConsoleErrorF("%s: No such file or directory.", file);
 	}
 
 	return true;
@@ -382,10 +382,10 @@ DEF_CONSOLE_CMD(ConRemove)
 	const FiosItem *item = _console_file_list.FindItem(file);
 	if (item != nullptr) {
 		if (!FiosDelete(item->name)) {
-			IConsolePrintF(CC_ERROR, "%s: Failed to delete file", file);
+			IConsoleErrorF("%s: Failed to delete file", file);
 		}
 	} else {
-		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		IConsoleErrorF("%s: No such file or directory.", file);
 	}
 
 	_console_file_list.InvalidateFileList();
@@ -427,10 +427,10 @@ DEF_CONSOLE_CMD(ConChangeDirectory)
 			case FIOS_TYPE_DIR: case FIOS_TYPE_DRIVE: case FIOS_TYPE_PARENT:
 				FiosBrowseTo(item);
 				break;
-			default: IConsolePrintF(CC_ERROR, "%s: Not a directory.", file);
+			default: IConsoleErrorF("%s: Not a directory.", file);
 		}
 	} else {
-		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		IConsoleErrorF("%s: No such file or directory.", file);
 	}
 
 	_console_file_list.InvalidateFileList();
@@ -484,7 +484,7 @@ static bool ConKickOrBan(const char *argv, bool ban, const char *reason)
 		 * would be reading from and writing to after returning. So we would read or write data
 		 * from freed memory up till the segfault triggers. */
 		if (client_id == CLIENT_ID_SERVER || client_id == _redirect_console_to_client) {
-			IConsolePrintF(CC_ERROR, "ERROR: Silly boy, you can not %s yourself!", ban ? "ban" : "kick");
+			IConsoleErrorF("ERROR: Silly boy, you can not %s yourself!", ban ? "ban" : "kick");
 			return true;
 		}
 
@@ -531,7 +531,7 @@ DEF_CONSOLE_CMD(ConKick)
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
 	if (kick_message_length >= 255) {
-		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered " PRINTF_SIZE " characters.", kick_message_length);
+		IConsoleErrorF("ERROR: Maximum kick message length is 254 characters. You entered " PRINTF_SIZE " characters.", kick_message_length);
 		return false;
 	} else {
 		return ConKickOrBan(argv[1], false, argv[2]);
@@ -555,7 +555,7 @@ DEF_CONSOLE_CMD(ConBan)
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
 	if (kick_message_length >= 255) {
-		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered " PRINTF_SIZE " characters.", kick_message_length);
+		IConsoleErrorF("ERROR: Maximum kick message length is 254 characters. You entered " PRINTF_SIZE " characters.", kick_message_length);
 		return false;
 	} else {
 		return ConKickOrBan(argv[1], true, argv[2]);
@@ -735,7 +735,7 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 
 	/* Check we have a valid company id! */
 	if (!Company::IsValidID(company_id) && company_id != COMPANY_SPECTATOR) {
-		IConsolePrintF(CC_ERROR, "Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
+		IConsoleErrorF("Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
 		return true;
 	}
 
@@ -756,7 +756,7 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 
 	/* Check if the company requires a password */
 	if (NetworkCompanyIsPassworded(company_id) && argc < 3) {
-		IConsolePrintF(CC_ERROR, "Company %d requires a password to join.", company_id + 1);
+		IConsoleErrorF("Company %d requires a password to join.", company_id + 1);
 		return true;
 	}
 
@@ -788,7 +788,7 @@ DEF_CONSOLE_CMD(ConMoveClient)
 	}
 
 	if (!Company::IsValidID(company_id) && company_id != COMPANY_SPECTATOR) {
-		IConsolePrintF(CC_ERROR, "Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
+		IConsoleErrorF("Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
 		return true;
 	}
 
@@ -827,7 +827,7 @@ DEF_CONSOLE_CMD(ConResetCompany)
 
 	/* Check valid range */
 	if (!Company::IsValidID(index)) {
-		IConsolePrintF(CC_ERROR, "Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
+		IConsoleErrorF("Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
 		return true;
 	}
 
@@ -1585,7 +1585,7 @@ DEF_CONSOLE_CMD(ConHelp)
 				cmd->proc(0, nullptr);
 				return true;
 			}
-			IConsolePrintF(CC_ERROR, "ERROR: alias is of special type, please see its execution-line: '%s'", alias->cmdline);
+			IConsoleErrorF("ERROR: alias is of special type, please see its execution-line: '%s'", alias->cmdline);
 			return true;
 		}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1659,7 +1659,7 @@ DEF_CONSOLE_CMD(ConCompanies)
 
 		char colour[512];
 		GetString(colour, STR_COLOUR_DARK_BLUE + _company_colours[c->index], lastof(colour));
-		IConsolePrintF(CC_INFO, "#:%d(%s) Company Name: '%s'  Year Founded: %d  Money: " OTTD_PRINTF64 "  Loan: " OTTD_PRINTF64 "  Value: " OTTD_PRINTF64 "  (T:%d, R:%d, P:%d, S:%d) %s",
+		IConsoleInfoF("#:%d(%s) Company Name: '%s'  Year Founded: %d  Money: " OTTD_PRINTF64 "  Loan: " OTTD_PRINTF64 "  Value: " OTTD_PRINTF64 "  (T:%d, R:%d, P:%d, S:%d) %s",
 			c->index + 1, colour, company_name,
 			c->inaugurated_year, (int64)c->money, (int64)c->current_loan, (int64)CalculateCompanyValue(c),
 			c->group_all[VEH_TRAIN].num_vehicle,

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2079,7 +2079,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 		}
 		if (started > 0) {
-			IConsolePrintF(CC_DEBUG, "Started profiling for GRFID%s %s", (started > 1) ? "s" : "", grfids.c_str());
+			IConsoleDebugF("Started profiling for GRFID%s %s", (started > 1) ? "s" : "", grfids.c_str());
 			if (argc >= 3) {
 				int days = std::max(atoi(argv[2]), 1);
 				_newgrf_profile_end_date = _date + days;
@@ -2087,7 +2087,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				char datestrbuf[32]{ 0 };
 				SetDParam(0, _newgrf_profile_end_date);
 				GetString(datestrbuf, STR_JUST_DATE_ISO, lastof(datestrbuf));
-				IConsolePrintF(CC_DEBUG, "Profiling will automatically stop on game date %s", datestrbuf);
+				IConsoleDebugF("Profiling will automatically stop on game date %s", datestrbuf);
 			} else {
 				_newgrf_profile_end_date = MAX_DAY;
 			}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -177,7 +177,7 @@ DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
  */
 static void IConsoleHelp(const char *str)
 {
-	IConsolePrintF(CC_WARNING, "- %s", str);
+	IConsoleWarningF("- %s", str);
 }
 
 /**
@@ -1779,9 +1779,9 @@ DEF_CONSOLE_CMD(ConCompanyPassword)
 	password = NetworkChangeCompanyPassword(company_id, password);
 
 	if (StrEmpty(password)) {
-		IConsolePrintF(CC_WARNING, "Company password cleared");
+		IConsoleWarningF("Company password cleared");
 	} else {
-		IConsolePrintF(CC_WARNING, "Company password changed to: %s", password);
+		IConsoleWarningF("Company password changed to: %s", password);
 	}
 
 	return true;
@@ -2031,12 +2031,12 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) { // safe cast, files.size() should not be larger than a few hundred in the most extreme cases
-				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not added.", grfnum);
+				IConsoleWarningF("GRF number %d out of range, not added.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];
 			if (std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; })) {
-				IConsolePrintF(CC_WARNING, "GRF number %d [%08X] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
+				IConsoleWarningF("GRF number %d [%08X] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
 				continue;
 			}
 			_newgrf_profilers.emplace_back(grf);
@@ -2053,7 +2053,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) {
-				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not removing.", grfnum);
+				IConsoleWarningF("GRF number %d out of range, not removing.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];
@@ -2092,9 +2092,9 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				_newgrf_profile_end_date = MAX_DAY;
 			}
 		} else if (_newgrf_profilers.empty()) {
-			IConsolePrintF(CC_WARNING, "No GRFs selected for profiling, did not start.");
+			IConsoleWarningF("No GRFs selected for profiling, did not start.");
 		} else {
-			IConsolePrintF(CC_WARNING, "Did not start profiling for any GRFs, all selected GRFs are already profiling.");
+			IConsoleWarningF("Did not start profiling for any GRFs, all selected GRFs are already profiling.");
 		}
 		return true;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -268,7 +268,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 			uint32 result;
 			if (GetArgumentInteger(&result, argv[1])) {
 				if (result >= MapSize()) {
-					IConsolePrint(CC_ERROR, "Tile does not exist");
+					IConsoleError("Tile does not exist");
 					return true;
 				}
 				ScrollMainWindowToTile((TileIndex)result);
@@ -281,7 +281,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 			uint32 x, y;
 			if (GetArgumentInteger(&x, argv[1]) && GetArgumentInteger(&y, argv[2])) {
 				if (x >= MapSizeX() || y >= MapSizeY()) {
-					IConsolePrint(CC_ERROR, "Tile does not exist");
+					IConsoleError("Tile does not exist");
 					return true;
 				}
 				ScrollMainWindowToTile(TileXY(x, y));
@@ -311,7 +311,7 @@ DEF_CONSOLE_CMD(ConSave)
 		IConsolePrint(CC_DEFAULT, "Saving map...");
 
 		if (SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, SAVE_DIR) != SL_OK) {
-			IConsolePrint(CC_ERROR, "Saving map failed");
+			IConsoleError("Saving map failed");
 		} else {
 			IConsolePrintF(CC_DEFAULT, "Map successfully saved to %s", filename);
 		}

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -23,7 +23,12 @@ void IConsoleClose();
 /* console output */
 void IConsolePrint(TextColour colour_code, const char *string);
 void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...) WARN_FORMAT(2, 3);
+void CDECL IConsoleDebugF(const char* format, ...) WARN_FORMAT(1, 2);
+void CDECL IConsoleInfoF(const char* format, ...) WARN_FORMAT(1, 2);
+void CDECL IConsoleWarningF(const char* format, ...) WARN_FORMAT(1, 2);
+void CDECL IConsoleErrorF(const char* format, ...) WARN_FORMAT(1, 2);
 void IConsoleDebug(const char *dbg, const char *string);
+void IConsoleInfo(const char* string);
 void IConsoleWarning(const char *string);
 void IConsoleError(const char *string);
 

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -23,14 +23,50 @@ void IConsoleClose();
 /* console output */
 void IConsolePrint(TextColour colour_code, const char *string);
 void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...) WARN_FORMAT(2, 3);
-void CDECL IConsoleDebugF(const char* format, ...) WARN_FORMAT(1, 2);
-void CDECL IConsoleInfoF(const char* format, ...) WARN_FORMAT(1, 2);
-void CDECL IConsoleWarningF(const char* format, ...) WARN_FORMAT(1, 2);
-void CDECL IConsoleErrorF(const char* format, ...) WARN_FORMAT(1, 2);
-void IConsoleDebug(const char *dbg, const char *string);
-void IConsoleInfo(const char* string);
-void IConsoleWarning(const char *string);
-void IConsoleError(const char *string);
+void CDECL IConsoleDebugF(const char *format, ...) WARN_FORMAT(1, 2);
+void CDECL IConsoleInfoF(const char *format, ...) WARN_FORMAT(1, 2);
+void CDECL IConsoleWarningF(const char *format, ...) WARN_FORMAT(1, 2);
+void CDECL IConsoleErrorF(const char *format, ...) WARN_FORMAT(1, 2);
+
+/**
+ * It is possible to print debugging information to the console,
+ * which is achieved by using this function. Can only be used by
+ * debug() in debug.cpp. You need at least a level 2 (developer) for debugging
+ * messages to show up
+ * @param dbg debugging category
+ * @param string debugging message
+ */
+static inline void IConsoleDebug(const char *dbg, const char *string)
+{
+	IConsoleDebugF("dbg: [%s] %s", dbg, string);
+}
+
+/**
+ * It is possible to print informational messages to the console
+ */
+static inline void IConsoleInfo(const char *string)
+{
+	IConsoleInfoF("INFO: %s", string);
+}
+
+/**
+ * It is possible to print warnings to the console. These are mostly
+ * errors or mishaps, but non-fatal. You need at least a level 1 (developer) for
+ * debugging messages to show up
+ */
+static inline void IConsoleWarning(const char *string)
+{
+	IConsoleWarningF("WARNING: %s", string);
+}
+
+/**
+ * It is possible to print error information to the console. This can include
+ * game errors, or errors in general you would want the user to notice
+ */
+static inline void IConsoleError(const char *string)
+{
+	IConsoleErrorF("ERROR: %s", string);
+}
 
 /* Parser */
 void IConsoleCmdExec(const char *cmdstr, const uint recurse_count = 0);

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -398,7 +398,7 @@ void IConsoleGUIInit()
 	IConsoleLine::Reset();
 	memset(_iconsole_history, 0, sizeof(_iconsole_history));
 
-	IConsolePrintF(CC_WARNING, "OpenTTD Game Console Revision 7 - %s", _openttd_revision);
+	IConsoleWarningF("OpenTTD Game Console Revision 7 - %s", _openttd_revision);
 	IConsolePrint(CC_WHITE,  "------------------------------------");
 	IConsolePrint(CC_WHITE,  "use \"help\" for more information");
 	IConsolePrint(CC_WHITE,  "");

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -389,7 +389,7 @@ void ShowErrorMessage(StringID summary_msg, StringID detailed_msg, WarningLevel 
 		if (textref_stack_size > 0) StopTextRefStackUsage();
 
 		switch (wl) {
-			case WL_WARNING: IConsolePrint(CC_WARNING, buf); break;
+			case WL_WARNING: IConsoleWarning(buf); break;
 			default:         IConsoleError(buf); break;
 		}
 	}

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1109,31 +1109,31 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 static bool CmdDumpSMF(byte argc, char *argv[])
 {
 	if (argc == 0) {
-		IConsolePrint(CC_WARNING, "Write the current song to a Standard MIDI File. Usage: 'dumpsmf <filename>'");
+		IConsoleWarning("Write the current song to a Standard MIDI File. Usage: 'dumpsmf <filename>'");
 		return true;
 	}
 	if (argc != 2) {
-		IConsolePrint(CC_WARNING, "You must specify a filename to write MIDI data to.");
+		IConsoleWarning("You must specify a filename to write MIDI data to.");
 		return false;
 	}
 
 	if (_midifile_instance == nullptr) {
-		IConsolePrint(CC_ERROR, "There is no MIDI file loaded currently, make sure music is playing, and you're using a driver that works with raw MIDI.");
+		IConsoleError("There is no MIDI file loaded currently, make sure music is playing, and you're using a driver that works with raw MIDI.");
 		return false;
 	}
 
 	char fnbuf[MAX_PATH] = { 0 };
 	if (seprintf(fnbuf, lastof(fnbuf), "%s%s", FiosGetScreenshotDir(), argv[1]) >= (int)lengthof(fnbuf)) {
-		IConsolePrint(CC_ERROR, "Filename too long.");
+		IConsoleError("Filename too long.");
 		return false;
 	}
 	IConsoleInfoF("Dumping MIDI to: %s", fnbuf);
 
 	if (_midifile_instance->WriteSMF(fnbuf)) {
-		IConsolePrint(CC_INFO, "File written successfully.");
+		IConsoleInfo("File written successfully.");
 		return true;
 	} else {
-		IConsolePrint(CC_ERROR, "An error occurred writing MIDI file.");
+		IConsoleError("An error occurred writing MIDI file.");
 		return false;
 	}
 }

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1127,7 +1127,7 @@ static bool CmdDumpSMF(byte argc, char *argv[])
 		IConsolePrint(CC_ERROR, "Filename too long.");
 		return false;
 	}
-	IConsolePrintF(CC_INFO, "Dumping MIDI to: %s", fnbuf);
+	IConsoleInfoF("Dumping MIDI to: %s", fnbuf);
 
 	if (_midifile_instance->WriteSMF(fnbuf)) {
 		IConsolePrint(CC_INFO, "File written successfully.");

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -966,7 +966,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet 
 	cp.my_cmd   = p->Recv_bool();
 
 	if (err != nullptr) {
-		IConsolePrintF(CC_ERROR, "WARNING: %s from server, dropping...", err);
+		IConsoleErrorF("WARNING: %s from server, dropping...", err);
 		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1849,7 +1849,7 @@ void NetworkServer_Tick(bool send_frame)
 				 * slow, but the connection is likely severed. Mentioning
 				 * frame_freq is not useful in this case. */
 				if (lag > (uint)DAY_TICKS && cs->lag_test == 0 && cs->last_packet + std::chrono::seconds(2) > std::chrono::steady_clock::now()) {
-					IConsolePrintF(CC_WARNING, "[%d] Client #%d is slow, try increasing [network.]frame_freq to a higher value!", _frame_counter, cs->client_id);
+					IConsoleWarningF("[%d] Client #%d is slow, try increasing [network.]frame_freq to a higher value!", _frame_counter, cs->client_id);
 					cs->lag_test = 1;
 				}
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1995,7 +1995,7 @@ void NetworkServerShowStatusToConsole()
 		const char *status;
 
 		status = (cs->status < (ptrdiff_t)lengthof(stat_str) ? stat_str[cs->status] : "unknown");
-		IConsolePrintF(CC_INFO, "Client #%1d  name: '%s'  status: '%s'  frame-lag: %3d  company: %1d  IP: %s",
+		IConsoleInfoF("Client #%1d  name: '%s'  status: '%s'  frame-lag: %3d  company: %1d  IP: %s",
 			cs->client_id, ci->client_name, status, lag,
 			ci->client_playas + (Company::IsValidID(ci->client_playas) ? 1 : 0),
 			cs->GetClientIP());
@@ -2174,13 +2174,13 @@ void NetworkPrintClients()
 {
 	for (NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {
 		if (_network_server) {
-			IConsolePrintF(CC_INFO, "Client #%1d  name: '%s'  company: %1d  IP: %s",
+			IConsoleInfoF("Client #%1d  name: '%s'  company: %1d  IP: %s",
 					ci->client_id,
 					ci->client_name,
 					ci->client_playas + (Company::IsValidID(ci->client_playas) ? 1 : 0),
 					ci->client_id == CLIENT_ID_SERVER ? "server" : NetworkClientSocket::GetByClientID(ci->client_id)->GetClientIP());
 		} else {
-			IConsolePrintF(CC_INFO, "Client #%1d  name: '%s'  company: %1d",
+			IConsoleInfoF("Client #%1d  name: '%s'  company: %1d",
 					ci->client_id,
 					ci->client_name,
 					ci->client_playas + (Company::IsValidID(ci->client_playas) ? 1 : 0));

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -95,12 +95,12 @@ uint32 NewGRFProfiler::Finish()
 	if (!this->active) return 0;
 
 	if (this->calls.empty()) {
-		IConsolePrintF(CC_DEBUG, "Finished profile of NewGRF [%08X], no events collected, not writing a file", BSWAP32(this->grffile->grfid));
+		IConsoleDebugF("Finished profile of NewGRF [%08X], no events collected, not writing a file", BSWAP32(this->grffile->grfid));
 		return 0;
 	}
 
 	std::string filename = this->GetOutputFilename();
-	IConsolePrintF(CC_DEBUG, "Finished profile of NewGRF [%08X], writing %u events to %s", BSWAP32(this->grffile->grfid), (uint)this->calls.size(), filename.c_str());
+	IConsoleDebugF("Finished profile of NewGRF [%08X], writing %u events to %s", BSWAP32(this->grffile->grfid), (uint)this->calls.size(), filename.c_str());
 
 	FILE *f = FioFOpenFile(filename, "wt", Subdirectory::NO_DIRECTORY);
 	FileCloser fcloser(f);
@@ -153,7 +153,7 @@ uint32 NewGRFProfiler::FinishAll()
 	}
 
 	if (total_microseconds > 0 && max_ticks > 0) {
-		IConsolePrintF(CC_DEBUG, "Total NewGRF callback processing: %u microseconds over %d ticks", total_microseconds, max_ticks);
+		IConsoleDebugF("Total NewGRF callback processing: %u microseconds over %d ticks", total_microseconds, max_ticks);
 	}
 
 	_newgrf_profile_end_date = MAX_DAY;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2154,7 +2154,7 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 		extern bool GetArgumentInteger(uint32 *value, const char *arg);
 		success = GetArgumentInteger(&val, value);
 		if (!success) {
-			IConsolePrintF(CC_ERROR, "'%s' is not an integer.", value);
+			IConsoleErrorF("'%s' is not an integer.", value);
 			return;
 		}
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2142,7 +2142,7 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 	const SettingDesc *sd = GetSettingFromName(name, &index);
 
 	if (sd == nullptr) {
-		IConsolePrintF(CC_WARNING, "'%s' is an unknown setting.", name);
+		IConsoleWarningF("'%s' is an unknown setting.", name);
 		return;
 	}
 
@@ -2192,14 +2192,14 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
 	const void *ptr;
 
 	if (sd == nullptr) {
-		IConsolePrintF(CC_WARNING, "'%s' is an unknown setting.", name);
+		IConsoleWarningF("'%s' is an unknown setting.", name);
 		return;
 	}
 
 	ptr = GetVariableAddress((_game_mode == GM_MENU || force_newgame) ? &_settings_newgame : &_settings_game, &sd->save);
 
 	if (sd->desc.cmd == SDT_STRING) {
-		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s'", name, (GetVarMemType(sd->save.conv) == SLE_VAR_STRQ) ? *(const char * const *)ptr : (const char *)ptr);
+		IConsoleWarningF("Current value for '%s' is: '%s'", name, (GetVarMemType(sd->save.conv) == SLE_VAR_STRQ) ? *(const char * const *)ptr : (const char *)ptr);
 	} else {
 		if (sd->desc.cmd == SDT_BOOLX) {
 			seprintf(value, lastof(value), (*(const bool*)ptr != 0) ? "on" : "off");
@@ -2207,7 +2207,7 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
 			seprintf(value, lastof(value), sd->desc.min < 0 ? "%d" : "%u", (int32)ReadValue(ptr, sd->save.conv));
 		}
 
-		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s' (min: %s%d, max: %u)",
+		IConsoleWarningF("Current value for '%s' is: '%s' (min: %s%d, max: %u)",
 			name, value, (sd->desc.flags & SGF_0ISDISABLED) ? "(0) " : "", sd->desc.min, sd->desc.max);
 	}
 }
@@ -2219,7 +2219,7 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
  */
 void IConsoleListSettings(const char *prefilter)
 {
-	IConsolePrintF(CC_WARNING, "All settings with their current value:");
+	IConsoleWarningF("All settings with their current value:");
 
 	for (const SettingDesc *sd = _settings; sd->save.cmd != SL_END; sd++) {
 		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
@@ -2237,7 +2237,7 @@ void IConsoleListSettings(const char *prefilter)
 		IConsolePrintF(CC_DEFAULT, "%s = %s", sd->desc.name, value);
 	}
 
-	IConsolePrintF(CC_WARNING, "Use 'setting' command to change a value");
+	IConsoleWarningF("Use 'setting' command to change a value");
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Implements changes mentioned in #8853 with a few added methods for consistency

## Description
Added IConsole*F( and IConsole*( methods to make console logging more consistent 
Updated calls to IConsole*F( and IConsole*( to new methods

## Limitations
Formatting of messages with log level text was inconsistent in the existing code. I chose to not modify the current output contents to prefix with the log level.  In some places the logged level did not match the apparent severity of the message. I did not update the function calls to match what I though the apparent severity was.

I chose to have the IConsoleDebugF( method signature match the other IConsole%LogLevel%F methods instead of the IConsoleDebug method.

There is at least one place where I did not update the IConsolePrint(CC_WARNING method to use IConsoleWarning( as the message may not have been output depending on the GUI developer setting.

Can be squashed to one commit and reworded if requested.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
