### PR TITLE
Cleanup: Remove some FOR_ALL_xxx helpers

### DIFF
--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -181,7 +181,7 @@ void InitializeSortedCargoSpecs()
 	_standard_cargo_mask = 0;
 
 	_sorted_standard_cargo_specs_size = 0;
-	FOR_ALL_SORTED_CARGOSPECS(cargo) {
+	for (const auto &cargo : _sorted_cargo_specs) {
 		if (cargo->classes & CC_SPECIAL) break;
 		_sorted_standard_cargo_specs_size++;
 		SetBit(_standard_cargo_mask, cargo->Index());

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -157,13 +157,6 @@ static inline bool IsCargoInClass(CargoID c, CargoClass cc)
 #define FOR_EACH_SET_CARGO_ID(var, cargo_bits) FOR_EACH_SET_BIT_EX(CargoID, var, CargoTypes, cargo_bits)
 
 /**
- * Loop header for iterating over cargoes, sorted by name. This includes phony cargoes like regearing cargoes.
- * @param var Reference getting the cargospec.
- * @see CargoSpec
- */
-#define FOR_ALL_SORTED_CARGOSPECS(var) for (uint8 index = 0; index < _sorted_cargo_specs.size() && (var = _sorted_cargo_specs[index], true) ; index++)
-
-/**
  * Loop header for iterating over 'real' cargoes, sorted by name. Phony cargoes like regearing cargoes are skipped.
  * @param var Reference getting the cargospec.
  * @see CargoSpec

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1862,8 +1862,7 @@ struct CompanyInfrastructureWindow : Window
 
 				size->width = std::max(size->width, GetStringBoundingBox(widget == WID_CI_ROAD_DESC ? STR_COMPANY_INFRASTRUCTURE_VIEW_ROAD_SECT : STR_COMPANY_INFRASTRUCTURE_VIEW_TRAM_SECT).width);
 
-				RoadType rt;
-				FOR_ALL_SORTED_ROADTYPES(rt) {
+				for (const auto &rt : _sorted_roadtypes) {
 					if (HasBit(this->roadtypes, rt) && RoadTypeIsRoad(rt) == (widget == WID_CI_ROAD_DESC)) {
 						lines++;
 						SetDParam(0, GetRoadTypeInfo(rt)->strings.name);
@@ -2005,8 +2004,7 @@ struct CompanyInfrastructureWindow : Window
 				DrawString(r.left, r.right, y, widget == WID_CI_ROAD_DESC ? STR_COMPANY_INFRASTRUCTURE_VIEW_ROAD_SECT : STR_COMPANY_INFRASTRUCTURE_VIEW_TRAM_SECT);
 
 				/* Draw name of each valid roadtype. */
-				RoadType rt;
-				FOR_ALL_SORTED_ROADTYPES(rt) {
+				for (const auto &rt : _sorted_roadtypes) {
 					if (HasBit(this->roadtypes, rt) && RoadTypeIsRoad(rt) == (widget == WID_CI_ROAD_DESC)) {
 						SetDParam(0, GetRoadTypeInfo(rt)->strings.name);
 						DrawString(r.left + offs_left, r.right - offs_right, y += FONT_HEIGHT_NORMAL, STR_WHITE_STRING);
@@ -2019,8 +2017,7 @@ struct CompanyInfrastructureWindow : Window
 			case WID_CI_ROAD_COUNT:
 			case WID_CI_TRAM_COUNT: {
 				uint32 road_tram_total = widget == WID_CI_ROAD_COUNT ? c->infrastructure.GetRoadTotal() : c->infrastructure.GetTramTotal();
-				RoadType rt;
-				FOR_ALL_SORTED_ROADTYPES(rt) {
+				for (const auto &rt : _sorted_roadtypes) {
 					if (HasBit(this->roadtypes, rt) && RoadTypeIsRoad(rt) == (widget == WID_CI_ROAD_COUNT)) {
 						this->DrawCountLine(r, y, c->infrastructure.road[rt], RoadMaintenanceCost(rt, c->infrastructure.road[rt], road_tram_total));
 					}

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1840,8 +1840,7 @@ struct CompanyInfrastructureWindow : Window
 
 				size->width = std::max(size->width, GetStringBoundingBox(STR_COMPANY_INFRASTRUCTURE_VIEW_RAIL_SECT).width);
 
-				RailType rt;
-				FOR_ALL_SORTED_RAILTYPES(rt) {
+				for (const auto &rt : _sorted_railtypes) {
 					if (HasBit(this->railtypes, rt)) {
 						lines++;
 						SetDParam(0, GetRailTypeInfo(rt)->strings.name);
@@ -1973,8 +1972,7 @@ struct CompanyInfrastructureWindow : Window
 
 				if (this->railtypes != RAILTYPES_NONE) {
 					/* Draw name of each valid railtype. */
-					RailType rt;
-					FOR_ALL_SORTED_RAILTYPES(rt) {
+					for (const auto &rt : _sorted_railtypes) {
 						if (HasBit(this->railtypes, rt)) {
 							SetDParam(0, GetRailTypeInfo(rt)->strings.name);
 							DrawString(r.left + offs_left, r.right - offs_right, y += FONT_HEIGHT_NORMAL, STR_WHITE_STRING);
@@ -1991,8 +1989,7 @@ struct CompanyInfrastructureWindow : Window
 			case WID_CI_RAIL_COUNT: {
 				/* Draw infrastructure count for each valid railtype. */
 				uint32 rail_total = c->infrastructure.GetRailTotal();
-				RailType rt;
-				FOR_ALL_SORTED_RAILTYPES(rt) {
+				for (const auto &rt : _sorted_railtypes) {
 					if (HasBit(this->railtypes, rt)) {
 						this->DrawCountLine(r, y, c->infrastructure.rail[rt], RailMaintenanceCost(rt, c->infrastructure.rail[rt], rail_total));
 					}

--- a/src/rail.h
+++ b/src/rail.h
@@ -464,10 +464,4 @@ RailType AllocateRailType(RailTypeLabel label);
 extern std::vector<RailType> _sorted_railtypes;
 extern RailTypes _railtypes_hidden_mask;
 
-/**
- * Loop header for iterating over railtypes, sorted by sortorder.
- * @param var Railtype.
- */
-#define FOR_ALL_SORTED_RAILTYPES(var) for (uint8 index = 0; index < _sorted_railtypes.size() && (var = _sorted_railtypes[index], true) ; index++)
-
 #endif /* RAIL_H */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2191,17 +2191,16 @@ DropDownList GetRailTypeDropDownList(bool for_replacement, bool all_option)
 	}
 
 	Dimension d = { 0, 0 };
-	RailType rt;
 	/* Get largest icon size, to ensure text is aligned on each menu item. */
 	if (!for_replacement) {
-		FOR_ALL_SORTED_RAILTYPES(rt) {
+		for (const auto &rt : _sorted_railtypes) {
 			if (!HasBit(used_railtypes, rt)) continue;
 			const RailtypeInfo *rti = GetRailTypeInfo(rt);
 			d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_rail));
 		}
 	}
 
-	FOR_ALL_SORTED_RAILTYPES(rt) {
+	for (const auto &rt : _sorted_railtypes) {
 		/* If it's not used ever, don't show it to the user. */
 		if (!HasBit(used_railtypes, rt)) continue;
 

--- a/src/road.h
+++ b/src/road.h
@@ -305,10 +305,4 @@ bool HasAnyRoadTypesAvail(CompanyID company, RoadTramType rtt);
 extern std::vector<RoadType> _sorted_roadtypes;
 extern RoadTypes _roadtypes_hidden_mask;
 
-/**
- * Loop header for iterating over roadtypes, sorted by sortorder.
- * @param var Roadtype.
- */
-#define FOR_ALL_SORTED_ROADTYPES(var) for (uint8 index = 0; index < _sorted_roadtypes.size() && (var = _sorted_roadtypes[index], true) ; index++)
-
 #endif /* ROAD_H */

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1313,17 +1313,16 @@ DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, b
 	}
 
 	Dimension d = { 0, 0 };
-	RoadType rt;
 	/* Get largest icon size, to ensure text is aligned on each menu item. */
 	if (!for_replacement) {
-		FOR_ALL_SORTED_ROADTYPES(rt) {
+		for (const auto &rt : _sorted_roadtypes) {
 			if (!HasBit(used_roadtypes, rt)) continue;
 			const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 			d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_road));
 		}
 	}
 
-	FOR_ALL_SORTED_ROADTYPES(rt) {
+	for (const auto &rt : _sorted_roadtypes) {
 		/* If it's not used ever, don't show it to the user. */
 		if (!HasBit(used_roadtypes, rt)) continue;
 
@@ -1365,13 +1364,12 @@ DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 
 	/* If it's not used ever, don't show it to the user. */
 	Dimension d = { 0, 0 };
-	RoadType rt;
-	FOR_ALL_SORTED_ROADTYPES(rt) {
+	for (const auto &rt : _sorted_roadtypes) {
 		if (!HasBit(used_roadtypes, rt)) continue;
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
 		d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_road));
 	}
-	FOR_ALL_SORTED_ROADTYPES(rt) {
+	for (const auto &rt : _sorted_roadtypes) {
 		if (!HasBit(used_roadtypes, rt)) continue;
 
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1171,8 +1171,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				CargoTypes cmask = args->GetInt64(SCC_CARGO_LIST);
 				bool first = true;
 
-				const CargoSpec *cs;
-				FOR_ALL_SORTED_CARGOSPECS(cs) {
+				for (const auto &cs : _sorted_cargo_specs) {
 					if (!HasBit(cmask, cs->Index())) continue;
 
 					if (buff >= last - 2) break; // ',' and ' '

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -513,8 +513,7 @@ struct RefitWindow : public Window {
 
 			/* Loop through all cargoes in the refit mask */
 			int current_index = 0;
-			const CargoSpec *cs;
-			FOR_ALL_SORTED_CARGOSPECS(cs) {
+			for (const auto &cs : _sorted_cargo_specs) {
 				CargoID cid = cs->Index();
 				/* Skip cargo type if it's not listed */
 				if (!HasBit(cmask, cid)) {


### PR DESCRIPTION
## Motivation / Problem

FOR_ALL_xxx macros are generally bad style, and are a left over from the old ways...

## Description

This change replaces three FOR_ALL_xxx macros with their range-iterator equivalents.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
