### PR TITLE
Change: support passing std::string directly to DEBUG

### DIFF
--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -153,7 +153,7 @@ template <class Tbase_set>
 bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_length, const std::string &tar_filename)
 {
 	bool ret = false;
-	DEBUG(grf, 1, "Checking %s for base " SET_TYPE " set", filename.c_str());
+	DEBUG(grf, 1, "Checking %s for base " SET_TYPE " set", filename);
 
 	Tbase_set *set = new Tbase_set();
 	IniFile *ini = new IniFile();
@@ -179,7 +179,7 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 			/* The more complete set takes precedence over the version number. */
 			if ((duplicate->valid_files == set->valid_files && duplicate->version >= set->version) ||
 					duplicate->valid_files > set->valid_files) {
-				DEBUG(grf, 1, "Not adding %s (%i) as base " SET_TYPE " set (duplicate, %s)", set->name.c_str(), set->version,
+				DEBUG(grf, 1, "Not adding %s (%i) as base " SET_TYPE " set (duplicate, %s)", set->name, set->version,
 						duplicate->valid_files > set->valid_files ? "less valid files" : "lower version");
 				set->next = BaseMedia<Tbase_set>::duplicate_sets;
 				BaseMedia<Tbase_set>::duplicate_sets = set;
@@ -195,7 +195,7 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 				 * version number until a new game is started which isn't a big problem */
 				if (BaseMedia<Tbase_set>::used_set == duplicate) BaseMedia<Tbase_set>::used_set = set;
 
-				DEBUG(grf, 1, "Removing %s (%i) as base " SET_TYPE " set (duplicate, %s)", duplicate->name.c_str(), duplicate->version,
+				DEBUG(grf, 1, "Removing %s (%i) as base " SET_TYPE " set (duplicate, %s)", duplicate->name, duplicate->version,
 						duplicate->valid_files < set->valid_files ? "less valid files" : "lower version");
 				duplicate->next = BaseMedia<Tbase_set>::duplicate_sets;
 				BaseMedia<Tbase_set>::duplicate_sets = duplicate;
@@ -209,7 +209,7 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 			ret = true;
 		}
 		if (ret) {
-			DEBUG(grf, 1, "Adding %s (%i) as base " SET_TYPE " set", set->name.c_str(), set->version);
+			DEBUG(grf, 1, "Adding %s (%i) as base " SET_TYPE " set", set->name, set->version);
 		}
 	} else {
 		delete set;

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -82,7 +82,7 @@ void FioSeekTo(size_t pos, int mode)
 	_fio.buffer = _fio.buffer_end = _fio.buffer_start + FIO_BUFFER_SIZE;
 	_fio.pos = pos;
 	if (fseek(_fio.cur_fh, _fio.pos, SEEK_SET) < 0) {
-		DEBUG(misc, 0, "Seeking in %s failed", _fio.filename.c_str());
+		DEBUG(misc, 0, "Seeking in %s failed", _fio.filename);
 	}
 }
 
@@ -685,7 +685,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t basepath_length, co
 			/* If we have only zeros in the block, it can be an end-of-file indicator */
 			if (memcmp(&th, &empty[0], 512) == 0) continue;
 
-			DEBUG(misc, 0, "The file '%s' isn't a valid tar-file", filename.c_str());
+			DEBUG(misc, 0, "The file '%s' isn't a valid tar-file", filename);
 			fclose(f);
 			return false;
 		}
@@ -783,7 +783,7 @@ bool TarScanner::AddFile(const std::string &filename, size_t basepath_length, co
 					}
 
 					if (destpos >= lastof(dest)) {
-						DEBUG(misc, 0, "The length of a link in tar-file '%s' is too large (malformed?)", filename.c_str());
+						DEBUG(misc, 0, "The length of a link in tar-file '%s' is too large (malformed?)", filename);
 						fclose(f);
 						return false;
 					}
@@ -815,14 +815,14 @@ bool TarScanner::AddFile(const std::string &filename, size_t basepath_length, co
 		/* Skip to the next block.. */
 		skip = Align(skip, 512);
 		if (fseek(f, skip, SEEK_CUR) < 0) {
-			DEBUG(misc, 0, "The file '%s' can't be read as a valid tar-file", filename.c_str());
+			DEBUG(misc, 0, "The file '%s' can't be read as a valid tar-file", filename);
 			fclose(f);
 			return false;
 		}
 		pos += skip;
 	}
 
-	DEBUG(misc, 1, "Found tar '%s' with " PRINTF_SIZE " new files", filename.c_str(), num);
+	DEBUG(misc, 1, "Found tar '%s' with " PRINTF_SIZE " new files", filename, num);
 	fclose(f);
 
 	/* Resolve file links and store directory links.
@@ -860,7 +860,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 
 	/* The file doesn't have a sub directory! */
 	if (dirname.empty()) {
-		DEBUG(misc, 1, "Extracting %s failed; archive rejected, the contents must be in a sub directory", tar_filename.c_str());
+		DEBUG(misc, 1, "Extracting %s failed; archive rejected, the contents must be in a sub directory", tar_filename);
 		return false;
 	}
 
@@ -870,7 +870,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 	if (p == std::string::npos) return false;
 
 	filename.replace(p + 1, std::string::npos, dirname);
-	DEBUG(misc, 8, "Extracting %s to directory %s", tar_filename.c_str(), filename.c_str());
+	DEBUG(misc, 8, "Extracting %s to directory %s", tar_filename, filename);
 	FioCreateDirectory(filename);
 
 	for (TarFileList::iterator it2 = _tar_filelist[subdir].begin(); it2 != _tar_filelist[subdir].end(); it2++) {
@@ -878,20 +878,20 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 
 		filename.replace(p + 1, std::string::npos, it2->first);
 
-		DEBUG(misc, 9, "  extracting %s", filename.c_str());
+		DEBUG(misc, 9, "  extracting %s", filename);
 
 		/* First open the file in the .tar. */
 		size_t to_copy = 0;
 		std::unique_ptr<FILE, FileDeleter> in(FioFOpenFileTar(it2->second, &to_copy));
 		if (!in) {
-			DEBUG(misc, 6, "Extracting %s failed; could not open %s", filename.c_str(), tar_filename.c_str());
+			DEBUG(misc, 6, "Extracting %s failed; could not open %s", filename, tar_filename);
 			return false;
 		}
 
 		/* Now open the 'output' file. */
 		std::unique_ptr<FILE, FileDeleter> out(fopen(filename.c_str(), "wb"));
 		if (!out) {
-			DEBUG(misc, 6, "Extracting %s failed; could not open %s", filename.c_str(), filename.c_str());
+			DEBUG(misc, 6, "Extracting %s failed; could not open %s", filename, filename);
 			return false;
 		}
 
@@ -904,7 +904,7 @@ bool ExtractTar(const std::string &tar_filename, Subdirectory subdir)
 		}
 
 		if (to_copy != 0) {
-			DEBUG(misc, 6, "Extracting %s failed; still %i bytes to copy", filename.c_str(), (int)to_copy);
+			DEBUG(misc, 6, "Extracting %s failed; still %i bytes to copy", filename, (int)to_copy);
 			return false;
 		}
 	}
