### PR TITLE
[Win32] Limit OpenGL video driver to OpenGL 3.2 or newer.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -548,6 +548,12 @@ const char *OpenGLBackend::Init(const Dimension &screen_res)
 	_gl_major_ver = atoi(ver);
 	_gl_minor_ver = minor != nullptr ? atoi(minor + 1) : 0;
 
+#ifdef _WIN32
+	/* Old drivers on Windows (especially if made by Intel) seem to be
+	 * unstable, so cull the oldest stuff here.  */
+	if (!IsOpenGLVersionAtLeast(3, 2)) return "Need at least OpenGL version 3.2 on Windows";
+#endif
+
 	if (!BindBasicOpenGLProcs()) return "Failed to bind basic OpenGL functions.";
 
 	SetupDebugOutput();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1360,14 +1360,22 @@ const char *VideoDriver_Win32OpenGL::AllocateContext()
 
 	/* Create OpenGL device context. Try to get an 3.2+ context if possible. */
 	if (_wglCreateContextAttribsARB != nullptr) {
+		/* Try for OpenGL 4.5 first. */
 		int attribs[] = {
-			WGL_CONTEXT_MAJOR_VERSION_ARB, 3,
-			WGL_CONTEXT_MINOR_VERSION_ARB, 2,
+			WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
+			WGL_CONTEXT_MINOR_VERSION_ARB, 5,
 			WGL_CONTEXT_FLAGS_ARB, _debug_driver_level >= 8 ? WGL_CONTEXT_DEBUG_BIT_ARB : 0,
 			_hasWGLARBCreateContextProfile ? WGL_CONTEXT_PROFILE_MASK_ARB : 0, WGL_CONTEXT_CORE_PROFILE_BIT_ARB, // Terminate list if WGL_ARB_create_context_profile isn't supported.
 			0
 		};
 		rc = _wglCreateContextAttribsARB(this->dc, nullptr, attribs);
+
+		if (rc == nullptr) {
+			/* Try again for a 3.2 context. */
+			attribs[1] = 3;
+			attribs[3] = 2;
+			rc = _wglCreateContextAttribsARB(this->dc, nullptr, attribs);
+		}
 	}
 
 	if (rc == nullptr) {


### PR DESCRIPTION
## Motivation / Problem / Description

All OpenGL issue reports with enough info seem to have in common that they happen on Windows with old hardware.

To limit potential problems, only accept drivers that can support OpenGL 3.2 or newer on Windows to cut off the oldest hardware/drivers. As all problem reports seem to be specific to Windows, I don't see a need to prematurely limit platforms besides Windows.

The check is done in the OpenGL backend and not in the Windows driver (by forcing it with `wglCreateContextAttribsARB`) as a missing `wglCreateContextAttribsARB` proc does not automatically mean a too old OpenGL version (and theoretically SDL2 could also be used). Many drivers supply the newest supported OGL version if nothing specific is requested.

While we're at it, let Windows aim for a 4.5 context first, before falling back to 3.2, as drivers are technically not required to expose the newer functionality as GL extensions (even if everything we use also has an alternative extension specified).


## Limitations

Once again, it is unknown if it fixes/circumvents any of the reported issues.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
