### PR TITLE
Cleanup: Leftover static const variable from a3b356e

### DIFF
--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -835,9 +835,6 @@ char *GRFBuildParamList(char *dst, const GRFConfig *c, const char *last)
 	return dst;
 }
 
-/** Base GRF ID for OpenTTD's base graphics GRFs. */
-static const uint32 OPENTTD_GRAPHICS_BASE_GRF_ID = BSWAP32(0xFF4F5400);
-
 /**
  * Search a textfile file next to this NewGRF.
  * @param type The type of the textfile to search for.


### PR DESCRIPTION
## Motivation / Problem
https://github.com/OpenTTD/OpenTTD/commit/a3b356e05782f8b53ef2e3a645eccd33a8c87c23 removed a no longer needed function, but left the `static const` variable that came with it in https://github.com/OpenTTD/OpenTTD/commit/f546de602b9c59c3fbaaea8fac5f008ed0443fea.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Remove the variable.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
