### PR TITLE
Change: do not disable NewGRF window apply button if dev tools are enabled

### DIFF
--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1255,7 +1255,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 		this->BuildAvailables();
 
-		this->SetWidgetDisabledState(WID_NS_APPLY_CHANGES, !this->editable || !this->modified);
+		this->SetWidgetDisabledState(WID_NS_APPLY_CHANGES, !((this->editable && this->modified) || _settings_client.gui.newgrf_developer_tools));
 		this->SetWidgetsDisabledState(!this->editable,
 			WID_NS_PRESET_LIST,
 			WID_NS_TOGGLE_PALETTE,


### PR DESCRIPTION
## Motivation / Problem

A recent change (https://github.com/OpenTTD/OpenTTD/pull/8934) disables the 'Apply' button until changes are made in the NewGRF window with the intention of helping the user know if changes need to be applied, as well as preventing persisting changes after closing the window if no changes have been made.

However, it's been requested that NewGRF developers want the 'Apply' button enabled if newgrf_developer_tools are enabled for debugging and testing purposes. Since it's a flag that is manually changed from the config file, I think it's fair to make this change.

## Description

Do not disable NewGRF window apply button if dev tools are enabled.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
