### PR TITLE
Change: [DorpsGek] also announce Discussion creation/comments from GitHub

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -10,6 +10,7 @@ notifications:
     only-by:
     - DorpsGek
   commit-comment:
+  discussion:
   pull-request:
   issue:
   tag-created:


### PR DESCRIPTION
## Motivation / Problem

Bot supports it, but needs to be enabled per repo.

## Description

Finally we can see when someone opened a Discussion.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
