### PR TITLE
Codechange: let the setting name be std::string

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -52,6 +52,7 @@ public:
 
 	void SetDParam(uint n, uint64 v);
 	void SetDParamStr(uint n, const char *str);
+	void SetDParamStr(uint n, const std::string &str);
 
 	void CopyOutDParams();
 };

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -164,6 +164,16 @@ void ErrorMessageData::SetDParamStr(uint n, const char *str)
 	this->strings[n] = stredup(str);
 }
 
+/**
+ * Set a rawstring parameter.
+ * @param n Parameter index
+ * @param str Raw string
+ */
+void ErrorMessageData::SetDParamStr(uint n, const std::string &str)
+{
+	this->SetDParamStr(n, str.c_str());
+}
+
 /** Define a queue with errors. */
 typedef std::list<ErrorMessageData> ErrorList;
 /** The actual queue with errors. */

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -483,14 +483,14 @@ void GamelogOldver()
  * @param oldval old setting value
  * @param newval new setting value
  */
-void GamelogSetting(const char *name, int32 oldval, int32 newval)
+void GamelogSetting(const std::string &name, int32 oldval, int32 newval)
 {
 	assert(_gamelog_action_type == GLAT_SETTING);
 
 	LoggedChange *lc = GamelogChange(GLCT_SETTING);
 	if (lc == nullptr) return;
 
-	lc->setting.name = stredup(name);
+	lc->setting.name = stredup(name.c_str());
 	lc->setting.oldval = oldval;
 	lc->setting.newval = newval;
 }

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -48,7 +48,7 @@ bool GamelogTestEmergency();
 void GamelogRevision();
 void GamelogMode();
 void GamelogOldver();
-void GamelogSetting(const char *name, int32 oldval, int32 newval);
+void GamelogSetting(const std::string &name, int32 oldval, int32 newval);
 
 void GamelogGRFUpdate(const GRFConfig *oldg, const GRFConfig *newg);
 void GamelogGRFAddList(const GRFConfig *newg);

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -828,7 +828,7 @@ struct SpriteAlignerWindow : Window {
 		switch (widget) {
 			case WID_SA_CAPTION:
 				SetDParam(0, this->current_sprite);
-				SetDParamStr(1, GetOriginFile(this->current_sprite)->GetSimplifiedFilename().c_str());
+				SetDParamStr(1, GetOriginFile(this->current_sprite)->GetSimplifiedFilename());
 				break;
 
 			case WID_SA_OFFSETS_ABS:

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -703,7 +703,7 @@ int openttd_main(int argc, char *argv[])
 			BaseGraphics::SetSet({});
 
 			ErrorMessageData msg(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_BASE_GRAPHICS_NOT_FOUND);
-			msg.SetDParamStr(0, graphics_set.c_str());
+			msg.SetDParamStr(0, graphics_set);
 			ScheduleErrorMessage(msg);
 		}
 	}
@@ -762,7 +762,7 @@ int openttd_main(int argc, char *argv[])
 			usererror("Failed to find a sounds set. Please acquire a sounds set for OpenTTD. See section 1.4 of README.md.");
 		} else {
 			ErrorMessageData msg(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_BASE_SOUNDS_NOT_FOUND);
-			msg.SetDParamStr(0, sounds_set.c_str());
+			msg.SetDParamStr(0, sounds_set);
 			ScheduleErrorMessage(msg);
 		}
 	}
@@ -774,7 +774,7 @@ int openttd_main(int argc, char *argv[])
 			usererror("Failed to find a music set. Please acquire a music set for OpenTTD. See section 1.4 of README.md.");
 		} else {
 			ErrorMessageData msg(STR_CONFIG_ERROR, STR_CONFIG_ERROR_INVALID_BASE_MUSIC_NOT_FOUND);
-			msg.SetDParamStr(0, music_set.c_str());
+			msg.SetDParamStr(0, music_set);
 			ScheduleErrorMessage(msg);
 		}
 	}

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -37,7 +37,7 @@
 
 	if ((sd->flags & SF_NO_NETWORK_SYNC) != 0) return false;
 
