### PR TITLE
Cleanup: [Fluidsynth] Remove fluid_player_join

### DIFF
--- a/src/music/fluidsynth.cpp
+++ b/src/music/fluidsynth.cpp
@@ -163,21 +163,12 @@ void MusicDriver_FluidSynth::PlaySong(const MusicSongInfo &song)
 
 void MusicDriver_FluidSynth::StopSong()
 {
-	{
-		std::lock_guard<std::mutex> lock{ _midi.synth_mutex };
-
-		if (_midi.player == nullptr) return;
-
-		fluid_player_stop(_midi.player);
-	}
-
-	/* The join must be run without lock as the Music rendering needs to be
-	 * running so FluidSynth's internals can actually stop the playing. */
-	if (fluid_player_join(_midi.player) != FLUID_OK) {
-		DEBUG(driver, 0, "Could not join player");
-	}
-
 	std::lock_guard<std::mutex> lock{ _midi.synth_mutex };
+
+	if (_midi.player == nullptr) return;
+
+	fluid_player_stop(_midi.player);
+	/* No fluid_player_join needed */
 	delete_fluid_player(_midi.player);
 	fluid_synth_system_reset(_midi.synth);
 	fluid_synth_all_sounds_off(_midi.synth, -1);


### PR DESCRIPTION
## Motivation / Problem

Broken function in the Fluidsynth API => https://github.com/FluidSynth/fluidsynth/issues/872.


## Description

The function fluid_player_join in the library is broken for the usecases it was used for (see their FluidSynth#872). It does not wait until it is safe to delete the player, so it is up to the end user to ensure that.

For OpenTTD we acquire a lock before fluid_synth_write_s16 and we acquire the same lock in the stop function. So, only one of the functions can be doing its thing, meaning we do not need to wait for the player to be stopped as it cannot be doing anything as we prevent that by the lock.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
