### PR TITLE
Fix #9329: [CMake] FindVersion.cmake relied on internal cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ add_custom_target(find_version
                 -DREV_MAJOR=${PROJECT_VERSION_MAJOR}
                 -DREV_MINOR=${PROJECT_VERSION_MINOR}
                 -DREV_BUILD=${PROJECT_VERSION_PATCH}
+                -DWINDOWS=${WIN32}
                 -P "${CMAKE_SOURCE_DIR}/cmake/scripts/FindVersion.cmake"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         BYPRODUCTS ${GENERATED_SOURCE_FILES}

--- a/cmake/scripts/FindVersion.cmake
+++ b/cmake/scripts/FindVersion.cmake
@@ -138,7 +138,7 @@ else()
     configure_file("${CMAKE_SOURCE_DIR}/src/rev.cpp.in"
             "${FIND_VERSION_BINARY_DIR}/rev.cpp")
 
-    if(WIN32)
+    if(WINDOWS)
         message(STATUS "Generating ottdres.rc")
         configure_file("${CMAKE_SOURCE_DIR}/src/os/windows/ottdres.rc.in"
                 "${FIND_VERSION_BINARY_DIR}/ottdres.rc")


### PR DESCRIPTION
## Motivation / Problem
`FindVersion.cmake` is ran via `cmake -P` and `WIN32` is only set on windows systems.
When cross-compiling for windows from linux, `WIN32` is set via the toolchain so configuration works, but `cmake -P` doesn't have it at build time.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Explicitly tell FindVersion.cmake it's targeting windows.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