@@ -1156,7 +1156,7 @@ void DeterminePaths(const char *exe)
 
 	for (Searchpath sp : _valid_searchpaths) {
 		if (sp == SP_WORKING_DIR && !_do_scan_working_directory) continue;
-		DEBUG(misc, 4, "%s added as search path", _searchpaths[sp].c_str());
+		DEBUG(misc, 4, "%s added as search path", _searchpaths[sp]);
 	}
 
 	std::string config_dir;
@@ -1189,7 +1189,7 @@ void DeterminePaths(const char *exe)
 		_config_file = config_dir + "openttd.cfg";
 	}
 
-	DEBUG(misc, 3, "%s found as config directory", config_dir.c_str());
+	DEBUG(misc, 3, "%s found as config directory", config_dir);
 
 	_highscore_file = config_dir + "hs.dat";
 	extern std::string _hotkeys_file;
@@ -1214,7 +1214,7 @@ void DeterminePaths(const char *exe)
 	FioCreateDirectory(_personal_dir);
 #endif
 
-	DEBUG(misc, 3, "%s found as personal directory", _personal_dir.c_str());
+	DEBUG(misc, 3, "%s found as personal directory", _personal_dir);
 
 	static const Subdirectory default_subdirs[] = {
 		SAVE_DIR, AUTOSAVE_DIR, SCENARIO_DIR, HEIGHTMAP_DIR, BASESET_DIR, NEWGRF_DIR, AI_DIR, AI_LIBRARY_DIR, GAME_DIR, GAME_LIBRARY_DIR, SCREENSHOT_DIR

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -123,7 +123,7 @@ void CheckExternalFiles()
 
 	const GraphicsSet *used_set = BaseGraphics::GetUsedSet();
 
-	DEBUG(grf, 1, "Using the %s base graphics set", used_set->name.c_str());
+	DEBUG(grf, 1, "Using the %s base graphics set", used_set->name);
 
 	static const size_t ERROR_MESSAGE_LENGTH = 256;
 	static const size_t MISSING_FILE_MESSAGE_LENGTH = 128;

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -112,7 +112,7 @@ bool IniFile::SaveToDisk(const std::string &filename)
 	SHFileOperation(&shfopt);
 #else
 	if (rename(file_new.c_str(), filename.c_str()) < 0) {
-		DEBUG(misc, 0, "Renaming %s to %s failed; configuration not saved", file_new.c_str(), filename.c_str());
+		DEBUG(misc, 0, "Renaming %s to %s failed; configuration not saved", file_new, filename);
 	}
 #endif
 

--- a/src/music/cocoa_m.cpp
+++ b/src/music/cocoa_m.cpp
@@ -119,7 +119,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 {
 	std::string filename = MidiFile::GetSMFFile(song);
 
-	DEBUG(driver, 2, "cocoa_m: trying to play '%s'", filename.c_str());
+	DEBUG(driver, 2, "cocoa_m: trying to play '%s'", filename);
 
 	this->StopSong();
 	if (_sequence != nullptr) {
@@ -173,7 +173,7 @@ void MusicDriver_Cocoa::PlaySong(const MusicSongInfo &song)
 	if (MusicPlayerStart(_player) != noErr) return;
 	_playing = true;
 
-	DEBUG(driver, 3, "cocoa_m: playing '%s'", filename.c_str());
+	DEBUG(driver, 3, "cocoa_m: playing '%s'", filename);
 }
 
 

--- a/src/music/dmusic.cpp
+++ b/src/music/dmusic.cpp
@@ -430,7 +430,7 @@ bool DLSFile::ReadDLSWaveList(FILE *f, DWORD list_length)
 
 bool DLSFile::LoadFile(const wchar_t *file)
 {
-	DEBUG(driver, 2, "DMusic: Try to load DLS file %s", FS2OTTD(file).c_str());
+	DEBUG(driver, 2, "DMusic: Try to load DLS file %s", FS2OTTD(file));
 
 	FILE *f = _wfopen(file, L"rb");
 	if (f == nullptr) return false;

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -248,7 +248,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 	std::chrono::seconds duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
 	if (!_resolve_timeout_error_message_shown && duration >= std::chrono::seconds(5)) {
 		DEBUG(net, 0, "getaddrinfo for hostname \"%s\", port %s, address family %s and socket type %s took %i seconds",
-				this->hostname.c_str(), port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), (int)duration.count());
+				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), (int)duration.count());
 		DEBUG(net, 0, "  this is likely an issue in the DNS name resolver's configuration causing it to time out");
 		_resolve_timeout_error_message_shown = true;
 	}
