### PR TITLE
Cleanup: Remove old FiosList helper methods.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -59,7 +59,7 @@ public:
 	/** Declare the file storage cache as being invalid, also clears all stored files. */
 	void InvalidateFileList()
 	{
-		this->Clear();
+		this->clear();
 		this->file_list_valid = false;
 	}
 
@@ -403,7 +403,7 @@ DEF_CONSOLE_CMD(ConListFiles)
 	}
 
 	_console_file_list.ValidateFileList(true);
-	for (uint i = 0; i < _console_file_list.Length(); i++) {
+	for (uint i = 0; i < _console_file_list.size(); i++) {
 		IConsolePrintF(CC_DEFAULT, "%d) %s", i, _console_file_list[i].title);
 	}
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -109,94 +109,10 @@ struct FiosItem {
 };
 
 /** List of file information. */
-class FileList {
+class FileList : public std::vector<FiosItem> {
 public:
-	~FileList();
-
-	/**
-	 * Construct a new entry in the file list.
-	 * @return Pointer to the new items to be initialized.
-	 */
-	inline FiosItem *Append()
-	{
-		return &this->files.emplace_back();
-	}
-
-	/**
-	 * Get the number of files in the list.
-	 * @return The number of files stored in the list.
-	 */
-	inline size_t Length() const
-	{
-		return this->files.size();
-	}
-
-	/**
-	 * Get a pointer to the first file information.
-	 * @return Address of the first file information.
-	 */
-	inline const FiosItem *Begin() const
-	{
-		return this->files.data();
-	}
-
-	/**
-	 * Get a pointer behind the last file information.
-	 * @return Address behind the last file information.
-	 */
-	inline const FiosItem *End() const
-	{
-		return this->Begin() + this->Length();
-	}
-
-	/**
-	 * Get a pointer to the indicated file information. File information must exist.
-	 * @return Address of the indicated existing file information.
-	 */
-	inline const FiosItem *Get(size_t index) const
-	{
-		return this->files.data() + index;
-	}
-
-	/**
-	 * Get a pointer to the indicated file information. File information must exist.
-	 * @return Address of the indicated existing file information.
-	 */
-	inline FiosItem *Get(size_t index)
-	{
-		return this->files.data() + index;
-	}
-
-	inline const FiosItem &operator[](size_t index) const
-	{
-		return this->files[index];
-	}
-
-	/**
-	 * Get a reference to the indicated file information. File information must exist.
-	 * @return The requested file information.
-	 */
-	inline FiosItem &operator[](size_t index)
-	{
-		return this->files[index];
-	}
-
-	/** Remove all items from the list. */
-	inline void Clear()
-	{
-		this->files.clear();
-	}
-
-	/** Compact the list down to the smallest block size boundary. */
-	inline void Compact()
-	{
-		this->files.shrink_to_fit();
-	}
-
 	void BuildFileList(AbstractFileType abstract_filetype, SaveLoadOperation fop);
 	const FiosItem *FindItem(const char *file);
-
-	std::vector<FiosItem> files; ///< The list of files.
 };
 
 enum SortingBits {

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -249,8 +249,8 @@ static void SortSaveGameList(FileList &file_list)
 	 * Drives (A:\ (windows only) are always under the files (FIOS_TYPE_DRIVE)
 	 * Only sort savegames/scenarios, not directories
 	 */
-	for (const FiosItem *item = file_list.Begin(); item != file_list.End(); item++) {
-		switch (item->type) {
+	for (const auto &item : file_list) {
+		switch (item.type) {
 			case FIOS_TYPE_DIR:    sort_start++; break;
 			case FIOS_TYPE_PARENT: sort_start++; break;
 			case FIOS_TYPE_DRIVE:  sort_end++;   break;
@@ -258,7 +258,7 @@ static void SortSaveGameList(FileList &file_list)
 		}
 	}
 
-	std::sort(file_list.files.begin() + sort_start, file_list.files.end() - sort_end);
+	std::sort(file_list.begin() + sort_start, file_list.end() - sort_end);
 }
 
 struct SaveLoadWindow : public Window {
@@ -437,14 +437,14 @@ public:
 
 				uint y = r.top + WD_FRAMERECT_TOP;
 				uint scroll_pos = this->vscroll->GetPosition();
-				for (uint row = 0; row < this->fios_items.Length(); row++) {
+				for (uint row = 0; row < this->fios_items.size(); row++) {
 					if (!this->fios_items_shown[row]) {
 						/* The current item is filtered out : we do not show it */
 						scroll_pos++;
 						continue;
 					}
 					if (row < scroll_pos) continue;
-					const FiosItem *item = this->fios_items.Get(row);
+					const FiosItem *item = &this->fios_items[row];
 
 					if (item == this->selected) {
 						GfxFillRect(r.left + 1, y, r.right, y + this->resize.step_height, PC_DARK_BLUE);
@@ -651,7 +651,7 @@ public:
 					if (!this->fios_items_shown[i]) y++;
 					i++;
 				}
-				const FiosItem *file = this->fios_items.Get(y);
+				const FiosItem *file = &this->fios_items[y];
 
 				const char *name = FiosBrowseTo(file);
 				if (name == nullptr) {
@@ -734,7 +734,7 @@ public:
 				if (!this->fios_items_shown[i]) y++;
 				i++;
 			}
-			const FiosItem *file = this->fios_items.Get(y);
+			const FiosItem *file = &this->fios_items[y];
 
 			if (file != this->highlighted) {
 				this->highlighted = file;
@@ -812,7 +812,7 @@ public:
 
 				_fios_path_changed = true;
 				this->fios_items.BuildFileList(this->abstract_filetype, this->fop);
-				this->vscroll->SetCount((uint)this->fios_items.Length());
+				this->vscroll->SetCount((uint)this->fios_items.size());
 				this->selected = nullptr;
 				_load_check_data.Clear();
 
@@ -852,10 +852,10 @@ public:
 
 			case SLIWD_FILTER_CHANGES:
 				/* Filter changes */
-				this->fios_items_shown.resize(this->fios_items.Length());
+				this->fios_items_shown.resize(this->fios_items.size());
 				uint items_shown_count = 0; ///< The number of items shown in the list
 				/* We pass through every fios item */
-				for (uint i = 0; i < this->fios_items.Length(); i++) {
+				for (uint i = 0; i < this->fios_items.size(); i++) {
 					if (this->string_filter.IsEmpty()) {
 						/* We don't filter anything out if the filter editbox is empty */
 						this->fios_items_shown[i] = true;

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -209,7 +209,7 @@ void FiosGetDrives(FileList &file_list)
 
 	GetLogicalDriveStrings(lengthof(drives), drives);
 	for (s = drives; *s != '\0';) {
-		FiosItem *fios = file_list.Append();
+		FiosItem *fios = &file_list.emplace_back();
 		fios->type = FIOS_TYPE_DRIVE;
 		fios->mtime = 0;
 		seprintf(fios->name, lastof(fios->name),  "%c:", s[0] & 0xFF);


### PR DESCRIPTION
## Motivation / Problem

FiosList class is a wrapper around std::vector with some compatibility methods added to support the old SmallVector-style callers. This is legacy and not necessary.

## Description

This change removes the crufty helpers, makes FiosList directly inherit of std::vector, and use the native std::vector methods and range iteratoers.

## Limitations

~~There is one section that should be a range iterator, but it seems not to work via "this".~~

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
