### PR TITLE
Fix #9348, 4d74e5: don't try to sell shares of spectators

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -67,7 +67,7 @@ Company::Company(uint16 name_1, bool is_ai)
 	this->clear_limit     = (uint32)_settings_game.construction.clear_frame_burst << 16;
 	this->tree_limit      = (uint32)_settings_game.construction.tree_frame_burst << 16;
 
-	for (uint j = 0; j < 4; j++) this->share_owners[j] = COMPANY_SPECTATOR;
+	for (uint j = 0; j < 4; j++) this->share_owners[j] = INVALID_OWNER;
 	InvalidateWindowData(WC_PERFORMANCE_DETAIL, 0, INVALID_COMPANY);
 }
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -324,10 +324,12 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 		Backup<CompanyID> cur_company2(_current_company, FILE_LINE);
 		const Company *c = Company::Get(old_owner);
 		for (i = 0; i < 4; i++) {
+			if (c->share_owners[i] == INVALID_OWNER) continue;
+
 			if (c->bankrupt_value == 0 && c->share_owners[i] == new_owner) {
 				/* You are the one buying the company; so don't sell the shares back to you. */
-				Company::Get(new_owner)->share_owners[i] = COMPANY_SPECTATOR;
-			} else if (c->share_owners[i] != INVALID_OWNER) {
+				Company::Get(new_owner)->share_owners[i] = INVALID_OWNER;
+			} else {
 				cur_company2.Change(c->share_owners[i]);
 				/* Sell the shares */
 				CommandCost res = DoCommand(0, old_owner, 0, DC_EXEC | DC_BANKRUPT, CMD_SELL_SHARE_IN_COMPANY);


### PR DESCRIPTION
Closes #9348 

## Motivation / Problem

Game does boom. I made game go boom. I fix. Me happy.

## Description

```
"new_owner" can be INVALID_OWNER, and as INVALID_OWNER ==
COMPANY_SPECTATORS, we could end up trying to sell shares of
nobody.
```

while at it, also renamed the last `COMPANY_SPECATORS` to `INVALID_OWNER` when talking about shares.
Spectators don't have shares after all.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
