### PR TITLE
Codechange: Disable pointer locking by default for Emscripten

### DIFF
--- a/os/emscripten/shell.html
+++ b/os/emscripten/shell.html
@@ -85,6 +85,8 @@
         position: absolute;
         width: 100%;
         z-index: 2;
+        /* OpenTTD draws the cursor itself */
+        cursor: none !important;
       }
     </style>
   </head>

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -2516,6 +2516,20 @@ strval   = STR_CONFIG_SETTING_AUTOSCROLL_DISABLED
 cat      = SC_BASIC
 
 [SDTC_VAR]
+ifdef    = __EMSCRIPTEN__
+var      = gui.scroll_mode
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = 2
+min      = 0
+max      = 3
+str      = STR_CONFIG_SETTING_SCROLLMODE
+strhelp  = STR_CONFIG_SETTING_SCROLLMODE_HELPTEXT
+strval   = STR_CONFIG_SETTING_SCROLLMODE_DEFAULT
+cat      = SC_BASIC
+
+[SDTC_VAR]
+ifndef    = __EMSCRIPTEN__
 var      = gui.scroll_mode
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN


### PR DESCRIPTION
## Motivation / Problem

See #9150.

## Description

This PR changes the default scroll mode so that pointer locking is not used by default, resolving the bad UX for the Emscripten port.

As this is a breaking change and needs further discussion, it's currently a draft.

## Limitations

- This is a breaking change.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
