### PR TITLE
Change: reworked the debug levels for network facility

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -91,7 +91,7 @@ static void _GenerateWorld()
 
 	try {
 		_generating_world = true;
-		if (_network_dedicated) DEBUG(net, 1, "Generating map, please wait...");
+		if (_network_dedicated) DEBUG(net, 3, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
 		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
@@ -188,7 +188,7 @@ static void _GenerateWorld()
 
 		ShowNewGRFError();
 
-		if (_network_dedicated) DEBUG(net, 1, "Map generated, starting game");
+		if (_network_dedicated) DEBUG(net, 3, "Map generated, starting game");
 		DEBUG(desync, 1, "new_map: %08x", _settings_game.game_creation.generation_seed);
 
 		if (_debug_desync_level > 0) {
@@ -204,7 +204,7 @@ static void _GenerateWorld()
 
 		if (_network_dedicated) {
 			/* Exit the game to prevent a return to main menu.  */
-			DEBUG(net, 0, "Generating map failed, aborting");
+			DEBUG(net, 0, "Generating map failed; closing server");
 			_exit_game = true;
 		} else {
 			SwitchToMode(_switch_mode);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1458,7 +1458,7 @@ static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uin
 		/* Never show steps smaller than 2%, even if it is a mod 5% */
 		if (_gws.percent <= last_percent + 2) return;
 
-		DEBUG(net, 1, "Map generation percentage complete: %d", _gws.percent);
+		DEBUG(net, 3, "Map generation percentage complete: %d", _gws.percent);
 		last_percent = _gws.percent;
 
 		return;

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -356,7 +356,7 @@ static SOCKET ListenLoopProc(addrinfo *runp)
 		DEBUG(net, 0, "Setting non-blocking mode failed: %s", NetworkError::GetLast().AsString());
 	}
 
-	DEBUG(net, 1, "Listening on %s", address.c_str());
+	DEBUG(net, 3, "Listening on %s", address.c_str());
 	return sock;
 }
 

--- a/src/network/core/core.cpp
+++ b/src/network/core/core.cpp
@@ -27,9 +27,9 @@ bool NetworkCoreInitialize()
 #ifdef _WIN32
 	{
 		WSADATA wsa;
-		DEBUG(net, 3, "[core] loading windows socket library");
+		DEBUG(net, 5, "Loading windows socket library");
 		if (WSAStartup(MAKEWORD(2, 0), &wsa) != 0) {
-			DEBUG(net, 0, "[core] WSAStartup failed, network unavailable");
+			DEBUG(net, 0, "WSAStartup failed, network unavailable");
 			return false;
 		}
 	}

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -51,7 +51,7 @@ const char *GetNetworkRevisionString()
 
 		/* Tag names are not mangled further. */
 		if (_openttd_revision_tagged) {
-			DEBUG(net, 1, "Network revision name is '%s'", network_revision);
+			DEBUG(net, 3, "Network revision name: %s", network_revision);
 			return network_revision;
 		}
 
@@ -71,7 +71,7 @@ const char *GetNetworkRevisionString()
 		/* Replace the git hash in revision string. */
 		strecpy(network_revision + hashofs, githash_suffix, network_revision + NETWORK_REVISION_LENGTH);
 		assert(strlen(network_revision) < NETWORK_REVISION_LENGTH); // strlen does not include terminator, constant does, hence strictly less than
-		DEBUG(net, 1, "Network revision name is '%s'", network_revision);
+		DEBUG(net, 3, "Network revision name: %s", network_revision);
 	}
 
 	return network_revision;

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -39,14 +39,14 @@ static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // BE
 	int sock = socket(AF_INET, SOCK_DGRAM, 0);
 
 	if (sock < 0) {
-		DEBUG(net, 0, "[core] error creating socket");
+		DEBUG(net, 0, "Could not create socket: %s", NetworkError::GetLast().AsString());
 		return;
 	}
 
 	char *output_pointer = nullptr;
 	int output_length = _netstat(sock, &output_pointer, 1);
 	if (output_length < 0) {
-		DEBUG(net, 0, "[core] error running _netstat");
+		DEBUG(net, 0, "Error running _netstat()");
 		return;
 	}
 
@@ -200,6 +200,6 @@ void NetworkFindBroadcastIPs(NetworkAddressList *broadcast)
 	int i = 0;
 	for (NetworkAddress &addr : *broadcast) {
 		addr.SetPort(NETWORK_DEFAULT_PORT);
-		DEBUG(net, 3, "%d) %s", i++, addr.GetHostname());
+		DEBUG(net, 3, "  %d) %s", i++, addr.GetHostname());
 	}
 }

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -90,7 +90,7 @@ SendPacketsState NetworkTCPSocketHandler::SendPackets(bool closing_down)
 			if (!err.WouldBlock()) {
 				/* Something went wrong.. close client! */
 				if (!closing_down) {
-					DEBUG(net, 0, "send failed with error %s", err.AsString());
+					DEBUG(net, 0, "Send failed: %s", err.AsString());
 					this->CloseConnection();
 				}
 				return SPS_CLOSED;
@@ -139,7 +139,7 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
 				NetworkError err = NetworkError::GetLast();
 				if (!err.WouldBlock()) {
 					/* Something went wrong... */
-					if (!err.IsConnectionReset()) DEBUG(net, 0, "recv failed with error %s", err.AsString());
+					if (!err.IsConnectionReset()) DEBUG(net, 0, "Recv failed: %s", err.AsString());
 					this->CloseConnection();
 					return nullptr;
 				}
@@ -167,7 +167,7 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
 			NetworkError err = NetworkError::GetLast();
 			if (!err.WouldBlock()) {
 				/* Something went wrong... */
-				if (!err.IsConnectionReset()) DEBUG(net, 0, "recv failed with error %s", err.AsString());
+				if (!err.IsConnectionReset()) DEBUG(net, 0, "Recv failed: %s", err.AsString());
 				this->CloseConnection();
 				return nullptr;
 			}

--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -93,9 +93,9 @@ NetworkRecvStatus NetworkAdminSocketHandler::HandlePacket(Packet *p)
 
 		default:
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[tcp/admin] received invalid packet type %d from '%s' (%s)", type, this->admin_name, this->admin_version);
+				DEBUG(net, 0, "[tcp/admin] Received invalid packet type %d from '%s' (%s)", type, this->admin_name, this->admin_version);
 			} else {
-				DEBUG(net, 0, "[tcp/admin] received illegal packet from '%s' (%s)", this->admin_name, this->admin_version);
+				DEBUG(net, 0, "[tcp/admin] Received illegal packet from '%s' (%s)", this->admin_name, this->admin_version);
 			}
 
 			this->CloseConnection();
