### PR TITLE
Fix #9243: [Network] For a dedicated server use a fallback client and server name

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -841,6 +841,27 @@ static void NetworkInitGameInfo()
 	strecpy(ci->client_name, _settings_client.network.client_name, lastof(ci->client_name));
 }
 
+/**
+ * Check whether the client and server name are set, for a dedicated server and if not set them to some default
+ * value and tell the user to change this as soon as possible.
+ * If the saved name is the default value, then the user is told to override  this value too.
+ * This is only meant dedicated servers, as for the other servers the GUI ensures a name has been entered.
+ */
+static void CheckClientAndServerName()
+{
+	static const char *fallback_client_name = "Unnamed Client";
+	if (StrEmpty(_settings_client.network.client_name) || strcmp(_settings_client.network.client_name, fallback_client_name) == 0) {
+		DEBUG(net, 0, "No \"client_name\" has been set, using \"%s\" instead. Please set this now using the \"name <new name>\" command.", fallback_client_name);
+		strecpy(_settings_client.network.client_name, fallback_client_name, lastof(_settings_client.network.client_name));
+	}
+
+	static const char *fallback_server_name = "Unnamed Server";
+	if (StrEmpty(_settings_client.network.server_name) || strcmp(_settings_client.network.server_name, fallback_server_name) == 0) {
+		DEBUG(net, 0, "No \"server_name\" has been set, using \"%s\" instead. Please set this now using the \"server_name <new name>\" command.", fallback_server_name);
+		strecpy(_settings_client.network.server_name, fallback_server_name, lastof(_settings_client.network.server_name));
+	}
+}
+
 bool NetworkServerStart()
 {
 	if (!_network_available) return false;
@@ -848,6 +869,9 @@ bool NetworkServerStart()
 	/* Call the pre-scripts */
 	IConsoleCmdExec("exec scripts/pre_server.scr 0");
 	if (_network_dedicated) IConsoleCmdExec("exec scripts/pre_dedicated.scr 0");
+
+	/* Check for the client and server names to be set, but only after the scripts had a chance to set them.*/
+	if (_network_dedicated) CheckClientAndServerName();
 
 	NetworkDisconnect(false, false);
 	NetworkInitialize(false);


### PR DESCRIPTION
## Motivation / Problem

Closes #9243. For dedicated servers client name would not be set.


## Description

Check whether the client and server name have been set, and if not set them with some default value. Furthermore warn the user about this with pointer on how to resolve the issue. Next to that also complain when that default value is used as name.
It is not necessary for the non-dedicated server as the GUI already checks the client name, and the server name will also have some default.


## Limitations

The server can still set its client name to be invalid with some effort, though that is then to be considered their problem for now. When/once the validation of string settings can be done, the issue of the previous line including setting bad/invalid server names can be solved once and for all, as it would just reject the new value before writing instead of writing the value and then running a post-change callback that has no way to revert the value to the old (correct) one.
The fallback is "Unnamed Client"  and "Unnamed Server". This capitalization has been chosen as the server variant is the one currently used, so it would also warn on the current "unset" server names.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
