### PR TITLE
"Feature": Bigger packets in network protocols

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -31,7 +31,21 @@ static const uint16 NETWORK_ADMIN_PORT            = 3977;         ///< The defau
 static const uint16 NETWORK_DEFAULT_DEBUGLOG_PORT = 3982;         ///< The default port debug-log is sent to (TCP)
 
 static const uint16 UDP_MTU                       = 1460;         ///< Number of bytes we can pack in a single UDP packet
-static const uint16 TCP_MTU                       = 1460;         ///< Number of bytes we can pack in a single TCP packet
+/*
+ * Technically a TCP packet could become 64kiB, however the high bit is kept so it becomes possible in the future
+ * to go to (significantly) larger packets if needed. This would entail a strategy such as employed for UTF-8.
+ *
+ * Packets up to 32 KiB have the high bit not set:
+ * 00000000 00000000 0bbbbbbb aaaaaaaa -> aaaaaaaa 0bbbbbbb
+ * Send_uint16(GB(size, 0, 15)
+ *
+ * Packets up to 1 GiB, first uint16 has high bit set so it knows to read a
+ * next uint16 for the remaining bits of the size.
+ * 00dddddd cccccccc bbbbbbbb aaaaaaaa -> cccccccc 10dddddd aaaaaaaa bbbbbbbb
+ * Send_uint16(GB(size, 16, 14) | 0b10 << 14)
+ * Send_uint16(GB(size,  0, 16))
+ */
+static const uint16 TCP_MTU                       = 32767;        ///< Number of bytes we can pack in a single TCP packet
 static const uint16 COMPAT_MTU                    = 1460;         ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION      =    1;         ///< What version of the admin network do we use?

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -30,7 +30,9 @@ static const uint16 NETWORK_DEFAULT_PORT          = 3979;         ///< The defau
 static const uint16 NETWORK_ADMIN_PORT            = 3977;         ///< The default port for admin network
 static const uint16 NETWORK_DEFAULT_DEBUGLOG_PORT = 3982;         ///< The default port debug-log is sent to (TCP)
 
-static const uint16 SEND_MTU                      = 1460;         ///< Number of bytes we can pack in a single packet
+static const uint16 UDP_MTU                       = 1460;         ///< Number of bytes we can pack in a single UDP packet
+static const uint16 TCP_MTU                       = 1460;         ///< Number of bytes we can pack in a single TCP packet
+static const uint16 COMPAT_MTU                    = 1460;         ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION      =    1;         ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION       =    4;         ///< What version of game-info do we use?
@@ -46,14 +48,14 @@ static const uint NETWORK_PASSWORD_LENGTH         =   33;         ///< The maxim
 static const uint NETWORK_CLIENTS_LENGTH          =  200;         ///< The maximum length for the list of clients that controls a company, in bytes including '\0'
 static const uint NETWORK_CLIENT_NAME_LENGTH      =   25;         ///< The maximum length of a client's name, in bytes including '\0'
 static const uint NETWORK_RCONCOMMAND_LENGTH      =  500;         ///< The maximum length of a rconsole command, in bytes including '\0'
-static const uint NETWORK_GAMESCRIPT_JSON_LENGTH  = SEND_MTU - 3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than SEND_MTU including header (3 bytes)
+static const uint NETWORK_GAMESCRIPT_JSON_LENGTH  = COMPAT_MTU-3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than COMPAT_MTU including header (3 bytes)
 static const uint NETWORK_CHAT_LENGTH             =  900;         ///< The maximum length of a chat message, in bytes including '\0'
 
 static const uint NETWORK_GRF_NAME_LENGTH         =   80;         ///< Maximum length of the name of a GRF
 
 /**
  * Maximum number of GRFs that can be sent.
- * This limit is reached when PACKET_UDP_SERVER_RESPONSE reaches the maximum size of SEND_MTU bytes.
+ * This limit is reached when PACKET_UDP_SERVER_RESPONSE reaches the maximum size of UDP_MTU bytes.
  */
 static const uint NETWORK_MAX_GRF_COUNT           =   62;
 

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -39,7 +39,7 @@ Packet::Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size)
 /**
  * Creates a packet to send
  * @param type  The type of the packet to send
- * @param limit The maximum number of bytes the packet may have. Default is SEND_MTU.
+ * @param limit The maximum number of bytes the packet may have. Default is COMPAT_MTU.
  *              Be careful of compatibility with older clients/servers when changing
  *              the limit as it might break things if the other side is not expecting
  *              much larger packets than what they support.

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -25,10 +25,11 @@ typedef uint8  PacketType; ///< Identifier for the packet
  * Internal entity of a packet. As everything is sent as a packet,
  * all network communication will need to call the functions that
  * populate the packet.
- * Every packet can be at most SEND_MTU bytes. Overflowing this
- * limit will give an assertion when sending (i.e. writing) the
- * packet. Reading past the size of the packet when receiving
- * will return all 0 values and "" in case of the string.
+ * Every packet can be at most a limited number bytes set in the
+ * constructor. Overflowing this limit will give an assertion when
+ * sending (i.e. writing) the packet. Reading past the size of the
+ * packet when receiving will return all 0 values and "" in case of
+ * the string.
  *
  * --- Points of attention ---
  *  - all > 1 byte integral values are written in little endian,
@@ -47,13 +48,15 @@ private:
 	PacketSize pos;
 	/** The buffer of this packet. */
 	std::vector<byte> buffer;
