### PR TITLE
Fix: Crash when CTRL-clicking on a sign

### DIFF
--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -566,7 +566,7 @@ static WindowDesc _query_sign_edit_desc(
 void HandleClickOnSign(const Sign *si)
 {
 	if (_ctrl_pressed && (si->owner == _local_company || (si->owner == OWNER_DEITY && _game_mode == GM_EDITOR))) {
-		RenameSign(si->index, nullptr);
+		RenameSign(si->index, "");
 		return;
 	}
 	ShowRenameSignWindow(si);


### PR DESCRIPTION
## Motivation / Problem

CTRL-clicking on a sign crashes the game.


## Description

`DoCommandP` tries to construct a `std::string` from a `nullptr`, which doesn't work.


## Limitations

No known limitations.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
