### PR TITLE
Fix: [Emscripten] Force secure WebSockets over HTTPS

### DIFF
--- a/os/emscripten/pre.js
+++ b/os/emscripten/pre.js
@@ -9,7 +9,15 @@ Module['websocket'] = { url: function(host, port, proto) {
      * If you run your own server you can setup your own WebSocket proxy in
      * front of it and let people connect to your server via the proxy. You
      * are best to add another "if" statement as above for this. */
-    return null;
+
+    if (location.protocol === 'https:') {
+        /* Insecure WebSockets do not work over HTTPS, so we force
+         * secure ones. */
+        return 'wss://';
+    } else {
+        /* Use the default provided by Emscripten. */
+        return null;
+    }
 } };
 
 Module.preRun.push(function() {


### PR DESCRIPTION
## Motivation / Problem

Emscripten uses insecure WebSockets for all connections by default. This doesn't work on HTTPS as browsers force secure WebSockets to be used (and block any insecure connection from even being opened).

## Description

This PR forces the use of the `wss://` protocol when OpenTTD is loaded over an HTTPS connection.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