+	/** The limit for the packet size. */
+	size_t limit;
 
 	/** Socket we're associated with. */
 	NetworkSocketHandler *cs;
 
 public:
-	Packet(NetworkSocketHandler *cs, size_t initial_read_size = sizeof(PacketSize));
-	Packet(PacketType type);
+	Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size = sizeof(PacketSize));
+	Packet(PacketType type, size_t limit = SEND_MTU);
 
 	static void AddToQueue(Packet **queue, Packet *packet);
 	static Packet *PopFromQueue(Packet **queue);

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -56,7 +56,7 @@ private:
 
 public:
 	Packet(NetworkSocketHandler *cs, size_t limit, size_t initial_read_size = sizeof(PacketSize));
-	Packet(PacketType type, size_t limit = SEND_MTU);
+	Packet(PacketType type, size_t limit = COMPAT_MTU);
 
 	static void AddToQueue(Packet **queue, Packet *packet);
 	static Packet *PopFromQueue(Packet **queue);

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -126,7 +126,7 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
 	if (!this->IsConnected()) return nullptr;
 
 	if (this->packet_recv == nullptr) {
-		this->packet_recv = new Packet(this);
+		this->packet_recv = new Packet(this, SEND_MTU);
 	}
 
 	Packet *p = this->packet_recv;

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -126,7 +126,7 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
 	if (!this->IsConnected()) return nullptr;
 
 	if (this->packet_recv == nullptr) {
-		this->packet_recv = new Packet(this, SEND_MTU);
+		this->packet_recv = new Packet(this, TCP_MTU);
 	}
 
 	Packet *p = this->packet_recv;

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -119,8 +119,8 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			struct sockaddr_storage client_addr;
 			memset(&client_addr, 0, sizeof(client_addr));
 
-			/* The limit is SEND_MTU, but also allocate that much as we need to read the whole packet in one go. */
-			Packet p(this, SEND_MTU, SEND_MTU);
+			/* The limit is UDP_MTU, but also allocate that much as we need to read the whole packet in one go. */
+			Packet p(this, UDP_MTU, UDP_MTU);
 			socklen_t client_len = sizeof(client_addr);
 
 			/* Try to receive anything */

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -119,7 +119,8 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			struct sockaddr_storage client_addr;
 			memset(&client_addr, 0, sizeof(client_addr));
 
