### PR TITLE
Feature: Reload NewGRF on SIGUSR1 signal

### DIFF
--- a/src/openttd.h
+++ b/src/openttd.h
@@ -82,5 +82,6 @@ void HandleExitGameRequest();
 void SwitchToMode(SwitchMode new_mode);
 
 void RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
+void RequestNewGRFReload();
 
 #endif /* OPENTTD_H */


### PR DESCRIPTION
## Motivation

Developing and tweaking NewGRFs can be quite tedious, especially the edit => build => reload cycle. I've improved on this somewhat by having a watcher on graphics, languages and NML files which rebuilds on changes, but I still have to switch to OpenTTD, enter the console and type the newgrf reload command. It would be awesome to avoid this last part in a way that allowed OpenTTD to stay open and not even require refocusing the window to see my changes.

## Description

This PR implements a `SIGUSR1` signal handler (open to changing this, `SIGHUP` or `SIGINFO` might be good alternatives), which calls the same `ReloadNewGRFData()` method that the console command calls, when receiving the signal. 

This enables NewGRF tooling (like my setup) to trigger the signal after a build.

## Limitations

As far as I know there's no equivalent signal handling for windows, so this is currently only available for unix-based systems.

I am totally unfamiliar with the OpenTTD codebase and a novice at C++, so I'm unsure if this is the best place to put the signal handling and if the approach is acceptable, but figured I'd give it a try.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
