### PR TITLE
Fix 3d7ab09: stopped trains not updating viewport hash when reversed for a second time

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1639,13 +1639,19 @@ void Vehicle::UpdateBoundingBoxCoordinates(bool update_cache) const
  */
 void Vehicle::UpdateViewport(bool dirty)
 {
-	Rect old_coord = this->sprite_cache.old_coord;
+	/* If the existing cache is invalid we should ignore it, as it will be set to the current coords by UpdateBoundingBoxCoordinates */
+	bool ignore_cached_coords = this->sprite_cache.old_coord.left == INVALID_COORD;
 
 	this->UpdateBoundingBoxCoordinates(true);
-	UpdateVehicleViewportHash(this, this->coord.left, this->coord.top, old_coord.left, old_coord.top);
+
+	if (ignore_cached_coords) {
+		UpdateVehicleViewportHash(this, this->coord.left, this->coord.top, INVALID_COORD, INVALID_COORD);
+	} else {
+		UpdateVehicleViewportHash(this, this->coord.left, this->coord.top, this->sprite_cache.old_coord.left, this->sprite_cache.old_coord.top);
+	}
 
 	if (dirty) {
-		if (old_coord.left == INVALID_COORD) {
+		if (ignore_cached_coords) {
 			this->sprite_cache.is_viewport_candidate = this->MarkAllViewportsDirty();
 		} else {
 			this->sprite_cache.is_viewport_candidate = ::MarkAllViewportsDirty(


### PR DESCRIPTION
## Motivation / Problem

peter1138 found a problem while investigating a pathfinder issue, which is that stopped/stuck trains do not correctly update their viewport hash and thus partial sprite problems occur. Example image attached.

![example](https://user-images.githubusercontent.com/13691859/116783170-200c9580-aa85-11eb-8092-ddd6662d1526.gif)


## Description

The viewport hash calculation is set up to use the sprite cache from _before_ the most recent bounding box update. This was done to fix a specific problem:

- When the vehicle is first placed on the map, it has no valid sprite cache.
- A valid sprite cache is needed as a starting point, so in this case it is set to the current coordinates.
- Because this will result in a new vehicle having "no updates" (current position = cached position) and thus not getting a viewport hash calculated, the coordinates from before this update are used.
- In most situations the coordinates being one vehicle movement step out of date is not noticeable, all that happens is the dirty rectangle is slightly larger than necessary.
- However, when a vehicle is reversed twice without otherwise moving, the co-ordinates of the train's current position will match the co-ordinates of its position from 2 moves ago, not 1 move ago. This causes the viewport hash to become out of sync with the actual position of the vehicle, and thus vehicles to not be drawn when a region becomes dirty.

This fix corrects the problem by only using the "old" position in the one case it is actually needed, when it contains an invalid coordinate.

## Limitations

I've run my usual series of checks - against the game demonstrating the issue, against some Timberwolf's Trains games from the original PR, against the abuse.grf size-changing train, and against ships doing traversing through rotations of >180 degrees on the spot.

No regressions observed, although these are only visual checks against currently known scenarios.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
