### PR TITLE
Fix: Missing 'Town names:' colon in map gen GUI

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -953,7 +953,7 @@ STR_GAME_OPTIONS_CURRENCY_MYR                                   :Malaysian Ringg
 STR_GAME_OPTIONS_ROAD_VEHICLES_DROPDOWN_LEFT                    :Drive on left
 STR_GAME_OPTIONS_ROAD_VEHICLES_DROPDOWN_RIGHT                   :Drive on right
 
-STR_GAME_OPTIONS_TOWN_NAMES_FRAME                               :{BLACK}Town names
+STR_GAME_OPTIONS_TOWN_NAMES_FRAME                               :{BLACK}Town names:
 STR_GAME_OPTIONS_TOWN_NAMES_DROPDOWN_TOOLTIP                    :{BLACK}Select style of town names
 
 ############ start of townname region


### PR DESCRIPTION
## Motivation / Problem

The map generation window has a missing colon after `Town names`.

![missing_colon](https://user-images.githubusercontent.com/55058389/114254380-ff1cbd00-997c-11eb-8129-77e3923e1eca.png)

## Description

I added the missing colon.

## Limitations

There was some discussion in #8566 about renaming the strings to reflect the fact that they are no longer in Options. This would become `STR_MAPGEN_TOWN_NAMES`. However, I assume this would break all existing translations. Thoughts?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
