### PR TITLE
Fix #8922: Show vehicle window for single vehicle in shared order grouping

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -892,7 +892,11 @@ public:
 						/* We do not support VehicleClicked() here since the contextual action may only make sense for individual vehicles */
 
 						if (vindex == v->index) {
-							ShowVehicleListWindow(v);
+							if (vehgroup.NumVehicles() == 1) {
+								ShowVehicleViewWindow(v);
+							} else {
+								ShowVehicleListWindow(v);
+							}
 						}
 						break;
 					}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1830,12 +1830,18 @@ public:
 						break;
 					}
 
-					case GB_SHARED_ORDERS:
+					case GB_SHARED_ORDERS: {
 						assert(vehgroup.NumVehicles() > 0);
+						const Vehicle *v = vehgroup.vehicles_begin[0];
 						/* We do not support VehicleClicked() here since the contextual action may only make sense for individual vehicles */
 
-						ShowVehicleListWindow(vehgroup.vehicles_begin[0]);
+						if (vehgroup.NumVehicles() == 1) {
+							ShowVehicleViewWindow(v);
+						} else {
+							ShowVehicleListWindow(v);
+						}
 						break;
+					}
 
 					default: NOT_REACHED();
 				}


### PR DESCRIPTION
## Motivation / Problem

Fixes #8922 - shared order list could have only one vehicle, which leads to a crash later when that vehicle is deleted.


## Description

When viewing by shared order groups, if a vehicle is not shared, don't open the shared order list (of just a single vehicle).  Instead, open the vehicle window.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
