### PR TITLE
Change: Reduce real sprite groups if possible.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -57,8 +57,6 @@ struct AirportResolverObject : public ResolverObject {
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
-
 	GrfSpecFeature GetFeature() const override;
 	uint32 GetDebugID() const override;
 };
@@ -217,16 +215,6 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 	}
 
 	return this->st->GetNewGRFVariable(this->ro, variable, parameter, available);
-}
-
-/* virtual */ const SpriteGroup *AirportResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	/* Airport action 2s should always have only 1 "loaded" state, but some
-	 * times things don't follow the spec... */
-	if (!group->loaded.empty())  return group->loaded[0];
-	if (!group->loading.empty()) return group->loading[0];
-
-	return nullptr;
 }
 
 GrfSpecFeature AirportResolverObject::GetFeature() const

--- a/src/newgrf_canal.cpp
+++ b/src/newgrf_canal.cpp
@@ -49,8 +49,6 @@ struct CanalResolverObject : public ResolverObject {
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
-
 	GrfSpecFeature GetFeature() const override;
 	uint32 GetDebugID() const override;
 };
@@ -106,14 +104,6 @@ struct CanalResolverObject : public ResolverObject {
 
 	*available = false;
 	return UINT_MAX;
-}
-
-
-/* virtual */ const SpriteGroup *CanalResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	if (group->loaded.empty()) return nullptr;
-
-	return group->loaded[0];
 }
 
 GrfSpecFeature CanalResolverObject::GetFeature() const

--- a/src/newgrf_cargo.cpp
+++ b/src/newgrf_cargo.cpp
@@ -19,21 +19,9 @@ struct CargoResolverObject : public ResolverObject {
 
 	CargoResolverObject(const CargoSpec *cs, CallbackID callback = CBID_NO_CALLBACK, uint32 callback_param1 = 0, uint32 callback_param2 = 0);
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
-
 	GrfSpecFeature GetFeature() const override;
 	uint32 GetDebugID() const override;
 };
-
-/* virtual */ const SpriteGroup *CargoResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	/* Cargo action 2s should always have only 1 "loaded" state, but some
-	 * times things don't follow the spec... */
-	if (!group->loaded.empty())  return group->loaded[0];
-	if (!group->loading.empty()) return group->loading[0];
-
-	return nullptr;
-}
 
 GrfSpecFeature CargoResolverObject::GetFeature() const
 {

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -63,8 +63,6 @@ struct GenericResolverObject : public ResolverObject {
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
-
 	GrfSpecFeature GetFeature() const override
 	{
 		return (GrfSpecFeature)this->generic_scope.feature;
@@ -145,14 +143,6 @@ void AddGenericCallback(uint8 feature, const GRFFile *file, const SpriteGroup *g
 
 	*available = false;
 	return UINT_MAX;
-}
-
-
-/* virtual */ const SpriteGroup *GenericResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	if (group->loaded.empty()) return nullptr;
-
-	return group->loaded[0];
 }
 
 /**

--- a/src/newgrf_railtype.cpp
+++ b/src/newgrf_railtype.cpp
@@ -58,13 +58,6 @@
 	return UINT_MAX;
 }
 
-/* virtual */ const SpriteGroup *RailTypeResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	if (!group->loading.empty()) return group->loading[0];
-	if (!group->loaded.empty())  return group->loaded[0];
-	return nullptr;
-}
-
 GrfSpecFeature RailTypeResolverObject::GetFeature() const
 {
 	return GSF_RAILTYPES;

--- a/src/newgrf_railtype.h
+++ b/src/newgrf_railtype.h
@@ -49,8 +49,6 @@ struct RailTypeResolverObject : public ResolverObject {
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
-
 	GrfSpecFeature GetFeature() const override;
 	uint32 GetDebugID() const override;
 };

--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -58,13 +58,6 @@
 	return UINT_MAX;
 }
 
-/* virtual */ const SpriteGroup *RoadTypeResolverObject::ResolveReal(const RealSpriteGroup *group) const
-{
-	if (!group->loading.empty()) return group->loading[0];
-	if (!group->loaded.empty())  return group->loaded[0];
-	return nullptr;
-}
-
 GrfSpecFeature RoadTypeResolverObject::GetFeature() const
 {
 	RoadType rt = GetRoadTypeByLabel(this->roadtype_scope.rti->label, false);

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -40,8 +40,6 @@ struct RoadTypeResolverObject : public ResolverObject {
 		}
 	}
 
-	const SpriteGroup *ResolveReal(const RealSpriteGroup *group) const override;
-
 	GrfSpecFeature GetFeature() const override;
 	uint32 GetDebugID() const override;
 };

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -124,6 +124,9 @@ static inline uint32 GetVariable(const ResolverObject &object, ScopeResolver *sc
  */
 /* virtual */ const SpriteGroup *ResolverObject::ResolveReal(const RealSpriteGroup *group) const
 {
+	if (!group->loaded.empty())  return group->loaded[0];
+	if (!group->loading.empty()) return group->loading[0];
+
 	return nullptr;
 }
 


### PR DESCRIPTION
## Motivation / Problem

Many NewGRF features using Act 3/2/1 chains don't require loading/loaded stages (which are determined by the `RealSpriteGroup`), however by spec they are still created, and evaluated on every chain resolve.

For features that do use loading/loaded stages, it is also fairly common for the same sprite or callback result to be returned.

## Description

This change skips creating a RealSpriteGroup if there is only one result, or if all results are the same.
It also deduplicates the different ResolveReal() resolver function for resolvers which don't care about loading/loaded stages.

## Limitations

The deduplication does not take account of the order of checking loading/loaded results which was previously inconsistent, therefore it's possible that if loading/loaded stages were supplied for a feature that does not expect it, a different result will now be used. But if this is the case then I think NewGRF is out-of-spec anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
