### PR TITLE
Fix: Correct minimum CMake version to 3.12, as it is actually required since d4f0b6f43

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT BINARY_NAME)
     set(BINARY_NAME openttd)


### PR DESCRIPTION
## Motivation / Problem

Builds with incorrect _openttd_newgrf_version value are being made with CMake older than 3.12, because CMAKE_PROJECT_VERSION_MAJOR/etc. is utilized since d4f0b6f43.

## Description

Bump minimum version to prevent silently making broken builds.

## Limitations

Users of old distros will complain?