### PR TITLE
Codechange: rename str_validate to StrMakeValid(InPlace)

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -111,7 +111,7 @@ void IConsolePrint(TextColour colour_code, const char *string)
 	 * characters and (when applicable) assign it to the console buffer */
 	str = stredup(string);
 	str_strip_colours(str);
-	str_validate(str, str + strlen(str));
+	StrMakeValidInPlace(str);
 
 	if (_network_dedicated) {
 		NetworkAdminConsole("console", str);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -342,7 +342,7 @@ bool FiosFileScanner::AddFile(const std::string &filename, size_t basepath_lengt
 		t = filename.c_str() + (ps == std::string::npos ? 0 : ps + 1);
 	}
 	strecpy(fios->title, t, lastof(fios->title));
-	str_validate(fios->title, lastof(fios->title));
+	StrMakeValidInPlace(fios->title, lastof(fios->title));
 
 	return true;
 }
@@ -394,7 +394,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 				std::string dirname = std::string(d_name) + PATHSEP;
 				SetDParamStr(0, dirname);
 				GetString(fios->title, STR_SAVELOAD_DIRECTORY, lastof(fios->title));
-				str_validate(fios->title, lastof(fios->title));
+				StrMakeValidInPlace(fios->title, lastof(fios->title));
 			}
 		}
 		closedir(dir);
@@ -446,7 +446,7 @@ static void GetFileTitle(const std::string &file, char *title, const char *last,
 	size_t read = fread(title, 1, last - title, f);
 	assert(title + read <= last);
 	title[read] = '\0';
-	str_validate(title, last);
+	StrMakeValidInPlace(title, last);
 	FioFCloseFile(f);
 }
 

--- a/src/highscore.cpp
+++ b/src/highscore.cpp
@@ -170,7 +170,7 @@ void LoadFromHighScore()
 					i = SP_SAVED_HIGHSCORE_END;
 					break;
 				}
-				str_validate(hs->company, lastof(hs->company), SVS_NONE);
+				StrMakeValidInPlace(hs->company, lastof(hs->company), SVS_NONE);
 				hs->title = EndGameGetPerformanceTitleFromValue(hs->score);
 			}
 		}

