### PR TITLE
Change: [Actions] use newly created Actions instead of custom shell-scripting

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -326,34 +326,8 @@ jobs:
 
     if: always() && github.event_name == 'pull_request'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - name: Get check suite ID
-      id: check_suite_id
-      uses: octokit/request-action@v2.x
-      with:
-        route: GET /repos/{repository}/actions/runs/{run_id}
-        repository: ${{ github.repository }}
-        run_id: ${{ github.run_id }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Get check runs
-      id: check_runs
-      uses: octokit/request-action@v2.x
-      with:
-        route: GET /repos/{repository}/check-suites/{check_suite_id}/check-runs
-        repository: ${{ github.repository }}
-        check_suite_id: ${{ fromJson(steps.check_suite_id.outputs.data).check_suite_id }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Check annotations
-      shell: bash
-      run: |
-        echo '[
-        ${{ toJson(fromJson(steps.check_runs.outputs.data).check_runs.*.output.title) }}, ${{ toJson(fromJson(steps.check_runs.outputs.data).check_runs.*.output.summary) }}
-        ]' | jq '.[0] as $t | .[1] as $s | reduce range(.[0] | length) as $i ([]; . + [if $t[$i] then $t[$i] + ": " + $s[$i] else empty end]) | .[]'
-
-        exit $(echo '${{ toJson(fromJson(steps.check_runs.outputs.data).check_runs.*.output.annotations_count) }}' | jq 'add')
+      uses: OpenTTD/actions/annotation-check@v2

--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -15,37 +15,7 @@ jobs:
         fetch-depth: 4
 
     - name: Get pull-request commits
-      run: |
-        set -x
-        # actions/checkout did a merge checkout of the pull-request. As such, the first
-        # commit is the merge commit. This means that on HEAD^ is the base branch, and
-        # on HEAD^2 are the commits from the pull-request. We now check if those trees
-        # have a common parent. If not, we fetch a few more commits till we do. In result,
-        # the log between HEAD^ and HEAD^2 will be the commits in the pull-request.
-        DEPTH=4
-        while [ -z "$(git merge-base HEAD^ HEAD^2)" ]; do
-            # Prevent infinite recursion
-            if [ ${DEPTH} -gt 256 ]; then
-                echo "No common parent between '${GITHUB_HEAD_REF}' and '${GITHUB_BASE_REF}'." >&2
-                exit 1
-            fi
-
-            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --deepen=${DEPTH} origin HEAD
-            DEPTH=$(( ${DEPTH} * 4 ))
-        done
-
-        # Just to show which commits we are going to evaluate.
-        git log --oneline HEAD^..HEAD^2
-
-    - name: Checkout commit-checker
-      uses: actions/checkout@v2
-      with:
-        repository: OpenTTD/OpenTTD-git-hooks
-        path: git-hooks
-        ref: master
+      uses: OpenTTD/actions/checkout-pull-request@v2
 
     - name: Check commits
-      run: |
-        set -x
-        HOOKS_DIR=./git-hooks/hooks GIT_DIR=.git ./git-hooks/hooks/check-commits.sh HEAD^..HEAD^2
-        echo "Commit checks passed"
+      uses: OpenTTD/OpenTTD-git-hooks@main


### PR DESCRIPTION
## Motivation / Problem

Between different repositories of OpenTTD we copy/pasted a lot of custom shell-script. This was difficult to maintain, and updating everything is a chore.


## Description

Today I introduced three new GitHub Actions:

- `OpenTTD/actions/annotation-check`
- `OpenTTD/actions/checkout-pull-request`
- `OpenTTD/OpenTTD-git-hooks`

Together they remove most of the custom shell scripting we have in GitHub workflows.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
