### PR TITLE
Codechange: move casting a "const char *" to "char *" to the caller

### DIFF
--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -309,10 +309,11 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 		return false;
 	}
 
-	if (!StrEmpty(text) && (GetCommandFlags(cmd) & CMD_STR_CTRL) == 0) {
+	std::string command_text = text == nullptr ? std::string{} : text;
+	if (!command_text.empty() && (GetCommandFlags(cmd) & CMD_STR_CTRL) == 0) {
 		/* The string must be valid, i.e. not contain special codes. Since some
 		 * can be made with GSText, make sure the control codes are removed. */
-		::StrMakeValidInPlace(text, SVS_NONE);
+		command_text = ::StrMakeValid(command_text, SVS_NONE);
 	}
 
 	/* Set the default callback to return a true/false result of the DoCommand */
@@ -328,7 +329,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	if (!estimate_only && _networking && !_generating_world) SetLastCommand(tile, p1, p2, cmd);
 
 	/* Try to perform the command. */
-	CommandCost res = ::DoCommandPInternal(tile, p1, p2, cmd, (_networking && !_generating_world) ? ScriptObject::GetActiveInstance()->GetDoCommandCallback() : nullptr, text, false, estimate_only);
+	CommandCost res = ::DoCommandPInternal(tile, p1, p2, cmd, (_networking && !_generating_world) ? ScriptObject::GetActiveInstance()->GetDoCommandCallback() : nullptr, command_text.c_str(), false, estimate_only);
 
 	/* We failed; set the error and bail out */
 	if (res.Failed()) {

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -157,7 +157,7 @@ SQInteger ScriptText::_set(HSQUIRRELVM vm)
 	if (sq_gettype(vm, 2) == OT_STRING) {
 		const SQChar *key_string;
 		sq_getstring(vm, 2, &key_string);
-		StrMakeValidInPlace(key_string);
+		StrMakeValidInPlace(const_cast<char *>(key_string));
 
 		if (strncmp(key_string, "param_", 6) != 0 || strlen(key_string) > 8) return SQ_ERROR;
 		k = atoi(key_string + 6);

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -122,7 +122,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 	while (SQ_SUCCEEDED(sq_next(vm, -2))) {
 		const SQChar *key;
 		if (SQ_FAILED(sq_getstring(vm, -2, &key))) return SQ_ERROR;
-		StrMakeValidInPlace(key);
+		StrMakeValidInPlace(const_cast<char *>(key));
 
 		if (strcmp(key, "name") == 0) {
 			const SQChar *sqvalue;
@@ -141,7 +141,7 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 			const SQChar *sqdescription;
 			if (SQ_FAILED(sq_getstring(vm, -1, &sqdescription))) return SQ_ERROR;
 			config.description = stredup(sqdescription);
-			StrMakeValidInPlace(config.description);
+			StrMakeValidInPlace(const_cast<char *>(config.description));
 			items |= 0x002;
 		} else if (strcmp(key, "min_value") == 0) {
 			SQInteger res;
@@ -226,7 +226,7 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 {
 	const SQChar *setting_name;
 	if (SQ_FAILED(sq_getstring(vm, -2, &setting_name))) return SQ_ERROR;
-	StrMakeValidInPlace(setting_name);
+	StrMakeValidInPlace(const_cast<char *>(setting_name));
 
 	ScriptConfigItem *config = nullptr;
 	for (auto &item : this->config_list) {
@@ -253,7 +253,7 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 		/* Because squirrel doesn't support identifiers starting with a digit,
 		 * we skip the first character. */
 		int key = atoi(key_string + 1);
-		StrMakeValidInPlace(label);
+		StrMakeValidInPlace(const_cast<char *>(label));
 
 		/* !Contains() prevents stredup from leaking. */
 		if (!config->labels->Contains(key)) config->labels->Insert(key, stredup(label));

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -448,7 +448,7 @@ bool Squirrel::CallStringMethodStrdup(HSQOBJECT instance, const char *method_nam
 	if (!this->CallMethod(instance, method_name, &ret, suspend)) return false;
 	if (ret._type != OT_STRING) return false;
 	*res = stredup(ObjectToString(&ret));
-	StrMakeValidInPlace(*res);
+	StrMakeValidInPlace(const_cast<char *>(*res));
 	return true;
 }
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -266,10 +266,10 @@ void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings s
  * otherwise use StrMakeValidInPlace(str, last, settings) variant.
  * @param str The string (of which you are sure ends with '\0') to validate.
  */
-void StrMakeValidInPlace(const char *str, StringValidationSettings settings)
+void StrMakeValidInPlace(char *str, StringValidationSettings settings)
 {
 	/* We know it is '\0' terminated. */
-	StrMakeValidInPlace(const_cast<char *>(str), str + strlen(str), settings);
+	StrMakeValidInPlace(str, str + strlen(str), settings);
 }
 
 /**

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -41,7 +41,7 @@ char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
 
 void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
 [[nodiscard]] std::string StrMakeValid(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
-void StrMakeValidInPlace(const char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+void StrMakeValidInPlace(char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);
 void str_strip_colours(char *str);


### PR DESCRIPTION
## Motivation / Problem

With #9306 I found out that the fact that `StrMakeValidInPlace` says `str` is a `const char*`, but really is changing the string, can have some nasty side-effects.

## Description

Play nice, don't pretend we are not going to change something we are. Let the caller figure out if casting from `const char*` to `char *` is a safe thing to do.

In one case (`ScriptObject::DoCommand`) it would result in very ugly code to let the caller do it, so instead duplicate the value and make the changes if needed.

## Limitations

I really wonder if some of these casts are in fact safe. But this code has been running for years now, so I guess it is?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
