### PR TITLE
Fix: Invalidate cached vehicle colourmaps when changing liveries setting.

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -63,6 +63,7 @@
 #include "roadveh.h"
 #include "fios.h"
 #include "strings_func.h"
+#include "vehicle_func.h"
 
 #include "void_map.h"
 #include "station_base.h"
@@ -1153,6 +1154,7 @@ static bool InvalidateNewGRFChangeWindows(int32 p1)
 static bool InvalidateCompanyLiveryWindow(int32 p1)
 {
 	InvalidateWindowClassesData(WC_COMPANY_COLOUR, -1);
+	ResetVehicleColourMap();
 	return RedrawScreen(p1);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Changing the liveries setting "Show vehicle-type specific liveries" does not have an immediately visible effect. 
The colour map for individual vehicles is cached, but changing the setting does not invalidate the cache.

## Description

This patch resolves this by calling the existing function to locally invalidate all cached vehicle colour maps.

## Limitations

Clearing cached colour maps should not have any other side effects. This information is not stored in save games.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
