### PR TITLE
Cleanup: Fix comment for only one plural form

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -534,7 +534,7 @@ static int DeterminePluralForm(int64 count, int plural_form)
 
 		/* Only one form.
 		 * Used in:
-		 *   Hungarian, Japanese, Korean, Turkish */
+		 *   Hungarian, Japanese, Turkish */
 		case 1:
 			return 0;
 


### PR DESCRIPTION
## Motivation / Problem
Korean uses plural 11, not 1.

## Description
There is already plural form ``11`` for Korean, but there was an old remnant comment at the comment of plural form ``1``.
I just modified the comment :)

## Limitations
None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
