### PR TITLE
Codechange: use std::string exclusively for settings

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -843,8 +843,8 @@ CommandCost CmdCompanyCtrl(TileIndex tile, DoCommandFlag flags, uint32 p1, uint3
 			if (client_id == _network_own_client_id) {
 				assert(_local_company == COMPANY_SPECTATOR);
 				SetLocalCompany(c->index);
-				if (!StrEmpty(_settings_client.network.default_company_pass)) {
-					NetworkChangeCompanyPassword(_local_company, _settings_client.network.default_company_pass);
+				if (!_settings_client.network.default_company_pass.empty()) {
+					NetworkChangeCompanyPassword(_local_company, _settings_client.network.default_company_pass.c_str());
 				}
 
 				/* Now that we have a new company, broadcast our company settings to

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -717,14 +717,14 @@ DEF_CONSOLE_CMD(ConClientNickChange)
 		return true;
 	}
 
-	char *client_name = argv[2];
+	std::string client_name(argv[2]);
 	StrTrimInPlace(client_name);
 	if (!NetworkIsValidClientName(client_name)) {
 		IConsoleError("Cannot give a client an empty name");
 		return true;
 	}
 
-	if (!NetworkServerChangeClientName(client_id, client_name)) {
+	if (!NetworkServerChangeClientName(client_id, client_name.c_str())) {
 		IConsoleError("Cannot give a client a duplicate name");
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -893,13 +893,13 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 			break;
 	}
 
-	if (StrEmpty(_settings_client.network.last_joined)) {
+	if (_settings_client.network.last_joined.empty()) {
 		IConsolePrint(CC_DEFAULT, "No server for reconnecting.");
 		return true;
 	}
 
 	/* Don't resolve the address first, just print it directly as it comes from the config file. */
-	IConsolePrintF(CC_DEFAULT, "Reconnecting to %s ...", _settings_client.network.last_joined);
+	IConsolePrintF(CC_DEFAULT, "Reconnecting to %s ...", _settings_client.network.last_joined.c_str());
 
 	return NetworkClientConnectGame(_settings_client.network.last_joined, playas);
 }

--- a/src/currency.h
+++ b/src/currency.h
@@ -70,11 +70,11 @@ enum Currencies {
 
 /** Specification of a currency. */
 struct CurrencySpec {
-	uint16 rate;
-	char separator[8];
-	Year to_euro;      ///< %Year of switching to the Euro. May also be #CF_NOEURO or #CF_ISEURO.
-	char prefix[16];
-	char suffix[16];
+	uint16 rate;           ///< The conversion rate compared to the base currency.
+	std::string separator; ///< The thousands separator for this currency.
+	Year to_euro;          ///< %Year of switching to the Euro. May also be #CF_NOEURO or #CF_ISEURO.
+	std::string prefix;    ///< Prefix to apply when formatting money in this currency.
+	std::string suffix;    ///< Suffix to apply when formatting money in this currency.
 	/**
 	 * The currency symbol is represented by two possible values, prefix and suffix
 	 * Usage of one or the other is determined by #symbol_pos.
@@ -89,11 +89,9 @@ struct CurrencySpec {
 
 	CurrencySpec() = default;
 
-	CurrencySpec(uint16 rate, const char *separator, Year to_euro, const char *prefix, const char *suffix, byte symbol_pos, StringID name) : rate(rate), to_euro(to_euro), symbol_pos(symbol_pos), name(name)
+	CurrencySpec(uint16 rate, const char *separator, Year to_euro, const char *prefix, const char *suffix, byte symbol_pos, StringID name) :
+		rate(rate), separator(separator), to_euro(to_euro), prefix(prefix), suffix(suffix), symbol_pos(symbol_pos), name(name)
 	{
-		strecpy(this->separator, separator, lastof(this->separator));
-		strecpy(this->prefix, prefix, lastof(this->prefix));
-		strecpy(this->suffix, suffix, lastof(this->suffix));
 	}
 };
 

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -53,7 +53,7 @@ void LoadCheckData::Clear()
 
 	this->map_size_x = this->map_size_y = 256; // Default for old savegames which do not store mapsize.
 	this->current_date = 0;
-	memset(&this->settings, 0, sizeof(this->settings));
+	this->settings = {};
 
 	for (auto &pair : this->companies) {
 		delete pair.second;

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -214,9 +214,9 @@ static inline bool GetDrawGlyphShadow(FontSize size)
 
 /** Settings for a single freetype font. */
 struct FreeTypeSubSetting {
-	char font[MAX_PATH]; ///< The name of the font, or path to the font.
-	uint size;           ///< The (requested) size of the font.
-	bool aa;             ///< Whether to do anti aliasing or not.
+	std::string font; ///< The name of the font, or path to the font.
+	uint size;        ///< The (requested) size of the font.
+	bool aa;          ///< Whether to do anti aliasing or not.
 
 	const void *os_handle = nullptr; ///< Optional native OS font info. Only valid during font search.
 };

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -38,13 +38,9 @@ IniItem::~IniItem()
  * Replace the current value with another value.
  * @param value the value to replace with.
  */
-void IniItem::SetValue(const char *value)
+void IniItem::SetValue(const std::string_view value)
 {
-	if (value == nullptr) {
-		this->value.reset();
-	} else {
-		this->value.emplace(value);
-	}
+	this->value.emplace(value);
 }
 
 /**

--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -31,7 +31,7 @@ struct IniItem {
 	IniItem(struct IniGroup *parent, const std::string &name);
 	~IniItem();
 
-	void SetValue(const char *value);
+	void SetValue(const std::string_view value);
 };
 
 /** A group within an ini file. */

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -127,7 +127,7 @@ void CheckGameCompatibility(NetworkGameInfo &ngi)
  */
 void FillStaticNetworkServerGameInfo()
 {
-	_network_game_info.use_password   = !StrEmpty(_settings_client.network.server_password);
+	_network_game_info.use_password   = !_settings_client.network.server_password.empty();
 	_network_game_info.start_date     = ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1);
 	_network_game_info.clients_max    = _settings_client.network.max_clients;
 	_network_game_info.companies_max  = _settings_client.network.max_companies;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -824,7 +824,7 @@ void NetworkClientJoinGame()
 	NetworkDisconnect();
 	NetworkInitialize();
 
-	strecpy(_settings_client.network.last_joined, _network_join.connection_string.c_str(), lastof(_settings_client.network.last_joined));
+	_settings_client.network.last_joined = _network_join.connection_string;
 	_network_join_status = NETWORK_JOIN_STATUS_CONNECTING;
 	ShowJoinStatusWindow();
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -887,7 +887,7 @@ bool NetworkServerStart()
 	if (!ServerNetworkGameSocketHandler::Listen(_settings_client.network.server_port)) return false;
 
 	/* Only listen for admins when the password isn't empty. */
-	if (!StrEmpty(_settings_client.network.admin_password)) {
+	if (!_settings_client.network.admin_password.empty()) {
 		DEBUG(net, 5, "Starting listeners for admins");
 		if (!ServerNetworkAdminSocketHandler::Listen(_settings_client.network.server_admin_port)) return false;
 	}

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -846,7 +846,7 @@ static void NetworkInitGameInfo()
 	NetworkClientInfo *ci = new NetworkClientInfo(CLIENT_ID_SERVER);
 	ci->client_playas = _network_dedicated ? COMPANY_SPECTATOR : COMPANY_FIRST;
 
-	strecpy(ci->client_name, _settings_client.network.client_name, lastof(ci->client_name));
+	strecpy(ci->client_name, _settings_client.network.client_name.c_str(), lastof(ci->client_name));
 }
 
 /**
@@ -857,10 +857,10 @@ static void NetworkInitGameInfo()
  */
 static void CheckClientAndServerName()
 {
-	static const char *fallback_client_name = "Unnamed Client";
-	if (StrEmpty(_settings_client.network.client_name) || strcmp(_settings_client.network.client_name, fallback_client_name) == 0) {
-		DEBUG(net, 1, "No \"client_name\" has been set, using \"%s\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name);
-		strecpy(_settings_client.network.client_name, fallback_client_name, lastof(_settings_client.network.client_name));
+	static const std::string fallback_client_name = "Unnamed Client";
+	if (_settings_client.network.client_name.empty() || _settings_client.network.client_name.compare(fallback_client_name) == 0) {
+		DEBUG(net, 1, "No \"client_name\" has been set, using \"%s\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name.c_str());
+		_settings_client.network.client_name = fallback_client_name;
 	}
 
 	static const std::string fallback_server_name = "Unnamed Server";

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -833,8 +833,8 @@ void NetworkClientJoinGame()
 
 static void NetworkInitGameInfo()
 {
-	if (StrEmpty(_settings_client.network.server_name)) {
-		strecpy(_settings_client.network.server_name, "Unnamed Server", lastof(_settings_client.network.server_name));
+	if (_settings_client.network.server_name.empty()) {
+		_settings_client.network.server_name = "Unnamed Server";
 	}
 
 	FillStaticNetworkServerGameInfo();
@@ -863,10 +863,10 @@ static void CheckClientAndServerName()
 		strecpy(_settings_client.network.client_name, fallback_client_name, lastof(_settings_client.network.client_name));
 	}
 
-	static const char *fallback_server_name = "Unnamed Server";
-	if (StrEmpty(_settings_client.network.server_name) || strcmp(_settings_client.network.server_name, fallback_server_name) == 0) {
-		DEBUG(net, 1, "No \"server_name\" has been set, using \"%s\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name);
-		strecpy(_settings_client.network.server_name, fallback_server_name, lastof(_settings_client.network.server_name));
+	static const std::string fallback_server_name = "Unnamed Server";
+	if (_settings_client.network.server_name.empty() || _settings_client.network.server_name.compare(fallback_server_name) == 0) {
+		DEBUG(net, 1, "No \"server_name\" has been set, using \"%s\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name.c_str());
+		_settings_client.network.server_name = fallback_server_name;
 	}
 }
 
@@ -1201,7 +1201,7 @@ static void NetworkGenerateServerId()
 	}
 
 	/* _settings_client.network.network_id is our id */
-	seprintf(_settings_client.network.network_id, lastof(_settings_client.network.network_id), "%s", hex_output);
+	_settings_client.network.network_id = hex_output;
 }
 
 class TCPNetworkDebugConnecter : TCPConnecter {
@@ -1241,7 +1241,7 @@ void NetworkStartUp()
 	_network_need_advertise = true;
 
 	/* Generate an server id when there is none yet */
-	if (StrEmpty(_settings_client.network.network_id)) NetworkGenerateServerId();
+	if (_settings_client.network.network_id.empty()) NetworkGenerateServerId();
 
 	_network_game_info = {};
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -84,7 +84,7 @@ ServerNetworkAdminSocketHandler::~ServerNetworkAdminSocketHandler()
  */
 /* static */ bool ServerNetworkAdminSocketHandler::AllowConnection()
 {
-	bool accept = !StrEmpty(_settings_client.network.admin_password) && _network_admins_connected < MAX_ADMINS;
+	bool accept = !_settings_client.network.admin_password.empty() && _network_admins_connected < MAX_ADMINS;
 	/* We can't go over the MAX_ADMINS limit here. However, if we accept
 	 * the connection, there has to be space in the pool. */
 	static_assert(NetworkAdminSocketPool::MAX_SIZE == MAX_ADMINS);
@@ -667,8 +667,8 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::Receive_ADMIN_JOIN(Packet *p)
 	char password[NETWORK_PASSWORD_LENGTH];
 	p->Recv_string(password, sizeof(password));
 
-	if (StrEmpty(_settings_client.network.admin_password) ||
-			strcmp(password, _settings_client.network.admin_password) != 0) {
+	if (_settings_client.network.admin_password.empty() ||
+			_settings_client.network.admin_password.compare(password) != 0) {
 		/* Password is invalid */
 		return this->SendError(NETWORK_ERROR_WRONG_PASSWORD);
 	}

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -35,9 +35,9 @@ extern StringList _network_host_list;
 extern StringList _network_ban_list;
 
 byte NetworkSpectatorCount();
-bool NetworkIsValidClientName(const char *client_name);
+bool NetworkIsValidClientName(const std::string_view client_name);
 bool NetworkValidateClientName();
-bool NetworkValidateClientName(char *client_name);
+bool NetworkValidateClientName(std::string &client_name);
 void NetworkUpdateClientName();
 bool NetworkCompanyHasClients(CompanyID company);
 const char *NetworkChangeCompanyPassword(CompanyID company_id, const char *password);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -990,7 +990,7 @@ struct NetworkStartServerWindow : public Window {
 		this->InitNested(WN_NETWORK_WINDOW_START);
 
 		this->querystrings[WID_NSS_GAMENAME] = &this->name_editbox;
-		this->name_editbox.text.Assign(_settings_client.network.server_name);
+		this->name_editbox.text.Assign(_settings_client.network.server_name.c_str());
 
 		this->SetFocusedWidget(WID_NSS_GAMENAME);
 	}
@@ -1136,7 +1136,7 @@ struct NetworkStartServerWindow : public Window {
 	void OnEditboxChanged(int wid) override
 	{
 		if (wid == WID_NSS_GAMENAME) {
-			strecpy(_settings_client.network.server_name, this->name_editbox.text.buf, lastof(_settings_client.network.server_name));
+			_settings_client.network.server_name = this->name_editbox.text.buf;
 		}
 	}
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -462,7 +462,7 @@ public:
 		this->FinishInitNested(WN_NETWORK_WINDOW_GAME);
 
 		this->querystrings[WID_NG_CLIENT] = &this->name_editbox;
-		this->name_editbox.text.Assign(_settings_client.network.client_name);
+		this->name_editbox.text.Assign(_settings_client.network.client_name.c_str());
 
 		this->querystrings[WID_NG_FILTER] = &this->filter_editbox;
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;
@@ -820,7 +820,7 @@ public:
 			case WID_NG_CLIENT:
 				/* Validation of the name will happen once the user tries to join or start a game, as getting
 				 * error messages while typing (e.g. when you clear the name) defeats the purpose of the check. */
-				strecpy(_settings_client.network.client_name, this->name_editbox.text.buf, lastof(_settings_client.network.client_name));
+				_settings_client.network.client_name = this->name_editbox.text.buf;
 				break;
 		}
 	}
@@ -2207,11 +2207,12 @@ public:
 			}
 
 			case WID_CL_CLIENT_NAME_EDIT: {
-				if (!NetworkValidateClientName(str)) break;
+				std::string client_name(str);
+				if (!NetworkValidateClientName(client_name)) break;
 
 				uint index;
 				GetSettingFromName("network.client_name", &index);
-				SetSettingValue(index, str);
+				SetSettingValue(index, client_name.c_str());
 				this->InvalidateData();
 				break;
 			}

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -828,7 +828,7 @@ public:
 	void OnQueryTextFinished(char *str) override
 	{
 		if (!StrEmpty(str)) {
-			strecpy(_settings_client.network.connect_to_ip, str, lastof(_settings_client.network.connect_to_ip));
+			_settings_client.network.connect_to_ip = str;
 			NetworkAddServer(str);
 			NetworkRebuildHostList();
 		}
@@ -1556,7 +1556,7 @@ static void ShowNetworkLobbyWindow(NetworkGameList *ngl)
 	DeleteWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_START);
 	DeleteWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);
 
-	strecpy(_settings_client.network.last_joined, ngl->connection_string.c_str(), lastof(_settings_client.network.last_joined));
+	_settings_client.network.last_joined = ngl->connection_string;
 
 	NetworkQueryLobbyServer(ngl->connection_string);
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1032,7 +1032,7 @@ struct NetworkStartServerWindow : public Window {
 		switch (widget) {
 			case WID_NSS_SETPWD:
 				/* If password is set, draw red '*' next to 'Set password' button. */
-				if (!StrEmpty(_settings_client.network.server_password)) DrawString(r.right + WD_FRAMERECT_LEFT, this->width - WD_FRAMERECT_RIGHT, r.top, "*", TC_RED);
+				if (!_settings_client.network.server_password.empty()) DrawString(r.right + WD_FRAMERECT_LEFT, this->width - WD_FRAMERECT_RIGHT, r.top, "*", TC_RED);
 		}
 	}
 
@@ -1156,7 +1156,7 @@ struct NetworkStartServerWindow : public Window {
 		if (str == nullptr) return;
 
 		if (this->widget_id == WID_NSS_SETPWD) {
-			strecpy(_settings_client.network.server_password, str, lastof(_settings_client.network.server_password));
+			_settings_client.network.server_password = str;
 		} else {
 			int32 value = atoi(str);
 			this->SetWidgetDirty(this->widget_id);
@@ -2583,7 +2583,7 @@ struct NetworkCompanyPasswordWindow : public Window {
 	void OnOk()
 	{
 		if (this->IsWidgetLowered(WID_NCP_SAVE_AS_DEFAULT_PASSWORD)) {
-			strecpy(_settings_client.network.default_company_pass, this->password_editbox.text.buf, lastof(_settings_client.network.default_company_pass));
+			_settings_client.network.default_company_pass = this->password_editbox.text.buf;
 		}
 
 		NetworkChangeCompanyPassword(_local_company, this->password_editbox.text.buf);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -648,7 +648,7 @@ public:
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_SERVER_VERSION); // server version
 			y += FONT_HEIGHT_NORMAL;
 
-			SetDParamStr(0, sel->connection_string.c_str());
+			SetDParamStr(0, sel->connection_string);
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_SERVER_ADDRESS); // server address
 			y += FONT_HEIGHT_NORMAL;
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1762,7 +1762,7 @@ void NetworkServerSetCompanyPassword(CompanyID company_id, const char *password,
 	if (!Company::IsValidHumanID(company_id)) return;
 
 	if (!already_hashed) {
-		password = GenerateCompanyPasswordHash(password, _settings_client.network.network_id, _settings_game.game_creation.generation_seed);
+		password = GenerateCompanyPasswordHash(password, _settings_client.network.network_id.c_str(), _settings_game.game_creation.generation_seed);
 	}
 
 	strecpy(_network_company_states[company_id].password, password, lastof(_network_company_states[company_id].password));

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -859,7 +859,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_NEWGRFS_CHECKED
 	NetworkClientInfo *ci = this->GetInfo();
 
 	/* We now want a password from the client else we do not allow him in! */
-	if (!StrEmpty(_settings_client.network.server_password)) {
+	if (!_settings_client.network.server_password.empty()) {
 		return this->SendNeedGamePassword();
 	}
 
@@ -957,8 +957,8 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_GAME_PASSWORD(P
 	p->Recv_string(password, sizeof(password));
 
 	/* Check game password. Allow joining if we cleared the password meanwhile */
-	if (!StrEmpty(_settings_client.network.server_password) &&
-			strcmp(password, _settings_client.network.server_password) != 0) {
+	if (!_settings_client.network.server_password.empty() &&
+			_settings_client.network.server_password.compare(password) != 0) {
 		/* Password is invalid */
 		return this->SendError(NETWORK_ERROR_WRONG_PASSWORD);
 	}
@@ -1439,12 +1439,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_RCON(Packet *p)
 	char pass[NETWORK_PASSWORD_LENGTH];
 	char command[NETWORK_RCONCOMMAND_LENGTH];
 
-	if (StrEmpty(_settings_client.network.rcon_password)) return NETWORK_RECV_STATUS_OKAY;
+	if (_settings_client.network.rcon_password.empty()) return NETWORK_RECV_STATUS_OKAY;
 
 	p->Recv_string(pass, sizeof(pass));
 	p->Recv_string(command, sizeof(command));
 
-	if (strcmp(pass, _settings_client.network.rcon_password) != 0) {
+	if (_settings_client.network.rcon_password.compare(pass) != 0) {
 		DEBUG(net, 1, "[rcon] Wrong password from client-id %d", this->client_id);
 		return NETWORK_RECV_STATUS_OKAY;
 	}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2588,6 +2588,22 @@ static ChangeInfoResult LoadTranslationTable(uint gvid, int numinfo, ByteReader 
 }
 
 /**
+ * Helper to read a DWord worth of bytes from the reader
+ * and to return it as a valid string.
+ * @param reader The source of the DWord.
+ * @return The read DWord as string.
+ */
+static std::string ReadDWordAsString(ByteReader *reader)
+{
+	char output[5];
+	for (int i = 0; i < 4; i++) output[i] = reader->ReadByte();
+	output[4] = '\0';
+	str_validate(output, lastof(output));
+
+	return std::string(output);
+}
+
+/**
  * Define properties for global variables
  * @param gvid ID of the global variable.
  * @param numinfo Number of subsequent IDs to change the property for.
@@ -2674,11 +2690,10 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 
 			case 0x0D: { // Currency prefix symbol
 				uint curidx = GetNewgrfCurrencyIdConverted(gvid + i);
-				uint32 tempfix = buf->ReadDWord();
+				std::string prefix = ReadDWordAsString(buf);
 
 				if (curidx < CURRENCY_END) {
-					memcpy(_currency_specs[curidx].prefix, &tempfix, 4);
-					_currency_specs[curidx].prefix[4] = 0;
+					_currency_specs[curidx].prefix = prefix;
 				} else {
 					grfmsg(1, "GlobalVarChangeInfo: Currency symbol %d out of range, ignoring", curidx);
 				}
@@ -2687,11 +2702,10 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 
 			case 0x0E: { // Currency suffix symbol
 				uint curidx = GetNewgrfCurrencyIdConverted(gvid + i);
-				uint32 tempfix = buf->ReadDWord();
+				std::string suffix = ReadDWordAsString(buf);
 
 				if (curidx < CURRENCY_END) {
-					memcpy(&_currency_specs[curidx].suffix, &tempfix, 4);
-					_currency_specs[curidx].suffix[4] = 0;
+					_currency_specs[curidx].suffix = suffix;
 				} else {
 					grfmsg(1, "GlobalVarChangeInfo: Currency symbol %d out of range, ignoring", curidx);
 				}

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -21,7 +21,7 @@ enum PersistentStorageMode {
 	PSM_LEAVE_GAMELOOP,   ///< Leave the gameloop, changes will be temporary.
 	PSM_ENTER_COMMAND,    ///< Enter command scope, changes will be permanent.
 	PSM_LEAVE_COMMAND,    ///< Leave command scope, revert to previous mode.
-	PSM_ENTER_TESTMODE,   ///< Enter command test mode, changes will be tempoary.
+	PSM_ENTER_TESTMODE,   ///< Enter command test mode, changes will be temporary.
 	PSM_LEAVE_TESTMODE,   ///< Leave command test mode, revert to previous mode.
 };
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -874,8 +874,8 @@ static void MakeNewGameDone()
 
 	/* We are the server, we start a new company (not dedicated),
 	 * so set the default password *if* needed. */
-	if (_network_server && !StrEmpty(_settings_client.network.default_company_pass)) {
-		NetworkChangeCompanyPassword(_local_company, _settings_client.network.default_company_pass);
+	if (_network_server && !_settings_client.network.default_company_pass.empty()) {
+		NetworkChangeCompanyPassword(_local_company, _settings_client.network.default_company_pass.c_str());
 	}
 
 	if (_settings_client.gui.pause_on_newgame) DoCommandP(0, PM_PAUSED_NORMAL, 1, CMD_PAUSE);

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -359,7 +359,7 @@ void LoadCoreTextFont(FontSize fs)
 		case FS_MONO:   settings = &_freetype.mono;   break;
 	}
 
-	if (StrEmpty(settings->font)) return;
+	if (settings->font.empty()) return;
 
 	CFAutoRelease<CTFontDescriptorRef> font_ref;
 
@@ -375,10 +375,10 @@ void LoadCoreTextFont(FontSize fs)
 
 		/* See if this is an absolute path. */
 		if (FileExists(settings->font)) {
-			path.reset(CFStringCreateWithCString(kCFAllocatorDefault, settings->font, kCFStringEncodingUTF8));
+			path.reset(CFStringCreateWithCString(kCFAllocatorDefault, settings->font.c_str(), kCFStringEncodingUTF8));
 		} else {
 			/* Scan the search-paths to see if it can be found. */
-			std::string full_font = FioFindFullPath(BASE_DIR, settings->font);
+			std::string full_font = FioFindFullPath(BASE_DIR, settings->font.c_str());
 			if (!full_font.empty()) {
 				path.reset(CFStringCreateWithCString(kCFAllocatorDefault, full_font.c_str(), kCFStringEncodingUTF8));
 			}
@@ -393,13 +393,13 @@ void LoadCoreTextFont(FontSize fs)
 				font_ref.reset((CTFontDescriptorRef)CFArrayGetValueAtIndex(descs.get(), 0));
 				CFRetain(font_ref.get());
 			} else {
-				ShowInfoF("Unable to load file '%s' for %s font, using default OS font selection instead", settings->font, SIZE_TO_NAME[fs]);
+				ShowInfoF("Unable to load file '%s' for %s font, using default OS font selection instead", settings->font.c_str(), SIZE_TO_NAME[fs]);
 			}
 		}
 	}
 
 	if (!font_ref) {
-		CFAutoRelease<CFStringRef> name(CFStringCreateWithCString(kCFAllocatorDefault, settings->font, kCFStringEncodingUTF8));
+		CFAutoRelease<CFStringRef> name(CFStringCreateWithCString(kCFAllocatorDefault, settings->font.c_str(), kCFStringEncodingUTF8));
 
 		/* Simply creating the font using CTFontCreateWithNameAndSize will *always* return
 		 * something, no matter the name. As such, we can't use it to check for existence.
@@ -417,7 +417,7 @@ void LoadCoreTextFont(FontSize fs)
 	}
 
 	if (!font_ref) {
-		ShowInfoF("Unable to use '%s' for %s font, using sprite font instead", settings->font, SIZE_TO_NAME[fs]);
+		ShowInfoF("Unable to use '%s' for %s font, using sprite font instead", settings->font.c_str(), SIZE_TO_NAME[fs]);
 		return;
 	}
 

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -24,7 +24,7 @@
 
 #include "safeguards.h"
 
-char _keyboard_opt[2][OSK_KEYBOARD_ENTRIES * 4 + 1];
+std::string _keyboard_opt[2];
 static WChar _keyboard[2][OSK_KEYBOARD_ENTRIES];
 
 enum KeyStateBits {
@@ -356,16 +356,16 @@ void GetKeyboardLayout()
 	char errormark[2][OSK_KEYBOARD_ENTRIES + 1]; // used for marking invalid chars
 	bool has_error = false; // true when an invalid char is detected
 
-	if (StrEmpty(_keyboard_opt[0])) {
+	if (_keyboard_opt[0].empty()) {
 		GetString(keyboard[0], STR_OSK_KEYBOARD_LAYOUT, lastof(keyboard[0]));
 	} else {
-		strecpy(keyboard[0], _keyboard_opt[0], lastof(keyboard[0]));
+		strecpy(keyboard[0], _keyboard_opt[0].c_str(), lastof(keyboard[0]));
 	}
 
-	if (StrEmpty(_keyboard_opt[1])) {
+	if (_keyboard_opt[1].empty()) {
 		GetString(keyboard[1], STR_OSK_KEYBOARD_LAYOUT_CAPS, lastof(keyboard[1]));
 	} else {
-		strecpy(keyboard[1], _keyboard_opt[1], lastof(keyboard[1]));
+		strecpy(keyboard[1], _keyboard_opt[1].c_str(), lastof(keyboard[1]));
 	}
 
 	for (uint j = 0; j < 2; j++) {

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -20,14 +20,14 @@
 
 #include "../safeguards.h"
 
-static char _ai_saveload_name[64];
-static int  _ai_saveload_version;
-static char _ai_saveload_settings[1024];
-static bool _ai_saveload_is_random;
+static std::string _ai_saveload_name;
+static int         _ai_saveload_version;
+static std::string _ai_saveload_settings;
+static bool        _ai_saveload_is_random;
 
 static const SaveLoad _ai_company[] = {
-	    SLEG_STR(_ai_saveload_name,        SLE_STRB),
-	    SLEG_STR(_ai_saveload_settings,    SLE_STRB),
+	   SLEG_SSTR(_ai_saveload_name,         SLE_STR),
+	   SLEG_SSTR(_ai_saveload_settings,     SLE_STR),
 	SLEG_CONDVAR(_ai_saveload_version,   SLE_UINT32, SLV_108, SL_MAX_VERSION),
 	SLEG_CONDVAR(_ai_saveload_is_random,   SLE_BOOL, SLV_136, SL_MAX_VERSION),
 	     SLE_END()
@@ -39,17 +39,16 @@ static void SaveReal_AIPL(int *index_ptr)
 	AIConfig *config = AIConfig::GetConfig(index);
 
 	if (config->HasScript()) {
-		strecpy(_ai_saveload_name, config->GetName(), lastof(_ai_saveload_name));
+		_ai_saveload_name = config->GetName();
 		_ai_saveload_version = config->GetVersion();
 	} else {
 		/* No AI is configured for this so store an empty string as name. */
-		_ai_saveload_name[0] = '\0';
+		_ai_saveload_name.clear();
 		_ai_saveload_version = -1;
 	}
 
 	_ai_saveload_is_random = config->IsRandom();
-	_ai_saveload_settings[0] = '\0';
-	config->SettingsToString(_ai_saveload_settings, lastof(_ai_saveload_settings));
+	_ai_saveload_settings = config->SettingsToString();
 
 	SlObject(nullptr, _ai_company);
 	/* If the AI was active, store his data too */
@@ -77,25 +76,25 @@ static void Load_AIPL()
 		}
 
 		AIConfig *config = AIConfig::GetConfig(index, AIConfig::SSS_FORCE_GAME);
-		if (StrEmpty(_ai_saveload_name)) {
+		if (_ai_saveload_name.empty()) {
 			/* A random AI. */
 			config->Change(nullptr, -1, false, true);
 		} else {
-			config->Change(_ai_saveload_name, _ai_saveload_version, false, _ai_saveload_is_random);
+			config->Change(_ai_saveload_name.c_str(), _ai_saveload_version, false, _ai_saveload_is_random);
 			if (!config->HasScript()) {
 				/* No version of the AI available that can load the data. Try to load the
 				 * latest version of the AI instead. */
-				config->Change(_ai_saveload_name, -1, false, _ai_saveload_is_random);
+				config->Change(_ai_saveload_name.c_str(), -1, false, _ai_saveload_is_random);
 				if (!config->HasScript()) {
-					if (strcmp(_ai_saveload_name, "%_dummy") != 0) {
-						DEBUG(script, 0, "The savegame has an AI by the name '%s', version %d which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+					if (_ai_saveload_name.compare("%_dummy") != 0) {
+						DEBUG(script, 0, "The savegame has an AI by the name '%s', version %d which is no longer available.", _ai_saveload_name.c_str(), _ai_saveload_version);
 						DEBUG(script, 0, "A random other AI will be loaded in its place.");
 					} else {
 						DEBUG(script, 0, "The savegame had no AIs available at the time of saving.");
 						DEBUG(script, 0, "A random available AI will be loaded now.");
 					}
 				} else {
-					DEBUG(script, 0, "The savegame has an AI by the name '%s', version %d which is no longer available.", _ai_saveload_name, _ai_saveload_version);
+					DEBUG(script, 0, "The savegame has an AI by the name '%s', version %d which is no longer available.", _ai_saveload_name.c_str(), _ai_saveload_version);
 					DEBUG(script, 0, "The latest version of that AI has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 				}
 				/* Make sure the AI doesn't get the saveload data, as it was not the

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -20,14 +20,14 @@
 
 #include "../safeguards.h"
 
-static char _game_saveload_name[64];
-static int  _game_saveload_version;
-static char _game_saveload_settings[1024];
-static bool _game_saveload_is_random;
+static std::string _game_saveload_name;
+static int         _game_saveload_version;
+static std::string _game_saveload_settings;
+static bool        _game_saveload_is_random;
 
 static const SaveLoad _game_script[] = {
-	    SLEG_STR(_game_saveload_name,        SLE_STRB),
-	    SLEG_STR(_game_saveload_settings,    SLE_STRB),
+	   SLEG_SSTR(_game_saveload_name,         SLE_STR),
+	   SLEG_SSTR(_game_saveload_settings,     SLE_STR),
 	    SLEG_VAR(_game_saveload_version,   SLE_UINT32),
 	    SLEG_VAR(_game_saveload_is_random,   SLE_BOOL),
 	     SLE_END()
@@ -38,17 +38,16 @@ static void SaveReal_GSDT(int *index_ptr)
 	GameConfig *config = GameConfig::GetConfig();
 
 	if (config->HasScript()) {
-		strecpy(_game_saveload_name, config->GetName(), lastof(_game_saveload_name));
+		_game_saveload_name = config->GetName();
 		_game_saveload_version = config->GetVersion();
 	} else {
 		/* No GameScript is configured for this so store an empty string as name. */
-		_game_saveload_name[0] = '\0';
+		_game_saveload_name.clear();
 		_game_saveload_version = -1;
 	}
 
 	_game_saveload_is_random = config->IsRandom();
-	_game_saveload_settings[0] = '\0';
-	config->SettingsToString(_game_saveload_settings, lastof(_game_saveload_settings));
+	_game_saveload_settings = config->SettingsToString();
 
 	SlObject(nullptr, _game_script);
 	Game::Save();
@@ -71,23 +70,23 @@ static void Load_GSDT()
 	}
 
 	GameConfig *config = GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME);
-	if (StrEmpty(_game_saveload_name)) {
+	if (_game_saveload_name.empty()) {
 	} else {
-		config->Change(_game_saveload_name, _game_saveload_version, false, _game_saveload_is_random);
+		config->Change(_game_saveload_name.c_str(), _game_saveload_version, false, _game_saveload_is_random);
 		if (!config->HasScript()) {
 			/* No version of the GameScript available that can load the data. Try to load the
 			 * latest version of the GameScript instead. */
-			config->Change(_game_saveload_name, -1, false, _game_saveload_is_random);
+			config->Change(_game_saveload_name.c_str(), -1, false, _game_saveload_is_random);
 			if (!config->HasScript()) {
-				if (strcmp(_game_saveload_name, "%_dummy") != 0) {
-					DEBUG(script, 0, "The savegame has an GameScript by the name '%s', version %d which is no longer available.", _game_saveload_name, _game_saveload_version);
+				if (_game_saveload_name.compare("%_dummy") != 0) {
+					DEBUG(script, 0, "The savegame has an GameScript by the name '%s', version %d which is no longer available.", _game_saveload_name.c_str(), _game_saveload_version);
 					DEBUG(script, 0, "This game will continue to run without GameScript.");
 				} else {
 					DEBUG(script, 0, "The savegame had no GameScript available at the time of saving.");
 					DEBUG(script, 0, "This game will continue to run without GameScript.");
 				}
 			} else {
-				DEBUG(script, 0, "The savegame has an GameScript by the name '%s', version %d which is no longer available.", _game_saveload_name, _game_saveload_version);
+				DEBUG(script, 0, "The savegame has an GameScript by the name '%s', version %d which is no longer available.", _game_saveload_name.c_str(), _game_saveload_version);
 				DEBUG(script, 0, "The latest version of that GameScript has been loaded instead, but it'll not get the savegame data as it's incompatible.");
 			}
 			/* Make sure the GameScript doesn't get the saveload data, as it was not the

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -585,7 +585,6 @@ static inline uint SlCalcConvMemLen(VarType conv)
 
 	switch (length << 4) {
 		case SLE_VAR_STRB:
-		case SLE_VAR_STRBQ:
 		case SLE_VAR_STR:
 		case SLE_VAR_STRQ:
 			return SlReadArrayLength();
@@ -881,7 +880,6 @@ static inline size_t SlCalcStringLen(const void *ptr, size_t length, VarType con
 			len = SIZE_MAX;
 			break;
 		case SLE_VAR_STRB:
-		case SLE_VAR_STRBQ:
 			str = (const char *)ptr;
 			len = length;
 			break;
@@ -920,7 +918,6 @@ static void SlString(void *ptr, size_t length, VarType conv)
 			switch (GetVarMemType(conv)) {
 				default: NOT_REACHED();
 				case SLE_VAR_STRB:
-				case SLE_VAR_STRBQ:
 					len = SlCalcNetStringLen((char *)ptr, length);
 					break;
 				case SLE_VAR_STR:
@@ -941,7 +938,6 @@ static void SlString(void *ptr, size_t length, VarType conv)
 			switch (GetVarMemType(conv)) {
 				default: NOT_REACHED();
 				case SLE_VAR_STRB:
-				case SLE_VAR_STRBQ:
 					if (len >= length) {
 						DEBUG(sl, 1, "String length in savegame is bigger than buffer, truncating");
 						SlCopyBytes(ptr, length);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -446,7 +446,6 @@ enum VarTypes {
 	SLE_VAR_U64   =  8 << 4,
 	SLE_VAR_NULL  =  9 << 4, ///< useful to write zeros in savegame.
 	SLE_VAR_STRB  = 10 << 4, ///< string (with pre-allocated buffer)
-	SLE_VAR_STRBQ = 11 << 4, ///< string enclosed in quotes (with pre-allocated buffer)
 	SLE_VAR_STR   = 12 << 4, ///< string pointer
 	SLE_VAR_STRQ  = 13 << 4, ///< string pointer enclosed in quotes
 	SLE_VAR_NAME  = 14 << 4, ///< old custom name to be converted to a char pointer
@@ -470,7 +469,6 @@ enum VarTypes {
 	SLE_CHAR         = SLE_FILE_I8  | SLE_VAR_CHAR,
 	SLE_STRINGID     = SLE_FILE_STRINGID | SLE_VAR_U32,
 	SLE_STRINGBUF    = SLE_FILE_STRING   | SLE_VAR_STRB,
-	SLE_STRINGBQUOTE = SLE_FILE_STRING   | SLE_VAR_STRBQ,
 	SLE_STRING       = SLE_FILE_STRING   | SLE_VAR_STR,
 	SLE_STRINGQUOTE  = SLE_FILE_STRING   | SLE_VAR_STRQ,
 	SLE_NAME         = SLE_FILE_STRINGID | SLE_VAR_NAME,
@@ -479,7 +477,6 @@ enum VarTypes {
 	SLE_UINT  = SLE_UINT32,
 	SLE_INT   = SLE_INT32,
 	SLE_STRB  = SLE_STRINGBUF,
-	SLE_STRBQ = SLE_STRINGBQUOTE,
 	SLE_STR   = SLE_STRING,
 	SLE_STRQ  = SLE_STRINGQUOTE,
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -934,7 +934,7 @@ static inline void SlSkipBytes(size_t length)
 	for (; length != 0; length--) SlReadByte();
 }
 
-extern char _savegame_format[8];
+extern std::string _savegame_format;
 extern bool _do_autosave;
 
 #endif /* SAVELOAD_H */

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -34,7 +34,7 @@
 static const char * const SCREENSHOT_NAME = "screenshot"; ///< Default filename of a saved screenshot.
 static const char * const HEIGHTMAP_NAME  = "heightmap";  ///< Default filename of a saved heightmap.
 
-char _screenshot_format_name[8];      ///< Extension of the current screenshot format (corresponds with #_cur_screenshot_format).
+std::string _screenshot_format_name;  ///< Extension of the current screenshot format (corresponds with #_cur_screenshot_format).
 uint _num_screenshot_formats;         ///< Number of available screenshot formats.
 uint _cur_screenshot_format;          ///< Index of the currently selected screenshot format in #_screenshot_formats.
 static char _screenshot_name[128];    ///< Filename of the screenshot file.
@@ -584,7 +584,7 @@ void InitializeScreenshotFormats()
 {
 	uint j = 0;
 	for (uint i = 0; i < lengthof(_screenshot_formats); i++) {
-		if (!strcmp(_screenshot_format_name, _screenshot_formats[i].extension)) {
+		if (_screenshot_format_name.compare(_screenshot_formats[i].extension) != 0) {
 			j = i;
 			break;
 		}

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -31,7 +31,7 @@ void MakeScreenshotWithConfirm(ScreenshotType t);
 bool MakeScreenshot(ScreenshotType t, std::string name, uint32 width = 0, uint32 height = 0);
 bool MakeMinimapWorldScreenshot();
 
-extern char _screenshot_format_name[8];
+extern std::string _screenshot_format_name;
 extern uint _num_screenshot_formats;
 extern uint _cur_screenshot_format;
 extern char _full_screenshot_name[MAX_PATH];

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -19,7 +19,7 @@
 {
 	uint i;
 	const SettingDesc *sd = GetSettingFromName(setting, &i);
-	return sd != nullptr && sd->desc.cmd != SDT_STRING;
+	return sd != nullptr && sd->desc.cmd != SDT_STDSTRING;
 }
 
 /* static */ int32 ScriptGameSettings::GetValue(const char *setting)

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -179,9 +179,9 @@ int ScriptConfig::GetVersion() const
 	return this->version;
 }
 
-void ScriptConfig::StringToSettings(const char *value)
+void ScriptConfig::StringToSettings(const std::string &value)
 {
-	char *value_copy = stredup(value);
+	char *value_copy = stredup(value.c_str());
 	char *s = value_copy;
 
 	while (s != nullptr) {
@@ -205,8 +205,10 @@ void ScriptConfig::StringToSettings(const char *value)
 	free(value_copy);
 }
 
-void ScriptConfig::SettingsToString(char *string, const char *last) const
+std::string ScriptConfig::SettingsToString() const
 {
+	char string[1024];
+	char *last = lastof(string);
 	char *s = string;
 	*s = '\0';
 	for (const auto &item : this->settings) {
@@ -216,7 +218,7 @@ void ScriptConfig::SettingsToString(char *string, const char *last) const
 		/* Check if the string would fit in the destination */
 		size_t needed_size = strlen(item.first) + 1 + strlen(no);
 		/* If it doesn't fit, skip the next settings */
-		if (string + needed_size > last) break;
+		if (s + needed_size > last) break;
 
 		s = strecat(s, item.first, last);
 		s = strecat(s, "=", last);
@@ -226,6 +228,8 @@ void ScriptConfig::SettingsToString(char *string, const char *last) const
 
 	/* Remove the last ',', but only if at least one setting was saved. */
 	if (s != string) s[-1] = '\0';
+
+	return string;
 }
 
 const char *ScriptConfig::GetTextfile(TextfileType type, CompanyID slot) const

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -169,13 +169,13 @@ public:
 	 * Convert a string which is stored in the config file or savegames to
 	 *  custom settings of this Script.
 	 */
-	void StringToSettings(const char *value);
+	void StringToSettings(const std::string &value);
 
 	/**
 	 * Convert the custom settings to a string that can be stored in the config
 	 *  file or savegames.
 	 */
-	void SettingsToString(char *string, const char *last) const;
+	std::string SettingsToString() const;
 
 	/**
 	 * Search a textfile file next to this script.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1420,8 +1420,8 @@ static bool UpdateClientName(int32 p1)
 
 static bool UpdateServerPassword(int32 p1)
 {
-	if (strcmp(_settings_client.network.server_password, "*") == 0) {
-		_settings_client.network.server_password[0] = '\0';
+	if (_settings_client.network.server_password.compare("*") == 0) {
+		_settings_client.network.server_password.clear();
 	}
 
 	NetworkServerUpdateGameInfo();
@@ -1430,8 +1430,8 @@ static bool UpdateServerPassword(int32 p1)
 
 static bool UpdateRconPassword(int32 p1)
 {
-	if (strcmp(_settings_client.network.rcon_password, "*") == 0) {
-		_settings_client.network.rcon_password[0] = '\0';
+	if (_settings_client.network.rcon_password.compare("*") == 0) {
+		_settings_client.network.rcon_password.clear();
 	}
 
 	return true;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1682,8 +1682,7 @@ static void AISaveConfig(IniFile *ini, const char *grpname)
 	for (CompanyID c = COMPANY_FIRST; c < MAX_COMPANIES; c++) {
 		AIConfig *config = AIConfig::GetConfig(c, AIConfig::SSS_FORCE_NEWGAME);
 		const char *name;
-		char value[1024];
-		config->SettingsToString(value, lastof(value));
+		std::string value = config->SettingsToString();
 
 		if (config->HasScript()) {
 			name = config->GetName();
@@ -1705,8 +1704,7 @@ static void GameSaveConfig(IniFile *ini, const char *grpname)
 
 	GameConfig *config = GameConfig::GetConfig(AIConfig::SSS_FORCE_NEWGAME);
 	const char *name;
-	char value[1024];
-	config->SettingsToString(value, lastof(value));
+	std::string value = config->SettingsToString();
 
 	if (config->HasScript()) {
 		name = config->GetName();

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2668,7 +2668,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_SEPARATOR:
 				SetDParamStr(0, _custom_currency.separator);
 				str = STR_JUST_RAW_STRING;
-				len = sizeof(_custom_currency.separator) - 1; // Number of characters excluding '\0' termination
+				len = 7;
 				line = WID_CC_SEPARATOR;
 				break;
 
@@ -2676,7 +2676,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_PREFIX:
 				SetDParamStr(0, _custom_currency.prefix);
 				str = STR_JUST_RAW_STRING;
-				len = sizeof(_custom_currency.prefix) - 1; // Number of characters excluding '\0' termination
+				len = 15;
 				line = WID_CC_PREFIX;
 				break;
 
@@ -2684,7 +2684,7 @@ struct CustomCurrencyWindow : Window {
 			case WID_CC_SUFFIX:
 				SetDParamStr(0, _custom_currency.suffix);
 				str = STR_JUST_RAW_STRING;
-				len = sizeof(_custom_currency.suffix) - 1; // Number of characters excluding '\0' termination
+				len = 15;
 				line = WID_CC_SUFFIX;
 				break;
 
@@ -2728,15 +2728,15 @@ struct CustomCurrencyWindow : Window {
 				break;
 
 			case WID_CC_SEPARATOR: // Thousands separator
-				strecpy(_custom_currency.separator, str, lastof(_custom_currency.separator));
+				_custom_currency.separator = str;
 				break;
 
 			case WID_CC_PREFIX:
-				strecpy(_custom_currency.prefix, str, lastof(_custom_currency.prefix));
+				_custom_currency.prefix = str;
 				break;
 
 			case WID_CC_SUFFIX:
-				strecpy(_custom_currency.suffix, str, lastof(_custom_currency.suffix));
+				_custom_currency.suffix = str;
 				break;
 
 			case WID_CC_YEAR: { // Year to switch to euro

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -26,7 +26,6 @@ enum SettingDescType : byte {
 	SDT_ONEOFMANY   = 2, ///< bitmasked number where only ONE bit may be set
 	SDT_MANYOFMANY  = 3, ///< bitmasked number where MULTIPLE bits may be set
 	SDT_INTLIST     = 4, ///< list of integers separated by a comma ','
-	SDT_STRING      = 5, ///< string with a pre-allocated buffer
 	SDT_STDSTRING   = 6, ///< \c std::string
 	SDT_END,
 	/* 9 more possible primitives */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -267,7 +267,7 @@ struct NetworkSettings {
 	std::string rcon_password;                            ///< password for rconsole (server side)
 	std::string admin_password;                           ///< password for the admin network
 	bool   server_advertise;                              ///< advertise the server to the masterserver
-	char   client_name[NETWORK_CLIENT_NAME_LENGTH];       ///< name of the player (as client)
+	std::string client_name;                              ///< name of the player (as client)
 	std::string default_company_pass;                     ///< default password for new companies in encrypted form
 	std::string connect_to_ip;                            ///< default for the "Add server" query
 	std::string network_id;                               ///< network ID for servers

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -214,16 +214,16 @@ struct MusicSettings {
 
 /** Settings related to currency/unit systems. */
 struct LocaleSettings {
-	byte   currency;                         ///< currency we currently use
-	byte   units_velocity;                   ///< unit system for velocity
-	byte   units_power;                      ///< unit system for power
-	byte   units_weight;                     ///< unit system for weight
-	byte   units_volume;                     ///< unit system for volume
-	byte   units_force;                      ///< unit system for force
-	byte   units_height;                     ///< unit system for height
-	char  *digit_group_separator;            ///< thousand separator for non-currencies
-	char  *digit_group_separator_currency;   ///< thousand separator for currencies
-	char  *digit_decimal_separator;          ///< decimal separator
+	byte        currency;                         ///< currency we currently use
+	byte        units_velocity;                   ///< unit system for velocity
+	byte        units_power;                      ///< unit system for power
+	byte        units_weight;                     ///< unit system for weight
+	byte        units_volume;                     ///< unit system for volume
+	byte        units_force;                      ///< unit system for force
+	byte        units_height;                     ///< unit system for height
+	std::string digit_group_separator;            ///< thousand separator for non-currencies
+	std::string digit_group_separator_currency;   ///< thousand separator for currencies
+	std::string digit_decimal_separator;          ///< decimal separator
 };
 
 /** Settings related to news */
@@ -247,42 +247,42 @@ struct NewsSettings {
 
 /** All settings related to the network. */
 struct NetworkSettings {
-	uint16 sync_freq;                                     ///< how often do we check whether we are still in-sync
-	uint8  frame_freq;                                    ///< how often do we send commands to the clients
-	uint16 commands_per_frame;                            ///< how many commands may be sent each frame_freq frames?
-	uint16 max_commands_in_queue;                         ///< how many commands may there be in the incoming queue before dropping the connection?
-	uint16 bytes_per_frame;                               ///< how many bytes may, over a long period, be received per frame?
-	uint16 bytes_per_frame_burst;                         ///< how many bytes may, over a short period, be received?
-	uint16 max_init_time;                                 ///< maximum amount of time, in game ticks, a client may take to initiate joining
-	uint16 max_join_time;                                 ///< maximum amount of time, in game ticks, a client may take to sync up during joining
-	uint16 max_download_time;                             ///< maximum amount of time, in game ticks, a client may take to download the map
-	uint16 max_password_time;                             ///< maximum amount of time, in game ticks, a client may take to enter the password
-	uint16 max_lag_time;                                  ///< maximum amount of time, in game ticks, a client may be lagging behind the server
-	bool   pause_on_join;                                 ///< pause the game when people join
-	uint16 server_port;                                   ///< port the server listens on
-	uint16 server_admin_port;                             ///< port the server listens on for the admin network
-	bool   server_admin_chat;                             ///< allow private chat for the server to be distributed to the admin network
+	uint16      sync_freq;                                ///< how often do we check whether we are still in-sync
+	uint8       frame_freq;                               ///< how often do we send commands to the clients
+	uint16      commands_per_frame;                       ///< how many commands may be sent each frame_freq frames?
+	uint16      max_commands_in_queue;                    ///< how many commands may there be in the incoming queue before dropping the connection?
+	uint16      bytes_per_frame;                          ///< how many bytes may, over a long period, be received per frame?
+	uint16      bytes_per_frame_burst;                    ///< how many bytes may, over a short period, be received?
+	uint16      max_init_time;                            ///< maximum amount of time, in game ticks, a client may take to initiate joining
+	uint16      max_join_time;                            ///< maximum amount of time, in game ticks, a client may take to sync up during joining
+	uint16      max_download_time;                        ///< maximum amount of time, in game ticks, a client may take to download the map
+	uint16      max_password_time;                        ///< maximum amount of time, in game ticks, a client may take to enter the password
+	uint16      max_lag_time;                             ///< maximum amount of time, in game ticks, a client may be lagging behind the server
+	bool        pause_on_join;                            ///< pause the game when people join
+	uint16      server_port;                              ///< port the server listens on
+	uint16      server_admin_port;                        ///< port the server listens on for the admin network
+	bool        server_admin_chat;                        ///< allow private chat for the server to be distributed to the admin network
 	std::string server_name;                              ///< name of the server
 	std::string server_password;                          ///< password for joining this server
 	std::string rcon_password;                            ///< password for rconsole (server side)
 	std::string admin_password;                           ///< password for the admin network
-	bool   server_advertise;                              ///< advertise the server to the masterserver
+	bool        server_advertise;                         ///< advertise the server to the masterserver
 	std::string client_name;                              ///< name of the player (as client)
 	std::string default_company_pass;                     ///< default password for new companies in encrypted form
 	std::string connect_to_ip;                            ///< default for the "Add server" query
 	std::string network_id;                               ///< network ID for servers
-	bool   autoclean_companies;                           ///< automatically remove companies that are not in use
-	uint8  autoclean_unprotected;                         ///< remove passwordless companies after this many months
-	uint8  autoclean_protected;                           ///< remove the password from passworded companies after this many months
-	uint8  autoclean_novehicles;                          ///< remove companies with no vehicles after this many months
-	uint8  max_companies;                                 ///< maximum amount of companies
-	uint8  max_clients;                                   ///< maximum amount of clients
-	uint8  max_spectators;                                ///< maximum amount of spectators
-	Year   restart_game_year;                             ///< year the server restarts
-	uint8  min_active_clients;                            ///< minimum amount of active clients to unpause the game
-	bool   reload_cfg;                                    ///< reload the config file before restarting
+	bool        autoclean_companies;                      ///< automatically remove companies that are not in use
+	uint8       autoclean_unprotected;                    ///< remove passwordless companies after this many months
+	uint8       autoclean_protected;                      ///< remove the password from passworded companies after this many months
+	uint8       autoclean_novehicles;                     ///< remove companies with no vehicles after this many months
+	uint8       max_companies;                            ///< maximum amount of companies
+	uint8       max_clients;                              ///< maximum amount of clients
+	uint8       max_spectators;                           ///< maximum amount of spectators
+	Year        restart_game_year;                        ///< year the server restarts
+	uint8       min_active_clients;                       ///< minimum amount of active clients to unpause the game
+	bool        reload_cfg;                               ///< reload the config file before restarting
 	std::string last_joined;                              ///< Last joined server
-	bool   no_http_content_downloads;                     ///< do not do content downloads over HTTP
+	bool        no_http_content_downloads;                ///< do not do content downloads over HTTP
 };
 
 /** Settings related to the creation of games. */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -263,12 +263,12 @@ struct NetworkSettings {
 	uint16 server_admin_port;                             ///< port the server listens on for the admin network
 	bool   server_admin_chat;                             ///< allow private chat for the server to be distributed to the admin network
 	char   server_name[NETWORK_NAME_LENGTH];              ///< name of the server
-	char   server_password[NETWORK_PASSWORD_LENGTH];      ///< password for joining this server
-	char   rcon_password[NETWORK_PASSWORD_LENGTH];        ///< password for rconsole (server side)
-	char   admin_password[NETWORK_PASSWORD_LENGTH];       ///< password for the admin network
+	std::string server_password;                          ///< password for joining this server
+	std::string rcon_password;                            ///< password for rconsole (server side)
+	std::string admin_password;                           ///< password for the admin network
 	bool   server_advertise;                              ///< advertise the server to the masterserver
 	char   client_name[NETWORK_CLIENT_NAME_LENGTH];       ///< name of the player (as client)
-	char   default_company_pass[NETWORK_PASSWORD_LENGTH]; ///< default password for new companies in encrypted form
+	std::string default_company_pass;                     ///< default password for new companies in encrypted form
 	char   connect_to_ip[NETWORK_HOSTNAME_PORT_LENGTH];   ///< default for the "Add server" query
 	char   network_id[NETWORK_SERVER_ID_LENGTH];          ///< network ID for servers
 	bool   autoclean_companies;                           ///< automatically remove companies that are not in use

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -269,7 +269,7 @@ struct NetworkSettings {
 	bool   server_advertise;                              ///< advertise the server to the masterserver
 	char   client_name[NETWORK_CLIENT_NAME_LENGTH];       ///< name of the player (as client)
 	std::string default_company_pass;                     ///< default password for new companies in encrypted form
-	char   connect_to_ip[NETWORK_HOSTNAME_PORT_LENGTH];   ///< default for the "Add server" query
+	std::string connect_to_ip;                            ///< default for the "Add server" query
 	char   network_id[NETWORK_SERVER_ID_LENGTH];          ///< network ID for servers
 	bool   autoclean_companies;                           ///< automatically remove companies that are not in use
 	uint8  autoclean_unprotected;                         ///< remove passwordless companies after this many months
@@ -281,7 +281,7 @@ struct NetworkSettings {
 	Year   restart_game_year;                             ///< year the server restarts
 	uint8  min_active_clients;                            ///< minimum amount of active clients to unpause the game
 	bool   reload_cfg;                                    ///< reload the config file before restarting
-	char   last_joined[NETWORK_HOSTNAME_PORT_LENGTH];     ///< Last joined server
+	std::string last_joined;                              ///< Last joined server
 	bool   no_http_content_downloads;                     ///< do not do content downloads over HTTP
 };
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -262,7 +262,7 @@ struct NetworkSettings {
 	uint16 server_port;                                   ///< port the server listens on
 	uint16 server_admin_port;                             ///< port the server listens on for the admin network
 	bool   server_admin_chat;                             ///< allow private chat for the server to be distributed to the admin network
-	char   server_name[NETWORK_NAME_LENGTH];              ///< name of the server
+	std::string server_name;                              ///< name of the server
 	std::string server_password;                          ///< password for joining this server
 	std::string rcon_password;                            ///< password for rconsole (server side)
 	std::string admin_password;                           ///< password for the admin network
@@ -270,7 +270,7 @@ struct NetworkSettings {
 	char   client_name[NETWORK_CLIENT_NAME_LENGTH];       ///< name of the player (as client)
 	std::string default_company_pass;                     ///< default password for new companies in encrypted form
 	std::string connect_to_ip;                            ///< default for the "Add server" query
-	char   network_id[NETWORK_SERVER_ID_LENGTH];          ///< network ID for servers
+	std::string network_id;                               ///< network ID for servers
 	bool   autoclean_companies;                           ///< automatically remove companies that are not in use
 	uint8  autoclean_unprotected;                         ///< remove passwordless companies after this many months
 	uint8  autoclean_protected;                           ///< remove the password from passworded companies after this many months

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -326,19 +326,10 @@ bool StrValid(const char *str, const char *last)
  * When there are spaces at the begin, the whole string is moved forward.
  * @param str The string to perform the in place left trimming on.
  */
-static void StrLeftTrimInPlace(char *str)
+static void StrLeftTrimInPlace(std::string &str)
 {
-	if (StrEmpty(str)) return;
-
-	char *first_non_space = str;
-	while (*first_non_space == ' ') first_non_space++;
-
-	if (first_non_space == str) return;
-
-	/* The source will reach '\0' first, but set the '\0' on the destination afterwards. */
-	char *dst = str;
-	for (char *src = first_non_space; *src != '\0'; dst++, src++) *dst = *src;
-	*dst = '\0';
+	size_t pos = str.find_first_not_of(' ');
+	str.erase(0, pos);
 }
 
 /**
@@ -347,24 +338,10 @@ static void StrLeftTrimInPlace(char *str)
  * When there are spaces at the end, the '\0' will be moved forward.
  * @param str The string to perform the in place left trimming on.
  */
-static void StrRightTrimInPlace(char *str)
+static void StrRightTrimInPlace(std::string &str)
 {
-	if (StrEmpty(str)) return;
-
-	char *end = str;
-	while (*end != '\0') end++;
-
-	char *last_non_space = end - 1;
-	while (last_non_space >= str && *last_non_space == ' ') last_non_space--;
-
-	/* The last non space points to the last character of the string that is not
-	 * a space. For a string with only spaces or an empty string this would be
-	 * the position before the begin of the string. The previous search ensures
-	 * that this location before the string is not read.
-	 * In any case, the character after the last non space character will be
-	 * either a space or the existing termination, so it can be set to '\0'.
-	 */
-	last_non_space[1] = '\0';
+	size_t pos = str.find_last_not_of(' ');
+	if (pos != std::string::npos) str.erase(pos + 1);
 }
 
 /**
@@ -374,7 +351,7 @@ static void StrRightTrimInPlace(char *str)
  * and when there are spaces at the back the '\0' termination is moved.
  * @param str The string to perform the in place trimming on.
  */
-void StrTrimInPlace(char *str)
+void StrTrimInPlace(std::string &str)
 {
 	StrLeftTrimInPlace(str);
 	StrRightTrimInPlace(str);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -49,7 +49,7 @@ bool strtolower(char *str);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
 bool StrValid(const char *str, const char *last) NOACCESS(2);
-void StrTrimInPlace(char *str);
+void StrTrimInPlace(std::string &str);
 
 /**
  * Check if a string buffer is empty.

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -486,7 +486,7 @@ static char *FormatGenericCurrency(char *buff, const CurrencySpec *spec, Money n
 	/* Add prefix part, following symbol_pos specification.
 	 * Here, it can can be either 0 (prefix) or 2 (both prefix and suffix).
 	 * The only remaining value is 1 (suffix), so everything that is not 1 */
-	if (spec->symbol_pos != 1) buff = strecpy(buff, spec->prefix, last);
+	if (spec->symbol_pos != 1) buff = strecpy(buff, spec->prefix.c_str(), last);
 
 	/* for huge numbers, compact the number into k or M */
 	if (compact) {
@@ -502,7 +502,7 @@ static char *FormatGenericCurrency(char *buff, const CurrencySpec *spec, Money n
 	}
 
 	const char *separator = _settings_game.locale.digit_group_separator_currency.c_str();
-	if (StrEmpty(separator)) separator = _currency->separator;
+	if (StrEmpty(separator)) separator = _currency->separator.c_str();
 	if (StrEmpty(separator)) separator = _langpack.langpack->digit_group_separator_currency;
 	buff = FormatNumber(buff, number, last, separator);
 	buff = strecpy(buff, multiplier, last);
@@ -510,7 +510,7 @@ static char *FormatGenericCurrency(char *buff, const CurrencySpec *spec, Money n
 	/* Add suffix part, following symbol_pos specification.
 	 * Here, it can can be either 1 (suffix) or 2 (both prefix and suffix).
 	 * The only remaining value is 1 (prefix), so everything that is not 0 */
-	if (spec->symbol_pos != 0) buff = strecpy(buff, spec->suffix, last);
+	if (spec->symbol_pos != 0) buff = strecpy(buff, spec->suffix.c_str(), last);
 
 	if (negative) {
 		if (buff + Utf8CharLen(SCC_POP_COLOUR) > last) return buff;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2090,9 +2090,9 @@ class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
 	void SetFontNames(FreeTypeSettings *settings, const char *font_name, const void *os_data) override
 	{
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
-		strecpy(settings->small.font,  font_name, lastof(settings->small.font));
-		strecpy(settings->medium.font, font_name, lastof(settings->medium.font));
-		strecpy(settings->large.font,  font_name, lastof(settings->large.font));
+		settings->small.font = font_name;
+		settings->medium.font = font_name;
+		settings->large.font = font_name;
 
 		settings->small.os_handle = os_data;
 		settings->medium.os_handle = os_data;
@@ -2123,15 +2123,14 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 	if (bad_font) {
 		/* We found an unprintable character... lets try whether we can find
 		 * a fallback font that can print the characters in the current language. */
-		FreeTypeSettings backup;
-		memcpy(&backup, &_freetype, sizeof(backup));
+		FreeTypeSettings backup = _freetype;
 
 		_freetype.mono.os_handle = nullptr;
 		_freetype.medium.os_handle = nullptr;
 
 		bad_font = !SetFallbackFont(&_freetype, _langpack.langpack->isocode, _langpack.langpack->winlangid, searcher);
 
-		memcpy(&_freetype, &backup, sizeof(backup));
+		_freetype = backup;
 
 		if (!bad_font) {
 			/* Show that we loaded fallback font. To do this properly we have

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -343,8 +343,8 @@ static char *FormatNumber(char *buff, int64 number, const char *last, const char
 	uint64 tot = 0;
 	for (int i = 0; i < max_digits; i++) {
 		if (i == max_digits - fractional_digits) {
-			const char *decimal_separator = _settings_game.locale.digit_decimal_separator;
-			if (decimal_separator == nullptr) decimal_separator = _langpack.langpack->digit_decimal_separator;
+			const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
+			if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
 			buff += seprintf(buff, last, "%s", decimal_separator);
 		}
 
@@ -368,8 +368,8 @@ static char *FormatNumber(char *buff, int64 number, const char *last, const char
 
 static char *FormatCommaNumber(char *buff, int64 number, const char *last, int fractional_digits = 0)
 {
-	const char *separator = _settings_game.locale.digit_group_separator;
-	if (separator == nullptr) separator = _langpack.langpack->digit_group_separator;
+	const char *separator = _settings_game.locale.digit_group_separator.c_str();
+	if (StrEmpty(separator)) separator = _langpack.langpack->digit_group_separator;
 	return FormatNumber(buff, number, last, separator, 1, fractional_digits);
 }
 
@@ -407,8 +407,8 @@ static char *FormatBytes(char *buff, int64 number, const char *last)
 		id++;
 	}
 
-	const char *decimal_separator = _settings_game.locale.digit_decimal_separator;
-	if (decimal_separator == nullptr) decimal_separator = _langpack.langpack->digit_decimal_separator;
+	const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
+	if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
 
 	if (number < 1024) {
 		id = 0;
@@ -501,9 +501,9 @@ static char *FormatGenericCurrency(char *buff, const CurrencySpec *spec, Money n
 		}
 	}
 
-	const char *separator = _settings_game.locale.digit_group_separator_currency;
-	if (separator == nullptr && !StrEmpty(_currency->separator)) separator = _currency->separator;
-	if (separator == nullptr) separator = _langpack.langpack->digit_group_separator_currency;
+	const char *separator = _settings_game.locale.digit_group_separator_currency.c_str();
+	if (StrEmpty(separator)) separator = _currency->separator;
+	if (StrEmpty(separator)) separator = _langpack.langpack->digit_group_separator_currency;
 	buff = FormatNumber(buff, number, last, separator);
 	buff = strecpy(buff, multiplier, last);
 

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -9,9 +9,9 @@ static const SettingDesc _currency_settings[] = {
 [post-amble]
 };
 [templates]
-SDT_VAR = SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDT_STR = SDT_STR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDT_END = SDT_END()
+SDT_VAR  = SDT_VAR ($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_SSTR = SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_END  = SDT_END()
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
@@ -41,10 +41,10 @@ def      = 1
 min      = 0
 max      = UINT16_MAX
 
-[SDT_STR]
+[SDT_SSTR]
 base     = CurrencySpec
 var      = separator
-type     = SLE_STRBQ
+type     = SLE_STRQ
 def      = "".""
 cat      = SC_BASIC
 
@@ -56,16 +56,16 @@ def      = 0
 min      = MIN_YEAR
 max      = MAX_YEAR
 
-[SDT_STR]
+[SDT_SSTR]
 base     = CurrencySpec
 var      = prefix
-type     = SLE_STRBQ
+type     = SLE_STRQ
 def      = nullptr
 
-[SDT_STR]
+[SDT_SSTR]
 base     = CurrencySpec
 var      = suffix
-type     = SLE_STRBQ
+type     = SLE_STRQ
 def      = "" credits""
 
 [SDT_END]

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -175,31 +175,31 @@ name     = ""rightclick_emulate""
 var      = _rightclick_emulate
 def      = false
 
-[SDTG_STR]
+[SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""small_font""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _freetype.small.font
 def      = nullptr
 
-[SDTG_STR]
+[SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""medium_font""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _freetype.medium.font
 def      = nullptr
 
-[SDTG_STR]
+[SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""large_font""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _freetype.large.font
 def      = nullptr
 
-[SDTG_STR]
+[SDTG_SSTR]
 ifdef    = HAS_TRUETYPE_FONT
 name     = ""mono_font""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _freetype.mono.font
 def      = nullptr
 

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -23,7 +23,6 @@ static const SettingDescGlobVarList _misc_settings[] = {
 SDTG_LIST  =  SDTG_LIST($name, $type, $length, $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_MMANY = SDTG_MMANY($name, $type,          $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_OMANY = SDTG_OMANY($name, $type,          $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDTG_STR   =   SDTG_STR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_SSTR  =  SDTG_SSTR($name, $type,          $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_BOOL  =  SDTG_BOOL($name,                 $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
 SDTG_VAR   =   SDTG_VAR($name, $type,          $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
@@ -156,16 +155,16 @@ var      = _cur_resolution
 def      = ""0,0""
 cat      = SC_BASIC
 
-[SDTG_STR]
+[SDTG_SSTR]
 name     = ""screenshot_format""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _screenshot_format_name
 def      = nullptr
 cat      = SC_EXPERT
 
-[SDTG_STR]
+[SDTG_SSTR]
 name     = ""savegame_format""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _savegame_format
 def      = nullptr
 cat      = SC_EXPERT
@@ -308,16 +307,16 @@ min      = 0
 max      = 0xFF
 cat      = SC_BASIC
 
-[SDTG_STR]
+[SDTG_SSTR]
 name     = ""keyboard""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _keyboard_opt[0]
 def      = nullptr
 cat      = SC_EXPERT
 
-[SDTG_STR]
+[SDTG_SSTR]
 name     = ""keyboard_caps""
-type     = SLE_STRB
+type     = SLE_STR
 var      = _keyboard_opt[1]
 def      = nullptr
 cat      = SC_EXPERT

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -107,6 +107,9 @@ static size_t ConvertLandscape(const char *value);
 #define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
+#define SDT_SSTR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDT_GENERAL(#var, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
+
 #define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra, startup)\
 	SDT_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, base, var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, load, from, to, cat, extra, startup)
 

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -129,6 +129,9 @@ static size_t ConvertLandscape(const char *value);
 #define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
+#define SDTC_SSTR(var, type, flags, guiflags, def, max_length, str, strhelp, strval, proc, from, to, cat, extra, startup)\
+	SDTG_GENERAL(#var, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, max_length, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
+
 #define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDTG_GENERAL(#var, SDT_ONEOFMANY, SL_VAR, type, flags, guiflags, _settings_client.var, 1, def, 0, max, 0, full, str, strhelp, strval, proc, from, to, cat, extra, startup)
 

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -73,9 +73,6 @@ static size_t ConvertLandscape(const char *value);
 #define SDTG_LIST(name, type, length, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDTG_GENERAL(name, SDT_INTLIST, SL_ARR, type, flags, guiflags, var, length, def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTG_STR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDTG_GENERAL(name, SDT_STRING, SL_STR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
-
 #define SDTG_SSTR(name, type, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
     SDTG_GENERAL(name, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, var, sizeof(var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
@@ -103,9 +100,6 @@ static size_t ConvertLandscape(const char *value);
 
 #define SDT_LIST(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDT_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, base, var, lengthof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
-
-#define SDT_STR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDT_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)
 
 #define SDT_SSTR(base, var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDT_GENERAL(#var, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, base, var, sizeof(((base*)8)->var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, nullptr, from, to, cat, extra, startup)

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -126,9 +126,6 @@ static size_t ConvertLandscape(const char *value);
 #define SDTC_LIST(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDTG_GENERAL(#var, SDT_INTLIST, SL_ARR, type, flags, guiflags, _settings_client.var, lengthof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 
-#define SDTC_STR(var, type, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDTG_GENERAL(#var, SDT_STRING, SL_STR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, 0, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
-
 #define SDTC_SSTR(var, type, flags, guiflags, def, max_length, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDTG_GENERAL(#var, SDT_STDSTRING, SL_STDSTR, type, flags, guiflags, _settings_client.var, sizeof(_settings_client.var), def, 0, max_length, 0, nullptr, str, strhelp, strval, proc, from, to, cat, extra, startup)
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3970,9 +3970,10 @@ def      = nullptr
 proc     = UpdateClientConfigValues
 cat      = SC_BASIC
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.connect_to_ip
-type     = SLE_STRB
+type     = SLE_STR
+length   = 0
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = nullptr
 
@@ -4075,9 +4076,10 @@ guiflags = SGF_NETWORK_ONLY
 def      = false
 cat      = SC_EXPERT
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.last_joined
-type     = SLE_STRB
+type     = SLE_STR
+length   = 0
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = """"
 cat      = SC_EXPERT

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3961,9 +3961,10 @@ length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = nullptr
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.server_name
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_NAME_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
@@ -3977,9 +3978,10 @@ length   = 0
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = nullptr
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.network_id
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_SERVER_ID_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -70,6 +70,7 @@ SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,            
 SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_STR   =   SDTC_STR(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,             $length,         $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra, $startup),
@@ -3924,35 +3925,39 @@ def      = nullptr
 proc     = UpdateClientName
 cat      = SC_BASIC
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.server_password
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
 proc     = UpdateServerPassword
 cat      = SC_BASIC
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.rcon_password
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
 proc     = UpdateRconPassword
 cat      = SC_BASIC
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.admin_password
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
 cat      = SC_BASIC
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.default_company_pass
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = nullptr
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -69,7 +69,6 @@ SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,      
 SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTC_STR   =   SDTC_STR(       $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,             $length,         $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
@@ -3917,9 +3916,10 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = false
 
-[SDTC_STR]
+[SDTC_SSTR]
 var      = network.client_name
-type     = SLE_STRB
+type     = SLE_STR
+length   = NETWORK_CLIENT_NAME_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = nullptr
 proc     = UpdateClientName

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -73,7 +73,7 @@ SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,            
 SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra, $startup),
-SDT_STR    =    SDT_STR($base, $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDT_SSTR   =   SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
 SDT_NULL   =   SDT_NULL($length, $from, $to),
 SDT_END    = SDT_END()
@@ -2640,7 +2640,7 @@ str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL
 
-[SDT_STR]
+[SDT_SSTR]
 base     = GameSettings
 var      = locale.digit_group_separator
 type     = SLE_STRQ
@@ -2650,7 +2650,7 @@ def      = nullptr
 proc     = RedrawScreen
 cat      = SC_BASIC
 
-[SDT_STR]
+[SDT_SSTR]
 base     = GameSettings
 var      = locale.digit_group_separator_currency
 type     = SLE_STRQ
@@ -2660,7 +2660,7 @@ def      = nullptr
 proc     = RedrawScreen
 cat      = SC_BASIC
 
-[SDT_STR]
+[SDT_SSTR]
 base     = GameSettings
 var      = locale.digit_decimal_separator
 type     = SLE_STRQ

--- a/src/textbuf_gui.h
+++ b/src/textbuf_gui.h
@@ -37,8 +37,7 @@ static const uint OSK_KEYBOARD_ENTRIES = 50;
 /**
  * The number of characters has to be OSK_KEYBOARD_ENTRIES. However, these
  * have to be UTF-8 encoded, which means up to 4 bytes per character.
- * Furthermore the string needs to be '\0'-terminated.
  */
-extern char _keyboard_opt[2][OSK_KEYBOARD_ENTRIES * 4 + 1];
+extern std::string _keyboard_opt[2];
 
 #endif /* TEXTBUF_GUI_H */

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -218,7 +218,7 @@ void TextfileWindow::SetupScrollbars(bool force_reflow)
 /* virtual */ void TextfileWindow::SetFontNames(FreeTypeSettings *settings, const char *font_name, const void *os_data)
 {
 #if defined(WITH_FREETYPE) || defined(_WIN32) || defined(WITH_COCOA)
-	strecpy(settings->mono.font, font_name, lastof(settings->mono.font));
+	settings->mono.font = font_name;
 	settings->mono.os_handle = os_data;
 #endif
 }


### PR DESCRIPTION
## Motivation / Problem

Some (string) settings you want to validate before the setting is written as to prevent the user from entering something invalid. For example an empty client name. Now the (string) validation can only happen in the post set update, so there is no way to revert anymore. To implement that it would be nice not to have to worry about three types of strings coming from the settings: a C-string buffer, a heap allocated C-string and std::string.

For the media things a start has already been made with std::string, so this is just the continuation of that change.


## Description

Everywhere where a C-string buffer or heap allocated C-string setting was used this is converted to std::string, along with some of the related logic for handling them. Arguably things might be pushed even further down the stacks, but that would balloon this PR so usually the bare minimum has been done.


## Limitations

Empty digit separators are not possible anymore as they now fall back to the language's default.
The overall diff could be smaller if I chose to go back to SDT_STR etc, instead of SDT_SSTR. However, I chose not to do that so other people with patches get a compile time failure instead of a weird crash when it interprets char buffers as std::string or so.
Some variables, those that do not go over the network, I have generally not given an artificial limit as it's not really important how long e.g. a hostname is. It might now truncate it at a later stage in the application, but when the underlying code has been updated to fully use std::string that truncation problem should have gone away.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
