### PR TITLE
Fix: missing <limits> include in network/core/packet.h

### DIFF
--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -17,6 +17,7 @@
 #include "core.h"
 #include "../../string_type.h"
 #include <functional>
+#include <limits>
 
 typedef uint16 PacketSize; ///< Size of the whole packet.
 typedef uint8  PacketType; ///< Identifier for the packet


### PR DESCRIPTION
## Motivation / Problem

```
In file included from /home/milek7/ottd3/src/script/api/../../network/core/tcp.h:16,
                 from /home/milek7/ottd3/src/script/api/../../network/core/tcp_game.h:16,
                 from /home/milek7/ottd3/src/script/api/../../network/network_internal.h:14,
                 from /home/milek7/ottd3/src/script/api/../../network/network_admin.h:13,
                 from /home/milek7/ottd3/src/script/api/script_admin.cpp:13:
/home/milek7/ottd3/src/script/api/../../network/core/packet.h: In member function ‘ssize_t Packet::TransferOut(F, D, Args&& ...)’:
/home/milek7/ottd3/src/script/api/../../network/core/packet.h:142:72: error: ‘numeric_limits’ is not a member of ‘std’
  142 |                 return TransferOutWithLimit<A>(transfer_function, std::numeric_limits<size_t>::max(), destination, std::forward<Args>(args)...);
      |                                                                        ^~~~~~~~~~~~~~
/home/milek7/ottd3/src/script/api/../../network/core/packet.h:142:93: error: expected primary-expression before ‘>’ token
  142 |                 return TransferOutWithLimit<A>(transfer_function, std::numeric_limits<size_t>::max(), destination, std::forward<Args>(args)...);
      |                                                                                             ^
/home/milek7/ottd3/src/script/api/../../network/core/packet.h:142:96: error: ‘::max’ has not been declared; did you mean ‘std::max’?
  142 |                 return TransferOutWithLimit<A>(transfer_function, std::numeric_limits<size_t>::max(), destination, std::forward<Args>(args)...);
      |                                                                                                ^~~
      |                                                                                                std::max
In file included from /usr/include/c++/12.0.0/algorithm:62,
                 from /home/milek7/ottd3/src/script/api/../../stdafx.h:88,
                 from /home/milek7/ottd3/src/script/api/script_admin.cpp:10:
/usr/include/c++/12.0.0/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
```