### PR TITLE
Several code refactors of the SaveLoad code

### DIFF
--- a/src/cheat_type.h
+++ b/src/cheat_type.h
@@ -28,12 +28,9 @@ struct Cheats {
 	Cheat switch_company;   ///< change to another company
 	Cheat money;            ///< get rich or poor
 	Cheat crossing_tunnels; ///< allow tunnels that cross each other
-	Cheat dummy1;           ///< empty cheat (build while in pause mode)
 	Cheat no_jetcrash;      ///< no jet will crash on small airports anymore
-	Cheat dummy2;           ///< empty cheat (change the climate of the map)
 	Cheat change_date;      ///< changes date ingame
 	Cheat setup_prod;       ///< setup raw-material production in game
-	Cheat dummy3;           ///< empty cheat (enable running el-engines on normal rail)
 	Cheat edit_max_hl;      ///< edit the maximum heightlevel; this is a cheat because of the fact that it needs to reset NewGRF game state and doing so as a simple configuration breaks the expectation of many
 };
 

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -87,8 +87,8 @@ SaveLoadTable GetLinkGraphJobDesc()
 SaveLoadTable GetLinkGraphScheduleDesc()
 {
 	static const SaveLoad schedule_desc[] = {
-		SLE_LST(LinkGraphSchedule, schedule, REF_LINK_GRAPH),
-		SLE_LST(LinkGraphSchedule, running,  REF_LINK_GRAPH_JOB),
+		SLE_REFLIST(LinkGraphSchedule, schedule, REF_LINK_GRAPH),
+		SLE_REFLIST(LinkGraphSchedule, running,  REF_LINK_GRAPH_JOB),
 	};
 	return schedule_desc;
 }

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -587,17 +587,17 @@ static inline uint SlGetArrayLength(size_t length)
 static inline uint SlCalcConvMemLen(VarType conv)
 {
 	static const byte conv_mem_size[] = {1, 1, 1, 2, 2, 4, 4, 8, 8, 0};
-	byte length = GB(conv, 4, 4);
 
-	switch (length << 4) {
+	switch (GetVarMemType(conv)) {
 		case SLE_VAR_STRB:
 		case SLE_VAR_STR:
 		case SLE_VAR_STRQ:
 			return SlReadArrayLength();
 
 		default:
-			assert(length < lengthof(conv_mem_size));
-			return conv_mem_size[length];
+			uint8 type = GetVarMemType(conv) >> 4;
+			assert(type < lengthof(conv_mem_size));
+			return conv_mem_size[type];
 	}
 }
 
@@ -610,9 +610,10 @@ static inline uint SlCalcConvMemLen(VarType conv)
 static inline byte SlCalcConvFileLen(VarType conv)
 {
 	static const byte conv_file_size[] = {1, 1, 2, 2, 4, 4, 8, 8, 2};
-	byte length = GB(conv, 0, 4);
-	assert(length < lengthof(conv_file_size));
-	return conv_file_size[length];
+
+	uint8 type = GetVarFileType(conv);
+	assert(type < lengthof(conv_file_size));
+	return conv_file_size[type];
 }
 
 /** Return the size in bytes of a reference (pointer) */

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1517,8 +1517,10 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 	}
 }
 
-bool SlObjectMember(void *ptr, const SaveLoad &sld)
+static bool SlObjectMember(void *object, const SaveLoad &sld)
 {
+	void *ptr = GetVariableAddress(object, sld);
+
 	assert(IsVariableSizeRight(sld));
 
 	VarType conv = GB(sld.conv, 0, 8);
@@ -1604,8 +1606,7 @@ void SlObject(void *object, const SaveLoadTable &slt)
 	}
 
 	for (auto &sld : slt) {
-		void *ptr = GetVariableAddress(object, sld);
-		SlObjectMember(ptr, sld);
+		SlObjectMember(object, sld);
 	}
 }
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1334,7 +1334,7 @@ public:
  * @param list The std::list to find the size of.
  * @param conv VarType type of variable that is used for calculating the size.
  */
-static inline size_t SlCalcListLen(const void *list, VarType conv)
+static inline size_t SlCalcRefListLen(const void *list, VarType conv)
 {
 	return SlStorageHelper<std::list, void *>::SlCalcLen(list, conv, SL_REF);
 }
@@ -1344,11 +1344,11 @@ static inline size_t SlCalcListLen(const void *list, VarType conv)
  * @param list The list being manipulated.
  * @param conv VarType type of variable that is used for calculating the size.
  */
