### PR TITLE
D3D11 video driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,14 @@ if(MSVC)
 endif()
 
 find_package(SSE)
-find_package(Xaudio2)
+
+if(WIN32)
+    find_package(Xaudio2)
+    find_package(D3D11)
+    if(D3D11_FOUND)
+        add_definitions(-DWITH_D3D11)
+    endif()
+endif()
 
 find_package(Grfcodec)
 

--- a/cmake/FindD3D11.cmake
+++ b/cmake/FindD3D11.cmake
@@ -1,0 +1,19 @@
+# Autodetect if D3D11, DXGI 1.5, d3dcompiler and WRL can be used.
+
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS "")
+
+check_cxx_source_compiles("
+    #undef NTDDI_VERSION
+    #undef _WIN32_WINNT
+
+    #define NTDDI_VERSION    NTDDI_VISTA
+    #define _WIN32_WINNT     _WIN32_WINNT_VISTA
+
+    #include <wrl/client.h>
+    #include <d3d11.h>
+    #include <dxgi1_5.h>
+    #include <d3dcompiler.h>
+    int main() { return 0; }"
+    D3D11_FOUND
+)

--- a/src/table/CMakeLists.txt
+++ b/src/table/CMakeLists.txt
@@ -90,3 +90,8 @@ add_files(
     opengl_shader.h
     CONDITION OPENGL_FOUND
 )
+
+add_files(
+    hlsl_shader.h
+    CONDITION D3D11_FOUND
+)

