### PR TITLE
Codechange: C++-ify lists for SaveLoad

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -17,6 +17,7 @@
 #include "cargo_type.h"
 #include "vehicle_type.h"
 #include "core/multimap.hpp"
+#include "saveload/saveload.h"
 #include <list>
 
 /** Unique identifier for a single cargo packet. */
@@ -32,7 +33,7 @@ struct GoodsEntry; // forward-declare for Stage() and RerouteStalePackets()
 
 template <class Tinst, class Tcont> class CargoList;
 class StationCargoList; // forward-declare, so we can use it in VehicleCargoList.
-extern const struct SaveLoad *GetCargoPacketDesc();
+extern SaveLoadTable GetCargoPacketDesc();
 
 typedef uint32 TileOrStationID;
 
@@ -58,7 +59,7 @@ private:
 	friend class VehicleCargoList;
 	friend class StationCargoList;
 	/** We want this to be saved, right? */
-	friend const struct SaveLoad *GetCargoPacketDesc();
+	friend SaveLoadTable GetCargoPacketDesc();
 public:
 	/** Maximum number of items in a single cargo packet. */
 	static const uint16 MAX_COUNT = UINT16_MAX;
@@ -305,7 +306,7 @@ public:
 	/** The super class ought to know what it's doing. */
 	friend class CargoList<VehicleCargoList, CargoPacketList>;
 	/** The vehicles have a cargo list (and we want that saved). */
-	friend const struct SaveLoad *GetVehicleDescription(VehicleType vt);
+	friend SaveLoadTable GetVehicleDescription(VehicleType vt);
 
 	friend class CargoShift;
 	friend class CargoTransfer;
@@ -456,7 +457,7 @@ public:
 	/** The super class ought to know what it's doing. */
 	friend class CargoList<StationCargoList, StationCargoPacketMap>;
 	/** The stations, via GoodsEntry, have a CargoList. */
-	friend const struct SaveLoad *GetGoodsDesc();
+	friend SaveLoadTable GetGoodsDesc();
 
 	friend class CargoLoad;
 	friend class CargoTransfer;

--- a/src/core/span_type.hpp
+++ b/src/core/span_type.hpp
@@ -1,0 +1,98 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file span_type.hpp Minimized implementation of C++20 std::span. */
+
+#ifndef CORE_SPAN_TYPE_HPP
+#define CORE_SPAN_TYPE_HPP
+
+/* This is a partial copy/paste from https://github.com/gsl-lite/gsl-lite/blob/master/include/gsl/gsl-lite.hpp */
+
+/* Template to check if a template variable defines size() and data(). */
+template <class, class = void>
+struct has_size_and_data : std::false_type{};
+template <class C>
+struct has_size_and_data
+<
+	C, std::void_t<
+		decltype(std::size(std::declval<C>())),
+		decltype(std::data(std::declval<C>()))>
+> : std::true_type{};
+
+/* Template to check if two elements are compatible. */
+template <class, class, class = void>
+struct is_compatible_element : std::false_type {};
+template <class C, class E>
+struct is_compatible_element
+<
+	C, E, std::void_t<
+		decltype(std::data(std::declval<C>())),
+		typename std::remove_pointer<decltype(std::data( std::declval<C&>()))>::type(*)[]>
+> : std::is_convertible<typename std::remove_pointer<decltype(std::data(std::declval<C&>()))>::type(*)[], E(*)[]>{};
+
+/* Template to check if a container is compatible. gsl-lite also includes is_array and is_std_array, but as we don't use them, they are omitted. */
+template <class C, class E>
+struct is_compatible_container : std::bool_constant
+<
+	has_size_and_data<C>::value
+	&& is_compatible_element<C,E>::value
+>{};
+
+/**
+ * A trimmed down version of what std::span will be in C++20.
+ *
+ * It is fully forwards compatible, so if this codebase switches to C++20,
+ * all "span" instances can be replaced by "std::span" without loss of
+ * functionality.
+ *
+ * Currently it only supports basic functionality:
+ * - size() and friends
+ * - begin() and friends
+ *
+ * It is meant to simplify function parameters, where we only want to walk
+ * a continuous list.
+ */
+template<class T>
+class span {
+public:
+	typedef T element_type;
+	typedef typename std::remove_cv< T >::type value_type;
+
+	typedef T &reference;
+	typedef T *pointer;
+	typedef const T &const_reference;
+	typedef const T *const_pointer;
+
+	typedef pointer iterator;
+	typedef const_pointer const_iterator;
+
+	typedef size_t size_type;
+	typedef std::ptrdiff_t difference_type;
+
+	constexpr span(pointer data_in, size_t size_in) : first(data_in), last(data_in + size_in) {}
+
+	template<class Container, typename std::enable_if<(is_compatible_container<Container, element_type>::value), int>::type = 0>
+	constexpr span(Container &list) noexcept : first(std::data(list)), last(std::data(list) + std::size(list)) {}
+	template<class Container, typename std::enable_if<(std::is_const<element_type>::value && is_compatible_container<Container, element_type>::value), int>::type = 0>
+	constexpr span(const Container &list) noexcept : first(std::data(list)), last(std::data(list) + std::size(list)) {}
+
+	constexpr size_t size() const noexcept { return static_cast<size_t>( last - first ); }
+	constexpr std::ptrdiff_t ssize() const noexcept { return static_cast<std::ptrdiff_t>( last - first ); }
+	constexpr bool empty() const noexcept { return size() == 0; }
+
+	constexpr iterator begin() const noexcept { return iterator(first); }
+	constexpr iterator end() const noexcept { return iterator(last); }
+
+	constexpr const_iterator cbegin() const noexcept { return const_iterator(first); }
+	constexpr const_iterator cend() const noexcept { return const_iterator(last); }
+
+private:
+	pointer first;
+	pointer last;
+};
+
+#endif /* CORE_SPAN_TYPE_HPP */

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -16,10 +16,10 @@
 #include "../station_base.h"
 #include "../cargotype.h"
 #include "../date_func.h"
+#include "../saveload/saveload.h"
 #include "linkgraph_type.h"
 #include <utility>
 
-struct SaveLoad;
 class LinkGraph;
 
 /**
@@ -525,8 +525,8 @@ public:
 protected:
 	friend class LinkGraph::ConstNode;
 	friend class LinkGraph::Node;
-	friend const SaveLoad *GetLinkGraphDesc();
-	friend const SaveLoad *GetLinkGraphJobDesc();
+	friend SaveLoadTable GetLinkGraphDesc();
+	friend SaveLoadTable GetLinkGraphJobDesc();
 	friend void SaveLoad_LinkGraph(LinkGraph &lg);
 
 	CargoID cargo;         ///< Cargo of this component's link graph.

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -52,7 +52,7 @@ private:
 	typedef std::vector<NodeAnnotation> NodeAnnotationVector;
 	typedef SmallMatrix<EdgeAnnotation> EdgeAnnotationMatrix;
 
-	friend const SaveLoad *GetLinkGraphJobDesc();
+	friend SaveLoadTable GetLinkGraphJobDesc();
 	friend class LinkGraphSchedule;
 
 protected:

--- a/src/linkgraph/linkgraphschedule.h
+++ b/src/linkgraph/linkgraphschedule.h
@@ -39,7 +39,7 @@ private:
 	~LinkGraphSchedule();
 	typedef std::list<LinkGraph *> GraphList;
 	typedef std::list<LinkGraphJob *> JobList;
-	friend const SaveLoad *GetLinkGraphScheduleDesc();
+	friend SaveLoadTable GetLinkGraphScheduleDesc();
 
 protected:
 	ComponentHandler *handlers[6]; ///< Handlers to be run for each job.

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -15,6 +15,7 @@
 #include "tile_type.h"
 #include "vehicle_type.h"
 #include "base_consist.h"
+#include "saveload/saveload.h"
 
 /** Unique identifier for an order backup. */
 typedef uint8 OrderBackupID;
