### PR TITLE
Fix some of the warnings from LGTM

### DIFF
--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -155,6 +155,7 @@ bmno_full_transparency:
 
 				if ((bt_last == BT_NONE && effective_width & 1) || bt_last == BT_ODD) {
 					if (src->a == 0) {
+						/* Complete transparency. */
 					} else if (src->a == 255) {
 						*anim = *(const uint16*) src_mv;
 						*dst = (src_mv->m >= PALETTE_ANIM_START) ? AdjustBrightneSSE(LookupColourInPalette(src_mv->m), src_mv->v) : *src;

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -395,11 +395,11 @@ struct DepotWindow : Window {
 
 		uint16 rows_in_display = wid->current_y / wid->resize_y;
 
-		uint16 num = this->vscroll->GetPosition() * this->num_columns;
+		uint num = this->vscroll->GetPosition() * this->num_columns;
 		uint maxval = static_cast<uint>(std::min<size_t>(this->vehicle_list.size(), num + (rows_in_display * this->num_columns)));
 		int y;
 		for (y = r.top + 1; num < maxval; y += this->resize.step_height) { // Draw the rows
-			for (byte i = 0; i < this->num_columns && num < maxval; i++, num++) {
+			for (uint i = 0; i < this->num_columns && num < maxval; i++, num++) {
 				/* Draw all vehicles in the current row */
 				const Vehicle *v = this->vehicle_list[num];
 				if (this->num_columns == 1) {

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -357,7 +357,7 @@ class BuildIndustryWindow : public Window {
 		int numcargo = 0;
 		int firstcargo = -1;
 
-		for (byte j = 0; j < cargolistlen; j++) {
+		for (int j = 0; j < cargolistlen; j++) {
 			if (cargolist[j] == CT_INVALID) continue;
 			numcargo++;
 			if (firstcargo < 0) {
@@ -419,7 +419,7 @@ public:
 		switch (widget) {
 			case WID_DPI_MATRIX_WIDGET: {
 				Dimension d = GetStringBoundingBox(STR_FUND_INDUSTRY_MANY_RANDOM_INDUSTRIES);
-				for (byte i = 0; i < this->count; i++) {
+				for (uint16 i = 0; i < this->count; i++) {
 					if (this->index[i] == INVALID_INDUSTRYTYPE) continue;
 					d = maxdim(d, GetStringBoundingBox(GetIndustrySpec(this->index[i])->name));
 				}
@@ -438,7 +438,7 @@ public:
 				uint extra_lines_newgrf = 0;
 				uint max_minwidth = FONT_HEIGHT_NORMAL * MAX_MINWIDTH_LINEHEIGHTS;
 				Dimension d = {0, 0};
-				for (byte i = 0; i < this->count; i++) {
+				for (uint16 i = 0; i < this->count; i++) {
 					if (this->index[i] == INVALID_INDUSTRYTYPE) continue;
 
 					const IndustrySpec *indsp = GetIndustrySpec(this->index[i]);
@@ -528,7 +528,7 @@ public:
 				int icon_bottom = icon_top + this->legend.height;
 
 				int y = r.top;
-				for (byte i = 0; i < this->vscroll->GetCapacity() && i + this->vscroll->GetPosition() < this->count; i++) {
+				for (uint16 i = 0; i < this->vscroll->GetCapacity() && i + this->vscroll->GetPosition() < this->count; i++) {
 					bool selected = this->selected_index == i + this->vscroll->GetPosition();
 
 					if (this->index[i + this->vscroll->GetPosition()] == INVALID_INDUSTRYTYPE) {

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -495,7 +495,7 @@ public:
 	 * Get the current size of the component.
 	 * @return Size.
 	 */
-	inline uint Size() const { return (uint)this->nodes.size(); }
+	inline uint16 Size() const { return (uint16)this->nodes.size(); }
 
 	/**
 	 * Get date of last compression.

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -101,7 +101,7 @@ LinkGraphJob::~LinkGraphJob()
 	/* Link graph has been merged into another one. */
 	if (!LinkGraph::IsValidID(this->link_graph.index)) return;
 
-	uint size = this->Size();
+	uint16 size = this->Size();
 	for (NodeID node_id = 0; node_id < size; ++node_id) {
 		Node from = (*this)[node_id];
 

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -260,7 +260,7 @@ void MultiCommodityFlow::Dijkstra(NodeID source_node, PathVector &paths)
 {
 	typedef std::set<Tannotation *, typename Tannotation::Comparator> AnnoSet;
 	Tedge_iterator iter(this->job);
-	uint size = this->job.Size();
+	uint16 size = this->job.Size();
 	AnnoSet annos;
 	paths.resize(size, nullptr);
 	for (NodeID node = 0; node < size; ++node) {
@@ -473,7 +473,7 @@ bool MCF1stPass::EliminateCycles(PathVector &path, NodeID origin_id, NodeID next
 bool MCF1stPass::EliminateCycles()
 {
 	bool cycles_found = false;
-	uint size = this->job.Size();
+	uint16 size = this->job.Size();
 	PathVector path(size, nullptr);
 	for (NodeID node = 0; node < size; ++node) {
 		/* Starting at each node in the graph find all cycles involving this
@@ -491,7 +491,7 @@ bool MCF1stPass::EliminateCycles()
 MCF1stPass::MCF1stPass(LinkGraphJob &job) : MultiCommodityFlow(job)
 {
 	PathVector paths;
-	uint size = job.Size();
+	uint16 size = job.Size();
 	uint accuracy = job.Settings().accuracy;
 	bool more_loops;
 	std::vector<bool> finished_sources(size);
@@ -540,7 +540,7 @@ MCF2ndPass::MCF2ndPass(LinkGraphJob &job) : MultiCommodityFlow(job)
 {
 	this->max_saturation = UINT_MAX; // disable artificial cap on saturation
 	PathVector paths;
-	uint size = job.Size();
+	uint16 size = job.Size();
 	uint accuracy = job.Settings().accuracy;
 	bool demand_left = true;
 	std::vector<bool> finished_sources(size);

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -170,7 +170,7 @@ bool NetworkAddress::IsInNetmask(const char *netmask)
 		int tmp_cidr = atoi(chr_cidr + 1);
 
 		/* Invalid CIDR, treat as single host */
-		if (tmp_cidr > 0 || tmp_cidr < cidr) cidr = tmp_cidr;
+		if (tmp_cidr > 0 && tmp_cidr < cidr) cidr = tmp_cidr;
 
 		/* Remove the / so that NetworkAddress works on the IP portion */
 		std::string ip_str(netmask, chr_cidr - netmask);

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -374,14 +374,13 @@ uint64 Packet::Recv_uint64()
  */
 void Packet::Recv_string(char *buffer, size_t size, StringValidationSettings settings)
 {
-	PacketSize pos;
 	char *bufp = buffer;
 	const char *last = buffer + size - 1;
 
 	/* Don't allow reading from a closed socket */
 	if (cs->HasClientQuit()) return;
 
-	pos = this->pos;
+	size_t pos = this->pos;
 	while (--size > 0 && pos < this->Size() && (*buffer++ = this->buffer[pos++]) != '\0') {}
 
 	if (size == 0 || pos == this->Size()) {
@@ -391,7 +390,9 @@ void Packet::Recv_string(char *buffer, size_t size, StringValidationSettings set
 		while (pos < this->Size() && this->buffer[pos] != '\0') pos++;
 		pos++;
 	}
-	this->pos = pos;
+
+	assert(pos <= std::numeric_limits<PacketSize>::max());
+	this->pos = static_cast<PacketSize>(pos);
 
 	str_validate(bufp, last, settings);
 }

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4746,6 +4746,7 @@ static void FeatureChangeInfo(ByteReader *buf)
 		/* GSF_ROADTYPES */     RoadTypeChangeInfo,
 		/* GSF_TRAMTYPES */     TramTypeChangeInfo,
 	};
+	static_assert(GSF_END == lengthof(handler));
 
 	uint8 feature  = buf->ReadByte();
 	uint8 numprops = buf->ReadByte();
@@ -4760,7 +4761,7 @@ static void FeatureChangeInfo(ByteReader *buf)
 	grfmsg(6, "FeatureChangeInfo: Feature 0x%02X, %d properties, to apply to %d+%d",
 	               feature, numprops, engine, numinfo);
 
-	if (feature >= lengthof(handler) || handler[feature] == nullptr) {
+	if (handler[feature] == nullptr) {
 		if (feature != GSF_CARGOES) grfmsg(1, "FeatureChangeInfo: Unsupported feature 0x%02X, skipping", feature);
 		return;
 	}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1219,7 +1219,7 @@ public:
 				StringID str = this->GetWidget<NWidgetCore>(widget)->widget_data;
 				for (auto station_class : this->station_classes) {
 					StationClass *stclass = StationClass::Get(station_class);
-					for (uint16 j = 0; j < stclass->GetSpecCount(); j++) {
+					for (uint j = 0; j < stclass->GetSpecCount(); j++) {
 						const StationSpec *statspec = stclass->GetSpec(j);
 						SetDParam(0, (statspec != nullptr && statspec->name != 0) ? statspec->name : STR_STATION_CLASS_DFLT);
 						d = maxdim(d, GetStringBoundingBox(str));

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -70,8 +70,7 @@ static void Load_GSDT()
 	}
 
 	GameConfig *config = GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME);
-	if (_game_saveload_name.empty()) {
-	} else {
+	if (!_game_saveload_name.empty()) {
 		config->Change(_game_saveload_name.c_str(), _game_saveload_version, false, _game_saveload_is_random);
 		if (!config->HasScript()) {
 			/* No version of the GameScript available that can load the data. Try to load the

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -139,7 +139,7 @@ static const SaveLoad _edge_desc[] = {
  */
 void SaveLoad_LinkGraph(LinkGraph &lg)
 {
-	uint size = lg.Size();
+	uint16 size = lg.Size();
 	for (NodeID from = 0; from < size; ++from) {
 		Node *node = &lg.nodes[from];
 		SlObject(node, _node_desc);

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -776,7 +776,7 @@ public:
 			case WID_SB_SEL_PAGE: {
 
 				/* Get max title width. */
-				for (uint16 i = 0; i < this->story_pages.size(); i++) {
+				for (size_t i = 0; i < this->story_pages.size(); i++) {
 					const StoryPage *s = this->story_pages[i];
 
 					if (s->title != nullptr) {
@@ -822,7 +822,7 @@ public:
 				if (!list.empty()) {
 					/* Get the index of selected page. */
 					int selected = 0;
-					for (uint16 i = 0; i < this->story_pages.size(); i++) {
+					for (size_t i = 0; i < this->story_pages.size(); i++) {
 						const StoryPage *p = this->story_pages[i];
 						if (p->index == this->selected_page_id) break;
 						selected++;

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -457,7 +457,7 @@ void EmitGender(Buffer *buffer, char *buf, int value)
 
 		/* This is a {G 0 foo bar two} command.
 		 * If no relative number exists, default to +0 */
-		if (!ParseRelNum(&buf, &argidx, &offset)) {}
+		ParseRelNum(&buf, &argidx, &offset);
 
 		const CmdStruct *cmd = _cur_pcs.cmd[argidx];
 		if (cmd == nullptr || (cmd->flags & C_GENDER) == 0) {

--- a/src/texteff.hpp
+++ b/src/texteff.hpp
@@ -24,7 +24,7 @@ enum TextEffectMode {
 	INVALID_TE_ID = 0xFFFF,
 };
 
-typedef uint16 TextEffectID;
+typedef size_t TextEffectID;
 
 void MoveAllTextEffects(uint delta_ms);
 TextEffectID AddTextEffect(StringID msg, int x, int y, uint8 duration, TextEffectMode mode);


### PR DESCRIPTION
## Motivation / Problem

Not having warnings from static analysers such as LGTM is something to aim for, especially when they point to real bugs or prevent them from ever happening.


## Description

Trying to fix the warnings by using safer routines or fixing the code where needed.

For the backport: only "Fix: [Network] Check on CIDR for netmask check considered everything valid" needs a backport as that is an actual bug, the others are more theoretical issues.


## Limitations

This solves only a small set of warnings, however this is done to keep the PR size down.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
