### PR TITLE
Add test framework and some basic unit tests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
 
-    - name: Build
+    - name: Build Game
       run: |
         mkdir build
         cd build
@@ -126,7 +126,7 @@ jobs:
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
 
-    - name: Build
+    - name: Build Game
       run: |
         mkdir build
         cd build
@@ -140,7 +140,7 @@ jobs:
         cmake --build . -j $(nproc)
         echo "::endgroup::"
 
-    - name: Test
+    - name: Regression Test
       run: |
         cd build
         ctest -j $(nproc)
@@ -183,6 +183,7 @@ jobs:
           libpng \
           lzo \
           zlib \
+          catch2 \
           # EOF
 
     - name: Install OpenGFX
@@ -203,7 +204,7 @@ jobs:
     - name: Install GCC problem matcher
       uses: ammaraskar/gcc-problem-matcher@master
 
-    - name: Build
+    - name: Build Game
       run: |
         mkdir build
         cd build
@@ -221,10 +222,41 @@ jobs:
         cmake --build . -j $(sysctl -n hw.logicalcpu)
         echo "::endgroup::"
 
-    - name: Test
+    - name: Regression Test
       run: |
         cd build
         ctest -j $(sysctl -n hw.logicalcpu)
+
+    - name: Build Unit Test
+      run: |
+        mkdir test
+        cd test
+
+        echo "::group::CMake"
+        cmake ${GITHUB_WORKSPACE} \
+          -DCMAKE_OSX_ARCHITECTURES=${{ matrix.full_arch }} \
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-osx \
+          -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake \
+          -DTEST=True \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        echo "Running on $(sysctl -n hw.logicalcpu) cores"
+        cmake --build . -j $(sysctl -n hw.logicalcpu)
+        echo "::endgroup::"
+
+    - name: Unit Test
+      run: |
+        cd test
+        ./openttd --reporter junit --out openttd_test_results.xml
+
+    - name: Upload Unit Test Results Artifact
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Unit Test Results Mac OS ${{ matrix.full_arch }}
+        path: test/openttd_test_results.xml
 
   windows:
     name: Windows
@@ -266,6 +298,7 @@ jobs:
           libpng \
           lzo \
           zlib \
+          catch2 \
           # EOF
 
     - name: Install OpenGFX
@@ -292,7 +325,7 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
 
-    - name: Build
+    - name: Build Game
       shell: bash
       run: |
         mkdir build
@@ -310,8 +343,40 @@ jobs:
         cmake --build .
         echo "::endgroup::"
 
-    - name: Test
+    - name: Regression Test
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}/build
         ctest
+
+    - name: Build Unit Test
+      shell: bash
+      run: |
+        mkdir test
+        cd test
+
+        echo "::group::CMake"
+        cmake .. \
+          -GNinja \
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static \
+          -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" \
+          -DTEST=True \
+          # EOF
+        echo "::endgroup::"
+
+        echo "::group::Build"
+        cmake --build .
+        echo "::endgroup::"
+
+    - name: Unit Test
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}/test
+        ./openttd --reporter junit --out openttd_test_results.xml
+
+    - name: Upload Test Results Artifact
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Unit Test Results ${{ matrix.os }} ${{ matrix.arch }}
+        path: test/openttd_test_results.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,12 @@ include_directories(${CMAKE_SOURCE_DIR}/src/3rdparty/squirrel/include)
 
 include(MSVCFilters)
 
-add_executable(openttd WIN32 ${GENERATED_SOURCE_FILES})
+if(NOT TEST)
+    add_executable(openttd WIN32 ${GENERATED_SOURCE_FILES})
+else()
+    add_executable(openttd ${GENERATED_SOURCE_FILES})
+endif()
+
 set_target_properties(openttd PROPERTIES OUTPUT_NAME "${BINARY_NAME}")
 # All other files are added via target_sources()
 

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -37,6 +37,10 @@ macro(compile_flags)
         "$<$<CONFIG:Debug>:-D_DEBUG>"
         "$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>" # FORTIFY_SOURCE should only be used in non-debug builds (requires -O1+)
     )
+    if(TEST)
+        add_compile_options("-DTEST")
+    endif()
+
     if(MINGW)
         add_link_options(
             "$<$<NOT:$<CONFIG:Debug>>:-fstack-protector>" # Prevent undefined references when _FORTIFY_SOURCE > 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,10 @@ add_subdirectory(table)
 add_subdirectory(video)
 add_subdirectory(widgets)
 
+if(TEST)
+    add_subdirectory(test)
+endif()
+
 add_files(
     viewport_sprite_sorter_sse4.cpp
     CONDITION SSE_FOUND

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -240,6 +240,7 @@ void CocoaSetupAutoreleasePool();
 void CocoaReleaseAutoreleasePool();
 #endif
 
+#ifndef TEST
 int CDECL main(int argc, char *argv[])
 {
 	/* Make sure our arguments contain only valid UTF-8 characters. */
@@ -267,6 +268,7 @@ int CDECL main(int argc, char *argv[])
 
 	return ret;
 }
+#endif
 
 #ifndef WITH_COCOA
 bool GetClipboardContents(char *buffer, const char *last)

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -402,6 +402,7 @@ void ShowInfo(const char *str)
 	}
 }
 
