### PR TITLE
Codechange: Acquire video buffer before taking game state lock to prevent erratic fast forward behaviour

### DIFF
--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -131,12 +131,13 @@ void VideoDriver::Tick()
 			this->fast_forward_via_key = false;
 		}
 
+		/* Locking video buffer can block (especially with vsync enabled), do it before taking game state lock. */
+		this->LockVideoBuffer();
+
 		{
 			/* Tell the game-thread to stop so we can have a go. */
 			std::lock_guard<std::mutex> lock_wait(this->game_thread_wait_mutex);
 			std::lock_guard<std::mutex> lock_state(this->game_state_mutex);
-
-			this->LockVideoBuffer();
 
 			this->DrainCommandQueue();
 


### PR DESCRIPTION
## Motivation / Problem

Fast forward behavior is erratic when using OpenGL and vsync is enabled. (it mainly doesn't work, but every few seconds it jumps working for fraction of second).


## Description

Acquire video buffer before taking game state lock.


## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
