### PR TITLE
Fix: fix nullptr deletion in DeleteWindowById

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1165,8 +1165,7 @@ Window *FindWindowByClass(WindowClass cls)
 void DeleteWindowById(WindowClass cls, WindowNumber number, bool force)
 {
 	Window *w = FindWindowById(cls, number);
-	if (force || w == nullptr ||
-			(w->flags & WF_STICKY) == 0) {
+	if (w != nullptr && (force || (w->flags & WF_STICKY) == 0)) {
 		delete w;
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

DeleteWindowById in window.cpp has incorrect logic since `delete w` is executed if `w == nullptr`.  The delete operator is overloadad but it seems to do nothing, so I assume that got mistakenly added at some point. I've observed this debugging and when the game is idle it gets continuously called by the news loop trying to close the latest window.

## Description

Fixing code in DeleteWindowById that can call `delete w` where w is nullptr.

## Limitations

Tested by playing the game a little bit, and all works fine.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
