### PR TITLE
Change: [CMake] Copy AI/GS compatibility files to build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ if(MSVC)
     target_sources(openttd PRIVATE "${CMAKE_SOURCE_DIR}/os/windows/openttd.manifest")
 endif()
 
+add_subdirectory(${CMAKE_SOURCE_DIR}/bin)
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)
 add_subdirectory(${CMAKE_SOURCE_DIR}/media)
 
@@ -240,7 +241,7 @@ if(IPO_FOUND)
     set_target_properties(openttd PROPERTIES INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL True)
     set_target_properties(openttd PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO True)
 endif()
-set_target_properties(openttd PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
+set_target_properties(openttd PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 process_compile_flags()
 
 include(LinkPackage)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(ai)
+add_subdirectory(game)

--- a/bin/ai/CMakeLists.txt
+++ b/bin/ai/CMakeLists.txt
@@ -1,0 +1,40 @@
+set(AI_COMPAT_SOURCE_FILES
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_0.7.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.0.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.1.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.2.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.3.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.4.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.5.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.6.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.7.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.8.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.9.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.10.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.11.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.12.nut
+)
+
+foreach(AI_COMPAT_SOURCE_FILE IN LISTS AI_COMPAT_SOURCE_FILES)
+    string(REPLACE "${CMAKE_SOURCE_DIR}/bin/" "" AI_COMPAT_SOURCE_FILE_NAME "${AI_COMPAT_SOURCE_FILE}")
+    string(CONCAT AI_COMPAT_BINARY_FILE "${CMAKE_BINARY_DIR}/" "${AI_COMPAT_SOURCE_FILE_NAME}")
+
+    add_custom_command(OUTPUT ${AI_COMPAT_BINARY_FILE}
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${AI_COMPAT_SOURCE_FILE}
+                    ${AI_COMPAT_BINARY_FILE}
+            MAIN_DEPENDENCY ${AI_COMPAT_SOURCE_FILE}
+            COMMENT "Copying ${AI_COMPAT_SOURCE_FILE_NAME}"
+    )
+
+    list(APPEND AI_COMPAT_BINARY_FILES ${AI_COMPAT_BINARY_FILE})
+endforeach()
+
+# Create a new target which copies all compat files
+add_custom_target(ai_compat_files
+        DEPENDS ${AI_COMPAT_BINARY_FILES}
+)
+
+add_dependencies(openttd
+    ai_compat_files
+)

--- a/bin/game/CMakeLists.txt
+++ b/bin/game/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(GS_COMPAT_SOURCE_FILES
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.2.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.3.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.4.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.5.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.6.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.7.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.8.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.9.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.10.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.11.nut
+	${CMAKE_CURRENT_SOURCE_DIR}/compat_1.12.nut
+)
+
+foreach(GS_COMPAT_SOURCE_FILE IN LISTS GS_COMPAT_SOURCE_FILES)
+    string(REPLACE "${CMAKE_SOURCE_DIR}/bin/" "" GS_COMPAT_SOURCE_FILE_NAME "${GS_COMPAT_SOURCE_FILE}")
+    string(CONCAT GS_COMPAT_BINARY_FILE "${CMAKE_BINARY_DIR}/" "${GS_COMPAT_SOURCE_FILE_NAME}")
+
+    add_custom_command(OUTPUT ${GS_COMPAT_BINARY_FILE}
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    ${GS_COMPAT_SOURCE_FILE}
+                    ${GS_COMPAT_BINARY_FILE}
+            MAIN_DEPENDENCY ${GS_COMPAT_SOURCE_FILE}
+            COMMENT "Copying ${GS_COMPAT_SOURCE_FILE_NAME}"
+    )
+
+    list(APPEND GS_COMPAT_BINARY_FILES ${GS_COMPAT_BINARY_FILE})
+endforeach()
+
+# Create a new target which copies all compat files
+add_custom_target(gs_compat_files
+        DEPENDS ${GS_COMPAT_BINARY_FILES}
+)
+
+add_dependencies(openttd
+    gs_compat_files
+)

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -26,8 +26,8 @@ install(TARGETS openttd
 install(DIRECTORY
                 ${CMAKE_BINARY_DIR}/lang
                 ${CMAKE_BINARY_DIR}/baseset
-                ${CMAKE_SOURCE_DIR}/bin/ai
-                ${CMAKE_SOURCE_DIR}/bin/game
+                ${CMAKE_BINARY_DIR}/ai
+                ${CMAKE_BINARY_DIR}/game
                 ${CMAKE_SOURCE_DIR}/bin/scripts
         DESTINATION ${DATA_DESTINATION_DIR}
         COMPONENT language_files)


### PR DESCRIPTION
Fixes #8618

## Motivation / Problem
When running `openttd` from build dir, Script API compatibility files are not found.
And for MSVC project build it's worse as lang files are not found either 😉.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
`compat_*.nut` files are now copied to build dir when compiling.
I also changed MSVC working dir to build dir (instead of bin).
Since build dir now contains the exact list of compat files, I decided to use them for install instead of bin dirs (which may contain extra stuff in an unclean checkout).
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
