### PR TITLE
Fix: decisions being made on uninitialised memory in the SDL video driver

### DIFF
--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -17,7 +17,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL_Base : public VideoDriver {
 public:
-	VideoDriver_SDL_Base() : sdl_window(nullptr) {}
+	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false) {}
 
 	const char *Start(const StringList &param) override;
 

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -36,7 +36,7 @@ class VideoDriver : public Driver {
 	const uint DEFAULT_WINDOW_HEIGHT = 480u; ///< Default window height.
 
 public:
-	VideoDriver() : is_game_threaded(true), change_blitter(nullptr) {}
+	VideoDriver() : fast_forward_key_pressed(false), fast_forward_via_key(false), is_game_threaded(true), change_blitter(nullptr) {}
 
 	/**
 	 * Mark a particular area dirty.

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -17,7 +17,7 @@
 /** Base class for Windows video drivers. */
 class VideoDriver_Win32Base : public VideoDriver {
 public:
-	VideoDriver_Win32Base() : main_wnd(nullptr), fullscreen(false) {}
+	VideoDriver_Win32Base() : main_wnd(nullptr), fullscreen(false), buffer_locked(false) {}
 
 	void Stop() override;
 


### PR DESCRIPTION
## Motivation / Problem
Valgrind:
==27199== Conditional jump or move depends on uninitialised value(s)
==27199==    at 0x858DBD: VideoDriver::Tick() (video_driver.cpp:150)
==27199==    by 0x85605C: VideoDriver_SDL_Base::LoopOnce() (sdl2_v.cpp:642)
==27199==    by 0x85609C: VideoDriver_SDL_Base::MainLoop() (sdl2_v.cpp:660)
==27199==    by 0xA44F07: openttd_main(int, char**) (openttd.cpp:837)
==27199==    by 0x7A7BB7: main (unix.cpp:262)
==27199== 
==27199== Conditional jump or move depends on uninitialised value(s)
==27199==    at 0x85632F: VideoDriver_SDL_Base::LockVideoBuffer() (sdl2_v.cpp:721)
==27199==    by 0x858E17: VideoDriver::Tick() (video_driver.cpp:160)
==27199==    by 0x85605C: VideoDriver_SDL_Base::LoopOnce() (sdl2_v.cpp:642)
==27199==    by 0x85609C: VideoDriver_SDL_Base::MainLoop() (sdl2_v.cpp:660)
==27199==    by 0xA44F07: openttd_main(int, char**) (openttd.cpp:837)
==27199==    by 0x7A7BB7: main (unix.cpp:262)

## Description
The issue in VideoDriver::Tick might trigger fast forward if unlucky, since the fast forward booleans could be non-false due to the uninitialised memory. Especially fast_forward_key_pressed is tricky as that only gets set for _DEBUG builds.
The VideoDriver_SDL_Base::LockVideoBuffer might cause locking not to happen when it should, if initialised incorrectly.

## Limitations
None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
