### PR TITLE
Codechange: Use std::string in console commands/aliases registration, and std::map instead our sorted linked list

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -204,38 +204,6 @@ bool GetArgumentInteger(uint32 *value, const char *arg)
 }
 
 /**
- * Add an item to an alphabetically sorted list.
- * @param base first item of the list
- * @param item_new the item to add
- */
-template<class T>
-void IConsoleAddSorted(T **base, T *item_new)
-{
-	if (*base == nullptr) {
-		*base = item_new;
-		return;
-	}
-
-	T *item_before = nullptr;
-	T *item = *base;
-	/* The list is alphabetically sorted, insert the new item at the correct location */
-	while (item != nullptr) {
-		if (item->name > item_new->name) break; // insert here
-
-		item_before = item;
-		item = item->next;
-	}
-
-	if (item_before == nullptr) {
-		*base = item_new;
-	} else {
-		item_before->next = item_new;
-	}
-
-	item_new->next = item;
-}
-
-/**
  * Creates a copy of a string with underscores removed from it
  * @param name String to remove the underscores from.
  * @return A copy of \a name, without underscores.

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1413,8 +1413,7 @@ DEF_CONSOLE_CMD(ConAlias)
 	if (alias == nullptr) {
 		IConsoleAliasRegister(argv[1], argv[2]);
 	} else {
-		free(alias->cmdline);
-		alias->cmdline = stredup(argv[2]);
+		alias->cmdline = argv[2];
 	}
 	return true;
 }
@@ -1514,7 +1513,7 @@ DEF_CONSOLE_CMD(ConInfoCmd)
 		return true;
 	}
 
-	IConsolePrintF(CC_DEFAULT, "command name: %s", cmd->name);
+	IConsolePrintF(CC_DEFAULT, "command name: %s", cmd->name.c_str());
 	IConsolePrintF(CC_DEFAULT, "command proc: %p", cmd->proc);
 
 	if (cmd->hook != nullptr) IConsoleWarning("command is hooked");
@@ -1573,7 +1572,6 @@ DEF_CONSOLE_CMD(ConHelp)
 		const IConsoleCmd *cmd;
 		const IConsoleAlias *alias;
 
-		RemoveUnderscores(argv[1]);
 		cmd = IConsoleCmdGet(argv[1]);
 		if (cmd != nullptr) {
 			cmd->proc(0, nullptr);
@@ -1587,7 +1585,7 @@ DEF_CONSOLE_CMD(ConHelp)
 				cmd->proc(0, nullptr);
 				return true;
 			}
-			IConsolePrintF(CC_ERROR, "ERROR: alias is of special type, please see its execution-line: '%s'", alias->cmdline);
+			IConsolePrintF(CC_ERROR, "ERROR: alias is of special type, please see its execution-line: '%s'", alias->cmdline.c_str());
 			return true;
 		}
 
@@ -1615,8 +1613,8 @@ DEF_CONSOLE_CMD(ConListCommands)
 	}
 
 	for (const IConsoleCmd *cmd = _iconsole_cmds; cmd != nullptr; cmd = cmd->next) {
-		if (argv[1] == nullptr || strstr(cmd->name, argv[1]) != nullptr) {
-			if (cmd->hook == nullptr || cmd->hook(false) != CHR_HIDE) IConsolePrintF(CC_DEFAULT, "%s", cmd->name);
+		if (argv[1] == nullptr || cmd->name.find(argv[1]) != std::string::npos) {
+			if (cmd->hook == nullptr || cmd->hook(false) != CHR_HIDE) IConsolePrintF(CC_DEFAULT, "%s", cmd->name.c_str());
 		}
 	}
 
@@ -1631,8 +1629,8 @@ DEF_CONSOLE_CMD(ConListAliases)
 	}
 
 	for (const IConsoleAlias *alias = _iconsole_aliases; alias != nullptr; alias = alias->next) {
-		if (argv[1] == nullptr || strstr(alias->name, argv[1]) != nullptr) {
-			IConsolePrintF(CC_DEFAULT, "%s => %s", alias->name, alias->cmdline);
+		if (argv[1] == nullptr || alias->name.find(argv[1]) != std::string::npos) {
+			IConsolePrintF(CC_DEFAULT, "%s => %s", alias->name.c_str(), alias->cmdline.c_str());
 		}
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1507,7 +1507,7 @@ DEF_CONSOLE_CMD(ConInfoCmd)
 
 	if (argc < 2) return false;
 
-	const IConsoleCmd *cmd = IConsoleCmdGet(argv[1]);
+	const IConsoleCmd *cmd = IConsole::CmdGet(argv[1]);
 	if (cmd == nullptr) {
 		IConsoleError("the given command was not found");
 		return true;
@@ -1572,7 +1572,7 @@ DEF_CONSOLE_CMD(ConHelp)
 		const IConsoleCmd *cmd;
 		const IConsoleAlias *alias;
 
-		cmd = IConsoleCmdGet(argv[1]);
+		cmd = IConsole::CmdGet(argv[1]);
 		if (cmd != nullptr) {
 			cmd->proc(0, nullptr);
 			return true;
@@ -1580,7 +1580,7 @@ DEF_CONSOLE_CMD(ConHelp)
 
 		alias = IConsoleAliasGet(argv[1]);
 		if (alias != nullptr) {
-			cmd = IConsoleCmdGet(alias->cmdline);
+			cmd = IConsole::CmdGet(alias->cmdline);
 			if (cmd != nullptr) {
 				cmd->proc(0, nullptr);
 				return true;
@@ -1612,7 +1612,8 @@ DEF_CONSOLE_CMD(ConListCommands)
 		return true;
 	}
 
-	for (const IConsoleCmd *cmd = _iconsole_cmds; cmd != nullptr; cmd = cmd->next) {
+	for (auto &it : IConsole::Commands()) {
+		const IConsoleCmd *cmd = &it.second;
 		if (argv[1] == nullptr || cmd->name.find(argv[1]) != std::string::npos) {
 			if (cmd->hook == nullptr || cmd->hook(false) != CHR_HIDE) IConsolePrintF(CC_DEFAULT, "%s", cmd->name.c_str());
 		}
@@ -2124,7 +2125,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 
 static void IConsoleDebugLibRegister()
 {
-	IConsoleCmdRegister("resettile",        ConResetTile);
+	IConsole::CmdRegister("resettile",        ConResetTile);
 	IConsoleAliasRegister("dbg_echo",       "echo %A; echo %B");
 	IConsoleAliasRegister("dbg_echo2",      "echo %!");
 }
@@ -2320,43 +2321,43 @@ DEF_CONSOLE_CMD(ConDumpInfo)
 
 void IConsoleStdLibRegister()
 {
-	IConsoleCmdRegister("debug_level",  ConDebugLevel);
-	IConsoleCmdRegister("echo",         ConEcho);
-	IConsoleCmdRegister("echoc",        ConEchoC);
-	IConsoleCmdRegister("exec",         ConExec);
-	IConsoleCmdRegister("exit",         ConExit);
-	IConsoleCmdRegister("part",         ConPart);
-	IConsoleCmdRegister("help",         ConHelp);
-	IConsoleCmdRegister("info_cmd",     ConInfoCmd);
-	IConsoleCmdRegister("list_cmds",    ConListCommands);
-	IConsoleCmdRegister("list_aliases", ConListAliases);
-	IConsoleCmdRegister("newgame",      ConNewGame);
-	IConsoleCmdRegister("restart",      ConRestart);
-	IConsoleCmdRegister("reload",       ConReload);
-	IConsoleCmdRegister("getseed",      ConGetSeed);
-	IConsoleCmdRegister("getdate",      ConGetDate);
-	IConsoleCmdRegister("getsysdate",   ConGetSysDate);
-	IConsoleCmdRegister("quit",         ConExit);
-	IConsoleCmdRegister("resetengines", ConResetEngines, ConHookNoNetwork);
-	IConsoleCmdRegister("reset_enginepool", ConResetEnginePool, ConHookNoNetwork);
-	IConsoleCmdRegister("return",       ConReturn);
-	IConsoleCmdRegister("screenshot",   ConScreenShot);
-	IConsoleCmdRegister("script",       ConScript);
-	IConsoleCmdRegister("scrollto",     ConScrollToTile);
-	IConsoleCmdRegister("alias",        ConAlias);
-	IConsoleCmdRegister("load",         ConLoad);
-	IConsoleCmdRegister("rm",           ConRemove);
-	IConsoleCmdRegister("save",         ConSave);
-	IConsoleCmdRegister("saveconfig",   ConSaveConfig);
-	IConsoleCmdRegister("ls",           ConListFiles);
-	IConsoleCmdRegister("cd",           ConChangeDirectory);
-	IConsoleCmdRegister("pwd",          ConPrintWorkingDirectory);
-	IConsoleCmdRegister("clear",        ConClearBuffer);
-	IConsoleCmdRegister("setting",      ConSetting);
-	IConsoleCmdRegister("setting_newgame", ConSettingNewgame);
-	IConsoleCmdRegister("list_settings",ConListSettings);
-	IConsoleCmdRegister("gamelog",      ConGamelogPrint);
-	IConsoleCmdRegister("rescan_newgrf", ConRescanNewGRF);
+	IConsole::CmdRegister("debug_level",             ConDebugLevel);
+	IConsole::CmdRegister("echo",                    ConEcho);
+	IConsole::CmdRegister("echoc",                   ConEchoC);
+	IConsole::CmdRegister("exec",                    ConExec);
+	IConsole::CmdRegister("exit",                    ConExit);
+	IConsole::CmdRegister("part",                    ConPart);
+	IConsole::CmdRegister("help",                    ConHelp);
+	IConsole::CmdRegister("info_cmd",                ConInfoCmd);
+	IConsole::CmdRegister("list_cmds",               ConListCommands);
+	IConsole::CmdRegister("list_aliases",            ConListAliases);
+	IConsole::CmdRegister("newgame",                 ConNewGame);
+	IConsole::CmdRegister("restart",                 ConRestart);
+	IConsole::CmdRegister("reload",                  ConReload);
+	IConsole::CmdRegister("getseed",                 ConGetSeed);
+	IConsole::CmdRegister("getdate",                 ConGetDate);
+	IConsole::CmdRegister("getsysdate",              ConGetSysDate);
+	IConsole::CmdRegister("quit",                    ConExit);
+	IConsole::CmdRegister("resetengines",            ConResetEngines,     ConHookNoNetwork);
+	IConsole::CmdRegister("reset_enginepool",        ConResetEnginePool,  ConHookNoNetwork);
+	IConsole::CmdRegister("return",                  ConReturn);
+	IConsole::CmdRegister("screenshot",              ConScreenShot);
+	IConsole::CmdRegister("script",                  ConScript);
+	IConsole::CmdRegister("scrollto",                ConScrollToTile);
+	IConsole::CmdRegister("alias",                   ConAlias);
+	IConsole::CmdRegister("load",                    ConLoad);
+	IConsole::CmdRegister("rm",                      ConRemove);
+	IConsole::CmdRegister("save",                    ConSave);
+	IConsole::CmdRegister("saveconfig",              ConSaveConfig);
+	IConsole::CmdRegister("ls",                      ConListFiles);
+	IConsole::CmdRegister("cd",                      ConChangeDirectory);
+	IConsole::CmdRegister("pwd",                     ConPrintWorkingDirectory);
+	IConsole::CmdRegister("clear",                   ConClearBuffer);
+	IConsole::CmdRegister("setting",                 ConSetting);
+	IConsole::CmdRegister("setting_newgame",         ConSettingNewgame);
+	IConsole::CmdRegister("list_settings",           ConListSettings);
+	IConsole::CmdRegister("gamelog",                 ConGamelogPrint);
+	IConsole::CmdRegister("rescan_newgrf",           ConRescanNewGRF);
 
 	IConsoleAliasRegister("dir",          "ls");
 	IConsoleAliasRegister("del",          "rm %+");
@@ -2367,56 +2368,56 @@ void IConsoleStdLibRegister()
 	IConsoleAliasRegister("list_patches", "list_settings %+");
 	IConsoleAliasRegister("developer",    "setting developer %+");
 
-	IConsoleCmdRegister("list_ai_libs", ConListAILibs);
-	IConsoleCmdRegister("list_ai",      ConListAI);
-	IConsoleCmdRegister("reload_ai",    ConReloadAI);
-	IConsoleCmdRegister("rescan_ai",    ConRescanAI);
-	IConsoleCmdRegister("start_ai",     ConStartAI);
-	IConsoleCmdRegister("stop_ai",      ConStopAI);
+	IConsole::CmdRegister("list_ai_libs",            ConListAILibs);
+	IConsole::CmdRegister("list_ai",                 ConListAI);
+	IConsole::CmdRegister("reload_ai",               ConReloadAI);
+	IConsole::CmdRegister("rescan_ai",               ConRescanAI);
+	IConsole::CmdRegister("start_ai",                ConStartAI);
+	IConsole::CmdRegister("stop_ai",                 ConStopAI);
 
-	IConsoleCmdRegister("list_game",    ConListGame);
-	IConsoleCmdRegister("list_game_libs", ConListGameLibs);
-	IConsoleCmdRegister("rescan_game",    ConRescanGame);
+	IConsole::CmdRegister("list_game",               ConListGame);
+	IConsole::CmdRegister("list_game_libs",          ConListGameLibs);
+	IConsole::CmdRegister("rescan_game",             ConRescanGame);
 
-	IConsoleCmdRegister("companies",       ConCompanies);
+	IConsole::CmdRegister("companies",               ConCompanies);
 	IConsoleAliasRegister("players",       "companies");
 
 	/* networking functions */
 
 /* Content downloading is only available with ZLIB */
 #if defined(WITH_ZLIB)