-			Packet p(this, SEND_MTU);
+			/* The limit is SEND_MTU, but also allocate that much as we need to read the whole packet in one go. */
+			Packet p(this, SEND_MTU, SEND_MTU);
 			socklen_t client_len = sizeof(client_addr);
 
 			/* Try to receive anything */

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -560,8 +560,8 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendConsole(const char *origi
 	/* If the length of both strings, plus the 2 '\0' terminations and 3 bytes of the packet
 	 * are bigger than the MTU, just ignore the message. Better safe than sorry. It should
 	 * never occur though as the longest strings are chat messages, which are still 30%
-	 * smaller than SEND_MTU. */
-	if (strlen(origin) + strlen(string) + 2 + 3 >= SEND_MTU) return NETWORK_RECV_STATUS_OKAY;
+	 * smaller than COMPAT_MTU. */
+	if (strlen(origin) + strlen(string) + 2 + 3 >= COMPAT_MTU) return NETWORK_RECV_STATUS_OKAY;
 
 	Packet *p = new Packet(ADMIN_PACKET_SERVER_CONSOLE);
 
@@ -610,7 +610,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCmdNames()
 	for (uint i = 0; i < CMD_END; i++) {
 		const char *cmdname = GetCommandName(i);
 
-		/* Should SEND_MTU be exceeded, start a new packet
+		/* Should COMPAT_MTU be exceeded, start a new packet
 		 * (magic 5: 1 bool "more data" and one uint16 "command id", one
 		 * byte for string '\0' termination and 1 bool "no more data" */
 		if (p->CanWriteToPacket(strlen(cmdname) + 5)) {

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -221,9 +221,9 @@ void ClientNetworkContentSocketHandler::RequestContentList(uint count, const Con
 		 * A packet begins with the packet size and a byte for the type.
 		 * Then this packet adds a uint16 for the count in this packet.
 		 * The rest of the packet can be used for the IDs. */
-		uint p_count = std::min<uint>(count, (COMPAT_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
+		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
 
-		Packet *p = new Packet(PACKET_CONTENT_CLIENT_INFO_ID, COMPAT_MTU);
+		Packet *p = new Packet(PACKET_CONTENT_CLIENT_INFO_ID, TCP_MTU);
 		p->Send_uint16(p_count);
 
 		for (uint i = 0; i < p_count; i++) {
@@ -248,10 +248,10 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 	this->Connect();
 
 	assert(cv->size() < 255);
-	assert(cv->size() < (COMPAT_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8)) /
+	assert(cv->size() < (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8)) /
 			(sizeof(uint8) + sizeof(uint32) + (send_md5sum ? /*sizeof(ContentInfo::md5sum)*/16 : 0)));
 
-	Packet *p = new Packet(send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID);
+	Packet *p = new Packet(send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID, TCP_MTU);
 	p->Send_uint8((uint8)cv->size());
 
 	for (const ContentInfo *ci : *cv) {
@@ -363,9 +363,9 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentFallback(const Co
 		 * A packet begins with the packet size and a byte for the type.
 		 * Then this packet adds a uint16 for the count in this packet.
 		 * The rest of the packet can be used for the IDs. */
-		uint p_count = std::min<uint>(count, (COMPAT_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
+		uint p_count = std::min<uint>(count, (TCP_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
 
-		Packet *p = new Packet(PACKET_CONTENT_CLIENT_CONTENT);
+		Packet *p = new Packet(PACKET_CONTENT_CLIENT_CONTENT, TCP_MTU);
 		p->Send_uint16(p_count);
 
 		for (uint i = 0; i < p_count; i++) {

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -221,9 +221,9 @@ void ClientNetworkContentSocketHandler::RequestContentList(uint count, const Con
 		 * A packet begins with the packet size and a byte for the type.
 		 * Then this packet adds a uint16 for the count in this packet.
 		 * The rest of the packet can be used for the IDs. */
-		uint p_count = std::min<uint>(count, (SEND_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
+		uint p_count = std::min<uint>(count, (COMPAT_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
 
-		Packet *p = new Packet(PACKET_CONTENT_CLIENT_INFO_ID);
+		Packet *p = new Packet(PACKET_CONTENT_CLIENT_INFO_ID, COMPAT_MTU);
 		p->Send_uint16(p_count);
 
 		for (uint i = 0; i < p_count; i++) {
@@ -248,7 +248,7 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentVector *cv, bo
 	this->Connect();
 
 	assert(cv->size() < 255);
-	assert(cv->size() < (SEND_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8)) /
+	assert(cv->size() < (COMPAT_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint8)) /
 			(sizeof(uint8) + sizeof(uint32) + (send_md5sum ? /*sizeof(ContentInfo::md5sum)*/16 : 0)));
 
 	Packet *p = new Packet(send_md5sum ? PACKET_CONTENT_CLIENT_INFO_EXTID_MD5 : PACKET_CONTENT_CLIENT_INFO_EXTID);
@@ -363,7 +363,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentFallback(const Co
 		 * A packet begins with the packet size and a byte for the type.
 		 * Then this packet adds a uint16 for the count in this packet.
 		 * The rest of the packet can be used for the IDs. */
-		uint p_count = std::min<uint>(count, (SEND_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
+		uint p_count = std::min<uint>(count, (COMPAT_MTU - sizeof(PacketSize) - sizeof(byte) - sizeof(uint16)) / sizeof(uint32));
 
 		Packet *p = new Packet(PACKET_CONTENT_CLIENT_CONTENT);
 		p->Send_uint16(p_count);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -158,7 +158,7 @@ struct PacketWriter : SaveFilter {
 		/* We want to abort the saving when the socket is closed. */
 		if (this->cs == nullptr) SlError(STR_NETWORK_ERROR_LOSTCONNECTION);
 
-		if (this->current == nullptr) this->current = new Packet(PACKET_SERVER_MAP_DATA);
+		if (this->current == nullptr) this->current = new Packet(PACKET_SERVER_MAP_DATA, TCP_MTU);
 
 		std::lock_guard<std::mutex> lock(this->mutex);
 
@@ -169,7 +169,7 @@ struct PacketWriter : SaveFilter {
 
 			if (!this->current->CanWriteToPacket(1)) {
 				this->AppendQueue();
-				if (buf != bufe) this->current = new Packet(PACKET_SERVER_MAP_DATA);
+				if (buf != bufe) this->current = new Packet(PACKET_SERVER_MAP_DATA, TCP_MTU);
 			}
 		}
 

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -256,10 +256,10 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_DETAIL_INFO(Packet *p, Networ
 /**
  * A client has requested the names of some NewGRFs.
  *
- * Replying this can be tricky as we have a limit of SEND_MTU bytes
+ * Replying this can be tricky as we have a limit of UDP_MTU bytes
  * in the reply packet and we can send up to 100 bytes per NewGRF
  * (GRF ID, MD5sum and NETWORK_GRF_NAME_LENGTH bytes for the name).
- * As SEND_MTU is _much_ less than 100 * NETWORK_MAX_GRF_COUNT, it
+ * As UDP_MTU is _much_ less than 100 * NETWORK_MAX_GRF_COUNT, it
  * could be that a packet overflows. To stop this we only reply
  * with the first N NewGRFs so that if the first N + 1 NewGRFs
  * would be sent, the packet overflows.
@@ -295,7 +295,7 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, Networ
 		 * The name could be an empty string, if so take the filename. */
 		packet_len += sizeof(c.grfid) + sizeof(c.md5sum) +
 				std::min(strlen(f->GetName()) + 1, (size_t)NETWORK_GRF_NAME_LENGTH);
-		if (packet_len > SEND_MTU - 4) { // 4 is 3 byte header + grf count in reply
+		if (packet_len > UDP_MTU - 4) { // 4 is 3 byte header + grf count in reply
 			break;
 		}
 		in_reply[in_reply_count] = f;


### PR DESCRIPTION
## Motivation / Problem

Some simple things in the network protocol are made much harder due to the hardcoded limit of 1460 bytes in a packet, even for cases where there is no real reason for such a low limit. This means that many things need to be split into several smaller packets, so allowing for larger packets requires fewer places where extra work is required to split communication in several smaller packets.


## Description

Differentiate between UDP and TCP for the maximum packet size, though default to the original size due to backward compatibility reasons. This means that, by default, the sent packets are still limited to the old amount. However, if it is safe for the protocol to increase the packet size, i.e. you know for certain that the other side accepts the larger packets, then you can let that specific packet to be created with a larger limit.
For now the limit is set to 32 767 bytes, one byte fewer than 32 KiB. This is done to keep the future open for sending even larger packets, but that requires special encoding of packet sizes and makes everything more complicated. For now the sending of save games will therefor use 32 KiB packets.
Receiving of TCP will always accept 32 KiB packets regardless of the version at the other side, UDP is still limited to 1460 bytes.

As it stands with this patch the transfer of save games and requesting information from the content server use the 32 KiB packets. For the save games it is safe as you need the same version of the client, and the content server does no check on the packet size being <= 1460, so it already happily accepts the larger packets.


## Limitations

The limit of packets is currently set to 32 767 bytes. The larger packet sizes are not implemented as there is no clear need for them yet. Limiting the packet size will allow you to prioritize other information channels (e.g. chat messages) instead of blocking the connection while downloading a large game or something.
UDP limit cannot be increased, mostly due to practical network limitations.
TCP limit for game cannot be increased for certain packets that can be sent in the early stages of joining. The first three pairs of PacketGameType as it stands now. The others could be increased, but as far as I can see it makes no sense for them as they are significantly smaller than 1460 bytes.


## Future potential

TCP limit for admin could be increased, but that requires a protocol bump so we are certain that the client supports it and we would still need to maintain the old version with smaller packets as well. But it would allow to send larger responses.
TCP limit for receiving data from the content server requires a protocol change so the server knows it can send the client larger packets. The client will happily accept the packets.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
