### PR TITLE
Feature: Button to reset game settings to their default values

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1138,6 +1138,7 @@ STR_CONFIG_SETTING_TREE_CAPTION                                 :{WHITE}Settings
 STR_CONFIG_SETTING_FILTER_TITLE                                 :{BLACK}Filter string:
 STR_CONFIG_SETTING_EXPAND_ALL                                   :{BLACK}Expand all
 STR_CONFIG_SETTING_COLLAPSE_ALL                                 :{BLACK}Collapse all
+STR_CONFIG_SETTING_RESET_ALL                                    :{BLACK}Reset all values
 STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT            :(no explanation available)
 STR_CONFIG_SETTING_DEFAULT_VALUE                                :{LTBLUE}Default value: {ORANGE}{STRING1}
 STR_CONFIG_SETTING_TYPE                                         :{LTBLUE}Setting type: {ORANGE}{STRING}
@@ -1146,6 +1147,8 @@ STR_CONFIG_SETTING_TYPE_GAME_MENU                               :Game setting (s
 STR_CONFIG_SETTING_TYPE_GAME_INGAME                             :Game setting (stored in save; affects only current game)
 STR_CONFIG_SETTING_TYPE_COMPANY_MENU                            :Company setting (stored in saves; affects only new games)
 STR_CONFIG_SETTING_TYPE_COMPANY_INGAME                          :Company setting (stored in save; affects only current company)
+STR_CONFIG_SETTING_RESET_ALL_CONFIRMATION_DIALOG_CAPTION        :{WHITE}Caution!
+STR_CONFIG_SETTING_RESET_ALL_CONFIRMATION_DIALOG_TEXT           :{WHITE}This action will reset all game settings to their default values.{}Are you sure you want to proceed?
 
 STR_CONFIG_SETTING_RESTRICT_CATEGORY                            :{BLACK}Category:
 STR_CONFIG_SETTING_RESTRICT_TYPE                                :{BLACK}Type:

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -44,6 +44,7 @@ enum GameSettingsWidgets {
 	WID_GS_HELP_TEXT,          ///< Information area to display help text of the selected option.
 	WID_GS_EXPAND_ALL,         ///< Expand all button.
 	WID_GS_COLLAPSE_ALL,       ///< Collapse all button.
+	WID_GS_RESET_ALL,          ///< Reset all button.
 	WID_GS_RESTRICT_CATEGORY,  ///< Label upfront to the category drop-down box to restrict the list of settings to show
 	WID_GS_RESTRICT_TYPE,      ///< Label upfront to the type drop-down box to restrict the list of settings to show
 	WID_GS_RESTRICT_DROPDOWN,  ///< The drop down box to restrict the list of settings


### PR DESCRIPTION
## Motivation / Problem

There is no easy way of resetting game settings to their fresh default values. Players can do this by either removing the OpenTTD config file (which has other undesired effects like removing the NewGRF presets, in addition to being difficult to find by users that are not familiar with where to find game config files in the local storage) or setting each value to its default one by one manually from the settings window itself.

## Description

This change introduces a button at the bottom of the game settings screen so the user can reset all values to their default values. The user will be prompted to confirm it though:

![image](https://user-images.githubusercontent.com/2025406/113632942-e466e300-9620-11eb-96c9-eed34876b087.png)

In addition, AFAIK the changes won't be persisted unless the user successfully exits OpenTTD.

## Limitations

I can't think of any, but please suggest.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