-	IConsoleCmdRegister("content",         ConContent);
+	IConsole::CmdRegister("content",                 ConContent);
 #endif /* defined(WITH_ZLIB) */
 
 	/*** Networking commands ***/
-	IConsoleCmdRegister("say",             ConSay, ConHookNeedNetwork);
-	IConsoleCmdRegister("say_company",     ConSayCompany, ConHookNeedNetwork);
+	IConsole::CmdRegister("say",                     ConSay,              ConHookNeedNetwork);
+	IConsole::CmdRegister("say_company",             ConSayCompany,       ConHookNeedNetwork);
 	IConsoleAliasRegister("say_player",    "say_company %+");
-	IConsoleCmdRegister("say_client",      ConSayClient, ConHookNeedNetwork);
+	IConsole::CmdRegister("say_client",              ConSayClient,        ConHookNeedNetwork);
 
-	IConsoleCmdRegister("connect",         ConNetworkConnect, ConHookClientOnly);
-	IConsoleCmdRegister("clients",         ConNetworkClients, ConHookNeedNetwork);
-	IConsoleCmdRegister("status",          ConStatus, ConHookServerOnly);
-	IConsoleCmdRegister("server_info",     ConServerInfo, ConHookServerOnly);
+	IConsole::CmdRegister("connect",                 ConNetworkConnect,   ConHookClientOnly);
+	IConsole::CmdRegister("clients",                 ConNetworkClients,   ConHookNeedNetwork);
+	IConsole::CmdRegister("status",                  ConStatus,           ConHookServerOnly);
+	IConsole::CmdRegister("server_info",             ConServerInfo,       ConHookServerOnly);
 	IConsoleAliasRegister("info",          "server_info");
