### PR TITLE
Fix: getaddrinfo/UDP blocking locks up whole game

### DIFF
--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -211,3 +211,10 @@ Last updated:    2011-02-16
      communication from an admin tool reach the programme. See section 1
      'Starting a server' further up for the ports and protocols used by OpenTTD.
      The ports can be configured in the config file.
+
+ - My advertising server warns a lot about getaddrinfo taking N seconds
+     This could be a transient issue with your (local) DNS server, but if the
+     problem persists there is likely a configuration issue in DNS resolving
+     on your computer. This seems to be a common configuration issue for
+     Docker instances, where the DNS resolving waits for a time out of usually
+     5 seconds.

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -74,18 +74,11 @@ uint32 _sync_seed_2;                  ///< Second part of the seed.
 #endif
 uint32 _sync_frame;                   ///< The frame to perform the sync check.
 bool _network_first_time;             ///< Whether we have finished joining or not.
-bool _network_udp_server;             ///< Is the UDP server started?
-uint16 _network_udp_broadcast;        ///< Timeout for the UDP broadcasts.
-uint8 _network_advertise_retries;     ///< The number of advertisement retries we did.
 CompanyMask _network_company_passworded; ///< Bitmask of the password status of all companies.
 
 /* Check whether NETWORK_NUM_LANDSCAPES is still in sync with NUM_LANDSCAPE */
 static_assert((int)NETWORK_NUM_LANDSCAPES == (int)NUM_LANDSCAPE);
 static_assert((int)NETWORK_COMPANY_NAME_LENGTH == MAX_LENGTH_COMPANY_NAME_CHARS * MAX_CHAR_LENGTH);
-
-extern NetworkUDPSocketHandler *_udp_client_socket; ///< udp client socket
-extern NetworkUDPSocketHandler *_udp_server_socket; ///< udp server socket
-extern NetworkUDPSocketHandler *_udp_master_socket; ///< udp master socket
 
 /** The amount of clients connected */
 byte _network_clients_connected = 0;
@@ -724,7 +717,7 @@ bool NetworkServerStart()
 
 	/* Try to start UDP-server */
 	DEBUG(net, 1, "starting listeners for incoming server queries");
-	_network_udp_server = _udp_server_socket->Listen();
+	NetworkUDPServerListen();
 
 	_network_company_states = CallocT<NetworkCompanyState>(MAX_COMPANIES);
 	_network_server = true;
@@ -1060,7 +1053,6 @@ void NetworkStartUp()
 	_network_available = NetworkCoreInitialize();
 	_network_dedicated = false;
 	_network_need_advertise = true;
-	_network_advertise_retries = 0;
 
 	/* Generate an server id when there is none yet */
 	if (StrEmpty(_settings_client.network.network_id)) NetworkGenerateServerId();

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -126,11 +126,6 @@ extern uint32 _network_join_bytes_total;
 
 extern uint8 _network_reconnect;
 
-extern bool _network_udp_server;
-extern uint16 _network_udp_broadcast;
-
-extern uint8 _network_advertise_retries;
-
 extern CompanyMask _network_company_passworded;
 
 void NetworkTCPQueryServer(NetworkAddress address);

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -47,6 +47,10 @@ NetworkUDPSocketHandler *_udp_client_socket = nullptr; ///< udp client socket
 NetworkUDPSocketHandler *_udp_server_socket = nullptr; ///< udp server socket
 NetworkUDPSocketHandler *_udp_master_socket = nullptr; ///< udp master socket
 
+static bool _network_udp_server;         ///< Is the UDP server started?
+static uint16 _network_udp_broadcast;    ///< Timeout for the UDP broadcasts.
+static uint8 _network_advertise_retries; ///< The number of advertisement retries we did.
+
 /**
  * Helper function doing the actual work for querying the server.
  * @param address The address of the server.
@@ -622,6 +626,13 @@ void NetworkUDPInitialize()
 
 	_network_udp_server = false;
 	_network_udp_broadcast = 0;
+	_network_advertise_retries = 0;
+}
+
+/** Start the listening of the UDP server component. */
+void NetworkUDPServerListen()
+{
+	_network_udp_server = _udp_server_socket->Listen();
 }
 
 /** Close all UDP related stuff. */

--- a/src/network/network_udp.h
+++ b/src/network/network_udp.h
@@ -19,6 +19,7 @@ void NetworkUDPQueryServer(NetworkAddress address, bool manually = false);
 void NetworkUDPAdvertise();
 void NetworkUDPRemoveAdvertise(bool blocking);
 void NetworkUDPClose();
+void NetworkUDPServerListen();
 void NetworkBackgroundUDPLoop();
 
 #endif /* NETWORK_UDP_H */


### PR DESCRIPTION
## Motivation / Problem

That getaddrinfo timing out/taking a long time for the advertising blocks the whole GameLoop. Consequently the server does not reply quickly enough to the master server for the advertising to sporadically fail, but more importantly other clients connected using UDP will be booted.

## Description

Firstly nielsm's solution (see #9001) is taken, but with some (significant) changes.
1. The locking is now done on a per-socket basis, so the server UDP processing can still happen while the master UDP processing is blocked
2. Some missed locks are added where applicable, and some code from network.cpp is moved to network_udp.cpp to accomplish that
3. Extra checking for a slow getaddrinfo is added, together with some hints in the troubleshooting so the user can solve the root cause of the problems.

Closes #9001 
Fixes #8878
## Limitations

Closing a server or unadvertising will still need to wait for the getaddrinfo resolving to complete, and actually it needs to wait until it has resolved for each socket it wants to send on. Similarly the unadvertise will still be blocky due to the same underlying getaddrinfo timeout.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
