### PR TITLE
Change: split check and update callbacks for settings

### DIFF
--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -593,9 +593,9 @@ void DrawRailCatenary(const TileInfo *ti)
 	DrawRailCatenaryRailway(ti);
 }
 
-bool SettingsDisableElrail(int32 p1)
+void SettingsDisableElrail(int32 new_value)
 {
-	bool disable = (p1 != 0);
+	bool disable = (new_value != 0);
 
 	/* we will now walk through all electric train engines and change their railtypes if it is the wrong one*/
 	const RailType old_railtype = disable ? RAILTYPE_ELECTRIC : RAILTYPE_RAIL;
@@ -639,5 +639,4 @@ bool SettingsDisableElrail(int32 p1)
 	 * rails. It may have unintended consequences if that function is ever
 	 * extended, though. */
 	ReinitGuiAfterToggleElrail(disable);
-	return true;
 }

--- a/src/elrail_func.h
+++ b/src/elrail_func.h
@@ -36,6 +36,6 @@ void DrawRailCatenary(const TileInfo *ti);
 void DrawRailCatenaryOnTunnel(const TileInfo *ti);
 void DrawRailCatenaryOnBridge(const TileInfo *ti);
 
-bool SettingsDisableElrail(int32 p1); ///< _settings_game.disable_elrail callback
+void SettingsDisableElrail(int32 new_value); ///< _settings_game.disable_elrail callback
 
 #endif /* ELRAIL_FUNC_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2204,6 +2204,7 @@ STR_NETWORK_ERROR_CLIENT_START                                  :{WHITE}Could no
 STR_NETWORK_ERROR_TIMEOUT                                       :{WHITE}Connection #{NUM} timed out
 STR_NETWORK_ERROR_SERVER_ERROR                                  :{WHITE}A protocol error was detected and the connection was closed
 STR_NETWORK_ERROR_BAD_PLAYER_NAME                               :{WHITE}Your player name has not been set. The name can be set at the top of the Multiplayer window
+STR_NETWORK_ERROR_BAD_SERVER_NAME                               :{WHITE}Your server name has not been set. The name can be set at the top of the Multiplayer window
 STR_NETWORK_ERROR_WRONG_REVISION                                :{WHITE}The revision of this client does not match the server's revision
 STR_NETWORK_ERROR_WRONG_PASSWORD                                :{WHITE}Wrong password
 STR_NETWORK_ERROR_SERVER_FULL                                   :{WHITE}The server is full

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -835,10 +835,6 @@ void NetworkClientJoinGame()
 
 static void NetworkInitGameInfo()
 {
-	if (_settings_client.network.server_name.empty()) {
-		_settings_client.network.server_name = "Unnamed Server";
-	}
-
 	FillStaticNetworkServerGameInfo();
 	/* The server is a client too */
 	_network_game_info.clients_on = _network_dedicated ? 0 : 1;
@@ -852,6 +848,25 @@ static void NetworkInitGameInfo()
 }
 
 /**
+ * Trim the given server name in place, i.e. remove leading and trailing spaces.
+ * After the trim check whether the server name is not empty.
+ * When the server name is empty a GUI error message is shown telling the
+ * user to set the servername and this function returns false.
+ *
+ * @param server_name The server name to validate. It will be trimmed of leading
+ *                    and trailing spaces.
+ * @return True iff the server name is valid.
+ */
+bool NetworkValidateServerName(std::string &server_name)
+{
+	StrTrimInPlace(server_name);
+	if (!server_name.empty()) return true;
+
+	ShowErrorMessage(STR_NETWORK_ERROR_BAD_SERVER_NAME, INVALID_STRING_ID, WL_ERROR);
+	return false;
+}
+
+/**
  * Check whether the client and server name are set, for a dedicated server and if not set them to some default
  * value and tell the user to change this as soon as possible.
  * If the saved name is the default value, then the user is told to override  this value too.
@@ -860,12 +875,14 @@ static void NetworkInitGameInfo()
 static void CheckClientAndServerName()
 {
 	static const std::string fallback_client_name = "Unnamed Client";
+	StrTrimInPlace(_settings_client.network.client_name);
 	if (_settings_client.network.client_name.empty() || _settings_client.network.client_name.compare(fallback_client_name) == 0) {
 		DEBUG(net, 1, "No \"client_name\" has been set, using \"%s\" instead. Please set this now using the \"name <new name>\" command", fallback_client_name.c_str());
 		_settings_client.network.client_name = fallback_client_name;
 	}
 
 	static const std::string fallback_server_name = "Unnamed Server";
+	StrTrimInPlace(_settings_client.network.server_name);
 	if (_settings_client.network.server_name.empty() || _settings_client.network.server_name.compare(fallback_server_name) == 0) {
 		DEBUG(net, 1, "No \"server_name\" has been set, using \"%s\" instead. Please set this now using the \"server_name <new name>\" command", fallback_server_name.c_str());
 		_settings_client.network.server_name = fallback_server_name;

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1344,27 +1344,22 @@ bool NetworkValidateClientName()
 }
 
 /**
- * Send the server our name.
+ * Send the server our name as callback from the setting.
+ * @param newname The new client name.
  */
