### PR TITLE
Codechange: merge guiflags and flags in settings .ini files

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -578,7 +578,7 @@ static inline uint SlGetArrayLength(size_t length)
  * @param conv VarType type of variable that is used for calculating the size
  * @return Return the size of this type in bytes
  */
-static inline uint SlCalcConvMemLen(VarType conv)
+uint SlCalcConvMemLen(VarType conv)
 {
 	static const byte conv_mem_size[] = {1, 1, 1, 2, 2, 4, 4, 8, 8, 0};
 	byte length = GB(conv, 4, 4);
@@ -1406,21 +1406,6 @@ static inline bool SlIsObjectValidInSavegame(const SaveLoad &sld)
 }
 
 /**
- * Are we going to load this variable when loading a savegame or not?
- * @note If the variable is skipped it is skipped in the savegame
- * bytestream itself as well, so there is no need to skip it somewhere else
- */
-static inline bool SlSkipVariableOnLoad(const SaveLoad &sld)
-{
-	if ((sld.conv & SLF_NO_NETWORK_SYNC) && _sl.action != SLA_SAVE && _networking && !_network_server) {
-		SlSkipBytes(SlCalcConvMemLen(sld.conv) * sld.length);
-		return true;
-	}
-
-	return false;
-}
-
-/**
  * Calculate the size of an object.
  * @param object to be measured.
  * @param slt The SaveLoad table with objects to save/load.
@@ -1532,7 +1517,6 @@ bool SlObjectMember(void *ptr, const SaveLoad &sld)
 		case SL_STDSTR:
 			/* CONDITIONAL saveload types depend on the savegame version */
 			if (!SlIsObjectValidInSavegame(sld)) return false;
-			if (SlSkipVariableOnLoad(sld)) return false;
 
 			switch (sld.cmd) {
 				case SL_VAR: SlSaveLoadConv(ptr, conv); break;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1402,10 +1402,7 @@ static void SlDeque(void *deque, VarType conv)
 /** Are we going to save this object or not? */
 static inline bool SlIsObjectValidInSavegame(const SaveLoad &sld)
 {
-	if (_sl_version < sld.version_from || _sl_version >= sld.version_to) return false;
-	if (sld.conv & SLF_NOT_IN_SAVE) return false;
-
-	return true;
+	return (_sl_version >= sld.version_from && _sl_version < sld.version_to);
 }
 
 /**

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -488,8 +488,6 @@ enum VarTypes {
 	SLF_NO_NETWORK_SYNC = 1 << 10, ///< do not synchronize over network (but it is saved if SLF_NOT_IN_SAVE is not set)
 	SLF_ALLOW_CONTROL   = 1 << 11, ///< allow control codes in the strings
 	SLF_ALLOW_NEWLINE   = 1 << 12, ///< allow new lines in the strings
-	SLF_HEX             = 1 << 13, ///< print numbers as hex in the config file (only useful for unsigned)
-	/* 2 more possible flags */
 };
 
 typedef uint32 VarType;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -483,11 +483,8 @@ enum VarTypes {
 
 	/* 8 bits allocated for a maximum of 8 flags
 	 * Flags directing saving/loading of a variable */
-	SLF_NOT_IN_SAVE     = 1 <<  8, ///< do not save with savegame, basically client-based
-	SLF_NOT_IN_CONFIG   = 1 <<  9, ///< do not save to config file
-	SLF_NO_NETWORK_SYNC = 1 << 10, ///< do not synchronize over network (but it is saved if SLF_NOT_IN_SAVE is not set)
-	SLF_ALLOW_CONTROL   = 1 << 11, ///< allow control codes in the strings
-	SLF_ALLOW_NEWLINE   = 1 << 12, ///< allow new lines in the strings
+	SLF_ALLOW_CONTROL   = 1 << 8, ///< Allow control codes in the strings.
+	SLF_ALLOW_NEWLINE   = 1 << 9, ///< Allow new lines in the strings.
 };
 
 typedef uint32 VarType;
@@ -671,7 +668,7 @@ using SaveLoadTable = span<const SaveLoad>;
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLE_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL | SLF_NOT_IN_CONFIG, length, from, to, 0, nullptr, 0}
+#define SLE_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0}
 
 /** Translate values ingame to different values in the savegame and vv. */
 #define SLE_WRITEBYTE(base, variable) SLE_GENERAL(SL_WRITEBYTE, base, variable, 0, 0, SL_MIN_VERSION, SL_MAX_VERSION, 0)
@@ -795,7 +792,7 @@ using SaveLoadTable = span<const SaveLoad>;
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLEG_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL | SLF_NOT_IN_CONFIG, length, from, to, 0, nullptr, 0}
+#define SLEG_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0}
 
 /**
  * Checks whether the savegame is below \a major.\a minor.

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -894,6 +894,7 @@ void WriteValue(void *ptr, VarType conv, int64 val);
 void SlSetArrayIndex(uint index);
 int SlIterateArray();
 
+uint SlCalcConvMemLen(VarType conv);
 void SlAutolength(AutolengthProc *proc, void *arg);
 size_t SlGetFieldLength();
 void SlSetLength(size_t length);

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -35,7 +35,7 @@
 
 	const SettingDesc *sd = GetSettingFromName(setting);
 
-	if ((sd->save.conv & SLF_NO_NETWORK_SYNC) != 0) return false;
+	if ((sd->flags & SF_NO_NETWORK_SYNC) != 0) return false;
 
 	return ScriptObject::DoCommand(0, 0, value, CMD_CHANGE_SETTING, sd->name);
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2023,6 +2023,8 @@ void IConsoleListSettings(const char *prefilter)
 static void LoadSettings(const SettingTable &settings, void *object)
 {
 	for (auto &osd : settings) {
+		if (osd->save.conv & SLF_NOT_IN_SAVE) continue;
+
 		void *ptr = GetVariableAddress(object, osd->save);
 
 		if (!SlObjectMember(ptr, osd->save)) continue;
@@ -2045,11 +2047,15 @@ static void SaveSettings(const SettingTable &settings, void *object)
 	 * SlCalcLength() because we have a different format. So do this manually */
 	size_t length = 0;
 	for (auto &sd : settings) {
+		if (sd->save.conv & SLF_NOT_IN_SAVE) continue;
+
 		length += SlCalcObjMemberLength(object, sd->save);
 	}
 	SlSetLength(length);
 
 	for (auto &sd : settings) {
+		if (sd->save.conv & SLF_NOT_IN_SAVE) continue;
+
 		void *ptr = GetVariableAddress(object, sd->save);
 		SlObjectMember(ptr, sd->save);
 	}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -274,8 +274,6 @@ void ListSettingDesc::FormatValue(char *buf, const char *last, const void *objec
 		}
 		if (IsSignedVarMemType(this->save.conv)) {
 			buf += seprintf(buf, last, (i == 0) ? "%d" : ",%d", v);
-		} else if (this->save.conv & SLF_HEX) {
-			buf += seprintf(buf, last, (i == 0) ? "0x%X" : ",0x%X", v);
 		} else {
 			buf += seprintf(buf, last, (i == 0) ? "%u" : ",%u", v);
 		}
