### PR TITLE
Change: Use gender-neutral pronouns

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2186,7 +2186,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: [NewGRF] Additional text in fund industry window is NewGRF supplied and thus should have a default colour (r22631)
 - Fix: Also initialise _old_vds with newgame settings; TTD savegames do not contain these settings [FS#4622] (r22626)
 - Fix: Do not zero the orders of disaster vehicles when converting savegames [FS#4642] (r22625)
-- Fix: When closing an AI company the local player cheated to, we need to cheat him to another company [FS#4654] (r22624, r22623)
+- Fix: When closing an AI company the local player cheated to, we need to cheat them to another company [FS#4654] (r22624, r22623)
 - Fix: When closing down companies their shares in other companies must be sold even if share trading is disabled at that point of time (r22622)
 - Fix: When asking the user to confirm an unsafe unpausing, there is no need to execute a command if 'no' is chosen. This also prevents crashing when clicking unpause while the confirm window is shown (r22621)
 - Fix: Enforce refit orders to be 'always go to depot' orders; service-only and stop-in-depot orders make no sense with refitting [FS#4651] (r22620)
@@ -2908,7 +2908,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: Chat message caused glitch when rejoining a network game [FS#3757] (r19629)
 - Fix: Desync when a command is received and in the queue while a client starts joining, i.e. save the game state. This can happen in two ways: with frame_freq > 1 a command received in a previous frame might not be executed yet or when a command is received in the same frame as the join but before the savegame is made. In both cases the joining client would not get all commands to get in-sync with the server (and the other clients) (r19620)
 - Fix: Company related graphs were not updated correctly after changing the company colour [FS#3763] (r19615)
-- Fix: Possible invalid read when server moves client to spectators before he finishes joining [FS#3755] (r19613)
+- Fix: Possible invalid read when server moves client to spectators before they finish joining [FS#3755] (r19613)
 - Fix: Crash when opening a savegame with a waypoint from around 0.4.0 [FS#3756] (r19612)
 - Fix: Improve joining behaviour; kicking clients when entering passwords that was just cleared, 'connection lost' for people failing the password, access restriction circumvention [CVE-2010-0401] [FS#3754] (r19610, r19609, r19608, r19607, r19606)
 - Fix: Desync debugging; false positives in the cache validity checks and saving/loading the command stream (r19619, r19617, r19602, r19601, r19600, r19596, r19593, r19592, r19589, r19587, r19586)
@@ -3263,7 +3263,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: Do not account for path reservation costs when entering a signal block via a 'block' signal. This way you will not get double penalties, both red signals and reservation costs, for the block signalled tracks [FS#2722] (r18535)
 - Fix: [NewGRF] An industry NewGRF that defined a too small size for action0 prop 0A could cause a crash (r18527)
 - Fix: Allegro does not like to work with extmidi, so warn the user about that [FS#3272] (r18520)
-- Fix: When you pass a signal at danger, in a PBS controlled area, do not try to do the 'safe' thing and stop, but continue going; the user wanted the train to pass the signal at danger so (s)he has to suffer the consequences. Of course one can always stop the train manually [FS#2891] (r18515)
+- Fix: When you pass a signal at danger, in a PBS controlled area, do not try to do the 'safe' thing and stop, but continue going; the user wanted the train to pass the signal at danger so they have to suffer the consequences. Of course one can always stop the train manually [FS#2891] (r18515)
 - Fix: No error message was created for the first fatal NewGRF error [FS#3368] (r18506)
 - Fix: Improve airport movement on several airports [FS#3169] (r18505)
 - Fix: Autoreplace and autorenew always reset their cargo sub type to 0. Now find a sub cargo type with the exact same name and use that, otherwise fallback to 0. So cargo sub types can be maintained via autoreplace *if* the new vehicle supports the same cargo sub type [FS#3159] (r18499)
@@ -3746,7 +3746,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: Make the join/spectate command require to be connected to a network game; in SP it could lead to crashes (r15514)
 - Fix: Generating a map with the original map generator with freeform edges on resulted in a crash [FS#2641] (r15511)
 - Fix: Pre-0.5 OpenTTD stored new_nonstop and full_load_any in a different way, savegame conversion was not working for them (r15500)
-- Fix: Crash when opening the game options when the currently loaded base graphics pack has less than 2 valid graphics files. For example when someone replaces all his/her original base graphics with custom work (but keeps the name) or renames the dos ones to windows or vice versa [FS#2630] (r15476)
+- Fix: Crash when opening the game options when the currently loaded base graphics pack has less than 2 valid graphics files. For example when someone replaces all their original base graphics with custom work (but keeps the name) or renames the dos ones to windows or vice versa [FS#2630] (r15476)
 
 
 0.7.0-beta1 (2009-02-16)
@@ -4508,7 +4508,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: Switching players (using the cheat) crashed on Big Endian machines [FS#1150] (r11023)
 - Fix: The canal border determination did not take oil rigs into consideration (r11022)
 - Fix: Do not display income/expenses when they do not belong to a 'valid' tile, like the money cheat/giving money [FS#1175] (r11021)
-- Fix: One could not give money when (s)he had too much money or rather: when casting the amount of money to an int32 becomes negative [FS#1174] (r11020)
+- Fix: One could not give money when they had too much money or rather: when casting the amount of money to an int32 becomes negative [FS#1174] (r11020)
 - Fix: When determining the gender of a string, do not assume that the gender is in the front of the string when there can be case switching code at that location [FS#1104] (r10792)
 - Fix: Determining whether there is a tunnel going under the lowered area is only needed in two directions instead of all four, so take the directions (one for each axis) to the nearest border (along the given axis) [FS#1058] (r10686)
 - Fix: Graphical glitches when the 'link landscape toolbar' patch is turned on when opening one of the construction toolbars [FS#1076] (r10685)
@@ -4569,7 +4569,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: Do not unconditionally assume that a tile has a depot (r11027)
 - Fix: Give a more correct error when building some things on tile 0 [FS#1173] (r11024)
 - Fix: Do not display income/expenses when they do not belong to a 'valid' tile, like the money cheat and giving money [FS#1175] (r11021)
-- Fix: One could not give money when (s)he had too much money [FS#1174] (r11020)
+- Fix: One could not give money when they had too much money [FS#1174] (r11020)
 - Fix: Disallow buying/selling shares in your own company or a bankrupt company [FS#1169] (r11018)
 - Fix: Crash when quitting the game in one of the end score windows [FS#1218] (r11071)
 
@@ -5529,7 +5529,7 @@ Note: OpenTTD was migrated to GitHub for 1.9, so SVN revision and FlySpray numbe
 - Fix: Vehicles slow down under bridge if the track is on a foundation
 - Fix: You can no longer change name of waypoints whom are owned by somebody else
 - Fix: Shares are now also sold when a company goes bankrupt [SF#1090313]
-- Fix: It is no longer possible to crash trains of other companies by building a depot close to a station; trains do no longer enter tiles that do not belong to his owner [SF#1087701]
+- Fix: It is no longer possible to crash trains of other companies by building a depot close to a station; trains do no longer enter tiles that do not belong to their owner [SF#1087701]
 - Fix: Crashed trains are not reported to have too few orders any more [SF#1087403]
 - Fix: Backup-order-list was not closed with an OT_NOTHING, [SF#1086375]
 - Fix: Docks now have a button to display the catchment area [SF#1085255]

--- a/os/emscripten/cmake/FindLibLZMA.cmake
+++ b/os/emscripten/cmake/FindLibLZMA.cmake
@@ -1,5 +1,5 @@
 # LibLZMA is a recent addition to the emscripten SDK, so it is possible
-# someone hasn't updated his SDK yet. Test out if the SDK supports LibLZMA.
+# someone hasn't updated their SDK yet. Test out if the SDK supports LibLZMA.
 include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_FLAGS "-sUSE_LIBLZMA=1")
 

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1025,7 +1025,7 @@ static bool AircraftController(Aircraft *v)
 	if (count == 0) return false;
 
 	/* If the plane will be a few subpixels away from the destination after
-	 * this movement loop, start nudging him towards the exact position for
+	 * this movement loop, start nudging it towards the exact position for
 	 * the whole loop. Otherwise, heavily depending on the speed of the plane,
 	 * it is possible we totally overshoot the target, causing the plane to
 	 * make a loop, and trying again, and again, and again .. */

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -91,7 +91,7 @@ public:
 	}
 
 	/**
-	 * Find the requested blitter and return his class.
+	 * Find the requested blitter and return its class.
 	 * @param name the blitter to select.
 	 * @post Sets the blitter so GetCurrentBlitter() returns it too.
 	 */

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -29,7 +29,7 @@ enum ConsoleHookResult {
  * effect they produce are carried out. The arguments to the commands
  * are given to them, each input word separated by a double-quote (") is an argument
  * If you want to handle multiple words as one, enclose them in double-quotes
- * eg. 'say "hello sexy boy"'
+ * eg. 'say "hello everybody"'
  */
 typedef bool IConsoleCmdProc(byte argc, char *argv[]);
 typedef ConsoleHookResult IConsoleHook(bool echo);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -311,7 +311,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 		for (const Company *c : Company::Iterate()) {
 			for (i = 0; i < 4; i++) {
 				if (c->share_owners[i] == old_owner) {
-					/* Sell his shares */
+					/* Sell its shares */
 					CommandCost res = DoCommand(0, c->index, 0, DC_EXEC | DC_BANKRUPT, CMD_SELL_SHARE_IN_COMPANY);
 					/* Because we are in a DoCommand, we can't just execute another one and
 					 *  expect the money to be removed. We need to do it ourself! */
@@ -337,7 +337,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 	}
 
 	/* Temporarily increase the company's money, to be sure that
-	 * removing his/her property doesn't fail because of lack of money.
+	 * removing their property doesn't fail because of lack of money.
 	 * Not too drastically though, because it could overflow */
 	if (new_owner == INVALID_OWNER) {
 		Company::Get(old_owner)->money = UINT64_MAX >> 2; // jackpot ;p

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -1417,7 +1417,7 @@ struct PerformanceRatingDetailWindow : Window {
 		int64 needed = _score_info[score_type].needed;
 		int   score  = _score_info[score_type].score;
 
-		/* SCORE_TOTAL has his own rules ;) */
+		/* SCORE_TOTAL has its own rules ;) */
 		if (score_type == SCORE_TOTAL) {
 			for (ScoreID i = SCORE_BEGIN; i < SCORE_END; i++) score += _score_info[i].score;
 			needed = SCORE_MAX;

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -480,7 +480,7 @@ bool GetHeightmapDimensions(DetailedFileType dft, const char *filename, uint *x,
 }
 
 /**
- * Load a heightmap from file and change the map in his current dimensions
+ * Load a heightmap from file and change the map in its current dimensions
  *  to a landscape representing the heightmap.
  * It converts pixels to height. The brighter, the higher.
  * @param dft Type of image file.

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -65,7 +65,7 @@ void LinkGraphJob::SpawnThread()
 		 * On the other hand, if you want to play games which make this hang noticeably
 		 * on a platform without threads then you'll probably get other problems first.
 		 * OK:
-		 * If someone comes and tells me that this hangs for him/her, I'll implement a
+		 * If someone comes and tells me that this hangs for them, I'll implement a
 		 * smaller grained "Step" method for all handlers and add some more ticks where
 		 * "Step" is called. No problem in principle. */
 		LinkGraphSchedule::Run(this);

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -129,7 +129,7 @@ CommandCost CmdDecreaseLoan(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
  * In case of an unsafe unpause, we want the
  * user to confirm that it might crash.
  * @param w         unused
- * @param confirmed whether the user confirms his/her action
+ * @param confirmed whether the user confirmed their action
  */
 static void AskUnsafeUnpauseCallback(Window *w, bool confirmed)
 {

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -274,7 +274,7 @@ protected:
 	virtual NetworkRecvStatus Receive_CLIENT_COMPANY_PASSWORD(Packet *p);
 
 	/**
-	 * The client is joined and ready to receive his map:
+	 * The client is joined and ready to receive their map:
 	 * uint32  Own client ID.
 	 * uint32  Generation seed.
 	 * string  Network ID of the server.

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -269,8 +269,8 @@ void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send,
 uint NetworkCalculateLag(const NetworkClientSocket *cs)
 {
 	int lag = cs->last_frame_server - cs->last_frame;
-	/* This client has missed his ACK packet after 1 DAY_TICKS..
-	 *  so we increase his lag for every frame that passes!
+	/* This client has missed their ACK packet after 1 DAY_TICKS..
+	 *  so we increase their lag for every frame that passes!
 	 * The packet can be out by a max of _net_frame_freq */
 	if (cs->last_frame_server + DAY_TICKS + _settings_client.network.frame_freq < _frame_counter) {
 		lag += _frame_counter - (cs->last_frame_server + DAY_TICKS + _settings_client.network.frame_freq);
@@ -680,7 +680,7 @@ public:
 };
 
 /**
- * Query a server to fetch his game-info for the lobby.
+ * Query a server to fetch the game-info for the lobby.
  * @param connection_string the address to query.
  */
 void NetworkQueryLobbyServer(const std::string &connection_string)

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -128,7 +128,7 @@ void NetworkUndrawChatMessage()
 	/* Sometimes we also need to hide the cursor
 	 *   This is because both textmessage and the cursor take a shot of the
 	 *   screen before drawing.
-	 *   Now the textmessage takes his shot and paints his data before the cursor
+	 *   Now the textmessage takes its shot and paints its data before the cursor
 	 *   does, so in the shot of the cursor is the screen-data of the textmessage
 	 *   included when the cursor hangs somewhere over the textmessage. To
 	 *   avoid wrong repaints, we undraw the cursor in that case, and everything

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -32,7 +32,7 @@ struct NetworkCompanyInfo : NetworkCompanyStats {
 	Money company_value;                            ///< The company value
 	Money money;                                    ///< The amount of money the company has
 	Money income;                                   ///< How much did the company earned last year
-	uint16 performance;                             ///< What was his performance last month?
+	uint16 performance;                             ///< What was their performance last month?
 	bool use_password;                              ///< Is there a password
 	char clients[NETWORK_CLIENTS_LENGTH];           ///< The clients that control this company (Name1, name2, ..)
 };

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -472,7 +472,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 		DEBUG(net, 1, "Client %d made an error and has been disconnected: %s", this->client_id, str);
 	}
 
-	/* The client made a mistake, so drop his connection now! */
+	/* The client made a mistake, so drop the connection now! */
 	return this->CloseConnection(NETWORK_RECV_STATUS_SERVER_ERROR);
 }
 
@@ -858,7 +858,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_NEWGRFS_CHECKED
 
 	NetworkClientInfo *ci = this->GetInfo();
 
-	/* We now want a password from the client else we do not allow him in! */
+	/* We now want a password from the client else we do not allow them in! */
 	if (!_settings_client.network.server_password.empty()) {
 		return this->SendNeedGamePassword();
 	}
@@ -995,7 +995,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMPANY_PASSWOR
 NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_GETMAP(Packet *p)
 {
 	/* The client was never joined.. so this is impossible, right?
-	 *  Ignore the packet, give the client a warning, and close his connection */
+	 *  Ignore the packet, give the client a warning, and close the connection */
 	if (this->status < STATUS_AUTHORIZED || this->HasClientQuit()) {
 		return this->SendError(NETWORK_ERROR_NOT_AUTHORIZED);
 	}
@@ -1063,7 +1063,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_MAP_OK(Packet *
 NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_COMMAND(Packet *p)
 {
 	/* The client was never joined.. so this is impossible, right?
-	 *  Ignore the packet, give the client a warning, and close his connection */
+	 *  Ignore the packet, give the client a warning, and close the connection */
 	if (this->status < STATUS_DONE_MAP || this->HasClientQuit()) {
 		return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
 	}
@@ -1857,7 +1857,7 @@ void NetworkServer_Tick(bool send_frame)
 					 * spamming the client. Strictly speaking this variable
 					 * tracks when we last received a packet from the client,
 					 * but as it is waiting, it will not send us any till we
-					 * start sending him data. */
+					 * start sending them data. */
 					cs->last_packet = std::chrono::steady_clock::now();
 				}
 				break;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3185,7 +3185,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint indtid, int numinfo, int pr
 
 					/* A copied tile should not have the animation infos copied too.
 					 * The anim_state should be left untouched, though
-					 * It is up to the author to animate them himself */
+					 * It is up to the author to animate them */
 					tsp->anim_production = INDUSTRYTILE_NOANIM;
 					tsp->anim_next = INDUSTRYTILE_NOANIM;
 

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -155,7 +155,7 @@ static uint32 GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint32
 		}
 	}
 	/* The tile has no spritegroup */
-	return 0xFF << 8 | ats->grf_prop.subst_id; // so just give him the substitute
+	return 0xFF << 8 | ats->grf_prop.subst_id; // so just give it the substitute
 }
 
 /* virtual */ uint32 AirportTileScopeResolver::GetVariable(byte variable, uint32 parameter, bool *available) const

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -264,7 +264,7 @@ void IndustryOverrideManager::SetEntitySpec(IndustrySpec *inds)
 
 	if (ind_id == invalid_ID) {
 		/* Not found.
-		 * Or it has already been overridden, so you've lost your place old boy.
+		 * Or it has already been overridden, so you've lost your place.
 		 * Or it is a simple substitute.
 		 * We need to find a free available slot */
 		ind_id = this->AddEntityID(inds->grf_prop.local_id, inds->grf_prop.grffile->grfid, inds->grf_prop.subst_id);
@@ -319,7 +319,7 @@ void ObjectOverrideManager::SetEntitySpec(ObjectSpec *spec)
 
 	if (type == invalid_ID) {
 		/* Not found.
-		 * Or it has already been overridden, so you've lost your place old boy.
+		 * Or it has already been overridden, so you've lost your place.
 		 * Or it is a simple substitute.
 		 * We need to find a free available slot */
 		type = this->AddEntityID(spec->grf_prop.local_id, spec->grf_prop.grffile->grfid, OBJECT_TRANSMITTER);

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -85,7 +85,7 @@ uint32 GetIndustryIDAtOffset(TileIndex tile, const Industry *i, uint32 cur_grfid
 		}
 	}
 	/* The tile has no spritegroup */
-	return 0xFF << 8 | indtsp->grf_prop.subst_id; // so just give him the substitute
+	return 0xFF << 8 | indtsp->grf_prop.subst_id; // so just give it the substitute
 }
 
 static uint32 GetClosestIndustry(TileIndex tile, IndustryType type, const Industry *current)

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -965,7 +965,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 
 void SwitchToMode(SwitchMode new_mode)
 {
-	/* If we are saving something, the network stays in his current state */
+	/* If we are saving something, the network stays in its current state */
 	if (new_mode != SM_SAVE_GAME) {
 		/* If the network is active, make it not-active */
 		if (_networking) {

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1039,7 +1039,7 @@ static void CancelLoadingDueToDeletedOrder(Vehicle *v)
 {
 	assert(v->current_order.IsType(OT_LOADING));
 	/* NON-stop flag is misused to see if a train is in a station that is
-	 * on his order list or not */
+	 * on its order list or not */
 	v->current_order.SetNonStopType(ONSF_STOP_EVERYWHERE);
 	/* When full loading, "cancel" that order so the vehicle doesn't
 	 * stay indefinitely at this station anymore. */

--- a/src/pathfinder/npf/aystar.cpp
+++ b/src/pathfinder/npf/aystar.cpp
@@ -144,14 +144,14 @@ void AyStar::CheckTile(AyStarNode *current, OpenListNode *parent)
 		/* Re-add it in the openlist_queue. */
 		this->openlist_queue.Push(check, new_f);
 	} else {
-		/* A new node, add him to the OpenList */
+		/* A new node, add it to the OpenList */
 		this->OpenListAdd(closedlist_parent, current, new_f, new_g);
 	}
 }
 
 /**
  * This function is the core of %AyStar. It handles one item and checks
- * his neighbour items. If they are valid, they are added to be checked too.
+ * its neighbour items. If they are valid, they are added to be checked too.
  * @return Possible values:
  *  - #AYSTAR_EMPTY_OPENLIST : indicates all items are tested, and no path has been found.
  *  - #AYSTAR_LIMIT_REACHED : Indicates that the max_search_nodes limit has been reached.

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -410,7 +410,7 @@ static void HandleAutoSignalPlacement()
 	}
 
 	/* _settings_client.gui.drag_signals_density is given as a parameter such that each user
-	 * in a network game can specify his/her own signal density */
+	 * in a network game can specify their own signal density */
 	DoCommandP(TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), p2,
 			_remove_button_clicked ?
 			CMD_REMOVE_SIGNAL_TRACK | CMD_MSG(STR_ERROR_CAN_T_REMOVE_SIGNALS_FROM) :

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -179,7 +179,7 @@ static void UpdateExclusiveRights()
 	 *     Build an array town_blocked[ town_id ][ company_id ]
 	 *     that stores if at least one station in that town is blocked for a company
 	 * 2.) Go through that array, if you find a town that is not blocked for
-	 *     one company, but for all others, then give him exclusivity.
+	 *     one company, but for all others, then give it exclusivity.
 	 */
 }
 

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -51,7 +51,7 @@ static void SaveReal_AIPL(int *index_ptr)
 	_ai_saveload_settings = config->SettingsToString();
 
 	SlObject(nullptr, _ai_company);
-	/* If the AI was active, store his data too */
+	/* If the AI was active, store its data too */
 	if (Company::IsValidAiID(index)) AI::Save(index);
 }
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2618,7 +2618,7 @@ static SaveOrLoadResult DoLoad(LoadFilter *reader, bool load_check)
 			fmt = _saveload_formats;
 			for (;;) {
 				if (fmt == endof(_saveload_formats)) {
-					/* Who removed LZO support? Bad bad boy! */
+					/* Who removed LZO support? */
 					NOT_REACHED();
 				}
 				if (fmt->tag == TO_BE32X('OTTD')) break;

--- a/src/script/api/script_controller.cpp
+++ b/src/script/api/script_controller.cpp
@@ -54,7 +54,7 @@
 	seprintf(log_message, lastof(log_message), "Break: %s", message);
 	ScriptLog::Log(ScriptLog::LOG_SQ_ERROR, log_message);
 
-	/* Inform script developer that his script has been paused and
+	/* Inform script developer that their script has been paused and
 	 * needs manual action to continue. */
 	ShowAIDebugWindow(ScriptObject::GetRootCompany());
 

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -365,7 +365,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 		IncreaseDoCommandCosts(res.GetCost());
 
 		/* Suspend the script player for 1+ ticks, so it simulates multiplayer. This
-		 *  both avoids confusion when a developer launched his script in a
+		 *  both avoids confusion when a developer launched the script in a
 		 *  multiplayer game, but also gives time for the GUI and human player
 		 *  to interact with the game. */
 		throw Script_Suspend(GetDoCommandDelay(), callback);

--- a/src/script/api/script_waypointlist.hpp
+++ b/src/script/api/script_waypointlist.hpp
@@ -34,7 +34,9 @@ public:
 class ScriptWaypointList_Vehicle : public ScriptList {
 public:
 	/**
-	 * @param vehicle_id The vehicle to get the list of waypoints he has in its orders from.
+	 * Get the waypoints from the orders of the given vehicle. Duplicates are
+	 * not added. Waypoints are added in the order of the vehicle's orders.
+	 * @param vehicle_id The vehicle to get the list of waypoints for.
 	 */
 	ScriptWaypointList_Vehicle(VehicleID vehicle_id);
 };

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -116,7 +116,7 @@ public:
 	void AnchorUnchangeableSettings();
 
 	/**
-	 * Get the value of a setting for this config. It might fallback to his
+	 * Get the value of a setting for this config. It might fallback to its
 	 *  'info' to find the default value (if not set or if not-custom difficulty
 	 *  level).
 	 * @return The (default) value of the setting, or -1 if the setting was not

--- a/src/script/script_info_dummy.cpp
+++ b/src/script/script_info_dummy.cpp
@@ -15,7 +15,7 @@
 
 #include "../safeguards.h"
 
-/* The reason this exists in C++, is that a user can trash his ai/ or game/ dir,
+/* The reason this exists in C++, is that a user can trash their ai/ or game/ dir,
  *  leaving no Scripts available. The complexity to solve this is insane, and
  *  therefore the alternative is used, and make sure there is always a Script
  *  available, no matter what the situation is. By defining it in C++, there

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -55,7 +55,7 @@ public:
 	virtual class ScriptInfo *FindLibrary(const char *library, int version) = 0;
 
 	/**
-	 * A script in multiplayer waits for the server to handle his DoCommand.
+	 * A script in multiplayer waits for the server to handle its DoCommand.
 	 *  It keeps waiting for this until this function is called.
 	 */
 	void Continue();

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -125,7 +125,7 @@ struct GUISettings {
 	bool   autosave_on_network_disconnect;   ///< save an autosave when you get disconnected from a network game with an error?
 	uint8  date_format_in_default_names;     ///< should the default savegame/screenshot name use long dates (31th Dec 2008), short dates (31-12-2008) or ISO dates (2008-12-31)
 	byte   max_num_autosaves;                ///< controls how many autosavegames are made before the game starts to overwrite (names them 0 to max_num_autosaves - 1)
-	bool   population_in_label;              ///< show the population of a town in his label?
+	bool   population_in_label;              ///< show the population of a town in its label?
 	uint8  right_mouse_btn_emulation;        ///< should we emulate right mouse clicking?
 	uint8  scrollwheel_scrolling;            ///< scrolling using the scroll wheel?
 	uint8  scrollwheel_multiplier;           ///< how much 'wheel' per incoming event from the OS?

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -257,7 +257,7 @@ Trackdir Ship::GetVehicleTrackdir() const
 	}
 
 	if (this->state == TRACK_BIT_WORMHOLE) {
-		/* ship on aqueduct, so just use his direction and assume a diagonal track */
+		/* ship on aqueduct, so just use its direction and assume a diagonal track */
 		return DiagDirToDiagTrackdir(DirToDiagDir(this->direction));
 	}
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -3468,7 +3468,7 @@ static void UpdateStationRating(Station *st)
 
 	for (const CargoSpec *cs : CargoSpec::Iterate()) {
 		GoodsEntry *ge = &st->goods[cs->Index()];
-		/* Slowly increase the rating back to his original level in the case we
+		/* Slowly increase the rating back to its original level in the case we
 		 *  didn't deliver cargo yet to this station. This happens when a bribe
 		 *  failed while you didn't moved that cargo yet to a station. */
 		if (!ge->HasRating() && ge->rating < INITIAL_STATION_RATING) {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -836,7 +836,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 		const char *&str = str_stack.top();
 
 		if (SCC_NEWGRF_FIRST <= b && b <= SCC_NEWGRF_LAST) {
-			/* We need to pass some stuff as it might be modified; oh boy. */
+			/* We need to pass some stuff as it might be modified. */
 			//todo: should argve be passed here too?
 			b = RemapNewGRFStringControlCode(b, buf_start, &buff, &str, (int64 *)args->GetDataPointer(), args->GetDataLeft(), dry_run);
 			if (b == 0) continue;

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -56,7 +56,7 @@ static bool UpdateClientConfigValues(int32 p1);
  * It is also a bit tricky since you would think that service_interval
  * for example doesn't need to be synched. Every client assigns the
  * service_interval value to the v->service_interval, meaning that every client
- * assigns his value. If the setting was company-based, that would mean that
+ * assigns its own value. If the setting was company-based, that would mean that
  * vehicles could decide on different moments that they are heading back to a
  * service depot, causing desyncs on a massive scale. */
 const SettingDesc _settings[] = {

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -4026,7 +4026,7 @@ Trackdir Train::GetVehicleTrackdir() const
 	}
 
 	if (this->track == TRACK_BIT_WORMHOLE) {
-		/* train in tunnel or on bridge, so just use his direction and assume a diagonal track */
+		/* train in tunnel or on bridge, so just use its direction and assume a diagonal track */
 		return DiagDirToDiagTrackdir(DirToDiagDir(this->direction));
 	}
 


### PR DESCRIPTION
## Motivation / Problem

See #9203; that PR was incomplete.


## Description

grep -Rn '([^C]him' src | grep -v src/lang
grep -Rn '[^Ttm]his[^t]' src | grep -v src/lang
grep -Rn '[^Ttgcs]her[^ie]' src | grep -v src/lang
grep -Rn 'boy' src | grep -v src/lang
grep -Rn '[^iaeou]she' src | grep -v src/lang
grep -Rn '[^sTtwWS_cC>p]he[^srlaixuc]' src | grep -v src/lang
And then some further manual filtering.


## Limitations

COPYING.md is kept untouched. Similarly pronouns referring to actual persons have been left alone as well, e.g. `Josef Drexler - For his great work on TTDPatch`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