--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -22,7 +22,7 @@
  */
 IniItem::IniItem(IniGroup *parent, const std::string &name) : next(nullptr)
 {
-	this->name = str_validate(name);
+	this->name = StrMakeValid(name);
 
 	*parent->last_item = this;
 	parent->last_item = &this->next;
@@ -50,7 +50,7 @@ void IniItem::SetValue(const std::string_view value)
  */
 IniGroup::IniGroup(IniLoadFile *parent, const std::string &name) : next(nullptr), type(IGT_VARIABLES), item(nullptr)
 {
-	this->name = str_validate(name);
+	this->name = StrMakeValid(name);
 
 	this->last_item = &this->item;
 	*parent->last_group = this;
@@ -288,7 +288,7 @@ void IniLoadFile::LoadFromDisk(const std::string &filename, Subdirectory subdir)
 			if (!quoted && e == t) {
 				item->value.reset();
 			} else {
-				item->value = str_validate(std::string(t));
+				item->value = StrMakeValid(std::string(t));
 			}
 		} else {
 			/* it's an orphan item */

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -997,7 +997,7 @@ struct QueryStringWindow : public Window
 	{
 		char *last_of = &this->editbox.text.buf[this->editbox.text.max_bytes - 1];
 		GetString(this->editbox.text.buf, str, last_of);
-		str_validate(this->editbox.text.buf, last_of, SVS_NONE);
+		StrMakeValidInPlace(this->editbox.text.buf, last_of, SVS_NONE);
 
 		/* Make sure the name isn't too long for the text buffer in the number of
 		 * characters (not bytes). max_chars also counts the '\0' characters. */

--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -394,7 +394,7 @@ void Packet::Recv_string(char *buffer, size_t size, StringValidationSettings set
 	assert(pos <= std::numeric_limits<PacketSize>::max());
 	this->pos = static_cast<PacketSize>(pos);
 
-	str_validate(bufp, last, settings);
+	StrMakeValidInPlace(bufp, last, settings);
 }
 
 /**
@@ -423,7 +423,7 @@ std::string Packet::Recv_string(size_t length, StringValidationSettings settings
 		while (this->Recv_uint8() != '\0') {}
 	}
 
-	return str_validate(str, settings);
+	return StrMakeValid(str, settings);
 }
 
 /**

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2598,7 +2598,7 @@ static std::string ReadDWordAsString(ByteReader *reader)
 	char output[5];
 	for (int i = 0; i < 4; i++) output[i] = reader->ReadByte();
 	output[4] = '\0';
-	str_validate(output, lastof(output));
+	StrMakeValidInPlace(output, lastof(output));
 
 	return std::string(output);
 }

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -174,7 +174,7 @@ int CDECL main(int argc, char *argv[])
 	SetRandomSeed(time(nullptr));
 
 	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (int i = 0; i < argc; i++) ValidateString(argv[i]);
+	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
 
 	return openttd_main(argc, argv);
 }

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -243,7 +243,7 @@ void CocoaReleaseAutoreleasePool();
 int CDECL main(int argc, char *argv[])
 {
 	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (int i = 0; i < argc; i++) ValidateString(argv[i]);
+	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
 
 #ifdef WITH_COCOA
 	CocoaSetupAutoreleasePool();

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -429,7 +429,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	argc = ParseCommandLine(cmdline, argv, lengthof(argv));
 
 	/* Make sure our arguments contain only valid UTF-8 characters. */
-	for (int i = 0; i < argc; i++) ValidateString(argv[i]);
+	for (int i = 0; i < argc; i++) StrMakeValidInPlace(argv[i]);
 
 	openttd_main(argc, argv);
 

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -234,7 +234,7 @@ static inline bool CheckOldSavegameType(FILE *f, char *temp, const char *last, u
 
 	bool ret = VerifyOldNameChecksum(temp, len);
 	temp[len - 2] = '\0'; // name is null-terminated in savegame, but it's better to be sure
-	str_validate(temp, last);
+	StrMakeValidInPlace(temp, last);
 
 	return ret;
 }

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -972,7 +972,7 @@ static void SlString(void *ptr, size_t length, VarType conv)
 			if ((conv & SLF_ALLOW_NEWLINE) != 0) {
 				settings = settings | SVS_ALLOW_NEWLINE;
 			}
-			str_validate((char *)ptr, (char *)ptr + len, settings);
+			StrMakeValidInPlace((char *)ptr, (char *)ptr + len, settings);
 			break;
 		}
 		case SLA_PTRS: break;
@@ -1016,7 +1016,7 @@ static void SlStdString(void *ptr, VarType conv)
 			if ((conv & SLF_ALLOW_NEWLINE) != 0) {
 				settings = settings | SVS_ALLOW_NEWLINE;
 			}
-			str_validate(buf, buf + len, settings);
+			StrMakeValidInPlace(buf, buf + len, settings);
 
 			// Store sanitized string.
 			str->assign(buf);

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -283,7 +283,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 {
 	char buffer[64];
 	::GetString(buffer, string, lastof(buffer));
-	::str_validate(buffer, lastof(buffer), SVS_NONE);
+	::StrMakeValidInPlace(buffer, lastof(buffer), SVS_NONE);
 	return ::stredup(buffer);
 }
 
@@ -312,7 +312,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	if (!StrEmpty(text) && (GetCommandFlags(cmd) & CMD_STR_CTRL) == 0) {
 		/* The string must be valid, i.e. not contain special codes. Since some
 		 * can be made with GSText, make sure the control codes are removed. */
-		::str_validate(const_cast<char *>(text), text + strlen(text), SVS_NONE);
+		::StrMakeValidInPlace(text, SVS_NONE);
 	}
 
 	/* Set the default callback to return a true/false result of the DoCommand */

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -82,7 +82,7 @@ SQInteger ScriptText::_SetParam(int parameter, HSQUIRRELVM vm)
 			sq_getstring(vm, -1, &value);
 
 			this->params[parameter] = stredup(value);
-			ValidateString(this->params[parameter]);
+			StrMakeValidInPlace(this->params[parameter]);
 			break;
 		}
 
@@ -157,7 +157,7 @@ SQInteger ScriptText::_set(HSQUIRRELVM vm)
 	if (sq_gettype(vm, 2) == OT_STRING) {
 		const SQChar *key_string;
 		sq_getstring(vm, 2, &key_string);
-		ValidateString(key_string);
+		StrMakeValidInPlace(key_string);
 
 		if (strncmp(key_string, "param_", 6) != 0 || strlen(key_string) > 8) return SQ_ERROR;
 		k = atoi(key_string + 6);

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -122,14 +122,14 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	while (SQ_SUCCEEDED(sq_next(vm, -2))) {
 		const SQChar *key;
 		if (SQ_FAILED(sq_getstring(vm, -2, &key))) return SQ_ERROR;
-		ValidateString(key);
+		StrMakeValidInPlace(key);
 
 		if (strcmp(key, "name") == 0) {
 			const SQChar *sqvalue;
 			if (SQ_FAILED(sq_getstring(vm, -1, &sqvalue))) return SQ_ERROR;
 			char *name = stredup(sqvalue);
 			char *s;
-			ValidateString(name);
+			StrMakeValidInPlace(name);
 
 			/* Don't allow '=' and ',' in configure setting names, as we need those
 			 *  2 chars to nicely store the settings as a string. */
@@ -141,7 +141,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 			const SQChar *sqdescription;
 			if (SQ_FAILED(sq_getstring(vm, -1, &sqdescription))) return SQ_ERROR;
 			config.description = stredup(sqdescription);
-			ValidateString(config.description);
+			StrMakeValidInPlace(config.description);
 			items |= 0x002;
 		} else if (strcmp(key, "min_value") == 0) {
 			SQInteger res;
@@ -226,7 +226,7 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 {
 	const SQChar *setting_name;
 	if (SQ_FAILED(sq_getstring(vm, -2, &setting_name))) return SQ_ERROR;
-	ValidateString(setting_name);
+	StrMakeValidInPlace(setting_name);
 
 	ScriptConfigItem *config = nullptr;
 	for (auto &item : this->config_list) {
@@ -253,7 +253,7 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 		/* Because squirrel doesn't support identifiers starting with a digit,
 		 * we skip the first character. */
 		int key = atoi(key_string + 1);
-		ValidateString(label);
+		StrMakeValidInPlace(label);
 
 		/* !Contains() prevents stredup from leaking. */
 		if (!config->labels->Contains(key)) config->labels->Insert(key, stredup(label));

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -448,7 +448,7 @@ bool Squirrel::CallStringMethodStrdup(HSQOBJECT instance, const char *method_nam
 	if (!this->CallMethod(instance, method_name, &ret, suspend)) return false;
 	if (ret._type != OT_STRING) return false;
 	*res = stredup(ObjectToString(&ret));
-	ValidateString(*res);
+	StrMakeValidInPlace(*res);
 	return true;
 }
 

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -116,7 +116,7 @@ namespace SQConvert {
 		char *tmp_str = stredup(tmp);
 		sq_poptop(vm);
 		ptr->push_back((void *)tmp_str);
-		str_validate(tmp_str, tmp_str + strlen(tmp_str));
+		StrMakeValidInPlace(tmp_str);
 		return tmp_str;
 	}
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -497,7 +497,7 @@ void StringSettingDesc::MakeValueValid(std::string &str) const
 	 * includes the '\0' termination for network transfer purposes.
 	 * Also ensure the string is valid after chopping of some bytes. */
 	std::string stdstr(str, this->max_length - 1);
-	str.assign(str_validate(stdstr, SVS_NONE));
+	str.assign(StrMakeValid(stdstr, SVS_NONE));
 }
 
 /**

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -186,7 +186,7 @@ void str_fix_scc_encoded(char *str, const char *last)
 
 
 template <class T>
-static void str_validate(T &dst, const char *str, const char *last, StringValidationSettings settings)
+static void StrMakeValidInPlace(T &dst, const char *str, const char *last, StringValidationSettings settings)
 {
 	/* Assume the ABSOLUTE WORST to be in str as it comes from the outside. */
 
@@ -246,48 +246,49 @@ static void str_validate(T &dst, const char *str, const char *last, StringValida
 }
 
 /**
- * Scans the string for valid characters and if it finds invalid ones,
- * replaces them with a question mark '?' (if not ignored)
- * @param str the string to validate
- * @param last the last valid character of str
- * @param settings the settings for the string validation.
+ * Scans the string for invalid characters and replaces then with a
+ * question mark '?' (if not ignored).
+ * @param str The string to validate.
+ * @param last The last valid character of str.
+ * @param settings The settings for the string validation.
  */
-void str_validate(char *str, const char *last, StringValidationSettings settings)
+void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings)
 {
 	char *dst = str;
-	str_validate(dst, str, last, settings);
+	StrMakeValidInPlace(dst, str, last, settings);
 	*dst = '\0';
 }
 
 /**
- * Scans the string for valid characters and if it finds invalid ones,
- * replaces them with a question mark '?' (if not ignored)
- * @param str the string to validate
- * @param settings the settings for the string validation.
+ * Scans the string for invalid characters and replaces then with a
+ * question mark '?' (if not ignored).
+ * Only use this function when you are sure the string ends with a '\0';
+ * otherwise use StrMakeValidInPlace(str, last, settings) variant.
+ * @param str The string (of which you are sure ends with '\0') to validate.
  */
-std::string str_validate(const std::string &str, StringValidationSettings settings)
+void StrMakeValidInPlace(const char *str, StringValidationSettings settings)
+{
+	/* We know it is '\0' terminated. */
+	StrMakeValidInPlace(const_cast<char *>(str), str + strlen(str), settings);
+}
+
+/**
+ * Scans the string for invalid characters and replaces then with a
+ * question mark '?' (if not ignored).
+ * @param str The string to validate.
+ * @param settings The settings for the string validation.
+ */
+std::string StrMakeValid(const std::string &str, StringValidationSettings settings)
 {
 	auto buf = str.data();
 	auto last = buf + str.size();
 
 	std::ostringstream dst;
 	std::ostreambuf_iterator<char> dst_iter(dst);
-	str_validate(dst_iter, buf, last, settings);
+	StrMakeValidInPlace(dst_iter, buf, last, settings);
 
 	return dst.str();
 }
-
-/**
- * Scans the string for valid characters and if it finds invalid ones,
- * replaces them with a question mark '?'.
- * @param str the string to validate
- */
-void ValidateString(const char *str)
-{
-	/* We know it is '\0' terminated. */
-	str_validate(const_cast<char *>(str), str + strlen(str) + 1);
-}
-
 
 /**
  * Checks whether the given string is valid, i.e. contains only

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -39,9 +39,9 @@ int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap)
 
 char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 
-void str_validate(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
-[[nodiscard]] std::string str_validate(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
-void ValidateString(const char *str);
+void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
+[[nodiscard]] std::string StrMakeValid(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+void StrMakeValidInPlace(const char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
 void str_strip_colours(char *str);

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -375,7 +375,7 @@ static void Xunzip(byte **bufp, size_t *sizep)
 	this->text = ReallocT(this->text, filesize + 1);
 	this->text[filesize] = '\0';
 
-	/* Replace tabs and line feeds with a space since str_validate removes those. */
+	/* Replace tabs and line feeds with a space since StrMakeValidInPlace removes those. */
 	for (char *p = this->text; *p != '\0'; p++) {
 		if (*p == '\t' || *p == '\r') *p = ' ';
 	}
@@ -384,7 +384,7 @@ static void Xunzip(byte **bufp, size_t *sizep)
 	char *p = this->text + (strncmp(u8"\ufeff", this->text, 3) == 0 ? 3 : 0);
 
 	/* Make sure the string is a valid UTF-8 sequence. */
-	str_validate(p, this->text + filesize, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE);
+	StrMakeValidInPlace(p, this->text + filesize, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE);
 
 	/* Split the string on newlines. */
 	int row = 0;

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -229,7 +229,7 @@ static void DedicatedHandleKeyInput()
 			break;
 		}
 	}
-	str_validate(input_line, lastof(input_line));
+	StrMakeValidInPlace(input_line, lastof(input_line));
 
 	IConsoleCmdExec(input_line); // execute command
 }


### PR DESCRIPTION
## Motivation / Problem

One too many times I fall into the trap that `str_validate` changes the string to become valid, instead of telling me if it is valid. So let's stop with annoying the developer, and use a name that is more explicit.

## Description

`ValidateString` used to do `str + strlen(str) + 1`. I do not know why it was doing the `+ 1`, as that always puts it outside the string. So while at it, I changed that to `str + strlen(str)` and changed all existing manual `str + strlen(str)` into using the wrapper function.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
