### PR TITLE
Packet encapsulation

### DIFF
--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -175,6 +175,21 @@ void Packet::Send_string(const char *data)
 	while ((this->buffer[this->size++] = *data++) != '\0') {}
 }
 
+/**
+ * Send as many of the bytes as possible in the packet. This can mean
+ * that it is possible that not all bytes are sent. To cope with this
+ * the function returns the amount of bytes that were actually sent.
+ * @param begin The begin of the buffer to send.
+ * @param end   The end of the buffer to send.
+ * @return The number of bytes that were added to this packet.
+ */
+size_t Packet::Send_bytes(const byte *begin, const byte *end)
+{
+	size_t amount = std::min<size_t>(end - begin, SEND_MTU - this->size);
+	memcpy(this->buffer + this->size, begin, amount);
+	this->size += static_cast<PacketSize>(amount);
+	return amount;
+}
 
 /*
  * Receiving commands

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -297,6 +297,16 @@ void Packet::PrepareToRead()
 }
 
 /**
+ * Get the \c PacketType from this packet.
+ * @return The packet type.
+ */
+PacketType Packet::GetPacketType() const
+{
+	assert(this->Size() >= sizeof(PacketSize) + sizeof(PacketType));
+	return static_cast<PacketType>(buffer[sizeof(PacketSize)]);
+}
+
+/**
  * Read a boolean from the packet.
  * @return The read data.
  */

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -73,6 +73,11 @@ void Packet::PrepareToSend()
 	this->buffer[1] = GB(this->size, 8, 8);
 
 	this->pos  = 0; // We start reading from here
+
+	/* Reallocate the packet as in 99+% of the times we send at most 25 bytes and
+	 * keeping the other 1400+ bytes wastes memory, especially when someone tries
+	 * to do a denial of service attack! */
+	this->buffer = ReallocT(this->buffer, this->size);
 }
 
 /**

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -63,6 +63,32 @@ Packet::~Packet()
 }
 
 /**
+ * Add the given Packet to the end of the queue of packets.
+ * @param queue  The pointer to the begin of the queue.
+ * @param packet The packet to append to the queue.
+ */
+/* static */ void Packet::AddToQueue(Packet **queue, Packet *packet)
+{
+	while (*queue != nullptr) queue = &(*queue)->next;
+	*queue = packet;
+}
+
+/**
+ * Pop the packet from the begin of the queue and set the
+ * begin of the queue to the second element in the queue.
+ * @param queue  The pointer to the begin of the queue.
+ * @return The Packet that used to be a the begin of the queue.
+ */
+/* static */ Packet *Packet::PopFromQueue(Packet **queue)
+{
+	Packet *p = *queue;
+	*queue = p->next;
+	p->next = nullptr;
+	return p;
+}
+
+
+/**
  * Writes the packet size from the raw packet from packet->size
  */
 void Packet::PrepareToSend()

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -231,6 +231,18 @@ bool Packet::HasPacketSizeData() const
 }
 
 /**
+ * Get the number of bytes in the packet.
+ * When sending a packet this is the size of the data up to that moment.
+ * When receiving a packet (before PrepareToRead) this is the allocated size for the data to be read.
+ * When reading a packet (after PrepareToRead) this is the full size of the packet.
+ * @return The packet's size.
+ */
+size_t Packet::Size() const
+{
+	return this->size;
+}
+
+/**
  * Reads the packet size from the raw packet and stores it in the packet->size
  * @return True iff the packet size seems plausible.
  */

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -62,6 +62,9 @@ public:
 	Packet(PacketType type);
 	~Packet();
 
+	static void AddToQueue(Packet **queue, Packet *packet);
+	static Packet *PopFromQueue(Packet **queue);
+
 	/* Sending/writing of packets */
 	void PrepareToSend();
 

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -65,13 +65,14 @@ public:
 	/* Sending/writing of packets */
 	void PrepareToSend();
 
-	bool CanWriteToPacket(size_t bytes_to_write);
-	void Send_bool  (bool   data);
-	void Send_uint8 (uint8  data);
-	void Send_uint16(uint16 data);
-	void Send_uint32(uint32 data);
-	void Send_uint64(uint64 data);
-	void Send_string(const char *data);
+	bool   CanWriteToPacket(size_t bytes_to_write);
+	void   Send_bool  (bool   data);
+	void   Send_uint8 (uint8  data);
+	void   Send_uint16(uint16 data);
+	void   Send_uint32(uint32 data);
+	void   Send_uint64(uint64 data);
+	void   Send_string(const char *data);
+	size_t Send_bytes (const byte *begin, const byte *end);
 
 	/* Reading/receiving of packets */
 	bool HasPacketSizeData() const;

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -77,6 +77,7 @@ public:
 	/* Reading/receiving of packets */
 	bool HasPacketSizeData() const;
 	bool ParsePacketSize();