@@ -259,7 +259,7 @@ SOCKET NetworkAddress::Resolve(int family, int socktype, int flags, SocketList *
 	if (e != 0) {
 		if (func != ResolveLoopProc) {
 			DEBUG(net, 0, "getaddrinfo for hostname \"%s\", port %s, address family %s and socket type %s failed: %s",
-				this->hostname.c_str(), port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), FS2OTTD(gai_strerror(e)).c_str());
+				this->hostname, port_name, AddressFamilyAsString(family), SocketTypeAsString(socktype), FS2OTTD(gai_strerror(e)));
 		}
 		return INVALID_SOCKET;
 	}
@@ -317,43 +317,43 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 
 	SOCKET sock = socket(runp->ai_family, runp->ai_socktype, runp->ai_protocol);
 	if (sock == INVALID_SOCKET) {
-		DEBUG(net, 0, "[%s] could not create %s socket on port %s: %s", type, family, address.c_str(), NetworkError::GetLast().AsString());
+		DEBUG(net, 0, "[%s] could not create %s socket on port %s: %s", type, family, address, NetworkError::GetLast().AsString());
 		return INVALID_SOCKET;
 	}
 
 	if (runp->ai_socktype == SOCK_STREAM && !SetNoDelay(sock)) {
-		DEBUG(net, 3, "[%s] setting TCP_NODELAY failed for port %s", type, address.c_str());
+		DEBUG(net, 3, "[%s] setting TCP_NODELAY failed for port %s", type, address);
 	}
 
 	int on = 1;
 	/* The (const char*) cast is needed for windows!! */
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&on, sizeof(on)) == -1) {
-		DEBUG(net, 3, "[%s] could not set reusable %s sockets for port %s: %s", type, family, address.c_str(), NetworkError::GetLast().AsString());
+		DEBUG(net, 3, "[%s] could not set reusable %s sockets for port %s: %s", type, family, address, NetworkError::GetLast().AsString());
 	}
 
 #ifndef __OS2__
 	if (runp->ai_family == AF_INET6 &&
 			setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&on, sizeof(on)) == -1) {
-		DEBUG(net, 3, "[%s] could not disable IPv4 over IPv6 on port %s: %s", type, address.c_str(), NetworkError::GetLast().AsString());
+		DEBUG(net, 3, "[%s] could not disable IPv4 over IPv6 on port %s: %s", type, address, NetworkError::GetLast().AsString());
 	}
 #endif
 
 	if (bind(sock, runp->ai_addr, (int)runp->ai_addrlen) != 0) {
-		DEBUG(net, 1, "[%s] could not bind on %s port %s: %s", type, family, address.c_str(), NetworkError::GetLast().AsString());
+		DEBUG(net, 1, "[%s] could not bind on %s port %s: %s", type, family, address, NetworkError::GetLast().AsString());
 		closesocket(sock);
 		return INVALID_SOCKET;
 	}
 
 	if (runp->ai_socktype != SOCK_DGRAM && listen(sock, 1) != 0) {
-		DEBUG(net, 1, "[%s] could not listen at %s port %s: %s", type, family, address.c_str(), NetworkError::GetLast().AsString());
+		DEBUG(net, 1, "[%s] could not listen at %s port %s: %s", type, family, address, NetworkError::GetLast().AsString());
 		closesocket(sock);
 		return INVALID_SOCKET;
 	}
 
 	/* Connection succeeded */
