### PR TITLE
Fix #9202: Invalid test for unset NewGRF override mapping.

### DIFF
--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -218,7 +218,6 @@ public:
 
 	inline uint16 GetMaxMapping() const { return max_new_entities; }
 	inline uint16 GetMaxOffset() const { return max_offset; }
-	inline bool IsValidID(uint16 entity_id) const { return entity_overrides[entity_id] != invalid_ID; }
 };
 
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -30,7 +30,8 @@ static const SaveLoad _newgrf_mapping_desc[] = {
 void Save_NewGRFMapping(const OverrideManagerBase &mapping)
 {
 	for (uint i = 0; i < mapping.GetMaxMapping(); i++) {
-		if (!mapping.IsValidID(i)) continue;
+		if (mapping.mapping_ID[i].grfid == 0 &&
+		    mapping.mapping_ID[i].entity_id == 0) continue;
 		SlSetArrayIndex(i);
 		SlObject(&mapping.mapping_ID[i], _newgrf_mapping_desc);
 	}


### PR DESCRIPTION
## Motivation / Problem

#9202 introduced and used an incorrect test for whether an override has been set.

## Description

Test for grfid and entity_id being non-zero instead.

## Limitations

May be better to revert and not care, savegames are compressed anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