-	IConsoleCmdRegister("reconnect",       ConNetworkReconnect, ConHookClientOnly);
-	IConsoleCmdRegister("rcon",            ConRcon, ConHookNeedNetwork);
+	IConsole::CmdRegister("reconnect",               ConNetworkReconnect, ConHookClientOnly);
+	IConsole::CmdRegister("rcon",                    ConRcon,             ConHookNeedNetwork);
 
-	IConsoleCmdRegister("join",            ConJoinCompany, ConHookNeedNetwork);
+	IConsole::CmdRegister("join",                    ConJoinCompany,      ConHookNeedNetwork);
 	IConsoleAliasRegister("spectate",      "join 255");
-	IConsoleCmdRegister("move",            ConMoveClient, ConHookServerOnly);
-	IConsoleCmdRegister("reset_company",   ConResetCompany, ConHookServerOnly);
+	IConsole::CmdRegister("move",                    ConMoveClient,       ConHookServerOnly);
+	IConsole::CmdRegister("reset_company",           ConResetCompany,     ConHookServerOnly);
 	IConsoleAliasRegister("clean_company", "reset_company %A");
-	IConsoleCmdRegister("client_name",     ConClientNickChange, ConHookServerOnly);
-	IConsoleCmdRegister("kick",            ConKick, ConHookServerOnly);
-	IConsoleCmdRegister("ban",             ConBan, ConHookServerOnly);
-	IConsoleCmdRegister("unban",           ConUnBan, ConHookServerOnly);
-	IConsoleCmdRegister("banlist",         ConBanList, ConHookServerOnly);
+	IConsole::CmdRegister("client_name",             ConClientNickChange, ConHookServerOnly);
+	IConsole::CmdRegister("kick",                    ConKick,             ConHookServerOnly);
+	IConsole::CmdRegister("ban",                     ConBan,              ConHookServerOnly);
+	IConsole::CmdRegister("unban",                   ConUnBan,            ConHookServerOnly);
+	IConsole::CmdRegister("banlist",                 ConBanList,          ConHookServerOnly);
 
