### PR TITLE
Fix: Corrupted savegame could cause heap corruption by writing outside link graph edge matrix.

### DIFF
--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -151,6 +151,7 @@ void SaveLoad_LinkGraph(LinkGraph &lg)
 		} else {
 			/* ... but as that wasted a lot of space we save a sparse matrix now. */
 			for (NodeID to = from; to != INVALID_NODE; to = lg.edges[from][to].next_edge) {
+				if (to >= size) SlErrorCorrupt("Link graph structure overflow");
 				SlObject(&lg.edges[from][to], _edge_desc);
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

Corrupted savegame could cause heap corruption by writing outside link graph edge matrix.

## Description

Check for valid array index.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
