### PR TITLE
Fix: [NewGRF] Negative results from cargo-income callback 39.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -979,7 +979,7 @@ Money GetTransportedGoodsIncome(uint num_pieces, uint dist, byte transit_days, C
 			int result = GB(callback, 0, 14);
 
 			/* Simulate a 15 bit signed value */
-			if (HasBit(callback, 14)) result -= 0x4000;
+			if (HasBit(callback, 14)) result -= 0x8000;
 
 			/* "The result should be a signed multiplier that gets multiplied
 			 * by the amount of cargo moved and the price factor, then gets


### PR DESCRIPTION
## Motivation / Problem

| Callback result | Expected meaning | Actual meaning | Comment |
| --- | --- | --- | --- |
| 0 to 0x3FFF | 0 to 0x3FFF | 0 to 0x3FFF | good |
| 0x4000 to 0x7FFF | -0x4000 to -1 | 0 to 0x3FFF | wrong |

## Description

The sign bit was discarded, now it is used.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
