### PR TITLE
Feature: [NewGRF] vehicle var 0x4E, 'date of last station departure'

### DIFF
--- a/src/date.cpp
+++ b/src/date.cpp
@@ -211,7 +211,10 @@ static void OnNewYear()
 		_cur_year--;
 		days_this_year = IsLeapYear(_cur_year) ? DAYS_IN_LEAP_YEAR : DAYS_IN_YEAR;
 		_date -= days_this_year;
-		for (Vehicle *v : Vehicle::Iterate()) v->date_of_last_service -= days_this_year;
+		for (Vehicle *v : Vehicle::Iterate()) {
+			v->date_of_last_service -= days_this_year;
+			v->last_station_departure_date -= days_this_year;
+		}
 		for (LinkGraph *lg : LinkGraph::Iterate()) lg->ShiftDates(-days_this_year);
 
 		/* Because the _date wraps here, and text-messages expire by game-days, we have to clean out

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -611,6 +611,8 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 				SetBit(v->grf_cache.cache_valid, NCVV_POSITION_IN_VEHICLE);
 			}
 			return v->grf_cache.position_in_vehicle;
+		case 0x4E: // Long date of last station departure
+			return v->last_station_departure_date;
 
 		/* Variables which use the parameter */
 		case 0x60: // Count consist's engine ID occurrence

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -327,6 +327,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 v1.11.0-RC1  Additional GS text for industries.
 	SLV_MAPGEN_SETTINGS_REVAMP,             ///< 290  PR#8891 v1.11  Revamp of some mapgen settings (snow coverage, desert coverage, heightmap height, custom terrain type).
 	SLV_GROUP_REPLACE_WAGON_REMOVAL,        ///< 291  PR#7441 Per-group wagon removal flag.
+	SLV_VEH_LAST_STATION_DEPARTURE,         ///< 292  PR#9093 NewGRF vehicle var last station departure date
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -619,6 +619,7 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		 SLE_CONDVAR(Vehicle, last_station_visited,  SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_5),
 		 SLE_CONDVAR(Vehicle, last_station_visited,  SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
 		 SLE_CONDVAR(Vehicle, last_loading_station,  SLE_UINT16,                 SLV_182, SL_MAX_VERSION),
+		 SLE_CONDVAR(Vehicle, last_station_departure_date,  SLE_INT32,             SLV_VEH_LAST_STATION_DEPARTURE, SL_MAX_VERSION),
 
 		     SLE_VAR(Vehicle, cargo_type,            SLE_UINT8),
 		 SLE_CONDVAR(Vehicle, cargo_subtype,         SLE_UINT8,                   SLV_35, SL_MAX_VERSION),

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -61,6 +61,7 @@ static const NIVariable _niv_vehicles[] = {
 	NIV(0x4B, "long date of last service"),
 	NIV(0x4C, "current max speed"),
 	NIV(0x4D, "position in articulated vehicle"),
+	NIV(0x4E, "long date of last station departure"),
 	NIV(0x60, "count vehicle id occurrences"),
 	// 0x61 not useful, since it requires register 0x10F
 	NIV(0x62, "curvature/position difference to other vehicle"),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -354,6 +354,7 @@ Vehicle::Vehicle(VehicleType type)
 	this->cargo_age_counter  = 1;
 	this->last_station_visited = INVALID_STATION;
 	this->last_loading_station = INVALID_STATION;
+	this->last_station_departure_date = INVALID_DATE;
 }
 
 /**
@@ -2278,6 +2279,7 @@ void Vehicle::LeaveStation()
 
 	HideFillingPercent(&this->fill_percent_te_id);
 	trip_occupancy = CalcPercentVehicleFilled(this, nullptr);
+	this->last_station_departure_date = _date;
 
 	if (this->type == VEH_TRAIN && !(this->vehstatus & VS_CRASHED)) {
 		/* Trigger station animation (trains only) */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -310,6 +310,7 @@ public:
 
 	StationID last_station_visited;     ///< The last station we stopped at.
 	StationID last_loading_station;     ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
+	Date last_station_departure_date;   ///< Date of the last station departure.
 
 	CargoID cargo_type;                 ///< type of cargo this vehicle is carrying
 	byte cargo_subtype;                 ///< Used for livery refits (NewGRF variations)


### PR DESCRIPTION
## Motivation / Problem

Extends NewGRF API with vehicle var 0x4E  'Last Station Departure Date'.
Using a "date" value makes this variable similar to use as "date of last service".
The use-cases are also similar (stuff that is refreshed/refilled/refurbished in stations, instead of in depots).

## Description

* vehicle property for long date (integer days since 1-1-0) of last station departure
* property will be DATE_INVALID until at least one station has been departed from
* date is set by LeaveStation()
* newgrf var 0x4E is provided to read the property
* var 0x4E provided in newgrf vehicle debug window
* exceeding max year handled in same ways as "date of last service"

## Limitations

* for trains or articulated RVs, the property is only updated for lead vehicle
  * seems like TMWFTLB to recursively set an identical value on every vehicle in the consist)
  * frosch indicates this is fine
  * newgrf can access the var with PARENT scope, no problems using it
* nml patch: https://github.com/OpenTTD/nml/pull/211
* needs newgrf documentation before PR is ready
* tested with a grf, works as expected

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
