### PR TITLE
Fix: Update text effect size when font zoom is changed.

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -219,6 +219,7 @@ void UpdateAllVirtCoords()
 	UpdateAllStationVirtCoords();
 	UpdateAllSignVirtCoords();
 	UpdateAllTownVirtCoords();
+	UpdateAllTextEffectVirtCoords();
 	RebuildViewportKdtree();
 }
 

--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -73,7 +73,16 @@ void UpdateTextEffect(TextEffectID te_id, StringID msg)
 	te->params_1 = GetDParam(0);
 	te->params_2 = GetDParam(1);
 
-	te->UpdatePosition(te->center, te->top, msg);
+	te->UpdatePosition(te->center, te->top, te->string_id, te->string_id - 1);
+}
+
+void UpdateAllTextEffectVirtCoords()
+{
+	for (auto &te : _text_effects) {
+		SetDParam(0, te.params_1);
+		SetDParam(1, te.params_2);
+		te.UpdatePosition(te.center, te.top, te.string_id, te.string_id - 1);
+	}
 }
 
 void RemoveTextEffect(TextEffectID te_id)

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -32,6 +32,7 @@ void InitTextEffects();
 void DrawTextEffects(DrawPixelInfo *dpi);
 void UpdateTextEffect(TextEffectID effect_id, StringID msg);
 void RemoveTextEffect(TextEffectID effect_id);
+void UpdateAllTextEffectVirtCoords();
 
 /* misc_gui.cpp */
 TextEffectID ShowFillingPercent(int x, int y, int z, uint8 percent, StringID colour);


### PR DESCRIPTION
## Motivation / Problem

Text effects (income and loading indicators) are cropped if the font zoom is changed (and possibly also language)

## Description

This change updates the size of all text effects when all other viewport signs are being updated.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
