### PR TITLE
[MinGW] Fix MinGW32 build failure and almost all MinGW32/MinGW64 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,7 @@ if(WIN32)
         -DUNICODE
         -D_UNICODE
         -DWITH_UNISCRIBE
+        -DPSAPI_VERSION=1
     )
 
     target_link_libraries(openttd
@@ -367,6 +368,7 @@ if(WIN32)
         winmm
         imm32
         usp10
+        psapi
     )
 endif()
 

--- a/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp
@@ -79,7 +79,7 @@ SQInstructionDesc g_InstrDesc[]={
 	{"_OP_NEWSLOTA"},
 	{"_OP_SCOPE_END"}
 };
-#endif
+
 void DumpLiteral(SQObjectPtr &o)
 {
 	switch(type(o)){
@@ -90,6 +90,7 @@ void DumpLiteral(SQObjectPtr &o)
 		default: printf("(%s %p)",GetTypeName(o),(void*)_rawval(o));break; break; //shut up compiler
 	}
 }
+#endif
 
 SQFuncState::SQFuncState(SQSharedState *ss,SQFuncState *parent,CompilerErrorFunc efunc,void *ed)
 {

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -633,7 +633,7 @@ static void CDECL CustomAbort(int signal)
 		mov safe_esp, esp
 	}
 #	else
