### PR TITLE
Change: by default, make "unload all" leave stations empty

### DIFF
--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -643,8 +643,8 @@ private:
 
 		DoCommandP(this->vehicle->tile, this->vehicle->index + (sel_ord << 20), MOF_UNLOAD | (unload_type << 4), CMD_MODIFY_ORDER | CMD_MSG(STR_ERROR_CAN_T_MODIFY_THIS_ORDER));
 
-		/* Transfer orders with leave empty as default */
-		if (unload_type == OUFB_TRANSFER) {
+		/* Transfer and unload orders with leave empty as default */
+		if (unload_type == OUFB_TRANSFER || unload_type == OUFB_UNLOAD) {
 			DoCommandP(this->vehicle->tile, this->vehicle->index + (sel_ord << 20), MOF_LOAD | (OLFB_NO_LOAD << 4), CMD_MODIFY_ORDER);
 			this->SetWidgetDirty(WID_O_FULL_LOAD);
 		}


### PR DESCRIPTION
Fixes #9265

## Motivation / Problem

Although you never have to use the `Unload` button, from a flow perspective it is very tempted to do:

Full load in station A
Unload in station B

To make a one-way trip happen.

Sadly, by default, `Unload` button makes it `Unload and take cargo`. This means that if for any reason the same cargo you are unloading is available at station B, it starts to load it up again. This is often unexpected, as shown by #9265. People also have a really hard time to come up with scenarios where this default makes sense.

## Description

The current default makes total sense code-wise. By default the loading is set to "take cargo", and the `Unload` button merely toggles the unload state to `Unload all` or `Unload if possible`.

Either way, `Transfer` already toggles to `and leave empty`, so with this PR so that `Unload`.

## Limitations

The order GUI is annoyingly weird, and makes little sense if you really play with it. Now if you press `Unload` twice, it doesn't return to the original state, but leaves `no loading` on. Transfer already had similar issues. Resolving this requires a nice change of the full Order GUI .. not for this PR :D

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
