### PR TITLE
Fix #9097: Upper 16 bits of cargo base payment rate were discarded.

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -59,7 +59,7 @@ struct CargoSpec {
 	uint8 rating_colour;
 	uint8 weight;                    ///< Weight of a single unit of this cargo type in 1/16 ton (62.5 kg).
 	uint16 multiplier;               ///< Capacity multiplier for vehicles. (8 fractional bits)
-	uint16 initial_payment;
+	uint32 initial_payment;          ///< Initial payment rate before inflation is applied.
 	uint8 transit_days[2];
 
 	bool is_freight;                 ///< Cargo type is considered to be freight (affects train freight multiplier).


### PR DESCRIPTION
## Motivation / Problem

NewGRF spec says that base payment rate is 32 bits, but it was loaded into a 16 bit variable. Values above 65535 would therefore be lower than expected.

## Description

initial_payment is changed to a uint32. This value is loaded into a Money variable after inflation is applied, so no immediate issues with overflow are anticipated.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
