### PR TITLE
Codechange: document/fix virtual function resolving in con/destructors

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -216,7 +216,8 @@ TrueTypeFontCache::TrueTypeFontCache(FontSize fs, int pixels) : FontCache(fs), r
  */
 TrueTypeFontCache::~TrueTypeFontCache()
 {
-	this->ClearFontCache();
+	/* Virtual functions get called statically in destructors, so make it explicit to remove any confusion. */
+	this->TrueTypeFontCache::ClearFontCache();
 
 	for (auto &iter : this->font_tables) {
 		free(iter.second.second);

--- a/src/network/core/core.h
+++ b/src/network/core/core.h
@@ -46,10 +46,7 @@ public:
 	NetworkSocketHandler() { this->has_quit = false; }
 
 	/** Close the socket when destructing the socket handler */
-	virtual ~NetworkSocketHandler() { this->Close(); }
-
-	/** Really close the socket */
-	virtual void Close() {}
+	virtual ~NetworkSocketHandler() {}
 
 	/**
 	 * Close the current connection; for TCP this will be mostly equivalent

--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -29,7 +29,8 @@ NetworkTCPSocketHandler::NetworkTCPSocketHandler(SOCKET s) :
 
 NetworkTCPSocketHandler::~NetworkTCPSocketHandler()
 {
-	this->CloseConnection();
+	/* Virtual functions get called statically in destructors, so make it explicit to remove any confusion. */
+	this->NetworkTCPSocketHandler::CloseConnection();
 
 	if (this->sock != INVALID_SOCKET) closesocket(this->sock);
 	this->sock = INVALID_SOCKET;

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -137,9 +137,11 @@ const char *ContentInfo::GetTextfile(TextfileType type) const
 	return ::GetTextfile(type, GetContentInfoSubDir(this->type), tmp);
 }
 
-void NetworkContentSocketHandler::Close()
+/**
+ * Close the actual socket.
+ */
+void NetworkContentSocketHandler::CloseSocket()
 {
-	CloseConnection();
 	if (this->sock == INVALID_SOCKET) return;
 
 	closesocket(this->sock);

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -21,7 +21,7 @@
 /** Base socket handler for all Content TCP sockets */
 class NetworkContentSocketHandler : public NetworkTCPSocketHandler {
 protected:
-	void Close() override;
+	void CloseSocket();
 
 	bool ReceiveInvalidPacket(PacketContentType type);
 
@@ -124,7 +124,11 @@ public:
 	}
 
 	/** On destructing of this class, the socket needs to be closed */
-	virtual ~NetworkContentSocketHandler() { this->Close(); }
+	virtual ~NetworkContentSocketHandler()
+	{
+		/* Virtual functions get called statically in destructors, so make it explicit to remove any confusion. */
+		this->CloseSocket();
+	}
 
 	bool ReceivePackets();
 };

--- a/src/network/core/udp.h
+++ b/src/network/core/udp.h
@@ -190,7 +190,7 @@ public:
 	virtual ~NetworkUDPSocketHandler() { this->Close(); }
 
 	bool Listen();
-	void Close() override;
+	void Close();
 
 	void SendPacket(Packet *p, NetworkAddress *recv, bool all = false, bool broadcast = false);
 	void ReceivePackets();

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -784,7 +784,9 @@ void ClientNetworkContentSocketHandler::Connect()
 void ClientNetworkContentSocketHandler::Close()
 {
 	if (this->sock == INVALID_SOCKET) return;
-	NetworkContentSocketHandler::Close();
+
+	this->CloseConnection();
+	this->CloseSocket();
 
 	this->OnDisconnect();
 }

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -107,7 +107,7 @@ public:
 
 	void Connect();
 	void SendReceive();
-	void Close() override;
+	void Close();
 
 	void RequestContentList(ContentType type);
 	void RequestContentList(uint count, const ContentID *content_ids);

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -37,6 +37,7 @@ void ScriptConfig::Change(const char *name, int version, bool force_exact_match,
 				this->SetSetting(item.name, InteractiveRandomRange(item.max_value + 1 - item.min_value) + item.min_value);
 			}
 		}
+
 		this->AddRandomDeviation();
 	}
 }
@@ -52,7 +53,9 @@ ScriptConfig::ScriptConfig(const ScriptConfig *config)
 	for (const auto &item : config->settings) {
 		this->settings[stredup(item.first)] = item.second;
 	}
-	this->AddRandomDeviation();
+
+	/* Virtual functions get called statically in constructors, so make it explicit to remove any confusion. */
+	this->ScriptConfig::AddRandomDeviation();
 }
 
 ScriptConfig::~ScriptConfig()

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1093,7 +1093,8 @@ Window::~Window()
 
 	/* Make sure we don't try to access this window as the focused window when it doesn't exist anymore. */
 	if (_focused_window == this) {
-		this->OnFocusLost();
+		/* Virtual functions get called statically in destructors, so make it explicit to remove any confusion. */
+		this->Window::OnFocusLost();
 		_focused_window = nullptr;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Virtual functions should not be invoked from a constructor or destructor of the same class. Confusingly, virtual functions are resolved statically (not dynamically) in constructors and destructors for the same class. The call should be made explicitly static by qualifying it using the scope resolution operator. https://lgtm.com/rules/2159620519/

## Description

Added documentation and the explicit static call where applicable and removed some pointless code. See the commit messages for more details.


## Limitations

The problems with the TCPConnecters are not solved as they are simply broken for failure cases when having no threads. #9255 has been made to solve that.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
