### PR TITLE
Fix: MakeScreenshot could crash when called from outside of VideoDriver::Tick, and acquire video buffer before taking game state lock to prevent erratic fast forward

### DIFF
--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -906,7 +906,7 @@ void MakeScreenshotWithConfirm(ScreenshotType t)
  */
 bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width, uint32 height)
 {
-	VideoDriver::VideoBufferLocker lock;
+	VideoDriver::VideoBufferPauseLockGuard video_lock;
 
 	if (t == SC_VIEWPORT) {
 		/* First draw the dirty parts of the screen and only then change the name

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -272,7 +272,7 @@ void VideoDriver_CocoaOpenGL::AllocateBackingStore(bool force)
 	CGLSetCurrentContext(this->gl_context);
 	NSRect frame = [ this->cocoaview getRealRect:[ this->cocoaview frame ] ];
 	OpenGLBackend::Get()->Resize(frame.size.width, frame.size.height, force);
-	if (this->buffer_locked) _screen.dst_ptr = this->GetVideoPointer();
+	if (this->buffer_lock > 0) _screen.dst_ptr = this->GetVideoPointer();
 	this->dirty_rect = {};
 
 	/* Redraw screen */

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -57,12 +57,12 @@ public:
 
 protected:
 	Rect dirty_rect;    ///< Region of the screen that needs redrawing.
-	bool buffer_locked; ///< Video buffer was locked by the main thread.
+	int buffer_lock;    ///< How many times the video buffer was locked by the current thread.
 
 	Dimension GetScreenSize() const override;
 	float GetDPIScale() override;
 	void InputLoop() override;
-	bool LockVideoBuffer() override;
+	void LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
 	bool PollEvent() override;
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -85,7 +85,7 @@ static const Dimension _default_resolutions[] = {
 VideoDriver_Cocoa::VideoDriver_Cocoa()
 {
 	this->setup         = false;
-	this->buffer_locked = false;
+	this->buffer_lock   = 0;
 
 	this->window    = nil;
 	this->cocoaview = nil;
@@ -269,27 +269,24 @@ float VideoDriver_Cocoa::GetDPIScale()
 }
 
 /** Lock video buffer for drawing if it isn't already mapped. */
-bool VideoDriver_Cocoa::LockVideoBuffer()
+void VideoDriver_Cocoa::LockVideoBuffer()
 {
-	if (this->buffer_locked) return false;
-	this->buffer_locked = true;
+	if (this->buffer_lock++ > 0) return;
 
 	_screen.dst_ptr = this->GetVideoPointer();
 	assert(_screen.dst_ptr != nullptr);
-
-	return true;
 }
 
 /** Unlock video buffer. */
 void VideoDriver_Cocoa::UnlockVideoBuffer()
 {
+	if (--this->buffer_lock > 0) return;
+
 	if (_screen.dst_ptr != nullptr) {
 		/* Hand video buffer back to the drawing backend. */
 		this->ReleaseVideoPointer();
 		_screen.dst_ptr = nullptr;
 	}
-
-	this->buffer_locked = false;
 }
 
 /**

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -716,24 +716,21 @@ Dimension VideoDriver_SDL_Base::GetScreenSize() const
 	return { static_cast<uint>(mode.w), static_cast<uint>(mode.h) };
 }
 
-bool VideoDriver_SDL_Base::LockVideoBuffer()
+void VideoDriver_SDL_Base::LockVideoBuffer()
 {
-	if (this->buffer_locked) return false;
-	this->buffer_locked = true;
+	if (this->buffer_lock++ > 0) return;
 
 	_screen.dst_ptr = this->GetVideoPointer();
 	assert(_screen.dst_ptr != nullptr);
-
-	return true;
 }
 
 void VideoDriver_SDL_Base::UnlockVideoBuffer()
 {
+	if (--this->buffer_lock > 0) return;
+
 	if (_screen.dst_ptr != nullptr) {
 		/* Hand video buffer back to the drawing backend. */
 		this->ReleaseVideoPointer();
 		_screen.dst_ptr = nullptr;
 	}
-
-	this->buffer_locked = false;
 }

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -17,7 +17,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL_Base : public VideoDriver {
 public:
-	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false) {}
+	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_lock(0) {}
 
 	const char *Start(const StringList &param) override;
 
@@ -46,12 +46,12 @@ public:
 protected:
 	struct SDL_Window *sdl_window; ///< Main SDL window.
 	Palette local_palette; ///< Copy of _cur_palette.
-	bool buffer_locked; ///< Video buffer was locked by the main thread.
+	int buffer_lock; ///< How many times the video buffer was locked by the current thread.
 	Rect dirty_rect; ///< Rectangle encompassing the dirty area of the video buffer.
 
 	Dimension GetScreenSize() const override;
 	void InputLoop() override;
-	bool LockVideoBuffer() override;
+	void LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
 	void CheckPaletteAnim() override;
 	bool PollEvent() override;

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -152,12 +152,14 @@ void VideoDriver::Tick()
 			this->fast_forward_via_key = false;
 		}
 
