### PR TITLE
Feature: Configurable subsidy duration

### DIFF
--- a/src/date_type.h
+++ b/src/date_type.h
@@ -28,6 +28,7 @@ typedef uint8  Day;   ///< Type for the day of the month, note: 1 based, first d
 static const int DAY_TICKS         =  74; ///< ticks per day
 static const int DAYS_IN_YEAR      = 365; ///< days per year
 static const int DAYS_IN_LEAP_YEAR = 366; ///< sometimes, you need one day more...
+static const int MONTHS_IN_YEAR    =  12; ///< months per year
 
 static const int STATION_RATING_TICKS     = 185; ///< cycle duration for updating station rating
 static const int STATION_ACCEPTANCE_TICKS = 250; ///< cycle duration for updating station acceptance

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -883,11 +883,11 @@ STR_NEWS_STATION_NOW_ACCEPTS_CARGO_AND_CARGO                    :{WHITE}{STATION
 
 STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED                               :{BIG_FONT}{BLACK}Offer of subsidy expired:{}{}{STRING} from {STRING2} to {STRING2} will now not attract a subsidy
 STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE                              :{BIG_FONT}{BLACK}Subsidy withdrawn:{}{}{STRING} service from {STRING2} to {STRING2} is no longer subsidised
-STR_NEWS_SERVICE_SUBSIDY_OFFERED                                :{BIG_FONT}{BLACK}Service subsidy offered:{}{}First {STRING} service from {STRING2} to {STRING2} will attract a year's subsidy from the local authority!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF                           :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay 50% extra for the next year!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_DOUBLE                         :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay double rates for the next year!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_TRIPLE                         :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay triple rates for the next year!
-STR_NEWS_SERVICE_SUBSIDY_AWARDED_QUADRUPLE                      :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay quadruple rates for the next year!
+STR_NEWS_SERVICE_SUBSIDY_OFFERED                                :{BIG_FONT}{BLACK}Service subsidy offered:{}{}First {STRING} service from {STRING2} to {STRING2} will attract a {NUM} year subsidy from the local authority!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF                           :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay 50% extra for the next {NUM} year{P "" s}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_DOUBLE                         :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay double rates for the next {NUM} year{P "" s}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_TRIPLE                         :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay triple rates for the next {NUM} year{P "" s}!
+STR_NEWS_SERVICE_SUBSIDY_AWARDED_QUADRUPLE                      :{BIG_FONT}{BLACK}Service subsidy awarded to {RAW_STRING}!{}{}{STRING} service from {STRING2} to {STRING2} will pay quadruple rates for the next {NUM} year{P "" s}!
 
 STR_NEWS_ROAD_REBUILDING                                        :{BIG_FONT}{BLACK}Traffic chaos in {TOWN}!{}{}Road rebuilding programme funded by {RAW_STRING} brings 6 months of misery to motorists!
 STR_NEWS_EXCLUSIVE_RIGHTS_TITLE                                 :{BIG_FONT}{BLACK}Transport monopoly!
@@ -1203,6 +1203,10 @@ STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS                           :Vehicle breakdo
 STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS_HELPTEXT                  :Control how often inadequately serviced vehicles may break down
 STR_CONFIG_SETTING_SUBSIDY_MULTIPLIER                           :Subsidy multiplier: {STRING2}
 STR_CONFIG_SETTING_SUBSIDY_MULTIPLIER_HELPTEXT                  :Set how much is paid for subsidised connections
+STR_CONFIG_SETTING_SUBSIDY_DURATION                             :Subsidy duration: {STRING2}
+STR_CONFIG_SETTING_SUBSIDY_DURATION_HELPTEXT                    :Set the number of years for which a subsidy is awarded
+STR_CONFIG_SETTING_SUBSIDY_DURATION_VALUE                       :{NUM} year{P "" s}
+STR_CONFIG_SETTING_SUBSIDY_DURATION_DISABLED                    :No subsidies
 STR_CONFIG_SETTING_CONSTRUCTION_COSTS                           :Construction costs: {STRING2}
 STR_CONFIG_SETTING_CONSTRUCTION_COSTS_HELPTEXT                  :Set level of construction and purchase costs
 STR_CONFIG_SETTING_RECESSIONS                                   :Recessions: {STRING2}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -328,6 +328,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 v1.11.0-RC1  Additional GS text for industries.
 	SLV_MAPGEN_SETTINGS_REVAMP,             ///< 290  PR#8891 v1.11  Revamp of some mapgen settings (snow coverage, desert coverage, heightmap height, custom terrain type).
 	SLV_GROUP_REPLACE_WAGON_REMOVAL,        ///< 291  PR#7441 Per-group wagon removal flag.
+	SLV_CUSTOM_SUBSIDY_DURATION,            ///< 292  PR#9081 Configurable subsidy duration.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -16,14 +16,15 @@
 
 static const SaveLoad _subsidies_desc[] = {
 	    SLE_VAR(Subsidy, cargo_type, SLE_UINT8),
-	    SLE_VAR(Subsidy, remaining,  SLE_UINT8),
-	SLE_CONDVAR(Subsidy, awarded,    SLE_UINT8,                 SLV_125, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, src_type,   SLE_UINT8,                 SLV_125, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, dst_type,   SLE_UINT8,                 SLV_125, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, src,        SLE_FILE_U8 | SLE_VAR_U16,   SL_MIN_VERSION, SLV_5),
-	SLE_CONDVAR(Subsidy, src,        SLE_UINT16,                  SLV_5, SL_MAX_VERSION),
-	SLE_CONDVAR(Subsidy, dst,        SLE_FILE_U8 | SLE_VAR_U16,   SL_MIN_VERSION, SLV_5),
-	SLE_CONDVAR(Subsidy, dst,        SLE_UINT16,                  SLV_5, SL_MAX_VERSION),
+	SLE_CONDVAR(Subsidy, remaining,  SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION, SLV_CUSTOM_SUBSIDY_DURATION),
+	SLE_CONDVAR(Subsidy, remaining,  SLE_UINT16,                SLV_CUSTOM_SUBSIDY_DURATION, SL_MAX_VERSION),
+	SLE_CONDVAR(Subsidy, awarded,    SLE_UINT8,                                     SLV_125, SL_MAX_VERSION),
+	SLE_CONDVAR(Subsidy, src_type,   SLE_UINT8,                                     SLV_125, SL_MAX_VERSION),
+	SLE_CONDVAR(Subsidy, dst_type,   SLE_UINT8,                                     SLV_125, SL_MAX_VERSION),
+	SLE_CONDVAR(Subsidy, src,        SLE_FILE_U8 | SLE_VAR_U16,                       SL_MIN_VERSION, SLV_5),
+	SLE_CONDVAR(Subsidy, src,        SLE_UINT16,                                      SLV_5, SL_MAX_VERSION),
+	SLE_CONDVAR(Subsidy, dst,        SLE_FILE_U8 | SLE_VAR_U16,                       SL_MIN_VERSION, SLV_5),
+	SLE_CONDVAR(Subsidy, dst,        SLE_UINT16,                                      SLV_5, SL_MAX_VERSION),
 };
 
 static void Save_SUBS()

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1691,6 +1691,7 @@ static SettingsContainer &GetSettingsTree()
 			accounting->Add(new SettingEntry("difficulty.initial_interest"));
 			accounting->Add(new SettingEntry("difficulty.max_loan"));
 			accounting->Add(new SettingEntry("difficulty.subsidy_multiplier"));
+			accounting->Add(new SettingEntry("difficulty.subsidy_duration"));
 			accounting->Add(new SettingEntry("economy.feeder_payment_share"));
 			accounting->Add(new SettingEntry("economy.infrastructure_maintenance"));
 			accounting->Add(new SettingEntry("difficulty.vehicle_costs"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -72,7 +72,8 @@ struct DifficultySettings {
 	byte   vehicle_costs;                    ///< amount of money spent on vehicle running cost
 	byte   competitor_speed;                 ///< the speed at which the AI builds
 	byte   vehicle_breakdowns;               ///< likelihood of vehicles breaking down
-	byte   subsidy_multiplier;               ///< amount of subsidy
+	byte   subsidy_multiplier;               ///< payment multiplier for subsidized deliveries
+	uint16 subsidy_duration;                 ///< duration of subsidies
 	byte   construction_cost;                ///< how expensive is building
 	byte   terrain_type;                     ///< the mountainousness of the landscape
 	byte   quantity_sea_lakes;               ///< the amount of seas/lakes

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -21,7 +21,7 @@ extern SubsidyPool _subsidy_pool;
 /** Struct about subsidies, offered and awarded */
 struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
 	CargoID cargo_type;  ///< Cargo type involved in this subsidy, CT_INVALID for invalid subsidy
-	byte remaining;      ///< Remaining months when this subsidy is valid
+	uint16 remaining;    ///< Remaining months when this subsidy is valid
 	CompanyID awarded;   ///< Subsidy is awarded to this company; INVALID_COMPANY if it's not awarded to anyone
 	SourceType src_type; ///< Source of subsidised path (ST_INDUSTRY or ST_TOWN)
 	SourceType dst_type; ///< Destination of subsidised path (ST_INDUSTRY or ST_TOWN)
@@ -52,11 +52,18 @@ struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
 
 /** Constants related to subsidies */
 static const uint SUBSIDY_OFFER_MONTHS         =  12; ///< Duration of subsidy offer
-static const uint SUBSIDY_CONTRACT_MONTHS      =  12; ///< Duration of subsidy after awarding
 static const uint SUBSIDY_PAX_MIN_POPULATION   = 400; ///< Min. population of towns for subsidised pax route
 static const uint SUBSIDY_CARGO_MIN_POPULATION = 900; ///< Min. population of destination town for cargo route
 static const uint SUBSIDY_MAX_PCT_TRANSPORTED  =  42; ///< Subsidy will be created only for towns/industries with less % transported
 static const uint SUBSIDY_MAX_DISTANCE         =  70; ///< Max. length of subsidised route (DistanceManhattan)
 static const uint SUBSIDY_TOWN_CARGO_RADIUS    =   6; ///< Extent of a tile area around town center when scanning for town cargo acceptance and production (6 ~= min catchmement + min station / 2)
+
+/** Types of subsidy news messages, which determine how the date is printed and whether to use singular or plural cargo names */
+enum class SubsidyDecodeParamType {
+	NewsOffered   = 0, ///< News item for an offered subsidy
+	NewsAwarded   = 1, ///< News item for an awarded subsidy
+	NewsWithdrawn = 2, ///< News item for a subsidy offer withdrawn, or expired subsidy
+	Gui           = 3, ///< Subsidies listed in the Subsidy GUI
+};
 
 #endif /* SUBSIDY_BASE_H */

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -15,8 +15,9 @@
 #include "company_type.h"
 #include "cargo_type.h"
 #include "news_type.h"
+#include "subsidy_base.h"
 
-std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, bool mode);
+std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode);
 void DeleteSubsidyWith(SourceType type, SourceID index);
 bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type, SourceID src, const Station *st);
 void RebuildSubsidisedSourceAndDestinationCache();

--- a/src/subsidy_gui.cpp
+++ b/src/subsidy_gui.cpp
@@ -161,7 +161,7 @@ struct SubsidyListWindow : Window {
 			if (!s->IsAwarded()) {
 				if (IsInsideMM(pos, 0, cap)) {
 					/* Displays the two offered towns */
-					SetupSubsidyDecodeParam(s, true);
+					SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::Gui);
 					SetDParam(7, _date - ymd.day + s->remaining * 32);
 					DrawString(x, right, y + pos * FONT_HEIGHT_NORMAL, STR_SUBSIDIES_OFFERED_FROM_TO);
 				}
@@ -184,7 +184,7 @@ struct SubsidyListWindow : Window {
 		for (const Subsidy *s : Subsidy::Iterate()) {
 			if (s->IsAwarded()) {
 				if (IsInsideMM(pos, 0, cap)) {
-					SetupSubsidyDecodeParam(s, true);
+					SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::Gui);
 					SetDParam(7, s->awarded);
 					SetDParam(8, _date - ymd.day + s->remaining * 32);
 

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -232,6 +232,19 @@ strhelp  = STR_CONFIG_SETTING_SUBSIDY_MULTIPLIER_HELPTEXT
 strval   = STR_SUBSIDY_X1_5
 
 [SDT_VAR]
+var      = difficulty.subsidy_duration
+type     = SLE_UINT16
+from     = SLV_CUSTOM_SUBSIDY_DURATION
+flags    = SF_GUI_0_IS_SPECIAL
+def      = 1
+min      = 0
+max      = 5000
+interval = 1
+str      = STR_CONFIG_SETTING_SUBSIDY_DURATION
+strhelp  = STR_CONFIG_SETTING_SUBSIDY_DURATION_HELPTEXT
+strval   = STR_CONFIG_SETTING_SUBSIDY_DURATION_VALUE
+
+[SDT_VAR]
 var      = difficulty.construction_cost
 type     = SLE_UINT8
 from     = SLV_97


### PR DESCRIPTION
## Motivation / Problem

Subsidies are hard-coded to last only one year, with a maximum distance of 70 tiles (Manhattan distance). While this incentivizes local, short-distance routes which ordinarily don't pay much, even with the subsidy multiplier the short duration of the subsidy often isn't worth the player's time and effort.

## Description

![subsidy_255](https://user-images.githubusercontent.com/55058389/115769172-3e81db00-a379-11eb-9eeb-7f499e24c9a9.png)

This PR adds a `Settings > Subsidy duration` to allow players to select the subsidy length, in years.

Slightly longer subsidies would be more powerful and beneficial to players. Additionally, allowing much longer subsidies would allow new gameplay modes, such as making unsubsidized NewGRF cargos unprofitable and forcing players to compete for long-term subsidies created by the game or a GS.

The setting defaults to 1, the current hard-coded duration. The minimum value is 0, which disables subsidies, and the maximum is 5000; a nice round number which doesn't overflow the uint16 storing the subsidy duration in months. The longest games I've seen in screenshots are between 500 and 1000 years, so this should be plenty of space for an effectively indefinite subsidy. _(Note: the maximum was originally 256 when I created the PR, but I realized this wasn't long enough.)_

I know that adding settings needs strong justification, so I considered several alternatives, none of which felt right:
- Inverse correlation with company score, using the same stages as the company HQ — introducing a Mario Kart item-like negative feedback loop to boost new and struggling companies while being less effective for larger companies. I actually started with this and it was cool, but would need major changes to news and the Subsidies GUI to display different information for each player.
- Inverse correlation with the selected subsidy payment multiplier, e.g. a 1.5x multiplier for 5 years or a 4x multiplier for 1 year. But this breaks existing gameplay styles and customization.
- The above, but chosen randomly for each subsidy and using a new "Random" option for the multiplier setting. It's a messy reuse of an existing setting. Bleh.

So I added a setting.

Note that while subsidies are randomly calculated each month without regard to how many subsidies currently exist, new subsidy offers will not accumulate forever since towns and industries with more than 42% of cargo transported are ineligible for new subsidies.

I also plan to look at increasing the maximum distance of the subsidy based on town and industry density to fix subsidies not being possible on low-density maps, but that is a separate project entirely.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
