### PR TITLE
Fix: Check for a validly mapped OpenGL screen buffer during driver init.

### DIFF
--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -69,6 +69,11 @@ const char *VideoDriver_SDL_OpenGL::Start(const StringList &param)
 	int w, h;
 	SDL_GetWindowSize(this->sdl_window, &w, &h);
 	this->ClientSizeChanged(w, h, true);
+	/* We should have a valid screen buffer now. If not, something went wrong and we should abort. */
+	if (_screen.dst_ptr == nullptr) {
+		this->Stop();
+		return "Can't get pointer to screen buffer";
+	}
 
 	SDL_GL_SetSwapInterval(GetDriverParamBool(param, "vsync") ? 1 : 0);
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1306,6 +1306,12 @@ const char *VideoDriver_Win32OpenGL::Start(const StringList &param)
 	}
 
 	this->ClientSizeChanged(this->width, this->height, true);
+	/* We should have a valid screen buffer now. If not, something went wrong and we should abort. */
+	if (_screen.dst_ptr == nullptr) {
+		this->Stop();
+		_cur_resolution = old_res;
+		return "Can't get pointer to screen buffer";
+	}
 
 	MarkWholeScreenDirty();
 


### PR DESCRIPTION
## Motivation / Problem

There's some unknown issue during bootstrap that causes a crash due to a an invalid screen pointer (see #8967 and #8969). The exact cause is unknown, but video driver init on SDL/Win32 doesn't check for a validly mapped buffer before suggesting success.


## Description

Check for valid mapping on Init, rejecting the OGL driver if not valid and falling back to the next driver.


## Limitations

If it is indeed the buffer mapping that fails, this would be a work-around. It is not fixing the real bug in this case though, as there's some underlying reason why the mapping fails.
If the issue is something else, this PR might simply not do anything.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