-void NetworkUpdateClientName()
+void NetworkUpdateClientName(const std::string &client_name)
 {
 	NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(_network_own_client_id);
-
 	if (ci == nullptr) return;
-	/* There is no validation on string settings, it is actually a post change callback.
-	 * This method is called from that post change callback. So, when the client name is
-	 * changed via the console there is no easy way to prevent an invalid name. Though,
-	 * we can prevent it getting sent here. */
-	if (!NetworkValidateClientName()) return;
 
 	/* Don't change the name if it is the same as the old name */
-	if (_settings_client.network.client_name.compare(ci->client_name) != 0) {
+	if (client_name.compare(ci->client_name) != 0) {
 		if (!_network_server) {
-			MyClient::SendSetName(_settings_client.network.client_name.c_str());
+			MyClient::SendSetName(client_name.c_str());
 		} else {
 			/* Copy to a temporary buffer so no #n gets added after our name in the settings when there are duplicate names. */
 			char temporary_name[NETWORK_CLIENT_NAME_LENGTH];
-			strecpy(temporary_name, _settings_client.network.client_name.c_str(), lastof(temporary_name));
+			strecpy(temporary_name, client_name.c_str(), lastof(temporary_name));
 			if (NetworkFindName(temporary_name, lastof(temporary_name))) {
 				NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, CC_DEFAULT, false, ci->client_name, temporary_name);
 				ci->client_name = temporary_name;

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -38,7 +38,7 @@ byte NetworkSpectatorCount();
 bool NetworkIsValidClientName(const std::string_view client_name);
 bool NetworkValidateClientName();
 bool NetworkValidateClientName(std::string &client_name);
-void NetworkUpdateClientName();
+void NetworkUpdateClientName(const std::string &client_name);
 bool NetworkCompanyHasClients(CompanyID company);
 std::string NetworkChangeCompanyPassword(CompanyID company_id, std::string password);
 void NetworkReboot();

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -38,6 +38,7 @@ byte NetworkSpectatorCount();
 bool NetworkIsValidClientName(const std::string_view client_name);
 bool NetworkValidateClientName();
 bool NetworkValidateClientName(std::string &client_name);
+bool NetworkValidateServerName(std::string &server_name);
 void NetworkUpdateClientName(const std::string &client_name);
 bool NetworkCompanyHasClients(CompanyID company);
 std::string NetworkChangeCompanyPassword(CompanyID company_id, std::string password);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1095,6 +1095,7 @@ struct NetworkStartServerWindow : public Window {
 				break;
 
 			case WID_NSS_GENERATE_GAME: // Start game
+				if (!CheckServerName()) return;
 				_is_network_server = true;
 				if (_ctrl_pressed) {
 					StartNewGameWithoutGUI(GENERATE_NEW_SEED);
@@ -1104,16 +1105,19 @@ struct NetworkStartServerWindow : public Window {
 				break;
 
 			case WID_NSS_LOAD_GAME:
+				if (!CheckServerName()) return;
 				_is_network_server = true;
 				ShowSaveLoadDialog(FT_SAVEGAME, SLO_LOAD);
 				break;
 
 			case WID_NSS_PLAY_SCENARIO:
+				if (!CheckServerName()) return;
 				_is_network_server = true;
 				ShowSaveLoadDialog(FT_SCENARIO, SLO_LOAD);
 				break;
 
 			case WID_NSS_PLAY_HEIGHTMAP:
+				if (!CheckServerName()) return;
 				_is_network_server = true;
 				ShowSaveLoadDialog(FT_HEIGHTMAP,SLO_LOAD);
 				break;
@@ -1133,11 +1137,13 @@ struct NetworkStartServerWindow : public Window {
 		this->SetDirty();
 	}
 
-	void OnEditboxChanged(int wid) override
+	bool CheckServerName()
 	{
-		if (wid == WID_NSS_GAMENAME) {
-			_settings_client.network.server_name = this->name_editbox.text.buf;
-		}
+		std::string str = this->name_editbox.text.buf;
+		if (!NetworkValidateServerName(str)) return false;
+
+		SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), str);
+		return true;
 	}
 
 	void OnTimeout() override
@@ -2199,16 +2205,13 @@ public:
 			case WID_CL_SERVER_NAME_EDIT: {
 				if (!_network_server) break;
 
-				SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), StrEmpty(str) ? "Unnamed Server" : str);
+				SetSettingValue(GetSettingFromName("network.server_name")->AsStringSetting(), str);
 				this->InvalidateData();
 				break;
 			}
 
 			case WID_CL_CLIENT_NAME_EDIT: {
-				std::string client_name(str);
-				if (!NetworkValidateClientName(client_name)) break;
-
-				SetSettingValue(GetSettingFromName("network.client_name")->AsStringSetting(), client_name);
+				SetSettingValue(GetSettingFromName("network.client_name")->AsStringSetting(), str);
 				this->InvalidateData();
 				break;
 			}

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2208,7 +2208,7 @@ public:
 				std::string client_name(str);
 				if (!NetworkValidateClientName(client_name)) break;
 
-				SetSettingValue(GetSettingFromName("network.client_name")->AsStringSetting(), client_name.c_str());
+				SetSettingValue(GetSettingFromName("network.client_name")->AsStringSetting(), client_name);
 				this->InvalidateData();
 				break;
 			}

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -282,15 +282,13 @@ void GRFParameterInfo::Finalize()
 /**
  * Update the palettes of the graphics from the config file.
  * Called when changing the default palette in advanced settings.
- * @param p1 Unused.
- * @return Always true.
+ * @param new_value Unused.
  */
-bool UpdateNewGRFConfigPalette(int32 p1)
+void UpdateNewGRFConfigPalette(int32 new_value)
 {
 	for (GRFConfig *c = _grfconfig_newgame; c != nullptr; c = c->next) c->SetSuitablePalette();
 	for (GRFConfig *c = _grfconfig_static;  c != nullptr; c = c->next) c->SetSuitablePalette();
 	for (GRFConfig *c = _all_grfs;          c != nullptr; c = c->next) c->SetSuitablePalette();
-	return true;
 }
 
 /**

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -239,6 +239,6 @@ void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFC
 GRFTextWrapper FindUnknownGRFName(uint32 grfid, uint8 *md5sum, bool create);
 
 void UpdateNewGRFScanStatus(uint num, const char *name);
-bool UpdateNewGRFConfigPalette(int32 p1 = 0);
+void UpdateNewGRFConfigPalette(int32 new_value = 0);
 
 #endif /* NEWGRF_CONFIG_H */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2130,10 +2130,9 @@ static void SetDefaultRailGui()
 /**
  * Updates the current signal variant used in the signal GUI
  * to the one adequate to current year.
- * @param p needed to be called when a setting changes
- * @return success, needed for settings
+ * @param new_value needed to be called when a setting changes
  */
-bool ResetSignalVariant(int32 p)
+void ResetSignalVariant(int32 new_value)
 {
 	SignalVariant new_variant = (_cur_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
 
@@ -2145,8 +2144,6 @@ bool ResetSignalVariant(int32 p)
 		}
 		_cur_signal_variant = new_variant;
 	}
-
-	return true;
 }
 
 /**

--- a/src/rail_gui.h
+++ b/src/rail_gui.h
@@ -15,7 +15,7 @@
 
 struct Window *ShowBuildRailToolbar(RailType railtype);
 void ReinitGuiAfterToggleElrail(bool disable);
-bool ResetSignalVariant(int32 = 0);
+void ResetSignalVariant(int32 = 0);
 void InitializeRailGUI();
 DropDownList GetRailTypeDropDownList(bool for_replacement = false, bool all_option = false);
 

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -150,13 +150,17 @@ struct IntSettingDesc : SettingDesc {
 	bool IsIntSetting() const override { return true; }
 
 	void ChangeValue(const void *object, int32 newvalue) const;
-	void Write_ValidateSetting(const void *object, int32 value) const;
+	void MakeValueValidAndWrite(const void *object, int32 value) const;
 
 	virtual size_t ParseValue(const char *str) const;
 	void FormatValue(char *buf, const char *last, const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	int32 Read(const void *object) const;
+
+private:
+	void MakeValueValid(int32 &value) const;
+	void Write(const void *object, int32 value) const;
 };
 
 /** Boolean setting. */

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -212,15 +212,31 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 
 /** String settings. */
 struct StringSettingDesc : SettingDesc {
+	/**
+	 * A check to be performed before the setting gets changed. The passed string may be
+	 * changed by the check if that is important, for example to remove unwanted white
+	 * space. The return value denotes whether the value, potentially after the changes,
+	 * is allowed to be used/set in the configuration.
+	 * @param value The prospective new value for the setting.
+	 * @return True when the setting is accepted.
+	 */
+	typedef bool PreChangeCheck(std::string &value);
+	/**
+	 * A callback to denote that a setting has been changed.
+	 * @param The new value for the setting.
+	 */
+	typedef void PostChangeCallback(const std::string &value);
+
 	StringSettingDesc(SaveLoad save, const char *name, SettingGuiFlag flags, bool startup, const char *def,
-			uint32 max_length, OnChange proc) :
+			uint32 max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
-			proc(proc) {}
+			pre_check(pre_check), post_callback(post_callback) {}
 	virtual ~StringSettingDesc() {}
 
-	std::string def;        ///< default value given when none is present
-	uint32 max_length;      ///< maximum length of the string, 0 means no maximum length
-	OnChange *proc;         ///< callback procedure for when the value is changed
+	std::string def;                   ///< Default value given when none is present
+	uint32 max_length;                 ///< Maximum length of the string, 0 means no maximum length
+	PreChangeCheck *pre_check;         ///< Callback to check for the validity of the setting.
+	PostChangeCallback *post_callback; ///< Callback when the setting has been changed.
 
 	bool IsStringSetting() const override { return true; }
 	void ChangeValue(const void *object, std::string &newval) const;

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -210,21 +210,25 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 struct StringSettingDesc : SettingDesc {
 	StringSettingDesc(SaveLoad save, const char *name, SettingGuiFlag flags, bool startup, const char *def,
 			uint32 max_length, OnChange proc) :
-		SettingDesc(save, name, flags, startup), def(def), max_length(max_length), proc(proc) {}
+		SettingDesc(save, name, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
+			proc(proc) {}
 	virtual ~StringSettingDesc() {}
 
-	const char *def;        ///< default value given when none is present
+	std::string def;        ///< default value given when none is present
 	uint32 max_length;      ///< maximum length of the string, 0 means no maximum length
 	OnChange *proc;         ///< callback procedure for when the value is changed
 
 	bool IsStringSetting() const override { return true; }
-	void ChangeValue(const void *object, const char *newval) const;
-	void Write_ValidateSetting(const void *object, const char *str) const;
+	void ChangeValue(const void *object, std::string &newval) const;
 
 	void FormatValue(char *buf, const char *last, const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	const std::string &Read(const void *object) const;
+
+private:
+	void MakeValueValid(std::string &str) const;
+	void Write(const void *object, const std::string &str) const;
 };
 
 /** List/array settings. */
@@ -255,7 +259,7 @@ typedef std::initializer_list<std::unique_ptr<const SettingDesc>> SettingTable;
 
 const SettingDesc *GetSettingFromName(const char *name);
 bool SetSettingValue(const IntSettingDesc *sd, int32 value, bool force_newgame = false);
-bool SetSettingValue(const StringSettingDesc *sd, const char *value, bool force_newgame = false);
+bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
 uint GetSettingIndex(const SettingDesc *sd);
 
 #endif /* SETTINGS_INTERNAL_H */

--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -5,19 +5,16 @@
 ;
 
 [pre-amble]
-static bool CheckInterval(int32 p1);
-static bool InvalidateDetailsWindow(int32 p1);
-static bool UpdateIntervalTrains(int32 p1);
-static bool UpdateIntervalRoadVeh(int32 p1);
-static bool UpdateIntervalShips(int32 p1);
-static bool UpdateIntervalAircraft(int32 p1);
+static void UpdateServiceInterval(int32 new_value);
+static bool CanUpdateServiceInterval(VehicleType type, int32 &new_value);
+static void UpdateServiceInterval(VehicleType type, int32 new_value);
 
 static const SettingTable _company_settings{
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
@@ -29,7 +26,8 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
@@ -82,7 +80,7 @@ var      = vehicle.servint_ispercent
 def      = false
 str      = STR_CONFIG_SETTING_SERVINT_ISPERCENT
 strhelp  = STR_CONFIG_SETTING_SERVINT_ISPERCENT_HELPTEXT
-proc     = CheckInterval
+post_cb  = UpdateServiceInterval
 
 [SDT_VAR]
 base     = CompanySettings
@@ -95,7 +93,8 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_TRAINS
 strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-proc     = UpdateIntervalTrains
+pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
+post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 
 [SDT_VAR]
 base     = CompanySettings
@@ -108,7 +107,8 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES
 strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-proc     = UpdateIntervalRoadVeh
+pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
+post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 
 [SDT_VAR]
 base     = CompanySettings
@@ -121,7 +121,8 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_SHIPS
 strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-proc     = UpdateIntervalShips
+pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
+post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 
 [SDT_VAR]
 base     = CompanySettings
@@ -134,4 +135,5 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_AIRCRAFT
 strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-proc     = UpdateIntervalAircraft
+pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
+post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -9,7 +9,7 @@ static const SettingTable _currency_settings{
 [post-amble]
 };
 [templates]
-SDT_VAR  = SDT_VAR ($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDT_VAR  = SDT_VAR ($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 SDT_SSTR = SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
@@ -22,7 +22,6 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
 pre_cb   = nullptr
 post_cb  = nullptr
 load     = nullptr

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -9,8 +9,8 @@ static const SettingTable _currency_settings{
 [post-amble]
 };
 [templates]
-SDT_VAR  = SDT_VAR ($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDT_SSTR = SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                 $proc, $from, $to, $cat, $extra, $startup),
+SDT_VAR  = SDT_VAR ($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDT_SSTR = SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
@@ -23,6 +23,8 @@ str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
 proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/gameopt_settings.ini
+++ b/src/table/gameopt_settings.ini
@@ -37,12 +37,12 @@ static const SettingTable _gameopt_settings{
 };
 [templates]
 SDTG_LIST    =  SDTG_LIST($name,       $type, $flags, $guiflags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
-SDTG_VAR     =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_VAR     =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 SDT_NULL     =   SDT_NULL(                                                   $length, $from, $to),
-SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -58,7 +58,8 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -21,12 +21,12 @@ static const SettingTable _misc_settings{
 [post-amble]
 };
 [templates]
-SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $guiflags, $var, $def,       $length,                                                $from, $to, $cat, $extra, $startup),
-SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $guiflags, $var, $def,       0,                                               $proc, $from, $to, $cat, $extra, $startup),
-SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $guiflags, $var, $def,       $length,                                                            $from, $to, $cat, $extra, $startup),
+SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $guiflags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -40,6 +40,8 @@ str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
 proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/misc_settings.ini
+++ b/src/table/misc_settings.ini
@@ -22,11 +22,11 @@ static const SettingTable _misc_settings{
 };
 [templates]
 SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $guiflags, $var, $def,       $length,                                                            $from, $to, $cat, $extra, $startup),
-SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $guiflags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $proc,             $from, $to, $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -39,7 +39,6 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
 pre_cb   = nullptr
 post_cb  = nullptr
 load     = nullptr

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -58,11 +58,11 @@ static size_t ConvertLandscape(const char *value);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
-#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	NSD(Int, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, min, max, interval, str, strhelp, strval, cat, proc)
+#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Int, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback)
 
-#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	NSD(Bool, SLEG_GENERAL(SL_VAR, var, SLE_BOOL | flags, 1, from, to, extra), name, guiflags, startup, def, str, strhelp, strval, cat, proc)
+#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Bool, SLEG_GENERAL(SL_VAR, var, SLE_BOOL | flags, 1, from, to, extra), name, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback)
 
 #define SDTG_LIST(name, type, flags, guiflags, var, def, length, from, to, cat, extra, startup)\
 	NSD(List, SLEG_GENERAL(SL_ARR, var, type | flags, length, from, to, extra), name, guiflags, startup, def)
@@ -70,22 +70,22 @@ static size_t ConvertLandscape(const char *value);
 #define SDTG_SSTR(name, type, flags, guiflags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	NSD(String, SLEG_GENERAL(SL_STDSTR, var, type | flags, sizeof(var), from, to, extra), name, guiflags, startup, def, max_length, pre_check, post_callback)
 
-#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	NSD(OneOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, max, str, strhelp, strval, cat, proc, full, nullptr)
+#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(OneOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
 
-#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, str, strhelp, strval, cat, proc, full, nullptr)
+#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(ManyOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
 
 #define SDTG_NULL(length, from, to)\
 	NSD(Null, SLEG_NULL(length, from, to))
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
-#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, min, max, interval, str, strhelp, strval, cat, proc)
+#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback)
 
-#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL | flags, 1, from, to, extra), #var, guiflags, startup, def, str, strhelp, strval, cat, proc)
+#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL | flags, 1, from, to, extra), #var, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback)
 
 #define SDT_LIST(base, var, type, flags, guiflags, def, from, to, cat, extra, startup)\
 	NSD(List, SLE_GENERAL(SL_ARR, base, var, type | flags, lengthof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def)
@@ -93,21 +93,21 @@ static size_t ConvertLandscape(const char *value);
 #define SDT_SSTR(base, var, type, flags, guiflags, def, pre_check, post_callback, from, to, cat, extra, startup)\
 	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type | flags, sizeof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def, 0, pre_check, post_callback)
 
-#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra, startup)\
-	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, max, str, strhelp, strval, cat, proc, full, load)
+#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
+	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, load)
 
-#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, proc, strhelp, strval, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, str, strhelp, strval, cat, proc, full, nullptr)
+#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, pre_check, post_callback, strhelp, strval, from, to, cat, extra, startup)\
+	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
 
 #define SDT_NULL(length, from, to)\
 	NSD(Null, SLE_CONDNULL(length, from, to))
 
 
-#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDTG_VAR(#var, type, flags, guiflags, _settings_client.var, def, min, max, interval, str, strhelp, strval, proc, from, to, cat, extra, startup)
+#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_VAR(#var, type, flags, guiflags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
 
-#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDTG_BOOL(#var, flags, guiflags, _settings_client.var, def, str, strhelp, strval, proc, from, to, cat, extra, startup)
+#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_BOOL(#var, flags, guiflags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
 
 #define SDTC_LIST(var, type, flags, guiflags, def, from, to, cat, extra, startup)\
 	SDTG_LIST(#var, type, flags, guiflags, _settings_client.var, def, lengthof(_settings_client.var), from, to, cat, extra, startup)
@@ -115,5 +115,5 @@ static size_t ConvertLandscape(const char *value);
 #define SDTC_SSTR(var, type, flags, guiflags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 	SDTG_SSTR(#var, type, flags, guiflags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 
-#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
-	SDTG_OMANY(#var, type, flags, guiflags, _settings_client.var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)
+#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_OMANY(#var, type, flags, guiflags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -67,8 +67,8 @@ static size_t ConvertLandscape(const char *value);
 #define SDTG_LIST(name, type, flags, guiflags, var, def, length, from, to, cat, extra, startup)\
 	NSD(List, SLEG_GENERAL(SL_ARR, var, type | flags, length, from, to, extra), name, guiflags, startup, def)
 
-#define SDTG_SSTR(name, type, flags, guiflags, var, def, max_length, proc, from, to, cat, extra, startup)\
-	NSD(String, SLEG_GENERAL(SL_STDSTR, var, type | flags, sizeof(var), from, to, extra), name, guiflags, startup, def, max_length, proc)
+#define SDTG_SSTR(name, type, flags, guiflags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(String, SLEG_GENERAL(SL_STDSTR, var, type | flags, sizeof(var), from, to, extra), name, guiflags, startup, def, max_length, pre_check, post_callback)
 
 #define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	NSD(OneOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, max, str, strhelp, strval, cat, proc, full, nullptr)
@@ -90,8 +90,8 @@ static size_t ConvertLandscape(const char *value);
 #define SDT_LIST(base, var, type, flags, guiflags, def, from, to, cat, extra, startup)\
 	NSD(List, SLE_GENERAL(SL_ARR, base, var, type | flags, lengthof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def)
 
-#define SDT_SSTR(base, var, type, flags, guiflags, def, proc, from, to, cat, extra, startup)\
-	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type | flags, sizeof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def, 0, proc)
+#define SDT_SSTR(base, var, type, flags, guiflags, def, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type | flags, sizeof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def, 0, pre_check, post_callback)
 
 #define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, load, cat, extra, startup)\
 	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, max, str, strhelp, strval, cat, proc, full, load)
@@ -112,8 +112,8 @@ static size_t ConvertLandscape(const char *value);
 #define SDTC_LIST(var, type, flags, guiflags, def, from, to, cat, extra, startup)\
 	SDTG_LIST(#var, type, flags, guiflags, _settings_client.var, def, lengthof(_settings_client.var), from, to, cat, extra, startup)
 
-#define SDTC_SSTR(var, type, flags, guiflags, def, max_length, proc, from, to, cat, extra, startup)\
-	SDTG_SSTR(#var, type, flags, guiflags, _settings_client.var, def, max_length, proc, from, to, cat, extra, startup)\
+#define SDTC_SSTR(var, type, flags, guiflags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_SSTR(#var, type, flags, guiflags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 
 #define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)\
 	SDTG_OMANY(#var, type, flags, guiflags, _settings_client.var, def, max, full, str, strhelp, strval, proc, from, to, cat, extra, startup)

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -3959,6 +3959,7 @@ length   = NETWORK_NAME_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
+pre_cb   = NetworkValidateServerName
 post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
 

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -6,46 +6,34 @@
 
 [pre-amble]
 /* Begin - Callback Functions for the various settings */
-static bool v_PositionMainToolbar(int32 p1);
-static bool v_PositionStatusbar(int32 p1);
-static bool PopulationInLabelActive(int32 p1);
-static bool RedrawScreen(int32 p1);
-static bool RedrawSmallmap(int32 p1);
-static bool StationSpreadChanged(int32 p1);
-static bool InvalidateBuildIndustryWindow(int32 p1);
-static bool CloseSignalGUI(int32 p1);
-static bool InvalidateTownViewWindow(int32 p1);
-static bool DeleteSelectStationWindow(int32 p1);
-static bool UpdateConsists(int32 p1);
-static bool TrainAccelerationModelChanged(int32 p1);
-static bool RoadVehAccelerationModelChanged(int32 p1);
-static bool TrainSlopeSteepnessChanged(int32 p1);
-static bool RoadVehSlopeSteepnessChanged(int32 p1);
-static bool DragSignalsDensityChanged(int32);
-static bool TownFoundingChanged(int32 p1);
-static bool DifficultyNoiseChange(int32 i);
-static bool MaxNoAIsChange(int32 i);
-static bool CheckRoadSide(int p1);
-static bool ChangeMaxHeightLevel(int32 p1);
-static bool CheckFreeformEdges(int32 p1);
-static bool ChangeDynamicEngines(int32 p1);
-static bool StationCatchmentChanged(int32 p1);
-static bool InvalidateVehTimetableWindow(int32 p1);
-static bool InvalidateCompanyLiveryWindow(int32 p1);
-static bool InvalidateNewGRFChangeWindows(int32 p1);
-static bool InvalidateIndustryViewWindow(int32 p1);
-static bool InvalidateAISettingsWindow(int32 p1);
-static bool RedrawTownAuthority(int32 p1);
-static bool InvalidateCompanyInfrastructureWindow(int32 p1);
-static bool InvalidateCompanyWindow(int32 p1);
-static bool ZoomMinMaxChanged(int32 p1);
-static bool SpriteZoomMinChanged(int32 p1);
-static bool MaxVehiclesChanged(int32 p1);
-static bool InvalidateShipPathCache(int32 p1);
+static void v_PositionMainToolbar(int32 new_value);
+static void v_PositionStatusbar(int32 new_value);
+static void RedrawSmallmap(int32 new_value);
+static void StationSpreadChanged(int32 new_value);
+static void CloseSignalGUI(int32 new_value);
+static void UpdateConsists(int32 new_value);
+static void TrainAccelerationModelChanged(int32 new_value);
+static void RoadVehAccelerationModelChanged(int32 new_value);
+static void TrainSlopeSteepnessChanged(int32 new_value);
+static void RoadVehSlopeSteepnessChanged(int32 new_value);
+static void TownFoundingChanged(int32 new_value);
+static void DifficultyNoiseChange(int32 new_value);
+static void MaxNoAIsChange(int32 new_value);
+static bool CheckRoadSide(int32 &new_value);
+static bool CheckMaxHeightLevel(int32 &new_value);
+static bool CheckFreeformEdges(int32 &new_value);
+static void UpdateFreeformEdges(int32 new_value);
+static bool CheckDynamicEngines(int32 &new_value);
+static void StationCatchmentChanged(int32 new_value);
+static void InvalidateCompanyLiveryWindow(int32 new_value);
+static void InvalidateNewGRFChangeWindows(int32 new_value);
+static void ZoomMinMaxChanged(int32 new_value);
+static void SpriteZoomMinChanged(int32 new_value);
+static void MaxVehiclesChanged(int32 new_value);
+static void InvalidateShipPathCache(int32 new_value);
 
 static bool ReplaceAsteriskWithEmptyPassword(std::string &newval);
 static void UpdateClientConfigValues();
-static bool UpdateClientConfigValues(int32 p1);
 
 /* End - Callback Functions for the various settings */
 
@@ -62,18 +50,18 @@ const SettingTable _settings{
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
-SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
-SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc,             $from, $to, $load, $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
 SDT_SSTR   =   SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDT_NULL   =   SDT_NULL($length, $from, $to),
 
 [validation]
@@ -91,7 +79,6 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
 pre_cb   = nullptr
 post_cb  = nullptr
 load     = nullptr
@@ -114,7 +101,7 @@ def      = 0
 min      = 0
 max      = MAX_COMPANIES - 1
 interval = 1
-proc     = MaxNoAIsChange
+post_cb  = MaxNoAIsChange
 cat      = SC_BASIC
 
 [SDT_NULL]
@@ -324,7 +311,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_CITY_APPROVAL
 strhelp  = STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT
 strval   = STR_CITY_APPROVAL_PERMISSIVE
-proc     = DifficultyNoiseChange
+post_cb  = DifficultyNoiseChange
 
 [SDTG_VAR]
 name     = ""diff_level""
@@ -384,7 +371,7 @@ full     = _roadsides
 str      = STR_CONFIG_SETTING_ROAD_SIDE
 strhelp  = STR_CONFIG_SETTING_ROAD_SIDE_HELPTEXT
 strval   = STR_GAME_OPTIONS_ROAD_VEHICLES_DROPDOWN_LEFT
-proc     = CheckRoadSide
+pre_cb   = CheckRoadSide
 cat      = SC_BASIC
 
 ; Construction
@@ -402,7 +389,8 @@ interval = 1
 str      = STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT
 strhelp  = STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_HELPTEXT
 strval   = STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_VALUE
-proc     = ChangeMaxHeightLevel
+pre_cb   = CheckMaxHeightLevel
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_SMALLMAP, 2); }
 cat      = SC_ADVANCED
 
 [SDT_VAR]
@@ -578,7 +566,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_SIGNALSIDE
 strhelp  = STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT
 strval   = STR_CONFIG_SETTING_SIGNALSIDE_LEFT
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -602,7 +590,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_TOWN_LAYOUT
 strhelp  = STR_CONFIG_SETTING_TOWN_LAYOUT_HELPTEXT
 strval   = STR_CONFIG_SETTING_TOWN_LAYOUT_DEFAULT
-proc     = TownFoundingChanged
+post_cb  = TownFoundingChanged
 
 [SDT_BOOL]
 base     = GameSettings
@@ -626,7 +614,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_TOWN_FOUNDING
 strhelp  = STR_CONFIG_SETTING_TOWN_FOUNDING_HELPTEXT
 strval   = STR_CONFIG_SETTING_TOWN_FOUNDING_FORBIDDEN
-proc     = TownFoundingChanged
+post_cb  = TownFoundingChanged
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -822,7 +810,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_TRAIN_ACCELERATION_MODEL
 strhelp  = STR_CONFIG_SETTING_TRAIN_ACCELERATION_MODEL_HELPTEXT
 strval   = STR_CONFIG_SETTING_ORIGINAL
-proc     = TrainAccelerationModelChanged
+post_cb  = TrainAccelerationModelChanged
 
 [SDT_VAR]
 base     = GameSettings
@@ -837,7 +825,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_ROAD_VEHICLE_ACCELERATION_MODEL
 strhelp  = STR_CONFIG_SETTING_ROAD_VEHICLE_ACCELERATION_MODEL_HELPTEXT
 strval   = STR_CONFIG_SETTING_ORIGINAL
-proc     = RoadVehAccelerationModelChanged
+post_cb  = RoadVehAccelerationModelChanged
 
 [SDT_VAR]
 base     = GameSettings
@@ -851,7 +839,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_TRAIN_SLOPE_STEEPNESS
 strhelp  = STR_CONFIG_SETTING_TRAIN_SLOPE_STEEPNESS_HELPTEXT
 strval   = STR_CONFIG_SETTING_PERCENTAGE
-proc     = TrainSlopeSteepnessChanged
+post_cb  = TrainSlopeSteepnessChanged
 cat      = SC_EXPERT
 
 [SDT_VAR]
@@ -866,7 +854,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS
 strhelp  = STR_CONFIG_SETTING_ROAD_VEHICLE_SLOPE_STEEPNESS_HELPTEXT
 strval   = STR_CONFIG_SETTING_PERCENTAGE
-proc     = RoadVehSlopeSteepnessChanged
+post_cb  = RoadVehSlopeSteepnessChanged
 cat      = SC_EXPERT
 
 [SDT_BOOL]
@@ -875,7 +863,7 @@ var      = pf.forbid_90_deg
 def      = false
 str      = STR_CONFIG_SETTING_FORBID_90_DEG
 strhelp  = STR_CONFIG_SETTING_FORBID_90_DEG_HELPTEXT
-proc     = InvalidateShipPathCache
+post_cb  = InvalidateShipPathCache
 cat      = SC_EXPERT
 
 [SDT_VAR]
@@ -998,7 +986,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_PATHFINDER_FOR_SHIPS
 strhelp  = STR_CONFIG_SETTING_PATHFINDER_FOR_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_PATHFINDER_NPF
-proc     = InvalidateShipPathCache
+post_cb  = InvalidateShipPathCache
 cat      = SC_EXPERT
 
 [SDT_BOOL]
@@ -1019,7 +1007,7 @@ max      = 5000
 str      = STR_CONFIG_SETTING_MAX_TRAINS
 strhelp  = STR_CONFIG_SETTING_MAX_TRAINS_HELPTEXT
 strval   = STR_JUST_COMMA
-proc     = MaxVehiclesChanged
+post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDT_VAR]
@@ -1032,7 +1020,7 @@ max      = 5000
 str      = STR_CONFIG_SETTING_MAX_ROAD_VEHICLES
 strhelp  = STR_CONFIG_SETTING_MAX_ROAD_VEHICLES_HELPTEXT
 strval   = STR_JUST_COMMA
-proc     = MaxVehiclesChanged
+post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDT_VAR]
@@ -1045,7 +1033,7 @@ max      = 5000
 str      = STR_CONFIG_SETTING_MAX_AIRCRAFT
 strhelp  = STR_CONFIG_SETTING_MAX_AIRCRAFT_HELPTEXT
 strval   = STR_JUST_COMMA
-proc     = MaxVehiclesChanged
+post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDT_VAR]
@@ -1058,7 +1046,7 @@ max      = 5000
 str      = STR_CONFIG_SETTING_MAX_SHIPS
 strhelp  = STR_CONFIG_SETTING_MAX_SHIPS_HELPTEXT
 strval   = STR_JUST_COMMA
-proc     = MaxVehiclesChanged
+post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDTG_BOOL]
@@ -1122,7 +1110,7 @@ guiflags = SGF_NO_NETWORK
 def      = true
 str      = STR_CONFIG_SETTING_WAGONSPEEDLIMITS
 strhelp  = STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT
-proc     = UpdateConsists
+post_cb  = UpdateConsists
 
 [SDT_BOOL]
 base     = GameSettings
@@ -1132,7 +1120,7 @@ guiflags = SGF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_DISABLE_ELRAILS
 strhelp  = STR_CONFIG_SETTING_DISABLE_ELRAILS_HELPTEXT
-proc     = SettingsDisableElrail
+post_cb  = SettingsDisableElrail
 cat      = SC_EXPERT
 
 [SDT_VAR]
@@ -1148,7 +1136,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_FREIGHT_TRAINS
 strhelp  = STR_CONFIG_SETTING_FREIGHT_TRAINS_HELPTEXT
 strval   = STR_JUST_COMMA
-proc     = UpdateConsists
+post_cb  = UpdateConsists
 
 ; order.timetabling
 [SDT_NULL]
@@ -1175,7 +1163,7 @@ var      = vehicle.dynamic_engines
 from     = SLV_95
 guiflags = SGF_NO_NETWORK
 def      = true
-proc     = ChangeDynamicEngines
+pre_cb   = CheckDynamicEngines
 cat      = SC_EXPERT
 
 [SDT_VAR]
@@ -1238,7 +1226,7 @@ max      = 64
 str      = STR_CONFIG_SETTING_STATION_SPREAD
 strhelp  = STR_CONFIG_SETTING_STATION_SPREAD_HELPTEXT
 strval   = STR_CONFIG_SETTING_TILE_LENGTH
-proc     = StationSpreadChanged
+post_cb  = StationSpreadChanged
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -1255,7 +1243,7 @@ var      = station.modified_catchment
 def      = true
 str      = STR_CONFIG_SETTING_CATCHMENT
 strhelp  = STR_CONFIG_SETTING_CATCHMENT_HELPTEXT
-proc     = StationCatchmentChanged
+post_cb  = StationCatchmentChanged
 cat      = SC_EXPERT
 
 [SDT_BOOL]
@@ -1265,7 +1253,7 @@ def      = true
 from     = SLV_SERVE_NEUTRAL_INDUSTRIES
 str      = STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES
 strhelp  = STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT
-proc     = StationCatchmentChanged
+post_cb  = StationCatchmentChanged
 
 [SDT_BOOL]
 base     = GameSettings
@@ -1308,7 +1296,7 @@ guiflags = SGF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_NOISE_LEVEL
 strhelp  = STR_CONFIG_SETTING_NOISE_LEVEL_HELPTEXT
-proc     = InvalidateTownViewWindow
+post_cb  = [](auto new_value) { InvalidateWindowClassesData(WC_TOWN_VIEW, new_value); }
 
 [SDT_BOOL]
 base     = GameSettings
@@ -1317,7 +1305,7 @@ from     = SLV_106
 def      = true
 str      = STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS
 strhelp  = STR_CONFIG_SETTING_DISTANT_JOIN_STATIONS_HELPTEXT
-proc     = DeleteSelectStationWindow
+post_cb  = [](auto) { DeleteWindowById(WC_SELECT_STATION, 0); }
 
 ##
 [SDT_BOOL]
@@ -1340,7 +1328,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD
 strhelp  = STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_HELPTEXT
 strval   = STR_CONFIG_SETTING_RAW_INDUSTRY_CONSTRUCTION_METHOD_NONE
-proc     = InvalidateBuildIndustryWindow
+post_cb  = [](auto) { InvalidateWindowData(WC_BUILD_INDUSTRY, 0); }
 cat      = SC_BASIC
 
 [SDT_VAR]
@@ -1373,7 +1361,7 @@ var      = economy.bribe
 def      = true
 str      = STR_CONFIG_SETTING_BRIBE
 strhelp  = STR_CONFIG_SETTING_BRIBE_HELPTEXT
-proc     = RedrawTownAuthority
+post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -1383,7 +1371,7 @@ from     = SLV_79
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_EXCLUSIVE
 strhelp  = STR_CONFIG_SETTING_ALLOW_EXCLUSIVE_HELPTEXT
-proc     = RedrawTownAuthority
+post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -1393,7 +1381,7 @@ from     = SLV_165
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS
 strhelp  = STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS_HELPTEXT
-proc     = RedrawTownAuthority
+post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -1403,7 +1391,7 @@ from     = SLV_160
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_FUND_ROAD
 strhelp  = STR_CONFIG_SETTING_ALLOW_FUND_ROAD_HELPTEXT
-proc     = RedrawTownAuthority
+post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -1505,7 +1493,7 @@ max      = ET_END - 1
 str      = STR_CONFIG_SETTING_ECONOMY_TYPE
 strhelp  = STR_CONFIG_SETTING_ECONOMY_TYPE_HELPTEXT
 strval   = STR_CONFIG_SETTING_ECONOMY_TYPE_ORIGINAL
-proc     = InvalidateIndustryViewWindow
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_INDUSTRY_VIEW); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -1514,7 +1502,7 @@ var      = economy.allow_shares
 def      = false
 str      = STR_CONFIG_SETTING_ALLOW_SHARES
 strhelp  = STR_CONFIG_SETTING_ALLOW_SHARES_HELPTEXT
-proc     = InvalidateCompanyWindow
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY); }
 
 [SDT_VAR]
 base     = GameSettings