-	if (!SetNonBlocking(sock)) DEBUG(net, 0, "[%s] setting non-blocking mode failed for %s port %s", type, family, address.c_str());
+	if (!SetNonBlocking(sock)) DEBUG(net, 0, "[%s] setting non-blocking mode failed for %s port %s", type, family, address);
 
-	DEBUG(net, 1, "[%s] listening on %s port %s", type, family, address.c_str());
+	DEBUG(net, 1, "[%s] listening on %s port %s", type, family, address);
 	return sock;
 }
 

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -62,13 +62,13 @@ void TCPConnecter::Connect(addrinfo *address)
 	if (!SetNonBlocking(sock)) DEBUG(net, 0, "Setting non-blocking mode failed");
 
 	NetworkAddress network_address = NetworkAddress(address->ai_addr, (int)address->ai_addrlen);
-	DEBUG(net, 4, "Attempting to connect to %s", network_address.GetAddressAsString().c_str());
+	DEBUG(net, 4, "Attempting to connect to %s", network_address.GetAddressAsString());
 
 	int err = connect(sock, address->ai_addr, (int)address->ai_addrlen);
 	if (err != 0 && !NetworkError::GetLast().IsConnectInProgress()) {
 		closesocket(sock);
 
-		DEBUG(net, 1, "Could not connect to %s: %s", network_address.GetAddressAsString().c_str(), NetworkError::GetLast().AsString());
+		DEBUG(net, 1, "Could not connect to %s: %s", network_address.GetAddressAsString(), NetworkError::GetLast().AsString());
 		return;
 	}
 
