### PR TITLE
Feature: ability to build overlapping bridges on different axes

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -56,6 +56,7 @@
       <tr><td style="width: 5em;"><tt>00</tt></td><td>no bridge</td></tr>
       <tr><td><tt>01</tt></td><td>Axis X (North-East)</td></tr>
       <tr><td><tt>02</tt></td><td>Axis Y (South-West)</td></tr>
+      <tr><td><tt>03</tt></td><td>Both Axis X and Y (overlapping)</td></tr>
      </table>
     <li>
      <a name="tropic_zone"></a>

--- a/src/bridge_map.cpp
+++ b/src/bridge_map.cpp
@@ -34,21 +34,29 @@ static TileIndex GetBridgeEnd(TileIndex tile, DiagDirection dir)
 
 /**
  * Finds the northern end of a bridge starting at a middle tile
- * @param t the bridge tile to find the bridge ramp for
+ * @param t    the bridge tile to find the bridge ramp for
+ * @param axis the axis to find the bridge ramp for
+ * @returns the tile where the bridge head is, or INVALID_TILE if it doesn't exist
  */
-TileIndex GetNorthernBridgeEnd(TileIndex t)
+TileIndex GetNorthernBridgeEndAtAxis(TileIndex t, Axis axis)
 {
-	return GetBridgeEnd(t, ReverseDiagDir(AxisToDiagDir(GetBridgeAxis(t))));
+	Axis bridge_axis = GetBridgeAxis(t);
+	if (bridge_axis != axis && bridge_axis != AXIS_END) return INVALID_TILE;
+	return GetBridgeEnd(t, ReverseDiagDir(AxisToDiagDir(axis)));
 }
 
 
 /**
  * Finds the southern end of a bridge starting at a middle tile
- * @param t the bridge tile to find the bridge ramp for
+ * @param t    the bridge tile to find the bridge ramp for
+ * @param axis the axis to find the bridge ramp for
+ * @returns the tile where the bridge head is, or INVALID_TILE if it doesn't exist
  */
-TileIndex GetSouthernBridgeEnd(TileIndex t)
+TileIndex GetSouthernBridgeEndAtAxis(TileIndex t, Axis axis)
 {
-	return GetBridgeEnd(t, AxisToDiagDir(GetBridgeAxis(t)));
+	Axis bridge_axis = GetBridgeAxis(t);
+	if (bridge_axis != axis && bridge_axis != AXIS_END) return INVALID_TILE;
+	return GetBridgeEnd(t, AxisToDiagDir(axis));
 }
 
 