@@ -1758,7 +1746,7 @@ from     = SLV_166
 def      = false
 str      = STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE
 strhelp  = STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE_HELPTEXT
-proc     = InvalidateCompanyInfrastructureWindow
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE); }
 cat      = SC_BASIC
 
 ##
@@ -2427,7 +2415,8 @@ base     = GameSettings
 var      = construction.freeform_edges
 from     = SLV_111
 def      = true
-proc     = CheckFreeformEdges
+pre_cb   = CheckFreeformEdges
+post_cb  = UpdateFreeformEdges
 cat      = SC_EXPERT
 
 [SDT_VAR]
@@ -2528,7 +2517,7 @@ flags    = SLF_NO_NETWORK_SYNC
 def      = 0
 max      = CURRENCY_END - 1
 full     = _locale_currencies
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDTG_OMANY]
@@ -2541,7 +2530,7 @@ flags    = SLF_NOT_IN_CONFIG
 def      = 1
 max      = 2
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_OMANY]
@@ -2554,7 +2543,7 @@ guiflags = SGF_MULTISTRING
 def      = 1
 max      = 3
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_HELPTEXT
@@ -2570,7 +2559,7 @@ guiflags = SGF_MULTISTRING
 def      = 1
 max      = 2
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_HELPTEXT
@@ -2586,7 +2575,7 @@ guiflags = SGF_MULTISTRING
 def      = 1
 max      = 2
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_HELPTEXT
@@ -2602,7 +2591,7 @@ guiflags = SGF_MULTISTRING
 def      = 1
 max      = 2
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_HELPTEXT
@@ -2618,7 +2607,7 @@ guiflags = SGF_MULTISTRING
 def      = 2
 max      = 2
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_HELPTEXT
@@ -2634,7 +2623,7 @@ guiflags = SGF_MULTISTRING
 def      = 1
 max      = 2
 full     = _locale_units
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 str      = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT
 strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_HELPTEXT
