### PR TITLE
Allow NewGRFs to give error popups, without disabling them.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3079,6 +3079,7 @@ STR_NEWGRF_ERROR_MSG_WARNING                                    :{RED}Warning: {
 STR_NEWGRF_ERROR_MSG_ERROR                                      :{RED}Error: {SILVER}{RAW_STRING}
 STR_NEWGRF_ERROR_MSG_FATAL                                      :{RED}Fatal: {SILVER}{RAW_STRING}
 STR_NEWGRF_ERROR_FATAL_POPUP                                    :{WHITE}A fatal NewGRF error has occurred: {}{STRING5}
+STR_NEWGRF_ERROR_POPUP                                          :{WHITE}A NewGRF error has occurred: {}{STRING5}
 STR_NEWGRF_ERROR_VERSION_NUMBER                                 :{1:RAW_STRING} will not work with the TTDPatch version reported by OpenTTD
 STR_NEWGRF_ERROR_DOS_OR_WINDOWS                                 :{1:RAW_STRING} is for the {RAW_STRING} version of TTD
 STR_NEWGRF_ERROR_UNSET_SWITCH                                   :{1:RAW_STRING} is designed to be used with {RAW_STRING}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -47,8 +47,8 @@ void ShowNewGRFError()
 	if (_game_mode == GM_MENU) return;
 
 	for (const GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
-		/* We only want to show fatal errors */
-		if (c->error == nullptr || c->error->severity != STR_NEWGRF_ERROR_MSG_FATAL) continue;
+		/* Only show Fatal and Error level messages */
+		if (c->error == nullptr || (c->error->severity != STR_NEWGRF_ERROR_MSG_FATAL && c->error->severity != STR_NEWGRF_ERROR_MSG_ERROR)) continue;
 
 		SetDParam   (0, c->error->message != STR_NULL ? c->error->message : STR_JUST_RAW_STRING);
 		SetDParamStr(1, c->error->custom_message.c_str());
@@ -57,7 +57,11 @@ void ShowNewGRFError()
 		for (uint i = 0; i < lengthof(c->error->param_value); i++) {
 			SetDParam(4 + i, c->error->param_value[i]);
 		}
-		ShowErrorMessage(STR_NEWGRF_ERROR_FATAL_POPUP, INVALID_STRING_ID, WL_CRITICAL);
+		if (c->error->severity == STR_NEWGRF_ERROR_MSG_FATAL) {
+			ShowErrorMessage(STR_NEWGRF_ERROR_FATAL_POPUP, INVALID_STRING_ID, WL_CRITICAL);
+		} else {
+			ShowErrorMessage(STR_NEWGRF_ERROR_POPUP, INVALID_STRING_ID, WL_ERROR);
+		}
 		break;
 	}
 }


### PR DESCRIPTION
Fixes #9115 by also creating an error pop-up for errors with the severity ERROR, instead of just FATAL. Also added a string for it, STR_NEWGRF_ERROR_POPUP, which is the string STR_NEWGRF_ERROR_FATAL_POPUP, but without the word "fatal". Also provided a translation in a few languages I'm confident enough in to remove a word.

## Motivation / Problem
Say you have a NewGRF, but you should only ever use it with another NewGRF, or a certain combination of settings is completely game breaking. You want to inform the players that they might need to rethink their choices, but you don't want to stop them from going ahead anyway, should they choose to ignore it.
AndyTheNorth raised a similar problem; people kept complaining that they didn't have vehicle newgrfs and they couldn't use FIRS as a result. The ideal solution would have been an error popup to explain to users that they don't have a compatible boat newgrf. The only way of doing this would have been by means of `error(FATAL,string(STR_ERROR));` in NML. This would disable the NewGRF, meaning NewGRFs that aren't FIRS compatible would have a hard time becoming FIRS compatible, and that I can't choose to just not have a ship newgrf because I don't use ships.

In NML you can have 4 different types of errors. NOTICE, WARNING, ERROR, and FATAL. You would expect all of these to behave differently in some way, but the only difference between WARNING and ERROR is the red word in the message in the NewGRF window. FATAL gives a popup message, but also disables the NewGRF. Now it would make sense to me if ERROR also gave a pop-up, making it distinct from the other 4.

With this change, NewGRF developers like Andy can tell players "Hey we have detected that you don't have a compatible Road Vehicle NewGRF. This means you will not be able to move goods via truck. Is this correct, and if  so are you sure about that?"
For beginning players who are told to play FIRS for whatever reason, this helps by telling them what is wrong. They might not know to look in the NewGRF window, and might miss the message. They might not know that they need a FIRS compatible NewGRF to use it.
For veteran players, this is nice because they might decide that they don't want to use ships anyway, so they can just press [x] and continue playing. Other veteran players might forgot to load a ship newgrf, when they meant to. It's nice to be told this upfront, and to not discover an hour into the game.

The direct motivation for this was a perceived issue with FIRS, but I believe this can be widely applicable.

## Description
In newgrf_gui.cpp there's a line of code that prevents a popup from appearing if the severity is not `FATAL`. I changed it so it also shows a popup if the severity is `ERROR`.

If the severity is `ERROR` instead of `FATAL` it will use a different string, `STR_NEWGRF_ERROR_POPUP` instead of `STR_NEWGRF_ERROR_FATAL_POPUP`, which omits the word "fatal" from the error message.

Example:
![image](https://user-images.githubusercontent.com/10280358/116255608-b170c480-a772-11eb-9afc-631091d84dce.png)

## Limitations
The feature itself is fairly complete.

Older NewGRFs might have used ERROR when it didn't give a popup, and loading it with this change will cause them to generate a pop-up. I think that's a very minor problem.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