+#ifndef TEST
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
 	int argc;
@@ -439,6 +440,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	free(cmdline);
 	return 0;
 }
+#endif
 
 char *getcwd(char *buf, size_t size)
 {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_files(
+    openttd_test.cpp
+    test_math_func.cpp
+    test_packet.cpp
+)

--- a/src/test/openttd_test.cpp
+++ b/src/test/openttd_test.cpp
@@ -1,0 +1,9 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/src/test/test_math_func.cpp
+++ b/src/test/test_math_func.cpp
@@ -1,0 +1,74 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <catch2/catch.hpp>
+
+#include "../stdafx.h"
+
+#include "../core/math_func.hpp"
+
+TEST_CASE("LeastCommonMultipleTest - Zero")
+{
+	CHECK(0 == LeastCommonMultiple(0, 0));
+	CHECK(0 == LeastCommonMultiple(0, 600));
+	CHECK(0 == LeastCommonMultiple(600, 0));
+}
+
+TEST_CASE("LeastCommonMultipleTest - FindLCM")
+{
+	CHECK(25 == LeastCommonMultiple(5, 25));
+	CHECK(25 == LeastCommonMultiple(25, 5));
+	CHECK(130 == LeastCommonMultiple(5, 26));
+	CHECK(130 == LeastCommonMultiple(26, 5));
+}
+
+TEST_CASE("GreatestCommonDivisorTest - Negative")
+{
+	CHECK(4 == GreatestCommonDivisor(4, -52));
+	// CHECK(3 == GreatestCommonDivisor(-27, 6)); // error - returns -3
+}
+
+TEST_CASE("GreatestCommonDivisorTest - Zero")
+{
+	CHECK(27 == GreatestCommonDivisor(0, 27));
+	CHECK(27 == GreatestCommonDivisor(27, 0));
+}
+
+TEST_CASE("GreatestCommonDivisorTest - FindGCD")
+{
+	CHECK(5 == GreatestCommonDivisor(5, 25));
+	CHECK(5 == GreatestCommonDivisor(25, 5));
+	CHECK(1 == GreatestCommonDivisor(7, 27));
+	CHECK(1 == GreatestCommonDivisor(27, 7));
+}
+
+TEST_CASE("DivideApproxTest - Negative")
+{
+	CHECK(-2 == DivideApprox(-5, 2));
+	CHECK(2 == DivideApprox(-5, -2));
+	CHECK(-1 == DivideApprox(-66, 80));
+}
+
+TEST_CASE("DivideApproxTest, Divide")
+{
+	CHECK(2 == DivideApprox(5, 2));
+	CHECK(3 == DivideApprox(80, 30));
+	CHECK(3 == DivideApprox(8, 3));
+	CHECK(0 == DivideApprox(3, 8));
+}
+
+TEST_CASE("IntSqrtTest - Zero")
+{
+	CHECK(0 == IntSqrt(0));
+}
+
+TEST_CASE("IntSqrtTest - FindSqRt")
+{
+	CHECK(5 == IntSqrt(25));
+	CHECK(10 == IntSqrt(100));
+	CHECK(9 == IntSqrt(88));
+	CHECK(1696 == IntSqrt(2876278));
+}

--- a/src/test/test_packet.cpp
+++ b/src/test/test_packet.cpp
@@ -1,0 +1,115 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <catch2/catch.hpp>
+
+#include "../stdafx.h"
+
+#include "../network/core/packet.h"
+
+TEST_CASE("Packet")
+{
+	auto packet = Packet(42);
+
+	CHECK(packet.pos == 0);
+	CHECK(packet.size == 3);
+
+	auto* newData = packet.buffer + 1;
+	CHECK(*++newData == 42);
+
+	SECTION("Send_bool")
+	{
+		packet.Send_bool(true);
+		packet.Send_bool(false);
+
+		CHECK(packet.size == 5);
+		CHECK(*++newData == 1);
+		CHECK(*++newData == 0);
+	}
+
+	SECTION("Send_uint8")
+	{
+		packet.Send_uint8(0xCD);
+		packet.Send_uint8(0xEF);
+
+		CHECK(packet.size == 5);
+		CHECK(*++newData == 0xCD);
+		CHECK(*++newData == 0xEF);
+	}
+
+	SECTION("Send_uint16")
+	{
+		packet.Send_uint16(0x89AB);
+		packet.Send_uint16(0xCDEF);
+
+		CHECK(packet.size == 7);
+		CHECK(*++newData == 0xAB);
+		CHECK(*++newData == 0x89);
+		CHECK(*++newData == 0xEF);
+		CHECK(*++newData == 0xCD);
+	}
+
+	SECTION("Send_uint32")
+	{
+		packet.Send_uint32(0x89ABCDEF);
+
+		CHECK(packet.size == 7);
+		CHECK(*++newData == 0xEF);
+		CHECK(*++newData == 0xCD);
+		CHECK(*++newData == 0xAB);
+		CHECK(*++newData == 0x89);
+	}
+
+	SECTION("Send_uint64")
+	{
+		packet.Send_uint64(0x0123456789ABCDEF);
+
+		CHECK(packet.size == 11);
+		CHECK(*++newData == 0xEF);
+		CHECK(*++newData == 0xCD);
+		CHECK(*++newData == 0xAB);
+		CHECK(*++newData == 0x89);
+		CHECK(*++newData == 0x67);
+		CHECK(*++newData == 0x45);
+		CHECK(*++newData == 0x23);
+		CHECK(*++newData == 0x01);
+	}
+
+	SECTION("Send_string - empty")
+	{
+		packet.Send_string("");
+
+		CHECK(packet.size == 4);
+		CHECK(*++newData == '\0');
+	}
+
+	SECTION("Send_string")
+	{
+		packet.Send_string("openttd");
+
+		CHECK(packet.size == 11);
+		CHECK(*++newData == 'o');
+		CHECK(*++newData == 'p');
+		CHECK(*++newData == 'e');
+		CHECK(*++newData == 'n');
+		CHECK(*++newData == 't');
+		CHECK(*++newData == 't');
+		CHECK(*++newData == 'd');
+		CHECK(*++newData == '\0');
+	}
+
+	SECTION("Send_string - null character")
+	{
+		packet.Send_string("open\0ttd");
+
+		CHECK(packet.size == 8);
+		CHECK(*++newData == 'o');
+		CHECK(*++newData == 'p');
+		CHECK(*++newData == 'e');
+		CHECK(*++newData == 'n');
+		CHECK(*++newData == '\0');
+	}
+}

--- a/src/test/test_packet.cpp
+++ b/src/test/test_packet.cpp
@@ -91,13 +91,13 @@ TEST_CASE("Packet")
 		packet.Send_string("openttd");
 
 		CHECK(packet.size == 11);
-		CHECK(*++newData == 'o');
-		CHECK(*++newData == 'p');
-		CHECK(*++newData == 'e');
-		CHECK(*++newData == 'n');
-		CHECK(*++newData == 't');
-		CHECK(*++newData == 't');
-		CHECK(*++newData == 'd');
+		CHECK(*++newData == 0x6F);
+		CHECK(*++newData == 0x70);
+		CHECK(*++newData == 0x65);
+		CHECK(*++newData == 0x6E);
+		CHECK(*++newData == 0x74);
+		CHECK(*++newData == 0x74);
+		CHECK(*++newData == 0x64);
 		CHECK(*++newData == '\0');
 	}
 