@@ -2811,7 +2800,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_TOOLBAR_POS
 strhelp  = STR_CONFIG_SETTING_TOOLBAR_POS_HELPTEXT
 strval   = STR_CONFIG_SETTING_HORIZONTAL_POS_LEFT
-proc     = v_PositionMainToolbar
+post_cb  = v_PositionMainToolbar
 cat      = SC_BASIC
 
 [SDTC_VAR]
@@ -2825,7 +2814,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_STATUSBAR_POS
 strhelp  = STR_CONFIG_SETTING_STATUSBAR_POS_HELPTEXT
 strval   = STR_CONFIG_SETTING_HORIZONTAL_POS_LEFT
-proc     = v_PositionStatusbar
+post_cb  = v_PositionStatusbar
 cat      = SC_BASIC
 
 [SDTC_VAR]
@@ -2866,7 +2855,7 @@ max      = ZOOM_LVL_OUT_4X
 str      = STR_CONFIG_SETTING_ZOOM_MIN
 strhelp  = STR_CONFIG_SETTING_ZOOM_MIN_HELPTEXT
 strval   = STR_CONFIG_SETTING_ZOOM_LVL_MIN
-proc     = ZoomMinMaxChanged
+post_cb  = ZoomMinMaxChanged
 startup  = true
 
 [SDTC_VAR]
