### PR TITLE
Fix: Corrupted savegame could crash the game by providing invalid gamelog enums.

### DIFF
--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -107,8 +107,11 @@ static void Load_GLOG_common(LoggedAction *&gamelog_action, uint &gamelog_action
 	assert(gamelog_action == nullptr);
 	assert(gamelog_actions == 0);
 
-	GamelogActionType at;
-	while ((at = (GamelogActionType)SlReadByte()) != GLAT_NONE) {
+	byte type;
+	while ((type = SlReadByte()) != GLAT_NONE) {
+		if (type >= GLAT_END) SlErrorCorrupt("Invalid gamelog action type");
+		GamelogActionType at = (GamelogActionType)type;
+
 		gamelog_action = ReallocT(gamelog_action, gamelog_actions + 1);
 		LoggedAction *la = &gamelog_action[gamelog_actions++];
 
@@ -118,16 +121,16 @@ static void Load_GLOG_common(LoggedAction *&gamelog_action, uint &gamelog_action
 		la->change = nullptr;
 		la->changes = 0;
 
-		GamelogChangeType ct;
-		while ((ct = (GamelogChangeType)SlReadByte()) != GLCT_NONE) {
+		while ((type = SlReadByte()) != GLCT_NONE) {
+			if (type >= GLCT_END) SlErrorCorrupt("Invalid gamelog change type");
+			GamelogChangeType ct = (GamelogChangeType)type;
+
 			la->change = ReallocT(la->change, la->changes + 1);
 
 			LoggedChange *lc = &la->change[la->changes++];
 			/* for SLE_STR, pointer has to be valid! so make it nullptr */
 			memset(lc, 0, sizeof(*lc));
 			lc->ct = ct;
-
-			assert((uint)ct < GLCT_END);
 
 			SlObject(lc, _glog_desc[ct]);
 		}


### PR DESCRIPTION
## Motivation / Problem

Corrupted savegame could crash the game by providing invalid gamelog enums. (`ct` is used as index to saveload description struct array, which potentially could be used to point to SaveLoad description of bigger size and subsequent heap overflow)

## Description

Check if enums have valid values.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
