### PR TITLE
Feature 7957, banlist: load/save ban lists from/to external files

### DIFF
--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -117,6 +117,8 @@ Last updated:    2011-02-16
  - You can protect your server with a password via the console: 'set server_pw',
    or via the Start Server menu.
 
+- You can ban or kick problemantic players via the console: 'ban client_ip_address' or 'kick client_ip_address'
+
  - When you have many clients connected to your server via Internet, watch your
    bandwidth (if you have any limit on it, set by your ISP). One client uses
    about 1.5 kilobytes per second up and down. To decrease this amount, setting
@@ -200,7 +202,7 @@ Last updated:    2011-02-16
 
  - You can chat with other players via ENTER or via SHIFT+T or via the ClientList
 
- - Servers can now kick players, so don't make them use it!
+ - Servers can kick or ban players, so don't make them use it!
 
 
 ## 6.0) Troubleshooting


### PR DESCRIPTION
## Motivation / Problem

Containerized instances of OpenTTD may not have a writable configuration file and may with to allow load/saving of the ban list from an external source.
See #7957 and [this comment](https://github.com/OpenTTD/OpenTTD/issues/7957#issuecomment-808734955) for details.

## Description

Implements a console command to support loading and saving ban lists to a user-specified file.

## Limitations

The openttd.cfg will be updated with the contents of the updated ban list when the user quits the server. This may not be desirable. This limitation appears acceptable when used under the circumstances described in #7957 (i.e. the openttd.cfg file is read-only).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)


I would like to have this merged in after #8894 is merged. The console API is improved in that branch and I'd like to use the new functions in this PR.