@@ -129,7 +129,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkAdminSocketHandler::ReceiveInvalidPacket(PacketAdminType type)
 {
-	DEBUG(net, 0, "[tcp/admin] received illegal packet type %d from admin %s (%s)", type, this->admin_name, this->admin_version);
+	DEBUG(net, 0, "[tcp/admin] Received illegal packet type %d from admin %s (%s)", type, this->admin_name, this->admin_version);
 	return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 }
 

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -72,7 +72,7 @@ void TCPConnecter::Connect(addrinfo *address)
 	}
 
 	NetworkAddress network_address = NetworkAddress(address->ai_addr, (int)address->ai_addrlen);
-	DEBUG(net, 4, "Attempting to connect to %s", network_address.GetAddressAsString().c_str());
+	DEBUG(net, 5, "Attempting to connect to %s", network_address.GetAddressAsString().c_str());
 
 	int err = connect(sock, address->ai_addr, (int)address->ai_addrlen);
 	if (err != 0 && !NetworkError::GetLast().IsConnectInProgress()) {
@@ -149,10 +149,10 @@ void TCPConnecter::OnResolved(addrinfo *ai)
 		}
 	}
 
-	if (_debug_net_level >= 5) {
-		DEBUG(net, 5, "%s resolved in:", this->connection_string.c_str());
+	if (_debug_net_level >= 6) {
+		DEBUG(net, 6, "%s resolved in:", this->connection_string.c_str());
 		for (const auto &address : this->addresses) {
-			DEBUG(net, 5, "- %s", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString().c_str());
+			DEBUG(net, 6, "- %s", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString().c_str());
 		}
 	}
 
@@ -188,7 +188,7 @@ void TCPConnecter::Resolve()
 	}
 
 	if (e != 0) {
-		DEBUG(misc, 0, "Failed to resolve DNS for %s", this->connection_string.c_str());
+		DEBUG(net, 0, "Failed to resolve DNS for %s", this->connection_string.c_str());
 		this->OnFailure();
 		return;
 	}
@@ -235,7 +235,7 @@ bool TCPConnecter::CheckActivity()
 	/* select() failed; hopefully next try it doesn't. */
 	if (n < 0) {
 		/* select() normally never fails; so hopefully it works next try! */
-		DEBUG(net, 1, "select() failed with %s", NetworkError::GetLast().AsString());
+		DEBUG(net, 1, "select() failed: %s", NetworkError::GetLast().AsString());
 		return false;
 	}
 
@@ -301,7 +301,7 @@ bool TCPConnecter::CheckActivity()
 	}
 	assert(connected_socket != INVALID_SOCKET);
 
-	DEBUG(net, 1, "Connected to %s", this->connection_string.c_str());
+	DEBUG(net, 3, "Connected to %s", this->connection_string.c_str());
 	if (_debug_net_level >= 5) {
 		DEBUG(net, 5, "- using %s", NetworkAddress::GetPeerName(connected_socket).c_str());
 	}

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -167,9 +167,9 @@ bool NetworkContentSocketHandler::HandlePacket(Packet *p)
 
 		default:
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[tcp/content] received invalid packet type %d", type);
+				DEBUG(net, 0, "[tcp/content] Received invalid packet type %d", type);
 			} else {
-				DEBUG(net, 0, "[tcp/content] received illegal packet");
+				DEBUG(net, 0, "[tcp/content] Received illegal packet");
 			}
 			return false;
 	}
@@ -220,7 +220,7 @@ bool NetworkContentSocketHandler::ReceivePackets()
  */
 bool NetworkContentSocketHandler::ReceiveInvalidPacket(PacketContentType type)
 {
-	DEBUG(net, 0, "[tcp/content] received illegal packet type %d", type);
+	DEBUG(net, 0, "[tcp/content] Received illegal packet type %d", type);
 	return false;
 }
 

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -117,9 +117,9 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet *p)
 			this->CloseConnection();
 
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[tcp/game] received invalid packet type %d from client %d", type, this->client_id);
+				DEBUG(net, 0, "[tcp/game] Received invalid packet type %d from client %d", type, this->client_id);
 			} else {
-				DEBUG(net, 0, "[tcp/game] received illegal packet from client %d", this->client_id);
+				DEBUG(net, 0, "[tcp/game] Received illegal packet from client %d", this->client_id);
 			}
 			return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
@@ -151,7 +151,7 @@ NetworkRecvStatus NetworkGameSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkGameSocketHandler::ReceiveInvalidPacket(PacketGameType type)
 {
-	DEBUG(net, 0, "[tcp/game] received illegal packet type %d from client %d", type, this->client_id);
+	DEBUG(net, 0, "[tcp/game] Received illegal packet type %d from client %d", type, this->client_id);
 	return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 }
 

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -49,7 +49,7 @@ public:
 			SetNonBlocking(s); // XXX error handling?
 
 			NetworkAddress address(sin, sin_len);
-			DEBUG(net, 1, "[%s] Client connected from %s on frame %d", Tsocket::GetName(), address.GetHostname(), _frame_counter);
+			DEBUG(net, 3, "[%s] Client connected from %s on frame %d", Tsocket::GetName(), address.GetHostname(), _frame_counter);
 
 			SetNoDelay(s); // XXX error handling?
 
@@ -61,10 +61,10 @@ public:
 					Packet p(Tban_packet);
 					p.PrepareToSend();
 