-	asm("movl %esp, _safe_esp");
+	asm("movl %%esp, %0" : "=rm" (safe_esp));
 #	endif
 	_safe_esp = safe_esp;
 #endif

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -620,8 +620,9 @@ void LoadWin32Font(FontSize fs)
 			if (AddFontResourceEx(fontPath, FR_PRIVATE, 0) != 0) {
 				/* Try a nice little undocumented function first for getting the internal font name.
 				 * Some documentation is found at: http://www.undocprint.org/winspool/getfontresourceinfo */
+				static DllLoader _gdi32(L"gdi32.dll");
 				typedef BOOL(WINAPI *PFNGETFONTRESOURCEINFO)(LPCTSTR, LPDWORD, LPVOID, DWORD);
-				static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(L"Gdi32"), "GetFontResourceInfoW");
+				static PFNGETFONTRESOURCEINFO GetFontResourceInfo = _gdi32.GetProcAddress("GetFontResourceInfoW");
 
 				if (GetFontResourceInfo != nullptr) {
 					/* Try to query an array of LOGFONTs that describe the file. */

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -144,7 +144,7 @@ void UniscribeResetScriptCache(FontSize size)
 /** Load the matching native Windows font. */
 static HFONT HFontFromFont(Font *font)
 {
-	if (font->fc->GetOSHandle() != nullptr) return CreateFontIndirect((const PLOGFONT)font->fc->GetOSHandle());
+	if (font->fc->GetOSHandle() != nullptr) return CreateFontIndirect(reinterpret_cast<PLOGFONT>(const_cast<void *>(font->fc->GetOSHandle())));
 
 	LOGFONT logfont;
 	ZeroMemory(&logfont, sizeof(LOGFONT));

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -50,30 +50,6 @@ bool MyShowCursor(bool show, bool toggle)
 	return !show;
 }
 
-/**
- * Helper function needed by dynamically loading libraries
- */
-bool LoadLibraryList(Function proc[], const char *dll)
-{
-	while (*dll != '\0') {
-		HMODULE lib;
-		lib = LoadLibrary(OTTD2FS(dll).c_str());
-
-		if (lib == nullptr) return false;
-		for (;;) {
-			FARPROC p;
-
-			while (*dll++ != '\0') { /* Nothing */ }
-			if (*dll == '\0') break;
-			p = GetProcAddress(lib, dll);
-			if (p == nullptr) return false;
-			*proc++ = (Function)p;
-		}
-		dll++;
-	}
-	return true;
-}
-
 void ShowOSErrorBox(const char *buf, bool system)
 {
 	MyShowCursor(true);
@@ -679,7 +655,8 @@ int OTTDStringCompare(const char *s1, const char *s2)
 #endif
 
 	if (first_time) {
-		_CompareStringEx = (PFNCOMPARESTRINGEX)GetProcAddress(GetModuleHandle(L"Kernel32"), "CompareStringEx");
+		static DllLoader _kernel32(L"Kernel32.dll");
+		_CompareStringEx = _kernel32.GetProcAddress("CompareStringEx");
 		first_time = false;
 	}
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -707,38 +707,6 @@ int OTTDStringCompare(const char *s1, const char *s2)
 	return CompareString(MAKELCID(_current_language->winlangid, SORT_DEFAULT), NORM_IGNORECASE, s1_buf, -1, s2_buf, -1);
 }
 
-/**
- * Is the current Windows version Vista or later?
- * @return True if the current Windows is Vista or later.
- */
-bool IsWindowsVistaOrGreater()
-{
-	typedef BOOL (WINAPI * LPVERIFYVERSIONINFO)(LPOSVERSIONINFOEX, DWORD, DWORDLONG);
-	typedef ULONGLONG (NTAPI * LPVERSETCONDITIONMASK)(ULONGLONG, DWORD, BYTE);
-#ifdef UNICODE
-	static LPVERIFYVERSIONINFO _VerifyVersionInfo = (LPVERIFYVERSIONINFO)GetProcAddress(GetModuleHandle(_T("Kernel32")), "VerifyVersionInfoW");
-#else
-	static LPVERIFYVERSIONINFO _VerifyVersionInfo = (LPVERIFYVERSIONINFO)GetProcAddress(GetModuleHandle(_T("Kernel32")), "VerifyVersionInfoA");
-#endif
-	static LPVERSETCONDITIONMASK _VerSetConditionMask = (LPVERSETCONDITIONMASK)GetProcAddress(GetModuleHandle(_T("Kernel32")), "VerSetConditionMask");
-
-	if (_VerifyVersionInfo != nullptr && _VerSetConditionMask != nullptr) {
-		OSVERSIONINFOEX osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
-		DWORDLONG dwlConditionMask = 0;
-		dwlConditionMask = _VerSetConditionMask(dwlConditionMask, VER_MAJORVERSION, VER_GREATER_EQUAL);
-		dwlConditionMask = _VerSetConditionMask(dwlConditionMask, VER_MINORVERSION, VER_GREATER_EQUAL);
-		dwlConditionMask = _VerSetConditionMask(dwlConditionMask, VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
-
-		osvi.dwMajorVersion = 6;
-		osvi.dwMinorVersion = 0;
-		osvi.wServicePackMajor = 0;
-
-		return _VerifyVersionInfo(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
-	} else {
-		return LOBYTE(GetVersion()) >= 6;
-	}
-}
-
 #ifdef _MSC_VER
 /* Based on code from MSDN: https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx */
 const DWORD MS_VC_EXCEPTION = 0x406D1388;

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -25,6 +25,5 @@ wchar_t *convert_to_fs(const char *name, wchar_t *utf16_buf, size_t buflen);
 
 void Win32SetCurrentLocaleName(const char *iso_code);
 int OTTDStringCompare(const char *s1, const char *s2);
-bool IsWindowsVistaOrGreater();
 
 #endif /* WIN32_H */

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -13,8 +13,47 @@
 #include <windows.h>
 bool MyShowCursor(bool show, bool toggle = false);
 
-typedef void (*Function)(int);
-bool LoadLibraryList(Function proc[], const char *dll);
+class DllLoader {
+public:
+	explicit DllLoader(LPCTSTR filename)
+	{
+		this->hmodule = ::LoadLibrary(filename);
+		if (this->hmodule == nullptr) this->success = false;
+	}
+
+
+	~DllLoader()
+	{
+		::FreeLibrary(this->hmodule);
+	}
+
+	bool Success() { return this->success; }
+
+	class ProcAddress {
+	public:
+		explicit ProcAddress(void *p) : p(p) {}
+
+		template <typename T, typename = std::enable_if_t<std::is_function_v<T>>>
+		operator T *() const
+		{
+			return reinterpret_cast<T *>(this->p);
+		}
+
+	private:
+		void *p;
+	};
+
+	ProcAddress GetProcAddress(const char *proc_name)
+	{
+		void *p = reinterpret_cast<void *>(::GetProcAddress(this->hmodule, proc_name));
+		if (p == nullptr) this->success = false;
+		return ProcAddress(p);
+	}
+
+private:
+	HMODULE hmodule = nullptr;
+	bool success = true;
+};
 
 char *convert_from_fs(const wchar_t *name, char *utf8_buf, size_t buflen);
 wchar_t *convert_to_fs(const char *name, wchar_t *utf16_buf, size_t buflen);

--- a/src/os/windows/win32.h
+++ b/src/os/windows/win32.h
@@ -19,10 +19,6 @@ bool LoadLibraryList(Function proc[], const char *dll);
 char *convert_from_fs(const wchar_t *name, char *utf8_buf, size_t buflen);
 wchar_t *convert_to_fs(const char *name, wchar_t *utf16_buf, size_t buflen);
 
-#if defined(__MINGW32__) && !defined(__MINGW64__)
-#define SHGFP_TYPE_CURRENT 0
-#endif /* __MINGW32__ */
-
 void Win32SetCurrentLocaleName(const char *iso_code);
 int OTTDStringCompare(const char *s1, const char *s2);
 

--- a/src/sound/win32_s.cpp
+++ b/src/sound/win32_s.cpp
@@ -17,6 +17,7 @@
 #include "win32_s.h"
 #include <windows.h>
 #include <mmsystem.h>
+#include <versionhelpers.h>
 #include "../os/windows/win32.h"
 #include "../thread.h"
 
@@ -69,7 +70,7 @@ const char *SoundDriver_Win32::Start(const StringList &parm)
 	wfex.nAvgBytesPerSec = wfex.nSamplesPerSec * wfex.nBlockAlign;
 
 	/* Limit buffer size to prevent overflows. */
-	_bufsize = GetDriverParamInt(parm, "bufsize", (GB(GetVersion(), 0, 8) > 5) ? 8192 : 4096);
+	_bufsize = GetDriverParamInt(parm, "bufsize", IsWindowsVistaOrGreater() ? 8192 : 4096);
 	_bufsize = std::min<int>(_bufsize, UINT16_MAX);
 
 	try {

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -956,10 +956,11 @@ float VideoDriver_Win32Base::GetDPIScale()
 	static bool init_done = false;
 	if (!init_done) {
 		init_done = true;
-
-		_GetDpiForWindow = (PFNGETDPIFORWINDOW)GetProcAddress(GetModuleHandle(L"User32"), "GetDpiForWindow");
-		_GetDpiForSystem = (PFNGETDPIFORSYSTEM)GetProcAddress(GetModuleHandle(L"User32"), "GetDpiForSystem");
-		_GetDpiForMonitor = (PFNGETDPIFORMONITOR)GetProcAddress(LoadLibrary(L"Shcore.dll"), "GetDpiForMonitor");
+		static DllLoader _user32(L"user32.dll");
+		static DllLoader _shcore(L"shcore.dll");
+		_GetDpiForWindow = _user32.GetProcAddress("GetDpiForWindow");
+		_GetDpiForSystem = _user32.GetProcAddress("GetDpiForSystem");
+		_GetDpiForMonitor = _shcore.GetProcAddress("GetDpiForMonitor");
 	}
 
 	UINT cur_dpi = 0;

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -25,6 +25,7 @@
 #include "win32_v.h"
 #include <windows.h>
 #include <imm.h>
+#include <versionhelpers.h>
 
 #include "../safeguards.h"
 

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1265,6 +1265,12 @@ static void LoadWGLExtensions()
 		if (rc != nullptr) {
 			wglMakeCurrent(dc, rc);
 
+#ifdef __MINGW32__
+			/* GCC doesn't understand the expected usage of wglGetProcAddress(). */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif /* __MINGW32__ */
+
 			/* Get list of WGL extensions. */
 			PFNWGLGETEXTENSIONSSTRINGARBPROC wglGetExtensionsStringARB = (PFNWGLGETEXTENSIONSSTRINGARBPROC)wglGetProcAddress("wglGetExtensionsStringARB");
 			if (wglGetExtensionsStringARB != nullptr) {
@@ -1279,6 +1285,9 @@ static void LoadWGLExtensions()
 				}
 			}
 
+#ifdef __MINGW32__
+#pragma GCC diagnostic pop
+#endif
 			wglMakeCurrent(nullptr, nullptr);
 			wglDeleteContext(rc);
 		}

--- a/src/walltime_func.h
+++ b/src/walltime_func.h
@@ -17,7 +17,7 @@ struct LocalTimeToStruct {
 	static inline std::tm ToTimeStruct(std::time_t time_since_epoch)
 	{
 		std::tm time = {};
-#ifdef WIN32
+#ifdef _WIN32
 		/* Windows has swapped the parameters around for localtime_s. */
 		localtime_s(&time, &time_since_epoch);
 #else
@@ -32,7 +32,7 @@ struct UTCTimeToStruct {
 	static inline std::tm ToTimeStruct(std::time_t time_since_epoch)
 	{
 		std::tm time = {};
-#ifdef WIN32
+#ifdef _WIN32
 		/* Windows has swapped the parameters around for gmtime_s. */
 		gmtime_s(&time, &time_since_epoch);
 #else


### PR DESCRIPTION
## Motivation / Problem
MinGW32 fails to build OpenTTD, and many warnings are generated by MinGW32 and MinGW64.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
First commit solves
```
  ../../../src/os/windows/win32.cpp: In function 'bool IsWindowsVistaOrGreater()':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(719,50): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'LPVERIFYVERSIONINFO' {aka 'int (__attribute__((stdcall)) *)(_OSVERSIONINFOEXW*, long unsigned int, long long unsigned int)'} [-Wcast-function-type]
    719 |  static LPVERIFYVERSIONINFO _VerifyVersionInfo = (LPVERIFYVERSIONINFO)GetProcAddress(GetModuleHandle(_T("Kernel32")), "VerifyVersionInfoW");
        |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(723,54): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'LPVERSETCONDITIONMASK' {aka 'long long unsigned int (__attribute__((stdcall)) *)(long long unsigned int, long unsigned int, unsigned char)'} [-Wcast-function-type]
    723 |  static LPVERSETCONDITIONMASK _VerSetConditionMask = (LPVERSETCONDITIONMASK)GetProcAddress(GetModuleHandle(_T("Kernel32")), "VerSetConditionMask");
        |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(726,64): warning G2E6658D9: missing initializer for member '_OSVERSIONINFOEXW::wSuiteMask' [-Wmissing-field-initializers]
    726 |   OSVERSIONINFOEX osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
        |                                                                ^
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(726,64): warning G2E6658D9: missing initializer for member '_OSVERSIONINFOEXW::wProductType' [-Wmissing-field-initializers]
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(726,64): warning G2E6658D9: missing initializer for member '_OSVERSIONINFOEXW::wReserved' [-Wmissing-field-initializers]
```

Second commit is just a cleanup (less `LoadLibraryList()` calls)

Next 3 commits are MinGW32 specific.
Third commit solves 
```
  In file included from ../../../src/os/windows/font_win32.h:14,
                   from ../../../src/os/windows/font_win32.cpp:12:
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.h(23,28): error G6B15EE17: expected identifier before numeric constant
     23 | #define SHGFP_TYPE_CURRENT 0
        |                            ^
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.h(23,28): error GC66A3811: expected '}' before numeric constant
  In file included from ../../../src/os/windows/font_win32.cpp:26:
  H:/msys64/mingw32/i686-w64-mingw32/include/shlobj.h:34:14: note: to match this '{'
     34 | typedef enum {
        |              ^
  In file included from ../../../src/os/windows/font_win32.h:14,
                   from ../../../src/os/windows/font_win32.cpp:12:
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.h(23,28): error G158F188C: expected unqualified-id before numeric constant
     23 | #define SHGFP_TYPE_CURRENT 0
        |                            ^
  In file included from ../../../src/os/windows/font_win32.cpp:26:
H:\msys64\mingw32\i686-w64-mingw32\include\shlobj.h(37,1): error G4B649FC0: expected declaration before '}' token
     37 | } SHGFP_TYPE;
        | ^
H:\msys64\mingw32\i686-w64-mingw32\include\shlobj.h(37,3): error GC5C65A22: 'SHGFP_TYPE' does not name a type; did you mean 'SF_TYPE'?
     37 | } SHGFP_TYPE;
        |   ^~~~~~~~~~
        |   SF_TYPE
```

Fourth commit solves
```
  ../../../src/video/win32_v.cpp: In member function 'virtual std::vector<int> VideoDriver_Win32Base::GetListOfMonitorRefreshRates()':
D:\developpement\GitHub\glx22\OpenTTD\src\video\win32_v.cpp(933,37): error G5335F942: invalid user-defined conversion from 'VideoDriver_Win32Base::GetListOfMonitorRefreshRates()::<lambda(HMONITOR, HDC, LPRECT, LPARAM)>' to 'MONITORENUMPROC' {aka 'int (__attribute__((stdcall)) *)(HMONITOR__*, HDC__*, tagRECT*, long int)'} [-fpermissive]
    933 |  }, reinterpret_cast<LPARAM>(&rates));
        |                                     ^
  ../../../src/video/win32_v.cpp:919:40: note: candidate is: 'constexpr VideoDriver_Win32Base::GetListOfMonitorRefreshRates()::<lambda(HMONITOR, HDC, LPRECT, LPARAM)>::operator BOOL (*)(HMONITOR, HDC, LPRECT, LPARAM)() const' (near match)
    919 |  EnumDisplayMonitors(nullptr, nullptr, [](HMONITOR hMonitor, HDC hDC, LPRECT rc, LPARAM data) -> BOOL {
        |                                        ^
  ../../../src/video/win32_v.cpp:919:40: note:   no known conversion from 'BOOL (*)(HMONITOR, HDC, LPRECT, LPARAM)' {aka 'int (*)(HMONITOR__*, HDC__*, tagRECT*, long int)'} to 'MONITORENUMPROC' {aka 'int (__attribute__((stdcall)) *)(HMONITOR__*, HDC__*, tagRECT*, long int)'}
  In file included from H:/msys64/mingw32/i686-w64-mingw32/include/windows.h:72,
                   from ../../../src/video/../os/windows/win32.h:13,
                   from ../../../src/video/win32_v.cpp:13:
  H:/msys64/mingw32/i686-w64-mingw32/include/winuser.h:5863:90: note:   initializing argument 3 of 'WINBOOL EnumDisplayMonitors(HDC, LPCRECT, MONITORENUMPROC, LPARAM)'
   5863 |   WINUSERAPI WINBOOL WINAPI EnumDisplayMonitors(HDC hdc,LPCRECT lprcClip,MONITORENUMPROC lpfnEnum,LPARAM dwData);
        |                                                                          ~~~~~~~~~~~~~~~~^~~~~~~~
```

Fifth commit solves
```
  ../../../src/os/windows/crashlog_win.cpp: In static member function 'static void CrashLog::InitThread()':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\crashlog_win.cpp(643,12): warning G8178BDC9: 'safe_esp' is used uninitialized in this function [-Wuninitialized]
    643 |  _safe_esp = safe_esp;
        |  ~~~~~~~~~~^~~~~~~~~~

  cmd.exe /C "cd . && H:\msys64\mingw32\bin\g++.exe -g -mwindows @CMakeFiles\openttd.rsp -o openttd.exe -Wl,--out-implib,libopenttd.dll.a -Wl,--major-image-version,0,--minor-image-version,0  && cd ."
  H:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/10.3.0/../../../../i686-w64-mingw32/bin/ld.exe: CMakeFiles/openttd.dir/src/os/windows/crashlog_win.cpp.obj: in function `ZN8CrashLog10InitThreadEv':
  D:\developpement\GitHub\glx22\OpenTTD\out\build\Mingw32-Debug/../../../src/os/windows/crashlog_win.cpp:641: undefined reference to `safe_esp'
D:\developpement\GitHub\glx22\OpenTTD\out\build\Mingw32-Debug\collect2.exe : error : ld returned 1 exit status
```

Following commits are for MinGW32 and MinGW64
Sixth commit solves
```
  ../../../src/3rdparty/squirrel/squirrel/sqfuncstate.cpp: In function 'void DumpLiteral(SQObjectPtr&)':
D:\developpement\GitHub\glx22\OpenTTD\src\3rdparty\squirrel\squirrel\sqfuncstate.cpp(88,27): warning G479D744D: format '%d' expects argument of type 'int', but argument 2 has type 'SQInteger' {aka 'long long int'} [-Wformat=]
     88 |   case OT_INTEGER: printf("{" OTTD_PRINTF64 "}",_integer(o));break;
        |                           ^~~~~~~~~~~~~~~~~~~~~
  In file included from ../../../src/3rdparty/squirrel/squirrel/sqfuncstate.cpp:5:
  D:/developpement/GitHub/glx22/OpenTTD/src/stdafx.h:303:31: note: format string is defined here
    303 | #   define OTTD_PRINTF64 "%I64d"
        |                           ~~~~^
        |                               |
        |                               int
        |                           %I64lld
```

Seventh commit solves
```
  ../../../src/os/windows/string_uniscribe.cpp: In function 'HFONT__* HFontFromFont(Font*)':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\string_uniscribe.cpp(147,68): warning GBB422243: cast from type 'const void*' to type 'PLOGFONT' {aka 'tagLOGFONTW*'} casts away qualifiers [-Wcast-qual]
    147 |  if (font->fc->GetOSHandle() != nullptr) return CreateFontIndirect((const PLOGFONT)font->fc->GetOSHandle());
        |                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\string_uniscribe.cpp(147,68): warning GCB925CEF: type qualifiers ignored on cast result type [-Wignored-qualifiers]
```

Eighth commit solves
```
  ../../../src/os/windows/win32.cpp: In function 'bool LoadLibraryList(void (**)(int), const char*)':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(70,14): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'Function' {aka 'void (*)(int)'} [-Wcast-function-type]
     70 |    *proc++ = (Function)p;
        |              ^~~~~~~~~~~
  ../../../src/os/windows/win32.cpp: In function 'int OTTDStringCompare(const char*, const char*)':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\win32.cpp(682,22): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNCOMPARESTRINGEX' {aka 'int (__attribute__((stdcall)) *)(const wchar_t*, long unsigned int, const wchar_t*, int, const wchar_t*, int, void*, void*, long int)'} [-Wcast-function-type]
    682 |   _CompareStringEx = (PFNCOMPARESTRINGEX)GetProcAddress(GetModuleHandle(L"Kernel32"), "CompareStringEx");
        |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../../../src/video/win32_v.cpp: In member function 'virtual float VideoDriver_Win32Base::GetDPIScale()':
D:\developpement\GitHub\glx22\OpenTTD\src\video\win32_v.cpp(959,22): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNGETDPIFORWINDOW' {aka 'unsigned int (__attribute__((stdcall)) *)(HWND__*)'} [-Wcast-function-type]
    959 |   _GetDpiForWindow = (PFNGETDPIFORWINDOW)GetProcAddress(GetModuleHandle(L"User32"), "GetDpiForWindow");
        |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
(+ line 960 GetDpiForSystem for MinGW64)
D:\developpement\GitHub\glx22\OpenTTD\src\video\win32_v.cpp(961,23): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNGETDPIFORMONITOR' {aka 'long int (__attribute__((stdcall)) *)(HMONITOR__*, int, unsigned int*, unsigned int*)'} [-Wcast-function-type]
    961 |   _GetDpiForMonitor = (PFNGETDPIFORMONITOR)GetProcAddress(LoadLibrary(L"Shcore.dll"), "GetDpiForMonitor");
        |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../../../src/os/windows/font_win32.cpp: In function 'void LoadWin32Font(FontSize)':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\font_win32.cpp(623,57): warning G0F8295B3: cast between incompatible function types from 'FARPROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNGETFONTRESOURCEINFO' {aka 'int (__attribute__((stdcall)) *)(const wchar_t*, long unsigned int*, void*, long unsigned int)'} [-Wcast-function-type]
    623 |     static PFNGETFONTRESOURCEINFO GetFontResourceInfo = (PFNGETFONTRESOURCEINFO)GetProcAddress(GetModuleHandle(L"Gdi32"), "GetFontResourceInfoW");
        |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Ninth commit solves
```
  ../../../src/video/win32_v.cpp: In function 'void LoadWGLExtensions()':
D:\developpement\GitHub\glx22\OpenTTD\src\video\win32_v.cpp(1267,65): warning G0F8295B3: cast between incompatible function types from 'PROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNWGLGETEXTENSIONSSTRINGARBPROC' {aka 'const char* (__attribute__((stdcall)) *)(HDC__*)'} [-Wcast-function-type]
   1267 |    PFNWGLGETEXTENSIONSSTRINGARBPROC wglGetExtensionsStringARB = (PFNWGLGETEXTENSIONSSTRINGARBPROC)wglGetProcAddress("wglGetExtensionsStringARB");
        |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\developpement\GitHub\glx22\OpenTTD\src\video\win32_v.cpp(1272,36): warning G0F8295B3: cast between incompatible function types from 'PROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNWGLCREATECONTEXTATTRIBSARBPROC' {aka 'HGLRC__* (__attribute__((stdcall)) *)(HDC__*, HGLRC__*, const int*)'} [-Wcast-function-type]
   1272 |      _wglCreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC)wglGetProcAddress("wglCreateContextAttribsARB");
        |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\developpement\GitHub\glx22\OpenTTD\src\video\win32_v.cpp(1276,28): warning G0F8295B3: cast between incompatible function types from 'PROC' {aka 'int (__attribute__((stdcall)) *)()'} to 'PFNWGLSWAPINTERVALEXTPROC' {aka 'int (__attribute__((stdcall)) *)(int)'} [-Wcast-function-type]
   1276 |      _wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
        |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

And last commit solves a build failure introduced recently.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
There's a remaining warning for MinGW32 release build, displayed at link time
```
  ../../../src/os/windows/font_win32.cpp: In function 'LoadWin32Font':
D:\developpement\GitHub\glx22\OpenTTD\src\os\windows\font_win32.cpp(630,33): warning GAE84912C: argument to 'alloca' may be too large [-Walloca-larger-than=]
    630 |       LOGFONT *buf = (LOGFONT *)AllocaM(byte, len);
        |                                 ^
```
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
