### PR TITLE
Codechange: use std::string with network's ContentInfo

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1812,7 +1812,7 @@ static void OutputContentState(const ContentInfo *const ci)
 
 	char buf[sizeof(ci->md5sum) * 2 + 1];
 	md5sumToString(buf, lastof(buf), ci->md5sum);
-	IConsolePrintF(state_to_colour[ci->state], "%d, %s, %s, %s, %08X, %s", ci->id, types[ci->type - 1], states[ci->state], ci->name, ci->unique_id, buf);
+	IConsolePrintF(state_to_colour[ci->state], "%d, %s, %s, %s, %08X, %s", ci->id, types[ci->type - 1], states[ci->state], ci->name.c_str(), ci->unique_id, buf);
 }
 
 DEF_CONSOLE_CMD(ConContent)
@@ -1882,7 +1882,7 @@ DEF_CONSOLE_CMD(ConContent)
 	if (strcasecmp(argv[1], "state") == 0) {
 		IConsolePrintF(CC_WHITE, "id, type, state, name");
 		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
-			if (argc > 2 && strcasestr((*iter)->name, argv[2]) == nullptr) continue;
+			if (argc > 2 && strcasestr((*iter)->name.c_str(), argv[2]) == nullptr) continue;
 			OutputContentState(*iter);
 		}
 		return true;

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -65,6 +65,7 @@ static const uint NETWORK_CLIENT_NAME_LENGTH      =   25;         ///< The maxim
 static const uint NETWORK_RCONCOMMAND_LENGTH      =  500;         ///< The maximum length of a rconsole command, in bytes including '\0'
 static const uint NETWORK_GAMESCRIPT_JSON_LENGTH  = COMPAT_MTU-3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than COMPAT_MTU including header (3 bytes)
 static const uint NETWORK_CHAT_LENGTH             =  900;         ///< The maximum length of a chat message, in bytes including '\0'
+static const uint NETWORK_CONTENT_TAG_LENGTH      =   32;         ///< The maximum length of a content's tag, in bytes including '\0'.
 
 static const uint NETWORK_GRF_NAME_LENGTH         =   80;         ///< Maximum length of the name of a GRF
 

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -65,6 +65,11 @@ static const uint NETWORK_CLIENT_NAME_LENGTH      =   25;         ///< The maxim
 static const uint NETWORK_RCONCOMMAND_LENGTH      =  500;         ///< The maximum length of a rconsole command, in bytes including '\0'
 static const uint NETWORK_GAMESCRIPT_JSON_LENGTH  = COMPAT_MTU-3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than COMPAT_MTU including header (3 bytes)
 static const uint NETWORK_CHAT_LENGTH             =  900;         ///< The maximum length of a chat message, in bytes including '\0'
+static const uint NETWORK_CONTENT_FILENAME_LENGTH =   48;         ///< The maximum length of a content's filename, in bytes including '\0'.
+static const uint NETWORK_CONTENT_NAME_LENGTH     =   32;         ///< The maximum length of a content's name, in bytes including '\0'.
+static const uint NETWORK_CONTENT_VERSION_LENGTH  =   16;         ///< The maximum length of a content's version, in bytes including '\0'.
+static const uint NETWORK_CONTENT_URL_LENGTH      =   96;         ///< The maximum length of a content's url, in bytes including '\0'.
+static const uint NETWORK_CONTENT_DESC_LENGTH     =  512;         ///< The maximum length of a content's description, in bytes including '\0'.
 static const uint NETWORK_CONTENT_TAG_LENGTH      =   32;         ///< The maximum length of a content's tag, in bytes including '\0'.
 
 static const uint NETWORK_GRF_NAME_LENGTH         =   80;         ///< Maximum length of the name of a GRF

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -25,7 +25,7 @@ ContentInfo::ContentInfo()
 	: /* Temporary... will be removed later in the PR. */
 	type((ContentType)0), id((ContentID)0), filesize(0), filename(""), name(""), version(""),
 	url(""), description(""), unique_id(0), md5sum(""), dependency_count(0), dependencies(nullptr),
-	tag_count(0), tags(nullptr), state((State)0), upgrade(false)
+	state((State)0), upgrade(false)
 {
 }
 
