### PR TITLE
Feature: Sign Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -746,6 +746,21 @@ jobs:
       with:
         arch: ${{ matrix.host }}
 
+    - name: Import code signing certificate
+      shell: powershell
+      # If this is run on a fork, there may not be a certificate set up - continue in this case
+      continue-on-error: true
+      run: |
+        $tempFile = [System.IO.Path]::GetTempFileName()
+        $bytes = [System.Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_P12)
+        [IO.File]::WriteAllBytes($tempFile, $bytes)
+        $pwd = ConvertTo-SecureString $env:WINDOWS_CERTIFICATE_PASSWORD -AsPlainText -Force
+        Import-PfxCertificate -FilePath $tempFile -CertStoreLocation Cert:\CurrentUser\My -Password $pwd
+        Remove-Item $tempFile
+      env:
+        WINDOWS_CERTIFICATE_P12: ${{ secrets.WINDOWS_CERTIFICATE_P12 }}
+        WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+
     - name: Build (with installer)
       if: needs.source.outputs.is_tag == 'true'
       shell: bash
@@ -761,12 +776,15 @@ jobs:
           -DOPTION_USE_NSIS=ON \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \
           # EOF
         echo "::endgroup::"
 
         echo "::group::Build"
         cmake --build .
         echo "::endgroup::"
+      env:
+        WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
 
     - name: Build (without installer)
       if: needs.source.outputs.is_tag != 'true'
@@ -782,12 +800,15 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \
           # EOF
         echo "::endgroup::"
 
         echo "::group::Build"
         cmake --build .
         echo "::endgroup::"
+      env:
+        WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
 
     - name: Create bundles
       shell: bash
@@ -808,6 +829,17 @@ jobs:
         # the end of this workflow.
         rm -f bundles/*.sha256
         echo "::endgroup::"
+
+    - name: Sign installer
+      if: needs.source.outputs.is_tag == 'true'
+      shell: bash
+      # If this is run on a fork, there may not be a certificate set up - continue in this case
+      continue-on-error: true
+      run: |
+        cd ${GITHUB_WORKSPACE}/build/bundles
+        ../../os/windows/sign.bat *.exe "${WINDOWS_CERTIFICATE_COMMON_NAME}"
+      env:
+        WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
 
     - name: Store bundles
       uses: actions/upload-artifact@v2

--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -138,6 +138,13 @@ elseif(WIN32)
     endif()
 
     set(CPACK_PACKAGE_FILE_NAME "openttd-#CPACK_PACKAGE_VERSION#-windows-${CPACK_SYSTEM_NAME}")
+
+    if(WINDOWS_CERTIFICATE_COMMON_NAME)
+      add_custom_command(TARGET openttd
+        POST_BUILD
+        COMMAND "${CMAKE_SOURCE_DIR}/os/windows/sign.bat" "$<TARGET_FILE:openttd>" "${WINDOWS_CERTIFICATE_COMMON_NAME}"
+      )
+    endif()
 elseif(UNIX)
     # With FHS, we can create deb/rpm/... Without it, they would be horribly broken
     # and not work. The other way around is also true; with FHS they are not

--- a/os/windows/sign.bat
+++ b/os/windows/sign.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Signing script
+REM Arguments: sign.bat exe_to_sign certificate_subject_name
+
+REM This is a loose wrapper around the Microsoft signtool application (included in the Windows SDK).
+REM See https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe for more details.
+
+REM Path to signtool.exe
+IF NOT DEFINED SIGNTOOL_PATH (SET SIGNTOOL_PATH=signtool)
+
+REM URL of the timestamp server
+IF NOT DEFINED SIGNTOOL_TIMESTAMP_URL (SET SIGNTOOL_TIMESTAMP_URL=http://timestamp.digicert.com)
+
+REM Sign with SHA-1 for Windows 7 and below
+"%SIGNTOOL_PATH%" sign -v -n %2 -t %SIGNTOOL_TIMESTAMP_URL% %1
+
+REM Sign with SHA-256 for Windows 8 and above
+"%SIGNTOOL_PATH%" sign -v -n %2 -tr %SIGNTOOL_TIMESTAMP_URL% -fd sha256 -td sha256 -as %1


### PR DESCRIPTION
Fixes #8056

## Motivation / Problem

Windows builds are currently unsigned, which can result in security warnings. We have finally managed to obtain a code signing certificate, in the name of OpenTTD Distribution Ltd, which should offer some reassurance to users.

## Description

Adds signing of the openttd.exe for Windows builds, alongside the installer if applicable.

## Limitations

The certificate details are stored in GitHub Secrets, in the same way as the Apple signing certificate. Signing of the openttd.exe file is performed as part of the build process, if CMAKE_SIGNING_CERTIFICATE is set to the common name of the certificate, which must be imported into the local user's certificate store. Signing of the installer is currently a manual process (integrating it with CPack is not as straightforward for Windows as it is for Apple), performed in the Actions script.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
