### PR TITLE
Fix: Add virtual destructor to link graph Path.

### DIFF
--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -367,6 +367,7 @@ public:
 	static Path *invalid_path;
 
 	Path(NodeID n, bool source = false);
+	virtual ~Path() = default;
 
 	/** Get the node this leg passes. */
 	inline NodeID GetNode() const { return this->node; }


### PR DESCRIPTION
## Motivation / Problem

Classes derived from Path were freed through base class pointer, but no virtual destructor was present.
```
==23279==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x604000029490 in thread T35 (ottd:linkgraph):
  object passed to delete has wrong type:
  size of the allocated type:   40 bytes;
  size of the deallocated type: 32 bytes.
    #0 0x7f6f6178acc9 in operator delete(void*, unsigned long) /home/milek7/gcc-git/src/gcc/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x55fa564c3e4c in MultiCommodityFlow::CleanupPaths(unsigned short, std::vector<Path*, std::allocator<Path*> >&) /home/milek7/ottd2/src/linkgraph/mcf.cpp:318
    #2 0x55fa564c69da in MCF2ndPass::MCF2ndPass(LinkGraphJob&) /home/milek7/ottd2/src/linkgraph/mcf.cpp:567
    #3 0x55fa564c3490 in MCFHandler<MCF2ndPass>::Run(LinkGraphJob&) const (/home/milek7/ottd2/build/openttd+0xaca7490)
    #4 0x55fa564bd53d in LinkGraphSchedule::Run(LinkGraphJob*) /home/milek7/ottd2/src/linkgraph/linkgraphschedule.cpp:90
    #5 0x55fa564af198 in StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}::operator()(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&) const (/home/milek7/ottd2/build/openttd+0xac93198)
    #6 0x55fa564bcc67 in void std::__invoke_impl<void, StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*>(std::__invoke_other, StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*&&, void (*&&)(LinkGraphJob*), LinkGraphJob*&&) /usr/include/c++/11.0.1/bits/invoke.h:61
    #7 0x55fa564bcb3f in _ZSt8__invokeIZ14StartNewThreadIPFvP12LinkGraphJobEJS2_EEbPSt6threadPKcOT_DpOT0_EUlS8_OS4_OS2_E_JS8_S4_S2_EENSt15__invoke_resultIS9_JDpSB_EE4typeESA_SD_ (/home/milek7/ottd2/build/openttd+0xaca0b3f)
    #8 0x55fa564bca36 in void std::thread::_Invoker<std::tuple<StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*> >::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) (/home/milek7/ottd2/build/openttd+0xaca0a36)
    #9 0x55fa564bc9b7 in std::thread::_Invoker<std::tuple<StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*> >::operator()() (/home/milek7/ottd2/build/openttd+0xaca09b7)
    #10 0x55fa564bc99b in std::thread::_State_impl<std::thread::_Invoker<std::tuple<StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*> > >::_M_run() (/home/milek7/ottd2/build/openttd+0xaca099b)
    #11 0x7f6f5ef994b3 in execute_native_thread_routine /home/milek7/gcc-git/src/gcc/libstdc++-v3/src/c++11/thread.cc:82
    #12 0x7f6f5f0fe298 in start_thread (/usr/lib/libpthread.so.0+0x9298)
    #13 0x7f6f5ec84052 in __GI___clone (/usr/lib/libc.so.6+0xff052)

0x604000029490 is located 0 bytes inside of 40-byte region [0x604000029490,0x6040000294b8)
allocated by thread T35 (ottd:linkgraph) here:
    #0 0x7f6f61789b69 in operator new(unsigned long) /home/milek7/gcc-git/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55fa564cb38b in void MultiCommodityFlow::Dijkstra<CapacityAnnotation, FlowEdgeIterator>(unsigned short, std::vector<Path*, std::allocator<Path*> >&) /home/milek7/ottd2/src/linkgraph/mcf.cpp:267
    #2 0x55fa564c66da in MCF2ndPass::MCF2ndPass(LinkGraphJob&) /home/milek7/ottd2/src/linkgraph/mcf.cpp:552
    #3 0x55fa564c3490 in MCFHandler<MCF2ndPass>::Run(LinkGraphJob&) const (/home/milek7/ottd2/build/openttd+0xaca7490)
    #4 0x55fa564bd53d in LinkGraphSchedule::Run(LinkGraphJob*) /home/milek7/ottd2/src/linkgraph/linkgraphschedule.cpp:90
    #5 0x55fa564af198 in StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}::operator()(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&) const (/home/milek7/ottd2/build/openttd+0xac93198)
    #6 0x55fa564bcc67 in void std::__invoke_impl<void, StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*>(std::__invoke_other, StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*&&, void (*&&)(LinkGraphJob*), LinkGraphJob*&&) /usr/include/c++/11.0.1/bits/invoke.h:61
    #7 0x55fa564bcb3f in _ZSt8__invokeIZ14StartNewThreadIPFvP12LinkGraphJobEJS2_EEbPSt6threadPKcOT_DpOT0_EUlS8_OS4_OS2_E_JS8_S4_S2_EENSt15__invoke_resultIS9_JDpSB_EE4typeESA_SD_ (/home/milek7/ottd2/build/openttd+0xaca0b3f)
    #8 0x55fa564bca36 in void std::thread::_Invoker<std::tuple<StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*> >::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) (/home/milek7/ottd2/build/openttd+0xaca0a36)
    #9 0x55fa564bc9b7 in std::thread::_Invoker<std::tuple<StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*> >::operator()() (/home/milek7/ottd2/build/openttd+0xaca09b7)
    #10 0x55fa564bc99b in std::thread::_State_impl<std::thread::_Invoker<std::tuple<StartNewThread<void (*)(LinkGraphJob*), LinkGraphJob*>(std::thread*, char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)::{lambda(char const*, void (*&&)(LinkGraphJob*), LinkGraphJob*&&)#1}, char const*, void (*)(LinkGraphJob*), LinkGraphJob*> > >::_M_run() (/home/milek7/ottd2/build/openttd+0xaca099b)
    #11 0x7f6f5ef994b3 in execute_native_thread_routine /home/milek7/gcc-git/src/gcc/libstdc++-v3/src/c++11/thread.cc:82
```

## Description

Add virtual destructor.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
