### PR TITLE
Add: [GitHub] use issue templates to make it more clear what we expect from users

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-## Version of OpenTTD
-
-## Expected result
-
-## Actual result
-
-## Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,17 @@
+---
+name: Bugs
+about: Found a bug in OpenTTD?
+title: "Bug Report"
+---
+
+## Version of OpenTTD
+<!-- Indicate what version of OpenTTD you are using, including your OS. -->
+
+## Expected result
+<!-- Describe in a few words what you expected to happen. -->
+
+## Actual result
+<!-- Descibe in a few words what actually happens. -->
+
+## Steps to reproduce
+<!-- As detailed as possible, please tell us how we can reproduce this. Feel free to attach a savegame (zip it first) to make it more clear. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+- name: Suggestions and ideas?
+  url: https://www.tt-forums.net/viewforum.php?f=32
+  about: Have a suggestion or an idea for a cool new feature? Post them on our forum!

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -1,0 +1,12 @@
+---
+name: Crash
+about: Did OpenTTD crash?
+title: "Crash Report"
+---
+<!-- Please zip the crash.log, crash.dmp and crash.sav and attach it to this crash report. -->
+
+## Version of OpenTTD
+<!-- Indicate what version of OpenTTD you are using, including your OS. -->
+
+## Steps to reproduce
+<!-- Please spend a few words if you can reproduce this problem. -->


### PR DESCRIPTION
## Motivation / Problem

Lately we have seen crash reports without the required files, and also suggestions that don't belong on our bug-tracker.

So, to solve that, lets power-up in GitHub, and add some issue templates.

## Description

See https://github.com/TrueBrain/OpenTTD/issues/new/choose for example

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
