### PR TITLE
Fix: Do not unlock railtypes when enabling wagons with GameScript

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -722,11 +722,9 @@ static void EnableEngineForCompany(EngineID eid, CompanyID company)
 
 	SetBit(e->company_avail, company);
 	if (e->type == VEH_TRAIN) {
-		assert(e->u.rail.railtype < RAILTYPE_END);
-		c->avail_railtypes = AddDateIntroducedRailTypes(c->avail_railtypes | GetRailTypeInfo(e->u.rail.railtype)->introduces_railtypes, _date);
+		c->avail_railtypes = GetCompanyRailtypes(c->index);
 	} else if (e->type == VEH_ROAD) {
-		assert(e->u.road.roadtype < ROADTYPE_END);
-		c->avail_roadtypes = AddDateIntroducedRoadTypes(c->avail_roadtypes | GetRoadTypeInfo(e->u.road.roadtype)->introduces_roadtypes, _date);
+		c->avail_roadtypes = GetCompanyRoadTypes(c->index);
 	}
 
 	if (company == _local_company) {


### PR DESCRIPTION
## Motivation / Problem

When enabling wagons with GS it also allowed their railtypes to be built which conflicted with how it's done in other places, including afterload so it led to desyncs (much like #8872).

## Steps to reproduce

1. Start a server with gamescript 
[monocar.zip](https://github.com/OpenTTD/OpenTTD/files/6292396/monocar.zip)
2. Connect a client to the same company
3. Build a monorail station on the server

## Description

Changes EnableEngineForCompany to use GetCompanyRailtypes/GetCompanyRoadTypes like everything else.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* **The bug fix is important enough to be backported? (label: 'backport requested')**
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
