### PR TITLE
Improve server logs for administration

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2484,11 +2484,12 @@ STR_NETWORK_SERVER_MESSAGE_GAME_REASON_LINK_GRAPH               :waiting for lin
 
 STR_NETWORK_MESSAGE_CLIENT_LEAVING                              :leaving
 STR_NETWORK_MESSAGE_CLIENT_JOINED                               :*** {RAW_STRING} has joined the game
-STR_NETWORK_MESSAGE_CLIENT_JOINED_ID                            :*** {RAW_STRING} has joined the game (Client #{2:NUM})
+STR_NETWORK_MESSAGE_CLIENT_JOINED_ID                            :*** {RAW_STRING} ({1:RAW_STRING}) has joined the game (Client #{2:NUM})
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_JOIN                         :*** {RAW_STRING} has joined company #{2:NUM}
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_SPECTATE                     :*** {RAW_STRING} has joined spectators
 STR_NETWORK_MESSAGE_CLIENT_COMPANY_NEW                          :*** {RAW_STRING} has started a new company (#{2:NUM})
 STR_NETWORK_MESSAGE_CLIENT_LEFT                                 :*** {RAW_STRING} has left the game ({2:STRING})
+STR_NETWORK_MESSAGE_CLIENT_LEFT_ID                              :*** {RAW_STRING} ({1:RAW_STRING}) has left the game ({2:STRING})
 STR_NETWORK_MESSAGE_NAME_CHANGE                                 :*** {RAW_STRING} has changed their name to {RAW_STRING}
 STR_NETWORK_MESSAGE_GIVE_MONEY                                  :*** {RAW_STRING} gave {2:CURRENCY_LONG} to {1:RAW_STRING}
 STR_NETWORK_MESSAGE_SERVER_SHUTDOWN                             :{WHITE}The server closed the session

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -24,7 +24,7 @@
  * Create a new socket for the game connection.
  * @param s The socket to connect with.
  */
-NetworkGameSocketHandler::NetworkGameSocketHandler(SOCKET s) : info(nullptr), client_id(INVALID_CLIENT_ID),
+NetworkGameSocketHandler::NetworkGameSocketHandler(SOCKET s, ClientID client_id) : info(nullptr), client_id(client_id),
 		last_frame(_frame_counter), last_frame_server(_frame_counter)
 {
 	this->sock = s;

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -496,7 +496,7 @@ protected:
 
 	NetworkRecvStatus HandlePacket(Packet *p);
 
-	NetworkGameSocketHandler(SOCKET s);
+	NetworkGameSocketHandler(SOCKET s, ClientID client_id = INVALID_CLIENT_ID);
 public:
 	ClientID client_id;          ///< Client identifier
 	uint32 last_frame;           ///< Last frame we have executed

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -242,7 +242,10 @@ void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send,
 			/* Show the Client ID for the server but not for the client. */
 			strid = _network_server ? STR_NETWORK_MESSAGE_CLIENT_JOINED_ID :  STR_NETWORK_MESSAGE_CLIENT_JOINED;
 			break;
-		case NETWORK_ACTION_LEAVE:          strid = STR_NETWORK_MESSAGE_CLIENT_LEFT; break;
+		case NETWORK_ACTION_LEAVE:
+			/* Show client identification for the server but not for the client. */
+			strid = _network_server ? STR_NETWORK_MESSAGE_CLIENT_LEFT_ID :  STR_NETWORK_MESSAGE_CLIENT_LEFT;
+			break;
 		case NETWORK_ACTION_NAME_CHANGE:    strid = STR_NETWORK_MESSAGE_NAME_CHANGE; break;
 		case NETWORK_ACTION_GIVE_MONEY:     strid = STR_NETWORK_MESSAGE_GIVE_MONEY; break;
 		case NETWORK_ACTION_CHAT_COMPANY:   strid = self_send ? STR_NETWORK_CHAT_TO_COMPANY : STR_NETWORK_CHAT_COMPANY; break;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -553,8 +553,7 @@ NetworkAddress ParseConnectionString(const std::string &connection_string, uint1
 	/* Register the login */
 	_network_clients_connected++;
 
-	ServerNetworkGameSocketHandler *cs = new ServerNetworkGameSocketHandler(s);
-	cs->client_address = address; // Save the IP of the client
+	new ServerNetworkGameSocketHandler(s, address);
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
 }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -211,6 +211,8 @@ ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(SOCKET s, Network
 	 * each Socket will be associated with at most one Info object. As
 	 * such if the Socket was allocated the Info object can as well. */
 	static_assert(NetworkClientSocketPool::MAX_SIZE == NetworkClientInfoPool::MAX_SIZE);
+
+	Debug(net, 3, "[{}] Accepting client #{} connection from {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP());
 }
 
 /**
@@ -277,7 +279,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	}
 
 	NetworkAdminClientError(this->client_id, NETWORK_ERROR_CONNECTION_LOST);
-	Debug(net, 3, "Closed client connection {}", this->client_id);
+	Debug(net, 3, "[{}] Closed client #{} connection from {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP());
 
 	/* We just lost one client :( */
 	if (this->status >= STATUS_AUTHORIZED) _network_game_info.clients_on--;

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -205,12 +205,8 @@ struct PacketWriter : SaveFilter {
  * Create a new socket for the server side of the game connection.
  * @param s The socket to connect with.
  */
-ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(SOCKET s) : NetworkGameSocketHandler(s)
+ServerNetworkGameSocketHandler::ServerNetworkGameSocketHandler(SOCKET s, NetworkAddress client_address) : NetworkGameSocketHandler(s, _network_client_id++), status(STATUS_INACTIVE), receive_limit(_settings_client.network.bytes_per_frame_burst), client_address(client_address)
 {
-	this->status = STATUS_INACTIVE;
-	this->client_id = _network_client_id++;
-	this->receive_limit = _settings_client.network.bytes_per_frame_burst;
-
 	/* The Socket and Info pools need to be the same in size. After all,
 	 * each Socket will be associated with at most one Info object. As
 	 * such if the Socket was allocated the Info object can as well. */

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -258,7 +258,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 		/* We did not receive a leave message from this client... */
 		std::string client_name = this->GetClientName();
 
-		NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, "", STR_NETWORK_ERROR_CLIENT_CONNECTION_LOST);
+		NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, this->GetClientIP(), STR_NETWORK_ERROR_CLIENT_CONNECTION_LOST);
 
 		/* Inform other clients of this... strange leaving ;) */
 		for (NetworkClientSocket *new_cs : NetworkClientSocket::Iterate()) {
@@ -384,7 +384,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 		if (error == NETWORK_ERROR_KICKED && !reason.empty()) {
 			NetworkTextMessage(NETWORK_ACTION_KICKED, CC_DEFAULT, false, client_name, reason, strid);
 		} else {
-			NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, "", strid);
+			NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, this->GetClientIP(), strid);
 		}
 
 		for (NetworkClientSocket *new_cs : NetworkClientSocket::Iterate()) {
@@ -943,7 +943,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_MAP_OK(Packet *
 	if (this->status == STATUS_DONE_MAP && !this->HasClientQuit()) {
 		std::string client_name = this->GetClientName();
 
-		NetworkTextMessage(NETWORK_ACTION_JOIN, CC_DEFAULT, false, client_name, "", this->client_id);
+		NetworkTextMessage(NETWORK_ACTION_JOIN, CC_DEFAULT, false, client_name, this->GetClientIP(), this->client_id);
 		InvalidateWindowData(WC_CLIENT_LIST, 0);
 
 		/* Mark the client as pre-active, and wait for an ACK
@@ -1062,7 +1062,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_ERROR(Packet *p
 
 	Debug(net, 1, "'{}' reported an error and is closing its connection: {}", client_name, GetString(strid));
 
-	NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, "", strid);
+	NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, this->GetClientIP(), strid);
 
 	for (NetworkClientSocket *new_cs : NetworkClientSocket::Iterate()) {
 		if (new_cs->status >= STATUS_AUTHORIZED) {
@@ -1084,7 +1084,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_QUIT(Packet *p)
 
 	/* The client wants to leave. Display this and report it to the other clients. */
 	std::string client_name = this->GetClientName();
-	NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, "", STR_NETWORK_MESSAGE_CLIENT_LEAVING);
+	NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, this->GetClientIP(), STR_NETWORK_MESSAGE_CLIENT_LEAVING);
 
 	for (NetworkClientSocket *new_cs : NetworkClientSocket::Iterate()) {
 		if (new_cs->status >= STATUS_AUTHORIZED && new_cs != this) {

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -72,7 +72,7 @@ public:
 	struct PacketWriter *savegame; ///< Writer used to write the savegame.
 	NetworkAddress client_address; ///< IP-address of the client (so they can be banned)
 
-	ServerNetworkGameSocketHandler(SOCKET s);
+	ServerNetworkGameSocketHandler(SOCKET s, NetworkAddress client_address);
 	~ServerNetworkGameSocketHandler();
 
 	virtual Packet *ReceivePacket() override;


### PR DESCRIPTION
## Motivation / Problem
Server administration requires quickly being able to act on entities when needed, for instance behaving wrongly.
In the case of OpenTTD, this is done either with the help of entity's client ID or IP address.

However, in its current state, the game never directy logs a direct relation between an entity's IP address and its client ID, which needs time-based guessing to discover it.
Once done, the client ID can be used to match with the entity's player name, but only with the help of the `STR_NETWORK_MESSAGE_CLIENT_JOINED_ID`, which is only available on entity's join.

This 2-step process, involving guessing

## Description
This proposal enhances the servers logs by adding entity's IP address:
- on client connection & connection close events in case the entity never fully joins
- on client join & leave to allow for an easier & quicker linking between entity's name & IP address

On a side job, some constructors have been rewritten to make us of member initialiser rather than in-constructor property definition.

## Limitations
`net` debug facility is busy from levels 1 to 6 (default level for dedicated servers), which makes it difficult to decide which level is the most appropriate for specific events.

Also, level 2 is already quite heavily used already, as `queried` events are very often triggered on a server.
Would it be worth burying those messages in a higher debug level, freeing space on level 2 for some other messages, hence allowing different level of server administrationg logging while avoiding pollution?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)