### PR TITLE
Fixes for Haiku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,10 @@ target_link_libraries(openttd
     Threads::Threads
 )
 
+if(HAIKU)
+    target_link_libraries(openttd "be" "network" "midi")
+endif()
+
 if(IPO_FOUND)
     set_target_properties(openttd PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE True)
     set_target_properties(openttd PROPERTIES INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL True)

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -158,7 +158,7 @@ macro(compile_flags)
         message(FATAL_ERROR "No warning flags are set for this compiler yet; please consider creating a Pull Request to add support for this compiler.")
     endif()
 
-    if(NOT WIN32)
+    if(NOT WIN32 AND NOT HAIKU)
         # rdynamic is used to get useful stack traces from crash reports.
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
     endif()

--- a/src/music/CMakeLists.txt
+++ b/src/music/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT OPTION_DEDICATED)
     add_files(
         bemidi.cpp
         bemidi.h
-        CONDITION OPTION_HAIKU
+        CONDITION HAIKU
     )
 
     add_files(

--- a/src/music/bemidi.h
+++ b/src/music/bemidi.h
@@ -12,6 +12,9 @@
 
 #include "music_driver.hpp"
 
+/* For BMidiSynthFile */
+#include <MidiSynthFile.h>
+
 /** The midi player for BeOS. */
 class MusicDriver_BeMidi : public MusicDriver {
 public:
@@ -27,6 +30,11 @@ public:
 
 	void SetVolume(byte vol) override;
 	const char *GetName() const override { return "bemidi"; }
+
+private:
+	BMidiSynthFile *midi_synth_file = nullptr;
+	double current_volume = 1.0;
+	bool just_started = false;
 };
 
 /** Factory for the BeOS midi player. */

--- a/src/network/core/host.cpp
+++ b/src/network/core/host.cpp
@@ -20,72 +20,7 @@
  */
 static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast);
 
-#if defined(__HAIKU__) /* doesn't have neither getifaddrs or net/if.h */
-/* Based on Andrew Bachmann's netstat+.c. Big thanks to him! */
-extern "C" int _netstat(int fd, char **output, int verbose);
-
-int seek_past_header(char **pos, const char *header)
-{
-	char *new_pos = strstr(*pos, header);
-	if (new_pos == 0) {
-		return B_ERROR;
-	}
-	*pos += strlen(header) + new_pos - *pos + 1;
-	return B_OK;
-}
-
-static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // BEOS implementation
-{
-	int sock = socket(AF_INET, SOCK_DGRAM, 0);
-
-	if (sock < 0) {
-		DEBUG(net, 0, "Could not create socket: %s", NetworkError::GetLast().AsString());
-		return;
-	}
-
-	char *output_pointer = nullptr;
-	int output_length = _netstat(sock, &output_pointer, 1);
-	if (output_length < 0) {
-		DEBUG(net, 0, "Error running _netstat()");
-		return;
-	}
-
-	char **output = &output_pointer;
-	if (seek_past_header(output, "IP Interfaces:") == B_OK) {
-		for (;;) {
-			uint32 n;
-			int fields, read;
-			uint8 i1, i2, i3, i4, j1, j2, j3, j4;
-			uint32 ip;
-			uint32 netmask;
-
-			fields = sscanf(*output, "%u: %hhu.%hhu.%hhu.%hhu, netmask %hhu.%hhu.%hhu.%hhu%n",
-												&n, &i1, &i2, &i3, &i4, &j1, &j2, &j3, &j4, &read);
-			read += 1;
-			if (fields != 9) {
-				break;
-			}
-
-			ip      = (uint32)i1 << 24 | (uint32)i2 << 16 | (uint32)i3 << 8 | (uint32)i4;
-			netmask = (uint32)j1 << 24 | (uint32)j2 << 16 | (uint32)j3 << 8 | (uint32)j4;
-
-			if (ip != INADDR_LOOPBACK && ip != INADDR_ANY) {
-				sockaddr_storage address;
-				memset(&address, 0, sizeof(address));
-				((sockaddr_in*)&address)->sin_addr.s_addr = htonl(ip | ~netmask);
-				NetworkAddress addr(address, sizeof(sockaddr));
-				if (std::none_of(broadcast->begin(), broadcast->end(), [&addr](NetworkAddress const& elem) -> bool { return elem == addr; })) broadcast->push_back(addr);
-			}
-			if (read < 0) {
-				break;
-			}
-			*output += read;
-		}
-		closesocket(sock);
-	}
-}
-
-#elif defined(HAVE_GETIFADDRS)
+#if defined(HAVE_GETIFADDRS)
 static void NetworkFindBroadcastIPsInternal(NetworkAddressList *broadcast) // GETIFADDRS implementation
 {
 	struct ifaddrs *ifap, *ifa;

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -108,6 +108,13 @@ typedef unsigned long in_addr_t;
 #		undef FD_SETSIZE
 #		define FD_SETSIZE 64
 #   endif
+
+/* Haiku says it supports FD_SETSIZE fds, but it really only supports 512. */
+#   if defined(__HAIKU__)
+#		undef FD_SETSIZE
+#		define FD_SETSIZE 512
+#   endif
+
 #endif /* UNIX */
 
 /* OS/2 stuff */

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -33,6 +33,7 @@
 #if defined(__HAIKU__)
 #	include <SupportDefs.h>
 #	include <unistd.h>
+#	define _DEFAULT_SOURCE
 #	define _GNU_SOURCE
 #	define TROUBLED_INTS
 #endif


### PR DESCRIPTION
## Motivation / Problem

It was failing to compile on Haiku.

## Description

Fix building flags and add workarounds for Haiku bemidi and sockets implementation.
Tested with SDL1.

## Limitations

I removed old network code for BeOS, but that's kind of moot point given that it requires gcc 2.95 and surely C++17 won't compile on it anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
