### PR TITLE
Update documentation for supported OSes, required libraries, and CMake options

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -78,6 +78,8 @@ files himself via the `ZERO_CHECK` project.
 
 ## All other platforms
 Minimum required version of CMake is 3.9.
+By default this produces a Debug build with assertations enabled.
+This is a far slower build than release builds.
 
 ```bash
 mkdir build
@@ -88,6 +90,25 @@ make
 
 For more information on how to use CMake (including how to make Release builds),
 we urge you to read [their excellent manual](https://cmake.org/cmake/help/latest/guide/user-interaction/index.html).
+
+## CMake Options
+
+Via CMake, several options can be influenced to get different types of
+builds.
+
+- `-DCMAKE_BUILD_TYPE=RelWithDebInfo`: build a release build. This is
+   significant faster than a debug build, but has far less useful information
+   in case of a crash.
+- `-DOPTION_DEDICATED=ON`: build OpenTTD without a GUI. Useful if you are
+   running a headless server, as it requires less libraries to operate.
+- `-DOPTION_USE_ASSERTS=OFF`: disable asserts. Use with care, as assert
+   statements capture early signs of trouble. Release builds have them
+   disabled by default.
+- `-DOPTION_USE_THREADS=OFF`: disable the use of threads. This will block
+   the interface in many places, and in general gives a worse experience of
+   the game. Use with care.
+- `-DOPTION_TOOLS_ONLY=ON`: only build tools like `strgen`. Does not build
+   the game itself. Useful for cross-compiling.
 
 ## Supported compilers
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -2,26 +2,27 @@
 
 ## Required/optional libraries
 
-The following libraries are used by OpenTTD for:
+OpenTTD makes use of the following external libraries:
 
-- zlib: (de)compressing of old (0.3.0-1.0.5) savegames, content downloads,
+- (encouraged) zlib: (de)compressing of old (0.3.0-1.0.5) savegames, content downloads,
    heightmaps
-- liblzo2: (de)compressing of old (pre 0.3.0) savegames
-- liblzma: (de)compressing of savegames (1.1.0 and later)
-- libpng: making screenshots and loading heightmaps
+- (encouraged) liblzma: (de)compressing of savegames (1.1.0 and later)
+- (encouraged) libpng: making screenshots and loading heightmaps
+- (optional) liblzo2: (de)compressing of old (pre 0.3.0) savegames
+
+For Linux, the following additional libraries are used (for non-dedicated only):
+
+- libSDL2: hardware access (video, sound, mouse)
 - libfreetype: loading generic fonts and rendering them
 - libfontconfig: searching for fonts, resolving font names to actual fonts
 - libicu: handling of right-to-left scripts (e.g. Arabic and Persian) and
-   natural sorting of strings (Linux only)
-- libSDL2: hardware access (video, sound, mouse) (not required for Windows or macOS)
+   natural sorting of strings
 
 OpenTTD does not require any of the libraries to be present, but without
 liblzma you cannot open most recent savegames and without zlib you cannot
 open most older savegames or use the content downloading system.
-Without libSDL/liballegro on non-Windows and non-macOS machines you have
-no graphical user interface; you would be building a dedicated server.
 
-## Windows:
+## Windows
 
 You need Microsoft Visual Studio 2017 or more recent.
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ For some platforms, you will need to refer to [the installation guide](https://w
 The free data files, split into OpenGFX for graphics, OpenSFX for sounds and
 OpenMSX for music can be found at:
 
-- https://www.openttd.org/download-opengfx for OpenGFX
-- https://www.openttd.org/download-opensfx for OpenSFX
-- https://www.openttd.org/download-openmsx for OpenMSX
+- https://www.openttd.org/downloads/opengfx-releases/ for OpenGFX
+- https://www.openttd.org/downloads/opensfx-releases/ for OpenSFX
+- https://www.openttd.org/downloads/openmsx-releases/ for OpenMSX
 
 Please follow the readme of these packages about the installation procedure.
 The Windows installer can optionally download and install these packages.

--- a/README.md
+++ b/README.md
@@ -46,15 +46,13 @@ OpenTTD has a [community-maintained wiki](https://wiki.openttd.org/), including 
 
 OpenTTD has been ported to several platforms and operating systems.
 
-The currently working platforms are:
+The currently supported platforms are:
 
-- FreeBSD (SDL)
-- Haiku (SDL)
-- Linux (SDL)
-- macOS (universal) (Cocoa video and sound drivers)
-- OpenBSD (SDL)
-- OS/2 (SDL)
-- Windows (Win32 GDI (faster) or SDL)
+- Linux (SDL (OpenGL and non-OpenGL))
+- macOS (universal) (Cocoa)
+- Windows (Win32 GDI / OpenGL)
+
+Other platforms may also work (in particular various BSD systems), but we don't actively test or maintain these.
 
 ### 1.3.1) Legacy support
 Platforms, languages and compilers change.


### PR DESCRIPTION
## Motivation / Problem

Docs were out of date. I am trying to fix them a bit.

Closes #9054 , as it is an alternative to it.
Fixes #8465 again. As I changed my opinion on the matter.

## Description

Bit of a mixed bag, but:

- We listed we officially supported some OSes I am pretty sure we haven't compiled in months / years. So lets drop the act. If they work on those OSes, great! If people want to make PRs for them: awesome! But .. "officially" supported is stretching it.
- Libraries didn't indicate when they were useful. #9054 tried to address some of it, but it was outdated anyway. This should be more correct (I hope :D).
- CMake options we created were not really documented, making it hard for someone to find them. Be a bit more upfront about them. #8465 already suggested this, but I was too blind to see this is useful.
- Some links were pointing to redirects, instead of the final destination.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
