### PR TITLE
Fix: CMake and GitHub Actions confusion about what is a (stable) tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         TZ='UTC' date +"%Y-%m-%d %H:%M UTC" > .release_date
         cat .ottdrev | cut -f 1 -d$'\t' > .version
 
-        if [ $(cat .ottdrev | cut -f 6 -d$'\t') = '1' ]; then
+        if [ $(cat .ottdrev | cut -f 5 -d$'\t') = '1' ]; then
           # Assume that all tags are always releases. Why else make a tag?
           IS_TAG="true"
 

--- a/cmake/scripts/FindVersion.cmake
+++ b/cmake/scripts/FindVersion.cmake
@@ -83,7 +83,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
         set(REV_ISTAG 1)
 
         string(REGEX REPLACE "^[0-9.]+$" "" STABLETAG "${TAG}")
-        if(NOT STABLETAG STREQUAL "")
+        if(STABLETAG STREQUAL "")
             set(REV_ISSTABLETAG 1)
         else()
             set(REV_ISSTABLETAG 0)


### PR DESCRIPTION
## Motivation / Problem

You can't have a release without things blowing up in your face :D

## Description

Two mistakes:
- GHA was looking at ISSTABLETAG to find if it started a build based on a tag. This should be ISTAG.
- CMake set ISSTABLETAG to true for betas and RC1 but not for the stable release.

I am not 100% sure about the last one, but what we have made no sense either way. This variable is used for `_openttd_newgrf_version`; I guess that means we pushed betas and RCs with the indication they were stable. So at the very least we have to push 1.11.0 as being stable. So this is not a regression for sure. But I have no clue if betas or RCs should be marked as "stable" or not.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
