### PR TITLE
Feature: use Happy Eyeballs to make network connections (TCP-only)

### DIFF
--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -171,11 +171,11 @@ public:
 		return this->CompareTo(address) < 0;
 	}
 
-	SOCKET Connect();
 	void Listen(int socktype, SocketList *sockets);
 
 	static const char *SocketTypeAsString(int socktype);
 	static const char *AddressFamilyAsString(int family);
+	static const std::string GetPeerName(SOCKET sock);
 };
 
 #endif /* NETWORK_CORE_ADDRESS_H */

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -203,9 +203,11 @@ int NetworkHTTPSocketHandler::HandleHeader()
 
 	*url = '\0';
 
+	std::string hostname = std::string(hname);
+
 	/* Restore the URL. */
 	*url = '/';
-	new NetworkHTTPContentConnecter(hname, callback, url, data, depth);
+	new NetworkHTTPContentConnecter(hostname, callback, url, data, depth);
 	return 0;
 }
 

--- a/src/network/core/tcp_http.h
+++ b/src/network/core/tcp_http.h
@@ -73,6 +73,7 @@ public:
 
 /** Connect with a HTTP server and do ONE query. */
 class NetworkHTTPContentConnecter : TCPConnecter {
+	std::string hostname;   ///< Hostname we are connecting to.
 	HTTPCallback *callback; ///< Callback to tell that we received some data (or won't).
 	const char *url;        ///< The URL we want to get at the server.
 	const char *data;       ///< The data to send
@@ -81,14 +82,15 @@ class NetworkHTTPContentConnecter : TCPConnecter {
 public:
 	/**
 	 * Start the connecting.
-	 * @param connection_string The address to connect to.
+	 * @param hostname The hostname to connect to.
 	 * @param callback The callback for HTTP retrieval.
 	 * @param url The url at the server.
 	 * @param data The data to send.
 	 * @param depth The depth (redirect recursion) of the queries.
 	 */
-	NetworkHTTPContentConnecter(const std::string &connection_string, HTTPCallback *callback, const char *url, const char *data = nullptr, int depth = 0) :
-		TCPConnecter(connection_string, 80),
+	NetworkHTTPContentConnecter(const std::string &hostname, HTTPCallback *callback, const char *url, const char *data = nullptr, int depth = 0) :
+		TCPConnecter(hostname, 80),
+		hostname(hostname),
 		callback(callback),
 		url(stredup(url)),
 		data(data),
@@ -110,7 +112,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		new NetworkHTTPSocketHandler(s, this->callback, this->address.GetHostname(), this->url, this->data, this->depth);
+		new NetworkHTTPSocketHandler(s, this->callback, this->hostname.c_str(), this->url, this->data, this->depth);
 		/* We've relinquished control of data now. */
 		this->data = nullptr;
 	}

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -120,5 +120,6 @@ bool NetworkFindName(char *new_name, const char *last);
 const char *GenerateCompanyPasswordHash(const char *password, const char *password_server_id, uint32 password_game_seed);
 
 NetworkAddress ParseConnectionString(const std::string &connection_string, uint16 default_port);
+std::string NormalizeConnectionString(const std::string &connection_string, uint16 default_port);
 
 #endif /* NETWORK_INTERNAL_H */


### PR DESCRIPTION
## Motivation / Problem

From time to time we get reports that the Online Content list not loading (#9198, #8582, https://www.tt-forums.net/viewtopic.php?f=31&t=66905 ) is the most common case. In 99.99% of these cases, the problem is the IPv6 setup of the local machine: the OS things IPv6 is functional (`getaddrinfo` reports IPv6 as preferred, an IPv6 socket can be created, etc), but the connection is never really established. As this is a problem on OS level, OpenTTD cannot really resolve the issue.

This problem is most noticeable with TCP, as for UDP we basically just send out our request on what-ever interface we can find, and it is more likely it will find its way (up-side of stateless sockets). So we do not see many reports of people that cannot load the multiplayer list.

With the upcoming STUN support, we switch the multiplayer list to TCP too. This means that it is more likely people will notice this problem, and cannot play multiplayer. So, the question is: can't we do a similar solution like browers: try both IPv6 and IPv4, and see which one works. This, as dwfreed on IRC pointed out, is called [Happy Eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs).

This PR sets out to implement exactly this: try both IPv6 and IPv4 (if available), in a smart way to not hurt our servers too much. As added benefit, it also means the round-robin DNS we use is used a bit smarter: if the first IPv4 doesn't work (times out), the second is already tried after 250ms instead of after 3s.

## Description

```
Hostnames like "content.openttd.org" resolve into multiple IPv4 and IPv6.
It is possible that either of the IPs is not working, either due to
a poorly configured OS (having IPv6 but no valid route), broken network
paths, or a service that is temporary unavailable.

Instead of trying the IPs one by one, waiting for a 3s timeout between
each, be a bit more like browsers, and stack attempts on top of each
other with slight delays. This is called Happy Eyebells.

Initially, try the first IPv6 address. If within 250ms there is no
connection yet, try the first IPv4 address. 250ms later, try the
second IPv6 address, etc, till all addresses are tried.

If any connection is created, abort all the other (pending) connections
and use the one that is created. If all fail 3s after the last connect(),
trigger a timeout for all.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
