### PR TITLE
Fix: Don't consider regression AIs when starting a random AI

### DIFF
--- a/regression/regression/info.nut
+++ b/regression/regression/info.nut
@@ -7,6 +7,7 @@ class Regression extends AIInfo {
 	function GetAPIVersion()  { return "1.12"; }
 	function GetDate()        { return "2007-03-18"; }
 	function CreateInstance() { return "Regression"; }
+	function UseAsRandomAI()  { return false; }
 }
 
 RegisterAI(Regression());

--- a/regression/stationlist/info.nut
+++ b/regression/stationlist/info.nut
@@ -7,6 +7,7 @@ class StationList extends AIInfo {
 	function GetAPIVersion()  { return "1.12"; }
 	function GetDate()        { return "2007-03-18"; }
 	function CreateInstance() { return "StationList"; }
+	function UseAsRandomAI()  { return false; }
 }
 
 RegisterAI(StationList());


### PR DESCRIPTION
## Motivation / Problem
AIs used for regression tests can be chosen as random AI.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Set them to not being usable as random AI.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