-					DEBUG(net, 1, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry.c_str());
+					DEBUG(net, 2, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry.c_str());
 
 					if (p.TransferOut<int>(send, s, 0) < 0) {
-						DEBUG(net, 0, "send failed with error %s", NetworkError::GetLast().AsString());
+						DEBUG(net, 0, "[%s] send failed: %s", Tsocket::GetName(), NetworkError::GetLast().AsString());
 					}
 					closesocket(s);
 					break;
@@ -81,7 +81,7 @@ public:
 				p.PrepareToSend();
 
 				if (p.TransferOut<int>(send, s, 0) < 0) {
-					DEBUG(net, 0, "send failed with error %s", NetworkError::GetLast().AsString());
+					DEBUG(net, 0, "[%s] send failed: %s", Tsocket::GetName(), NetworkError::GetLast().AsString());
 				}
 				closesocket(s);
 
@@ -150,7 +150,7 @@ public:
 		}
 
 		if (sockets.size() == 0) {
-			DEBUG(net, 0, "[server] could not start network: could not create listening socket");
+			DEBUG(net, 0, "Could not start network: could not create listening socket");
 			ShowNetworkError(STR_NETWORK_ERROR_SERVER_START);
 			return false;
 		}
@@ -165,7 +165,7 @@ public:
 			closesocket(s.second);
 		}
 		sockets.clear();
-		DEBUG(net, 1, "[%s] closed listeners", Tsocket::GetName());
+		DEBUG(net, 5, "[%s] Closed listeners", Tsocket::GetName());
 	}
 };
 

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -95,16 +95,16 @@ void NetworkUDPSocketHandler::SendPacket(Packet *p, NetworkAddress *recv, bool a
 			/* Enable broadcast */
 			unsigned long val = 1;
 			if (setsockopt(s.second, SOL_SOCKET, SO_BROADCAST, (char *) &val, sizeof(val)) < 0) {
-				DEBUG(net, 1, "[udp] setting broadcast failed with: %s", NetworkError::GetLast().AsString());
+				DEBUG(net, 1, "Setting broadcast mode failed: %s", NetworkError::GetLast().AsString());
 			}
 		}
 
 		/* Send the buffer */
 		ssize_t res = p->TransferOut<int>(sendto, s.second, 0, (const struct sockaddr *)send.GetAddress(), send.GetAddressLength());
-		DEBUG(net, 7, "[udp] sendto(%s)", send.GetAddressAsString().c_str());
+		DEBUG(net, 7, "sendto(%s)", send.GetAddressAsString().c_str());
 
 		/* Check for any errors, but ignore it otherwise */
-		if (res == -1) DEBUG(net, 1, "[udp] sendto(%s) failed with: %s", send.GetAddressAsString().c_str(), NetworkError::GetLast().AsString());
+		if (res == -1) DEBUG(net, 1, "sendto(%s) failed: %s", send.GetAddressAsString().c_str(), NetworkError::GetLast().AsString());
 
 		if (!all) break;
 	}
@@ -140,7 +140,7 @@ void NetworkUDPSocketHandler::ReceivePackets()
 			/* If the size does not match the packet must be corrupted.
 			 * Otherwise it will be marked as corrupted later on. */
 			if (!p.ParsePacketSize() || (size_t)nbytes != p.Size()) {
-				DEBUG(net, 1, "received a packet with mismatching size from %s", address.GetAddressAsString().c_str());
+				DEBUG(net, 1, "Received a packet with mismatching size from %s", address.GetAddressAsString().c_str());
 				continue;
 			}
 			p.PrepareToRead();
@@ -181,9 +181,9 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet *p, NetworkAddress *client_
 
 		default:
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[udp] received invalid packet type %d from %s", type, client_addr->GetAddressAsString().c_str());
+				DEBUG(net, 0, "[udp] Received invalid packet type %d from %s", type, client_addr->GetAddressAsString().c_str());
 			} else {
-				DEBUG(net, 0, "[udp] received illegal packet from %s", client_addr->GetAddressAsString().c_str());
+				DEBUG(net, 0, "[udp] Received illegal packet from %s", client_addr->GetAddressAsString().c_str());
 			}
 			break;
 	}
@@ -196,7 +196,7 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet *p, NetworkAddress *client_
  */
 void NetworkUDPSocketHandler::ReceiveInvalidPacket(PacketUDPType type, NetworkAddress *client_addr)
 {
-	DEBUG(net, 0, "[udp] received packet type %d on wrong port from %s", type, client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 0, "[udp] Received packet type %d on wrong port from %s", type, client_addr->GetAddressAsString().c_str());
 }
 
 void NetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_FIND_SERVER, client_addr); }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -136,7 +136,7 @@ void ClientNetworkEmergencySave()
 	if (!_networking) return;
 
 	const char *filename = "netsave.sav";
-	DEBUG(net, 0, "Client: Performing emergency save (%s)", filename);
+	DEBUG(net, 3, "Performing emergency save: %s", filename);
 	SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, AUTOSAVE_DIR, false);
 }
 
@@ -172,7 +172,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	 */
 	if (this->sock == INVALID_SOCKET) return status;
 
-	DEBUG(net, 1, "Closed client connection %d", this->client_id);
+	DEBUG(net, 3, "Closed client connection %d", this->client_id);
 
 	this->SendPackets(true);
 
@@ -286,7 +286,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 #endif
 				ShowNetworkError(STR_NETWORK_ERROR_DESYNC);
 				DEBUG(desync, 1, "sync_err: %08x; %02x", _date, _date_fract);
-				DEBUG(net, 0, "Sync error detected!");
+				DEBUG(net, 0, "Sync error detected");
 				my_client->ClientError(NETWORK_RECV_STATUS_DESYNC);
 				return false;
 			}
@@ -301,7 +301,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 			_sync_frame = 0;
 		} else if (_sync_frame < _frame_counter) {
-			DEBUG(net, 1, "Missed frame for sync-test (%d / %d)", _sync_frame, _frame_counter);
+			DEBUG(net, 1, "Missed frame for sync-test: %d / %d", _sync_frame, _frame_counter);
 			_sync_frame = 0;
 		}
 	}
