### PR TITLE
Codechange: allow Connect() to bind to a local address

### DIFF
--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -40,7 +40,8 @@ private:
 	 */
 	typedef SOCKET (*LoopProc)(addrinfo *runp);
 
-	SOCKET Resolve(int family, int socktype, int flags, SocketList *sockets, LoopProc func);
+	template<typename T>
+	SOCKET Resolve(int family, int socktype, int flags, SocketList *sockets, T func, bool resolve_only = false);
 public:
 	/**
 	 * Create a network address based on a resolved IP and port.
@@ -175,6 +176,7 @@ public:
 	}
 
 	SOCKET Connect();
+	SOCKET Connect(NetworkAddress &bind_address);
 	void Listen(int socktype, SocketList *sockets);
 
 	static const char *SocketTypeAsString(int socktype);


### PR DESCRIPTION
## Motivation / Problem

For STUN I need a method that a `connect()` can be bound to a local address (to reuse a local address, as that is what STUN does). I was looking for a clean way to implement this.

I see two methods of doing this:
1) add a `connect_bind_address` variable to `NetworkAddress`, and pass `this` from `Resolve()` into `func` so it can read this address again. This is a lot of poking holes, and adds a variable specific for one flow (out of the three that exist).
2) use a lambda with a capture to bypass all this and only send the `NetworkAddress` to `ConnectLoopProc` directly.

In this PR I present the second option, mostly as my C++ knowledge is not sufficient to know if there are any downsides to this approach.

## Description

```
This is currently not used, but later commits will make use of
this.
```

It uses a capture lambda to inject some extra parameters to the callback function, without anything in between knowing about it.

## Limitations

- During testing this works, but I have no clue how many compilers accept this (should be C++17?)
- My C++ knowledge is limited, so I pieced this together from what LordAro told me last week, but please, look at this carefully :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
