### PR TITLE
Fix: lobby window doesn't close if no connection could be established

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -752,7 +752,7 @@ public:
 				break;
 
 			case WID_NG_REFRESH: // Refresh
-				if (this->server != nullptr) NetworkTCPQueryServer(this->server->connection_string);
+				if (this->server != nullptr) NetworkQueryServer(this->server->connection_string);
 				break;
 
 			case WID_NG_NEWGRF: // NewGRF Settings
@@ -1487,7 +1487,7 @@ struct NetworkLobbyWindow : public Window {
 				/* Clear the information so removed companies don't remain */
 				for (auto &company : this->company_info) company = {};
 
-				NetworkTCPQueryServer(this->server->connection_string, true);
+				NetworkQueryLobbyServer(this->server->connection_string);
 				break;
 		}
 	}
@@ -1557,7 +1557,7 @@ static void ShowNetworkLobbyWindow(NetworkGameList *ngl)
 
 	strecpy(_settings_client.network.last_joined, ngl->connection_string.c_str(), lastof(_settings_client.network.last_joined));
 
-	NetworkTCPQueryServer(ngl->connection_string, true);
+	NetworkQueryLobbyServer(ngl->connection_string);
 
 	new NetworkLobbyWindow(&_network_lobby_window_desc, ngl);
 }

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -87,7 +87,8 @@ extern uint8 _network_reconnect;
 
 extern CompanyMask _network_company_passworded;
 
-void NetworkTCPQueryServer(const std::string &connection_string, bool request_company_info = false);
+void NetworkQueryServer(const std::string &connection_string);
+void NetworkQueryLobbyServer(const std::string &connection_string);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port);
 struct NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually = true);


### PR DESCRIPTION
## Motivation / Problem

In some cases it is possible that you could open the Lobby window, but the connection to the server could not be established. This leaves you in this weird state where the Lobby window is not receiving any company info, but also doesn't tell you the connection is not established.

## Description

Drop out of the Lobby window if the connection could not be established.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
