### PR TITLE
Codechange: Use __attribute__ access none to silence GCC 11 -Wmaybe-uninitialized warnings

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -138,6 +138,12 @@
 #	endif
 #endif /* __GNUC__ || __clang__ */
 
+#if __GNUC__ > 11 || (__GNUC__ == 11 && __GNUC_MINOR__ >= 1)
+#      define NOACCESS(args) __attribute__ ((access (none, args)))
+#else
+#      define NOACCESS(args)
+#endif
+
 #if defined(__WATCOMC__)
 #	define NORETURN
 #	define CDECL

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -30,25 +30,25 @@
 #include "core/bitmath_func.hpp"
 #include "string_type.h"
 
-char *strecat(char *dst, const char *src, const char *last);
-char *strecpy(char *dst, const char *src, const char *last);
-char *stredup(const char *src, const char *last = nullptr);
+char *strecat(char *dst, const char *src, const char *last) NOACCESS(3);
+char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
+char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
 
-int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4);
-int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0);
+int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4) NOACCESS(2);
+int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0) NOACCESS(2);
 
 char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 
-void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
 std::string str_validate(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void ValidateString(const char *str);
 
-void str_fix_scc_encoded(char *str, const char *last);
+void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
 void str_strip_colours(char *str);
 bool strtolower(char *str);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
-bool StrValid(const char *str, const char *last);
+bool StrValid(const char *str, const char *last) NOACCESS(2);
 void StrTrimInPlace(char *str);
 
 /**


### PR DESCRIPTION
## Motivation / Problem
GCC11 generates warnings like these:
```
/home/milek7/ottd3/src/settings.cpp: In function ‘GRFConfig* LoadGRFPresetFromConfig(const char*)’:
/home/milek7/ottd3/src/settings.cpp:1859:17: warning: ‘<unknown>’ may be used uninitialized [-Wmaybe-uninitialized]
 1859 |         seprintf(section, section + len - 1, "preset-%s", config_name);
      |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/milek7/ottd3/src/currency.h:14,
                 from /home/milek7/ottd3/src/settings.cpp:26:
/home/milek7/ottd3/src/string_func.h:37:11: note: by argument 2 of type ‘const char*’ to ‘int seprintf(char*, const char*, const char*, ...)’ declared here
   37 | int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4);
      |           ^~~~~~~~
/home/milek7/ottd3/src/settings.cpp: In function ‘void SaveGRFPresetToConfig(const char*, GRFConfig*)’:
/home/milek7/ottd3/src/settings.cpp:1878:17: warning: ‘<unknown>’ may be used uninitialized [-Wmaybe-uninitialized]
 1878 |         seprintf(section, section + len - 1, "preset-%s", config_name);
```


## Description

Use `__attribute__` access none to specify that arguments pointing at buffer end are never dereferenced.

## Limitations

`__has_attribute` cannot be utilized because `none` is recently added option to `access` attribute.

Pre-release GCC11.0 builds will also generate this warning, but it cannot be included in version check as early GCC11.0 builds didn't know about `none` option. (thus this PR checks for >11.1 release)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
