### PR TITLE
Fix #9267, 47a99bb: [Squirrel] Heap use after free

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqclass.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqclass.cpp
@@ -34,7 +34,13 @@ SQClass::SQClass(SQSharedState *ss,SQClass *base)
 
 void SQClass::Finalize() {
 	_attributes = _null_;
-	_defaultvalues.resize(0);
+	/* SQInstance's Finalize depends on the size of this sqvector, so instead of
+	 * resizing, all SQObjectPtrs are set to "null" so it holds no references to
+	 * other objects anymore. That way everything gets released properly. */
+	for (SQUnsignedInteger i = 0; i < _defaultvalues.size(); i++) {
+		_defaultvalues[i].val = _null_;
+		_defaultvalues[i].attrs = _null_;
+	}
 	_methods.resize(0);
 	_metamethods.resize(0);
 	__ObjRelease(_members);


### PR DESCRIPTION
## Motivation / Problem

Fixes #9267


## Description

Due to 47a99bb the order of elements in the garbage collection chain has changed causing the class to be finalised before the instances of that class. Since the instance's array of member values depends on the size of the values in the class, the class finalisation resetting that size to 0 causes not all finalisations to run, which subsequently causes a heap use after free in the more aggressive final attempts of releasing objects. So, just set the SQObjectPtrs to 'null' during the finalisation of the SQClass so the SQInstance can release all instance variables during its finalisation and the aggressive releaseing attempts are not needed anymore.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
