### PR TITLE
Fix: [Network] don't mark the last-joined server as manual

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -476,7 +476,7 @@ public:
 		EM_ASM(if (window["openttd_server_list"]) openttd_server_list());
 #endif
 
-		this->last_joined = NetworkAddServer(_settings_client.network.last_joined);
+		this->last_joined = NetworkAddServer(_settings_client.network.last_joined, false);
 		this->server = this->last_joined;
 
 		this->requery_timer.SetInterval(MILLISECONDS_PER_TICK);


### PR DESCRIPTION
## Motivation / Problem

When joining a game, it is marked as last-joined. Next time you open the Multiplayer GUI, it was marked as "manually added". That means that slowly your list gets more and more "manually" added servers. Which is rather annoying.

I consider "manually" added only the ones you did via "add server". Last-joined should just be that, the one you joined last. If I join another server later, the server before should be forgotten about.

This is a personal opinion one could disagree with. But if we want this old behaviour, we really should not call it "manually", but "history" or something, possibly even with a date of the last join. But I digress, and not something for this PR.


## Description

Make last-joined no longer marked as "manually".


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
