### PR TITLE
Feature: [NewGRF] Maximum curve speed modifier for rail vehicles

### DIFF
--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -59,6 +59,7 @@ struct RailVehicleInfo {
 	byte tractive_effort;           ///< Tractive effort coefficient
 	byte air_drag;                  ///< Coefficient of air drag
 	byte user_def_data;             ///< Property 0x25: "User-defined bit mask" Used only for (very few) NewGRF vehicles
+	int16 curve_speed_mod;          ///< Modifier to maximum speed in curves (fixed-point binary with 8 fractional bits)
 };
 
 /** Information about a ship vehicle. */

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1333,6 +1333,10 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 				break;
 			}
 
+			case PROP_TRAIN_CURVE_SPEED_MOD: // 0x2E Curve speed modifier
+				rvi->curve_speed_mod = buf->ReadWord();
+				break;
+
 			default:
 				ret = CommonVehicleChangeInfo(ei, prop, buf);
 				break;

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1177,16 +1177,23 @@ uint16 GetVehicleCallbackParent(CallbackID callback, uint32 param1, uint32 param
 
 
 /* Callback 36 handlers */
-uint GetVehicleProperty(const Vehicle *v, PropertyID property, uint orig_value)
+int GetVehicleProperty(const Vehicle *v, PropertyID property, int orig_value, bool is_signed)
 {
-	return GetEngineProperty(v->engine_type, property, orig_value, v);
+	return GetEngineProperty(v->engine_type, property, orig_value, v, is_signed);
 }
 
 
-uint GetEngineProperty(EngineID engine, PropertyID property, uint orig_value, const Vehicle *v)
+int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, const Vehicle *v, bool is_signed)
 {
 	uint16 callback = GetVehicleCallback(CBID_VEHICLE_MODIFY_PROPERTY, property, 0, engine, v);
-	if (callback != CALLBACK_FAILED) return callback;
+	if (callback != CALLBACK_FAILED) {
+		if (is_signed) {
+			/* Sign extend 15 bit integer */
+			return static_cast<int16>(callback << 1) >> 1;
+		} else {
+			return callback;
+		}
+	}
 
 	return orig_value;
 }

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -100,8 +100,8 @@ bool UsesWagonOverride(const Vehicle *v);
 
 /* Handler to Evaluate callback 36. If the callback fails (i.e. most of the
  * time) orig_value is returned */
-uint GetVehicleProperty(const Vehicle *v, PropertyID property, uint orig_value);
-uint GetEngineProperty(EngineID engine, PropertyID property, uint orig_value, const Vehicle *v = nullptr);
+int GetVehicleProperty(const Vehicle *v, PropertyID property, int orig_value, bool is_signed = false);
+int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, const Vehicle *v = nullptr, bool is_signed = false);
 
 enum VehicleTrigger {
 	VEHICLE_TRIGGER_NEW_CARGO     = 0x01,

--- a/src/newgrf_properties.h
+++ b/src/newgrf_properties.h
@@ -28,6 +28,7 @@ enum PropertyID {
 	PROP_TRAIN_SHORTEN_FACTOR                   = 0x21, ///< Shorter vehicles
 	PROP_TRAIN_USER_DATA                        = 0x25, ///< User defined data for vehicle variable 0x42
 	PROP_TRAIN_CARGO_AGE_PERIOD                 = 0x2B, ///< Number of ticks before carried cargo is aged
+	PROP_TRAIN_CURVE_SPEED_MOD                  = 0x2E, ///< Modifier to maximum speed in curves
 
 	PROP_ROADVEH_RUNNING_COST_FACTOR            = 0x09, ///< Yearly runningcost
 	PROP_ROADVEH_CARGO_CAPACITY                 = 0x0F, ///< Capacity

--- a/src/table/engines.h
+++ b/src/table/engines.h
@@ -386,7 +386,7 @@ static const EngineInfo _orig_engine_info[] = {
  * Tractive effort coefficient by default is the same as TTDPatch, 0.30*256=76
  * Air drag value depends on the top speed of the vehicle.
  */
-#define RVI(a, b, c, d, e, f, g, h, i, j, k) { a, b, c, j, d, e, f, g, h, k, i, 0, 0, 0, VE_DEFAULT, 0, 76, 0, 0 }
+#define RVI(a, b, c, d, e, f, g, h, i, j, k) { a, b, c, j, d, e, f, g, h, k, i, 0, 0, 0, VE_DEFAULT, 0, 76, 0, 0, 0 }
 #define M RAILVEH_MULTIHEAD
 #define W RAILVEH_WAGON
 #define G RAILVEH_SINGLEHEAD

--- a/src/train.h
+++ b/src/train.h
@@ -72,6 +72,7 @@ struct TrainCache {
 
 	/* cached values, recalculated on load and each time a vehicle is added to/removed from the consist. */
 	bool cached_tilt;           ///< train can tilt; feature provides a bonus in curves
+	int cached_curve_speed_mod; ///< curve speed modifier of the entire train
 
 	byte user_def_data;         ///< Cached property 0x25. Can be set by Callback 0x36.
 
@@ -310,6 +311,15 @@ protected: // These functions should not be called outside acceleration code.
 	inline uint16 GetMaxTrackSpeed() const
 	{
 		return GetRailTypeInfo(GetRailType(this->tile))->max_speed;
+	}
+
+	/**
+	 * Returns the curve speed modifier of this vehicle.
+	 * @return Current curve speed modifier, in fixed-point binary representation with 8 fractional bits.
+	 */
+	inline int GetCurveSpeedModifier() const
+	{
+		return GetVehicleProperty(this, PROP_TRAIN_CURVE_SPEED_MOD, RailVehInfo(this->engine_type)->curve_speed_mod, true);
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

Prior to https://github.com/OpenTTD/OpenTTD/commit/0f91cb04791b329c5e457588a39d1e7a43e43136, rail type's `curve_speed` essentially worked as a vehicle property. A rail vehicle could set its curve speed advantage to an arbitrary value by choosing the proper "home" rail type and the advantage would apply when traveling on compatible rail types.

Currently, the only way a rail vehicle can control its curve speed bonus is via the tilt property, which is a flat 20% bonus. There are no other ways in which the original behavior can be recovered. NUTS (and possibly other NewGRFs) relied on that behavior quite heavily.


## Description

This PR fixes the stated problem by introducing a new rail vehicle property: `curve_speed_mod` (0x2E). A 16 bit signed fixed-point binary number with 8 fractional bits, ranging from -128 to 127.996. 0 represents no bonus (default behavior), positive numbers increase maximum curve speed, negative numbers decrease. As an example, the value 1.0 (0x0100) would double the vehicle's speed in curves.

The way this property works is analogous to tilt. Each part of the consist has its own `curve_speed_mod` and the curve speed advantage of the entire consist is given by its weakest link.

Moreover, NewGRFs can also affect `curve_speed_mod` via callback 0x36. The resulting 15 bits represent values from -64 to 63.996. To support negative modifiers, `GetEngineProperty` and `GetVehicleProperty` now optionally allow negative numbers (existing uses are unaffected).

This change also expands the possible design space compared to the original behavior: NewGRFs can provide powerful trains that travel slowly in curves; wagons that, when refitted to fragile cargo, must travel slowly in curves; and so on.

NML support: https://github.com/OpenTTD/nml/pull/222

## Limitations

No known limitations.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
