### PR TITLE
Codechange: use AsIntSetting()->Read() wrapper if possible

### DIFF
--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -254,9 +254,8 @@ static_assert(lengthof(_news_type_data) == NT_END);
 NewsDisplay NewsTypeData::GetDisplay() const
 {
 	const SettingDesc *sd = GetSettingFromName(this->name);
-	assert(sd != nullptr);
-	void *ptr = GetVariableAddress(nullptr, &sd->save);
-	return (NewsDisplay)ReadValue(ptr, sd->save.conv);
+	assert(sd != nullptr && sd->IsIntSetting());
+	return (NewsDisplay)sd->AsIntSetting()->Read(nullptr);
 }
 
 /** Window class displaying a news item. */

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -26,9 +26,7 @@
 	if (!IsValid(setting)) return -1;
 
 	const SettingDesc *sd = GetSettingFromName(setting);
-
-	void *ptr = GetVariableAddress(&_settings_game, &sd->save);
-	return (int32)ReadValue(ptr, sd->save.conv);
+	return sd->AsIntSetting()->Read(&_settings_game);
 }
 
 /* static */ bool ScriptGameSettings::SetValue(const char *setting, int value)


### PR DESCRIPTION
## Motivation / Problem

Two places still used the old ways of accessing setting variables. We now have a shiny new method!

## Description

Use Settings wrappers to access values of Settings (instead of accessing the backend storage yourself).


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
