### PR TITLE
Fix: [Network] Prevent stalling save game transfer when compression is slow

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -592,7 +592,7 @@ void ServerNetworkGameSocketHandler::CheckNextClientToSendMap(NetworkClientSocke
 /** This sends the map to the client */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 {
-	static uint sent_packets; // How many packets we did send successfully last time
+	static uint16 sent_packets; // How many packets we did send successfully last time
 
 	if (this->status < STATUS_AUTHORIZED) {
 		/* Illegal call, return error and ignore the packet */
@@ -652,8 +652,10 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 				return NETWORK_RECV_STATUS_CONN_LOST;
 
 			case SPS_ALL_SENT:
-				/* All are sent, increase the sent_packets */
-				if (has_packets) sent_packets *= 2;
+				/* All are sent, increase the sent_packets but do not overflow! */
+				if (has_packets && sent_packets < std::numeric_limits<decltype(sent_packets)>::max() / 2) {
+					sent_packets *= 2;
+				}
 				break;
 
 			case SPS_PARTLY_SENT:


### PR DESCRIPTION
## Motivation / Problem

If the threaded savegame logic yields packets slow enough, e.g. 1 every tick, and the network is fast enough, i.e. it can handle 33 packets / second (~400 kbps or ~8 Mbps with #9099), then `sent_packets` would be doubled every tick. From an initial value of 4 
it would take 29 ticks to get to 2**31 and on tick 30 it would overflow into 0. From that moment on the server cannot send any packets anymore as `i < sent_packets` would always return false.

## Description

Just limit to how far `send_packets` can be doubled. Similarly, reduce the type size because the number of packets that may be sent per tick becomes quite hilarious quickly.


## Limitations

This artificially limits the save game transfer speed to 1400 MiB/s (or 35 GiB/s with #9099 applied). If the saving would be able to saturate the network link, this artificial limit is reached after 91 MiB (or 2 GiB with #9099 applied) of the save game was already sent due to the ramp up from 4 to 32768 packets per second every tick.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
