### PR TITLE
Codechange: [Network] Use std::string for network game info

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -392,7 +392,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 				fios->mtime = 0;
 				strecpy(fios->name, d_name, lastof(fios->name));
 				std::string dirname = std::string(d_name) + PATHSEP;
-				SetDParamStr(0, dirname.c_str());
+				SetDParamStr(0, dirname);
 				GetString(fios->title, STR_SAVELOAD_DIRECTORY, lastof(fios->title));
 				str_validate(fios->title, lastof(fios->title));
 			}

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -537,7 +537,7 @@ public:
 							const CompanyProperties &c = *pair.second;
 							if (!c.name.empty()) {
 								SetDParam(1, STR_JUST_RAW_STRING);
-								SetDParamStr(2, c.name.c_str());
+								SetDParamStr(2, c.name);
 							} else {
 								SetDParam(1, c.name_1);
 								SetDParam(2, c.name_2);

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -673,6 +673,28 @@ int DrawString(int left, int right, int top, const char *str, TextColour colour,
  * @return In case of left or center alignment the right most pixel we have drawn to.
  *         In case of right alignment the left most pixel we have drawn to.
  */
+int DrawString(int left, int right, int top, const std::string &str, TextColour colour, StringAlignment align, bool underline, FontSize fontsize)
+{
+	return DrawString(left, right, top, str.c_str(), colour, align, underline, fontsize);
+}
+
+/**
+ * Draw string, possibly truncated to make it fit in its allocated space
+ *
+ * @param left   The left most position to draw on.
+ * @param right  The right most position to draw on.
+ * @param top    The top most position to draw on.
+ * @param str    String to draw.
+ * @param colour Colour used for drawing the string, for details see _string_colourmap in
+ *               table/palettes.h or docs/ottd-colourtext-palette.png or the enum TextColour in gfx_type.h
+ * @param align  The alignment of the string when drawing left-to-right. In the
+ *               case a right-to-left language is chosen this is inverted so it
+ *               will be drawn in the right direction.
+ * @param underline Whether to underline what has been drawn or not.
+ * @param fontsize The size of the initial characters.
+ * @return In case of left or center alignment the right most pixel we have drawn to.
+ *         In case of right alignment the left most pixel we have drawn to.
+ */
 int DrawString(int left, int right, int top, StringID str, TextColour colour, StringAlignment align, bool underline, FontSize fontsize)
 {
 	char buffer[DRAW_STRING_BUFFER];
@@ -804,6 +826,28 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, const char *st
 	}
 
 	return ((align & SA_VERT_MASK) == SA_BOTTOM) ? first_line : last_line;
+}
+
+
+/**
+ * Draw string, possibly over multiple lines.
+ *
+ * @param left   The left most position to draw on.
+ * @param right  The right most position to draw on.
+ * @param top    The top most position to draw on.
+ * @param bottom The bottom most position to draw on.
+ * @param str    String to draw.
+ * @param colour Colour used for drawing the string, for details see _string_colourmap in
+ *               table/palettes.h or docs/ottd-colourtext-palette.png or the enum TextColour in gfx_type.h
+ * @param align  The horizontal and vertical alignment of the string.
+ * @param underline Whether to underline all strings
+ * @param fontsize The size of the initial characters.
+ *
+ * @return If \a align is #SA_BOTTOM, the top to where we have written, else the bottom to where we have written.
+ */
+int DrawStringMultiLine(int left, int right, int top, int bottom, const std::string &str, TextColour colour, StringAlignment align, bool underline, FontSize fontsize)
+{
+	return DrawStringMultiLine(left, right, top, bottom, str.c_str(), colour, align, underline, fontsize);
 }
 
 /**

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -92,8 +92,10 @@ void DrawSpriteViewport(SpriteID img, PaletteID pal, int x, int y, const SubSpri
 void DrawSprite(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub = nullptr, ZoomLevel zoom = ZOOM_LVL_GUI);
 
 int DrawString(int left, int right, int top, const char *str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL);
+int DrawString(int left, int right, int top, const std::string &str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL);
 int DrawString(int left, int right, int top, StringID str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL);
 int DrawStringMultiLine(int left, int right, int top, int bottom, const char *str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL);
+int DrawStringMultiLine(int left, int right, int top, int bottom, const std::string &str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL);
 int DrawStringMultiLine(int left, int right, int top, int bottom, StringID str, TextColour colour = TC_FROMSTRING, StringAlignment align = (SA_TOP | SA_LEFT), bool underline = false, FontSize fontsize = FS_NORMAL);
 
 void DrawCharCentered(WChar c, const Rect &r, TextColour colour);

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -972,7 +972,7 @@ public:
 		}
 
 		if (!i->text.empty()) {
-			SetDParamStr(0, i->text.c_str());
+			SetDParamStr(0, i->text);
 			y += WD_PAR_VSEP_WIDE;
 			y = DrawStringMultiLine(left + WD_FRAMERECT_LEFT, right - WD_FRAMERECT_RIGHT, y, UINT16_MAX, STR_JUST_RAW_STRING, TC_BLACK);
 		}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -572,12 +572,12 @@ public:
 				/* Draw the accepted cargoes, if any. Otherwise, will print "Nothing". */
 				GetAllCargoSuffixes(CARGOSUFFIX_IN, CST_FUND, nullptr, this->selected_type, indsp, indsp->accepts_cargo, cargo_suffix);
 				std::string cargostring = this->MakeCargoListString(indsp->accepts_cargo, cargo_suffix, lengthof(indsp->accepts_cargo), STR_INDUSTRY_VIEW_REQUIRES_N_CARGO);
-				y = DrawStringMultiLine(left, right, y, bottom, cargostring.c_str());
+				y = DrawStringMultiLine(left, right, y, bottom, cargostring);
 
 				/* Draw the produced cargoes, if any. Otherwise, will print "Nothing". */
 				GetAllCargoSuffixes(CARGOSUFFIX_OUT, CST_FUND, nullptr, this->selected_type, indsp, indsp->produced_cargo, cargo_suffix);
 				cargostring = this->MakeCargoListString(indsp->produced_cargo, cargo_suffix, lengthof(indsp->produced_cargo), STR_INDUSTRY_VIEW_PRODUCES_N_CARGO);
-				y = DrawStringMultiLine(left, right, y, bottom, cargostring.c_str());
+				y = DrawStringMultiLine(left, right, y, bottom, cargostring);
 
 				/* Get the additional purchase info text, if it has not already been queried. */
 				if (HasBit(indsp->callback_mask, CBM_IND_FUND_MORE_TEXT)) {

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -462,7 +462,7 @@ struct MusicTrackSelectionWindow : public Window {
 				SetDParam(0, STR_MUSIC_PLAYLIST_ALL + _settings_client.music.playlist);
 				break;
 			case WID_MTS_CAPTION:
-				SetDParamStr(0, BaseMusic::GetUsedSet()->name.c_str());
+				SetDParamStr(0, BaseMusic::GetUsedSet()->name);
 				break;
 		}
 	}

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -112,7 +112,7 @@ bool IsNetworkCompatibleVersion(const char *other)
 void CheckGameCompatibility(NetworkGameInfo &ngi)
 {
 	/* Check if we are allowed on this server based on the revision-check. */
-	ngi.version_compatible = IsNetworkCompatibleVersion(ngi.server_revision);
+	ngi.version_compatible = IsNetworkCompatibleVersion(ngi.server_revision.c_str());
 	ngi.compatible = ngi.version_compatible;
 
 	/* Check if we have all the GRFs on the client-system too. */
@@ -138,8 +138,8 @@ void FillStaticNetworkServerGameInfo()
 	_network_game_info.dedicated      = _network_dedicated;
 	_network_game_info.grfconfig      = _grfconfig;
 
-	strecpy(_network_game_info.server_name, _settings_client.network.server_name, lastof(_network_game_info.server_name));
-	strecpy(_network_game_info.server_revision, GetNetworkRevisionString(), lastof(_network_game_info.server_revision));
+	_network_game_info.server_name = _settings_client.network.server_name;
+	_network_game_info.server_revision = GetNetworkRevisionString();
 }
 
 /**
@@ -295,8 +295,8 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info)
 			FALLTHROUGH;
 
 		case 1:
-			p->Recv_string(info->server_name,     sizeof(info->server_name));
-			p->Recv_string(info->server_revision, sizeof(info->server_revision));
+			info->server_name = p->Recv_string(NETWORK_NAME_LENGTH);
+			info->server_revision = p->Recv_string(NETWORK_REVISION_LENGTH);
 			p->Recv_uint8 (); // Used to contain server-lang.
 			info->use_password   = p->Recv_bool  ();
 			info->clients_max    = p->Recv_uint8 ();

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -60,22 +60,22 @@
  * The game information that is sent from the server to the client.
  */
 struct NetworkServerGameInfo {
-	GRFConfig *grfconfig;                           ///< List of NewGRF files used
-	Date start_date;                                ///< When the game started
-	Date game_date;                                 ///< Current date
-	uint16 map_width;                               ///< Map width
-	uint16 map_height;                              ///< Map height
-	char server_name[NETWORK_NAME_LENGTH];          ///< Server name
-	char server_revision[NETWORK_REVISION_LENGTH];  ///< The version number the server is using (e.g.: 'r304' or 0.5.0)
-	bool dedicated;                                 ///< Is this a dedicated server?
-	bool use_password;                              ///< Is this server passworded?
-	byte clients_on;                                ///< Current count of clients on server
-	byte clients_max;                               ///< Max clients allowed on server
-	byte companies_on;                              ///< How many started companies do we have
-	byte companies_max;                             ///< Max companies allowed on server
-	byte spectators_on;                             ///< How many spectators do we have?
-	byte spectators_max;                            ///< Max spectators allowed on server
-	byte landscape;                                 ///< The used landscape
+	GRFConfig *grfconfig;        ///< List of NewGRF files used
+	Date start_date;             ///< When the game started
+	Date game_date;              ///< Current date
+	uint16 map_width;            ///< Map width
+	uint16 map_height;           ///< Map height
+	std::string server_name;     ///< Server name
+	std::string server_revision; ///< The version number the server is using (e.g.: 'r304' or 0.5.0)
+	bool dedicated;              ///< Is this a dedicated server?
+	bool use_password;           ///< Is this server passworded?
+	byte clients_on;             ///< Current count of clients on server
+	byte clients_max;            ///< Max clients allowed on server
+	byte companies_on;           ///< How many started companies do we have
+	byte companies_max;          ///< Max companies allowed on server
+	byte spectators_on;          ///< How many spectators do we have?
+	byte spectators_max;         ///< Max spectators allowed on server
+	byte landscape;              ///< The used landscape
 };
 
 /**

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -656,9 +656,9 @@ NetworkGameList *NetworkAddServer(const std::string &connection_string)
 
 	/* Ensure the item already exists in the list */
 	NetworkGameList *item = NetworkGameListAddItem(connection_string);
-	if (StrEmpty(item->info.server_name)) {
+	if (item->info.server_name.empty()) {
 		ClearGRFConfigList(&item->info.grfconfig);
-		strecpy(item->info.server_name, connection_string.c_str(), lastof(item->info.server_name));
+		item->info.server_name = connection_string;
 		item->manually = true;
 
 		NetworkRebuildHostList();
@@ -1163,7 +1163,7 @@ void NetworkStartUp()
 	/* Generate an server id when there is none yet */
 	if (StrEmpty(_settings_client.network.network_id)) NetworkGenerateServerId();
 
-	memset(&_network_game_info, 0, sizeof(_network_game_info));
+	_network_game_info = {};
 
 	NetworkInitialize();
 	DEBUG(net, 3, "[core] network online, multiplayer available");

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -47,10 +47,10 @@ static void NetworkGameListHandleDelayedInsert()
 		NetworkGameList *item = NetworkGameListAddItem(ins_item->connection_string);
 
 		if (item != nullptr) {
-			if (StrEmpty(item->info.server_name)) {
+			if (item->info.server_name.empty()) {
 				ClearGRFConfigList(&item->info.grfconfig);
-				memset(&item->info, 0, sizeof(item->info));
-				strecpy(item->info.server_name, ins_item->info.server_name, lastof(item->info.server_name));
+				item->info = {};
+				item->info.server_name = ins_item->info.server_name;
 				item->online = false;
 			}
 			item->manually |= ins_item->manually;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -271,7 +271,7 @@ protected:
 	/** Sort servers by name. */
 	static bool NGameNameSorter(NetworkGameList * const &a, NetworkGameList * const &b)
 	{
-		int r = strnatcmp(a->info.server_name, b->info.server_name, true); // Sort by name (natural sorting).
+		int r = strnatcmp(a->info.server_name.c_str(), b->info.server_name.c_str(), true); // Sort by name (natural sorting).
 		if (r == 0) r = a->connection_string.compare(b->connection_string);
 
 		return r < 0;
@@ -324,7 +324,7 @@ protected:
 	static bool NGameAllowedSorter(NetworkGameList * const &a, NetworkGameList * const &b)
 	{
 		/* The servers we do not know anything about (the ones that did not reply) should be at the bottom) */
-		int r = StrEmpty(a->info.server_revision) - StrEmpty(b->info.server_revision);
+		int r = a->info.server_revision.empty() - b->info.server_revision.empty();
 
 		/* Reverse default as we are interested in version-compatible clients first */
 		if (r == 0) r = b->info.version_compatible - a->info.version_compatible;
@@ -361,7 +361,7 @@ protected:
 		assert((*item) != nullptr);
 
 		sf.ResetState();
-		sf.AddLine((*item)->info.server_name);
+		sf.AddLine((*item)->info.server_name.c_str());
 		return sf.GetState();
 	}
 

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -91,7 +91,7 @@ static void DoNetworkUDPQueryServer(const std::string &connection_string, bool n
 {
 	/* Clear item in gamelist */
 	NetworkGameList *item = new NetworkGameList(connection_string, manually);
-	strecpy(item->info.server_name, connection_string.c_str(), lastof(item->info.server_name));
+	item->info.server_name = connection_string;
 	NetworkGameListAddItemDelayed(item);
 
 	std::unique_lock<std::mutex> lock(_udp_client.mutex, std::defer_lock);
@@ -362,7 +362,7 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAd
 	}
 
 	if (client_addr->GetAddress()->ss_family == AF_INET6) {
-		strecat(item->info.server_name, " (IPv6)", lastof(item->info.server_name));
+		item->info.server_name.append(" (IPv6)");
 	}
 
 	UpdateNetworkGameWindow();

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -51,9 +51,9 @@ void ShowNewGRFError()
 		if (c->error == nullptr || (c->error->severity != STR_NEWGRF_ERROR_MSG_FATAL && c->error->severity != STR_NEWGRF_ERROR_MSG_ERROR)) continue;
 
 		SetDParam   (0, c->error->message != STR_NULL ? c->error->message : STR_JUST_RAW_STRING);
-		SetDParamStr(1, c->error->custom_message.c_str());
+		SetDParamStr(1, c->error->custom_message);
 		SetDParamStr(2, c->filename);
-		SetDParamStr(3, c->error->data.c_str());
+		SetDParamStr(3, c->error->data);
 		for (uint i = 0; i < lengthof(c->error->param_value); i++) {
 			SetDParam(4 + i, c->error->param_value[i]);
 		}
@@ -70,9 +70,9 @@ static void ShowNewGRFInfo(const GRFConfig *c, uint x, uint y, uint right, uint 
 {
 	if (c->error != nullptr) {
 		char message[512];
-		SetDParamStr(0, c->error->custom_message.c_str()); // is skipped by built-in messages
+		SetDParamStr(0, c->error->custom_message); // is skipped by built-in messages
 		SetDParamStr(1, c->filename);
-		SetDParamStr(2, c->error->data.c_str());
+		SetDParamStr(2, c->error->data);
 		for (uint i = 0; i < lengthof(c->error->param_value); i++) {
 			SetDParam(3 + i, c->error->param_value[i]);
 		}
@@ -750,7 +750,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			case WID_NS_PRESET_LIST: {
 				Dimension d = GetStringBoundingBox(STR_NUM_CUSTOM);
 				for (const auto &i : this->grf_presets) {
-					SetDParamStr(0, i.c_str());
+					SetDParamStr(0, i);
 					d = maxdim(d, GetStringBoundingBox(STR_JUST_RAW_STRING));
 				}
 				d.width += padding.width;
@@ -783,7 +783,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 					SetDParam(0, STR_NUM_CUSTOM);
 				} else {
 					SetDParam(0, STR_JUST_RAW_STRING);
-					SetDParamStr(1, this->grf_presets[this->preset].c_str());
+					SetDParamStr(1, this->grf_presets[this->preset]);
 				}
 				break;
 		}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1631,7 +1631,7 @@ static GRFConfig *GRFLoadConfig(IniFile *ini, const char *grpname, bool is_stati
 				SetDParam(1, STR_CONFIG_ERROR_INVALID_GRF_UNKNOWN);
 			}
 
-			SetDParamStr(0, StrEmpty(filename) ? item->name.c_str() : filename);
+			SetDParamStr(0, StrEmpty(filename) ? item->name : filename);
 			ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_GRF, WL_CRITICAL);
 			delete c;
 			continue;

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -123,7 +123,7 @@ struct BaseSetTextfileWindow : public TextfileWindow {
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, content_type);
-			SetDParamStr(1, this->baseset->name.c_str());
+			SetDParamStr(1, this->baseset->name);
 		}
 	}
 };
@@ -304,10 +304,10 @@ struct GameOptionsWindow : Window {
 			case WID_GO_LANG_DROPDOWN:         SetDParamStr(0, _current_language->own_name); break;
 			case WID_GO_GUI_ZOOM_DROPDOWN:     SetDParam(0, _gui_zoom_dropdown[_gui_zoom_cfg != ZOOM_LVL_CFG_AUTO ? ZOOM_LVL_OUT_4X - _gui_zoom_cfg + 1 : 0]); break;
 			case WID_GO_FONT_ZOOM_DROPDOWN:    SetDParam(0, _font_zoom_dropdown[_font_zoom_cfg != ZOOM_LVL_CFG_AUTO ? ZOOM_LVL_OUT_4X - _font_zoom_cfg + 1 : 0]); break;
-			case WID_GO_BASE_GRF_DROPDOWN:     SetDParamStr(0, BaseGraphics::GetUsedSet()->name.c_str()); break;
+			case WID_GO_BASE_GRF_DROPDOWN:     SetDParamStr(0, BaseGraphics::GetUsedSet()->name); break;
 			case WID_GO_BASE_GRF_STATUS:       SetDParam(0, BaseGraphics::GetUsedSet()->GetNumInvalid()); break;
-			case WID_GO_BASE_SFX_DROPDOWN:     SetDParamStr(0, BaseSounds::GetUsedSet()->name.c_str()); break;
-			case WID_GO_BASE_MUSIC_DROPDOWN:   SetDParamStr(0, BaseMusic::GetUsedSet()->name.c_str()); break;
+			case WID_GO_BASE_SFX_DROPDOWN:     SetDParamStr(0, BaseSounds::GetUsedSet()->name); break;
+			case WID_GO_BASE_MUSIC_DROPDOWN:   SetDParamStr(0, BaseMusic::GetUsedSet()->name); break;
 			case WID_GO_BASE_MUSIC_STATUS:     SetDParam(0, BaseMusic::GetUsedSet()->GetNumInvalid()); break;
 			case WID_GO_REFRESH_RATE_DROPDOWN: SetDParam(0, _settings_client.gui.refresh_rate); break;
 			case WID_GO_RESOLUTION_DROPDOWN: {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -297,6 +297,17 @@ void SetDParamStr(uint n, const char *str)
 }
 
 /**
+ * This function is used to "bind" the C string of a std::string to a OpenTTD dparam slot.
+ * The caller has to ensure that the std::string reference remains valid while the string is shown.
+ * @param n slot of the string
+ * @param str string to bind
+ */
+void SetDParamStr(uint n, const std::string &str)
+{
+	SetDParamStr(n, str.c_str());
+}
+
+/**
  * Shift the string parameters in the global string parameter array by \a amount positions, making room at the beginning.
  * @param amount Number of positions to shift.
  */

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -205,6 +205,7 @@ void SetDParamMaxValue(uint n, uint64 max_value, uint min_count = 0, FontSize si
 void SetDParamMaxDigits(uint n, uint count, FontSize size = FS_NORMAL);
 
 void SetDParamStr(uint n, const char *str);
+void SetDParamStr(uint n, const std::string &str);
 
 void CopyInDParam(int offs, const uint64 *src, int num);
 void CopyOutDParam(uint64 *dst, int offs, int num);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -435,7 +435,7 @@ public:
 		}
 
 		if (!this->town->text.empty()) {
-			SetDParamStr(0, this->town->text.c_str());
+			SetDParamStr(0, this->town->text);
 			DrawStringMultiLine(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y += FONT_HEIGHT_NORMAL, UINT16_MAX, STR_JUST_RAW_STRING, TC_BLACK);
 		}
 	}
@@ -517,7 +517,7 @@ public:
 		if (_settings_game.economy.station_noise_level) aimed_height += FONT_HEIGHT_NORMAL;
 
 		if (!this->town->text.empty()) {
-			SetDParamStr(0, this->town->text.c_str());
+			SetDParamStr(0, this->town->text);
 			aimed_height += GetStringHeight(STR_JUST_RAW_STRING, width - WD_FRAMERECT_LEFT - WD_FRAMERECT_RIGHT);
 		}
 

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -65,7 +65,7 @@ StringID DropDownListParamStringItem::String() const
 
 StringID DropDownListCharStringItem::String() const
 {
-	SetDParamStr(0, this->raw_string.c_str());
+	SetDParamStr(0, this->raw_string);
 	return this->string;
 }
 


### PR DESCRIPTION
## Motivation / Problem

Simplification of string handling for the network game info, so less chance on buffer overruns.


## Description

Addition of some helper functions to pass std::string to SetDParamStr and DrawString.
Replace the C-string server name and revision with a std::string variant.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
