### PR TITLE
Codechange: add a wrapper function to find all settings based on prefix

### DIFF
--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -20,8 +20,6 @@
 typedef LinkGraph::BaseNode Node;
 typedef LinkGraph::BaseEdge Edge;
 
-const SettingDesc *GetSettingDescription(uint index);
-
 static uint16 _num_nodes;
 
 /**
@@ -70,17 +68,10 @@ const SaveLoad *GetLinkGraphJobDesc()
 
 	/* Build the SaveLoad array on first call and don't touch it later on */
 	if (saveloads.size() == 0) {
-		size_t prefixlen = strlen(prefix);
+		GetSettingSaveLoadByPrefix(prefix, saveloads);
 
-		int setting = 0;
-		const SettingDesc *desc = GetSettingDescription(setting);
-		while (desc != nullptr) {
-			if (desc->name != nullptr && strncmp(desc->name, prefix, prefixlen) == 0) {
-				SaveLoad sl = desc->save;
-				sl.address_proc = proc;
-				saveloads.push_back(sl);
-			}
-			desc = GetSettingDescription(++setting);
+		for (auto &sl : saveloads) {
+			sl.address_proc = proc;
 		}
 
 		int i = 0;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -94,17 +94,6 @@ typedef void SettingDescProcList(IniFile *ini, const char *grpname, StringList &
 static bool IsSignedVarMemType(VarType vt);
 
 /**
- * Get the setting at the given index into the settings table.
- * @param index The index to look for.
- * @return The setting at the given index, or nullptr when the index is invalid.
- */
-const SettingDesc *GetSettingDescription(uint index)
-{
-	if (index >= _settings.size()) return nullptr;
-	return _settings.begin()[index].get();
-}
-
-/**
  * Groups in openttd.cfg that are actually lists.
  */
 static const char * const _list_group_names[] = {
@@ -1737,6 +1726,21 @@ static const SettingDesc *GetSettingFromName(const char *name, const SettingTabl
 	}
 
 	return nullptr;
+}
+
+/**
+ * Get the SaveLoad from all settings matching the prefix.
+ * @param prefix The prefix to look for.
+ * @param saveloads A vector to store the result in.
+ */
+void GetSettingSaveLoadByPrefix(const char *prefix, std::vector<SaveLoad> &saveloads)
+{
+	size_t prefixlen = strlen(prefix);
+
+	for (auto &sd : _settings) {
+		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
+		if (strncmp(sd->name, prefix, prefixlen) == 0) saveloads.push_back(sd->save);
+	}
 }
 
 /**

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -300,6 +300,7 @@ struct NullSettingDesc : SettingDesc {
 typedef std::initializer_list<std::unique_ptr<const SettingDesc>> SettingTable;
 
 const SettingDesc *GetSettingFromName(const char *name);
+void GetSettingSaveLoadByPrefix(const char *prefix, std::vector<SaveLoad> &saveloads);
 bool SetSettingValue(const IntSettingDesc *sd, int32 value, bool force_newgame = false);
 bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
 


### PR DESCRIPTION
Depends on #9311.

## Motivation / Problem

One more piece of code that depends on index access into `_settings`.

## Description

After this, `_settings` is free of indexed access, meaning we can finally start splitting it into several arrays after this PR.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
