### PR TITLE
Fix: [Emscripten] Use non-XDG directories to simplify local storage (#9207)

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -347,7 +347,7 @@ typedef unsigned char byte;
 #endif
 
 /* Define the the platforms that use XDG */
-#if defined(WITH_PERSONAL_DIR) && defined(UNIX) && !defined(__APPLE__)
+#if defined(WITH_PERSONAL_DIR) && defined(UNIX) && !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
 #	define USE_XDG
 #endif
 


### PR DESCRIPTION
## Motivation / Problem

Savegames and config settings are currently not stored properly on Emscripten.

## Description

At some point the Emscripten port has started using the XDG-specified directory (`$HOME/.local/share/openttd`) to store OpenTTD data, however, the persistent IDBFS filesystem is mounted on `$HOME/.openttd`.

This PR disables XDG support on Emscripten so everything is kept in one place. Since Emscripten is not a full Unix platform with other applications running, there is really no point in using the XDG directory that I see.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
