### PR TITLE
Feature: build vehicle name filter

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -32,6 +32,7 @@
 #include "autoreplace_func.h"
 #include "querystring_gui.h"
 #include "stringfilter_type.h"
+#include "hotkeys.h"
 
 #include "widgets/build_vehicle_widget.h"
 
@@ -1041,6 +1042,11 @@ void DisplayVehicleSortDropDown(Window *w, VehicleType vehicle_type, int selecte
 	ShowDropDownMenu(w, _engine_sort_listing[vehicle_type], selected, button, 0, hidden_mask);
 }
 
+/** Enum referring to the Hotkeys in the build vehicle window */
+enum BuildVehicleHotkeys {
+	BVHK_FOCUS_FILTER_BOX, ///< Focus the edit box for editing the filter string
+};
+
 /** GUI for building vehicles. */
 struct BuildVehicleWindow : Window {
 	VehicleType vehicle_type;                   ///< Type of vehicles shown in the window.
@@ -1713,13 +1719,37 @@ struct BuildVehicleWindow : Window {
 			this->InvalidateData();
 		}
 	}
+
+	EventState OnHotkey(int hotkey) override
+	{
+		switch (hotkey) {
+			case BVHK_FOCUS_FILTER_BOX:
+				this->SetFocusedWidget(WID_BV_FILTER);
+				SetFocusedWindow(this); // The user has asked to give focus to the text box, so make sure this window is focused.
+				break;
+
+			default:
+				return ES_NOT_HANDLED;
+		}
+
+		return ES_HANDLED;
+	}
+
+	static HotkeyList hotkeys;
 };
+
+static Hotkey buildvehicle_hotkeys[] = {
+	Hotkey('F', "focus_filter_box", BVHK_FOCUS_FILTER_BOX),
+	HOTKEY_LIST_END
+};
+HotkeyList BuildVehicleWindow::hotkeys("buildvehicle", buildvehicle_hotkeys);
 
 static WindowDesc _build_vehicle_desc(
 	WDP_AUTO, "build_vehicle", 240, 268,
 	WC_BUILD_VEHICLE, WC_NONE,
 	WDF_CONSTRUCTION,
-	_nested_build_vehicle_widgets, lengthof(_nested_build_vehicle_widgets)
+	_nested_build_vehicle_widgets, lengthof(_nested_build_vehicle_widgets),
+	&BuildVehicleWindow::hotkeys
 );
 
 void ShowBuildVehicleWindow(TileIndex tile, VehicleType type)

--- a/src/widgets/build_vehicle_widget.h
+++ b/src/widgets/build_vehicle_widget.h
@@ -16,6 +16,7 @@ enum BuildVehicleWidgets {
 	WID_BV_SORT_ASCENDING_DESCENDING, ///< Sort direction.
 	WID_BV_SORT_DROPDOWN,             ///< Criteria of sorting dropdown.
 	WID_BV_CARGO_FILTER_DROPDOWN,     ///< Cargo filter dropdown.
+	WID_BV_FILTER,                    ///< Filter by name.
 	WID_BV_SHOW_HIDDEN_ENGINES,       ///< Toggle whether to display the hidden vehicles.
 	WID_BV_LIST,                      ///< List of vehicles.
 	WID_BV_SCROLLBAR,                 ///< Scrollbar of list.


### PR DESCRIPTION
## Motivation / Problem

As discussed in https://github.com/OpenTTD/OpenTTD/discussions/8723, users will benefit from having the option to filter the Build Vehicle list by typing a string. This would be especially useful when playing with NewGRF that include tons of vehicles.

## Description

This change adds a textbox to the Build Vehicle window so users can enter a keyword to find vehicles that match that keyboard. This works for all the types of vehicles and it's compatible with the existing filters.

This is what it looks like:

![image](https://user-images.githubusercontent.com/2025406/114251997-01b8eb80-9958-11eb-9b09-8a3f3f10c55c.png)

The text boxes do not immediately get focus to not break user's hotkeys.

## Limitations

Nope.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
