### PR TITLE
Codechange: use setting name instead of index for HandleOldDiffCustom()

### DIFF
--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -61,6 +61,9 @@ enum IndustryDensity {
 
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
+	byte   competitor_start_time;            ///< Unused value, used to load old savegames.
+	byte   competitor_intelligence;          ///< Unused value, used to load old savegames.
+
 	byte   max_no_competitors;               ///< the number of competitors (AIs)
 	byte   number_towns;                     ///< the amount of towns
 	byte   industry_density;                 ///< The industry density. @see IndustryDensity

--- a/src/table/settings/gameopt_settings.ini
+++ b/src/table/settings/gameopt_settings.ini
@@ -15,6 +15,7 @@
 
 [pre-amble]
 static const uint GAME_DIFFICULTY_NUM = 18;
+static const std::array<std::string, GAME_DIFFICULTY_NUM> _old_diff_settings{"max_no_competitors", "competitor_start_time", "number_towns", "industry_density", "max_loan", "initial_interest", "vehicle_costs", "competitor_speed", "competitor_intelligence", "vehicle_breakdowns", "subsidy_multiplier", "construction_cost", "terrain_type", "quantity_sea_lakes", "economy", "line_reverse_mode", "disasters", "town_council_tolerance"};
 static uint16 _old_diff_custom[GAME_DIFFICULTY_NUM];
 uint8 _old_diff_level;                                 ///< Old difficulty level from old savegames
 uint8 _old_units;                                      ///< Old units from old savegames

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -94,7 +94,7 @@ startup  = false
 
 
 ; Saved settings variables.
-; Do not ADD or REMOVE something in this "difficulty.XXX" table or before it. It breaks savegame compatibility.
+; The next 18 entries are important for savegame compatibility. Do NOT remove those. See HandleOldDiffCustom() for more details.
 [SDT_VAR]
 var      = difficulty.max_no_competitors
 type     = SLE_UINT8
@@ -106,10 +106,14 @@ interval = 1
 post_cb  = MaxNoAIsChange
 cat      = SC_BASIC
 
-[SDT_NULL]
-length   = 1
+[SDT_VAR]
+var      = difficulty.competitor_start_time
+type     = SLE_UINT8
 from     = SLV_97
 to       = SLV_110
+def      = 2
+min      = 0
+max      = 3
 
 [SDT_VAR]
 var      = difficulty.number_towns
@@ -192,10 +196,14 @@ strhelp  = STR_CONFIG_SETTING_CONSTRUCTION_SPEED_HELPTEXT
 strval   = STR_AI_SPEED_VERY_SLOW
 cat      = SC_BASIC
 
-[SDT_NULL]
-length   = 1
+[SDT_VAR]
+var      = difficulty.competitor_intelligence
+type     = SLE_UINT8
 from     = SLV_97
 to       = SLV_110
+def      = 0
+min      = 0
+max      = 2
 
 [SDT_VAR]
 var      = difficulty.vehicle_breakdowns


### PR DESCRIPTION
## Motivation / Problem

In the future I would like to move settings around. For this, I cannot have things that depend on being on a certain index.


## Description

So, instead, use strings.

I tested this with savegame version 0, 4, 113, and recent. Seems to work as expected. But boy, this was complicated code to validate.

## Limitations

I would rather iterate over a `_difficulty_settings`, but this is not (yet) possible. Future PRs will address that, removing the string-list and two unused settings again.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
