### PR TITLE
Few things to cleanup in the network code

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -916,7 +916,7 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 	uint16 rport = NETWORK_DEFAULT_PORT;
 	CompanyID join_as = COMPANY_NEW_COMPANY;
 
-	ParseConnectionString(&company, &port, ip);
+	ParseGameConnectionString(&company, &port, ip);
 
 	IConsolePrintF(CC_DEFAULT, "Connecting to %s...", ip);
 	if (company != nullptr) {

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -222,7 +222,7 @@ protected:
 
 	/**
 	 * Welcome a connected admin to the game:
-	 * string  Name of the Server (e.g. as advertised to master server).
+	 * string  Name of the Server.
 	 * string  OpenTTD version string.
 	 * bool    Server is dedicated.
 	 * string  Name of the Map.

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -171,9 +171,9 @@ bool NetworkContentSocketHandler::HandlePacket(Packet *p)
 
 		default:
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[tcp/content] received invalid packet type %d from %s", type, this->client_addr.GetAddressAsString().c_str());
+				DEBUG(net, 0, "[tcp/content] received invalid packet type %d", type);
 			} else {
-				DEBUG(net, 0, "[tcp/content] received illegal packet from %s", this->client_addr.GetAddressAsString().c_str());
+				DEBUG(net, 0, "[tcp/content] received illegal packet");
 			}
 			return false;
 	}
@@ -224,7 +224,7 @@ bool NetworkContentSocketHandler::ReceivePackets()
  */
 bool NetworkContentSocketHandler::ReceiveInvalidPacket(PacketContentType type)
 {
-	DEBUG(net, 0, "[tcp/content] received illegal packet type %d from %s", type, this->client_addr.GetAddressAsString().c_str());
+	DEBUG(net, 0, "[tcp/content] received illegal packet type %d", type);
 	return false;
 }
 

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -95,7 +95,6 @@ struct ContentInfo {
 /** Base socket handler for all Content TCP sockets */
 class NetworkContentSocketHandler : public NetworkTCPSocketHandler {
 protected:
-	NetworkAddress client_addr; ///< The address we're connected to.
 	void Close() override;
 
 	bool ReceiveInvalidPacket(PacketContentType type);
@@ -193,9 +192,8 @@ public:
 	 * @param s  the socket we are connected with
 	 * @param address IP etc. of the client
 	 */
-	NetworkContentSocketHandler(SOCKET s = INVALID_SOCKET, const NetworkAddress &address = NetworkAddress()) :
-		NetworkTCPSocketHandler(s),
-		client_addr(address)
+	NetworkContentSocketHandler(SOCKET s = INVALID_SOCKET) :
+		NetworkTCPSocketHandler(s)
 	{
 	}
 

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -203,10 +203,8 @@ int NetworkHTTPSocketHandler::HandleHeader()
 	*url = '\0';
 
 	/* Fetch the hostname, and possible port number. */
-	const char *company = nullptr;
 	const char *port = nullptr;
-	ParseConnectionString(&company, &port, hname);
-	if (company != nullptr) return_error("[tcp/http] invalid hostname");
+	ParseConnectionString(&port, hname);
 
 	NetworkAddress address(hname, port == nullptr ? 80 : atoi(port));
 

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -43,7 +43,8 @@ void NetworkReboot();
 void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
-void ParseConnectionString(const char **company, const char **port, char *connection_string);
+void ParseConnectionString(const char **port, char *connection_string);
+void ParseGameConnectionString(const char **company, const char **port, char *connection_string);
 void NetworkStartDebugLog(NetworkAddress address);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -478,7 +478,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 			uint16 rport = NETWORK_DEFAULT_PORT;
 			CompanyID join_as = COMPANY_NEW_COMPANY;
 
-			ParseConnectionString(&company, &port, network_conn);
+			ParseGameConnectionString(&company, &port, network_conn);
 
 			if (company != nullptr) {
 				join_as = (CompanyID)atoi(company);
@@ -584,11 +584,8 @@ int openttd_main(int argc, char *argv[])
 			dedicated = true;
 			SetDebugString("net=6");
 			if (mgo.opt != nullptr) {
-				/* Use the existing method for parsing (openttd -n).
-				 * However, we do ignore the #company part. */
-				const char *temp = nullptr;
 				const char *port = nullptr;
-				ParseConnectionString(&temp, &port, mgo.opt);
+				ParseConnectionString(&port, mgo.opt);
 				if (!StrEmpty(mgo.opt)) scanner->dedicated_host = mgo.opt;
 				if (port != nullptr) scanner->dedicated_port = atoi(port);
 			}
@@ -774,13 +771,12 @@ int openttd_main(int argc, char *argv[])
 	NetworkStartUp(); // initialize network-core
 
 	if (debuglog_conn != nullptr && _network_available) {
-		const char *not_used = nullptr;
 		const char *port = nullptr;
 		uint16 rport;
 
 		rport = NETWORK_DEFAULT_DEBUGLOG_PORT;
 
-		ParseConnectionString(&not_used, &port, debuglog_conn);
+		ParseConnectionString(&port, debuglog_conn);
 		if (port != nullptr) rport = atoi(port);
 
 		NetworkStartDebugLog(NetworkAddress(debuglog_conn, rport));


### PR DESCRIPTION
## Motivation / Problem

While working on adding STUN to the network code, I found some bits and pieces that are not really doing it for me. So I addressed them :D

## Description

- `ParseConnectionString` was, most likely out of laziness, abused a few times. I un-lazied-it.
- NetworkContentSocketHandler had a never-write-only-read variable.
- Docs were a bit confusing to me

Nothing shocking here, just upkeep.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
