### PR TITLE
Feature: show upload date in the network content window

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2312,6 +2312,7 @@ STR_CONTENT_DETAIL_DESCRIPTION                                  :{SILVER}Descrip
 STR_CONTENT_DETAIL_URL                                          :{SILVER}URL: {WHITE}{RAW_STRING}
 STR_CONTENT_DETAIL_TYPE                                         :{SILVER}Type: {WHITE}{STRING}
 STR_CONTENT_DETAIL_FILESIZE                                     :{SILVER}Download size: {WHITE}{BYTES}
+STR_CONTENT_DETAIL_UPLOAD_DATE                                  :{SILVER}Upload date: {WHITE}{RAW_STRING}
 STR_CONTENT_DETAIL_SELECTED_BECAUSE_OF                          :{SILVER}Selected because of: {WHITE}{RAW_STRING}
 STR_CONTENT_DETAIL_DEPENDENCIES                                 :{SILVER}Dependencies: {WHITE}{RAW_STRING}
 STR_CONTENT_DETAIL_TAGS                                         :{SILVER}Tags: {WHITE}{RAW_STRING}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2282,6 +2282,8 @@ STR_CONTENT_TYPE_CAPTION                                        :{BLACK}Type
 STR_CONTENT_TYPE_CAPTION_TOOLTIP                                :{BLACK}Type of the content
 STR_CONTENT_NAME_CAPTION                                        :{BLACK}Name
 STR_CONTENT_NAME_CAPTION_TOOLTIP                                :{BLACK}Name of the content
+STR_CONTENT_UPLOAD_DATE_CAPTION                                 :{BLACK}Upload date
+STR_CONTENT_UPLOAD_DATE_CAPTION_TOOLTIP                         :{BLACK}Latest upload date of the content
 STR_CONTENT_MATRIX_TOOLTIP                                      :{BLACK}Click on a line to see the details{}Click on the checkbox to select it for downloading
 STR_CONTENT_SELECT_ALL_CAPTION                                  :{BLACK}Select all
 STR_CONTENT_SELECT_ALL_CAPTION_TOOLTIP                          :{BLACK}Mark all content to be downloaded

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -76,6 +76,7 @@ struct ContentInfo {
 	ContentID *dependencies; ///< Malloced array of dependencies (unique server side ids)
 	uint8 tag_count;         ///< Number of tags
 	char (*tags)[32];        ///< Malloced array of tags (strings)
+	uint32 upload_date;      ///< Upload date as epoch timestamp
 	State state;             ///< Whether the content info is selected (for download)
 	bool upgrade;            ///< This item is an upgrade
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -74,6 +74,8 @@ bool ClientNetworkContentSocketHandler::Receive_SERVER_INFO(Packet *p)
 	ci->tags = MallocT<char[32]>(ci->tag_count);
 	for (uint i = 0; i < ci->tag_count; i++) p->Recv_string(ci->tags[i], lengthof(*ci->tags));
 
+	ci->upload_date = p->Recv_uint32();
+
 	if (!ci->IsValid()) {
 		delete ci;
 		this->Close();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -724,6 +724,14 @@ public:
 		SetDParam(0, this->selected->filesize);
 		y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_FILESIZE);
 
+		if (this->selected->upload_date != 0) {
+			char buffer[64];
+			time_t epoch_time = this->selected->upload_date;
+			strftime(buffer, sizeof(buffer), "%Y-%m-%d", localtime(&epoch_time));
+			SetDParamStr(0, buffer);
+			y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_UPLOAD_DATE);
+		}
+
 		if (this->selected->dependency_count != 0) {
 			/* List dependencies */
 			char buf[DRAW_STRING_BUFFER] = "";

--- a/src/widgets/network_content_widget.h
+++ b/src/widgets/network_content_widget.h
@@ -28,6 +28,7 @@ enum NetworkContentListWidgets {
 	WID_NCL_CHECKBOX,       ///< Button above checkboxes.
 	WID_NCL_TYPE,           ///< 'Type' button.
 	WID_NCL_NAME,           ///< 'Name' button.
+	WID_NCL_UPLOAD_DATE,    ///< 'Upload date' button.
 
 	WID_NCL_MATRIX,         ///< Panel with list of content.
 	WID_NCL_SCROLLBAR,      ///< Scrollbar of matrix.


### PR DESCRIPTION
## Motivation / Problem

Upload date is present in every content in BaNaNaS but not used in OpenTTD since it's not sent to the client. https://github.com/OpenTTD/bananas-server/pull/43 changes it so it gets sent.

## Description

This code change makes OpenTTD show the upload date for a given NewGRF in the online content window. In addition, a column in the content list has been added to sort by upload date as well.

![image](https://user-images.githubusercontent.com/2025406/112893573-b2d5a100-908f-11eb-8259-6cbd7cb367b7.png)

## Limitations

See https://github.com/OpenTTD/bananas-server/pull/43 for full details, but in particular I've focused on making sure this doesn't break older versions. Here is what I have successfully tested:

1. Bananas returning the new field, OpenTTD not knowing about it -> OpenTTD ignores it as it has read the latest field it knows about it (tags) and moves on to the next NewGRF. No memory leak or anything out of normal.
2. Bananas returning the new field, OpenTTD knowing about it -> OpenTTD reads it successfully.
3. ~~Bananas not returning the new field, OpenTTD expecting it -> OpenTTD tries to read it but does not actually read it. I used CanReadFromPacket() to verify and make it safe in case we have to rollback Bananas and newer OpenTTD clients still want the value.~~ finally didn't end up including this, see conversation below.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
