### PR TITLE
Adds hotkey for the new filter edit boxes.

### DIFF
--- a/src/object.h
+++ b/src/object.h
@@ -18,6 +18,6 @@ void UpdateCompanyHQ(TileIndex tile, uint score);
 
 void BuildObject(ObjectType type, TileIndex tile, CompanyID owner = OWNER_NONE, struct Town *town = nullptr, uint8 view = 0);
 
-void ShowBuildObjectPicker();
+Window *ShowBuildObjectPicker();
 
 #endif /* OBJECT_H */


### PR DESCRIPTION
## Motivation / Problem

If you want to filter something its easier to use the keyboard than hunting for the edit box with your mouse.

## Description

Adds hotkey to focus the filter edit boxes.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
