### PR TITLE
Fix: [Script] Ensure the saved script strings are properly validated and terminated when being read from the save game

### DIFF
--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -569,8 +569,9 @@ bool ScriptInstance::IsPaused()
 
 		case SQSL_STRING: {
 			SlObject(nullptr, _script_byte);
-			static char buf[256];
+			static char buf[std::numeric_limits<decltype(_script_sl_byte)>::max()];
 			SlArray(buf, _script_sl_byte, SLE_CHAR);
+			StrMakeValidInPlace(buf, buf + _script_sl_byte);
 			if (vm != nullptr) sq_pushstring(vm, buf, -1);
 			return true;
 		}


### PR DESCRIPTION
## Motivation / Problem

Just set the string data length to 255 and fill it will all non-zeros. When buf[255] is also non-zeros, this will read beyond the bounds when making the string. Similarly the maximum value of _script_sl_byte can only be 255 though 256 bytes are allocated for the buffer.


## Description

Allocate just enough memory for a buffer of _script_sl_byte long.
Perform a string validation on the string coming from the save game ensuring termination and valid Utf8 characters


## Limitations

Potentially a game script that put some non-Utf8 characters in their strings would get different information when loading compared to what they saved. However, a string should be a valid string. If you want something else stored, use an array of integers.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
