### PR TITLE
Make Window destruction not rely on undefined behavior

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1289,7 +1289,7 @@ void ShowQuery(StringID caption, StringID message, Window *parent, QueryCallback
 {
 	if (parent == nullptr) parent = FindWindowById(WC_MAIN_WINDOW, 0);
 
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class != WC_CONFIRM_POPUP_QUERY) continue;
 
 		const QueryWindow *qw = (const QueryWindow *)w;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -245,6 +245,7 @@ static void SndPlayScreenCoordFx(SoundID sound, int left, int right, int top, in
 {
 	if (_settings_client.music.effect_vol == 0) return;
 
+	/* Iterate from back, so that main viewport is checked first */
 	for (const Window *w : Window::IterateFromBack()) {
 		const Viewport *vp = w->viewport;
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -266,35 +266,36 @@ void InitializeWindowViewport(Window *w, int x, int y,
 
 static Point _vp_move_offs;
 
-static void DoSetViewportPosition(const Window *w, int left, int top, int width, int height)
+static void DoSetViewportPosition(Window::IteratorToFront it, int left, int top, int width, int height)
 {
-	for (const Window *w : Window::IterateFromBack(w)) {
+	for (; !it.IsEnd(); ++it) {
+		const Window *w = *it;
 		if (left + width > w->left &&
 				w->left + w->width > left &&
 				top + height > w->top &&
 				w->top + w->height > top) {
 
 			if (left < w->left) {
-				DoSetViewportPosition(w, left, top, w->left - left, height);
-				DoSetViewportPosition(w, left + (w->left - left), top, width - (w->left - left), height);
+				DoSetViewportPosition(it, left, top, w->left - left, height);
+				DoSetViewportPosition(it, left + (w->left - left), top, width - (w->left - left), height);
 				return;
 			}
 
 			if (left + width > w->left + w->width) {
-				DoSetViewportPosition(w, left, top, (w->left + w->width - left), height);
-				DoSetViewportPosition(w, left + (w->left + w->width - left), top, width - (w->left + w->width - left), height);
+				DoSetViewportPosition(it, left, top, (w->left + w->width - left), height);
+				DoSetViewportPosition(it, left + (w->left + w->width - left), top, width - (w->left + w->width - left), height);
 				return;
 			}
 
 			if (top < w->top) {
-				DoSetViewportPosition(w, left, top, width, (w->top - top));
-				DoSetViewportPosition(w, left, top + (w->top - top), width, height - (w->top - top));
+				DoSetViewportPosition(it, left, top, width, (w->top - top));
+				DoSetViewportPosition(it, left, top + (w->top - top), width, height - (w->top - top));
 				return;
 			}
 
 			if (top + height > w->top + w->height) {
-				DoSetViewportPosition(w, left, top, width, (w->top + w->height - top));
-				DoSetViewportPosition(w, left, top + (w->top + w->height - top), width, height - (w->top + w->height - top));
+				DoSetViewportPosition(it, left, top, width, (w->top + w->height - top));
+				DoSetViewportPosition(it, left, top + (w->top + w->height - top), width, height - (w->top + w->height - top));
 				return;
 			}
 
@@ -380,7 +381,11 @@ static void SetViewportPosition(Window *w, int x, int y)
 		i = top + height - _screen.height;
 		if (i >= 0) height -= i;
 
-		if (height > 0) DoSetViewportPosition(w->z_front, left, top, width, height);
+		if (height > 0) {
+			Window::IteratorToFront it(w);
+			++it;
+			DoSetViewportPosition(it, left, top, width, height);
+		}
 	}
 }
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1480,7 +1480,7 @@ void ViewportSign::MarkDirty(ZoomLevel maxzoom) const
 		zoomlevels[zoom].bottom = this->top    + ScaleByZoom(VPSM_TOP + FONT_HEIGHT_NORMAL + VPSM_BOTTOM + 1, zoom);
 	}
 
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		Viewport *vp = w->viewport;
 		if (vp != nullptr && vp->zoom <= maxzoom) {
 			assert(vp->width != 0);
@@ -1953,7 +1953,7 @@ bool MarkAllViewportsDirty(int left, int top, int right, int bottom)
 {
 	bool dirty = false;
 
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		Viewport *vp = w->viewport;
 		if (vp != nullptr) {
 			assert(vp->width != 0);
@@ -1966,7 +1966,7 @@ bool MarkAllViewportsDirty(int left, int top, int right, int bottom)
 
 void ConstrainAllViewportsZoom()
 {
-	for (Window *w : Window::IterateFromFront()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->viewport == nullptr) continue;
 
 		ZoomLevel zoom = static_cast<ZoomLevel>(Clamp(w->viewport->zoom, _settings_client.gui.zoom_min, _settings_client.gui.zoom_max));

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -501,7 +501,7 @@ void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int butt
  */
 int HideDropDownMenu(Window *pw)
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->window_class != WC_DROPDOWN_MENU) continue;
 
 		DropdownWindow *dw = dynamic_cast<DropdownWindow*>(w);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1168,14 +1168,10 @@ void DeleteWindowById(WindowClass cls, WindowNumber number, bool force)
  */
 void DeleteWindowByClass(WindowClass cls)
 {
-restart_search:
-	/* When we find the window to delete, we need to restart the search
-	 * as deleting this window could cascade in deleting (many) others
-	 * anywhere in the z-array */
+	/* Note: the container remains stable, even when deleting windows. */
 	for (Window *w : Window::IterateFromBack()) {
 		if (w->window_class == cls) {
 			delete w;
-			goto restart_search;
 		}
 	}
 }
@@ -1188,14 +1184,10 @@ restart_search:
  */
 void DeleteCompanyWindows(CompanyID id)
 {
-restart_search:
-	/* When we find the window to delete, we need to restart the search
-	 * as deleting this window could cascade in deleting (many) others
-	 * anywhere in the z-array */
+	/* Note: the container remains stable, even when deleting windows. */
 	for (Window *w : Window::IterateFromBack()) {
 		if (w->owner == id) {
 			delete w;
-			goto restart_search;
 		}
 	}
 
@@ -3325,10 +3317,7 @@ void CallWindowGameTickEvent()
  */
 void DeleteNonVitalWindows()
 {
-restart_search:
-	/* When we find the window to delete, we need to restart the search
-	 * as deleting this window could cascade in deleting (many) others
-	 * anywhere in the z-array */
+	/* Note: the container remains stable, even when deleting windows. */
 	for (const Window *w : Window::IterateFromBack()) {
 		if (w->window_class != WC_MAIN_WINDOW &&
 				w->window_class != WC_SELECT_GAME &&
@@ -3338,7 +3327,6 @@ restart_search:
 				(w->flags & WF_STICKY) == 0) { // do not delete windows which are 'pinned'
 
 			delete w;
-			goto restart_search;
 		}
 	}
 }
@@ -3355,14 +3343,10 @@ void DeleteAllNonVitalWindows()
 	/* Delete every window except for stickied ones, then sticky ones as well */
 	DeleteNonVitalWindows();
 
-restart_search:
-	/* When we find the window to delete, we need to restart the search
-	 * as deleting this window could cascade in deleting (many) others
-	 * anywhere in the z-array */
+	/* Note: the container remains stable, even when deleting windows. */
 	for (const Window *w : Window::IterateFromBack()) {
 		if (w->flags & WF_STICKY) {
 			delete w;
-			goto restart_search;
 		}
 	}
 }
@@ -3384,14 +3368,10 @@ void DeleteAllMessages()
  */
 void DeleteConstructionWindows()
 {
-restart_search:
-	/* When we find the window to delete, we need to restart the search
-	 * as deleting this window could cascade in deleting (many) others
-	 * anywhere in the z-array */
+	/* Note: the container remains stable, even when deleting windows. */
 	for (const Window *w : Window::IterateFromBack()) {
 		if (w->window_desc->flags & WDF_CONSTRUCTION) {
 			delete w;
-			goto restart_search;
 		}
 	}
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1055,7 +1055,7 @@ void Window::SetShaded(bool make_shaded)
  */
 static Window *FindChildWindow(const Window *w, WindowClass wc)
 {
-	for (Window *v : Window::IterateFromBack()) {
+	for (Window *v : Window::Iterate()) {
 		if ((wc == WC_INVALID || wc == v->window_class) && v->parent == w) return v;
 	}
 
@@ -1129,7 +1129,7 @@ Window::~Window()
  */
 Window *FindWindowById(WindowClass cls, WindowNumber number)
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->window_class == cls && w->window_number == number) return w;
 	}
 
@@ -1144,7 +1144,7 @@ Window *FindWindowById(WindowClass cls, WindowNumber number)
  */
 Window *FindWindowByClass(WindowClass cls)
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->window_class == cls) return w;
 	}
 
@@ -1172,7 +1172,7 @@ void DeleteWindowById(WindowClass cls, WindowNumber number, bool force)
 void DeleteWindowByClass(WindowClass cls)
 {
 	/* Note: the container remains stable, even when deleting windows. */
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->window_class == cls) {
 			delete w;
 		}
@@ -1188,7 +1188,7 @@ void DeleteWindowByClass(WindowClass cls)
 void DeleteCompanyWindows(CompanyID id)
 {
 	/* Note: the container remains stable, even when deleting windows. */
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->owner == id) {
 			delete w;
 		}
@@ -1207,7 +1207,7 @@ void DeleteCompanyWindows(CompanyID id)
  */
 void ChangeWindowOwner(Owner old_owner, Owner new_owner)
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->owner != old_owner) continue;
 
 		switch (w->window_class) {
@@ -1576,7 +1576,7 @@ static bool IsGoodAutoPlace1(int left, int top, int width, int height, int toolb
 	if (left < 0 || top < toolbar_y || right > _screen.width || bottom > _screen.height) return false;
 
 	/* Make sure it is not obscured by any window. */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == WC_MAIN_WINDOW) continue;
 
 		if (right > w->left &&
@@ -1621,7 +1621,7 @@ static bool IsGoodAutoPlace2(int left, int top, int width, int height, int toolb
 	if (top < toolbar_y || top > _screen.height - (height >> 2)) return false;
 
 	/* Make sure it is not obscured by any window. */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == WC_MAIN_WINDOW) continue;
 
 		if (left + width > w->left &&
@@ -1658,7 +1658,7 @@ static Point GetAutoPlacePosition(int width, int height)
 	 * The new window must be entirely on-screen, and not overlap with an existing window.
 	 * Eight starting points are tried, two at each corner.
 	 */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == WC_MAIN_WINDOW) continue;
 
 		if (IsGoodAutoPlace1(w->left + w->width,         w->top,                      width, height, toolbar_y, pt)) return pt;
@@ -1675,7 +1675,7 @@ static Point GetAutoPlacePosition(int width, int height)
 	 * The new window may be partly off-screen, and must not overlap with an existing window.
 	 * Only four starting points are tried.
 	 */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == WC_MAIN_WINDOW) continue;
 
 		if (IsGoodAutoPlace2(w->left + w->width, w->top,             width, height, toolbar_y, pt)) return pt;
@@ -1692,7 +1692,7 @@ static Point GetAutoPlacePosition(int width, int height)
 	int offset_y = std::max<int>(NWidgetLeaf::closebox_dimension.height, FONT_HEIGHT_NORMAL + WD_CAPTIONTEXT_TOP + WD_CAPTIONTEXT_BOTTOM);
 
 restart:
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->left == left && w->top == top) {
 			left += offset_x;
 			top += offset_y;
@@ -1896,7 +1896,7 @@ void UnInitWindowSystem()
 {
 	UnshowCriticalError();
 
-	for (Window *w : Window::IterateFromFront()) delete w;
+	for (Window *w : Window::Iterate()) delete w;
 
 	for (Window *w = _z_front_window; w != nullptr; /* nothing */) {
 		Window *to_del = w;
@@ -1925,7 +1925,7 @@ static void DecreaseWindowCounters()
 	if (_scroller_click_timeout != 0) _scroller_click_timeout--;
 	if (hundredth_tick_timeout != 0) hundredth_tick_timeout--;
 
-	for (Window *w : Window::IterateFromFront()) {
+	for (Window *w : Window::Iterate()) {
 		if (!_network_dedicated && hundredth_tick_timeout == 0) w->OnHundredthTick();
 
 		if (_scroller_click_timeout == 0) {
@@ -1951,7 +1951,7 @@ static void DecreaseWindowCounters()
 		w->OnMouseLoop();
 	}
 
-	for (Window *w : Window::IterateFromFront()) {
+	for (Window *w : Window::Iterate()) {
 		if ((w->flags & WF_TIMEOUT) && --w->timeout_timer == 0) {
 			CLRBITS(w->flags, WF_TIMEOUT);
 
@@ -2190,7 +2190,7 @@ static EventState HandleWindowDragging()
 	if (_left_button_down && _cursor.delta.x == 0 && _cursor.delta.y == 0) return ES_HANDLED;
 
 	/* Otherwise find the window... */
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->flags & WF_DRAGGING) {
 			/* Stop the dragging if the left mouse button was released */
 			if (!_left_button_down) {
@@ -2210,7 +2210,7 @@ static EventState HandleWindowDragging()
 				int vsnap = _settings_client.gui.window_snap_radius;
 				int delta;
 
-				for (const Window *v : Window::IterateFromBack()) {
+				for (const Window *v : Window::Iterate()) {
 					if (v == w) continue; // Don't snap at yourself
 
 					if (y + w->height > v->top && y < v->top + v->height) {
@@ -2423,7 +2423,7 @@ static void HandleScrollbarScrolling(Window *w)
  */
 static EventState HandleActiveWidget()
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->mouse_capture_widget >= 0) {
 			/* Abort if no button is clicked any more. */
 			if (!_left_button_down) {
@@ -3095,7 +3095,7 @@ void InputLoop()
  */
 void CallWindowRealtimeTickEvent(uint delta_ms)
 {
-	for (Window *w : Window::IterateFromFront()) {
+	for (Window *w : Window::Iterate()) {
 		w->OnRealtimeTick(delta_ms);
 	}
 }
@@ -3124,7 +3124,7 @@ void UpdateWindows()
 	}
 
 	/* Process invalidations before anything else. */
-	for (Window *w : Window::IterateFromFront()) {
+	for (Window *w : Window::Iterate()) {
 		w->ProcessScheduledInvalidations();
 		w->ProcessHighlightedInvalidations();
 	}
@@ -3157,7 +3157,7 @@ void UpdateWindows()
 	if (window_timer.HasElapsed()) {
 		window_timer.SetInterval(MILLISECONDS_PER_TICK);
 
-		for (Window *w : Window::IterateFromFront()) {
+		for (Window *w : Window::Iterate()) {
 			if ((w->flags & WF_WHITE_BORDER) && --w->white_border_timer == 0) {
 				CLRBITS(w->flags, WF_WHITE_BORDER);
 				w->SetDirty();
@@ -3167,7 +3167,7 @@ void UpdateWindows()
 
 	DrawDirtyBlocks();
 
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		/* Update viewport only if window is not shaded. */
 		if (w->viewport != nullptr && !w->IsShaded()) UpdateViewportPosition(w);
 	}
@@ -3183,7 +3183,7 @@ void UpdateWindows()
  */
 void SetWindowDirty(WindowClass cls, WindowNumber number)
 {
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == cls && w->window_number == number) w->SetDirty();
 	}
 }
@@ -3196,7 +3196,7 @@ void SetWindowDirty(WindowClass cls, WindowNumber number)
  */
 void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, byte widget_index)
 {
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == cls && w->window_number == number) {
 			w->SetWidgetDirty(widget_index);
 		}
@@ -3209,7 +3209,7 @@ void SetWindowWidgetDirty(WindowClass cls, WindowNumber number, byte widget_inde
  */
 void SetWindowClassesDirty(WindowClass cls)
 {
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class == cls) w->SetDirty();
 	}
 }
@@ -3281,7 +3281,7 @@ void Window::ProcessHighlightedInvalidations()
  */
 void InvalidateWindowData(WindowClass cls, WindowNumber number, int data, bool gui_scope)
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->window_class == cls && w->window_number == number) {
 			w->InvalidateData(data, gui_scope);
 		}
@@ -3298,7 +3298,7 @@ void InvalidateWindowData(WindowClass cls, WindowNumber number, int data, bool g
  */
 void InvalidateWindowClassesData(WindowClass cls, int data, bool gui_scope)
 {
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (w->window_class == cls) {
 			w->InvalidateData(data, gui_scope);
 		}
@@ -3310,7 +3310,7 @@ void InvalidateWindowClassesData(WindowClass cls, int data, bool gui_scope)
  */
 void CallWindowGameTickEvent()
 {
-	for (Window *w : Window::IterateFromFront()) {
+	for (Window *w : Window::Iterate()) {
 		w->OnGameTick();
 	}
 }
@@ -3324,7 +3324,7 @@ void CallWindowGameTickEvent()
 void DeleteNonVitalWindows()
 {
 	/* Note: the container remains stable, even when deleting windows. */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_class != WC_MAIN_WINDOW &&
 				w->window_class != WC_SELECT_GAME &&
 				w->window_class != WC_MAIN_TOOLBAR &&
@@ -3350,7 +3350,7 @@ void DeleteAllNonVitalWindows()
 	DeleteNonVitalWindows();
 
 	/* Note: the container remains stable, even when deleting windows. */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->flags & WF_STICKY) {
 			delete w;
 		}
@@ -3375,13 +3375,13 @@ void DeleteAllMessages()
 void DeleteConstructionWindows()
 {
 	/* Note: the container remains stable, even when deleting windows. */
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->window_desc->flags & WDF_CONSTRUCTION) {
 			delete w;
 		}
 	}
 
-	for (const Window *w : Window::IterateFromBack()) w->SetDirty();
+	for (const Window *w : Window::Iterate()) w->SetDirty();
 }
 
 /** Delete all always on-top windows to get an empty screen */
@@ -3400,7 +3400,7 @@ void ReInitAllWindows(bool zoom_changed)
 	extern void InitDepotWindowBlockSizes();
 	InitDepotWindowBlockSizes();
 
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		if (zoom_changed) w->nested_root->AdjustPaddingForZoom();
 		w->ReInit();
 	}
@@ -3490,7 +3490,7 @@ int PositionNetworkChatWindow(Window *w)
  */
 void ChangeVehicleViewports(VehicleID from_index, VehicleID to_index)
 {
-	for (const Window *w : Window::IterateFromBack()) {
+	for (const Window *w : Window::Iterate()) {
 		if (w->viewport != nullptr && w->viewport->follow_vehicle == from_index) {
 			w->viewport->follow_vehicle = to_index;
 			w->SetDirty();
@@ -3508,7 +3508,7 @@ void RelocateAllWindows(int neww, int newh)
 {
 	DeleteWindowById(WC_DROPDOWN_MENU, 0);
 
-	for (Window *w : Window::IterateFromBack()) {
+	for (Window *w : Window::Iterate()) {
 		int left, top;
 		/* XXX - this probably needs something more sane. For example specifying
 		 * in a 'backup'-desc that the window should always be centered. */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -896,7 +896,10 @@ static bool MayBeShown(const Window *w)
  */
 static void DrawOverlappedWindow(Window *w, int left, int top, int right, int bottom)
 {
-	for (const Window *v : Window::IterateFromBack(w->z_front)) {
+	Window::IteratorToFront it(w);
+	++it;
+	for (; !it.IsEnd(); ++it) {
+		const Window *v = *it;
 		if (MayBeShown(v) &&
 				right > v->left &&
 				bottom > v->top &&
@@ -2530,7 +2533,10 @@ static bool MaybeBringWindowToFront(Window *w)
 		w_height = w->unshaded_size.height;
 	}
 
-	for (Window *u : Window::IterateFromBack(w->z_front)) {
+	Window::IteratorToFront it(w);
+	++it;
+	for (; !it.IsEnd(); ++it) {
+		Window *u = *it;
 		/* A modal child will prevent the activation of the parent window */
 		if (u->parent == w && (u->window_desc->flags & WDF_MODAL)) {
 			u->SetWhiteBorder();

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -813,65 +813,59 @@ public:
 
 	/**
 	 * Iterator to iterate all valid Windows
-	 * @tparam T Type of the class/struct that is going to be iterated
 	 * @tparam Tfront Wether we iterate from front
 	 */
-	template <class T, bool Tfront>
+	template <bool Tfront>
 	struct WindowIterator {
-		typedef T value_type;
-		typedef T *pointer;
-		typedef T &reference;
+		typedef Window *value_type;
+		typedef value_type *pointer;
+		typedef value_type &reference;
 		typedef size_t difference_type;
 		typedef std::forward_iterator_tag iterator_category;
 
-		explicit WindowIterator(T *start) : w(start)
+		explicit WindowIterator(const Window *start) : w(const_cast<Window *>(start))
 		{
 			this->Validate();
 		}
 
 		bool operator==(const WindowIterator &other) const { return this->w == other.w; }
 		bool operator!=(const WindowIterator &other) const { return !(*this == other); }
-		T * operator*() const { return this->w; }
+		Window * operator*() const { return this->w; }
 		WindowIterator & operator++() { this->Next(); this->Validate(); return *this; }
 
 	private:
-		T *w;
+		Window *w;
 		void Validate() { while (this->w != nullptr && this->w->window_class == WC_INVALID) this->Next(); }
 		void Next() { if (this->w != nullptr) this->w = Tfront ? this->w->z_back : this->w->z_front; }
 	};
 
 	/**
 	 * Iterable ensemble of all valid Windows
-	 * @tparam T Type of the class/struct that is going to be iterated
 	 * @tparam Tfront Wether we iterate from front
 	 */
-	template <class T, bool Tfront>
+	template <bool Tfront>
 	struct Iterate {
-		Iterate(T *from) : from(from) {}
-		WindowIterator<T, Tfront> begin() { return WindowIterator<T, Tfront>(this->from); }
-		WindowIterator<T, Tfront> end() { return WindowIterator<T, Tfront>(nullptr); }
+		Iterate(const Window *from) : from(from) {}
+		WindowIterator<Tfront> begin() { return WindowIterator<Tfront>(this->from); }
+		WindowIterator<Tfront> end() { return WindowIterator<Tfront>(nullptr); }
 		bool empty() { return this->begin() == this->end(); }
 	private:
-		T *from;
+		const Window *from;
 	};
 
 	/**
 	 * Returns an iterable ensemble of all valid Window from back to front
-	 * @tparam T Type of the class/struct that is going to be iterated
 	 * @param from index of the first Window to consider
 	 * @return an iterable ensemble of all valid Window
 	 */
-	template <class T = Window>
-	static Iterate<T, false> IterateFromBack(T *from = _z_back_window) { return Iterate<T, false>(from); }
+	static Iterate<false> IterateFromBack(const Window *from = _z_back_window) { return Iterate<false>(from); }
 
 	/**
 	 * Returns an iterable ensemble of all valid Window from front to back
-	 * @tparam T Type of the class/struct that is going to be iterated
 	 * @param from index of the first Window to consider
 	 * @return an iterable ensemble of all valid Window
 	 */
-	template <class T = Window>
-	static Iterate<T, true> IterateFromFront(T *from = _z_front_window) { return Iterate<T, true>(from); }
+	static Iterate<true> IterateFromFront(const Window *from = _z_front_window) { return Iterate<true>(from); }
 };
 
 /**

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -833,39 +833,28 @@ public:
 		Window * operator*() const { return this->w; }
 		WindowIterator & operator++() { this->Next(); this->Validate(); return *this; }
 
+		bool IsEnd() const { return this->w == nullptr; }
+
 	private:
 		Window *w;
 		void Validate() { while (this->w != nullptr && this->w->window_class == WC_INVALID) this->Next(); }
 		void Next() { if (this->w != nullptr) this->w = Tfront ? this->w->z_back : this->w->z_front; }
 	};
+	using IteratorToFront = WindowIterator<false>; //!< Iterate in Z order towards front.
+	using IteratorToBack = WindowIterator<true>; //!< Iterate in Z order towards back.
 
 	/**
 	 * Iterable ensemble of all valid Windows
 	 * @tparam Tfront Wether we iterate from front
 	 */
 	template <bool Tfront>
-	struct Iterate {
-		Iterate(const Window *from) : from(from) {}
-		WindowIterator<Tfront> begin() { return WindowIterator<Tfront>(this->from); }
+	struct AllWindows {
+		AllWindows() {}
+		WindowIterator<Tfront> begin() { return WindowIterator<Tfront>(Tfront ? _z_front_window : _z_back_window); }
 		WindowIterator<Tfront> end() { return WindowIterator<Tfront>(nullptr); }
-		bool empty() { return this->begin() == this->end(); }
-	private:
-		const Window *from;
 	};
-
-	/**
-	 * Returns an iterable ensemble of all valid Window from back to front
-	 * @param from index of the first Window to consider
-	 * @return an iterable ensemble of all valid Window
-	 */
-	static Iterate<false> IterateFromBack(const Window *from = _z_back_window) { return Iterate<false>(from); }
-
-	/**
-	 * Returns an iterable ensemble of all valid Window from front to back
-	 * @param from index of the first Window to consider
-	 * @return an iterable ensemble of all valid Window
-	 */
-	static Iterate<true> IterateFromFront(const Window *from = _z_front_window) { return Iterate<true>(from); }
+	using IterateFromBack = AllWindows<false>; //!< Iterate all windows in Z order from back to front.
+	using IterateFromFront = AllWindows<true>; //!< Iterate all windows in Z order from front to back.
 };
 
 /**

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -853,6 +853,7 @@ public:
 		WindowIterator<Tfront> begin() { return WindowIterator<Tfront>(Tfront ? _z_front_window : _z_back_window); }
 		WindowIterator<Tfront> end() { return WindowIterator<Tfront>(nullptr); }
 	};
+	using Iterate = AllWindows<false>; //!< Iterate all windows in whatever order is easiest.
 	using IterateFromBack = AllWindows<false>; //!< Iterate all windows in Z order from back to front.
 	using IterateFromFront = AllWindows<true>; //!< Iterate all windows in Z order from front to back.
 };


### PR DESCRIPTION
## Motivation / Problem

There are various loops in OpenTTD, which iterate over all windows, and conditionally close some.
Because closing windows propagates to child windows, iterating over all windows while closing them is not easy.

OpenTTD solves this problem by keeping windows in the window list, and just marking the entries as invalid.
Later the list is cleaned from invalid entries.

However, currently OpenTTD uses an intrusive double-linked list for windows. So the list pointers in the Window class must stay valid even after destruction of the window. This has some problems:
* The memory for Windows is allocated with operator new, but deallocated with free().
* Access to the z_front/back pointers in the destructor must be obfuscated, in the hope that the compiler optimisation does not break the list.

## Description

This PR replaces the intrusive list with a non-intrusive std::list<Window*>.
Windows keep a reference to their list entry, and set the list entry to nullptr in the Window destructor, to mark the entry as invalid.

Other changes:
* Because the iteration over lists is not quite the same in both directions, iterating backwards is slightly awkward. To use the more straight-forward forward-iteration when the iteration order does not matter, a third iteratable "Iterate" is added in addition to "IterateFromBack" and "IterateFromFront".

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