@@ -33,7 +33,6 @@ ContentInfo::ContentInfo()
 ContentInfo::~ContentInfo()
 {
 	free(this->dependencies);
-	free(this->tags);
 }
 
 /**
@@ -44,10 +43,9 @@ void ContentInfo::TransferFrom(ContentInfo *other)
 {
 	if (other != this) {
 		free(this->dependencies);
-		free(this->tags);
 		*this = *other;
 		other->dependencies = nullptr;
-		other->tags = nullptr;
+		other->tags.clear();
 	}
 }
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -49,22 +49,6 @@ void ContentInfo::TransferFrom(ContentInfo *other)
 }
 
 /**
- * Get the size of the data as send over the network.
- * @return the size.
- */
-size_t ContentInfo::Size() const
-{
-	size_t len = 0;
-	for (uint i = 0; i < this->tag_count; i++) len += strlen(this->tags[i]) + 1;
-
-	/* The size is never larger than the content info size plus the size of the
-	 * tags and dependencies */
-	return sizeof(*this) +
-			sizeof(this->dependency_count) +
-			sizeof(*this->dependencies) * this->dependency_count;
-}
-
-/**
  * Is the state either selected or autoselected?
  * @return true iff that's the case
  */

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -20,33 +20,6 @@
 
 #include "../../safeguards.h"
 
-/** Clear everything in the struct */
-ContentInfo::ContentInfo()
-	: /* Temporary... will be removed later in the PR. */
-	type((ContentType)0), id((ContentID)0), filesize(0), filename(""), name(""), version(""),
-	url(""), description(""), unique_id(0), md5sum(""),
-	state((State)0), upgrade(false)
-{
-}
-
-/** Free everything allocated */
-ContentInfo::~ContentInfo()
-{
-}
-
-/**
- * Copy data from other #ContentInfo and take ownership of allocated stuff.
- * @param other Source to copy from. #dependencies and #tags will be NULLed.
- */
-void ContentInfo::TransferFrom(ContentInfo *other)
-{
-	if (other != this) {
-		*this = *other;
-		other->dependencies.clear();
-		other->tags.clear();
-	}
-}
-
 /**
  * Is the state either selected or autoselected?
  * @return true iff that's the case

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -24,7 +24,7 @@
 ContentInfo::ContentInfo()
 	: /* Temporary... will be removed later in the PR. */
 	type((ContentType)0), id((ContentID)0), filesize(0), filename(""), name(""), version(""),
-	url(""), description(""), unique_id(0), md5sum(""), dependency_count(0), dependencies(nullptr),
+	url(""), description(""), unique_id(0), md5sum(""),
 	state((State)0), upgrade(false)
 {
 }
@@ -32,7 +32,6 @@ ContentInfo::ContentInfo()
 /** Free everything allocated */
 ContentInfo::~ContentInfo()
 {
-	free(this->dependencies);
 }
 
 /**
@@ -42,9 +41,8 @@ ContentInfo::~ContentInfo()
 void ContentInfo::TransferFrom(ContentInfo *other)
 {
 	if (other != this) {
-		free(this->dependencies);
 		*this = *other;
-		other->dependencies = nullptr;
+		other->dependencies.clear();
 		other->tags.clear();
 	}
 }

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -22,8 +22,11 @@
 
 /** Clear everything in the struct */
 ContentInfo::ContentInfo()
+	: /* Temporary... will be removed later in the PR. */
+	type((ContentType)0), id((ContentID)0), filesize(0), filename(""), name(""), version(""),
+	url(""), description(""), unique_id(0), md5sum(""), dependency_count(0), dependencies(nullptr),
+	tag_count(0), tags(nullptr), state((State)0), upgrade(false)
 {
-	memset(this, 0, sizeof(*this));
 }
 
 /** Free everything allocated */
@@ -42,7 +45,7 @@ void ContentInfo::TransferFrom(ContentInfo *other)
 	if (other != this) {
 		free(this->dependencies);
 		free(this->tags);
-		memcpy(this, other, sizeof(ContentInfo));
+		*this = *other;
 		other->dependencies = nullptr;
 		other->tags = nullptr;
 	}

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -26,6 +26,7 @@ enum ContentType {
 	CONTENT_TYPE_GAME          = 9, ///< The content consists of a game script
 	CONTENT_TYPE_GAME_LIBRARY  = 10, ///< The content consists of a GS library
 	CONTENT_TYPE_END,               ///< Helper to mark the end of the types
+	INVALID_CONTENT_TYPE       = 0xFF, ///< Invalid/uninitialized content
 };
 
 /** Enum with all types of TCP content packets. The order MUST not be changed **/
