### PR TITLE
Fix #9264: Do not attach temporary wagons to free wagon chains when autoreplacing

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1178,7 +1178,7 @@ CommandCost CmdMoveRailVehicle(TileIndex tile, DoCommandFlag flags, uint32 p1, u
 	/* if nothing is selected as destination, try and find a matching vehicle to drag to. */
 	Train *dst;
 	if (d == INVALID_VEHICLE) {
-		dst = src->IsEngine() ? nullptr : FindGoodVehiclePos(src);
+		dst = (src->IsEngine() || (flags & DC_AUTOREPLACE)) ? nullptr : FindGoodVehiclePos(src);
 	} else {
 		dst = Train::GetIfValid(d);
 		if (dst == nullptr) return CMD_ERROR;


### PR DESCRIPTION
## Motivation / Problem

Various failure conditions due to free-wagon chains exceeding the train length limit during autoreplace operations, see: #9264.

## Description

Wagons created or moved during an autoreplace operation should always either be sold or attached to a replacement vehicle before the operation has completed.
Therefore it isn't necessary for them to be attached to an existing free wagon chain, (temporarily or otherwise).
This avoids the various failure paths associated with exceeded free wagon chain length limits.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
