### PR TITLE
Codechange: use connection_string in favour of NetworkAddress

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -77,7 +77,7 @@ protected:
 	NetworkAddress address;
 
 public:
-	TCPConnecter(const NetworkAddress &address);
+	TCPConnecter(const std::string &connection_string, uint16 default_port);
 	/** Silence the warnings */
 	virtual ~TCPConnecter() {}
 

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -13,6 +13,7 @@
 #include "../../thread.h"
 
 #include "tcp.h"
+#include "../network_internal.h"
 
 #include "../../safeguards.h"
 
@@ -21,15 +22,16 @@ static std::vector<TCPConnecter *> _tcp_connecters;
 
 /**
  * Create a new connecter for the given address
- * @param address the (un)resolved address to connect to
+ * @param connection_string the address to connect to
  */
-TCPConnecter::TCPConnecter(const NetworkAddress &address) :
+TCPConnecter::TCPConnecter(const std::string &connection_string, uint16 default_port) :
 	connected(false),
 	aborted(false),
 	killed(false),
-	sock(INVALID_SOCKET),
-	address(address)
+	sock(INVALID_SOCKET)
 {
+	this->address = ParseConnectionString(connection_string, default_port);
+
 	_tcp_connecters.push_back(this);
 	if (!StartNewThread(nullptr, "ottd:tcp", &TCPConnecter::ThreadEntry, this)) {
 		this->Connect();

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -203,11 +203,9 @@ int NetworkHTTPSocketHandler::HandleHeader()
 
 	*url = '\0';
 
-	NetworkAddress address = ParseConnectionString(hname, 80);
-
 	/* Restore the URL. */
 	*url = '/';
-	new NetworkHTTPContentConnecter(address, callback, url, data, depth);
+	new NetworkHTTPContentConnecter(hname, callback, url, data, depth);
 	return 0;
 }
 

--- a/src/network/core/tcp_http.h
+++ b/src/network/core/tcp_http.h
@@ -81,16 +81,14 @@ class NetworkHTTPContentConnecter : TCPConnecter {
 public:
 	/**
 	 * Start the connecting.
-	 * @param address  the address to connect to
-	 * @param callback the callback for HTTP retrieval
-	 * @param url      the url at the server
-	 * @param data     the data to send
-	 * @param depth    the depth (redirect recursion) of the queries
+	 * @param connection_string The address to connect to.
+	 * @param callback The callback for HTTP retrieval.
+	 * @param url The url at the server.
+	 * @param data The data to send.
+	 * @param depth The depth (redirect recursion) of the queries.
 	 */
-	NetworkHTTPContentConnecter(const NetworkAddress &address,
-			HTTPCallback *callback, const char *url,
-			const char *data = nullptr, int depth = 0) :
-		TCPConnecter(address),
+	NetworkHTTPContentConnecter(const std::string &connection_string, HTTPCallback *callback, const char *url, const char *data = nullptr, int depth = 0) :
+		TCPConnecter(connection_string, 80),
 		callback(callback),
 		url(stredup(url)),
 		data(data),

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -145,7 +145,7 @@ void ClientNetworkEmergencySave()
  * Create a new socket for the client side of the game connection.
  * @param s The socket to connect with.
  */
-ClientNetworkGameSocketHandler::ClientNetworkGameSocketHandler(SOCKET s, NetworkAddress address) : NetworkGameSocketHandler(s), address(address), savegame(nullptr), status(STATUS_INACTIVE)
+ClientNetworkGameSocketHandler::ClientNetworkGameSocketHandler(SOCKET s, const std::string &connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string), savegame(nullptr), status(STATUS_INACTIVE)
 {
 	assert(ClientNetworkGameSocketHandler::my_client == nullptr);
 	ClientNetworkGameSocketHandler::my_client = this;
@@ -581,7 +581,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packe
 	NetworkGameList *item = GetLobbyGameInfo();
 	if (item == nullptr) {
 		/* This is not the lobby, so add it to the game list. */
-		item = NetworkGameListAddItem(this->address);
+		item = NetworkGameListAddItem(this->connection_string);
 	}
 
 	/* Clear any existing GRFConfig chain. */

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -15,7 +15,7 @@
 /** Class for handling the client side of the game connection. */
 class ClientNetworkGameSocketHandler : public ZeroedMemoryAllocator, public NetworkGameSocketHandler {
 private:
-	NetworkAddress address;        ///< Address we are connected to.
+	std::string connection_string; ///< Address we are connected to.
 	struct PacketReader *savegame; ///< Packet reader for reading the savegame.
 	byte token;                    ///< The token we need to send back to the server to prove we're the right client.
 
@@ -76,7 +76,7 @@ protected:
 	static NetworkRecvStatus SendMapOk();
 	void CheckConnection();
 public:
-	ClientNetworkGameSocketHandler(SOCKET s, NetworkAddress address);
+	ClientNetworkGameSocketHandler(SOCKET s, const std::string &connection_string);
 	~ClientNetworkGameSocketHandler();
 
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
@@ -115,10 +115,10 @@ void NetworkClientSetCompanyPassword(const char *password);
 /** Information required to join a server. */
 struct NetworkJoinInfo {
 	NetworkJoinInfo() : company(COMPANY_SPECTATOR), server_password(nullptr), company_password(nullptr) {}
-	NetworkAddress address;       ///< The address of the server to join.
-	CompanyID company;            ///< The company to join.
-	const char *server_password;  ///< The password of the server to join.
-	const char *company_password; ///< The password of the company to join.
+	std::string connection_string; ///< The address of the server to join.
+	CompanyID company;             ///< The company to join.
+	const char *server_password;   ///< The password of the server to join.
+	const char *company_password;  ///< The password of the company to join.
 };
 
 extern NetworkJoinInfo _network_join;

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -343,8 +343,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const Conten
 
 	this->http_response_index = -1;
 
-	NetworkAddress address(NETWORK_CONTENT_MIRROR_HOST, NETWORK_CONTENT_MIRROR_PORT);
-	new NetworkHTTPContentConnecter(address, this, NETWORK_CONTENT_MIRROR_URL, content_request);
+	new NetworkHTTPContentConnecter(NETWORK_CONTENT_MIRROR_HOST, this, NETWORK_CONTENT_MIRROR_URL, content_request);
 	/* NetworkHTTPContentConnecter takes over freeing of content_request! */
 }
 
@@ -744,7 +743,7 @@ public:
 	 * Initiate the connecting.
 	 * @param address The address of the server.
 	 */
-	NetworkContentConnecter(const NetworkAddress &address) : TCPConnecter(address) {}
+	NetworkContentConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_CONTENT_SERVER_PORT) {}
 
 	void OnFailure() override
 	{
@@ -770,7 +769,7 @@ void ClientNetworkContentSocketHandler::Connect()
 {
 	if (this->sock != INVALID_SOCKET || this->isConnecting) return;
 	this->isConnecting = true;
-	new NetworkContentConnecter(NetworkAddress(NETWORK_CONTENT_SERVER_HOST, NETWORK_CONTENT_SERVER_PORT, AF_UNSPEC));
+	new NetworkContentConnecter(NETWORK_CONTENT_SERVER_HOST);
 }
 
 /**

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -16,19 +16,19 @@
 
 /** Structure with information shown in the game list (GUI) */
 struct NetworkGameList {
-	NetworkGameInfo info;   ///< The game information of this server
-	NetworkAddress address; ///< The connection info of the game server
-	bool online;            ///< False if the server did not respond (default status)
-	bool manually;          ///< True if the server was added manually
-	uint8 retries;          ///< Number of retries (to stop requerying)
-	NetworkGameList *next;  ///< Next pointer to make a linked game list
+	NetworkGameInfo info;          ///< The game information of this server
+	std::string connection_string; ///< Address of the server
+	bool online;                   ///< False if the server did not respond (default status)
+	bool manually;                 ///< True if the server was added manually
+	uint8 retries;                 ///< Number of retries (to stop requerying)
+	NetworkGameList *next;         ///< Next pointer to make a linked game list
 };
 
 /** Game list of this client */
 extern NetworkGameList *_network_game_list;
 
 void NetworkGameListAddItemDelayed(NetworkGameList *item);
-NetworkGameList *NetworkGameListAddItem(NetworkAddress address);
+NetworkGameList *NetworkGameListAddItem(const std::string &connection_string);
 void NetworkGameListRemoveItem(NetworkGameList *remove);
 void NetworkGameListRequery();
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -272,7 +272,9 @@ protected:
 	static bool NGameNameSorter(NetworkGameList * const &a, NetworkGameList * const &b)
 	{
 		int r = strnatcmp(a->info.server_name, b->info.server_name, true); // Sort by name (natural sorting).
-		return r == 0 ? a->address.CompareTo(b->address) < 0: r < 0;
+		if (r == 0) r = a->connection_string.compare(b->connection_string);
+
+		return r < 0;
 	}
 
 	/**
@@ -646,8 +648,7 @@ public:
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_SERVER_VERSION); // server version
 			y += FONT_HEIGHT_NORMAL;
 
-			std::string address = sel->address.GetAddressAsString();
-			SetDParamStr(0, address.c_str());
+			SetDParamStr(0, sel->connection_string.c_str());
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_SERVER_ADDRESS); // server address
 			y += FONT_HEIGHT_NORMAL;
 
@@ -751,7 +752,7 @@ public:
 				break;
 
 			case WID_NG_REFRESH: // Refresh
-				if (this->server != nullptr) NetworkTCPQueryServer(this->server->address);
+				if (this->server != nullptr) NetworkTCPQueryServer(this->server->connection_string);
 				break;
 
 			case WID_NG_NEWGRF: // NewGRF Settings
@@ -1471,22 +1472,22 @@ struct NetworkLobbyWindow : public Window {
 
 			case WID_NL_JOIN:     // Join company
 				/* Button can be clicked only when it is enabled. */
-				NetworkClientConnectGame(this->server->address, this->company);
+				NetworkClientConnectGame(this->server->connection_string, this->company);
 				break;
 
 			case WID_NL_NEW:      // New company
-				NetworkClientConnectGame(this->server->address, COMPANY_NEW_COMPANY);
+				NetworkClientConnectGame(this->server->connection_string, COMPANY_NEW_COMPANY);
 				break;
 
 			case WID_NL_SPECTATE: // Spectate game
-				NetworkClientConnectGame(this->server->address, COMPANY_SPECTATOR);
+				NetworkClientConnectGame(this->server->connection_string, COMPANY_SPECTATOR);
 				break;
 
 			case WID_NL_REFRESH:  // Refresh
 				/* Clear the information so removed companies don't remain */
 				for (auto &company : this->company_info) company = {};
 
-				NetworkTCPQueryServer(this->server->address, true);
+				NetworkTCPQueryServer(this->server->connection_string, true);
 				break;
 		}
 	}
@@ -1554,9 +1555,9 @@ static void ShowNetworkLobbyWindow(NetworkGameList *ngl)
 	DeleteWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_START);
 	DeleteWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);
 
