### PR TITLE
Fix: Use FluidSynth default soundfont

### DIFF
--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -77,12 +77,22 @@ const char *MusicDriver_FluidSynth::Start(const StringList &param)
 	/* Load a SoundFont and reset presets (so that new instruments
 	 * get used from the SoundFont) */
 	if (!sfont_name) {
-		int i;
 		sfont_id = FLUID_FAILED;
-		for (i = 0; default_sf[i]; i++) {
-			if (!fluid_is_soundfont(default_sf[i])) continue;
-			sfont_id = fluid_synth_sfload(_midi.synth, default_sf[i], 1);
-			if (sfont_id != FLUID_FAILED) break;
+
+		/* Try loading the default soundfont registered with FluidSynth. */
+		char *default_soundfont;
+		fluid_settings_dupstr(_midi.settings, "synth.default-soundfont", &default_soundfont);
+		if (fluid_is_soundfont(default_soundfont)) {
+			sfont_id = fluid_synth_sfload(_midi.synth, default_soundfont, 1);
+		}
+
+		/* If no default soundfont found, try our own list. */
+		if (sfont_id == FLUID_FAILED) {
+			for (int i = 0; default_sf[i]; i++) {
+				if (!fluid_is_soundfont(default_sf[i])) continue;
+				sfont_id = fluid_synth_sfload(_midi.synth, default_sf[i], 1);
+				if (sfont_id != FLUID_FAILED) break;
+			}
 		}
 		if (sfont_id == FLUID_FAILED) return "Could not open any sound font";
 	} else {


### PR DESCRIPTION
## Motivation / Problem

FluidSynth provides a build option to set a default soundfont which may be overridden by Linux distributions such as Debian to support alternative soundfont providers (such as Fluid, OPL-3, MuseScore, ...). This PR enables OpenTTD to use this default soundfont if present, which is arguably more flexible than maintaining the hard-coded list in the OpenTTD code base.

As an immediate benefit of this, the Flatpak build of OpenTTD will no longer require patching the hard-coded list. Instead, only FluidSynth needs to be configured with an appropriate default soundfont in place inside the runtime.

## Description

The implementation now loads the default soundfont configured with FluidSynth, if any. The previous find-first lookup from the hard-coded soundfont list is still used as a fallback if no suitable default soundfont is found.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
