### PR TITLE
Fix: Honor default soundfont for FluidSynth

### DIFF
--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -29,7 +29,15 @@ static FMusicDriver_FluidSynth iFMusicDriver_FluidSynth;
 
 /** List of sound fonts to try by default. */
 static const char *default_sf[] = {
-	/* Debian/Ubuntu/OpenSUSE preferred */
+	/* FluidSynth preferred */
+	/* See: https://www.fluidsynth.org/api/settings_synth.html#settings_synth_default-soundfont */
+	"/usr/share/soundfonts/default.sf2",
+
+	/* Debian/Ubuntu preferred */
+	/* See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=929185 */
+	"/usr/share/sounds/sf3/default-GM.sf3",
+
+	/* OpenSUSE preferred */
 	"/usr/share/sounds/sf2/FluidR3_GM.sf2",
 
 	/* RedHat/Fedora/Arch preferred */


### PR DESCRIPTION
Debian now provides a default soundfont for FluidSynth via its alternatives system.

In short, FluidSynth is configured to look for `/usr/share/sounds/sf3/default-GM.sf3` as its default soundfont, and each soundfront package (FluidR3, OPL-3, MuseScore...) may provide or override this symlink. By default, FluidSynth is installed on Debian with the `TimGM6mb` soundfont due to its limited size.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=929185 for further details.

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
