### PR TITLE
Fix #6322: Attempt to crash the script instead of the whole game

### DIFF
--- a/src/script/script_fatalerror.hpp
+++ b/src/script/script_fatalerror.hpp
@@ -19,7 +19,7 @@ public:
 	 * Creates a "fatal error" exception.
 	 * @param msg The message describing the cause of the fatal error.
 	 */
-	Script_FatalError(const char *msg) :
+	Script_FatalError(const std::string &msg) :
 		msg(msg)
 	{}
 
@@ -27,10 +27,10 @@ public:
 	 * The error message associated with the fatal error.
 	 * @return The error message.
 	 */
-	const char *GetErrorMessage() { return msg; }
+	const std::string &GetErrorMessage() const { return msg; }
 
 private:
-	const char *msg; ///< The error message.
+	const std::string msg; ///< The error message.
 };
 
 #endif /* SCRIPT_FATALERROR_HPP */

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -100,7 +100,7 @@ void ScriptInstance::Initialize(const char *main_script, const char *instance_na
 		ScriptObject::SetAllowDoCommand(true);
 	} catch (Script_FatalError &e) {
 		this->is_dead = true;
-		this->engine->ThrowError(e.GetErrorMessage());
+		this->engine->ThrowError(e.GetErrorMessage().c_str());
 		this->engine->ResumeError();
 		this->Died();
 	}
@@ -228,7 +228,7 @@ void ScriptInstance::GameLoop()
 			this->callback = e.GetSuspendCallback();
 		} catch (Script_FatalError &e) {
 			this->is_dead = true;
-			this->engine->ThrowError(e.GetErrorMessage());
+			this->engine->ThrowError(e.GetErrorMessage().c_str());
 			this->engine->ResumeError();
 			this->Died();
 		}
@@ -249,7 +249,7 @@ void ScriptInstance::GameLoop()
 		this->callback = e.GetSuspendCallback();
 	} catch (Script_FatalError &e) {
 		this->is_dead = true;
-		this->engine->ThrowError(e.GetErrorMessage());
+		this->engine->ThrowError(e.GetErrorMessage().c_str());
 		this->engine->ResumeError();
 		this->Died();
 	}
@@ -505,7 +505,7 @@ void ScriptInstance::Save()
 			/* If we don't mark the script as dead here cleaning up the squirrel
 			 * stack could throw Script_FatalError again. */
 			this->is_dead = true;
-			this->engine->ThrowError(e.GetErrorMessage());
+			this->engine->ThrowError(e.GetErrorMessage().c_str());
 			this->engine->ResumeError();
 			SaveEmpty();
 			/* We can't kill the script here, so mark it as crashed (not dead) and

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -38,7 +38,7 @@ bool ScriptScanner::AddFile(const std::string &filename, size_t basepath_length,
 	try {
 		this->engine->LoadScript(filename.c_str());
 	} catch (Script_FatalError &e) {
-		DEBUG(script, 0, "Fatal error '%s' when trying to load the script '%s'.", e.GetErrorMessage(), filename.c_str());
+		DEBUG(script, 0, "Fatal error '%s' when trying to load the script '%s'.", e.GetErrorMessage().c_str(), filename.c_str());
 		return false;
 	}
 	return true;

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -21,7 +21,13 @@
 #include <../squirrel/sqvm.h>
 #include "../core/alloc_func.hpp"
 
-#include "../safeguards.h"
+/**
+ * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS
+ * does not have enough memory the game does not go into unrecoverable error mode and kill the
+ * whole game, but rather let the AI die though then we need to circumvent MallocT/ReallocT.
+ *
+ * So no #include "../safeguards.h" here as is required, but after the allocator's implementation.
+ */
 
 /*
  * If changing the call paths into the scripting engine, define this symbol to enable full debugging of allocations.
@@ -32,6 +38,13 @@
 struct ScriptAllocator {
 	size_t allocated_size;   ///< Sum of allocated data size
 	size_t allocation_limit; ///< Maximum this allocator may use before allocations fail
+	/**
+	 * Whether the error has already been thrown, so to not throw secondary errors in
+	 * the handling of the allocation error. This as the handling of the error will
+	 * throw a Squirrel error so the Squirrel stack can be dumped, however that gets
+	 * allocated by this allocator and then you might end up in an infinite loop.
+	 */
+	bool error_thrown;
 
 	static const size_t SAFE_LIMIT = 0x8000000; ///< 128 MiB, a safe choice for almost any situation
 
@@ -44,10 +57,51 @@ struct ScriptAllocator {
 		if (this->allocated_size > this->allocation_limit) throw Script_FatalError("Maximum memory allocation exceeded");
 	}
 
