### PR TITLE
Feature: make NewGRF active list react on key presses

### DIFF
--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -716,6 +716,21 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		}
 	}
 
+	/** Given a position it selects the corresponding item from the list of active NewGRFs */
+	void SelectActive(int position)
+	{
+		GRFConfig *c;
+		for (c = this->actives; c != nullptr && position > 0; c = c->next, position--) {}
+
+		if (this->active_sel != c) {
+			DeleteWindowByClass(WC_GRF_PARAMETERS);
+			DeleteWindowByClass(WC_TEXTFILE);
+		}
+		this->active_sel = c;
+		this->avail_sel = nullptr;
+		this->avail_pos = -1;
+	}
+
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
 	{
 		switch (widget) {
@@ -997,20 +1012,11 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			case WID_NS_FILE_LIST: { // Select an active GRF.
 				ResetObjectToPlace();
 
-				uint i = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_NS_FILE_LIST);
-
-				GRFConfig *c;
-				for (c = this->actives; c != nullptr && i > 0; c = c->next, i--) {}
-
-				if (this->active_sel != c) {
-					DeleteWindowByClass(WC_GRF_PARAMETERS);
-					DeleteWindowByClass(WC_TEXTFILE);
-				}
-				this->active_sel = c;
-				this->avail_sel = nullptr;
-				this->avail_pos = -1;
+				int pos = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_NS_FILE_LIST);
+				this->SelectActive(pos);
 
 				this->InvalidateData();
+
 				if (click_count == 1) {
 					if (this->editable && this->active_sel != nullptr) SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
 					break;
@@ -1314,10 +1320,29 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		this->SetWidgetDisabledState(WID_NS_PRESET_SAVE, has_missing);
 	}
 
-	EventState OnKeyPress(WChar key, uint16 keycode) override
+	EventState OnKeyPressForActiveList(uint16 keycode)
 	{
-		if (!this->editable) return ES_NOT_HANDLED;
+		/* Get total actives and index of current selection. */
+		int active_pos = 0;
+		int active_count = 0;
+		for (GRFConfig *c = this->actives; c != nullptr; c = c->next, active_count++) {}
+		for (GRFConfig *c = this->actives; c != nullptr && c != this->active_sel; c = c->next, active_pos++) {}
 
+		if (this->vscroll2->UpdateListPositionOnKeyPress(active_pos, keycode) == ES_NOT_HANDLED) return ES_NOT_HANDLED;
+
+		active_pos = std::min(active_pos, active_count);
+
+		if (this->actives != nullptr) {
+			this->SelectActive(active_pos);
+			this->vscroll->ScrollTowards(active_pos == active_count - 1 ? active_pos + 1 : active_pos);
+			this->InvalidateData(0);
+		}
+
+		return ES_HANDLED;
+	}
+
+	EventState OnKeyPressForAvailList(uint16 keycode)
+	{
 		if (this->vscroll2->UpdateListPositionOnKeyPress(this->avail_pos, keycode) == ES_NOT_HANDLED) return ES_NOT_HANDLED;
 
 		if (this->avail_pos >= 0) {
@@ -1330,6 +1355,17 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		}
 
 		return ES_HANDLED;
+	}
+
+	EventState OnKeyPress(WChar key, uint16 keycode) override
+	{
+		if (!this->editable) return ES_NOT_HANDLED;
+
+		if (this->IsWidgetFocused(WID_NS_FILE_LIST)) {
+			return OnKeyPressForActiveList(keycode);
+		} else {
+			return OnKeyPressForAvailList(keycode);
+		}
 	}
 
 	void OnEditboxChanged(int wid) override


### PR DESCRIPTION
## Motivation / Problem

Currently all key presses (up, down, home, end, page up, page down) in the NewGRF window are assumed to be used to move up or down the list of available NewGRFs. Even if the list of active NewGRFs has focus.

## Description

This code change lets the user move up and down the list of active NewGRFs using the keys mentioned above, same as with the available ones.

I've made sure that when reaching the last one the scrollbar goes one extra position down to keep having room for dragging stuff there.

Please make a deployment and give it a try.

## Limitations

Clicking somewhere else like in the background of the window makes the list lose focus so the next keystokes will be processed by the available list.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
