### PR TITLE
Fix ef991b17: server was trying to free() a packet created with "new CommandPacket()"

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1072,7 +1072,7 @@ void NetworkGameLoop()
 				if (cp != nullptr) {
 					NetworkSendCommand(cp->tile, cp->p1, cp->p2, cp->cmd & ~CMD_FLAGS_MASK, nullptr, cp->text, cp->company);
 					DEBUG(desync, 0, "Injecting: %08x; %02x; %02x; %06x; %08x; %08x; %08x; \"%s\" (%s)", _date, _date_fract, (int)_current_company, cp->tile, cp->p1, cp->p2, cp->cmd, cp->text.c_str(), GetCommandName(cp->cmd));
-					free(cp);
+					delete cp;
 					cp = nullptr;
 				}
 				if (check_sync_state) {

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1758,7 +1758,7 @@ static void NetworkHandleCommandQueue(NetworkClientSocket *cs)
 	CommandPacket *cp;
 	while ((cp = cs->outgoing_queue.Pop()) != nullptr) {
 		cs->SendCommand(cp);
-		free(cp);
+		delete cp;
 	}
 }
 


### PR DESCRIPTION

## Motivation / Problem

GCC analyzer complained about us being a bad boy.

```
==19244==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x6070002a4fc0
    #0 0x7f51d1ec17cf in __interceptor_free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf)
    #1 0x55de60866b8f in NetworkHandleCommandQueue OpenTTD/src/network/network_server.cpp:1761

0x6070002a4fc0 is located 0 bytes inside of 80-byte region [0x6070002a4fc0,0x6070002a5010)
allocated by thread T0 here:
    #0 0x7f51d1ec3947 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10f947)
    #1 0x55de607e8e36 in CommandQueue::Append(CommandPacket*) OpenTTD/src/network/network_command.cpp:59
```


## Description

Introduced in ef991b17 (tnx @glx22 for checking out what revision it was).



## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