-	IConsoleCmdRegister("pause",           ConPauseGame, ConHookServerOnly);
-	IConsoleCmdRegister("unpause",         ConUnpauseGame, ConHookServerOnly);
+	IConsole::CmdRegister("pause",                   ConPauseGame,        ConHookServerOnly);
+	IConsole::CmdRegister("unpause",                 ConUnpauseGame,      ConHookServerOnly);
 
-	IConsoleCmdRegister("company_pw",      ConCompanyPassword, ConHookNeedNetwork);
+	IConsole::CmdRegister("company_pw",              ConCompanyPassword,  ConHookNeedNetwork);
 	IConsoleAliasRegister("company_password",      "company_pw %+");
 
 	IConsoleAliasRegister("net_frame_freq",        "setting frame_freq %+");
@@ -2445,12 +2446,12 @@ void IConsoleStdLibRegister()
 #ifdef _DEBUG
 	IConsoleDebugLibRegister();
 #endif
-	IConsoleCmdRegister("fps",     ConFramerate);
-	IConsoleCmdRegister("fps_wnd", ConFramerateWindow);
+	IConsole::CmdRegister("fps",                     ConFramerate);
+	IConsole::CmdRegister("fps_wnd",                 ConFramerateWindow);
 
 	/* NewGRF development stuff */
