### PR TITLE
Fixes for window handling changes from f6d5c01

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -188,7 +188,7 @@ struct DropdownWindow : Window {
 	{
 		/* Make the dropdown "invisible", so it doesn't affect new window placement.
 		 * Also mark it dirty in case the callback deals with the screen. (e.g. screenshots). */
-		this->window_class = WC_INVALID;
+		*this->z_position = nullptr;
 		this->SetDirty();
 
 		Window *w2 = FindWindowById(this->parent_wnd_class, this->parent_wnd_num);
@@ -304,7 +304,7 @@ struct DropdownWindow : Window {
 		if (this->click_delay != 0 && --this->click_delay == 0) {
 			/* Make the dropdown "invisible", so it doesn't affect new window placement.
 			 * Also mark it dirty in case the callback deals with the screen. (e.g. screenshots). */
-			this->window_class = WC_INVALID;
+			*this->z_position = nullptr;
 			this->SetDirty();
 
 			w2->OnDropdownSelect(this->parent_button, this->selected_index);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3489,6 +3489,6 @@ void RelocateAllWindows(int neww, int newh)
  */
 PickerWindowBase::~PickerWindowBase()
 {
-	this->window_class = WC_INVALID; // stop the ancestor from freeing the already (to be) child
+	*this->z_position = nullptr; // stop the ancestor from freeing the already (to be) child
 	ResetObjectToPlace();
 }


### PR DESCRIPTION
Fixes #9269
## Motivation / Problem
Since f6d5c01, windows' deletion is immediate.
Dropdowns and Pickers are abusing WC_INVALID class to hide themselves (triggering the assert in #9269).
~~`ProcessScheduledInvalidations()` can do invalid reads if window is self deleted during `OnInvalidateData()`~~
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Hide Dropdowns and Pickers by removing them from the opened windows list.
~~Modify `OnInvalidateData()` to return `true` if the window is self deleted, and check the return value to prevent invalid reads.~~
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
~~Probably need to do the same for `InvalidateData()` as it calls `OnInvalidateData()`.~~
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
