### PR TITLE
Fix #9147: Asynchronously do screenshots during draw tick.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1416,7 +1416,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 	ScreenshotType type = SC_VIEWPORT;
 	uint32 width = 0;
 	uint32 height = 0;
-	const char *name = nullptr;
+	std::string name{};
 	uint32 arg_index = 1;
 
 	if (argc > arg_index) {

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -244,6 +244,28 @@ static void LoadSpriteTables()
 }
 
 
+static void RealChangeBlitter(const char *repl_blitter)
+{
+	const char *cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
+	if (strcmp(cur_blitter, repl_blitter) == 0) return;
+
+	DEBUG(driver, 1, "Switching blitter from '%s' to '%s'... ", cur_blitter, repl_blitter);
+	Blitter *new_blitter = BlitterFactory::SelectBlitter(repl_blitter);
+	if (new_blitter == nullptr) NOT_REACHED();
+	DEBUG(driver, 1, "Successfully switched to %s.", repl_blitter);
+
+	if (!VideoDriver::GetInstance()->AfterBlitterChange()) {
+		/* Failed to switch blitter, let's hope we can return to the old one. */
+		if (BlitterFactory::SelectBlitter(cur_blitter) == nullptr || !VideoDriver::GetInstance()->AfterBlitterChange()) usererror("Failed to reinitialize video driver. Specify a fixed blitter in the config");
+	}
+
+	/* Clear caches that might have sprites for another blitter. */
+	VideoDriver::GetInstance()->ClearSystemSprites();
+	ClearFontCache();
+	GfxClearSpriteCache();
+	ReInitAllWindows(false);
+}
+
 /**
  * Check blitter needed by NewGRF config and switch if needed.
  * @return False when nothing changed, true otherwise.
@@ -309,7 +331,7 @@ static bool SwitchNewGRFBlitter()
 		if (BlitterFactory::GetBlitterFactory(repl_blitter) == nullptr) continue;
 
 		/* Inform the video driver we want to switch blitter as soon as possible. */
-		VideoDriver::GetInstance()->ChangeBlitter(repl_blitter);
+		VideoDriver::GetInstance()->QueueOnMainThread(std::bind(&RealChangeBlitter, repl_blitter));
 		break;
 	}
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -864,7 +864,7 @@ static ScreenshotType _confirmed_screenshot_type; ///< Screenshot type the curre
  */
 static void ScreenshotConfirmationCallback(Window *w, bool confirmed)
 {
-	if (confirmed) MakeScreenshot(_confirmed_screenshot_type, nullptr);
+	if (confirmed) MakeScreenshot(_confirmed_screenshot_type, {});
 }
 
 /**
@@ -890,24 +890,20 @@ void MakeScreenshotWithConfirm(ScreenshotType t)
 		ShowQuery(STR_WARNING_SCREENSHOT_SIZE_CAPTION, STR_WARNING_SCREENSHOT_SIZE_MESSAGE, nullptr, ScreenshotConfirmationCallback);
 	} else {
 		/* Less than 64M pixels, just do it */
-		MakeScreenshot(t, nullptr);
+		MakeScreenshot(t, {});
 	}
 }
 
 /**
  * Make a screenshot.
- * Unconditionally take a screenshot of the requested type.
  * @param t    the type of screenshot to make.
  * @param name the name to give to the screenshot.
  * @param width the width of the screenshot of, or 0 for current viewport width (only works for SC_ZOOMEDIN and SC_DEFAULTZOOM).
  * @param height the height of the screenshot of, or 0 for current viewport height (only works for SC_ZOOMEDIN and SC_DEFAULTZOOM).
  * @return true iff the screenshot was made successfully
- * @see MakeScreenshotWithConfirm
  */
-bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width, uint32 height)
+static bool RealMakeScreenshot(ScreenshotType t, std::string name, uint32 width, uint32 height)
 {
-	VideoDriver::VideoBufferLocker lock;
-
 	if (t == SC_VIEWPORT) {
 		/* First draw the dirty parts of the screen and only then change the name
 		 * of the screenshot. This way the screenshot will always show the name
@@ -918,7 +914,7 @@ bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width, uint32 hei
 	}
 
 	_screenshot_name[0] = '\0';
-	if (name != nullptr) strecpy(_screenshot_name, name, lastof(_screenshot_name));
+	if (!name.empty()) strecpy(_screenshot_name, name.c_str(), lastof(_screenshot_name));
 
 	bool ret;
 	switch (t) {
@@ -967,6 +963,32 @@ bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width, uint32 hei
 	}
 
 	return ret;
+}
+
+/**
+ * Schedule making a screenshot.
+ * Unconditionally take a screenshot of the requested type.
+ * @param t    the type of screenshot to make.
+ * @param name the name to give to the screenshot.
+ * @param width the width of the screenshot of, or 0 for current viewport width (only works for SC_ZOOMEDIN and SC_DEFAULTZOOM).
+ * @param height the height of the screenshot of, or 0 for current viewport height (only works for SC_ZOOMEDIN and SC_DEFAULTZOOM).
+ * @return true iff the screenshot was successfully made.
+ * @see MakeScreenshotWithConfirm
+ */
+bool MakeScreenshot(ScreenshotType t, std::string name, uint32 width, uint32 height)
+{
+	if (t == SC_CRASHLOG) {
+		/* Video buffer might or might not be locked. */
+		VideoDriver::VideoBufferLocker lock;
+
+		return RealMakeScreenshot(t, name, width, height);
+	}
+
+	VideoDriver::GetInstance()->QueueOnMainThread([=] { // Capture by value to not break scope.
+		RealMakeScreenshot(t, name, width, height);
+	});
+
+	return true;
 }
 
 

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -28,7 +28,7 @@ enum ScreenshotType {
 void SetupScreenshotViewport(ScreenshotType t, struct Viewport *vp, uint32 width = 0, uint32 height = 0);
 bool MakeHeightmapScreenshot(const char *filename);
 void MakeScreenshotWithConfirm(ScreenshotType t);
-bool MakeScreenshot(ScreenshotType t, const char *name, uint32 width = 0, uint32 height = 0);
+bool MakeScreenshot(ScreenshotType t, std::string name, uint32 width = 0, uint32 height = 0);
 bool MakeMinimapWorldScreenshot();
 
 extern char _screenshot_format_name[8];

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -97,27 +97,6 @@ void VideoDriver::StopGameThread()
 	this->game_thread.join();
 }
 
-void VideoDriver::RealChangeBlitter(const char *repl_blitter)
-{
-	const char *cur_blitter = BlitterFactory::GetCurrentBlitter()->GetName();
-
-	DEBUG(driver, 1, "Switching blitter from '%s' to '%s'... ", cur_blitter, repl_blitter);
-	Blitter *new_blitter = BlitterFactory::SelectBlitter(repl_blitter);
-	if (new_blitter == nullptr) NOT_REACHED();
-	DEBUG(driver, 1, "Successfully switched to %s.", repl_blitter);
-
-	if (!this->AfterBlitterChange()) {
-		/* Failed to switch blitter, let's hope we can return to the old one. */
-		if (BlitterFactory::SelectBlitter(cur_blitter) == nullptr || !this->AfterBlitterChange()) usererror("Failed to reinitialize video driver. Specify a fixed blitter in the config");
-	}
-
-	/* Clear caches that might have sprites for another blitter. */
-	this->ClearSystemSprites();
-	ClearFontCache();
-	GfxClearSpriteCache();
-	ReInitAllWindows(false);
-}
-
 void VideoDriver::Tick()
 {
 	if (!this->is_game_threaded && std::chrono::steady_clock::now() >= this->next_game_tick) {
@@ -159,10 +138,7 @@ void VideoDriver::Tick()
 
 			this->LockVideoBuffer();
 
-			if (this->change_blitter != nullptr) {
-				this->RealChangeBlitter(this->change_blitter);
-				this->change_blitter = nullptr;
-			}
+			this->DrainCommandQueue();
 
 			while (this->PollEvent()) {}
 			::InputLoop();

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <functional>
 
 extern std::string _ini_videodriver;
 extern std::vector<Dimension> _resolutions;
@@ -36,7 +37,7 @@ class VideoDriver : public Driver {
 	const uint DEFAULT_WINDOW_HEIGHT = 480u; ///< Default window height.
 
 public:
-	VideoDriver() : fast_forward_key_pressed(false), fast_forward_via_key(false), is_game_threaded(true), change_blitter(nullptr) {}
+	VideoDriver() : fast_forward_key_pressed(false), fast_forward_via_key(false), is_game_threaded(true) {}
 
 	/**
 	 * Mark a particular area dirty.
@@ -178,12 +179,16 @@ public:
 	}
 
 	/**
-	 * Queue a request to change the blitter. This is not executed immediately,
-	 * but instead on the next draw-tick.
+	 * Queue a function to be called on the main thread with game state
+	 * lock held and video buffer locked. Queued functions will be
+	 * executed on the next draw tick.
+	 * @param func Function to call.
 	 */
-	void ChangeBlitter(const char *new_blitter)
+	void QueueOnMainThread(std::function<void()> &&func)
 	{
-		this->change_blitter = new_blitter;
+		std::lock_guard<std::mutex> lock(this->cmd_queue_mutex);
+
+		this->cmd_queue.emplace_back(std::forward<std::function<void()>>(func));
 	}
 
 	void GameLoopPause();
@@ -328,11 +333,29 @@ protected:
 	static void GameThreadThunk(VideoDriver *drv);
 
 private:
+	std::mutex cmd_queue_mutex;
+	std::vector<std::function<void()>> cmd_queue;
+
+	/** Execute all queued commands. */
+	void DrainCommandQueue()
+	{
+		std::vector<std::function<void()>> cmds{};
+
+		{
+			/* Exchange queue with an empty one to limit the time we
+			 * hold the mutex. This also ensures that queued functions can
+			 * add new functions to the queue without everything blocking. */
+			std::lock_guard<std::mutex> lock(this->cmd_queue_mutex);
+			cmds.swap(this->cmd_queue);
+		}
+
+		for (auto &f : cmds) {
+			f();
+		}
+	}
+
 	void GameLoop();
 	void GameThread();
-	void RealChangeBlitter(const char *repl_blitter);
-
-	const char *change_blitter; ///< Request to change the blitter. nullptr if no pending request.
 };
 
 #endif /* VIDEO_VIDEO_DRIVER_HPP */


### PR DESCRIPTION
## Motivation / Problem

Screenshots can be triggered from the game thread (e.g. by using rcon). If an accelerated video driver is in use, this causes an illegal OpenGL access as the game thread has no OpenGL context.


## Description

Due to a similar problem, changing blitters was already delayed to be execute by the draw tick later on. This PR generalises this delay and uses it to move the actual screenshoting into the draw tick as well.

PR #9140 should be safe after this PR.

## Limitations

The screenshot contents will be the screen after the current game tick has computed. Before, if the screenshot was triggered by GUI input, it would capture the state before the game tick.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
