### PR TITLE
Fix #9028: [OpenGL] Clear cursor cache on destroying the OpenGL backend.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -510,7 +510,7 @@ OpenGLBackend::~OpenGLBackend()
 		_glDeleteBuffers(1, &this->anim_pbo);
 	}
 	if (_glDeleteTextures != nullptr) {
-		ClearCursorCache();
+		this->InternalClearCursorCache();
 		OpenGLSprite::Destroy();
 
 		_glDeleteTextures(1, &this->vid_texture);
@@ -1082,12 +1082,7 @@ void OpenGLBackend::PopulateCursorCache()
 		this->clear_cursor_cache = false;
 		this->last_sprite_pal = (PaletteID)-1;
 
-		Sprite *sp;
-		while ((sp = this->cursor_cache.Pop()) != nullptr) {
-			OpenGLSprite *sprite = (OpenGLSprite *)sp->data;
-			sprite->~OpenGLSprite();
-			free(sp);
-		}
+		this->InternalClearCursorCache();
 	}
 
 	this->cursor_pos = _cursor.pos;
@@ -1112,6 +1107,19 @@ void OpenGLBackend::PopulateCursorCache()
 
 /**
  * Clear all cached cursor sprites.
+ */
+void OpenGLBackend::InternalClearCursorCache()
+{
+	Sprite *sp;
+	while ((sp = this->cursor_cache.Pop()) != nullptr) {
+		OpenGLSprite *sprite = (OpenGLSprite *)sp->data;
+		sprite->~OpenGLSprite();
+		free(sp);
+	}
+}
+
+/**
+ * Queue a request for cursor cache clear.
  */
 void OpenGLBackend::ClearCursorCache()
 {

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -77,6 +77,8 @@ private:
 	const char *Init();
 	bool InitShaders();
 
+	void InternalClearCursorCache();
+
 	void RenderOglSprite(OpenGLSprite *gl_sprite, PaletteID pal, int x, int y, ZoomLevel zoom);
 
 public:


### PR DESCRIPTION
## Motivation / Problem

Since [436cdf1](https://github.com/OpenTTD/OpenTTD/commit/436cdf1fc898097a8cbe6226ad32a4055a6ca4d9) destroying the OpenGL backend only requested a clear of the cursor cache but didn't actually perform.


## Description

Split the cache clear into an internal function so that it can be used on destruction without the request queue logic.


## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
