### PR TITLE
Cleanup: set the base in the setting templates, instead of defining the base for every setting

### DIFF
--- a/src/table/company_settings.ini
+++ b/src/table/company_settings.ini
@@ -13,11 +13,11 @@ static const SettingTable _company_settings{
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL(CompanySettings, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
-SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for CompanySettings.$var exceeds storage size");
 
 [defaults]
 flags    = 0
@@ -38,7 +38,6 @@ startup  = false
 
 
 [SDT_BOOL]
-base     = CompanySettings
 var      = engine_renew
 def      = true
 str      = STR_CONFIG_SETTING_AUTORENEW_VEHICLE
@@ -46,7 +45,6 @@ strhelp  = STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = CompanySettings
 var      = engine_renew_months
 type     = SLE_INT16
 guiflags = SGF_PER_COMPANY | SGF_DISPLAY_ABS
@@ -58,7 +56,6 @@ strhelp  = STR_CONFIG_SETTING_AUTORENEW_MONTHS_HELPTEXT
 strval   = STR_CONFIG_SETTING_AUTORENEW_MONTHS_VALUE_BEFORE
 
 [SDT_VAR]
-base     = CompanySettings
 var      = engine_renew_money
 type     = SLE_UINT
 guiflags = SGF_PER_COMPANY | SGF_CURRENCY
@@ -70,12 +67,10 @@ strhelp  = STR_CONFIG_SETTING_AUTORENEW_MONEY_HELPTEXT
 strval   = STR_JUST_CURRENCY_LONG
 
 [SDT_BOOL]
-base     = CompanySettings
 var      = renew_keep_length
 def      = false
 
 [SDT_BOOL]
-base     = CompanySettings
 var      = vehicle.servint_ispercent
 def      = false
 str      = STR_CONFIG_SETTING_SERVINT_ISPERCENT
@@ -83,7 +78,6 @@ strhelp  = STR_CONFIG_SETTING_SERVINT_ISPERCENT_HELPTEXT
 post_cb  = UpdateServiceInterval
 
 [SDT_VAR]
-base     = CompanySettings
 var      = vehicle.servint_trains
 type     = SLE_UINT16
 guiflags = SGF_PER_COMPANY | SGF_0ISDISABLED
@@ -97,7 +91,6 @@ pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_v
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 
 [SDT_VAR]
-base     = CompanySettings
 var      = vehicle.servint_roadveh
 type     = SLE_UINT16
 guiflags = SGF_PER_COMPANY | SGF_0ISDISABLED
@@ -111,7 +104,6 @@ pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_va
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 
 [SDT_VAR]
-base     = CompanySettings
 var      = vehicle.servint_ships
 type     = SLE_UINT16
 guiflags = SGF_PER_COMPANY | SGF_0ISDISABLED
@@ -125,7 +117,6 @@ pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_va
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 
 [SDT_VAR]
-base     = CompanySettings
 var      = vehicle.servint_aircraft
 type     = SLE_UINT16
 guiflags = SGF_PER_COMPANY | SGF_0ISDISABLED

--- a/src/table/currency_settings.ini
+++ b/src/table/currency_settings.ini
@@ -9,11 +9,11 @@ static const SettingTable _currency_settings{
 [post-amble]
 };
 [templates]
-SDT_VAR  = SDT_VAR ($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_SSTR = SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_SSTR = SDT_SSTR(CurrencySpec, $var, $type, $flags, $guiflags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
-SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for CurrencySpec.$var exceeds storage size");
 
 [defaults]
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
@@ -34,7 +34,6 @@ startup  = false
 
 
 [SDT_VAR]
-base     = CurrencySpec
 var      = rate
 type     = SLE_UINT16
 def      = 1
@@ -42,14 +41,12 @@ min      = 0
 max      = UINT16_MAX
 
 [SDT_SSTR]
-base     = CurrencySpec
 var      = separator
 type     = SLE_STRQ
 def      = "".""
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = CurrencySpec
 var      = to_euro
 type     = SLE_INT32
 def      = 0
@@ -57,13 +54,11 @@ min      = MIN_YEAR
 max      = MAX_YEAR
 
 [SDT_SSTR]
-base     = CurrencySpec
 var      = prefix
 type     = SLE_STRQ
 def      = nullptr
 
 [SDT_SSTR]
-base     = CurrencySpec
 var      = suffix
 type     = SLE_STRQ
 def      = "" credits""

--- a/src/table/gameopt_settings.ini
+++ b/src/table/gameopt_settings.ini
@@ -36,20 +36,20 @@ static const SettingTable _gameopt_settings{
 [post-amble]
 };
 [templates]
-SDTG_LIST    =  SDTG_LIST($name,       $type, $flags, $guiflags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
-SDTG_VAR     =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_NULL     =   SDT_NULL(                                                   $length, $from, $to),
-SDTC_OMANY   = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY   = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY    =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR      =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $guiflags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
+SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $guiflags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_NULL     =   SDT_NULL(                                                          $length,                                                            $from, $to),
+SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
-SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
-SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
 
 [defaults]
 flags    = 0
@@ -104,7 +104,6 @@ max      = SP_CUSTOM
 cat      = SC_BASIC
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.currency
 type     = SLE_UINT8
 flags    = SLF_NO_NETWORK_SYNC
@@ -126,7 +125,6 @@ cat      = SC_BASIC
 # There are only 21 predefined town_name values (0-20), but you can have more with newgrf action F so allow
 # these bigger values (21-255). Invalid values will fallback to english on use and (undefined string) in GUI.
 [SDT_OMANY]
-base     = GameSettings
 var      = game_creation.town_name
 type     = SLE_UINT8
 def      = 0
@@ -135,7 +133,6 @@ full     = _town_names
 cat      = SC_BASIC
 
 [SDT_OMANY]
-base     = GameSettings
 var      = game_creation.landscape
 type     = SLE_UINT8
 def      = 0
@@ -145,7 +142,6 @@ load     = ConvertLandscape
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.snow_line_height
 type     = SLE_UINT8
 def      = DEF_SNOWLINE_HEIGHT * TILE_HEIGHT
@@ -174,7 +170,6 @@ full     = _autosave_interval
 cat      = SC_BASIC
 
 [SDT_OMANY]
-base     = GameSettings
 var      = vehicle.road_side
 type     = SLE_UINT8
 def      = 1

--- a/src/table/settings.ini
+++ b/src/table/settings.ini
@@ -50,27 +50,27 @@ const SettingTable _settings{
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,              $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name,       $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name,       $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_BOOL  =  SDTC_BOOL(       $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_LIST  =  SDTC_LIST(       $var, $type, $flags, $guiflags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(       $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_SSTR  =  SDTC_SSTR(       $var, $type, $flags, $guiflags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(       $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_BOOL   =   SDT_BOOL($base, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY($base, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_SSTR   =   SDT_SSTR($base, $var, $type, $flags, $guiflags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR($base, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_NULL   =   SDT_NULL($length, $from, $to),
+SDTG_BOOL  =  SDTG_BOOL($name,                     $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_LIST  =  SDTC_LIST(              $var, $type, $flags, $guiflags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $guiflags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_SSTR   =   SDT_SSTR(GameSettings, $var, $type, $flags, $guiflags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_NULL   =   SDT_NULL(                                                                $length,                                                     $from, $to),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTC_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
-SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
-SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
 
 [defaults]
 flags    = 0
@@ -93,7 +93,6 @@ startup  = false
 ; Saved settings variables.
 ; Do not ADD or REMOVE something in this "difficulty.XXX" table or before it. It breaks savegame compatibility.
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.max_no_competitors
 type     = SLE_UINT8
 from     = SLV_97
@@ -110,7 +109,6 @@ from     = SLV_97
 to       = SLV_110
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.number_towns
 type     = SLE_UINT8
 from     = SLV_97
@@ -123,7 +121,6 @@ strval   = STR_NUM_VERY_LOW
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.industry_density
 type     = SLE_UINT8
 from     = SLV_97
@@ -138,7 +135,6 @@ strval   = STR_FUNDING_ONLY
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.max_loan
 type     = SLE_UINT32
 from     = SLV_97
@@ -153,7 +149,6 @@ strval   = STR_JUST_CURRENCY_LONG
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.initial_interest
 type     = SLE_UINT8
 from     = SLV_97
@@ -167,7 +162,6 @@ strhelp  = STR_CONFIG_SETTING_INTEREST_RATE_HELPTEXT
 strval   = STR_CONFIG_SETTING_PERCENTAGE
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.vehicle_costs
 type     = SLE_UINT8
 from     = SLV_97
@@ -182,7 +176,6 @@ strval   = STR_SEA_LEVEL_LOW
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.competitor_speed
 type     = SLE_UINT8
 from     = SLV_97
@@ -202,7 +195,6 @@ from     = SLV_97
 to       = SLV_110
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.vehicle_breakdowns
 type     = SLE_UINT8
 from     = SLV_97
@@ -217,7 +209,6 @@ strval   = STR_DISASTER_NONE
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.subsidy_multiplier
 type     = SLE_UINT8
 from     = SLV_97
@@ -231,7 +222,6 @@ strhelp  = STR_CONFIG_SETTING_SUBSIDY_MULTIPLIER_HELPTEXT
 strval   = STR_SUBSIDY_X1_5
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.construction_cost
 type     = SLE_UINT8
 from     = SLV_97
@@ -246,7 +236,6 @@ strval   = STR_SEA_LEVEL_LOW
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.terrain_type
 type     = SLE_UINT8
 from     = SLV_97
@@ -261,7 +250,6 @@ strval   = STR_TERRAIN_TYPE_VERY_FLAT
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.quantity_sea_lakes
 type     = SLE_UINT8
 from     = SLV_97
@@ -274,7 +262,6 @@ strval   = STR_SEA_LEVEL_VERY_LOW
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = difficulty.economy
 from     = SLV_97
 def      = false
@@ -282,7 +269,6 @@ str      = STR_CONFIG_SETTING_RECESSIONS
 strhelp  = STR_CONFIG_SETTING_RECESSIONS_HELPTEXT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = difficulty.line_reverse_mode
 from     = SLV_97
 def      = false
@@ -290,7 +276,6 @@ str      = STR_CONFIG_SETTING_TRAIN_REVERSING
 strhelp  = STR_CONFIG_SETTING_TRAIN_REVERSING_HELPTEXT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = difficulty.disasters
 from     = SLV_97
 def      = false
@@ -299,7 +284,6 @@ strhelp  = STR_CONFIG_SETTING_DISASTERS_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = difficulty.town_council_tolerance
 type     = SLE_UINT8
 from     = SLV_97
@@ -328,7 +312,6 @@ cat      = SC_BASIC
 ; There are only 21 predefined town_name values (0-20), but you can have more with newgrf action F so allow
 ; these bigger values (21-255). Invalid values will fallback to english on use and (undefined string) in GUI.
 [SDT_OMANY]
-base     = GameSettings
 var      = game_creation.town_name
 type     = SLE_UINT8
 from     = SLV_97
@@ -339,7 +322,6 @@ full     = _town_names
 cat      = SC_BASIC
 
 [SDT_OMANY]
-base     = GameSettings
 var      = game_creation.landscape
 type     = SLE_UINT8
 from     = SLV_97
@@ -360,7 +342,6 @@ from     = SLV_97
 to       = SLV_164
 
 [SDT_OMANY]
-base     = GameSettings
 var      = vehicle.road_side
 type     = SLE_UINT8
 from     = SLV_97
@@ -377,7 +358,6 @@ cat      = SC_BASIC
 ; Construction
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.map_height_limit
 type     = SLE_UINT8
 from     = SLV_194
@@ -394,7 +374,6 @@ post_cb  = [](auto) { InvalidateWindowClassesData(WC_SMALLMAP, 2); }
 cat      = SC_ADVANCED
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.heightmap_height
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
@@ -405,14 +384,12 @@ max      = MAX_MAP_HEIGHT_LIMIT
 interval = 1
 
 [SDT_BOOL]
-base     = GameSettings
 var      = construction.build_on_slopes
 guiflags = SGF_NO_NETWORK
 def      = true
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.command_pause_level
 type     = SLE_UINT8
 from     = SLV_154
@@ -426,7 +403,6 @@ strhelp  = STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_HELPTEXT
 strval   = STR_CONFIG_SETTING_COMMAND_PAUSE_LEVEL_NO_ACTIONS
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.terraform_per_64k_frames
 type     = SLE_UINT32
 from     = SLV_156
@@ -437,7 +413,6 @@ interval = 1
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.terraform_frame_burst
 type     = SLE_UINT16
 from     = SLV_156
@@ -448,7 +423,6 @@ interval = 1
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.clear_per_64k_frames
 type     = SLE_UINT32
 from     = SLV_156
@@ -459,7 +433,6 @@ interval = 1
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.clear_frame_burst
 type     = SLE_UINT16
 from     = SLV_156
@@ -470,7 +443,6 @@ interval = 1
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.tree_per_64k_frames
 type     = SLE_UINT32
 from     = SLV_175
@@ -481,7 +453,6 @@ interval = 1
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.tree_frame_burst
 type     = SLE_UINT16
 from     = SLV_175
@@ -492,7 +463,6 @@ interval = 1
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = construction.autoslope
 from     = SLV_75
 def      = true
@@ -501,14 +471,12 @@ strhelp  = STR_CONFIG_SETTING_AUTOSLOPE_HELPTEXT
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = construction.extra_dynamite
 def      = true
 str      = STR_CONFIG_SETTING_EXTRADYNAMITE
 strhelp  = STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.max_bridge_length
 type     = SLE_UINT16
 from     = SLV_159
@@ -522,7 +490,6 @@ strhelp  = STR_CONFIG_SETTING_MAX_BRIDGE_LENGTH_HELPTEXT
 strval   = STR_CONFIG_SETTING_TILE_LENGTH
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.max_bridge_height
 type     = SLE_UINT8
 from     = SLV_194
@@ -537,7 +504,6 @@ strval   = STR_JUST_COMMA
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.max_tunnel_length
 type     = SLE_UINT16
 from     = SLV_159
@@ -556,7 +522,6 @@ length   = 1
 to       = SLV_159
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.train_signal_side
 type     = SLE_UINT8
 guiflags = SGF_MULTISTRING | SGF_NO_NETWORK
@@ -570,7 +535,6 @@ post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = station.never_expire_airports
 guiflags = SGF_NO_NETWORK
 def      = false
@@ -578,7 +542,6 @@ str      = STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS
 strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.town_layout
 type     = SLE_UINT8
 from     = SLV_59
@@ -593,7 +556,6 @@ strval   = STR_CONFIG_SETTING_TOWN_LAYOUT_DEFAULT
 post_cb  = TownFoundingChanged
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.allow_town_roads
 from     = SLV_113
 guiflags = SGF_NO_NETWORK
@@ -602,7 +564,6 @@ str      = STR_CONFIG_SETTING_ALLOW_TOWN_ROADS
 strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_ROADS_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.found_town
 type     = SLE_UINT8
 from     = SLV_128
@@ -618,7 +579,6 @@ post_cb  = TownFoundingChanged
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.allow_town_level_crossings
 from     = SLV_143
 guiflags = SGF_NO_NETWORK
@@ -627,7 +587,6 @@ str      = STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS
 strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.town_cargogen_mode
 type     = SLE_UINT8
 from     = SLV_TOWN_CARGOGEN
@@ -644,7 +603,6 @@ cat      = SC_ADVANCED
 ; link graph
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.recalc_interval
 type     = SLE_UINT16
 from     = SLV_183
@@ -658,7 +616,6 @@ strhelp  = STR_CONFIG_SETTING_LINKGRAPH_INTERVAL_HELPTEXT
 extra    = offsetof(LinkGraphSettings, recalc_interval)
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.recalc_time
 type     = SLE_UINT16
 from     = SLV_183
@@ -673,7 +630,6 @@ extra    = offsetof(LinkGraphSettings, recalc_time)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.distribution_pax
 type     = SLE_UINT8
 from     = SLV_183
@@ -689,7 +645,6 @@ extra    = offsetof(LinkGraphSettings, distribution_pax)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.distribution_mail
 type     = SLE_UINT8
 from     = SLV_183
@@ -705,7 +660,6 @@ extra    = offsetof(LinkGraphSettings, distribution_mail)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.distribution_armoured
 type     = SLE_UINT8
 from     = SLV_183
@@ -721,7 +675,6 @@ extra    = offsetof(LinkGraphSettings, distribution_armoured)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.distribution_default
 type     = SLE_UINT8
 from     = SLV_183
@@ -737,7 +690,6 @@ extra    = offsetof(LinkGraphSettings, distribution_default)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.accuracy
 type     = SLE_UINT8
 from     = SLV_183
@@ -752,7 +704,6 @@ extra    = offsetof(LinkGraphSettings, accuracy)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.demand_distance
 type     = SLE_UINT8
 from     = SLV_183
@@ -767,7 +718,6 @@ extra    = offsetof(LinkGraphSettings, demand_distance)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.demand_size
 type     = SLE_UINT8
 from     = SLV_183
@@ -782,7 +732,6 @@ extra    = offsetof(LinkGraphSettings, demand_size)
 
 
 [SDT_VAR]
-base     = GameSettings
 var      = linkgraph.short_path_saturation
 type     = SLE_UINT8
 from     = SLV_183
@@ -799,7 +748,6 @@ extra    = offsetof(LinkGraphSettings, short_path_saturation)
 ; Vehicles
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.train_acceleration_model
 type     = SLE_UINT8
 guiflags = SGF_MULTISTRING
@@ -813,7 +761,6 @@ strval   = STR_CONFIG_SETTING_ORIGINAL
 post_cb  = TrainAccelerationModelChanged
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.roadveh_acceleration_model
 type     = SLE_UINT8
 from     = SLV_139
@@ -828,7 +775,6 @@ strval   = STR_CONFIG_SETTING_ORIGINAL
 post_cb  = RoadVehAccelerationModelChanged
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.train_slope_steepness
 type     = SLE_UINT8
 from     = SLV_133
@@ -843,7 +789,6 @@ post_cb  = TrainSlopeSteepnessChanged
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.roadveh_slope_steepness
 type     = SLE_UINT8
 from     = SLV_139
@@ -858,7 +803,6 @@ post_cb  = RoadVehSlopeSteepnessChanged
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.forbid_90_deg
 def      = false
 str      = STR_CONFIG_SETTING_FORBID_90_DEG
@@ -867,7 +811,6 @@ post_cb  = InvalidateShipPathCache
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.max_train_length
 type     = SLE_UINT8
 from     = SLV_159
@@ -886,7 +829,6 @@ length   = 1
 to       = SLV_159
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.smoke_amount
 type     = SLE_UINT8
 from     = SLV_145
@@ -906,20 +848,17 @@ to       = SLV_159
 ; path finder
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.roadveh_queue
 def      = true
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.new_pathfinding_all
 to       = SLV_87
 def      = false
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.yapf.ship_use_yapf
 from     = SLV_28
 to       = SLV_87
@@ -927,7 +866,6 @@ def      = false
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.yapf.road_use_yapf
 from     = SLV_28
 to       = SLV_87
@@ -935,7 +873,6 @@ def      = true
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.yapf.rail_use_yapf
 from     = SLV_28
 to       = SLV_87
@@ -944,7 +881,6 @@ cat      = SC_EXPERT
 
 ##
 [SDT_VAR]
-base     = GameSettings
 var      = pf.pathfinder_for_trains
 type     = SLE_UINT8
 from     = SLV_87
@@ -959,7 +895,6 @@ strval   = STR_CONFIG_SETTING_PATHFINDER_NPF
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.pathfinder_for_roadvehs
 type     = SLE_UINT8
 from     = SLV_87
@@ -974,7 +909,6 @@ strval   = STR_CONFIG_SETTING_PATHFINDER_NPF
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.pathfinder_for_ships
 type     = SLE_UINT8
 from     = SLV_87
@@ -990,7 +924,6 @@ post_cb  = InvalidateShipPathCache
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = vehicle.never_expire_vehicles
 guiflags = SGF_NO_NETWORK
 def      = false
@@ -998,7 +931,6 @@ str      = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES
 strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.max_trains
 type     = SLE_UINT16
 def      = 500
@@ -1011,7 +943,6 @@ post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.max_roadveh
 type     = SLE_UINT16
 def      = 500
@@ -1024,7 +955,6 @@ post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.max_aircraft
 type     = SLE_UINT16
 def      = 200
@@ -1037,7 +967,6 @@ post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.max_ships
 type     = SLE_UINT16
 def      = 300
@@ -1097,14 +1026,12 @@ max      = 800
 to       = SLV_120
 
 [SDT_BOOL]
-base     = GameSettings
 var      = order.no_servicing_if_no_breakdowns
 def      = true
 str      = STR_CONFIG_SETTING_NOSERVICE
 strhelp  = STR_CONFIG_SETTING_NOSERVICE_HELPTEXT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = vehicle.wagon_speed_limits
 guiflags = SGF_NO_NETWORK
 def      = true
@@ -1113,7 +1040,6 @@ strhelp  = STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT
 post_cb  = UpdateConsists
 
 [SDT_BOOL]
-base     = GameSettings
 var      = vehicle.disable_elrails
 from     = SLV_38
 guiflags = SGF_NO_NETWORK
@@ -1124,7 +1050,6 @@ post_cb  = SettingsDisableElrail
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.freight_trains
 type     = SLE_UINT8
 from     = SLV_39
@@ -1145,7 +1070,6 @@ from     = SLV_67
 to       = SLV_159
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.plane_speed
 type     = SLE_UINT8
 from     = SLV_90
@@ -1158,7 +1082,6 @@ strhelp  = STR_CONFIG_SETTING_PLANE_SPEED_HELPTEXT
 strval   = STR_CONFIG_SETTING_PLANE_SPEED_VALUE
 
 [SDT_BOOL]
-base     = GameSettings
 var      = vehicle.dynamic_engines
 from     = SLV_95
 guiflags = SGF_NO_NETWORK
@@ -1167,7 +1090,6 @@ pre_cb   = CheckDynamicEngines
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.plane_crashes
 type     = SLE_UINT8
 from     = SLV_138
@@ -1193,14 +1115,12 @@ to       = SLV_93
 def      = true
 
 [SDT_BOOL]
-base     = GameSettings
 var      = order.improved_load
 guiflags = SGF_NO_NETWORK
 def      = true
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = order.selectgoods
 def      = true
 cat      = SC_EXPERT
@@ -1217,7 +1137,6 @@ length   = 1
 to       = SLV_159
 
 [SDT_VAR]
-base     = GameSettings
 var      = station.station_spread
 type     = SLE_UINT8
 def      = 12
@@ -1230,7 +1149,6 @@ post_cb  = StationSpreadChanged
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = order.serviceathelipad
 def      = true
 str      = STR_CONFIG_SETTING_SERVICEATHELIPAD
@@ -1238,7 +1156,6 @@ strhelp  = STR_CONFIG_SETTING_SERVICEATHELIPAD_HELPTEXT
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = station.modified_catchment
 def      = true
 str      = STR_CONFIG_SETTING_CATCHMENT
@@ -1247,7 +1164,6 @@ post_cb  = StationCatchmentChanged
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = station.serve_neutral_industries
 def      = true
 from     = SLV_SERVE_NEUTRAL_INDUSTRIES
@@ -1256,7 +1172,6 @@ strhelp  = STR_CONFIG_SETTING_SERVE_NEUTRAL_INDUSTRIES_HELPTEXT
 post_cb  = StationCatchmentChanged
 
 [SDT_BOOL]
-base     = GameSettings
 var      = order.gradual_loading
 from     = SLV_40
 guiflags = SGF_NO_NETWORK
@@ -1264,7 +1179,6 @@ def      = true
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = construction.road_stop_on_town_road
 from     = SLV_47
 def      = true
@@ -1273,7 +1187,6 @@ strhelp  = STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = construction.road_stop_on_competitor_road
 from     = SLV_114
 def      = true
@@ -1282,14 +1195,12 @@ strhelp  = STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = station.adjacent_stations
 from     = SLV_62
 def      = true
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.station_noise_level
 from     = SLV_96
 guiflags = SGF_NO_NETWORK
@@ -1299,7 +1210,6 @@ strhelp  = STR_CONFIG_SETTING_NOISE_LEVEL_HELPTEXT
 post_cb  = [](auto new_value) { InvalidateWindowClassesData(WC_TOWN_VIEW, new_value); }
 
 [SDT_BOOL]
-base     = GameSettings
 var      = station.distant_join_stations
 from     = SLV_106
 def      = true
@@ -1309,7 +1219,6 @@ post_cb  = [](auto) { DeleteWindowById(WC_SELECT_STATION, 0); }
 
 ##
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.inflation
 guiflags = SGF_NO_NETWORK
 def      = false
@@ -1318,7 +1227,6 @@ strhelp  = STR_CONFIG_SETTING_INFLATION_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.raw_industry_construction
 type     = SLE_UINT8
 guiflags = SGF_MULTISTRING
@@ -1332,7 +1240,6 @@ post_cb  = [](auto) { InvalidateWindowData(WC_BUILD_INDUSTRY, 0); }
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.industry_platform
 type     = SLE_UINT8
 from     = SLV_148
@@ -1345,7 +1252,6 @@ strval   = STR_CONFIG_SETTING_TILE_LENGTH
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.multiple_industry_per_town
 def      = false
 str      = STR_CONFIG_SETTING_MULTIPINDTOWN
@@ -1356,7 +1262,6 @@ length   = 1
 to       = SLV_141
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.bribe
 def      = true
 str      = STR_CONFIG_SETTING_BRIBE
@@ -1365,7 +1270,6 @@ post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.exclusive_rights
 from     = SLV_79
 def      = true
@@ -1375,7 +1279,6 @@ post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.fund_buildings
 from     = SLV_165
 def      = true
@@ -1385,7 +1288,6 @@ post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.fund_roads
 from     = SLV_160
 def      = true
@@ -1395,7 +1297,6 @@ post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.give_money
 from     = SLV_79
 def      = true
@@ -1404,7 +1305,6 @@ strhelp  = STR_CONFIG_SETTING_ALLOW_GIVE_MONEY_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.snow_line_height
 type     = SLE_UINT8
 guiflags = SGF_SCENEDIT_ONLY
@@ -1418,7 +1318,6 @@ strval   = STR_JUST_COMMA
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.snow_coverage
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
@@ -1433,7 +1332,6 @@ strval   = STR_CONFIG_SETTING_SNOW_COVERAGE_VALUE
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.desert_coverage
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
@@ -1452,7 +1350,6 @@ length   = 4
 to       = SLV_144
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.starting_year
 type     = SLE_INT32
 def      = DEF_START_YEAR
@@ -1468,7 +1365,6 @@ length   = 4
 to       = SLV_105
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.ending_year
 type     = SLE_INT32
 from     = SLV_ENDING_YEAR
@@ -1483,7 +1379,6 @@ strval   = STR_CONFIG_SETTING_ENDING_YEAR_VALUE
 cat      = SC_ADVANCED
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.type
 type     = SLE_UINT8
 guiflags = SGF_MULTISTRING
@@ -1497,7 +1392,6 @@ post_cb  = [](auto) { InvalidateWindowClassesData(WC_INDUSTRY_VIEW); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.allow_shares
 def      = false
 str      = STR_CONFIG_SETTING_ALLOW_SHARES
@@ -1505,7 +1399,6 @@ strhelp  = STR_CONFIG_SETTING_ALLOW_SHARES_HELPTEXT
 post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY); }
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.min_years_for_shares
 type     = SLE_UINT8
 from     = SLV_TRADING_AGE
@@ -1519,7 +1412,6 @@ strval   = STR_JUST_INT
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.feeder_payment_share
 type     = SLE_UINT8
 from     = SLV_134
@@ -1532,7 +1424,6 @@ strval   = STR_CONFIG_SETTING_PERCENTAGE
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.town_growth_rate
 type     = SLE_UINT8
 from     = SLV_54
@@ -1545,7 +1436,6 @@ strhelp  = STR_CONFIG_SETTING_TOWN_GROWTH_HELPTEXT
 strval   = STR_CONFIG_SETTING_TOWN_GROWTH_NONE
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.larger_towns
 type     = SLE_UINT8
 from     = SLV_54
@@ -1559,7 +1449,6 @@ strhelp  = STR_CONFIG_SETTING_LARGER_TOWNS_HELPTEXT
 strval   = STR_CONFIG_SETTING_LARGER_TOWNS_VALUE
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.initial_city_size
 type     = SLE_UINT8
 from     = SLV_56
@@ -1572,7 +1461,6 @@ strhelp  = STR_CONFIG_SETTING_CITY_SIZE_MULTIPLIER_HELPTEXT
 strval   = STR_JUST_COMMA
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.mod_road_rebuild
 from     = SLV_77
 def      = true
@@ -1584,7 +1472,6 @@ length   = 1
 to       = SLV_107
 
 [SDT_OMANY]
-base     = GameSettings
 var      = script.settings_profile
 type     = SLE_UINT8
 from     = SLV_178
@@ -1599,7 +1486,6 @@ strval   = STR_CONFIG_SETTING_AI_PROFILE_EASY
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = ai.ai_in_multiplayer
 def      = true
 str      = STR_CONFIG_SETTING_AI_IN_MULTIPLAYER
@@ -1607,35 +1493,30 @@ strhelp  = STR_CONFIG_SETTING_AI_IN_MULTIPLAYER_HELPTEXT
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = ai.ai_disable_veh_train
 def      = false
 str      = STR_CONFIG_SETTING_AI_BUILDS_TRAINS
 strhelp  = STR_CONFIG_SETTING_AI_BUILDS_TRAINS_HELPTEXT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = ai.ai_disable_veh_roadveh
 def      = false
 str      = STR_CONFIG_SETTING_AI_BUILDS_ROAD_VEHICLES
 strhelp  = STR_CONFIG_SETTING_AI_BUILDS_ROAD_VEHICLES_HELPTEXT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = ai.ai_disable_veh_aircraft
 def      = false
 str      = STR_CONFIG_SETTING_AI_BUILDS_AIRCRAFT
 strhelp  = STR_CONFIG_SETTING_AI_BUILDS_AIRCRAFT_HELPTEXT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = ai.ai_disable_veh_ship
 def      = false
 str      = STR_CONFIG_SETTING_AI_BUILDS_SHIPS
 strhelp  = STR_CONFIG_SETTING_AI_BUILDS_SHIPS_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = script.script_max_opcode_till_suspend
 type     = SLE_UINT32
 from     = SLV_107
@@ -1650,7 +1531,6 @@ strval   = STR_JUST_COMMA
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = script.script_max_memory_megabytes
 type     = SLE_UINT32
 from     = SLV_SCRIPT_MEMLIMIT
@@ -1666,7 +1546,6 @@ cat      = SC_EXPERT
 
 ##
 [SDT_VAR]
-base     = GameSettings
 var      = vehicle.extend_vehicle_life
 type     = SLE_UINT8
 def      = 0
@@ -1675,7 +1554,6 @@ max      = 100
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.dist_local_authority
 type     = SLE_UINT8
 def      = 20
@@ -1684,7 +1562,6 @@ max      = 60
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.reverse_at_signals
 from     = SLV_159
 def      = false
@@ -1692,7 +1569,6 @@ str      = STR_CONFIG_SETTING_REVERSE_AT_SIGNALS
 strhelp  = STR_CONFIG_SETTING_REVERSE_AT_SIGNALS_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.wait_oneway_signal
 type     = SLE_UINT8
 def      = 15
@@ -1701,7 +1577,6 @@ max      = 255
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.wait_twoway_signal
 type     = SLE_UINT8
 def      = 41
@@ -1710,7 +1585,6 @@ max      = 255
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.town_noise_population[0]
 type     = SLE_UINT16
 from     = SLV_96
@@ -1720,7 +1594,6 @@ max      = 65535
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.town_noise_population[1]
 type     = SLE_UINT16
 from     = SLV_96
@@ -1730,7 +1603,6 @@ max      = 65535
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = economy.town_noise_population[2]
 type     = SLE_UINT16
 from     = SLV_96
@@ -1740,7 +1612,6 @@ max      = 65535
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = economy.infrastructure_maintenance
 from     = SLV_166
 def      = false
@@ -1751,7 +1622,6 @@ cat      = SC_BASIC
 
 ##
 [SDT_VAR]
-base     = GameSettings
 var      = pf.wait_for_pbs_path
 type     = SLE_UINT8
 from     = SLV_100
@@ -1761,14 +1631,12 @@ max      = 255
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.reserve_paths
 from     = SLV_100
 def      = false
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.path_backoff_interval
 type     = SLE_UINT8
 from     = SLV_100
@@ -1785,7 +1653,6 @@ to       = SLV_REMOVE_OPF
 
 ##
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_max_search_nodes
 type     = SLE_UINT
 def      = 10000
@@ -1794,7 +1661,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_firstred_penalty
 type     = SLE_UINT
 def      = 10 * NPF_TILE_LENGTH
@@ -1803,7 +1669,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_firstred_exit_penalty
 type     = SLE_UINT
 def      = 100 * NPF_TILE_LENGTH
@@ -1812,7 +1677,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_lastred_penalty
 type     = SLE_UINT
 def      = 10 * NPF_TILE_LENGTH
@@ -1821,7 +1685,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_station_penalty
 type     = SLE_UINT
 def      = 1 * NPF_TILE_LENGTH
@@ -1830,7 +1693,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_slope_penalty
 type     = SLE_UINT
 def      = 1 * NPF_TILE_LENGTH
@@ -1839,7 +1701,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_curve_penalty
 type     = SLE_UINT
 def      = 1 * NPF_TILE_LENGTH
@@ -1848,7 +1709,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_depot_reverse_penalty
 type     = SLE_UINT
 def      = 50 * NPF_TILE_LENGTH
@@ -1857,7 +1717,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_pbs_cross_penalty
 type     = SLE_UINT
 from     = SLV_100
@@ -1867,7 +1726,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_rail_pbs_signal_back_penalty
 type     = SLE_UINT
 from     = SLV_100
@@ -1877,7 +1735,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_buoy_penalty
 type     = SLE_UINT
 def      = 2 * NPF_TILE_LENGTH
@@ -1886,7 +1743,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_water_curve_penalty
 type     = SLE_UINT
 def      = 1 * NPF_TILE_LENGTH
@@ -1895,7 +1751,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_road_curve_penalty
 type     = SLE_UINT
 def      = 1 * NPF_TILE_LENGTH
@@ -1904,7 +1759,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_crossing_penalty
 type     = SLE_UINT
 def      = 3 * NPF_TILE_LENGTH
@@ -1913,7 +1767,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_road_drive_through_penalty
 type     = SLE_UINT
 from     = SLV_47
@@ -1923,7 +1776,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_road_dt_occupied_penalty
 type     = SLE_UINT
 from     = SLV_130
@@ -1933,7 +1785,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.npf_road_bay_occupied_penalty
 type     = SLE_UINT
 from     = SLV_130
@@ -1943,7 +1794,6 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.npf.maximum_go_to_depot_penalty
 type     = SLE_UINT
 from     = SLV_131
@@ -1954,14 +1804,12 @@ cat      = SC_EXPERT
 
 ##
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.yapf.disable_node_optimization
 from     = SLV_28
 def      = false
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.max_search_nodes
 type     = SLE_UINT
 from     = SLV_28
@@ -1971,14 +1819,12 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_BOOL]
-base     = GameSettings
 var      = pf.yapf.rail_firstred_twoway_eol
 from     = SLV_28
 def      = false
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_firstred_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -1988,7 +1834,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_firstred_exit_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -1998,7 +1843,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_lastred_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2008,7 +1852,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_lastred_exit_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2018,7 +1861,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_station_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2028,7 +1870,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_slope_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2038,7 +1879,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_curve45_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2048,7 +1888,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_curve90_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2058,7 +1897,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_depot_reverse_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2068,7 +1906,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_crossing_penalty
 type     = SLE_UINT
 from     = SLV_28
@@ -2078,7 +1915,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_look_ahead_max_signals
 type     = SLE_UINT
 from     = SLV_28
@@ -2088,7 +1924,6 @@ max      = 100
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_look_ahead_signal_p0
 type     = SLE_INT
 from     = SLV_28
@@ -2098,7 +1933,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_look_ahead_signal_p1
 type     = SLE_INT
 from     = SLV_28
@@ -2108,7 +1942,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_look_ahead_signal_p2
 type     = SLE_INT
 from     = SLV_28
@@ -2118,7 +1951,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_pbs_cross_penalty
 type     = SLE_UINT
 from     = SLV_100
@@ -2128,7 +1960,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_pbs_station_penalty
 type     = SLE_UINT
 from     = SLV_100
@@ -2138,7 +1969,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_pbs_signal_back_penalty
 type     = SLE_UINT
 from     = SLV_100
@@ -2148,7 +1978,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_doubleslip_penalty
 type     = SLE_UINT
 from     = SLV_100
@@ -2158,7 +1987,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_longer_platform_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2168,7 +1996,6 @@ max      = 20000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_longer_platform_per_tile_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2178,7 +2005,6 @@ max      = 20000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_shorter_platform_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2188,7 +2014,6 @@ max      = 20000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.rail_shorter_platform_per_tile_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2198,7 +2023,6 @@ max      = 20000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.road_slope_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2208,7 +2032,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.road_curve_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2218,7 +2041,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.road_crossing_penalty
 type     = SLE_UINT
 from     = SLV_33
@@ -2228,7 +2050,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.road_stop_penalty
 type     = SLE_UINT
 from     = SLV_47
@@ -2238,7 +2059,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.road_stop_occupied_penalty
 type     = SLE_UINT
 from     = SLV_130
@@ -2248,7 +2068,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.road_stop_bay_occupied_penalty
 type     = SLE_UINT
 from     = SLV_130
@@ -2258,7 +2077,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.maximum_go_to_depot_penalty
 type     = SLE_UINT
 from     = SLV_131
@@ -2268,7 +2086,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.ship_curve45_penalty
 type     = SLE_UINT
 from     = SLV_SHIP_CURVE_PENALTY
@@ -2278,7 +2095,6 @@ max      = 1000000
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = pf.yapf.ship_curve90_penalty
 type     = SLE_UINT
 from     = SLV_SHIP_CURVE_PENALTY
@@ -2289,7 +2105,6 @@ cat      = SC_EXPERT
 
 ##
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.land_generator
 type     = SLE_UINT8
 from     = SLV_30
@@ -2302,7 +2117,6 @@ strhelp  = STR_CONFIG_SETTING_LAND_GENERATOR_HELPTEXT
 strval   = STR_CONFIG_SETTING_LAND_GENERATOR_ORIGINAL
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.oil_refinery_limit
 type     = SLE_UINT8
 from     = SLV_30
@@ -2314,7 +2128,6 @@ strval   = STR_CONFIG_SETTING_TILE_LENGTH
 strhelp  = STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.tgen_smoothness
 type     = SLE_UINT8
 from     = SLV_30
@@ -2328,7 +2141,6 @@ strval   = STR_CONFIG_SETTING_ROUGHNESS_OF_TERRAIN_VERY_SMOOTH
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.variety
 type     = SLE_UINT8
 from     = SLV_197
@@ -2341,7 +2153,6 @@ strhelp  = STR_CONFIG_SETTING_VARIETY_HELPTEXT
 strval   = STR_VARIETY_NONE
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.generation_seed
 type     = SLE_UINT32
 from     = SLV_30
@@ -2351,7 +2162,6 @@ max      = UINT32_MAX
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.tree_placer
 type     = SLE_UINT8
 from     = SLV_30
@@ -2365,7 +2175,6 @@ strval   = STR_CONFIG_SETTING_TREE_PLACER_NONE
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.heightmap_rotation
 type     = SLE_UINT8
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
@@ -2378,7 +2187,6 @@ strval   = STR_CONFIG_SETTING_HEIGHTMAP_ROTATION_COUNTER_CLOCKWISE
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.se_flat_world_height
 type     = SLE_UINT8
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
@@ -2391,7 +2199,6 @@ cat      = SC_BASIC
 
 ##
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.map_x
 type     = SLE_UINT8
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
@@ -2401,7 +2208,6 @@ max      = MAX_MAP_SIZE_BITS
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.map_y
 type     = SLE_UINT8
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
@@ -2411,7 +2217,6 @@ max      = MAX_MAP_SIZE_BITS
 cat      = SC_BASIC
 
 [SDT_BOOL]
-base     = GameSettings
 var      = construction.freeform_edges
 from     = SLV_111
 def      = true
@@ -2420,7 +2225,6 @@ post_cb  = UpdateFreeformEdges
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.water_borders
 type     = SLE_UINT8
 from     = SLV_111
@@ -2429,7 +2233,6 @@ min      = 0
 max      = 16
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.custom_town_number
 type     = SLE_UINT16
 from     = SLV_115
@@ -2439,7 +2242,6 @@ max      = 5000
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = construction.extra_tree_placement
 type     = SLE_UINT8
 from     = SLV_132
@@ -2453,7 +2255,6 @@ strval   = STR_CONFIG_SETTING_EXTRA_TREE_PLACEMENT_NO_SPREAD
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.custom_terrain_type
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
@@ -2464,7 +2265,6 @@ max      = MAX_MAP_HEIGHT_LIMIT
 interval = 1
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.custom_sea_level
 type     = SLE_UINT8
 from     = SLV_149
@@ -2474,7 +2274,6 @@ max      = CUSTOM_SEA_LEVEL_MAX_PERCENTAGE
 cat      = SC_BASIC
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.min_river_length
 type     = SLE_UINT8
 from     = SLV_163
@@ -2484,7 +2283,6 @@ max      = 255
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.river_route_random
 type     = SLE_UINT8
 from     = SLV_163
@@ -2494,7 +2292,6 @@ max      = 255
 cat      = SC_EXPERT
 
 [SDT_VAR]
-base     = GameSettings
 var      = game_creation.amount_of_rivers
 type     = SLE_UINT8
 from     = SLV_163
@@ -2509,7 +2306,6 @@ strval   = STR_RIVERS_NONE
 ; locale
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.currency
 type     = SLE_UINT8
 from     = SLV_97
@@ -2534,7 +2330,6 @@ post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.units_velocity
 type     = SLE_UINT8
 from     = SLV_184
@@ -2550,7 +2345,6 @@ strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_IMPERIAL
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.units_power
 type     = SLE_UINT8
 from     = SLV_184
@@ -2566,7 +2360,6 @@ strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_IMPERIAL
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.units_weight
 type     = SLE_UINT8
 from     = SLV_184
@@ -2582,7 +2375,6 @@ strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_IMPERIAL
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.units_volume
 type     = SLE_UINT8
 from     = SLV_184
@@ -2598,7 +2390,6 @@ strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_IMPERIAL
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.units_force
 type     = SLE_UINT8
 from     = SLV_184
@@ -2614,7 +2405,6 @@ strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_IMPERIAL
 
 [SDT_OMANY]
-base     = GameSettings
 var      = locale.units_height
 type     = SLE_UINT8
 from     = SLV_184
@@ -2630,7 +2420,6 @@ strhelp  = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_HELPTEXT
 strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL
 
 [SDT_SSTR]
-base     = GameSettings
 var      = locale.digit_group_separator
 type     = SLE_STRQ
 from     = SLV_118
@@ -2640,7 +2429,6 @@ post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_SSTR]
-base     = GameSettings
 var      = locale.digit_group_separator_currency
 type     = SLE_STRQ
 from     = SLV_118
@@ -2650,7 +2438,6 @@ post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
 
 [SDT_SSTR]
-base     = GameSettings
 var      = locale.digit_decimal_separator
 type     = SLE_STRQ
 from     = SLV_126

--- a/src/table/window_settings.ini
+++ b/src/table/window_settings.ini
@@ -10,14 +10,13 @@ static const SettingTable _window_settings{
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL($base, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR($base, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL(WindowDesc, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
-SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for $base.$var exceeds storage size");
+SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for WindowDesc.$var exceeds storage size");
 
 [defaults]
-base     = WindowDesc
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 guiflags = SGF_NONE
 interval = 0


### PR DESCRIPTION
## Motivation / Problem

In the ini files for settings there is a "base" for some types of settings. The base can only be a single class for the whole setting table. So, why define the base for each of the settings, instead of "fixing" it in the template? This will also prevent people from attempting to use a different base for the setting table as they would need to change the template instead of just changing the base of the setting.


## Description

Replace $base with the base used for the setting in the different ini files.
Remove the lines with `base = <...>` from the ini files.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
