### PR TITLE
Codechange: Don't save unused NewGRF override mappings.

### DIFF
--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -218,6 +218,7 @@ public:
 
 	inline uint16 GetMaxMapping() const { return max_new_entities; }
 	inline uint16 GetMaxOffset() const { return max_offset; }
+	inline bool IsValidID(uint16 entity_id) const { return entity_overrides[entity_id] != invalid_ID; }
 };
 
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -30,6 +30,7 @@ static const SaveLoad _newgrf_mapping_desc[] = {
 void Save_NewGRFMapping(const OverrideManagerBase &mapping)
 {
 	for (uint i = 0; i < mapping.GetMaxMapping(); i++) {
+		if (!mapping.IsValidID(i)) continue;
 		SlSetArrayIndex(i);
 		SlObject(&mapping.mapping_ID[i], _newgrf_mapping_desc);
 	}


### PR DESCRIPTION
## Motivation / Problem

Saveload code for NewGRF entity override manager saves all entries for a table, regardless of whether they are mapped or not.

This is not a huge issue but is wasteful for saving objects as 64000 empty entries as saved.

## Description

This is resolved by testing if the override is valid, and only saving if so. The Saveload array already copes with sparse loading/saving so no saveload changes are needed.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