@@ -60,6 +68,20 @@ TileIndex GetOtherBridgeEnd(TileIndex tile)
 {
 	assert(IsBridgeTile(tile));
 	return GetBridgeEnd(tile, GetTunnelBridgeDirection(tile));
+}
+
+
+/**
+ * Returns the height ('z') of the lowest bridge at a tile
+ * @param tile the tile at which the bridge(s) are
+ * @return the height of the lowest bridge.
+ */
+int GetLowestBridgeHeight(TileIndex tile) {
+	TileIndex north_head_x = GetNorthernBridgeEndAtAxis(tile, AXIS_X);
+	TileIndex north_head_y = GetNorthernBridgeEndAtAxis(tile, AXIS_Y);
+	if (north_head_x == INVALID_TILE) return GetBridgeHeight(north_head_y);
+	else if (north_head_y == INVALID_TILE) return GetBridgeHeight(north_head_x);
+	else return std::min(GetBridgeHeight(north_head_x), GetBridgeHeight(north_head_y));
 }
 
 /**

--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -71,11 +71,13 @@ static inline Axis GetBridgeAxis(TileIndex t)
 	return (Axis)(GB(_m[t].type, 2, 2) - 1);
 }
 
-TileIndex GetNorthernBridgeEnd(TileIndex t);
-TileIndex GetSouthernBridgeEnd(TileIndex t);
+TileIndex GetNorthernBridgeEndAtAxis(TileIndex t, Axis axis);
+TileIndex GetSouthernBridgeEndAtAxis(TileIndex t, Axis axis);
 TileIndex GetOtherBridgeEnd(TileIndex t);
 
+int GetLowestBridgeHeight(TileIndex tile);
 int GetBridgeHeight(TileIndex tile);
+
 /**
  * Get the height ('z') of a bridge in pixels.
  * @param tile the bridge ramp tile to get the bridge height from
@@ -84,6 +86,16 @@ int GetBridgeHeight(TileIndex tile);
 static inline int GetBridgePixelHeight(TileIndex tile)
 {
 	return GetBridgeHeight(tile) * TILE_HEIGHT;
+}
+
+/**
+ * Get the height ('z') of the lowest bridge in pixels.
+ * @param tile the tile at which the bridge(s) are
+ * @return the height of the bridge in pixels
+ */
+static inline int GetLowestBridgePixelHeight(TileIndex tile)
+{
+	return GetLowestBridgeHeight(tile) * TILE_HEIGHT;
 }
 
 /**

--- a/src/direction_type.h
+++ b/src/direction_type.h
@@ -123,7 +123,7 @@ DECLARE_POSTFIX_INCREMENT(DiagDirDiff)
 enum Axis {
 	AXIS_X = 0,          ///< The X axis
 	AXIS_Y = 1,          ///< The y axis
-	AXIS_END,            ///< Used for iterations
+	AXIS_END,            ///< Used for iterations and to represent both axis (in overlapping bridges)
 	INVALID_AXIS = 0xFF, ///< Flag for an invalid Axis
 };
 /** Helper information for extract tool. */

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -411,12 +411,24 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 		if ((PPPallowed[i] & PPPpreferred[i]) != 0) PPPallowed[i] &= PPPpreferred[i];
 
 		if (IsBridgeAbove(ti->tile)) {
-			Track bridgetrack = GetBridgeAxis(ti->tile) == AXIS_X ? TRACK_X : TRACK_Y;
-			int height = GetBridgeHeight(GetNorthernBridgeEnd(ti->tile));
+			if (GetBridgeAxis(ti->tile) == AXIS_X || GetBridgeAxis(ti->tile) == AXIS_END) {
+				/* Through the X axis */
+				int height = GetBridgeHeight(GetNorthernBridgeEndAtAxis(ti->tile, AXIS_X));
 
-			if ((height <= GetTileMaxZ(ti->tile) + 1) &&
-					(i == PCPpositions[bridgetrack][0] || i == PCPpositions[bridgetrack][1])) {
-				SetBit(OverridePCP, i);
+				if ((height <= GetTileMaxZ(ti->tile) + 1) &&
+					(i == PCPpositions[TRACK_X][0] || i == PCPpositions[TRACK_X][1])) {
+					SetBit(OverridePCP, i);
+				}
+			}
+
+			if (GetBridgeAxis(ti->tile) == AXIS_Y || GetBridgeAxis(ti->tile) == AXIS_END) {
+				/* Through the Y axis */
+				int height = GetBridgeHeight(GetNorthernBridgeEndAtAxis(ti->tile, AXIS_Y));
+
+				if ((height <= GetTileMaxZ(ti->tile) + 1) &&
+					(i == PCPpositions[TRACK_Y][0] || i == PCPpositions[TRACK_Y][1])) {
+					SetBit(OverridePCP, i);
+				}
 			}
 		}
 
@@ -450,8 +462,7 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 
 	/* Don't draw a wire under a low bridge */
 	if (IsBridgeAbove(ti->tile) && !IsTransparencySet(TO_BRIDGES)) {
-		int height = GetBridgeHeight(GetNorthernBridgeEnd(ti->tile));
-
+		int height = GetLowestBridgeHeight(ti->tile);
 		if (height <= GetTileMaxZ(ti->tile) + 1) return;
 	}
 
@@ -494,15 +505,16 @@ static void DrawRailCatenaryRailway(const TileInfo *ti)
 }
 
 /**
- * Draws wires on a tunnel tile
+ * Draws wires on a bridge tile
  *
  * DrawTile_TunnelBridge() calls this function to draw the wires on the bridge.
  *
- * @param ti The Tileinfo to draw the tile for
+ * @param ti                 the Tileinfo to draw the tile for
+ * @param bridge_height_diff the height diff between this bridge and the one above, or -1 if there is no bridge above
  */
