### PR TITLE
Feature: News/advice setting to warn if no depot order in vehicle schedule

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -872,6 +872,7 @@ STR_NEWS_VEHICLE_HAS_TOO_FEW_ORDERS                             :{WHITE}{VEHICLE
 STR_NEWS_VEHICLE_HAS_VOID_ORDER                                 :{WHITE}{VEHICLE} has a void order
 STR_NEWS_VEHICLE_HAS_DUPLICATE_ENTRY                            :{WHITE}{VEHICLE} has duplicate orders
 STR_NEWS_VEHICLE_HAS_INVALID_ENTRY                              :{WHITE}{VEHICLE} has an invalid station in its orders
+STR_NEWS_VEHICLE_NO_DEPOT_ORDER                                 :{WHITE}{VEHICLE} does not have a depot order in its schedule
 STR_NEWS_PLANE_USES_TOO_SHORT_RUNWAY                            :{WHITE}{VEHICLE} has in its orders an airport whose runway is too short
 
 STR_NEWS_VEHICLE_IS_GETTING_OLD                                 :{WHITE}{VEHICLE} is getting old
@@ -1410,6 +1411,9 @@ STR_CONFIG_SETTING_ORDER_REVIEW_HELPTEXT                        :When enabled, t
 STR_CONFIG_SETTING_ORDER_REVIEW_OFF                             :No
 STR_CONFIG_SETTING_ORDER_REVIEW_EXDEPOT                         :Yes, but exclude stopped vehicles
 STR_CONFIG_SETTING_ORDER_REVIEW_ON                              :Of all vehicles
+
+STR_CONFIG_SETTING_WARN_NO_DEPOT_ORDER                          :Warn if a vehicle does not have a depot order in its schedule: {STRING2}
+STR_CONFIG_SETTING_WARN_NO_DEPOT_ORDER_HELPTEXT                 :When enabled, and when breakdowns are also enabled, a news message gets sent when a train, road vehicle, or ship does not have a depot order in its schedule
 
 STR_CONFIG_SETTING_WARN_INCOME_LESS                             :Warn if a vehicle's income is negative: {STRING2}
 STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT                    :When enabled, a news message gets sent when a vehicle has not made any profit within a calendar year

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -671,6 +671,7 @@ static void DeleteOrderWarnings(const Vehicle *v)
 	DeleteVehicleNews(v->index, STR_NEWS_VEHICLE_HAS_VOID_ORDER);
 	DeleteVehicleNews(v->index, STR_NEWS_VEHICLE_HAS_DUPLICATE_ENTRY);
 	DeleteVehicleNews(v->index, STR_NEWS_VEHICLE_HAS_INVALID_ENTRY);
+	DeleteVehicleNews(v->index, STR_NEWS_VEHICLE_NO_DEPOT_ORDER);
 	DeleteVehicleNews(v->index, STR_NEWS_PLANE_USES_TOO_SHORT_RUNWAY);
 }
 
@@ -1745,6 +1746,11 @@ void CheckOrders(const Vehicle *v)
 #ifdef WITH_ASSERT
 		if (v->orders != nullptr) v->orders->DebugCheckSanity();
 #endif
+
+		/* If the vehicle is not an aircraft and breakdowns are enabled, check if it has a depot order. If not, check if we should send a warning. */
+		if (message == INVALID_STRING_ID && v->type != VEH_AIRCRAFT && _settings_client.gui.no_depot_order_warn && _settings_game.difficulty.vehicle_breakdowns != 0 && !v->HasDepotOrder()) {
+			message = STR_NEWS_VEHICLE_NO_DEPOT_ORDER;
+		}
 
 		/* We don't have a problem */
 		if (message == INVALID_STRING_ID) return;

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1655,6 +1655,7 @@ static SettingsContainer &GetSettingsTree()
 			advisors->Add(new SettingEntry("news_display.arrival_other"));
 			advisors->Add(new SettingEntry("news_display.advice"));
 			advisors->Add(new SettingEntry("gui.order_review_system"));
+			advisors->Add(new SettingEntry("gui.no_depot_order_warn"));
 			advisors->Add(new SettingEntry("gui.vehicle_income_warn"));
 			advisors->Add(new SettingEntry("gui.lost_vehicle_warn"));
 			advisors->Add(new SettingEntry("gui.show_finances"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -106,6 +106,7 @@ struct GUISettings {
 	bool   sg_full_load_any;                 ///< new full load calculation, any cargo must be full read from pre v93 savegames
 	bool   lost_vehicle_warn;                ///< if a vehicle can't find its destination, show a warning
 	uint8  order_review_system;              ///< perform order reviews on vehicles
+	bool   no_depot_order_warn;              ///< if a non-air vehicle doesn't have at least one depot order, show a warning
 	bool   vehicle_income_warn;              ///< if a vehicle isn't generating income, show a warning
 	bool   show_finances;                    ///< show finances at end of year
 	bool   sg_new_nonstop;                   ///< ttdpatch compatible nonstop handling read from pre v93 savegames

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -547,6 +547,13 @@ strval   = STR_CONFIG_SETTING_ORDER_REVIEW_OFF
 cat      = SC_BASIC
 
 [SDTC_BOOL]
+var      = gui.no_depot_order_warn
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = true
+str      = STR_CONFIG_SETTING_WARN_NO_DEPOT_ORDER
+strhelp  = STR_CONFIG_SETTING_WARN_NO_DEPOT_ORDER_HELPTEXT
+
+[SDTC_BOOL]
 var      = gui.lost_vehicle_warn
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true


### PR DESCRIPTION
## Motivation / Problem

One of the biggest frustrations players report with breakdowns is trains getting lost when they hit their automatic service interval and wander off to find a depot.

This is easily fixed by giving the train an explicit service order, which disables automatic servicing. But this is not obvious to players, who assume breakdowns are "broken" and disable them.

## Description

This is an upstreamed patch from @JGRennison, with some minor changes.

When breakdowns are enabled and a vehicle doesn't have a depot order in its schedule, a warning message is generated similar to when a vehicle's income is negative, it has duplicate orders, or it has incomplete orders. This nudges players toward explicitly giving depot orders, which will prevent their trains from getting lost trying to auto-service.

Aircraft are not included in these checks, because when they hit their service interval they continue their flight and service at their destination airport's hanger before heading to the terminal to load/unload. Explicit depot orders are not necessary. Helicopters are serviced when they land at the 1-tile skyscraper heliports and at oil rigs, even though these don't have hangers.

Obviously, this is not the only way to play with breakdowns. This warning message can be turned off in `Settings > News / Advisors`, like the other vehicle checks. It is enabled by default to aid new players, following the precedent we've set with #8463.

## Limitations

This feature is intentionally active only when breakdowns are enabled. However, when autoreplace* is used, vehicles needing replacement, which don't have a depot order, will still wander off to find a depot when they hit their automatic service interval. I think this is less of a problem and forcing this feature upon players who disable breakdowns might be frustrating. Thoughts?

*Autoreplace upgrades vehicles to another type, as opposed to autorenew which simply buys a new copy of the same vehicle.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
