### PR TITLE
Codechange: Suppress warnings when asserts are disabled

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -597,6 +597,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlag flags, bool wagon
 
 					/* Sell wagon */
 					CommandCost ret = DoCommand(0, wagon->index, 0, DC_EXEC, GetCmdSellVeh(wagon));
+					(void)ret; // assert only
 					assert(ret.Succeeded());
 					new_vehs[i] = nullptr;
 
@@ -652,6 +653,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlag flags, bool wagon
 
 				for (int i = num_units - 1; i > 0; i--) {
 					CommandCost ret = CmdMoveVehicle(old_vehs[i], old_head, DC_EXEC | DC_AUTOREPLACE, false);
+					(void)ret; // assert only
 					assert(ret.Succeeded());
 				}
 			}

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -221,8 +221,9 @@ DriverFactoryBase::DriverFactoryBase(Driver::Type type, int priority, const char
 	strecpy(buf, GetDriverTypeName(type), lastof(buf));
 	strecpy(buf + 5, name, lastof(buf));
 
-	std::pair<Drivers::iterator, bool> P = GetDrivers().insert(Drivers::value_type(buf, this));
-	assert(P.second);
+	Drivers &drivers = GetDrivers();
+	assert(drivers.find(buf) == drivers.end());
+	drivers.insert(Drivers::value_type(buf, this));
 }
 
 /**

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -549,6 +549,7 @@ void SetupEngines()
 		 * in any case, and we just cleaned the pool. */
 		assert(Engine::CanAllocateItem());
 		const Engine *e = new Engine(eid.type, eid.internal_id);
+		(void)e; // assert only
 		assert(e->index == index);
 		index++;
 	}
@@ -1003,8 +1004,7 @@ static void NewVehicleAvailable(Engine *e)
 
 	if (e->type == VEH_TRAIN) {
 		/* maybe make another rail type available */
-		RailType railtype = e->u.rail.railtype;
-		assert(railtype < RAILTYPE_END);
+		assert(e->u.rail.railtype < RAILTYPE_END);
 		for (Company *c : Company::Iterate()) c->avail_railtypes = AddDateIntroducedRailTypes(c->avail_railtypes | GetRailTypeInfo(e->u.rail.railtype)->introduces_railtypes, _date);
 	} else if (e->type == VEH_ROAD) {
 		/* maybe make another road type available */

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2140,6 +2140,7 @@ static Industry *CreateNewIndustry(TileIndex tile, IndustryType type, IndustryAv
 	Industry *i = nullptr;
 	size_t layout_index = RandomRange((uint32)indspec->layouts.size());
 	CommandCost ret = CreateNewIndustryHelper(tile, type, DC_EXEC, indspec, layout_index, seed, GB(seed2, 0, 16), OWNER_NONE, creation_type, &i);
+	(void)ret; // assert only
 	assert(i != nullptr || ret.Failed());
 	return i;
 }

--- a/src/misc/hashtable.hpp
+++ b/src/misc/hashtable.hpp
@@ -240,6 +240,7 @@ public:
 	void Pop(Titem_ &item)
 	{
 		bool ret = TryPop(item);
+		(void)ret; // assert only
 		assert(ret);
 	}
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -194,8 +194,7 @@ public:
 		} else {
 			this->SelectFirstAvailableObject(true);
 		}
-		ObjectClass *objclass = ObjectClass::Get(_selected_object_class);
-		assert(objclass->GetUISpecCount() > 0); // object GUI should be disabled elsewise
+		assert(ObjectClass::Get(_selected_object_class)->GetUISpecCount() > 0); // object GUI should be disabled elsewise
 	}
 
 	void SetStringParameters(int widget) const override

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -229,7 +229,9 @@ static void ResizeSpriteOut(SpriteLoader::Sprite *sprite, ZoomLevel zoom)
 
 	SpriteLoader::CommonPixel *dst = sprite[zoom].data;
 	const SpriteLoader::CommonPixel *src = sprite[zoom - 1].data;
+#ifndef NDEBUG
 	const SpriteLoader::CommonPixel *src_end = src + sprite[zoom - 1].height * sprite[zoom - 1].width;