@@ -57,25 +58,20 @@ struct ContentInfo {
 		INVALID,        ///< The content's invalid
 	};
 
-	ContentType type;        ///< Type of content
-	ContentID id;            ///< Unique (server side) ID for the content
-	uint32 filesize;         ///< Size of the file
-	std::string filename;    ///< Filename (for the .tar.gz; only valid on download)
-	std::string name;        ///< Name of the content
-	std::string version;     ///< Version of the content
-	std::string url;         ///< URL related to the content
-	std::string description; ///< Description of the content
-	uint32 unique_id;        ///< Unique ID; either GRF ID or shortname
-	byte md5sum[16];         ///< The MD5 checksum
-	std::vector<ContentID> dependencies; ///< The dependencies (unique server side ids)
-	StringList tags;         ///< Tags associated with the content
-	State state;             ///< Whether the content info is selected (for download)
-	bool upgrade;            ///< This item is an upgrade
-
-	ContentInfo();
-	~ContentInfo();
-
-	void TransferFrom(ContentInfo *other);
+	ContentType type = INVALID_CONTENT_TYPE; ///< Type of content
+	ContentID id = INVALID_CONTENT_ID;       ///< Unique (server side) ID for the content
+	uint32 filesize = 0;                     ///< Size of the file
+	std::string filename;                    ///< Filename (for the .tar.gz; only valid on download)
+	std::string name;                        ///< Name of the content
+	std::string version;                     ///< Version of the content
+	std::string url;                         ///< URL related to the content
+	std::string description;                 ///< Description of the content
+	uint32 unique_id = 0;                    ///< Unique ID; either GRF ID or shortname
+	byte md5sum[16] = {0};                   ///< The MD5 checksum
+	std::vector<ContentID> dependencies;     ///< The dependencies (unique server side ids)
+	StringList tags;                         ///< Tags associated with the content
+	State state = State::UNSELECTED;         ///< Whether the content info is selected (for download)
+	bool upgrade = false;                    ///< This item is an upgrade
 
 	bool IsSelected() const;
 	bool IsValid() const;

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -60,11 +60,11 @@ struct ContentInfo {
 	ContentType type;        ///< Type of content
 	ContentID id;            ///< Unique (server side) ID for the content
 	uint32 filesize;         ///< Size of the file
-	char filename[48];       ///< Filename (for the .tar.gz; only valid on download)
-	char name[32];           ///< Name of the content
-	char version[16];        ///< Version of the content
-	char url[96];            ///< URL related to the content
-	char description[512];   ///< Description of the content
+	std::string filename;    ///< Filename (for the .tar.gz; only valid on download)
+	std::string name;        ///< Name of the content
+	std::string version;     ///< Version of the content
+	std::string url;         ///< URL related to the content
+	std::string description; ///< Description of the content
 	uint32 unique_id;        ///< Unique ID; either GRF ID or shortname
 	byte md5sum[16];         ///< The MD5 checksum
 	std::vector<ContentID> dependencies; ///< The dependencies (unique server side ids)

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -79,7 +79,6 @@ struct ContentInfo {
 
 	void TransferFrom(ContentInfo *other);
 
-	size_t Size() const;
 	bool IsSelected() const;
 	bool IsValid() const;
 	const char *GetTextfile(TextfileType type) const;

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -69,8 +69,7 @@ struct ContentInfo {
 	byte md5sum[16];         ///< The MD5 checksum
 	uint8 dependency_count;  ///< Number of dependencies
 	ContentID *dependencies; ///< Malloced array of dependencies (unique server side ids)
-	uint8 tag_count;         ///< Number of tags
-	char (*tags)[32];        ///< Malloced array of tags (strings)
+	StringList tags;         ///< Tags associated with the content
 	State state;             ///< Whether the content info is selected (for download)
 	bool upgrade;            ///< This item is an upgrade
 

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -67,8 +67,7 @@ struct ContentInfo {
 	char description[512];   ///< Description of the content
 	uint32 unique_id;        ///< Unique ID; either GRF ID or shortname
 	byte md5sum[16];         ///< The MD5 checksum
-	uint8 dependency_count;  ///< Number of dependencies
-	ContentID *dependencies; ///< Malloced array of dependencies (unique server side ids)
+	std::vector<ContentID> dependencies; ///< The dependencies (unique server side ids)
 	StringList tags;         ///< Tags associated with the content
 	State state;             ///< Whether the content info is selected (for download)
 	bool upgrade;            ///< This item is an upgrade

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -150,9 +150,8 @@ bool ClientNetworkContentSocketHandler::Receive_SERVER_INFO(Packet *p)
 			 * As ici might be selected by the content window we cannot delete that.
 			 * However, we want to keep most of the values of ci, except the values
 			 * we (just) already preserved.
-			 * So transfer data and ownership of allocated memory from ci to ici.
 			 */
-			ici->TransferFrom(ci);
+			*ici = *ci;
 			delete ci;
 
 			this->OnReceiveContentInfo(ici);

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -70,9 +70,9 @@ bool ClientNetworkContentSocketHandler::Receive_SERVER_INFO(Packet *p)
 	ci->dependencies = MallocT<ContentID>(ci->dependency_count);
 	for (uint i = 0; i < ci->dependency_count; i++) ci->dependencies[i] = (ContentID)p->Recv_uint32();
 
-	ci->tag_count = p->Recv_uint8();
-	ci->tags = MallocT<char[32]>(ci->tag_count);
-	for (uint i = 0; i < ci->tag_count; i++) p->Recv_string(ci->tags[i], lengthof(*ci->tags));
+	uint tag_count = p->Recv_uint8();
+	ci->tags.reserve(tag_count);
+	for (uint i = 0; i < tag_count; i++) ci->tags.push_back(p->Recv_string(NETWORK_CONTENT_TAG_LENGTH));
 
 	if (!ci->IsValid()) {
 		delete ci;

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -147,7 +147,7 @@ void BaseNetworkContentDownloadStatusWindow::DrawWidget(const Rect &r, int widge
 void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInfo *ci, int bytes)
 {
 	if (ci->id != this->cur_id) {
-		strecpy(this->name, ci->filename, lastof(this->name));
+		strecpy(this->name, ci->filename.c_str(), lastof(this->name));
 		this->cur_id = ci->id;
 		this->downloaded_files++;
 	}
@@ -408,7 +408,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	/** Sort content by name. */
 	static bool NameSorter(const ContentInfo * const &a, const ContentInfo * const &b)
 	{
-		return strnatcmp(a->name, b->name, true) < 0; // Sort by name (natural sorting).
+		return strnatcmp(a->name.c_str(), b->name.c_str(), true) < 0; // Sort by name (natural sorting).
 	}
 
 	/** Sort content by type. */
@@ -445,7 +445,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		filter.string_filter.ResetState();
 		for (auto &tag : (*a)->tags) filter.string_filter.AddLine(tag.c_str());
 
-		filter.string_filter.AddLine((*a)->name);
+		filter.string_filter.AddLine((*a)->name.c_str());
 		return filter.string_filter.GetState();
 	}
 
@@ -703,17 +703,17 @@ public:
 		SetDParamStr(0, this->selected->name);
 		y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_NAME);
 
-		if (!StrEmpty(this->selected->version)) {
+		if (!this->selected->version.empty()) {
 			SetDParamStr(0, this->selected->version);
 			y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_VERSION);
 		}
 
-		if (!StrEmpty(this->selected->description)) {
+		if (!this->selected->description.empty()) {
 			SetDParamStr(0, this->selected->description);
 			y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_DESCRIPTION);
 		}
 
-		if (!StrEmpty(this->selected->url)) {
+		if (!this->selected->url.empty()) {
 			SetDParamStr(0, this->selected->url);
 			y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_URL);
 		}
@@ -736,7 +736,7 @@ public:
 					const ContentInfo *ci = *iter;
 					if (ci->id != cid) continue;
 
-					p += seprintf(p, lastof(buf), p == buf ? "%s" : ", %s", (*iter)->name);
+					p += seprintf(p, lastof(buf), p == buf ? "%s" : ", %s", (*iter)->name.c_str());
 					break;
 				}
 			}
@@ -765,7 +765,7 @@ public:
 			for (const ContentInfo *ci : tree) {
 				if (ci == this->selected || ci->state != ContentInfo::SELECTED) continue;
 
-				p += seprintf(p, lastof(buf), buf == p ? "%s" : ", %s", ci->name);
+				p += seprintf(p, lastof(buf), buf == p ? "%s" : ", %s", ci->name.c_str());
 			}
 			if (p != buf) {
 				SetDParamStr(0, buf);
@@ -842,7 +842,7 @@ public:
 			case WID_NCL_OPEN_URL:
 				if (this->selected != nullptr) {
 					extern void OpenBrowser(const char *url);
-					OpenBrowser(this->selected->url);
+					OpenBrowser(this->selected->url.c_str());
 				}
 				break;
 
@@ -983,7 +983,7 @@ public:
 		this->SetWidgetDisabledState(WID_NCL_UNSELECT, this->filesize_sum == 0);
 		this->SetWidgetDisabledState(WID_NCL_SELECT_ALL, !show_select_all);
 		this->SetWidgetDisabledState(WID_NCL_SELECT_UPDATE, !show_select_upgrade);
-		this->SetWidgetDisabledState(WID_NCL_OPEN_URL, this->selected == nullptr || StrEmpty(this->selected->url));
+		this->SetWidgetDisabledState(WID_NCL_OPEN_URL, this->selected == nullptr || this->selected->url.empty());
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
 			this->SetWidgetDisabledState(WID_NCL_TEXTFILE + tft, this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE || this->selected->GetTextfile(tft) == nullptr);
 		}

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -443,9 +443,8 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	static bool CDECL TagNameFilter(const ContentInfo * const *a, ContentListFilterData &filter)
 	{
 		filter.string_filter.ResetState();
-		for (int i = 0; i < (*a)->tag_count; i++) {
-			filter.string_filter.AddLine((*a)->tags[i]);
-		}
+		for (auto &tag : (*a)->tags) filter.string_filter.AddLine(tag.c_str());
+
 		filter.string_filter.AddLine((*a)->name);
 		return filter.string_filter.GetState();
 	}
@@ -747,12 +746,12 @@ public:
 			y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_DEPENDENCIES);
 		}
 
