### PR TITLE
Codechange: use NetworkAddress instead of two host/port variables where possible

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -901,8 +901,7 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 	/* Don't resolve the address first, just print it directly as it comes from the config file. */
 	IConsolePrintF(CC_DEFAULT, "Reconnecting to %s ...", _settings_client.network.last_joined);
 
-	NetworkAddress address = ParseConnectionString(_settings_client.network.last_joined, NETWORK_DEFAULT_PORT);
-	NetworkClientConnectGame(address, playas);
+	NetworkClientConnectGame(_settings_client.network.last_joined, playas);
 	return true;
 }
 
@@ -918,23 +917,7 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 	if (argc < 2) return false;
 	if (_networking) NetworkDisconnect(); // we are in network-mode, first close it!
 
-	CompanyID join_as = COMPANY_NEW_COMPANY;
-	NetworkAddress address = ParseGameConnectionString(&join_as, argv[1], NETWORK_DEFAULT_PORT);
-
-	IConsolePrintF(CC_DEFAULT, "Connecting to %s...", address.GetAddressAsString().c_str());
-	if (join_as != COMPANY_NEW_COMPANY) {
-		IConsolePrintF(CC_DEFAULT, "    company-no: %d", join_as);
-
-		/* From a user pov 0 is a new company, internally it's different and all
-		 * companies are offset by one to ease up on users (eg companies 1-8 not 0-7) */
-		if (join_as != COMPANY_SPECTATOR) {
-			if (join_as > MAX_COMPANIES) return false;
-			join_as--;
-		}
-	}
-
-	NetworkClientConnectGame(address, join_as);
-
+	NetworkClientConnectGame(argv[1], COMPANY_NEW_COMPANY);
 	return true;
 }
 

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -101,8 +101,8 @@ void NetworkAddress::GetAddressAsString(char *buffer, const char *last, bool wit
  */
 std::string NetworkAddress::GetAddressAsString(bool with_family)
 {
-	/* 6 = for the : and 5 for the decimal port number */
-	char buf[NETWORK_HOSTNAME_LENGTH + 6 + 7];
+	/* 7 extra are for with_family, which adds " (IPvX)". */
+	char buf[NETWORK_HOSTNAME_PORT_LENGTH + 7];
 	this->GetAddressAsString(buf, lastof(buf), with_family);
 	return buf;
 }

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -56,6 +56,7 @@ static const byte NETWORK_MASTER_SERVER_VERSION   =    2;         ///< What vers
 static const uint NETWORK_NAME_LENGTH             =   80;         ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH     =  128;         ///< The maximum length of the company name, in bytes including '\0'
 static const uint NETWORK_HOSTNAME_LENGTH         =   80;         ///< The maximum length of the host name, in bytes including '\0'
+static const uint NETWORK_HOSTNAME_PORT_LENGTH    =   80 + 6;     ///< The maximum length of the host name + port, in bytes including '\0'. The extra six is ":" + port number (with a max of 65536)
 static const uint NETWORK_SERVER_ID_LENGTH        =   33;         ///< The maximum length of the network id of the servers, in bytes including '\0'
 static const uint NETWORK_REVISION_LENGTH         =   33;         ///< The maximum length of the revision, in bytes including '\0'
 static const uint NETWORK_PASSWORD_LENGTH         =   33;         ///< The maximum length of the password, in bytes including '\0' (must be >= NETWORK_SERVER_ID_LENGTH)

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -74,7 +74,6 @@ struct NetworkGameInfo : NetworkServerGameInfo {
 	uint16 map_width;                               ///< Map width
 	uint16 map_height;                              ///< Map height
 	char server_name[NETWORK_NAME_LENGTH];          ///< Server name
-	char hostname[NETWORK_HOSTNAME_LENGTH];         ///< Hostname of the server (if any)
 	char server_revision[NETWORK_REVISION_LENGTH];  ///< The version number the server is using (e.g.: 'r304' or 0.5.0)
 	bool dedicated;                                 ///< Is this a dedicated server?
 	bool version_compatible;                        ///< Can we connect to this server or not? (based on server_revision)

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -12,7 +12,7 @@
 #include "../../stdafx.h"
 #include "../../debug.h"
 #include "../../rev.h"
-#include "../network_func.h"
+#include "../network_internal.h"
 #include "game_info.h"
 
 #include "tcp_http.h"

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -203,11 +203,7 @@ int NetworkHTTPSocketHandler::HandleHeader()
 
 	*url = '\0';
 
-	/* Fetch the hostname, and possible port number. */
-	const char *port = nullptr;
-	ParseConnectionString(&port, hname);
-
-	NetworkAddress address(hname, port == nullptr ? 80 : atoi(port));
+	NetworkAddress address = ParseConnectionString(hname, 80);
 
 	/* Restore the URL. */
 	*url = '/';

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -18,7 +18,6 @@
 // #define DEBUG_FAILED_DUMP_COMMANDS
 
 #include "network_type.h"
-#include "core/address.h"
 #include "../console_type.h"
 #include "../gfx_type.h"
 #include "../openttd.h"
@@ -47,14 +46,12 @@ void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
 void ParseFullConnectionString(const char **company, const char **port, char *connection_string);
-NetworkAddress ParseConnectionString(const char *connection_string, int default_port);
-NetworkAddress ParseGameConnectionString(CompanyID *company, const char *connection_string, int default_port);
-void NetworkStartDebugLog(NetworkAddress &address);
+void NetworkStartDebugLog(const std::string &connection_string);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
-void NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+void NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const char *msg, int64 data = 0);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -18,6 +18,7 @@
 // #define DEBUG_FAILED_DUMP_COMMANDS
 
 #include "network_type.h"
+#include "core/address.h"
 #include "../console_type.h"
 #include "../gfx_type.h"
 #include "../openttd.h"
@@ -45,14 +46,15 @@ void NetworkReboot();
 void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
-void ParseConnectionString(const char **port, char *connection_string);
-void ParseGameConnectionString(const char **company, const char **port, char *connection_string);
-void NetworkStartDebugLog(const char *hostname, uint16 port);
+void ParseFullConnectionString(const char **company, const char **port, char *connection_string);
+NetworkAddress ParseConnectionString(const char *connection_string, int default_port);
+NetworkAddress ParseGameConnectionString(CompanyID *company, const char *connection_string, int default_port);
+void NetworkStartDebugLog(NetworkAddress &address);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
-void NetworkClientConnectGame(const char *hostname, uint16 port, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+void NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const char *msg, int64 data = 0);

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -51,7 +51,6 @@ static void NetworkGameListHandleDelayedInsert()
 				ClearGRFConfigList(&item->info.grfconfig);
 				memset(&item->info, 0, sizeof(item->info));
 				strecpy(item->info.server_name, ins_item->info.server_name, lastof(item->info.server_name));
-				strecpy(item->info.hostname, ins_item->info.hostname, lastof(item->info.hostname));
 				item->online = false;
 			}
 			item->manually |= ins_item->manually;

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -151,7 +151,7 @@ void NetworkGameListRequery()
 
 		/* item gets mostly zeroed by NetworkUDPQueryServer */
 		uint8 retries = item->retries;