-	IConsoleCmdRegister("reload_newgrfs",  ConNewGRFReload, ConHookNewGRFDeveloperTool);
-	IConsoleCmdRegister("newgrf_profile",  ConNewGRFProfile, ConHookNewGRFDeveloperTool);
+	IConsole::CmdRegister("reload_newgrfs",          ConNewGRFReload,     ConHookNewGRFDeveloperTool);
+	IConsole::CmdRegister("newgrf_profile",          ConNewGRFProfile,    ConHookNewGRFDeveloperTool);
 
-	IConsoleCmdRegister("dump_info", ConDumpInfo);
+	IConsole::CmdRegister("dump_info",               ConDumpInfo);
 }

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1409,9 +1409,9 @@ DEF_CONSOLE_CMD(ConAlias)
 
 	if (argc < 3) return false;
 
-	alias = IConsoleAliasGet(argv[1]);
+	alias = IConsole::AliasGet(argv[1]);
 	if (alias == nullptr) {
-		IConsoleAliasRegister(argv[1], argv[2]);
+		IConsole::AliasRegister(argv[1], argv[2]);
 	} else {
 		alias->cmdline = argv[2];
 	}
@@ -1578,7 +1578,7 @@ DEF_CONSOLE_CMD(ConHelp)
 			return true;
 		}
 
