### PR TITLE
Feature: Ctrl-Click on vehicle list in GB_SHARED_ORDERS opens order window

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -24,6 +24,7 @@
 #include "core/geometry_func.hpp"
 #include "company_base.h"
 #include "company_gui.h"
+#include "gui.h"
 
 #include "widgets/group_widget.h"
 
@@ -745,17 +746,19 @@ public:
 						NOT_REACHED();
 				}
 				if (v) {
-					this->vehicle_sel = v->index;
-
 					if (_ctrl_pressed) {
-						this->SelectGroup(v->group_id);
+						if (this->grouping == GB_NONE) {
+							this->SelectGroup(v->group_id);
+						} else {
+							ShowOrdersWindow(v);
+						}
+					} else {
+						this->vehicle_sel = v->index;
+						SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
+						SetMouseCursorVehicle(v, EIT_IN_LIST);
+						_cursor.vehchain = true;
+						this->SetDirty();
 					}
-
-					SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
-					SetMouseCursorVehicle(v, EIT_IN_LIST);
-					_cursor.vehchain = true;
-
-					this->SetDirty();
 				}
 
 				break;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -325,6 +325,10 @@ STR_SORT_BY_AVERAGE_PROFIT_THIS_YEAR                            :Average profit 
 STR_GROUP_BY_NONE                                               :None
 STR_GROUP_BY_SHARED_ORDERS                                      :Shared orders
 
+# Order button in shared orders vehicle list
+STR_GOTO_ORDER_VIEW                                             :{BLACK}Orders
+STR_GOTO_ORDER_VIEW_TOOLTIP                                     :{BLACK}Open the order view
+
 # Tooltips for the main toolbar
 ###length 31
 STR_TOOLBAR_TOOLTIP_PAUSE_GAME                                  :{BLACK}Pause game

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1843,10 +1843,14 @@ public:
 						const Vehicle *v = vehgroup.vehicles_begin[0];
 						/* We do not support VehicleClicked() here since the contextual action may only make sense for individual vehicles */
 
-						if (vehgroup.NumVehicles() == 1) {
-							ShowVehicleViewWindow(v);
+						if (_ctrl_pressed) {
+							ShowOrdersWindow(v);
 						} else {
-							ShowVehicleListWindow(v);
+							if (vehgroup.NumVehicles() == 1) {
+								ShowVehicleViewWindow(v);
+							} else {
+								ShowVehicleListWindow(v);
+							}
 						}
 						break;
 					}

--- a/src/widgets/vehicle_widget.h
+++ b/src/widgets/vehicle_widget.h
@@ -61,7 +61,10 @@ enum VehicleDetailsWidgets {
 
 /** Widgets of the #VehicleListWindow class. */
 enum VehicleListWidgets {
-	WID_VL_CAPTION,                  ///< Caption of window.
+	WID_VL_CAPTION,                  ///< Caption of window (for non shared orders windows).
+	WID_VL_CAPTION_SHARED_ORDERS,    ///< Caption of window (for shared orders windows).
+	WID_VL_CAPTION_SELECTION,        ///< Selection for caption.
+	WID_VL_ORDER_VIEW,               ///< Button to open order window (for shared orders windows).
 	WID_VL_GROUP_ORDER,              ///< Group order.
 	WID_VL_GROUP_BY_PULLDOWN,        ///< Group by dropdown list.
 	WID_VL_SORT_ORDER,               ///< Sort order.


### PR DESCRIPTION
## Motivation / Problem

To figure out which vehicle group we want (e.g. to clone) when looking at a vehicle list (e.g. at a station), we need to look at the order list.  However, it takes 3 clicks (from "Bardingstone Heights - 48 trains" to "Train #83 (Orders)"), which is a bit unsatisfactory:

![image](https://user-images.githubusercontent.com/6948096/120161344-c46f2c80-c229-11eb-89f1-27211320ac51.png)



## Description

### Ctrl-Click on vehicle list window

This PR implements Ctrl-Click in the vehicle list window.  Ctrl-Clicking on a vehicle in the vehicle list window (when "Group by" is set to "Shared orders") will open the order list of the first vehicle sharing those orders.

### Issues with group GUI window

There is a slight change in behaviour for the group GUI window:

![image](https://user-images.githubusercontent.com/6948096/120162044-93dbc280-c22a-11eb-8852-87c11e27e89d.png)

Ctrl-Clicking on a vehicle in the group window used to select the group in which the vehicle is in, but now it doesn't do that (when "Group by" is set to "Shared orders").  Well I think that was previously a bug - since vehicles from different groups could share orders, there may not be a unique group to select.

### Issues with shared order list window

The shared orders window can't be grouped by shared orders, and it is pointless to do so anyway.  But it still makes sense to want to open the order window to see the list of orders.  Hence this PR adds a button at the top right corner to open the order list.  The button is in a similar position to the the "Orders" button in the timetable window.

![image](https://user-images.githubusercontent.com/6948096/120168762-d05eec80-c231-11eb-8b1a-a5a8f9d2e629.png)

## Unanswered questions

Should the order window have a title that feels more like the orders are shared, such as "Shared orders of Train #83 and 9 other vehicles" instead of "Train #83 (Orders)"?  Since with shared orders, we no longer think of the order list as a property of a single vehicle, but instead logically each vehicle subscribes to some (shared) order list.  Apart from the "Skip" button (and possibly the "Timetable" button which I'm not too familiar with), everything else pertains to things that are shared.

## Note

With the addition of this PR, it is now possible to open the orders window without first opening the associated vehicle window.  When closing a vehicle window, the associated orders window is automatically closed too, so it seems that previously such a situation could never happen.  This PR doesn't seem to break anything though.  But it does raise the question of whether we should head towards further decoupling between the order window and the vehicle window in the future, at least when the vehicle has shared orders.

In any case, this PR can be merged without answering the unanswered questions yet, so it isn't a blocking issue.

## Limitations

Not that I know of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