-	return ScriptObject::DoCommand(0, 0, value, CMD_CHANGE_SETTING, sd->name);
+	return ScriptObject::DoCommand(0, 0, value, CMD_CHANGE_SETTING, sd->name.c_str());
 }
 
 /* static */ bool ScriptGameSettings::IsDisabledVehicleType(ScriptVehicle::VehicleType vehicle_type)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1980,13 +1980,13 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
 	const void *object = (_game_mode == GM_MENU || force_newgame) ? &_settings_newgame : &_settings_game;
 
 	if (sd->IsStringSetting()) {
-		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s'", name, sd->AsStringSetting()->Read(object).c_str());
+		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s'", sd->name.c_str(), sd->AsStringSetting()->Read(object).c_str());
 	} else if (sd->IsIntSetting()) {
 		char value[20];
 		sd->FormatValue(value, lastof(value), object);
 		const IntSettingDesc *int_setting = sd->AsIntSetting();
 		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s' (min: %s%d, max: %u)",
-			name, value, (sd->flags & SF_GUI_0_IS_SPECIAL) ? "(0) " : "", int_setting->min, int_setting->max);
+			sd->name.c_str(), value, (sd->flags & SF_GUI_0_IS_SPECIAL) ? "(0) " : "", int_setting->min, int_setting->max);
 	}
 }
 
@@ -2001,10 +2001,10 @@ void IConsoleListSettings(const char *prefilter)
 
 	for (auto &sd : _settings) {
 		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
-		if (prefilter != nullptr && strstr(sd->name, prefilter) == nullptr) continue;
+		if (prefilter != nullptr && sd->name.find(prefilter) == std::string::npos) continue;
 		char value[80];
 		sd->FormatValue(value, lastof(value), &GetGameSettings());
-		IConsolePrintF(CC_DEFAULT, "%s = %s", sd->name, value);
+		IConsolePrintF(CC_DEFAULT, "%s = %s", sd->name.c_str(), value);
 	}
 
 	IConsolePrintF(CC_WARNING, "Use 'setting' command to change a value");

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -301,8 +301,8 @@ struct NullSettingDesc : SettingDesc {
 
 typedef std::initializer_list<std::unique_ptr<const SettingDesc>> SettingTable;
 
-const SettingDesc *GetSettingFromName(const char *name);
-void GetSettingSaveLoadByPrefix(const char *prefix, std::vector<SaveLoad> &saveloads);
+const SettingDesc *GetSettingFromName(const std::string_view name);
+void GetSettingSaveLoadByPrefix(const std::string_view prefix, std::vector<SaveLoad> &saveloads);
 bool SetSettingValue(const IntSettingDesc *sd, int32 value, bool force_newgame = false);
 bool SetSettingValue(const StringSettingDesc *sd, const std::string value, bool force_newgame = false);
 

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -69,11 +69,11 @@ struct IniItem;
 
 /** Properties of config file settings. */
 struct SettingDesc {
-	SettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup) :
+	SettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup) :
 		name(name), flags(flags), startup(startup), save(save) {}
 	virtual ~SettingDesc() {}
 
-	const char *name;   ///< Name of the setting. Used in configuration file and for console.
+	std::string name;   ///< Name of the setting. Used in configuration file and for console.
 	SettingFlag flags;  ///< Handles how a setting would show up in the GUI (text/currency, etc.).
 	bool startup;       ///< Setting has to be loaded directly at startup?.
 	SaveLoad save;      ///< Internal structure (going to savegame, parts to config).
@@ -140,7 +140,7 @@ struct IntSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(int32 value);
 
-	IntSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, int32 def,
+	IntSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, int32 def,
 			int32 min, uint32 max, int32 interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def), min(min), max(max), interval(interval),
