### PR TITLE
Fix: If a thread is blocking on UDP send, it can block the entire main loop

### DIFF
--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -646,7 +646,10 @@ void NetworkUDPClose()
 /** Receive the UDP packets. */
 void NetworkBackgroundUDPLoop()
 {
-	std::lock_guard<std::mutex> lock(_network_udp_mutex);
+	/* Try to take the lock, but do nothing if the mutex is locked by another thread.
+	 * Avoid blocking the entire main network loop over handling incoming UDP in a timely manner. */
+	if (!_network_udp_mutex.try_lock()) return;
+	std::lock_guard<std::mutex> lock(_network_udp_mutex, std::adopt_lock);
 
 	if (_network_udp_server) {
 		_udp_server_socket->ReceivePackets();


### PR DESCRIPTION
## Motivation / Problem
Under some rare configurations, UDP sends can block. Since we hold a mutex on some objects for this, it can cause blocking of the main loop which will eventually cause clients to drop.


## Description
For example, the advertise to master server thread takes the UDP lock and tries to send on a socket.
https://github.com/OpenTTD/OpenTTD/blob/39b7ef31f8754a7e9d535d3b061a2e167ccd1338/src/network/network_udp.cpp#L555-L565

If this send blocks, it will cause the main loop to block in an unexpected way.


## Limitations
This may cause some other UDP responses (prospective clients' info requests) to be delayed/lost, but probably preferable over lose active clients.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
