### PR TITLE
Fix: Incorrect vertical alignment of icon and text in DropDownListIconItem.

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -72,13 +72,7 @@ StringID DropDownListCharStringItem::String() const
 DropDownListIconItem::DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked) : DropDownListParamStringItem(string, result, masked), sprite(sprite), pal(pal)
 {
 	this->dim = GetSpriteSize(sprite);
-	if (this->dim.height < (uint)FONT_HEIGHT_NORMAL) {
-		this->sprite_y = (FONT_HEIGHT_NORMAL - dim.height) / 2;
-		this->text_y = 0;
-	} else {
-		this->sprite_y = 0;
-		this->text_y = (dim.height - FONT_HEIGHT_NORMAL) / 2;
-	}
+	this->sprite_y = dim.height;
 }
 
 uint DropDownListIconItem::Height(uint width) const
@@ -94,8 +88,8 @@ uint DropDownListIconItem::Width() const
 void DropDownListIconItem::Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const
 {
 	bool rtl = _current_text_dir == TD_RTL;
-	DrawSprite(this->sprite, this->pal, rtl ? right - this->dim.width - WD_FRAMERECT_RIGHT : left + WD_FRAMERECT_LEFT, top + this->sprite_y);
-	DrawString(left + WD_FRAMERECT_LEFT + (rtl ? 0 : (this->dim.width + WD_FRAMERECT_LEFT)), right - WD_FRAMERECT_RIGHT - (rtl ? (this->dim.width + WD_FRAMERECT_RIGHT) : 0), top + this->text_y, this->String(), sel ? TC_WHITE : TC_BLACK);
+	DrawSprite(this->sprite, this->pal, rtl ? right - this->dim.width - WD_FRAMERECT_RIGHT : left + WD_FRAMERECT_LEFT, CenterBounds(top, bottom, this->sprite_y));
+	DrawString(left + WD_FRAMERECT_LEFT + (rtl ? 0 : (this->dim.width + WD_FRAMERECT_LEFT)), right - WD_FRAMERECT_RIGHT - (rtl ? (this->dim.width + WD_FRAMERECT_RIGHT) : 0), CenterBounds(top, bottom, FONT_HEIGHT_NORMAL), this->String(), sel ? TC_WHITE : TC_BLACK);
 }
 
 void DropDownListIconItem::SetDimension(Dimension d)

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -84,7 +84,6 @@ class DropDownListIconItem : public DropDownListParamStringItem {
 	PaletteID pal;
 	Dimension dim;
 	uint sprite_y;
-	uint text_y;
 public:
 	DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked);
 


### PR DESCRIPTION
## Motivation / Problem

Vertical alignment of the sprite and text could be wrong for some drop down list items.

This happens if the bounding dimensions are changed so that each item is the same size, as happens on the railtype/roadtype dropdown lists, as the vertical offset was calculated before this dimension is changed.

## Description

This is resolved by determining the centre when drawing.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