-	strecpy(_settings_client.network.last_joined, ngl->address.GetAddressAsString(false).c_str(), lastof(_settings_client.network.last_joined));
+	strecpy(_settings_client.network.last_joined, ngl->connection_string.c_str(), lastof(_settings_client.network.last_joined));
 
-	NetworkTCPQueryServer(ngl->address, true);
+	NetworkTCPQueryServer(ngl->connection_string, true);
 
 	new NetworkLobbyWindow(&_network_lobby_window_desc, ngl);
 }

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -87,7 +87,7 @@ extern uint8 _network_reconnect;
 
 extern CompanyMask _network_company_passworded;
 
-void NetworkTCPQueryServer(NetworkAddress address, bool request_company_info = false);
+void NetworkTCPQueryServer(const std::string &connection_string, bool request_company_info = false);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port);
 struct NetworkGameList *NetworkAddServer(const std::string &connection_string);
@@ -119,8 +119,6 @@ StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkFindName(char *new_name, const char *last);
 const char *GenerateCompanyPasswordHash(const char *password, const char *password_server_id, uint32 password_game_seed);
 
-bool NetworkClientConnectGame(NetworkAddress &address, CompanyID join_as, const char *join_server_password = nullptr, const char *join_company_password = nullptr);
 NetworkAddress ParseConnectionString(const std::string &connection_string, int default_port);