-void DrawRailCatenaryOnBridge(const TileInfo *ti)
+void DrawRailCatenaryOnBridge(const TileInfo *ti, Axis axis, int bridge_height_diff)
 {
-	TileIndex end = GetSouthernBridgeEnd(ti->tile);
+	TileIndex end = GetSouthernBridgeEndAtAxis(ti->tile, axis);
 	TileIndex start = GetOtherBridgeEnd(end);
 
 	uint length = GetTunnelBridgeLength(start, end);
@@ -510,7 +522,6 @@ void DrawRailCatenaryOnBridge(const TileInfo *ti)
 	uint height;
 
 	const SortableSpriteStruct *sss;
-	Axis axis = GetBridgeAxis(ti->tile);
 	TLG tlg = GetTLG(ti->tile);
 
 	RailCatenarySprite offset = (RailCatenarySprite)(axis == AXIS_X ? 0 : WIRE_Y_FLAT_BOTH - WIRE_X_FLAT_BOTH);
@@ -528,10 +539,12 @@ void DrawRailCatenaryOnBridge(const TileInfo *ti)
 
 	SpriteID wire_base = GetWireBase(end, TCX_ON_BRIDGE);
 
-	AddSortableSpriteToDraw(wire_base + sss->image_offset, PAL_NONE, ti->x + sss->x_offset, ti->y + sss->y_offset,
-		sss->x_size, sss->y_size, sss->z_size, height + sss->z_offset,
-		IsTransparencySet(TO_CATENARY)
-	);
+	if (bridge_height_diff != 1) {
+		AddSortableSpriteToDraw(wire_base + sss->image_offset, PAL_NONE, ti->x + sss->x_offset, ti->y + sss->y_offset,
+			sss->x_size, sss->y_size, sss->z_size, height + sss->z_offset,
+			IsTransparencySet(TO_CATENARY)
+		);
+	}
 
 	SpriteID pylon_base = GetPylonBase(end, TCX_ON_BRIDGE);
 

--- a/src/elrail_func.h
+++ b/src/elrail_func.h
@@ -34,7 +34,7 @@ static inline bool HasRailCatenaryDrawn(RailType rt)
 
 void DrawRailCatenary(const TileInfo *ti);
 void DrawRailCatenaryOnTunnel(const TileInfo *ti);
-void DrawRailCatenaryOnBridge(const TileInfo *ti);
+void DrawRailCatenaryOnBridge(const TileInfo *ti, Axis axis, int bridge_height_diff);
 
 void SettingsDisableElrail(int32 new_value); ///< _settings_game.disable_elrail callback
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -300,7 +300,7 @@ CommandCost CmdBuildObject(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 	for (TileIndex t : ta) {
 		if (IsBridgeAbove(t) && (
 				!(spec->flags & OBJECT_FLAG_ALLOW_UNDER_BRIDGE) ||
-				(GetTileMaxZ(t) + spec->height >= GetBridgeHeight(GetSouthernBridgeEnd(t))))) {
+				(GetTileMaxZ(t) + spec->height >= GetLowestBridgeHeight(tile)))) {
 			return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
 		}
 	}

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1378,8 +1378,7 @@ void DrawRoadTypeCatenary(const TileInfo *ti, RoadType rt, RoadBits rb)
 {
 	/* Don't draw the catenary under a low bridge */
 	if (IsBridgeAbove(ti->tile) && !IsTransparencySet(TO_CATENARY)) {
-		int height = GetBridgeHeight(GetNorthernBridgeEnd(ti->tile));
-
+		int height = GetLowestBridgeHeight(ti->tile);
 		if (height <= GetTileMaxZ(ti->tile) + 1) return;
 	}
 
@@ -1640,7 +1639,7 @@ static void DrawRoadBits(TileInfo *ti)
 
 	/* Do not draw details (street lights, trees) under low bridge */
 	if (IsBridgeAbove(ti->tile) && (roadside == ROADSIDE_TREES || roadside == ROADSIDE_STREET_LIGHTS)) {
-		int height = GetBridgeHeight(GetNorthernBridgeEnd(ti->tile));
+		int height = GetLowestBridgeHeight(ti->tile);
 		int minz = GetTileMaxZ(ti->tile) + 2;
 
 		if (roadside == ROADSIDE_TREES) minz++;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1253,7 +1253,11 @@ bool AfterLoadGame()
 					case DIAGDIR_NW: if ((v->y_pos & 0xF) !=  0)            continue; break;
 				}
 			} else if (v->z_pos > GetSlopePixelZ(v->x_pos, v->y_pos)) {
-				v->tile = GetNorthernBridgeEnd(v->tile);
+				/* Before SLV_42 a tile could have a single bridge above it,
+				 * so only one of the two calls here would return a valid tile */
+				TileIndex tile_at_x = GetNorthernBridgeEndAtAxis(v->tile, AXIS_X);
+				TileIndex tile_at_y = GetNorthernBridgeEndAtAxis(v->tile, AXIS_Y);
+				v->tile = tile_at_x != INVALID_TILE ? tile_at_x : tile_at_y;
 				v->UpdatePosition();
 			} else {
 				continue;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -337,6 +337,7 @@ enum SaveLoadVersion : uint16 {
 
 	SLV_TABLE_CHUNKS,                       ///< 295  PR#9322 Introduction of CH_TABLE and CH_SPARSE_TABLE.
 	SLV_SCRIPT_INT64,                       ///< 296  PR#9415 SQInteger is 64bit but was saved as 32bit.
+	SLV_BRIDGES_OVER_BRIDGES,               ///< 297  PR#9043 Bridges over bridges.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -253,8 +253,8 @@ CommandCost CmdTerraformLand(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 
 			if (pass == 0) {
 				/* Check if bridge would take damage */
-				if (IsBridgeAbove(t)) {
-					int bridge_height = GetBridgeHeight(GetSouthernBridgeEnd(t));
+				if (IsBridgeAbove(tile)) {
+					int bridge_height = GetLowestBridgeHeight(tile);
 
 					/* Check if bridge would take damage. */
 					if (direction == 1 && bridge_height <= z_max) {

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -930,7 +930,7 @@ static bool IsRoadAllowedHere(Town *t, TileIndex tile, DiagDirection dir)
 	if (DistanceFromEdge(tile) == 0) return false;
 
 	/* Prevent towns from building roads under bridges along the bridge. Looks silly. */
-	if (IsBridgeAbove(tile) && GetBridgeAxis(tile) == DiagDirToAxis(dir)) return false;
+	if (IsBridgeAbove(tile) && (GetBridgeAxis(tile) == DiagDirToAxis(dir) || GetBridgeAxis(tile) == AXIS_END)) return false;
 
 	/* Check if there already is a road at this point? */
 	if (GetTownRoadBits(tile) == ROAD_NONE) {

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -437,11 +437,13 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 		const TileIndex heads[] = {tile_start, tile_end};
 		for (int i = 0; i < 2; i++) {
 			if (IsBridgeAbove(heads[i])) {
-				TileIndex north_head = GetNorthernBridgeEnd(heads[i]);
+				if (GetBridgeAxis(heads[i]) == direction || GetBridgeAxis(heads[i]) == AXIS_END) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
 
-				if (direction == GetBridgeAxis(heads[i])) return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
+				TileIndex north_head_x = GetNorthernBridgeEndAtAxis(heads[i], AXIS_X);
+				TileIndex north_head_y = GetNorthernBridgeEndAtAxis(heads[i], AXIS_Y);
 
-				if (z_start + 1 == GetBridgeHeight(north_head)) {
+				if ((north_head_x != INVALID_TILE && z_start + 1 == GetBridgeHeight(north_head_x))
+					|| (north_head_y != INVALID_TILE && z_start + 1 == GetBridgeHeight(north_head_y))) {
 					return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
 				}
 			}
@@ -462,8 +464,13 @@ CommandCost CmdBuildBridge(TileIndex end_tile, DoCommandFlag flags, uint32 p1, u
 			}
 
 			if (IsBridgeAbove(tile)) {
-				/* Disallow crossing bridges for the time being */
-				return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
+				TileIndex existing_bridge_head = GetNorthernBridgeEndAtAxis(tile, direction == AXIS_X ? AXIS_Y : AXIS_X);
+				int existing_bridge_z_start = GetBridgeHeight(existing_bridge_head);
+
+				if (z_start + 1 == existing_bridge_z_start) {
+					/* Disallow crossing bridges at same elevation */
+					return_cmd_error(STR_ERROR_MUST_DEMOLISH_BRIDGE_FIRST);
+				}
 			}
 
 			switch (GetTileType(tile)) {
@@ -1006,7 +1013,7 @@ static CommandCost DoClearBridge(TileIndex tile, DoCommandFlag flags)
 				int minz = GetTileMaxZ(c) + 3;
 				if (height < minz) SetRoadside(c, ROADSIDE_PAVED);
 			}
-			ClearBridgeMiddle(c);
+			ClearSingleBridgeMiddle(c, DiagDirToAxis(direction));
 			MarkTileDirtyByTile(c, height - TileHeight(c));
 		}
 
@@ -1089,8 +1096,9 @@ static int DrawPillarColumn(int z_bottom, int z_top, const PalSpriteID *psid, in
  * @param x Sprite X position of front pillar.
  * @param y Sprite Y position of front pillar.
  * @param z_bridge Absolute height of bridge bottom.
+ * @param bridge_height_diff the bridge height difference, positive if there is a bridge above, 0 if no bridge above.
  */
-static void DrawBridgePillars(const PalSpriteID *psid, const TileInfo *ti, Axis axis, bool drawfarpillar, int x, int y, int z_bridge)
+static void DrawBridgePillars(const PalSpriteID *psid, const TileInfo *ti, Axis axis, bool drawfarpillar, int x, int y, int z_bridge, int bridge_height_diff)
 {
 	static const int bounding_box_size[2]  = {16, 2}; ///< bounding box size of pillars along bridge direction
 	static const int back_pillar_offset[2] = { 0, 9}; ///< sprite position offset of back facing pillar
@@ -1260,7 +1268,7 @@ static void DrawBridgeRoadBits(TileIndex head_tile, int x, int y, int z, int off
 }
 
 /**
- * Draws a tunnel of bridge tile.
+ * Draws a tunnel or bridge tile.
  * For tunnels, this is rather simple, as you only need to draw the entrance.
  * Bridges are a bit more complex. base_offset is where the sprite selection comes into play
  * and it works a bit like a bitmask.<p> For bridge heads:
@@ -1288,7 +1296,7 @@ static void DrawTile_TunnelBridge(TileInfo *ti)
 		 */
 
 		static const int _tunnel_BB[4][12] = {
-			/*  tunnnel-roof  |  Z-separator  | tram-catenary
+			/*  tunnel-roof  |  Z-separator  | tram-catenary
 			 * w  h  bb_x bb_y| x   y   w   h |bb_x bb_y w h */
 			{  1,  0, -15, -14,  0, 15, 16,  1, 0, 1, 16, 15 }, // NE
 			{  0,  1, -14, -15, 15,  0,  1, 16, 1, 0, 15, 16 }, // SE
@@ -1533,11 +1541,72 @@ static BridgePieces CalcBridgePiece(uint north, uint south)
 	}
 }
 
+
+/** Bridge middle subsprite for overlapping bridges */
+static const int INF = 1000;
+static const SubSprite bridge_subsprite_per_height[8] = {
+	{ -INF, 1 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, 0 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, -1 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, -2 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, -3 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, -4 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, -5 * (int)TILE_HEIGHT, INF, INF },
+	{ -INF, -6 * (int)TILE_HEIGHT, INF, INF },
+};
+
 /**
- * Draw the middle bits of a bridge.
- * @param ti Tile information of the tile to draw it on.
+ * Draws the floor and the far part of bridge.
+ * @param psid the bridge sprite to be drawn
+ * @param a    the given axis
+ * @param x    the x position
+ * @param y    the y position
+ * @param z    the z position
+ * @param bridge_height_diff the bridge height difference, positive if there is a bridge above, 0 if no bridge above
+ * @param sub  the bridge middle subsprite, if needed
  */
-void DrawBridgeMiddle(const TileInfo *ti)
+void DrawBridgeFloor(const PalSpriteID* psid, Axis axis, int x, int y, int z, int bridge_height_diff, const SubSprite *sub)
+{
+	if (IsInvisibilitySet(TO_BRIDGES)) return;
+
+	/* If there are bridges above, extend the bounding box towards z no more than the bridge above */
+	int dz = bridge_height_diff > 0 ? (bridge_height_diff - 1) * TILE_HEIGHT - BRIDGE_Z_START : 0x28;
+	if (axis == AXIS_X) {
+		AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 16, 1, dz, z, IsTransparencySet(TO_BRIDGES), 0, 0, BRIDGE_Z_START, sub);
+	} else {
+		AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 1, 16, dz, z, IsTransparencySet(TO_BRIDGES), 0, 0, BRIDGE_Z_START, sub);
+	}
+}
+
+/**
+ * Draws the bridge roof, which is the component which is logically between the vehicle and the camera.
+ * @param psid the bridge sprite to be drawn
+ * @param a    the given axis
+ * @param x    the x position
+ * @param y    the y position
+ * @param z    the z position
+ * @param bridge_height_diff the bridge height difference, positive if there is a bridge above, 0 if no bridge above
+ * @param sub  the bridge middle subsprite, if needed
+ */
+void DrawBridgeRoof(const PalSpriteID *psid, Axis axis, int x, int y, int z, int bridge_height_diff, const SubSprite *sub)
+{
+	if (IsInvisibilitySet(TO_BRIDGES)) return;
+
+	/* If there are bridges above, extend the bounding box towards z no more than the bridge above */
+	int dz = bridge_height_diff > 0 ? (bridge_height_diff - 1) * TILE_HEIGHT - BRIDGE_Z_START : 0x28;
+	if (axis == AXIS_X) {
+		if (psid->sprite & SPRITE_MASK) AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 16, 4, dz, z, IsTransparencySet(TO_BRIDGES), 0, 3, BRIDGE_Z_START, sub);
+	} else {
+		if (psid->sprite & SPRITE_MASK) AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 4, 16, dz, z, IsTransparencySet(TO_BRIDGES), 3, 0, BRIDGE_Z_START, sub);
+	}
+}
+
+/**
+ * Draws the middle bits of a bridge that goes through the given axis.
+ * @param ti tile information of the tile to draw it on.
+ * @param a  the given axis
+ */
+void DrawBridgeMiddleAtAxis(const TileInfo *ti, Axis axis)
 {
 	/* Sectional view of bridge bounding boxes:
 	 *
@@ -1555,13 +1624,20 @@ void DrawBridgeMiddle(const TileInfo *ti)
 	 *
 	 */
 
-	if (!IsBridgeAbove(ti->tile)) return;
-
-	TileIndex rampnorth = GetNorthernBridgeEnd(ti->tile);
-	TileIndex rampsouth = GetSouthernBridgeEnd(ti->tile);
+	TileIndex rampnorth = GetNorthernBridgeEndAtAxis(ti->tile, axis);
+	TileIndex rampsouth = GetSouthernBridgeEndAtAxis(ti->tile, axis);
 	TransportType transport_type = GetTunnelBridgeTransportType(rampsouth);
 
-	Axis axis = GetBridgeAxis(ti->tile);
+	/* Check whether there is another bridge above this bridge tile */
+	TileIndex other_bridge_head = GetNorthernBridgeEndAtAxis(ti->tile, axis == AXIS_X ? AXIS_Y : AXIS_X);
+	int bridge_height_diff = other_bridge_head != INVALID_TILE ? GetBridgeHeight(other_bridge_head) - GetBridgeHeight(rampnorth) : 0;
+
+	const SubSprite *sub = nullptr;
+	if (bridge_height_diff > 0) {
+		/* Pick the appropiated subsprite for the given height difference */
+		sub = &bridge_subsprite_per_height[std::min(bridge_height_diff, (int)lengthof(bridge_subsprite_per_height) - 1)];
+	}
+
 	BridgePieces piece = CalcBridgePiece(
 		GetTunnelBridgeLength(ti->tile, rampnorth) + 1,
 		GetTunnelBridgeLength(ti->tile, rampsouth) + 1
@@ -1570,7 +1646,7 @@ void DrawBridgeMiddle(const TileInfo *ti)
 	const PalSpriteID *psid;
 	bool drawfarpillar;
 	if (transport_type != TRANSPORT_WATER) {
-		BridgeType type =  GetBridgeType(rampsouth);
+		BridgeType type = GetBridgeType(rampsouth);
 		drawfarpillar = !HasBit(GetBridgeSpec(type)->flags, 0);
 
 		uint base_offset;
@@ -1599,14 +1675,8 @@ void DrawBridgeMiddle(const TileInfo *ti)
 	/* Draw Trambits as SpriteCombine */
 	if (transport_type == TRANSPORT_ROAD || transport_type == TRANSPORT_RAIL) StartSpriteCombine();
 
-	/* Draw floor and far part of bridge*/
-	if (!IsInvisibilitySet(TO_BRIDGES)) {
-		if (axis == AXIS_X) {
-			AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 16, 1, 0x28, z, IsTransparencySet(TO_BRIDGES), 0, 0, BRIDGE_Z_START);
-		} else {
-			AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 1, 16, 0x28, z, IsTransparencySet(TO_BRIDGES), 0, 0, BRIDGE_Z_START);
-		}
-	}
+	/* Draw floor and far part of bridge */
+	DrawBridgeFloor(psid, axis, x, y, z, bridge_height_diff, sub);
 
 	psid++;
 
@@ -1634,20 +1704,18 @@ void DrawBridgeMiddle(const TileInfo *ti)
 		EndSpriteCombine();
 
 		if (HasRailCatenaryDrawn(GetRailType(rampsouth))) {
-			DrawRailCatenaryOnBridge(ti);
+			DrawRailCatenaryOnBridge(ti, axis, bridge_height_diff);
 		}
 	}
 
-	/* draw roof, the component of the bridge which is logically between the vehicle and the camera */
-	if (!IsInvisibilitySet(TO_BRIDGES)) {
-		if (axis == AXIS_X) {
-			y += 12;
-			if (psid->sprite & SPRITE_MASK) AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 16, 4, 0x28, z, IsTransparencySet(TO_BRIDGES), 0, 3, BRIDGE_Z_START);
-		} else {
-			x += 12;
-			if (psid->sprite & SPRITE_MASK) AddSortableSpriteToDraw(psid->sprite, psid->pal, x, y, 4, 16, 0x28, z, IsTransparencySet(TO_BRIDGES), 3, 0, BRIDGE_Z_START);
-		}
+	if (axis == AXIS_X) {
+		y += 12;
+	} else {
+		x += 12;
 	}
+
+	/* draw roof, the component of the bridge which is logically between the vehicle and the camera */
+	DrawBridgeRoof(psid, axis, x, y, z, bridge_height_diff, sub);
 
 	/* Draw TramFront as SpriteCombine */
 	if (transport_type == TRANSPORT_ROAD) EndSpriteCombine();
@@ -1656,7 +1724,23 @@ void DrawBridgeMiddle(const TileInfo *ti)
 	if (IsInvisibilitySet(TO_BRIDGES)) return;
 
 	psid++;
-	DrawBridgePillars(psid, ti, axis, drawfarpillar, x, y, z);
+	DrawBridgePillars(psid, ti, axis, drawfarpillar, x, y, z, bridge_height_diff);
+}
+
+/**
+ * Draw the middle bits of a bridge.
+ * @param ti Tile information of the tile to draw it on.
+ */
+void DrawBridgeMiddle(const TileInfo *ti)
+{
+	if (!IsBridgeAbove(ti->tile)) return;
+
+	TileIndex rampnorth_x = GetNorthernBridgeEndAtAxis(ti->tile, AXIS_X);
+	TileIndex rampnorth_y = GetNorthernBridgeEndAtAxis(ti->tile, AXIS_Y);
+
+	/* There is a single bridge to draw */
+	if (rampnorth_x != INVALID_TILE) DrawBridgeMiddleAtAxis(ti, AXIS_X);
+	if (rampnorth_y != INVALID_TILE) DrawBridgeMiddleAtAxis(ti, AXIS_Y);
 }
 
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1252,8 +1252,7 @@ static void ViewportAddLandscape()
 
 				if (IsBridgeAbove(tile_info.tile)) {
 					/* Is the bridge visible? */
-					TileIndex bridge_tile = GetNorthernBridgeEnd(tile_info.tile);
-					int bridge_height = ZOOM_LVL_BASE * (GetBridgePixelHeight(bridge_tile) - TilePixelHeight(tile_info.tile));
+					int bridge_height = ZOOM_LVL_BASE * (GetLowestBridgePixelHeight(tile_info.tile) - TilePixelHeight(tile_info.tile));
 					if (min_visible_height < bridge_height + MAX_TILE_EXTENT_TOP) tile_visible = true;
 				}
 


### PR DESCRIPTION
## Motivation / Problem

OpenTTD doesn't support building a bridge that crosses another bridge perpendicularly.

## Description

This change introduces the ability to build bridges on top of other bridges in the opposite axis.

![image](https://user-images.githubusercontent.com/2025406/116646456-f2143d80-a92c-11eb-8110-cb9c929ea08d.png)

This are the major changes made as part of this PR:
* `GetNorthernBridgeEnd` removed, replaced by `GetNorthernBridgeEndAtAxis`, which require the axis to be passed
* `GetSouthernBridgeEnd` removed, replaced by `GetSouthernBridgeEndAtAxis`, which require the axis to be passed
* `GetBridgeAxis  can now return more than AXIS_X or AXIS_Y, so made sure all callers handle that
* Took care of all callers of the functions above to work properly in all scenarios
* Implemented some helper functions, for instance one that gets the lowest height of a bridge within a tile in case it has two bridges, used for drawing stuff mainly
* Made sure bridges cannot cross other ones at the same z!
* Tested as many terraform actions as I could to verify nothing is broken
* Tested as many combinations of bridge over bridges as I could to make sure it functions well
* Used `SubSprite` to clip the bottom bridge middles properly

## Limitations

This change doesn't implement the ability of stacking bridges on the same axis as demanded here: https://github.com/JGRennison/OpenTTD-patches/issues/245.

However, here are my findings to do so.

Today, the type byte within the `Tile` struct has 2 bits reserved for tunnelbridge information, bits 2 and 3, one for each axis (X and Y). For that reason, there is no straightforward way of implementing the ability of stacking bridges on the same axis. The way OpenTTD knows where the tunnelbridge heads are based on a given bridge tile is by iterating through the axis until it hits the head (see `GetNorthernBridgeEndAtAxis(`)). A tunnelbridge head is defined as a tile of a given type. Tile type is stored in bits 4 to 7, that is there are up to 16 tile types, one of them being `MP_TUNNELBRIDGE`.

With that being said, there is no current way of stacking bridges on the same axis without either using more of the bits from `Tile` or from `TileExtended`. For that reason, I'd rather get this PR in first, and eventually work on stacking bridges, which would require a good amount of work. I don't even know where the documentation for `TileExtended` is and what those bits mean.

This is the approach I'd go with to get this one:

I'd pick a max number of stacked bridges, let's say 2 per axis, so a total of 4.
I'd pick spare bits from `TileExtended` enough to be able to represent the number of stacked bridges.
The current bits within `Tile`'s type would be used to determine whether there is or there is not a tunnelbridge on a given tile and axis, as it's done now.
The new bit from `TileExtended` for instance would be used to describe whether there is one bridge on that axis (bit set to 0) or two (bit set to 1). Viola, one single bit to get this done. Less than I expected.
But hold on, we still need to draw everything right, just like the problems we have in this PR.
To find the bridge heads it would be easy, the new bit will tell us if we have to iterate until we find one bridge head or a second one too.

I have a pending commit to achieve so, still WIP, that will be published as a draft once this one gets in.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
