### PR TITLE
Change: Disable NewGRF window apply button if no change was made

### DIFF
--- a/src/window_type.h
+++ b/src/window_type.h
@@ -703,9 +703,11 @@ enum WindowClass {
 /** Data value for #Window::OnInvalidateData() of windows with class #WC_GAME_OPTIONS. */
 enum GameOptionsInvalidationData {
 	GOID_DEFAULT = 0,
-	GOID_NEWGRF_RESCANNED,     ///< NewGRFs were just rescanned.
-	GOID_NEWGRF_LIST_EDITED,   ///< List of active NewGRFs is being edited.
-	GOID_NEWGRF_PRESET_LOADED, ///< A NewGRF preset was picked.
+	GOID_NEWGRF_RESCANNED,       ///< NewGRFs were just rescanned.
+	GOID_NEWGRF_CURRENT_LOADED,  ///< The current list of active NewGRF has been loaded.
+	GOID_NEWGRF_LIST_EDITED,     ///< List of active NewGRFs is being edited.
+	GOID_NEWGRF_CHANGES_MADE,    ///< Changes have been made to a given NewGRF either through the palette or its parameters.
+	GOID_NEWGRF_CHANGES_APPLIED, ///< The active NewGRF list changes have been applied.
 };
 
 struct Window;


### PR DESCRIPTION
## Motivation / Problem

The NewGRF window has a 'Apply changes' button that's always enabled, even if the user has not made any change to the NewGRF. In addition, closing the NewGRF window without having made any change executes the reload of NewGRF which can take some time.

## Description

This change makes the 'Apply changes' button to be disabled (grayed out) by default until changes are made, including loading a preset, dragging/dropping from/to the inactive NewGRFs list, clicking on the 'Add' or 'Remove' button, toggling the palette, and opening the parameters window. I believe with this all changes are covered. I have also verified with the scenario editor, where NewGRFs cannot be modified by default unless the hidden developer option is changed in the configuration file.

## Limitations

None I can think of.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
