### PR TITLE
Fix #8922: Crash when selling last member of shared order group while window was open

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1762,9 +1762,6 @@ public:
 
 	void OnPaint() override
 	{
-		this->BuildVehicleList();
-		this->SortVehicleList();
-
 		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_VL_MANAGE_VEHICLES_DROPDOWN)) {
 			HideDropDownMenu(this);
 		}
@@ -1913,6 +1910,14 @@ public:
 	 */
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
+		this->BuildVehicleList();
+		this->SortVehicleList();
+
+		if (this->vli.type == VL_SHARED_ORDERS && this->vehicles.size() == 0) {
+			delete this;
+			return;
+		}
+
 		if (!gui_scope && HasBit(data, 31) && this->vli.type == VL_SHARED_ORDERS) {
 			/* Needs to be done in command-scope, so everything stays valid */
 			this->vli.index = GB(data, 0, 20);


### PR DESCRIPTION
## Motivation / Problem
#8922
Vehicle GUI window (while showing shared orders) could become empty while open (selling all vehicles in group)
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Close the window when shared order window's vehicle list becomes empty
Window was doing updates of internal state in OnPaint rather than OnInvalidateData which struck me as a bit weird, so moved stuff

Played around with it a bit (though not extensively), window still updates when it should, and doesn't crash
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