+		/* Locking video buffer can block (especially with vsync enabled), do it before taking game state lock. */
+		std::lock_guard<std::recursive_mutex> lock_video(this->video_buffer_mutex);
+		this->LockVideoBuffer();
+
 		{
 			/* Tell the game-thread to stop so we can have a go. */
 			std::lock_guard<std::mutex> lock_wait(this->game_thread_wait_mutex);
 			std::lock_guard<std::mutex> lock_state(this->game_state_mutex);
-
-			this->LockVideoBuffer();
 
 			if (this->change_blitter != nullptr) {
 				this->RealChangeBlitter(this->change_blitter);
@@ -180,6 +182,8 @@ void VideoDriver::Tick()
 
 		this->UnlockVideoBuffer();
 	}
+
+	std::lock_guard<std::mutex> lock_yield(this->draw_yield_mutex);
 }
 
 void VideoDriver::SleepTillNextTick()

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -979,27 +979,24 @@ float VideoDriver_Win32Base::GetDPIScale()
 	return cur_dpi > 0 ? cur_dpi / 96.0f : 1.0f; // Default Windows DPI value is 96.
 }
 
-bool VideoDriver_Win32Base::LockVideoBuffer()
+void VideoDriver_Win32Base::LockVideoBuffer()
 {
-	if (this->buffer_locked) return false;
-	this->buffer_locked = true;
+	if (this->buffer_lock++ > 0) return;
 
 	_screen.dst_ptr = this->GetVideoPointer();
 	assert(_screen.dst_ptr != nullptr);
-
-	return true;
 }
 
 void VideoDriver_Win32Base::UnlockVideoBuffer()
 {
+	if (--this->buffer_lock > 0) return;
+
 	assert(_screen.dst_ptr != nullptr);
 	if (_screen.dst_ptr != nullptr) {
 		/* Hand video buffer back to the drawing backend. */
 		this->ReleaseVideoPointer();
 		_screen.dst_ptr = nullptr;
 	}
-
-	this->buffer_locked = false;
 }
 
 

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -17,7 +17,7 @@
 /** Base class for Windows video drivers. */
 class VideoDriver_Win32Base : public VideoDriver {
 public:
-	VideoDriver_Win32Base() : main_wnd(nullptr), fullscreen(false), buffer_locked(false) {}
+	VideoDriver_Win32Base() : main_wnd(nullptr), fullscreen(false) {}
 
 	void Stop() override;
 
@@ -45,12 +45,12 @@ protected:
 	int width_org = 0;      ///< Original monitor resolution width, before we changed it.
 	int height_org = 0;     ///< Original monitor resolution height, before we changed it.
 
-	bool buffer_locked;     ///< Video buffer was locked by the main thread.
+	int buffer_lock = 0;    ///< How many times the video buffer was locked by the current thread.
 
 	Dimension GetScreenSize() const override;
 	float GetDPIScale() override;
 	void InputLoop() override;
-	bool LockVideoBuffer() override;
+	void LockVideoBuffer() override;
 	void UnlockVideoBuffer() override;
 	void CheckPaletteAnim() override;
 	bool PollEvent() override;


### PR DESCRIPTION
Closes #9140, closes #9147.

## Motivation / Problem

While there was nothing wrong with #9140 itself, it was discovered that MakeScreenshot locking is broken anyway, as described in #9147.

## Description

This attempts to fix the issue by adding yield mutex for draw thread, recursive mutex for video buffer and slightly awry locking sequence in MakeScreenshot. Because order of these locking operations interacts with #9140 this cannot be easily split into two commits, so it is already integrated with previous PR.

## Limitations

I'm not too happy about the complexity of this, maybe it is just better to disallow screenshots from rcon when real video driver is loaded...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
