### PR TITLE
Codechange: Use COINIT_MULTITHREADED in CoInitializeEx

### DIFF
--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -1071,7 +1071,7 @@ static const char *LoadDefaultDLSFile(const char *user_dls)
 const char *MusicDriver_DMusic::Start(const StringList &parm)
 {
 	/* Initialize COM */
-	if (FAILED(CoInitializeEx(nullptr, COINITBASE_MULTITHREADED))) return "COM initialization failed";
+	if (FAILED(CoInitializeEx(nullptr, COINIT_MULTITHREADED))) return "COM initialization failed";
 
 	/* Create the DirectMusic object */
 	if (FAILED(CoCreateInstance(


### PR DESCRIPTION
## Motivation / Problem

Build with MSVC v141_xp toolset fails due to undeclared `COINITBASE_MULTITHREADED`.

## Description

I'm not sure from where this came from, `COINITBASE_MULTITHREADED` seems not mentioned in MS docs. Change it to documented `COINIT_MULTITHREADED`.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
