### PR TITLE
Fix: [MinGW] Set minimum OS version to Windows XP

### DIFF
--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -7,9 +7,6 @@
 
 /** @file network_chat_gui.cpp GUI for handling chat messages. */
 
-#include <stdarg.h> /* va_list */
-#include <deque>
-
 #include "../stdafx.h"
 #include "../strings_func.h"
 #include "../blitter/factory.hpp"
@@ -27,6 +24,9 @@
 #include "../widgets/network_chat_widget.h"
 
 #include "table/strings.h"
+
+#include <stdarg.h> /* va_list */
+#include <deque>
 
 #include "../safeguards.h"
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -19,7 +19,6 @@
  * <li>repeat this until everything is done, and flush any remaining output to file
  * </ol>
  */
-#include <deque>
 
 #include "../stdafx.h"
 #include "../debug.h"
@@ -44,6 +43,7 @@
 #include "../fios.h"
 #include "../error.h"
 #include <atomic>
+#include <deque>
 #include <string>
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>

--- a/src/script/api/script_date.cpp
+++ b/src/script/api/script_date.cpp
@@ -7,10 +7,11 @@
 
 /** @file script_date.cpp Implementation of ScriptDate. */
 
-#include <time.h>
 #include "../../stdafx.h"
 #include "script_date.hpp"
 #include "../../date_func.h"
+
+#include <time.h>
 
 #include "../../safeguards.h"
 

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -7,8 +7,6 @@
 
 /** @file squirrel.cpp the implementation of the Squirrel class. It handles all Squirrel-stuff and gives a nice API back to work with. */
 
-#include <stdarg.h>
-#include <map>
 #include "../stdafx.h"
 #include "../debug.h"
 #include "squirrel_std.hpp"
@@ -20,6 +18,9 @@
 #include <../squirrel/sqpcheader.h>
 #include <../squirrel/sqvm.h>
 #include "../core/alloc_func.hpp"
+
+#include <stdarg.h>
+#include <map>
 
 /**
  * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -10,6 +10,15 @@
 #ifndef STDAFX_H
 #define STDAFX_H
 
+#if defined(_WIN32)
+	/* MinGW defaults to Windows 7 if none of these are set, and they must be set before any MinGW header is included */
+#	define NTDDI_VERSION NTDDI_WINXP // Windows XP
+#	define _WIN32_WINNT 0x501        // Windows XP
+#	define _WIN32_WINDOWS 0x501      // Windows XP
+#	define WINVER 0x0501             // Windows XP
+#	define _WIN32_IE_ 0x0600         // 6.0 (XP+)
+#endif
+
 #ifdef _MSC_VER
 	/* Stop Microsoft (and clang-cl) compilers from complaining about potentially-unsafe/potentially-non-standard functions */
 #	define _CRT_SECURE_NO_DEPRECATE
@@ -158,12 +167,6 @@
 /* Stuff for MSVC */
 #if defined(_MSC_VER)
 #	pragma once
-#	define NTDDI_VERSION NTDDI_WINXP // Windows XP
-#	define _WIN32_WINNT 0x501        // Windows XP
-#	define _WIN32_WINDOWS 0x501      // Windows XP
-#	define WINVER 0x0501             // Windows XP
-#	define _WIN32_IE_ 0x0600         // 6.0 (XP+)
-
 #	define NOMINMAX                // Disable min/max macros in windows.h.
 
 #	pragma warning(disable: 4244)  // 'conversion' conversion from 'type1' to 'type2', possible loss of data


### PR DESCRIPTION
## Motivation / Problem
Compilation with MinGW fails since #7441 has been merged.
After some digging in headers, I found MinGW defaults to Windows 7 target (and cause some unexpected stuff, like `GF_END` to be defined), while we set MSVC to target Windows XP.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Set the same target for all Windows compilers.
I needed to move the definitions on top of  `stdafx.h` because any MinGW header (even non windows API ones) will `define _WIN32_WINNT 0x0601` if it's not yet defined.
I also needed to reorder `#include` lines in some files for the same reason, `stdafx.h` MUST be the first included file :)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
