### PR TITLE
Several network code related fixes (four for one special!)

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -74,6 +74,7 @@ private:
 	std::chrono::steady_clock::time_point last_attempt; ///< Time we last tried to connect.
 
 	std::atomic<bool> is_resolved = false;              ///< Whether resolving is done.
+	std::string connection_string;                      ///< Current address we are connecting to (before resolving).
 
 	void Resolve();
 	void OnResolved(addrinfo *ai);
@@ -84,8 +85,6 @@ private:
 	static void ResolveThunk(TCPConnecter *connecter);
 
 public:
-	std::string connection_string;                      ///< Current address we are connecting to (before resolving).
-
 	TCPConnecter(const std::string &connection_string, uint16 default_port);
 	virtual ~TCPConnecter();
 

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <chrono>
 #include <map>
+#include <thread>
 
 /** The states of sending the packets. */
 enum SendPacketsState {
@@ -65,6 +66,9 @@ public:
  */
 class TCPConnecter {
 private:
+	std::thread resolve_thread;                         ///< Thread used during resolving.
+	std::atomic<bool> is_resolved = false;              ///< Whether resolving is done.
+
 	addrinfo *ai = nullptr;                             ///< getaddrinfo() allocated linked-list of resolved addresses.
 	std::vector<addrinfo *> addresses;                  ///< Addresses we can connect to.
 	std::map<SOCKET, NetworkAddress> sock_to_address;   ///< Mapping of a socket to the real address it is connecting to. USed for DEBUG statements.
@@ -73,7 +77,6 @@ private:
 	std::vector<SOCKET> sockets;                        ///< Pending connect() attempts.
 	std::chrono::steady_clock::time_point last_attempt; ///< Time we last tried to connect.
 
-	std::atomic<bool> is_resolved = false;              ///< Whether resolving is done.
 	std::string connection_string;                      ///< Current address we are connecting to (before resolving).
 
 	void Resolve();

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -32,13 +32,17 @@ TCPConnecter::TCPConnecter(const std::string &connection_string, uint16 default_
 
 	_tcp_connecters.push_back(this);
 
-	if (!StartNewThread(nullptr, "ottd:resolve", &TCPConnecter::ResolveThunk, this)) {
+	if (!StartNewThread(&this->resolve_thread, "ottd:resolve", &TCPConnecter::ResolveThunk, this)) {
 		this->Resolve();
 	}
 }
 
 TCPConnecter::~TCPConnecter()
 {
+	if (this->resolve_thread.joinable()) {
+		this->resolve_thread.join();
+	}
+
 	for (const auto &socket : this->sockets) {
 		closesocket(socket);
 	}
@@ -187,6 +191,7 @@ void TCPConnecter::Resolve()
 
 	this->ai = ai;
 	this->OnResolved(ai);
+
 	this->is_resolved = true;
 }
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1145,8 +1145,11 @@ static void NetworkGenerateServerId()
 }
 
 class TCPNetworkDebugConnecter : TCPConnecter {
+private:
+	std::string connection_string;
+
 public:
-	TCPNetworkDebugConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_DEBUGLOG_PORT) {}
+	TCPNetworkDebugConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_DEBUGLOG_PORT), connection_string(connection_string) {}
 
 	void OnFailure() override
 	{

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -628,11 +628,6 @@ private:
 public:
 	TCPQueryConnecter(const std::string &connection_string, bool request_company_info) : TCPConnecter(connection_string, NETWORK_DEFAULT_PORT), request_company_info(request_company_info), connection_string(connection_string) {}
 
-	void OnFailure() override
-	{
-		NetworkDisconnect();
-	}
-
 	void OnConnect(SOCKET s) override
 	{
 		_networking = true;
@@ -650,7 +645,6 @@ void NetworkTCPQueryServer(const std::string &connection_string, bool request_co
 {
 	if (!_network_available) return;
 
-	NetworkDisconnect();
 	NetworkInitialize();
 
 	new TCPQueryConnecter(connection_string, request_company_info);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -657,7 +657,7 @@ void NetworkTCPQueryServer(const std::string &connection_string, bool request_co
  * @param connection_string The IP:port of the server to add.
  * @return The entry on the game list.
  */
-NetworkGameList *NetworkAddServer(const std::string &connection_string)
+NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually)
 {
 	if (connection_string.empty()) return nullptr;
 
@@ -666,13 +666,14 @@ NetworkGameList *NetworkAddServer(const std::string &connection_string)
 	if (item->info.server_name.empty()) {
 		ClearGRFConfigList(&item->info.grfconfig);
 		item->info.server_name = connection_string;
-		item->manually = true;
 
 		NetworkRebuildHostList();
 		UpdateNetworkGameWindow();
+
+		NetworkTCPQueryServer(connection_string);
 	}
 
-	NetworkTCPQueryServer(connection_string);
+	if (manually) item->manually = true;
 
 	return item;
 }
@@ -1202,7 +1203,7 @@ extern "C" {
 
 void CDECL em_openttd_add_server(const char *connection_string)
 {
-	NetworkAddServer(connection_string);
+	NetworkAddServer(connection_string, false);
 }
 
 }

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -90,7 +90,7 @@ extern CompanyMask _network_company_passworded;
 void NetworkTCPQueryServer(const std::string &connection_string, bool request_company_info = false);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port);
-struct NetworkGameList *NetworkAddServer(const std::string &connection_string);
+struct NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually = true);
 void NetworkRebuildHostList();
 void UpdateNetworkGameWindow();
 


### PR DESCRIPTION
## Motivation / Problem

- `TCPConnecter` dtor was making illegal writes/reads when killed before resolving was done
- You couldn't query two servers at once

Both required fixing. And I had 2 code cleanups in my queue .. might as well add them.

## Description

`TCPConnecter` dtor was a bit evil, as two problems intersected:
- `connection_string` was already free'd before the dtor of `TCPConnecter` was called. This was not expected. But because private/public wasn't set correctly for it, `TCPQueryConnecter` was already freeing the memory in his ctor. This was unintentional.
- `TCPConnecter` didn't join the resolve thread, so it could still be pending, and reading/writing information. Now instead, wait till the resolve thread finishes before destroying `TCPConnecter`.
- `NetworkTCPQueryServer` disconnected the network. No clue why .. most likely once that sounded like a good idea, but it is totally unneeded now.
- If you added a server that was already on the master-server listing, it was never marked as manual. So a game client restart still didn't make it show up. That is unexpected.
- While at it, also only query a server again if we didn't already have info about it. No need to constantly request information of a server .. it is unlikely to have changed.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
