### PR TITLE
Add: std::string support to Packet

### DIFF
--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -178,12 +178,11 @@ void Packet::Send_uint64(uint64 data)
  * the string + '\0'. No size-byte or something.
  * @param data The string to send
  */
-void Packet::Send_string(const char *data)
+void Packet::Send_string(const std::string_view data)
 {
-	assert(data != nullptr);
-	/* Length of the string + 1 for the '\0' termination. */
-	assert(this->CanWriteToPacket(strlen(data) + 1));
-	while (this->buffer.emplace_back(*data++) != '\0') {}
+	assert(this->CanWriteToPacket(data.size() + 1));
+	this->buffer.insert(this->buffer.end(), data.begin(), data.end());
+	this->buffer.emplace_back('\0');
 }
 
 /**

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -71,7 +71,7 @@ public:
 	void   Send_uint16(uint16 data);
 	void   Send_uint32(uint32 data);
 	void   Send_uint64(uint64 data);
-	void   Send_string(const char *data);
+	void   Send_string(const std::string_view data);
 	size_t Send_bytes (const byte *begin, const byte *end);
 
 	/* Reading/receiving of packets */

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -88,6 +88,7 @@ public:
 	uint32 Recv_uint32();
 	uint64 Recv_uint64();
 	void   Recv_string(char *buffer, size_t size, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+	std::string Recv_string(size_t length, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 	size_t RemainingBytesToTransfer() const;
 


### PR DESCRIPTION
## Motivation / Problem

We are slowly moving away from C-strings to std::string. Packet is one of the low level elements that needs support, so std::string can be used in many other places in network code too.


## Description

Replace the send function with a variant using std::string_view, and add a new receive function that returns a std::string.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
