### PR TITLE
Change: allow pause/unpause console command in single player too

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -160,11 +160,24 @@ DEF_CONSOLE_HOOK(ConHookNoNetwork)
 	return CHR_ALLOW;
 }
 
+/**
+ * Check if are either in singleplayer or a server.
+ * @return True iff we are either in singleplayer or a server.
+ */
+DEF_CONSOLE_HOOK(ConHookServerOrNoNetwork)
+{
+	if (_networking && !_network_server) {
+		if (echo) IConsoleError("This command is only available to a network server.");
+		return CHR_DISALLOW;
+	}
+	return CHR_ALLOW;
+}
+
 DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
 		if (_game_mode == GM_MENU) {
-			if (echo) IConsoleError("This command is only available in game and editor.");
+			if (echo) IConsoleError("This command is only available in-game and in the editor.");
 			return CHR_DISALLOW;
 		}
 		return ConHookNoNetwork(echo);
@@ -209,7 +222,7 @@ DEF_CONSOLE_CMD(ConResetEnginePool)
 	}
 
 	if (_game_mode == GM_MENU) {
-		IConsoleError("This command is only available in game and editor.");
+		IConsoleError("This command is only available in-game and in the editor.");
 		return true;
 	}
 
@@ -622,6 +635,11 @@ DEF_CONSOLE_CMD(ConPauseGame)
 		return true;
 	}
 
+	if (_game_mode == GM_MENU) {
+		IConsoleError("This command is only available in-game and in the editor.");
+		return true;
+	}
+
 	if ((_pause_mode & PM_PAUSED_NORMAL) == PM_UNPAUSED) {
 		DoCommandP(0, PM_PAUSED_NORMAL, 1, CMD_PAUSE);
 		if (!_networking) IConsolePrint(CC_DEFAULT, "Game paused.");
@@ -636,6 +654,11 @@ DEF_CONSOLE_CMD(ConUnpauseGame)
 {
 	if (argc == 0) {
 		IConsoleHelp("Unpause a network game. Usage: 'unpause'");
+		return true;
+	}
+
+	if (_game_mode == GM_MENU) {
+		IConsoleError("This command is only available in-game and in the editor.");
 		return true;
 	}
 
@@ -2393,8 +2416,8 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("unban",                   ConUnBan,            ConHookServerOnly);
 	IConsole::CmdRegister("banlist",                 ConBanList,          ConHookServerOnly);
 
-	IConsole::CmdRegister("pause",                   ConPauseGame,        ConHookServerOnly);
-	IConsole::CmdRegister("unpause",                 ConUnpauseGame,      ConHookServerOnly);
+	IConsole::CmdRegister("pause",                   ConPauseGame,        ConHookServerOrNoNetwork);
+	IConsole::CmdRegister("unpause",                 ConUnpauseGame,      ConHookServerOrNoNetwork);
 
 	IConsole::CmdRegister("company_pw",              ConCompanyPassword,  ConHookNeedNetwork);
 	IConsole::AliasRegister("company_password",      "company_pw %+");


### PR DESCRIPTION
## Motivation / Problem

For some weird reason, `pause`/`unpause` console command only works in network games. I couldn't think of a single reason for that to make sense.

Mainly I needed this to ensure games are unpaused after game-start for automated testing. Now in `game_start.scr` I can do `unpause`, and I am sure the game is not paused. Sweet.

## Description

Fixed the weird limitation.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
