### PR TITLE
Fix #8874: show a warning when a NewGRF scan is requested multiple times

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1351,7 +1351,9 @@ DEF_CONSOLE_CMD(ConRescanNewGRF)
 		return true;
 	}
 
-	RequestNewGRFScan();
+	if (!RequestNewGRFScan()) {
+		IConsoleWarning("NewGRF scanning is already running. Please wait until completed to run again.");
+	}
 
 	return true;
 }

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1450,11 +1450,15 @@ static void DoAutosave()
  * done in the game-thread, and not in the draw-thread (which most often
  * triggers this request).
  * @param callback Optional callback to call when NewGRF scan is completed.
+ * @return True when the NewGRF scan was actually requested, false when the scan was already running.
  */
-void RequestNewGRFScan(NewGRFScanCallback *callback)
+bool RequestNewGRFScan(NewGRFScanCallback *callback)
 {
+	if (_request_newgrf_scan) return false;
+
 	_request_newgrf_scan = true;
 	_request_newgrf_scan_callback = callback;
+	return true;
 }
 
 void GameLoop()

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -81,6 +81,6 @@ void HandleExitGameRequest();
 
 void SwitchToMode(SwitchMode new_mode);
 
-void RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
+bool RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
 
 #endif /* OPENTTD_H */


### PR DESCRIPTION
## Motivation / Problem

See #8874. Dumping many rescannewgrf commands onto the console will, in the old situation, drop many rescans without notifying the user.


## Description

Check whether a NewGRF scan is running before actually requesting a new one. The function to request the scan will return true when a scan was triggered and false when one was already running. In case one was already running, show a warning.


## Limitations

Really want to know? ;)
- the UI is blocked while rescanning, so the suggestion from Eddi-z cannot be done as either the scanning has not started and then there is no need to stop, or the scanning was already done and it will trigger a new scan.
- now the callback of the first rescan is passed on, instead of the callback of the last rescan request in that tick. This could be solved by making a list of callback, but comes with its own can of worms, and even then someone clicking in the UI and rescanning from the console in the same tick seems unlikely.
- there is a new message on the console that might mess with bots processing it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
