### PR TITLE
Fix: building on Raspberry Pi failed because of const vs constexpr

### DIFF
--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -82,7 +82,7 @@ struct Pool : PoolBase {
 	/* Ensure Tmax_size is within the bounds of Tindex. */
 	static_assert((uint64)(Tmax_size - 1) >> 8 * sizeof(Tindex) == 0);
 
-	static const size_t MAX_SIZE = Tmax_size; ///< Make template parameter accessible from outside
+	static constexpr size_t MAX_SIZE = Tmax_size; ///< Make template parameter accessible from outside
 
 	const char * const name; ///< Name of this pool
 


### PR DESCRIPTION
## Motivation / Problem

Building OpenTTD on Raspberry Pi breaks because of this. Reported twice now, once via IRC and once via Discord.


## Description

We had this problem before, but I cannot remember where/when/how. Either way, without this, we get `undefined references` to `MAX_SIZE` at `industry_cmd.cpp:2219` and `town_cmd.cpp:2247`.

I am pretty sure last time we deduced the reasoning behind it and that it was solid. I just completely forgot what that reason is, but I am sure this is fine :D

After some digging: 9b800a96ed32720ff60b74e498a0e0a6351004f9 here we had a similar issue with `const` vs `constexpr` when it was a static const as a member.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
