### PR TITLE
Fix #9255: [Network] TCPConnecter crashes when hostname not found

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -66,8 +66,22 @@ public:
  */
 class TCPConnecter {
 private:
+	/**
+	 * The current status of the connecter.
+	 *
+	 * We track the status like this to ensure everything is executed from the
+	 * game-thread, and not at another random time where we might not have the
+	 * lock on the game-state.
+	 */
+	enum class Status {
+		INIT,       ///< TCPConnecter is created but resolving hasn't started.
+		RESOLVING,  ///< The hostname is being resolved (threaded).
+		FAILURE,    ///< Resolving failed.
+		CONNECTING, ///< We are currently connecting.
+	};
+
 	std::thread resolve_thread;                         ///< Thread used during resolving.
-	std::atomic<bool> is_resolved = false;              ///< Whether resolving is done.
+	std::atomic<Status> status = Status::INIT;          ///< The current status of the connecter.
 
 	addrinfo *ai = nullptr;                             ///< getaddrinfo() allocated linked-list of resolved addresses.
 	std::vector<addrinfo *> addresses;                  ///< Addresses we can connect to.


### PR DESCRIPTION
Fixes #9255

## Motivation / Problem

#9255 reports two problems:

- ctor calls `Resolve()` which can call `OnFailure` which is not yet loaded at that point in time.
- `Resolve` can call `OnFailure` while the game-state is not locked.

## Description

By solving the second the first automagically solves itself, but I think it is a pitfall the next person will in before you know it. As such, I also addressed the first one. Call it overkill.

Basically:
- `OnFailure` in `Resolve` is delayed till the game-state is locked (in `CheckActivity`, which guarantees this).
- `Resolve` is called from `CheckActivity` and no longer in the ctor.

I could combine both nicely in a single enum, which also helps understanding a bit more what the step are that are taken by the resolvement.

The status is not updated to failure/success in `CheckActivity` itself, as both result in a `return true` which will destroy the object seconds later. In other words, nobody will be able to read this updated status anyway.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
