### PR TITLE
Fix #9008: Validate starting year given on the command line.

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -455,7 +455,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		/* restore saved music volume */
 		MusicDriver::GetInstance()->SetVolume(_settings_client.music.music_vol);
 
-		if (startyear != INVALID_YEAR) _settings_newgame.game_creation.starting_year = startyear;
+		if (startyear != INVALID_YEAR) IConsoleSetSetting("game_creation.starting_year", startyear);
 		if (generation_seed != GENERATE_NEW_SEED) _settings_newgame.game_creation.generation_seed = generation_seed;
 
 		if (dedicated_host != nullptr) {


### PR DESCRIPTION
## Motivation / Problem
See #9008. The validation on settings should also apply on settings passed through the command line.

## Description
The issue is solved by using IConsoleSetSetting, which performs validation and clamping if required, instead of writing the variable directly.

## Limitations
It is now using a hard coded string, so any change to the setting name will not break the compilation of the code. It will break the -t command line functionality with an assertion even when the input value is valid, so it ought to be caught relatively quickly.

## Checklist for review
Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
