### PR TITLE
Fix: some memory/resource leaks

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -939,6 +939,7 @@ DEF_CONSOLE_CMD(ConExec)
 	}
 
 	if (_script_current_depth == 11) {
+		FioFCloseFile(script_file);
 		IConsoleError("Maximum 'exec' depth reached; script A is calling script B is calling script C ... more than 10 times.");
 		return true;
 	}

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -7394,7 +7394,7 @@ static void GRFInhibit(ByteReader *buf)
 		if (file != nullptr && file != _cur.grfconfig) {
 			grfmsg(2, "GRFInhibit: Deactivating file '%s'", file->filename);
 			GRFError *error = DisableGrf(STR_NEWGRF_ERROR_FORCEFULLY_DISABLED, file);
-			error->data = stredup(_cur.grfconfig->GetName());
+			error->data = _cur.grfconfig->GetName();
 		}
 	}
 }

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -54,7 +54,7 @@ CommandCost CmdPlaceSign(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 		si->y = y;
 		si->z = GetSlopePixelZ(x, y);
 		if (!StrEmpty(text)) {
-			si->name = stredup(text);
+			si->name = text;
 		}
 		si->UpdateVirtCoord();
 		InvalidateWindowData(WC_SIGN_LIST, 0, 0);

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2004,7 +2004,7 @@ CommandCost CmdFoundTown(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 
 		old_generating_world.Restore();
 
 		if (t != nullptr && !StrEmpty(text)) {
-			t->name = stredup(text);
+			t->name = text;
 			t->UpdateVirtCoord();
 		}
 


### PR DESCRIPTION
## Motivation / Problem

I let coverity rerun its checks after about 7 years and it found a few memory/resource leaks.


## Description

Do not duplicate the C-strings and properly close the files.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
