### PR TITLE
Fix: Apply master effect volume during mixing instead of sound start.

### DIFF
--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -11,6 +11,7 @@
 #include <math.h>
 #include "core/math_func.hpp"
 #include "framerate_type.h"
+#include "settings_type.h"
 
 #include "safeguards.h"
 #include "mixer.h"
@@ -60,7 +61,7 @@ static int RateConversion(T *b, int frac_pos)
 	return ((b[0] * ((1 << 16) - frac_pos)) + (b[1] * frac_pos)) >> 16;
 }
 
-static void mix_int16(MixerChannel *sc, int16 *buffer, uint samples)
+static void mix_int16(MixerChannel *sc, int16 *buffer, uint samples, uint8 effect_vol)
 {
 	if (samples > sc->samples_left) samples = sc->samples_left;
 	sc->samples_left -= samples;
@@ -69,8 +70,8 @@ static void mix_int16(MixerChannel *sc, int16 *buffer, uint samples)
 	const int16 *b = (const int16 *)sc->memory + sc->pos;
 	uint32 frac_pos = sc->frac_pos;
 	uint32 frac_speed = sc->frac_speed;
-	int volume_left = sc->volume_left;
-	int volume_right = sc->volume_right;
+	int volume_left = sc->volume_left * effect_vol / 255;
+	int volume_right = sc->volume_right * effect_vol / 255;
 
 	if (frac_speed == 0x10000) {
 		/* Special case when frac_speed is 0x10000 */
@@ -96,7 +97,7 @@ static void mix_int16(MixerChannel *sc, int16 *buffer, uint samples)
 	sc->pos = b - (const int16 *)sc->memory;
 }
 
-static void mix_int8_to_int16(MixerChannel *sc, int16 *buffer, uint samples)
+static void mix_int8_to_int16(MixerChannel *sc, int16 *buffer, uint samples, uint8 effect_vol)
 {
 	if (samples > sc->samples_left) samples = sc->samples_left;
 	sc->samples_left -= samples;
@@ -105,8 +106,8 @@ static void mix_int8_to_int16(MixerChannel *sc, int16 *buffer, uint samples)
 	const int8 *b = sc->memory + sc->pos;
 	uint32 frac_pos = sc->frac_pos;
 	uint32 frac_speed = sc->frac_speed;
-	int volume_left = sc->volume_left;
-	int volume_right = sc->volume_right;
+	int volume_left = sc->volume_left * effect_vol / 255;
+	int volume_right = sc->volume_right * effect_vol / 255;
 
 	if (frac_speed == 0x10000) {
 		/* Special case when frac_speed is 0x10000 */
@@ -154,13 +155,15 @@ void MxMixSamples(void *buffer, uint samples)
 	/* Fetch music if a sampled stream is available */
 	if (_music_stream) _music_stream((int16*)buffer, samples);
 
+	uint8 effect_vol = _settings_client.music.effect_vol;
+
 	/* Mix each channel */
 	for (mc = _channels; mc != endof(_channels); mc++) {
 		if (mc->active) {
 			if (mc->is16bit) {
-				mix_int16(mc, (int16*)buffer, samples);
+				mix_int16(mc, (int16*)buffer, samples, effect_vol);
 			} else {
-				mix_int8_to_int16(mc, (int16*)buffer, samples);
+				mix_int8_to_int16(mc, (int16*)buffer, samples, effect_vol);
 			}
 			if (mc->samples_left == 0) MxCloseChannel(mc);
 		}

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -252,7 +252,7 @@ static void SndPlayScreenCoordFx(SoundID sound, int left, int right, int top, in
 			StartSound(
 				sound,
 				panning,
-				(_settings_client.music.effect_vol * _vol_factor_by_zoom[vp->zoom - ZOOM_LVL_BEGIN]) / 256
+				_vol_factor_by_zoom[vp->zoom - ZOOM_LVL_BEGIN]
 			);
 			return;
 		}
@@ -281,7 +281,7 @@ void SndPlayVehicleFx(SoundID sound, const Vehicle *v)
 
 void SndPlayFx(SoundID sound)
 {
-	StartSound(sound, 0.5, _settings_client.music.effect_vol);
+	StartSound(sound, 0.5, UINT8_MAX);
 }
 
 INSTANTIATE_BASE_MEDIA_METHODS(BaseMedia<SoundsSet>, SoundsSet)


### PR DESCRIPTION
This makes the volume control work as most players would expect, affecting
existing playing sounds as well as new sounds.

## Motivation / Problem

Changing master effect volume does not have any effect on sounds that are currently playing. It's always been this way but is pretty odd and makes setting desired volume a little harder than it needs to be.

## Description

This is solved by applying the current master effect volume during the mixing process, instead of at the start of playing a sound.

## Limitations

There's a slight difference of using /255 vs /256. Not sure what difference this has in practical terms.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
