### PR TITLE
Codechange: use "[[maybe_unused]]" instead of a wide variety of other ways we had

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -835,8 +835,7 @@ public:
 			nkeys++;
 			SQInteger val = _fs->PopTarget();
 			SQInteger key = _fs->PopTarget();
-			SQInteger attrs = hasattrs ? _fs->PopTarget():-1;
-			(void)attrs; // assert only
+			[[maybe_unused]] SQInteger attrs = hasattrs ? _fs->PopTarget():-1;
 			assert((hasattrs && attrs == key-1) || !hasattrs);
 			unsigned char flags = (hasattrs?NEW_SLOT_ATTRIBUTES_FLAG:0)|(isstatic?NEW_SLOT_STATIC_FLAG:0);
 			SQInteger table = _fs->TopTarget(); //<<BECAUSE OF THIS NO COMMON EMIT FUNC IS POSSIBLE

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -1471,9 +1471,7 @@ bool SQVM::DeleteSlot(const SQObjectPtr &self,const SQObjectPtr &key,SQObjectPtr
 
 bool SQVM::Call(SQObjectPtr &closure,SQInteger nparams,SQInteger stackbase,SQObjectPtr &outres,SQBool raiseerror,SQBool can_suspend)
 {
-#ifdef WITH_ASSERT
-	SQInteger prevstackbase = _stackbase;
-#endif
+	[[maybe_unused]] SQInteger prevstackbase = _stackbase;
 	switch(type(closure)) {
 	case OT_CLOSURE: {
 		assert(!can_suspend || this->_can_suspend);
@@ -1504,11 +1502,9 @@ bool SQVM::Call(SQObjectPtr &closure,SQInteger nparams,SQInteger stackbase,SQObj
 	default:
 		return false;
 	}
-#ifdef WITH_ASSERT
 	if(!_suspended) {
 		assert(_stackbase == prevstackbase);
 	}
-#endif
 	return true;
 }
 

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -596,8 +596,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlag flags, bool wagon
 					assert(RailVehInfo(wagon->engine_type)->railveh_type == RAILVEH_WAGON);
 
 					/* Sell wagon */
-					CommandCost ret = DoCommand(0, wagon->index, 0, DC_EXEC, GetCmdSellVeh(wagon));
-					(void)ret; // assert only
+					[[maybe_unused]] CommandCost ret = DoCommand(0, wagon->index, 0, DC_EXEC, GetCmdSellVeh(wagon));
 					assert(ret.Succeeded());
 					new_vehs[i] = nullptr;
 
@@ -650,8 +649,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlag flags, bool wagon
 				assert(Train::From(old_head)->GetNextUnit() == nullptr);
 
 				for (int i = num_units - 1; i > 0; i--) {
-					CommandCost ret = CmdMoveVehicle(old_vehs[i], old_head, DC_EXEC | DC_AUTOREPLACE, false);
-					(void)ret; // assert only
+					[[maybe_unused]] CommandCost ret = CmdMoveVehicle(old_vehs[i], old_head, DC_EXEC | DC_AUTOREPLACE, false);
 					assert(ret.Succeeded());
 				}
 			}

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -33,9 +33,9 @@ DEFINE_POOL_METHOD(inline)::Pool(const char *name) :
 		first_free(0),
 		first_unused(0),
 		items(0),
-#ifdef OTTD_ASSERT
+#ifdef WITH_ASSERT
 		checked(0),
-#endif /* OTTD_ASSERT */
+#endif /* WITH_ASSERT */
 		cleaning(false),
 		data(nullptr),
 		alloc_cache(nullptr)
@@ -133,10 +133,10 @@ DEFINE_POOL_METHOD(void *)::GetNew(size_t size)
 {
 	size_t index = this->FindFirstFree();
 
-#ifdef OTTD_ASSERT
+#ifdef WITH_ASSERT
 	assert(this->checked != 0);
 	this->checked--;
-#endif /* OTTD_ASSERT */
+#endif /* WITH_ASSERT */
 	if (index == NO_FREE_ITEM) {
 		error("%s: no more free items", this->name);
 	}

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -90,9 +90,9 @@ struct Pool : PoolBase {
 	size_t first_free;   ///< No item with index lower than this is free (doesn't say anything about this one!)
 	size_t first_unused; ///< This and all higher indexes are free (doesn't say anything about first_unused-1 !)
 	size_t items;        ///< Number of used indexes (non-nullptr)
-#ifdef OTTD_ASSERT
+#ifdef WITH_ASSERT
 	size_t checked;      ///< Number of items we checked for
-#endif /* OTTD_ASSERT */
+#endif /* WITH_ASSERT */
 	bool cleaning;       ///< True if cleaning pool (deleting all items)
 
 	Titem **data;        ///< Pointer to array of pointers to Titem
@@ -130,9 +130,9 @@ struct Pool : PoolBase {
 	inline bool CanAllocate(size_t n = 1)
 	{
 		bool ret = this->items <= Tmax_size - n;
-#ifdef OTTD_ASSERT
+#ifdef WITH_ASSERT
 		this->checked = ret ? n : 0;
-#endif /* OTTD_ASSERT */
+#endif /* WITH_ASSERT */
 		return ret;
 	}
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -537,8 +537,7 @@ void SetupEngines()
 		/* Assert is safe; there won't be more than 256 original vehicles
 		 * in any case, and we just cleaned the pool. */
 		assert(Engine::CanAllocateItem());
-		const Engine *e = new Engine(eid.type, eid.internal_id);
-		(void)e; // assert only
+		[[maybe_unused]] const Engine *e = new Engine(eid.type, eid.internal_id);
 		assert(e->index == index);
 		index++;
 	}

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -101,8 +101,7 @@ static void LoadGrfFileIndexed(const char *filename, const SpriteID *index_tbl, 
 		uint end = *index_tbl++;
 
 		do {
-			bool b = LoadNextSprite(start, file, sprite_id);
-			(void)b; // Unused without asserts
+			[[maybe_unused]] bool b = LoadNextSprite(start, file, sprite_id);
 			assert(b);
 			sprite_id++;
 		} while (++start <= end);

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2139,8 +2139,7 @@ static Industry *CreateNewIndustry(TileIndex tile, IndustryType type, IndustryAv
 	uint32 seed2 = Random();
 	Industry *i = nullptr;
 	size_t layout_index = RandomRange((uint32)indspec->layouts.size());
-	CommandCost ret = CreateNewIndustryHelper(tile, type, DC_EXEC, indspec, layout_index, seed, GB(seed2, 0, 16), OWNER_NONE, creation_type, &i);
-	(void)ret; // assert only
+	[[maybe_unused]] CommandCost ret = CreateNewIndustryHelper(tile, type, DC_EXEC, indspec, layout_index, seed, GB(seed2, 0, 16), OWNER_NONE, creation_type, &i);
 	assert(i != nullptr || ret.Failed());
 	return i;
 }

--- a/src/misc/hashtable.hpp
+++ b/src/misc/hashtable.hpp
@@ -239,8 +239,7 @@ public:
 	/** non-const item search & removal */
 	void Pop(Titem_ &item)
 	{
-		bool ret = TryPop(item);
-		(void)ret; // assert only
+		[[maybe_unused]] bool ret = TryPop(item);
 		assert(ret);
 	}
 

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -1045,8 +1045,7 @@ static NPFFoundTargetData NPFRouteInternal(AyStarNode *start1, bool ignore_start
 	_npf_aystar.user_data = user;
 
 	/* GO! */
-	int r = _npf_aystar.Main();
-	(void)r; // assert only
+	[[maybe_unused]] int r = _npf_aystar.Main();
 	assert(r != AYSTAR_STILL_BUSY);
 
 	if (result.best_bird_dist != 0) {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1474,14 +1474,12 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 	return 0;
 }
 
-#ifdef OTTD_ASSERT
-
 /**
  * Check whether the variable size of the variable in the saveload configuration
  * matches with the actual variable size.
  * @param sld The saveload configuration to test.
  */
-static bool IsVariableSizeRight(const SaveLoad &sld)
+[[maybe_unused]] static bool IsVariableSizeRight(const SaveLoad &sld)
 {
 	switch (sld.cmd) {
 		case SL_VAR:
@@ -1522,13 +1520,9 @@ static bool IsVariableSizeRight(const SaveLoad &sld)
 	}
 }
 
-#endif /* OTTD_ASSERT */
-
 bool SlObjectMember(void *ptr, const SaveLoad &sld)
 {
-#ifdef OTTD_ASSERT
 	assert(IsVariableSizeRight(sld));
-#endif
 
 	VarType conv = GB(sld.conv, 0, 8);
 	switch (sld.cmd) {

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -651,8 +651,7 @@ SQRESULT Squirrel::LoadFile(HSQUIRRELVM vm, const char *filename, SQBool printer
 	}
 	unsigned short bom = 0;
 	if (size >= 2) {
-		size_t sr = fread(&bom, 1, sizeof(bom), file);
-		(void)sr; // Inside tar, no point checking return value of fread
+		[[maybe_unused]] size_t sr = fread(&bom, 1, sizeof(bom), file);
 	}
 
 	SQLEXREADFUNC func;

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -262,9 +262,7 @@ static void ResizeSpriteOut(SpriteLoader::Sprite *sprite, ZoomLevel zoom)
 
 	SpriteLoader::CommonPixel *dst = sprite[zoom].data;
 	const SpriteLoader::CommonPixel *src = sprite[zoom - 1].data;
-#ifdef WITH_ASSERT
-	const SpriteLoader::CommonPixel *src_end = src + sprite[zoom - 1].height * sprite[zoom - 1].width;
-#endif
+	[[maybe_unused]] const SpriteLoader::CommonPixel *src_end = src + sprite[zoom - 1].height * sprite[zoom - 1].width;
 
 	for (uint y = 0; y < sprite[zoom].height; y++) {
 		const SpriteLoader::CommonPixel *src_ln = src + sprite[zoom - 1].width;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -435,11 +435,6 @@ void NORETURN CDECL error(const char *str, ...) WARN_FORMAT(1, 2);
 #	define assert(expression) if (unlikely(!(expression))) error("Assertion failed at line %i of %s: %s", __LINE__, __FILE__, #expression);
 #endif
 
-/* Asserts are enabled if NDEBUG isn't defined or WITH_ASSERT is defined. */
-#if !defined(NDEBUG) || defined(WITH_ASSERT)
-#	define OTTD_ASSERT
-#endif
-
 #if defined(OPENBSD)
 	/* OpenBSD uses strcasecmp(3) */
 #	define _stricmp strcasecmp

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -438,9 +438,6 @@ void NORETURN CDECL error(const char *str, ...) WARN_FORMAT(1, 2);
 /* Asserts are enabled if NDEBUG isn't defined or WITH_ASSERT is defined. */
 #if !defined(NDEBUG) || defined(WITH_ASSERT)
 #	define OTTD_ASSERT
-#	define assert_msg(expression, msg, ...) if (unlikely(!(expression))) error("Assertion failed at line %i of %s: %s\n\t" msg, __LINE__, __FILE__, #expression, __VA_ARGS__);
-#else
-#	define assert_msg(expression, msg, ...)
 #endif
 
 #if defined(OPENBSD)

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -658,9 +658,7 @@ static void HeightMapCurves(uint level)
 			for (uint t = 0; t < lengthof(curve_maps); t++) {
 				if (!HasBit(corner_bits, t)) continue;
 
-#ifdef WITH_ASSERT
-				bool found = false;
-#endif
+				[[maybe_unused]] bool found = false;
 				const control_point_t *cm = curve_maps[t].list;
 				for (uint i = 0; i < curve_maps[t].length - 1; i++) {
 					const control_point_t &p1 = cm[i];

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -106,13 +106,17 @@ Town::~Town()
 	 * and remove from list of sorted towns */
 	CloseWindowById(WC_TOWN_VIEW, this->index);
 
-	/* Check no industry is related to us. */
 #ifdef WITH_ASSERT
-	for (const Industry *i : Industry::Iterate()) assert(i->town != this);
+	/* Check no industry is related to us. */
+	for (const Industry *i : Industry::Iterate()) {
+		assert(i->town != this);
+	}
 
 	/* ... and no object is related to us. */
-	for (const Object *o : Object::Iterate()) assert(o->town != this);
-#endif
+	for (const Object *o : Object::Iterate()) {
+		assert(o->town != this);
+	}
+#endif /* WITH_ASSERT */
 
 	/* Check no tile is related to us. */
 	for (TileIndex tile = 0; tile < MapSize(); ++tile) {
@@ -2177,8 +2181,7 @@ static Town *CreateRandomTown(uint attempts, uint32 townnameparts, TownSize size
 		if (t->cache.population > 0) return t;
 
 		Backup<CompanyID> cur_company(_current_company, OWNER_TOWN, FILE_LINE);
-		CommandCost rc = DoCommand(t->xy, t->index, 0, DC_EXEC, CMD_DELETE_TOWN);
-		(void)rc; // assert only
+		[[maybe_unused]] CommandCost rc = DoCommand(t->xy, t->index, 0, DC_EXEC, CMD_DELETE_TOWN);
 		cur_company.Restore();
 		assert(rc.Succeeded());
 
@@ -2279,8 +2282,7 @@ HouseZonesBits GetTownRadiusGroup(const Town *t, TileIndex tile)
  */
 static inline void ClearMakeHouseTile(TileIndex tile, Town *t, byte counter, byte stage, HouseID type, byte random_bits)
 {
-	CommandCost cc = DoCommand(tile, 0, 0, DC_EXEC | DC_AUTO | DC_NO_WATER, CMD_LANDSCAPE_CLEAR);
-	(void)cc; // assert only
+	[[maybe_unused]] CommandCost cc = DoCommand(tile, 0, 0, DC_EXEC | DC_AUTO | DC_NO_WATER, CMD_LANDSCAPE_CLEAR);
 	assert(cc.Succeeded());
 
 	IncreaseBuildingCount(t, type);

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -600,9 +600,7 @@ static char *MakeCzechTownName(char *buf, const char *last, uint32 seed)
 		return strecpy(buf, _name_czech_real[SeedModChance(4, lengthof(_name_czech_real), seed)], last);
 	}
 
-#ifdef WITH_ASSERT
-	const char *orig = buf;
-#endif
+	[[maybe_unused]] const char *orig = buf;
 
 	/* Probability of prefixes/suffixes
 	 * 0..11 prefix, 12..13 prefix+suffix, 14..17 suffix, 18..31 nothing */

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -1846,8 +1846,7 @@ static void ChangeTileOwner_TunnelBridge(TileIndex tile, Owner old_owner, Owner 
 		if (tt == TRANSPORT_RAIL) {
 			/* Since all of our vehicles have been removed, it is safe to remove the rail
 			 * bridge / tunnel. */
-			CommandCost ret = DoCommand(tile, 0, 0, DC_EXEC | DC_BANKRUPT, CMD_LANDSCAPE_CLEAR);
-			(void)ret; // assert only
+			[[maybe_unused]] CommandCost ret = DoCommand(tile, 0, 0, DC_EXEC | DC_BANKRUPT, CMD_LANDSCAPE_CLEAR);
 			assert(ret.Succeeded());
 		} else {
 			/* In any other case, we can safely reassign the ownership to OWNER_NONE. */

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -953,9 +953,7 @@ void CallVehicleTicks()
 	PerformanceAccumulator::Reset(PFE_GL_AIRCRAFT);
 
 	for (Vehicle *v : Vehicle::Iterate()) {
-#ifdef WITH_ASSERT
-		size_t vehicle_index = v->index;
-#endif
+		[[maybe_unused]] size_t vehicle_index = v->index;
 
 		/* Vehicle could be deleted in this tick */
 		if (!v->Tick()) {

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -53,8 +53,7 @@ bool VehicleListIdentifier::UnpackIfValid(uint32 data)
 /* static */ VehicleListIdentifier VehicleListIdentifier::UnPack(uint32 data)
 {
 	VehicleListIdentifier result;
-	bool ret = result.UnpackIfValid(data);
-	(void)ret; // assert only
+	[[maybe_unused]] bool ret = result.UnpackIfValid(data);
 	assert(ret);
 	return result;
 }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1272,9 +1272,7 @@ void NWidgetHorizontal::SetupSmallestSize(Window *w, bool init_array)
 		this->smallest_y = std::max(this->smallest_y, child_wid->smallest_y + child_wid->padding_top + child_wid->padding_bottom);
 	}
 	/* 1b. Make the container higher if needed to accommodate all children nicely. */
-#ifdef WITH_ASSERT
-	uint max_smallest = this->smallest_y + 3 * max_vert_fill; // Upper limit to computing smallest height.
-#endif
+	[[maybe_unused]] uint max_smallest = this->smallest_y + 3 * max_vert_fill; // Upper limit to computing smallest height.
 	uint cur_height = this->smallest_y;
 	for (;;) {
 		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
@@ -1439,9 +1437,7 @@ void NWidgetVertical::SetupSmallestSize(Window *w, bool init_array)
 		this->smallest_x = std::max(this->smallest_x, child_wid->smallest_x + child_wid->padding_left + child_wid->padding_right);
 	}
 	/* 1b. Make the container wider if needed to accommodate all children nicely. */
-#ifdef WITH_ASSERT
-	uint max_smallest = this->smallest_x + 3 * max_hor_fill; // Upper limit to computing smallest height.
-#endif
+	[[maybe_unused]] uint max_smallest = this->smallest_x + 3 * max_hor_fill; // Upper limit to computing smallest height.
 	uint cur_width = this->smallest_x;
 	for (;;) {
 		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {


### PR DESCRIPTION
## Motivation / Problem

@frosch123 made the mistake of pointing out C++17 has `[[maybe_unused]]`. so yeah .. OCD triggers, down the rabbit hole we went. Tnx mate ;)


## Description

```
While at it, replace OTTD_ASSERT with WITH_ASSERT, as this
is always set if assert() is valid. No matter if NDEBUG is set
or not.
```

Also removed `assert_msg`. I do not think we have used that in a while, and it completely unused.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
