### PR TITLE
Social rich presence plugins

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -35,6 +35,7 @@
 #include "game/game.hpp"
 #include "goal_base.h"
 #include "story_base.h"
+#include "network/social_presence.h"
 #include "widgets/statusbar_widget.h"
 
 #include "table/strings.h"
@@ -120,7 +121,17 @@ void SetLocalCompany(CompanyID new_company)
 	/* ... and redraw the whole screen. */
 	MarkWholeScreenDirty();
 	InvalidateWindowClassesData(WC_SIGN_LIST, -1);
+
 	InvalidateWindowClassesData(WC_GOALS_LIST);
+
+	if (_local_company == COMPANY_SPECTATOR || _local_company == OWNER_NONE) {
+		SocialEnterSpectate();
+	} else {
+		char company_name[128];
+		SetDParam(0, _local_company);
+		GetString(company_name, STR_COMPANY_NAME, lastof(company_name));
+		SocialEnterCompany(company_name, _local_company);
+	}
 }
 
 /**

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -94,6 +94,14 @@ void Company::PostDestructor(size_t index)
 	InvalidateWindowData(WC_ERRMSG, 0);
 }
 
+static void SocialUpdateCompanyName()
+{
+	char company_name[128];
+	SetDParam(0, _local_company);
+	GetString(company_name, STR_COMPANY_NAME, lastof(company_name));
+	SocialEnterCompany(company_name, _local_company);
+}
+
 /**
  * Sets the local company and updates the settings that are set on a
  * per-company basis to reflect the core's state in the GUI.
@@ -127,10 +135,7 @@ void SetLocalCompany(CompanyID new_company)
 	if (_local_company == COMPANY_SPECTATOR || _local_company == OWNER_NONE) {
 		SocialEnterSpectate();
 	} else {
-		char company_name[128];
-		SetDParam(0, _local_company);
-		GetString(company_name, STR_COMPANY_NAME, lastof(company_name));
-		SocialEnterCompany(company_name, _local_company);
+		SocialUpdateCompanyName();
 	}
 }
 
@@ -385,6 +390,7 @@ set_name:;
 		c->name_2 = strp;
 
 		MarkWholeScreenDirty();
+		if (c->index == _local_company) SocialUpdateCompanyName();
 
 		if (c->is_ai) {
 			CompanyNewsInformation *cni = MallocT<CompanyNewsInformation>(1);
@@ -1095,6 +1101,7 @@ CommandCost CmdRenameCompany(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 		}
 		MarkWholeScreenDirty();
 		CompanyAdminUpdate(c);
+		if (_current_company == _local_company) SocialUpdateCompanyName();
 	}
 
 	return CommandCost();

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2279,6 +2279,15 @@ STR_NETWORK_MESSAGE_SERVER_SHUTDOWN                             :{WHITE}The serv
 STR_NETWORK_MESSAGE_SERVER_REBOOT                               :{WHITE}The server is restarting...{}Please wait...
 STR_NETWORK_MESSAGE_KICKED                                      :*** {RAW_STRING} was kicked. Reason: ({RAW_STRING})
 
+# Social presence related messages
+STR_SOCIAL_ERROR_CANNOT_JOIN                                    :{WHITE}Cannot join requested network game, you are already in a game
+STR_SOCIAL_JOIN_REQUEST_CAPTION                                 :{WHITE}Outside request
+STR_SOCIAL_JOIN_REQUEST_TEXT                                    :{BLACK}A friend is asking if they can join this game too.{}Let them in?{}{}{LTBLUE}{RAW_STRING}
+STR_SOCIAL_JOIN_REQUEST_ACCEPT                                  :{BLACK}Accept
+STR_SOCIAL_JOIN_REQUEST_ACCEPT_TOOLTIP                          :{BLACK}The other player will receive the address and port of this server, but not any passwords required.
+STR_SOCIAL_JOIN_REQUEST_REJECT                                  :{BLACK}Reject
+STR_SOCIAL_JOIN_REQUEST_REJECT_TOOLTIP                          :{BLACK}The other player will not be given the address of this server.
+
 # Content downloading window
 STR_CONTENT_TITLE                                               :{WHITE}Content downloading
 STR_CONTENT_TYPE_CAPTION                                        :{BLACK}Type

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -25,4 +25,7 @@ add_files(
     network_type.h
     network_udp.cpp
     network_udp.h
+    social_plugin_api.h
+    social_presence.cpp
+    social_presence.h
 )

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -598,7 +598,7 @@ struct SocialJoinRequestWindow : public Window {
 		switch (widget) {
 			case WID_SJR_MESSAGE:
 			{
-				int text_width = max(0, (int)size->width - WD_FRAMETEXT_LEFT - WD_FRAMETEXT_RIGHT);
+				int text_width = std::max(0, (int)size->width - WD_FRAMETEXT_LEFT - WD_FRAMETEXT_RIGHT);
 				SetDParamStr(0, this->friend_name.c_str());
 				size->height = WD_FRAMERECT_TOP + GetStringHeight(STR_SOCIAL_JOIN_REQUEST_TEXT, text_width) + WD_FRAMERECT_BOTTOM;
 				break;

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -22,6 +22,7 @@
 #include "network.h"
 #include "network_client.h"
 #include "network_base.h"
+#include "social_presence.h"
 
 #include "../widgets/network_chat_widget.h"
 
@@ -554,4 +555,15 @@ void ShowNetworkChatQueryWindow(DestType type, int dest)
 {
 	DeleteWindowByClass(WC_SEND_NETWORK_MSG);
 	new NetworkChatWindow(&_chat_window_desc, type, dest);
+}
+
+
+void SocialHandleJoinRequest(void *join_request_cookie, const std::string &friend_name)
+{
+	// TODO
+}
+
+void SocialCancelJoinRequest(void *join_request_cookie)
+{
+	// TODO
 }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -28,6 +28,7 @@
 #include "network_client.h"
 #include "../core/backup_type.hpp"
 #include "../thread.h"
+#include "social_presence.h"
 
 #include "table/strings.h"
 
@@ -889,6 +890,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 
 	/* Say we received the map and loaded it correctly! */
 	SendMapOk();
