### PR TITLE
Fix: Freeing LanguagePack with wrong size.

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1256,7 +1256,7 @@ void SanitizeFilename(char *filename)
  * @return Pointer to new memory containing the loaded data, or \c nullptr if loading failed.
  * @note If \a maxsize less than the length of the file, loading fails.
  */
-std::unique_ptr<char> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize)
+std::unique_ptr<char[]> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize)
 {
 	FILE *in = fopen(filename.c_str(), "rb");
 	if (in == nullptr) return nullptr;
@@ -1268,10 +1268,7 @@ std::unique_ptr<char> ReadFileToMem(const std::string &filename, size_t &lenp, s
 	fseek(in, 0, SEEK_SET);
 	if (len > maxsize) return nullptr;
 
-	/* std::unique_ptr assumes new/delete unless a custom deleter is supplied.
-	 * As we don't want to have to carry that deleter all over the place, use
-	 * new directly to allocate the memory instead of malloc. */
-	std::unique_ptr<char> mem(static_cast<char *>(::operator new(len + 1)));
+	std::unique_ptr<char[]> mem = std::make_unique<char[]>(len + 1);
 
 	mem.get()[len] = 0;
 	if (fread(mem.get(), len, 1, in) != 1) return nullptr;

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -49,7 +49,7 @@ const char *FiosGetScreenshotDir();
 void SanitizeFilename(char *filename);
 void AppendPathSeparator(std::string &buf);
 void DeterminePaths(const char *exe);
-std::unique_ptr<char> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize);
+std::unique_ptr<char[]> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize);
 bool FileExists(const std::string &filename);
 bool ExtractTar(const std::string &tar_filename, Subdirectory subdir);
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -185,8 +185,16 @@ struct LanguagePack : public LanguagePackHeader {
 	char data[]; // list of strings
 };
 
+struct LanguagePackDeleter {
+	void operator()(LanguagePack *langpack)
+	{
+		/* LanguagePack is in fact reinterpreted char[], we need to reinterpret it back to free it properly. */
+		delete[] reinterpret_cast<char*>(langpack);
+	}
+};
+
 struct LoadedLanguagePack {
-	std::unique_ptr<LanguagePack> langpack;
+	std::unique_ptr<LanguagePack, LanguagePackDeleter> langpack;
 
 	std::vector<char *> offsets;
 
@@ -1713,7 +1721,7 @@ bool ReadLanguagePack(const LanguageMetadata *lang)
 {
 	/* Current language pack */
 	size_t len = 0;
-	std::unique_ptr<LanguagePack> lang_pack(reinterpret_cast<LanguagePack *>(ReadFileToMem(lang->file, len, 1U << 20).release()));
+	std::unique_ptr<LanguagePack, LanguagePackDeleter> lang_pack(reinterpret_cast<LanguagePack *>(ReadFileToMem(lang->file, len, 1U << 20).release()));
 	if (!lang_pack) return false;
 
 	/* End of read data (+ terminating zero added in ReadFileToMem()) */


### PR DESCRIPTION
## Motivation / Problem

AddressSanitizer complains:
```
==1707680==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x7f369345e800 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   168159 bytes;
  size of the deallocated type: 572 bytes.
    #0 0x7f369b8a9cc9 in operator delete(void*, unsigned long) /home/milek7/gcc-git/src/gcc/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x55e29b86ce1b in std::default_delete<LanguagePack>::operator()(LanguagePack*) const /usr/include/c++/11.0.1/bits/unique_ptr.h:85
    #2 0x55e29b86bda4 in std::unique_ptr<LanguagePack, std::default_delete<LanguagePack> >::~unique_ptr() /usr/include/c++/11.0.1/bits/unique_ptr.h:361
    #3 0x55e29b87161b in LoadedLanguagePack::~LoadedLanguagePack() (/home/milek7/ottd2/build/openttd+0xb62861b)
    #4 0x7f3698ce7696 in __run_exit_handlers (/usr/lib/libc.so.6+0x3f696)
    #5 0x7f3698ce783d in exit (/usr/lib/libc.so.6+0x3f83d)
    #6 0x7f3698ccfb2b in __libc_start_main (/usr/lib/libc.so.6+0x27b2b)
    #7 0x55e29aafc08d in _start (/home/milek7/ottd2/build/openttd+0xa8b308d)

0x7f369345e800 is located 0 bytes inside of 168159-byte region [0x7f369345e800,0x7f36934878df)
allocated by thread T0 here:
    #0 0x7f369b8a8b69 in operator new(unsigned long) /home/milek7/gcc-git/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55e29b287305 in ReadFileToMem(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long&, unsigned long) /home/milek7/ottd2/src/fileio.cpp:1274
    #2 0x55e29b867459 in ReadLanguagePack(LanguageMetadata const*) /home/milek7/ottd2/src/strings.cpp:1716
    #3 0x55e29b869444 in InitializeLanguagePacks() /home/milek7/ottd2/src/strings.cpp:1971
    #4 0x55e29b6052a8 in openttd_main(int, char**) /home/milek7/ottd2/src/openttd.cpp:723
    #5 0x55e29af5d2c4 in main /home/milek7/ottd2/src/os/unix/unix.cpp:265
    #6 0x7f3698ccfb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)

SUMMARY: AddressSanitizer: new-delete-type-mismatch /home/milek7/gcc-git/src/gcc/libsanitizer/asan/asan_new_delete.cpp:172 in operator delete(void*, unsigned long)
```

## Description

Currently ReadFileToMem uses operator `new` directly to create object with given size. Afterwards it is reinterpreted to LanguagePack, and it is freed as such, but it is incorrect to free object with mismatched size. This makes AddressSanitizer complain.
This PR removes hackery from ReadFileToMem and makes it return regular `char[]`. On side of language pack code, custom deleter is used in `unique_ptr` to free reinterpreted pointer properly.


## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')

