### PR TITLE
Add: Plural support for Romanian translations

### DIFF
--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -1,7 +1,7 @@
 ##name Romanian
 ##ownname Românӑ
 ##isocode ro_RO
-##plural 0
+##plural 14
 ##textdir ltr
 ##digitsep .
 ##digitsepcur .

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -628,6 +628,12 @@ static int DeterminePluralForm(int64 count, int plural_form)
 		 *  Scottish Gaelic */
 		case 13:
 			return ((n == 1 || n == 11) ? 0 : (n == 2 || n == 12) ? 1 : ((n > 2 && n < 11) || (n > 12 && n < 20)) ? 2 : 3);
+
+		/* Three forms: special case for numbers ending in 00 or [2-9][0-9].
+		 * Used in:
+		 *   Romanian */
+		case 14:
+			return n == 1 ? 0 : (n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2;
 	}
 }
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -629,7 +629,7 @@ static int DeterminePluralForm(int64 count, int plural_form)
 		case 13:
 			return ((n == 1 || n == 11) ? 0 : (n == 2 || n == 12) ? 1 : ((n > 2 && n < 11) || (n > 12 && n < 20)) ? 2 : 3);
 
-		/* Three forms: special cases for 0 or numbers ending in 20 to 99.
+		/* Three forms: special cases for 1, 0 and numbers ending in 01 to 19.
 		 * Used in:
 		 *   Romanian */
 		case 14:

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -629,7 +629,7 @@ static int DeterminePluralForm(int64 count, int plural_form)
 		case 13:
 			return ((n == 1 || n == 11) ? 0 : (n == 2 || n == 12) ? 1 : ((n > 2 && n < 11) || (n > 12 && n < 20)) ? 2 : 3);
 
-		/* Three forms: special case for numbers ending in 00 or [2-9][0-9].
+		/* Three forms: special cases for 0 or numbers ending in 20 to 99.
 		 * Used in:
 		 *   Romanian */
 		case 14:


### PR DESCRIPTION
## Description
This PR adds plural support for Romanian translations.

## Details
The second plural form **always** - without exception - has the preposition "de". Examples:
```
0 beers = 0 beri
1 beer = 1 bere
20 beers = 20 de beri
99 beers = 99 de beri
420 beers = 420 de beri
```

This can be formatted as: `{P bere beri "de beri"}`

Is there a better way to format these plurals?