+
+	SocialCompleteEnterMultiplayer();
 
 	/* New company/spectator (invalid company) or company we want to join is not active
 	 * Switch local company to spectator and await the server's judgement */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -30,6 +30,7 @@
 #include "../map_type.h"
 #include "../guitimer_func.h"
 #include "../zoom_func.h"
+#include "social_presence.h"
 
 #include "../widgets/network_widget.h"
 
@@ -1339,6 +1340,8 @@ struct NetworkLobbyWindow : public Window {
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NL_SCROLLBAR);
 		this->FinishInitNested(WN_NETWORK_WINDOW_LOBBY);
+
+		SocialBeginEnterMultiplayer(server->info.server_name, "");
 	}
 
 	CompanyID NetworkLobbyFindCompanyIndex(byte pos) const
@@ -2220,4 +2223,9 @@ void ShowNetworkCompanyPasswordWindow(Window *parent)
 	DeleteWindowById(WC_COMPANY_PASSWORD_WINDOW, 0);
 
 	new NetworkCompanyPasswordWindow(&_network_company_password_window_desc, parent);
+}
+
+void SocialJoinRequestedGame(const std::string &server_cookie)
+{
+	// TODO
 }

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -31,6 +31,7 @@
 #include "../guitimer_func.h"
 #include "../zoom_func.h"
 #include "social_presence.h"
+#include "../error.h"
 
 #include "../widgets/network_widget.h"
 
@@ -2227,5 +2228,19 @@ void ShowNetworkCompanyPasswordWindow(Window *parent)
 
 void SocialJoinRequestedGame(const std::string &server_cookie)
 {
-	// TODO
+	/* If player is not on main menu, don't connect. Don't want to interrupt any current game. */
+	if (_game_mode != GM_MENU) {
+		ShowErrorMessage(STR_SOCIAL_ERROR_CANNOT_JOIN, STR_NONE, WL_WARNING);
+		return;
+	}
+
+	/* Okay let's try to join! */
+	const char *company;
+	const char *port;
+	char *server_cookie_cstr = stredup(server_cookie.c_str());
+	ParseConnectionString(&company, &port, server_cookie_cstr);
+	NetworkAddress addr(server_cookie_cstr, atoi(port));
+	free(server_cookie_cstr);
+
+	NetworkClientConnectGame(addr, COMPANY_SPECTATOR);
 }

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1341,7 +1341,7 @@ struct NetworkLobbyWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_NL_SCROLLBAR);
 		this->FinishInitNested(WN_NETWORK_WINDOW_LOBBY);
 
