### PR TITLE
Support NewGRF cargoes with default vehicles

### DIFF
--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -61,6 +61,7 @@ enum CargoType {
 	CT_PLASTIC      = 10,
 	CT_FIZZY_DRINKS = 11,
 
+	NUM_ORIGINAL_CARGO = 12,
 	NUM_CARGO       = 64,   ///< Maximal number of cargo types in a game.
 
 	CT_AUTO_REFIT   = 0xFD, ///< Automatically choose cargo type when doing auto refitting.

--- a/src/cargotype.cpp
+++ b/src/cargotype.cpp
@@ -78,6 +78,28 @@ void SetupCargoForClimate(LandscapeID l)
 }
 
 /**
+ * Get the cargo ID of a default cargo, if present.
+ * @param l Landscape
+ * @param ct Default cargo type.
+ * @return ID number if the cargo exists, else #CT_INVALID
+ */
+CargoID GetDefaultCargoID(LandscapeID l, CargoType ct)
+{
+	assert(l < lengthof(_default_climate_cargo));
+
+	if (ct == CT_INVALID) return CT_INVALID;
+
+	assert(ct < lengthof(_default_climate_cargo[0]));
+	CargoLabel cl = _default_climate_cargo[l][ct];
+	/* Bzzt: check if cl is just an index into the cargo table */
+	if (cl < lengthof(_default_cargo)) {
+		cl = _default_cargo[cl].label;
+	}
+
+	return GetCargoIDByLabel(cl);
+}
+
+/**
  * Get the cargo ID by cargo label.
  * @param cl Cargo type to get.
  * @return ID number if the cargo exists, else #CT_INVALID

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -177,6 +177,7 @@ extern CargoTypes _standard_cargo_mask;
 void SetupCargoForClimate(LandscapeID l);
 CargoID GetCargoIDByLabel(CargoLabel cl);
 CargoID GetCargoIDByBitnum(uint8 bitnum);
+CargoID GetDefaultCargoID(LandscapeID l, CargoType ct);
 
 void InitializeSortedCargoSpecs();
 extern std::vector<const CargoSpec *> _sorted_cargo_specs;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8755,64 +8755,115 @@ GRFFile::~GRFFile()
 
 
 /**
- * List of what cargo labels are refittable for the given the vehicle-type.
- * Only currently active labels are applied.
- */
-static const CargoLabel _default_refitmasks_rail[] = {
-	'PASS', 'COAL', 'MAIL', 'LVST', 'GOOD', 'GRAI', 'WHEA', 'MAIZ', 'WOOD',
-	'IORE', 'STEL', 'VALU', 'GOLD', 'DIAM', 'PAPR', 'FOOD', 'FRUT', 'CORE',
-	'WATR', 'SUGR', 'TOYS', 'BATT', 'SWET', 'TOFF', 'COLA', 'CTCD', 'BUBL',
-	'PLST', 'FZDR',
-	0 };
-
-static const CargoLabel _default_refitmasks_road[] = {
-	0 };
-
-static const CargoLabel _default_refitmasks_ships[] = {
-	'COAL', 'MAIL', 'LVST', 'GOOD', 'GRAI', 'WHEA', 'MAIZ', 'WOOD', 'IORE',
-	'STEL', 'VALU', 'GOLD', 'DIAM', 'PAPR', 'FOOD', 'FRUT', 'CORE', 'WATR',
-	'RUBR', 'SUGR', 'TOYS', 'BATT', 'SWET', 'TOFF', 'COLA', 'CTCD', 'BUBL',
-	'PLST', 'FZDR',
-	0 };
-
-static const CargoLabel _default_refitmasks_aircraft[] = {
-	'PASS', 'MAIL', 'GOOD', 'VALU', 'GOLD', 'DIAM', 'FOOD', 'FRUT', 'SUGR',
-	'TOYS', 'BATT', 'SWET', 'TOFF', 'COLA', 'CTCD', 'BUBL', 'PLST', 'FZDR',
-	0 };
-
-static const CargoLabel * const _default_refitmasks[] = {
-	_default_refitmasks_rail,
-	_default_refitmasks_road,
-	_default_refitmasks_ships,
-	_default_refitmasks_aircraft,
-};
-
-
-/**
  * Precalculate refit masks from cargo classes for all vehicles.
  */
 static void CalculateRefitMasks()
 {
+	CargoTypes original_known_cargoes = 0;
+	for (int ct = 0; ct != NUM_ORIGINAL_CARGO; ++ct) {
+		CargoID cid = GetDefaultCargoID(_settings_game.game_creation.landscape, static_cast<CargoType>(ct));
+		if (cid != CT_INVALID) SetBit(original_known_cargoes, cid);
+	}
+
 	for (Engine *e : Engine::Iterate()) {
 		EngineID engine = e->index;
 		EngineInfo *ei = &e->info;
 		bool only_defaultcargo; ///< Set if the vehicle shall carry only the default cargo
 
-		/* If the NewGRF did not set any cargo properties, we apply default cargo translation. */
+		/* If the NewGRF did not set any cargo properties, we apply default values. */
 		if (_gted[engine].defaultcargo_grf == nullptr) {
+			/* If the vehicle has any capacity, apply the default refit masks */
+			if (e->type != VEH_TRAIN || e->u.rail.capacity != 0) {
+				static constexpr byte T = 1 << LT_TEMPERATE;
+				static constexpr byte A = 1 << LT_ARCTIC;
+				static constexpr byte S = 1 << LT_TROPIC;
+				static constexpr byte Y = 1 << LT_TOYLAND;
+				static const struct DefaultRefitMasks {
+					byte climate;
+					CargoType cargo_type;
+					CargoTypes cargo_allowed;
+					CargoTypes cargo_disallowed;
+				} _default_refit_masks[] = {
+					{T | A | S | Y, CT_PASSENGERS, CC_PASSENGERS,               0},
+					{T | A | S    , CT_MAIL,       CC_MAIL,                     0},
+					{T | A | S    , CT_VALUABLES,  CC_ARMOURED,                 CC_LIQUID},
+					{            Y, CT_MAIL,       CC_MAIL | CC_ARMOURED,       CC_LIQUID},
+					{T | A        , CT_COAL,       CC_BULK,                     0},
+					{        S    , CT_COPPER_ORE, CC_BULK,                     0},
+					{            Y, CT_SUGAR,      CC_BULK,                     0},
+					{T | A | S    , CT_OIL,        CC_LIQUID,                   0},
+					{            Y, CT_COLA,       CC_LIQUID,                   0},
+					{T            , CT_GOODS,      CC_PIECE_GOODS | CC_EXPRESS, CC_LIQUID | CC_PASSENGERS},
+					{    A | S    , CT_GOODS,      CC_PIECE_GOODS | CC_EXPRESS, CC_LIQUID | CC_PASSENGERS | CC_REFRIGERATED},
+					{    A | S    , CT_FOOD,       CC_REFRIGERATED,             0},
+					{            Y, CT_CANDY,      CC_PIECE_GOODS | CC_EXPRESS, CC_LIQUID | CC_PASSENGERS},
+				};
+
+				if (e->type == VEH_AIRCRAFT) {
+					/* Aircraft default to "light" cargoes */
+					_gted[engine].cargo_allowed = CC_PASSENGERS | CC_MAIL | CC_ARMOURED | CC_EXPRESS;
+					_gted[engine].cargo_disallowed = CC_LIQUID;
+				} else if (e->type == VEH_SHIP) {
+					switch (ei->cargo_type) {
+						case CT_PASSENGERS:
+							/* Ferries */
+							_gted[engine].cargo_allowed = CC_PASSENGERS;
+							_gted[engine].cargo_disallowed = 0;
+							break;
+						case CT_OIL:
+							/* Tankers */
+							_gted[engine].cargo_allowed = CC_LIQUID;
+							_gted[engine].cargo_disallowed = 0;
+							break;
+						default:
+							/* Cargo ships */
+							if (_settings_game.game_creation.landscape == LT_TOYLAND) {
+								/* No tanker in toyland :( */
+								_gted[engine].cargo_allowed = CC_MAIL | CC_ARMOURED | CC_EXPRESS | CC_BULK | CC_PIECE_GOODS | CC_LIQUID;
+								_gted[engine].cargo_disallowed = CC_PASSENGERS;
+							} else {
+								_gted[engine].cargo_allowed = CC_MAIL | CC_ARMOURED | CC_EXPRESS | CC_BULK | CC_PIECE_GOODS;
+								_gted[engine].cargo_disallowed = CC_LIQUID | CC_PASSENGERS;
+							}
+							break;
+					}
+					e->u.ship.old_refittable = true;
+				} else if (e->type == VEH_TRAIN && e->u.rail.railveh_type != RAILVEH_WAGON) {
+					/* Train engines default to all cargoes, so you can build single-cargo consists with fast engines.
+					 * Trains loading multiple cargoes may start stations accepting unwanted cargoes. */
+					_gted[engine].cargo_allowed = CC_PASSENGERS | CC_MAIL | CC_ARMOURED | CC_EXPRESS | CC_BULK | CC_PIECE_GOODS | CC_LIQUID;
+					_gted[engine].cargo_disallowed = 0;
+				} else {
+					/* Train wagons and road vehicles are classified by their default cargo type */
+					for (const auto &drm : _default_refit_masks) {
+						if (!HasBit(drm.climate, _settings_game.game_creation.landscape)) continue;
+						if (drm.cargo_type != ei->cargo_type) continue;
+
+						_gted[engine].cargo_allowed = drm.cargo_allowed;
+						_gted[engine].cargo_disallowed = drm.cargo_disallowed;
+						break;
+					}
+
+					/* All original cargoes have specialised vehicles, so exclude them */
+					_gted[engine].ctt_exclude_mask = original_known_cargoes;
+				}
+			}
+			_gted[engine].UpdateRefittability(_gted[engine].cargo_allowed != 0);
+
 			/* Translate cargo_type using the original climate-specific cargo table. */
 			ei->cargo_type = GetDefaultCargoID(_settings_game.game_creation.landscape, static_cast<CargoType>(ei->cargo_type));
+			if (ei->cargo_type != CT_INVALID) ClrBit(_gted[engine].ctt_exclude_mask, ei->cargo_type);
 		}
 
-		/* Did the newgrf specify any refitting? If not, use defaults. */
-		if (_gted[engine].refittability != GRFTempEngineData::UNSET) {
+		/* Compute refittability */
+		{
 			CargoTypes mask = 0;
 			CargoTypes not_mask = 0;
 			CargoTypes xor_mask = ei->refit_mask;
 
 			/* If the original masks set by the grf are zero, the vehicle shall only carry the default cargo.
 			 * Note: After applying the translations, the vehicle may end up carrying no defined cargo. It becomes unavailable in that case. */
-			only_defaultcargo = _gted[engine].refittability == GRFTempEngineData::EMPTY;
+			only_defaultcargo = _gted[engine].refittability != GRFTempEngineData::NONEMPTY;
 
 			if (_gted[engine].cargo_allowed != 0) {
 				/* Build up the list of cargo types from the set cargo classes. */
@@ -8827,26 +8878,6 @@ static void CalculateRefitMasks()
 			/* Apply explicit refit includes/excludes. */
 			ei->refit_mask |= _gted[engine].ctt_include_mask;
 			ei->refit_mask &= ~_gted[engine].ctt_exclude_mask;
-		} else {
-			CargoTypes xor_mask = 0;
-
-			/* Don't apply default refit mask to wagons nor engines with no capacity */
-			if (e->type != VEH_TRAIN || (e->u.rail.capacity != 0 && e->u.rail.railveh_type != RAILVEH_WAGON)) {
-				const CargoLabel *cl = _default_refitmasks[e->type];
-				for (uint i = 0;; i++) {
-					if (cl[i] == 0) break;
-
-					CargoID cargo = GetCargoIDByLabel(cl[i]);
-					if (cargo == CT_INVALID) continue;
-
-					SetBit(xor_mask, cargo);
-				}
-			}
-
-			ei->refit_mask = xor_mask & _cargo_mask;
-
-			/* If the mask is zero, the vehicle shall only carry the default cargo */
-			only_defaultcargo = (ei->refit_mask == 0);
 		}
 
 		/* Clear invalid cargoslots (from default vehicles or pre-NewCargo GRFs) */

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8798,6 +8798,12 @@ static void CalculateRefitMasks()
 		EngineInfo *ei = &e->info;
 		bool only_defaultcargo; ///< Set if the vehicle shall carry only the default cargo
 
+		/* If the NewGRF did not set any cargo properties, we apply default cargo translation. */
+		if (_gted[engine].defaultcargo_grf == nullptr) {
+			/* Translate cargo_type using the original climate-specific cargo table. */
+			ei->cargo_type = GetDefaultCargoID(_settings_game.game_creation.landscape, static_cast<CargoType>(ei->cargo_type));
+		}
+
 		/* Did the newgrf specify any refitting? If not, use defaults. */
 		if (_gted[engine].refittability != GRFTempEngineData::UNSET) {
 			CargoTypes mask = 0;
@@ -8844,7 +8850,7 @@ static void CalculateRefitMasks()
 		}
 
 		/* Clear invalid cargoslots (from default vehicles or pre-NewCargo GRFs) */
-		if (!HasBit(_cargo_mask, ei->cargo_type)) ei->cargo_type = CT_INVALID;
+		if (ei->cargo_type != CT_INVALID && !HasBit(_cargo_mask, ei->cargo_type)) ei->cargo_type = CT_INVALID;
 
 		/* Ensure that the vehicle is either not refittable, or that the default cargo is one of the refittable cargoes.
 		 * Note: Vehicles refittable to no cargo are handle differently to vehicle refittable to a single cargo. The latter might have subtypes. */

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -96,7 +96,7 @@ static const CargoSpec _default_cargo[] = {
 
 
 /** Table of cargo types available in each climate, by default */
-static const CargoLabel _default_climate_cargo[NUM_LANDSCAPE][12] = {
+static const CargoLabel _default_climate_cargo[NUM_LANDSCAPE][NUM_ORIGINAL_CARGO] = {
 	{ 'PASS', 'COAL', 'MAIL', 'OIL_', 'LVST', 'GOOD', 'GRAI', 'WOOD', 'IORE', 'STEL', 'VALU',     33, },
 	{ 'PASS', 'COAL', 'MAIL', 'OIL_', 'LVST', 'GOOD', 'WHEA', 'WOOD',     34, 'PAPR', 'GOLD', 'FOOD', },
 	{ 'PASS', 'RUBR', 'MAIL',      4, 'FRUT', 'GOOD', 'MAIZ',     11, 'CORE', 'WATR', 'DIAM', 'FOOD', },


### PR DESCRIPTION
## Motivation / Problem

When players use a NewGRF industry set with new cargoes, but no vehicle NewGRF, there are some effects:
* Many cargoes cannot be transported.
* Train wagons, road vehicles and ships transport unsuitable cargoes by default, especially if not refittable.

This causes a lot of confusion amongst many new players, and a lot of annoyance for one NewGRF author.

## Description

The PR detects whether default vehicles are used, or whether default vehicles are only trivially modified by NewGRF (stuff like names, but not cargoes or refittability).

If this is the case:
* The default cargo type of vehicles is translated according to the original cargo tables. So a livestock wagon will transport livestock, no matter which cargo slot is used for livestock.
* If vehicles only transport default cargoes, which are removed/replaced by the industry NewGRF, the vehicle become unavailable.
* Refittabilty is defined by cargo classes and explicit lists for the default cargoes, just like NewGRF vehicles would do.

As a result:
* All cargoes are transportable via train/road/ship.
* Some cargoes are transportable via aircraft.

When a NewGRF defines the default cargo type and/or refittability of a vehicle, this PR changes nothing.

## Limitations

This PR changes the refittability of vehicles in vanilla, also when using only default vehicles and default industries/cargoes.
* This will break people's workflows.
* This affects savegames:
    * Vehicles in savegames keep their cargo type, even if no longer a refit option.
    * The cargo types for newly purchased vehicles change.
    * Refit orders and auto-renew breaks.

## Detail rules
* Aircraft are refittable to all passenger/mail/express/armoured cargoes, except liquids.
* Passenger ferries and busses are refittable to all passenger-like cargoes (e.g. also tourists).
* Oil tankers are refittable to all liquid cargoes, including water and rubber.
* Freight ships are refittable to all cargoes, except passengers or liquid.
* In toyland there is no oil tanker, so the toyland cargo ship transports also liquids.
* Train MUs are refittable to all cargoes. This allows to use these fast engines with all wagons, and still have a single-cargo consist. If the engines would not be refittable to everythnig, this makes stations accept unwanted cargoes.
* Coal/copper/sugar trucks/wagons are refittable to all bulk cargoes, unless there is a specialised default vehicle, so not iron ore, etc.
* Iron ore and grain trucks/wagons keep their specialised role, they are not refittable.
* Oil/cola trucks/wagons are refittable to all liquid cargoes, unless there is a specialised default vehicle, so not water, etc.
* Goods/candy trucks/wagons are refittable to all piece/express cargoes, except liquids and tourists.
  If arctic/tropic refrigerated cargoes are also excluded, they use the food wagon.
  Again, this catches only cargoes without specialised vehicles.
* Food trucks/wagons are refittable to all refrigerated cargoes, including liquids.
* Armoured trucks/wagons are refittable to all armoured cargoes. In toyland the mail truck/wagon takes over this role.

## Scenario: FIRS 4 'Basic Temperate'
* Milk is transportable by both oil and food trucks/wagons.
* Andy knows why Kaolin is both bulk and liquid.
* Ships
    * Oil tanker: Alcohol (default), Chemicals, Kaolin, Milk
    * Cargo ship: All but Passengers, Alcohol, Chemicals, Kaolin, Milk
    * Toyland cargo ship: All but Passengers
* Aircraft: Passengers, Mail, Engineering Supplies, Farm Supplies, Fish, Food, Fruit, Goods
* Temperate trains/road vehicles:
    * Coal trucks/wagons: Coal (default), Kaolin, Sand, Scrap Metal
    * Goods trucks/wagons: Engineering Supplies, Farm Supplies, Fish, Food, Fruit, Goods (default)
    * Oil trucks/wagons: Alcohol (default), Chemicals, Kaolin, Milk
    * Livestock trucks/wagons: Livestock only
    * Iron Ore trucks/wagons: Iron Ore only
    * Steel trucks/wagons: Steel only
    * Other trucks/wagons not available: Grain, Wood, Armoured
* Arctic trains/road vehicles:
    * Coal trucks/wagons: Coal (default), Iron Ore, Kaolin, Sand, Scrap Metal
    * Goods trucks/wagons: Engineering Supplies, Farm Supplies, Goods (default), Steel
    * Food trucks/wagons: Fish, Food, Fruit, Milk
    * Oil trucks/wagons: Alcohol (default), Chemicals, Kaolin, Milk
    * Livestock trucks/wagons: Livestock only
    * Other trucks/wagons not available: Oil, Grain, Wood, Armoured, Paper
* Tropic trains/road vehicles:
    * Copper Ore trucks/wagons: Coal (default), Iron Ore, Kaolin, Sand, Scrap Metal
    * Goods trucks/wagons: Engineering Supplies, Farm Supplies, Goods (default), Livestock, Steel
    * Food trucks/wagons: Fish, Food, Milk
    * Oil trucks/wagons: Alcohol (default), Chemicals, Kaolin, Milk
    * Fruit trucks/wagons: Fruit only
    * Other trucks/wagons not available: Grain, Wood, Armoured, Rubber, Water
* Toyland trains/road vehicles:
    * Sugar trucks/wagons: Coal (default), Iron Ore, Kaolin, Sand, Scrap Metal
    * Sweet trucks/wagons: Engineering Supplies, Farm Supplies, Fish, Food, Fruit, Goods (default), Livestock, Steel
    * Cola trucks/wagons: Alcohol (default), Chemicals, Kaolin, Milk
    * No other trucks/wagons available.

## Scenario: Vanilla, default vehicles, default cargoes
| Engine | OpenTTD 0.1 | OpenTTD 1.11 | this PR |
| --- | --- | --- | --- |
| Manley-Morel DMU and similar | Only Passengers | All but Oil | Everything |
| SH '125' | Only Mail | All but Oil | Everything |
| Aircraft | All but Mail, Oil, Rubber, Tropic Food | Passengers, Mail, Food, Fruit, Goods, Valuables, Gold, Diamonds, All Toyland Stuff | Passengers, Mail, Food, Fruit, Goods, Valuables, Gold, Diamonds, Sweets |
| Oil Tanker | Oil | Oil | Oil, Rubber, Water |
| Cargo Ship | All (including water) but Passenger, Oil, Rubber, Tropic Food | All but Passenger, Oil | All but Passenger, Oil, Rubber, Water |

So, wrt. savegames this affects:
* Aircraft in toyland transporting non-passengers.
* Ships in tropic transporting water or rubber.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
