### PR TITLE
Fix #9152, #9153: screenshot command showed error messages when successful

### DIFF
--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -957,7 +957,7 @@ bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width, uint32 hei
 		if (t == SC_HEIGHTMAP) {
 			SetDParamStr(0, _screenshot_name);
 			SetDParam(1, _heightmap_highest_peak);
-			ShowErrorMessage(STR_MESSAGE_HEIGHTMAP_SUCCESSFULLY, INVALID_STRING_ID, WL_CRITICAL);
+			ShowErrorMessage(STR_MESSAGE_HEIGHTMAP_SUCCESSFULLY, INVALID_STRING_ID, WL_WARNING);
 		} else {
 			SetDParamStr(0, _screenshot_name);
 			ShowErrorMessage(STR_MESSAGE_SCREENSHOT_SUCCESSFULLY, INVALID_STRING_ID, WL_WARNING);


### PR DESCRIPTION
Closes #9152 
Closes #9153

## Motivation / Problem

See #9152, #9153


## Description

Change WL_CRITICAL to WL_WARNING for the `ShowErrorMessage` about the successful saving of the heightmap.


## Limitations

Conceptually `WL_INFO` should have been used as well as for the screenshot, but that removes the feedback to the console which might be considered an even bigger regression.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