@@ -139,9 +139,9 @@ void TCPConnecter::OnResolved(addrinfo *ai)
 	}
 
 	if (_debug_net_level >= 5) {
-		DEBUG(net, 5, "%s resolved in:", this->connection_string.c_str());
+		DEBUG(net, 5, "%s resolved in:", this->connection_string);
 		for (const auto &address : this->addresses) {
-			DEBUG(net, 5, "- %s", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString().c_str());
+			DEBUG(net, 5, "- %s", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
 		}
 	}
 
@@ -171,13 +171,13 @@ void TCPConnecter::Resolve()
 	auto end = std::chrono::steady_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);
 	if (!getaddrinfo_timeout_error_shown && duration >= std::chrono::seconds(5)) {
-		DEBUG(net, 0, "getaddrinfo() for address \"%s\" took %i seconds", this->connection_string.c_str(), (int)duration.count());
+		DEBUG(net, 0, "getaddrinfo() for address \"%s\" took %i seconds", this->connection_string, (int)duration.count());
 		DEBUG(net, 0, "  This is likely an issue in the DNS name resolver's configuration causing it to time out");
 		getaddrinfo_timeout_error_shown = true;
 	}
 
 	if (e != 0) {
-		DEBUG(misc, 0, "Failed to resolve DNS for %s", this->connection_string.c_str());
+		DEBUG(misc, 0, "Failed to resolve DNS for %s", this->connection_string);
 		this->OnFailure();
 		return;
 	}
@@ -240,7 +240,7 @@ bool TCPConnecter::CheckActivity()
 
 		/* More than 3 seconds no socket reported activity, and there are no
 		 * more address to try. Timeout the attempt. */