@@ -2880,7 +2869,7 @@ max      = ZOOM_LVL_MAX
 str      = STR_CONFIG_SETTING_ZOOM_MAX
 strhelp  = STR_CONFIG_SETTING_ZOOM_MAX_HELPTEXT
 strval   = STR_CONFIG_SETTING_ZOOM_LVL_OUT_2X
-proc     = ZoomMinMaxChanged
+post_cb  = ZoomMinMaxChanged
 startup  = true
 
 [SDTC_VAR]
@@ -2894,7 +2883,7 @@ max      = ZOOM_LVL_OUT_4X
 str      = STR_CONFIG_SETTING_SPRITE_ZOOM_MIN
 strhelp  = STR_CONFIG_SETTING_SPRITE_ZOOM_MIN_HELPTEXT
 strval   = STR_CONFIG_SETTING_SPRITE_ZOOM_LVL_MIN
-proc     = SpriteZoomMinChanged
+post_cb  = SpriteZoomMinChanged
 
 [SDTC_BOOL]
 var      = gui.population_in_label
@@ -2902,7 +2891,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_POPULATION_IN_LABEL
 strhelp  = STR_CONFIG_SETTING_POPULATION_IN_LABEL_HELPTEXT
-proc     = PopulationInLabelActive
+post_cb  = [](auto) { UpdateAllTownVirtCoords(); }
 
 [SDTC_BOOL]
 var      = gui.link_terraform_toolbar
