### PR TITLE
Add: '-X' option to ignore global folders in the search path

### DIFF
--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -27,7 +27,7 @@ const char *FiosGetScreenshotDir();
 
 void SanitizeFilename(char *filename);
 void AppendPathSeparator(std::string &buf);
-void DeterminePaths(const char *exe);
+void DeterminePaths(const char *exe, bool only_local_path);
 std::unique_ptr<char[]> ReadFileToMem(const std::string &filename, size_t &lenp, size_t maxsize);
 bool FileExists(const std::string &filename);
 bool ExtractTar(const std::string &tar_filename, Subdirectory subdir);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -197,6 +197,7 @@ static void ShowHelp()
 		"  -M music_set        = Force the music set (see below)\n"
 		"  -c config_file      = Use 'config_file' instead of 'openttd.cfg'\n"
 		"  -x                  = Never save configuration changes to disk\n"
+		"  -X                  = Don't use global folders to search for files\n"
 		"  -q savegame         = Write some information about the savegame and exit\n"
 		"\n",
 		lastof(buf)
@@ -506,6 +507,7 @@ static const OptionData _options[] = {
 	 GETOPT_SHORT_VALUE('G'),
 	 GETOPT_SHORT_VALUE('c'),
 	 GETOPT_SHORT_NOVAL('x'),
+	 GETOPT_SHORT_NOVAL('X'),
 	 GETOPT_SHORT_VALUE('q'),
 	 GETOPT_SHORT_NOVAL('h'),
 	GETOPT_END()
@@ -530,6 +532,7 @@ int openttd_main(int argc, char *argv[])
 	std::unique_ptr<AfterNewGRFScan> scanner(new AfterNewGRFScan());
 	bool dedicated = false;
 	char *debuglog_conn = nullptr;
+	bool only_local_path = false;
 
 	extern bool _dedicated_forks;
 	_dedicated_forks = false;
@@ -608,7 +611,7 @@ int openttd_main(int argc, char *argv[])
 			}
 			break;
 		case 'q': {
-			DeterminePaths(argv[0]);
+			DeterminePaths(argv[0], only_local_path);
 			if (StrEmpty(mgo.opt)) {
 				ret = 1;
 				return ret;
@@ -637,6 +640,7 @@ int openttd_main(int argc, char *argv[])
 		case 'G': scanner->generation_seed = strtoul(mgo.opt, nullptr, 10); break;
 		case 'c': _config_file = mgo.opt; break;
 		case 'x': scanner->save_config = false; break;
+		case 'X': only_local_path = true; break;
 		case 'h':
 			i = -2; // Force printing of help.
 			break;
@@ -650,7 +654,7 @@ int openttd_main(int argc, char *argv[])
 		 *
 		 * The next two functions are needed to list the graphics sets. We can't do them earlier
 		 * because then we cannot show it on the debug console as that hasn't been configured yet. */
-		DeterminePaths(argv[0]);
+		DeterminePaths(argv[0], only_local_path);
 		TarScanner::DoScan(TarScanner::BASESET);
 		BaseGraphics::FindSets();
 		BaseSounds::FindSets();
@@ -659,7 +663,7 @@ int openttd_main(int argc, char *argv[])
 		return ret;
 	}
 
-	DeterminePaths(argv[0]);
+	DeterminePaths(argv[0], only_local_path);
 	TarScanner::DoScan(TarScanner::BASESET);
 
 	if (dedicated) DEBUG(net, 3, "Starting dedicated server, version %s", _openttd_revision);


### PR DESCRIPTION
## Motivation / Problem

Imagine this: you have 400 NewGRFs and 4 basesets in your `~/.local/share/openttd` folder. You want to run some automated tests for OpenTTD that has 10 NewGRFs and 1 baseset. Owh no, it still looks all those other NewGRFs too!

But wait, we have `-c` you say! Yeah .. that doesn't work for the global folders.

Okay okay .. so I just rename that `~/.local/share/openttd` folder every time .. well .. I am crazy, but not that crazy.

## Description

So I present you with an alternative: `-X`. This setting completely ignores global folders and only use the ones you gave with `-c`. Nice.

```
This is extreme useful for automated testing. Without this, OpenTTD
will always look in your personal-dir (like ~/.local/share/openttd
or %USER%\Documents\OpenTTD). For most users this is exactly what
we want, that there is a shared place for all their files.

However, for automated testing this is rather annoying, as your
local development files influence the automated test. As such,
'-X' counters this, and only gives the local folders. This is
especially useful in combination with '-x' and '-c'.
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
