### PR TITLE
Fix: artificially limit heightmap sizes to something reasonable

### DIFF
--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -23,6 +23,40 @@
 #include "safeguards.h"
 
 /**
+ * Maximum number of pixels for one dimension of a heightmap image.
+ * Do not allow images for which the longest side is twice the maximum number of
+ * tiles along the longest side of the (tile) map.
+ */
+static const uint MAX_HEIGHTMAP_SIDE_LENGTH_IN_PIXELS = 2 * MAX_MAP_SIZE;
+
+/*
+ * Maximum size in pixels of the heightmap image.
+ */
+static const uint MAX_HEIGHTMAP_SIZE_PIXELS = 256 << 20; // ~256 million
+/*
+ * When loading a PNG or BMP the 24 bpp variant requires at least 4 bytes per pixel
+ * of memory to load the data. Make sure the "reasonable" limit is well within the
+ * maximum amount of memory allocatable on 32 bit platforms.
+ */
+static_assert(MAX_HEIGHTMAP_SIZE_PIXELS < UINT32_MAX / 8);
+
+/**
+ * Check whether the loaded dimension of the heightmap image are considered valid enough
+ * to attempt to load the image. In other words, the width and height are not beyond the
+ * #MAX_HEIGHTMAP_SIDE_LENGTH_IN_PIXELS limit and the total number of pixels does not
+ * exceed #MAX_HEIGHTMAP_SIZE_PIXELS. A width or height less than 1 are disallowed too.
+ * @param width The width of the to be loaded height map.
+ * @param height The height of the to be loaded height map.
+ * @return True iff the dimensions are within the limits.
+ */
+static inline bool IsValidHeightmapDimension(size_t width, size_t height)
+{
+	return (uint64)width * height <= MAX_HEIGHTMAP_SIZE_PIXELS &&
+		width > 0 && width <= MAX_HEIGHTMAP_SIDE_LENGTH_IN_PIXELS &&
+		height > 0 && height <= MAX_HEIGHTMAP_SIDE_LENGTH_IN_PIXELS;
+}
+
+/**
  * Convert RGB colours to Grayscale using 29.9% Red, 58.7% Green, 11.4% Blue
  *  (average luminosity formula, NTSC Colour Space)
  */
@@ -146,8 +180,7 @@ static bool ReadHeightmapPNG(const char *filename, uint *x, uint *y, byte **map)
 	uint width = png_get_image_width(png_ptr, info_ptr);
 	uint height = png_get_image_height(png_ptr, info_ptr);
 
-	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
-	if ((uint64)width * height >= (size_t)-1) {
+	if (!IsValidHeightmapDimension(width, height)) {
 		ShowErrorMessage(STR_ERROR_PNGMAP, STR_ERROR_HEIGHTMAP_TOO_LARGE, WL_ERROR);
 		fclose(fp);
 		png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
@@ -255,8 +288,7 @@ static bool ReadHeightmapBMP(const char *filename, uint *x, uint *y, byte **map)
 		return false;
 	}
 
-	/* Check if image dimensions don't overflow a size_t to avoid memory corruption. */
-	if ((uint64)info.width * info.height >= (size_t)-1 / (info.bpp == 24 ? 3 : 1)) {
+	if (!IsValidHeightmapDimension(info.width, info.height)) {
 		ShowErrorMessage(STR_ERROR_BMPMAP, STR_ERROR_HEIGHTMAP_TOO_LARGE, WL_ERROR);
 		fclose(f);
 		BmpDestroyData(&data);
@@ -295,6 +327,8 @@ static void GrayscaleToMapHeights(uint img_width, uint img_height, byte *map)
 {
 	/* Defines the detail of the aspect ratio (to avoid doubles) */
 	const uint num_div = 16384;
+	/* Ensure multiplication with num_div does not cause overflows. */
+	static_assert(num_div <= std::numeric_limits<uint>::max() / MAX_HEIGHTMAP_SIDE_LENGTH_IN_PIXELS);
 
 	uint width, height;
 	uint row, col;


### PR DESCRIPTION
## Motivation / Problem

LGTM:
`if ((uint64)width * height >= (size_t)-1) {`
Comparison is always false because ... * ... <= 18446744065119617024.

Considering 18446744065119617023 a valid size is well outside of the realm of sanity for any of our players computers. So, I added some more sane limits.

If someone pushes a PNG or BMP with just under size_t dimensions into BaNaNaS and anyone trying to load that heightmap, it will crash their game when trying to allocate memory. After all, make the size so you want to allocate slightly less than (size_t)-1 and that allocation will fail as there is guaranteed not enough memory, as OpenTTD will already be using more than 1 byte.


## Description

Introduce a limit on the maximum side length of an heightmap image to be at most 2 times `MAX_MAP_SIZE` (so currently 8192), and a limit on the maximum amount of bytes to allocated for a heightmap set at 1 gigabyte.
With a 24bpp BMP that 1 GB allocation limit would result in an image with ~256 million pixels, so that limit won't be practically reached yet with 8192 maximum side lengths. However, when the maximum map size is changed, or at least the maximum size along one edge (such as in JGRPP) the size length limit becomes larger and this gets into play.


## Limitations

See description; you can't load gigapixel size height maps anymore.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