@@ -34,7 +35,7 @@ static const uint32 MAKE_ORDER_BACKUP_FLAG = 1U << 31;
  */
 struct OrderBackup : OrderBackupPool::PoolItem<&_order_backup_pool>, BaseConsist {
 private:
-	friend const struct SaveLoad *GetOrderBackupDescription(); ///< Saving and loading of order backups.
+	friend SaveLoadTable GetOrderBackupDescription(); ///< Saving and loading of order backups.
 	friend void Load_BKOR();   ///< Creating empty orders upon savegame loading.
 	uint32 user;               ///< The user that requested the backup.
 	TileIndex tile;            ///< Tile of the depot where the order was changed.

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -18,6 +18,7 @@
 #include "station_type.h"
 #include "vehicle_type.h"
 #include "date_type.h"
+#include "saveload/saveload.h"
 
 typedef Pool<Order, OrderID, 256, 0xFF0000> OrderPool;
 typedef Pool<OrderList, OrderListID, 128, 64000> OrderListPool;
@@ -31,9 +32,9 @@ extern OrderListPool _orderlist_pool;
  */
 struct Order : OrderPool::PoolItem<&_order_pool> {
 private:
-	friend const struct SaveLoad *GetVehicleDescription(VehicleType vt); ///< Saving and loading the current order of vehicles.
+	friend SaveLoadTable GetVehicleDescription(VehicleType vt); ///< Saving and loading the current order of vehicles.
 	friend void Load_VEHS();                                             ///< Loading of ancient vehicles.
-	friend const struct SaveLoad *GetOrderDescription();                 ///< Saving and loading of orders.
+	friend SaveLoadTable GetOrderDescription();                 ///< Saving and loading of orders.
 
 	uint8 type;           ///< The type of order + non-stop flags
 	uint8 flags;          ///< Load/unload types, depot order/action types.
@@ -250,7 +251,7 @@ void DeleteOrder(Vehicle *v, VehicleOrderID sel_ord);
 struct OrderList : OrderListPool::PoolItem<&_orderlist_pool> {
 private:
 	friend void AfterLoadVehicles(bool part_of_load); ///< For instantiating the shared vehicle chain
-	friend const struct SaveLoad *GetOrderListDescription(); ///< Saving and loading of order lists.
+	friend SaveLoadTable GetOrderListDescription(); ///< Saving and loading of order lists.
 
 	StationID GetBestLoadableNext(const Vehicle *v, const Order *o1, const Order *o2) const;
 

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -30,7 +30,6 @@ static const SaveLoad _ai_company[] = {
 	   SLEG_SSTR(_ai_saveload_settings,     SLE_STR),
 	SLEG_CONDVAR(_ai_saveload_version,   SLE_UINT32, SLV_108, SL_MAX_VERSION),
 	SLEG_CONDVAR(_ai_saveload_is_random,   SLE_BOOL, SLV_136, SL_MAX_VERSION),
-	     SLE_END()
 };
 
 static void SaveReal_AIPL(int *index_ptr)

--- a/src/saveload/autoreplace_sl.cpp
+++ b/src/saveload/autoreplace_sl.cpp
@@ -21,7 +21,6 @@ static const SaveLoad _engine_renew_desc[] = {
 	    SLE_REF(EngineRenew, next,     REF_ENGINE_RENEWS),
 	SLE_CONDVAR(EngineRenew, group_id, SLE_UINT16, SLV_60, SL_MAX_VERSION),
 	SLE_CONDVAR(EngineRenew, replace_when_old, SLE_BOOL, SLV_175, SL_MAX_VERSION),
-	SLE_END()
 };
 
 static void Save_ERNW()

--- a/src/saveload/cargomonitor_sl.cpp
+++ b/src/saveload/cargomonitor_sl.cpp
@@ -24,7 +24,6 @@ struct TempStorage {
 static const SaveLoad _cargomonitor_pair_desc[] = {
 	SLE_VAR(TempStorage, number, SLE_UINT32),
 	SLE_VAR(TempStorage, amount, SLE_UINT32),
-	SLE_END()
 };
 
 static CargoMonitorID FixupCargoMonitor(CargoMonitorID number)

--- a/src/saveload/cargopacket_sl.cpp
+++ b/src/saveload/cargopacket_sl.cpp
@@ -83,7 +83,7 @@
  * some of the variables itself are private.
  * @return the saveload description for CargoPackets.
  */
-const SaveLoad *GetCargoPacketDesc()
+SaveLoadTable GetCargoPacketDesc()
 {
 	static const SaveLoad _cargopacket_desc[] = {
 		     SLE_VAR(CargoPacket, source,          SLE_UINT16),
@@ -97,8 +97,6 @@ const SaveLoad *GetCargoPacketDesc()
 
 		/* Used to be paid_for, but that got changed. */
 		SLE_CONDNULL(1, SL_MIN_VERSION, SLV_121),
-
-		SLE_END()
 	};
 	return _cargopacket_desc;
 }

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -293,8 +293,6 @@ static const SaveLoad _company_desc[] = {
 	SLE_CONDVAR(CompanyProperties, terraform_limit,       SLE_UINT32,                SLV_156, SL_MAX_VERSION),
 	SLE_CONDVAR(CompanyProperties, clear_limit,           SLE_UINT32,                SLV_156, SL_MAX_VERSION),
 	SLE_CONDVAR(CompanyProperties, tree_limit,            SLE_UINT32,                SLV_175, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 static const SaveLoad _company_settings_desc[] = {
@@ -314,8 +312,6 @@ static const SaveLoad _company_settings_desc[] = {
 	SLE_CONDVAR(Company, settings.vehicle.servint_ships,     SLE_UINT16,     SLV_120, SL_MAX_VERSION),
 
 	SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
-
-	SLE_END()
 };
 
 static const SaveLoad _company_settings_skip_desc[] = {
@@ -336,8 +332,6 @@ static const SaveLoad _company_settings_skip_desc[] = {
 	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_ships
 
 	SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
-
-	SLE_END()
 };
 
 static const SaveLoad _company_economy_desc[] = {
@@ -353,8 +347,6 @@ static const SaveLoad _company_economy_desc[] = {
 	SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, 32,           SLV_170, SLV_EXTEND_CARGOTYPES),
 	SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, NUM_CARGO,    SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
 	    SLE_VAR(CompanyEconomyEntry, performance_history, SLE_INT32),
-
-	SLE_END()
 };
 
 /* We do need to read this single value, as the bigger it gets, the more data is stored */
@@ -390,7 +382,6 @@ static const SaveLoad _company_ai_desc[] = {
 	SLE_CONDNULL(32, SL_MIN_VERSION, SLV_107),
 
 	SLE_CONDNULL(64, SLV_2, SLV_107),
-	SLE_END()
 };
 
 static const SaveLoad _company_ai_build_rec_desc[] = {
@@ -399,14 +390,12 @@ static const SaveLoad _company_ai_build_rec_desc[] = {
 	SLE_CONDNULL(2, SL_MIN_VERSION, SLV_6),
 	SLE_CONDNULL(4, SLV_6, SLV_107),
 	SLE_CONDNULL(8, SL_MIN_VERSION, SLV_107),
-	SLE_END()
 };
 
 static const SaveLoad _company_livery_desc[] = {
 	SLE_CONDVAR(Livery, in_use,  SLE_UINT8, SLV_34, SL_MAX_VERSION),
 	SLE_CONDVAR(Livery, colour1, SLE_UINT8, SLV_34, SL_MAX_VERSION),
 	SLE_CONDVAR(Livery, colour2, SLE_UINT8, SLV_34, SL_MAX_VERSION),
-	SLE_END()
 };
 
 static void SaveLoad_PLYR_common(Company *c, CompanyProperties *cprops)

--- a/src/saveload/depot_sl.cpp
+++ b/src/saveload/depot_sl.cpp
@@ -25,7 +25,6 @@ static const SaveLoad _depot_desc[] = {
 	 SLE_CONDVAR(Depot, town_cn,    SLE_UINT16,               SLV_141, SL_MAX_VERSION),
 	SLE_CONDSSTR(Depot, name,       SLE_STR,                  SLV_141, SL_MAX_VERSION),
 	 SLE_CONDVAR(Depot, build_date, SLE_INT32,                SLV_142, SL_MAX_VERSION),
-	 SLE_END()
 };
 
 static void Save_DEPT()

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -46,7 +46,6 @@ static const SaveLoad _economy_desc[] = {
 	    SLE_VAR(Economy, infl_amount,                   SLE_UINT8),
 	    SLE_VAR(Economy, infl_amount_pr,                SLE_UINT8),
 	SLE_CONDVAR(Economy, industry_daily_change_counter, SLE_UINT32,                SLV_102, SL_MAX_VERSION),
-	    SLE_END()
 };
 
 /** Economy variables */
@@ -67,7 +66,6 @@ static const SaveLoad _cargopayment_desc[] = {
 	    SLE_VAR(CargoPayment, route_profit,    SLE_INT64),
 	    SLE_VAR(CargoPayment, visual_profit,   SLE_INT64),
 	SLE_CONDVAR(CargoPayment, visual_transfer, SLE_INT64, SLV_181, SL_MAX_VERSION),
-	    SLE_END()
 };
 
 static void Save_CAPY()

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -42,8 +42,6 @@ static const SaveLoad _engine_desc[] = {
 	SLE_CONDSSTR(Engine, name,                SLE_STR,                    SLV_84, SL_MAX_VERSION),
 
 	SLE_CONDNULL(16,                                                       SLV_2, SLV_144), // old reserved space
-
-	SLE_END()
 };
 
 static std::vector<Engine*> _temp_engine;
@@ -173,7 +171,6 @@ static const SaveLoad _engine_id_mapping_desc[] = {
 	SLE_VAR(EngineIDMapping, internal_id,   SLE_UINT16),
 	SLE_VAR(EngineIDMapping, type,          SLE_UINT8),
 	SLE_VAR(EngineIDMapping, substitute_id, SLE_UINT8),
-	SLE_END()
 };
 
 static void Save_EIDS()

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -30,7 +30,6 @@ static const SaveLoad _game_script[] = {
 	   SLEG_SSTR(_game_saveload_settings,     SLE_STR),
 	    SLEG_VAR(_game_saveload_version,   SLE_UINT32),
 	    SLEG_VAR(_game_saveload_is_random,   SLE_BOOL),
-	     SLE_END()
 };
 
 static void SaveReal_GSDT(int *index_ptr)
@@ -117,12 +116,10 @@ static uint _game_saveload_strings;
 static const SaveLoad _game_language_header[] = {
 	SLEG_SSTR(_game_saveload_string, SLE_STR),
 	 SLEG_VAR(_game_saveload_strings, SLE_UINT32),
-	  SLE_END()
 };
 
 static const SaveLoad _game_language_string[] = {
 	SLEG_SSTR(_game_saveload_string, SLE_STR | SLF_ALLOW_CONTROL),
-	  SLE_END()
 };
 
 static void SaveReal_GSTR(const LanguageStrings *ls)

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -17,13 +17,11 @@
 
 static const SaveLoad _glog_action_desc[] = {
 	SLE_VAR(LoggedAction, tick,              SLE_UINT16),
-	SLE_END()
 };
 
 static const SaveLoad _glog_mode_desc[] = {
 	SLE_VAR(LoggedChange, mode.mode,         SLE_UINT8),
 	SLE_VAR(LoggedChange, mode.landscape,    SLE_UINT8),
-	SLE_END()
 };
 
 static const SaveLoad _glog_revision_desc[] = {
@@ -31,62 +29,53 @@ static const SaveLoad _glog_revision_desc[] = {
 	SLE_VAR(LoggedChange, revision.newgrf,   SLE_UINT32),
 	SLE_VAR(LoggedChange, revision.slver,    SLE_UINT16),
 	SLE_VAR(LoggedChange, revision.modified, SLE_UINT8),
-	SLE_END()
 };
 
 static const SaveLoad _glog_oldver_desc[] = {
 	SLE_VAR(LoggedChange, oldver.type,       SLE_UINT32),
 	SLE_VAR(LoggedChange, oldver.version,    SLE_UINT32),
-	SLE_END()
 };
 
 static const SaveLoad _glog_setting_desc[] = {
 	SLE_STR(LoggedChange, setting.name,      SLE_STR,    128),
 	SLE_VAR(LoggedChange, setting.oldval,    SLE_INT32),
 	SLE_VAR(LoggedChange, setting.newval,    SLE_INT32),
-	SLE_END()
 };
 
 static const SaveLoad _glog_grfadd_desc[] = {
 	SLE_VAR(LoggedChange, grfadd.grfid,      SLE_UINT32    ),
 	SLE_ARR(LoggedChange, grfadd.md5sum,     SLE_UINT8,  16),
-	SLE_END()
 };
 
 static const SaveLoad _glog_grfrem_desc[] = {
 	SLE_VAR(LoggedChange, grfrem.grfid,      SLE_UINT32),
-	SLE_END()
 };
 
 static const SaveLoad _glog_grfcompat_desc[] = {
 	SLE_VAR(LoggedChange, grfcompat.grfid,   SLE_UINT32    ),
 	SLE_ARR(LoggedChange, grfcompat.md5sum,  SLE_UINT8,  16),
-	SLE_END()
 };
 
 static const SaveLoad _glog_grfparam_desc[] = {
 	SLE_VAR(LoggedChange, grfparam.grfid,    SLE_UINT32),
-	SLE_END()
 };
 
 static const SaveLoad _glog_grfmove_desc[] = {
 	SLE_VAR(LoggedChange, grfmove.grfid,     SLE_UINT32),
 	SLE_VAR(LoggedChange, grfmove.offset,    SLE_INT32),
-	SLE_END()
 };
 
 static const SaveLoad _glog_grfbug_desc[] = {
 	SLE_VAR(LoggedChange, grfbug.data,       SLE_UINT64),
 	SLE_VAR(LoggedChange, grfbug.grfid,      SLE_UINT32),
 	SLE_VAR(LoggedChange, grfbug.bug,        SLE_UINT8),
-	SLE_END()
 };
 
 static const SaveLoad _glog_emergency_desc[] = {
-	SLE_END()
+	SLE_CONDNULL(0, SL_MIN_VERSION, SL_MIN_VERSION), // Just an empty list, to keep the rest of the code easier.
 };
 
-static const SaveLoad * const _glog_desc[] = {
+static const SaveLoadTable _glog_desc[] = {
 	_glog_mode_desc,
 	_glog_revision_desc,
 	_glog_oldver_desc,

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -21,7 +21,6 @@ static const SaveLoad _goals_desc[] = {
 	    SLE_STR(Goal, text,      SLE_STR | SLF_ALLOW_CONTROL, 0),
 	SLE_CONDSTR(Goal, progress,  SLE_STR | SLF_ALLOW_CONTROL, 0, SLV_182, SL_MAX_VERSION),
 	SLE_CONDVAR(Goal, completed, SLE_BOOL, SLV_182, SL_MAX_VERSION),
-	    SLE_END()
 };
 
 static void Save_GOAL()

--- a/src/saveload/group_sl.cpp
+++ b/src/saveload/group_sl.cpp
@@ -26,7 +26,6 @@ static const SaveLoad _group_desc[] = {
 	 SLE_CONDVAR(Group, livery.colour1,     SLE_UINT8,                     SLV_GROUP_LIVERIES, SL_MAX_VERSION),
 	 SLE_CONDVAR(Group, livery.colour2,     SLE_UINT8,                     SLV_GROUP_LIVERIES, SL_MAX_VERSION),
 	 SLE_CONDVAR(Group, parent,             SLE_UINT16,                    SLV_189, SL_MAX_VERSION),
-	     SLE_END()
 };
 
 static void Save_GRPS()

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -75,8 +75,6 @@ static const SaveLoad _industry_desc[] = {
 	SLE_CONDSSTR(Industry, text,     SLE_STR | SLF_ALLOW_CONTROL,     SLV_INDUSTRY_TEXT, SL_MAX_VERSION),
 
 	SLE_CONDNULL(32, SLV_2, SLV_144), // old reserved space
-
-	SLE_END()
 };
 
 static void Save_INDY()
@@ -139,7 +137,6 @@ static void Ptrs_INDY()
 /** Description of the data to save and load in #IndustryBuildData. */
 static const SaveLoad _industry_builder_desc[] = {
 	SLEG_VAR(_industry_builder.wanted_inds, SLE_UINT32),
-	SLEG_END()
 };
 
 /** Load/save industry builder. */
@@ -155,7 +152,6 @@ static const SaveLoad _industrytype_builder_desc[] = {
 	SLE_VAR(IndustryTypeBuildData, target_count, SLE_UINT16),
 	SLE_VAR(IndustryTypeBuildData, max_wait,     SLE_UINT16),
 	SLE_VAR(IndustryTypeBuildData, wait_count,   SLE_UINT16),
-	SLE_END()
 };
 
 /** Save industry-type build data. */

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -95,7 +95,6 @@ struct LabelObject {
 
 static const SaveLoad _label_object_desc[] = {
 	SLE_VAR(LabelObject, label, SLE_UINT32),
-	SLE_END(),
 };
 
 static void Save_RAIL()

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -26,13 +26,12 @@ static uint16 _num_nodes;
  * Get a SaveLoad array for a link graph.
  * @return SaveLoad array for link graph.
  */
-const SaveLoad *GetLinkGraphDesc()
+SaveLoadTable GetLinkGraphDesc()
 {
 	static const SaveLoad link_graph_desc[] = {
 		 SLE_VAR(LinkGraph, last_compression, SLE_INT32),
 		SLEG_VAR(_num_nodes,                  SLE_UINT16),
 		 SLE_VAR(LinkGraph, cargo,            SLE_UINT8),
-		 SLE_END()
 	};
 	return link_graph_desc;
 }
@@ -46,7 +45,7 @@ const SaveLoad *GetLinkGraphDesc()
  * Of course the settings have to be saved and loaded, too, to avoid desyncs.
  * @return Array of SaveLoad structs.
  */
-const SaveLoad *GetLinkGraphJobDesc()
+SaveLoadTable GetLinkGraphJobDesc()
 {
 	static std::vector<SaveLoad> saveloads;
 	static const char *prefix = "linkgraph.";
@@ -54,7 +53,6 @@ const SaveLoad *GetLinkGraphJobDesc()
 	static const SaveLoad job_desc[] = {
 		SLE_VAR(LinkGraphJob, join_date,        SLE_INT32),
 		SLE_VAR(LinkGraphJob, link_graph.index, SLE_UINT16),
-		SLE_END()
 	};
 
 	/* The member offset arithmetic below is only valid if the types in question
@@ -74,25 +72,23 @@ const SaveLoad *GetLinkGraphJobDesc()
 			sl.address_proc = proc;
 		}
 
-		int i = 0;
-		do {
-			saveloads.push_back(job_desc[i++]);
-		} while (saveloads.back().cmd != SL_END);
+		for (auto &sld : job_desc) {
+			saveloads.push_back(sld);
+		}
 	}
 
-	return &saveloads[0];
+	return saveloads;
 }
 
 /**
  * Get a SaveLoad array for the link graph schedule.
  * @return SaveLoad array for the link graph schedule.
  */
-const SaveLoad *GetLinkGraphScheduleDesc()
+SaveLoadTable GetLinkGraphScheduleDesc()
 {
 	static const SaveLoad schedule_desc[] = {
 		SLE_LST(LinkGraphSchedule, schedule, REF_LINK_GRAPH),
 		SLE_LST(LinkGraphSchedule, running,  REF_LINK_GRAPH_JOB),
-		SLE_END()
 	};
 	return schedule_desc;
 }
@@ -108,7 +104,6 @@ static const SaveLoad _node_desc[] = {
 	    SLE_VAR(Node, demand,      SLE_UINT32),
 	    SLE_VAR(Node, station,     SLE_UINT16),
 	    SLE_VAR(Node, last_update, SLE_INT32),
-	    SLE_END()
 };
 
 /**
@@ -121,7 +116,6 @@ static const SaveLoad _edge_desc[] = {
 	     SLE_VAR(Edge, last_unrestricted_update, SLE_INT32),
 	 SLE_CONDVAR(Edge, last_restricted_update,   SLE_INT32, SLV_187, SL_MAX_VERSION),
 	     SLE_VAR(Edge, next_edge,                SLE_UINT16),
-	     SLE_END()
 };
 
 /**

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -20,10 +20,9 @@
 static uint32 _map_dim_x;
 static uint32 _map_dim_y;
 
-static const SaveLoadGlobVarList _map_dimensions[] = {
+static const SaveLoad _map_dimensions[] = {
 	SLEG_CONDVAR(_map_dim_x, SLE_UINT32, SLV_6, SL_MAX_VERSION),
 	SLEG_CONDVAR(_map_dim_y, SLE_UINT32, SLV_6, SL_MAX_VERSION),
-	    SLEG_END()
 };
 
 static void Save_MAPS()

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -68,7 +68,7 @@ void ResetViewportAfterLoadGame()
 
 byte _age_cargo_skip_counter; ///< Skip aging of cargo? Used before savegame version 162.
 
-static const SaveLoadGlobVarList _date_desc[] = {
+static const SaveLoad _date_desc[] = {
 	SLEG_CONDVAR(_date,                   SLE_FILE_U16 | SLE_VAR_I32,  SL_MIN_VERSION,  SLV_31),
 	SLEG_CONDVAR(_date,                   SLE_INT32,                  SLV_31, SL_MAX_VERSION),
 	    SLEG_VAR(_date_fract,             SLE_UINT16),
@@ -90,10 +90,9 @@ static const SaveLoadGlobVarList _date_desc[] = {
 	    SLEG_VAR(_trees_tick_ctr,         SLE_UINT8),
 	SLEG_CONDVAR(_pause_mode,             SLE_UINT8,                   SLV_4, SL_MAX_VERSION),
 	SLE_CONDNULL(4, SLV_11, SLV_120),
-	    SLEG_END()
 };
 
-static const SaveLoadGlobVarList _date_check_desc[] = {
+static const SaveLoad _date_check_desc[] = {
 	SLEG_CONDVAR(_load_check_data.current_date,  SLE_FILE_U16 | SLE_VAR_I32,  SL_MIN_VERSION,  SLV_31),
 	SLEG_CONDVAR(_load_check_data.current_date,  SLE_INT32,                  SLV_31, SL_MAX_VERSION),
 	    SLE_NULL(2),                       // _date_fract
@@ -115,7 +114,6 @@ static const SaveLoadGlobVarList _date_check_desc[] = {
 	    SLE_NULL(1),                       // _trees_tick_ctr
 	SLE_CONDNULL(1, SLV_4, SL_MAX_VERSION),    // _pause_mode
 	SLE_CONDNULL(4, SLV_11, SLV_120),
-	    SLEG_END()
 };
 
 /* Save load date related variables as well as persistent tick counters
@@ -134,13 +132,12 @@ static void Check_DATE()
 }
 
 
-static const SaveLoadGlobVarList _view_desc[] = {
+static const SaveLoad _view_desc[] = {
 	SLEG_CONDVAR(_saved_scrollpos_x,    SLE_FILE_I16 | SLE_VAR_I32, SL_MIN_VERSION, SLV_6),
 	SLEG_CONDVAR(_saved_scrollpos_x,    SLE_INT32,                  SLV_6, SL_MAX_VERSION),
 	SLEG_CONDVAR(_saved_scrollpos_y,    SLE_FILE_I16 | SLE_VAR_I32, SL_MIN_VERSION, SLV_6),
 	SLEG_CONDVAR(_saved_scrollpos_y,    SLE_INT32,                  SLV_6, SL_MAX_VERSION),
 	    SLEG_VAR(_saved_scrollpos_zoom, SLE_UINT8),
-	    SLEG_END()
 };
 
 static void SaveLoad_VIEW()

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -20,7 +20,6 @@ static const SaveLoad _newgrf_mapping_desc[] = {
 	SLE_VAR(EntityIDMapping, grfid,         SLE_UINT32),
 	SLE_VAR(EntityIDMapping, entity_id,     SLE_UINT8),
 	SLE_VAR(EntityIDMapping, substitute_id, SLE_UINT8),
-	SLE_END()
 };
 
 /**
@@ -65,7 +64,6 @@ static const SaveLoad _grfconfig_desc[] = {
 	    SLE_ARR(GRFConfig, param,            SLE_UINT32, 0x80),
 	    SLE_VAR(GRFConfig, num_params,       SLE_UINT8),
 	SLE_CONDVAR(GRFConfig, palette,          SLE_UINT8,  SLV_101, SL_MAX_VERSION),
-	SLE_END()
 };
 
 

--- a/src/saveload/object_sl.cpp
+++ b/src/saveload/object_sl.cpp
@@ -25,8 +25,6 @@ static const SaveLoad _object_desc[] = {
 	SLE_CONDVAR(Object, colour,                     SLE_UINT8,                  SLV_148, SL_MAX_VERSION),
 	SLE_CONDVAR(Object, view,                       SLE_UINT8,                  SLV_155, SL_MAX_VERSION),
 	SLE_CONDVAR(Object, type,                       SLE_UINT16,                 SLV_186, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 static void Save_OBJS()

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -99,7 +99,7 @@ Order UnpackOldOrder(uint16 packed)
 	return order;
 }
 
-const SaveLoad *GetOrderDescription()
+SaveLoadTable GetOrderDescription()
 {
 	static const SaveLoad _order_desc[] = {
 		     SLE_VAR(Order, type,           SLE_UINT8),
@@ -115,7 +115,6 @@ const SaveLoad *GetOrderDescription()
 		/* Leftover from the minor savegame version stuff
 		 * We will never use those free bytes, but we have to keep this line to allow loading of old savegames */
 		SLE_CONDNULL(10,                                  SLV_5,  SLV_36),
-		     SLE_END()
 	};
 
 	return _order_desc;
@@ -196,11 +195,10 @@ static void Ptrs_ORDR()
 	}
 }
 
-const SaveLoad *GetOrderListDescription()
+SaveLoadTable GetOrderListDescription()
 {
 	static const SaveLoad _orderlist_desc[] = {
 		SLE_REF(OrderList, first,              REF_ORDER),
-		SLE_END()
 	};
 
 	return _orderlist_desc;
@@ -233,7 +231,7 @@ static void Ptrs_ORDL()
 	}
 }
 
-const SaveLoad *GetOrderBackupDescription()
+SaveLoadTable GetOrderBackupDescription()
 {
 	static const SaveLoad _order_backup_desc[] = {
 		     SLE_VAR(OrderBackup, user,                     SLE_UINT32),
@@ -252,7 +250,6 @@ const SaveLoad *GetOrderBackupDescription()
 		 SLE_CONDVAR(OrderBackup, vehicle_flags,            SLE_FILE_U8 | SLE_VAR_U16, SLV_176, SLV_180),
 		 SLE_CONDVAR(OrderBackup, vehicle_flags,            SLE_UINT16,                SLV_180, SL_MAX_VERSION),
 		     SLE_REF(OrderBackup, orders,                   REF_ORDER),
-		     SLE_END()
 	};
 
 	return _order_backup_desc;

--- a/src/saveload/saveload_internal.h
+++ b/src/saveload/saveload_internal.h
@@ -23,7 +23,7 @@ void ResetOldNames();
 void ResetOldWaypoints();
 void MoveBuoysToWaypoints();
 void MoveWaypointsToBaseStations();
-const SaveLoad *GetBaseStationDescription();
+SaveLoadTable GetBaseStationDescription();
 
 void AfterLoadVehicles(bool part_of_load);
 void FixupTrainLengths();

--- a/src/saveload/signs_sl.cpp
+++ b/src/saveload/signs_sl.cpp
@@ -26,7 +26,6 @@ static const SaveLoad _sign_desc[] = {
 	SLE_CONDVAR(Sign, owner, SLE_UINT8,                  SLV_6, SL_MAX_VERSION),
 	SLE_CONDVAR(Sign, z,     SLE_FILE_U8  | SLE_VAR_I32, SL_MIN_VERSION, SLV_164),
 	SLE_CONDVAR(Sign, z,     SLE_INT32,                SLV_164, SL_MAX_VERSION),
-	SLE_END()
 };
 
 /** Save all signs */

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -154,8 +154,6 @@ static const SaveLoad _roadstop_desc[] = {
 
 	SLE_CONDNULL(4, SL_MIN_VERSION, SLV_25),
 	SLE_CONDNULL(1, SLV_25, SLV_26),
-
-	SLE_END()
 };
 
 static const SaveLoad _old_station_desc[] = {
@@ -213,8 +211,6 @@ static const SaveLoad _old_station_desc[] = {
 
 	/* reserve extra space in savegame here. (currently 32 bytes) */
 	SLE_CONDNULL(32, SLV_2, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 static uint16 _waiting_acceptance;
@@ -227,8 +223,6 @@ static Money  _cargo_feeder_share;
 static const SaveLoad _station_speclist_desc[] = {
 	SLE_CONDVAR(StationSpecList, grfid,    SLE_UINT32, SLV_27, SL_MAX_VERSION),
 	SLE_CONDVAR(StationSpecList, localidx, SLE_UINT8,  SLV_27, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 std::list<CargoPacket *> _packets;
@@ -247,7 +241,6 @@ static const SaveLoad _flow_desc[] = {
 	    SLE_VAR(FlowSaveLoad, via,        SLE_UINT16),
 	    SLE_VAR(FlowSaveLoad, share,      SLE_UINT32),
 	SLE_CONDVAR(FlowSaveLoad, restricted, SLE_BOOL, SLV_187, SL_MAX_VERSION),
-	    SLE_END()
 };
 
 /**
@@ -255,7 +248,7 @@ static const SaveLoad _flow_desc[] = {
  * some of the variables itself are private.
  * @return the saveload description for GoodsEntry.
  */
-const SaveLoad *GetGoodsDesc()
+SaveLoadTable GetGoodsDesc()
 {
 	static const SaveLoad goods_desc[] = {
 		SLEG_CONDVAR(            _waiting_acceptance,  SLE_UINT16,                  SL_MIN_VERSION, SLV_68),
@@ -279,7 +272,6 @@ const SaveLoad *GetGoodsDesc()
 		 SLE_CONDVAR(GoodsEntry, node,                 SLE_UINT16,                SLV_183, SL_MAX_VERSION),
 		SLEG_CONDVAR(            _num_flows,           SLE_UINT32,                SLV_183, SL_MAX_VERSION),
 		 SLE_CONDVAR(GoodsEntry, max_waiting_cargo,    SLE_UINT32,                SLV_183, SL_MAX_VERSION),
-		SLE_END()
 	};
 
 	return goods_desc;
@@ -290,7 +282,6 @@ typedef std::pair<const StationID, std::list<CargoPacket *> > StationCargoPair;
 static const SaveLoad _cargo_list_desc[] = {
 	SLE_VAR(StationCargoPair, first,  SLE_UINT16),
 	SLE_LST(StationCargoPair, second, REF_CARGO_PACKET),
-	SLE_END()
 };
 
 /**
@@ -398,8 +389,6 @@ static const SaveLoad _base_station_desc[] = {
 	      SLE_VAR(BaseStation, random_bits,            SLE_UINT16),
 	      SLE_VAR(BaseStation, waiting_triggers,       SLE_UINT8),
 	      SLE_VAR(BaseStation, num_specs,              SLE_UINT8),
-
-	      SLE_END()
 };
 
 static OldPersistentStorage _old_st_persistent_storage;
@@ -440,8 +429,6 @@ static const SaveLoad _station_desc[] = {
 	      SLE_LST(Station, loading_vehicles,           REF_VEHICLE),
 	  SLE_CONDVAR(Station, always_accepted,            SLE_FILE_U32 | SLE_VAR_U64, SLV_127, SLV_EXTEND_CARGOTYPES),
 	  SLE_CONDVAR(Station, always_accepted,            SLE_UINT64,                 SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
-
-	      SLE_END()
 };
 
 static const SaveLoad _waypoint_desc[] = {
@@ -453,15 +440,13 @@ static const SaveLoad _waypoint_desc[] = {
 	  SLE_CONDVAR(Waypoint, train_station.tile,        SLE_UINT32,                  SLV_124, SL_MAX_VERSION),
 	  SLE_CONDVAR(Waypoint, train_station.w,           SLE_FILE_U8 | SLE_VAR_U16,   SLV_124, SL_MAX_VERSION),
 	  SLE_CONDVAR(Waypoint, train_station.h,           SLE_FILE_U8 | SLE_VAR_U16,   SLV_124, SL_MAX_VERSION),
-
-	      SLE_END()
 };
 
 /**
  * Get the base station description to be used for SL_ST_INCLUDE
  * @return the base station description.
  */
-const SaveLoad *GetBaseStationDescription()
+SaveLoadTable GetBaseStationDescription()
 {
 	return _base_station_desc;
 }
@@ -469,7 +454,7 @@ const SaveLoad *GetBaseStationDescription()
 static void RealSave_STNN(BaseStation *bst)
 {
 	bool waypoint = (bst->facilities & FACIL_WAYPOINT) != 0;
-	SlObject(bst, waypoint ? _waypoint_desc : _station_desc);
+	SlObject(bst, waypoint ? SaveLoadTable(_waypoint_desc) : SaveLoadTable(_station_desc));
 
 	if (!waypoint) {
 		Station *st = Station::From(bst);
@@ -524,7 +509,7 @@ static void Load_STNN()
 		bool waypoint = (SlReadByte() & FACIL_WAYPOINT) != 0;
 
 		BaseStation *bst = waypoint ? (BaseStation *)new (index) Waypoint() : new (index) Station();
-		SlObject(bst, waypoint ? _waypoint_desc : _station_desc);
+		SlObject(bst, waypoint ? SaveLoadTable(_waypoint_desc) : SaveLoadTable(_station_desc));
 
 		if (!waypoint) {
 			Station *st = Station::From(bst);

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -18,7 +18,6 @@ static const SaveLoad _storage_desc[] = {
 	 SLE_CONDVAR(PersistentStorage, grfid,    SLE_UINT32,                  SLV_6, SL_MAX_VERSION),
 	 SLE_CONDARR(PersistentStorage, storage,  SLE_UINT32,  16,           SLV_161, SLV_EXTEND_PERSISTENT_STORAGE),
 	 SLE_CONDARR(PersistentStorage, storage,  SLE_UINT32, 256,           SLV_EXTEND_PERSISTENT_STORAGE, SL_MAX_VERSION),
-	 SLE_END()
 };
 
 /** Load persistent storage data. */

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -34,7 +34,6 @@ static const SaveLoad _story_page_elements_desc[] = {
 	SLE_CONDVAR(StoryPageElement, type,          SLE_UINT8,                  SLV_185, SL_MAX_VERSION),
 	    SLE_VAR(StoryPageElement, referenced_id, SLE_UINT32),
 	    SLE_STR(StoryPageElement, text,          SLE_STR | SLF_ALLOW_CONTROL, 0),
-	    SLE_END()
 };
 
 static void Save_STORY_PAGE_ELEMENT()
@@ -69,7 +68,6 @@ static const SaveLoad _story_pages_desc[] = {
 	SLE_CONDVAR(StoryPage, company,    SLE_FILE_U16 | SLE_VAR_U8,  SL_MIN_VERSION,   SLV_185),
 	SLE_CONDVAR(StoryPage, company,    SLE_UINT8,                  SLV_185, SL_MAX_VERSION),
 	    SLE_STR(StoryPage, title,      SLE_STR | SLF_ALLOW_CONTROL, 0),
-	    SLE_END()
 };
 
 static void Save_STORY_PAGE()

--- a/src/saveload/subsidy_sl.cpp
+++ b/src/saveload/subsidy_sl.cpp
@@ -24,7 +24,6 @@ static const SaveLoad _subsidies_desc[] = {
 	SLE_CONDVAR(Subsidy, src,        SLE_UINT16,                  SLV_5, SL_MAX_VERSION),
 	SLE_CONDVAR(Subsidy, dst,        SLE_FILE_U8 | SLE_VAR_U16,   SL_MIN_VERSION, SLV_5),
 	SLE_CONDVAR(Subsidy, dst,        SLE_UINT16,                  SLV_5, SL_MAX_VERSION),
-	SLE_END()
 };
 
 static void Save_SUBS()

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -194,8 +194,6 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDNULL(4, SLV_166, SLV_EXTEND_CARGOTYPES),  ///< cargo_produced, no longer in use
 	SLE_CONDNULL(8, SLV_EXTEND_CARGOTYPES, SLV_REMOVE_TOWN_CARGO_CACHE),  ///< cargo_produced, no longer in use
 	SLE_CONDNULL(30, SLV_2, SLV_REMOVE_TOWN_CARGO_CACHE), ///< old reserved space
-
-	SLE_END()
 };
 
 static const SaveLoad _town_supplied_desc[] = {
@@ -203,8 +201,6 @@ static const SaveLoad _town_supplied_desc[] = {
 	SLE_CONDVAR(TransportedCargoStat<uint32>, new_max, SLE_UINT32, SLV_165, SL_MAX_VERSION),
 	SLE_CONDVAR(TransportedCargoStat<uint32>, old_act, SLE_UINT32, SLV_165, SL_MAX_VERSION),
 	SLE_CONDVAR(TransportedCargoStat<uint32>, new_act, SLE_UINT32, SLV_165, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 static const SaveLoad _town_received_desc[] = {
@@ -212,8 +208,6 @@ static const SaveLoad _town_received_desc[] = {
 	SLE_CONDVAR(TransportedCargoStat<uint16>, new_max, SLE_UINT16, SLV_165, SL_MAX_VERSION),
 	SLE_CONDVAR(TransportedCargoStat<uint16>, old_act, SLE_UINT16, SLV_165, SL_MAX_VERSION),
 	SLE_CONDVAR(TransportedCargoStat<uint16>, new_act, SLE_UINT16, SLV_165, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 static void Save_HIDS()
@@ -226,14 +220,13 @@ static void Load_HIDS()
 	Load_NewGRFMapping(_house_mngr);
 }
 
-const SaveLoad *GetTileMatrixDesc()
+SaveLoadTable GetTileMatrixDesc()
 {
 	/* Here due to private member vars. */
 	static const SaveLoad _tilematrix_desc[] = {
 		SLE_VAR(AcceptanceMatrix, area.tile, SLE_UINT32),
 		SLE_VAR(AcceptanceMatrix, area.w,    SLE_UINT16),
 		SLE_VAR(AcceptanceMatrix, area.h,    SLE_UINT16),
-		SLE_END()
 	};
 
 	return _tilematrix_desc;

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -578,7 +578,7 @@ static uint32 _cargo_loaded_at_xy;
  * @param vt the vehicle type. Can be VEH_END for the common vehicle description data
  * @return the saveload description
  */
-const SaveLoad *GetVehicleDescription(VehicleType vt)
+SaveLoadTable GetVehicleDescription(VehicleType vt)
 {
 	/** Save and load of vehicles */
 	static const SaveLoad _common_veh_desc[] = {
@@ -712,10 +712,7 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		 SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
 
 		SLE_CONDNULL(10,                                                           SLV_2, SLV_144), // old reserved space
-
-		     SLE_END()
 	};
-
 
 	static const SaveLoad _train_desc[] = {
 		SLE_WRITEBYTE(Vehicle, type),
@@ -734,8 +731,6 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(2, SLV_2, SLV_20),
 		 SLE_CONDVAR(Train, gv_flags,            SLE_UINT16,                 SLV_139, SL_MAX_VERSION),
 		SLE_CONDNULL(11, SLV_2, SLV_144), // old reserved space
-
-		     SLE_END()
 	};
 
 	static const SaveLoad _roadveh_desc[] = {
@@ -756,8 +751,6 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		 SLE_CONDNULL(4,                                                              SLV_69, SLV_131),
 		 SLE_CONDNULL(2,                                                               SLV_6, SLV_131),
 		 SLE_CONDNULL(16,                                                              SLV_2, SLV_144), // old reserved space
-
-		      SLE_END()
 	};
 
 	static const SaveLoad _ship_desc[] = {
@@ -768,8 +761,6 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		  SLE_CONDVAR(Ship, rotation,                  SLE_UINT8,                  SLV_SHIP_ROTATION, SL_MAX_VERSION),
 
 		SLE_CONDNULL(16, SLV_2, SLV_144), // old reserved space
-
-		     SLE_END()
 	};
 
 	static const SaveLoad _aircraft_desc[] = {
@@ -791,8 +782,6 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		 SLE_CONDVAR(Aircraft, flags,                 SLE_UINT8,                  SLV_167, SL_MAX_VERSION),
 
 		SLE_CONDNULL(13,                                                           SLV_2, SLV_144), // old reserved space
-
-		     SLE_END()
 	};
 
 	static const SaveLoad _special_desc[] = {
@@ -821,8 +810,6 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		 SLE_CONDVAR(Vehicle, spritenum,             SLE_UINT8,                    SLV_2, SL_MAX_VERSION),
 
 		SLE_CONDNULL(15,                                                           SLV_2, SLV_144), // old reserved space
-
-		     SLE_END()
 	};
 
 	static const SaveLoad _disaster_desc[] = {
@@ -862,12 +849,10 @@ const SaveLoad *GetVehicleDescription(VehicleType vt)
 		 SLE_CONDVAR(DisasterVehicle, flags,                     SLE_UINT8,                  SLV_194, SL_MAX_VERSION),
 
 		SLE_CONDNULL(16,                                                           SLV_2, SLV_144), // old reserved space
-
-		     SLE_END()
 	};
 
 
-	static const SaveLoad * const _veh_descs[] = {
+	static const SaveLoadTable _veh_descs[] = {
 		_train_desc,
 		_roadveh_desc,
 		_ship_desc,

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -180,8 +180,6 @@ static const SaveLoad _old_waypoint_desc[] = {
 	SLE_CONDVAR(OldWaypoint, localidx,   SLE_UINT8,                   SLV_3, SL_MAX_VERSION),
 	SLE_CONDVAR(OldWaypoint, grfid,      SLE_UINT32,                 SLV_17, SL_MAX_VERSION),
 	SLE_CONDVAR(OldWaypoint, owner,      SLE_UINT8,                 SLV_101, SL_MAX_VERSION),
-
-	SLE_END()
 };
 
 static void Load_WAYP()

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -343,7 +343,6 @@ static byte _script_sl_byte; ///< Used as source/target by the script saveload c
 /** SaveLoad array that saves/loads exactly one byte. */
 static const SaveLoad _script_byte[] = {
 	SLEG_VAR(_script_sl_byte, SLE_UINT8),
-	SLE_END()
 };
 
 /* static */ bool ScriptInstance::SaveObject(HSQUIRRELVM vm, SQInteger index, int max_depth, bool test)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -258,7 +258,7 @@ static bool LoadIntList(const char *str, void *array, int nelems, VarType type)
  */
 void ListSettingDesc::FormatValue(char *buf, const char *last, const void *object) const
 {
-	const byte *p = static_cast<const byte *>(GetVariableAddress(object, &this->save));
+	const byte *p = static_cast<const byte *>(GetVariableAddress(object, this->save));
 	int i, v = 0;
 
 	for (i = 0; i != this->save.length; i++) {
@@ -446,7 +446,7 @@ void IntSettingDesc::MakeValueValid(int32 &val) const
  */
 void IntSettingDesc::Write(const void *object, int32 val) const
 {
-	void *ptr = GetVariableAddress(object, &this->save);
+	void *ptr = GetVariableAddress(object, this->save);
 	WriteValue(ptr, this->save.conv, (int64)val);
 }
 
@@ -457,7 +457,7 @@ void IntSettingDesc::Write(const void *object, int32 val) const
  */
 int32 IntSettingDesc::Read(const void *object) const
 {
-	void *ptr = GetVariableAddress(object, &this->save);
+	void *ptr = GetVariableAddress(object, this->save);
 	return (int32)ReadValue(ptr, this->save.conv);
 }
 
@@ -486,7 +486,7 @@ void StringSettingDesc::MakeValueValid(std::string &str) const
  */
 void StringSettingDesc::Write(const void *object, const std::string &str) const
 {
-	reinterpret_cast<std::string *>(GetVariableAddress(object, &this->save))->assign(str);
+	reinterpret_cast<std::string *>(GetVariableAddress(object, this->save))->assign(str);
 }
 
 /**
@@ -496,7 +496,7 @@ void StringSettingDesc::Write(const void *object, const std::string &str) const
  */
 const std::string &StringSettingDesc::Read(const void *object) const
 {
-	return *reinterpret_cast<std::string *>(GetVariableAddress(object, &this->save));
+	return *reinterpret_cast<std::string *>(GetVariableAddress(object, this->save));
 }
 
 /**
@@ -560,7 +560,7 @@ void StringSettingDesc::ParseValue(const IniItem *item, void *object) const
 void ListSettingDesc::ParseValue(const IniItem *item, void *object) const
 {
 	const char *str = (item == nullptr) ? this->def : item->value.has_value() ? item->value->c_str() : nullptr;
-	void *ptr = GetVariableAddress(object, &this->save);
+	void *ptr = GetVariableAddress(object, this->save);
 	if (!LoadIntList(str, ptr, this->save.length, GetVarMemType(this->save.conv))) {
 		ErrorMessageData msg(STR_CONFIG_ERROR, STR_CONFIG_ERROR_ARRAY);
 		msg.SetDParamStr(0, this->name);
@@ -2025,9 +2025,9 @@ void IConsoleListSettings(const char *prefilter)
 static void LoadSettings(const SettingTable &settings, void *object)
 {
 	for (auto &osd : settings) {
-		void *ptr = GetVariableAddress(object, &osd->save);
+		void *ptr = GetVariableAddress(object, osd->save);
 
-		if (!SlObjectMember(ptr, &osd->save)) continue;
+		if (!SlObjectMember(ptr, osd->save)) continue;
 		if (osd->IsIntSetting()) {
 			const IntSettingDesc *int_setting = osd->AsIntSetting();
 			int_setting->MakeValueValidAndWrite(object, int_setting->Read(object));
@@ -2047,13 +2047,13 @@ static void SaveSettings(const SettingTable &settings, void *object)
 	 * SlCalcLength() because we have a different format. So do this manually */
 	size_t length = 0;
 	for (auto &sd : settings) {
-		length += SlCalcObjMemberLength(object, &sd->save);
+		length += SlCalcObjMemberLength(object, sd->save);
 	}
 	SlSetLength(length);
 
 	for (auto &sd : settings) {
-		void *ptr = GetVariableAddress(object, &sd->save);
-		SlObjectMember(ptr, &sd->save);
+		void *ptr = GetVariableAddress(object, sd->save);
+		SlObjectMember(ptr, sd->save);
 	}
 }
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -22,6 +22,7 @@
 #include "group_type.h"
 #include "base_consist.h"
 #include "network/network.h"
+#include "saveload/saveload.h"
 #include <list>
 #include <map>
 
@@ -198,9 +199,8 @@ typedef Pool<Vehicle, VehicleID, 512, 0xFF000> VehiclePool;
 extern VehiclePool _vehicle_pool;
 
 /* Some declarations of functions, so we can make them friendly */
-struct SaveLoad;
 struct GroundVehicleCache;
-extern const SaveLoad *GetVehicleDescription(VehicleType vt);
+extern SaveLoadTable GetVehicleDescription(VehicleType vt);
 struct LoadgameState;
 extern bool LoadOldVehicle(LoadgameState *ls, int num);
 extern void FixOldVehicles();
@@ -232,7 +232,7 @@ private:
 	Vehicle *previous_shared;           ///< NOSAVE: pointer to the previous vehicle in the shared order chain
 
 public:
-	friend const SaveLoad *GetVehicleDescription(VehicleType vt); ///< So we can use private/protected variables in the saveload code
+	friend SaveLoadTable GetVehicleDescription(VehicleType vt); ///< So we can use private/protected variables in the saveload code
 	friend void FixOldVehicles();
 	friend void AfterLoadVehicles(bool part_of_load);             ///< So we can set the #previous and #first pointers while loading
 	friend bool LoadOldVehicle(LoadgameState *ls, int num);       ///< So we can set the proper next pointer while loading


### PR DESCRIPTION
## Motivation / Problem

I kept getting annoyed about two things:
1) to constantly see C-style list iterators
2) to not know whether `Saveload *` was indicating a single item or a list of items.

So why not fix both in 1 go?

## Description

```
Basically, this changes "SaveLoad *" to either:
1) "SaveLoadTable" if a list of SaveLoads was meant
2) "SaveLoad &" if a single entry was meant

As added bonus, this removes SL_END / SLE_END / SLEG_END
```

As we have parts that need dynamic SaveLoad lists, `SaveLoad []` is not always possible to use. In those cases `std::vector<SaveLoad>` is used, but converting that to a `SaveLoad []` is not possible ofc.

What I turned up doing, is copying parts of gsl-lite into `core/span_type.hpp` to give us a `std::span`-lite variant (`std::span` is C++20). This allows both types to be used by SaveLoad functions, without them knowing the details of the container.

For `SaveLoad []` the `span<>` stores the `first` and `last` element, and after that you can safely move the span around. For `std::vector` it does the same. So we have one type which captures both in a safe manner.

Mind you, `span<>` doesn't own the memory, so no using stack variables now :)

## Limitations

- We can argue if copying parts of gsl-lite is a good idea, or that we should just drop it in 3rdparty and be done with it. We could also upgrade to C++20.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
