### PR TITLE
Fix: [CMake] Use the right run-time library depending on vcpkg triplet

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -4,20 +4,22 @@
 #
 macro(compile_flags)
     if(MSVC)
-        # Switch to MT (static) instead of MD (dynamic) binary
+        if(VCPKG_TARGET_TRIPLET MATCHES "-static" AND NOT VCPKG_TARGET_TRIPLET MATCHES "-md")
+            # Switch to MT (static) instead of MD (dynamic) binary
 
-        # For MSVC two generators are available
-        # - a command line generator (Ninja) using CMAKE_BUILD_TYPE to specify the
-        #   configuration of the build tree
-        # - an IDE generator (Visual Studio) using CMAKE_CONFIGURATION_TYPES to
-        #   specify all configurations that will be available in the generated solution
-        list(APPEND MSVC_CONFIGS "${CMAKE_BUILD_TYPE}" "${CMAKE_CONFIGURATION_TYPES}")
+            # For MSVC two generators are available
+            # - a command line generator (Ninja) using CMAKE_BUILD_TYPE to specify the
+            #   configuration of the build tree
+            # - an IDE generator (Visual Studio) using CMAKE_CONFIGURATION_TYPES to
+            #   specify all configurations that will be available in the generated solution
+            list(APPEND MSVC_CONFIGS "${CMAKE_BUILD_TYPE}" "${CMAKE_CONFIGURATION_TYPES}")
 
-        # Set usage of static runtime for all configurations
-        foreach(MSVC_CONFIG ${MSVC_CONFIGS})
-            string(TOUPPER "CMAKE_CXX_FLAGS_${MSVC_CONFIG}" MSVC_FLAGS)
-            string(REPLACE "/MD" "/MT" ${MSVC_FLAGS} "${${MSVC_FLAGS}}")
-        endforeach()
+            # Set usage of static runtime for all configurations
+            foreach(MSVC_CONFIG ${MSVC_CONFIGS})
+                string(TOUPPER "CMAKE_CXX_FLAGS_${MSVC_CONFIG}" MSVC_FLAGS)
+                string(REPLACE "/MD" "/MT" ${MSVC_FLAGS} "${${MSVC_FLAGS}}")
+            endforeach()
+        endif()
 
         # "If /Zc:rvalueCast is specified, the compiler follows section 5.4 of the
         # C++11 standard". We need C++11 for the way we use threads.


### PR DESCRIPTION
Fixes #8814

## Motivation / Problem
During configuration, we force using static run-time library on windows. This is ok when using `x64-windows-static` or `x86-windows-static` triplets, but it causes crashes at run time with `x64-windows` triplet.
Also `x64-windows-static-md` triplet simply fails to link due to mismatched run-time library types.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Analyse `VCPKG_TARGET_TRIPLET` to determine if run-time type switching is needed.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Highly depends on vcpkg consistency in triplet values, but I see no other way with vcpkg variables available in cmake.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
