### PR TITLE
Fix #9353: [Script] Garbage collecting on priority queues could crash the game

### DIFF
--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -254,9 +254,12 @@ void ScriptInstance::GameLoop()
 	}
 }
 
-void ScriptInstance::CollectGarbage() const
+void ScriptInstance::CollectGarbage()
 {
-	if (this->is_started && !this->IsDead()) this->engine->CollectGarbage();
+	if (this->is_started && !this->IsDead()) {
+		ScriptObject::ActiveInstance active(this);
+		this->engine->CollectGarbage();
+	}
 }
 
 /* static */ void ScriptInstance::DoCommandReturn(ScriptInstance *instance)

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -68,7 +68,7 @@ public:
 	/**
 	 * Let the VM collect any garbage.
 	 */
-	void CollectGarbage() const;
+	void CollectGarbage();
 
 	/**
 	 * Get the storage of this script.


### PR DESCRIPTION
## Motivation / Problem

Fixes #9353.


## Description

The desctructor of ScriptPriorityQueue depends on ActiveInstance being in scope. For the garbage collection this was not the case, so add it to the garbage collection too just like for the game loop and others.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
