### PR TITLE
Change: [Actions] Add a 2 minutes timeout for regression test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -143,7 +143,7 @@ jobs:
     - name: Test
       run: |
         cd build
-        ctest -j $(nproc)
+        ctest -j $(nproc) --timeout 120
 
   macos:
     name: Mac OS
@@ -224,7 +224,7 @@ jobs:
     - name: Test
       run: |
         cd build
-        ctest -j $(sysctl -n hw.logicalcpu)
+        ctest -j $(sysctl -n hw.logicalcpu) --timeout 120
 
   windows:
     name: Windows
@@ -314,4 +314,4 @@ jobs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}/build
-        ctest
+        ctest --timeout 120


### PR DESCRIPTION
## Motivation / Problem
When regression test triggers an infinite loop, it will run until GHA timeouts, blocking all queued runs for the same amount of time.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Adds a timeout for all tests, 2 minutes should be more than enough for each test to complete.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