-		DEBUG(net, 0, "Timeout while connecting to %s", this->connection_string.c_str());
+		DEBUG(net, 0, "Timeout while connecting to %s", this->connection_string);
 
 		for (const auto &socket : this->sockets) {
 			closesocket(socket);
@@ -253,7 +253,7 @@ bool TCPConnecter::CheckActivity()
 	for (auto it = this->sockets.begin(); it != this->sockets.end(); /* nothing */) {
 		NetworkError socket_error = GetSocketError(*it);
 		if (socket_error.HasError()) {
-			DEBUG(net, 1, "Could not connect to %s: %s", NetworkAddress::GetPeerName(*it).c_str(), socket_error.AsString());
+			DEBUG(net, 1, "Could not connect to %s: %s", NetworkAddress::GetPeerName(*it), socket_error.AsString());
 			closesocket(*it);
 			it = this->sockets.erase(it);
 		} else {
@@ -284,9 +284,9 @@ bool TCPConnecter::CheckActivity()
 	}
 	assert(connected_socket != INVALID_SOCKET);
 
-	DEBUG(net, 1, "Connected to %s", this->connection_string.c_str());
+	DEBUG(net, 1, "Connected to %s", this->connection_string);
 	if (_debug_net_level >= 5) {
-		DEBUG(net, 5, "- using %s", NetworkAddress::GetPeerName(connected_socket).c_str());
+		DEBUG(net, 5, "- using %s", NetworkAddress::GetPeerName(connected_socket));
 	}
 
 	this->OnConnect(connected_socket);

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -61,7 +61,7 @@ public:
 					Packet p(Tban_packet);
 					p.PrepareToSend();
 
-					DEBUG(net, 1, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry.c_str());
+					DEBUG(net, 1, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry);
 
 					if (p.TransferOut<int>(send, s, 0) < 0) {
 						DEBUG(net, 0, "send failed with error %s", NetworkError::GetLast().AsString());

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -101,10 +101,10 @@ void NetworkUDPSocketHandler::SendPacket(Packet *p, NetworkAddress *recv, bool a
 
 		/* Send the buffer */
 		ssize_t res = p->TransferOut<int>(sendto, s.second, 0, (const struct sockaddr *)send.GetAddress(), send.GetAddressLength());
-		DEBUG(net, 7, "[udp] sendto(%s)", send.GetAddressAsString().c_str());
+		DEBUG(net, 7, "[udp] sendto(%s)", send.GetAddressAsString());
 
 		/* Check for any errors, but ignore it otherwise */
-		if (res == -1) DEBUG(net, 1, "[udp] sendto(%s) failed with: %s", send.GetAddressAsString().c_str(), NetworkError::GetLast().AsString());
+		if (res == -1) DEBUG(net, 1, "[udp] sendto(%s) failed with: %s", send.GetAddressAsString(), NetworkError::GetLast().AsString());
 
 		if (!all) break;
 	}
@@ -140,7 +140,7 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			/* If the size does not match the packet must be corrupted.
 			 * Otherwise it will be marked as corrupted later on. */
 			if (!p.ParsePacketSize() || (size_t)nbytes != p.Size()) {
-				DEBUG(net, 1, "received a packet with mismatching size from %s", address.GetAddressAsString().c_str());
+				DEBUG(net, 1, "received a packet with mismatching size from %s", address.GetAddressAsString());
 				continue;
 			}
 			p.PrepareToRead();
@@ -181,9 +181,9 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet *p, NetworkAddress *client_
 
 		default:
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[udp] received invalid packet type %d from %s", type, client_addr->GetAddressAsString().c_str());
+				DEBUG(net, 0, "[udp] received invalid packet type %d from %s", type, client_addr->GetAddressAsString());
 			} else {
-				DEBUG(net, 0, "[udp] received illegal packet from %s", client_addr->GetAddressAsString().c_str());
+				DEBUG(net, 0, "[udp] received illegal packet from %s", client_addr->GetAddressAsString());
 			}
 			break;
 	}
@@ -196,7 +196,7 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet *p, NetworkAddress *client_
  */
 void NetworkUDPSocketHandler::ReceiveInvalidPacket(PacketUDPType type, NetworkAddress *client_addr)
 {
-	DEBUG(net, 0, "[udp] received packet type %d on wrong port from %s", type, client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 0, "[udp] received packet type %d on wrong port from %s", type, client_addr->GetAddressAsString());
 }
 
 void NetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_FIND_SERVER, client_addr); }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1150,12 +1150,12 @@ public:
 
 	void OnFailure() override
 	{
-		DEBUG(net, 0, "Failed to open connection to %s for redirecting DEBUG()", this->connection_string.c_str());
+		DEBUG(net, 0, "Failed to open connection to %s for redirecting DEBUG()", this->connection_string);
 	}
 
 	void OnConnect(SOCKET s) override
 	{
-		DEBUG(net, 0, "Redirecting DEBUG() to %s", this->connection_string.c_str());
+		DEBUG(net, 0, "Redirecting DEBUG() to %s", this->connection_string);
 
 		extern SOCKET _debug_socket;
 		_debug_socket = s;

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -67,7 +67,7 @@ struct UDPSocket {
 		std::unique_lock<std::mutex> lock(mutex, std::defer_lock);
 		if (!lock.try_lock()) {
 			if (++receive_iterations_locked % 32 == 0) {
-				DEBUG(net, 0, "[udp] %s background UDP loop processing appears to be blocked. Your OS may be low on UDP send buffers.", name.c_str());
+				DEBUG(net, 0, "[udp] %s background UDP loop processing appears to be blocked. Your OS may be low on UDP send buffers.", name);
 			}
 			return;
 		}
@@ -252,7 +252,7 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, Networ
 	uint8 in_reply_count = 0;
 	size_t packet_len = 0;
 
-	DEBUG(net, 6, "[udp] newgrf data request from %s", client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 6, "[udp] newgrf data request from %s", client_addr->GetAddressAsString());
 
 	num_grfs = p->Recv_uint8 ();
 	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
@@ -314,7 +314,7 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAd
 	/* Just a fail-safe.. should never happen */
 	if (_network_udp_server) return;
 
-	DEBUG(net, 4, "[udp] server response from %s", client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 4, "[udp] server response from %s", client_addr->GetAddressAsString());
 
 	/* Find next item */
 	item = NetworkGameListAddItem(client_addr->GetAddressAsString(false));
@@ -409,7 +409,7 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_NEWGRFS(Packet *p, NetworkAdd
 	uint8 num_grfs;
 	uint i;
 
-	DEBUG(net, 6, "[udp] newgrf data reply from %s", client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 6, "[udp] newgrf data reply from %s", client_addr->GetAddressAsString());
 
 	num_grfs = p->Recv_uint8 ();
 	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
@@ -461,7 +461,7 @@ void NetworkUDPQueryMasterServer()
 	std::lock_guard<std::mutex> lock(_udp_client.mutex);
 	_udp_client.socket->SendPacket(&p, &out_addr, true);
 
-	DEBUG(net, 2, "[udp] master server queried at %s", out_addr.GetAddressAsString().c_str());
+	DEBUG(net, 2, "[udp] master server queried at %s", out_addr.GetAddressAsString());
 }
 
 /** Find all servers */
@@ -525,8 +525,8 @@ static void NetworkUDPAdvertiseThread()
 	if (_session_key == 0 && session_key_retries++ == 2) {
 		DEBUG(net, 0, "[udp] advertising to the master server is failing");
 		DEBUG(net, 0, "[udp]   we are not receiving the session key from the server");
-		DEBUG(net, 0, "[udp]   please allow udp packets from %s to you to be delivered", out_addr.GetAddressAsString(false).c_str());
-		DEBUG(net, 0, "[udp]   please allow udp packets from you to %s to be delivered", out_addr.GetAddressAsString(false).c_str());
+		DEBUG(net, 0, "[udp]   please allow udp packets from %s to you to be delivered", out_addr.GetAddressAsString(false));
+		DEBUG(net, 0, "[udp]   please allow udp packets from you to %s to be delivered", out_addr.GetAddressAsString(false));
 	}
 	if (_session_key != 0 && _network_advertise_retries == 0) {
 		DEBUG(net, 0, "[udp] advertising to the master server is failing");

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -221,7 +221,7 @@ void CoreTextFontCache::SetFontSize(int pixels)
 	CFStringGetCString(font_name.get(), name, lengthof(name), kCFStringEncodingUTF8);
 	this->font_name = name;
 
-	DEBUG(freetype, 2, "Loaded font '%s' with size %d", this->font_name.c_str(), pixels);
+	DEBUG(freetype, 2, "Loaded font '%s' with size %d", this->font_name, pixels);
 }
 
 GlyphID CoreTextFontCache::MapCharToGlyph(WChar key)

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -439,7 +439,7 @@ void Win32FontCache::SetFontSize(FontSize fs, int pixels)
 	this->glyph_size.cx = otm->otmTextMetrics.tmMaxCharWidth;
 	this->glyph_size.cy = otm->otmTextMetrics.tmHeight;
 
-	DEBUG(freetype, 2, "Loaded font '%s' with size %d", FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFullName)).c_str(), pixels);
+	DEBUG(freetype, 2, "Loaded font '%s' with size %d", FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFullName)), pixels);
 }
 
 /**

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -281,7 +281,7 @@ bool LoadOldSaveGame(const std::string &file)
 	ls.file = FioFOpenFile(file, "rb", NO_DIRECTORY);
 
 	if (ls.file == nullptr) {
-		DEBUG(oldloader, 0, "Cannot open file '%s'", file.c_str());
+		DEBUG(oldloader, 0, "Cannot open file '%s'", file);
 		return false;
 	}
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2825,7 +2825,7 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
 		}
 
 		if (fop == SLO_SAVE) { // SAVE game
-			DEBUG(desync, 1, "save: %08x; %02x; %s", _date, _date_fract, filename.c_str());
+			DEBUG(desync, 1, "save: %08x; %02x; %s", _date, _date_fract, filename);
 			if (_network_server || !_settings_client.gui.threaded_saves) threaded = false;
 
 			return DoSave(new FileWriter(fh), threaded);
@@ -2833,7 +2833,7 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
 
 		/* LOAD game */
 		assert(fop == SLO_LOAD || fop == SLO_CHECK);