--- a/src/table/hlsl_shader.h
+++ b/src/table/hlsl_shader.h
@@ -1,0 +1,173 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file hlsl_shader.h HLSL shader programs. */
+
+#define _hlsl_cbuffer \
+R"STR(
+	cbuffer UniformConstantBuffer : register(b0)
+	{
+		float4 sprite;
+		float2 screen;
+		float zoom;
+		bool rgb;
+		bool crash;
+	};
+)STR"
+
+/** HLSL vertex shader that positions a sprite on screen. */
+static const char _vertex_shader_sprite_hlsl[] =
+_hlsl_cbuffer
+R"STR(
+	struct vs_out
+	{
+		float4 position : SV_POSITION;
+		float2 texcoord : TEXCOORD;
+	};
+
+	static const float4 vert_array[] = {
+		//       x     y    u    v
+		float4( 1.0, -1.0, 1.0, 1.0),
+		float4(-1.0, -1.0, 0.0, 1.0),
+		float4( 1.0,  1.0, 1.0, 0.0),
+		float4(-1.0,  1.0, 0.0, 0.0)
+	};
+
+	vs_out vs_main(uint id: SV_VertexID)
+	{
+		float2 size = sprite.zw / screen.xy;
+		float2 offset = ((2.0 * sprite.xy + sprite.zw) / screen.xy - 1.0) * float2(1.0, -1.0);
+
+		vs_out output;
+		output.texcoord = vert_array[id].zw;
+		output.position = float4(vert_array[id].xy * size + offset, 0.0, 1.0);
+
+		return output;
+	};
+)STR";
+
+/** HLSL pixel shader that reads the fragment colour from a 32bpp texture. */
+static const char _frag_shader_direct_hlsl[] =
+R"STR(
+	uniform Texture2D colour_tex : register(t0);
+	uniform SamplerState texture_sampler : register(s0);
+
+	struct vs_out
+	{
+		float4 position : SV_POSITION;
+		float2 texcoord : TEXCOORD;
+	};
+
+	float4 ps_main(vs_out input) : SV_TARGET
+	{
+		return colour_tex.Sample(texture_sampler, input.texcoord);
+	};
+)STR";
+
+/** HLSL pixel shader that reads the fragment colour from a 32bpp texture. */
+static const char _frag_shader_palette_hlsl[] =
+R"STR(
+	uniform Texture2D colour_tex : register(t0);
+	uniform Texture1D palette : register(t1);
+	uniform SamplerState texture_sampler : register(s0);
+
+	struct vs_out
+	{
+		float4 position : SV_POSITION;
+		float2 texcoord : TEXCOORD;
+	};
+
+	float4 ps_main(vs_out input) : SV_TARGET
+	{
+		float idx = colour_tex.Sample(texture_sampler, input.texcoord).x;
+		return palette.Sample(texture_sampler, idx);
+	};
+)STR";
+
+/** Pixel shader function for remap brightness modulation. */
+#define _frag_shader_remap_func_hlsl \
+R"STR(
+	float max3(float3 v)
+	{
+		return max(max(v.x, v.y), v.z);
+	}
+
+	float3 adj_brightness(float3 colour, float3 brightness)
+	{
+		float3 adj = colour * (brightness > 0.0 ? brightness / 0.5 : 1.0);
+		float3 ob_vec = clamp(adj - 1.0, 0.0, 1.0);
+		float ob = (ob_vec.r + ob_vec.g + ob_vec.b) / 2.0;
+		return clamp(adj + ob * (1.0 - adj), 0.0, 1.0);
+	}
+)STR"
+
+/** HLSL pixel shader that performs a palette lookup to read the colour from an 8bpp texture. */
+static const char _frag_shader_rgb_mask_blend_hlsl[] =
+_hlsl_cbuffer
+_frag_shader_remap_func_hlsl
+R"STR(
+	uniform Texture2D colour_tex : register(t0);
+	uniform Texture1D palette : register(t1);
+	uniform Texture2D remap_tex : register(t2);
+	uniform SamplerState texture_sampler : register(s0);
+
+	struct vs_out
+	{
+		float4 position : SV_POSITION;
+		float2 texcoord : TEXCOORD;
+	};
+
+	float4 ps_main(vs_out input) : SV_TARGET
+	{
+		float idx = remap_tex.SampleLevel(texture_sampler, input.texcoord, zoom).r;
+		float4 remap_col = palette.Sample(texture_sampler, idx);
+		float4 rgb_col = colour_tex.SampleLevel(texture_sampler, input.texcoord, zoom);
+
+		float4 output;
+		output.a = rgb ? rgb_col.a : remap_col.a;
+		output.rgb = idx > 0.0 ? adj_brightness(remap_col.rgb, max3(rgb_col.rgb)) : rgb_col.rgb;
+
+		return output;
+	};
+)STR";
+
+/** HLSL pixel shader that performs a palette lookup to read the colour from a sprite texture. */
+static const char _frag_shader_sprite_blend_hlsl[] =
+_hlsl_cbuffer
+_frag_shader_remap_func_hlsl
+R"STR(
+	uniform Texture2D colour_tex : register(t0);
+	uniform Texture1D palette : register(t1);
+	uniform Texture2D remap_tex : register(t2);
+	uniform Texture1D pal : register(t3);
+	uniform SamplerState texture_sampler : register(s0);
+
+	struct vs_out
+	{
+		float4 position : SV_POSITION;
+		float2 texcoord : TEXCOORD;
+	};
+
+	float4 ps_main(vs_out input) : SV_TARGET
+	{
+		float idx = remap_tex.SampleLevel(texture_sampler, input.texcoord, zoom).r;
+		float r = pal.Sample(texture_sampler, idx).r;
+		float4 remap_col = palette.Sample(texture_sampler, r);
+		float4 rgb_col = colour_tex.SampleLevel(texture_sampler, input.texcoord, zoom);
+
+		if (crash && idx == 0.0)
+			rgb_col.rgb = float2(dot(rgb_col.rgb, float3(0.199325561523, 0.391342163085, 0.076004028320)), 0.0).rrr;
+
+		float4 output;
+		output.a = rgb && (r > 0.0 || idx == 0.0) ? rgb_col.a : remap_col.a;
+		output.rgb = idx > 0.0 ? adj_brightness(remap_col.rgb, max3(rgb_col.rgb)) : rgb_col.rgb;
+
+		return output;
+	};
+)STR";

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -14,6 +14,12 @@ if(NOT OPTION_DEDICATED)
     )
 
     add_files(
+        d3d11.cpp
+        d3d11.h
+        CONDITION D3D11_FOUND
+    )
+
+    add_files(
         sdl_v.cpp
         sdl_v.h
         CONDITION SDL_FOUND

--- a/src/video/d3d11.cpp
+++ b/src/video/d3d11.cpp
@@ -1,0 +1,437 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file d3d11.cpp D3D11 video driver support. */
+
+#include "../stdafx.h"
+
+#include "d3d11.h"
+
+#include "../core/geometry_func.hpp"
+#include "../core/mem_func.hpp"
+#include "../core/math_func.hpp"
+#include "../core/mem_func.hpp"
+#include "../gfx_func.h"
+#include "../debug.h"
+#include "../blitter/factory.hpp"
+#include "../zoom_func.h"
+#include "../table/hlsl_shader.h"
+
+#include <d3dcompiler.h>
+
+D3D11Backend* D3D11Backend::instance = nullptr;
+
+struct HlslConstantBuffer {
+	FLOAT sprite[4];
+	FLOAT screen[2];
+	FLOAT zoom;
+	BOOL rgb;
+	BOOL crash;
+	FLOAT pad[3];
+};
+
+static HMODULE d3d11_module;
+static HMODULE d3dcompiler_module;
+
+static PFN_D3D11_CREATE_DEVICE _D3D11CreateDevice;
+static pD3DCompile _D3DCompile;
+
+static char* CompileShader(const char *source, const char *func, const char *profile, ComPtr<ID3DBlob> &code)
+{
+	ComPtr<ID3DBlob> error;
+
+	HRESULT result = _D3DCompile(source, strlen(source),
+		nullptr, nullptr, nullptr,
+		func, profile, D3DCOMPILE_ENABLE_STRICTNESS, 0, &code, &error);
+
+	if (FAILED(result)) {
+		if (error) {
+			return (char*)error->GetBufferPointer();
+		}
+
+		return "Shader compile error";
+	}
+
+	return nullptr;
+}
+
+static const char* CreateVertexShader(ID3D11Device *device, const char* source, ComPtr<ID3D11VertexShader> &shader)
+{
+	ComPtr<ID3DBlob> code;
+
+	const char *msg = CompileShader(source, "vs_main", "vs_4_0", code);
+	if (msg != nullptr)
+		return msg;
+
+	HRESULT result = device->CreateVertexShader(code->GetBufferPointer(), code->GetBufferSize(), nullptr, &shader);
+
+	if (FAILED(result)) {
+		return "Failed to create vertex shader";
+	}
+
+	return nullptr;
+}
+
+static const char* CreatePixelShader(ID3D11Device* device, const char* source, ComPtr<ID3D11PixelShader> &shader)
+{
+	ComPtr<ID3DBlob> code;
+
+	const char* msg = CompileShader(source, "ps_main", "ps_4_0", code);
+	if (msg != nullptr)
+		return msg;
+
+	HRESULT result = device->CreatePixelShader(code->GetBufferPointer(), code->GetBufferSize(), nullptr, &shader);
+
+	if (FAILED(result)) {
+		return "Failed to create pixel shader";
+	}
+
+	return nullptr;
+}
+
+/**
+ * Create and initialize the singleton back-end class.
+ * @return nullptr on success, error message otherwise.
+ */
+const char* D3D11Backend::Create()
+{
+	if (D3D11Backend::instance != nullptr) D3D11Backend::Destroy();
+
+	for (int ver = D3D_COMPILER_VERSION; ver >= 40; ver--) {
+		std::string dllname = "d3dcompiler_" + std::to_string(ver) + ".dll";
+		d3dcompiler_module = LoadLibraryA(dllname.c_str());
+		if (d3dcompiler_module != nullptr) break;
+	}
+
+	if (d3dcompiler_module == nullptr) return "Failed to load d3dcompiler library";
+
+	_D3DCompile = (pD3DCompile)GetProcAddress(d3dcompiler_module, "D3DCompile");
+	if (_D3DCompile == nullptr) return "Failed to import D3DCompile function";
+
+	d3d11_module = LoadLibraryA("d3d11.dll");
+	if (d3d11_module == nullptr) return "Failed to load d3d11 library";
+
+	_D3D11CreateDevice = (PFN_D3D11_CREATE_DEVICE)GetProcAddress(d3d11_module, "D3D11CreateDevice");
+	if (_D3D11CreateDevice == nullptr) return "Failed to import D3D11CreateDevice function";
+
+	D3D11Backend::instance = new D3D11Backend();
+	const char *err = D3D11Backend::instance->Init();
+	if (err != nullptr) {
+		delete D3D11Backend::instance;
+		D3D11Backend::instance = nullptr;
+	}
+	return err;
+}
+
+/**
+ * Free resources and destroy singleton back-end class.
+ */
+void D3D11Backend::Destroy()
+{
+	delete D3D11Backend::instance;
+	D3D11Backend::instance = nullptr;
+
+	if (d3d11_module != nullptr) FreeLibrary(d3d11_module);
+	if (d3dcompiler_module != nullptr) FreeLibrary(d3dcompiler_module);
+
+	d3d11_module = nullptr;
+	d3dcompiler_module = nullptr;
+
+	_D3D11CreateDevice = nullptr;
+	_D3DCompile = nullptr;
+}
+
+/**
+ * Check for the needed D3D11 functionality and allocate all resources.
+ * @return Error string or nullptr if successful.
+ */
+const char* D3D11Backend::Init()
+{
+	D3D_FEATURE_LEVEL feature_level = D3D_FEATURE_LEVEL_10_0;
+	UINT device_flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_SINGLETHREADED;
+	//device_flags |= D3D11_CREATE_DEVICE_DEBUG; /* Uncomment to create device with debug layer. */
+
+	HRESULT result = _D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+		device_flags, &feature_level, 1, D3D11_SDK_VERSION,
+		&this->device, nullptr, &this->device_ctx);
+
+	if (FAILED(result))
+		return "Failed to create D3D11 device";
+
+	const char* err;
+
+	err = CreateVertexShader(this->device.Get(), _vertex_shader_sprite_hlsl, this->vertex_shader);
+	if (err != nullptr) return err;
+
+	err = CreatePixelShader(this->device.Get(), _frag_shader_direct_hlsl, this->direct_shader);
+	if (err != nullptr) return err;
+
+	err = CreatePixelShader(this->device.Get(), _frag_shader_palette_hlsl, this->palette_shader);
+	if (err != nullptr) return err;
+
+	err = CreatePixelShader(this->device.Get(), _frag_shader_rgb_mask_blend_hlsl, this->rgb_mask_blend_shader);
+	if (err != nullptr) return err;
+
+	err = CreatePixelShader(this->device.Get(), _frag_shader_sprite_blend_hlsl, this->sprite_blend_shader);
+	if (err != nullptr) return err;
+
+	D3D11_BUFFER_DESC cbuffer_desc;
+	cbuffer_desc.ByteWidth = sizeof(HlslConstantBuffer);
+	cbuffer_desc.Usage = D3D11_USAGE_IMMUTABLE;
+	cbuffer_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	cbuffer_desc.CPUAccessFlags = 0;
+	cbuffer_desc.MiscFlags = 0;
+	cbuffer_desc.StructureByteStride = 0;
+
+	HlslConstantBuffer constant;
+	constant.screen[0] = 1.0f;
+	constant.screen[1] = 1.0f;
+	constant.sprite[0] = 0.0f;
+	constant.sprite[1] = 0.0f;
+	constant.sprite[2] = 1.0f;
+	constant.sprite[3] = 1.0f;
+	constant.zoom = 0.0f;
+	constant.rgb = TRUE;
+	constant.crash = FALSE;
+
+	D3D11_SUBRESOURCE_DATA data;
+	data.pSysMem = &constant;
+	data.SysMemPitch = sizeof(constant);
+	data.SysMemSlicePitch = 0;
+
+	result = device->CreateBuffer(&cbuffer_desc, &data, &this->constant_buffer);
+	if (FAILED(result)) return "Failed to constant buffer";
+
+	D3D11_TEXTURE1D_DESC desc;
+	desc.Width = 256;
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.MiscFlags = 0;
+	desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+
+	result = device->CreateTexture1D(&desc, nullptr, &this->pal_texture);
+	if (FAILED(result)) return "Failed to create texture";
+
+	result = device->CreateShaderResourceView(this->pal_texture.Get(), nullptr, &this->pal_texture_srv);
+	if (FAILED(result)) return "Failed to resource view";
+
+	D3D11_SAMPLER_DESC sampler_desc;
+	memset(&sampler_desc, 0, sizeof(sampler_desc));
+	sampler_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+	sampler_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+	sampler_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+	sampler_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+	sampler_desc.ComparisonFunc = D3D11_COMPARISON_NEVER;
+	sampler_desc.MaxLOD = D3D11_FLOAT32_MAX;
+
+	result = device->CreateSamplerState(&sampler_desc, &texture_sampler);
+	if (FAILED(result)) return "Failed to create sampler state";
+
+	return nullptr;
+}
+
+void D3D11Backend::UpdatePalette(const Colour* pal, uint first, uint length)
+{
+	assert(first + length <= 256);
+
+	D3D11_BOX box;
+	box.front = 0;
+	box.back = 1;
+	box.left = first;
+	box.right = first + length;
+	box.top = 0;
+	box.bottom = 1;
+
+	device_ctx->UpdateSubresource(pal_texture.Get(), 0, &box, pal + first, 256, 0);
+}
+
+const char* D3D11Backend::Resize(int w, int h)
+{
+	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
+
+	D3D11_TEXTURE2D_DESC desc;
+	desc.Width = w;
+	desc.Height = h;
+	desc.MipLevels = 1;
+	desc.ArraySize = 1;
+	desc.SampleDesc.Count = 1;
+	desc.SampleDesc.Quality = 0;
+	desc.MiscFlags = 0;
+
+	if (bpp == 8) {
+		desc.Format = DXGI_FORMAT_R8_UNORM;
+	}
+	else {
+		desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	}
+
+	desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.CPUAccessFlags = 0;
+
+	HRESULT result = device->CreateTexture2D(&desc, nullptr, &this->vid_texture);
+	if (FAILED(result)) return "Failed to create texture";
+
+	desc.BindFlags = 0;
+	desc.Usage = D3D11_USAGE_STAGING;
+	desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE;
+
+	result = device->CreateTexture2D(&desc, nullptr, &this->vid_texture_staging);
+	if (FAILED(result)) return "Failed to create texture";
+
+	desc.Format = DXGI_FORMAT_R8_UNORM;
+
+	/* Does this blitter need a separate animation buffer? */
+	if (BlitterFactory::GetCurrentBlitter()->NeedsAnimationBuffer()) {
+		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		desc.Usage = D3D11_USAGE_DEFAULT;
+		desc.CPUAccessFlags = 0;
+
+		result = device->CreateTexture2D(&desc, nullptr, &this->anim_texture);
+		if (FAILED(result)) return "Failed to create texture";
+
+		desc.BindFlags = 0;
+		desc.Usage = D3D11_USAGE_STAGING;
+		desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE;
+
+		result = device->CreateTexture2D(&desc, nullptr, &this->anim_texture_staging);
+		if (FAILED(result)) return "Failed to create texture";
+	}
+	else {
+		/* Allocate dummy texture that always reads as 0 == no remap. */
+		desc.Width = 1;
+		desc.Height = 1;
+		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		desc.Usage = D3D11_USAGE_IMMUTABLE;
+		desc.CPUAccessFlags = 0;
+
+		byte dummy = 0;
+		D3D11_SUBRESOURCE_DATA data;
+		data.pSysMem = &dummy;
+		data.SysMemPitch = 1;
+		data.SysMemSlicePitch = 0;
+
+		result = device->CreateTexture2D(&desc, &data, &this->anim_texture);
+		if (FAILED(result)) return "Failed to create texture";
+
+		this->anim_texture_staging.Reset();
+	}
+
+	result = device->CreateShaderResourceView(this->vid_texture.Get(), nullptr, &this->vid_texture_srv);
+	if (FAILED(result)) return "Failed to create resource view";
+
+	result = device->CreateShaderResourceView(this->anim_texture.Get(), nullptr, &this->anim_texture_srv);
+	if (FAILED(result)) return "Failed to create resource view";
+
+	/* Set new viewport. */
+	_screen.height = h;
+	_screen.width = w;
+	_screen.dst_ptr = nullptr;
+
+	return nullptr;
+}
+
+ComPtr<ID3D11Device> D3D11Backend::GetDevice()
+{
+	return this->device;
+}
+
+void D3D11Backend::Paint(ComPtr<ID3D11RenderTargetView> rendertarget)
+{
+	FLOAT background_color[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+	device_ctx->ClearRenderTargetView(rendertarget.Get(), background_color);
+	device_ctx->OMSetRenderTargets(1, rendertarget.GetAddressOf(), nullptr);
+
+	device_ctx->VSSetShader(vertex_shader.Get(), nullptr, 0);
+	device_ctx->VSSetConstantBuffers(0, 1, constant_buffer.GetAddressOf());
+	device_ctx->PSSetConstantBuffers(0, 1, constant_buffer.GetAddressOf());
+
+	ID3D11ShaderResourceView* resources[4] = { nullptr };
+	resources[0] = this->vid_texture_srv.Get();
+	resources[1] = this->pal_texture_srv.Get();
+	if (BlitterFactory::GetCurrentBlitter()->NeedsAnimationBuffer()) {
+		resources[2] = this->anim_texture_srv.Get();
+		device_ctx->PSSetShader(this->rgb_mask_blend_shader.Get(), nullptr, 0);
+	}
+	else {
+		if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 8) {
+			device_ctx->PSSetShader(this->palette_shader.Get(), nullptr, 0);
+		}
+		else {
+			device_ctx->PSSetShader(this->direct_shader.Get(), nullptr, 0);
+		}
+	}
+
+	device_ctx->PSSetSamplers(0, 1, texture_sampler.GetAddressOf());
+	device_ctx->PSSetShaderResources(0, 4, resources);
+
+	D3D11_VIEWPORT viewport = { 0.0f, 0.0f, (float)_screen.width, (float)_screen.height, 0.0f, 1.0f };
+	device_ctx->RSSetViewports(1, &viewport);
+
+	device_ctx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+	device_ctx->Draw(4, 0);
+
+	device_ctx->ClearState();
+}
+
+void* D3D11Backend::GetVideoBuffer()
+{
+	D3D11_MAPPED_SUBRESOURCE mapped;
+	device_ctx->Map(vid_texture_staging.Get(), 0, D3D11_MAP_READ_WRITE, 0, &mapped);
+
+	int bpp = BlitterFactory::GetCurrentBlitter()->GetScreenDepth();
+	_screen.pitch = mapped.RowPitch / bpp * 8;
+
+	return mapped.pData;
+}
+
+std::pair<uint8*, int> D3D11Backend::GetAnimBuffer()
+{
+	D3D11_MAPPED_SUBRESOURCE mapped;
+	device_ctx->Map(anim_texture_staging.Get(), 0, D3D11_MAP_READ_WRITE, 0, &mapped);
+
+	return std::make_pair((uint8_t*)mapped.pData, mapped.RowPitch);
+}
+
+void D3D11Backend::ReleaseVideoBuffer(const Rect& update_rect)
+{
+	device_ctx->Unmap(vid_texture_staging.Get(), 0);
+
+	if (!IsEmptyRect(update_rect)) {
+		D3D11_BOX box;
+		box.front = 0;
+		box.back = 1;
+		box.left = update_rect.left;
+		box.right = update_rect.right;
+		box.top = update_rect.top;
+		box.bottom = update_rect.bottom;
+
+		device_ctx->CopySubresourceRegion(vid_texture.Get(), 0, update_rect.left, update_rect.top, 0, vid_texture_staging.Get(), 0, &box);
+	}
+}
+
+void D3D11Backend::ReleaseAnimBuffer(const Rect& update_rect)
+{
+	device_ctx->Unmap(anim_texture_staging.Get(), 0);
+
+	if (!IsEmptyRect(update_rect)) {
+		D3D11_BOX box;
+		box.front = 0;
+		box.back = 1;
+		box.left = update_rect.left;
+		box.right = update_rect.right;
+		box.top = update_rect.top;
+		box.bottom = update_rect.bottom;
+
+		device_ctx->CopySubresourceRegion(anim_texture.Get(), 0, update_rect.left, update_rect.top, 0, anim_texture_staging.Get(), 0, &box);
+	}
+}