-		SocialBeginEnterMultiplayer(server->info.server_name, "");
+		SocialBeginEnterMultiplayer(server->info.server_name, server->address.GetAddressAsString(false));
 	}
 
 	CompanyID NetworkLobbyFindCompanyIndex(byte pos) const

--- a/src/network/social_plugin_api.h
+++ b/src/network/social_plugin_api.h
@@ -39,7 +39,7 @@ extern "C" {
 /* Various constants for the API */
 enum {
 	/** Version number of the API defined in this header, must be passed to the init functions */
-	OTTD_SOCIAL_PLUGIN_API_VERSION = 1,
+	OTTD_SOCIAL_PLUGIN_API_VERSION = 2,
 };
 
 /** Response values for join requests */
@@ -80,12 +80,16 @@ struct OpenTTD_SocialPluginCallbacks {
 	void (*cancel_join_request)(void *join_request_cookie);
 	/** Inform OpenTTD that the local user requested to join another player's game and was accepted */
 	void (*join_requested_game)(const char *server_cookie);
+	/** String indicating the launch command for OpenTTD, the plugin must make a copy of this to its own memory */
+	const char *launch_command;
 };
 
 /**
  * Type of the init function the plug-in is expected to export from its dynamic library.
  * On platforms where this method of initialisation is inconvenient, a different method can be used.
  * The plugin must verify the api_version passed by OpenTTD is supported before filling the api struct.
+ * @note The launch_command field of callbacks must point to a valid C string for the duration of this call,
+ *       but may be freed after the call returns.
  * @param[in]  api_version  The API version OpenTTD uses.
  * @param[out] api          Structure the plugin must fill with function pointers.
  * @param[in]  callbacks    Function pointers for the plug-in to call back into OpenTTD. These will stay valid until shutdown.

--- a/src/network/social_plugin_api.h
+++ b/src/network/social_plugin_api.h
@@ -1,5 +1,3 @@
-/* $Id$ */
-
 /*
  * This file is part of OpenTTD.
  * Unlike the rest of OpenTTD, this file is covered by the MIT license,

--- a/src/network/social_plugin_api.h
+++ b/src/network/social_plugin_api.h
@@ -39,7 +39,7 @@ extern "C" {
 /* Various constants for the API */
 enum {
 	/** Version number of the API defined in this header, must be passed to the init functions */
-	OTTD_SOCIAL_PLUGIN_API_VERSION = 2,
+	OTTD_SOCIAL_PLUGIN_API_VERSION = 3,
 };
 
 /** Response values for join requests */
@@ -70,6 +70,10 @@ struct OpenTTD_SocialPluginApi {
 	void (*exit_gameplay)();
 	/** OpenTTD calls this function when the player responds to a received join request */
 	void (*respond_join_request)(void *join_request_cookie, OpenTTD_SocialPluginApi_JoinRequestResponse response);
+	/** OpenTTD calls this function to display a web browser via integration */
+	void (*show_web_browser)(const char *uri);
+	/** OpenTTD calls this function to get the user's preferred player name */
+	void (*get_preferred_player_name)(char *name_buffer, unsigned int name_buffer_size);
 };
 
 /** Function pointers supplied by OpenTTD, for the plug-in to call */

--- a/src/network/social_plugin_api.h
+++ b/src/network/social_plugin_api.h
@@ -3,7 +3,7 @@
  * Unlike the rest of OpenTTD, this file is covered by the MIT license,
  * to allow non-free implementations of the described API.
  *
- * Copyright 2019 OpenTTD project
+ * Copyright 2021 OpenTTD project
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files

--- a/src/network/social_plugin_api.h
+++ b/src/network/social_plugin_api.h
@@ -1,0 +1,100 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * Unlike the rest of OpenTTD, this file is covered by the MIT license,
+ * to allow non-free implementations of the described API.
+ *
+ * Copyright 2019 OpenTTD project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/** @file social_plugin_api.h Interface definitions for game to report/respond to social media presence. */
+
+#ifndef OPENTTD_SOCIAL_PLUGIN_API_H
+#define OPENTTD_SOCIAL_PLUGIN_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Various constants for the API */
+enum {
+	/** Version number of the API defined in this header, must be passed to the init functions */
+	OTTD_SOCIAL_PLUGIN_API_VERSION = 1,
+};
+
+/** Response values for join requests */
+enum OpenTTD_SocialPluginApi_JoinRequestResponse {
+	/** Player chose not to respond to the request */
+	OTTD_JRR_IGNORE = 0,
+	/** Player accepts the request */
+	OTTD_JRR_ACCEPT = 1,
+	/** Player rejects the request */
+	OTTD_JRR_REJECT = 2,
+};
+
+/** Function pointers supplied by the plug-in for OpenTTD to call */
+struct OpenTTD_SocialPluginApi {
+	/** OpenTTD calls this function when it prepares to exit */
+	void (*shutdown)();
+	/** OpenTTD calls this function at regular intervals, where it is safe to call the callback functions */
+	void (*event_loop)();
+	/** OpenTTD calls this function when the player enters a singleplayer game */
+	void (*enter_singleplayer)();
+	/** OpenTTD calls this function when the player enters a multiplayer game */
+	void (*enter_multiplayer)(const char *server_name, const char *server_cookie);
+	/** OpenTTD calls this function when the player changes controlled company, or the company changes name */
+	void (*enter_company)(const char *company_name, int company_id);
+	/** OpenTTD calls this function when the player joins the spectators */
+	void (*enter_spectate)();
+	/** OpenTTD calls this function when the player leaves the main gameplay */
+	void (*exit_gameplay)();
+	/** OpenTTD calls this function when the player responds to a received join request */
+	void (*respond_join_request)(void *join_request_cookie, OpenTTD_SocialPluginApi_JoinRequestResponse response);
+};
+
+/** Function pointers supplied by OpenTTD, for the plug-in to call */
+struct OpenTTD_SocialPluginCallbacks {
+	/** Inform OpenTTD that another user wants to join their current game */
+	void (*handle_join_request)(void *join_request_cookie, const char *friend_name);
+	/** Inform OpenTTD that a user retracted their previous join request */
+	void (*cancel_join_request)(void *join_request_cookie);
+	/** Inform OpenTTD that the local user requested to join another player's game and was accepted */
+	void (*join_requested_game)(const char *server_cookie);
+};
+
+/**
+ * Type of the init function the plug-in is expected to export from its dynamic library.
+ * On platforms where this method of initialisation is inconvenient, a different method can be used.
+ * The plugin must verify the api_version passed by OpenTTD is supported before filling the api struct.
+ * @param[in]  api_version  The API version OpenTTD uses.
+ * @param[out] api          Structure the plugin must fill with function pointers.
+ * @param[in]  callbacks    Function pointers for the plug-in to call back into OpenTTD. These will stay valid until shutdown.
+ * @return                  Non-zero on success, zero if the requested api_version is not supported.
+ */
+typedef int (*OpenTTD_SocialPluginInit)(int api_version, struct OpenTTD_SocialPluginApi *api, const struct OpenTTD_SocialPluginCallbacks *callbacks);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* OPENTTD_SOCIAL_PLUGIN_API_H */

--- a/src/network/social_presence.cpp
+++ b/src/network/social_presence.cpp
@@ -1,5 +1,3 @@
-/* $Id$ */
-
 /*
  * This file is part of OpenTTD.
  * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.

--- a/src/network/social_presence.cpp
+++ b/src/network/social_presence.cpp
@@ -1,0 +1,117 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file social_presence.cpp Base implementation of social presence support. */
+
+#include "../stdafx.h"
+#include <string>
+#include "social_presence.h"
+#include "social_plugin_api.h"
+
+
+static bool _social_loaded = false;
+static OpenTTD_SocialPluginApi _social_api{};
+static OpenTTD_SocialPluginCallbacks _social_callbacks{};
+
+static struct {
+	std::string server_name;
+	std::string server_cookie;
+} _social_multiplayer_status;
+
+/* Implemented by platform */
+extern OpenTTD_SocialPluginInit SocialLoadPlugin();
+
+
+static void Callback_handle_join_request(void *join_request_cookie, const char *friend_name)
+{
+	SocialHandleJoinRequest(join_request_cookie, friend_name);
+}
+
+static void Callback_cancel_join_request(void *join_request_cookie)
+{
+	SocialCancelJoinRequest(join_request_cookie);
+}
+
+static void Callback_join_requested_game(const char *server_cookie)
+{
+	SocialJoinRequestedGame(server_cookie);
+}
+
+
+void SocialStartup()
+{
+	if (_social_loaded) return;
+
+	OpenTTD_SocialPluginInit init = SocialLoadPlugin();
+
+	_social_callbacks.handle_join_request = Callback_handle_join_request;
+	_social_callbacks.cancel_join_request = Callback_cancel_join_request;
+	_social_callbacks.join_requested_game = Callback_join_requested_game;
+
+	if (init != nullptr) {
+		_social_loaded = init(OTTD_SOCIAL_PLUGIN_API_VERSION, &_social_api, &_social_callbacks) != 0;
+	}
+}
+
+void SocialShutdown()
+{
+	if (_social_loaded) _social_api.shutdown();
+	_social_loaded = false;
+}
+
+void SocialEventLoop()
+{
+	if (_social_loaded) _social_api.event_loop();
+}
+
+void SocialEnterSingleplayer()
+{
+	if (_social_loaded) _social_api.enter_singleplayer();
+}
+
+void SocialBeginEnterMultiplayer(const std::string &server_name, const std::string &server_cookie)
+{
+	_social_multiplayer_status.server_name = server_name;
+	_social_multiplayer_status.server_cookie = server_cookie;
+}
+
+void SocialCompleteEnterMultiplayer()
+{
+	if (_social_loaded && !_social_multiplayer_status.server_cookie.empty()) {
+		_social_api.enter_multiplayer(_social_multiplayer_status.server_name.c_str(), _social_multiplayer_status.server_cookie.c_str());
+	}
+}
+
+void SocialEnterCompany(const std::string &company_name, CompanyID company_id)
+{
+	if (_social_loaded) _social_api.enter_company(company_name.c_str(), company_id);
+}
+
+void SocialEnterSpectate()
+{
+	if (_social_loaded) _social_api.enter_spectate();
+}
+
+void SocialExitGameplay()
+{
+	if (_social_loaded) _social_api.exit_gameplay();
+}
+
+void SocialRespondJoinRequest(void *join_request_cookie, SocialJoinRequestResponse response)
+{
+	OpenTTD_SocialPluginApi_JoinRequestResponse api_rsp;
+	switch (response) {
+		case SocialJoinRequestResponse::Ignore: api_rsp = OTTD_JRR_IGNORE; break;
+		case SocialJoinRequestResponse::Accept: api_rsp = OTTD_JRR_ACCEPT; break;
+		case SocialJoinRequestResponse::Reject: api_rsp = OTTD_JRR_REJECT; break;
+		default: return;
+	}
+
+	if (_social_loaded) _social_api.respond_join_request(join_request_cookie, api_rsp);
+}

--- a/src/network/social_presence.cpp
+++ b/src/network/social_presence.cpp
@@ -15,6 +15,7 @@
 #include "social_plugin_api.h"
 #include "../debug.h"
 #include "../video/video_driver.hpp"
+#include "core/config.h"
 
 
 static bool _social_loaded = false;
@@ -125,3 +126,26 @@ void SocialRespondJoinRequest(void *join_request_cookie, SocialJoinRequestRespon
 
 	if (_social_loaded) _social_api.respond_join_request(join_request_cookie, api_rsp);
 }
+
+void SocialOpenBrowser(const char *url)
+{
+	if (_social_loaded && _social_api.show_web_browser != nullptr) {
+		_social_api.show_web_browser(url);
+	} else {
+		extern void OSOpenBrowser(const char *url);
+		OSOpenBrowser(url);
+	}
+}
+
+std::string SocialGetPreferredPlayerName()
+{
+	if (!_social_loaded) return std::string();
+	if (_social_api.get_preferred_player_name == nullptr) return std::string();
+
+	char name_buffer[NETWORK_CLIENT_NAME_LENGTH + 1] = {};
+	_social_api.get_preferred_player_name(name_buffer, sizeof(name_buffer) - 1);
+	*(lastof(name_buffer)) = '\0';
+	return std::string(name_buffer);
+}
+
+

--- a/src/network/social_presence.cpp
+++ b/src/network/social_presence.cpp
@@ -101,6 +101,7 @@ void SocialEnterSpectate()
 void SocialExitGameplay()
 {
 	if (_social_loaded) _social_api.exit_gameplay();
+	_social_multiplayer_status.server_cookie.clear();
 }
 
 void SocialRespondJoinRequest(void *join_request_cookie, SocialJoinRequestResponse response)

--- a/src/network/social_presence.h
+++ b/src/network/social_presence.h
@@ -1,5 +1,3 @@
-/* $Id$ */
-
 /*
  * This file is part of OpenTTD.
  * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.

--- a/src/network/social_presence.h
+++ b/src/network/social_presence.h
@@ -44,6 +44,8 @@ void SocialEnterSpectate();
 void SocialExitGameplay();
 /** Game calls this when player accepts a remote join request */
 void SocialRespondJoinRequest(void *join_request_cookie, SocialJoinRequestResponse response);
+/** Game calls this to open the social integration's preferred web browser */
+void SocialOpenBrowser(const char *url);
 
 
 /* Functions called from social plug-in on certain events */

--- a/src/network/social_presence.h
+++ b/src/network/social_presence.h
@@ -21,6 +21,7 @@ enum class SocialJoinRequestResponse {
 	Ignore,
 };
 
+
 /* Functions implemented by social plug-in */
 
 /** Main loop calls this to detect and initialise social plug-in */

--- a/src/network/social_presence.h
+++ b/src/network/social_presence.h
@@ -1,0 +1,57 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file social_presence.h Interface definitions for game to report/respond to social media presence. */
+
+#ifndef NETWORK_SOCIAL_PRESENCE_H
+#define NETWORK_SOCIAL_PRESENCE_H
+
+#include "../company_type.h"
+#include <string>
+
+enum class SocialJoinRequestResponse {
+	Accept,
+	Reject,
+	Ignore,
+};
+
+/* Functions implemented by social plug-in */
+
+/** Main loop calls this to detect and initialise social plug-in */
+void SocialStartup();
+/** Main loop calls this to shut down social plug-in */
+void SocialShutdown();
+/** Main loop calls this, let social plug-in handle events */
+void SocialEventLoop();
+/** Game calls this when player starts/loads a singleplayer game */
+void SocialEnterSingleplayer();
+/** GUI calls this when player joins/starts a multiplayer */
+void SocialBeginEnterMultiplayer(const std::string &server_name, const std::string &server_cookie);
+/** Network code calls this when joining/starting a multiplayer game completes */
+void SocialCompleteEnterMultiplayer();
+/** Game calls this when player joins a company, or player's company changes name */
+void SocialEnterCompany(const std::string &company_name, CompanyID company_id);
+/** Game calls this when player enters spectate-mode */
+void SocialEnterSpectate();
+/** Game calls this when player leaves main gameplay mode */
+void SocialExitGameplay();
+/** Game calls this when player accepts a remote join request */
+void SocialRespondJoinRequest(void *join_request_cookie, SocialJoinRequestResponse response);
+
+
+/* Functions called from social plug-in on certain events */
+
+/** Social plug-in calls this (from inside SocialEventLoop) if it receives a join request from a friend */
+void SocialHandleJoinRequest(void *join_request_cookie, const std::string &friend_name);
+/** Social plug-in calls this if a friend retracts a join request */
+void SocialCancelJoinRequest(void *join_request_cookie);
+/** Social plug-in calls this if the user received an accept on a join request */
+void SocialJoinRequestedGame(const std::string &server_cookie);
+
+#endif /* NETWORK_SOCIAL_PRESENCE_H */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -400,8 +400,7 @@ void OpenBrowser(const char *url)
 	/* Make sure we only accept urls that are sure to open a browser. */
 	if (strstr(url, "http://") != url && strstr(url, "https://") != url) return;
 
-	extern void OSOpenBrowser(const char *url);
-	OSOpenBrowser(url);
+	SocialOpenBrowser(url);
 }
 
 /** Callback structure of statements to be executed after the NewGRF scan. */

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -17,6 +17,7 @@
 #include "../../string_func.h"
 #include "../../textbuf_gui.h"
 #include "../../thread.h"