@@ -106,10 +106,34 @@ TEST_CASE("Packet")
 		packet.Send_string("open\0ttd");
 
 		CHECK(packet.size == 8);
-		CHECK(*++newData == 'o');
-		CHECK(*++newData == 'p');
-		CHECK(*++newData == 'e');
-		CHECK(*++newData == 'n');
+		CHECK(*++newData == 0x6F);
+		CHECK(*++newData == 0x70);
+		CHECK(*++newData == 0x65);
+		CHECK(*++newData == 0x6E);
+		CHECK(*++newData == '\0');
+	}
+
+	SECTION("Send_string - emoji")
+	{
+		packet.Send_string("🚂🚌🚆🚗");
+
+		CHECK(packet.size == 20);
+		CHECK(*++newData == 0xF0); // locomotive
+		CHECK(*++newData == 0x9F);
+		CHECK(*++newData == 0x9A);
+		CHECK(*++newData == 0x82);
+		CHECK(*++newData == 0xF0); // bus
+		CHECK(*++newData == 0x9F);
+		CHECK(*++newData == 0x9A);
+		CHECK(*++newData == 0x8C);
+		CHECK(*++newData == 0xF0); // train
+		CHECK(*++newData == 0x9F);
+		CHECK(*++newData == 0x9A);
+		CHECK(*++newData == 0x86);
+		CHECK(*++newData == 0xF0); // automobile
+		CHECK(*++newData == 0x9F);
+		CHECK(*++newData == 0x9A);
+		CHECK(*++newData == 0x97);
 		CHECK(*++newData == '\0');
 	}
 }


### PR DESCRIPTION
## Motivation

Tests for new and existing code will make development & refactoring easier.
And will make it easier to detect regressions and unintended changes.

## Description

Added Catch2 header only test framework.
Math tests from #7796

## Limitations

Prototype implementation to get feedback

Catch2 doesn't seem to be available in the Ubuntu 20.04 package repository
CMake FetchContent could be used instead: https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md

My CMake knowledge is to limited and/or the OpenTTD CMake setup is to advanced for me to do a correct test target integration. The current solution with CMake arguments is not ideal.
Other options, in 'quality' order
1. create a openttd_lib which is used by openttd and openttd_test
has the advantage of a single compile for most of the sources
2. re-use the sources list for openttd in openttd_test
two compiles, but no manual action needed to keep in sync
3. specify the required source files for openttd_test separately
lots of dependencies make it hard to include all the required files, manual updates needed for new files
