### PR TITLE
Change: Shortcut varaction chains for callbacks and triggers.

### DIFF
--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -35,6 +35,9 @@ TemporaryStorageArray<int32, 0x110> _temp_store;
 {
 	if (group == nullptr) return nullptr;
 
+	/* Exit early if chain doesn't have requisite flags -- result will fail so no need to evaluate. */
+	if ((object.flags & group->flags) != object.flags) return nullptr;
+
 	const GRFFile *grf = object.grffile;
 	auto profiler = std::find_if(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](const NewGRFProfiler &pr) { return pr.grffile == grf; });
 


### PR DESCRIPTION
## Motivation / Problem

By design, an unhandled callback often ends up following the default graphics chain. Depending on the variables accessed this could potentially be expensive.

## Description

If a varaction chain does contain any callback results, do not continue evaluating the chain. This possibly avoids processing complex graphical chains which can never end in a callback result.

## Limitations

This is not really benchmarked and is hypothetical at this point. It's not impossible that the additional test causes more work over all.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
