### PR TITLE
Fix #6598: prevent client crashes due to failing connects

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -901,8 +901,7 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 	/* Don't resolve the address first, just print it directly as it comes from the config file. */
 	IConsolePrintF(CC_DEFAULT, "Reconnecting to %s ...", _settings_client.network.last_joined);
 
-	NetworkClientConnectGame(_settings_client.network.last_joined, playas);
-	return true;
+	return NetworkClientConnectGame(_settings_client.network.last_joined, playas);
 }
 
 DEF_CONSOLE_CMD(ConNetworkConnect)
@@ -917,8 +916,7 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 	if (argc < 2) return false;
 	if (_networking) NetworkDisconnect(); // we are in network-mode, first close it!
 
-	NetworkClientConnectGame(argv[1], COMPANY_NEW_COMPANY);
-	return true;
+	return NetworkClientConnectGame(argv[1], COMPANY_NEW_COMPANY);
 }
 
 /*********************************

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -914,7 +914,6 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 	}
 
 	if (argc < 2) return false;
-	if (_networking) NetworkDisconnect(); // we are in network-mode, first close it!
 
 	return NetworkClientConnectGame(argv[1], COMPANY_NEW_COMPANY);
 }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -762,9 +762,9 @@ bool NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const 
 
 	strecpy(_settings_client.network.last_joined, address.GetAddressAsString(false).c_str(), lastof(_settings_client.network.last_joined));
 
-	_network_join_as = join_as;
-	_network_join_server_password = join_server_password;
-	_network_join_company_password = join_company_password;
+	_network_join.company = join_as;
+	_network_join.server_password = join_server_password;
+	_network_join.company_password = join_company_password;
 
 	NetworkDisconnect();
 	NetworkInitialize();

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -115,6 +115,7 @@ void NetworkClientSetCompanyPassword(const char *password);
 /** Information required to join a server. */
 struct NetworkJoinInfo {
 	NetworkJoinInfo() : company(COMPANY_SPECTATOR), server_password(nullptr), company_password(nullptr) {}
+	NetworkAddress address;       ///< The address of the server to join.
 	CompanyID company;            ///< The company to join.
 	const char *server_password;  ///< The password of the server to join.
 	const char *company_password; ///< The password of the company to join.

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -112,9 +112,14 @@ typedef ClientNetworkGameSocketHandler MyClient;
 void NetworkClient_Connected();
 void NetworkClientSetCompanyPassword(const char *password);
 
-extern CompanyID _network_join_as;
+/** Information required to join a server. */
+struct NetworkJoinInfo {
+	NetworkJoinInfo() : company(COMPANY_SPECTATOR), server_password(nullptr), company_password(nullptr) {}
+	CompanyID company;            ///< The company to join.
+	const char *server_password;  ///< The password of the server to join.
+	const char *company_password; ///< The password of the company to join.
+};
 
-extern const char *_network_join_server_password;
-extern const char *_network_join_company_password;
+extern NetworkJoinInfo _network_join;
 
 #endif /* NETWORK_CLIENT_H */

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -52,6 +52,7 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
 bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+void NetworkClientJoinGame();
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const char *msg, int64 data = 0);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -51,7 +51,7 @@ void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 
 void NetworkUpdateClientInfo(ClientID client_id);
 void NetworkClientsToSpectators(CompanyID cid);
-void NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
 void NetworkClientRequestMove(CompanyID company, const char *pass = "");
 void NetworkClientSendRcon(const char *password, const char *command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const char *msg, int64 data = 0);

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -119,7 +119,7 @@ StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkFindName(char *new_name, const char *last);
 const char *GenerateCompanyPasswordHash(const char *password, const char *password_server_id, uint32 password_game_seed);
 
-void NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
+bool NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
 NetworkAddress ParseConnectionString(const std::string &connection_string, int default_port);
 NetworkAddress ParseGameConnectionString(CompanyID *company, const std::string &connection_string, int default_port);
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1068,6 +1068,11 @@ void SwitchToMode(SwitchMode new_mode)
 			break;
 		}
 
+		case SM_JOIN_GAME: // Join a multiplayer game
+			LoadIntroGame();
+			NetworkClientJoinGame();
+			break;
+
 		case SM_MENU: // Switch to game intro menu
 			LoadIntroGame();
 			if (BaseSounds::ini_set.empty() && BaseSounds::GetUsedSet()->fallback && SoundDriver::GetInstance()->HasOutput()) {

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -36,6 +36,7 @@ enum SwitchMode {
 	SM_START_HEIGHTMAP,   ///< Load a heightmap and start a new game from it.
 	SM_LOAD_HEIGHTMAP,    ///< Load heightmap from scenario editor.
 	SM_RESTART_HEIGHTMAP, ///< Load a heightmap and start a new game from it with current settings.
+	SM_JOIN_GAME,         ///< Join a network game.
 };
 
 /** Display Options */


### PR DESCRIPTION
Closes #6598 

## Motivation / Problem

See #6598. Though the premise is, if you are in a network game and you use (re)connect from the console you can get into a weird limbo state when that attempt fails. This is mostly due to NetworkDisconnect closing/freeing things that might be used later, causing many potential places with reading invalid data.


## Description

The first step is to remove the NetworkDisconnect from the `connect` command. This solves all cases where a client tries to join an invalid company number.
The second step is more involved. Upon the join it checks whether the user is in main menu. When it is in the main menu, it will happily continue. When it is not in the main menu, it will load the main menu and trigger the join process to start.


## Limitations

Reconnect and connect from within a network game is now slower as it first needs to load the main menu.


## Backporting

Backport the following commits:
* Fix #6598: Do not disconnect before company number validation … -> should work without any extra effort
* Fix #6598: Prevent invalid memory accesses when abandoning a join fro… -> will cause conflicts, that require using the old `_network_join_...` variables and adding a `_network_join_address` variable that can be "local" to network.cpp. The strecpy with last_join should be kept out too.

Leave the following two commits out / do not backport:
* Change: [Console] Show help when passing invalid company number -> mostly required due to another change that is not in 1.11, which moved the validation out of the console command
* Codechange: Move join information into a single structure -> makes the code nicer/more maintainable, but not needed for the fix


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