+#endif
 
 	for (uint y = 0; y < sprite[zoom].height; y++) {
 		const SpriteLoader::CommonPixel *src_ln = src + sprite[zoom - 1].width;

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -658,7 +658,9 @@ static void HeightMapCurves(uint level)
 			for (uint t = 0; t < lengthof(curve_maps); t++) {
 				if (!HasBit(corner_bits, t)) continue;
 
+#ifndef NDEBUG
 				bool found = false;
+#endif
 				const control_point_t *cm = curve_maps[t].list;
 				for (uint i = 0; i < curve_maps[t].length - 1; i++) {
 					const control_point_t &p1 = cm[i];
@@ -666,7 +668,9 @@ static void HeightMapCurves(uint level)
 
 					if (*h >= p1.x && *h < p2.x) {
 						ht[t] = p1.y + (*h - p1.x) * (p2.y - p1.y) / (p2.x - p1.x);
+#ifndef NDEBUG
 						found = true;
+#endif
 						break;
 					}
 				}

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -107,10 +107,12 @@ Town::~Town()
 	DeleteWindowById(WC_TOWN_VIEW, this->index);
 
 	/* Check no industry is related to us. */
+#ifndef NDEBUG
 	for (const Industry *i : Industry::Iterate()) assert(i->town != this);
 
 	/* ... and no object is related to us. */
 	for (const Object *o : Object::Iterate()) assert(o->town != this);
+#endif
 
 	/* Check no tile is related to us. */
 	for (TileIndex tile = 0; tile < MapSize(); ++tile) {
@@ -2176,6 +2178,7 @@ static Town *CreateRandomTown(uint attempts, uint32 townnameparts, TownSize size
 
 		Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
 		CommandCost rc = DoCommand(t->xy, t->index, 0, DC_EXEC, CMD_DELETE_TOWN);
+		(void)rc; // assert only
 		cur_company.Restore();
 		assert(rc.Succeeded());
 
@@ -2277,7 +2280,7 @@ HouseZonesBits GetTownRadiusGroup(const Town *t, TileIndex tile)
 static inline void ClearMakeHouseTile(TileIndex tile, Town *t, byte counter, byte stage, HouseID type, byte random_bits)
 {
 	CommandCost cc = DoCommand(tile, 0, 0, DC_EXEC | DC_AUTO | DC_NO_WATER, CMD_LANDSCAPE_CLEAR);
-
+	(void)cc; // assert only
 	assert(cc.Succeeded());
 
 	IncreaseBuildingCount(t, type);

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -600,7 +600,9 @@ static char *MakeCzechTownName(char *buf, const char *last, uint32 seed)
 		return strecpy(buf, _name_czech_real[SeedModChance(4, lengthof(_name_czech_real), seed)], last);
 	}
 
+#ifndef NDEBUG
 	const char *orig = buf;
+#endif
 
 	/* Probability of prefixes/suffixes
 	 * 0..11 prefix, 12..13 prefix+suffix, 14..17 suffix, 18..31 nothing */

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1847,6 +1847,7 @@ static void ChangeTileOwner_TunnelBridge(TileIndex tile, Owner old_owner, Owner 
 			/* Since all of our vehicles have been removed, it is safe to remove the rail
 			 * bridge / tunnel. */
 			CommandCost ret = DoCommand(tile, 0, 0, DC_EXEC | DC_BANKRUPT, CMD_LANDSCAPE_CLEAR);
+			(void)ret; // assert only
 			assert(ret.Succeeded());
 		} else {
 			/* In any other case, we can safely reassign the ownership to OWNER_NONE. */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -953,7 +953,10 @@ void CallVehicleTicks()
 	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
 
 	for (Vehicle *v : Vehicle::Iterate()) {
+#ifndef NDEBUG
 		size_t vehicle_index = v->index;
+#endif
+
 		/* Vehicle could be deleted in this tick */
 		if (!v->Tick()) {
 			assert(Vehicle::Get(vehicle_index) == nullptr);

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -54,6 +54,7 @@ bool VehicleListIdentifier::UnpackIfValid(uint32 data)
 {
 	VehicleListIdentifier result;
 	bool ret = result.UnpackIfValid(data);
+	(void)ret; // assert only
 	assert(ret);
 	return result;
 }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1156,7 +1156,9 @@ void NWidgetHorizontal::SetupSmallestSize(Window *w, bool init_array)
 		this->smallest_y = std::max(this->smallest_y, child_wid->smallest_y + child_wid->padding_top + child_wid->padding_bottom);
 	}
 	/* 1b. Make the container higher if needed to accommodate all children nicely. */
+#ifndef NDEBUG
 	uint max_smallest = this->smallest_y + 3 * max_vert_fill; // Upper limit to computing smallest height.
+#endif
 	uint cur_height = this->smallest_y;
 	for (;;) {
 		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
@@ -1321,7 +1323,9 @@ void NWidgetVertical::SetupSmallestSize(Window *w, bool init_array)
 		this->smallest_x = std::max(this->smallest_x, child_wid->smallest_x + child_wid->padding_left + child_wid->padding_right);
 	}
 	/* 1b. Make the container wider if needed to accommodate all children nicely. */
+#ifndef NDEBUG
 	uint max_smallest = this->smallest_x + 3 * max_hor_fill; // Upper limit to computing smallest height.
+#endif
 	uint cur_width = this->smallest_x;
 	for (;;) {
 		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {


### PR DESCRIPTION
## Motivation / Problem

Similar to #8916, but with more.

This should give a clean build log for release builds too .. I hope :D


## Description

Some parts could be rewritten to be nicer, this for sure was the lazy approach. But some code is just a bit horrible in terms of `assert` usage. Too close to a release to really worry about this.

Tested with both GCC 9 and CLang 10, both Debug and Release, all with asserts disabled.

It should make no functional changes .. but .. please look at this carefully :D


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
