### PR TITLE
Codechange: [Network] Use std::string for admin name and version

### DIFF
--- a/src/network/core/tcp_admin.cpp
+++ b/src/network/core/tcp_admin.cpp
@@ -30,8 +30,6 @@ static_assert((int)CRR_END       == (int)ADMIN_CRR_END);
 NetworkAdminSocketHandler::NetworkAdminSocketHandler(SOCKET s) : status(ADMIN_STATUS_INACTIVE)
 {
 	this->sock = s;
-	this->admin_name[0] = '\0';
-	this->admin_version[0] = '\0';
 }
 
 NetworkRecvStatus NetworkAdminSocketHandler::CloseConnection(bool error)
@@ -89,9 +87,9 @@ NetworkRecvStatus NetworkAdminSocketHandler::HandlePacket(Packet *p)
 
 		default:
 			if (this->HasClientQuit()) {
-				DEBUG(net, 0, "[tcp/admin] Received invalid packet type %d from '%s' (%s)", type, this->admin_name, this->admin_version);
+				DEBUG(net, 0, "[tcp/admin] Received invalid packet type %d from '%s' (%s)", type, this->admin_name.c_str(), this->admin_version.c_str());
 			} else {
-				DEBUG(net, 0, "[tcp/admin] Received illegal packet from '%s' (%s)", this->admin_name, this->admin_version);
+				DEBUG(net, 0, "[tcp/admin] Received illegal packet from '%s' (%s)", this->admin_name.c_str(), this->admin_version.c_str());
 			}
 
 			this->CloseConnection();
