### PR TITLE
Codechange: [Network] Use std::string for client and company name

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -844,7 +844,7 @@ static void NetworkInitGameInfo()
 	NetworkClientInfo *ci = new NetworkClientInfo(CLIENT_ID_SERVER);
 	ci->client_playas = _network_dedicated ? COMPANY_SPECTATOR : COMPANY_FIRST;
 
-	strecpy(ci->client_name, _settings_client.network.client_name.c_str(), lastof(ci->client_name));
+	ci->client_name = _settings_client.network.client_name;
 }
 
 /**

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -22,10 +22,10 @@ extern NetworkClientInfoPool _networkclientinfo_pool;
 
 /** Container for all information known about a client. */
 struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_pool> {
-	ClientID client_id;                             ///< Client identifier (same as ClientState->client_id)
-	char client_name[NETWORK_CLIENT_NAME_LENGTH];   ///< Name of the client
-	CompanyID client_playas;                        ///< As which company is this client playing (CompanyID)
-	Date join_date;                                 ///< Gamedate the client has joined
+	ClientID client_id;      ///< Client identifier (same as ClientState->client_id)
+	std::string client_name; ///< Name of the client
+	CompanyID client_playas; ///< As which company is this client playing (CompanyID)
+	Date join_date;          ///< Gamedate the client has joined
 
 	/**
 	 * Create a new client.

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -332,7 +332,7 @@ struct NetworkChatWindow : public Window {
 			/* Skip inactive clients */
 			for (NetworkClientInfo *ci : NetworkClientInfo::Iterate(*item)) {
 				*item = ci->index;
-				return ci->client_name;
+				return ci->client_name.c_str();
 			}
 			*item = MAX_CLIENT_SLOTS;
 		}

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -618,7 +618,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMPANY_INFO(Pa
 		NetworkCompanyInfo *company_info = GetLobbyCompanyInfo(current);
 		if (company_info == nullptr) return NETWORK_RECV_STATUS_CLOSE_QUERY;
 
-		p->Recv_string(company_info->company_name, sizeof(company_info->company_name));
+		company_info->company_name = p->Recv_string(NETWORK_COMPANY_NAME_LENGTH);
 		company_info->inaugurated_year = p->Recv_uint32();
 		company_info->company_value    = p->Recv_uint64();
 		company_info->money            = p->Recv_uint64();
@@ -633,7 +633,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMPANY_INFO(Pa
 		}
 		company_info->ai               = p->Recv_bool();
 
-		p->Recv_string(company_info->clients, sizeof(company_info->clients));
+		company_info->clients = p->Recv_string(NETWORK_CLIENTS_LENGTH);
 
 		SetWindowDirty(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_LOBBY);
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1283,7 +1283,7 @@ struct NetworkLobbyWindow : public Window {
 	{
 		/* Scroll through all this->company_info and get the 'pos' item that is not empty. */
 		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
-			if (!StrEmpty(this->company_info[i].company_name)) {
+			if (!this->company_info[i].company_name.empty()) {
 				if (pos-- == 0) return i;
 			}
 		}
@@ -1398,7 +1398,7 @@ struct NetworkLobbyWindow : public Window {
 		GfxFillRect(r.left + 1, r.top + 1, r.right - 1, r.top + detail_height - 1, PC_DARK_BLUE);
 		DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, r.top + 12, STR_NETWORK_GAME_LOBBY_COMPANY_INFO, TC_FROMSTRING, SA_HOR_CENTER);
 
-		if (this->company == INVALID_COMPANY || StrEmpty(this->company_info[this->company].company_name)) return;
+		if (this->company == INVALID_COMPANY || this->company_info[this->company].company_name.empty()) return;
 
 		int y = r.top + detail_height + 4;
 		const NetworkGameInfo *gi = &this->server->info;

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -27,14 +27,14 @@ void ShowNetworkCompanyPasswordWindow(Window *parent);
 
 /** Company information stored at the client side */
 struct NetworkCompanyInfo : NetworkCompanyStats {
-	char company_name[NETWORK_COMPANY_NAME_LENGTH]; ///< Company name
-	Year inaugurated_year;                          ///< What year the company started in
-	Money company_value;                            ///< The company value
-	Money money;                                    ///< The amount of money the company has
-	Money income;                                   ///< How much did the company earned last year
-	uint16 performance;                             ///< What was their performance last month?
-	bool use_password;                              ///< Is there a password
-	char clients[NETWORK_CLIENTS_LENGTH];           ///< The clients that control this company (Name1, name2, ..)
+	std::string company_name; ///< Company name
+	Year inaugurated_year;    ///< What year the company started in
+	Money company_value;      ///< The company value
+	Money money;              ///< The amount of money the company has
+	Money income;             ///< How much did the company earn last year
+	uint16 performance;       ///< What was his performance last month?
+	bool use_password;        ///< Is there a password
+	std::string clients;      ///< The clients that control this company (Name1, name2, ..)
 };
 
 NetworkCompanyInfo *GetLobbyCompanyInfo(CompanyID company);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -372,13 +372,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCompanyInfo()
 	NetworkPopulateCompanyStats(company_stats);
 
 	/* Make a list of all clients per company */
-	char clients[MAX_COMPANIES][NETWORK_CLIENTS_LENGTH];
-	memset(clients, 0, sizeof(clients));
+	std::string clients[MAX_COMPANIES];
 
 	/* Add the local player (if not dedicated) */
 	const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
 	if (ci != nullptr && Company::IsValidID(ci->client_playas)) {
-		strecpy(clients[ci->client_playas], ci->client_name, lastof(clients[ci->client_playas]));
+		clients[ci->client_playas] = ci->client_name;
 	}
 
 	for (NetworkClientSocket *csi : NetworkClientSocket::Iterate()) {
@@ -388,11 +387,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCompanyInfo()
 
 		ci = csi->GetInfo();
 		if (ci != nullptr && Company::IsValidID(ci->client_playas)) {
-			if (!StrEmpty(clients[ci->client_playas])) {
-				strecat(clients[ci->client_playas], ", ", lastof(clients[ci->client_playas]));
+			if (!clients[ci->client_playas].empty()) {
+				clients[ci->client_playas] += ", ";
 			}
 
-			strecat(clients[ci->client_playas], client_name, lastof(clients[ci->client_playas]));
+			clients[ci->client_playas] += client_name;
 		}
 	}
 
@@ -407,7 +406,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCompanyInfo()
 		p->Send_bool  (true);
 		this->SendCompanyInformation(p, company, &company_stats[company->index]);
 
-		if (StrEmpty(clients[company->index])) {
+		if (clients[company->index].empty()) {
 			p->Send_string("<none>");
 		} else {
 			p->Send_string(clients[company->index]);

--- a/src/script/api/script_client.cpp
+++ b/src/script/api/script_client.cpp
@@ -36,7 +36,7 @@ static NetworkClientInfo *FindClientInfo(ScriptClient::ClientID client)
 {
 	NetworkClientInfo *ci = FindClientInfo(client);
 	if (ci == nullptr) return nullptr;
-	return stredup(ci->client_name);
+	return stredup(ci->client_name.c_str());
 }
 
 /* static */ ScriptCompany::CompanyID ScriptClient::GetCompany(ScriptClient::ClientID client)


### PR DESCRIPTION
## Motivation / Problem

Partial conversion of C-string to std::string is not done.


## Description

Change `NetworkClientInfo::client_name`, `NetworkCompanyInfo::company_name` and `NetworkCompanyInfo::clients` to std::string.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
