### PR TITLE
Add: [[nodiscard]] to std::string str_validate

### DIFF
--- a/src/string_func.h
+++ b/src/string_func.h
@@ -40,7 +40,7 @@ int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap)
 char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 
 void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
-std::string str_validate(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+[[nodiscard]] std::string str_validate(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void ValidateString(const char *str);
 
 void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);


### PR DESCRIPTION
## Motivation / Problem

The std::string version of str_validate creates a new string, contrary to the C-string str_validate which changes the buffer that was passed. As a result, anyone mistaken in the behavior will not get the expected result. The code will compile fine, but the validation will not happen. Especially when that data is to be considered insecure, that can be a major issue.


## Description

Add [[nodiscard]] to the std::string version so the compiler will complain whenever the returned cleaned/validate string is not used.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
