### PR TITLE
Change: Query for servers on opening multiplayer window

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -488,6 +488,10 @@ public:
 		this->servers.SetSortFuncs(this->sorter_funcs);
 		this->servers.SetFilterFuncs(this->filter_funcs);
 		this->servers.ForceRebuild();
+
+		/* To not confuse any players on why no servers are showing,
+		 * we query for servers on launch. */
+		NetworkUDPQueryMasterServer();
 	}
 
 	~NetworkGameWindow()


### PR DESCRIPTION
## Motivation / Problem
When a new user starts out with the game and wants to play some multiplayer it could confuse many on why no servers show up. I personally had this issue when starting out and I've seen people ask on the OpenTTD discord on why no servers are showing up. I think in general it simply only adds confusion and I personally don't know any other game that doesn't automatically search.
A few people have pointed out that as soon as one finds why no servers show up, it's just normal to click search.

## Description

This makes the game query the master server for all servers when opening the multiplayer window.

## Limitations

None, really? Only possibly that some people just want to join a LAN server that then gets lost in-between all other servers.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
    * ~~ai_changelog.hpp, gs_changelog.hpp need updating.~~
    * ~~The compatibility wrappers (compat_*.nut) need updating.~~
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
    * ~~newgrf_debug_data.h may need updating.~~
    * ~~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~~
