### PR TITLE
Cleanup: remove #ifdefs for compiling the old content server

### DIFF
--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -10,14 +10,12 @@
  */
 
 #include "../../stdafx.h"
-#ifndef OPENTTD_MSU
 #include "../../textfile_gui.h"
 #include "../../newgrf_config.h"
 #include "../../base_media_base.h"
 #include "../../ai/ai.hpp"
 #include "../../game/game.hpp"
 #include "../../fios.h"
-#endif /* OPENTTD_MSU */
 #include "tcp_content.h"
 
 #include "../../safeguards.h"
@@ -92,7 +90,6 @@ bool ContentInfo::IsValid() const
 	return this->state < ContentInfo::INVALID && this->type >= CONTENT_TYPE_BEGIN && this->type < CONTENT_TYPE_END;
 }
 
-#ifndef OPENTTD_MSU
 /**
  * Search a textfile file next to this file in the content list.
  * @param type The type of the textfile to search for.
@@ -139,7 +136,6 @@ const char *ContentInfo::GetTextfile(TextfileType type) const
 	if (tmp == nullptr) return nullptr;
 	return ::GetTextfile(type, GetContentInfoSubDir(this->type), tmp);
 }
-#endif /* OPENTTD_MSU */
 
 void NetworkContentSocketHandler::Close()
 {
@@ -236,7 +232,6 @@ bool NetworkContentSocketHandler::Receive_SERVER_INFO(Packet *p) { return this->
 bool NetworkContentSocketHandler::Receive_CLIENT_CONTENT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_CONTENT_CLIENT_CONTENT); }
 bool NetworkContentSocketHandler::Receive_SERVER_CONTENT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_CONTENT_SERVER_CONTENT); }
 
-#ifndef OPENTTD_MSU
 /**
  * Helper to get the subdirectory a #ContentInfo is located in.
  * @param type The type of content.
@@ -261,4 +256,3 @@ Subdirectory GetContentInfoSubDir(ContentType type)
 		case CONTENT_TYPE_HEIGHTMAP:    return HEIGHTMAP_DIR;
 	}
 }
-#endif /* OPENTTD_MSU */

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -129,8 +129,6 @@ public:
 	bool ReceivePackets();
 };
 
-#ifndef OPENTTD_MSU
 Subdirectory GetContentInfoSubDir(ContentType type);
-#endif /* OPENTTD_MSU */
 
 #endif /* NETWORK_CORE_TCP_CONTENT_H */

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -82,9 +82,7 @@ struct ContentInfo {
 	size_t Size() const;
 	bool IsSelected() const;
 	bool IsValid() const;
-#ifndef OPENTTD_MSU
 	const char *GetTextfile(TextfileType type) const;
-#endif /* OPENTTD_MSU */
 };
 
 #endif /* NETWORK_CORE_TCP_CONTENT_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

Dead preprocessor code. The content server has been rewritten in Python. The old one cannot be built from git without some serious love, and likely fails to build in many other places due to all the changes over the last decade.


## Description

Remove it.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