+#include "../../network/social_plugin_api.h"
 
 #include "table/strings.h"
 
@@ -211,4 +212,9 @@ void OSOpenBrowser(const char *url)
 
 void SetCurrentThreadName(const char *)
 {
+}
+
+OpenTTD_SocialPluginInit SocialLoadPlugin()
+{
+	return nullptr;
 }

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -16,6 +16,7 @@
 #include "../../string_func.h"
 #include "../../fios.h"
 #include "../../thread.h"
+#include "../../network/social_plugin_api.h"
 
 
 #include <dirent.h>
@@ -320,4 +321,9 @@ void SetCurrentThreadName(const char *threadName) {
 #if defined(__APPLE__)
 	MacOSSetThreadName(threadName);
 #endif /* defined(__APPLE__) */
+}
+
+OpenTTD_SocialPluginInit SocialLoadPlugin()
+{
+	return nullptr;
 }

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -799,7 +799,6 @@ OpenTTD_SocialPluginInit SocialLoadPlugin()
 				TCHAR plugin_name[MAX_PATH]{};
 				value[lengthof(value) - 1] = _T('\0');
 				if (value_type == REG_EXPAND_SZ) {
-					TCHAR expand_value[MAX_PATH];
 					ExpandEnvironmentStrings(value, plugin_name, lengthof(plugin_name));
 				} else if (value_type == REG_SZ) {
 					MemCpyT(plugin_name, value, lengthof(plugin_name));

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -813,6 +813,8 @@ OpenTTD_SocialPluginInit SocialLoadPlugin()
 					if (init_addr != nullptr) return init_addr;
 					DEBUG(misc, 1, "Social: Not a valid plugin library, init function not found");
 					FreeLibrary(plugin_library);
+				} else {
+					DEBUG(misc, 0, "Social: Failed to load DLL, error code = %u", GetLastError());
 				}
 			} else {
 				RegCloseKey(reg);

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -22,6 +22,7 @@
 #include "../window_gui.h"
 #include "../window_func.h"
 #include "../framerate_type.h"
+#include "../network/social_presence.h"
 #include "win32_v.h"
 #include <windows.h>
 #include <imm.h>

--- a/src/widgets/network_chat_widget.h
+++ b/src/widgets/network_chat_widget.h
@@ -19,4 +19,11 @@ enum NetWorkChatWidgets {
 	WID_NC_SENDBUTTON,  ///< Send button.
 };
 
+/** Widgets of the #NetworkJoinStatusWindow class. */
+enum SocialJoinRequestWidgets {
+	WID_SJR_MESSAGE,     ///< Message area.
+	WID_SJR_ACCEPT,      ///< Accept button.
+	WID_SJR_REJECT,      ///< Reject button.
+};
+
 #endif /* WIDGETS_NETWORK_CHAT_WIDGET_H */

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -124,4 +124,5 @@ enum NetworkCompanyPasswordWidgets {
 	WID_NCP_OK,                       ///< Safe the password etc.
 };
 
+
 #endif /* WIDGETS_NETWORK_WIDGET_H */

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -491,6 +491,12 @@ enum WindowClass {
 	WC_SEND_NETWORK_MSG,
 
 	/**
+	 * Outside player request to join; %Window numbers:
+	 *   - 0 = #SocialJoinRequestWidgets
+	 */
+	WC_SOCIAL_JOIN_REQUEST,
+
+	/**
 	 * Company password query; %Window numbers:
 	 *   - 0 = #NetworkCompanyPasswordWidgets
 	 */


### PR DESCRIPTION
## Motivation / Problem
There's long been interest in being able to "broadcast" your status of playing OpenTTD and possibly being in a multiplayer server, to friends on Discord and similar social platforms. This is even more relevant with the recent Steam release, where features that could allow friends to join your current game, or you to directly send invites, would be popular.


## Description
This PR adds a generic interface for OpenTTD to load a "social plugin", an external dynamic library that implements whatever integration. This PR does not integrate with anything in itself. This level of indirection is to avoid having to potentially link OpenTTD directly with proprietary libraries that might not be compatible with GPL.

A proof-of-concept integration for Discord is here: https://github.com/nielsmh/ottd-discord


## Limitations
Can only load one social plugin currently, it might be better to support loading and updating any number of social plugins, for example to have Steam and Discord integrations active at the same time.

Needs a per-platform loader for the social plugins, that finds and loads the dynamic libraries. Currently only implemented for Win32.

Support for game invites is not complete, some more specification is needed there.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