--- a/src/video/d3d11.h
+++ b/src/video/d3d11.h
@@ -1,0 +1,83 @@
+/* $Id$ */
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file d3d11.h D3D11 video driver support. */
+
+#ifndef VIDEO_D3D11_H
+#define VIDEO_D3D11_H
+
+#include "../core/alloc_type.hpp"
+#include "../core/geometry_type.hpp"
+#include "../gfx_type.h"
+#include "../spriteloader/spriteloader.hpp"
+#include "../misc/lrucache.hpp"
+
+// Vista required for WRL header
+#undef NTDDI_VERSION
+#undef _WIN32_WINNT
+
+#define NTDDI_VERSION    NTDDI_VISTA
+#define _WIN32_WINNT     _WIN32_WINNT_VISTA
+
+#include <wrl/client.h>
+#include <d3d11.h>
+
+using Microsoft::WRL::ComPtr;
+
+class D3D11Backend {
+private:
+	static D3D11Backend* instance;
+
+	ComPtr<ID3D11Device> device;
+	ComPtr<ID3D11DeviceContext> device_ctx;
+
+	ComPtr<ID3D11VertexShader> vertex_shader;
+	ComPtr<ID3D11PixelShader> direct_shader;
+	ComPtr<ID3D11PixelShader> palette_shader;
+	ComPtr<ID3D11PixelShader> rgb_mask_blend_shader;
+	ComPtr<ID3D11PixelShader> sprite_blend_shader;
+
+	ComPtr<ID3D11Buffer> constant_buffer;
+
+	ComPtr<ID3D11Texture2D> vid_texture;
+	ComPtr<ID3D11Texture2D> vid_texture_staging;
+	ComPtr<ID3D11ShaderResourceView> vid_texture_srv;
+
+	ComPtr<ID3D11Texture2D> anim_texture;
+	ComPtr<ID3D11Texture2D> anim_texture_staging;
+	ComPtr<ID3D11ShaderResourceView> anim_texture_srv;
+
+	ComPtr<ID3D11Texture1D> pal_texture;
+	ComPtr<ID3D11ShaderResourceView> pal_texture_srv;
+
+	ComPtr<ID3D11SamplerState> texture_sampler;
+
+public:
+	/** Get singleton instance of this class. */
+	static inline D3D11Backend* Get()
+	{
+		return D3D11Backend::instance;
+	}
+	static const char* Create();
+	static void Destroy();
+
+	const char* Init();
+
+	void UpdatePalette(const Colour* pal, uint first, uint length);
+	const char* Resize(int w, int h);
+	ComPtr<ID3D11Device> GetDevice();
+	void Paint(ComPtr<ID3D11RenderTargetView> rendertarget);
+
+	void* GetVideoBuffer();
+	std::pair<uint8*, int> GetAnimBuffer();
+	void ReleaseVideoBuffer(const Rect& update_rect);
+	void ReleaseAnimBuffer(const Rect& update_rect);
+};
+
+#endif

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -147,6 +147,11 @@ public:
 		return nullptr;
 	}
 
