### PR TITLE
Fix typo and improve bug report instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -5,13 +5,13 @@ title: "Bug Report"
 ---
 
 ## Version of OpenTTD
-<!-- Indicate what version of OpenTTD you are using, including your OS. -->
+<!-- Fill in below what version of OpenTTD you are using, including your OS. -->
 
 ## Expected result
 <!-- Describe in a few words what you expected to happen. -->
 
 ## Actual result
-<!-- Descibe in a few words what actually happens. -->
+<!-- Describe in a few words what actually happens. -->
 
 ## Steps to reproduce
 <!-- As detailed as possible, please tell us how we can reproduce this. Feel free to attach a savegame (zip it first) to make it more clear. -->

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -6,7 +6,7 @@ title: "Crash Report"
 <!-- Please zip the crash.log, crash.dmp and crash.sav and attach it to this crash report. -->
 
 ## Version of OpenTTD
-<!-- Indicate what version of OpenTTD you are using, including your OS. -->
+<!-- Fill in below what version of OpenTTD you are using, including your OS. -->
 
 ## Steps to reproduce
 <!-- Please spend a few words if you can reproduce this problem. -->


### PR DESCRIPTION
## Motivation / Problem

Per #9103, there is a typo in the new bug report instructions added in #9092, "Describe":
`<!-- Descibe in a few words what actually happens. -->`

Also, @nielsmh left a comment on #9092 after it was merged, suggesting additional instruction text.

## Description

- I fixed the typo (closes #9103).
- While I was at it, I reworded the instructions.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
