### PR TITLE
Change: reworded many of the network errors during connect/listen

### DIFF
--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -64,8 +64,12 @@ void TCPConnecter::Connect(addrinfo *address)
 		return;
 	}
 
-	if (!SetNoDelay(sock)) DEBUG(net, 1, "Setting TCP_NODELAY failed");
-	if (!SetNonBlocking(sock)) DEBUG(net, 0, "Setting non-blocking mode failed");
+	if (!SetNoDelay(sock)) {
+		DEBUG(net, 1, "Setting TCP_NODELAY failed: %s", NetworkError::GetLast().AsString());
+	}
+	if (!SetNonBlocking(sock)) {
+		DEBUG(net, 0, "Setting non-blocking mode failed: %s", NetworkError::GetLast().AsString());
+	}
 
 	NetworkAddress network_address = NetworkAddress(address->ai_addr, (int)address->ai_addrlen);
 	DEBUG(net, 4, "Attempting to connect to %s", network_address.GetAddressAsString().c_str());


### PR DESCRIPTION
## Motivation / Problem

#9017 gave a review comment that the debug statements in the ListenProc is a bit wonky. As a good citizen, I don't just fix the line I touched, but I went through all of them in both `listen()` and `connect()`.

## Description

I did a few things:
- All errors now show the OS error too; otherwise debugging problems can be hard.
- I bumped fatal errors to level 0, so the user actually sees what part failed.
- I removed many of the "tcp" and "ipv4" prefixes; they are rarely relevant for the error happening.
- I often removed the address from the error. For example, if `socket()` fails, it is not really important to what you were trying to `listen()`. The fact that we cannot do a simple `socket()` really is a big issue. Only if `bind()` fails, it is worth mentioning what we were trying to binding to.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
