### PR TITLE
Fix to Polish town names generation

### DIFF
--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -1480,7 +1480,7 @@ static const char * const _name_polish_2_n[] = {
 	"Pilzno",
 	"Przodkowo",
 	"Strzelno",
-	"Susz",
+	"Leszno",
 	"Jaworzno",
 	"Choszczno",
 	"Mogilno",

--- a/src/table/townname.h
+++ b/src/table/townname.h
@@ -1386,7 +1386,7 @@ static const char * const _name_polish_2_o[] = {
 	"Zakopane",
 	u8"Szklarska Por\u0119ba",
 	"Bochnia",
-	"Golub-Dobrzyn",
+	u8"Golub-Dobrzy\u0144",
 	"Chojnice",
 	"Ostrowiec",
 	"Otwock",


### PR DESCRIPTION
## Motivation / Problem

Polish name generation has a small bug which results in grammatically incorrect names.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

The name "Susz" is masculine, not neuter. The correct associations are "Susz Morski", "Susz Górny", not "Susz Morskie" or "Susz Górne" like now in the game.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