@@ -2922,7 +2911,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR
 strhelp  = STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_HELPTEXT
 strval   = STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_GREEN
-proc     = RedrawSmallmap
+post_cb  = RedrawSmallmap
 
 [SDTC_VAR]
 var      = gui.liveries
@@ -2935,7 +2924,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_LIVERIES
 strhelp  = STR_CONFIG_SETTING_LIVERIES_HELPTEXT
 strval   = STR_CONFIG_SETTING_LIVERIES_NONE
-proc     = InvalidateCompanyLiveryWindow
+post_cb  = InvalidateCompanyLiveryWindow
 
 [SDTC_VAR]
 var      = gui.starting_colour
@@ -3017,7 +3006,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS
 strhelp  = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS_HELPTEXT
-proc     = InvalidateVehTimetableWindow
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_VEHICLE_TIMETABLE, VIWD_MODIFY_ORDERS); }
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
@@ -3026,7 +3015,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE
 strhelp  = STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE_HELPTEXT
-proc     = InvalidateVehTimetableWindow
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_VEHICLE_TIMETABLE, VIWD_MODIFY_ORDERS); }
 
 [SDTC_BOOL]
 var      = gui.quick_goto
@@ -3047,7 +3036,7 @@ max      = 2
 str      = STR_CONFIG_SETTING_LOADING_INDICATORS
 strhelp  = STR_CONFIG_SETTING_LOADING_INDICATORS_HELPTEXT
 strval   = STR_CONFIG_SETTING_COMPANIES_OFF
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDTC_VAR]
@@ -3069,7 +3058,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI
 strhelp  = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI_HELPTEXT
