### PR TITLE
Feature: let AI developers edit non-editable AI/Game Script Parameters

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -592,7 +592,10 @@ struct AISettingsWindow : public Window {
 private:
 	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
-		return _game_mode == GM_MENU || ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot)) || (config_item.flags & SCRIPTCONFIG_INGAME) != 0;
+		return _game_mode == GM_MENU
+			|| ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot))
+			|| (config_item.flags & SCRIPTCONFIG_INGAME) != 0
+			|| _settings_client.gui.ai_developer_tools;
 	}
 };
 


### PR DESCRIPTION
## Motivation / Problem

There is no way to modify non-editable AI/Game Script params during the game or during the scenario editor.

## Description

This code change makes non-editable AI/Game Script params editable during the game or during the scenario editor if _ai_developer_tools_ is set to true in the config file. This will help AI developers and other developers being able to change the params they created in those cases.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
