### PR TITLE
Codechange: [Network] split CloseSocket and CloseConnection more clearly

### DIFF
--- a/src/network/core/core.h
+++ b/src/network/core/core.h
@@ -40,7 +40,9 @@ struct Packet;
  * SocketHandler for all network sockets in OpenTTD.
  */
 class NetworkSocketHandler {
+private:
 	bool has_quit; ///< Whether the current client has quit/send a bad packet
+
 public:
 	/** Create a new unbound socket */
 	NetworkSocketHandler() { this->has_quit = false; }
@@ -49,12 +51,13 @@ public:
 	virtual ~NetworkSocketHandler() {}
 
 	/**
-	 * Close the current connection; for TCP this will be mostly equivalent
-	 * to Close(), but for UDP it just means the packet has to be dropped.
-	 * @param error Whether we quit under an error condition or not.
-	 * @return new status of the connection.
+	 * Mark the connection as closed.
+	 *
+	 * This doesn't mean the actual connection is closed, but just that we
+	 * act like it is. This is useful for UDP, which doesn't normally close
+	 * a socket, but its handler might need to pretend it does.
 	 */
-	virtual NetworkRecvStatus CloseConnection(bool error = true) { this->has_quit = true; return NETWORK_RECV_STATUS_OKAY; }
+	void MarkClosed() { this->has_quit = true; }
 
 	/**
 	 * Whether the current client connected to the socket has quit.

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -222,7 +222,7 @@ bool Packet::CanReadFromPacket(size_t bytes_to_read, bool close_connection)
 
 	/* Check if variable is within packet-size */
 	if (this->pos + bytes_to_read > this->Size()) {
-		if (close_connection) this->cs->NetworkSocketHandler::CloseConnection();
+		if (close_connection) this->cs->NetworkSocketHandler::MarkClosed();
 		return false;
 	}
 

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -33,6 +33,8 @@ class NetworkTCPSocketHandler : public NetworkSocketHandler {
 private:
 	Packet *packet_queue;     ///< Packets that are awaiting delivery
 	Packet *packet_recv;      ///< Partially received packet
+
+	void EmptyPacketQueue();
 public:
 	SOCKET sock;              ///< The socket currently connected to
 	bool writable;            ///< Can we write to this socket?
@@ -43,7 +45,9 @@ public:
 	 */
 	bool IsConnected() const { return this->sock != INVALID_SOCKET; }
 
-	NetworkRecvStatus CloseConnection(bool error = true) override;
+	virtual NetworkRecvStatus CloseConnection(bool error = true);
+	void CloseSocket();
+
 	virtual void SendPacket(Packet *packet);
 	SendPacketsState SendPackets(bool closing_down = false);
 

--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -34,10 +34,6 @@ NetworkAdminSocketHandler::NetworkAdminSocketHandler(SOCKET s) : status(ADMIN_ST
 	this->admin_version[0] = '\0';
 }
 
-NetworkAdminSocketHandler::~NetworkAdminSocketHandler()
-{
-}
-
 NetworkRecvStatus NetworkAdminSocketHandler::CloseConnection(bool error)
 {
 	delete this;

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -482,7 +482,6 @@ public:
 	NetworkRecvStatus CloseConnection(bool error = true) override;
 
 	NetworkAdminSocketHandler(SOCKET s);
-	~NetworkAdminSocketHandler();
 
 	NetworkRecvStatus ReceivePackets();
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -138,17 +138,6 @@ const char *ContentInfo::GetTextfile(TextfileType type) const
 }
 
 /**
- * Close the actual socket.
- */
-void NetworkContentSocketHandler::CloseSocket()
-{
-	if (this->sock == INVALID_SOCKET) return;
-
-	closesocket(this->sock);
-	this->sock = INVALID_SOCKET;
-}
-
-/**
  * Handle the given packet, i.e. pass it to the right
  * parser receive command.
  * @param p the packet to handle

--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -21,8 +21,6 @@
 /** Base socket handler for all Content TCP sockets */
 class NetworkContentSocketHandler : public NetworkTCPSocketHandler {
 protected:
-	void CloseSocket();
-
 	bool ReceiveInvalidPacket(PacketContentType type);
 
 	/**

--- a/src/network/core/tcp_http.cpp
+++ b/src/network/core/tcp_http.cpp
@@ -68,17 +68,18 @@ NetworkHTTPSocketHandler::NetworkHTTPSocketHandler(SOCKET s,
 /** Free whatever needs to be freed. */
 NetworkHTTPSocketHandler::~NetworkHTTPSocketHandler()
 {
-	this->CloseConnection();
+	this->CloseSocket();
 
-	if (this->sock != INVALID_SOCKET) closesocket(this->sock);
-	this->sock = INVALID_SOCKET;
 	free(this->data);
 }
 
-NetworkRecvStatus NetworkHTTPSocketHandler::CloseConnection(bool error)
+/**
+ * Close the actual socket of the connection.
+ */
+void NetworkHTTPSocketHandler::CloseSocket()
 {
-	NetworkSocketHandler::CloseConnection(error);
-	return NETWORK_RECV_STATUS_OKAY;
+	if (this->sock != INVALID_SOCKET) closesocket(this->sock);
+	this->sock = INVALID_SOCKET;
 }
 
 /**
@@ -313,7 +314,7 @@ int NetworkHTTPSocketHandler::Receive()
 			if (ret < 0) cur->callback->OnFailure();
 			if (ret <= 0) {
 				/* Then... the connection can be closed */
-				cur->CloseConnection();
+				cur->CloseSocket();
 				iter = _http_connections.erase(iter);
 				delete cur;
 				continue;

--- a/src/network/core/tcp_http.h
+++ b/src/network/core/tcp_http.h
@@ -58,7 +58,7 @@ public:
 		return this->sock != INVALID_SOCKET;
 	}
 
-	NetworkRecvStatus CloseConnection(bool error = true) override;
+	void CloseSocket();
 
 	NetworkHTTPSocketHandler(SOCKET sock, HTTPCallback *callback,
 			const char *host, const char *url, const char *data, int depth);

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -44,7 +44,7 @@ NetworkUDPSocketHandler::NetworkUDPSocketHandler(NetworkAddressList *bind)
 bool NetworkUDPSocketHandler::Listen()
 {
 	/* Make sure socket is closed */
-	this->Close();
+	this->CloseSocket();
 
 	for (NetworkAddress &addr : this->bind) {
 		addr.Listen(SOCK_DGRAM, &this->sockets);
@@ -54,20 +54,14 @@ bool NetworkUDPSocketHandler::Listen()
 }
 
 /**
- * Close the given UDP socket
+ * Close the actual UDP socket.
  */
-void NetworkUDPSocketHandler::Close()
+void NetworkUDPSocketHandler::CloseSocket()
 {
 	for (auto &s : this->sockets) {
 		closesocket(s.second);
 	}
 	this->sockets.clear();
-}
-
-NetworkRecvStatus NetworkUDPSocketHandler::CloseConnection(bool error)
-{
-	NetworkSocketHandler::CloseConnection(error);
-	return NETWORK_RECV_STATUS_OKAY;
 }
 
 /**

--- a/src/network/core/udp.h
+++ b/src/network/core/udp.h
@@ -49,8 +49,6 @@ protected:
 	/** The opened sockets. */
 	SocketList sockets;
 
-	NetworkRecvStatus CloseConnection(bool error = true) override;
-
 	void ReceiveInvalidPacket(PacketUDPType, NetworkAddress *client_addr);
 
 	/**
@@ -187,10 +185,10 @@ public:
 	NetworkUDPSocketHandler(NetworkAddressList *bind = nullptr);
 
 	/** On destructing of this class, the socket needs to be closed */
-	virtual ~NetworkUDPSocketHandler() { this->Close(); }
+	virtual ~NetworkUDPSocketHandler() { this->CloseSocket(); }
 
 	bool Listen();
-	void Close();
+	void CloseSocket();
 
 	void SendPacket(Packet *p, NetworkAddress *recv, bool all = false, bool broadcast = false);
 	void ReceivePackets();

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -158,6 +158,7 @@ ClientNetworkGameSocketHandler::~ClientNetworkGameSocketHandler()
 	ClientNetworkGameSocketHandler::my_client = nullptr;
 
 	delete this->savegame;
+	delete this->GetInfo();
 }
 
 NetworkRecvStatus ClientNetworkGameSocketHandler::CloseConnection(NetworkRecvStatus status)
@@ -182,7 +183,6 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	 * which would trigger the server to close the connection as well. */
 	CSleep(3 * MILLISECONDS_PER_TICK);
 
-	delete this->GetInfo();
 	delete this;
 
 	return status;

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -200,7 +200,7 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 	/* We just want to close the connection.. */
 	if (res == NETWORK_RECV_STATUS_CLOSE_QUERY) {
-		this->NetworkSocketHandler::CloseConnection();
+		this->NetworkSocketHandler::MarkClosed();
 		this->CloseConnection(res);
 		_networking = false;
 

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -107,7 +107,7 @@ public:
 
 	void Connect();
 	void SendReceive();
-	void Close();
+	NetworkRecvStatus CloseConnection(bool error = true) override;
 
 	void RequestContentList(ContentType type);
 	void RequestContentList(uint count, const ContentID *content_ids);

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -260,7 +260,7 @@ public:
 	{
 		if (widget == WID_NCDS_CANCELOK) {
 			if (this->downloaded_bytes != this->total_bytes) {
-				_network_content_client.Close();
+				_network_content_client.CloseConnection();
 				delete this;
 			} else {
 				/* If downloading succeeded, close the online content window. This will close

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -54,10 +54,10 @@ struct UDPSocket {
 
 	UDPSocket(const std::string &name_) : name(name_), socket(nullptr) {}
 
-	void Close()
+	void CloseSocket()
 	{
 		std::lock_guard<std::mutex> lock(mutex);
-		socket->Close();
+		socket->CloseSocket();
 		delete socket;
 		socket = nullptr;
 	}
@@ -619,9 +619,9 @@ void NetworkUDPServerListen()
 /** Close all UDP related stuff. */
 void NetworkUDPClose()
 {
-	_udp_client.Close();
-	_udp_server.Close();
-	_udp_master.Close();
+	_udp_client.CloseSocket();
+	_udp_server.CloseSocket();
+	_udp_master.CloseSocket();
 
 	_network_udp_server = false;
 	_network_udp_broadcast = 0;


### PR DESCRIPTION
## Motivation / Problem

During work on the Network code I kept hitting a problem: I got totally confused with `Close` vs `CloseConnection`.

Turns out: its not me!

Depending on the file you look at, it has a different meaning.

Yippie!

Lets add some sanity to the code, shall we?


## Description

There should be no functional difference with this PR.

Simple new rules:
- CloseSocket -> Closes the OS socket
- CloseConnection -> TCP only, cleans up the connection (but leaves the socket open)
- MarkClosed -> Only meant to hint the socket is closed. Mainly used to not make this have any functional change.

As added bonus, the dtors are a lot easier to understand now too.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