-proc     = CloseSignalGUI
+post_cb  = CloseSignalGUI
 cat      = SC_EXPERT
 
 [SDTC_VAR]
@@ -3095,7 +3084,7 @@ max      = 20
 str      = STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY
 strhelp  = STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_HELPTEXT
 strval   = STR_CONFIG_SETTING_DRAG_SIGNALS_DENSITY_VALUE
-proc     = DragSignalsDensityChanged
+post_cb  = [](auto) { InvalidateWindowData(WC_BUILD_SIGNAL, 0); }
 cat      = SC_BASIC
 
 [SDTC_BOOL]
@@ -3117,7 +3106,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE
 strhelp  = STR_CONFIG_SETTING_SEMAPHORE_BUILD_BEFORE_DATE_HELPTEXT
 strval   = STR_JUST_INT
-proc     = ResetSignalVariant
+post_cb  = ResetSignalVariant
 
 [SDTC_BOOL]
 var      = gui.vehicle_income_warn
@@ -3213,7 +3202,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION
 strhelp  = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDTC_VAR]
@@ -3286,7 +3275,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_EXPENSES_LAYOUT
 strhelp  = STR_CONFIG_SETTING_EXPENSES_LAYOUT_HELPTEXT
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 
 [SDTC_VAR]
 var      = gui.station_gui_group_order
@@ -3334,7 +3323,7 @@ max      = 5
 str      = STR_CONFIG_SETTING_GRAPH_LINE_THICKNESS
 strhelp  = STR_CONFIG_SETTING_GRAPH_LINE_THICKNESS_HELPTEXT
 strval   = STR_JUST_COMMA
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 
 [SDTC_BOOL]
 var      = gui.show_newgrf_name
