### PR TITLE
Fix: [NewGRF] industry variables 65 and 66, object variable 46

### DIFF
--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -286,11 +286,11 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 			TileIndex tile = GetNearbyTile(parameter, this->tile, true);
 			return GetTownRadiusGroup(this->industry->town, tile) << 16 | std::min(DistanceManhattan(tile, this->industry->town->xy), 0xFFFFu);
 		}
-		/* Get square of Euclidian distance of closes town */
+		/* Get square of Euclidian distance of closest town */
 		case 0x66: {
 			if (this->tile == INVALID_TILE) break;
 			TileIndex tile = GetNearbyTile(parameter, this->tile, true);
-			return GetTownRadiusGroup(this->industry->town, tile) << 16 | std::min(DistanceSquare(tile, this->industry->town->xy), 0xFFFFu);
+			return DistanceSquare(tile, this->industry->town->xy);
 		}
 
 		/* Count of industry, distance of closest instance

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -281,13 +281,17 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 			if (this->tile == INVALID_TILE) break;
 			return GetClosestIndustry(this->tile, MapNewGRFIndustryType(parameter, indspec->grf_prop.grffile->grfid), this->industry);
 		/* Get town zone and Manhattan distance of closest town */
-		case 0x65:
+		case 0x65: {
 			if (this->tile == INVALID_TILE) break;
-			return GetTownRadiusGroup(this->industry->town, this->tile) << 16 | std::min(DistanceManhattan(this->tile, this->industry->town->xy), 0xFFFFu);
+			TileIndex tile = GetNearbyTile(parameter, this->tile, true);
+			return GetTownRadiusGroup(this->industry->town, tile) << 16 | std::min(DistanceManhattan(tile, this->industry->town->xy), 0xFFFFu);
+		}
 		/* Get square of Euclidian distance of closes town */
-		case 0x66:
+		case 0x66: {
 			if (this->tile == INVALID_TILE) break;
-			return GetTownRadiusGroup(this->industry->town, this->tile) << 16 | std::min(DistanceSquare(this->tile, this->industry->town->xy), 0xFFFFu);
+			TileIndex tile = GetNearbyTile(parameter, this->tile, true);
+			return GetTownRadiusGroup(this->industry->town, tile) << 16 | std::min(DistanceSquare(tile, this->industry->town->xy), 0xFFFFu);
+		}
 
 		/* Count of industry, distance of closest instance
 		 * 68 is the same as 67, but with a filtering on selected layout */

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -303,8 +303,8 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte local_id, uint32 grfid, 
 		/* Get town zone and Manhattan distance of closest town */
 		case 0x45: return GetTownRadiusGroup(t, this->tile) << 16 | std::min(DistanceManhattan(this->tile, t->xy), 0xFFFFu);
 
-		/* Get square of Euclidian distance of closes town */
-		case 0x46: return GetTownRadiusGroup(t, this->tile) << 16 | std::min(DistanceSquare(this->tile, t->xy), 0xFFFFu);
+		/* Get square of Euclidian distance of closest town */
+		case 0x46: return DistanceSquare(this->tile, t->xy);
 
 		/* Object colour */
 		case 0x47: return this->obj->colour;


### PR DESCRIPTION
## Motivation / Problem

NFO spec and TTDP agree on this behavior:
* Industry variables 65 and 66 use the parameters as *signed* tile offset.
* Industry variable 66 and object variable 46 return no town zone, and use 32bit for the squared euclidian distance. (you can exceed 16bit already on a 256x256 map.)

OTTD contains various copy&paste mistakes that make it differ in the above items.

## Description

The variables are fixed.
If a NewGRF would read the townzone from the euclidian-distance variable, it would break.
NewGRF written in NML are not affected (NML read the townzone from the correct variable).
NewGRF written in NFO (if there are any), are likely not affected, if the authors read the specs instead of OTTD source.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
