### PR TITLE
Fix #9015: Don't set free space value if not requested.

### DIFF
--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -247,7 +247,7 @@ bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
 
 	ULARGE_INTEGER bytes_free;
 	bool retval = GetDiskFreeSpaceEx(OTTD2FS(path).c_str(), &bytes_free, nullptr, nullptr);
-	if (retval) *tot = bytes_free.QuadPart;
+	if (retval && tot != nullptr) *tot = bytes_free.QuadPart;
 
 	SetErrorMode(sem); // reset previous setting
 	return retval;


### PR DESCRIPTION
## Motivation / Problem

As per #9015, entering the console command `pwd` on Windows causes a crash.

## Description

Test if the 'output' parameter for returning free disk space is set before writing to it.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
