### PR TITLE
Fix: [OpenGL] Check maximum supported texture size against screen resolution.

### DIFF
--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -254,7 +254,7 @@ const char *VideoDriver_CocoaOpenGL::AllocateContext(bool allow_software)
 
 	CGLSetCurrentContext(this->gl_context);
 
-	return OpenGLBackend::Create(&GetOGLProcAddressCallback);
+	return OpenGLBackend::Create(&GetOGLProcAddressCallback, this->GetScreenSize());
 }
 
 NSView *VideoDriver_CocoaOpenGL::AllocateDrawView()

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -464,16 +464,17 @@ void SetupDebugOutput()
 /**
  * Create and initialize the singleton back-end class.
  * @param get_proc Callback to get an OpenGL function from the OS driver.
+ * @param screen_res Current display resolution.
  * @return nullptr on success, error message otherwise.
  */
-/* static */ const char *OpenGLBackend::Create(GetOGLProcAddressProc get_proc)
+/* static */ const char *OpenGLBackend::Create(GetOGLProcAddressProc get_proc, const Dimension &screen_res)
 {
 	if (OpenGLBackend::instance != nullptr) OpenGLBackend::Destroy();
 
 	GetOGLProcAddress = get_proc;
 
 	OpenGLBackend::instance = new OpenGLBackend();
-	return OpenGLBackend::instance->Init();
+	return OpenGLBackend::instance->Init(screen_res);
 }
 
 /**
@@ -521,9 +522,10 @@ OpenGLBackend::~OpenGLBackend()
 
 /**
  * Check for the needed OpenGL functionality and allocate all resources.
+ * @param screen_res Current display resolution.
  * @return Error string or nullptr if successful.
  */
-const char *OpenGLBackend::Init()
+const char *OpenGLBackend::Init(const Dimension &screen_res)
 {
 	if (!BindBasicInfoProcs()) return "OpenGL not supported";
 
@@ -580,6 +582,11 @@ const char *OpenGLBackend::Init()
 		this->persistent_mapping_supported = false;
 	}
 	if (this->persistent_mapping_supported) DEBUG(driver, 3, "OpenGL: Using persistent buffer mapping");
+
+	/* Check maximum texture size against screen resolution. */
+	GLint max_tex_size = 0;
+	_glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_tex_size);
+	if (std::max(screen_res.width, screen_res.height) > (uint)max_tex_size) return "Max supported texture size is too small";
 
 	/* Check available texture units. */
 	GLint max_tex_units = 0;

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -74,7 +74,7 @@ private:
 	OpenGLBackend();
 	~OpenGLBackend();
 
-	const char *Init();
+	const char *Init(const Dimension &screen_res);
 	bool InitShaders();
 
 	void InternalClearCursorCache();
@@ -87,7 +87,7 @@ public:
 	{
 		return OpenGLBackend::instance;
 	}
-	static const char *Create(GetOGLProcAddressProc get_proc);
+	static const char *Create(GetOGLProcAddressProc get_proc, const Dimension &screen_res);
 	static void Destroy();
 
 	void PrepareContext();

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -117,7 +117,7 @@ const char *VideoDriver_SDL_OpenGL::AllocateContext()
 
 	ToggleVsync(_video_vsync);
 
-	return OpenGLBackend::Create(&GetOGLProcAddressCallback);
+	return OpenGLBackend::Create(&GetOGLProcAddressCallback, this->GetScreenSize());
 }
 
 void VideoDriver_SDL_OpenGL::PopulateSystemSprites()

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1380,7 +1380,7 @@ const char *VideoDriver_Win32OpenGL::AllocateContext()
 	this->ToggleVsync(_video_vsync);
 
 	this->gl_rc = rc;
-	return OpenGLBackend::Create(&GetOGLProcAddressCallback);
+	return OpenGLBackend::Create(&GetOGLProcAddressCallback, this->GetScreenSize());
 }
 
 bool VideoDriver_Win32OpenGL::ToggleFullscreen(bool full_screen)


### PR DESCRIPTION
## Motivation / Problem

The OpenGL init code assumes that a full screen texture is supported, but does not check. The assumption isn't that outlandish, as you'd have to use some high-res (> full HD) screen on really old hardware/drivers to trigger it, but better be safe.


## Description / Limitations

Check max texture size against screen resolution to make sure we can always resize the window / switch to fullscreen, as we don't support runtime switching of the used video driver.

We don't know if this is in fact an issue or if this commit is fixing anything, but it shouldn't hurt. This is also ignoring multi-monitor setups or displays that are attached after OpenTTD is started.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