-		if (this->selected->tag_count != 0) {
+		if (!this->selected->tags.empty()) {
 			/* List all tags */
 			char buf[DRAW_STRING_BUFFER] = "";
 			char *p = buf;
-			for (uint i = 0; i < this->selected->tag_count; i++) {
-				p += seprintf(p, lastof(buf), i == 0 ? "%s" : ", %s", this->selected->tags[i]);
+			for (auto &tag : this->selected->tags) {
+				p += seprintf(p, lastof(buf), p == buf ? "%s" : ", %s", tag.c_str());
 			}
 			SetDParamStr(0, buf);
 			y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_TAGS);

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -725,13 +725,11 @@ public:
 		SetDParam(0, this->selected->filesize);
 		y = DrawStringMultiLine(r.left + DETAIL_LEFT, r.right - DETAIL_RIGHT, y, max_y, STR_CONTENT_DETAIL_FILESIZE);
 
-		if (this->selected->dependency_count != 0) {
+		if (!this->selected->dependencies.empty()) {
 			/* List dependencies */
 			char buf[DRAW_STRING_BUFFER] = "";
 			char *p = buf;
-			for (uint i = 0; i < this->selected->dependency_count; i++) {
-				ContentID cid = this->selected->dependencies[i];
-
+			for (auto &cid : this->selected->dependencies) {
 				/* Try to find the dependency */
 				ConstContentIterator iter = _network_content_client.Begin();
 				for (; iter != _network_content_client.End(); iter++) {

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1550,7 +1550,7 @@ void ShowMissingContentWindow(const GRFConfig *list)
 		ContentInfo *ci = new ContentInfo();
 		ci->type = CONTENT_TYPE_NEWGRF;
 		ci->state = ContentInfo::DOES_NOT_EXIST;
-		strecpy(ci->name, c->GetName(), lastof(ci->name));
+		ci->name = c->GetName();
 		ci->unique_id = BSWAP32(c->ident.grfid);
 		memcpy(ci->md5sum, HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum, sizeof(ci->md5sum));
 		cv.push_back(ci);


### PR DESCRIPTION
## Motivation / Problem

C-string to std::string conversion.


## Description

Replace custom allocation of tags/dependencies arrays with vectors, use proper initializations and use std::string instead of string buffers.


## Limitations

Maximum sizes for the fields are magic numbers. However, since they are only used ones as parameter to `Recv_String`, I'm not certain how much benefit adding some constants with those values is going to add. Then you'd need to document that it is to limit the data received from the content server, but... the only place where they are used already implies it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