@@ -182,7 +182,7 @@ private:
 
 /** Boolean setting. */
 struct BoolSettingDesc : IntSettingDesc {
-	BoolSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, bool def,
+	BoolSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, bool def,
 			StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		IntSettingDesc(save, name, flags, startup, def, 0, 1, 0, str, str_help, str_val, cat,
@@ -198,7 +198,7 @@ struct BoolSettingDesc : IntSettingDesc {
 struct OneOfManySettingDesc : IntSettingDesc {
 	typedef size_t OnConvert(const char *value); ///< callback prototype for conversion error
 
-	OneOfManySettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, int32 def,
+	OneOfManySettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, int32 def,
 			int32 max, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
 			std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -222,7 +222,7 @@ struct OneOfManySettingDesc : IntSettingDesc {
 
 /** Many of many setting. */
 struct ManyOfManySettingDesc : OneOfManySettingDesc {
-	ManyOfManySettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup,
+	ManyOfManySettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup,
 		int32 def, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 		PreChangeCheck pre_check, PostChangeCallback post_callback,
 		std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -251,7 +251,7 @@ struct StringSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(const std::string &value);
 
-	StringSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, const char *def,
+	StringSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, const char *def,
 			uint32 max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
 			pre_check(pre_check), post_callback(post_callback) {}
@@ -277,7 +277,7 @@ private:
 
 /** List/array settings. */
 struct ListSettingDesc : SettingDesc {
-	ListSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, const char *def) :
+	ListSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, const char *def) :
 		SettingDesc(save, name, flags, startup), def(def) {}
 	virtual ~ListSettingDesc() {}
 
@@ -291,7 +291,7 @@ struct ListSettingDesc : SettingDesc {
 /** Placeholder for settings that have been removed, but might still linger in the savegame. */
 struct NullSettingDesc : SettingDesc {
 	NullSettingDesc(SaveLoad save) :
-		SettingDesc(save, "", SF_NOT_IN_CONFIG, false) {}
+		SettingDesc(save, {}, SF_NOT_IN_CONFIG, false) {}
 	virtual ~NullSettingDesc() {}
 
 	void FormatValue(char *buf, const char *last, const void *object) const override { NOT_REACHED(); }

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -35,7 +35,7 @@ static bool WarnCorruptSprite(const SpriteFile &file, size_t file_pos, int line)
 {
 	static byte warning_level = 0;
 	if (warning_level == 0) {
-		SetDParamStr(0, file.GetSimplifiedFilename().c_str());
+		SetDParamStr(0, file.GetSimplifiedFilename());
 		ShowErrorMessage(STR_NEWGRF_ERROR_CORRUPT_SPRITE, INVALID_STRING_ID, WL_ERROR);
 	}
 	DEBUG(sprite, warning_level, "[%i] Loading corrupted sprite from %s at position %i", line, file.GetSimplifiedFilename().c_str(), (int)file_pos);

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -358,6 +358,33 @@ void StrTrimInPlace(std::string &str)
 	StrRightTrimInPlace(str);
 }
 
+/**
+ * Check whether the given string starts with the given prefix.
+ * @param str    The string to look at.
+ * @param prefix The prefix to look for.
+ * @return True iff the begin of the string is the same as the prefix.
+ */
+bool StrStartsWith(const std::string_view str, const std::string_view prefix)
+{
+	size_t prefix_len = prefix.size();
+	if (str.size() < prefix_len) return false;
+	return str.compare(0, prefix_len, prefix, 0, prefix_len) == 0;
+}
+
+/**
+ * Check whether the given string ends with the given suffix.
+ * @param str    The string to look at.
+ * @param suffix The suffix to look for.
+ * @return True iff the end of the string is the same as the suffix.
+ */
+bool StrEndsWith(const std::string_view str, const std::string_view suffix)
+{
+	size_t suffix_len = suffix.size();
+	if (str.size() < suffix_len) return false;
+	return str.compare(str.size() - suffix_len, suffix_len, suffix, 0, suffix_len) == 0;
+}
+
+
 /** Scans the string for colour codes and strips them */
 void str_strip_colours(char *str)
 {

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -51,6 +51,9 @@ bool strtolower(std::string &str, std::string::size_type offs = 0);
 bool StrValid(const char *str, const char *last) NOACCESS(2);
 void StrTrimInPlace(std::string &str);
 
+bool StrStartsWith(const std::string_view str, const std::string_view prefix);
+bool StrEndsWith(const std::string_view str, const std::string_view suffix);
+
 /**
  * Check if a string buffer is empty.
  *

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -989,14 +989,14 @@ post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDTG_BOOL]
-name     = nullptr
+name     = {}
 flags    = SF_NO_NETWORK
 var      = _old_vds.servint_ispercent
 def      = false
 to       = SLV_120
 
 [SDTG_VAR]
-name     = nullptr
+name     = {}
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_trains
@@ -1006,7 +1006,7 @@ max      = 800
 to       = SLV_120
 
 [SDTG_VAR]
-name     = nullptr
+name     = {}
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_roadveh
@@ -1016,7 +1016,7 @@ max      = 800
 to       = SLV_120
 
 [SDTG_VAR]
-name     = nullptr
+name     = {}
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_ships
@@ -1026,7 +1026,7 @@ max      = 800
 to       = SLV_120
 
 [SDTG_VAR]
-name     = nullptr
+name     = {}
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_aircraft


### PR DESCRIPTION
## Motivation / Problem

Conversion of C-string to std::string is not completed yet. And since we're heavily refactoring settings, lets tackle one there too.


## Description

Introduce helper functions for determining a string starts or ends with a given prefix/suffix.
Introduce helper function for passing std::string as SetDParamStr for error messages.
Rewrite some internal code to make use of those.

Sort of feature: when doing something like 'set engine_renew on', instead of it saying 'engine_renew = on' it will now mention the fully qualified name, i.e. 'company.engine_renew'.


## Limitations

Left script and gamelog code alone... something with rabbit holes ;)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