@@ -978,13 +978,13 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_FRAME(Packet *p
 	/* Receive the token. */
 	if (p->CanReadFromPacket(sizeof(uint8))) this->token = p->Recv_uint8();
 
-	DEBUG(net, 5, "Received FRAME %d", _frame_counter_server);
+	DEBUG(net, 7, "Received FRAME %d", _frame_counter_server);
 
 	/* Let the server know that we received this frame correctly
 	 *  We do this only once per day, to save some bandwidth ;) */
 	if (!_network_first_time && last_ack_frame < _frame_counter) {
 		last_ack_frame = _frame_counter + DAY_TICKS;
-		DEBUG(net, 4, "Sent ACK at %d", _frame_counter);
+		DEBUG(net, 7, "Sent ACK at %d", _frame_counter);
 		SendAck();
 	}
 
@@ -1100,7 +1100,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_QUIT(Packet *p)
 		NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, ci->client_name, nullptr, STR_NETWORK_MESSAGE_CLIENT_LEAVING);
 		delete ci;
 	} else {
-		DEBUG(net, 0, "Unknown client (%d) is leaving the game", client_id);
+		DEBUG(net, 1, "Unknown client (%d) is leaving the game", client_id);
 	}
 
 	InvalidateWindowData(WC_CLIENT_LIST, 0);
@@ -1180,7 +1180,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MOVE(Packet *p)
 
 	if (client_id == 0) {
 		/* definitely an invalid client id, debug message and do nothing. */
-		DEBUG(net, 0, "[move] received invalid client index = 0");
+		DEBUG(net, 1, "Received invalid client index = 0");
 		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
 

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -333,7 +333,7 @@ void NetworkGameSocketHandler::SendCommand(Packet *p, const CommandPacket *cp)
 	}
 
 	if (callback == lengthof(_callback_table)) {
-		DEBUG(net, 0, "Unknown callback. (Pointer: %p) No callback sent", cp->callback);
+		DEBUG(net, 0, "Unknown callback for command; no callback sent (command: %d)", cp->cmd);
 		callback = 0; // _callback_table[0] == nullptr
 	}
 	p->Send_uint8 (callback);

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -112,7 +112,6 @@ void NetworkGameListRemoveItem(NetworkGameList *remove)
 			ClearGRFConfigList(&remove->info.grfconfig);
 			delete remove;
 
-			DEBUG(net, 4, "[gamelist] removed server from list");
 			NetworkRebuildHostList();
 			UpdateNetworkGameWindow();
 			return;

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -283,7 +283,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	}
 
 	NetworkAdminClientError(this->client_id, NETWORK_ERROR_CONNECTION_LOST);
-	DEBUG(net, 1, "Closed client connection %d", this->client_id);
+	DEBUG(net, 3, "Closed client connection %d", this->client_id);
 
 	/* We just lost one client :( */
 	if (this->status >= STATUS_AUTHORIZED) _network_game_info.clients_on--;
@@ -448,7 +448,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 
 		this->GetClientName(client_name, lastof(client_name));
 
-		DEBUG(net, 1, "'%s' made an error and has been disconnected. Reason: '%s'", client_name, str);
+		DEBUG(net, 1, "'%s' made an error and has been disconnected: %s", client_name, str);
 
 		if (error == NETWORK_ERROR_KICKED && reason != nullptr) {
 			NetworkTextMessage(NETWORK_ACTION_KICKED, CC_DEFAULT, false, client_name, reason, strid);
@@ -469,7 +469,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 
 		NetworkAdminClientError(this->client_id, error);
 	} else {
-		DEBUG(net, 1, "Client %d made an error and has been disconnected. Reason: '%s'", this->client_id, str);
+		DEBUG(net, 1, "Client %d made an error and has been disconnected: %s", this->client_id, str);
 	}
 
 	/* The client made a mistake, so drop his connection now! */
@@ -1144,7 +1144,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_ERROR(Packet *p
 	StringID strid = GetNetworkErrorMsg(errorno);
 	GetString(str, strid, lastof(str));
 
-	DEBUG(net, 2, "'%s' reported an error and is closing its connection (%s)", client_name, str);
+	DEBUG(net, 1, "'%s' reported an error and is closing its connection: %s", client_name, str);
 
 	NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, nullptr, strid);
 
@@ -1335,7 +1335,7 @@ void NetworkServerSendChat(NetworkAction action, DestType desttype, int dest, co
 			break;
 		}
 		default:
-			DEBUG(net, 0, "[server] received unknown chat destination type %d. Doing broadcast instead", desttype);
+			DEBUG(net, 1, "Received unknown chat destination type %d; doing broadcast instead", desttype);
 			FALLTHROUGH;
 
 		case DESTTYPE_BROADCAST:
@@ -1445,11 +1445,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_RCON(Packet *p)
 	p->Recv_string(command, sizeof(command));
 
 	if (strcmp(pass, _settings_client.network.rcon_password) != 0) {
-		DEBUG(net, 0, "[rcon] wrong password from client-id %d", this->client_id);
+		DEBUG(net, 1, "[rcon] Wrong password from client-id %d", this->client_id);
 		return NETWORK_RECV_STATUS_OKAY;
 	}
 
-	DEBUG(net, 0, "[rcon] client-id %d executed: '%s'", this->client_id, command);
+	DEBUG(net, 3, "[rcon] Client-id %d executed: %s", this->client_id, command);
 
 	_redirect_console_to_client = this->client_id;
 	IConsoleCmdExec(command);
@@ -1474,7 +1474,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_MOVE(Packet *p)
 
 		/* Incorrect password sent, return! */
 		if (strcmp(password, _network_company_states[company_id].password) != 0) {
-			DEBUG(net, 2, "[move] wrong password from client-id #%d for company #%d", this->client_id, company_id + 1);
+			DEBUG(net, 2, "Wrong password from client-id #%d for company #%d", this->client_id, company_id + 1);
 			return NETWORK_RECV_STATUS_OKAY;
 		}
 	}
