### PR TITLE
Codechange: add and use the ability to store (lists of) structs in savegames

### DIFF
--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -305,8 +305,8 @@ public:
 	friend class StationCargoList;
 	/** The super class ought to know what it's doing. */
 	friend class CargoList<VehicleCargoList, CargoPacketList>;
-	/** The vehicles have a cargo list (and we want that saved). */
-	friend SaveLoadTable GetVehicleDescription(VehicleType vt);
+	/* So we can use private/protected variables in the saveload code */
+	friend class SlVehicleCommon;
 
 	friend class CargoShift;
 	friend class CargoTransfer;

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -456,8 +456,8 @@ protected:
 public:
 	/** The super class ought to know what it's doing. */
 	friend class CargoList<StationCargoList, StationCargoPacketMap>;
-	/** The stations, via GoodsEntry, have a CargoList. */
-	friend SaveLoadTable GetGoodsDesc();
+	/* So we can use private/protected variables in the saveload code */
+	friend class SlStationGoods;
 
 	friend class CargoLoad;
 	friend class CargoTransfer;

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -98,28 +98,30 @@ struct CompanyProperties {
 	CompanyEconomyEntry old_economy[MAX_HISTORY_QUARTERS]; ///< Economic data of the company of the last #MAX_HISTORY_QUARTERS quarters.
 	byte num_valid_stat_ent;                               ///< Number of valid statistical entries in #old_economy.
 
+	Livery livery[LS_END];
+
+	EngineRenewList engine_renew_list; ///< Engine renewals of this company.
+	CompanySettings settings;          ///< settings specific for each company
+
 	// TODO: Change some of these member variables to use relevant INVALID_xxx constants
 	CompanyProperties()
 		: name_2(0), name_1(0), president_name_1(0), president_name_2(0),
 		  face(0), money(0), money_fraction(0), current_loan(0), colour(0), block_preview(0),
 		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0),
 		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
-		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false) {}
+		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false), engine_renew_list(nullptr) {}
 };
 
-struct Company : CompanyPool::PoolItem<&_company_pool>, CompanyProperties {
+struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 	Company(uint16 name_1 = 0, bool is_ai = false);
 	~Company();
 
-	Livery livery[LS_END];
 	RailTypes avail_railtypes;         ///< Rail types available to this company.
 	RoadTypes avail_roadtypes;         ///< Road types available to this company.
 
 	class AIInstance *ai_instance;
 	class AIInfo *ai_info;
 
-	EngineRenewList engine_renew_list; ///< Engine renewals of this company.
-	CompanySettings settings;          ///< settings specific for each company
 	GroupStatistics group_all[VEH_COMPANY_END];      ///< NOSAVE: Statistics for the ALL_GROUP group.
 	GroupStatistics group_default[VEH_COMPANY_END];  ///< NOSAVE: Statistics for the DEFAULT_GROUP group.
 

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -527,7 +527,8 @@ protected:
 	friend class LinkGraph::Node;
 	friend SaveLoadTable GetLinkGraphDesc();
 	friend SaveLoadTable GetLinkGraphJobDesc();
-	friend void SaveLoad_LinkGraph(LinkGraph &lg);
+	friend class SlLinkgraphNode;
+	friend class SlLinkgraphEdge;
 
 	CargoID cargo;         ///< Cargo of this component's link graph.
 	Date last_compression; ///< Last time the capacities and supplies were compressed.

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -32,9 +32,11 @@ extern OrderListPool _orderlist_pool;
  */
 struct Order : OrderPool::PoolItem<&_order_pool> {
 private:
-	friend SaveLoadTable GetVehicleDescription(VehicleType vt); ///< Saving and loading the current order of vehicles.
 	friend void Load_VEHS();                                             ///< Loading of ancient vehicles.
 	friend SaveLoadTable GetOrderDescription();                 ///< Saving and loading of orders.
+	/* So we can use private/protected variables in the saveload code */
+	friend class SlVehicleCommon;
+	friend class SlVehicleDisaster;
 
 	uint8 type;           ///< The type of order + non-stop flags
 	uint8 flags;          ///< Load/unload types, depot order/action types.

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -236,7 +236,201 @@ void AfterLoadCompanyStats()
 	}
 }
 
+/* We do need to read this single value, as the bigger it gets, the more data is stored */
+struct CompanyOldAI {
+	uint8 num_build_rec;
+};
 