-static void SlList(void *list, VarType conv)
+static void SlRefList(void *list, VarType conv)
 {
 	/* Automatically calculate the length? */
 	if (_sl.need_length != NL_NONE) {
-		SlSetLength(SlCalcListLen(list, conv));
+		SlSetLength(SlCalcRefListLen(list, conv));
 		/* Determine length only? */
 		if (_sl.need_length == NL_CALCLENGTH) return;
 	}
@@ -1430,7 +1430,7 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 		case SL_REF:
 		case SL_ARR:
 		case SL_STR:
-		case SL_LST:
+		case SL_REFLIST:
 		case SL_DEQUE:
 		case SL_STDSTR:
 			/* CONDITIONAL saveload types depend on the savegame version */
@@ -1441,7 +1441,7 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 				case SL_REF: return SlCalcRefLen();
 				case SL_ARR: return SlCalcArrayLen(sld.length, sld.conv);
 				case SL_STR: return SlCalcStringLen(GetVariableAddress(object, sld), sld.length, sld.conv);
-				case SL_LST: return SlCalcListLen(GetVariableAddress(object, sld), sld.conv);
+				case SL_REFLIST: return SlCalcRefListLen(GetVariableAddress(object, sld), sld.conv);
 				case SL_DEQUE: return SlCalcDequeLen(GetVariableAddress(object, sld), sld.conv);
 				case SL_STDSTR: return SlCalcStdStringLen(GetVariableAddress(object, sld));
 				default: NOT_REACHED();
@@ -1515,7 +1515,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 		case SL_REF:
 		case SL_ARR:
 		case SL_STR:
-		case SL_LST:
+		case SL_REFLIST:
 		case SL_DEQUE:
 		case SL_STDSTR:
 			/* CONDITIONAL saveload types depend on the savegame version */
@@ -1526,7 +1526,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 				case SL_REF: SlSaveLoadRef(ptr, conv); break;
 				case SL_ARR: SlArray(ptr, sld.length, conv); break;
 				case SL_STR: SlString(ptr, sld.length, sld.conv); break;
-				case SL_LST: SlList(ptr, conv); break;
+				case SL_REFLIST: SlRefList(ptr, conv); break;
 				case SL_DEQUE: SlDeque(ptr, conv); break;
 				case SL_STDSTR: SlStdString(ptr, sld.conv); break;
 				default: NOT_REACHED();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -905,7 +905,6 @@ void SlWriteByte(byte b);
 void SlGlobList(const SaveLoadTable &slt);
 void SlArray(void *array, size_t length, VarType conv);
 void SlObject(void *object, const SaveLoadTable &slt);
-bool SlObjectMember(void *object, const SaveLoad &sld);
 void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
 void NORETURN SlErrorCorrupt(const char *msg);
 void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -495,10 +495,10 @@ typedef uint32 VarType;
 enum SaveLoadType : byte {
 	SL_VAR         =  0, ///< Save/load a variable.
 	SL_REF         =  1, ///< Save/load a reference.
-	SL_ARR         =  2, ///< Save/load an array.
+	SL_ARR         =  2, ///< Save/load a fixed-size array of #SL_VAR elements.
 	SL_STR         =  3, ///< Save/load a string.
-	SL_LST         =  4, ///< Save/load a list.
-	SL_DEQUE       =  5, ///< Save/load a deque.
+	SL_REFLIST     =  4, ///< Save/load a list of #SL_REF elements.
+	SL_DEQUE       =  5, ///< Save/load a deque of #SL_VAR elements.
 	SL_STDSTR      =  6, ///< Save/load a \c std::string.
 	/* non-normal save-load types */
 	SL_WRITEBYTE   =  8,
@@ -557,7 +557,7 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLE_CONDREF(base, variable, type, from, to) SLE_GENERAL(SL_REF, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of an array in some savegame versions.
+ * Storage of a fixed-size array of #SL_VAR elements in some savegame versions.
  * @param base     Name of the class or struct containing the array.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -589,17 +589,17 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLE_CONDSSTR(base, variable, type, from, to) SLE_GENERAL(SL_STDSTR, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a list in some savegame versions.
+ * Storage of a list of #SL_REF elements in some savegame versions.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLE_CONDLST(base, variable, type, from, to) SLE_GENERAL(SL_LST, base, variable, type, 0, from, to, 0)
+#define SLE_CONDREFLIST(base, variable, type, from, to) SLE_GENERAL(SL_REFLIST, base, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a deque in some savegame versions.
+ * Storage of a deque of #SL_VAR elements in some savegame versions.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -625,7 +625,7 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLE_REF(base, variable, type) SLE_CONDREF(base, variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
- * Storage of an array in every version of a savegame.
+ * Storage of fixed-size array of #SL_VAR elements in every version of a savegame.
  * @param base     Name of the class or struct containing the array.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
@@ -651,12 +651,12 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLE_SSTR(base, variable, type) SLE_CONDSSTR(base, variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
- * Storage of a list in every savegame version.
+ * Storage of a list of #SL_REF elements in every savegame version.
  * @param base     Name of the class or struct containing the list.
  * @param variable Name of the variable in the class or struct referenced by \a base.
  * @param type     Storage of the data in memory and in the savegame.
  */
-#define SLE_LST(base, variable, type) SLE_CONDLST(base, variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
+#define SLE_REFLIST(base, variable, type) SLE_CONDREFLIST(base, variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
  * Empty space in every savegame version.
@@ -709,7 +709,7 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLEG_CONDREF(variable, type, from, to) SLEG_GENERAL(SL_REF, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a global array in some savegame versions.
+ * Storage of a global fixed-size array of #SL_VAR elements in some savegame versions.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
  * @param length   Number of elements in the array.
@@ -738,13 +738,13 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLEG_CONDSSTR(variable, type, from, to) SLEG_GENERAL(SL_STDSTR, variable, type, 0, from, to, 0)
 
 /**
- * Storage of a global list in some savegame versions.
+ * Storage of a global reference list in some savegame versions.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLEG_CONDLST(variable, type, from, to) SLEG_GENERAL(SL_LST, variable, type, 0, from, to, 0)
+#define SLEG_CONDREFLIST(variable, type, from, to) SLEG_GENERAL(SL_REFLIST, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a global variable in every savegame version.
@@ -761,7 +761,7 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLEG_REF(variable, type) SLEG_CONDREF(variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
- * Storage of a global array in every savegame version.
+ * Storage of a global fixed-size array of #SL_VAR elements in every savegame version.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
  */
@@ -782,11 +782,11 @@ using SaveLoadTable = span<const SaveLoad>;
 #define SLEG_SSTR(variable, type) SLEG_CONDSSTR(variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
- * Storage of a global list in every savegame version.
+ * Storage of a global reference list in every savegame version.
  * @param variable Name of the global variable.
  * @param type     Storage of the data in memory and in the savegame.
  */
-#define SLEG_LST(variable, type) SLEG_CONDLST(variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
+#define SLEG_REFLIST(variable, type) SLEG_CONDREFLIST(variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
  * Empty global space in some savegame versions.

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -207,7 +207,7 @@ static const SaveLoad _old_station_desc[] = {
 	SLE_CONDVAR(Station, waiting_triggers,           SLE_UINT8,                  SLV_27, SL_MAX_VERSION),
 	SLE_CONDVAR(Station, num_specs,                  SLE_UINT8,                  SLV_27, SL_MAX_VERSION),
 
-	SLE_CONDLST(Station, loading_vehicles,           REF_VEHICLE,                SLV_57, SL_MAX_VERSION),
+	SLE_CONDREFLIST(Station, loading_vehicles,       REF_VEHICLE,                SLV_57, SL_MAX_VERSION),
 
 	/* reserve extra space in savegame here. (currently 32 bytes) */
 	SLE_CONDNULL(32, SLV_2, SL_MAX_VERSION),
@@ -265,7 +265,7 @@ SaveLoadTable GetGoodsDesc()
 		SLEG_CONDVAR(            _cargo_feeder_share,  SLE_FILE_U32 | SLE_VAR_I64, SLV_14, SLV_65),
 		SLEG_CONDVAR(            _cargo_feeder_share,  SLE_INT64,                  SLV_65, SLV_68),
 		 SLE_CONDVAR(GoodsEntry, amount_fract,         SLE_UINT8,                 SLV_150, SL_MAX_VERSION),
-		SLEG_CONDLST(            _packets,             REF_CARGO_PACKET,           SLV_68, SLV_183),
+		SLEG_CONDREFLIST(        _packets,             REF_CARGO_PACKET,           SLV_68, SLV_183),
 		SLEG_CONDVAR(            _num_dests,           SLE_UINT32,                SLV_183, SL_MAX_VERSION),
 		 SLE_CONDVAR(GoodsEntry, cargo.reserved_count, SLE_UINT,                  SLV_181, SL_MAX_VERSION),
 		 SLE_CONDVAR(GoodsEntry, link_graph,           SLE_UINT16,                SLV_183, SL_MAX_VERSION),
@@ -281,7 +281,7 @@ typedef std::pair<const StationID, std::list<CargoPacket *> > StationCargoPair;
 
 static const SaveLoad _cargo_list_desc[] = {
 	SLE_VAR(StationCargoPair, first,  SLE_UINT16),
-	SLE_LST(StationCargoPair, second, REF_CARGO_PACKET),
+	SLE_REFLIST(StationCargoPair, second, REF_CARGO_PACKET),
 };
 
 /**
@@ -426,7 +426,7 @@ static const SaveLoad _station_desc[] = {
 	      SLE_VAR(Station, time_since_unload,          SLE_UINT8),
 	      SLE_VAR(Station, last_vehicle_type,          SLE_UINT8),
 	      SLE_VAR(Station, had_vehicle_of_type,        SLE_UINT8),
-	      SLE_LST(Station, loading_vehicles,           REF_VEHICLE),
+	  SLE_REFLIST(Station, loading_vehicles,           REF_VEHICLE),
 	  SLE_CONDVAR(Station, always_accepted,            SLE_FILE_U32 | SLE_VAR_U64, SLV_127, SLV_EXTEND_CARGOTYPES),
 	  SLE_CONDVAR(Station, always_accepted,            SLE_UINT64,                 SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
 };

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -189,7 +189,7 @@ static const SaveLoad _town_desc[] = {
 	SLE_CONDVAR(Town, larger_town,           SLE_BOOL,                  SLV_56, SL_MAX_VERSION),
 	SLE_CONDVAR(Town, layout,                SLE_UINT8,                SLV_113, SL_MAX_VERSION),
 
-	SLE_CONDLST(Town, psa_list,            REF_STORAGE,                SLV_161, SL_MAX_VERSION),
+	SLE_CONDREFLIST(Town, psa_list,          REF_STORAGE,              SLV_161, SL_MAX_VERSION),
 
 	SLE_CONDNULL(4, SLV_166, SLV_EXTEND_CARGOTYPES),  ///< cargo_produced, no longer in use
 	SLE_CONDNULL(8, SLV_EXTEND_CARGOTYPES, SLV_REMOVE_TOWN_CARGO_CACHE),  ///< cargo_produced, no longer in use

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -629,7 +629,7 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		     SLE_VAR(Vehicle, cargo_cap,             SLE_UINT16),
 		 SLE_CONDVAR(Vehicle, refit_cap,             SLE_UINT16,                 SLV_182, SL_MAX_VERSION),
 		SLEG_CONDVAR(         _cargo_count,          SLE_UINT16,                   SL_MIN_VERSION,  SLV_68),
-		 SLE_CONDLST(Vehicle, cargo.packets,         REF_CARGO_PACKET,            SLV_68, SL_MAX_VERSION),
+		SLE_CONDREFLIST(Vehicle, cargo.packets,      REF_CARGO_PACKET,            SLV_68, SL_MAX_VERSION),
 		 SLE_CONDARR(Vehicle, cargo.action_counts,   SLE_UINT, VehicleCargoList::NUM_MOVE_TO_ACTION, SLV_181, SL_MAX_VERSION),
 		 SLE_CONDVAR(Vehicle, cargo_age_counter,     SLE_UINT16,                 SLV_162, SL_MAX_VERSION),
 


### PR DESCRIPTION
Depends on #9335

## Motivation / Problem

When you start fiddling with the SaveLoad code, you find many odd things. And sometimes they annoy me enough that you get this collection of commits.


## Description

First commit is #9335, after that:

- First patch is some code hygiene
- Second patch too
- Third: `SL_DEQEUE` suggested to support signed values, but they were silently cast to unsigned .. which, with conversion code like `SLE_FILE_I8 | SLE_VAR_I32` might not work as you expect. Luckily, nobody was using this code for signed values, but let's make sure we are ahead of this issue.
- Forth: `SlList` is very similar to `SlDeque`, but a copied the code. So, together with the third commit, I changed the `SlDequeHelper` into a more general one, where anything supporting `begin()` and `end()` will work on.
- Fifth: `SL_LST` is a list of references, which the name did not tell you. The way reference are done is already very error-prone, and this wasn't helping. So I renamed it to `SL_REFLST` to be more obvious of its function.
- Sixth: cheat-chunk was weird. Just that. Weird. Made it slightly less weird.

I could have made 4 PRs out of this too, so if this is too hard to review, let me know, and I will split it up :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
