### PR TITLE
Fix: [Win32] Font glyphs of certain widths broke

### DIFF
--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -498,7 +498,7 @@ void Win32FontCache::ClearFontCache()
 		 * For anti-aliased rendering, GDI uses the strange value range of 0 to 64,
 		 * inclusively. To map this to 0 to 255, we shift left by two and then
 		 * subtract one. */
-		uint pitch = Align(aa ? gm.gmBlackBoxX : std::max(gm.gmBlackBoxX / 8u, 1u), 4);
+		uint pitch = Align(aa ? gm.gmBlackBoxX : std::max((gm.gmBlackBoxX + 7u) / 8u, 1u), 4);
 
 		/* Draw shadow for medium size. */
 		if (this->fs == FS_NORMAL && !aa) {


### PR DESCRIPTION
## Motivation / Problem
Font glyphs between 33 and 39 pixels wide, in the Win32 font system, used wrong alignment and caused glyphs to appear broken.
When in the 33 to 39 pixel range, glyphs without AA were rounded down to 32 pixel pitch, instead of up to 64 pixel pitch.

Example with a 36 pixel wide glyph (the W):
![image](https://user-images.githubusercontent.com/1062071/114264990-86564900-99ee-11eb-8d70-13b588dd1f4d.png)
This is Georgia, size 18, with 2x font size in Options, AA disabled.


## Description
Fix by rounding up instead of down.


## Limitations
None expected.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
