### PR TITLE
Fix: [Script] doxygen_filter is very strict about DOXYGEN_API usage

### DIFF
--- a/src/script/api/script_priorityqueue.hpp
+++ b/src/script/api/script_priorityqueue.hpp
@@ -76,7 +76,7 @@ public:
 	SQInteger Peek(HSQUIRRELVM vm);
 	SQInteger Exists(HSQUIRRELVM vm);
 	SQInteger Clear(HSQUIRRELVM vm);
-#endif
+#endif /* DOXYGEN_API */
 
 	/**
 	 * Check if the queue is empty.

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -88,7 +88,7 @@ public:
 	 * @param ... Optional arguments for this string.
 	 */
 	ScriptText(StringID string, ...);
-#endif
+#endif /* DOXYGEN_API */
 	~ScriptText();
 
 #ifndef DOXYGEN_API


### PR DESCRIPTION
## Motivation / Problem
Some api documentation is not generated. This is due to `doxygen_filter.awk` outputting incomplete files.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
`doxygen_filter.awk` expects `#endif /* DOXYGEN_API */` to detect the end of a conditional block.
(Seems `script_text.hpp` was parsed fine by luck)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
