### PR TITLE
Codechange: Remove FOR_ALL_CHUNK_HANDLERS

### DIFF
--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -120,6 +120,8 @@ static void Save_AIPL()
 	}
 }
 
-extern const ChunkHandler _ai_chunk_handlers[] = {
-	{ 'AIPL', Save_AIPL, Load_AIPL, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler ai_chunk_handlers[] = {
+	{ 'AIPL', Save_AIPL, Load_AIPL, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _ai_chunk_handlers(ai_chunk_handlers);

--- a/src/saveload/airport_sl.cpp
+++ b/src/saveload/airport_sl.cpp
@@ -34,7 +34,9 @@ static void Load_ATID()
 	Load_NewGRFMapping(_airporttile_mngr);
 }
 
-extern const ChunkHandler _airport_chunk_handlers[] = {
+static const ChunkHandler airport_chunk_handlers[] = {
 	{ 'ATID', Save_ATID, Load_ATID, nullptr, nullptr, CH_ARRAY },
-	{ 'APID', Save_APID, Load_APID, nullptr, nullptr, CH_ARRAY | CH_LAST },
+	{ 'APID', Save_APID, Load_APID, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _airport_chunk_handlers(airport_chunk_handlers);

--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -55,6 +55,8 @@ static void Load_ANIT()
  * "Definition" imported by the saveload code to be able to load and save
  * the animated tile table.
  */
-extern const ChunkHandler _animated_tile_chunk_handlers[] = {
-	{ 'ANIT', Save_ANIT, Load_ANIT, nullptr, nullptr, CH_RIFF | CH_LAST},
+static const ChunkHandler animated_tile_chunk_handlers[] = {
+	{ 'ANIT', Save_ANIT, Load_ANIT, nullptr, nullptr, CH_RIFF },
 };
+
+extern const ChunkHandlerTable _animated_tile_chunk_handlers(animated_tile_chunk_handlers);

--- a/src/saveload/autoreplace_sl.cpp
+++ b/src/saveload/autoreplace_sl.cpp
@@ -55,6 +55,8 @@ static void Ptrs_ERNW()
 	}
 }
 
-extern const ChunkHandler _autoreplace_chunk_handlers[] = {
-	{ 'ERNW', Save_ERNW, Load_ERNW, Ptrs_ERNW, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler autoreplace_chunk_handlers[] = {
+	{ 'ERNW', Save_ERNW, Load_ERNW, Ptrs_ERNW, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _autoreplace_chunk_handlers(autoreplace_chunk_handlers);

--- a/src/saveload/cargomonitor_sl.cpp
+++ b/src/saveload/cargomonitor_sl.cpp
@@ -117,7 +117,9 @@ static void LoadPickup()
 }
 
 /** Chunk definition of the cargomonitoring maps. */
-extern const ChunkHandler _cargomonitor_chunk_handlers[] = {
-	{ 'CMDL', SaveDelivery, LoadDelivery, nullptr, nullptr, CH_ARRAY},
-	{ 'CMPU', SavePickup,   LoadPickup,   nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler cargomonitor_chunk_handlers[] = {
+	{ 'CMDL', SaveDelivery, LoadDelivery, nullptr, nullptr, CH_ARRAY },
+	{ 'CMPU', SavePickup,   LoadPickup,   nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _cargomonitor_chunk_handlers(cargomonitor_chunk_handlers);

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -126,6 +126,8 @@ static void Load_CAPA()
 }
 
 /** Chunk handlers related to cargo packets. */
-extern const ChunkHandler _cargopacket_chunk_handlers[] = {
-	{ 'CAPA', Save_CAPA, Load_CAPA, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler cargopacket_chunk_handlers[] = {
+	{ 'CAPA', Save_CAPA, Load_CAPA, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _cargopacket_chunk_handlers(cargopacket_chunk_handlers);

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -48,6 +48,8 @@ static void Load_CHTS()
 }
 
 /** Chunk handlers related to cheats. */
-extern const ChunkHandler _cheat_chunk_handlers[] = {
-	{ 'CHTS', Save_CHTS, Load_CHTS, nullptr, nullptr, CH_RIFF | CH_LAST},
+static const ChunkHandler cheat_chunk_handlers[] = {
+	{ 'CHTS', Save_CHTS, Load_CHTS, nullptr, nullptr, CH_RIFF },
 };
+
+extern const ChunkHandlerTable _cheat_chunk_handlers(cheat_chunk_handlers);

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -527,6 +527,8 @@ static void Ptrs_PLYR()
 }
 
 
-extern const ChunkHandler _company_chunk_handlers[] = {
-	{ 'PLYR', Save_PLYR, Load_PLYR, Ptrs_PLYR, Check_PLYR, CH_ARRAY | CH_LAST},
+static const ChunkHandler company_chunk_handlers[] = {
+	{ 'PLYR', Save_PLYR, Load_PLYR, Ptrs_PLYR, Check_PLYR, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _company_chunk_handlers(company_chunk_handlers);

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -56,6 +56,8 @@ static void Ptrs_DEPT()
 	}
 }
 
-extern const ChunkHandler _depot_chunk_handlers[] = {
-	{ 'DEPT', Save_DEPT, Load_DEPT, Ptrs_DEPT, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler depot_chunk_handlers[] = {
+	{ 'DEPT', Save_DEPT, Load_DEPT, Ptrs_DEPT, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _depot_chunk_handlers(depot_chunk_handlers);

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -94,9 +94,11 @@ static void Ptrs_CAPY()
 }
 
 
-extern const ChunkHandler _economy_chunk_handlers[] = {
-	{ 'CAPY', Save_CAPY,     Load_CAPY,     Ptrs_CAPY, nullptr, CH_ARRAY},
-	{ 'PRIC', nullptr,       Load_PRIC,     nullptr,   nullptr, CH_RIFF },
-	{ 'CAPR', nullptr,       Load_CAPR,     nullptr,   nullptr, CH_RIFF },
-	{ 'ECMY', Save_ECMY,     Load_ECMY,     nullptr,   nullptr, CH_RIFF | CH_LAST},
+static const ChunkHandler economy_chunk_handlers[] = {
+	{ 'CAPY', Save_CAPY, Load_CAPY, Ptrs_CAPY, nullptr, CH_ARRAY },
+	{ 'PRIC', nullptr,   Load_PRIC, nullptr,   nullptr, CH_RIFF  },
+	{ 'CAPR', nullptr,   Load_CAPR, nullptr,   nullptr, CH_RIFF  },
+	{ 'ECMY', Save_ECMY, Load_ECMY, nullptr,   nullptr, CH_RIFF  },
 };
+
+extern const ChunkHandlerTable _economy_chunk_handlers(economy_chunk_handlers);

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -193,8 +193,10 @@ static void Load_EIDS()
 	}
 }
 
-extern const ChunkHandler _engine_chunk_handlers[] = {
-	{ 'EIDS', Save_EIDS, Load_EIDS, nullptr, nullptr, CH_ARRAY          },
-	{ 'ENGN', Save_ENGN, Load_ENGN, nullptr, nullptr, CH_ARRAY          },
-	{ 'ENGS', nullptr,   Load_ENGS, nullptr, nullptr, CH_RIFF | CH_LAST },
+static const ChunkHandler engine_chunk_handlers[] = {
+	{ 'EIDS', Save_EIDS, Load_EIDS, nullptr, nullptr, CH_ARRAY },
+	{ 'ENGN', Save_ENGN, Load_ENGN, nullptr, nullptr, CH_ARRAY },
+	{ 'ENGS', nullptr,   Load_ENGS, nullptr, nullptr, CH_RIFF  },
 };
+
+extern const ChunkHandlerTable _engine_chunk_handlers(engine_chunk_handlers);

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -173,7 +173,9 @@ static void Save_GSTR()
 	}
 }
 
-extern const ChunkHandler _game_chunk_handlers[] = {
+static const ChunkHandler game_chunk_handlers[] = {
 	{ 'GSTR', Save_GSTR, Load_GSTR, nullptr, nullptr, CH_ARRAY },
-	{ 'GSDT', Save_GSDT, Load_GSDT, nullptr, nullptr, CH_ARRAY | CH_LAST},
+	{ 'GSDT', Save_GSDT, Load_GSDT, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _game_chunk_handlers(game_chunk_handlers);

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -168,6 +168,8 @@ static void Check_GLOG()
 	Load_GLOG_common(_load_check_data.gamelog_action, _load_check_data.gamelog_actions);
 }
 
-extern const ChunkHandler _gamelog_chunk_handlers[] = {
-	{ 'GLOG', Save_GLOG, Load_GLOG, nullptr, Check_GLOG, CH_RIFF | CH_LAST }
+static const ChunkHandler gamelog_chunk_handlers[] = {
+	{ 'GLOG', Save_GLOG, Load_GLOG, nullptr, Check_GLOG, CH_RIFF }
 };
+
+extern const ChunkHandlerTable _gamelog_chunk_handlers(gamelog_chunk_handlers);

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -40,6 +40,8 @@ static void Load_GOAL()
 	}
 }
 
-extern const ChunkHandler _goal_chunk_handlers[] = {
-	{ 'GOAL', Save_GOAL, Load_GOAL, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler goal_chunk_handlers[] = {
+	{ 'GOAL', Save_GOAL, Load_GOAL, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _goal_chunk_handlers(goal_chunk_handlers);

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -55,6 +55,8 @@ static void Load_GRPS()
 	}
 }
 
-extern const ChunkHandler _group_chunk_handlers[] = {
-	{ 'GRPS', Save_GRPS, Load_GRPS, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler group_chunk_handlers[] = {
+	{ 'GRPS', Save_GRPS, Load_GRPS, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _group_chunk_handlers(group_chunk_handlers);

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -176,10 +176,12 @@ static void Load_ITBL()
 	}
 }
 
-extern const ChunkHandler _industry_chunk_handlers[] = {
-	{ 'INDY', Save_INDY,     Load_INDY,     Ptrs_INDY, nullptr, CH_ARRAY},
-	{ 'IIDS', Save_IIDS,     Load_IIDS,     nullptr,   nullptr, CH_ARRAY},
-	{ 'TIDS', Save_TIDS,     Load_TIDS,     nullptr,   nullptr, CH_ARRAY},
-	{ 'IBLD', LoadSave_IBLD, LoadSave_IBLD, nullptr,   nullptr, CH_RIFF},
-	{ 'ITBL', Save_ITBL,     Load_ITBL,     nullptr,   nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler industry_chunk_handlers[] = {
+	{ 'INDY', Save_INDY,     Load_INDY,     Ptrs_INDY, nullptr, CH_ARRAY },
+	{ 'IIDS', Save_IIDS,     Load_IIDS,     nullptr,   nullptr, CH_ARRAY },
+	{ 'TIDS', Save_TIDS,     Load_TIDS,     nullptr,   nullptr, CH_ARRAY },
+	{ 'IBLD', LoadSave_IBLD, LoadSave_IBLD, nullptr,   nullptr, CH_RIFF  },
+	{ 'ITBL', Save_ITBL,     Load_ITBL,     nullptr,   nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _industry_chunk_handlers(industry_chunk_handlers);

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -121,7 +121,9 @@ static void Load_RAIL()
 	}
 }
 
-extern const ChunkHandler _labelmaps_chunk_handlers[] = {
-	{ 'RAIL', Save_RAIL, Load_RAIL, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler labelmaps_chunk_handlers[] = {
+	{ 'RAIL', Save_RAIL, Load_RAIL, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _labelmaps_chunk_handlers(labelmaps_chunk_handlers);
 

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -280,8 +280,10 @@ static void Ptrs_LGRS()
 	SlObject(&LinkGraphSchedule::instance, GetLinkGraphScheduleDesc());
 }
 
-extern const ChunkHandler _linkgraph_chunk_handlers[] = {
+static const ChunkHandler linkgraph_chunk_handlers[] = {
 	{ 'LGRP', Save_LGRP, Load_LGRP, nullptr,   nullptr, CH_ARRAY },
 	{ 'LGRJ', Save_LGRJ, Load_LGRJ, nullptr,   nullptr, CH_ARRAY },
-	{ 'LGRS', Save_LGRS, Load_LGRS, Ptrs_LGRS, nullptr, CH_LAST  }
+	{ 'LGRS', Save_LGRS, Load_LGRS, Ptrs_LGRS, nullptr, CH_RIFF  }
 };
+
+extern const ChunkHandlerTable _linkgraph_chunk_handlers(linkgraph_chunk_handlers);

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -294,7 +294,7 @@ static void Save_MAP8()
 }
 
 
-extern const ChunkHandler _map_chunk_handlers[] = {
+static const ChunkHandler map_chunk_handlers[] = {
 	{ 'MAPS', Save_MAPS, Load_MAPS, nullptr, Check_MAPS, CH_RIFF },
 	{ 'MAPT', Save_MAPT, Load_MAPT, nullptr, nullptr,    CH_RIFF },
 	{ 'MAPH', Save_MAPH, Load_MAPH, nullptr, nullptr,    CH_RIFF },
@@ -305,5 +305,7 @@ extern const ChunkHandler _map_chunk_handlers[] = {
 	{ 'MAP5', Save_MAP5, Load_MAP5, nullptr, nullptr,    CH_RIFF },
 	{ 'MAPE', Save_MAP6, Load_MAP6, nullptr, nullptr,    CH_RIFF },
 	{ 'MAP7', Save_MAP7, Load_MAP7, nullptr, nullptr,    CH_RIFF },
-	{ 'MAP8', Save_MAP8, Load_MAP8, nullptr, nullptr,    CH_RIFF | CH_LAST },
+	{ 'MAP8', Save_MAP8, Load_MAP8, nullptr, nullptr,    CH_RIFF },
 };
+
+extern const ChunkHandlerTable _map_chunk_handlers(map_chunk_handlers);

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -145,7 +145,9 @@ static void SaveLoad_VIEW()
 	SlGlobList(_view_desc);
 }
 
-extern const ChunkHandler _misc_chunk_handlers[] = {
-	{ 'DATE', SaveLoad_DATE, SaveLoad_DATE, nullptr, Check_DATE, CH_RIFF},
-	{ 'VIEW', SaveLoad_VIEW, SaveLoad_VIEW, nullptr, nullptr,    CH_RIFF | CH_LAST},
+static const ChunkHandler misc_chunk_handlers[] = {
+	{ 'DATE', SaveLoad_DATE, SaveLoad_DATE, nullptr, Check_DATE, CH_RIFF },
+	{ 'VIEW', SaveLoad_VIEW, SaveLoad_VIEW, nullptr, nullptr,    CH_RIFF },
 };
+
+extern const ChunkHandlerTable _misc_chunk_handlers(misc_chunk_handlers);

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -111,6 +111,8 @@ static void Check_NGRF()
 	Load_NGRF_common(_load_check_data.grfconfig);
 }
 
-extern const ChunkHandler _newgrf_chunk_handlers[] = {
-	{ 'NGRF', Save_NGRF, Load_NGRF, nullptr, Check_NGRF, CH_ARRAY | CH_LAST }
+static const ChunkHandler newgrf_chunk_handlers[] = {
+	{ 'NGRF', Save_NGRF, Load_NGRF, nullptr, Check_NGRF, CH_ARRAY }
 };
+
+extern const ChunkHandlerTable _newgrf_chunk_handlers(newgrf_chunk_handlers);

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -66,7 +66,9 @@ static void Load_OBID()
 	Load_NewGRFMapping(_object_mngr);
 }
 
-extern const ChunkHandler _object_chunk_handlers[] = {
+static const ChunkHandler object_chunk_handlers[] = {
 	{ 'OBID', Save_OBID, Load_OBID, nullptr,   nullptr, CH_ARRAY },
-	{ 'OBJS', Save_OBJS, Load_OBJS, Ptrs_OBJS, nullptr, CH_ARRAY | CH_LAST},
+	{ 'OBJS', Save_OBJS, Load_OBJS, Ptrs_OBJS, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _object_chunk_handlers(object_chunk_handlers);

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -286,8 +286,10 @@ static void Ptrs_BKOR()
 	}
 }
 
-extern const ChunkHandler _order_chunk_handlers[] = {
-	{ 'BKOR', Save_BKOR, Load_BKOR, Ptrs_BKOR, nullptr, CH_ARRAY},
-	{ 'ORDR', Save_ORDR, Load_ORDR, Ptrs_ORDR, nullptr, CH_ARRAY},
-	{ 'ORDL', Save_ORDL, Load_ORDL, Ptrs_ORDL, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler order_chunk_handlers[] = {
+	{ 'BKOR', Save_BKOR, Load_BKOR, Ptrs_BKOR, nullptr, CH_ARRAY },
+	{ 'ORDR', Save_ORDR, Load_ORDR, Ptrs_ORDR, nullptr, CH_ARRAY },
+	{ 'ORDL', Save_ORDL, Load_ORDL, Ptrs_ORDL, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _order_chunk_handlers(order_chunk_handlers);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -214,86 +214,92 @@ struct SaveLoadParams {
 
 static SaveLoadParams _sl; ///< Parameters used for/at saveload.
 
-/* these define the chunks */
-extern const ChunkHandler _gamelog_chunk_handlers[];
-extern const ChunkHandler _map_chunk_handlers[];
-extern const ChunkHandler _misc_chunk_handlers[];
-extern const ChunkHandler _name_chunk_handlers[];
-extern const ChunkHandler _cheat_chunk_handlers[] ;
-extern const ChunkHandler _setting_chunk_handlers[];
-extern const ChunkHandler _company_chunk_handlers[];
-extern const ChunkHandler _engine_chunk_handlers[];
-extern const ChunkHandler _veh_chunk_handlers[];
-extern const ChunkHandler _waypoint_chunk_handlers[];
-extern const ChunkHandler _depot_chunk_handlers[];
-extern const ChunkHandler _order_chunk_handlers[];
-extern const ChunkHandler _town_chunk_handlers[];
-extern const ChunkHandler _sign_chunk_handlers[];
-extern const ChunkHandler _station_chunk_handlers[];
-extern const ChunkHandler _industry_chunk_handlers[];
-extern const ChunkHandler _economy_chunk_handlers[];
-extern const ChunkHandler _subsidy_chunk_handlers[];
-extern const ChunkHandler _cargomonitor_chunk_handlers[];
-extern const ChunkHandler _goal_chunk_handlers[];
-extern const ChunkHandler _story_page_chunk_handlers[];
-extern const ChunkHandler _ai_chunk_handlers[];
-extern const ChunkHandler _game_chunk_handlers[];
-extern const ChunkHandler _animated_tile_chunk_handlers[];
-extern const ChunkHandler _newgrf_chunk_handlers[];
-extern const ChunkHandler _group_chunk_handlers[];
-extern const ChunkHandler _cargopacket_chunk_handlers[];
-extern const ChunkHandler _autoreplace_chunk_handlers[];
-extern const ChunkHandler _labelmaps_chunk_handlers[];
-extern const ChunkHandler _linkgraph_chunk_handlers[];
-extern const ChunkHandler _airport_chunk_handlers[];
-extern const ChunkHandler _object_chunk_handlers[];
-extern const ChunkHandler _persistent_storage_chunk_handlers[];
+static const std::vector<ChunkHandler> &ChunkHandlers()
+{
+	/* These define the chunks */
+	extern const ChunkHandlerTable _gamelog_chunk_handlers;
+	extern const ChunkHandlerTable _map_chunk_handlers;
+	extern const ChunkHandlerTable _misc_chunk_handlers;
+	extern const ChunkHandlerTable _name_chunk_handlers;
+	extern const ChunkHandlerTable _cheat_chunk_handlers;
+	extern const ChunkHandlerTable _setting_chunk_handlers;
+	extern const ChunkHandlerTable _company_chunk_handlers;
+	extern const ChunkHandlerTable _engine_chunk_handlers;
+	extern const ChunkHandlerTable _veh_chunk_handlers;
+	extern const ChunkHandlerTable _waypoint_chunk_handlers;
+	extern const ChunkHandlerTable _depot_chunk_handlers;
+	extern const ChunkHandlerTable _order_chunk_handlers;
+	extern const ChunkHandlerTable _town_chunk_handlers;
+	extern const ChunkHandlerTable _sign_chunk_handlers;
+	extern const ChunkHandlerTable _station_chunk_handlers;
+	extern const ChunkHandlerTable _industry_chunk_handlers;
+	extern const ChunkHandlerTable _economy_chunk_handlers;
+	extern const ChunkHandlerTable _subsidy_chunk_handlers;
+	extern const ChunkHandlerTable _cargomonitor_chunk_handlers;
+	extern const ChunkHandlerTable _goal_chunk_handlers;
+	extern const ChunkHandlerTable _story_page_chunk_handlers;
+	extern const ChunkHandlerTable _ai_chunk_handlers;
+	extern const ChunkHandlerTable _game_chunk_handlers;
+	extern const ChunkHandlerTable _animated_tile_chunk_handlers;
+	extern const ChunkHandlerTable _newgrf_chunk_handlers;
+	extern const ChunkHandlerTable _group_chunk_handlers;
+	extern const ChunkHandlerTable _cargopacket_chunk_handlers;
+	extern const ChunkHandlerTable _autoreplace_chunk_handlers;
+	extern const ChunkHandlerTable _labelmaps_chunk_handlers;
+	extern const ChunkHandlerTable _linkgraph_chunk_handlers;
+	extern const ChunkHandlerTable _airport_chunk_handlers;
+	extern const ChunkHandlerTable _object_chunk_handlers;
+	extern const ChunkHandlerTable _persistent_storage_chunk_handlers;
 
-/** Array of all chunks in a savegame, \c nullptr terminated. */
-static const ChunkHandler * const _chunk_handlers[] = {
-	_gamelog_chunk_handlers,
-	_map_chunk_handlers,
-	_misc_chunk_handlers,
-	_name_chunk_handlers,
-	_cheat_chunk_handlers,
-	_setting_chunk_handlers,
-	_veh_chunk_handlers,
-	_waypoint_chunk_handlers,
-	_depot_chunk_handlers,
-	_order_chunk_handlers,
-	_industry_chunk_handlers,
-	_economy_chunk_handlers,
-	_subsidy_chunk_handlers,
-	_cargomonitor_chunk_handlers,
-	_goal_chunk_handlers,
-	_story_page_chunk_handlers,
-	_engine_chunk_handlers,
-	_town_chunk_handlers,
-	_sign_chunk_handlers,
-	_station_chunk_handlers,
-	_company_chunk_handlers,
-	_ai_chunk_handlers,
-	_game_chunk_handlers,
-	_animated_tile_chunk_handlers,
-	_newgrf_chunk_handlers,
-	_group_chunk_handlers,
-	_cargopacket_chunk_handlers,
-	_autoreplace_chunk_handlers,
-	_labelmaps_chunk_handlers,
-	_linkgraph_chunk_handlers,
-	_airport_chunk_handlers,
-	_object_chunk_handlers,
-	_persistent_storage_chunk_handlers,
-	nullptr,
-};
+	/** List of all chunks in a savegame. */
+	static const ChunkHandlerTable _chunk_handler_tables[] = {
+		_gamelog_chunk_handlers,
+		_map_chunk_handlers,
+		_misc_chunk_handlers,
+		_name_chunk_handlers,
+		_cheat_chunk_handlers,
+		_setting_chunk_handlers,
+		_veh_chunk_handlers,
+		_waypoint_chunk_handlers,
+		_depot_chunk_handlers,
+		_order_chunk_handlers,
+		_industry_chunk_handlers,
+		_economy_chunk_handlers,
+		_subsidy_chunk_handlers,
+		_cargomonitor_chunk_handlers,
+		_goal_chunk_handlers,
+		_story_page_chunk_handlers,
+		_engine_chunk_handlers,
+		_town_chunk_handlers,
+		_sign_chunk_handlers,
+		_station_chunk_handlers,
+		_company_chunk_handlers,
+		_ai_chunk_handlers,
+		_game_chunk_handlers,
+		_animated_tile_chunk_handlers,
+		_newgrf_chunk_handlers,
+		_group_chunk_handlers,
+		_cargopacket_chunk_handlers,
+		_autoreplace_chunk_handlers,
+		_labelmaps_chunk_handlers,
+		_linkgraph_chunk_handlers,
+		_airport_chunk_handlers,
+		_object_chunk_handlers,
+		_persistent_storage_chunk_handlers,
+	};
 
-/**
- * Iterate over all chunk handlers.
- * @param ch the chunk handler iterator
- */
-#define FOR_ALL_CHUNK_HANDLERS(ch) \
-	for (const ChunkHandler * const *chsc = _chunk_handlers; *chsc != nullptr; chsc++) \
-		for (const ChunkHandler *ch = *chsc; ch != nullptr; ch = (ch->flags & CH_LAST) ? nullptr : ch + 1)
+	static std::vector<ChunkHandler> _chunk_handlers;
+
+	if (_chunk_handlers.empty()) {
+		for (auto &chunk_handler_table : _chunk_handler_tables) {
+			for (auto &chunk_handler : chunk_handler_table) {
+				_chunk_handlers.push_back(chunk_handler);
+			}
+		}
+	}
+
+	return _chunk_handlers;
+}
 
 /** Null all pointers (convert index -> nullptr) */
 static void SlNullPointers()
@@ -305,10 +311,10 @@ static void SlNullPointers()
 	 * pointers from other pools. */
 	_sl_version = SAVEGAME_VERSION;
 
-	FOR_ALL_CHUNK_HANDLERS(ch) {
-		if (ch->ptrs_proc != nullptr) {
-			DEBUG(sl, 3, "Nulling pointers for %c%c%c%c", ch->id >> 24, ch->id >> 16, ch->id >> 8, ch->id);
-			ch->ptrs_proc();
+	for (auto &ch : ChunkHandlers()) {
+		if (ch.ptrs_proc != nullptr) {
+			DEBUG(sl, 3, "Nulling pointers for %c%c%c%c", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);
+			ch.ptrs_proc();
 		}
 	}
 
@@ -1660,7 +1666,7 @@ void SlAutolength(AutolengthProc *proc, void *arg)
  * Load a chunk of data (eg vehicles, stations, etc.)
  * @param ch The chunkhandler that will be used for the operation
  */
-static void SlLoadChunk(const ChunkHandler *ch)
+static void SlLoadChunk(const ChunkHandler &ch)
 {
 	byte m = SlReadByte();
 	size_t len;
@@ -1672,11 +1678,11 @@ static void SlLoadChunk(const ChunkHandler *ch)
 	switch (m) {
 		case CH_ARRAY:
 			_sl.array_index = 0;
-			ch->load_proc();
+			ch.load_proc();
 			if (_next_offs != 0) SlErrorCorrupt("Invalid array length");
 			break;
 		case CH_SPARSE_ARRAY:
-			ch->load_proc();
+			ch.load_proc();
 			if (_next_offs != 0) SlErrorCorrupt("Invalid array length");
 			break;
 		default:
@@ -1686,7 +1692,7 @@ static void SlLoadChunk(const ChunkHandler *ch)
 				len += SlReadUint16();
 				_sl.obj_len = len;
 				endoffs = _sl.reader->GetSize() + len;
-				ch->load_proc();
+				ch.load_proc();
 				if (_sl.reader->GetSize() != endoffs) SlErrorCorrupt("Invalid chunk size");
 			} else {
 				SlErrorCorrupt("Invalid chunk type");
@@ -1700,7 +1706,7 @@ static void SlLoadChunk(const ChunkHandler *ch)
  * If the chunkhandler is nullptr, the chunk is skipped.
  * @param ch The chunkhandler that will be used for the operation
  */
-static void SlLoadCheckChunk(const ChunkHandler *ch)
+static void SlLoadCheckChunk(const ChunkHandler &ch)
 {
 	byte m = SlReadByte();
 	size_t len;
@@ -1712,15 +1718,15 @@ static void SlLoadCheckChunk(const ChunkHandler *ch)
 	switch (m) {
 		case CH_ARRAY:
 			_sl.array_index = 0;
-			if (ch->load_check_proc) {
-				ch->load_check_proc();
+			if (ch.load_check_proc) {
+				ch.load_check_proc();
 			} else {
 				SlSkipArray();
 			}
 			break;
 		case CH_SPARSE_ARRAY:
-			if (ch->load_check_proc) {
-				ch->load_check_proc();
+			if (ch.load_check_proc) {
+				ch.load_check_proc();
 			} else {
 				SlSkipArray();
 			}
@@ -1732,8 +1738,8 @@ static void SlLoadCheckChunk(const ChunkHandler *ch)
 				len += SlReadUint16();
 				_sl.obj_len = len;
 				endoffs = _sl.reader->GetSize() + len;
-				if (ch->load_check_proc) {
-					ch->load_check_proc();
+				if (ch.load_check_proc) {
+					ch.load_check_proc();
 				} else {
 					SlSkipBytes(len);
 				}
@@ -1750,18 +1756,18 @@ static void SlLoadCheckChunk(const ChunkHandler *ch)
  * prefixed by an ID identifying it, followed by data, and terminator where appropriate
  * @param ch The chunkhandler that will be used for the operation
  */
-static void SlSaveChunk(const ChunkHandler *ch)
+static void SlSaveChunk(const ChunkHandler &ch)
 {
-	ChunkSaveLoadProc *proc = ch->save_proc;
+	ChunkSaveLoadProc *proc = ch.save_proc;
 
 	/* Don't save any chunk information if there is no save handler. */
 	if (proc == nullptr) return;
 
-	SlWriteUint32(ch->id);
-	DEBUG(sl, 2, "Saving chunk %c%c%c%c", ch->id >> 24, ch->id >> 16, ch->id >> 8, ch->id);
+	SlWriteUint32(ch.id);
+	DEBUG(sl, 2, "Saving chunk %c%c%c%c", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);
 
-	_sl.block_mode = ch->flags & CH_TYPE_MASK;
-	switch (ch->flags & CH_TYPE_MASK) {
+	_sl.block_mode = ch.type;
+	switch (ch.type) {
 		case CH_RIFF:
 			_sl.need_length = NL_WANTLENGTH;
 			proc();
@@ -1784,7 +1790,7 @@ static void SlSaveChunk(const ChunkHandler *ch)
 /** Save all chunks */
 static void SlSaveChunks()
 {
-	FOR_ALL_CHUNK_HANDLERS(ch) {
+	for (auto &ch : ChunkHandlers()) {
 		SlSaveChunk(ch);
 	}
 
@@ -1800,7 +1806,7 @@ static void SlSaveChunks()
  */
 static const ChunkHandler *SlFindChunkHandler(uint32 id)
 {
-	FOR_ALL_CHUNK_HANDLERS(ch) if (ch->id == id) return ch;
+	for (auto &ch : ChunkHandlers()) if (ch.id == id) return &ch;
 	return nullptr;
 }
 
@@ -1815,7 +1821,7 @@ static void SlLoadChunks()
 
 		ch = SlFindChunkHandler(id);
 		if (ch == nullptr) SlErrorCorrupt("Unknown chunk type");
-		SlLoadChunk(ch);
+		SlLoadChunk(*ch);
 	}
 }
 
@@ -1830,7 +1836,7 @@ static void SlLoadCheckChunks()
 
 		ch = SlFindChunkHandler(id);
 		if (ch == nullptr) SlErrorCorrupt("Unknown chunk type");
-		SlLoadCheckChunk(ch);
+		SlLoadCheckChunk(*ch);
 	}
 }
 
@@ -1839,10 +1845,10 @@ static void SlFixPointers()
 {
 	_sl.action = SLA_PTRS;
 
-	FOR_ALL_CHUNK_HANDLERS(ch) {
-		if (ch->ptrs_proc != nullptr) {
-			DEBUG(sl, 3, "Fixing pointers for %c%c%c%c", ch->id >> 24, ch->id >> 16, ch->id >> 8, ch->id);
-			ch->ptrs_proc();
+	for (auto &ch : ChunkHandlers()) {
+		if (ch.ptrs_proc != nullptr) {
+			DEBUG(sl, 3, "Fixing pointers for %c%c%c%c", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);
+			ch.ptrs_proc();
 		}
 	}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -14,6 +14,7 @@
 #include "../strings_type.h"
 #include "../core/span_type.hpp"
 #include <string>
+#include <vector>
 
 /** SaveLoad versions
  * Previous savegame versions, the trunk revision where they were
@@ -378,6 +379,13 @@ SaveOrLoadResult LoadWithFilter(struct LoadFilter *reader);
 typedef void ChunkSaveLoadProc();
 typedef void AutolengthProc(void *arg);
 
+/** Type of a chunk. */
+enum ChunkType {
+	CH_RIFF = 0,
+	CH_ARRAY = 1,
+	CH_SPARSE_ARRAY = 2,
+};
+
 /** Handlers and description of chunk. */
 struct ChunkHandler {
 	uint32 id;                          ///< Unique ID (4 letters).
@@ -385,8 +393,11 @@ struct ChunkHandler {
 	ChunkSaveLoadProc *load_proc;       ///< Load procedure of the chunk.
 	ChunkSaveLoadProc *ptrs_proc;       ///< Manipulate pointers in the chunk.
 	ChunkSaveLoadProc *load_check_proc; ///< Load procedure for game preview.
-	uint32 flags;                       ///< Flags of the chunk. @see ChunkType
+	ChunkType type;                     ///< Type of the chunk. @see ChunkType
 };
+
+/** A table of ChunkHandler entries. */
+using ChunkHandlerTable = span<const ChunkHandler>;
 
 /** Type of reference (#SLE_REF, #SLE_CONDREF). */
 enum SLRefType {
@@ -402,15 +413,6 @@ enum SLRefType {
 	REF_STORAGE        =  9, ///< Load/save a reference to a persistent storage.
 	REF_LINK_GRAPH     = 10, ///< Load/save a reference to a link graph.
 	REF_LINK_GRAPH_JOB = 11, ///< Load/save a reference to a link graph job.
-};
-
-/** Flags of a chunk. */
-enum ChunkType {
-	CH_RIFF         =  0,
-	CH_ARRAY        =  1,
-	CH_SPARSE_ARRAY =  2,
-	CH_TYPE_MASK    =  3,
-	CH_LAST         =  8, ///< Last chunk in this array.
 };
 
 /**

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -62,6 +62,8 @@ static void Load_SIGN()
 }
 
 /** Chunk handlers related to signs. */
-extern const ChunkHandler _sign_chunk_handlers[] = {
-	{ 'SIGN', Save_SIGN, Load_SIGN, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler sign_chunk_handlers[] = {
+	{ 'SIGN', Save_SIGN, Load_SIGN, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _sign_chunk_handlers(sign_chunk_handlers);

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -613,8 +613,10 @@ static void Ptrs_ROADSTOP()
 	}
 }
 
-extern const ChunkHandler _station_chunk_handlers[] = {
+static const ChunkHandler station_chunk_handlers[] = {
 	{ 'STNS', nullptr,       Load_STNS,     Ptrs_STNS,     nullptr, CH_ARRAY },
 	{ 'STNN', Save_STNN,     Load_STNN,     Ptrs_STNN,     nullptr, CH_ARRAY },
-	{ 'ROAD', Save_ROADSTOP, Load_ROADSTOP, Ptrs_ROADSTOP, nullptr, CH_ARRAY | CH_LAST},
+	{ 'ROAD', Save_ROADSTOP, Load_ROADSTOP, Ptrs_ROADSTOP, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _station_chunk_handlers(station_chunk_handlers);

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -44,6 +44,8 @@ static void Save_PSAC()
 }
 
 /** Chunk handler for persistent storages. */
-extern const ChunkHandler _persistent_storage_chunk_handlers[] = {
-	{ 'PSAC', Save_PSAC, Load_PSAC, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler persistent_storage_chunk_handlers[] = {
+	{ 'PSAC', Save_PSAC, Load_PSAC, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _persistent_storage_chunk_handlers(persistent_storage_chunk_handlers);

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -95,7 +95,9 @@ static void Load_STORY_PAGE()
 	_story_page_next_sort_value = max_sort_value + 1;
 }
 
-extern const ChunkHandler _story_page_chunk_handlers[] = {
-	{ 'STPE', Save_STORY_PAGE_ELEMENT, Load_STORY_PAGE_ELEMENT, nullptr, nullptr, CH_ARRAY},
-	{ 'STPA', Save_STORY_PAGE,         Load_STORY_PAGE,         nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler story_page_chunk_handlers[] = {
+	{ 'STPE', Save_STORY_PAGE_ELEMENT, Load_STORY_PAGE_ELEMENT, nullptr, nullptr, CH_ARRAY },
+	{ 'STPA', Save_STORY_PAGE,         Load_STORY_PAGE,         nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _story_page_chunk_handlers(story_page_chunk_handlers);

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -131,6 +131,8 @@ static void Load_NAME()
 }
 
 /** Chunk handlers related to strings. */
-extern const ChunkHandler _name_chunk_handlers[] = {
-	{ 'NAME', nullptr, Load_NAME, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler name_chunk_handlers[] = {
+	{ 'NAME', nullptr, Load_NAME, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _name_chunk_handlers(name_chunk_handlers);

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -43,6 +43,8 @@ static void Load_SUBS()
 	}
 }
 
-extern const ChunkHandler _subsidy_chunk_handlers[] = {
-	{ 'SUBS', Save_SUBS, Load_SUBS, nullptr, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler subsidy_chunk_handlers[] = {
+	{ 'SUBS', Save_SUBS, Load_SUBS, nullptr, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _subsidy_chunk_handlers(subsidy_chunk_handlers);

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -296,7 +296,9 @@ static void Ptrs_TOWN()
 }
 
 /** Chunk handler for towns. */
-extern const ChunkHandler _town_chunk_handlers[] = {
+static const ChunkHandler town_chunk_handlers[] = {
 	{ 'HIDS', Save_HIDS, Load_HIDS, nullptr,   nullptr, CH_ARRAY },
-	{ 'CITY', Save_TOWN, Load_TOWN, Ptrs_TOWN, nullptr, CH_ARRAY | CH_LAST},
+	{ 'CITY', Save_TOWN, Load_TOWN, Ptrs_TOWN, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _town_chunk_handlers(town_chunk_handlers);

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -931,6 +931,8 @@ static void Ptrs_VEHS()
 	}
 }
 
-extern const ChunkHandler _veh_chunk_handlers[] = {
-	{ 'VEHS', Save_VEHS, Load_VEHS, Ptrs_VEHS, nullptr, CH_SPARSE_ARRAY | CH_LAST},
+static const ChunkHandler veh_chunk_handlers[] = {
+	{ 'VEHS', Save_VEHS, Load_VEHS, Ptrs_VEHS, nullptr, CH_SPARSE_ARRAY },
 };
+
+extern const ChunkHandlerTable _veh_chunk_handlers(veh_chunk_handlers);

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -224,6 +224,8 @@ static void Ptrs_WAYP()
 	}
 }
 
-extern const ChunkHandler _waypoint_chunk_handlers[] = {
-	{ 'CHKP', nullptr, Load_WAYP, Ptrs_WAYP, nullptr, CH_ARRAY | CH_LAST},
+static const ChunkHandler waypoint_chunk_handlers[] = {
+	{ 'CHKP', nullptr, Load_WAYP, Ptrs_WAYP, nullptr, CH_ARRAY },
 };
+
+extern const ChunkHandlerTable _waypoint_chunk_handlers(waypoint_chunk_handlers);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2085,10 +2085,12 @@ static void Save_PATS()
 	SaveSettings(_settings, &_settings_game);
 }
 
-extern const ChunkHandler _setting_chunk_handlers[] = {
-	{ 'OPTS', nullptr,      Load_OPTS, nullptr, nullptr,       CH_RIFF},
-	{ 'PATS', Save_PATS, Load_PATS, nullptr, Check_PATS, CH_RIFF | CH_LAST},
+static const ChunkHandler setting_chunk_handlers[] = {
+	{ 'OPTS', nullptr,   Load_OPTS, nullptr, nullptr,    CH_RIFF },
+	{ 'PATS', Save_PATS, Load_PATS, nullptr, Check_PATS, CH_RIFF },
 };
+
+extern const ChunkHandlerTable _setting_chunk_handlers(setting_chunk_handlers);
 
 static bool IsSignedVarMemType(VarType vt)
 {


### PR DESCRIPTION
## Motivation / Problem
Chunk handlers are stored in an static array of pointers to static arrays, using special values as markers for the end of array.
`FOR_ALL_CHUNK_HANDLERS()` parses the arrays to get each handler.
Every new handler must be added manually to the list.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
~~I added a map of `ChunkHandler` pointers, indexed by chunk id, and stored inside `ChunkHandler` struct itself.~~
`_chunk_handlers` is now a vector of `ChunkHandler` pointers.
Now every handler is automatically registered, simplifying addition of new handler.
Then I could remove end markers, and enforce chunk type validation.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Order of chunks in new savegames will be different, but it should not matter.
Groups of chunk handlers are reordered, but the order inside each group is kept.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
