### PR TITLE
Codechange: [Network] Use more std::string in server code

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -724,7 +724,7 @@ DEF_CONSOLE_CMD(ConClientNickChange)
 		return true;
 	}
 
-	if (!NetworkServerChangeClientName(client_id, client_name.c_str())) {
+	if (!NetworkServerChangeClientName(client_id, client_name)) {
 		IConsoleError("Cannot give a client a duplicate name");
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -473,7 +473,7 @@ DEF_CONSOLE_CMD(ConClearBuffer)
  * Network Core Console Commands
  **********************************/
 
-static bool ConKickOrBan(const char *argv, bool ban, const char *reason)
+static bool ConKickOrBan(const char *argv, bool ban, const std::string &reason)
 {
 	uint n;
 
@@ -527,7 +527,7 @@ DEF_CONSOLE_CMD(ConKick)
 	if (argc != 2 && argc != 3) return false;
 
 	/* No reason supplied for kicking */
-	if (argc == 2) return ConKickOrBan(argv[1], false, nullptr);
+	if (argc == 2) return ConKickOrBan(argv[1], false, {});
 
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
@@ -551,7 +551,7 @@ DEF_CONSOLE_CMD(ConBan)
 	if (argc != 2 && argc != 3) return false;
 
 	/* No reason supplied for kicking */
-	if (argc == 2) return ConKickOrBan(argv[1], true, nullptr);
+	if (argc == 2) return ConKickOrBan(argv[1], true, {});
 
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1358,9 +1358,8 @@ void NetworkUpdateClientName(const std::string &client_name)
 			MyClient::SendSetName(client_name);
 		} else {
 			/* Copy to a temporary buffer so no #n gets added after our name in the settings when there are duplicate names. */
-			char temporary_name[NETWORK_CLIENT_NAME_LENGTH];
-			strecpy(temporary_name, client_name.c_str(), lastof(temporary_name));
-			if (NetworkFindName(temporary_name, lastof(temporary_name))) {
+			std::string temporary_name = client_name;
+			if (NetworkMakeClientNameUnique(temporary_name)) {
 				NetworkTextMessage(NETWORK_ACTION_NAME_CHANGE, CC_DEFAULT, false, ci->client_name, temporary_name);
 				ci->client_name = temporary_name;
 				NetworkUpdateClientInfo(CLIENT_ID_SERVER);

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -491,7 +491,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetPassword(const std::str
  * Tell the server that we like to change the name of the client.
  * @param name The new name.
  */
-NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const char *name)
+NetworkRecvStatus ClientNetworkGameSocketHandler::SendSetName(const std::string &name)
 {
 	Packet *p = new Packet(PACKET_CLIENT_SET_NAME);
 
@@ -516,7 +516,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::SendQuit()
  * @param pass The password for the remote command.
  * @param command The actual command.
  */
-NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(const std::string &pass, const char *command)
+NetworkRecvStatus ClientNetworkGameSocketHandler::SendRCon(const std::string &pass, const std::string &command)
 {
 	Packet *p = new Packet(PACKET_CLIENT_RCON);
 	p->Send_string(pass);
@@ -1258,7 +1258,7 @@ void NetworkClient_Connected()
  * @param password The password.
  * @param command The command to execute.
  */
-void NetworkClientSendRcon(const std::string &password, const char *command)
+void NetworkClientSendRcon(const std::string &password, const std::string &command)
 {
 	MyClient::SendRCon(password, command);
 }
@@ -1355,7 +1355,7 @@ void NetworkUpdateClientName(const std::string &client_name)
 	/* Don't change the name if it is the same as the old name */
 	if (client_name.compare(ci->client_name) != 0) {
 		if (!_network_server) {
-			MyClient::SendSetName(client_name.c_str());
+			MyClient::SendSetName(client_name);
 		} else {
 			/* Copy to a temporary buffer so no #n gets added after our name in the settings when there are duplicate names. */
 			char temporary_name[NETWORK_CLIENT_NAME_LENGTH];

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -95,8 +95,8 @@ public:
 
 	static NetworkRecvStatus SendChat(NetworkAction action, DestType type, int dest, const std::string &msg, int64 data);
 	static NetworkRecvStatus SendSetPassword(const std::string &password);
-	static NetworkRecvStatus SendSetName(const char *name);
-	static NetworkRecvStatus SendRCon(const std::string &password, const char *command);
+	static NetworkRecvStatus SendSetName(const std::string &name);
+	static NetworkRecvStatus SendRCon(const std::string &password, const std::string &command);
 	static NetworkRecvStatus SendMove(CompanyID company, const std::string &password);
 
 	static bool IsConnected();

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -77,7 +77,7 @@ bool NetworkServerChangeClientName(ClientID client_id, const std::string &new_na
 
 
 void NetworkServerDoMove(ClientID client_id, CompanyID company_id);
-void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const char *string);
+void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const std::string &string);
 void NetworkServerSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, ClientID from_id, int64 data = 0, bool from_admin = false);
 
 void NetworkServerKickClient(ClientID client_id, const char *reason);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -55,7 +55,7 @@ void NetworkClientsToSpectators(CompanyID cid);
 bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password = "", const std::string &join_company_password = "");
 void NetworkClientJoinGame();
 void NetworkClientRequestMove(CompanyID company, const std::string &pass = "");
-void NetworkClientSendRcon(const std::string &password, const char *command);
+void NetworkClientSendRcon(const std::string &password, const std::string &command);
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, int64 data = 0);
 bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio);
 bool NetworkCompanyIsPassworded(CompanyID company_id);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -73,7 +73,7 @@ void NetworkServerUpdateGameInfo();
 void NetworkServerShowStatusToConsole();
 bool NetworkServerStart();
 void NetworkServerNewCompany(const Company *company, NetworkClientInfo *ci);
-bool NetworkServerChangeClientName(ClientID client_id, const char *new_name);
+bool NetworkServerChangeClientName(ClientID client_id, const std::string &new_name);
 
 
 void NetworkServerDoMove(ClientID client_id, CompanyID company_id);

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -80,9 +80,9 @@ void NetworkServerDoMove(ClientID client_id, CompanyID company_id);
 void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const std::string &string);
 void NetworkServerSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, ClientID from_id, int64 data = 0, bool from_admin = false);
 
-void NetworkServerKickClient(ClientID client_id, const char *reason);
-uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, const char *reason);
-uint NetworkServerKickOrBanIP(const char *ip, bool ban, const char *reason);
+void NetworkServerKickClient(ClientID client_id, const std::string &reason);
+uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, const std::string &reason);
+uint NetworkServerKickOrBanIP(const std::string &ip, bool ban, const std::string &reason);
 
 void NetworkInitChatMessage();
 void CDECL NetworkAddChatMessage(TextColour colour, uint duration, const std::string &message);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1661,7 +1661,7 @@ enum DropDownAdmin {
  */
 static void AdminClientKickCallback(Window *w, bool confirmed)
 {
-	if (confirmed) NetworkServerKickClient(_admin_client_id, nullptr);
+	if (confirmed) NetworkServerKickClient(_admin_client_id, {});
 }
 
 /**
@@ -1671,7 +1671,7 @@ static void AdminClientKickCallback(Window *w, bool confirmed)
  */
 static void AdminClientBanCallback(Window *w, bool confirmed)
 {
-	if (confirmed) NetworkServerKickOrBanIP(_admin_client_id, true, nullptr);
+	if (confirmed) NetworkServerKickOrBanIP(_admin_client_id, true, {});
 }
 
 /**

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -117,7 +117,7 @@ void ShowNetworkError(StringID error_string);
 void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send, const std::string &name, const std::string &str = "", int64 data = 0);
 uint NetworkCalculateLag(const NetworkClientSocket *cs);
 StringID GetNetworkErrorMsg(NetworkErrorCode err);
-bool NetworkFindName(char *new_name, const char *last);
+bool NetworkMakeClientNameUnique(std::string &new_name);
 std::string GenerateCompanyPasswordHash(const std::string &password, const std::string &password_server_id, uint32 password_game_seed);
 
 NetworkAddress ParseConnectionString(const std::string &connection_string, uint16 default_port);

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1719,7 +1719,7 @@ bool NetworkFindName(char *new_name, const char *last)
  * @param new_name the new name for the client
  * @return true iff the name was changed
  */
-bool NetworkServerChangeClientName(ClientID client_id, const char *new_name)
+bool NetworkServerChangeClientName(ClientID client_id, const std::string &new_name)
 {
 	/* Check if the name's already in use */
 	for (NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -785,7 +785,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGame()
  * @param colour The colour of the result.
  * @param command The command that was executed.
  */
-NetworkRecvStatus ServerNetworkGameSocketHandler::SendRConResult(uint16 colour, const char *command)
+NetworkRecvStatus ServerNetworkGameSocketHandler::SendRConResult(uint16 colour, const std::string &command)
 {
 	Packet *p = new Packet(PACKET_SERVER_RCON);
 
@@ -1424,22 +1424,20 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_RCON(Packet *p)
 {
 	if (this->status != STATUS_ACTIVE) return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
 
-	char command[NETWORK_RCONCOMMAND_LENGTH];
-
 	if (_settings_client.network.rcon_password.empty()) return NETWORK_RECV_STATUS_OKAY;
 
 	std::string password = p->Recv_string(NETWORK_PASSWORD_LENGTH);
-	p->Recv_string(command, sizeof(command));
+	std::string command = p->Recv_string(NETWORK_RCONCOMMAND_LENGTH);
 
 	if (_settings_client.network.rcon_password.compare(password) != 0) {
 		DEBUG(net, 1, "[rcon] Wrong password from client-id %d", this->client_id);
 		return NETWORK_RECV_STATUS_OKAY;
 	}
 
-	DEBUG(net, 3, "[rcon] Client-id %d executed: %s", this->client_id, command);
+	DEBUG(net, 3, "[rcon] Client-id %d executed: %s", this->client_id, command.c_str());
 
 	_redirect_console_to_client = this->client_id;
-	IConsoleCmdExec(command);
+	IConsoleCmdExec(command.c_str());
 	_redirect_console_to_client = INVALID_CLIENT_ID;
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -2046,7 +2044,7 @@ void NetworkServerDoMove(ClientID client_id, CompanyID company_id)
  * @param colour_code The colour of the text.
  * @param string The actual reply.
  */
-void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const char *string)
+void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const std::string &string)
 {
 	NetworkClientSocket::GetByClientID(client_id)->SendRConResult(colour_code, string);
 }

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -429,12 +429,12 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCompanyInfo()
  * @param error The error to disconnect for.
  * @param reason In case of kicking a client, specifies the reason for kicking the client.
  */
-NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode error, const char *reason)
+NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode error, const std::string &reason)
 {
 	Packet *p = new Packet(PACKET_SERVER_ERROR);
 
 	p->Send_uint8(error);
-	if (reason != nullptr) p->Send_string(reason);
+	if (!reason.empty()) p->Send_string(reason);
 	this->SendPacket(p);
 
 	StringID strid = GetNetworkErrorMsg(error);
@@ -447,7 +447,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 
 		DEBUG(net, 1, "'%s' made an error and has been disconnected: %s", client_name, GetString(strid).c_str());
 
-		if (error == NETWORK_ERROR_KICKED && reason != nullptr) {
+		if (error == NETWORK_ERROR_KICKED && !reason.empty()) {
 			NetworkTextMessage(NETWORK_ACTION_KICKED, CC_DEFAULT, false, client_name, reason, strid);
 		} else {
 			NetworkTextMessage(NETWORK_ACTION_LEAVE, CC_DEFAULT, false, client_name, "", strid);
@@ -2054,7 +2054,7 @@ void NetworkServerSendRcon(ClientID client_id, TextColour colour_code, const std
  * @param client_id The client to kick.
  * @param reason In case of kicking a client, specifies the reason for kicking the client.
  */
-void NetworkServerKickClient(ClientID client_id, const char *reason)
+void NetworkServerKickClient(ClientID client_id, const std::string &reason)
 {
 	if (client_id == CLIENT_ID_SERVER) return;
 	NetworkClientSocket::GetByClientID(client_id)->SendError(NETWORK_ERROR_KICKED, reason);
@@ -2066,7 +2066,7 @@ void NetworkServerKickClient(ClientID client_id, const char *reason)
  * @param ban Whether to ban or kick.
  * @param reason In case of kicking a client, specifies the reason for kicking the client.
  */
-uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, const char *reason)
+uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, const std::string &reason)
 {
 	return NetworkServerKickOrBanIP(NetworkClientSocket::GetByClientID(client_id)->GetClientIP(), ban, reason);
 }
@@ -2077,7 +2077,7 @@ uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, const char *reason)
  * @param ban Whether to ban or just kick.
  * @param reason In case of kicking a client, specifies the reason for kicking the client.
  */
-uint NetworkServerKickOrBanIP(const char *ip, bool ban, const char *reason)
+uint NetworkServerKickOrBanIP(const std::string &ip, bool ban, const std::string &reason)
 {
 	/* Add address to ban-list */
 	if (ban) {
@@ -2101,7 +2101,7 @@ uint NetworkServerKickOrBanIP(const char *ip, bool ban, const char *reason)
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 		if (cs->client_id == CLIENT_ID_SERVER) continue;
 		if (cs->client_id == _redirect_console_to_client) continue;
-		if (cs->client_address.IsInNetmask(ip)) {
+		if (cs->client_address.IsInNetmask(ip.c_str())) {
 			NetworkServerKickClient(cs->client_id, reason);
 			n++;
 		}

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -93,7 +93,7 @@ public:
 	NetworkRecvStatus SendMove(ClientID client_id, CompanyID company_id);
 
 	NetworkRecvStatus SendClientInfo(NetworkClientInfo *ci);
-	NetworkRecvStatus SendError(NetworkErrorCode error, const char *reason = nullptr);
+	NetworkRecvStatus SendError(NetworkErrorCode error, const std::string &reason = {});
 	NetworkRecvStatus SendChat(NetworkAction action, ClientID client_id, bool self_send, const std::string &msg, int64 data);
 	NetworkRecvStatus SendJoin(ClientID client_id);
 	NetworkRecvStatus SendFrame();

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -89,7 +89,7 @@ public:
 	NetworkRecvStatus SendQuit(ClientID client_id);
 	NetworkRecvStatus SendShutdown();
 	NetworkRecvStatus SendNewGame();
-	NetworkRecvStatus SendRConResult(uint16 colour, const char *command);
+	NetworkRecvStatus SendRConResult(uint16 colour, const std::string &command);
 	NetworkRecvStatus SendMove(ClientID client_id, CompanyID company_id);
 
 	NetworkRecvStatus SendClientInfo(NetworkClientInfo *ci);


### PR DESCRIPTION
## Motivation / Problem

Partial conversion of C-string to std::string is not done.


## Description

Change some internal code related to kicking/banning, rcon and client names to use std::string over C-strings.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
