### PR TITLE
Fix b3003dd1: swap SERVER_GAME_INFO with CLIENT_GAME_INFO

### DIFF
--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -43,8 +43,8 @@ enum PacketGameType {
 	PACKET_SERVER_COMPANY_INFO,          ///< Information about a single company.
 
 	/* Packets used to get the game info. */
-	PACKET_CLIENT_GAME_INFO,             ///< Request information about the server.
 	PACKET_SERVER_GAME_INFO,             ///< Information about the server.
+	PACKET_CLIENT_GAME_INFO,             ///< Request information about the server.
 
 	/*
 	 * Packets after here assume that the client


### PR DESCRIPTION
## Motivation / Problem

Basically, as last minute change I both moved the packets to be close to the top, and made the order the same as the other 3 packet-pairs. Together meant this was not doing what it should.

## Description

```
The idea is that if you query an older server that does not support
this packet yet, the client receives an error. The assumption was
that on every "illegal packet" the connection would be closed. This
turns out to be false.

Now CLIENT_GAME_INFO aligns with the old PACKET_CLIENT_NEWGRFS_CHECKED,
which does a pre-check (which fails), and an error is sent back
and the connection is closed.

This is not a nice solution, but it is the best we got.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
