### PR TITLE
Codechange: [Network] Remove C-string Packet::Recv_string

### DIFF
--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -367,37 +367,6 @@ uint64 Packet::Recv_uint64()
 }
 
 /**
- * Reads a string till it finds a '\0' in the stream.
- * @param buffer The buffer to put the data into.
- * @param size   The size of the buffer.
- * @param settings The string validation settings.
- */
-void Packet::Recv_string(char *buffer, size_t size, StringValidationSettings settings)
-{
-	char *bufp = buffer;
-	const char *last = buffer + size - 1;
-
-	/* Don't allow reading from a closed socket */
-	if (cs->HasClientQuit()) return;
-
-	size_t pos = this->pos;
-	while (--size > 0 && pos < this->Size() && (*buffer++ = this->buffer[pos++]) != '\0') {}
-
-	if (size == 0 || pos == this->Size()) {
-		*buffer = '\0';
-		/* If size was sooner to zero then the string in the stream
-		 *  skip till the \0, so than packet can be read out correctly for the rest */
-		while (pos < this->Size() && this->buffer[pos] != '\0') pos++;
-		pos++;
-	}
-
-	assert(pos <= std::numeric_limits<PacketSize>::max());
-	this->pos = static_cast<PacketSize>(pos);
-
-	StrMakeValidInPlace(bufp, last, settings);
-}
-
-/**
  * Reads characters (bytes) from the packet until it finds a '\0', or reaches a
  * maximum of \c length characters.
  * When the '\0' has not been reached in the first \c length read characters,

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -87,7 +87,6 @@ public:
 	uint16 Recv_uint16();
 	uint32 Recv_uint32();
 	uint64 Recv_uint64();
-	void   Recv_string(char *buffer, size_t size, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 	std::string Recv_string(size_t length, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 	size_t RemainingBytesToTransfer() const;

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -874,13 +874,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_JOIN(Packet *p)
 		return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
 	}
 
-	char client_revision[NETWORK_REVISION_LENGTH];
-
-	p->Recv_string(client_revision, sizeof(client_revision));
+	std::string client_revision = p->Recv_string(NETWORK_REVISION_LENGTH);
 	uint32 newgrf_version = p->Recv_uint32();
 
 	/* Check if the client has revision control enabled */
-	if (!IsNetworkCompatibleVersion(client_revision) || _openttd_newgrf_version != newgrf_version) {
+	if (!IsNetworkCompatibleVersion(client_revision.c_str()) || _openttd_newgrf_version != newgrf_version) {
 		/* Different revisions!! */
 		return this->SendError(NETWORK_ERROR_WRONG_REVISION);
 	}

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -415,15 +415,14 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_NEWGRFS(Packet *p, NetworkAdd
 	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
 
 	for (i = 0; i < num_grfs; i++) {
-		char name[NETWORK_GRF_NAME_LENGTH];
 		GRFIdentifier c;
 
 		DeserializeGRFIdentifier(p, &c);
-		p->Recv_string(name, sizeof(name));
+		std::string name = p->Recv_string(NETWORK_GRF_NAME_LENGTH);
 
 		/* An empty name is not possible under normal circumstances
 		 * and causes problems when showing the NewGRF list. */
-		if (StrEmpty(name)) continue;
+		if (name.empty()) continue;
 
 		/* Try to find the GRFTextWrapper for the name of this GRF ID and MD5sum tuple.
 		 * If it exists and not resolved yet, then name of the fake GRF is

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -539,10 +539,10 @@ void AddGRFTextToList(GRFTextWrapper &list, byte langid, uint32 grfid, bool allo
  * @param list The list where the text should be added to.
  * @param text_to_add The text to add to the list.
  */
-void AddGRFTextToList(GRFTextWrapper &list, const char *text_to_add)
+void AddGRFTextToList(GRFTextWrapper &list, const std::string &text_to_add)
 {
 	if (!list) list.reset(new GRFTextList());
-	AddGRFTextToList(*list, GRFLX_UNSPECIFIED, std::string(text_to_add));
+	AddGRFTextToList(*list, GRFLX_UNSPECIFIED, text_to_add);
 }
 
 /**

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -42,7 +42,7 @@ void SetCurrentGrfLangID(byte language_id);
 std::string TranslateTTDPatchCodes(uint32 grfid, uint8 language_id, bool allow_newlines, const std::string &str, StringControlCode byte80 = SCC_NEWGRF_PRINT_WORD_STRING_ID);
 void AddGRFTextToList(GRFTextList &list, byte langid, uint32 grfid, bool allow_newlines, const char *text_to_add);
 void AddGRFTextToList(GRFTextWrapper &list, byte langid, uint32 grfid, bool allow_newlines, const char *text_to_add);
-void AddGRFTextToList(GRFTextWrapper &list, const char *text_to_add);
+void AddGRFTextToList(GRFTextWrapper &list, const std::string &text_to_add);
 
 bool CheckGrfLangID(byte lang_id, byte grf_version);
 


### PR DESCRIPTION
## Motivation / Problem

Final step in the conversion of C-string to std::string in network packets.


## Description

Change receiving the NewGRF name and OpenTTD revision to std::strings and remove the C-string Packet::Recv_String.


## Limitations

Preferably IsNetworkCompatibleVersion would accept std::string or std::string_view, but it currently does not. Given the complexity of that function and the lack of unit testing ability that is left to a future PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
