### PR TITLE
Codechange: [Network] More std::string with less code

### DIFF
--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -28,10 +28,10 @@ typedef SmallMap<NetworkAddress, SOCKET> SocketList;    ///< Type for a mapping 
  */
 class NetworkAddress {
 private:
-	char hostname[NETWORK_HOSTNAME_LENGTH]; ///< The hostname
-	int address_length;                     ///< The length of the resolved address
-	sockaddr_storage address;               ///< The resolved address
-	bool resolved;                          ///< Whether the address has been (tried to be) resolved
+	std::string hostname;     ///< The hostname
+	int address_length;       ///< The length of the resolved address
+	sockaddr_storage address; ///< The resolved address
+	bool resolved;            ///< Whether the address has been (tried to be) resolved
 
 	/**
 	 * Helper function to resolve something to a socket.
@@ -52,7 +52,6 @@ public:
 		address(address),
 		resolved(address_length != 0)
 	{
-		*this->hostname = '\0';
 	}
 
 	/**
@@ -64,7 +63,6 @@ public:
 		address_length(address_length),
 		resolved(address_length != 0)
 	{
-		*this->hostname = '\0';
 		memset(&this->address, 0, sizeof(this->address));
 		memcpy(&this->address, address, address_length);
 	}
@@ -75,16 +73,15 @@ public:
 	 * @param port the port
 	 * @param family the address family
 	 */
-	NetworkAddress(const char *hostname = "", uint16 port = 0, int family = AF_UNSPEC) :
+	NetworkAddress(std::string_view hostname = "", uint16 port = 0, int family = AF_UNSPEC) :
 		address_length(0),
 		resolved(false)
 	{
-		/* Also handle IPv6 bracket enclosed hostnames */
-		if (StrEmpty(hostname)) hostname = "";
-		if (*hostname == '[') hostname++;
-		strecpy(this->hostname, StrEmpty(hostname) ? "" : hostname, lastof(this->hostname));
-		char *tmp = strrchr(this->hostname, ']');
-		if (tmp != nullptr) *tmp = '\0';
+		if (!hostname.empty() && hostname.front() == '[' && hostname.back() == ']') {
+			hostname.remove_prefix(1);
+			hostname.remove_suffix(1);
+		}
+		this->hostname = hostname;
 
 		memset(&this->address, 0, sizeof(this->address));
 		this->address.ss_family = family;

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -28,11 +28,11 @@ NetworkUDPSocketHandler::NetworkUDPSocketHandler(NetworkAddressList *bind)
 			this->bind.push_back(addr);
 		}
 	} else {
-		/* As hostname nullptr and port 0/nullptr don't go well when
+		/* As an empty hostname and port 0 don't go well when
 		 * resolving it we need to add an address for each of
 		 * the address families we support. */
-		this->bind.emplace_back(nullptr, 0, AF_INET);
-		this->bind.emplace_back(nullptr, 0, AF_INET6);
+		this->bind.emplace_back("", 0, AF_INET);
+		this->bind.emplace_back("", 0, AF_INET6);
 	}
 }
 

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -45,7 +45,7 @@ void NetworkReboot();
 void NetworkDisconnect(bool blocking = false, bool close_admins = true);
 void NetworkGameLoop();
 void NetworkBackgroundLoop();
-void ParseFullConnectionString(const char **company, const char **port, char *connection_string);
+std::string_view ParseFullConnectionString(const std::string &connection_string, uint16 &port, CompanyID *company_id = nullptr);
 void NetworkStartDebugLog(const std::string &connection_string);
 void NetworkPopulateCompanyStats(NetworkCompanyStats *stats);
 

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -57,7 +57,7 @@ static void NetworkGameListHandleDelayedInsert()
 			if (item->manually) NetworkRebuildHostList();
 			UpdateNetworkGameWindow();
 		}
-		free(ins_item);
+		delete ins_item;
 	}
 }
 
@@ -80,9 +80,7 @@ NetworkGameList *NetworkGameListAddItem(const std::string &connection_string)
 		prev_item = item;
 	}
 