-		NetworkUDPQueryServer(NetworkAddress(item->address));
+		NetworkUDPQueryServer(item->address);
 		item->retries = (retries >= REFRESH_GAMEINFO_X_REQUERIES) ? 0 : retries;
 	}
 }

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -645,9 +645,8 @@ public:
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_SERVER_VERSION); // server version
 			y += FONT_HEIGHT_NORMAL;
 
-			char network_addr_buffer[NETWORK_HOSTNAME_LENGTH + 6 + 7];
-			sel->address.GetAddressAsString(network_addr_buffer, lastof(network_addr_buffer));
-			SetDParamStr(0, network_addr_buffer);
+			std::string address = sel->address.GetAddressAsString();
+			SetDParamStr(0, address.c_str());
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_SERVER_ADDRESS); // server address
 			y += FONT_HEIGHT_NORMAL;
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -119,4 +119,8 @@ StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkFindName(char *new_name, const char *last);
 const char *GenerateCompanyPasswordHash(const char *password, const char *password_server_id, uint32 password_game_seed);
 
+void NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+NetworkAddress ParseConnectionString(const std::string &connection_string, int default_port);
+NetworkAddress ParseGameConnectionString(CompanyID *company, const std::string &connection_string, int default_port);
+
 #endif /* NETWORK_INTERNAL_H */

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -92,7 +92,6 @@ static void DoNetworkUDPQueryServer(NetworkAddress &address, bool needs_mutex, b
 	/* Clear item in gamelist */
 	NetworkGameList *item = CallocT<NetworkGameList>(1);
 	address.GetAddressAsString(item->info.server_name, lastof(item->info.server_name));
-	strecpy(item->info.hostname, address.GetHostname(), lastof(item->info.hostname));
 	item->address = address;
 	item->manually = manually;
 	NetworkGameListAddItemDelayed(item);
@@ -363,10 +362,6 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAd
 
 			this->SendPacket(&packet, &item->address);
 		}