+class SlCompanyOldAIBuildRec : public DefaultSaveLoadHandler<SlCompanyOldAIBuildRec, CompanyOldAI> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_CONDNULL(2, SL_MIN_VERSION, SLV_6),
+		SLE_CONDNULL(4, SLV_6, SLV_107),
+		SLE_CONDNULL(2, SL_MIN_VERSION, SLV_6),
+		SLE_CONDNULL(4, SLV_6, SLV_107),
+		SLE_CONDNULL(8, SL_MIN_VERSION, SLV_107),
+	};
+
+	void GenericSaveLoad(CompanyOldAI *old_ai) const
+	{
+		for (int i = 0; i != old_ai->num_build_rec; i++) {
+			SlObject(nullptr, this->GetDescription());
+		}
+	}
+
+	// No Save(); this is for backwards compatibility.
+	void Load(CompanyOldAI *old_ai) const override { this->GenericSaveLoad(old_ai); }
+	void LoadCheck(CompanyOldAI *old_ai) const override { this->GenericSaveLoad(old_ai); }
+	void FixPointers(CompanyOldAI *old_ai) const override { this->GenericSaveLoad(old_ai); }
+};
+
+class SlCompanyOldAI : public DefaultSaveLoadHandler<SlCompanyOldAI, CompanyProperties> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_107),
+		SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_13),
+		SLE_CONDNULL(4, SLV_13, SLV_107),
+		SLE_CONDNULL(8,  SL_MIN_VERSION, SLV_107),
+		 SLE_CONDVAR(CompanyOldAI, num_build_rec, SLE_UINT8, SL_MIN_VERSION, SLV_107),
+		SLE_CONDNULL(3,  SL_MIN_VERSION, SLV_107),
+
+		SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
+		SLE_CONDNULL(4,  SLV_6, SLV_107),
+		SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
+		SLE_CONDNULL(4,  SLV_6, SLV_107),
+		SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_107),
+
+		SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
+		SLE_CONDNULL(4,  SLV_6, SLV_107),
+		SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
+		SLE_CONDNULL(4,  SLV_6, SLV_107),
+		SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_107),
+
+		SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_69),
+		SLE_CONDNULL(4,  SLV_69, SLV_107),
+
+		SLE_CONDNULL(18, SL_MIN_VERSION, SLV_107),
+		SLE_CONDNULL(20, SL_MIN_VERSION, SLV_107),
+		SLE_CONDNULL(32, SL_MIN_VERSION, SLV_107),
+
+		SLE_CONDNULL(64, SLV_2, SLV_107),
+		SLEG_STRUCTLIST(SlCompanyOldAIBuildRec),
+	};
+
+	void GenericSaveLoad(CompanyProperties *c) const
+	{
+		if (!c->is_ai) return;
+
+		CompanyOldAI old_ai;
+		SlObject(&old_ai, this->GetDescription());
+	}
+
+	// No Save(); this is for backwards compatibility.
+	void Load(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void LoadCheck(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void FixPointers(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+};
+
+class SlCompanySettings : public DefaultSaveLoadHandler<SlCompanySettings, CompanyProperties> {
+public:
+	inline static const SaveLoad description[] = {
+		/* Engine renewal settings */
+		SLE_CONDNULL(512, SLV_16, SLV_19),
+		SLE_CONDREF(CompanyProperties, engine_renew_list,            REF_ENGINE_RENEWS,   SLV_19, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.engine_renew,        SLE_BOOL,            SLV_16, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.engine_renew_months, SLE_INT16,           SLV_16, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.engine_renew_money,  SLE_UINT32,          SLV_16, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.renew_keep_length,   SLE_BOOL,             SLV_2, SL_MAX_VERSION),
+
+		/* Default vehicle settings */
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ispercent,   SLE_BOOL,     SLV_120, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_trains,    SLE_UINT16,     SLV_120, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_roadveh,   SLE_UINT16,     SLV_120, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_aircraft,  SLE_UINT16,     SLV_120, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ships,     SLE_UINT16,     SLV_120, SL_MAX_VERSION),
+
+		SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
+	};
+
+	void GenericSaveLoad(CompanyProperties *c) const
+	{
+		SlObject(c, this->GetDescription());
+	}
+
+	void Save(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void Load(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void LoadCheck(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void FixPointers(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+};
+
+class SlCompanyEconomy : public DefaultSaveLoadHandler<SlCompanyEconomy, CompanyProperties> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_CONDVAR(CompanyEconomyEntry, income,              SLE_FILE_I32 | SLE_VAR_I64, SL_MIN_VERSION, SLV_2),
+		SLE_CONDVAR(CompanyEconomyEntry, income,              SLE_INT64,                  SLV_2, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyEconomyEntry, expenses,            SLE_FILE_I32 | SLE_VAR_I64, SL_MIN_VERSION, SLV_2),
+		SLE_CONDVAR(CompanyEconomyEntry, expenses,            SLE_INT64,                  SLV_2, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyEconomyEntry, company_value,       SLE_FILE_I32 | SLE_VAR_I64, SL_MIN_VERSION, SLV_2),
+		SLE_CONDVAR(CompanyEconomyEntry, company_value,       SLE_INT64,                  SLV_2, SL_MAX_VERSION),
+
+		SLE_CONDVAR(CompanyEconomyEntry, delivered_cargo[NUM_CARGO - 1], SLE_INT32,       SL_MIN_VERSION, SLV_170),
+		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, 32,           SLV_170, SLV_EXTEND_CARGOTYPES),
+		SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, NUM_CARGO,    SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
+		    SLE_VAR(CompanyEconomyEntry, performance_history, SLE_INT32),
+	};
+
+	void GenericSaveLoad(CompanyProperties *c) const
+	{
+		SlObject(&c->cur_economy, this->GetDescription());
+	}
+
+	void Save(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void Load(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void LoadCheck(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void FixPointers(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+};
+
+class SlCompanyOldEconomy : public SlCompanyEconomy {
+public:
+	void GenericSaveLoad(CompanyProperties *c) const
+	{
+		if (c->num_valid_stat_ent > lengthof(c->old_economy)) SlErrorCorrupt("Too many old economy entries");
+
+		for (int i = 0; i < c->num_valid_stat_ent; i++) {
+			SlObject(&c->old_economy[i], this->GetDescription());
+		}
+	}
+
+	void Save(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void Load(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void LoadCheck(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void FixPointers(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+};
+
+class SlCompanyLiveries : public DefaultSaveLoadHandler<SlCompanyLiveries, CompanyProperties> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_CONDVAR(Livery, in_use,  SLE_UINT8, SLV_34, SL_MAX_VERSION),
+		SLE_CONDVAR(Livery, colour1, SLE_UINT8, SLV_34, SL_MAX_VERSION),
+		SLE_CONDVAR(Livery, colour2, SLE_UINT8, SLV_34, SL_MAX_VERSION),
+	};
+
+	void GenericSaveLoad(CompanyProperties *c) const
+	{
+		int num_liveries = IsSavegameVersionBefore(SLV_63) ? LS_END - 4 : (IsSavegameVersionBefore(SLV_85) ? LS_END - 2: LS_END);
+		bool update_in_use = IsSavegameVersionBefore(SLV_GROUP_LIVERIES);
+
+		for (int i = 0; i < num_liveries; i++) {
+			SlObject(&c->livery[i], this->GetDescription());
+			if (update_in_use && i != LS_DEFAULT) {
+				if (c->livery[i].in_use == 0) {
+					c->livery[i].colour1 = c->livery[LS_DEFAULT].colour1;
+					c->livery[i].colour2 = c->livery[LS_DEFAULT].colour2;
+				} else {
+					c->livery[i].in_use = 3;
+				}
+			}
+		}
+
+		if (num_liveries < LS_END) {
+			/* We want to insert some liveries somewhere in between. This means some have to be moved. */
+			memmove(&c->livery[LS_FREIGHT_WAGON], &c->livery[LS_PASSENGER_WAGON_MONORAIL], (LS_END - LS_FREIGHT_WAGON) * sizeof(c->livery[0]));
+			c->livery[LS_PASSENGER_WAGON_MONORAIL] = c->livery[LS_MONORAIL];
+			c->livery[LS_PASSENGER_WAGON_MAGLEV]   = c->livery[LS_MAGLEV];
+		}
+
+		if (num_liveries == LS_END - 4) {
+			/* Copy bus/truck liveries over to trams */
+			c->livery[LS_PASSENGER_TRAM] = c->livery[LS_BUS];
+			c->livery[LS_FREIGHT_TRAM]   = c->livery[LS_TRUCK];
+		}
+	}
+
+	void Save(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void Load(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void LoadCheck(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+	void FixPointers(CompanyProperties *c) const override { this->GenericSaveLoad(c); }
+};
 
 /* Save/load of companies */
 static const SaveLoad _company_desc[] = {
@@ -293,190 +487,18 @@ static const SaveLoad _company_desc[] = {
 	SLE_CONDVAR(CompanyProperties, terraform_limit,       SLE_UINT32,                SLV_156, SL_MAX_VERSION),
 	SLE_CONDVAR(CompanyProperties, clear_limit,           SLE_UINT32,                SLV_156, SL_MAX_VERSION),
 	SLE_CONDVAR(CompanyProperties, tree_limit,            SLE_UINT32,                SLV_175, SL_MAX_VERSION),
+	SLEG_STRUCT(SlCompanySettings),
+	SLEG_CONDSTRUCT(SlCompanyOldAI,                                                  SL_MIN_VERSION, SLV_107),
+	SLEG_STRUCT(SlCompanyEconomy),
+	SLEG_STRUCTLIST(SlCompanyOldEconomy),
+	SLEG_CONDSTRUCTLIST(SlCompanyLiveries,                                           SLV_34, SL_MAX_VERSION),
 };
-
-static const SaveLoad _company_settings_desc[] = {
-	/* Engine renewal settings */
-	SLE_CONDNULL(512, SLV_16, SLV_19),
-	SLE_CONDREF(Company, engine_renew_list,            REF_ENGINE_RENEWS,   SLV_19, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.engine_renew,        SLE_BOOL,            SLV_16, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.engine_renew_months, SLE_INT16,           SLV_16, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.engine_renew_money,  SLE_UINT32,          SLV_16, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.renew_keep_length,   SLE_BOOL,             SLV_2, SL_MAX_VERSION),
-
-	/* Default vehicle settings */
-	SLE_CONDVAR(Company, settings.vehicle.servint_ispercent,   SLE_BOOL,     SLV_120, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.vehicle.servint_trains,    SLE_UINT16,     SLV_120, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.vehicle.servint_roadveh,   SLE_UINT16,     SLV_120, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.vehicle.servint_aircraft,  SLE_UINT16,     SLV_120, SL_MAX_VERSION),
-	SLE_CONDVAR(Company, settings.vehicle.servint_ships,     SLE_UINT16,     SLV_120, SL_MAX_VERSION),
-
-	SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
-};
-
-static const SaveLoad _company_settings_skip_desc[] = {
-	/* Engine renewal settings */
-	SLE_CONDNULL(512, SLV_16, SLV_19),
-	SLE_CONDNULL(2, SLV_19, SLV_69),                 // engine_renew_list
-	SLE_CONDNULL(4, SLV_69, SL_MAX_VERSION),     // engine_renew_list
-	SLE_CONDNULL(1, SLV_16, SL_MAX_VERSION),     // settings.engine_renew
-	SLE_CONDNULL(2, SLV_16, SL_MAX_VERSION),     // settings.engine_renew_months
-	SLE_CONDNULL(4, SLV_16, SL_MAX_VERSION),     // settings.engine_renew_money
-	SLE_CONDNULL(1,  SLV_2, SL_MAX_VERSION),     // settings.renew_keep_length
-
-	/* Default vehicle settings */
-	SLE_CONDNULL(1, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_ispercent
-	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_trains
-	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_roadveh
-	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_aircraft
-	SLE_CONDNULL(2, SLV_120, SL_MAX_VERSION),    // settings.vehicle.servint_ships
-
-	SLE_CONDNULL(63, SLV_2, SLV_144), // old reserved space
-};
-
-static const SaveLoad _company_economy_desc[] = {
-	/* these were changed to 64-bit in savegame format 2 */
-	SLE_CONDVAR(CompanyEconomyEntry, income,              SLE_FILE_I32 | SLE_VAR_I64, SL_MIN_VERSION, SLV_2),
-	SLE_CONDVAR(CompanyEconomyEntry, income,              SLE_INT64,                  SLV_2, SL_MAX_VERSION),
-	SLE_CONDVAR(CompanyEconomyEntry, expenses,            SLE_FILE_I32 | SLE_VAR_I64, SL_MIN_VERSION, SLV_2),
-	SLE_CONDVAR(CompanyEconomyEntry, expenses,            SLE_INT64,                  SLV_2, SL_MAX_VERSION),
-	SLE_CONDVAR(CompanyEconomyEntry, company_value,       SLE_FILE_I32 | SLE_VAR_I64, SL_MIN_VERSION, SLV_2),
-	SLE_CONDVAR(CompanyEconomyEntry, company_value,       SLE_INT64,                  SLV_2, SL_MAX_VERSION),
-
-	SLE_CONDVAR(CompanyEconomyEntry, delivered_cargo[NUM_CARGO - 1], SLE_INT32,       SL_MIN_VERSION, SLV_170),
-	SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, 32,           SLV_170, SLV_EXTEND_CARGOTYPES),
-	SLE_CONDARR(CompanyEconomyEntry, delivered_cargo,     SLE_UINT32, NUM_CARGO,    SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
-	    SLE_VAR(CompanyEconomyEntry, performance_history, SLE_INT32),
-};
-
-/* We do need to read this single value, as the bigger it gets, the more data is stored */
-struct CompanyOldAI {
-	uint8 num_build_rec;
-};
-
-static const SaveLoad _company_ai_desc[] = {
-	SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_107),
-	SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_13),
-	SLE_CONDNULL(4, SLV_13, SLV_107),
-	SLE_CONDNULL(8,  SL_MIN_VERSION, SLV_107),
-	 SLE_CONDVAR(CompanyOldAI, num_build_rec, SLE_UINT8, SL_MIN_VERSION, SLV_107),
-	SLE_CONDNULL(3,  SL_MIN_VERSION, SLV_107),
-
-	SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
-	SLE_CONDNULL(4,  SLV_6, SLV_107),
-	SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
-	SLE_CONDNULL(4,  SLV_6, SLV_107),
-	SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_107),
-
-	SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
-	SLE_CONDNULL(4,  SLV_6, SLV_107),
-	SLE_CONDNULL(2,  SL_MIN_VERSION,  SLV_6),
-	SLE_CONDNULL(4,  SLV_6, SLV_107),
-	SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_107),
-
-	SLE_CONDNULL(2,  SL_MIN_VERSION, SLV_69),
-	SLE_CONDNULL(4,  SLV_69, SLV_107),
-
-	SLE_CONDNULL(18, SL_MIN_VERSION, SLV_107),
-	SLE_CONDNULL(20, SL_MIN_VERSION, SLV_107),
-	SLE_CONDNULL(32, SL_MIN_VERSION, SLV_107),
-
-	SLE_CONDNULL(64, SLV_2, SLV_107),
-};
-
-static const SaveLoad _company_ai_build_rec_desc[] = {
-	SLE_CONDNULL(2, SL_MIN_VERSION, SLV_6),
-	SLE_CONDNULL(4, SLV_6, SLV_107),
-	SLE_CONDNULL(2, SL_MIN_VERSION, SLV_6),
-	SLE_CONDNULL(4, SLV_6, SLV_107),
-	SLE_CONDNULL(8, SL_MIN_VERSION, SLV_107),
-};
-
-static const SaveLoad _company_livery_desc[] = {
-	SLE_CONDVAR(Livery, in_use,  SLE_UINT8, SLV_34, SL_MAX_VERSION),
-	SLE_CONDVAR(Livery, colour1, SLE_UINT8, SLV_34, SL_MAX_VERSION),
-	SLE_CONDVAR(Livery, colour2, SLE_UINT8, SLV_34, SL_MAX_VERSION),
-};
-
-static void SaveLoad_PLYR_common(Company *c, CompanyProperties *cprops)
-{
-	int i;
-
-	SlObject(cprops, _company_desc);
-	if (c != nullptr) {
-		SlObject(c, _company_settings_desc);
-	} else {
-		char nothing;
-		SlObject(&nothing, _company_settings_skip_desc);
-	}
-
-	/* Keep backwards compatible for savegames, so load the old AI block */
-	if (IsSavegameVersionBefore(SLV_107) && cprops->is_ai) {
-		CompanyOldAI old_ai;
-		char nothing;
-
-		SlObject(&old_ai, _company_ai_desc);
-		for (i = 0; i != old_ai.num_build_rec; i++) {
-			SlObject(&nothing, _company_ai_build_rec_desc);
-		}
-	}
-
-	/* Write economy */
-	SlObject(&cprops->cur_economy, _company_economy_desc);
-
-	/* Write old economy entries. */
-	if (cprops->num_valid_stat_ent > lengthof(cprops->old_economy)) SlErrorCorrupt("Too many old economy entries");
-	for (i = 0; i < cprops->num_valid_stat_ent; i++) {
-		SlObject(&cprops->old_economy[i], _company_economy_desc);
-	}
-
-	/* Write each livery entry. */
-	int num_liveries = IsSavegameVersionBefore(SLV_63) ? LS_END - 4 : (IsSavegameVersionBefore(SLV_85) ? LS_END - 2: LS_END);
-	bool update_in_use = IsSavegameVersionBefore(SLV_GROUP_LIVERIES);
-	if (c != nullptr) {
-		for (i = 0; i < num_liveries; i++) {
-			SlObject(&c->livery[i], _company_livery_desc);
-			if (update_in_use && i != LS_DEFAULT) {
-				if (c->livery[i].in_use == 0) {
-					c->livery[i].colour1 = c->livery[LS_DEFAULT].colour1;
-					c->livery[i].colour2 = c->livery[LS_DEFAULT].colour2;
-				} else {
-					c->livery[i].in_use = 3;
-				}
-			}
-		}
-
-		if (num_liveries < LS_END) {
-			/* We want to insert some liveries somewhere in between. This means some have to be moved. */
-			memmove(&c->livery[LS_FREIGHT_WAGON], &c->livery[LS_PASSENGER_WAGON_MONORAIL], (LS_END - LS_FREIGHT_WAGON) * sizeof(c->livery[0]));
-			c->livery[LS_PASSENGER_WAGON_MONORAIL] = c->livery[LS_MONORAIL];
-			c->livery[LS_PASSENGER_WAGON_MAGLEV]   = c->livery[LS_MAGLEV];
-		}
-
-		if (num_liveries == LS_END - 4) {
-			/* Copy bus/truck liveries over to trams */
-			c->livery[LS_PASSENGER_TRAM] = c->livery[LS_BUS];
-			c->livery[LS_FREIGHT_TRAM]   = c->livery[LS_TRUCK];
-		}
-	} else {
-		/* Skip liveries */
-		Livery dummy_livery;
-		for (i = 0; i < num_liveries; i++) {
-			SlObject(&dummy_livery, _company_livery_desc);
-		}
-	}
-}
-
-static void SaveLoad_PLYR(Company *c)
-{
-	SaveLoad_PLYR_common(c, c);
-}
 
 static void Save_PLYR()
 {
 	for (Company *c : Company::Iterate()) {
 		SlSetArrayIndex(c->index);
-		SlAutolength((AutolengthProc*)SaveLoad_PLYR, c);
+		SlObject(c, _company_desc);
 	}
 }
 
@@ -485,7 +507,7 @@ static void Load_PLYR()
 	int index;
 	while ((index = SlIterateArray()) != -1) {
 		Company *c = new (index) Company();
-		SaveLoad_PLYR(c);
+		SlObject(c, _company_desc);
 		_company_colours[index] = (Colours)c->colour;
 	}
 }
@@ -495,7 +517,7 @@ static void Check_PLYR()
 	int index;
 	while ((index = SlIterateArray()) != -1) {
 		CompanyProperties *cprops = new CompanyProperties();
-		SaveLoad_PLYR_common(nullptr, cprops);
+		SlObject(cprops, _company_desc);
 
 		/* We do not load old custom names */
 		if (IsSavegameVersionBefore(SLV_84)) {
@@ -522,7 +544,7 @@ static void Check_PLYR()
 static void Ptrs_PLYR()
 {
 	for (Company *c : Company::Iterate()) {
-		SlObject(c, _company_settings_desc);
+		SlObject(c, _company_desc);
 	}
 }
 

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -144,75 +144,6 @@ void SaveLoad_LinkGraph(LinkGraph &lg)
 }
 
 /**
- * Save a link graph job.
- * @param lgj LinkGraphJob to be saved.
- */
-static void DoSave_LGRJ(LinkGraphJob *lgj)
-{
-	SlObject(lgj, GetLinkGraphJobDesc());
-	_num_nodes = lgj->Size();
-	SlObject(const_cast<LinkGraph *>(&lgj->Graph()), GetLinkGraphDesc());
-	SaveLoad_LinkGraph(const_cast<LinkGraph &>(lgj->Graph()));
-}
-
-/**
- * Save a link graph.
- * @param lg LinkGraph to be saved.
- */
-static void DoSave_LGRP(LinkGraph *lg)
-{
-	_num_nodes = lg->Size();
-	SlObject(lg, GetLinkGraphDesc());
-	SaveLoad_LinkGraph(*lg);
-}
-
-/**
- * Load all link graphs.
- */
-static void Load_LGRP()
-{
-	int index;
-	while ((index = SlIterateArray()) != -1) {
-		if (!LinkGraph::CanAllocateItem()) {
-			/* Impossible as they have been present in previous game. */
-			NOT_REACHED();
-		}
-		LinkGraph *lg = new (index) LinkGraph();
-		SlObject(lg, GetLinkGraphDesc());
-		lg->Init(_num_nodes);
-		SaveLoad_LinkGraph(*lg);
-	}
-}
-
-/**
- * Load all link graph jobs.
- */
-static void Load_LGRJ()
-{
-	int index;
-	while ((index = SlIterateArray()) != -1) {
-		if (!LinkGraphJob::CanAllocateItem()) {
-			/* Impossible as they have been present in previous game. */
-			NOT_REACHED();
-		}
-		LinkGraphJob *lgj = new (index) LinkGraphJob();
-		SlObject(lgj, GetLinkGraphJobDesc());
-		LinkGraph &lg = const_cast<LinkGraph &>(lgj->Graph());
-		SlObject(&lg, GetLinkGraphDesc());
-		lg.Init(_num_nodes);
-		SaveLoad_LinkGraph(lg);
-	}
-}
-
-/**
- * Load the link graph schedule.
- */
-static void Load_LGRS()
-{
-	SlObject(&LinkGraphSchedule::instance, GetLinkGraphScheduleDesc());
-}
-
-/**
  * Spawn the threads for running link graph calculations.
  * Has to be done after loading as the cargo classes might have changed.
  */
@@ -243,6 +174,17 @@ void AfterLoadLinkGraphs()
 }
 
 /**
+ * Save a link graph.
+ * @param lg LinkGraph to be saved.
+ */
+static void DoSave_LGRP(LinkGraph *lg)
+{
+	_num_nodes = lg->Size();
+	SlObject(lg, GetLinkGraphDesc());
+	SaveLoad_LinkGraph(*lg);
+}
+
+/**
  * Save all link graphs.
  */
 static void Save_LGRP()
@@ -251,6 +193,36 @@ static void Save_LGRP()
 		SlSetArrayIndex(lg->index);
 		SlAutolength((AutolengthProc*)DoSave_LGRP, lg);
 	}
+}
+
+/**
+ * Load all link graphs.
+ */
+static void Load_LGRP()
+{
+	int index;
+	while ((index = SlIterateArray()) != -1) {
+		if (!LinkGraph::CanAllocateItem()) {
+			/* Impossible as they have been present in previous game. */
+			NOT_REACHED();
+		}
+		LinkGraph *lg = new (index) LinkGraph();
+		SlObject(lg, GetLinkGraphDesc());
+		lg->Init(_num_nodes);
+		SaveLoad_LinkGraph(*lg);
+	}
+}
+
+/**
+ * Save a link graph job.
+ * @param lgj LinkGraphJob to be saved.
+ */
+static void DoSave_LGRJ(LinkGraphJob *lgj)
+{
+	SlObject(lgj, GetLinkGraphJobDesc());
+	_num_nodes = lgj->Size();
+	SlObject(const_cast<LinkGraph *>(&lgj->Graph()), GetLinkGraphDesc());
+	SaveLoad_LinkGraph(const_cast<LinkGraph &>(lgj->Graph()));
 }
 
 /**
@@ -265,9 +237,37 @@ static void Save_LGRJ()
 }
 
 /**
+ * Load all link graph jobs.
+ */
+static void Load_LGRJ()
+{
+	int index;
+	while ((index = SlIterateArray()) != -1) {
+		if (!LinkGraphJob::CanAllocateItem()) {
+			/* Impossible as they have been present in previous game. */
+			NOT_REACHED();
+		}
+		LinkGraphJob *lgj = new (index) LinkGraphJob();
+		SlObject(lgj, GetLinkGraphJobDesc());
+		LinkGraph &lg = const_cast<LinkGraph &>(lgj->Graph());
+		SlObject(&lg, GetLinkGraphDesc());
+		lg.Init(_num_nodes);
+		SaveLoad_LinkGraph(lg);
+	}
+}
+
+/**
  * Save the link graph schedule.
  */
 static void Save_LGRS()
+{
+	SlObject(&LinkGraphSchedule::instance, GetLinkGraphScheduleDesc());
+}
+
+/**
+ * Load the link graph schedule.
+ */
+static void Load_LGRS()
 {
 	SlObject(&LinkGraphSchedule::instance, GetLinkGraphScheduleDesc());
 }

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1447,9 +1447,7 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 				default: NOT_REACHED();
 			}
 			break;
-		case SL_WRITEBYTE: return 1; // a byte is logically of size 1
-		case SL_VEH_INCLUDE: return SlCalcObjLength(object, GetVehicleDescription(VEH_END));
-		case SL_ST_INCLUDE: return SlCalcObjLength(object, GetBaseStationDescription());
+		case SL_SAVEBYTE: return 1; // a byte is logically of size 1
 		case SL_STRUCT:
 		case SL_STRUCTLIST: {
 			if (!SlIsObjectValidInSavegame(sld)) break;
@@ -1555,10 +1553,10 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 			break;
 		}
 
-		/* SL_WRITEBYTE writes a value to the savegame to identify the type of an object.
+		/* SL_SAVEBYTE writes a value to the savegame to identify the type of an object.
 		 * When loading, the value is read explicitly with SlReadByte() to determine which
 		 * object description to use. */
-		case SL_WRITEBYTE: {
+		case SL_SAVEBYTE: {
 			void *ptr = GetVariableAddress(object, sld);
 
 			switch (_sl.action) {
@@ -1569,19 +1567,6 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 				case SLA_NULL: break;
 				default: NOT_REACHED();
 			}
-			break;
-		}
-
-		/* SL_VEH_INCLUDE loads common code for vehicles */
-		case SL_VEH_INCLUDE: {
-			void *ptr = GetVariableAddress(object, sld);
-			SlObject(ptr, GetVehicleDescription(VEH_END));
-			break;
-		}
-
-		case SL_ST_INCLUDE: {
-			void *ptr = GetVariableAddress(object, sld);
-			SlObject(ptr, GetBaseStationDescription());
 			break;
 		}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -570,10 +570,7 @@ enum SaveLoadType : byte {
 	SL_STDSTR      =  6, ///< Save/load a \c std::string.
 	SL_STRUCT      =  7, ///< Save/load a struct.
 	SL_STRUCTLIST  =  8, ///< Save/load a list of structs.
-	/* non-normal save-load types */
-	SL_WRITEBYTE   =  9,
-	SL_VEH_INCLUDE = 10,
-	SL_ST_INCLUDE  = 11,
+	SL_SAVEBYTE    =  9, ///< Save (but not load) a byte.
 };
 
 typedef void *SaveLoadAddrProc(void *base, size_t extra);
@@ -740,11 +737,17 @@ struct SaveLoad {
  */
 #define SLE_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
 
-/** Translate values ingame to different values in the savegame and vv. */
-#define SLE_WRITEBYTE(base, variable) SLE_GENERAL(SL_WRITEBYTE, base, variable, 0, 0, SL_MIN_VERSION, SL_MAX_VERSION, 0)
-
-#define SLE_VEH_INCLUDE() {SL_VEH_INCLUDE, 0, 0, SL_MIN_VERSION, SL_MAX_VERSION, 0, [] (void *b, size_t) { return b; }, 0, nullptr}
-#define SLE_ST_INCLUDE() {SL_ST_INCLUDE, 0, 0, SL_MIN_VERSION, SL_MAX_VERSION, 0, [] (void *b, size_t) { return b; }, 0, nullptr}
+/**
+ * Only write byte during saving; never read it during loading.
+ * When using SLE_SAVEBYTE you will have to read this byte before the table
+ * this is in is read. This also means SLE_SAVEBYTE can only be used at the
+ * top of a chunk.
+ * This is intended to be used to indicate what type of entry this is in a
+ * list of entries.
+ * @param base     Name of the class or struct containing the variable.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ */
+#define SLE_SAVEBYTE(base, variable) SLE_GENERAL(SL_SAVEBYTE, base, variable, 0, 0, SL_MIN_VERSION, SL_MAX_VERSION, 0)
 
 /**
  * Storage of global simple variables, references (pointers), and arrays.

--- a/src/saveload/saveload_internal.h
+++ b/src/saveload/saveload_internal.h
@@ -23,7 +23,6 @@ void ResetOldNames();
 void ResetOldWaypoints();
 void MoveBuoysToWaypoints();
 void MoveWaypointsToBaseStations();
-SaveLoadTable GetBaseStationDescription();
 
 void AfterLoadVehicles(bool part_of_load);
 void FixupTrainLengths();

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -374,89 +374,125 @@ static void Ptrs_STNS()
 	}
 }
 
-
-static const SaveLoad _base_station_desc[] = {
-	      SLE_VAR(BaseStation, xy,                     SLE_UINT32),
-	      SLE_REF(BaseStation, town,                   REF_TOWN),
-	      SLE_VAR(BaseStation, string_id,              SLE_STRINGID),
-	     SLE_SSTR(BaseStation, name,                   SLE_STR | SLF_ALLOW_CONTROL),
-	      SLE_VAR(BaseStation, delete_ctr,             SLE_UINT8),
-	      SLE_VAR(BaseStation, owner,                  SLE_UINT8),
-	      SLE_VAR(BaseStation, facilities,             SLE_UINT8),
-	      SLE_VAR(BaseStation, build_date,             SLE_INT32),
-
-	/* Used by newstations for graphic variations */
-	      SLE_VAR(BaseStation, random_bits,            SLE_UINT16),
-	      SLE_VAR(BaseStation, waiting_triggers,       SLE_UINT8),
-	      SLE_VAR(BaseStation, num_specs,              SLE_UINT8),
-};
-
 static OldPersistentStorage _old_st_persistent_storage;
 
-static const SaveLoad _station_desc[] = {
-	SLE_WRITEBYTE(Station, facilities),
-	SLE_ST_INCLUDE(),
+/**
+ * SaveLoad handler for the BaseStation, which all other stations / waypoints
+ * make use of.
+ */
+class SlStationBase : public DefaultSaveLoadHandler<SlStationBase, BaseStation> {
+public:
+	inline static const SaveLoad description[] = {
+		    SLE_VAR(BaseStation, xy,                     SLE_UINT32),
+		    SLE_REF(BaseStation, town,                   REF_TOWN),
+		    SLE_VAR(BaseStation, string_id,              SLE_STRINGID),
+		   SLE_SSTR(BaseStation, name,                   SLE_STR | SLF_ALLOW_CONTROL),
+		    SLE_VAR(BaseStation, delete_ctr,             SLE_UINT8),
+		    SLE_VAR(BaseStation, owner,                  SLE_UINT8),
+		    SLE_VAR(BaseStation, facilities,             SLE_UINT8),
+		    SLE_VAR(BaseStation, build_date,             SLE_INT32),
 
-	      SLE_VAR(Station, train_station.tile,         SLE_UINT32),
-	      SLE_VAR(Station, train_station.w,            SLE_FILE_U8 | SLE_VAR_U16),
-	      SLE_VAR(Station, train_station.h,            SLE_FILE_U8 | SLE_VAR_U16),
+		/* Used by newstations for graphic variations */
+		    SLE_VAR(BaseStation, random_bits,            SLE_UINT16),
+		    SLE_VAR(BaseStation, waiting_triggers,       SLE_UINT8),
+		    SLE_VAR(BaseStation, num_specs,              SLE_UINT8),
+	};
 
-	      SLE_REF(Station, bus_stops,                  REF_ROADSTOPS),
-	      SLE_REF(Station, truck_stops,                REF_ROADSTOPS),
-	 SLE_CONDNULL(4, SL_MIN_VERSION, SLV_MULTITILE_DOCKS),
-	  SLE_CONDVAR(Station, ship_station.tile,          SLE_UINT32,                SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
-	  SLE_CONDVAR(Station, ship_station.w,             SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
-	  SLE_CONDVAR(Station, ship_station.h,             SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
-	  SLE_CONDVAR(Station, docking_station.tile,       SLE_UINT32,                SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
-	  SLE_CONDVAR(Station, docking_station.w,          SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
-	  SLE_CONDVAR(Station, docking_station.h,          SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
-	      SLE_VAR(Station, airport.tile,               SLE_UINT32),
-	  SLE_CONDVAR(Station, airport.w,                  SLE_FILE_U8 | SLE_VAR_U16, SLV_140, SL_MAX_VERSION),
-	  SLE_CONDVAR(Station, airport.h,                  SLE_FILE_U8 | SLE_VAR_U16, SLV_140, SL_MAX_VERSION),
-	      SLE_VAR(Station, airport.type,               SLE_UINT8),
-	  SLE_CONDVAR(Station, airport.layout,             SLE_UINT8,                 SLV_145, SL_MAX_VERSION),
-	      SLE_VAR(Station, airport.flags,              SLE_UINT64),
-	  SLE_CONDVAR(Station, airport.rotation,           SLE_UINT8,                 SLV_145, SL_MAX_VERSION),
-	 SLEG_CONDARR(_old_st_persistent_storage.storage,  SLE_UINT32, 16,            SLV_145, SLV_161),
-	  SLE_CONDREF(Station, airport.psa,                REF_STORAGE,               SLV_161, SL_MAX_VERSION),
+	void GenericSaveLoad(BaseStation *bst) const
+	{
+		SlObject(bst, this->GetDescription());
+	}
 
-	      SLE_VAR(Station, indtype,                    SLE_UINT8),
-
-	      SLE_VAR(Station, time_since_load,            SLE_UINT8),
-	      SLE_VAR(Station, time_since_unload,          SLE_UINT8),
-	      SLE_VAR(Station, last_vehicle_type,          SLE_UINT8),
-	      SLE_VAR(Station, had_vehicle_of_type,        SLE_UINT8),
-	  SLE_REFLIST(Station, loading_vehicles,           REF_VEHICLE),
-	  SLE_CONDVAR(Station, always_accepted,            SLE_FILE_U32 | SLE_VAR_U64, SLV_127, SLV_EXTEND_CARGOTYPES),
-	  SLE_CONDVAR(Station, always_accepted,            SLE_UINT64,                 SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
-};
-
-static const SaveLoad _waypoint_desc[] = {
-	SLE_WRITEBYTE(Waypoint, facilities),
-	SLE_ST_INCLUDE(),
-
-	      SLE_VAR(Waypoint, town_cn,                   SLE_UINT16),
-
-	  SLE_CONDVAR(Waypoint, train_station.tile,        SLE_UINT32,                  SLV_124, SL_MAX_VERSION),
-	  SLE_CONDVAR(Waypoint, train_station.w,           SLE_FILE_U8 | SLE_VAR_U16,   SLV_124, SL_MAX_VERSION),
-	  SLE_CONDVAR(Waypoint, train_station.h,           SLE_FILE_U8 | SLE_VAR_U16,   SLV_124, SL_MAX_VERSION),
+	void Save(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+	void Load(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+	void FixPointers(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
 };
 
 /**
- * Get the base station description to be used for SL_ST_INCLUDE
- * @return the base station description.
+ * SaveLoad handler for a normal station (read: not a waypoint).
  */
-SaveLoadTable GetBaseStationDescription()
-{
-	return _base_station_desc;
-}
+class SlStationNormal : public DefaultSaveLoadHandler<SlStationNormal, BaseStation> {
+public:
+	inline static const SaveLoad description[] = {
+		SLEG_STRUCT(SlStationBase),
+		    SLE_VAR(Station, train_station.tile,         SLE_UINT32),
+		    SLE_VAR(Station, train_station.w,            SLE_FILE_U8 | SLE_VAR_U16),
+		    SLE_VAR(Station, train_station.h,            SLE_FILE_U8 | SLE_VAR_U16),
+
+		    SLE_REF(Station, bus_stops,                  REF_ROADSTOPS),
+		    SLE_REF(Station, truck_stops,                REF_ROADSTOPS),
+		SLE_CONDNULL(4, SL_MIN_VERSION, SLV_MULTITILE_DOCKS),
+		SLE_CONDVAR(Station, ship_station.tile,          SLE_UINT32,                SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, ship_station.w,             SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, ship_station.h,             SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, docking_station.tile,       SLE_UINT32,                SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, docking_station.w,          SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, docking_station.h,          SLE_FILE_U8 | SLE_VAR_U16, SLV_MULTITILE_DOCKS, SL_MAX_VERSION),
+		    SLE_VAR(Station, airport.tile,               SLE_UINT32),
+		SLE_CONDVAR(Station, airport.w,                  SLE_FILE_U8 | SLE_VAR_U16, SLV_140, SL_MAX_VERSION),
+		SLE_CONDVAR(Station, airport.h,                  SLE_FILE_U8 | SLE_VAR_U16, SLV_140, SL_MAX_VERSION),
+		    SLE_VAR(Station, airport.type,               SLE_UINT8),
+		SLE_CONDVAR(Station, airport.layout,             SLE_UINT8,                 SLV_145, SL_MAX_VERSION),
+		    SLE_VAR(Station, airport.flags,              SLE_UINT64),
+		SLE_CONDVAR(Station, airport.rotation,           SLE_UINT8,                 SLV_145, SL_MAX_VERSION),
+		SLEG_CONDARR(_old_st_persistent_storage.storage,  SLE_UINT32, 16,            SLV_145, SLV_161),
+		SLE_CONDREF(Station, airport.psa,                REF_STORAGE,               SLV_161, SL_MAX_VERSION),
+
+		    SLE_VAR(Station, indtype,                    SLE_UINT8),
+
+		    SLE_VAR(Station, time_since_load,            SLE_UINT8),
+		    SLE_VAR(Station, time_since_unload,          SLE_UINT8),
+		    SLE_VAR(Station, last_vehicle_type,          SLE_UINT8),
+		    SLE_VAR(Station, had_vehicle_of_type,        SLE_UINT8),
+		SLE_REFLIST(Station, loading_vehicles,           REF_VEHICLE),
+		SLE_CONDVAR(Station, always_accepted,            SLE_FILE_U32 | SLE_VAR_U64, SLV_127, SLV_EXTEND_CARGOTYPES),
+		SLE_CONDVAR(Station, always_accepted,            SLE_UINT64,                 SLV_EXTEND_CARGOTYPES, SL_MAX_VERSION),
+	};
+
+	void GenericSaveLoad(BaseStation *bst) const
+	{
+		if ((bst->facilities & FACIL_WAYPOINT) != 0) return;
+		SlObject(bst, this->GetDescription());
+	}
+
+	void Save(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+	void Load(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+	void FixPointers(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+};
+
+class SlStationWaypoint : public DefaultSaveLoadHandler<SlStationWaypoint, BaseStation> {
+public:
+	inline static const SaveLoad description[] = {
+		SLEG_STRUCT(SlStationBase),
+		    SLE_VAR(Waypoint, town_cn,                   SLE_UINT16),
+
+		SLE_CONDVAR(Waypoint, train_station.tile,        SLE_UINT32,                  SLV_124, SL_MAX_VERSION),
+		SLE_CONDVAR(Waypoint, train_station.w,           SLE_FILE_U8 | SLE_VAR_U16,   SLV_124, SL_MAX_VERSION),
+		SLE_CONDVAR(Waypoint, train_station.h,           SLE_FILE_U8 | SLE_VAR_U16,   SLV_124, SL_MAX_VERSION),
+	};
+
+	void GenericSaveLoad(BaseStation *bst) const
+	{
+		if ((bst->facilities & FACIL_WAYPOINT) == 0) return;
+		SlObject(bst, this->GetDescription());
+	}
+
+	void Save(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+	void Load(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+	void FixPointers(BaseStation *bst) const override { this->GenericSaveLoad(bst); }
+};
+
+static const SaveLoad _station_desc[] = {
+	SLE_SAVEBYTE(BaseStation, facilities),
+	SLEG_STRUCT(SlStationNormal),
+	SLEG_STRUCT(SlStationWaypoint),
+};
 
 static void RealSave_STNN(BaseStation *bst)
 {
-	bool waypoint = (bst->facilities & FACIL_WAYPOINT) != 0;
-	SlObject(bst, waypoint ? SaveLoadTable(_waypoint_desc) : SaveLoadTable(_station_desc));
+	SlObject(bst, _station_desc);
 
-	if (!waypoint) {
+	if ((bst->facilities & FACIL_WAYPOINT) == 0) {
 		Station *st = Station::From(bst);
 		for (CargoID i = 0; i < NUM_CARGO; i++) {
 			_num_dests = (uint32)st->goods[i].cargo.Packets()->MapSize();
@@ -509,7 +545,7 @@ static void Load_STNN()
 		bool waypoint = (SlReadByte() & FACIL_WAYPOINT) != 0;
 
 		BaseStation *bst = waypoint ? (BaseStation *)new (index) Waypoint() : new (index) Station();
-		SlObject(bst, waypoint ? SaveLoadTable(_waypoint_desc) : SaveLoadTable(_station_desc));
+		SlObject(bst, _station_desc);
 
 		if (!waypoint) {
 			Station *st = Station::From(bst);
@@ -583,7 +619,7 @@ static void Ptrs_STNN()
 	}
 
 	for (Waypoint *wp : Waypoint::Iterate()) {
-		SlObject(wp, _waypoint_desc);
+		SlObject(wp, _station_desc);
 	}
 }
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -573,150 +573,169 @@ static uint16 _cargo_paid_for;
 static Money  _cargo_feeder_share;
 static uint32 _cargo_loaded_at_xy;
 
-/**
- * Make it possible to make the saveload tables "friends" of other classes.
- * @param vt the vehicle type. Can be VEH_END for the common vehicle description data
- * @return the saveload description
- */
-SaveLoadTable GetVehicleDescription(VehicleType vt)
-{
-	/** Save and load of vehicles */
-	static const SaveLoad _common_veh_desc[] = {
-		     SLE_VAR(Vehicle, subtype,               SLE_UINT8),
+class SlVehicleCommon : public DefaultSaveLoadHandler<SlVehicleCommon, Vehicle> {
+public:
+#if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)
+	/* This table access private members of other classes; they have this
+	 * class as friend. For MSVC CL 19.15 and 19.16 this doesn't work for
+	 * "inline static const", so we are forced to wrap the table in a
+	 * function. CL 19.16 is the latest for VS2017. */
+	inline static const SaveLoad description[] = {{}};
+	SaveLoadTable GetDescription() const override {
+#else
+	inline
+#endif
+	static const SaveLoad description[] = {
+		    SLE_VAR(Vehicle, subtype,               SLE_UINT8),
 
-		     SLE_REF(Vehicle, next,                  REF_VEHICLE_OLD),
-		 SLE_CONDVAR(Vehicle, name,                  SLE_NAME,                     SL_MIN_VERSION,  SLV_84),
+		    SLE_REF(Vehicle, next,                  REF_VEHICLE_OLD),
+		SLE_CONDVAR(Vehicle, name,                  SLE_NAME,                     SL_MIN_VERSION,  SLV_84),
 		SLE_CONDSSTR(Vehicle, name,                  SLE_STR | SLF_ALLOW_CONTROL,  SLV_84, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, unitnumber,            SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_8),
-		 SLE_CONDVAR(Vehicle, unitnumber,            SLE_UINT16,                   SLV_8, SL_MAX_VERSION),
-		     SLE_VAR(Vehicle, owner,                 SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, tile,                  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, tile,                  SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, dest_tile,             SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, dest_tile,             SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, unitnumber,            SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_8),
+		SLE_CONDVAR(Vehicle, unitnumber,            SLE_UINT16,                   SLV_8, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, owner,                 SLE_UINT8),
+		SLE_CONDVAR(Vehicle, tile,                  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, tile,                  SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, dest_tile,             SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, dest_tile,             SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
 
-		 SLE_CONDVAR(Vehicle, x_pos,                 SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, x_pos,                 SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, y_pos,                 SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, y_pos,                 SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, z_pos,                 SLE_FILE_U8  | SLE_VAR_I32,   SL_MIN_VERSION, SLV_164),
-		 SLE_CONDVAR(Vehicle, z_pos,                 SLE_INT32,                  SLV_164, SL_MAX_VERSION),
-		     SLE_VAR(Vehicle, direction,             SLE_UINT8),
+		SLE_CONDVAR(Vehicle, x_pos,                 SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, x_pos,                 SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, y_pos,                 SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, y_pos,                 SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, z_pos,                 SLE_FILE_U8  | SLE_VAR_I32,   SL_MIN_VERSION, SLV_164),
+		SLE_CONDVAR(Vehicle, z_pos,                 SLE_INT32,                  SLV_164, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, direction,             SLE_UINT8),
 
 		SLE_CONDNULL(2,                                                            SL_MIN_VERSION,  SLV_58),
-		     SLE_VAR(Vehicle, spritenum,             SLE_UINT8),
+		    SLE_VAR(Vehicle, spritenum,             SLE_UINT8),
 		SLE_CONDNULL(5,                                                            SL_MIN_VERSION,  SLV_58),
-		     SLE_VAR(Vehicle, engine_type,           SLE_UINT16),
+		    SLE_VAR(Vehicle, engine_type,           SLE_UINT16),
 
 		SLE_CONDNULL(2,                                                            SL_MIN_VERSION,  SLV_152),
-		     SLE_VAR(Vehicle, cur_speed,             SLE_UINT16),
-		     SLE_VAR(Vehicle, subspeed,              SLE_UINT8),
-		     SLE_VAR(Vehicle, acceleration,          SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, motion_counter,        SLE_UINT32,                   SLV_VEH_MOTION_COUNTER, SL_MAX_VERSION),
-		     SLE_VAR(Vehicle, progress,              SLE_UINT8),
+		    SLE_VAR(Vehicle, cur_speed,             SLE_UINT16),
+		    SLE_VAR(Vehicle, subspeed,              SLE_UINT8),
+		    SLE_VAR(Vehicle, acceleration,          SLE_UINT8),
+		SLE_CONDVAR(Vehicle, motion_counter,        SLE_UINT32,                   SLV_VEH_MOTION_COUNTER, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, progress,              SLE_UINT8),
 
-		     SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, last_station_visited,  SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_5),
-		 SLE_CONDVAR(Vehicle, last_station_visited,  SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, last_loading_station,  SLE_UINT16,                 SLV_182, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
+		SLE_CONDVAR(Vehicle, last_station_visited,  SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_5),
+		SLE_CONDVAR(Vehicle, last_station_visited,  SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, last_loading_station,  SLE_UINT16,                 SLV_182, SL_MAX_VERSION),
 
-		     SLE_VAR(Vehicle, cargo_type,            SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, cargo_subtype,         SLE_UINT8,                   SLV_35, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, cargo_type,            SLE_UINT8),
+		SLE_CONDVAR(Vehicle, cargo_subtype,         SLE_UINT8,                   SLV_35, SL_MAX_VERSION),
 		SLEG_CONDVAR(         _cargo_days,           SLE_UINT8,                    SL_MIN_VERSION,  SLV_68),
 		SLEG_CONDVAR(         _cargo_source,         SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_7),
 		SLEG_CONDVAR(         _cargo_source,         SLE_UINT16,                   SLV_7,  SLV_68),
 		SLEG_CONDVAR(         _cargo_source_xy,      SLE_UINT32,                  SLV_44,  SLV_68),
-		     SLE_VAR(Vehicle, cargo_cap,             SLE_UINT16),
-		 SLE_CONDVAR(Vehicle, refit_cap,             SLE_UINT16,                 SLV_182, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, cargo_cap,             SLE_UINT16),
+		SLE_CONDVAR(Vehicle, refit_cap,             SLE_UINT16,                 SLV_182, SL_MAX_VERSION),
 		SLEG_CONDVAR(         _cargo_count,          SLE_UINT16,                   SL_MIN_VERSION,  SLV_68),
 		SLE_CONDREFLIST(Vehicle, cargo.packets,      REF_CARGO_PACKET,            SLV_68, SL_MAX_VERSION),
-		 SLE_CONDARR(Vehicle, cargo.action_counts,   SLE_UINT, VehicleCargoList::NUM_MOVE_TO_ACTION, SLV_181, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, cargo_age_counter,     SLE_UINT16,                 SLV_162, SL_MAX_VERSION),
+		SLE_CONDARR(Vehicle, cargo.action_counts,   SLE_UINT, VehicleCargoList::NUM_MOVE_TO_ACTION, SLV_181, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, cargo_age_counter,     SLE_UINT16,                 SLV_162, SL_MAX_VERSION),
 
-		     SLE_VAR(Vehicle, day_counter,           SLE_UINT8),
-		     SLE_VAR(Vehicle, tick_counter,          SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, running_ticks,         SLE_UINT8,                   SLV_88, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, day_counter,           SLE_UINT8),
+		    SLE_VAR(Vehicle, tick_counter,          SLE_UINT8),
+		SLE_CONDVAR(Vehicle, running_ticks,         SLE_UINT8,                   SLV_88, SL_MAX_VERSION),
 
-		     SLE_VAR(Vehicle, cur_implicit_order_index,  SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, cur_real_order_index,  SLE_UINT8,                  SLV_158, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, cur_implicit_order_index,  SLE_UINT8),
+		SLE_CONDVAR(Vehicle, cur_real_order_index,  SLE_UINT8,                  SLV_158, SL_MAX_VERSION),
 		/* num_orders is now part of OrderList and is not saved but counted */
 		SLE_CONDNULL(1,                                                            SL_MIN_VERSION, SLV_105),
 
 		/* This next line is for version 4 and prior compatibility.. it temporarily reads
-		 type and flags (which were both 4 bits) into type. Later on this is
-		 converted correctly */
-		 SLE_CONDVAR(Vehicle, current_order.type,    SLE_UINT8,                    SL_MIN_VERSION,   SLV_5),
-		 SLE_CONDVAR(Vehicle, current_order.dest,    SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_5),
+		type and flags (which were both 4 bits) into type. Later on this is
+		converted correctly */
+		SLE_CONDVAR(Vehicle, current_order.type,    SLE_UINT8,                    SL_MIN_VERSION,   SLV_5),
+		SLE_CONDVAR(Vehicle, current_order.dest,    SLE_FILE_U8  | SLE_VAR_U16,   SL_MIN_VERSION,   SLV_5),
 
 		/* Orders for version 5 and on */
-		 SLE_CONDVAR(Vehicle, current_order.type,    SLE_UINT8,                    SLV_5, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, current_order.flags,   SLE_UINT8,                    SLV_5, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, current_order.dest,    SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.type,    SLE_UINT8,                    SLV_5, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.flags,   SLE_UINT8,                    SLV_5, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.dest,    SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
 
 		/* Refit in current order */
-		 SLE_CONDVAR(Vehicle, current_order.refit_cargo,   SLE_UINT8,             SLV_36, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.refit_cargo,   SLE_UINT8,             SLV_36, SL_MAX_VERSION),
 		SLE_CONDNULL(1,                                                           SLV_36, SLV_182), // refit_subtype
 
 		/* Timetable in current order */
-		 SLE_CONDVAR(Vehicle, current_order.wait_time,     SLE_UINT16,            SLV_67, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, current_order.travel_time,   SLE_UINT16,            SLV_67, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, current_order.max_speed,     SLE_UINT16,           SLV_174, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, timetable_start,       SLE_INT32,                  SLV_129, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.wait_time,     SLE_UINT16,            SLV_67, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.travel_time,   SLE_UINT16,            SLV_67, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order.max_speed,     SLE_UINT16,           SLV_174, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, timetable_start,       SLE_INT32,                  SLV_129, SL_MAX_VERSION),
 
-		 SLE_CONDREF(Vehicle, orders,                REF_ORDER,                    SL_MIN_VERSION, SLV_105),
-		 SLE_CONDREF(Vehicle, orders,                REF_ORDERLIST,              SLV_105, SL_MAX_VERSION),
+		SLE_CONDREF(Vehicle, orders,                REF_ORDER,                    SL_MIN_VERSION, SLV_105),
+		SLE_CONDREF(Vehicle, orders,                REF_ORDERLIST,              SLV_105, SL_MAX_VERSION),
 
-		 SLE_CONDVAR(Vehicle, age,                   SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
-		 SLE_CONDVAR(Vehicle, age,                   SLE_INT32,                   SLV_31, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, max_age,               SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
-		 SLE_CONDVAR(Vehicle, max_age,               SLE_INT32,                   SLV_31, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, date_of_last_service,  SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
-		 SLE_CONDVAR(Vehicle, date_of_last_service,  SLE_INT32,                   SLV_31, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                   SL_MIN_VERSION,  SLV_31),
-		 SLE_CONDVAR(Vehicle, service_interval,      SLE_FILE_U32 | SLE_VAR_U16,  SLV_31, SLV_180),
-		 SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                 SLV_180, SL_MAX_VERSION),
-		     SLE_VAR(Vehicle, reliability,           SLE_UINT16),
-		     SLE_VAR(Vehicle, reliability_spd_dec,   SLE_UINT16),
-		     SLE_VAR(Vehicle, breakdown_ctr,         SLE_UINT8),
-		     SLE_VAR(Vehicle, breakdown_delay,       SLE_UINT8),
-		     SLE_VAR(Vehicle, breakdowns_since_last_service, SLE_UINT8),
-		     SLE_VAR(Vehicle, breakdown_chance,      SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, build_year,            SLE_FILE_U8 | SLE_VAR_I32,    SL_MIN_VERSION,  SLV_31),
-		 SLE_CONDVAR(Vehicle, build_year,            SLE_INT32,                   SLV_31, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, age,                   SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
+		SLE_CONDVAR(Vehicle, age,                   SLE_INT32,                   SLV_31, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, max_age,               SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
+		SLE_CONDVAR(Vehicle, max_age,               SLE_INT32,                   SLV_31, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, date_of_last_service,  SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
+		SLE_CONDVAR(Vehicle, date_of_last_service,  SLE_INT32,                   SLV_31, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                   SL_MIN_VERSION,  SLV_31),
+		SLE_CONDVAR(Vehicle, service_interval,      SLE_FILE_U32 | SLE_VAR_U16,  SLV_31, SLV_180),
+		SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                 SLV_180, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, reliability,           SLE_UINT16),
+		    SLE_VAR(Vehicle, reliability_spd_dec,   SLE_UINT16),
+		    SLE_VAR(Vehicle, breakdown_ctr,         SLE_UINT8),
+		    SLE_VAR(Vehicle, breakdown_delay,       SLE_UINT8),
+		    SLE_VAR(Vehicle, breakdowns_since_last_service, SLE_UINT8),
+		    SLE_VAR(Vehicle, breakdown_chance,      SLE_UINT8),
+		SLE_CONDVAR(Vehicle, build_year,            SLE_FILE_U8 | SLE_VAR_I32,    SL_MIN_VERSION,  SLV_31),
+		SLE_CONDVAR(Vehicle, build_year,            SLE_INT32,                   SLV_31, SL_MAX_VERSION),
 
-		     SLE_VAR(Vehicle, load_unload_ticks,     SLE_UINT16),
+		    SLE_VAR(Vehicle, load_unload_ticks,     SLE_UINT16),
 		SLEG_CONDVAR(         _cargo_paid_for,       SLE_UINT16,                  SLV_45, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, vehicle_flags,         SLE_FILE_U8 | SLE_VAR_U16,   SLV_40, SLV_180),
-		 SLE_CONDVAR(Vehicle, vehicle_flags,         SLE_UINT16,                 SLV_180, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, vehicle_flags,         SLE_FILE_U8 | SLE_VAR_U16,   SLV_40, SLV_180),
+		SLE_CONDVAR(Vehicle, vehicle_flags,         SLE_UINT16,                 SLV_180, SL_MAX_VERSION),
 
-		 SLE_CONDVAR(Vehicle, profit_this_year,      SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
-		 SLE_CONDVAR(Vehicle, profit_this_year,      SLE_INT64,                   SLV_65, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, profit_last_year,      SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
-		 SLE_CONDVAR(Vehicle, profit_last_year,      SLE_INT64,                   SLV_65, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, profit_this_year,      SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
+		SLE_CONDVAR(Vehicle, profit_this_year,      SLE_INT64,                   SLV_65, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, profit_last_year,      SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
+		SLE_CONDVAR(Vehicle, profit_last_year,      SLE_INT64,                   SLV_65, SL_MAX_VERSION),
 		SLEG_CONDVAR(         _cargo_feeder_share,   SLE_FILE_I32 | SLE_VAR_I64,  SLV_51,  SLV_65),
 		SLEG_CONDVAR(         _cargo_feeder_share,   SLE_INT64,                   SLV_65,  SLV_68),
 		SLEG_CONDVAR(         _cargo_loaded_at_xy,   SLE_UINT32,                  SLV_51,  SLV_68),
-		 SLE_CONDVAR(Vehicle, value,                 SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
-		 SLE_CONDVAR(Vehicle, value,                 SLE_INT64,                   SLV_65, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, value,                 SLE_FILE_I32 | SLE_VAR_I64,   SL_MIN_VERSION,  SLV_65),
+		SLE_CONDVAR(Vehicle, value,                 SLE_INT64,                   SLV_65, SL_MAX_VERSION),
 
-		 SLE_CONDVAR(Vehicle, random_bits,           SLE_UINT8,                    SLV_2, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, waiting_triggers,      SLE_UINT8,                    SLV_2, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, random_bits,           SLE_UINT8,                    SLV_2, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, waiting_triggers,      SLE_UINT8,                    SLV_2, SL_MAX_VERSION),
 
-		 SLE_CONDREF(Vehicle, next_shared,           REF_VEHICLE,                  SLV_2, SL_MAX_VERSION),
+		SLE_CONDREF(Vehicle, next_shared,           REF_VEHICLE,                  SLV_2, SL_MAX_VERSION),
 		SLE_CONDNULL(2,                                                            SLV_2,  SLV_69),
 		SLE_CONDNULL(4,                                                           SLV_69, SLV_101),
 
-		 SLE_CONDVAR(Vehicle, group_id,              SLE_UINT16,                  SLV_60, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, group_id,              SLE_UINT16,                  SLV_60, SL_MAX_VERSION),
 
-		 SLE_CONDVAR(Vehicle, current_order_time,    SLE_UINT32,                  SLV_67, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, current_order_time,    SLE_UINT32,                  SLV_67, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
 
 		SLE_CONDNULL(10,                                                           SLV_2, SLV_144), // old reserved space
 	};
+#if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)
+		return description;
+	}
+#endif
 
-	static const SaveLoad _train_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type),
-		SLE_VEH_INCLUDE(),
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		SlObject(v, this->GetDescription());
+	}
+
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
+
+class SlVehicleTrain : public DefaultSaveLoadHandler<SlVehicleTrain, Vehicle> {
+public:
+	inline static const SaveLoad description[] = {
+		 SLEG_STRUCT(SlVehicleCommon),
 		     SLE_VAR(Train, crash_anim_pos,      SLE_UINT16),
 		     SLE_VAR(Train, force_proceed,       SLE_UINT8),
 		     SLE_VAR(Train, railtype,            SLE_UINT8),
@@ -733,9 +752,21 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(11, SLV_2, SLV_144), // old reserved space
 	};
 
-	static const SaveLoad _roadveh_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type),
-		SLE_VEH_INCLUDE(),
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		if (v->type != VEH_TRAIN) return;
+		SlObject(v, this->GetDescription());
+	}
+
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
+
+class SlVehicleRoadVeh : public DefaultSaveLoadHandler<SlVehicleRoadVeh, Vehicle> {
+public:
+	inline static const SaveLoad description[] = {
+		  SLEG_STRUCT(SlVehicleCommon),
 		      SLE_VAR(RoadVehicle, state,                SLE_UINT8),
 		      SLE_VAR(RoadVehicle, frame,                SLE_UINT8),
 		      SLE_VAR(RoadVehicle, blocked_ctr,          SLE_UINT16),
@@ -753,9 +784,21 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		 SLE_CONDNULL(16,                                                              SLV_2, SLV_144), // old reserved space
 	};
 
-	static const SaveLoad _ship_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type),
-		SLE_VEH_INCLUDE(),
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		if (v->type != VEH_ROAD) return;
+		SlObject(v, this->GetDescription());
+	}
+
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
+
+class SlVehicleShip : public DefaultSaveLoadHandler<SlVehicleShip, Vehicle> {
+public:
+	inline static const SaveLoad description[] = {
+		  SLEG_STRUCT(SlVehicleCommon),
 		      SLE_VAR(Ship, state,                     SLE_UINT8),
 		SLE_CONDDEQUE(Ship, path,                      SLE_UINT8,                  SLV_SHIP_PATH_CACHE, SL_MAX_VERSION),
 		  SLE_CONDVAR(Ship, rotation,                  SLE_UINT8,                  SLV_SHIP_ROTATION, SL_MAX_VERSION),
@@ -763,9 +806,21 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(16, SLV_2, SLV_144), // old reserved space
 	};
 
-	static const SaveLoad _aircraft_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type),
-		SLE_VEH_INCLUDE(),
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		if (v->type != VEH_SHIP) return;
+		SlObject(v, this->GetDescription());
+	}
+
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
+
+class SlVehicleAircraft : public DefaultSaveLoadHandler<SlVehicleAircraft, Vehicle> {
+public:
+	inline static const SaveLoad description[] = {
+		 SLEG_STRUCT(SlVehicleCommon),
 		     SLE_VAR(Aircraft, crashed_counter,       SLE_UINT16),
 		     SLE_VAR(Aircraft, pos,                   SLE_UINT8),
 
@@ -784,9 +839,20 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(13,                                                           SLV_2, SLV_144), // old reserved space
 	};
 
-	static const SaveLoad _special_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type),
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		if (v->type != VEH_AIRCRAFT) return;
+		SlObject(v, this->GetDescription());
+	}
 
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
+
+class SlVehicleEffect : public DefaultSaveLoadHandler<SlVehicleEffect, Vehicle> {
+public:
+	inline static const SaveLoad description[] = {
 		     SLE_VAR(Vehicle, subtype,               SLE_UINT8),
 
 		 SLE_CONDVAR(Vehicle, tile,                  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
@@ -812,58 +878,90 @@ SaveLoadTable GetVehicleDescription(VehicleType vt)
 		SLE_CONDNULL(15,                                                           SLV_2, SLV_144), // old reserved space
 	};
 
-	static const SaveLoad _disaster_desc[] = {
-		SLE_WRITEBYTE(Vehicle, type),
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		if (v->type != VEH_EFFECT) return;
+		SlObject(v, this->GetDescription());
+	}
 
-		     SLE_REF(Vehicle, next,                  REF_VEHICLE_OLD),
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
 
-		     SLE_VAR(Vehicle, subtype,               SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, tile,                  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, tile,                  SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, dest_tile,             SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, dest_tile,             SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+class SlVehicleDisaster : public DefaultSaveLoadHandler<SlVehicleDisaster, Vehicle> {
+public:
+#if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)
+	/* This table access private members of other classes; they have this
+	 * class as friend. For MSVC CL 19.15 and 19.16 this doesn't work for
+	 * "inline static const", so we are forced to wrap the table in a
+	 * function. CL 19.16 is the latest for VS2017. */
+	inline static const SaveLoad description[] = {{}};
+	SaveLoadTable GetDescription() const override {
+#else
+	inline
+#endif
+	static const SaveLoad description[] = {
+		    SLE_REF(Vehicle, next,                  REF_VEHICLE_OLD),
 
-		 SLE_CONDVAR(Vehicle, x_pos,                 SLE_FILE_I16 | SLE_VAR_I32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, x_pos,                 SLE_INT32,                    SLV_6, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, y_pos,                 SLE_FILE_I16 | SLE_VAR_I32,   SL_MIN_VERSION,   SLV_6),
-		 SLE_CONDVAR(Vehicle, y_pos,                 SLE_INT32,                    SLV_6, SL_MAX_VERSION),
-		 SLE_CONDVAR(Vehicle, z_pos,                 SLE_FILE_U8  | SLE_VAR_I32,   SL_MIN_VERSION, SLV_164),
-		 SLE_CONDVAR(Vehicle, z_pos,                 SLE_INT32,                  SLV_164, SL_MAX_VERSION),
-		     SLE_VAR(Vehicle, direction,             SLE_UINT8),
+		    SLE_VAR(Vehicle, subtype,               SLE_UINT8),
+		SLE_CONDVAR(Vehicle, tile,                  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, tile,                  SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, dest_tile,             SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, dest_tile,             SLE_UINT32,                   SLV_6, SL_MAX_VERSION),
+
+		SLE_CONDVAR(Vehicle, x_pos,                 SLE_FILE_I16 | SLE_VAR_I32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, x_pos,                 SLE_INT32,                    SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, y_pos,                 SLE_FILE_I16 | SLE_VAR_I32,   SL_MIN_VERSION,   SLV_6),
+		SLE_CONDVAR(Vehicle, y_pos,                 SLE_INT32,                    SLV_6, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, z_pos,                 SLE_FILE_U8  | SLE_VAR_I32,   SL_MIN_VERSION, SLV_164),
+		SLE_CONDVAR(Vehicle, z_pos,                 SLE_INT32,                  SLV_164, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, direction,             SLE_UINT8),
 
 		SLE_CONDNULL(5,                                                            SL_MIN_VERSION,  SLV_58),
-		     SLE_VAR(Vehicle, owner,                 SLE_UINT8),
-		     SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
-		 SLE_CONDVAR(Vehicle, current_order.dest,    SLE_FILE_U8 | SLE_VAR_U16,    SL_MIN_VERSION,   SLV_5),
-		 SLE_CONDVAR(Vehicle, current_order.dest,    SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, owner,                 SLE_UINT8),
+		    SLE_VAR(Vehicle, vehstatus,             SLE_UINT8),
+		SLE_CONDVAR(Vehicle, current_order.dest,    SLE_FILE_U8 | SLE_VAR_U16,    SL_MIN_VERSION,   SLV_5),
+		SLE_CONDVAR(Vehicle, current_order.dest,    SLE_UINT16,                   SLV_5, SL_MAX_VERSION),
 
-		     SLE_VAR(Vehicle, sprite_cache.sprite_seq.seq[0].sprite, SLE_FILE_U16 | SLE_VAR_U32),
-		 SLE_CONDVAR(Vehicle, age,                   SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
-		 SLE_CONDVAR(Vehicle, age,                   SLE_INT32,                   SLV_31, SL_MAX_VERSION),
-		     SLE_VAR(Vehicle, tick_counter,          SLE_UINT8),
+		    SLE_VAR(Vehicle, sprite_cache.sprite_seq.seq[0].sprite, SLE_FILE_U16 | SLE_VAR_U32),
+		SLE_CONDVAR(Vehicle, age,                   SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
+		SLE_CONDVAR(Vehicle, age,                   SLE_INT32,                   SLV_31, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, tick_counter,          SLE_UINT8),
 
-		 SLE_CONDVAR(DisasterVehicle, image_override,            SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION, SLV_191),
-		 SLE_CONDVAR(DisasterVehicle, image_override,            SLE_UINT32,                 SLV_191, SL_MAX_VERSION),
-		 SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target,  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION, SLV_191),
-		 SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target,  SLE_UINT32,                 SLV_191, SL_MAX_VERSION),
-		 SLE_CONDVAR(DisasterVehicle, flags,                     SLE_UINT8,                  SLV_194, SL_MAX_VERSION),
+		SLE_CONDVAR(DisasterVehicle, image_override,            SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION, SLV_191),
+		SLE_CONDVAR(DisasterVehicle, image_override,            SLE_UINT32,                 SLV_191, SL_MAX_VERSION),
+		SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target,  SLE_FILE_U16 | SLE_VAR_U32,   SL_MIN_VERSION, SLV_191),
+		SLE_CONDVAR(DisasterVehicle, big_ufo_destroyer_target,  SLE_UINT32,                 SLV_191, SL_MAX_VERSION),
+		SLE_CONDVAR(DisasterVehicle, flags,                     SLE_UINT8,                  SLV_194, SL_MAX_VERSION),
 
 		SLE_CONDNULL(16,                                                           SLV_2, SLV_144), // old reserved space
 	};
+#if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)
+		return description;
+	}
+#endif
 
+	void GenericSaveLoad(Vehicle *v) const
+	{
+		if (v->type != VEH_DISASTER) return;
+		SlObject(v, this->GetDescription());
+	}
 
-	static const SaveLoadTable _veh_descs[] = {
-		_train_desc,
-		_roadveh_desc,
-		_ship_desc,
-		_aircraft_desc,
-		_special_desc,
-		_disaster_desc,
-		_common_veh_desc,
-	};
+	void Save(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void Load(Vehicle *v) const override { this->GenericSaveLoad(v); }
+	void FixPointers(Vehicle *v) const override { this->GenericSaveLoad(v); }
+};
 
-	return _veh_descs[vt];
-}
+const static SaveLoad _vehicle_desc[] = {
+	SLE_SAVEBYTE(Vehicle, type),
+	SLEG_STRUCT(SlVehicleTrain),
+	SLEG_STRUCT(SlVehicleRoadVeh),
+	SLEG_STRUCT(SlVehicleShip),
+	SLEG_STRUCT(SlVehicleAircraft),
+	SLEG_STRUCT(SlVehicleEffect),
+	SLEG_STRUCT(SlVehicleDisaster),
+};
 
 /** Will be called when the vehicles need to be saved. */
 static void Save_VEHS()
@@ -871,7 +969,7 @@ static void Save_VEHS()
 	/* Write the vehicles */
 	for (Vehicle *v : Vehicle::Iterate()) {
 		SlSetArrayIndex(v->index);
-		SlObject(v, GetVehicleDescription(v->type));
+		SlObject(v, _vehicle_desc);
 	}
 }
 
@@ -897,7 +995,7 @@ void Load_VEHS()
 			default: SlErrorCorrupt("Invalid vehicle type");
 		}
 
-		SlObject(v, GetVehicleDescription(vtype));
+		SlObject(v, _vehicle_desc);
 
 		if (_cargo_count != 0 && IsCompanyBuildableVehicleType(v) && CargoPacket::CanAllocateItem()) {
 			/* Don't construct the packet with station here, because that'll fail with old savegames */
@@ -924,10 +1022,10 @@ void Load_VEHS()
 	}
 }
 
-static void Ptrs_VEHS()
+void Ptrs_VEHS()
 {
 	for (Vehicle *v : Vehicle::Iterate()) {
-		SlObject(v, GetVehicleDescription(v->type));
+		SlObject(v, _vehicle_desc);
 	}
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2024,7 +2024,7 @@ static std::vector<SaveLoad> GetSettingsDesc(const SettingTable &settings, bool 
 
 		if (is_loading && (sd->flags & SF_NO_NETWORK_SYNC) && _networking && !_network_server) {
 			/* We don't want to read this setting, so we do need to skip over it. */
-			saveloads.push_back({sd->save.cmd, GetVarFileType(sd->save.conv) | SLE_VAR_NULL, sd->save.length, sd->save.version_from, sd->save.version_to, 0, nullptr, 0});
+			saveloads.push_back({sd->save.cmd, GetVarFileType(sd->save.conv) | SLE_VAR_NULL, sd->save.length, sd->save.version_from, sd->save.version_to, 0, nullptr, 0, nullptr});
 			continue;
 		}
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -200,7 +200,6 @@ extern VehiclePool _vehicle_pool;
 
 /* Some declarations of functions, so we can make them friendly */
 struct GroundVehicleCache;
-extern SaveLoadTable GetVehicleDescription(VehicleType vt);
 struct LoadgameState;
 extern bool LoadOldVehicle(LoadgameState *ls, int num);
 extern void FixOldVehicles();
@@ -232,10 +231,13 @@ private:
 	Vehicle *previous_shared;           ///< NOSAVE: pointer to the previous vehicle in the shared order chain
 
 public:
-	friend SaveLoadTable GetVehicleDescription(VehicleType vt); ///< So we can use private/protected variables in the saveload code
 	friend void FixOldVehicles();
 	friend void AfterLoadVehicles(bool part_of_load);             ///< So we can set the #previous and #first pointers while loading
 	friend bool LoadOldVehicle(LoadgameState *ls, int num);       ///< So we can set the proper next pointer while loading
+	/* So we can use private/protected variables in the saveload code */
+	friend class SlVehicleCommon;
+	friend class SlVehicleDisaster;
+	friend void Ptrs_VEHS();
 
 	TileIndex tile;                     ///< Current tile index
 


### PR DESCRIPTION
## Motivation / Problem

In a few places (stations, vehicles, towns, companies, ..) the SaveLoad code needs to handle either structs in structs, or lists of structs in structs.

This is all done manually, and not only hard to read, also easy to mess up.


## Description

Introduce `SL_STRUCT` and `SL_STRUCTLIST` to embed a struct in another struct.

For example, for Vehicles it used to have a special `SL` command to embed the common vehicle structure. This meant that SaveLoad needed to know about Vehicles.

Now, the common vehicle sub-struct is called `SlVehicleCommon` and to save it you can use:
```
SLEG_STRUCT(SlVehicleCommon)
```

This works with structs in structs in structs in structs in structs in ... just fine too.

NOTE: I made several commits to introduce `SL_STRUCT` in the rest of the code, as I am hoping that makes reviewing easier. 
NOTE 2: I left a lot of odd constructs in there, just to make review easier. The code really could use a cleanup, but .. I am trying not to do everything at once, also for my own sanity :D
NOTE 3: there should be no difference before or after this PR in respect to what is written/loaded from disk.

## Limitations

- I tested this with ~500 savegames, ranging from TTDp till 1.11.2, validating that they load and run. Nothing that wasn't broken before this PR is broken now. So I think there are no regressions, but with this many changes in the SaveLoad code, that cannot be guaranteed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
