### PR TITLE
Fix: [OpenGL] Increase timeout when waiting for the GPU to be done with the drawing buffer.

### DIFF
--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -1150,7 +1150,7 @@ void OpenGLBackend::ClearCursorCache()
 void *OpenGLBackend::GetVideoBuffer()
 {
 #ifndef NO_GL_BUFFER_SYNC
-	if (this->sync_vid_mapping != nullptr) _glClientWaitSync(this->sync_vid_mapping, GL_SYNC_FLUSH_COMMANDS_BIT, 10000000);
+	if (this->sync_vid_mapping != nullptr) _glClientWaitSync(this->sync_vid_mapping, GL_SYNC_FLUSH_COMMANDS_BIT, 100000000); // 100ms timeout.
 #endif
 
 	if (!this->persistent_mapping_supported) {
@@ -1174,7 +1174,7 @@ uint8 *OpenGLBackend::GetAnimBuffer()
 	if (this->anim_pbo == 0) return nullptr;
 
 #ifndef NO_GL_BUFFER_SYNC
-	if (this->sync_anim_mapping != nullptr) _glClientWaitSync(this->sync_anim_mapping, GL_SYNC_FLUSH_COMMANDS_BIT, 10000000);
+	if (this->sync_anim_mapping != nullptr) _glClientWaitSync(this->sync_anim_mapping, GL_SYNC_FLUSH_COMMANDS_BIT, 100000000); // 100ms timeout.
 #endif
 
 	if (!this->persistent_mapping_supported) {


### PR DESCRIPTION
## Motivation / Problem

Screen refresh could glitch if v-sync was enabled with lower refresh rates.

## Description

Increase the buffer sync timeout to make sure we definitely wait longer than the screen refresh.

## Limitations

If the GPU is extremely busy, the new timeout will make stutter more likely but graphical glitches a lot less likely.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