+	/**
+	 * Catch all validation for the allocation; did it allocate too much memory according
+	 * to the allocation limit or did the allocation at the OS level maybe fail? In those
+	 * error situations a Script_FatalError is thrown, but once that has been done further
+	 * allocations are allowed to make it possible for Squirrel to throw the error and
+	 * clean everything up.
+	 * @param requested_size The requested size that was requested to be allocated.
+	 * @param p              The pointer to the allocated object, or null if allocation failed.
+	 */
+	void CheckAllocation(size_t requested_size, const void *p)
+	{
+		if (this->allocated_size > this->allocation_limit && !this->error_thrown) {
+			/* Do not allow allocating more than the allocation limit, except when an error is
+			 * already as then the allocation is for throwing that error in Squirrel, the
+			 * associated stack trace information and while cleaning up the AI. */
+			this->error_thrown = true;
+			char buff[128];
+			seprintf(buff, lastof(buff), "Maximum memory allocation exceeded by " PRINTF_SIZE " bytes when allocating " PRINTF_SIZE " bytes",
+				this->allocated_size - this->allocation_limit, requested_size);
+			throw Script_FatalError(buff);
+		}
+
+		if (p == nullptr) {
+			/* The OS did not have enough memory to allocate the object, regardless of the
+			 * limit imposed by OpenTTD on the amount of memory that may be allocated. */
+			if (this->error_thrown) {
+				/* The allocation is called in the error handling of a memory allocation
+				 * failure, then not being able to allocate that small amount of memory
+				 * means there is no other choice than to bug out completely. */
+				MallocError(requested_size);
+			}
+
+			this->error_thrown = true;
+			char buff[64];
+			seprintf(buff, lastof(buff), "Out of memory. Cannot allocate " PRINTF_SIZE " bytes", requested_size);
+			throw Script_FatalError(buff);
+		}
+	}
+
 	void *Malloc(SQUnsignedInteger size)
 	{
-		void *p = MallocT<char>(size);
+		void *p = malloc(size);
 		this->allocated_size += size;
+
+		this->CheckAllocation(size, p);
 
 #ifdef SCRIPT_DEBUG_ALLOCATIONS
 		assert(p != nullptr);
@@ -73,10 +127,12 @@ struct ScriptAllocator {
 		this->allocations.erase(p);
 #endif
 
-		void *new_p = ReallocT<char>(static_cast<char *>(p), size);
+		void *new_p = realloc(p, size);
 
 		this->allocated_size -= oldsize;
 		this->allocated_size += size;
+
+		this->CheckAllocation(size, p);
 
 #ifdef SCRIPT_DEBUG_ALLOCATIONS
 		assert(new_p != nullptr);
@@ -104,6 +160,7 @@ struct ScriptAllocator {
 		this->allocated_size = 0;
 		this->allocation_limit = static_cast<size_t>(_settings_game.script.script_max_memory_megabytes) << 20;
 		if (this->allocation_limit == 0) this->allocation_limit = SAFE_LIMIT; // in case the setting is somehow zero
+		this->error_thrown = false;
 	}
 
 	~ScriptAllocator()
@@ -113,6 +170,14 @@ struct ScriptAllocator {
 #endif
 	}
 };
+
+/**
+ * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS
+ * does not have enough memory the game does not go into unrecoverable error mode and kill the
+ * whole game, but rather let the AI die though then we need to circumvent MallocT/ReallocT.
+ * For the rest of this code, the safeguards should be in place though!
+ */
+#include "../safeguards.h"
 
 ScriptAllocator *_squirrel_allocator = nullptr;
 


### PR DESCRIPTION
## Motivation / Problem

See #6322. A script allocating (way) too much memory can crash the game which is arguably worse than crashing just the script.


## Description

The solution is two fold:

1. Enable the limit check in the allocation logic, instead of relying on it to be checked after the "tick"
2. Not using MallocT/ReallocT but the raw malloc/realloc, so instead of (M|Re)allocError killing the game the script is killed.

As side effect some extra information about the allocation was added to the error message that could potentially help the script's developer, but that required changing the error message in Script_FatalError from char* to std::string&.


## Limitations

Scripts can now be killed earlier, and probably even during saving, when the memory limit is reached. Previously if the memory was returned before the save or tick finished, the script would just continue.
It is a somewhat open question whether the old behavior of limit testing should be maintained, so the AI can for short bursts and saving use more memory. That would mean this change does not impact the scripts as much, however the benefit of doing it when the allocation happens is that the log will show exactly where the limit got exceeded and by how much. This could then help the script developer see where a huge amount of memory got allocated (in error) and that would make fixing the underlying issues in the scripts easier.

In case the OS is out of memory, and there is not even enough memory to go through the script engine cleanup the game will still crash out with MallocError. Though, not going through the script engine cleanup will leave some "backups" to be not restored so the game would be in an undefined state and it would likely crash at another place.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