-		alias = IConsoleAliasGet(argv[1]);
+		alias = IConsole::AliasGet(argv[1]);
 		if (alias != nullptr) {
 			cmd = IConsole::CmdGet(alias->cmdline);
 			if (cmd != nullptr) {
@@ -1629,7 +1629,8 @@ DEF_CONSOLE_CMD(ConListAliases)
 		return true;
 	}
 
-	for (const IConsoleAlias *alias = _iconsole_aliases; alias != nullptr; alias = alias->next) {
+	for (auto &it : IConsole::Aliases()) {
+		const IConsoleAlias *alias = &it.second;
 		if (argv[1] == nullptr || alias->name.find(argv[1]) != std::string::npos) {
 			IConsolePrintF(CC_DEFAULT, "%s => %s", alias->name.c_str(), alias->cmdline.c_str());
 		}
@@ -2126,8 +2127,8 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 static void IConsoleDebugLibRegister()
 {
 	IConsole::CmdRegister("resettile",        ConResetTile);
-	IConsoleAliasRegister("dbg_echo",       "echo %A; echo %B");
-	IConsoleAliasRegister("dbg_echo2",      "echo %!");
+	IConsole::AliasRegister("dbg_echo",       "echo %A; echo %B");
+	IConsole::AliasRegister("dbg_echo2",      "echo %!");
 }
 #endif
 
@@ -2359,14 +2360,14 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("gamelog",                 ConGamelogPrint);
 	IConsole::CmdRegister("rescan_newgrf",           ConRescanNewGRF);
 
-	IConsoleAliasRegister("dir",          "ls");
-	IConsoleAliasRegister("del",          "rm %+");
-	IConsoleAliasRegister("newmap",       "newgame");
-	IConsoleAliasRegister("patch",        "setting %+");
-	IConsoleAliasRegister("set",          "setting %+");
-	IConsoleAliasRegister("set_newgame",  "setting_newgame %+");
-	IConsoleAliasRegister("list_patches", "list_settings %+");
-	IConsoleAliasRegister("developer",    "setting developer %+");
+	IConsole::AliasRegister("dir",                   "ls");
+	IConsole::AliasRegister("del",                   "rm %+");
+	IConsole::AliasRegister("newmap",                "newgame");
+	IConsole::AliasRegister("patch",                 "setting %+");
+	IConsole::AliasRegister("set",                   "setting %+");
+	IConsole::AliasRegister("set_newgame",           "setting_newgame %+");
+	IConsole::AliasRegister("list_patches",          "list_settings %+");
+	IConsole::AliasRegister("developer",             "setting developer %+");
 
 	IConsole::CmdRegister("list_ai_libs",            ConListAILibs);
 	IConsole::CmdRegister("list_ai",                 ConListAI);
@@ -2380,7 +2381,7 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("rescan_game",             ConRescanGame);
 
 	IConsole::CmdRegister("companies",               ConCompanies);
-	IConsoleAliasRegister("players",       "companies");
+	IConsole::AliasRegister("players",               "companies");
 
 	/* networking functions */
 
@@ -2392,22 +2393,22 @@ void IConsoleStdLibRegister()
 	/*** Networking commands ***/
 	IConsole::CmdRegister("say",                     ConSay,              ConHookNeedNetwork);
 	IConsole::CmdRegister("say_company",             ConSayCompany,       ConHookNeedNetwork);
-	IConsoleAliasRegister("say_player",    "say_company %+");
+	IConsole::AliasRegister("say_player",            "say_company %+");
 	IConsole::CmdRegister("say_client",              ConSayClient,        ConHookNeedNetwork);
 
 	IConsole::CmdRegister("connect",                 ConNetworkConnect,   ConHookClientOnly);
 	IConsole::CmdRegister("clients",                 ConNetworkClients,   ConHookNeedNetwork);
 	IConsole::CmdRegister("status",                  ConStatus,           ConHookServerOnly);
 	IConsole::CmdRegister("server_info",             ConServerInfo,       ConHookServerOnly);
-	IConsoleAliasRegister("info",          "server_info");
+	IConsole::AliasRegister("info",                  "server_info");
 	IConsole::CmdRegister("reconnect",               ConNetworkReconnect, ConHookClientOnly);
 	IConsole::CmdRegister("rcon",                    ConRcon,             ConHookNeedNetwork);
 
 	IConsole::CmdRegister("join",                    ConJoinCompany,      ConHookNeedNetwork);
-	IConsoleAliasRegister("spectate",      "join 255");
+	IConsole::AliasRegister("spectate",              "join 255");
 	IConsole::CmdRegister("move",                    ConMoveClient,       ConHookServerOnly);
 	IConsole::CmdRegister("reset_company",           ConResetCompany,     ConHookServerOnly);
-	IConsoleAliasRegister("clean_company", "reset_company %A");
+	IConsole::AliasRegister("clean_company",         "reset_company %A");
 	IConsole::CmdRegister("client_name",             ConClientNickChange, ConHookServerOnly);
 	IConsole::CmdRegister("kick",                    ConKick,             ConHookServerOnly);
 	IConsole::CmdRegister("ban",                     ConBan,              ConHookServerOnly);
@@ -2418,29 +2419,29 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("unpause",                 ConUnpauseGame,      ConHookServerOnly);
 
 	IConsole::CmdRegister("company_pw",              ConCompanyPassword,  ConHookNeedNetwork);
-	IConsoleAliasRegister("company_password",      "company_pw %+");
+	IConsole::AliasRegister("company_password",      "company_pw %+");
 
-	IConsoleAliasRegister("net_frame_freq",        "setting frame_freq %+");
-	IConsoleAliasRegister("net_sync_freq",         "setting sync_freq %+");
-	IConsoleAliasRegister("server_pw",             "setting server_password %+");
-	IConsoleAliasRegister("server_password",       "setting server_password %+");
-	IConsoleAliasRegister("rcon_pw",               "setting rcon_password %+");
-	IConsoleAliasRegister("rcon_password",         "setting rcon_password %+");
-	IConsoleAliasRegister("name",                  "setting client_name %+");
-	IConsoleAliasRegister("server_name",           "setting server_name %+");
-	IConsoleAliasRegister("server_port",           "setting server_port %+");
-	IConsoleAliasRegister("server_advertise",      "setting server_advertise %+");
-	IConsoleAliasRegister("max_clients",           "setting max_clients %+");
-	IConsoleAliasRegister("max_companies",         "setting max_companies %+");
-	IConsoleAliasRegister("max_spectators",        "setting max_spectators %+");
-	IConsoleAliasRegister("max_join_time",         "setting max_join_time %+");
-	IConsoleAliasRegister("pause_on_join",         "setting pause_on_join %+");
-	IConsoleAliasRegister("autoclean_companies",   "setting autoclean_companies %+");
-	IConsoleAliasRegister("autoclean_protected",   "setting autoclean_protected %+");
-	IConsoleAliasRegister("autoclean_unprotected", "setting autoclean_unprotected %+");
-	IConsoleAliasRegister("restart_game_year",     "setting restart_game_year %+");
-	IConsoleAliasRegister("min_players",           "setting min_active_clients %+");
-	IConsoleAliasRegister("reload_cfg",            "setting reload_cfg %+");
+	IConsole::AliasRegister("net_frame_freq",        "setting frame_freq %+");
+	IConsole::AliasRegister("net_sync_freq",         "setting sync_freq %+");
+	IConsole::AliasRegister("server_pw",             "setting server_password %+");
+	IConsole::AliasRegister("server_password",       "setting server_password %+");
+	IConsole::AliasRegister("rcon_pw",               "setting rcon_password %+");
+	IConsole::AliasRegister("rcon_password",         "setting rcon_password %+");
+	IConsole::AliasRegister("name",                  "setting client_name %+");
+	IConsole::AliasRegister("server_name",           "setting server_name %+");
+	IConsole::AliasRegister("server_port",           "setting server_port %+");
+	IConsole::AliasRegister("server_advertise",      "setting server_advertise %+");
+	IConsole::AliasRegister("max_clients",           "setting max_clients %+");
+	IConsole::AliasRegister("max_companies",         "setting max_companies %+");
+	IConsole::AliasRegister("max_spectators",        "setting max_spectators %+");
+	IConsole::AliasRegister("max_join_time",         "setting max_join_time %+");
+	IConsole::AliasRegister("pause_on_join",         "setting pause_on_join %+");
+	IConsole::AliasRegister("autoclean_companies",   "setting autoclean_companies %+");
+	IConsole::AliasRegister("autoclean_protected",   "setting autoclean_protected %+");
+	IConsole::AliasRegister("autoclean_unprotected", "setting autoclean_unprotected %+");
+	IConsole::AliasRegister("restart_game_year",     "setting restart_game_year %+");
+	IConsole::AliasRegister("min_players",           "setting min_active_clients %+");
+	IConsole::AliasRegister("reload_cfg",            "setting reload_cfg %+");
 
 	/* debugging stuff */
 #ifdef _DEBUG

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -54,33 +54,30 @@ struct IConsoleCmd {
  * - ";" allows for combining commands (see example 'ng')
  */
 struct IConsoleAlias {
-	std::string name;           ///< name of the alias
-	IConsoleAlias *next;        ///< next alias in list
+	IConsoleAlias(const std::string &name, const std::string &cmdline) : name(name), cmdline(cmdline) {}
 
+	std::string name;           ///< name of the alias
 	std::string cmdline;        ///< command(s) that is/are being aliased
 };
 
 struct IConsole
 {
 	typedef std::map<std::string, IConsoleCmd> CommandList;
+	typedef std::map<std::string, IConsoleAlias> AliasList;
 
 	/* console parser */
 	static CommandList &Commands();
+	static AliasList &Aliases();
 
 	/* Commands */
 	static void CmdRegister(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook = nullptr);
 	static IConsoleCmd *CmdGet(const std::string &name);
+	static void AliasRegister(const std::string &name, const std::string &cmd);
+	static IConsoleAlias *AliasGet(const std::string &name);
 };
-
-/* console parser */
-extern IConsoleAlias *_iconsole_aliases; ///< List of registered aliases.
 
 /* console functions */
 void IConsoleClearBuffer();
-
-/* Commands */
-void IConsoleAliasRegister(const std::string &name, const std::string &cmd);
-IConsoleAlias *IConsoleAliasGet(const std::string &name);
 
 /* console std lib (register ingame commands/aliases) */
 void IConsoleStdLibRegister();

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -11,6 +11,7 @@
 #define CONSOLE_INTERNAL_H
 
 #include "gfx_type.h"
+#include <map>
 
 static const uint ICON_CMDLN_SIZE     = 1024; ///< maximum length of a typed in command
 static const uint ICON_MAX_STREAMSIZE = 2048; ///< maximum length of a totally expanded command
@@ -33,9 +34,9 @@ enum ConsoleHookResult {
 typedef bool IConsoleCmdProc(byte argc, char *argv[]);
 typedef ConsoleHookResult IConsoleHook(bool echo);
 struct IConsoleCmd {
-	std::string name;         ///< name of command
-	IConsoleCmd *next;        ///< next command in list
+	IConsoleCmd(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook) : name(name), proc(proc), hook(hook) {}
 
+	std::string name;         ///< name of command
 	IConsoleCmdProc *proc;    ///< process executed when command is typed
 	IConsoleHook *hook;       ///< any special trigger action that needs executing
 };
@@ -59,17 +60,26 @@ struct IConsoleAlias {
 	std::string cmdline;        ///< command(s) that is/are being aliased
 };
 
+struct IConsole
+{
+	typedef std::map<std::string, IConsoleCmd> CommandList;
+
+	/* console parser */
+	static CommandList &Commands();
+
+	/* Commands */
+	static void CmdRegister(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook = nullptr);
+	static IConsoleCmd *CmdGet(const std::string &name);
+};
+
 /* console parser */
-extern IConsoleCmd   *_iconsole_cmds;    ///< List of registered commands.
 extern IConsoleAlias *_iconsole_aliases; ///< List of registered aliases.
 
 /* console functions */
 void IConsoleClearBuffer();
 
 /* Commands */
-void IConsoleCmdRegister(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook = nullptr);
 void IConsoleAliasRegister(const std::string &name, const std::string &cmd);
-IConsoleCmd *IConsoleCmdGet(const std::string &name);
 IConsoleAlias *IConsoleAliasGet(const std::string &name);
 
 /* console std lib (register ingame commands/aliases) */

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -33,7 +33,7 @@ enum ConsoleHookResult {
 typedef bool IConsoleCmdProc(byte argc, char *argv[]);
 typedef ConsoleHookResult IConsoleHook(bool echo);
 struct IConsoleCmd {
-	char *name;               ///< name of command
+	std::string name;         ///< name of command
 	IConsoleCmd *next;        ///< next command in list
 
 	IConsoleCmdProc *proc;    ///< process executed when command is typed
@@ -53,10 +53,10 @@ struct IConsoleCmd {
  * - ";" allows for combining commands (see example 'ng')
  */
 struct IConsoleAlias {
-	char *name;                 ///< name of the alias
+	std::string name;           ///< name of the alias
 	IConsoleAlias *next;        ///< next alias in list
 
-	char *cmdline;              ///< command(s) that is/are being aliased
+	std::string cmdline;        ///< command(s) that is/are being aliased
 };
 
 /* console parser */
@@ -67,10 +67,10 @@ extern IConsoleAlias *_iconsole_aliases; ///< List of registered aliases.
 void IConsoleClearBuffer();
 
 /* Commands */
-void IConsoleCmdRegister(const char *name, IConsoleCmdProc *proc, IConsoleHook *hook = nullptr);
-void IConsoleAliasRegister(const char *name, const char *cmd);
-IConsoleCmd *IConsoleCmdGet(const char *name);
-IConsoleAlias *IConsoleAliasGet(const char *name);
+void IConsoleCmdRegister(const std::string &name, IConsoleCmdProc *proc, IConsoleHook *hook = nullptr);
+void IConsoleAliasRegister(const std::string &name, const std::string &cmd);
+IConsoleCmd *IConsoleCmdGet(const std::string &name);
+IConsoleAlias *IConsoleAliasGet(const std::string &name);
 
 /* console std lib (register ingame commands/aliases) */
 void IConsoleStdLibRegister();
@@ -81,6 +81,5 @@ bool GetArgumentInteger(uint32 *value, const char *arg);
 void IConsoleGUIInit();
 void IConsoleGUIFree();
 void IConsoleGUIPrint(TextColour colour_code, char *string);
-char *RemoveUnderscores(char *name);
 
 #endif /* CONSOLE_INTERNAL_H */

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1142,7 +1142,7 @@ static void RegisterConsoleMidiCommands()
 {
 	static bool registered = false;
 	if (!registered) {
-		IConsoleCmdRegister("dumpsmf", CmdDumpSMF);
+		IConsole::CmdRegister("dumpsmf", CmdDumpSMF);
 		registered = true;
 	}
 }


### PR DESCRIPTION
Multiple commits to ease reviewing, but should be squashed I think.

## Motivation / Problem
When registering a command or alias in console, memory is manually allocated to store the data in global custom sorted linked lists. And we rely on OS to free this memory at exit.

Also, underscores are removed from commands/aliases names on registration, but each access needs to remove underscores to find them (and some were forgetting the removal, at least `info_cmd`). And names in `list_cmds` output didn't match names shown in `help`.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
`std::string` is used to store names, and alias command.
Custom sorted linked list is replaced with `std::map` enclosed inside a static struct.
Map key uses names without underscores, but commands/aliases themselves store the name with underscores for display.
Underscore removal is handled inside the accessors, so the caller doesn't have to care about it.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