@@ -621,7 +619,7 @@ static void IniSaveSettings(IniFile *ini, const SettingTable &settings_table, co
 void IntSettingDesc::FormatValue(char *buf, const char *last, const void *object) const
 {
 	uint32 i = (uint32)this->Read(object);
-	seprintf(buf, last, IsSignedVarMemType(this->save.conv) ? "%d" : (this->save.conv & SLF_HEX) ? "%X" : "%u", i);
+	seprintf(buf, last, IsSignedVarMemType(this->save.conv) ? "%d" : "%u", i);
 }
 
 void BoolSettingDesc::FormatValue(char *buf, const char *last, const void *object) const

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2025,9 +2025,15 @@ static void LoadSettings(const SettingTable &settings, void *object)
 	for (auto &osd : settings) {
 		if (osd->save.conv & SLF_NOT_IN_SAVE) continue;
 
-		void *ptr = GetVariableAddress(object, osd->save);
+		SaveLoad sl = osd->save;
+		if ((osd->save.conv & SLF_NO_NETWORK_SYNC) && _networking && !_network_server) {
+			/* We don't want to read this setting, so we do need to skip over it. */
+			sl = SLE_NULL(static_cast<uint16>(SlCalcConvMemLen(osd->save.conv) * osd->save.length));
+		}
 
-		if (!SlObjectMember(ptr, osd->save)) continue;
+		void *ptr = GetVariableAddress(object, sl);
+		if (!SlObjectMember(ptr, sl)) continue;
+
 		if (osd->IsIntSetting()) {
 			const IntSettingDesc *int_setting = osd->AsIntSetting();
 			int_setting->MakeValueValidAndWrite(object, int_setting->Read(object));

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -14,16 +14,19 @@
 
 enum SettingFlag : uint16 {
 	SF_NONE = 0,
-	SF_GUI_0_IS_SPECIAL        = 1 << 0, ///< A value of zero is possible and has a custom string (the one after "strval").
-	SF_GUI_NEGATIVE_IS_SPECIAL = 1 << 1, ///< A negative value has another string (the one after "strval").
-	SF_GUI_DROPDOWN            = 1 << 2, ///< The value represents a limited number of string-options (internally integer) presented as dropdown.
-	SF_GUI_CURRENCY            = 1 << 3, ///< The number represents money, so when reading value multiply by exchange rate.
-	SF_NETWORK_ONLY            = 1 << 4, ///< This setting only applies to network games.
-	SF_NO_NETWORK              = 1 << 5, ///< This setting does not apply to network games; it may not be changed during the game.
-	SF_NEWGAME_ONLY            = 1 << 6, ///< This setting cannot be changed in a game.
-	SF_SCENEDIT_TOO            = 1 << 7, ///< This setting can be changed in the scenario editor (only makes sense when SF_NEWGAME_ONLY is set).
-	SF_SCENEDIT_ONLY           = 1 << 8, ///< This setting can only be changed in the scenario editor.
-	SF_PER_COMPANY             = 1 << 9, ///< This setting can be different for each company (saved in company struct).
+	SF_GUI_0_IS_SPECIAL        = 1 <<  0, ///< A value of zero is possible and has a custom string (the one after "strval").
+	SF_GUI_NEGATIVE_IS_SPECIAL = 1 <<  1, ///< A negative value has another string (the one after "strval").
+	SF_GUI_DROPDOWN            = 1 <<  2, ///< The value represents a limited number of string-options (internally integer) presented as dropdown.
+	SF_GUI_CURRENCY            = 1 <<  3, ///< The number represents money, so when reading value multiply by exchange rate.
+	SF_NETWORK_ONLY            = 1 <<  4, ///< This setting only applies to network games.
+	SF_NO_NETWORK              = 1 <<  5, ///< This setting does not apply to network games; it may not be changed during the game.
+	SF_NEWGAME_ONLY            = 1 <<  6, ///< This setting cannot be changed in a game.
+	SF_SCENEDIT_TOO            = 1 <<  7, ///< This setting can be changed in the scenario editor (only makes sense when SF_NEWGAME_ONLY is set).
+	SF_SCENEDIT_ONLY           = 1 <<  8, ///< This setting can only be changed in the scenario editor.
+	SF_PER_COMPANY             = 1 <<  9, ///< This setting can be different for each company (saved in company struct).
+	SF_NOT_IN_SAVE             = 1 << 10, ///< Do not save with savegame, basically client-based.
+	SF_NOT_IN_CONFIG           = 1 << 11, ///< Do not save to config file.
+	SF_NO_NETWORK_SYNC         = 1 << 12, ///< Do not synchronize over network (but it is saved if SF_NOT_IN_SAVE is not set).
 };
 DECLARE_ENUM_AS_BIT_SET(SettingFlag)
 
@@ -288,7 +291,7 @@ struct ListSettingDesc : SettingDesc {
 /** Placeholder for settings that have been removed, but might still linger in the savegame. */
 struct NullSettingDesc : SettingDesc {
 	NullSettingDesc(SaveLoad save) :
-		SettingDesc(save, "", SF_NONE, false) {}
+		SettingDesc(save, "", SF_NOT_IN_CONFIG, false) {}
 	virtual ~NullSettingDesc() {}
 
 	void FormatValue(char *buf, const char *last, const void *object) const override { NOT_REACHED(); }

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -58,62 +58,62 @@ static size_t ConvertLandscape(const char *value);
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */
-#define SDTG_VAR(name, type, flags, guiflags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(Int, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback)
+#define SDTG_VAR(name, type, flags, var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Int, SLEG_GENERAL(SL_VAR, var, type, 1, from, to, extra), name, flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback)
 
-#define SDTG_BOOL(name, flags, guiflags, var, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(Bool, SLEG_GENERAL(SL_VAR, var, SLE_BOOL | flags, 1, from, to, extra), name, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback)
+#define SDTG_BOOL(name, flags, var, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Bool, SLEG_GENERAL(SL_VAR, var, SLE_BOOL, 1, from, to, extra), name, flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback)
 
-#define SDTG_LIST(name, type, flags, guiflags, var, def, length, from, to, cat, extra, startup)\
-	NSD(List, SLEG_GENERAL(SL_ARR, var, type | flags, length, from, to, extra), name, guiflags, startup, def)
+#define SDTG_LIST(name, type, flags, var, def, length, from, to, cat, extra, startup)\
+	NSD(List, SLEG_GENERAL(SL_ARR, var, type, length, from, to, extra), name, flags, startup, def)
 
-#define SDTG_SSTR(name, type, flags, guiflags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(String, SLEG_GENERAL(SL_STDSTR, var, type | flags, sizeof(var), from, to, extra), name, guiflags, startup, def, max_length, pre_check, post_callback)
+#define SDTG_SSTR(name, type, flags, var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(String, SLEG_GENERAL(SL_STDSTR, var, type, sizeof(var), from, to, extra), name, flags, startup, def, max_length, pre_check, post_callback)
 
-#define SDTG_OMANY(name, type, flags, guiflags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(OneOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
+#define SDTG_OMANY(name, type, flags, var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(OneOfMany, SLEG_GENERAL(SL_VAR, var, type, 1, from, to, extra), name, flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
 
-#define SDTG_MMANY(name, type, flags, guiflags, var, def, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLEG_GENERAL(SL_VAR, var, type | flags, 1, from, to, extra), name, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
+#define SDTG_MMANY(name, type, flags, var, def, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(ManyOfMany, SLEG_GENERAL(SL_VAR, var, type, 1, from, to, extra), name, flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
 
 #define SDTG_NULL(length, from, to)\
 	NSD(Null, SLEG_NULL(length, from, to))
 
 /* Macros for various objects to go in the configuration file.
  * This section is for structures where their various members are saved */
-#define SDT_VAR(base, var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback)
+#define SDT_VAR(base, var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Int, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), #var, flags, startup, def, min, max, interval, str, strhelp, strval, cat, pre_check, post_callback)
 
-#define SDT_BOOL(base, var, flags, guiflags, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL | flags, 1, from, to, extra), #var, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback)
+#define SDT_BOOL(base, var, flags, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(Bool, SLE_GENERAL(SL_VAR, base, var, SLE_BOOL, 1, from, to, extra), #var, flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback)
 
-#define SDT_LIST(base, var, type, flags, guiflags, def, from, to, cat, extra, startup)\
-	NSD(List, SLE_GENERAL(SL_ARR, base, var, type | flags, lengthof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def)
+#define SDT_LIST(base, var, type, flags, def, from, to, cat, extra, startup)\
+	NSD(List, SLE_GENERAL(SL_ARR, base, var, type, lengthof(((base*)8)->var), from, to, extra), #var, flags, startup, def)
 
-#define SDT_SSTR(base, var, type, flags, guiflags, def, pre_check, post_callback, from, to, cat, extra, startup)\
-	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type | flags, sizeof(((base*)8)->var), from, to, extra), #var, guiflags, startup, def, 0, pre_check, post_callback)
+#define SDT_SSTR(base, var, type, flags, def, pre_check, post_callback, from, to, cat, extra, startup)\
+	NSD(String, SLE_GENERAL(SL_STDSTR, base, var, type, sizeof(((base*)8)->var), from, to, extra), #var, flags, startup, def, 0, pre_check, post_callback)
 
-#define SDT_OMANY(base, var, type, flags, guiflags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
-	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, load)
+#define SDT_OMANY(base, var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, load, cat, extra, startup)\
+	NSD(OneOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), #var, flags, startup, def, max, str, strhelp, strval, cat, pre_check, post_callback, full, load)
 
-#define SDT_MMANY(base, var, type, flags, guiflags, def, full, str, pre_check, post_callback, strhelp, strval, from, to, cat, extra, startup)\
-	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type | flags, 1, from, to, extra), #var, guiflags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
+#define SDT_MMANY(base, var, type, flags, def, full, str, pre_check, post_callback, strhelp, strval, from, to, cat, extra, startup)\
+	NSD(ManyOfMany, SLE_GENERAL(SL_VAR, base, var, type, 1, from, to, extra), #var, flags, startup, def, str, strhelp, strval, cat, pre_check, post_callback, full, nullptr)
 
 #define SDT_NULL(length, from, to)\
 	NSD(Null, SLE_CONDNULL(length, from, to))
 
 
-#define SDTC_VAR(var, type, flags, guiflags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	SDTG_VAR(#var, type, flags, guiflags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
+#define SDTC_VAR(var, type, flags, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_VAR(#var, type, flags, _settings_client.var, def, min, max, interval, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
 
-#define SDTC_BOOL(var, flags, guiflags, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	SDTG_BOOL(#var, flags, guiflags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
+#define SDTC_BOOL(var, flags, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_BOOL(#var, flags, _settings_client.var, def, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
 
-#define SDTC_LIST(var, type, flags, guiflags, def, from, to, cat, extra, startup)\
-	SDTG_LIST(#var, type, flags, guiflags, _settings_client.var, def, lengthof(_settings_client.var), from, to, cat, extra, startup)
+#define SDTC_LIST(var, type, flags, def, from, to, cat, extra, startup)\
+	SDTG_LIST(#var, type, flags, _settings_client.var, def, lengthof(_settings_client.var), from, to, cat, extra, startup)
 
-#define SDTC_SSTR(var, type, flags, guiflags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
-	SDTG_SSTR(#var, type, flags, guiflags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
+#define SDTC_SSTR(var, type, flags, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_SSTR(#var, type, flags, _settings_client.var, def, max_length, pre_check, post_callback, from, to, cat, extra, startup)\
 
-#define SDTC_OMANY(var, type, flags, guiflags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
-	SDTG_OMANY(#var, type, flags, guiflags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)
+#define SDTC_OMANY(var, type, flags, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)\
+	SDTG_OMANY(#var, type, flags, _settings_client.var, def, max, full, str, strhelp, strval, pre_check, post_callback, from, to, cat, extra, startup)

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -16,15 +16,14 @@ static const SettingTable _company_settings{
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL(CompanySettings, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL(CompanySettings, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(CompanySettings, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for CompanySettings.$var exceeds storage size");
 
 [defaults]
-flags    = 0
-guiflags = SF_PER_COMPANY
+flags    = SF_PER_COMPANY
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
@@ -50,7 +49,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = engine_renew_months
 type     = SLE_INT16
-guiflags = SF_PER_COMPANY | SF_GUI_NEGATIVE_IS_SPECIAL
+flags    = SF_PER_COMPANY | SF_GUI_NEGATIVE_IS_SPECIAL
 def      = 6
 min      = -12
 max      = 12
@@ -61,7 +60,7 @@ strval   = STR_CONFIG_SETTING_AUTORENEW_MONTHS_VALUE_BEFORE
 [SDT_VAR]
 var      = engine_renew_money
 type     = SLE_UINT
-guiflags = SF_PER_COMPANY | SF_GUI_CURRENCY
+flags    = SF_PER_COMPANY | SF_GUI_CURRENCY
 def      = 100000
 min      = 0
 max      = 2000000
@@ -83,7 +82,7 @@ post_cb  = UpdateServiceInterval
 [SDT_VAR]
 var      = vehicle.servint_trains
 type     = SLE_UINT16
-guiflags = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
+flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
 def      = 150
 min      = 5
 max      = 800
@@ -96,7 +95,7 @@ post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 [SDT_VAR]
 var      = vehicle.servint_roadveh
 type     = SLE_UINT16
-guiflags = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
+flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
 def      = 150
 min      = 5
 max      = 800
@@ -109,7 +108,7 @@ post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 [SDT_VAR]
 var      = vehicle.servint_ships
 type     = SLE_UINT16
-guiflags = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
+flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
 def      = 360
 min      = 5
 max      = 800
@@ -122,7 +121,7 @@ post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 [SDT_VAR]
 var      = vehicle.servint_aircraft
 type     = SLE_UINT16
-guiflags = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
+flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
 def      = 100
 min      = 5
 max      = 800

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -11,15 +11,14 @@ static const SettingTable _currency_settings{
 [post-amble]
 };
 [templates]
-SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_SSTR = SDT_SSTR(CurrencySpec, $var, $type, $flags, $guiflags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  = SDT_VAR (CurrencySpec, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_SSTR = SDT_SSTR(CurrencySpec, $var, $type, $flags, $def,                                                 $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for CurrencySpec.$var exceeds storage size");
 
 [defaults]
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NONE
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT

--- a/src/table/settings/gameopt_settings.ini
+++ b/src/table/settings/gameopt_settings.ini
@@ -46,13 +46,13 @@ static const SettingTable _gameopt_settings{
 [post-amble]
 };
 [templates]
-SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $guiflags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
-SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $guiflags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_LIST    =  SDTG_LIST($name,              $type, $flags, $var, $def, $length, $from, $to, $cat, $extra, $startup),
+SDTG_VAR     =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval,  $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 SDT_NULL     =   SDT_NULL(                                                          $length,                                                            $from, $to),
-SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $guiflags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $guiflags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $guiflags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY   = SDTC_OMANY(              $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY   = SDTG_OMANY($name,              $type, $flags, $var, $def, $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY    =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,       $max, $full,            $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_VAR      =    SDT_VAR(GameSettings, $var, $type, $flags, $def, $min, $max,        $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -62,8 +62,7 @@ SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$va
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
 
 [defaults]
-flags    = 0
-guiflags = SF_NONE
+flags    = SF_NONE
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
@@ -84,7 +83,7 @@ name     = ""diff_custom""
 sdt_cmd  = SDT_INTLIST
 sle_cmd  = SL_ARR
 type     = SLE_FILE_I16 | SLE_VAR_U16
-flags    = SLF_NOT_IN_CONFIG
+flags    = SF_NOT_IN_CONFIG
 var      = _old_diff_custom
 length   = 17
 def      = nullptr
@@ -95,19 +94,18 @@ name     = ""diff_custom""
 sdt_cmd  = SDT_INTLIST
 sle_cmd  = SL_ARR
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_CONFIG
+flags    = SF_NOT_IN_CONFIG
 var      = _old_diff_custom
 length   = 18
 def      = nullptr
 full     = nullptr
 from     = SLV_4
 
-##
 [SDTG_VAR]
 name     = ""diff_level""
 var      = _old_diff_level
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_CONFIG
+flags    = SF_NOT_IN_CONFIG
 def      = SP_CUSTOM
 min      = SP_EASY
 max      = SP_CUSTOM
@@ -116,7 +114,7 @@ cat      = SC_BASIC
 [SDT_OMANY]
 var      = locale.currency
 type     = SLE_UINT8
-flags    = SLF_NO_NETWORK_SYNC
+flags    = SF_NO_NETWORK_SYNC
 def      = 0
 max      = CURRENCY_END - 1
 full     = _locale_currencies
@@ -126,7 +124,7 @@ cat      = SC_BASIC
 name     = ""units""
 var      = _old_units
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_CONFIG
+flags    = SF_NOT_IN_CONFIG
 def      = 1
 max      = 2
 full     = _locale_units
@@ -172,8 +170,7 @@ to       = SLV_23
 [SDTC_OMANY]
 var      = gui.autosave
 type     = SLE_UINT8
-from     = SLV_23
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 1
 max      = 4
 full     = _autosave_interval

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -24,20 +24,19 @@ static const SettingTable _misc_settings{
 [post-amble]
 };
 [templates]
-SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $guiflags, $var, $def,       $length,                                                            $from, $to, $cat, $extra, $startup),
-SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $guiflags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $guiflags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $guiflags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_LIST  =  SDTG_LIST($name, $type, $flags, $var, $def,       $length,                                                            $from, $to, $cat, $extra, $startup),
+SDTG_MMANY = SDTG_MMANY($name, $type, $flags, $var, $def,                        $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name, $type, $flags, $var, $def,       $max,            $full, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_SSTR  =  SDTG_SSTR($name, $type, $flags, $var, $def,       0,                                               $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,        $flags, $var, $def,                               $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval,        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTG_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 
 [defaults]
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NONE
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -53,18 +53,18 @@ const SettingTable _settings{
 [post-amble]
 };
 [templates]
-SDTG_BOOL  =  SDTG_BOOL($name,                     $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $guiflags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_LIST  =  SDTC_LIST(              $var, $type, $flags, $guiflags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
-SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $guiflags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $guiflags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $guiflags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
-SDT_SSTR   =   SDT_SSTR(GameSettings, $var, $type, $flags, $guiflags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
-SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $guiflags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_BOOL  =  SDTG_BOOL($name,                     $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_VAR   =   SDTG_VAR($name,              $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTG_OMANY = SDTG_OMANY($name,              $type, $flags, $var, $def,       $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_LIST  =  SDTC_LIST(              $var, $type, $flags, $def,                                                                          $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_BOOL   =   SDT_BOOL(GameSettings, $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_OMANY  =  SDT_OMANY(GameSettings, $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $load, $cat, $extra, $startup),
+SDT_SSTR   =   SDT_SSTR(GameSettings, $var, $type, $flags, $def,                                                       $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDT_VAR    =    SDT_VAR(GameSettings, $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDT_NULL   =   SDT_NULL(                                                                $length,                                                     $from, $to),
 
 [validation]
@@ -76,8 +76,7 @@ SDT_OMANY = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$va
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for GameSettings.$var exceeds storage size");
 
 [defaults]
-flags    = 0
-guiflags = SF_NONE
+flags    = SF_NONE
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
@@ -119,7 +118,7 @@ max      = 3
 var      = difficulty.number_towns
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = 2
 min      = 0
 max      = 4
@@ -131,7 +130,7 @@ cat      = SC_BASIC
 var      = difficulty.industry_density
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = ID_END - 1
 min      = 0
 max      = ID_END - 1
@@ -145,7 +144,7 @@ cat      = SC_BASIC
 var      = difficulty.max_loan
 type     = SLE_UINT32
 from     = SLV_97
-guiflags = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_CURRENCY
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_CURRENCY
 def      = 300000
 min      = 0
 max      = 2000000000
@@ -159,7 +158,7 @@ cat      = SC_BASIC
 var      = difficulty.initial_interest
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO
 def      = 2
 min      = 2
 max      = 4
@@ -172,7 +171,7 @@ strval   = STR_CONFIG_SETTING_PERCENTAGE
 var      = difficulty.vehicle_costs
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_DROPDOWN
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -186,7 +185,7 @@ cat      = SC_BASIC
 var      = difficulty.competitor_speed
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 4
@@ -209,7 +208,7 @@ max      = 2
 var      = difficulty.vehicle_breakdowns
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -223,7 +222,7 @@ cat      = SC_BASIC
 var      = difficulty.subsidy_multiplier
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 3
@@ -236,7 +235,7 @@ strval   = STR_SUBSIDY_X1_5
 var      = difficulty.construction_cost
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_DROPDOWN
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -250,7 +249,7 @@ cat      = SC_BASIC
 var      = difficulty.terrain_type
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
 def      = 1
 min      = 0
 max      = 5
@@ -264,7 +263,7 @@ cat      = SC_BASIC
 var      = difficulty.quantity_sea_lakes
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = 0
 min      = 0
 max      = 4
@@ -298,7 +297,7 @@ cat      = SC_BASIC
 var      = difficulty.town_council_tolerance
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -312,7 +311,7 @@ post_cb  = DifficultyNoiseChange
 name     = ""diff_level""
 var      = _old_diff_level
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_CONFIG
+flags    = SF_NOT_IN_CONFIG
 from     = SLV_97
 to       = SLV_178
 def      = 3
@@ -326,7 +325,7 @@ cat      = SC_BASIC
 var      = game_creation.town_name
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = 0
 max      = 255
 full     = _town_names
@@ -336,7 +335,7 @@ cat      = SC_BASIC
 var      = game_creation.landscape
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
 def      = 0
 max      = 3
 full     = _climates
@@ -356,7 +355,7 @@ to       = SLV_164
 var      = vehicle.road_side
 type     = SLE_UINT8
 from     = SLV_97
-guiflags = SF_GUI_DROPDOWN | SF_NO_NETWORK
+flags    = SF_GUI_DROPDOWN | SF_NO_NETWORK
 def      = 1
 max      = 1
 full     = _roadsides
@@ -372,7 +371,7 @@ cat      = SC_BASIC
 var      = construction.map_height_limit
 type     = SLE_UINT8
 from     = SLV_194
-guiflags = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_0_IS_SPECIAL
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_0_IS_SPECIAL
 def      = 0
 min      = MIN_MAP_HEIGHT_LIMIT
 max      = MAX_MAP_HEIGHT_LIMIT
@@ -388,7 +387,7 @@ cat      = SC_ADVANCED
 var      = game_creation.heightmap_height
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = MAP_HEIGHT_LIMIT_AUTO_MINIMUM
 min      = MIN_HEIGHTMAP_HEIGHT
 max      = MAX_MAP_HEIGHT_LIMIT
@@ -396,7 +395,7 @@ interval = 1
 
 [SDT_BOOL]
 var      = construction.build_on_slopes
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 cat      = SC_EXPERT
 
@@ -404,7 +403,7 @@ cat      = SC_EXPERT
 var      = construction.command_pause_level
 type     = SLE_UINT8
 from     = SLV_154
-guiflags = SF_GUI_DROPDOWN | SF_NO_NETWORK
+flags    = SF_GUI_DROPDOWN | SF_NO_NETWORK
 def      = 1
 min      = 0
 max      = 3
@@ -491,7 +490,7 @@ strhelp  = STR_CONFIG_SETTING_EXTRADYNAMITE_HELPTEXT
 var      = construction.max_bridge_length
 type     = SLE_UINT16
 from     = SLV_159
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = 64
 min      = 1
 max      = MAX_MAP_SIZE
@@ -504,7 +503,7 @@ strval   = STR_CONFIG_SETTING_TILE_LENGTH
 var      = construction.max_bridge_height
 type     = SLE_UINT8
 from     = SLV_194
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = 12
 min      = 1
 max      = MAX_TILE_HEIGHT
@@ -518,7 +517,7 @@ cat      = SC_EXPERT
 var      = construction.max_tunnel_length
 type     = SLE_UINT16
 from     = SLV_159
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = 64
 min      = 1
 max      = MAX_MAP_SIZE
@@ -535,7 +534,7 @@ to       = SLV_159
 [SDT_VAR]
 var      = construction.train_signal_side
 type     = SLE_UINT8
-guiflags = SF_GUI_DROPDOWN | SF_NO_NETWORK
+flags    = SF_GUI_DROPDOWN | SF_NO_NETWORK
 def      = 1
 min      = 0
 max      = 2
@@ -547,7 +546,7 @@ cat      = SC_BASIC
 
 [SDT_BOOL]
 var      = station.never_expire_airports
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS
 strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS_HELPTEXT
@@ -556,7 +555,7 @@ strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_AIRPORTS_HELPTEXT
 var      = economy.town_layout
 type     = SLE_UINT8
 from     = SLV_59
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = TL_ORIGINAL
 min      = TL_BEGIN
 max      = NUM_TLS - 1
@@ -569,7 +568,7 @@ post_cb  = TownFoundingChanged
 [SDT_BOOL]
 var      = economy.allow_town_roads
 from     = SLV_113
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_TOWN_ROADS
 strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_ROADS_HELPTEXT
@@ -578,7 +577,7 @@ strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_ROADS_HELPTEXT
 var      = economy.found_town
 type     = SLE_UINT8
 from     = SLV_128
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = TF_FORBIDDEN
 min      = TF_BEGIN
 max      = TF_END - 1
@@ -592,7 +591,7 @@ cat      = SC_BASIC
 [SDT_BOOL]
 var      = economy.allow_town_level_crossings
 from     = SLV_143
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS
 strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT
@@ -601,7 +600,7 @@ strhelp  = STR_CONFIG_SETTING_ALLOW_TOWN_LEVEL_CROSSINGS_HELPTEXT
 var      = economy.town_cargogen_mode
 type     = SLE_UINT8
 from     = SLV_TOWN_CARGOGEN
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = TCGM_BITCOUNT
 min      = TCGM_BEGIN
 max      = TCGM_END - 1
@@ -644,7 +643,7 @@ extra    = offsetof(LinkGraphSettings, recalc_time)
 var      = linkgraph.distribution_pax
 type     = SLE_UINT8
 from     = SLV_183
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = DT_MANUAL
 min      = DT_MIN
 max      = DT_MAX
@@ -659,7 +658,7 @@ extra    = offsetof(LinkGraphSettings, distribution_pax)
 var      = linkgraph.distribution_mail
 type     = SLE_UINT8
 from     = SLV_183
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = DT_MANUAL
 min      = DT_MIN
 max      = DT_MAX
@@ -674,7 +673,7 @@ extra    = offsetof(LinkGraphSettings, distribution_mail)
 var      = linkgraph.distribution_armoured
 type     = SLE_UINT8
 from     = SLV_183
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = DT_MANUAL
 min      = DT_MIN
 max      = DT_MAX
@@ -689,7 +688,7 @@ extra    = offsetof(LinkGraphSettings, distribution_armoured)
 var      = linkgraph.distribution_default
 type     = SLE_UINT8
 from     = SLV_183
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = DT_MANUAL
 min      = DT_BEGIN
 max      = DT_MAX_NONSYMMETRIC
@@ -761,7 +760,7 @@ extra    = offsetof(LinkGraphSettings, short_path_saturation)
 [SDT_VAR]
 var      = vehicle.train_acceleration_model
 type     = SLE_UINT8
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 1
@@ -775,7 +774,7 @@ post_cb  = TrainAccelerationModelChanged
 var      = vehicle.roadveh_acceleration_model
 type     = SLE_UINT8
 from     = SLV_139
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 1
@@ -843,7 +842,7 @@ to       = SLV_159
 var      = vehicle.smoke_amount
 type     = SLE_UINT8
 from     = SLV_145
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -895,7 +894,7 @@ cat      = SC_EXPERT
 var      = pf.pathfinder_for_trains
 type     = SLE_UINT8
 from     = SLV_87
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 1
 max      = 2
@@ -909,7 +908,7 @@ cat      = SC_EXPERT
 var      = pf.pathfinder_for_roadvehs
 type     = SLE_UINT8
 from     = SLV_87
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 1
 max      = 2
@@ -923,7 +922,7 @@ cat      = SC_EXPERT
 var      = pf.pathfinder_for_ships
 type     = SLE_UINT8
 from     = SLV_87
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 1
 max      = 2
@@ -936,7 +935,7 @@ cat      = SC_EXPERT
 
 [SDT_BOOL]
 var      = vehicle.never_expire_vehicles
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES
 strhelp  = STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT
@@ -991,7 +990,7 @@ cat      = SC_BASIC
 
 [SDTG_BOOL]
 name     = nullptr
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 var      = _old_vds.servint_ispercent
 def      = false
 to       = SLV_120
@@ -999,7 +998,7 @@ to       = SLV_120
 [SDTG_VAR]
 name     = nullptr
 type     = SLE_UINT16
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_trains
 def      = 150
 min      = 5
@@ -1009,7 +1008,7 @@ to       = SLV_120
 [SDTG_VAR]
 name     = nullptr
 type     = SLE_UINT16
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_roadveh
 def      = 150
 min      = 5
@@ -1019,7 +1018,7 @@ to       = SLV_120
 [SDTG_VAR]
 name     = nullptr
 type     = SLE_UINT16
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_ships
 def      = 360
 min      = 5
@@ -1029,7 +1028,7 @@ to       = SLV_120
 [SDTG_VAR]
 name     = nullptr
 type     = SLE_UINT16
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_aircraft
 def      = 150
 min      = 5
@@ -1044,7 +1043,7 @@ strhelp  = STR_CONFIG_SETTING_NOSERVICE_HELPTEXT
 
 [SDT_BOOL]
 var      = vehicle.wagon_speed_limits
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 str      = STR_CONFIG_SETTING_WAGONSPEEDLIMITS
 strhelp  = STR_CONFIG_SETTING_WAGONSPEEDLIMITS_HELPTEXT
@@ -1053,7 +1052,7 @@ post_cb  = UpdateConsists
 [SDT_BOOL]
 var      = vehicle.disable_elrails
 from     = SLV_38
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_DISABLE_ELRAILS
 strhelp  = STR_CONFIG_SETTING_DISABLE_ELRAILS_HELPTEXT
@@ -1064,7 +1063,7 @@ cat      = SC_EXPERT
 var      = vehicle.freight_trains
 type     = SLE_UINT8
 from     = SLV_39
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = 1
 min      = 1
 max      = 255
@@ -1084,7 +1083,7 @@ to       = SLV_159
 var      = vehicle.plane_speed
 type     = SLE_UINT8
 from     = SLV_90
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = 4
 min      = 1
 max      = 4
@@ -1095,7 +1094,7 @@ strval   = STR_CONFIG_SETTING_PLANE_SPEED_VALUE
 [SDT_BOOL]
 var      = vehicle.dynamic_engines
 from     = SLV_95
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 pre_cb   = CheckDynamicEngines
 cat      = SC_EXPERT
@@ -1104,7 +1103,7 @@ cat      = SC_EXPERT
 var      = vehicle.plane_crashes
 type     = SLE_UINT8
 from     = SLV_138
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 2
@@ -1127,7 +1126,7 @@ def      = true
 
 [SDT_BOOL]
 var      = order.improved_load
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 cat      = SC_EXPERT
 
@@ -1185,7 +1184,7 @@ post_cb  = StationCatchmentChanged
 [SDT_BOOL]
 var      = order.gradual_loading
 from     = SLV_40
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = true
 cat      = SC_EXPERT
 
@@ -1214,7 +1213,7 @@ cat      = SC_EXPERT
 [SDT_BOOL]
 var      = economy.station_noise_level
 from     = SLV_96
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_NOISE_LEVEL
 strhelp  = STR_CONFIG_SETTING_NOISE_LEVEL_HELPTEXT
@@ -1231,7 +1230,7 @@ post_cb  = [](auto) { CloseWindowById(WC_SELECT_STATION, 0); }
 ##
 [SDT_BOOL]
 var      = economy.inflation
-guiflags = SF_NO_NETWORK
+flags    = SF_NO_NETWORK
 def      = false
 str      = STR_CONFIG_SETTING_INFLATION
 strhelp  = STR_CONFIG_SETTING_INFLATION_HELPTEXT
@@ -1240,7 +1239,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = construction.raw_industry_construction
 type     = SLE_UINT8
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -1318,7 +1317,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = game_creation.snow_line_height
 type     = SLE_UINT8
-guiflags = SF_SCENEDIT_ONLY
+flags    = SF_SCENEDIT_ONLY
 def      = DEF_SNOWLINE_HEIGHT
 min      = MIN_SNOWLINE_HEIGHT
 max      = MAX_SNOWLINE_HEIGHT
@@ -1332,7 +1331,7 @@ cat      = SC_BASIC
 var      = game_creation.snow_coverage
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = DEF_SNOW_COVERAGE
 min      = 0
 max      = 100
@@ -1346,7 +1345,7 @@ cat      = SC_BASIC
 var      = game_creation.desert_coverage
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = DEF_DESERT_COVERAGE
 min      = 0
 max      = 100
@@ -1379,7 +1378,7 @@ to       = SLV_105
 var      = game_creation.ending_year
 type     = SLE_INT32
 from     = SLV_ENDING_YEAR
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_GUI_0_IS_SPECIAL
 def      = DEF_END_YEAR
 min      = MIN_YEAR
 max      = MAX_YEAR - 1
@@ -1392,7 +1391,7 @@ cat      = SC_ADVANCED
 [SDT_VAR]
 var      = economy.type
 type     = SLE_UINT8
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = ET_SMOOTH
 min      = ET_BEGIN
 max      = ET_END - 1
@@ -1438,7 +1437,7 @@ cat      = SC_EXPERT
 var      = economy.town_growth_rate
 type     = SLE_UINT8
 from     = SLV_54
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 4
@@ -1450,7 +1449,7 @@ strval   = STR_CONFIG_SETTING_TOWN_GROWTH_NONE
 var      = economy.larger_towns
 type     = SLE_UINT8
 from     = SLV_54
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_GUI_0_IS_SPECIAL
 def      = 4
 min      = 0
 max      = 255
@@ -1486,7 +1485,7 @@ to       = SLV_107
 var      = script.settings_profile
 type     = SLE_UINT8
 from     = SLV_178
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = SP_EASY
 min      = SP_EASY
 max      = SP_HARD
@@ -1531,7 +1530,7 @@ strhelp  = STR_CONFIG_SETTING_AI_BUILDS_SHIPS_HELPTEXT
 var      = script.script_max_opcode_till_suspend
 type     = SLE_UINT32
 from     = SLV_107
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = 10000
 min      = 500
 max      = 250000
@@ -1545,7 +1544,7 @@ cat      = SC_EXPERT
 var      = script.script_max_memory_megabytes
 type     = SLE_UINT32
 from     = SLV_SCRIPT_MEMLIMIT
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = 1024
 min      = 8
 max      = 8192
@@ -2119,7 +2118,7 @@ cat      = SC_EXPERT
 var      = game_creation.land_generator
 type     = SLE_UINT8
 from     = SLV_30
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
 def      = 1
 min      = 0
 max      = 1
@@ -2142,7 +2141,7 @@ strhelp  = STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT
 var      = game_creation.tgen_smoothness
 type     = SLE_UINT8
 from     = SLV_30
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
 def      = 1
 min      = TGEN_SMOOTHNESS_BEGIN
 max      = TGEN_SMOOTHNESS_END - 1
@@ -2155,7 +2154,7 @@ cat      = SC_BASIC
 var      = game_creation.variety
 type     = SLE_UINT8
 from     = SLV_197
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
 def      = 0
 min      = 0
 max      = 5
@@ -2176,7 +2175,7 @@ cat      = SC_EXPERT
 var      = game_creation.tree_placer
 type     = SLE_UINT8
 from     = SLV_30
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY | SF_SCENEDIT_TOO
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY | SF_SCENEDIT_TOO
 def      = 2
 min      = 0
 max      = 2
@@ -2188,8 +2187,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = game_creation.heightmap_rotation
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 1
@@ -2200,7 +2198,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = game_creation.se_flat_world_height
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 1
 min      = 0
 max      = 15
@@ -2212,7 +2210,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = game_creation.map_x
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 8
 min      = MIN_MAP_SIZE_BITS
 max      = MAX_MAP_SIZE_BITS
@@ -2221,7 +2219,7 @@ cat      = SC_BASIC
 [SDT_VAR]
 var      = game_creation.map_y
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 8
 min      = MIN_MAP_SIZE_BITS
 max      = MAX_MAP_SIZE_BITS
@@ -2256,7 +2254,7 @@ cat      = SC_BASIC
 var      = construction.extra_tree_placement
 type     = SLE_UINT8
 from     = SLV_132
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 3
@@ -2269,7 +2267,7 @@ cat      = SC_BASIC
 var      = game_creation.custom_terrain_type
 type     = SLE_UINT8
 from     = SLV_MAPGEN_SETTINGS_REVAMP
-guiflags = SF_NEWGAME_ONLY
+flags    = SF_NEWGAME_ONLY
 def      = MAP_HEIGHT_LIMIT_AUTO_MINIMUM
 min      = MIN_CUSTOM_TERRAIN_TYPE
 max      = MAX_MAP_HEIGHT_LIMIT
@@ -2306,7 +2304,7 @@ cat      = SC_EXPERT
 var      = game_creation.amount_of_rivers
 type     = SLE_UINT8
 from     = SLV_163
-guiflags = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
+flags    = SF_GUI_DROPDOWN | SF_NEWGAME_ONLY
 def      = 2
 min      = 0
 max      = 3
@@ -2320,7 +2318,7 @@ strval   = STR_RIVERS_NONE
 var      = locale.currency
 type     = SLE_UINT8
 from     = SLV_97
-flags    = SLF_NO_NETWORK_SYNC
+flags    = SF_NO_NETWORK_SYNC
 def      = 0
 max      = CURRENCY_END - 1
 full     = _locale_currencies
@@ -2333,7 +2331,7 @@ var      = _old_units
 type     = SLE_UINT8
 from     = SLV_97
 to       = SLV_184
-flags    = SLF_NOT_IN_CONFIG
+flags    = SF_NOT_IN_CONFIG
 def      = 1
 max      = 2
 full     = _locale_units
@@ -2344,8 +2342,7 @@ cat      = SC_BASIC
 var      = locale.units_velocity
 type     = SLE_UINT8
 from     = SLV_184
-flags    = SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 3
 full     = _locale_units
@@ -2359,8 +2356,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_VELOCITY_IMPERIAL
 var      = locale.units_power
 type     = SLE_UINT8
 from     = SLV_184
-flags    = SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _locale_units
@@ -2374,8 +2370,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_POWER_IMPERIAL
 var      = locale.units_weight
 type     = SLE_UINT8
 from     = SLV_184
-flags    = SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _locale_units
@@ -2389,8 +2384,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_WEIGHT_IMPERIAL
 var      = locale.units_volume
 type     = SLE_UINT8
 from     = SLV_184
-flags    = SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _locale_units
@@ -2404,8 +2398,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_VOLUME_IMPERIAL
 var      = locale.units_force
 type     = SLE_UINT8
 from     = SLV_184
-flags    = SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _locale_units
@@ -2419,8 +2412,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_FORCE_IMPERIAL
 var      = locale.units_height
 type     = SLE_UINT8
 from     = SLV_184
-flags    = SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _locale_units
@@ -2434,7 +2426,7 @@ strval   = STR_CONFIG_SETTING_LOCALISATION_UNITS_HEIGHT_IMPERIAL
 var      = locale.digit_group_separator
 type     = SLE_STRQ
 from     = SLV_118
-flags    = SLF_NO_NETWORK_SYNC
+flags    = SF_NO_NETWORK_SYNC
 def      = nullptr
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
@@ -2443,7 +2435,7 @@ cat      = SC_BASIC
 var      = locale.digit_group_separator_currency
 type     = SLE_STRQ
 from     = SLV_118
-flags    = SLF_NO_NETWORK_SYNC
+flags    = SF_NO_NETWORK_SYNC
 def      = nullptr
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
@@ -2452,7 +2444,7 @@ cat      = SC_BASIC
 var      = locale.digit_decimal_separator
 type     = SLE_STRQ
 from     = SLV_126
-flags    = SLF_NO_NETWORK_SYNC
+flags    = SF_NO_NETWORK_SYNC
 def      = nullptr
 post_cb  = [](auto) { MarkWholeScreenDirty(); }
 cat      = SC_BASIC
@@ -2464,8 +2456,7 @@ cat      = SC_BASIC
 [SDTC_OMANY]
 var      = gui.autosave
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 4
 full     = _autosave_interval
@@ -2476,15 +2467,14 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.threaded_saves
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 cat      = SC_EXPERT
 
 [SDTC_OMANY]
 var      = gui.date_format_in_default_names
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _savegame_date
@@ -2494,7 +2484,7 @@ strval   = STR_CONFIG_SETTING_DATE_FORMAT_IN_SAVE_NAMES_LONG
 
 [SDTC_BOOL]
 var      = gui.show_finances
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SHOWFINANCES
 strhelp  = STR_CONFIG_SETTING_SHOWFINANCES_HELPTEXT
@@ -2503,8 +2493,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.auto_scrolling
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 3
@@ -2516,8 +2505,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.scroll_mode
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 3
@@ -2528,14 +2516,14 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.smooth_scroll
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_SMOOTH_SCROLLING
 strhelp  = STR_CONFIG_SETTING_SMOOTH_SCROLLING_HELPTEXT
 
 [SDTC_BOOL]
 var      = gui.right_mouse_wnd_close
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE
 strhelp  = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_HELPTEXT
@@ -2546,8 +2534,7 @@ cat      = SC_BASIC
 ifdef    = __APPLE__
 var      = gui.right_mouse_btn_emulation
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -2558,7 +2545,7 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.measure_tooltip
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_MEASURE_TOOLTIP
 strhelp  = STR_CONFIG_SETTING_MEASURE_TOOLTIP_HELPTEXT
@@ -2567,7 +2554,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.errmsg_duration
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 5
 min      = 0
 max      = 20
@@ -2578,8 +2565,7 @@ strval   = STR_CONFIG_SETTING_ERRMSG_DURATION_VALUE
 [SDTC_VAR]
 var      = gui.hover_delay_ms
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL
 def      = 250
 min      = 50
 max      = 6000
@@ -2591,11 +2577,11 @@ strval   = STR_CONFIG_SETTING_HOVER_DELAY_VALUE
 [SDTC_OMANY]
 var      = gui.osk_activation
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 str      = STR_CONFIG_SETTING_OSK_ACTIVATION
 strhelp  = STR_CONFIG_SETTING_OSK_ACTIVATION_HELPTEXT
 strval   = STR_CONFIG_SETTING_OSK_ACTIVATION_DISABLED
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_GUI_DROPDOWN
 full     = _osk_activation
 def      = 1
 min      = 0
@@ -2605,8 +2591,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.toolbar_pos
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -2619,8 +2604,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.statusbar_pos
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -2633,8 +2617,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.window_snap_radius
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL
 def      = 10
 min      = 1
 max      = 32
@@ -2646,8 +2629,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.window_soft_limit
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL
 def      = 20
 min      = 5
 max      = 255
@@ -2660,8 +2642,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.zoom_min
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = ZOOM_LVL_MIN
 min      = ZOOM_LVL_MIN
 max      = ZOOM_LVL_OUT_4X
@@ -2674,8 +2655,7 @@ startup  = true
 [SDTC_VAR]
 var      = gui.zoom_max
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = ZOOM_LVL_MAX
 min      = ZOOM_LVL_OUT_8X
 max      = ZOOM_LVL_MAX
@@ -2688,8 +2668,7 @@ startup  = true
 [SDTC_VAR]
 var      = gui.sprite_zoom_min
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = ZOOM_LVL_MIN
 min      = ZOOM_LVL_MIN
 max      = ZOOM_LVL_OUT_4X
@@ -2700,7 +2679,7 @@ post_cb  = SpriteZoomMinChanged
 
 [SDTC_BOOL]
 var      = gui.population_in_label
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_POPULATION_IN_LABEL
 strhelp  = STR_CONFIG_SETTING_POPULATION_IN_LABEL_HELPTEXT
@@ -2708,7 +2687,7 @@ post_cb  = [](auto) { UpdateAllTownVirtCoords(); }
 
 [SDTC_BOOL]
 var      = gui.link_terraform_toolbar
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR
 strhelp  = STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR_HELPTEXT
@@ -2716,8 +2695,7 @@ strhelp  = STR_CONFIG_SETTING_LINK_TERRAFORM_TOOLBAR_HELPTEXT
 [SDTC_VAR]
 var      = gui.smallmap_land_colour
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -2729,8 +2707,7 @@ post_cb  = RedrawSmallmap
 [SDTC_VAR]
 var      = gui.liveries
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 2
@@ -2742,8 +2719,7 @@ post_cb  = InvalidateCompanyLiveryWindow
 [SDTC_VAR]
 var      = gui.starting_colour
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = COLOUR_END
 min      = 0
 max      = COLOUR_END
@@ -2753,7 +2729,7 @@ strval   = STR_COLOUR_DARK_BLUE
 
 [SDTC_BOOL]
 var      = gui.auto_remove_signals
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_AUTO_REMOVE_SIGNALS
 strhelp  = STR_CONFIG_SETTING_AUTO_REMOVE_SIGNALS_HELPTEXT
@@ -2761,7 +2737,7 @@ cat      = SC_ADVANCED
 
 [SDTC_BOOL]
 var      = gui.prefer_teamchat
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_PREFER_TEAMCHAT
 strhelp  = STR_CONFIG_SETTING_PREFER_TEAMCHAT_HELPTEXT
@@ -2770,8 +2746,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.scrollwheel_scrolling
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -2783,7 +2758,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.scrollwheel_multiplier
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 5
 min      = 1
 max      = 15
@@ -2795,7 +2770,7 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.pause_on_newgame
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_PAUSE_ON_NEW_GAME
 strhelp  = STR_CONFIG_SETTING_PAUSE_ON_NEW_GAME_HELPTEXT
@@ -2804,8 +2779,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.advanced_vehicle_list
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -2815,7 +2789,7 @@ strval   = STR_CONFIG_SETTING_COMPANIES_OFF
 
 [SDTC_BOOL]
 var      = gui.timetable_in_ticks
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS
 strhelp  = STR_CONFIG_SETTING_TIMETABLE_IN_TICKS_HELPTEXT
@@ -2824,7 +2798,7 @@ cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = gui.timetable_arrival_departure
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE
 strhelp  = STR_CONFIG_SETTING_TIMETABLE_SHOW_ARRIVAL_DEPARTURE_HELPTEXT
@@ -2832,7 +2806,7 @@ post_cb  = [](auto) { InvalidateWindowClassesData(WC_VEHICLE_TIMETABLE, VIWD_MOD
 
 [SDTC_BOOL]
 var      = gui.quick_goto
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_QUICKGOTO
 strhelp  = STR_CONFIG_SETTING_QUICKGOTO_HELPTEXT
@@ -2841,8 +2815,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.loading_indicators
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -2855,8 +2828,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.default_rail_type
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 min      = 0
 max      = 2
@@ -2867,7 +2839,7 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.enable_signal_gui
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI
 strhelp  = STR_CONFIG_SETTING_ENABLE_SIGNAL_GUI_HELPTEXT
@@ -2877,7 +2849,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.coloured_news_year
 type     = SLE_INT32
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 2000
 min      = MIN_YEAR
 max      = MAX_YEAR
@@ -2890,7 +2862,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.drag_signals_density
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 4
 min      = 1
 max      = 20
@@ -2902,7 +2874,7 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.drag_signals_fixed_distance
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE
 strhelp  = STR_CONFIG_SETTING_DRAG_SIGNALS_FIXED_DISTANCE_HELPTEXT
@@ -2911,7 +2883,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.semaphore_build_before
 type     = SLE_INT32
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 1950
 min      = MIN_YEAR
 max      = MAX_YEAR
@@ -2923,7 +2895,7 @@ post_cb  = ResetSignalVariant
 
 [SDTC_BOOL]
 var      = gui.vehicle_income_warn
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_WARN_INCOME_LESS
 strhelp  = STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT
@@ -2932,8 +2904,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.order_review_system
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 2
@@ -2944,14 +2915,14 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.lost_vehicle_warn
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_WARN_LOST_VEHICLE
 strhelp  = STR_CONFIG_SETTING_WARN_LOST_VEHICLE_HELPTEXT
 
 [SDTC_BOOL]
 var      = gui.new_nonstop
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT
 strhelp  = STR_CONFIG_SETTING_NONSTOP_BY_DEFAULT_HELPTEXT
@@ -2960,8 +2931,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.stop_location
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 2
@@ -2973,45 +2943,45 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.keep_all_autosave
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 
 [SDTC_BOOL]
 var      = gui.autosave_on_exit
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.autosave_on_network_disconnect
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.max_num_autosaves
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 16
 min      = 0
 max      = 255
 
 [SDTC_BOOL]
 var      = gui.auto_euro
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 
 [SDTC_VAR]
 var      = gui.news_message_timeout
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 2
 min      = 1
 max      = 255
 
 [SDTC_BOOL]
 var      = gui.show_track_reservation
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION
 strhelp  = STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT
@@ -3021,8 +2991,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.default_signal_type
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 2
@@ -3035,8 +3004,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = gui.cycle_signal_types
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 min      = 0
 max      = 2
@@ -3048,7 +3016,7 @@ strval   = STR_CONFIG_SETTING_CYCLE_SIGNAL_NORMAL
 [SDTC_VAR]
 var      = gui.station_numtracks
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 1
 min      = 1
 max      = 7
@@ -3056,7 +3024,7 @@ max      = 7
 [SDTC_VAR]
 var      = gui.station_platlength
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 5
 min      = 1
 max      = 7
@@ -3064,19 +3032,19 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.station_dragdrop
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.station_show_coverage
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.persistent_buildingtools
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS
 strhelp  = STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS_HELPTEXT
@@ -3084,7 +3052,7 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = gui.expenses_layout
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_EXPENSES_LAYOUT
 strhelp  = STR_CONFIG_SETTING_EXPENSES_LAYOUT_HELPTEXT
@@ -3093,7 +3061,7 @@ post_cb  = [](auto) { MarkWholeScreenDirty(); }
 [SDTC_VAR]
 var      = gui.station_gui_group_order
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 0
 min      = 0
 max      = 5
@@ -3102,7 +3070,7 @@ interval = 1
 [SDTC_VAR]
 var      = gui.station_gui_sort_by
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 0
 min      = 0
 max      = 3
@@ -3111,7 +3079,7 @@ interval = 1
 [SDTC_VAR]
 var      = gui.station_gui_sort_order
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 0
 min      = 0
 max      = 1
@@ -3120,7 +3088,7 @@ interval = 1
 [SDTC_VAR]
 var      = gui.missing_strings_threshold
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 25
 min      = 1
 max      = UINT8_MAX
@@ -3129,7 +3097,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.graph_line_thickness
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 3
 min      = 1
 max      = 5
@@ -3140,7 +3108,7 @@ post_cb  = [](auto) { MarkWholeScreenDirty(); }
 
 [SDTC_BOOL]
 var      = gui.show_newgrf_name
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 str      = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME
 strhelp  = STR_CONFIG_SETTING_SHOW_NEWGRF_NAME_HELPTEXT
@@ -3151,19 +3119,19 @@ cat      = SC_ADVANCED
 [SDTC_BOOL]
 ifdef    = DEDICATED
 var      = gui.show_date_in_logs
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 
 [SDTC_BOOL]
 ifndef   = DEDICATED
 var      = gui.show_date_in_logs
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 
 [SDTC_VAR]
 var      = gui.settings_restriction_mode
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 0
 min      = 0
 max      = 2
@@ -3171,7 +3139,7 @@ max      = 2
 [SDTC_VAR]
 var      = gui.developer
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 1
 min      = 0
 max      = 2
@@ -3179,35 +3147,34 @@ cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = gui.newgrf_developer_tools
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 post_cb  = InvalidateNewGRFChangeWindows
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = gui.ai_developer_tools
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 post_cb  = [](auto) { InvalidateWindowClassesData(WC_AI_SETTINGS); }
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = gui.scenario_developer
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 post_cb  = InvalidateNewGRFChangeWindows
 
 [SDTC_BOOL]
 var      = gui.newgrf_show_old_versions
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_EXPERT
 
 [SDTC_VAR]
 var      = gui.newgrf_default_palette
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 min      = 0
 max      = 1
@@ -3217,7 +3184,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.console_backlog_timeout
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 100
 min      = 10
 max      = 65500
@@ -3225,7 +3192,7 @@ max      = 65500
 [SDTC_VAR]
 var      = gui.console_backlog_length
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 100
 min      = 10
 max      = 65500
@@ -3233,7 +3200,7 @@ max      = 65500
 [SDTC_VAR]
 var      = gui.refresh_rate
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 60
 min      = 10
 max      = 1000
@@ -3243,8 +3210,7 @@ startup  = true
 [SDTC_VAR]
 var      = gui.fast_forward_speed_limit
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL | SF_NO_NETWORK
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NO_NETWORK
 def      = 2500
 min      = 0
 max      = 50000
@@ -3256,56 +3222,56 @@ cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = sound.news_ticker
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_TICKER
 strhelp  = STR_CONFIG_SETTING_SOUND_TICKER_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.news_full
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_NEWS
 strhelp  = STR_CONFIG_SETTING_SOUND_NEWS_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.new_year
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_NEW_YEAR
 strhelp  = STR_CONFIG_SETTING_SOUND_NEW_YEAR_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.confirm
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_CONFIRM
 strhelp  = STR_CONFIG_SETTING_SOUND_CONFIRM_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.click_beep
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_CLICK
 strhelp  = STR_CONFIG_SETTING_SOUND_CLICK_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.disaster
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_DISASTER
 strhelp  = STR_CONFIG_SETTING_SOUND_DISASTER_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.vehicle
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_VEHICLE
 strhelp  = STR_CONFIG_SETTING_SOUND_VEHICLE_HELPTEXT
 
 [SDTC_BOOL]
 var      = sound.ambient
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 str      = STR_CONFIG_SETTING_SOUND_AMBIENT
 strhelp  = STR_CONFIG_SETTING_SOUND_AMBIENT_HELPTEXT
@@ -3313,7 +3279,7 @@ strhelp  = STR_CONFIG_SETTING_SOUND_AMBIENT_HELPTEXT
 [SDTC_VAR]
 var      = music.playlist
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 0
 min      = 0
 max      = 5
@@ -3323,7 +3289,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = music.music_vol
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 50
 min      = 0
 max      = 127
@@ -3333,7 +3299,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = music.effect_vol
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 100
 min      = 0
 max      = 127
@@ -3343,34 +3309,33 @@ cat      = SC_BASIC
 [SDTC_LIST]
 var      = music.custom_1
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = nullptr
 cat      = SC_BASIC
 
 [SDTC_LIST]
 var      = music.custom_2
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = nullptr
 cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = music.playing
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = true
 cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = music.shuffle
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_BASIC
 
 [SDTC_OMANY]
 var      = news_display.arrival_player
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3381,8 +3346,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.arrival_other
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _news_display
@@ -3393,8 +3357,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.accident
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3405,8 +3368,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.company_info
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3417,8 +3379,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.open
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _news_display
@@ -3429,8 +3390,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.close
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _news_display
@@ -3441,8 +3401,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.economy
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3453,8 +3412,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.production_player
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _news_display
@@ -3465,8 +3423,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.production_other
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 max      = 2
 full     = _news_display
@@ -3477,8 +3434,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.production_nobody
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 0
 max      = 2
 full     = _news_display
@@ -3489,8 +3445,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.advice
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3501,8 +3456,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.new_vehicles
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3513,8 +3467,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.acceptance
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3525,8 +3478,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.subsidies
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 1
 max      = 2
 full     = _news_display
@@ -3537,8 +3489,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_OMANY]
 var      = news_display.general
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_DROPDOWN
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 def      = 2
 max      = 2
 full     = _news_display
@@ -3549,7 +3500,7 @@ strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 [SDTC_VAR]
 var      = gui.network_chat_box_width_pct
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 40
 min      = 10
 max      = 100
@@ -3558,7 +3509,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.network_chat_box_height
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 25
 min      = 5
 max      = 255
@@ -3567,7 +3518,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = gui.network_chat_timeout
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = 20
 min      = 1
 max      = 65535
@@ -3576,8 +3527,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.sync_freq
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NOT_IN_CONFIG | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NOT_IN_CONFIG | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 100
 min      = 0
 max      = 100
@@ -3586,8 +3536,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.frame_freq
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NOT_IN_CONFIG | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NOT_IN_CONFIG | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 0
 min      = 0
 max      = 100
@@ -3596,8 +3545,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.commands_per_frame
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 2
 min      = 1
 max      = 65535
@@ -3606,8 +3554,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.max_commands_in_queue
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 16
 min      = 1
 max      = 65535
@@ -3616,8 +3563,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.bytes_per_frame
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 8
 min      = 1
 max      = 65535
@@ -3626,8 +3572,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.bytes_per_frame_burst
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 256
 min      = 1
 max      = 65535
@@ -3636,8 +3581,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.max_init_time
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 100
 min      = 0
 max      = 32000
@@ -3646,8 +3590,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.max_join_time
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 500
 min      = 0
 max      = 32000
@@ -3655,8 +3598,7 @@ max      = 32000
 [SDTC_VAR]
 var      = network.max_download_time
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 1000
 min      = 0
 max      = 32000
@@ -3664,8 +3606,7 @@ max      = 32000
 [SDTC_VAR]
 var      = network.max_password_time
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 2000
 min      = 0
 max      = 32000
@@ -3673,23 +3614,20 @@ max      = 32000
 [SDTC_VAR]
 var      = network.max_lag_time
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 500
 min      = 0
 max      = 32000
 
 [SDTC_BOOL]
 var      = network.pause_on_join
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = true
 
 [SDTC_VAR]
 var      = network.server_port
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = NETWORK_DEFAULT_PORT
 min      = 0
 max      = 65535
@@ -3698,8 +3636,7 @@ cat      = SC_EXPERT
 [SDTC_VAR]
 var      = network.server_admin_port
 type     = SLE_UINT16
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = NETWORK_ADMIN_PORT
 min      = 0
 max      = 65535
@@ -3707,22 +3644,20 @@ cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = network.server_admin_chat
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = true
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = network.server_advertise
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = false
 
 [SDTC_SSTR]
 var      = network.client_name
 type     = SLE_STR
 length   = NETWORK_CLIENT_NAME_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = nullptr
 pre_cb   = NetworkValidateClientName
 post_cb  = NetworkUpdateClientName
@@ -3732,8 +3667,7 @@ cat      = SC_BASIC
 var      = network.server_password
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = nullptr
 pre_cb   = ReplaceAsteriskWithEmptyPassword
 post_cb  = [](auto) { NetworkServerUpdateGameInfo(); }
@@ -3743,8 +3677,7 @@ cat      = SC_BASIC
 var      = network.rcon_password
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = nullptr
 pre_cb   = ReplaceAsteriskWithEmptyPassword
 cat      = SC_BASIC
@@ -3753,8 +3686,7 @@ cat      = SC_BASIC
 var      = network.admin_password
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = nullptr
 cat      = SC_BASIC
 
@@ -3762,15 +3694,14 @@ cat      = SC_BASIC
 var      = network.default_company_pass
 type     = SLE_STR
 length   = NETWORK_PASSWORD_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = nullptr
 
 [SDTC_SSTR]
 var      = network.server_name
 type     = SLE_STR
 length   = NETWORK_NAME_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = nullptr
 pre_cb   = NetworkValidateServerName
 post_cb  = [](auto) { UpdateClientConfigValues(); }
@@ -3780,28 +3711,25 @@ cat      = SC_BASIC
 var      = network.connect_to_ip
 type     = SLE_STR
 length   = 0
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = nullptr
 
 [SDTC_SSTR]
 var      = network.network_id
 type     = SLE_STR
 length   = NETWORK_SERVER_ID_LENGTH
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = nullptr
 
 [SDTC_BOOL]
 var      = network.autoclean_companies
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = false
 
 [SDTC_VAR]
 var      = network.autoclean_unprotected
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
 def      = 12
 min      = 0
 max      = 240
@@ -3809,8 +3737,7 @@ max      = 240
 [SDTC_VAR]
 var      = network.autoclean_protected
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
 def      = 36
 min      = 0
 max      = 240
@@ -3818,8 +3745,7 @@ max      = 240
 [SDTC_VAR]
 var      = network.autoclean_novehicles
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
 def      = 0
 min      = 0
 max      = 240
@@ -3827,8 +3753,7 @@ max      = 240
 [SDTC_VAR]
 var      = network.max_companies
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 15
 min      = 1
 max      = MAX_COMPANIES
@@ -3838,8 +3763,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = network.max_clients
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 25
 min      = 2
 max      = MAX_CLIENTS
@@ -3849,8 +3773,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = network.max_spectators
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 15
 min      = 0
 max      = MAX_CLIENTS
@@ -3860,8 +3783,7 @@ cat      = SC_BASIC
 [SDTC_VAR]
 var      = network.restart_game_year
 type     = SLE_INT32
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY
 def      = 0
 min      = MIN_YEAR
 max      = MAX_YEAR
@@ -3870,16 +3792,14 @@ interval = 1
 [SDTC_VAR]
 var      = network.min_active_clients
 type     = SLE_UINT8
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = 0
 min      = 0
 max      = MAX_CLIENTS
 
 [SDTC_BOOL]
 var      = network.reload_cfg
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NETWORK_ONLY
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = false
 cat      = SC_EXPERT
 
@@ -3887,12 +3807,12 @@ cat      = SC_EXPERT
 var      = network.last_joined
 type     = SLE_STR
 length   = 0
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = """"
 cat      = SC_EXPERT
 
 [SDTC_BOOL]
 var      = network.no_http_content_downloads
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_EXPERT

--- a/src/table/settings/win32_settings.ini
+++ b/src/table/settings/win32_settings.ini
@@ -17,15 +17,14 @@ static const SettingTable _win32_settings{
 };
 #endif /* _WIN32 */
 [templates]
-SDTG_BOOL = SDTG_BOOL($name,        $flags, $guiflags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $guiflags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_BOOL = SDTG_BOOL($name,        $flags, $var, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDTG_VAR  =  SDTG_VAR($name, $type, $flags, $var, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDTG_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 
 [defaults]
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NONE
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT

--- a/src/table/settings/window_settings.ini
+++ b/src/table/settings/window_settings.ini
@@ -13,15 +13,14 @@ static const SettingTable _window_settings{
 [post-amble]
 };
 [templates]
-SDT_BOOL = SDT_BOOL(WindowDesc, $var,        $flags, $guiflags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
-SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $guiflags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_BOOL = SDT_BOOL(WindowDesc, $var,        $flags, $def,                        $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
+SDT_VAR  =  SDT_VAR(WindowDesc, $var, $type, $flags, $def, $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to, $cat, $extra, $startup),
 
 [validation]
 SDT_VAR = static_assert($max <= MAX_$type, "Maximum value for WindowDesc.$var exceeds storage size");
 
 [defaults]
-flags    = SLF_NOT_IN_SAVE | SLF_NO_NETWORK_SYNC
-guiflags = SF_NONE
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 interval = 0
 str      = STR_NULL
 strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT


### PR DESCRIPTION
## Motivation / Problem

While working on SaveLoad I ran into the issue that it has two flags which have nothing to do with SaveLoad. Additionally, the Settings were settings SaveLoad settings directly, which gave for some confusing ini file .. `flags` vs `guiflags`.


## Description

Simplify the situation by only having `flags`.

This now means that `SF_NOT_IN_CONFIG`, `SF_NOT_IN_SAVE` and `SF_NO_NETWORK_SYNC` remain within the Setting, and don't pollute SaveLoad for no good reason.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