-NetworkAddress ParseGameConnectionString(CompanyID *company, const std::string &connection_string, int default_port);
 
 #endif /* NETWORK_INTERNAL_H */

--- a/src/network/network_udp.h
+++ b/src/network/network_udp.h
@@ -15,7 +15,7 @@
 void NetworkUDPInitialize();
 void NetworkUDPSearchGame();
 void NetworkUDPQueryMasterServer();
-void NetworkUDPQueryServer(NetworkAddress address, bool manually = false);
+void NetworkUDPQueryServer(const std::string &connection_string, bool manually = false);
 void NetworkUDPAdvertise();
 void NetworkUDPRemoveAdvertise(bool blocking);
 void NetworkUDPClose();


### PR DESCRIPTION
## Motivation / Problem

During work on the STUN support, I kept running into the issue that `NetworkAddress` modifies its own object when it is resolved (which is done lazy). With the STUN support PR, we get "invite codes", which is another form besides ip:port to indicate the address of a server.

When analyzing this problem, I came to the realisation that we store `NetworkAddress` in many places, like `NetworkGameList`, while we simply mean to store the address where the server is. There is no need to have this uber complex object assigned to it for that, a simple string is sufficient. This also helps for "invite codes", as that is just another serialization of a servr address.

This means we now resolve connection strings to `NetworkAddress` a lot later now. The downside is that we do it slightly more often (every time you refresh/join a server instead of once when adding it).

## Description

```
We now resolve the connection_string to a NetworkAddress in a much
later state. This means there are fewer places constructing a NetworkAddress.

The main benefit of this is in later PRs that introduce different types
of NetworkAddresses. Storing this in things like NetworkGameList is
rather complex, especially as NetworkAddress has to be mutable at all
times.

Additionally, the NetworkAddress is a complex object to store simple
information: how to connect to this server.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
