### PR TITLE
Add: adhere the autosave_on_exit setting for Null videodriver

### DIFF
--- a/src/video/null_v.cpp
+++ b/src/video/null_v.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../gfx_func.h"
 #include "../blitter/factory.hpp"
+#include "../saveload/saveload.h"
 #include "../window_func.h"
 #include "null_v.h"
 
@@ -51,6 +52,12 @@ void VideoDriver_Null::MainLoop()
 		::GameLoop();
 		::InputLoop();
 		::UpdateWindows();
+	}
+
+	/* If requested, make a save just before exit. The normal exit-flow is
+	 * not triggered from this driver, so we have to do this manually. */
+	if (_settings_client.gui.autosave_on_exit) {
+		DoExitSave();
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

Our scripting stuff is rarely useful, but I now had a use, it wasn't supplying. 

For automated testing, I want to load an (old) savegame, run for a few ticks, and save&exit, so I could compare it with later results.

But .. there is no way to do this "run for a few ticks, and save&exit" currently. I could see two possible solutions:

1) have a console command that "delayed executes" a command, so I can say: "execute in 200 ticks: save & exit".
2) have a script that is called just after the game is stopping but before anything is shut down.
3) (tnx to @glx22) make sure `autosave_on_exit` also works for the null driver.

## Description

I went with 3), as 2) felt weird and dirty. 1) would be ideal, but is a lot more work.

```
This is especially useful for automated-testing, to make a save
when the game quits while using "-vnull:ticks=N".
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
