### PR TITLE
Codechange: Scale sprite font size once.

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -428,14 +428,14 @@ void FreeTypeFontCache::SetFontSize(FontSize fs, FT_Face face, int pixels)
 {
 	if (pixels == 0) {
 		/* Try to determine a good height based on the minimal height recommended by the font. */
-		int scaled_height = ScaleFontTrad(_default_font_height[this->fs]);
+		int scaled_height = ScaleFontTrad(this->GetDefaultFontHeight(this->fs));
 		pixels = scaled_height;
 
 		TT_Header *head = (TT_Header *)FT_Get_Sfnt_Table(this->face, ft_sfnt_head);
 		if (head != nullptr) {
 			/* Font height is minimum height plus the difference between the default
 			 * height for this font size and the small size. */
-			int diff = scaled_height - ScaleFontTrad(_default_font_height[FS_SMALL]);
+			int diff = scaled_height - ScaleFontTrad(this->GetDefaultFontHeight(FS_SMALL));
 			pixels = Clamp(std::min<uint>(head->Lowest_Rec_PPEM, MAX_FONT_MIN_REC_SIZE) + diff, scaled_height, MAX_FONT_SIZE);
 		}
 	} else {

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -87,7 +87,6 @@ public:
 	virtual void ClearFontCache();
 	virtual const Sprite *GetGlyph(GlyphID key);
 	virtual uint GetGlyphWidth(GlyphID key);
-	virtual int GetHeight() const;
 	virtual bool GetDrawGlyphShadow();
 	virtual GlyphID MapCharToGlyph(WChar key) { assert(IsPrintable(key)); return SPRITE_GLYPH | key; }
 	virtual const void *GetFontTable(uint32 tag, size_t &length) { length = 0; return nullptr; }
@@ -102,6 +101,7 @@ public:
 SpriteFontCache::SpriteFontCache(FontSize fs) : FontCache(fs), glyph_to_spriteid_map(nullptr)
 {
 	this->InitializeUnicodeGlyphMap();
+	this->height = ScaleFontTrad(this->GetDefaultFontHeight(this->fs));
 }
 
 /**
@@ -177,6 +177,7 @@ void SpriteFontCache::ClearGlyphToSpriteMap()
 void SpriteFontCache::ClearFontCache()
 {
 	Layouter::ResetFontCache(this->fs);
+	this->height = ScaleFontTrad(this->GetDefaultFontHeight(this->fs));
 }
 
 const Sprite *SpriteFontCache::GetGlyph(GlyphID key)
@@ -191,11 +192,6 @@ uint SpriteFontCache::GetGlyphWidth(GlyphID key)
 	SpriteID sprite = this->GetUnicodeGlyph(key);
 	if (sprite == 0) sprite = this->GetUnicodeGlyph('?');
 	return SpriteExists(sprite) ? GetSprite(sprite, ST_FONT)->width + ScaleFontTrad(this->fs != FS_NORMAL ? 1 : 0) : 0;
-}
-
-int SpriteFontCache::GetHeight() const
-{
-	return ScaleFontTrad(this->height);
 }
 
 bool SpriteFontCache::GetDrawGlyphShadow()

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -45,7 +45,7 @@ public:
 	 * Get the height of the font.
 	 * @return The height of the font.
 	 */
-	virtual int GetHeight() const { return this->height; }
+	inline int GetHeight() const { return this->height; }
 
 	/**
 	 * Get the ascender value of the font.


### PR DESCRIPTION
## Motivation / Problem

Calling GetHeight() on a sprite font calls ScaleFontTrad() every time. This cascades back to all GetCharacterHeight(FS_xxx) and all FONT_HEIGHT_xxx calls.
Scaling is not expensive, but it does not change either -- the cache is reset if the zoom level is changed. This call is also a virtual method call.

## Description

The change sets the scaled font height once on init instead of every call to GetHeight(). This also avoids the need for GetHeight() to be a virtual method call. 

Also included slightly randomly is a clean up to remove a direct access to the _default_font_height array in the FreeTypeFontCache.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