-		DEBUG(desync, 1, "load: %s", filename.c_str());
+		DEBUG(desync, 1, "load: %s", filename);
 		return DoLoad(new FileReader(fh), fop == SLO_CHECK);
 	} catch (...) {
 		/* This code may be executed both for old and new save games. */

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -124,7 +124,7 @@ bool ScriptInstance::LoadCompatibilityScripts(const char *api_version, Subdirect
 		if (this->engine->LoadScript(buf.c_str())) return true;
 
 		ScriptLog::Error("Failed to load API compatibility script");
-		DEBUG(script, 0, "Error compiling / running API compatibility script: %s", buf.c_str());
+		DEBUG(script, 0, "Error compiling / running API compatibility script: %s", buf);
 		return false;
 	}
 

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -38,7 +38,7 @@ bool ScriptScanner::AddFile(const std::string &filename, size_t basepath_length,
 	try {
 		this->engine->LoadScript(filename.c_str());
 	} catch (Script_FatalError &e) {
-		DEBUG(script, 0, "Fatal error '%s' when trying to load the script '%s'.", e.GetErrorMessage().c_str(), filename.c_str());
+		DEBUG(script, 0, "Fatal error '%s' when trying to load the script '%s'.", e.GetErrorMessage(), filename);
 		return false;
 	}
 	return true;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1496,7 +1496,7 @@ static void AILoadConfig(IniFile *ini, const char *grpname)
 		config->Change(item->name.c_str());
 		if (!config->HasScript()) {
 			if (item->name != "none") {
-				DEBUG(script, 0, "The AI by the name '%s' was no longer found, and removed from the list.", item->name.c_str());
+				DEBUG(script, 0, "The AI by the name '%s' was no longer found, and removed from the list.", item->name);
 				continue;
 			}
 		}
@@ -1523,7 +1523,7 @@ static void GameLoadConfig(IniFile *ini, const char *grpname)
 	config->Change(item->name.c_str());
 	if (!config->HasScript()) {
 		if (item->name != "none") {
-			DEBUG(script, 0, "The GameScript by the name '%s' was no longer found, and removed from the list.", item->name.c_str());
+			DEBUG(script, 0, "The GameScript by the name '%s' was no longer found, and removed from the list.", item->name);
 			return;
 		}
 	}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2043,7 +2043,7 @@ bool MissingGlyphSearcher::FindMissingGlyphs()
 					default: NOT_REACHED();
 				}
 
-				DEBUG(freetype, 0, "Font is missing glyphs to display char 0x%X in %s font size", c, size_name.c_str());
+				DEBUG(freetype, 0, "Font is missing glyphs to display char 0x%X in %s font size", c, size_name);
 				return true;
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

Many changes/conversions changing variables to std::string end up with changing calls to `DEBUG` to add `.c_str()`. 
This problem compounded by MSVC not complaining about this, and it even just seeming to work out of the box. So you might only find out the forgotten `.c_str()`s when having created the PR.


## Description

Add effectively a C++-wrapper around the existing `debug` that performs the conversion where needed, and let `DEBUG` use that.


## Limitations

Slightly more code in the debug header, but fewer chances on mistakes and fewer changes required when converting towards std::string. For now the conversion functions are in the debug header, though they should probably go to a different location once this functionality gets used in more places.
Furthermore `WARN_FORMAT` cannot look at the parameters anymore, so we'd be losing that bit of help. So the question is what's worse, not having that warning or `c_str()` in many places.


## Future work

Other printf style functions could be converted, though there it cannot be injected as easily as the functions are called directly. In other words, the existing functions need to be renamed and then the wrapper can be added.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
