### PR TITLE
Fix: [Network] don't rebuild the host-list during iterating the list

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -701,7 +701,6 @@ NetworkGameList *NetworkAddServer(const std::string &connection_string, bool man
 		ClearGRFConfigList(&item->info.grfconfig);
 		item->info.server_name = connection_string;
 
-		NetworkRebuildHostList();
 		UpdateNetworkGameWindow();
 
 		NetworkQueryServer(connection_string);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -830,6 +830,7 @@ public:
 		if (!StrEmpty(str)) {
 			strecpy(_settings_client.network.connect_to_ip, str, lastof(_settings_client.network.connect_to_ip));
 			NetworkAddServer(str);
+			NetworkRebuildHostList();
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

I noticed random string-errors when opening the GUI with more than 1 server. It turns out, we were changing a list while iterating it. Although this went fine, the `std::string` used from the list was free'd, causing invalid reads.

It is a bit timing depending, so reproducing it isn't always as easy.

## Description

```
Additionally, only rebuild it when we added a new manual server,
as otherwise it is a noop anyway.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