@@ -125,7 +123,7 @@ NetworkRecvStatus NetworkAdminSocketHandler::ReceivePackets()
  */
 NetworkRecvStatus NetworkAdminSocketHandler::ReceiveInvalidPacket(PacketAdminType type)
 {
-	DEBUG(net, 0, "[tcp/admin] Received illegal packet type %d from admin %s (%s)", type, this->admin_name, this->admin_version);
+	DEBUG(net, 0, "[tcp/admin] Received illegal packet type %d from admin %s (%s)", type, this->admin_name.c_str(), this->admin_version.c_str());
 	return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 }
 

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -109,9 +109,9 @@ enum AdminCompanyRemoveReason {
 /** Main socket handler for admin related connections. */
 class NetworkAdminSocketHandler : public NetworkTCPSocketHandler {
 protected:
-	char admin_name[NETWORK_CLIENT_NAME_LENGTH];           ///< Name of the admin.
-	char admin_version[NETWORK_REVISION_LENGTH];           ///< Version string of the admin.
-	AdminStatus status;                                    ///< Status of this admin.
+	std::string admin_name;    ///< Name of the admin.
+	std::string admin_version; ///< Version string of the admin.
+	AdminStatus status;        ///< Status of this admin.
 
 	NetworkRecvStatus ReceiveInvalidPacket(PacketAdminType type);
 

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -64,7 +64,7 @@ public:
 	NetworkRecvStatus SendChat(NetworkAction action, DestType desttype, ClientID client_id, const std::string &msg, int64 data);
 	NetworkRecvStatus SendRcon(uint16 colour, const char *command);
 	NetworkRecvStatus SendConsole(const char *origin, const char *command);
-	NetworkRecvStatus SendGameScript(const char *json);
+	NetworkRecvStatus SendGameScript(const std::string_view json);
 	NetworkRecvStatus SendCmdNames();
 	NetworkRecvStatus SendCmdLogging(ClientID client_id, const CommandPacket *cp);
 	NetworkRecvStatus SendRconEnd(const char *command);
@@ -110,7 +110,7 @@ void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_i
 void NetworkAdminUpdate(AdminUpdateFrequency freq);
 void NetworkServerSendAdminRcon(AdminIndex admin_index, TextColour colour_code, const char *string);
 void NetworkAdminConsole(const char *origin, const char *string);
-void NetworkAdminGameScript(const char *json);
+void NetworkAdminGameScript(const std::string_view json);
 void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket *cp);
 
 #endif /* NETWORK_ADMIN_H */

--- a/src/network/network_admin.h
+++ b/src/network/network_admin.h
@@ -62,12 +62,12 @@ public:
 	NetworkRecvStatus SendCompanyStats();
 
 	NetworkRecvStatus SendChat(NetworkAction action, DestType desttype, ClientID client_id, const std::string &msg, int64 data);
-	NetworkRecvStatus SendRcon(uint16 colour, const char *command);
-	NetworkRecvStatus SendConsole(const char *origin, const char *command);
+	NetworkRecvStatus SendRcon(uint16 colour, const std::string_view command);
+	NetworkRecvStatus SendConsole(const std::string_view origin, const std::string_view command);
 	NetworkRecvStatus SendGameScript(const std::string_view json);
 	NetworkRecvStatus SendCmdNames();
 	NetworkRecvStatus SendCmdLogging(ClientID client_id, const CommandPacket *cp);
-	NetworkRecvStatus SendRconEnd(const char *command);
+	NetworkRecvStatus SendRconEnd(const std::string_view command);
 
 	static void Send();
 	static void AcceptConnection(SOCKET s, const NetworkAddress &address);
@@ -108,8 +108,8 @@ void NetworkAdminCompanyRemove(CompanyID company_id, AdminCompanyRemoveReason bc
 
 void NetworkAdminChat(NetworkAction action, DestType desttype, ClientID client_id, const std::string &msg, int64 data = 0, bool from_admin = false);
 void NetworkAdminUpdate(AdminUpdateFrequency freq);
-void NetworkServerSendAdminRcon(AdminIndex admin_index, TextColour colour_code, const char *string);
-void NetworkAdminConsole(const char *origin, const char *string);
+void NetworkServerSendAdminRcon(AdminIndex admin_index, TextColour colour_code, const std::string_view string);
+void NetworkAdminConsole(const std::string_view origin, const std::string_view string);
 void NetworkAdminGameScript(const std::string_view json);
 void NetworkAdminCmdLogging(const NetworkClientSocket *owner, const CommandPacket *cp);
 

--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -139,7 +139,7 @@
 		return 1;
 	}
 
-	NetworkAdminGameScript(json.c_str());
+	NetworkAdminGameScript(json);
 
 	sq_pushinteger(vm, 1);
 	return 1;

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -134,7 +134,7 @@ ScriptEventAdminPort::~ScriptEventAdminPort()
 
 SQInteger ScriptEventAdminPort::GetObject(HSQUIRRELVM vm)
 {
-	char *p = this->json;
+	const char *p = this->json;
 
 	if (this->ReadTable(vm, p) == nullptr) {
 		sq_pushnull(vm);
@@ -144,9 +144,9 @@ SQInteger ScriptEventAdminPort::GetObject(HSQUIRRELVM vm)
 	return 1;
 }
 
-char *ScriptEventAdminPort::ReadString(HSQUIRRELVM vm, char *p)
+const char *ScriptEventAdminPort::ReadString(HSQUIRRELVM vm, const char *p)
 {
-	char *value = p;
+	const char *value = p;
 
 	bool escape = false;
 	for (;;) {
@@ -168,14 +168,13 @@ char *ScriptEventAdminPort::ReadString(HSQUIRRELVM vm, char *p)
 		p++;
 	}
 
-	*p = '\0';
-	sq_pushstring(vm, value, -1);
-	*p++ = '"';
+	sq_pushstring(vm, value, p - value);
+	p++; // Step past the end-of-string marker (")
 
 	return p;
 }
 
-char *ScriptEventAdminPort::ReadTable(HSQUIRRELVM vm, char *p)
+const char *ScriptEventAdminPort::ReadTable(HSQUIRRELVM vm, const char *p)
 {
 	sq_newtable(vm);
 
@@ -218,7 +217,7 @@ char *ScriptEventAdminPort::ReadTable(HSQUIRRELVM vm, char *p)
 	return p;
 }
 
-char *ScriptEventAdminPort::ReadValue(HSQUIRRELVM vm, char *p)
+const char *ScriptEventAdminPort::ReadValue(HSQUIRRELVM vm, const char *p)
 {
 	SKIP_EMPTY(p);
 
@@ -257,7 +256,7 @@ char *ScriptEventAdminPort::ReadValue(HSQUIRRELVM vm, char *p)
 			sq_newarray(vm, 0);
 
 			/* Empty array? */
-			char *p2 = p + 1;
+			const char *p2 = p + 1;
 			SKIP_EMPTY(p2);
 			if (*p2 == ']') {
 				p = p2 + 1;

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -118,15 +118,10 @@ bool ScriptEventCompanyAskMerger::AcceptMerger()
 	return ScriptObject::DoCommand(0, this->owner, 0, CMD_BUY_COMPANY);
 }
 
-ScriptEventAdminPort::ScriptEventAdminPort(const char *json) :
+ScriptEventAdminPort::ScriptEventAdminPort(const std::string &json) :
 		ScriptEvent(ET_ADMIN_PORT),
-		json(stredup(json))
+		json(json)
 {
-}
-
-ScriptEventAdminPort::~ScriptEventAdminPort()
-{
-	free(this->json);
 }
 
 #define SKIP_EMPTY(p) while (*(p) == ' ' || *(p) == '\n' || *(p) == '\r') (p)++;
@@ -134,7 +129,7 @@ ScriptEventAdminPort::~ScriptEventAdminPort()
 
 SQInteger ScriptEventAdminPort::GetObject(HSQUIRRELVM vm)
 {
-	const char *p = this->json;
+	const char *p = this->json.c_str();
 
 	if (this->ReadTable(vm, p) == nullptr) {
 		sq_pushnull(vm);
@@ -168,7 +163,8 @@ const char *ScriptEventAdminPort::ReadString(HSQUIRRELVM vm, const char *p)
 		p++;
 	}
 
-	sq_pushstring(vm, value, p - value);
+	size_t len = p - value;
+	sq_pushstring(vm, value, len);
 	p++; // Step past the end-of-string marker (")
 
 	return p;

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -860,21 +860,21 @@ private:
 	 * @param vm The VM used.
 	 * @param p The (part of the) JSON string reading.
 	 */
-	char *ReadTable(HSQUIRRELVM vm, char *p);
+	const char *ReadTable(HSQUIRRELVM vm, const char *p);
 
 	/**
 	 * Read a value from a JSON string.
 	 * @param vm The VM used.
 	 * @param p The (part of the) JSON string reading.
 	 */
-	char *ReadValue(HSQUIRRELVM vm, char *p);
+	const char *ReadValue(HSQUIRRELVM vm, const char *p);
 
 	/**
 	 * Read a string from a JSON string.
 	 * @param vm The VM used.
 	 * @param p The (part of the) JSON string reading.
 	 */
-	char *ReadString(HSQUIRRELVM vm, char *p);
+	const char *ReadString(HSQUIRRELVM vm, const char *p);
 };
 
 /**

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -837,8 +837,7 @@ public:
 	/**
 	 * @param json The JSON string which got sent.
 	 */
-	ScriptEventAdminPort(const char *json);
-	~ScriptEventAdminPort();
+	ScriptEventAdminPort(const std::string &json);
 
 	/**
 	 * Convert an ScriptEvent to the real instance.
@@ -853,7 +852,7 @@ public:
 	SQInteger GetObject(HSQUIRRELVM vm);
 
 private:
-	char *json; ///< The JSON string.
+	std::string json; ///< The JSON string.
 
 	/**
 	 * Read a table from a JSON string.


### PR DESCRIPTION
## Motivation / Problem

Partial conversion of C-string to std::string is not done.


## Description

Change `NetworkAdminSocketHandler::admin_name` and `NetworkAdminSocketHandler::admin_version` to std::string, and change the parameters of many admin related functions to either std::string or std::string_view depending on the situation.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
