### PR TITLE
Fix #9242: Tree tick handler did not scale by map size.

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -812,6 +812,9 @@ static void TileLoop_Trees(TileIndex tile)
  */
 bool DecrementTreeCounter()
 {
+	/* Ensure _trees_tick_ctr can be decremented past zero only once for the largest map size. */
+	static_assert(2 * (MAX_MAP_SIZE_BITS - MIN_MAP_SIZE_BITS) - 4 <= std::numeric_limits<byte>::digits);
+
 	/* byte underflow */
 	byte old_trees_tick_ctr = _trees_tick_ctr;
 	_trees_tick_ctr -= ScaleByMapSize(1);

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -22,6 +22,7 @@
 #include "company_base.h"
 #include "core/random_func.hpp"
 #include "newgrf_generic.h"
+#include "date_func.h"
 
 #include "table/strings.h"
 #include "table/tree_land.h"
@@ -803,6 +804,20 @@ static void TileLoop_Trees(TileIndex tile)
 	MarkTileDirtyByTile(tile);
 }
 
+/**
+ * Decrement the tree tick counter.
+ * The interval is scaled by map size to allow for the same density regardless of size.
+ * Adjustment for map sizes below the standard 256 * 256 are handled earlier.
+ * @return true if the counter was decremented past zero
+ */
+bool DecrementTreeCounter()
+{
+	/* byte underflow */
+	byte old_trees_tick_ctr = _trees_tick_ctr;
+	_trees_tick_ctr -= ScaleByMapSize(1);
+	return old_trees_tick_ctr <= _trees_tick_ctr;
+}
+
 void OnTick_Trees()
 {
 	/* Don't spread trees if that's not allowed */
@@ -812,16 +827,24 @@ void OnTick_Trees()
 	TileIndex tile;
 	TreeType tree;
 
+	/* Skip some tree ticks for map sizes below 256 * 256. 64 * 64 is 16 times smaller, so
+	 * this is the maximum number of ticks that are skipped. Number of ticks to skip is
+	 * inversely proportional to map size, so that is handled to create a mask. */
+	int skip = ScaleByMapSize(16);
+	if (skip < 16 && (_tick_counter & (16 / skip - 1)) != 0) return;
+
 	/* place a tree at a random rainforest spot */
-	if (_settings_game.game_creation.landscape == LT_TROPIC &&
-			(r = Random(), tile = RandomTileSeed(r), GetTropicZone(tile) == TROPICZONE_RAINFOREST) &&
-			CanPlantTreesOnTile(tile, false) &&
-			(tree = GetRandomTreeType(tile, GB(r, 24, 8))) != TREE_INVALID) {
-		PlantTreesOnTile(tile, tree, 0, 0);
+	if (_settings_game.game_creation.landscape == LT_TROPIC) {
+		for (uint c = ScaleByMapSize(1); c > 0; c--) {
+			if ((r = Random(), tile = RandomTileSeed(r), GetTropicZone(tile) == TROPICZONE_RAINFOREST) &&
+				CanPlantTreesOnTile(tile, false) &&
+				(tree = GetRandomTreeType(tile, GB(r, 24, 8))) != TREE_INVALID) {
+				PlantTreesOnTile(tile, tree, 0, 0);
+			}
+		}
 	}
 
-	/* byte underflow */
-	if (--_trees_tick_ctr != 0 || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST) return;
+	if (!DecrementTreeCounter() || _settings_game.construction.extra_tree_placement == ETP_SPREAD_RAINFOREST) return;
 
 	/* place a tree at a random spot */
 	r = Random();


### PR DESCRIPTION
## Motivation / Problem

Tree tick handler did not scale by map size.

This means that random tree generation density is higher on small maps and lower on large maps. This difference is enough to make the Lumber Mill impractical to use on large maps.

## Description

This change skips ticks on maps smaller than 256x256 and increases iterations or shortens the interval on maps larger than 256x256.

Although #9242 is primarily about the Lumber Mill, this issue affects all random tree generation after a game is started.

## Limitations

For simplicity the counter decrement function now triggers when the counter passes zero, instead of when the counter reaches zero. Slight timing difference but shouldn't affect much.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
