### PR TITLE
Feature: support non-ASCII currency separator

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -506,7 +506,12 @@ static void Write_ValidateString(void *ptr, const SaveLoad *sld, const char *p)
 	switch (GetVarMemType(sld->conv)) {
 		case SLE_VAR_STRB:
 		case SLE_VAR_STRBQ:
-			if (p != nullptr) strecpy((char*)ptr, (const char*)p, (char*)ptr + sld->length - 1);
+			if (p != nullptr) {
+				char *begin = (char*)ptr;
+				char *end = begin + sld->length - 1;
+				strecpy(begin, p, end);
+				str_validate(begin, end, SVS_NONE);
+			}
 			break;
 
 		case SLE_VAR_STR:

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -563,8 +563,6 @@ static void IniLoadSettings(IniFile *ini, const SettingDesc *sd, const char *grp
 						*(char**)ptr = p == nullptr ? nullptr : stredup((const char*)p);
 						break;
 
-					case SLE_VAR_CHAR: if (p != nullptr) *(char *)ptr = *(const char *)p; break;
-
 					default: NOT_REACHED();
 				}
 				break;
@@ -716,7 +714,6 @@ static void IniSaveSettings(IniFile *ini, const SettingDesc *sd, const char *grp
 						}
 						break;
 
-					case SLE_VAR_CHAR: buf[0] = *(char*)ptr; buf[1] = '\0'; break;
 					default: NOT_REACHED();
 				}
 				break;

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2676,7 +2676,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_SEPARATOR:
 				SetDParamStr(0, _custom_currency.separator);
 				str = STR_JUST_RAW_STRING;
-				len = 1;
+				len = sizeof(_custom_currency.separator) - 1; // Number of characters excluding '\0' termination
 				line = WID_CC_SEPARATOR;
 				break;
 
@@ -2684,7 +2684,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_PREFIX:
 				SetDParamStr(0, _custom_currency.prefix);
 				str = STR_JUST_RAW_STRING;
-				len = 12;
+				len = sizeof(_custom_currency.prefix) - 1; // Number of characters excluding '\0' termination
 				line = WID_CC_PREFIX;
 				break;
 
@@ -2692,7 +2692,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_SUFFIX:
 				SetDParamStr(0, _custom_currency.suffix);
 				str = STR_JUST_RAW_STRING;
-				len = 12;
+				len = sizeof(_custom_currency.suffix) - 1; // Number of characters excluding '\0' termination
 				line = WID_CC_SUFFIX;
 				break;
 

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -10,7 +10,6 @@ static const SettingDesc _currency_settings[] = {
 };
 [templates]
 SDT_VAR = SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDT_CHR = SDT_CHR($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDT_END = SDT_END()
 
@@ -42,9 +41,10 @@ def      = 1
 min      = 0
 max      = UINT16_MAX
 
-[SDT_CHR]
+[SDT_STR]
 base     = CurrencySpec
 var      = separator
+type     = SLE_STRBQ
 def      = "".""
 cat      = SC_BASIC
 

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -107,9 +107,6 @@ static size_t ConvertLandscape(const char *value);
 #define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
-#define SDT_CHR(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDT_GENERAL(#var, SDT_STRING, SL_VAR, SLE_CHAR, flags, guiflags, base, var, 1, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
-
 #define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra, startup)\
 	SDT_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, load, from, to, cat, extra, startup)
 


### PR DESCRIPTION
## Motivation / Problem

The currency separator, in the configuration for the INI file is a single character which means only ASCII characters may be used as separator. The separator field itself is 8 bytes long, so it feels like someone did consider non-ASCII characters but did not follow through.
Next to this the string length limiting that is happening when writing the string into the configuration could cause a valid multibyte encoded Utf8 character to only be placed there partially. As a result, the configuration has become an "invalid" string.


## Description

Solved by:
* changing the configuration for the INI file to use SDT_STR instead of SDT_CHR and the same type as prefix and suffix.
* changing the settings GUI to support the number of bytes allowed by the buffers in CurrencySpec; remove the magic constants in the code with sizeof. Changes separator from 1 to 7 bytes and prefix/suffix from 12 to 15.
* running str_validate after strecpy since strecpy might have trimmed the string
* some refactoring of writing strings, meaning the same validation is also applied for strings coming from the console/set functions.


## Limitations

Support for a single character in a configuration file is lost, though technically that was already effectively a 2 byte string as it will always set the byte after the character to '\0'. However, the currency separator was the only thing that made use of it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