@@ -1597,7 +1597,7 @@ void NetworkUpdateClientInfo(ClientID client_id)
 static void NetworkCheckRestartMap()
 {
 	if (_settings_client.network.restart_game_year != 0 && _cur_year >= _settings_client.network.restart_game_year) {
-		DEBUG(net, 0, "Auto-restarting map. Year %d reached", _cur_year);
+		DEBUG(net, 3, "Auto-restarting map: year %d reached", _cur_year);
 
 		_settings_newgame.game_creation.generation_seed = GENERATE_NEW_SEED;
 		switch(_file_to_saveload.abstract_ftype) {

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -67,7 +67,7 @@ struct UDPSocket {
 		std::unique_lock<std::mutex> lock(mutex, std::defer_lock);
 		if (!lock.try_lock()) {
 			if (++receive_iterations_locked % 32 == 0) {
-				DEBUG(net, 0, "[udp] %s background UDP loop processing appears to be blocked. Your OS may be low on UDP send buffers.", name.c_str());
+				DEBUG(net, 0, "%s background UDP loop processing appears to be blocked. Your OS may be low on UDP send buffers.", name.c_str());
 			}
 			return;
 		}
@@ -133,7 +133,7 @@ public:
 void MasterNetworkUDPSocketHandler::Receive_MASTER_ACK_REGISTER(Packet *p, NetworkAddress *client_addr)
 {
 	_network_advertise_retries = 0;
-	DEBUG(net, 2, "[udp] advertising on master server successful (%s)", NetworkAddress::AddressFamilyAsString(client_addr->GetAddress()->ss_family));
+	DEBUG(net, 3, "Advertising on master server successful (%s)", NetworkAddress::AddressFamilyAsString(client_addr->GetAddress()->ss_family));
 
 	/* We are advertised, but we don't want to! */
 	if (!_settings_client.network.server_advertise) NetworkUDPRemoveAdvertise(false);
@@ -142,7 +142,7 @@ void MasterNetworkUDPSocketHandler::Receive_MASTER_ACK_REGISTER(Packet *p, Netwo
 void MasterNetworkUDPSocketHandler::Receive_MASTER_SESSION_KEY(Packet *p, NetworkAddress *client_addr)
 {
 	_session_key = p->Recv_uint64();
-	DEBUG(net, 2, "[udp] received new session key from master server (%s)", NetworkAddress::AddressFamilyAsString(client_addr->GetAddress()->ss_family));
+	DEBUG(net, 6, "Received new session key from master server (%s)", NetworkAddress::AddressFamilyAsString(client_addr->GetAddress()->ss_family));
 }
 
 ///*** Communication with clients (we are server) ***/
@@ -175,7 +175,7 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, Networ
 	/* Let the client know that we are here */
 	this->SendPacket(&packet, client_addr);
 
-	DEBUG(net, 2, "[udp] queried from %s", client_addr->GetHostname());
+	DEBUG(net, 7, "Queried from %s", client_addr->GetHostname());
 }
 
 void ServerNetworkUDPSocketHandler::Receive_CLIENT_DETAIL_INFO(Packet *p, NetworkAddress *client_addr)
@@ -252,7 +252,7 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, Networ
 	uint8 in_reply_count = 0;
 	size_t packet_len = 0;
 
-	DEBUG(net, 6, "[udp] newgrf data request from %s", client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 7, "NewGRF data request from %s", client_addr->GetAddressAsString().c_str());
 
 	num_grfs = p->Recv_uint8 ();
 	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
@@ -314,7 +314,7 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAd
 	/* Just a fail-safe.. should never happen */
 	if (_network_udp_server) return;
 
-	DEBUG(net, 4, "[udp] server response from %s", client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 3, "Server response from %s", client_addr->GetAddressAsString().c_str());
 
 	/* Find next item */
 	item = NetworkGameListAddItem(client_addr->GetAddressAsString(false));
@@ -409,7 +409,7 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_NEWGRFS(Packet *p, NetworkAdd
 	uint8 num_grfs;
 	uint i;
 
-	DEBUG(net, 6, "[udp] newgrf data reply from %s", client_addr->GetAddressAsString().c_str());
+	DEBUG(net, 7, "NewGRF data reply from %s", client_addr->GetAddressAsString().c_str());
 
 	num_grfs = p->Recv_uint8 ();
 	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
@@ -441,7 +441,7 @@ static void NetworkUDPBroadCast(NetworkUDPSocketHandler *socket)
 	for (NetworkAddress &addr : _broadcast_list) {
 		Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
 
-		DEBUG(net, 4, "[udp] broadcasting to %s", addr.GetHostname());
+		DEBUG(net, 5, "Broadcasting to %s", addr.GetHostname());
 
 		socket->SendPacket(&p, &addr, true, true);
 	}
@@ -461,7 +461,7 @@ void NetworkUDPQueryMasterServer()
 	std::lock_guard<std::mutex> lock(_udp_client.mutex);
 	_udp_client.socket->SendPacket(&p, &out_addr, true);
 
-	DEBUG(net, 2, "[udp] master server queried at %s", out_addr.GetAddressAsString().c_str());
+	DEBUG(net, 6, "Master server queried at %s", out_addr.GetAddressAsString().c_str());
 }
 
 /** Find all servers */
@@ -470,7 +470,7 @@ void NetworkUDPSearchGame()
 	/* We are still searching.. */
 	if (_network_udp_broadcast > 0) return;
 
-	DEBUG(net, 0, "[udp] searching server");
+	DEBUG(net, 3, "Searching server");
 
 	NetworkUDPBroadCast(_udp_client.socket);
 	_network_udp_broadcast = 300; // Stay searching for 300 ticks
@@ -481,7 +481,7 @@ void NetworkUDPSearchGame()
  */
 static void NetworkUDPRemoveAdvertiseThread()
 {
-	DEBUG(net, 1, "[udp] removing advertise from master server");
+	DEBUG(net, 3, "Removing advertise from master server");
 
 	/* Find somewhere to send */
 	NetworkAddress out_addr(NETWORK_MASTER_SERVER_HOST, NETWORK_MASTER_SERVER_PORT);
@@ -518,22 +518,22 @@ static void NetworkUDPAdvertiseThread()
 	/* Find somewhere to send */
 	NetworkAddress out_addr(NETWORK_MASTER_SERVER_HOST, NETWORK_MASTER_SERVER_PORT);
 
-	DEBUG(net, 1, "[udp] advertising to master server");
+	DEBUG(net, 3, "Advertising to master server");
 
 	/* Add a bit more messaging when we cannot get a session key */
 	static byte session_key_retries = 0;
 	if (_session_key == 0 && session_key_retries++ == 2) {
-		DEBUG(net, 0, "[udp] advertising to the master server is failing");
-		DEBUG(net, 0, "[udp]   we are not receiving the session key from the server");
-		DEBUG(net, 0, "[udp]   please allow udp packets from %s to you to be delivered", out_addr.GetAddressAsString(false).c_str());
-		DEBUG(net, 0, "[udp]   please allow udp packets from you to %s to be delivered", out_addr.GetAddressAsString(false).c_str());
+		DEBUG(net, 0, "Advertising to the master server is failing");
+		DEBUG(net, 0, "  we are not receiving the session key from the server");
+		DEBUG(net, 0, "  please allow udp packets from %s to you to be delivered", out_addr.GetAddressAsString(false).c_str());
+		DEBUG(net, 0, "  please allow udp packets from you to %s to be delivered", out_addr.GetAddressAsString(false).c_str());
 	}
 	if (_session_key != 0 && _network_advertise_retries == 0) {
-		DEBUG(net, 0, "[udp] advertising to the master server is failing");
-		DEBUG(net, 0, "[udp]   we are not receiving the acknowledgement from the server");
-		DEBUG(net, 0, "[udp]   this usually means that the master server cannot reach us");
-		DEBUG(net, 0, "[udp]   please allow udp and tcp packets to port %u to be delivered", _settings_client.network.server_port);
-		DEBUG(net, 0, "[udp]   please allow udp and tcp packets from port %u to be delivered", _settings_client.network.server_port);
+		DEBUG(net, 0, "Advertising to the master server is failing");
+		DEBUG(net, 0, "  we are not receiving the acknowledgement from the server");
+		DEBUG(net, 0, "  this usually means that the master server cannot reach us");
+		DEBUG(net, 0, "  please allow udp and tcp packets to port %u to be delivered", _settings_client.network.server_port);
+		DEBUG(net, 0, "  please allow udp and tcp packets from port %u to be delivered", _settings_client.network.server_port);
 	}
 
 	/* Send the packet */
@@ -589,7 +589,7 @@ void NetworkUDPInitialize()
 	/* If not closed, then do it. */
 	if (_udp_server.socket != nullptr) NetworkUDPClose();
 
-	DEBUG(net, 1, "[udp] initializing listeners");
+	DEBUG(net, 3, "Initializing UDP listeners");
 	assert(_udp_client.socket == nullptr && _udp_server.socket == nullptr && _udp_master.socket == nullptr);
 
 	std::scoped_lock lock(_udp_client.mutex, _udp_server.mutex, _udp_master.mutex);
@@ -625,7 +625,7 @@ void NetworkUDPClose()
 
 	_network_udp_server = false;
 	_network_udp_broadcast = 0;
-	DEBUG(net, 1, "[udp] closed listeners");
+	DEBUG(net, 5, "Closed UDP listeners");
 }
 
 /** Receive the UDP packets. */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -560,7 +560,7 @@ int openttd_main(int argc, char *argv[])
 			videodriver = "dedicated";
 			blitter = "null";
 			dedicated = true;
-			SetDebugString("net=6");
+			SetDebugString("net=4");
 			if (mgo.opt != nullptr) {
 				scanner->dedicated_host = ParseFullConnectionString(mgo.opt, scanner->dedicated_port);
 			}
@@ -666,7 +666,7 @@ int openttd_main(int argc, char *argv[])
 	DeterminePaths(argv[0]);
 	TarScanner::DoScan(TarScanner::BASESET);
 
-	if (dedicated) DEBUG(net, 0, "Starting dedicated version %s", _openttd_revision);
+	if (dedicated) DEBUG(net, 3, "Starting dedicated server, version %s", _openttd_revision);
 	if (_dedicated_forks && !dedicated) _dedicated_forks = false;
 
 #if defined(UNIX)
@@ -945,7 +945,7 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 				 * special cases which make clients desync immediately. So we fall
 				 * back to just generating a new game with the current settings.
 				 */
-				DEBUG(net, 0, "Loading game failed, so a new (random) game will be started!");
+				DEBUG(net, 0, "Loading game failed, so a new (random) game will be started");
 				MakeNewGame(false, true);
 				return false;
 			}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -566,8 +566,8 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_119)) {
 		_pause_mode = (_pause_mode == 2) ? PM_PAUSED_NORMAL : PM_UNPAUSED;
 	} else if (_network_dedicated && (_pause_mode & PM_PAUSED_ERROR) != 0) {
-		DEBUG(net, 0, "The loading savegame was paused due to an error state.");
-		DEBUG(net, 0, "  The savegame cannot be used for multiplayer!");
+		DEBUG(net, 0, "The loading savegame was paused due to an error state");
+		DEBUG(net, 0, "  This savegame cannot be used for multiplayer");
 		/* Restore the signals */
 		ResetSignalHandlers();
 		return false;

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -256,7 +256,7 @@ void VideoDriver_Dedicated::MainLoop()
 		 *  intro game... */
 		if (SaveOrLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.detail_ftype, BASE_DIR) == SL_ERROR) {
 			/* Loading failed, pop out.. */
-			DEBUG(net, 0, "Loading requested map failed, aborting");
+			DEBUG(net, 0, "Loading requested map failed; closing server.");
 			return;
 		} else {
 			/* We can load this game, so go ahead */


### PR DESCRIPTION
## Motivation / Problem

Running a dedicated server shows a lot of information that is not all that relevant.

Also, during working on the STUN patch, I noticed that often I saw too much debugging, or not enough.

After reading #9171 I came to realisation we have been trying to do "our own thing" instead of looking to the world. That gave me inspiration to just use the default: fatal / error / warning / info / debug / trace setup. This PR implements that.


## Description

```
It now follows very simple rules:
0 - Fatal, user should know about this
1 - Error, but we are recovering
2 - Warning, wrong but okay if you don't know
3 - Info, information you might care about
4 -
5 - Debug #1 - High level debug messages
6 - Debug #2 - Low level debug messages
7 - Trace information
```

I also applied some consistency to all strings:
- Start with a capital.
- Use `: %s` for error instead of all the combinations we had (`with error`, `failed with`, ...).
- Removed prefixes like `[udp]` which don't really mean anything.

Also:
- Changed the debug logging level of dedicated servers to be 4 (so no debug-messages).
- Moved some DEBUG statements to the `desync` facility, as it had little to do with `net`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

## Complete list of debug messages on net facility

In case you find it easier to read the full list of messages we now have, here you go, sorted by level:

```
(net, 0, "  This is likely an issue in the DNS name resolver's configuration causing it to time out");
(net, 0, "  This savegame cannot be used for multiplayer");
(net, 0, "  please allow udp and tcp packets from port %u to be delivered", _settings_client.network.server_port);
(net, 0, "  please allow udp and tcp packets to port %u to be delivered", _settings_client.network.server_port);
(net, 0, "  please allow udp packets from %s to you to be delivered", out_addr.GetAddressAsString(false).c_str());
(net, 0, "  please allow udp packets from you to %s to be delivered", out_addr.GetAddressAsString(false).c_str());
(net, 0, "  this is likely an issue in the DNS name resolver's configuration causing it to time out");
(net, 0, "  this usually means that the master server cannot reach us");
(net, 0, "  we are not receiving the acknowledgement from the server");
(net, 0, "  we are not receiving the session key from the server");
(net, 0, "%s background UDP loop processing appears to be blocked. Your OS may be low on UDP send buffers.", name.c_str());
(net, 0, "Advertising to the master server is failing");
(net, 0, "Advertising to the master server is failing");
(net, 0, "Could not bind socket on %s: %s", address.c_str(), NetworkError::GetLast().AsString());
(net, 0, "Could not create %s %s socket: %s", NetworkAddress::SocketTypeAsString(address->ai_socktype), NetworkAddress::AddressFamilyAsString(address->ai_family), NetworkError::GetLast().AsString());
(net, 0, "Could not create %s %s socket: %s", type, family, NetworkError::GetLast().AsString());
(net, 0, "Could not create socket: %s", NetworkError::GetLast().AsString());
(net, 0, "Could not listen on socket: %s", NetworkError::GetLast().AsString());
(net, 0, "Could not start network: could not create listening socket");
(net, 0, "Error running _netstat()");
(net, 0, "Failed to open connection to %s for redirecting DEBUG()", this->connection_string.c_str());
(net, 0, "Failed to resolve DNS for %s", this->connection_string.c_str());
(net, 0, "Generating map failed; closing server");
(net, 0, "Loading game failed, so a new (random) game will be started");
(net, 0, "Loading requested map failed; closing server.");
(net, 0, "Recv failed: %s", err.AsString());
(net, 0, "Recv failed: %s", err.AsString());
(net, 0, "Recv failed: %s", err.AsString());
(net, 0, "Send failed: %s", err.AsString());
(net, 0, "Setting non-blocking mode failed: %s", NetworkError::GetLast().AsString());
(net, 0, "Setting non-blocking mode failed: %s", NetworkError::GetLast().AsString());
(net, 0, "Setting reuse-address mode failed: %s", NetworkError::GetLast().AsString());
(net, 0, "Sync error detected");
(net, 0, "The loading savegame was paused due to an error state");
(net, 0, "Timeout while connecting to %s", this->connection_string.c_str());
(net, 0, "Unknown callback for command; no callback sent (command: %d)", cp->cmd);
(net, 0, "WSAStartup failed, network unavailable");
(net, 0, "[%s] send failed: %s", Tsocket::GetName(), NetworkError::GetLast().AsString());
(net, 0, "[%s] send failed: %s", Tsocket::GetName(), NetworkError::GetLast().AsString());
(net, 0, "[tcp/admin] Received illegal packet from '%s' (%s)", this->admin_name, this->admin_version);
(net, 0, "[tcp/admin] Received illegal packet type %d from admin %s (%s)", type, this->admin_name, this->admin_version);
(net, 0, "[tcp/admin] Received invalid packet type %d from '%s' (%s)", type, this->admin_name, this->admin_version);
(net, 0, "[tcp/content] Received illegal packet type %d", type);
(net, 0, "[tcp/content] Received illegal packet");
(net, 0, "[tcp/content] Received invalid packet type %d", type);
(net, 0, "[tcp/game] Received illegal packet from client %d", this->client_id);
(net, 0, "[tcp/game] Received illegal packet type %d from client %d", type, this->client_id);
(net, 0, "[tcp/game] Received invalid packet type %d from client %d", type, this->client_id);
(net, 0, "[udp] Received illegal packet from %s", client_addr->GetAddressAsString().c_str());
(net, 0, "[udp] Received invalid packet type %d from %s", type, client_addr->GetAddressAsString().c_str());
(net, 0, "[udp] Received packet type %d on wrong port from %s", type, client_addr->GetAddressAsString().c_str());
(net, 0, "getaddrinfo for hostname \"%s\", port %s, address family %s and socket type %s failed: %s",
(net, 0, "getaddrinfo for hostname \"%s\", port %s, address family %s and socket type %s took %i seconds",
(net, 0, "getaddrinfo() for address \"%s\" took %i seconds", this->connection_string.c_str(), (int)duration.count());
(net, 1, "'%s' made an error and has been disconnected: %s", client_name, str);
(net, 1, "'%s' reported an error and is closing its connection: %s", client_name, str);
(net, 1, "Client %d made an error and has been disconnected: %s", this->client_id, str);
(net, 1, "Could not connect to %s: %s", network_address.GetAddressAsString().c_str(), NetworkError::GetLast().AsString());
(net, 1, "Could not connect to %s: %s", this->sock_to_address[*it].GetAddressAsString().c_str(), socket_error.AsString());
(net, 1, "Missed frame for sync-test: %d / %d", _sync_frame, _frame_counter);
(net, 1, "No \"client_name\" has been set, using \"%s\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name);
(net, 1, "No \"server_name\" has been set, using \"%s\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name);
(net, 1, "Received a packet with mismatching size from %s", address.GetAddressAsString().c_str());
(net, 1, "Received invalid client index = 0");
(net, 1, "Received unknown chat destination type %d; doing broadcast instead", desttype);
(net, 1, "Setting TCP_NODELAY failed: %s", NetworkError::GetLast().AsString());
(net, 1, "Setting broadcast mode failed: %s", NetworkError::GetLast().AsString());
(net, 1, "Setting no-delay mode failed: %s", NetworkError::GetLast().AsString());
(net, 1, "Unknown client (%d) is leaving the game", client_id);
(net, 1, "[admin] Empty company given for update");
(net, 1, "[admin] Invalid chat action %d from admin '%s' (%s).", action, this->admin_name, this->admin_version);
(net, 1, "[admin] Not supported poll %d (%d) from '%s' (%s).", type, d1, this->admin_name, this->admin_version);
(net, 1, "[admin] Not supported update frequency %d (%d) from '%s' (%s)", type, freq, this->admin_name, this->admin_version);
(net, 1, "[admin] The admin '%s' (%s) made an error and has been disconnected: '%s'", this->admin_name, this->admin_version, str);
(net, 1, "[rcon] Wrong password from client-id %d", this->client_id);
(net, 1, "[tcp/http] Header too big");
(net, 1, "[tcp/http] Unhandled status reply %s", status);
(net, 1, "select() failed: %s", NetworkError::GetLast().AsString());
(net, 1, "sendto(%s) failed: %s", send.GetAddressAsString().c_str(), NetworkError::GetLast().AsString());
(net, 1, msg); return -1; }
(net, 2, "Wrong password from client-id #%d for company #%d", this->client_id, company_id + 1);
(net, 2, "[%s] Banned ip tried to join (%s), refused", Tsocket::GetName(), entry.c_str());
(net, 2, "[admin] Admin did not send its authorisation within %d seconds", (uint32)std::chrono::duration_cast<std::chrono::seconds>(ADMIN_AUTHORISATION_TIMEOUT).count());
(net, 3, " %d) %s", i++, addr.GetHostname());
(net, 3, "Advertising on master server successful (%s)", NetworkAddress::AddressFamilyAsString(client_addr->GetAddress()->ss_family));
(net, 3, "Advertising to master server");
(net, 3, "Auto-restarting map: year %d reached", _cur_year);
(net, 3, "Closed client connection %d", this->client_id);
(net, 3, "Closed client connection %d", this->client_id);
(net, 3, "Connected to %s", this->connection_string.c_str());
(net, 3, "Could not disable IPv4 over IPv6: %s", NetworkError::GetLast().AsString());
(net, 3, "Detected broadcast addresses:");
(net, 3, "Generating map, please wait...");
(net, 3, "Initializing UDP listeners");
(net, 3, "Listening on %s", address.c_str());
(net, 3, "Map generated, starting game");
(net, 3, "Map generation percentage complete: %d", _gws.percent);
(net, 3, "Network online, multiplayer available");
(net, 3, "Network revision name: %s", network_revision);
(net, 3, "Network revision name: %s", network_revision);
(net, 3, "Performing emergency save: %s", filename);
(net, 3, "Redirecting DEBUG() to %s", this->connection_string.c_str());
(net, 3, "Removing advertise from master server");
(net, 3, "Searching server");
(net, 3, "Server response from %s", client_addr->GetAddressAsString().c_str());
(net, 3, "Shutting down network");
(net, 3, "Starting dedicated server, version %s", _openttd_revision);
(net, 3, "Starting network");
(net, 3, "[%s] Client connected from %s on frame %d", Tsocket::GetName(), address.GetHostname(), _frame_counter);
(net, 3, "[admin] '%s' (%s) has connected", this->admin_name, this->admin_version);
(net, 3, "[admin] '%s' (%s) has disconnected", this->admin_name, this->admin_version);
(net, 3, "[admin] Rcon command from '%s' (%s): %s", this->admin_name, this->admin_version, command);
(net, 3, "[rcon] Client-id %d executed: %s", this->client_id, command);
(net, 5, "- using %s", NetworkAddress::GetPeerName(connected_socket).c_str());
(net, 5, "Attempting to connect to %s", network_address.GetAddressAsString().c_str());
(net, 5, "Broadcasting to %s", addr.GetHostname());
(net, 5, "Closed UDP listeners");
(net, 5, "Loading windows socket library");
(net, 5, "Starting listeners for admins");
(net, 5, "Starting listeners for clients");
(net, 5, "Starting listeners for incoming server queries");
(net, 5, "[%s] Closed listeners", Tsocket::GetName());
(net, 5, "[tcp/http] Requesting %s%s", host, url);
(net, 6, "%s resolved in:", this->connection_string.c_str());
(net, 6, "- %s", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString().c_str());
(net, 6, "Master server queried at %s", out_addr.GetAddressAsString().c_str());
(net, 6, "Received new session key from master server (%s)", NetworkAddress::AddressFamilyAsString(client_addr->GetAddress()->ss_family));
(net, 6, "[admin] GameScript JSON from '%s' (%s): %s", this->admin_name, this->admin_version, json);
(net, 6, "[admin] Ping from '%s' (%s): %d", this->admin_name, this->admin_version, d1);
(net, 7, "NewGRF data reply from %s", client_addr->GetAddressAsString().c_str());
(net, 7, "NewGRF data request from %s", client_addr->GetAddressAsString().c_str());
(net, 7, "Queried from %s", client_addr->GetHostname());
(net, 7, "Received FRAME %d", _frame_counter_server);
(net, 7, "Sent ACK at %d", _frame_counter);
(net, 7, "[tcp/http] Downloading %i bytes", len);
(net, 7, "[tcp/http] Redirecting to %s", uri);
(net, 7, "sendto(%s)", send.GetAddressAsString().c_str());
```