+	size_t Size() const;
 	void PrepareToRead();
 
 	bool   CanReadFromPacket(size_t bytes_to_read, bool close_connection = false);

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -40,6 +40,7 @@ typedef uint8  PacketType; ///< Identifier for the packet
  *     (year % 4 == 0) and ((year % 100 != 0) or (year % 400 == 0))
  */
 struct Packet {
+private:
 	/** The next packet. Used for queueing packets before sending. */
 	Packet *next;
 	/**
@@ -52,8 +53,6 @@ struct Packet {
 	PacketSize pos;
 	/** The buffer of this packet, of basically variable length up to SEND_MTU. */
 	byte *buffer;
-
-private:
 	/** Socket we're associated with. */
 	NetworkSocketHandler *cs;
 
@@ -82,6 +81,7 @@ public:
 	bool ParsePacketSize();
 	size_t Size() const;
 	void PrepareToRead();
+	PacketType GetPacketType() const;
 
 	bool   CanReadFromPacket(size_t bytes_to_read, bool close_connection = false);
 	bool   Recv_bool  ();

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -63,6 +63,7 @@ public:
 	/* Sending/writing of packets */
 	void PrepareToSend();
 
+	bool CanWriteToPacket(size_t bytes_to_write);
 	void Send_bool  (bool   data);
 	void Send_uint8 (uint8  data);
 	void Send_uint16(uint16 data);
@@ -75,7 +76,7 @@ public:
 	bool ParsePacketSize();
 	void PrepareToRead();
 
-	bool   CanReadFromPacket (uint bytes_to_read);
+	bool   CanReadFromPacket(size_t bytes_to_read, bool close_connection = false);
 	bool   Recv_bool  ();
 	uint8  Recv_uint8 ();
 	uint16 Recv_uint16();

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -71,7 +71,8 @@ public:
 	void Send_string(const char *data);
 
 	/* Reading/receiving of packets */
-	void ReadRawPacketSize();
+	bool HasPacketSizeData() const;
+	bool ParsePacketSize();
 	void PrepareToRead();
 
 	bool   CanReadFromPacket (uint bytes_to_read);

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -65,11 +65,6 @@ void NetworkTCPSocketHandler::SendPacket(Packet *packet)
 
 	packet->PrepareToSend();
 
-	/* Reallocate the packet as in 99+% of the times we send at most 25 bytes and
-	 * keeping the other 1400+ bytes wastes memory, especially when someone tries
-	 * to do a denial of service attack! */
-	packet->buffer = ReallocT(packet->buffer, packet->size);
-
 	/* Locate last packet buffered for the client */
 	p = this->packet_queue;
 	if (p == nullptr) {

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -103,7 +103,7 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 
 	p = this->packet_queue;
 	while (p != nullptr) {
-		res = send(this->sock, (const char*)p->buffer + p->pos, p->size - p->pos, 0);
+		res = p->TransferOut<int>(send, this->sock, 0);
 		if (res == -1) {
 			int err = GET_LAST_ERROR();
 			if (err != EWOULDBLOCK) {
@@ -122,10 +122,8 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 			return SPS_CLOSED;
 		}
 
-		p->pos += res;
-
 		/* Is this packet sent? */
-		if (p->pos == p->size) {
+		if (p->RemainingBytesToTransfer() == 0) {
 			/* Go to the next packet */
 			this->packet_queue = p->next;
 			delete p;

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -63,7 +63,7 @@ public:
 
 					DEBUG(net, 1, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry.c_str());
 
-					if (send(s, (const char*)p.buffer, p.size, 0) < 0) {
+					if (p.TransferOut<int>(send, s, 0) < 0) {
 						DEBUG(net, 0, "send failed with error %d", GET_LAST_ERROR());
 					}
 					closesocket(s);
@@ -80,7 +80,7 @@ public:
 				Packet p(Tfull_packet);
 				p.PrepareToSend();
 
-				if (send(s, (const char*)p.buffer, p.size, 0) < 0) {
+				if (p.TransferOut<int>(send, s, 0) < 0) {
 					DEBUG(net, 0, "send failed with error %d", GET_LAST_ERROR());
 				}
 				closesocket(s);

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -137,7 +137,7 @@ void NetworkUDPSocketHandler::ReceivePackets()
 
 			/* If the size does not match the packet must be corrupted.
 			 * Otherwise it will be marked as corrupted later on. */
-			if (!p.ParsePacketSize() || nbytes != p.size) {
+			if (!p.ParsePacketSize() || (size_t)nbytes != p.Size()) {
 				DEBUG(net, 1, "received a packet with mismatching size from %s", address.GetAddressAsString().c_str());
 				continue;
 			}

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -134,14 +134,14 @@ void NetworkUDPSocketHandler::ReceivePackets()
 #endif
 
 			NetworkAddress address(client_addr, client_len);
-			p.PrepareToRead();
 
 			/* If the size does not match the packet must be corrupted.
 			 * Otherwise it will be marked as corrupted later on. */
-			if (nbytes != p.size) {
+			if (!p.ParsePacketSize() || nbytes != p.size) {
 				DEBUG(net, 1, "received a packet with mismatching size from %s", address.GetAddressAsString().c_str());
 				continue;
 			}
+			p.PrepareToRead();
 
 			/* Handle the packet */
 			this->HandleUDPPacket(&p, &address);

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -119,12 +119,12 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			struct sockaddr_storage client_addr;
 			memset(&client_addr, 0, sizeof(client_addr));
 
-			Packet p(this);
+			Packet p(this, SEND_MTU);
 			socklen_t client_len = sizeof(client_addr);
 
 			/* Try to receive anything */
 			SetNonBlocking(s.second); // Some OSes seem to lose the non-blocking status of the socket
-			int nbytes = recvfrom(s.second, (char*)p.buffer, SEND_MTU, 0, (struct sockaddr *)&client_addr, &client_len);
+			ssize_t nbytes = p.TransferIn<int>(recvfrom, s.second, 0, (struct sockaddr *)&client_addr, &client_len);
 
 			/* Did we get the bytes for the base header of the packet? */
 			if (nbytes <= 0) break;    // No data, i.e. no packet

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -99,7 +99,7 @@ void NetworkUDPSocketHandler::SendPacket(Packet *p, NetworkAddress *recv, bool a
 		}
 
 		/* Send the buffer */
-		int res = sendto(s.second, (const char*)p->buffer, p->size, 0, (const struct sockaddr *)send.GetAddress(), send.GetAddressLength());
+		ssize_t res = p->TransferOut<int>(sendto, s.second, 0, (const struct sockaddr *)send.GetAddress(), send.GetAddressLength());
 		DEBUG(net, 7, "[udp] sendto(%s)", send.GetAddressAsString().c_str());
 
 		/* Check for any errors, but ignore it otherwise */

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -613,7 +613,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
 		/* Should SEND_MTU be exceeded, start a new packet
 		 * (magic 5: 1 bool "more data" and one uint16 "command id", one
 		 * byte for string '\0' termination and 1 bool "no more data" */
-		if (p->size + strlen(cmdname) + 5 >= SEND_MTU) {
+		if (p->CanWriteToPacket(strlen(cmdname) + 5)) {
 			p->Send_bool(false);
 			this->SendPacket(p);
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -928,7 +928,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_FRAME(Packet *p
 	}
 #endif
 	/* Receive the token. */
-	if (p->pos != p->size) this->token = p->Recv_uint8();
+	if (p->CanReadFromPacket(sizeof(uint8))) this->token = p->Recv_uint8();
 
 	DEBUG(net, 5, "Received FRAME %d", _frame_counter_server);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -626,7 +626,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 
 		for (uint i = 0; (has_packets = this->savegame->HasPackets()) && i < sent_packets; i++) {
 			Packet *p = this->savegame->PopPacket();
-			last_packet = p->buffer[2] == PACKET_SERVER_MAP_DONE;
+			last_packet = p->GetPacketType() == PACKET_SERVER_MAP_DONE;
 
 			this->SendPacket(p);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -247,7 +247,7 @@ Packet *ServerNetworkGameSocketHandler::ReceivePacket()
 	/* We can receive a packet, so try that and if needed account for
 	 * the amount of received data. */
 	Packet *p = this->NetworkTCPSocketHandler::ReceivePacket();
-	if (p != nullptr) this->receive_limit -= p->size;
+	if (p != nullptr) this->receive_limit -= p->Size();
 	return p;
 }
 
@@ -1821,7 +1821,7 @@ void NetworkServer_Tick(bool send_frame)
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 		/* We allow a number of bytes per frame, but only to the burst amount
 		 * to be available for packet receiving at any particular time. */
-		cs->receive_limit = std::min<int>(cs->receive_limit + _settings_client.network.bytes_per_frame,
+		cs->receive_limit = std::min<size_t>(cs->receive_limit + _settings_client.network.bytes_per_frame,
 				_settings_client.network.bytes_per_frame_burst);
 
 		/* Check if the speed of the client is what we can expect from a client */

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -174,12 +174,10 @@ struct PacketWriter : SaveFilter {
 
 		byte *bufe = buf + size;
 		while (buf != bufe) {
-			size_t to_write = std::min<size_t>(SEND_MTU - this->current->size, bufe - buf);
-			memcpy(this->current->buffer + this->current->size, buf, to_write);
-			this->current->size += (PacketSize)to_write;
-			buf += to_write;
+			size_t written = this->current->Send_bytes(buf, bufe);
+			buf += written;
 
-			if (this->current->size == SEND_MTU) {
+			if (!this->current->CanWriteToPacket(1)) {
 				this->AppendQueue();
 				if (buf != bufe) this->current = new Packet(PACKET_SERVER_MAP_DATA);
 			}

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -67,7 +67,7 @@ public:
 	uint32 last_token_frame;     ///< The last frame we received the right token
 	ClientStatus status;         ///< Status of this client
 	CommandQueue outgoing_queue; ///< The command-queue awaiting delivery
-	int receive_limit;           ///< Amount of bytes that we can receive at this moment
+	size_t receive_limit;        ///< Amount of bytes that we can receive at this moment
 
 	struct PacketWriter *savegame; ///< Writer used to write the savegame.
 	NetworkAddress client_address; ///< IP-address of the client (so he can be banned)

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -220,23 +220,23 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_DETAIL_INFO(Packet *p, Networ
 	static const uint MIN_CI_SIZE = 54;
 	uint max_cname_length = NETWORK_COMPANY_NAME_LENGTH;
 
-	if (Company::GetNumItems() * (MIN_CI_SIZE + NETWORK_COMPANY_NAME_LENGTH) >= (uint)SEND_MTU - packet.size) {
+	if (!packet.CanWriteToPacket(Company::GetNumItems() * (MIN_CI_SIZE + NETWORK_COMPANY_NAME_LENGTH))) {
 		/* Assume we can at least put the company information in the packets. */
-		assert(Company::GetNumItems() * MIN_CI_SIZE < (uint)SEND_MTU - packet.size);
+		assert(packet.CanWriteToPacket(Company::GetNumItems() * MIN_CI_SIZE));
 
 		/* At this moment the company names might not fit in the
 		 * packet. Check whether that is really the case. */
 
 		for (;;) {
-			int free = SEND_MTU - packet.size;
+			size_t required = 0;
 			for (const Company *company : Company::Iterate()) {
 				char company_name[NETWORK_COMPANY_NAME_LENGTH];
 				SetDParam(0, company->index);
 				GetString(company_name, STR_COMPANY_NAME, company_name + max_cname_length - 1);
-				free -= MIN_CI_SIZE;
-				free -= (int)strlen(company_name);
+				required += MIN_CI_SIZE;
+				required += strlen(company_name);
 			}
-			if (free >= 0) break;
+			if (packet.CanWriteToPacket(required)) break;
 
 			/* Try again, with slightly shorter strings. */
 			assert(max_cname_length > 0);


### PR DESCRIPTION
## Motivation / Problem

The pointers and state of the Packet class are updated by other functions all over the place. This makes further changes more difficult as the logic for packet size and reading/writing location is spread all over the network code.

The major benefit at the end is to make it much easier to introduce larger packet sizes, a big first step is in https://github.com/rubidium42/OpenTTD/tree/bigger_packets which makes OpenTTD accept (TCP) packets up to 32767 bytes, and uses that size to send save games as well as to the content server (which is not limited by the current MTU). Later changes could then also be done for e.g. receiving data from the content server or certain admin commands. However, that requires changes to the protocol to determine whether the other side accepts such large packets which is beyond the scope of that patch.


## Description

Removes all the direct access to the state variables of a Packet.


## Limitations

Any patch messing manually with the Packet state will be broken.

Technically it is possible to extend the Packet size even more, but for save games it does not seem wise to send even larger packets as then it will also take longer before we start with sending data.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
