### PR TITLE
Fix: TCP handling code is not posix compliant

### DIFF
--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -87,7 +87,7 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 		res = p->TransferOut<int>(send, this->sock, 0);
 		if (res == -1) {
 			int err = NetworkGetLastError();
-			if (err != EWOULDBLOCK) {
+			if (err != EWOULDBLOCK && err != EAGAIN) {
 				/* Something went wrong.. close client! */
 				if (!closing_down) {
 					DEBUG(net, 0, "send failed with error %s", NetworkGetErrorString(err));
@@ -137,7 +137,7 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
 			res = p->TransferIn<int>(recv, this->sock, 0);
 			if (res == -1) {
 				int err = NetworkGetLastError();
-				if (err != EWOULDBLOCK) {
+				if (err != EWOULDBLOCK && err != EAGAIN) {
 					/* Something went wrong... (ECONNRESET is connection reset by peer) */
 					if (err != ECONNRESET) DEBUG(net, 0, "recv failed with error %s", NetworkGetErrorString(err));
 					this->CloseConnection();
@@ -165,7 +165,7 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
 		res = p->TransferIn<int>(recv, this->sock, 0);
 		if (res == -1) {
 			int err = NetworkGetLastError();
-			if (err != EWOULDBLOCK) {
+			if (err != EWOULDBLOCK && err != EAGAIN) {
 				/* Something went wrong... (ECONNRESET is connection reset by peer) */
 				if (err != ECONNRESET) DEBUG(net, 0, "recv failed with error %s", NetworkGetErrorString(err));
 				this->CloseConnection();

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -226,7 +226,7 @@ int NetworkHTTPSocketHandler::Receive()
 		ssize_t res = recv(this->sock, (char *)this->recv_buffer + this->recv_pos, lengthof(this->recv_buffer) - this->recv_pos, 0);
 		if (res == -1) {
 			int err = NetworkGetLastError();
-			if (err != EWOULDBLOCK) {
+			if (err != EWOULDBLOCK && err != EAGAIN) {
 				/* Something went wrong... (ECONNRESET is connection reset by peer) */
 				if (err != ECONNRESET) DEBUG(net, 0, "recv failed with error %s", NetworkGetErrorString(err));
 				return -1;


### PR DESCRIPTION
## Motivation / Problem

When calling send or receive on a non-blocking socket, we only check for EWOULDBLOCK for partial completion, even though POSIX mandates that the call could return either EWOULDBLOCK or EAGAIN. This means that on certain operating systems that return EAGAIN from these functions (and don't define them as being the same error code), all of the TCP code would be broken.

## Description

We check whether errno is set to EWOULDBLOCK or EAGAIN, instead of just EWOULDBLOCK.

## Limitations

I believe I've fixed every bit of code that uses EWOULDBLOCK/EAGAIN in this project. General POSIX compatibility may still be unsolved. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
