### PR TITLE
Fix #8935: [OSX] Crash when clicking 'Save' due to wrongly-threaded OS call.

### DIFF
--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -224,7 +224,7 @@ bool VideoDriver_Cocoa::AfterBlitterChange()
  */
 void VideoDriver_Cocoa::EditBoxLostFocus()
 {
-	[ [ this->cocoaview inputContext ] discardMarkedText ];
+	[ [ this->cocoaview inputContext ] performSelectorOnMainThread:@selector(discardMarkedText) withObject:nil waitUntilDone:[ NSThread isMainThread ] ];
 	/* Clear any marked string from the current edit box. */
 	HandleTextInput(nullptr, true);
 }


### PR DESCRIPTION
## Motivation / Problem

Possible crash when clicking 'Save' in the save dialog due to an OS function being called from the wrong thread when the focus of the editbox is relinquished upon closing.


## Description

Asynchronously call the OS API to discard the current text input on the main thread to satisfy macOS.


## Limitations

Only sparingly tested and slightly modified from what I posted in #8935 to better approximate current behaviour.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
