### PR TITLE
Fix f7e390bd: getpeername() doesn't work on closed sockets

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -15,8 +15,9 @@
 #include "address.h"
 #include "packet.h"
 
-#include <chrono>
 #include <atomic>
+#include <chrono>
+#include <map>
 
 /** The states of sending the packets. */
 enum SendPacketsState {
@@ -66,6 +67,7 @@ class TCPConnecter {
 private:
 	addrinfo *ai = nullptr;                             ///< getaddrinfo() allocated linked-list of resolved addresses.
 	std::vector<addrinfo *> addresses;                  ///< Addresses we can connect to.
+	std::map<SOCKET, NetworkAddress> sock_to_address;   ///< Mapping of a socket to the real address it is connecting to. USed for DEBUG statements.
 	size_t current_address = 0;                         ///< Current index in addresses we are trying.
 
 	std::vector<SOCKET> sockets;                        ///< Pending connect() attempts.


### PR DESCRIPTION
## Motivation / Problem

I blindly assumed `getpeername()` works on sockets, opened or recently closed. I was wrong.

Initially testing didn't show this, as I made a last minute change to this, and failed to test this specific flow.


## Description

Store the real address we are connecting to in a map, so for debug statements we can show more useful information.

This is a bit more bookkeeping, so easier to mess up; but at least it is better than not knowing what failed exactly.

As extra bonus, found a few minor mistakes: `close` instead of `closesocket`, and not cleaning the list on timeout, causing the sockets to be closed twice (absolutely no harm in doing that, just not useful).

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