@@ -3342,7 +3331,7 @@ flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME
 strhelp  = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME_HELPTEXT
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_ADVANCED
 
 ; For the dedicated build we'll enable dates in logs by default.
@@ -3379,21 +3368,21 @@ cat      = SC_EXPERT
 var      = gui.newgrf_developer_tools
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false
-proc     = InvalidateNewGRFChangeWindows
+post_cb  = InvalidateNewGRFChangeWindows
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = gui.ai_developer_tools
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false
-proc     = InvalidateAISettingsWindow
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_AI_SETTINGS); }
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = gui.scenario_developer
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false
-proc     = InvalidateNewGRFChangeWindows
+post_cb  = InvalidateNewGRFChangeWindows
 
 [SDTC_BOOL]
 var      = gui.newgrf_show_old_versions
@@ -3409,7 +3398,7 @@ guiflags = SGF_MULTISTRING
 def      = 1
 min      = 0
 max      = 1
-proc     = UpdateNewGRFConfigPalette
+post_cb  = UpdateNewGRFConfigPalette
 cat      = SC_EXPERT
 
 [SDTC_VAR]
@@ -4029,7 +4018,7 @@ guiflags = SGF_NETWORK_ONLY
 def      = 15
 min      = 1
 max      = MAX_COMPANIES
-proc     = UpdateClientConfigValues
+post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
 
 [SDTC_VAR]
@@ -4040,7 +4029,7 @@ guiflags = SGF_NETWORK_ONLY
 def      = 25
 min      = 2
 max      = MAX_CLIENTS
-proc     = UpdateClientConfigValues
+post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
 
 [SDTC_VAR]
@@ -4051,7 +4040,7 @@ guiflags = SGF_NETWORK_ONLY
 def      = 15
 min      = 0
 max      = MAX_CLIENTS
-proc     = UpdateClientConfigValues
+post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
 
 [SDTC_VAR]

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -43,9 +43,8 @@ static bool SpriteZoomMinChanged(int32 p1);
 static bool MaxVehiclesChanged(int32 p1);
 static bool InvalidateShipPathCache(int32 p1);
 
-static bool UpdateClientName(int32 p1);
-static bool UpdateServerPassword(int32 p1);
-static bool UpdateRconPassword(int32 p1);
+static bool ReplaceAsteriskWithEmptyPassword(std::string &newval);
+static void UpdateClientConfigValues();
 static bool UpdateClientConfigValues(int32 p1);
 
 /* End - Callback Functions for the various settings */
@@ -54,7 +53,7 @@ static bool UpdateClientConfigValues(int32 p1);
  * These include for example the GUI settings and will not be saved with the
  * savegame.
  * It is also a bit tricky since you would think that service_interval
- * for example doesn't need to be synched. Every client assigns the
+ * for example does not need to be synched. Every client assigns the
  * service_interval value to the v->service_interval, meaning that every client
  * assigns its own value. If the setting was company-based, that would mean that
  * vehicles could decide on different moments that they are heading back to a
@@ -63,18 +62,18 @@ const SettingTable _settings{
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                                                              $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,             $length,                                  $proc, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc, $from, $to, $load, $cat, $extra, $startup),
-SDT_SSTR   =   SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                       $proc, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to,        $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $proc,             $from, $to, $load, $cat, $extra, $startup),
+SDT_SSTR   =   SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $proc,             $from, $to,        $cat, $extra, $startup),
 SDT_NULL   =   SDT_NULL($length, $from, $to),
 
 [validation]
@@ -93,6 +92,8 @@ str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
 proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION
@@ -2646,7 +2647,7 @@ type     = SLE_STRQ
 from     = SLV_118
 flags    = SLF_NO_NETWORK_SYNC
 def      = nullptr
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_SSTR]
@@ -2656,7 +2657,7 @@ type     = SLE_STRQ
 from     = SLV_118
 flags    = SLF_NO_NETWORK_SYNC
 def      = nullptr
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_SSTR]
@@ -2666,7 +2667,7 @@ type     = SLE_STRQ
 from     = SLV_126
 flags    = SLF_NO_NETWORK_SYNC
 def      = nullptr
-proc     = RedrawScreen
+post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 
@@ -3921,7 +3922,8 @@ type     = SLE_STR
 length   = NETWORK_CLIENT_NAME_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = nullptr
-proc     = UpdateClientName
+pre_cb   = NetworkValidateClientName
+post_cb  = NetworkUpdateClientName
 cat      = SC_BASIC
 
 [SDTC_SSTR]
@@ -3931,7 +3933,8 @@ length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
-proc     = UpdateServerPassword
+pre_cb   = ReplaceAsteriskWithEmptyPassword
+post_cb  = [](auto) { NetworkServerUpdateGameInfo(); }
 cat      = SC_BASIC
 
 [SDTC_SSTR]
@@ -3941,7 +3944,7 @@ length   = NETWORK_PASSWORD_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
-proc     = UpdateRconPassword
+pre_cb   = ReplaceAsteriskWithEmptyPassword
 cat      = SC_BASIC
 
 [SDTC_SSTR]
@@ -3967,7 +3970,7 @@ length   = NETWORK_NAME_LENGTH
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NETWORK_ONLY
 def      = nullptr
-proc     = UpdateClientConfigValues
+post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
 
 [SDTC_SSTR]

--- a/src/table/win32_settings.ini
+++ b/src/table/win32_settings.ini
@@ -14,8 +14,8 @@ static const SettingTable _win32_settings{
 };
 #endif /* _WIN32 */
 [templates]
-SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -27,7 +27,8 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION

--- a/src/table/window_settings.ini
+++ b/src/table/window_settings.ini
@@ -10,8 +10,8 @@ static const SettingTable _window_settings{
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $proc, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
@@ -24,7 +24,8 @@ interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
 strval   = STR_NULL
-proc     = nullptr
+pre_cb   = nullptr
+post_cb  = nullptr
 load     = nullptr
 from     = SL_MIN_VERSION
 to       = SL_MAX_VERSION


### PR DESCRIPTION
## Motivation / Problem

In the settings there is currently one callback that does both check whether a change is allowed, and it updates when a change is performed. This means that one first needs to set the new value, then call that callback and when that fails the value needs to be reset again.
Similarly there is no useful callback for strings, as the callback will be called with `0` as parameter and that cannot be used.

The goal was to be able to validate the server and client name when they are entered from the console, and not be in a situation where the old name is lost once the validation of the name is happening.


## Description

Split the validation/check/pre change callback from the update/post change callback.
The pre-change callback will be of type `bool Func(std::string &new_value)` or `bool Func(int32 &new_value)` which allows the pre change to update the value if needed. For example removing/clearing a bit that should never be set, or more useful for strings trimming white space or replacing * with an empty string.
The post-change callback will be of type `void Func(const std::string &new_value)` or `void Func(int32 new_value)`.

The effect of splitting these changes is that it becomes way clearer on which settings there are actual checks, and for which there is merely a post-change callback.

As added bonus with this precheck it becomes impossible to clear the server and client name via the console or the UI. The only viable path is clearing it in the configuration, but that should only be feasible for the dedicated server and there are guards in place to replace the empty names with something.


## Limitations

None that I know of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