-	}
-
-	if (item->info.hostname[0] == '\0') {
-		seprintf(item->info.hostname, lastof(item->info.hostname), "%s", client_addr->GetHostname());
 	}
 
 	if (client_addr->GetAddress()->ss_family == AF_INET6) {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -473,21 +473,10 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		if (_switch_mode != SM_NONE) MakeNewgameSettingsLive();
 
 		if (_network_available && network_conn != nullptr) {
-			CompanyID join_as = COMPANY_NEW_COMPANY;
-			NetworkAddress address = ParseGameConnectionString(&join_as, network_conn, NETWORK_DEFAULT_PORT);
-
-			if (join_as != COMPANY_NEW_COMPANY && join_as != COMPANY_SPECTATOR) {
-				join_as--;
-				if (join_as >= MAX_COMPANIES) {
-					delete this;
-					return;
-				}
-			}
-
 			LoadIntroGame();
 			_switch_mode = SM_NONE;
 
-			NetworkClientConnectGame(address, join_as, join_server_password, join_company_password);
+			NetworkClientConnectGame(network_conn, COMPANY_NEW_COMPANY, join_server_password, join_company_password);
 		}
 
 		/* After the scan we're not used anymore. */
@@ -763,8 +752,7 @@ int openttd_main(int argc, char *argv[])
 	NetworkStartUp(); // initialize network-core
 
 	if (debuglog_conn != nullptr && _network_available) {
-		NetworkAddress address = ParseConnectionString(debuglog_conn, NETWORK_DEFAULT_DEBUGLOG_PORT);
-		NetworkStartDebugLog(address);
+		NetworkStartDebugLog(debuglog_conn);
 	}
 
 	if (!HandleBootstrap()) {
@@ -1476,8 +1464,7 @@ void GameLoop()
 		if (_network_reconnect > 0 && --_network_reconnect == 0) {
 			/* This means that we want to reconnect to the last host
 			 * We do this here, because it means that the network is really closed */
-			NetworkAddress address = ParseConnectionString(_settings_client.network.last_joined, NETWORK_DEFAULT_PORT);
-			NetworkClientConnectGame(address, COMPANY_SPECTATOR);
+			NetworkClientConnectGame(_settings_client.network.last_joined, COMPANY_SPECTATOR);
 		}
 		/* Singleplayer */
 		StateGameLoop();

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -269,7 +269,7 @@ struct NetworkSettings {
 	bool   server_advertise;                              ///< advertise the server to the masterserver
 	char   client_name[NETWORK_CLIENT_NAME_LENGTH];       ///< name of the player (as client)
 	char   default_company_pass[NETWORK_PASSWORD_LENGTH]; ///< default password for new companies in encrypted form
-	char   connect_to_ip[NETWORK_HOSTNAME_LENGTH];        ///< default for the "Add server" query
+	char   connect_to_ip[NETWORK_HOSTNAME_PORT_LENGTH];   ///< default for the "Add server" query
 	char   network_id[NETWORK_SERVER_ID_LENGTH];          ///< network ID for servers
 	bool   autoclean_companies;                           ///< automatically remove companies that are not in use
 	uint8  autoclean_unprotected;                         ///< remove passwordless companies after this many months
@@ -281,8 +281,7 @@ struct NetworkSettings {
 	Year   restart_game_year;                             ///< year the server restarts
 	uint8  min_active_clients;                            ///< minimum amount of active clients to unpause the game
 	bool   reload_cfg;                                    ///< reload the config file before restarting
-	char   last_host[NETWORK_HOSTNAME_LENGTH];            ///< IP address of the last joined server
-	uint16 last_port;                                     ///< port of the last joined server
+	char   last_joined[NETWORK_HOSTNAME_PORT_LENGTH];     ///< Last joined server
 	bool   no_http_content_downloads;                     ///< do not do content downloads over HTTP
 };
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -4069,19 +4069,10 @@ def      = false
 cat      = SC_EXPERT
 
 [SDTC_STR]
-var      = network.last_host
+var      = network.last_joined
 type     = SLE_STRB
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = """"
-cat      = SC_EXPERT
-
-[SDTC_VAR]
-var      = network.last_port
-type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-def      = 0
-min      = 0
-max      = UINT16_MAX
 cat      = SC_EXPERT
 
 [SDTC_BOOL]


### PR DESCRIPTION
## Motivation / Problem

While working on the network code, I noticed we had `last_host` and `last_port`, which is a bit weird. As most other settings are a combination of the two. Working towards STUN support, this also becomes a bit problematic, as `last_joined` can become a non host/port pair. As says, I set out to collapse `last_host`/`last_port` into `last_joined`.

Sadly, the rabbit hole was a bit deeper.

## Description

This PR changes a few things, without functional changes:

- Remove the write-only variable `hostname` in the `NetworkGameInfo`.
- Use the `std::string` variant of `GetAddressAsString` where possible (reducing the amount of times I had to read `+ 6 + 7` with a bad comment) (basically: deduplication)
- Use `NetworkAddress` for host/port pairs where possible. I know, this is a bit ironic, as recently someone changed (cbad518bf3c7e6d05b62d8c1d063b89d974e5f33) a few of these from `NetworkAddress` into host/port, but that is just not working out.
- Added a few helper functions to also return `NetworkAddress` instead of host/port to deduplicate code. This is mostly around `ParseConnectingString` and friends.
- `last_host`/`last_port` was set in various of places and also used in the GUI, while there is a `this->server` telling the same. Simplified this by only setting the now new `last_joined` when joining a server or opening a lobby, but otherwise not using it.

There is one functional changes in this PR:

The location `connect_to_ip` was set was weird. This happened on `NetworkAddServer`. This was called from two places. 1) when clicking "Add Server" and fill in an IP. The comment suggests it was meant for that. 2) when you open the Network GUI for every server you manually added. This often means `connect_to_ip` changed to something completely different. I removed this last flow, and it is now only 1)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
