### PR TITLE
Change: use TCP for everything except for master-server and initial server scan

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -65,10 +65,14 @@ Module.preRun.push(function() {
     }
 
     window.openttd_server_list = function() {
-        add_server = Module.cwrap("em_openttd_add_server", null, ["string", "number"]);
+        add_server = Module.cwrap("em_openttd_add_server", null, ["string"]);
 
-        /* Add servers that support WebSocket here. Example:
-         *  add_server("localhost", 3979); */
+        /* Add servers that support WebSocket here. Examples:
+         *  add_server("localhost");
+         *  add_server("localhost:3979");
+         *  add_server("127.0.0.1:3979");
+         *  add_server("[::1]:3979");
+         */
     }
 
     var leftButtonDown = false;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2217,6 +2217,7 @@ STR_NETWORK_ERROR_TIMEOUT_COMPUTER                              :{WHITE}Your com
 STR_NETWORK_ERROR_TIMEOUT_MAP                                   :{WHITE}Your computer took too long to download the map
 STR_NETWORK_ERROR_TIMEOUT_JOIN                                  :{WHITE}Your computer took too long to join the server
 STR_NETWORK_ERROR_INVALID_CLIENT_NAME                           :{WHITE}Your player name is not valid
+STR_NETWORK_ERROR_SERVER_TOO_OLD                                :{WHITE}The queried server is too old for this client
 
 ############ Leave those lines in this order!!
 STR_NETWORK_ERROR_CLIENT_GENERAL                                :general error

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -15,12 +15,14 @@
 /** Class for handling the client side of the game connection. */
 class ClientNetworkGameSocketHandler : public ZeroedMemoryAllocator, public NetworkGameSocketHandler {
 private:
+	NetworkAddress address;        ///< Address we are connected to.
 	struct PacketReader *savegame; ///< Packet reader for reading the savegame.
 	byte token;                    ///< The token we need to send back to the server to prove we're the right client.
 
 	/** Status of the connection with the server. */
 	enum ServerStatus {
 		STATUS_INACTIVE,      ///< The client is not connected nor active.
+		STATUS_GAME_INFO,     ///< We are trying to get the game information.
 		STATUS_COMPANY_INFO,  ///< We are trying to get company information.
 		STATUS_JOIN,          ///< We are trying to join a server.
 		STATUS_NEWGRFS_CHECK, ///< Last action was checking NewGRFs.
@@ -74,13 +76,13 @@ protected:
 	static NetworkRecvStatus SendMapOk();
 	void CheckConnection();
 public:
-	ClientNetworkGameSocketHandler(SOCKET s);
+	ClientNetworkGameSocketHandler(SOCKET s, NetworkAddress address);
 	~ClientNetworkGameSocketHandler();
 
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
 	void ClientError(NetworkRecvStatus res);
 
-	static NetworkRecvStatus SendInformationQuery();
+	static NetworkRecvStatus SendInformationQuery(bool request_company_info);
 
 	static NetworkRecvStatus SendJoin();
 	static NetworkRecvStatus SendCommand(const CommandPacket *cp);

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -69,15 +69,6 @@ static void NetworkGameListHandleDelayedInsert()
  */
 NetworkGameList *NetworkGameListAddItem(NetworkAddress address)
 {
-	const char *hostname = address.GetHostname();
-
-	/* Do not query the 'any' address. */
-	if (StrEmpty(hostname) ||
-			strcmp(hostname, "0.0.0.0") == 0 ||
-			strcmp(hostname, "::") == 0) {
-		return nullptr;
-	}
-
 	NetworkGameList *item, *prev_item;
 
 	prev_item = nullptr;
@@ -95,7 +86,6 @@ NetworkGameList *NetworkGameListAddItem(NetworkAddress address)
 	} else {
 		prev_item->next = item;
 	}
-	DEBUG(net, 4, "[gamelist] added server to list");
 
 	UpdateNetworkGameWindow();
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -472,9 +472,8 @@ public:
 		EM_ASM(if (window["openttd_server_list"]) openttd_server_list());
 #endif
 
-		this->last_joined = NetworkGameListAddItem(ParseConnectionString(_settings_client.network.last_joined, NETWORK_DEFAULT_PORT));
+		this->last_joined = NetworkAddServer(_settings_client.network.last_joined);
 		this->server = this->last_joined;
-		if (this->last_joined != nullptr) NetworkUDPQueryServer(this->last_joined->address);
 
 		this->requery_timer.SetInterval(MILLISECONDS_PER_TICK);
 
@@ -750,7 +749,7 @@ public:
 				break;
 
 			case WID_NG_REFRESH: // Refresh
-				if (this->server != nullptr) NetworkUDPQueryServer(this->server->address);
+				if (this->server != nullptr) NetworkTCPQueryServer(this->server->address);
 				break;
 
 			case WID_NG_NEWGRF: // NewGRF Settings
@@ -971,7 +970,7 @@ void ShowNetworkGameWindow()
 		first = false;
 		/* Add all servers from the config file to our list. */
 		for (const auto &iter : _network_host_list) {
-			NetworkAddServer(iter.c_str());
+			NetworkAddServer(iter);
 		}
 	}
 
@@ -1485,7 +1484,7 @@ struct NetworkLobbyWindow : public Window {
 				/* Clear the information so removed companies don't remain */
 				for (auto &company : this->company_info) company = {};
 
-				NetworkTCPQueryServer(this->server->address);
+				NetworkTCPQueryServer(this->server->address, true);
 				break;
 		}
 	}
@@ -1555,7 +1554,7 @@ static void ShowNetworkLobbyWindow(NetworkGameList *ngl)
 
 	strecpy(_settings_client.network.last_joined, ngl->address.GetAddressAsString(false).c_str(), lastof(_settings_client.network.last_joined));
 
-	NetworkTCPQueryServer(ngl->address);
+	NetworkTCPQueryServer(ngl->address, true);
 
 	new NetworkLobbyWindow(&_network_lobby_window_desc, ngl);
 }

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -87,10 +87,10 @@ extern uint8 _network_reconnect;
 
 extern CompanyMask _network_company_passworded;
 
-void NetworkTCPQueryServer(NetworkAddress address);
+void NetworkTCPQueryServer(NetworkAddress address, bool request_company_info = false);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port);
-void NetworkAddServer(const char *b);
+struct NetworkGameList *NetworkAddServer(const std::string &connection_string);
 void NetworkRebuildHostList();
 void UpdateNetworkGameWindow();
 


### PR DESCRIPTION
## Motivation / Problem

In the next step to deprecate UDP more, we now also do refresh prior to the lobby over TCP.

This is the first commit that actually breaks the network protocol. Clients using master can no longer refresh older servers. That is to say: they see the list come in from the Master Server, they see them being queried over UDP, but as soon as they manually hit refresh, it shows an error the server is too old.

Also, the last server joined and manually added servers will give similar popups.

Further commits will set out to remove the rest of UDP as the master server is being replaced by Game Coordinator, but to keep things reviewable, this is another small step!

## Description

```
This means that pressing Refresh button and adding servers manually
now uses TCP.

The master-server and initial scan are still UDP as they will be
replaced by Game Coordinator; no need to change this now.

If we query a server that is too old, show a proper warning to the
user informing him the server is too old.
```

## Limitations

Using the nightly can be confusing to players, as all servers do show up, but refreshing gives an error. Mind you: they can never join them anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
