### PR TITLE
Codechange: rename _SQ64 into POINTER_IS_64BIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,7 @@ if(WIN32)
 endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    add_definitions(-D_SQ64)
+    add_definitions(-DPOINTER_IS_64BIT)
 endif()
 
 include(CreateRegression)

--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -198,7 +198,7 @@ bmno_full_transparency:
 							m_colour = r == 0 ? m_colour : cmap; \
 							m_colour = m != 0 ? m_colour : srcm; \
 							}
-#ifdef _SQ64
+#ifdef POINTER_IS_64BIT
 						uint64 srcs = _mm_cvtsi128_si64(srcABCD);
 						uint64 dsts;
 						if (animated) dsts = _mm_cvtsi128_si64(dstABCD);
@@ -380,7 +380,7 @@ bm_normal:
 					else                           Draw<BM_NORMAL, RM_WITH_SKIP, BT_ODD, true, true>(bp, zoom);
 				}
 			} else {
-#ifdef _SQ64
+#ifdef POINTER_IS_64BIT
 				if (sprite_flags & SF_TRANSLUCENT) {
 					if (sprite_flags & SF_NO_ANIM) Draw<BM_NORMAL, RM_WITH_MARGIN, BT_NONE, true, false>(bp, zoom);
 					else                           Draw<BM_NORMAL, RM_WITH_MARGIN, BT_NONE, true, true>(bp, zoom);

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -34,7 +34,7 @@ static inline void InsertSecondUint32(const uint32 value, __m128i &into)
 
 static inline void LoadUint64(const uint64 value, __m128i &into)
 {
-#ifdef _SQ64
+#ifdef POINTER_IS_64BIT
 	into = _mm_cvtsi64_si128(value);
 #else
 	#if (SSE_VERSION >= 4)
@@ -297,7 +297,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 							m_colour = r == 0 ? m_colour : cmap; \
 							m_colour = m != 0 ? m_colour : srcm; \
 							}
-#ifdef _SQ64
+#ifdef POINTER_IS_64BIT
 						uint64 srcs = _mm_cvtsi128_si64(srcABCD);
 						uint64 remapped_src = 0;
 						CMOV_REMAP(c0, 0, srcs, mvX2);

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -126,7 +126,7 @@ char *CrashLog::LogOpenTTDVersion(char *buffer, const char *last) const
 			_openttd_revision,
 			_openttd_revision_modified,
 			_openttd_newgrf_version,
-#ifdef _SQ64
+#ifdef POINTER_IS_64BIT
 			64,
 #else
 			32,

--- a/src/os/macosx/osx_stdafx.h
+++ b/src/os/macosx/osx_stdafx.h
@@ -73,8 +73,8 @@
 #endif
 
 /* Check for mismatching 'architectures' */
-#if !defined(STRGEN) && !defined(SETTINGSGEN) && ((defined(__LP64__) && !defined(_SQ64)) || (!defined(__LP64__) && defined(_SQ64)))
-#	error "Compiling 64 bits without _SQ64 set! (or vice versa)"
+#if !defined(STRGEN) && !defined(SETTINGSGEN) && ((defined(__LP64__) && !defined(POINTER_IS_64BIT)) || (!defined(__LP64__) && defined(POINTER_IS_64BIT)))
+#	error "Compiling 64 bits without POINTER_IS_64BIT set! (or vice versa)"
 #endif
 
 /* Name conflict */

--- a/src/viewport_sprite_sorter_sse4.cpp
+++ b/src/viewport_sprite_sorter_sse4.cpp
@@ -19,7 +19,7 @@
 
 #include "safeguards.h"
 
-#ifdef _SQ64
+#ifdef POINTER_IS_64BIT
 	static_assert((sizeof(ParentSpriteToDraw) % 16) == 0);
 #	define LOAD_128 _mm_load_si128
 #else


### PR DESCRIPTION
## Motivation / Problem

I was looking through the code and found an remnant of the past.


## Description

Back in the day Squirrel could be compiled either 32bit or 64bit. `_SQ64` indicate which of the two. This of course was problematic, as we had AIs that did work on a 64bit system, but failed on a 32bit. So yeah .. since 39e90ec6 Squirrel is always in 64bit mode.

Just ... some people found out that `_SQ64` indicate if the system was 64bit or not, and started to use that in a few other places in the code too. And so now we are left with a codebase where the reference to Squirrel is lost in the meaning of the define (read: it is not used anywhere in Squirrel, yet carries the name).

So, lets rename the variable in to what it means, so the other usages feel a bit more legit :) We are now `_SQ64` free! \o/


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
