### PR TITLE
Codechange: use setting name instead of index for CmdChange(Company)Setting

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -544,7 +544,7 @@ public:
 					DoCommandP(0, this->sel_group | (GroupFlags::GF_REPLACE_WAGON_REMOVAL << 16), (HasBit(g->flags, GroupFlags::GF_REPLACE_WAGON_REMOVAL) ? 0 : 1) | (_ctrl_pressed << 1), CMD_SET_GROUP_FLAG);
 				} else {
 					// toggle renew_keep_length
-					DoCommandP(0, GetCompanySettingIndex("company.renew_keep_length"), Company::Get(_local_company)->settings.renew_keep_length ? 0 : 1, CMD_CHANGE_COMPANY_SETTING);
+					DoCommandP(0, 0, Company::Get(_local_company)->settings.renew_keep_length ? 0 : 1, CMD_CHANGE_COMPANY_SETTING, nullptr, "company.renew_keep_length");
 				}
 				break;
 			}

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -260,7 +260,7 @@
 
 /* static */ bool ScriptCompany::SetAutoRenewStatus(bool autorenew)
 {
-	return ScriptObject::DoCommand(0, ::GetCompanySettingIndex("company.engine_renew"), autorenew ? 1 : 0, CMD_CHANGE_COMPANY_SETTING);
+	return ScriptObject::DoCommand(0, 0, autorenew ? 1 : 0, CMD_CHANGE_COMPANY_SETTING, "company.engine_renew");
 }
 
 /* static */ bool ScriptCompany::GetAutoRenewStatus(CompanyID company)
@@ -273,7 +273,7 @@
 
 /* static */ bool ScriptCompany::SetAutoRenewMonths(int16 months)
 {
-	return ScriptObject::DoCommand(0, ::GetCompanySettingIndex("company.engine_renew_months"), months, CMD_CHANGE_COMPANY_SETTING);
+	return ScriptObject::DoCommand(0, 0, months, CMD_CHANGE_COMPANY_SETTING, "company.engine_renew_months");
 }
 
 /* static */ int16 ScriptCompany::GetAutoRenewMonths(CompanyID company)
@@ -288,7 +288,7 @@
 {
 	EnforcePrecondition(false, money >= 0);
 	EnforcePrecondition(false, (int64)money <= UINT32_MAX);
-	return ScriptObject::DoCommand(0, ::GetCompanySettingIndex("company.engine_renew_money"), money, CMD_CHANGE_COMPANY_SETTING);
+	return ScriptObject::DoCommand(0, 0, money, CMD_CHANGE_COMPANY_SETTING, "company.engine_renew_money");
 }
 
 /* static */ Money ScriptCompany::GetAutoRenewMoney(CompanyID company)

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -39,7 +39,7 @@
 
 	if ((sd->save.conv & SLF_NO_NETWORK_SYNC) != 0) return false;
 
-	return ScriptObject::DoCommand(0, GetSettingIndex(sd), value, CMD_CHANGE_SETTING);
+	return ScriptObject::DoCommand(0, 0, value, CMD_CHANGE_SETTING, sd->name);
 }
 
 /* static */ bool ScriptGameSettings::IsDisabledVehicleType(ScriptVehicle::VehicleType vehicle_type)

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -118,7 +118,7 @@
 {
 	if (HasWagonRemoval() == enable_removal) return true;
 
-	return ScriptObject::DoCommand(0, ::GetCompanySettingIndex("company.renew_keep_length"), enable_removal ? 1 : 0, CMD_CHANGE_COMPANY_SETTING);
+	return ScriptObject::DoCommand(0, 0, enable_removal ? 1 : 0, CMD_CHANGE_COMPANY_SETTING, "company.renew_keep_length");
 }
 
 /* static */ bool ScriptGroup::HasWagonRemoval()

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -32,7 +32,6 @@ struct GRFConfig *LoadGRFPresetFromConfig(const char *config_name);
 void SaveGRFPresetToConfig(const char *config_name, struct GRFConfig *config);
 void DeleteGRFPresetFromConfig(const char *config_name);
 
-uint GetCompanySettingIndex(const char *name);
 void SetDefaultCompanySettings(CompanyID cid);
 
 void SyncCompanySettings();

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -302,6 +302,5 @@ typedef std::initializer_list<std::unique_ptr<const SettingDesc>> SettingTable;
 const SettingDesc *GetSettingFromName(const char *name);
 bool SetSettingValue(const IntSettingDesc *sd, int32 value, bool force_newgame = false);
 bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
-uint GetSettingIndex(const SettingDesc *sd);
 
 #endif /* SETTINGS_INTERNAL_H */

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -2533,6 +2533,21 @@ str      = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE
 strhelp  = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_HELPTEXT
 cat      = SC_BASIC
 
+; We might need to emulate a right mouse button on mac
+[SDTC_VAR]
+ifdef    = __APPLE__
+var      = gui.right_mouse_btn_emulation
+type     = SLE_UINT8
+flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+guiflags = SGF_MULTISTRING
+def      = 0
+min      = 0
+max      = 2
+str      = STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU
+strhelp  = STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_HELPTEXT
+strval   = STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_COMMAND
+cat      = SC_BASIC
+
 [SDTC_BOOL]
 var      = gui.measure_tooltip
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
@@ -3873,24 +3888,3 @@ var      = network.no_http_content_downloads
 flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_EXPERT
-
-; Since the network code (CmdChangeSetting and friends) use the index in this array to decide
-; which setting the server is talking about all conditional compilation of this array must be at the
-; end. This isn't really the best solution, the settings the server can tell the client about should
-; either use a separate array or some other form of identifier.
-
-;
-; We might need to emulate a right mouse button on mac
-[SDTC_VAR]
-ifdef    = __APPLE__
-var      = gui.right_mouse_btn_emulation
-type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SGF_MULTISTRING
-def      = 0
-min      = 0
-max      = 2
-str      = STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU
-strhelp  = STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_HELPTEXT
-strval   = STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_COMMAND
-cat      = SC_BASIC


### PR DESCRIPTION
## Motivation / Problem

I am working towards splitting up `settings.ini` into several files. But I find these gems that requires addressing first.

## Description

These two especially I wanted to address:

- There are now constraints on settings.ini you might not expected. For example, conditional settings always have to come last, as otherwise they would influence the index.
- Adding additional SettingTables to read from would mean several functions need to be aware of this. Now a far few less.

And as bonus:
- The code becomes a lot simpler because of this.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