+	virtual int GetAnimBufferPitch()
+	{
+		NOT_REACHED();
+	}
+
 	/**
 	 * An edit box lost the input focus. Abort character compositing if necessary.
 	 */

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -137,6 +137,7 @@ public:
 
 	bool HasAnimBuffer() override { return true; }
 	uint8 *GetAnimBuffer() override { return this->anim_buffer; }
+	int GetAnimBufferPitch() override { return _screen.pitch; }
 
 	void ToggleVsync(bool vsync) override;
 


### PR DESCRIPTION
## Motivation / Problem

OpenGL experience on Windows might be subpar, fresh Windows installations might not have OpenGL drivers installed, etc.

## Description

Mostly port of the OpenGL driver.

## Limitations

- Feature level 10_0 required. Might be possible to get lower with slightly more code.

- ~Fullscreen not yet implemented.~
Generally DXGI model doesn't play too well with existing code. ~What win32 does currently, recreating the window for each mode switch is completely unnecessary, in DXGI we can resize/switch modes without recreating window or even swapchain. However to do that requires rework of win32 base driver window creation code.~ Moreover, we might want to ditch exclusive fullscreen mode entirely and switch to borderless fullscreen windows. On modern compositors exclusive fullscreen have no benefits

- Exclusive fullscreen is implemented, but on purpose it is not allowed to change system resolution. It can be changed by adding `DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH` to swapchain creation flags, but I'm not sure if this is desired.

- ~I had to align staging texture width to 128 pixels, otherwise pitch gets screwed, I have no idea why.~ Fixed.

- I didn't implement sprite cursor drawing.

- Might not be that necessary after all, as during development of this I found bug that likely caused most of the OpenGL crashes (fixed in #9100)

- ~Codestyle might be off.~