### PR TITLE
Fix: [Network] mark server as offline when no longer reachable

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -627,6 +627,14 @@ private:
 public:
 	TCPQueryConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
 
+	void OnFailure() override
+	{
+		NetworkGameList *item = NetworkGameListAddItem(connection_string);
+		item->online = false;
+
+		UpdateNetworkGameWindow();
+	}
+
 	void OnConnect(SOCKET s) override
 	{
 		_networking = true;


### PR DESCRIPTION
## Motivation / Problem

When refreshing a server, it showed online if it was offline. That is just weird.

## Description

Hook into the OnFailure callback, and mark the server as offline.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