-	item = CallocT<NetworkGameList>(1);
-	item->next = nullptr;
-	item->connection_string = resolved_connection_string;
+	item = new NetworkGameList(resolved_connection_string);
 
 	if (prev_item == nullptr) {
 		_network_game_list = item;
@@ -112,8 +110,7 @@ void NetworkGameListRemoveItem(NetworkGameList *remove)
 
 			/* Remove GRFConfig information */
 			ClearGRFConfigList(&remove->info.grfconfig);
-			free(remove);
-			remove = nullptr;
+			delete remove;
 
 			DEBUG(net, 4, "[gamelist] removed server from list");
 			NetworkRebuildHostList();

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -16,12 +16,17 @@
 
 /** Structure with information shown in the game list (GUI) */
 struct NetworkGameList {
-	NetworkGameInfo info;          ///< The game information of this server
-	std::string connection_string; ///< Address of the server
-	bool online;                   ///< False if the server did not respond (default status)
-	bool manually;                 ///< True if the server was added manually
-	uint8 retries;                 ///< Number of retries (to stop requerying)
-	NetworkGameList *next;         ///< Next pointer to make a linked game list
+	NetworkGameList(const std::string &connection_string, bool manually = false) :
+		connection_string(connection_string), manually(manually)
+	{
+	}
+
+	NetworkGameInfo info = {};       ///< The game information of this server
+	std::string connection_string;   ///< Address of the server
+	bool online = false;             ///< False if the server did not respond (default status)
+	bool manually = false;           ///< True if the server was added manually
+	uint8 retries = 0;               ///< Number of retries (to stop requerying)
+	NetworkGameList *next = nullptr; ///< Next pointer to make a linked game list
 };
 
 /** Game list of this client */

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -119,6 +119,6 @@ StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkFindName(char *new_name, const char *last);
 const char *GenerateCompanyPasswordHash(const char *password, const char *password_server_id, uint32 password_game_seed);
 
-NetworkAddress ParseConnectionString(const std::string &connection_string, int default_port);
+NetworkAddress ParseConnectionString(const std::string &connection_string, uint16 default_port);
 
 #endif /* NETWORK_INTERNAL_H */

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -90,10 +90,8 @@ static UDPSocket _udp_master("Master"); ///< udp master socket
 static void DoNetworkUDPQueryServer(const std::string &connection_string, bool needs_mutex, bool manually)
 {
 	/* Clear item in gamelist */
-	NetworkGameList *item = CallocT<NetworkGameList>(1);
+	NetworkGameList *item = new NetworkGameList(connection_string, manually);
 	strecpy(item->info.server_name, connection_string.c_str(), lastof(item->info.server_name));
-	item->connection_string = connection_string;
-	item->manually = manually;
 	NetworkGameListAddItemDelayed(item);
 
 	std::unique_lock<std::mutex> lock(_udp_client.mutex, std::defer_lock);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -405,7 +405,7 @@ void OpenBrowser(const char *url)
 struct AfterNewGRFScan : NewGRFScanCallback {
 	Year startyear;                    ///< The start year.
 	uint32 generation_seed;            ///< Seed for the new game.
-	char *dedicated_host;              ///< Hostname for the dedicated server.
+	std::string dedicated_host;        ///< Hostname for the dedicated server.
 	uint16 dedicated_port;             ///< Port for the dedicated server.
 	char *network_conn;                ///< Information about the server to connect to, or nullptr.
 	const char *join_server_password;  ///< The password to join the server with.
@@ -417,7 +417,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 	 */
 	AfterNewGRFScan() :
 			startyear(INVALID_YEAR), generation_seed(GENERATE_NEW_SEED),
-			dedicated_host(nullptr), dedicated_port(0), network_conn(nullptr),
+			dedicated_port(0), network_conn(nullptr),
 			join_server_password(nullptr), join_company_password(nullptr),
 			save_config(true)
 	{
@@ -458,7 +458,7 @@ struct AfterNewGRFScan : NewGRFScanCallback {
 		if (startyear != INVALID_YEAR) IConsoleSetSetting("game_creation.starting_year", startyear);
 		if (generation_seed != GENERATE_NEW_SEED) _settings_newgame.game_creation.generation_seed = generation_seed;
 
-		if (dedicated_host != nullptr) {
+		if (!dedicated_host.empty()) {
 			_network_bind_list.clear();
 			_network_bind_list.emplace_back(dedicated_host);
 		}
@@ -565,10 +565,7 @@ int openttd_main(int argc, char *argv[])
 			dedicated = true;
 			SetDebugString("net=6");
 			if (mgo.opt != nullptr) {
-				const char *port = nullptr;
-				ParseFullConnectionString(nullptr, &port, mgo.opt);
-				if (!StrEmpty(mgo.opt)) scanner->dedicated_host = mgo.opt;
-				if (port != nullptr) scanner->dedicated_port = atoi(port);
+				scanner->dedicated_host = ParseFullConnectionString(mgo.opt, scanner->dedicated_port);
 			}
 			break;
 		case 'f': _dedicated_forks = true; break;


### PR DESCRIPTION
## Motivation / Problem

Connection string parsing was modifying the input data which I find kind of odd.


## Description

So, I rewrote it to make use of std::string_view for the different parts.
For that NetworkAddress needed to accept std::string_view, so made hostname a std::string, which in it turn required NetworkGameList to be new/deleted instead of calloc/freed.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
