### PR TITLE
Fix: [CMake] Don't include regression AIs in bundles

### DIFF
--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -30,7 +30,9 @@ install(DIRECTORY
                 ${CMAKE_BINARY_DIR}/game
                 ${CMAKE_SOURCE_DIR}/bin/scripts
         DESTINATION ${DATA_DESTINATION_DIR}
-        COMPONENT language_files)
+        COMPONENT language_files
+        REGEX "ai/[^\.]+$" EXCLUDE # Ignore subdirs in ai dir
+)
 
 install(FILES
                 ${CMAKE_SOURCE_DIR}/COPYING.md


### PR DESCRIPTION
## Motivation / Problem
In #8906, I though it was a smart move to install script compat files from build dir. But I was forgetting regression AIs were also in this directory. And they ended up in bundles.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This is a revert of the install related changes I made in #8906.
I then excluded any `CMakeLists.txt` from installation.

I tried another option, using build dir as install source, but the regex to filter AIs subdirs was way harder to read (I'll show it in a suggestion comment).
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
