### PR TITLE
Fix #9174: Don't update text effect if it has been reset.

### DIFF
--- a/src/texteff.cpp
+++ b/src/texteff.cpp
@@ -79,6 +79,7 @@ void UpdateTextEffect(TextEffectID te_id, StringID msg)
 void UpdateAllTextEffectVirtCoords()
 {
 	for (auto &te : _text_effects) {
+		if (te.string_id == INVALID_STRING_ID) continue;
 		SetDParam(0, te.params_1);
 		SetDParam(1, te.params_2);
 		te.UpdatePosition(te.center, te.top, te.string_id, te.string_id - 1);


### PR DESCRIPTION
## Motivation / Problem

#9174 introduces a bug caused by looking up INVALID_STRING_ID.

## Description

Don't update text effect signs with INVALID_STRING_ID.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
