### PR TITLE
Fix: [OpenGL] Main loop expects to start with the video buffer unmapped.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1154,6 +1154,7 @@ void *OpenGLBackend::GetVideoBuffer()
 #endif
 
 	if (!this->persistent_mapping_supported) {
+		assert(this->vid_buffer == nullptr);
 		_glBindBuffer(GL_PIXEL_UNPACK_BUFFER, this->vid_pbo);
 		this->vid_buffer = _glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_READ_WRITE);
 	} else if (this->vid_buffer == nullptr) {

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -74,6 +74,8 @@ const char *VideoDriver_SDL_OpenGL::Start(const StringList &param)
 		this->Stop();
 		return "Can't get pointer to screen buffer";
 	}
+	/* Main loop expects to start with the buffer unmapped. */
+	this->ReleaseVideoPointer();
 
 	return nullptr;
 }

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1311,6 +1311,8 @@ const char *VideoDriver_Win32OpenGL::Start(const StringList &param)
 		_cur_resolution = old_res;
 		return "Can't get pointer to screen buffer";
 	}
+	/* Main loop expects to start with the buffer unmapped. */
+	this->ReleaseVideoPointer();
 
 	MarkWholeScreenDirty();
 


### PR DESCRIPTION
## Motivation / Problem

The video driver main loop assumes that the video buffer is not locked at entry, but Win32 and SDL finish their Init with the buffer mapped. When persistent mapping is not used, double locking the same buffer is not well defined and might or might not work.

## Description

After we checked for a working buffer mapping in Init, unmap the buffer again to satisfy the main loop entry.

The OSX video driver does it differently and doesn't lock the buffer on init. Making Win32 and SDL identical like OSX would be possible very easily, but I kinda like the check for a successful mapping at Init.

## Limitations

Potential source of the recent OpenGL crashes, even if I don't see any obvious change from 1.11.0 to 1.11.1 there.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
