### PR TITLE
Codechange: Slider widget used different range for drawing vs setting.

### DIFF
--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -16,6 +16,7 @@
 
 #include "../safeguards.h"
 
+static const int SLIDER_WIDTH = 3;
 
 /**
  * Draw a volume slider widget with know at given value
@@ -24,8 +25,6 @@
  */
 void DrawVolumeSliderWidget(Rect r, byte value)
 {
-	static const int slider_width = 3;
-
 	/* Draw a wedge indicating low to high volume level. */
 	const int ha = (r.bottom - r.top) / 5;
 	int wx1 = r.left, wx2 = r.right;
@@ -40,7 +39,7 @@ void DrawVolumeSliderWidget(Rect r, byte value)
 	GfxDrawLine(wedge[0].x, wedge[0].y, wedge[1].x, wedge[1].y, shadow);
 
 	/* Draw a slider handle indicating current volume level. */
-	const int sw = ScaleGUITrad(slider_width);
+	const int sw = ScaleGUITrad(SLIDER_WIDTH);
 	if (_current_text_dir == TD_RTL) value = 127 - value;
 	const int x = r.left + (value * (r.right - r.left - sw) / 127);
 	DrawFrameRect(x, r.top, x + sw, r.bottom, COLOUR_GREY, FR_NONE);
@@ -55,12 +54,10 @@ void DrawVolumeSliderWidget(Rect r, byte value)
  */
 bool ClickVolumeSliderWidget(Rect r, Point pt, byte &value)
 {
-	byte new_vol = Clamp((pt.x - r.left) * 127 / (r.right - r.left), 0, 127);
+	const int sw = ScaleGUITrad(SLIDER_WIDTH);
+	byte new_vol = Clamp((pt.x - r.left - sw / 2) * 127 / (r.right - r.left - sw), 0, 127);
 	if (_current_text_dir == TD_RTL) new_vol = 127 - new_vol;
 
-	/* Clamp to make sure min and max are properly settable */
-	if (new_vol > 124) new_vol = 127;
-	if (new_vol < 3) new_vol = 0;
 	if (new_vol != value) {
 		value = new_vol;
 		return true;


### PR DESCRIPTION
## Motivation / Problem

Volume slider widget does not handle input position using the same range as drawing position.

## Description

Use the same range for both input position and drawing position. This means that no workaround for setting the extremes is necessary any more.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
