### PR TITLE
Fix: [Network] Reading beyond the length of the server's ID when hashing passwords

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -176,12 +176,15 @@ const char *GenerateCompanyPasswordHash(const char *password, const char *passwo
 	if (StrEmpty(password)) return password;
 
 	char salted_password[NETWORK_SERVER_ID_LENGTH];
+	size_t password_length = strlen(password);
+	size_t password_server_id_length = strlen(password_server_id);
 
-	memset(salted_password, 0, sizeof(salted_password));
-	seprintf(salted_password, lastof(salted_password), "%s", password);
 	/* Add the game seed and the server's ID as the salt. */
 	for (uint i = 0; i < NETWORK_SERVER_ID_LENGTH - 1; i++) {
-		salted_password[i] ^= password_server_id[i] ^ (password_game_seed >> (i % 32));
+		char password_char = (i < password_length ? password[i] : 0);
+		char server_id_char = (i < password_server_id_length ? password_server_id[i] : 0);
+		char seed_char = password_game_seed >> (i % 32);
+		salted_password[i] = password_char ^ server_id_char ^ seed_char;
 	}
 
 	Md5 checksum;


### PR DESCRIPTION
## Motivation / Problem

Under normal circumstances the server's ID is 32 characters excluding '\0', however this can be changed at the server. This ID is sent to the server for company name hashing. The client reads it into a statically allocated buffer of 33 bytes, but fills only the bytes it received from the server. However, the hash assumes all 33 bytes are set, thus potentially reading uninitialized data, or a part of the server ID of a previous game in the hashing routine.
It is still reading from memory assigned to the server ID, so nothing bad happens, except that company passwords might not work correctly.


## Description

Get the length of the network/server  ID string when hashing, and interpret anything after that length as '\0'.
Kept the result of the hashing the same, except when the overread would occur.


## Limitations

Xor-ing for salting is not a common practice anymore, usually strings are just appended after each other. I chose not to break those for now as that could break (custom) servers that save the company passwords locally, so it would be better to change the hashing logic when there is a way to denote versions/types of hashes.
Using std::string would make some things easier/nicer, but to be able to backport this I have done the minimal amount. I have a branch where it does convert it to std::string, but that requires many related commits so not suitable for a backport.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
