### PR TITLE
Fix 91b8ce07: dedicated servers could no longer create screenshots

### DIFF
--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -270,6 +270,7 @@ void VideoDriver_Dedicated::MainLoop()
 
 	while (!_exit_game) {
 		if (!_dedicated_forks) DedicatedHandleKeyInput();
+		this->DrainCommandQueue();
 
 		ChangeGameSpeed(_ddc_fastforward);
 		this->Tick();

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -319,23 +319,6 @@ protected:
 		return std::chrono::microseconds(1000000 / _settings_client.gui.refresh_rate);
 	}
 
-	std::chrono::steady_clock::time_point next_game_tick;
-	std::chrono::steady_clock::time_point next_draw_tick;
-
-	bool fast_forward_key_pressed; ///< The fast-forward key is being pressed.
-	bool fast_forward_via_key; ///< The fast-forward was enabled by key press.
-
-	bool is_game_threaded;
-	std::thread game_thread;
-	std::mutex game_state_mutex;
-	std::mutex game_thread_wait_mutex;
-
-	static void GameThreadThunk(VideoDriver *drv);
-
-private:
-	std::mutex cmd_queue_mutex;
-	std::vector<std::function<void()>> cmd_queue;
-
 	/** Execute all queued commands. */
 	void DrainCommandQueue()
 	{
@@ -353,6 +336,23 @@ private:
 			f();
 		}
 	}
+
+	std::chrono::steady_clock::time_point next_game_tick;
+	std::chrono::steady_clock::time_point next_draw_tick;
+
+	bool fast_forward_key_pressed; ///< The fast-forward key is being pressed.
+	bool fast_forward_via_key; ///< The fast-forward was enabled by key press.
+
+	bool is_game_threaded;
+	std::thread game_thread;
+	std::mutex game_state_mutex;
+	std::mutex game_thread_wait_mutex;
+
+	static void GameThreadThunk(VideoDriver *drv);
+
+private:
+	std::mutex cmd_queue_mutex;
+	std::vector<std::function<void()>> cmd_queue;
 
 	void GameLoop();
 	void GameThread();


### PR DESCRIPTION
Fixes #9231.

## Motivation / Problem

Reported via Discord by TELK, creating minimap screenshots on Dedicated server was no longer possible.

## Description

```
    Although most commands are not useful on a dedicated server,
    screenshot commands should be dequeued.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
