### PR TITLE
Make effect volume slider non-linear

### DIFF
--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -46,7 +46,7 @@ static MxStreamCallback _music_stream = nullptr;
  * stops overflowing when too many sounds are played at the same time, which
  * causes an even worse sound quality.
  */
-static const int MAX_VOLUME = 128 * 128;
+static const int MAX_VOLUME = 32767;
 
 /**
  * Perform the rate conversion between the input and output.

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -155,7 +155,13 @@ void MxMixSamples(void *buffer, uint samples)
 	/* Fetch music if a sampled stream is available */
 	if (_music_stream) _music_stream((int16*)buffer, samples);
 
-	uint8 effect_vol = _settings_client.music.effect_vol;
+	/* Apply simple x^3 scaling to master effect volume. This increases the
+	 * perceived difference in loudness to better match expectations. effect_vol
+	 * is expected to be in the range 0-127 hence the division by 127 * 127 to
+	 * get back into range. */
+	uint8 effect_vol = (_settings_client.music.effect_vol *
+	                    _settings_client.music.effect_vol *
+	                    _settings_client.music.effect_vol) / (127 * 127);
 
 	/* Mix each channel */
 	for (mc = _channels; mc != endof(_channels); mc++) {


### PR DESCRIPTION
## Motivation / Problem

The effect volume slider has barely any effect on perceived volume until down into the low values.

## Description

This is because perceived audio loudness is non-linear, but our code treats it as such,

This is approximately documented here: https://www.dr-lex.be/info-stuff/volumecontrols.html

This change introduces x^3 scaling rather than the suggested x^4 or x^5 scaling, as this "feels" fine and whereas the latter curves seem excessive. This is just a game, not professional audio mixing software, after all. It also feels similar to how the music volume slider already works, at least for the soft-synth on Windows.

And additional change to increase the permitted sample range values to avoid clipping is included, but the volume slider change doesn't have any bearing on that.

## Limitations

Existing volume adjustment will probably be too quiet now, however the level can easily be adjusted up.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
