### PR TITLE
Codechange: make [Save|Load]Settings() behave more like other Save/Load code

### DIFF
--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -893,7 +893,6 @@ void WriteValue(void *ptr, VarType conv, int64 val);
 void SlSetArrayIndex(uint index);
 int SlIterateArray();
 
-uint SlCalcConvMemLen(VarType conv);
 void SlAutolength(AutolengthProc *proc, void *arg);
 size_t SlGetFieldLength();
 void SlSetLength(size_t length);


### PR DESCRIPTION
Depends on #9333 (not really needed, but I don't want to conflict-resolve it later on).

## Motivation / Problem

One of these things .. Settings SaveLoad had custom code which was rather difficult to read.


## Description

The code is now much simpler. First it prepares what it will load. Next it loads it.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
