### PR TITLE
Codechange: Replace more FOR_ALL_XXX macros with range-based for loops

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1345,12 +1345,12 @@ static uint ScanPath(FileScanner *fs, const char *extension, const char *path, s
  * @param extension the extension of files to search for.
  * @param tar       the tar to search in.
  */
-static uint ScanTar(FileScanner *fs, const char *extension, TarFileList::iterator tar)
+static uint ScanTar(FileScanner *fs, const char *extension, const TarFileList::value_type &tar)
 {
 	uint num = 0;
-	const auto &filename = (*tar).first;
+	const auto &filename = tar.first;
 
-	if (MatchesExtension(extension, filename.c_str()) && fs->AddFile(filename, 0, (*tar).second.tar_filename)) num++;
+	if (MatchesExtension(extension, filename.c_str()) && fs->AddFile(filename, 0, tar.second.tar_filename)) num++;
 
 	return num;
 }
@@ -1369,7 +1369,6 @@ uint FileScanner::Scan(const char *extension, Subdirectory sd, bool tars, bool r
 	this->subdir = sd;
 
 	Searchpath sp;
-	TarFileList::iterator tar;
 	uint num = 0;
 
 	FOR_ALL_SEARCHPATHS(sp) {
@@ -1381,7 +1380,7 @@ uint FileScanner::Scan(const char *extension, Subdirectory sd, bool tars, bool r
 	}
 
 	if (tars && sd != NO_DIRECTORY) {
-		FOR_ALL_TARS(tar, sd) {
+		for (const auto &tar : _tar_filelist[sd]) {
 			num += ScanTar(this, extension, tar);
 		}
 	}

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -13,6 +13,7 @@
 #include "core/enum_type.hpp"
 #include "fileio_type.h"
 #include <string>
+#include <vector>
 
 void FioSeekTo(size_t pos, int mode);
 void FioSeekToFile(uint8 slot, size_t pos);
@@ -25,16 +26,6 @@ void FioCloseAll();
 void FioOpenFile(int slot, const std::string &filename, Subdirectory subdir);
 void FioReadBlock(void *ptr, size_t size);
 void FioSkipBytes(int n);
-
-/**
- * Checks whether the given search path is a valid search path
- * @param sp the search path to check
- * @return true if the search path is valid
- */
-bool IsValidSearchPath(Searchpath sp);
-
-/** Iterator for all the search paths */
-#define FOR_ALL_SEARCHPATHS(sp) for (sp = SP_FIRST_DIR; sp < NUM_SEARCHPATHS; sp++) if (IsValidSearchPath(sp))
 
 void FioFCloseFile(FILE *f);
 FILE *FioFOpenFile(const std::string &filename, const char *mode, Subdirectory subdir, size_t *filesize = nullptr);
@@ -54,6 +45,7 @@ bool FileExists(const std::string &filename);
 bool ExtractTar(const std::string &tar_filename, Subdirectory subdir);
 
 extern std::string _personal_dir; ///< custom directory for personal settings, saves, newgrf, etc.
+extern std::vector<Searchpath> _valid_searchpaths;
 
 /** Helper for scanning for files with a given name */
 class FileScanner {

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -582,8 +582,7 @@ static FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::s
 		 * collections of NewGRFs or 32 bpp graphics replacement PNGs.
 		 */
 		bool match = false;
-		Searchpath sp;
-		FOR_ALL_SEARCHPATHS(sp) {
+		for (Searchpath sp : _valid_searchpaths) {
 			std::string buf = FioGetDirectory(sp, HEIGHTMAP_DIR);
 
 			if (buf.compare(0, buf.size(), it->second.tar_filename, 0, buf.size()) == 0) {

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -249,16 +249,15 @@ GameStrings *LoadTranslations()
 		if (!tar_filename.empty() && (iter = _tar_list[GAME_DIR].find(tar_filename)) != _tar_list[GAME_DIR].end()) {
 			/* The main script is in a tar file, so find all files that
 			 * are in the same tar and add them to the langfile scanner. */
-			TarFileList::iterator tar;
-			FOR_ALL_TARS(tar, GAME_DIR) {
+			for (const auto &tar : _tar_filelist[GAME_DIR]) {
 				/* Not in the same tar. */
-				if (tar->second.tar_filename != iter->first) continue;
+				if (tar.second.tar_filename != iter->first) continue;
 
 				/* Check the path and extension. */
-				if (tar->first.size() <= ldir.size() || tar->first.compare(0, ldir.size(), ldir) != 0) continue;
-				if (tar->first.compare(tar->first.size() - 4, 4, ".txt") != 0) continue;
+				if (tar.first.size() <= ldir.size() || tar.first.compare(0, ldir.size(), ldir) != 0) continue;
+				if (tar.first.compare(tar.first.size() - 4, 4, ".txt") != 0) continue;
 
-				scanner.AddFile(tar->first, 0, tar_filename);
+				scanner.AddFile(tar.first, 0, tar_filename);
 			}
 		} else {
 			/* Scan filesystem */

--- a/src/road.h
+++ b/src/road.h
@@ -32,7 +32,7 @@ enum RoadTramTypes : uint8 {
 };
 DECLARE_ENUM_AS_BIT_SET(RoadTramTypes)
 
-#define FOR_ALL_ROADTRAMTYPES(x) for (RoadTramType x : { RTT_ROAD, RTT_TRAM })
+static const RoadTramType _roadtramtypes[] = { RTT_ROAD, RTT_TRAM };
 
 /** Roadtype flags. Starts with RO instead of R because R is used for rails */
 enum RoadTypeFlags {

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1238,7 +1238,7 @@ static CommandCost ClearTile_Road(TileIndex tile, DoCommandFlag flags)
 			/* Clear the road if only one piece is on the tile OR we are not using the DC_AUTO flag */
 			if ((HasExactlyOneBit(b) && GetRoadBits(tile, RTT_TRAM) == ROAD_NONE) || !(flags & DC_AUTO)) {
 				CommandCost ret(EXPENSES_CONSTRUCTION);
-				FOR_ALL_ROADTRAMTYPES(rtt) {
+				for (RoadTramType rtt : _roadtramtypes) {
 					if (!MayHaveRoad(tile) || GetRoadType(tile, rtt) == INVALID_ROADTYPE) continue;
 
 					CommandCost tmp_ret = RemoveRoad(tile, flags, GetRoadBits(tile, rtt), rtt, true);
@@ -2203,7 +2203,7 @@ static void ChangeTileOwner_Road(TileIndex tile, Owner old_owner, Owner new_owne
 				Company::Get(new_owner)->infrastructure.road[rt] += 2;
 
 				SetTileOwner(tile, new_owner);
-				FOR_ALL_ROADTRAMTYPES(rtt) {
+				for (RoadTramType rtt : _roadtramtypes) {
 					if (GetRoadOwner(tile, rtt) == old_owner) {
 						SetRoadOwner(tile, rtt, new_owner);
 					}
@@ -2213,7 +2213,7 @@ static void ChangeTileOwner_Road(TileIndex tile, Owner old_owner, Owner new_owne
 		return;
 	}
 
-	FOR_ALL_ROADTRAMTYPES(rtt) {
+	for (RoadTramType rtt : _roadtramtypes) {
 		/* Update all roadtypes, no matter if they are present */
 		if (GetRoadOwner(tile, rtt) == old_owner) {
 			RoadType rt = GetRoadType(tile, rtt);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1854,7 +1854,7 @@ bool AfterLoadGame()
 				}
 			} else if (IsTileType(t, MP_ROAD)) {
 				/* works for all RoadTileType */
-				FOR_ALL_ROADTRAMTYPES(rtt) {
+				for (RoadTramType rtt : _roadtramtypes) {
 					/* update even non-existing road types to update tile owner too */
 					Owner o = GetRoadOwner(t, rtt);
 					if (o < MAX_COMPANIES && !Company::IsValidID(o)) SetRoadOwner(t, rtt, OWNER_NONE);

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -128,7 +128,7 @@ void AfterLoadCompanyStats()
 				}
 
 				/* Iterate all present road types as each can have a different owner. */
-				FOR_ALL_ROADTRAMTYPES(rtt) {
+				for (RoadTramType rtt : _roadtramtypes) {
 					RoadType rt = GetRoadType(tile, rtt);
 					if (rt == INVALID_ROADTYPE) continue;
 					c = Company::GetIfValid(IsRoadDepot(tile) ? GetTileOwner(tile) : GetRoadOwner(tile, rtt));
@@ -151,7 +151,7 @@ void AfterLoadCompanyStats()
 					case STATION_BUS:
 					case STATION_TRUCK: {
 						/* Iterate all present road types as each can have a different owner. */
-						FOR_ALL_ROADTRAMTYPES(rtt) {
+						for (RoadTramType rtt : _roadtramtypes) {
 							RoadType rt = GetRoadType(tile, rtt);
 							if (rt == INVALID_ROADTYPE) continue;
 							c = Company::GetIfValid(GetRoadOwner(tile, rtt));
@@ -209,7 +209,7 @@ void AfterLoadCompanyStats()
 
 						case TRANSPORT_ROAD: {
 							/* Iterate all present road types as each can have a different owner. */
-							FOR_ALL_ROADTRAMTYPES(rtt) {
+							for (RoadTramType rtt : _roadtramtypes) {
 								RoadType rt = GetRoadType(tile, rtt);
 								if (rt == INVALID_ROADTYPE) continue;
 								c = Company::GetIfValid(GetRoadOwner(tile, rtt));

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -116,8 +116,7 @@ bool ScriptInstance::LoadCompatibilityScripts(const char *api_version, Subdirect
 {
 	char script_name[32];
 	seprintf(script_name, lastof(script_name), "compat_%s.nut", api_version);
-	Searchpath sp;
-	FOR_ALL_SEARCHPATHS(sp) {
+	for (Searchpath sp : _valid_searchpaths) {
 		std::string buf = FioGetDirectory(sp, dir);
 		buf += script_name;
 		if (!FileExists(buf)) continue;

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -224,16 +224,15 @@ static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, S
 	if (!tar_filename.empty() && (iter = _tar_list[dir].find(tar_filename)) != _tar_list[dir].end()) {
 		/* The main script is in a tar file, so find all files that
 		 * are in the same tar and add them to the MD5 checksumming. */
-		TarFileList::iterator tar;
-		FOR_ALL_TARS(tar, dir) {
+		for (const auto &tar : _tar_filelist[dir]) {
 			/* Not in the same tar. */
-			if (tar->second.tar_filename != iter->first) continue;
+			if (tar.second.tar_filename != iter->first) continue;
 
 			/* Check the extension. */
-			const char *ext = strrchr(tar->first.c_str(), '.');
+			const char *ext = strrchr(tar.first.c_str(), '.');
 			if (ext == nullptr || strcasecmp(ext, ".nut") != 0) continue;
 
-			checksum.AddFile(tar->first, 0, tar_filename);
+			checksum.AddFile(tar.first, 0, tar_filename);
 		}
 	} else {
 		char path[MAX_PATH];

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2029,7 +2029,7 @@ static CommandCost RemoveRoadStop(TileIndex tile, DoCommandFlag flags)
 		}
 
 		/* Update company infrastructure counts. */
-		FOR_ALL_ROADTRAMTYPES(rtt) {
+		for (RoadTramType rtt : _roadtramtypes) {
 			RoadType rt = GetRoadType(tile, rtt);
 			UpdateCompanyRoadInfrastructure(rt, GetRoadOwner(tile, rtt), -static_cast<int>(ROAD_STOP_TRACKBIT_FACTOR));
 		}
@@ -2110,7 +2110,7 @@ CommandCost CmdRemoveRoadStop(TileIndex tile, DoCommandFlag flags, uint32 p1, ui
 		RoadType road_type[] = { INVALID_ROADTYPE, INVALID_ROADTYPE };
 		Owner road_owner[] = { OWNER_NONE, OWNER_NONE };
 		if (IsDriveThroughStopTile(cur_tile)) {
-			FOR_ALL_ROADTRAMTYPES(rtt) {
+			for (RoadTramType rtt : _roadtramtypes) {
 				road_type[rtt] = GetRoadType(cur_tile, rtt);
 				if (road_type[rtt] == INVALID_ROADTYPE) continue;
 				road_owner[rtt] = GetRoadOwner(cur_tile, rtt);
@@ -4179,7 +4179,7 @@ void DeleteOilRig(TileIndex tile)
 static void ChangeTileOwner_Station(TileIndex tile, Owner old_owner, Owner new_owner)
 {
 	if (IsRoadStopTile(tile)) {
-		FOR_ALL_ROADTRAMTYPES(rtt) {
+		for (RoadTramType rtt : _roadtramtypes) {
 			/* Update all roadtypes, no matter if they are present */
 			if (GetRoadOwner(tile, rtt) == old_owner) {
 				RoadType rt = GetRoadType(tile, rtt);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1949,9 +1949,7 @@ static void GetLanguageList(const char *path)
  */
 void InitializeLanguagePacks()
 {
-	Searchpath sp;
-
-	FOR_ALL_SEARCHPATHS(sp) {
+	for (Searchpath sp : _valid_searchpaths) {
 		std::string path = FioGetDirectory(sp, LANG_DIR);
 		GetLanguageList(path.c_str());
 	}

--- a/src/tar_type.h
+++ b/src/tar_type.h
@@ -28,6 +28,4 @@ typedef std::map<std::string, TarFileListEntry> TarFileList;
 extern std::array<TarList, NUM_SUBDIRS> _tar_list;
 extern TarFileList _tar_filelist[NUM_SUBDIRS];
 
-#define FOR_ALL_TARS(tar, sd) for (tar = _tar_filelist[sd].begin(); tar != _tar_filelist[sd].end(); tar++)
-
 #endif /* TAR_TYPE_H */

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1811,7 +1811,7 @@ static void ChangeTileOwner_TunnelBridge(TileIndex tile, Owner old_owner, Owner 
 	 * don't want to update the infrastructure counts twice. */
 	uint num_pieces = tile < other_end ? (GetTunnelBridgeLength(tile, other_end) + 2) * TUNNELBRIDGE_TRACKBIT_FACTOR : 0;
 
-	FOR_ALL_ROADTRAMTYPES(rtt) {
+	for (RoadTramType rtt : _roadtramtypes) {
 		/* Update all roadtypes, no matter if they are present */
 		if (GetRoadOwner(tile, rtt) == old_owner) {
 			RoadType rt = GetRoadType(tile, rtt);


### PR DESCRIPTION
## Motivation / Problem
Continuing to reduce the number of FOR_XXX macro when it's possible.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
`FOR_ALL_TARS` was a basic iteration using `_tar_filelist[sd].begin()` and `_tar_filelist[sd].end()`, so I just replaced all usage by direct range-based for loops using `_tar_filelist[sd]`.
`FOR_ALL_SEARCHPATHS` was iterating all the `Searchpath` enum, skipping empty searchpaths. As all these searchpaths are set only once in `DeterminePaths()`, I think it's simpler to just store valid searchpaths once they're set, and then use this stored value directly in for loops.
`FOR_ALL_ROADTRAMTYPES` is a range-based for loop with direct initialisation in the macro. It's better to add a static array with the 2 values, and use that in explicit for loops.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
