### PR TITLE
Consolidate IConsolePrint functions and improve some of the messages

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -88,14 +88,13 @@ void IConsoleFree()
  * as well as to a logfile. If the network server is a dedicated server, all activities
  * are also logged. All lines to print are added to a temporary buffer which can be
  * used as a history to print them onscreen
- * @param colour_code the colour of the command. Red in case of errors, etc.
- * @param string the message entered or output on the console (notice, error, etc.)
+ * @param colour_code The colour of the command.
+ * @param string The message to output on the console (notice, error, etc.)
  */
-void IConsolePrint(TextColour colour_code, const char *string)
+void IConsolePrint(TextColour colour_code, const std::string &string)
 {
 	assert(IsValidConsoleColour(colour_code));
 
-	char *str;
 	if (_redirect_console_to_client != INVALID_CLIENT_ID) {
 		/* Redirect the string to the client */
 		NetworkServerSendRcon(_redirect_console_to_client, colour_code, string);
@@ -109,7 +108,7 @@ void IConsolePrint(TextColour colour_code, const char *string)
 
 	/* Create a copy of the string, strip if of colours and invalid
 	 * characters and (when applicable) assign it to the console buffer */
-	str = stredup(string);
+	char *str = stredup(string.c_str());
 	str_strip_colours(str);
 	StrMakeValidInPlace(str);
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -145,26 +145,6 @@ void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
 }
 
 /**
- * It is possible to print warnings to the console. These are mostly
- * errors or mishaps, but non-fatal. You need at least a level 1 (developer) for
- * debugging messages to show up
- */
-void IConsoleWarning(const char *string)
-{
-	if (_settings_client.gui.developer == 0) return;
-	IConsolePrintF(CC_WARNING, "WARNING: %s", string);
-}
-
-/**
- * It is possible to print error information to the console. This can include
- * game errors, or errors in general you would want the user to notice
- */
-void IConsoleError(const char *string)
-{
-	IConsolePrintF(CC_ERROR, "ERROR: %s", string);
-}
-
-/**
  * Change a string into its number representation. Supports
  * decimal and hexadecimal numbers as well as 'on'/'off' 'true'/'false'
  * @param *value the variable a successful conversion will be put in

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -145,20 +145,6 @@ void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
 }
 
 /**
- * It is possible to print debugging information to the console,
- * which is achieved by using this function. Can only be used by
- * debug() in debug.cpp. You need at least a level 2 (developer) for debugging
- * messages to show up
- * @param dbg debugging category
- * @param string debugging message
- */
-void IConsoleDebug(const char *dbg, const char *string)
-{
-	if (_settings_client.gui.developer <= 1) return;
-	IConsolePrintF(CC_DEBUG, "dbg: [%s] %s", dbg, string);
-}
-
-/**
  * It is possible to print warnings to the console. These are mostly
  * errors or mishaps, but non-fatal. You need at least a level 1 (developer) for
  * debugging messages to show up

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -229,7 +229,7 @@ static std::string RemoveUnderscores(std::string name)
 /* static */ void IConsole::AliasRegister(const std::string &name, const std::string &cmd)
 {
 	auto result = IConsole::Aliases().try_emplace(RemoveUnderscores(name), name, cmd);
-	if (!result.second) IConsoleError("an alias with this name already exists; insertion aborted");
+	if (!result.second) IConsolePrint(CC_ERROR, "An alias with the name '{}' already exists.", name);
 }
 
 /**
@@ -259,7 +259,7 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 	Debug(console, 6, "Requested command is an alias; parsing...");
 
 	if (recurse_count > ICON_MAX_RECURSE) {
-		IConsoleError("Too many alias expansions, recursion limit reached. Aborting");
+		IConsolePrint(CC_ERROR, "Too many alias expansions, recursion limit reached.");
 		return;
 	}
 
@@ -305,8 +305,8 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 						int param = *cmdptr - 'A';
 
 						if (param < 0 || param >= tokencount) {
-							IConsoleError("too many or wrong amount of parameters passed to alias, aborting");
-							IConsolePrintF(CC_WARNING, "Usage of alias '%s': %s", alias->name.c_str(), alias->cmdline.c_str());
+							IConsolePrint(CC_ERROR, "Too many or wrong amount of parameters passed to alias.");
+							IConsolePrint(CC_HELP, "Usage of alias '{}': {}", alias->name, alias->cmdline);
 							return;
 						}
 
@@ -325,7 +325,7 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 		}
 
 		if (alias_stream >= lastof(alias_buffer) - 1) {
-			IConsoleError("Requested alias execution would overflow execution buffer");
+			IConsolePrint(CC_ERROR, "Requested alias execution would overflow execution buffer.");
 			return;
 		}
 	}
@@ -351,8 +351,7 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 
 	for (cmdptr = cmdstr; *cmdptr != '\0'; cmdptr++) {
 		if (!IsValidChar(*cmdptr, CS_ALPHANUMERAL)) {
-			IConsoleError("command contains malformed characters, aborting");
-			IConsolePrintF(CC_ERROR, "ERROR: command was: '%s'", cmdstr);
+			IConsolePrint(CC_ERROR, "Command '{}' contains malformed characters.", cmdstr);
 			return;
 		}
 	}
@@ -367,7 +366,7 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 	 * of characters in our stream or the max amount of tokens we can handle */
 	for (cmdptr = cmdstr, t_index = 0, tstream_i = 0; *cmdptr != '\0'; cmdptr++) {
 		if (tstream_i >= lengthof(tokenstream)) {
-			IConsoleError("command line too long");
+			IConsolePrint(CC_ERROR, "Command line too long.");
 			return;
 		}
 
@@ -388,7 +387,7 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 			longtoken = !longtoken;
 			if (!foundtoken) {
 				if (t_index >= lengthof(tokens)) {
-					IConsoleError("command line too long");
+					IConsolePrint(CC_ERROR, "Command line too long.");
 					return;
 				}
 				tokens[t_index++] = &tokenstream[tstream_i];
@@ -406,7 +405,7 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 
 			if (!foundtoken) {
 				if (t_index >= lengthof(tokens)) {
-					IConsoleError("command line too long");
+					IConsolePrint(CC_ERROR, "Command line too long.");
 					return;
 				}
 				tokens[t_index++] = &tokenstream[tstream_i - 1];
@@ -447,5 +446,5 @@ void IConsoleCmdExec(const char *cmdstr, const uint recurse_count)
 		return;
 	}
 
-	IConsoleError("command not found");
+	IConsolePrint(CC_ERROR, "Command '{}' not found.", tokens[0]);
 }

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -267,7 +267,7 @@ static void IConsoleAliasExec(const IConsoleAlias *alias, byte tokencount, char 
 
 						if (param < 0 || param >= tokencount) {
 							IConsolePrint(CC_ERROR, "Too many or wrong amount of parameters passed to alias.");
-							IConsolePrint(CC_HELP, "Usage of alias '{}': {}", alias->name, alias->cmdline);
+							IConsolePrint(CC_HELP, "Usage of alias '{}': '{}'.", alias->name, alias->cmdline);
 							return;
 						}
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -59,7 +59,7 @@ static void IConsoleWriteToLogFile(const char *string)
 				fwrite("\n", 1, 1, _iconsole_output_file) != 1) {
 			fclose(_iconsole_output_file);
 			_iconsole_output_file = nullptr;
-			IConsolePrintF(CC_DEFAULT, "cannot write to log file");
+			IConsolePrint(CC_ERROR, "Cannot write to console log file; closing the log file.");
 		}
 	}
 }
@@ -67,7 +67,7 @@ static void IConsoleWriteToLogFile(const char *string)
 bool CloseConsoleLogIfActive()
 {
 	if (_iconsole_output_file != nullptr) {
-		IConsolePrintF(CC_DEFAULT, "file output complete");
+		IConsolePrint(CC_INFO, "Console log file closed.");
 		fclose(_iconsole_output_file);
 		_iconsole_output_file = nullptr;
 		return true;
@@ -123,25 +123,6 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 
 	IConsoleWriteToLogFile(str);
 	IConsoleGUIPrint(colour_code, str);
-}
-
-/**
- * Handle the printing of text entered into the console or redirected there
- * by any other means. Uses printf() style format, for more information look
- * at IConsolePrint()
- */
-void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...)
-{
-	assert(IsValidConsoleColour(colour_code));
-
-	va_list va;
-	char buf[ICON_MAX_STREAMSIZE];
-
-	va_start(va, format);
-	vseprintf(buf, lastof(buf), format, va);
-	va_end(va);
-
-	IConsolePrint(colour_code, buf);
 }
 
 /**

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -191,7 +191,7 @@ DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
  */
 static void IConsoleHelp(const char *str)
 {
-	IConsolePrintF(CC_HELP, "- {}", str);
+	IConsolePrint(CC_HELP, "- {}", str);
 }
 
 /**
@@ -325,9 +325,9 @@ DEF_CONSOLE_CMD(ConSave)
 		IConsolePrint(CC_DEFAULT, "Saving map...");
 
 		if (SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, SAVE_DIR) != SL_OK) {
-			IConsolePrint(CC_ERROR, "Saving map failed");
+			IConsolePrint(CC_ERROR, "Saving map failed.");
 		} else {
-			IConsolePrintF(CC_DEFAULT, "Map successfully saved to %s", filename);
+			IConsolePrint(CC_INFO, "Map successfully saved to '{}'.", filename);
 		}
 		free(filename);
 		return true;
@@ -417,7 +417,7 @@ DEF_CONSOLE_CMD(ConListFiles)
 
 	_console_file_list.ValidateFileList(true);
 	for (uint i = 0; i < _console_file_list.size(); i++) {
-		IConsolePrintF(CC_DEFAULT, "%d) %s", i, _console_file_list[i].title);
+		IConsolePrint(CC_DEFAULT, "{}) {}", i, _console_file_list[i].title);
 	}
 
 	return true;
@@ -523,7 +523,7 @@ static bool ConKickOrBan(const char *argv, bool ban, const std::string &reason)
 	if (n == 0) {
 		IConsolePrint(CC_DEFAULT, ban ? "Client not online, address added to banlist." : "Client not found.");
 	} else {
-		IConsolePrintF(CC_DEFAULT, "%sed %u client(s).", ban ? "Bann" : "Kick", n);
+		IConsolePrint(CC_DEFAULT, "{}ed {} client(s).", ban ? "Bann" : "Kick", n);
 	}
 
 	return true;
@@ -598,9 +598,7 @@ DEF_CONSOLE_CMD(ConUnBan)
 	}
 
 	if (index < _network_ban_list.size()) {
-		char msg[64];
-		seprintf(msg, lastof(msg), "Unbanned %s", _network_ban_list[index].c_str());
-		IConsolePrint(CC_DEFAULT, msg);
+		IConsolePrint(CC_DEFAULT, "Unbanned {}.", _network_ban_list[index]);
 		_network_ban_list.erase(_network_ban_list.begin() + index);
 	} else {
 		IConsolePrint(CC_DEFAULT, "Invalid list index or IP not in ban-list.");
@@ -621,7 +619,7 @@ DEF_CONSOLE_CMD(ConBanList)
 
 	uint i = 1;
 	for (const auto &entry : _network_ban_list) {
-		IConsolePrintF(CC_DEFAULT, "  %d) %s", i, entry.c_str());
+		IConsolePrint(CC_DEFAULT, "  {}) {}", i, entry);
 		i++;
 	}
 
@@ -713,9 +711,9 @@ DEF_CONSOLE_CMD(ConServerInfo)
 		return true;
 	}
 
-	IConsolePrintF(CC_DEFAULT, "Current/maximum clients:    %2d/%2d", _network_game_info.clients_on, _settings_client.network.max_clients);
-	IConsolePrintF(CC_DEFAULT, "Current/maximum companies:  %2d/%2d", (int)Company::GetNumItems(), _settings_client.network.max_companies);
-	IConsolePrintF(CC_DEFAULT, "Current/maximum spectators: %2d/%2d", NetworkSpectatorCount(), _settings_client.network.max_spectators);
+	IConsolePrint(CC_DEFAULT, "Current/maximum clients:    {:3d}/{:3d}", _network_game_info.clients_on, _settings_client.network.max_clients);
+	IConsolePrint(CC_DEFAULT, "Current/maximum companies:  {:3d}/{:3d}", Company::GetNumItems(), _settings_client.network.max_companies);
+	IConsolePrint(CC_DEFAULT, "Current/maximum spectators: {:3d}/{:3d}", NetworkSpectatorCount(), _settings_client.network.max_spectators);
 
 	return true;
 }
@@ -922,7 +920,7 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 	}
 
 	/* Don't resolve the address first, just print it directly as it comes from the config file. */
-	IConsolePrintF(CC_DEFAULT, "Reconnecting to %s ...", _settings_client.network.last_joined.c_str());
+	IConsolePrint(CC_DEFAULT, "Reconnecting to {} ...", _settings_client.network.last_joined);
 
 	return NetworkClientConnectGame(_settings_client.network.last_joined, playas);
 }
@@ -1025,9 +1023,12 @@ DEF_CONSOLE_CMD(ConScript)
 	if (!CloseConsoleLogIfActive()) {
 		if (argc < 2) return false;
 
-		IConsolePrintF(CC_DEFAULT, "file output started to: %s", argv[1]);
 		_iconsole_output_file = fopen(argv[1], "ab");
-		if (_iconsole_output_file == nullptr) IConsolePrint(CC_ERROR, "Could not open file '{}'.", argv[1]);
+		if (_iconsole_output_file == nullptr) {
+			IConsolePrint(CC_ERROR, "Could not open console log file '{}'.", argv[1]);
+		} else {
+			IConsolePrint(CC_INFO, "Console log output started to: '{}'", argv[1]);
+		}
 	}
 
 	return true;
@@ -1117,7 +1118,7 @@ static void PrintLineByLine(char *buf)
 	for (char *p2 = buf; *p2 != '\0'; p2++) {
 		if (*p2 == '\n') {
 			*p2 = '\0';
-			IConsolePrintF(CC_DEFAULT, "%s", p);
+			IConsolePrint(CC_DEFAULT, p);
 			p = p2 + 1;
 		}
 	}
@@ -1257,7 +1258,7 @@ DEF_CONSOLE_CMD(ConReloadAI)
 
 	CompanyID company_id = (CompanyID)(atoi(argv[1]) - 1);
 	if (!Company::IsValidID(company_id)) {
-		IConsolePrintF(CC_DEFAULT, "Unknown company. Company range is between 1 and %d.", MAX_COMPANIES);
+		IConsolePrint(CC_ERROR, "Unknown company. Company range is between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
@@ -1295,7 +1296,7 @@ DEF_CONSOLE_CMD(ConStopAI)
 
 	CompanyID company_id = (CompanyID)(atoi(argv[1]) - 1);
 	if (!Company::IsValidID(company_id)) {
-		IConsolePrintF(CC_DEFAULT, "Unknown company. Company range is between 1 and %d.", MAX_COMPANIES);
+		IConsolePrint(CC_ERROR, "Unknown company. Company range is between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
@@ -1368,7 +1369,7 @@ DEF_CONSOLE_CMD(ConGetSeed)
 		return true;
 	}
 
-	IConsolePrintF(CC_DEFAULT, "Generation Seed: %u", _settings_game.game_creation.generation_seed);
+	IConsolePrint(CC_DEFAULT, "Generation Seed: {}", _settings_game.game_creation.generation_seed);
 	return true;
 }
 
@@ -1381,7 +1382,7 @@ DEF_CONSOLE_CMD(ConGetDate)
 
 	YearMonthDay ymd;
 	ConvertDateToYMD(_date, &ymd);
-	IConsolePrintF(CC_DEFAULT, "Date: %04d-%02d-%02d", ymd.year, ymd.month + 1, ymd.day);
+	IConsolePrint(CC_DEFAULT, "Date: {:04d}-{:02d}-{:02d}", ymd.year, ymd.month + 1, ymd.day);
 	return true;
 }
 
@@ -1394,7 +1395,7 @@ DEF_CONSOLE_CMD(ConGetSysDate)
 
 	char buffer[lengthof("2000-01-02 03:04:05")];
 	LocalTime::Format(buffer, lastof(buffer), "%Y-%m-%d %H:%M:%S");
-	IConsolePrintF(CC_DEFAULT, "System Date: %s", buffer);
+	IConsolePrint(CC_DEFAULT, "System Date: {}", buffer);
 	return true;
 }
 
@@ -1532,7 +1533,7 @@ DEF_CONSOLE_CMD(ConDebugLevel)
 	if (argc > 2) return false;
 
 	if (argc == 1) {
-		IConsolePrintF(CC_DEFAULT, "Current debug-level: '%s'", GetDebugString());
+		IConsolePrint(CC_DEFAULT, "Current debug-level: '{}'", GetDebugString());
 	} else {
 		SetDebugString(argv[1]);
 	}
@@ -1585,7 +1586,7 @@ DEF_CONSOLE_CMD(ConHelp)
 				cmd->proc(0, nullptr);
 				return true;
 			}
-			IConsolePrintF(CC_ERROR, "ERROR: alias is of special type, please see its execution-line: '%s'", alias->cmdline.c_str());
+			IConsolePrint(CC_ERROR, "Alias is of special type, please see its execution-line: '{}'.", alias->cmdline);
 			return true;
 		}
 
@@ -1615,7 +1616,7 @@ DEF_CONSOLE_CMD(ConListCommands)
 	for (auto &it : IConsole::Commands()) {
 		const IConsoleCmd *cmd = &it.second;
 		if (argv[1] == nullptr || cmd->name.find(argv[1]) != std::string::npos) {
-			if (cmd->hook == nullptr || cmd->hook(false) != CHR_HIDE) IConsolePrintF(CC_DEFAULT, "%s", cmd->name.c_str());
+			if (cmd->hook == nullptr || cmd->hook(false) != CHR_HIDE) IConsolePrint(CC_DEFAULT, cmd->name);
 		}
 	}
 
@@ -1632,7 +1633,7 @@ DEF_CONSOLE_CMD(ConListAliases)
 	for (auto &it : IConsole::Aliases()) {
 		const IConsoleAlias *alias = &it.second;
 		if (argv[1] == nullptr || alias->name.find(argv[1]) != std::string::npos) {
-			IConsolePrintF(CC_DEFAULT, "%s => %s", alias->name.c_str(), alias->cmdline.c_str());
+			IConsolePrint(CC_DEFAULT, "{} => {}", alias->name, alias->cmdline);
 		}
 	}
 
@@ -1661,7 +1662,7 @@ DEF_CONSOLE_CMD(ConCompanies)
 
 		char colour[512];
 		GetString(colour, STR_COLOUR_DARK_BLUE + _company_colours[c->index], lastof(colour));
-		IConsolePrintF(CC_INFO, "#:%d(%s) Company Name: '%s'  Year Founded: %d  Money: " OTTD_PRINTF64 "  Loan: " OTTD_PRINTF64 "  Value: " OTTD_PRINTF64 "  (T:%d, R:%d, P:%d, S:%d) %s",
+		IConsolePrint(CC_INFO, "#:{}({}) Company Name: '{}'  Year Founded: {}  Money: {}  Loan: {}  Value: {}  (T:{}, R:{}, P:{}, S:{}) {}",
 			c->index + 1, colour, company_name,
 			c->inaugurated_year, (int64)c->money, (int64)c->current_loan, (int64)CalculateCompanyValue(c),
 			c->group_all[VEH_TRAIN].num_vehicle,
@@ -1705,7 +1706,7 @@ DEF_CONSOLE_CMD(ConSayCompany)
 
 	CompanyID company_id = (CompanyID)(atoi(argv[1]) - 1);
 	if (!Company::IsValidID(company_id)) {
-		IConsolePrintF(CC_DEFAULT, "Unknown company. Company range is between 1 and %d.", MAX_COMPANIES);
+		IConsolePrint(CC_DEFAULT, "Unknown company. Company range is between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
@@ -1742,18 +1743,15 @@ DEF_CONSOLE_CMD(ConSayClient)
 DEF_CONSOLE_CMD(ConCompanyPassword)
 {
 	if (argc == 0) {
-		const char *helpmsg;
-
 		if (_network_dedicated) {
-			helpmsg = "Change the password of a company. Usage: 'company_pw <company-no> \"<password>\"";
+			IConsolePrint(CC_HELP, "Change the password of a company. Usage: 'company_pw <company-no> \"<password>\".");
 		} else if (_network_server) {
-			helpmsg = "Change the password of your or any other company. Usage: 'company_pw [<company-no>] \"<password>\"'";
+			IConsolePrint(CC_HELP, "Change the password of your or any other company. Usage: 'company_pw [<company-no>] \"<password>\"'.");
 		} else {
-			helpmsg = "Change the password of your company. Usage: 'company_pw \"<password>\"'";
+			IConsolePrint(CC_HELP, "Change the password of your company. Usage: 'company_pw \"<password>\"'.");
 		}
 
-		IConsoleHelp(helpmsg);
-		IConsoleHelp("Use \"*\" to disable the password.");
+		IConsolePrint(CC_HELP, "Use \"*\" to disable the password.");
 		return true;
 	}
 
@@ -1807,17 +1805,17 @@ static ContentType StringToContentType(const char *str)
 struct ConsoleContentCallback : public ContentCallback {
 	void OnConnect(bool success)
 	{
-		IConsolePrintF(CC_DEFAULT, "Content server connection %s", success ? "established" : "failed");
+		IConsolePrint(CC_DEFAULT, "Content server connection {}.", success ? "established" : "failed");
 	}
 
 	void OnDisconnect()
 	{
-		IConsolePrintF(CC_DEFAULT, "Content server connection closed");
+		IConsolePrint(CC_DEFAULT, "Content server connection closed.");
 	}
 
 	void OnDownloadComplete(ContentID cid)
 	{
-		IConsolePrintF(CC_DEFAULT, "Completed download of %d", cid);
+		IConsolePrint(CC_DEFAULT, "Completed download of {}.", cid);
 	}
 };
 
@@ -1834,7 +1832,7 @@ static void OutputContentState(const ContentInfo *const ci)
 
 	char buf[sizeof(ci->md5sum) * 2 + 1];
 	md5sumToString(buf, lastof(buf), ci->md5sum);
-	IConsolePrintF(state_to_colour[ci->state], "%d, %s, %s, %s, %08X, %s", ci->id, types[ci->type - 1], states[ci->state], ci->name.c_str(), ci->unique_id, buf);
+	IConsolePrint(state_to_colour[ci->state], "{}, {}, {}, {}, {:08X}, {}", ci->id, types[ci->type - 1], states[ci->state], ci->name, ci->unique_id, buf);
 }
 
 DEF_CONSOLE_CMD(ConContent)
@@ -1869,7 +1867,7 @@ DEF_CONSOLE_CMD(ConContent)
 	if (strcasecmp(argv[1], "select") == 0) {
 		if (argc <= 2) {
 			/* List selected content */
-			IConsolePrintF(CC_WHITE, "id, type, state, name");
+			IConsolePrint(CC_WHITE, "id, type, state, name");
 			for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
 				if ((*iter)->state != ContentInfo::SELECTED && (*iter)->state != ContentInfo::AUTOSELECTED) continue;
 				OutputContentState(*iter);
@@ -1902,7 +1900,7 @@ DEF_CONSOLE_CMD(ConContent)
 	}
 
 	if (strcasecmp(argv[1], "state") == 0) {
-		IConsolePrintF(CC_WHITE, "id, type, state, name");
+		IConsolePrint(CC_WHITE, "id, type, state, name");
 		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
 			if (argc > 2 && strcasestr((*iter)->name.c_str(), argv[2]) == nullptr) continue;
 			OutputContentState(*iter);
@@ -1914,7 +1912,7 @@ DEF_CONSOLE_CMD(ConContent)
 		uint files;
 		uint bytes;
 		_network_content_client.DownloadSelectedContent(files, bytes);
-		IConsolePrintF(CC_DEFAULT, "Downloading %d file(s) (%d bytes)", files, bytes);
+		IConsolePrint(CC_DEFAULT, "Downloading {} file(s) ({} bytes).", files, bytes);
 		return true;
 	}
 
@@ -2022,7 +2020,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			bool active = selected && profiler->active;
 			TextColour tc = active ? TC_LIGHT_BLUE : selected ? TC_GREEN : CC_INFO;
 			const char *statustext = active ? " (active)" : selected ? " (selected)" : "";
-			IConsolePrintF(tc, "%d: [%08X] %s%s", i, BSWAP32(grf->grfid), grf->filename, statustext);
+			IConsolePrint(tc, "{}: [{:08X}] {}{}", i, BSWAP32(grf->grfid), grf->filename, statustext);
 			i++;
 		}
 		return true;
@@ -2081,7 +2079,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 		}
 		if (started > 0) {
-			IConsolePrintF(CC_DEBUG, "Started profiling for GRFID%s %s", (started > 1) ? "s" : "", grfids.c_str());
+			IConsolePrint(CC_DEBUG, "Started profiling for GRFID{} {}", (started > 1) ? "s" : "", grfids);
 			if (argc >= 3) {
 				int days = std::max(atoi(argv[2]), 1);
 				_newgrf_profile_end_date = _date + days;
@@ -2089,7 +2087,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				char datestrbuf[32]{ 0 };
 				SetDParam(0, _newgrf_profile_end_date);
 				GetString(datestrbuf, STR_JUST_DATE_ISO, lastof(datestrbuf));
-				IConsolePrintF(CC_DEBUG, "Profiling will automatically stop on game date %s", datestrbuf);
+				IConsolePrint(CC_DEBUG, "Profiling will automatically stop on game date {}.", datestrbuf);
 			} else {
 				_newgrf_profile_end_date = MAX_DAY;
 			}
@@ -2165,12 +2163,12 @@ DEF_CONSOLE_CMD(ConFramerateWindow)
 
 static void ConDumpRoadTypes()
 {
-	IConsolePrintF(CC_DEFAULT, "  Flags:");
-	IConsolePrintF(CC_DEFAULT, "    c = catenary");
-	IConsolePrintF(CC_DEFAULT, "    l = no level crossings");
-	IConsolePrintF(CC_DEFAULT, "    X = no houses");
-	IConsolePrintF(CC_DEFAULT, "    h = hidden");
-	IConsolePrintF(CC_DEFAULT, "    T = buildable by towns");
+	IConsolePrint(CC_DEFAULT, "  Flags:");
+	IConsolePrint(CC_DEFAULT, "    c = catenary");
+	IConsolePrint(CC_DEFAULT, "    l = no level crossings");
+	IConsolePrint(CC_DEFAULT, "    X = no houses");
+	IConsolePrint(CC_DEFAULT, "    h = hidden");
+	IConsolePrint(CC_DEFAULT, "    T = buildable by towns");
 
 	std::map<uint32, const GRFFile *> grfs;
 	for (RoadType rt = ROADTYPE_BEGIN; rt < ROADTYPE_END; rt++) {
@@ -2182,7 +2180,7 @@ static void ConDumpRoadTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrintF(CC_DEFAULT, "  %02u %s %c%c%c%c, Flags: %c%c%c%c%c, GRF: %08X, %s",
+		IConsolePrint(CC_DEFAULT, "  {:02d} {} {:c}{:c}{:c}{:c}, Flags: {}{}{}{}{}, GRF: {:08X}, {}",
 				(uint)rt,
 				RoadTypeIsTram(rt) ? "Tram" : "Road",
 				rti->label >> 24, rti->label >> 16, rti->label >> 8, rti->label,
@@ -2196,19 +2194,19 @@ static void ConDumpRoadTypes()
 		);
 	}
 	for (const auto &grf : grfs) {
-		IConsolePrintF(CC_DEFAULT, "  GRF: %08X = %s", BSWAP32(grf.first), grf.second->filename);
+		IConsolePrint(CC_DEFAULT, "  GRF: {:08X} = {}", BSWAP32(grf.first), grf.second->filename);
 	}
 }
 
 static void ConDumpRailTypes()
 {
-	IConsolePrintF(CC_DEFAULT, "  Flags:");
-	IConsolePrintF(CC_DEFAULT, "    c = catenary");
-	IConsolePrintF(CC_DEFAULT, "    l = no level crossings");
-	IConsolePrintF(CC_DEFAULT, "    h = hidden");
-	IConsolePrintF(CC_DEFAULT, "    s = no sprite combine");
-	IConsolePrintF(CC_DEFAULT, "    a = always allow 90 degree turns");
-	IConsolePrintF(CC_DEFAULT, "    d = always disallow 90 degree turns");
+	IConsolePrint(CC_DEFAULT, "  Flags:");
+	IConsolePrint(CC_DEFAULT, "    c = catenary");
+	IConsolePrint(CC_DEFAULT, "    l = no level crossings");
+	IConsolePrint(CC_DEFAULT, "    h = hidden");
+	IConsolePrint(CC_DEFAULT, "    s = no sprite combine");
+	IConsolePrint(CC_DEFAULT, "    a = always allow 90 degree turns");
+	IConsolePrint(CC_DEFAULT, "    d = always disallow 90 degree turns");
 
 	std::map<uint32, const GRFFile *> grfs;
 	for (RailType rt = RAILTYPE_BEGIN; rt < RAILTYPE_END; rt++) {
@@ -2220,7 +2218,7 @@ static void ConDumpRailTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrintF(CC_DEFAULT, "  %02u %c%c%c%c, Flags: %c%c%c%c%c%c, GRF: %08X, %s",
+		IConsolePrint(CC_DEFAULT, "  {:02d} {:c}{:c}{:c}{:c}, Flags: {}{}{}{}{}{}, GRF: {:08X}, {}",
 				(uint)rt,
 				rti->label >> 24, rti->label >> 16, rti->label >> 8, rti->label,
 				HasBit(rti->flags, RTF_CATENARY)          ? 'c' : '-',
@@ -2234,24 +2232,24 @@ static void ConDumpRailTypes()
 		);
 	}
 	for (const auto &grf : grfs) {
-		IConsolePrintF(CC_DEFAULT, "  GRF: %08X = %s", BSWAP32(grf.first), grf.second->filename);
+		IConsolePrint(CC_DEFAULT, "  GRF: {:08X} = {}", BSWAP32(grf.first), grf.second->filename);
 	}
 }
 
 static void ConDumpCargoTypes()
 {
-	IConsolePrintF(CC_DEFAULT, "  Cargo classes:");
-	IConsolePrintF(CC_DEFAULT, "    p = passenger");
-	IConsolePrintF(CC_DEFAULT, "    m = mail");
-	IConsolePrintF(CC_DEFAULT, "    x = express");
-	IConsolePrintF(CC_DEFAULT, "    a = armoured");
-	IConsolePrintF(CC_DEFAULT, "    b = bulk");
-	IConsolePrintF(CC_DEFAULT, "    g = piece goods");
-	IConsolePrintF(CC_DEFAULT, "    l = liquid");
-	IConsolePrintF(CC_DEFAULT, "    r = refrigerated");
-	IConsolePrintF(CC_DEFAULT, "    h = hazardous");
-	IConsolePrintF(CC_DEFAULT, "    c = covered/sheltered");
-	IConsolePrintF(CC_DEFAULT, "    S = special");
+	IConsolePrint(CC_DEFAULT, "  Cargo classes:");
+	IConsolePrint(CC_DEFAULT, "    p = passenger");
+	IConsolePrint(CC_DEFAULT, "    m = mail");
+	IConsolePrint(CC_DEFAULT, "    x = express");
+	IConsolePrint(CC_DEFAULT, "    a = armoured");
+	IConsolePrint(CC_DEFAULT, "    b = bulk");
+	IConsolePrint(CC_DEFAULT, "    g = piece goods");
+	IConsolePrint(CC_DEFAULT, "    l = liquid");
+	IConsolePrint(CC_DEFAULT, "    r = refrigerated");
+	IConsolePrint(CC_DEFAULT, "    h = hazardous");
+	IConsolePrint(CC_DEFAULT, "    c = covered/sheltered");
+	IConsolePrint(CC_DEFAULT, "    S = special");
 
 	std::map<uint32, const GRFFile *> grfs;
 	for (CargoID i = 0; i < NUM_CARGO; i++) {
@@ -2263,7 +2261,7 @@ static void ConDumpCargoTypes()
 			grfid = grf->grfid;
 			grfs.emplace(grfid, grf);
 		}
-		IConsolePrintF(CC_DEFAULT, "  %02u Bit: %2u, Label: %c%c%c%c, Callback mask: 0x%02X, Cargo class: %c%c%c%c%c%c%c%c%c%c%c, GRF: %08X, %s",
+		IConsolePrint(CC_DEFAULT, "  {:02d} Bit: {:2d}, Label: {:c}{:c}{:c}{:c}, Callback mask: 0x{:02X}, Cargo class: {}{}{}{}{}{}{}{}{}{}{}, GRF: {:08X}, {}",
 				(uint)i,
 				spec->bitnum,
 				spec->label >> 24, spec->label >> 16, spec->label >> 8, spec->label,
@@ -2284,7 +2282,7 @@ static void ConDumpCargoTypes()
 		);
 	}
 	for (const auto &grf : grfs) {
-		IConsolePrintF(CC_DEFAULT, "  GRF: %08X = %s", BSWAP32(grf.first), grf.second->filename);
+		IConsolePrint(CC_DEFAULT, "  GRF: {:08X} = {}", BSWAP32(grf.first), grf.second->filename);
 	}
 }
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -191,7 +191,7 @@ DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
  */
 static void IConsoleHelp(const char *str)
 {
-	IConsolePrintF(CC_WARNING, "- %s", str);
+	IConsolePrintF(CC_HELP, "- {}", str);
 }
 
 /**
@@ -1173,25 +1173,25 @@ DEF_CONSOLE_CMD(ConStartAI)
 	}
 
 	if (_game_mode != GM_NORMAL) {
-		IConsoleWarning("AIs can only be managed in a game.");
+		IConsolePrint(CC_ERROR, "AIs can only be managed in a game.");
 		return true;
 	}
 
 	if (Company::GetNumItems() == CompanyPool::MAX_SIZE) {
-		IConsoleWarning("Can't start a new AI (no more free slots).");
+		IConsolePrint(CC_ERROR, "Can't start a new AI (no more free slots).");
 		return true;
 	}
 	if (_networking && !_network_server) {
-		IConsoleWarning("Only the server can start a new AI.");
+		IConsolePrint(CC_ERROR, "Only the server can start a new AI.");
 		return true;
 	}
 	if (_networking && !_settings_game.ai.ai_in_multiplayer) {
-		IConsoleWarning("AIs are not allowed in multiplayer by configuration.");
-		IConsoleWarning("Switch AI -> AI in multiplayer to True.");
+		IConsolePrint(CC_ERROR, "AIs are not allowed in multiplayer by configuration.");
+		IConsolePrint(CC_ERROR, "Switch AI -> AI in multiplayer to True.");
 		return true;
 	}
 	if (!AI::CanStartNew()) {
-		IConsoleWarning("Can't start a new AI.");
+		IConsolePrint(CC_ERROR, "Can't start a new AI.");
 		return true;
 	}
 
@@ -1223,7 +1223,7 @@ DEF_CONSOLE_CMD(ConStartAI)
 		}
 
 		if (!config->HasScript()) {
-			IConsoleWarning("Failed to load the specified AI");
+			IConsolePrint(CC_ERROR, "Failed to load the specified AI.");
 			return true;
 		}
 		if (argc == 3) {
@@ -1246,12 +1246,12 @@ DEF_CONSOLE_CMD(ConReloadAI)
 	}
 
 	if (_game_mode != GM_NORMAL) {
-		IConsoleWarning("AIs can only be managed in a game.");
+		IConsolePrint(CC_ERROR, "AIs can only be managed in a game.");
 		return true;
 	}
 
 	if (_networking && !_network_server) {
-		IConsoleWarning("Only the server can reload an AI.");
+		IConsolePrint(CC_ERROR, "Only the server can reload an AI.");
 		return true;
 	}
 
@@ -1263,7 +1263,7 @@ DEF_CONSOLE_CMD(ConReloadAI)
 
 	/* In singleplayer mode the player can be in an AI company, after cheating or loading network save with an AI in first slot. */
 	if (Company::IsHumanID(company_id) || company_id == _local_company) {
-		IConsoleWarning("Company is not controlled by an AI.");
+		IConsolePrint(CC_ERROR, "Company is not controlled by an AI.");
 		return true;
 	}
 
@@ -1284,12 +1284,12 @@ DEF_CONSOLE_CMD(ConStopAI)
 	}
 
 	if (_game_mode != GM_NORMAL) {
-		IConsoleWarning("AIs can only be managed in a game.");
+		IConsolePrint(CC_ERROR, "AIs can only be managed in a game.");
 		return true;
 	}
 
 	if (_networking && !_network_server) {
-		IConsoleWarning("Only the server can stop an AI.");
+		IConsolePrint(CC_ERROR, "Only the server can stop an AI.");
 		return true;
 	}
 
@@ -1301,7 +1301,7 @@ DEF_CONSOLE_CMD(ConStopAI)
 
 	/* In singleplayer mode the player can be in an AI company, after cheating or loading network save with an AI in first slot. */
 	if (Company::IsHumanID(company_id) || company_id == _local_company) {
-		IConsoleWarning("Company is not controlled by an AI.");
+		IConsolePrint(CC_ERROR, "Company is not controlled by an AI.");
 		return true;
 	}
 
@@ -1320,7 +1320,7 @@ DEF_CONSOLE_CMD(ConRescanAI)
 	}
 
 	if (_networking && !_network_server) {
-		IConsoleWarning("Only the server can rescan the AI dir for scripts.");
+		IConsolePrint(CC_ERROR, "Only the server can rescan the AI dir for scripts.");
 		return true;
 	}
 
@@ -1337,7 +1337,7 @@ DEF_CONSOLE_CMD(ConRescanGame)
 	}
 
 	if (_networking && !_network_server) {
-		IConsoleWarning("Only the server can rescan the Game Script dir for scripts.");
+		IConsolePrint(CC_ERROR, "Only the server can rescan the Game Script dir for scripts.");
 		return true;
 	}
 
@@ -1354,7 +1354,7 @@ DEF_CONSOLE_CMD(ConRescanNewGRF)
 	}
 
 	if (!RequestNewGRFScan()) {
-		IConsoleWarning("NewGRF scanning is already running. Please wait until completed to run again.");
+		IConsolePrint(CC_ERROR, "NewGRF scanning is already running. Please wait until completed to run again.");
 	}
 
 	return true;
@@ -1514,10 +1514,9 @@ DEF_CONSOLE_CMD(ConInfoCmd)
 		return true;
 	}
 
-	IConsolePrintF(CC_DEFAULT, "command name: %s", cmd->name.c_str());
-	IConsolePrintF(CC_DEFAULT, "command proc: %p", cmd->proc);
+	IConsolePrint(CC_DEFAULT, "Command name: '{}'", cmd->name);
 
-	if (cmd->hook != nullptr) IConsoleWarning("command is hooked");
+	if (cmd->hook != nullptr) IConsolePrint(CC_DEFAULT, "Command is hooked.");
 
 	return true;
 }
@@ -1594,7 +1593,7 @@ DEF_CONSOLE_CMD(ConHelp)
 		return true;
 	}
 
-	IConsolePrint(CC_WARNING, " ---- OpenTTD Console Help ---- ");
+	IConsolePrint(TC_LIGHT_BLUE, " ---- OpenTTD Console Help ---- ");
 	IConsolePrint(CC_DEFAULT, " - commands: [command to list all commands: list_cmds]");
 	IConsolePrint(CC_DEFAULT, " call commands with '<command> <arg2> <arg3>...'");
 	IConsolePrint(CC_DEFAULT, " - to assign strings, or use them as arguments, enclose it within quotes");
@@ -1782,9 +1781,9 @@ DEF_CONSOLE_CMD(ConCompanyPassword)
 	password = NetworkChangeCompanyPassword(company_id, password);
 
 	if (password.empty()) {
-		IConsolePrintF(CC_WARNING, "Company password cleared");
+		IConsolePrint(CC_INFO, "Company password cleared.");
 	} else {
-		IConsolePrintF(CC_WARNING, "Company password changed to: %s", password.c_str());
+		IConsolePrint(CC_INFO, "Company password changed to '{}'.", password);
 	}
 
 	return true;
@@ -2034,12 +2033,12 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) { // safe cast, files.size() should not be larger than a few hundred in the most extreme cases
-				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not added.", grfnum);
+				IConsolePrint(CC_WARNING, "GRF number {} out of range, not added.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];
 			if (std::any_of(_newgrf_profilers.begin(), _newgrf_profilers.end(), [&](NewGRFProfiler &pr) { return pr.grffile == grf; })) {
-				IConsolePrintF(CC_WARNING, "GRF number %d [%08X] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
+				IConsolePrint(CC_WARNING, "GRF number {} [{:08X}] is already selected for profiling.", grfnum, BSWAP32(grf->grfid));
 				continue;
 			}
 			_newgrf_profilers.emplace_back(grf);
@@ -2056,7 +2055,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) {
-				IConsolePrintF(CC_WARNING, "GRF number %d out of range, not removing.", grfnum);
+				IConsolePrint(CC_WARNING, "GRF number {} out of range, not removing.", grfnum);
 				continue;
 			}
 			GRFFile *grf = files[grfnum - 1];
@@ -2095,9 +2094,9 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				_newgrf_profile_end_date = MAX_DAY;
 			}
 		} else if (_newgrf_profilers.empty()) {
-			IConsolePrintF(CC_WARNING, "No GRFs selected for profiling, did not start.");
+			IConsolePrint(CC_ERROR, "No GRFs selected for profiling, did not start.");
 		} else {
-			IConsolePrintF(CC_WARNING, "Did not start profiling for any GRFs, all selected GRFs are already profiling.");
+			IConsolePrint(CC_ERROR, "Did not start profiling for any GRFs, all selected GRFs are already profiling.");
 		}
 		return true;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -186,22 +186,13 @@ DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
 }
 
 /**
- * Show help for the console.
- * @param str String to print in the console.
- */
-static void IConsoleHelp(const char *str)
-{
-	IConsolePrint(CC_HELP, "- {}", str);
-}
-
-/**
  * Reset status of all engines.
  * @return Will always succeed.
  */
 DEF_CONSOLE_CMD(ConResetEngines)
 {
 	if (argc == 0) {
-		IConsoleHelp("Reset status data of all engines. This might solve some issues with 'lost' engines. Usage: 'resetengines'");
+		IConsolePrint(CC_HELP, "Reset status data of all engines. This might solve some issues with 'lost' engines. Usage: 'resetengines'.");
 		return true;
 	}
 
@@ -217,7 +208,7 @@ DEF_CONSOLE_CMD(ConResetEngines)
 DEF_CONSOLE_CMD(ConResetEnginePool)
 {
 	if (argc == 0) {
-		IConsoleHelp("Reset NewGRF allocations of engine slots. This will remove invalid engine definitions, and might make default engines available again.");
+		IConsolePrint(CC_HELP, "Reset NewGRF allocations of engine slots. This will remove invalid engine definitions, and might make default engines available again.");
 		return true;
 	}
 
@@ -243,8 +234,8 @@ DEF_CONSOLE_CMD(ConResetEnginePool)
 DEF_CONSOLE_CMD(ConResetTile)
 {
 	if (argc == 0) {
-		IConsoleHelp("Reset a tile to bare land. Usage: 'resettile <tile>'");
-		IConsoleHelp("Tile can be either decimal (34161) or hexadecimal (0x4a5B)");
+		IConsolePrint(CC_HELP, "Reset a tile to bare land. Usage: 'resettile <tile>'.");
+		IConsolePrint(CC_HELP, "Tile can be either decimal (34161) or hexadecimal (0x4a5B).");
 		return true;
 	}
 
@@ -273,9 +264,9 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 {
 	switch (argc) {
 		case 0:
-			IConsoleHelp("Center the screen on a given tile.");
-			IConsoleHelp("Usage: 'scrollto <tile>' or 'scrollto <x> <y>'");
-			IConsoleHelp("Numbers can be either decimal (34161) or hexadecimal (0x4a5B).");
+			IConsolePrint(CC_HELP, "Center the screen on a given tile.");
+			IConsolePrint(CC_HELP, "Usage: 'scrollto <tile>' or 'scrollto <x> <y>'.");
+			IConsolePrint(CC_HELP, "Numbers can be either decimal (34161) or hexadecimal (0x4a5B).");
 			return true;
 
 		case 2: {
@@ -316,7 +307,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 DEF_CONSOLE_CMD(ConSave)
 {
 	if (argc == 0) {
-		IConsoleHelp("Save the current game. Usage: 'save <filename>'");
+		IConsolePrint(CC_HELP, "Save the current game. Usage: 'save <filename>'.");
 		return true;
 	}
 
@@ -343,8 +334,8 @@ DEF_CONSOLE_CMD(ConSave)
 DEF_CONSOLE_CMD(ConSaveConfig)
 {
 	if (argc == 0) {
-		IConsoleHelp("Saves the configuration for new games to the configuration file, typically 'openttd.cfg'.");
-		IConsoleHelp("It does not save the configuration of the current game to the configuration file.");
+		IConsolePrint(CC_HELP, "Saves the configuration for new games to the configuration file, typically 'openttd.cfg'.");
+		IConsolePrint(CC_HELP, "It does not save the configuration of the current game to the configuration file.");
 		return true;
 	}
 
@@ -356,7 +347,7 @@ DEF_CONSOLE_CMD(ConSaveConfig)
 DEF_CONSOLE_CMD(ConLoad)
 {
 	if (argc == 0) {
-		IConsoleHelp("Load a game by name or index. Usage: 'load <file | number>'");
+		IConsolePrint(CC_HELP, "Load a game by name or index. Usage: 'load <file | number>'.");
 		return true;
 	}
 
@@ -385,7 +376,7 @@ DEF_CONSOLE_CMD(ConLoad)
 DEF_CONSOLE_CMD(ConRemove)
 {
 	if (argc == 0) {
-		IConsoleHelp("Remove a savegame by name or index. Usage: 'rm <file | number>'");
+		IConsolePrint(CC_HELP, "Remove a savegame by name or index. Usage: 'rm <file | number>'.");
 		return true;
 	}
 
@@ -411,7 +402,7 @@ DEF_CONSOLE_CMD(ConRemove)
 DEF_CONSOLE_CMD(ConListFiles)
 {
 	if (argc == 0) {
-		IConsoleHelp("List all loadable savegames and directories in the current dir via console. Usage: 'ls | dir'");
+		IConsolePrint(CC_HELP, "List all loadable savegames and directories in the current dir via console. Usage: 'ls | dir'.");
 		return true;
 	}
 
@@ -427,7 +418,7 @@ DEF_CONSOLE_CMD(ConListFiles)
 DEF_CONSOLE_CMD(ConChangeDirectory)
 {
 	if (argc == 0) {
-		IConsoleHelp("Change the dir via console. Usage: 'cd <directory | number>'");
+		IConsolePrint(CC_HELP, "Change the dir via console. Usage: 'cd <directory | number>'.");
 		return true;
 	}
 
@@ -456,7 +447,7 @@ DEF_CONSOLE_CMD(ConPrintWorkingDirectory)
 	const char *path;
 
 	if (argc == 0) {
-		IConsoleHelp("Print out the current working directory. Usage: 'pwd'");
+		IConsolePrint(CC_HELP, "Print out the current working directory. Usage: 'pwd'.");
 		return true;
 	}
 
@@ -472,7 +463,7 @@ DEF_CONSOLE_CMD(ConPrintWorkingDirectory)
 DEF_CONSOLE_CMD(ConClearBuffer)
 {
 	if (argc == 0) {
-		IConsoleHelp("Clear the console buffer. Usage: 'clear'");
+		IConsolePrint(CC_HELP, "Clear the console buffer. Usage: 'clear'.");
 		return true;
 	}
 
@@ -532,8 +523,8 @@ static bool ConKickOrBan(const char *argv, bool ban, const std::string &reason)
 DEF_CONSOLE_CMD(ConKick)
 {
 	if (argc == 0) {
-		IConsoleHelp("Kick a client from a network game. Usage: 'kick <ip | client-id> [<kick-reason>]'");
-		IConsoleHelp("For client-id's, see the command 'clients'");
+		IConsolePrint(CC_HELP, "Kick a client from a network game. Usage: 'kick <ip | client-id> [<kick-reason>]'.");
+		IConsolePrint(CC_HELP, "For client-id's, see the command 'clients'.");
 		return true;
 	}
 
@@ -555,9 +546,9 @@ DEF_CONSOLE_CMD(ConKick)
 DEF_CONSOLE_CMD(ConBan)
 {
 	if (argc == 0) {
-		IConsoleHelp("Ban a client from a network game. Usage: 'ban <ip | client-id> [<ban-reason>]'");
-		IConsoleHelp("For client-id's, see the command 'clients'");
-		IConsoleHelp("If the client is no longer online, you can still ban their IP");
+		IConsolePrint(CC_HELP, "Ban a client from a network game. Usage: 'ban <ip | client-id> [<ban-reason>]'.");
+		IConsolePrint(CC_HELP, "For client-id's, see the command 'clients'.");
+		IConsolePrint(CC_HELP, "If the client is no longer online, you can still ban their IP.");
 		return true;
 	}
 
@@ -579,8 +570,8 @@ DEF_CONSOLE_CMD(ConBan)
 DEF_CONSOLE_CMD(ConUnBan)
 {
 	if (argc == 0) {
-		IConsoleHelp("Unban a client from a network game. Usage: 'unban <ip | banlist-index>'");
-		IConsoleHelp("For a list of banned IP's, see the command 'banlist'");
+		IConsolePrint(CC_HELP, "Unban a client from a network game. Usage: 'unban <ip | banlist-index>'.");
+		IConsolePrint(CC_HELP, "For a list of banned IP's, see the command 'banlist'.");
 		return true;
 	}
 
@@ -611,7 +602,7 @@ DEF_CONSOLE_CMD(ConUnBan)
 DEF_CONSOLE_CMD(ConBanList)
 {
 	if (argc == 0) {
-		IConsoleHelp("List the IP's of banned clients: Usage 'banlist'");
+		IConsolePrint(CC_HELP, "List the IP's of banned clients: Usage 'banlist'.");
 		return true;
 	}
 
@@ -629,7 +620,7 @@ DEF_CONSOLE_CMD(ConBanList)
 DEF_CONSOLE_CMD(ConPauseGame)
 {
 	if (argc == 0) {
-		IConsoleHelp("Pause a network game. Usage: 'pause'");
+		IConsolePrint(CC_HELP, "Pause a network game. Usage: 'pause'.");
 		return true;
 	}
 
@@ -651,7 +642,7 @@ DEF_CONSOLE_CMD(ConPauseGame)
 DEF_CONSOLE_CMD(ConUnpauseGame)
 {
 	if (argc == 0) {
-		IConsoleHelp("Unpause a network game. Usage: 'unpause'");
+		IConsolePrint(CC_HELP, "Unpause a network game. Usage: 'unpause'.");
 		return true;
 	}
 
@@ -677,8 +668,8 @@ DEF_CONSOLE_CMD(ConUnpauseGame)
 DEF_CONSOLE_CMD(ConRcon)
 {
 	if (argc == 0) {
-		IConsoleHelp("Remote control the server from another client. Usage: 'rcon <password> <command>'");
-		IConsoleHelp("Remember to enclose the command in quotes, otherwise only the first parameter is sent");
+		IConsolePrint(CC_HELP, "Remote control the server from another client. Usage: 'rcon <password> <command>'.");
+		IConsolePrint(CC_HELP, "Remember to enclose the command in quotes, otherwise only the first parameter is sent.");
 		return true;
 	}
 
@@ -695,7 +686,7 @@ DEF_CONSOLE_CMD(ConRcon)
 DEF_CONSOLE_CMD(ConStatus)
 {
 	if (argc == 0) {
-		IConsoleHelp("List the status of all clients connected to the server. Usage 'status'");
+		IConsolePrint(CC_HELP, "List the status of all clients connected to the server. Usage 'status'.");
 		return true;
 	}
 
@@ -706,8 +697,8 @@ DEF_CONSOLE_CMD(ConStatus)
 DEF_CONSOLE_CMD(ConServerInfo)
 {
 	if (argc == 0) {
-		IConsoleHelp("List current and maximum client/company limits. Usage 'server_info'");
-		IConsoleHelp("You can change these values by modifying settings 'network.max_clients', 'network.max_companies' and 'network.max_spectators'");
+		IConsolePrint(CC_HELP, "List current and maximum client/company limits. Usage 'server_info'.");
+		IConsolePrint(CC_HELP, "You can change these values by modifying settings 'network.max_clients', 'network.max_companies' and 'network.max_spectators'.");
 		return true;
 	}
 
@@ -721,8 +712,8 @@ DEF_CONSOLE_CMD(ConServerInfo)
 DEF_CONSOLE_CMD(ConClientNickChange)
 {
 	if (argc != 3) {
-		IConsoleHelp("Change the nickname of a connected client. Usage: 'client_name <client-id> <new-name>'");
-		IConsoleHelp("For client-id's, see the command 'clients'");
+		IConsolePrint(CC_HELP, "Change the nickname of a connected client. Usage: 'client_name <client-id> <new-name>'.");
+		IConsolePrint(CC_HELP, "For client-id's, see the command 'clients'.");
 		return true;
 	}
 
@@ -755,8 +746,8 @@ DEF_CONSOLE_CMD(ConClientNickChange)
 DEF_CONSOLE_CMD(ConJoinCompany)
 {
 	if (argc < 2) {
-		IConsoleHelp("Request joining another company. Usage: join <company-id> [<password>]");
-		IConsoleHelp("For valid company-id see company list, use 255 for spectator");
+		IConsolePrint(CC_HELP, "Request joining another company. Usage: 'join <company-id> [<password>]'.");
+		IConsolePrint(CC_HELP, "For valid company-id see company list, use 255 for spectator.");
 		return true;
 	}
 
@@ -802,8 +793,8 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 DEF_CONSOLE_CMD(ConMoveClient)
 {
 	if (argc < 3) {
-		IConsoleHelp("Move a client to another company. Usage: move <client-id> <company-id>");
-		IConsoleHelp("For valid client-id see 'clients', for valid company-id see 'companies', use 255 for moving to spectators");
+		IConsolePrint(CC_HELP, "Move a client to another company. Usage: 'move <client-id> <company-id>'.");
+		IConsolePrint(CC_HELP, "For valid client-id see 'clients', for valid company-id see 'companies', use 255 for moving to spectators.");
 		return true;
 	}
 
@@ -845,8 +836,8 @@ DEF_CONSOLE_CMD(ConMoveClient)
 DEF_CONSOLE_CMD(ConResetCompany)
 {
 	if (argc == 0) {
-		IConsoleHelp("Remove an idle company from the game. Usage: 'reset_company <company-id>'");
-		IConsoleHelp("For company-id's, see the list of companies from the dropdown menu. Company 1 is 1, etc.");
+		IConsolePrint(CC_HELP, "Remove an idle company from the game. Usage: 'reset_company <company-id>'.");
+		IConsolePrint(CC_HELP, "For company-id's, see the list of companies from the dropdown menu. Company 1 is 1, etc.");
 		return true;
 	}
 
@@ -885,7 +876,7 @@ DEF_CONSOLE_CMD(ConResetCompany)
 DEF_CONSOLE_CMD(ConNetworkClients)
 {
 	if (argc == 0) {
-		IConsoleHelp("Get a list of connected clients including their ID, name, company-id, and IP. Usage: 'clients'");
+		IConsolePrint(CC_HELP, "Get a list of connected clients including their ID, name, company-id, and IP. Usage: 'clients'.");
 		return true;
 	}
 
@@ -897,9 +888,9 @@ DEF_CONSOLE_CMD(ConNetworkClients)
 DEF_CONSOLE_CMD(ConNetworkReconnect)
 {
 	if (argc == 0) {
-		IConsoleHelp("Reconnect to server to which you were connected last time. Usage: 'reconnect [<company>]'");
-		IConsoleHelp("Company 255 is spectator (default, if not specified), 0 means creating new company.");
-		IConsoleHelp("All others are a certain company with Company 1 being #1");
+		IConsolePrint(CC_HELP, "Reconnect to server to which you were connected last time. Usage: 'reconnect [<company>]'.");
+		IConsolePrint(CC_HELP, "Company 255 is spectator (default, if not specified), 0 means creating new company.");
+		IConsolePrint(CC_HELP, "All others are a certain company with Company 1 being #1.");
 		return true;
 	}
 
@@ -928,9 +919,9 @@ DEF_CONSOLE_CMD(ConNetworkReconnect)
 DEF_CONSOLE_CMD(ConNetworkConnect)
 {
 	if (argc == 0) {
-		IConsoleHelp("Connect to a remote OTTD server and join the game. Usage: 'connect <ip>'");
-		IConsoleHelp("IP can contain port and company: 'IP[:Port][#Company]', eg: 'server.ottd.org:443#2'");
-		IConsoleHelp("Company #255 is spectator all others are a certain company with Company 1 being #1");
+		IConsolePrint(CC_HELP, "Connect to a remote OTTD server and join the game. Usage: 'connect <ip>'.");
+		IConsolePrint(CC_HELP, "IP can contain port and company: 'IP[:Port][#Company]', eg: 'server.ottd.org:443#2'.");
+		IConsolePrint(CC_HELP, "Company #255 is spectator all others are a certain company with Company 1 being #1.");
 		return true;
 	}
 
@@ -946,7 +937,7 @@ DEF_CONSOLE_CMD(ConNetworkConnect)
 DEF_CONSOLE_CMD(ConExec)
 {
 	if (argc == 0) {
-		IConsoleHelp("Execute a local script file. Usage: 'exec <script> <?>'");
+		IConsolePrint(CC_HELP, "Execute a local script file. Usage: 'exec <script> <?>'.");
 		return true;
 	}
 
@@ -997,7 +988,7 @@ DEF_CONSOLE_CMD(ConExec)
 DEF_CONSOLE_CMD(ConReturn)
 {
 	if (argc == 0) {
-		IConsoleHelp("Stop executing a running script. Usage: 'return'");
+		IConsolePrint(CC_HELP, "Stop executing a running script. Usage: 'return'.");
 		return true;
 	}
 
@@ -1015,8 +1006,8 @@ DEF_CONSOLE_CMD(ConScript)
 	extern FILE *_iconsole_output_file;
 
 	if (argc == 0) {
-		IConsoleHelp("Start or stop logging console output to a file. Usage: 'script <filename>'");
-		IConsoleHelp("If filename is omitted, a running log is stopped if it is active");
+		IConsolePrint(CC_HELP, "Start or stop logging console output to a file. Usage: 'script <filename>'.");
+		IConsolePrint(CC_HELP, "If filename is omitted, a running log is stopped if it is active.");
 		return true;
 	}
 
@@ -1038,7 +1029,7 @@ DEF_CONSOLE_CMD(ConScript)
 DEF_CONSOLE_CMD(ConEcho)
 {
 	if (argc == 0) {
-		IConsoleHelp("Print back the first argument to the console. Usage: 'echo <arg>'");
+		IConsolePrint(CC_HELP, "Print back the first argument to the console. Usage: 'echo <arg>'.");
 		return true;
 	}
 
@@ -1050,7 +1041,7 @@ DEF_CONSOLE_CMD(ConEcho)
 DEF_CONSOLE_CMD(ConEchoC)
 {
 	if (argc == 0) {
-		IConsoleHelp("Print back the first argument to the console in a given colour. Usage: 'echoc <colour> <arg2>'");
+		IConsolePrint(CC_HELP, "Print back the first argument to the console in a given colour. Usage: 'echoc <colour> <arg2>'.");
 		return true;
 	}
 
@@ -1062,8 +1053,8 @@ DEF_CONSOLE_CMD(ConEchoC)
 DEF_CONSOLE_CMD(ConNewGame)
 {
 	if (argc == 0) {
-		IConsoleHelp("Start a new game. Usage: 'newgame [seed]'");
-		IConsoleHelp("The server can force a new game using 'newgame'; any client joined will rejoin after the server is done generating the new game.");
+		IConsolePrint(CC_HELP, "Start a new game. Usage: 'newgame [seed]'.");
+		IConsolePrint(CC_HELP, "The server can force a new game using 'newgame'; any client joined will rejoin after the server is done generating the new game.");
 		return true;
 	}
 
@@ -1074,11 +1065,11 @@ DEF_CONSOLE_CMD(ConNewGame)
 DEF_CONSOLE_CMD(ConRestart)
 {
 	if (argc == 0) {
-		IConsoleHelp("Restart game. Usage: 'restart'");
-		IConsoleHelp("Restarts a game. It tries to reproduce the exact same map as the game started with.");
-		IConsoleHelp("However:");
-		IConsoleHelp(" * restarting games started in another version might create another map due to difference in map generation");
-		IConsoleHelp(" * restarting games based on scenarios, loaded games or heightmaps will start a new game based on the settings stored in the scenario/savegame");
+		IConsolePrint(CC_HELP, "Restart game. Usage: 'restart'.");
+		IConsolePrint(CC_HELP, "Restarts a game. It tries to reproduce the exact same map as the game started with.");
+		IConsolePrint(CC_HELP, "However:");
+		IConsolePrint(CC_HELP, " * restarting games started in another version might create another map due to difference in map generation.");
+		IConsolePrint(CC_HELP, " * restarting games based on scenarios, loaded games or heightmaps will start a new game based on the settings stored in the scenario/savegame.");
 		return true;
 	}
 
@@ -1092,10 +1083,10 @@ DEF_CONSOLE_CMD(ConRestart)
 DEF_CONSOLE_CMD(ConReload)
 {
 	if (argc == 0) {
-		IConsoleHelp("Reload game. Usage: 'reload'");
-		IConsoleHelp("Reloads a game.");
-		IConsoleHelp(" * if you started from a savegame / scenario / heightmap, that exact same savegame / scenario / heightmap will be loaded.");
-		IConsoleHelp(" * if you started from a new game, this acts the same as 'restart'.");
+		IConsolePrint(CC_HELP, "Reload game. Usage: 'reload'.");
+		IConsolePrint(CC_HELP, "Reloads a game.");
+		IConsolePrint(CC_HELP, " * if you started from a savegame / scenario / heightmap, that exact same savegame / scenario / heightmap will be loaded.");
+		IConsolePrint(CC_HELP, " * if you started from a new game, this acts the same as 'restart'.");
 		return true;
 	}
 
@@ -1167,9 +1158,9 @@ DEF_CONSOLE_CMD(ConListGame)
 DEF_CONSOLE_CMD(ConStartAI)
 {
 	if (argc == 0 || argc > 3) {
-		IConsoleHelp("Start a new AI. Usage: 'start_ai [<AI>] [<settings>]'");
-		IConsoleHelp("Start a new AI. If <AI> is given, it starts that specific AI (if found).");
-		IConsoleHelp("If <settings> is given, it is parsed and the AI settings are set to that.");
+		IConsolePrint(CC_HELP, "Start a new AI. Usage: 'start_ai [<AI>] [<settings>]'.");
+		IConsolePrint(CC_HELP, "Start a new AI. If <AI> is given, it starts that specific AI (if found).");
+		IConsolePrint(CC_HELP, "If <settings> is given, it is parsed and the AI settings are set to that.");
 		return true;
 	}
 
@@ -1241,8 +1232,8 @@ DEF_CONSOLE_CMD(ConStartAI)
 DEF_CONSOLE_CMD(ConReloadAI)
 {
 	if (argc != 2) {
-		IConsoleHelp("Reload an AI. Usage: 'reload_ai <company-id>'");
-		IConsoleHelp("Reload the AI with the given company id. For company-id's, see the list of companies from the dropdown menu. Company 1 is 1, etc.");
+		IConsolePrint(CC_HELP, "Reload an AI. Usage: 'reload_ai <company-id>'.");
+		IConsolePrint(CC_HELP, "Reload the AI with the given company id. For company-id's, see the list of companies from the dropdown menu. Company 1 is 1, etc.");
 		return true;
 	}
 
@@ -1279,8 +1270,8 @@ DEF_CONSOLE_CMD(ConReloadAI)
 DEF_CONSOLE_CMD(ConStopAI)
 {
 	if (argc != 2) {
-		IConsoleHelp("Stop an AI. Usage: 'stop_ai <company-id>'");
-		IConsoleHelp("Stop the AI with the given company id. For company-id's, see the list of companies from the dropdown menu. Company 1 is 1, etc.");
+		IConsolePrint(CC_HELP, "Stop an AI. Usage: 'stop_ai <company-id>'.");
+		IConsolePrint(CC_HELP, "Stop the AI with the given company id. For company-id's, see the list of companies from the dropdown menu. Company 1 is 1, etc.");
 		return true;
 	}
 
@@ -1316,7 +1307,7 @@ DEF_CONSOLE_CMD(ConStopAI)
 DEF_CONSOLE_CMD(ConRescanAI)
 {
 	if (argc == 0) {
-		IConsoleHelp("Rescan the AI dir for scripts. Usage: 'rescan_ai'");
+		IConsolePrint(CC_HELP, "Rescan the AI dir for scripts. Usage: 'rescan_ai'.");
 		return true;
 	}
 
@@ -1333,7 +1324,7 @@ DEF_CONSOLE_CMD(ConRescanAI)
 DEF_CONSOLE_CMD(ConRescanGame)
 {
 	if (argc == 0) {
-		IConsoleHelp("Rescan the Game Script dir for scripts. Usage: 'rescan_game'");
+		IConsolePrint(CC_HELP, "Rescan the Game Script dir for scripts. Usage: 'rescan_game'.");
 		return true;
 	}
 
@@ -1350,7 +1341,7 @@ DEF_CONSOLE_CMD(ConRescanGame)
 DEF_CONSOLE_CMD(ConRescanNewGRF)
 {
 	if (argc == 0) {
-		IConsoleHelp("Rescan the data dir for NewGRFs. Usage: 'rescan_newgrf'");
+		IConsolePrint(CC_HELP, "Rescan the data dir for NewGRFs. Usage: 'rescan_newgrf'.");
 		return true;
 	}
 
@@ -1364,8 +1355,8 @@ DEF_CONSOLE_CMD(ConRescanNewGRF)
 DEF_CONSOLE_CMD(ConGetSeed)
 {
 	if (argc == 0) {
-		IConsoleHelp("Returns the seed used to create this game. Usage: 'getseed'");
-		IConsoleHelp("The seed can be used to reproduce the exact same map as the game started with.");
+		IConsolePrint(CC_HELP, "Returns the seed used to create this game. Usage: 'getseed'.");
+		IConsolePrint(CC_HELP, "The seed can be used to reproduce the exact same map as the game started with.");
 		return true;
 	}
 
@@ -1376,7 +1367,7 @@ DEF_CONSOLE_CMD(ConGetSeed)
 DEF_CONSOLE_CMD(ConGetDate)
 {
 	if (argc == 0) {
-		IConsoleHelp("Returns the current date (year-month-day) of the game. Usage: 'getdate'");
+		IConsolePrint(CC_HELP, "Returns the current date (year-month-day) of the game. Usage: 'getdate'.");
 		return true;
 	}
 
@@ -1389,7 +1380,7 @@ DEF_CONSOLE_CMD(ConGetDate)
 DEF_CONSOLE_CMD(ConGetSysDate)
 {
 	if (argc == 0) {
-		IConsoleHelp("Returns the current date (year-month-day) of your system. Usage: 'getsysdate'");
+		IConsolePrint(CC_HELP, "Returns the current date (year-month-day) of your system. Usage: 'getsysdate'.");
 		return true;
 	}
 
@@ -1405,7 +1396,7 @@ DEF_CONSOLE_CMD(ConAlias)
 	IConsoleAlias *alias;
 
 	if (argc == 0) {
-		IConsoleHelp("Add a new alias, or redefine the behaviour of an existing alias . Usage: 'alias <name> <command>'");
+		IConsolePrint(CC_HELP, "Add a new alias, or redefine the behaviour of an existing alias . Usage: 'alias <name> <command>'.");
 		return true;
 	}
 
@@ -1423,15 +1414,15 @@ DEF_CONSOLE_CMD(ConAlias)
 DEF_CONSOLE_CMD(ConScreenShot)
 {
 	if (argc == 0) {
-		IConsoleHelp("Create a screenshot of the game. Usage: 'screenshot [viewport | normal | big | giant | heightmap | minimap] [no_con] [size <width> <height>] [<filename>]'");
-		IConsoleHelp("'viewport' (default) makes a screenshot of the current viewport (including menus, windows, ..), "
-				"'normal' makes a screenshot of the visible area, "
-				"'big' makes a zoomed-in screenshot of the visible area, "
-				"'giant' makes a screenshot of the whole map, "
-				"'heightmap' makes a heightmap screenshot of the map that can be loaded in as heightmap, "
-				"'minimap' makes a top-viewed minimap screenshot of the whole world which represents one tile by one pixel. "
-				"'no_con' hides the console to create the screenshot (only useful in combination with 'viewport'). "
-				"'size' sets the width and height of the viewport to make a screenshot of (only useful in combination with 'normal' or 'big').");
+		IConsolePrint(CC_HELP, "Create a screenshot of the game. Usage: 'screenshot [viewport | normal | big | giant | heightmap | minimap] [no_con] [size <width> <height>] [<filename>]'.");
+		IConsolePrint(CC_HELP, "  'viewport' (default) makes a screenshot of the current viewport (including menus, windows).");
+		IConsolePrint(CC_HELP, "  'normal' makes a screenshot of the visible area.");
+		IConsolePrint(CC_HELP, "  'big' makes a zoomed-in screenshot of the visible area.");
+		IConsolePrint(CC_HELP, "  'giant' makes a screenshot of the whole map.");
+		IConsolePrint(CC_HELP, "  'heightmap' makes a heightmap screenshot of the map that can be loaded in as heightmap.");
+		IConsolePrint(CC_HELP, "  'minimap' makes a top-viewed minimap screenshot of the whole world which represents one tile by one pixel.");
+		IConsolePrint(CC_HELP, "  'no_con' hides the console to create the screenshot (only useful in combination with 'viewport').");
+		IConsolePrint(CC_HELP, "  'size' sets the width and height of the viewport to make a screenshot of (only useful in combination with 'normal' or 'big').");
 		return true;
 	}
 
@@ -1503,7 +1494,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 DEF_CONSOLE_CMD(ConInfoCmd)
 {
 	if (argc == 0) {
-		IConsoleHelp("Print out debugging information about a command. Usage: 'info_cmd <cmd>'");
+		IConsolePrint(CC_HELP, "Print out debugging information about a command. Usage: 'info_cmd <cmd>'.");
 		return true;
 	}
 
@@ -1525,8 +1516,8 @@ DEF_CONSOLE_CMD(ConInfoCmd)
 DEF_CONSOLE_CMD(ConDebugLevel)
 {
 	if (argc == 0) {
-		IConsoleHelp("Get/set the default debugging level for the game. Usage: 'debug_level [<level>]'");
-		IConsoleHelp("Level can be any combination of names, levels. Eg 'net=5 ms=4'. Remember to enclose it in \"'s");
+		IConsolePrint(CC_HELP, "Get/set the default debugging level for the game. Usage: 'debug_level [<level>]'.");
+		IConsolePrint(CC_HELP, "Level can be any combination of names, levels. Eg 'net=5 ms=4'. Remember to enclose it in \"'\"s.");
 		return true;
 	}
 
@@ -1544,7 +1535,7 @@ DEF_CONSOLE_CMD(ConDebugLevel)
 DEF_CONSOLE_CMD(ConExit)
 {
 	if (argc == 0) {
-		IConsoleHelp("Exit the game. Usage: 'exit'");
+		IConsolePrint(CC_HELP, "Exit the game. Usage: 'exit'.");
 		return true;
 	}
 
@@ -1557,7 +1548,7 @@ DEF_CONSOLE_CMD(ConExit)
 DEF_CONSOLE_CMD(ConPart)
 {
 	if (argc == 0) {
-		IConsoleHelp("Leave the currently joined/running game (only ingame). Usage: 'part'");
+		IConsolePrint(CC_HELP, "Leave the currently joined/running game (only ingame). Usage: 'part'.");
 		return true;
 	}
 
@@ -1609,7 +1600,7 @@ DEF_CONSOLE_CMD(ConHelp)
 DEF_CONSOLE_CMD(ConListCommands)
 {
 	if (argc == 0) {
-		IConsoleHelp("List all registered commands. Usage: 'list_cmds [<pre-filter>]'");
+		IConsolePrint(CC_HELP, "List all registered commands. Usage: 'list_cmds [<pre-filter>]'.");
 		return true;
 	}
 
@@ -1626,7 +1617,7 @@ DEF_CONSOLE_CMD(ConListCommands)
 DEF_CONSOLE_CMD(ConListAliases)
 {
 	if (argc == 0) {
-		IConsoleHelp("List all registered aliases. Usage: 'list_aliases [<pre-filter>]'");
+		IConsolePrint(CC_HELP, "List all registered aliases. Usage: 'list_aliases [<pre-filter>]'.");
 		return true;
 	}
 
@@ -1643,7 +1634,7 @@ DEF_CONSOLE_CMD(ConListAliases)
 DEF_CONSOLE_CMD(ConCompanies)
 {
 	if (argc == 0) {
-		IConsoleHelp("List the details of all companies in the game. Usage 'companies'");
+		IConsolePrint(CC_HELP, "List the details of all companies in the game. Usage 'companies'.");
 		return true;
 	}
 
@@ -1678,7 +1669,7 @@ DEF_CONSOLE_CMD(ConCompanies)
 DEF_CONSOLE_CMD(ConSay)
 {
 	if (argc == 0) {
-		IConsoleHelp("Chat to your fellow players in a multiplayer game. Usage: 'say \"<msg>\"'");
+		IConsolePrint(CC_HELP, "Chat to your fellow players in a multiplayer game. Usage: 'say \"<msg>\"'.");
 		return true;
 	}
 
@@ -1697,8 +1688,8 @@ DEF_CONSOLE_CMD(ConSay)
 DEF_CONSOLE_CMD(ConSayCompany)
 {
 	if (argc == 0) {
-		IConsoleHelp("Chat to a certain company in a multiplayer game. Usage: 'say_company <company-no> \"<msg>\"'");
-		IConsoleHelp("CompanyNo is the company that plays as company <companyno>, 1 through max_companies");
+		IConsolePrint(CC_HELP, "Chat to a certain company in a multiplayer game. Usage: 'say_company <company-no> \"<msg>\"'.");
+		IConsolePrint(CC_HELP, "CompanyNo is the company that plays as company <companyno>, 1 through max_companies.");
 		return true;
 	}
 
@@ -1723,8 +1714,8 @@ DEF_CONSOLE_CMD(ConSayCompany)
 DEF_CONSOLE_CMD(ConSayClient)
 {
 	if (argc == 0) {
-		IConsoleHelp("Chat to a certain client in a multiplayer game. Usage: 'say_client <client-no> \"<msg>\"'");
-		IConsoleHelp("For client-id's, see the command 'clients'");
+		IConsolePrint(CC_HELP, "Chat to a certain client in a multiplayer game. Usage: 'say_client <client-no> \"<msg>\"'.");
+		IConsolePrint(CC_HELP, "For client-id's, see the command 'clients'.");
 		return true;
 	}
 
@@ -1844,13 +1835,13 @@ DEF_CONSOLE_CMD(ConContent)
 	}
 
 	if (argc <= 1) {
-		IConsoleHelp("Query, select and download content. Usage: 'content update|upgrade|select [id]|unselect [all|id]|state [filter]|download'");
-		IConsoleHelp("  update: get a new list of downloadable content; must be run first");
-		IConsoleHelp("  upgrade: select all items that are upgrades");
-		IConsoleHelp("  select: select a specific item given by its id. If no parameter is given, all selected content will be listed");
-		IConsoleHelp("  unselect: unselect a specific item given by its id or 'all' to unselect all");
-		IConsoleHelp("  state: show the download/select state of all downloadable content. Optionally give a filter string");
-		IConsoleHelp("  download: download all content you've selected");
+		IConsolePrint(CC_HELP, "Query, select and download content. Usage: 'content update|upgrade|select [id]|unselect [all|id]|state [filter]|download'.");
+		IConsolePrint(CC_HELP, "  update: get a new list of downloadable content; must be run first.");
+		IConsolePrint(CC_HELP, "  upgrade: select all items that are upgrades.");
+		IConsolePrint(CC_HELP, "  select: select a specific item given by its id. If no parameter is given, all selected content will be listed.");
+		IConsolePrint(CC_HELP, "  unselect: unselect a specific item given by its id or 'all' to unselect all.");
+		IConsolePrint(CC_HELP, "  state: show the download/select state of all downloadable content. Optionally give a filter string.");
+		IConsolePrint(CC_HELP, "  download: download all content you've selected.");
 		return true;
 	}
 
@@ -1923,8 +1914,8 @@ DEF_CONSOLE_CMD(ConContent)
 DEF_CONSOLE_CMD(ConSetting)
 {
 	if (argc == 0) {
-		IConsoleHelp("Change setting for all clients. Usage: 'setting <name> [<value>]'");
-		IConsoleHelp("Omitting <value> will print out the current value of the setting.");
+		IConsolePrint(CC_HELP, "Change setting for all clients. Usage: 'setting <name> [<value>]'.");
+		IConsolePrint(CC_HELP, "Omitting <value> will print out the current value of the setting.");
 		return true;
 	}
 
@@ -1942,8 +1933,8 @@ DEF_CONSOLE_CMD(ConSetting)
 DEF_CONSOLE_CMD(ConSettingNewgame)
 {
 	if (argc == 0) {
-		IConsoleHelp("Change setting for the next game. Usage: 'setting_newgame <name> [<value>]'");
-		IConsoleHelp("Omitting <value> will print out the current value of the setting.");
+		IConsolePrint(CC_HELP, "Change setting for the next game. Usage: 'setting_newgame <name> [<value>]'.");
+		IConsolePrint(CC_HELP, "Omitting <value> will print out the current value of the setting.");
 		return true;
 	}
 
@@ -1961,7 +1952,7 @@ DEF_CONSOLE_CMD(ConSettingNewgame)
 DEF_CONSOLE_CMD(ConListSettings)
 {
 	if (argc == 0) {
-		IConsoleHelp("List settings. Usage: 'list_settings [<pre-filter>]'");
+		IConsolePrint(CC_HELP, "List settings. Usage: 'list_settings [<pre-filter>]'.");
 		return true;
 	}
 
@@ -1980,7 +1971,7 @@ DEF_CONSOLE_CMD(ConGamelogPrint)
 DEF_CONSOLE_CMD(ConNewGRFReload)
 {
 	if (argc == 0) {
-		IConsoleHelp("Reloads all active NewGRFs from disk. Equivalent to reapplying NewGRFs via the settings, but without asking for confirmation. This might crash OpenTTD!");
+		IConsolePrint(CC_HELP, "Reloads all active NewGRFs from disk. Equivalent to reapplying NewGRFs via the settings, but without asking for confirmation. This might crash OpenTTD!");
 		return true;
 	}
 
@@ -1991,19 +1982,19 @@ DEF_CONSOLE_CMD(ConNewGRFReload)
 DEF_CONSOLE_CMD(ConNewGRFProfile)
 {
 	if (argc == 0) {
-		IConsoleHelp("Collect performance data about NewGRF sprite requests and callbacks. Sub-commands can be abbreviated.");
-		IConsoleHelp("Usage: newgrf_profile [list]");
-		IConsoleHelp("  List all NewGRFs that can be profiled, and their status.");
-		IConsoleHelp("Usage: newgrf_profile select <grf-num>...");
-		IConsoleHelp("  Select one or more GRFs for profiling.");
-		IConsoleHelp("Usage: newgrf_profile unselect <grf-num>...");
-		IConsoleHelp("  Unselect one or more GRFs from profiling. Use the keyword \"all\" instead of a GRF number to unselect all. Removing an active profiler aborts data collection.");
-		IConsoleHelp("Usage: newgrf_profile start [<num-days>]");
-		IConsoleHelp("  Begin profiling all selected GRFs. If a number of days is provided, profiling stops after that many in-game days.");
-		IConsoleHelp("Usage: newgrf_profile stop");
-		IConsoleHelp("  End profiling and write the collected data to CSV files.");
-		IConsoleHelp("Usage: newgrf_profile abort");
-		IConsoleHelp("  End profiling and discard all collected data.");
+		IConsolePrint(CC_HELP, "Collect performance data about NewGRF sprite requests and callbacks. Sub-commands can be abbreviated.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile [list]':");
+		IConsolePrint(CC_HELP, "  List all NewGRFs that can be profiled, and their status.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile select <grf-num>...':");
+		IConsolePrint(CC_HELP, "  Select one or more GRFs for profiling.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile unselect <grf-num>...':");
+		IConsolePrint(CC_HELP, "  Unselect one or more GRFs from profiling. Use the keyword \"all\" instead of a GRF number to unselect all. Removing an active profiler aborts data collection.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile start [<num-days>]':");
+		IConsolePrint(CC_HELP, "  Begin profiling all selected GRFs. If a number of days is provided, profiling stops after that many in-game days.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile stop':");
+		IConsolePrint(CC_HELP, "  End profiling and write the collected data to CSV files.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile abort':");
+		IConsolePrint(CC_HELP, "  End profiling and discard all collected data.");
 		return true;
 	}
 
@@ -2135,7 +2126,7 @@ DEF_CONSOLE_CMD(ConFramerate)
 	extern void ConPrintFramerate(); // framerate_gui.cpp
 
 	if (argc == 0) {
-		IConsoleHelp("Show frame rate and game speed information");
+		IConsolePrint(CC_HELP, "Show frame rate and game speed information.");
 		return true;
 	}
 
@@ -2148,7 +2139,7 @@ DEF_CONSOLE_CMD(ConFramerateWindow)
 	extern void ShowFramerateWindow();
 
 	if (argc == 0) {
-		IConsoleHelp("Open the frame rate window");
+		IConsolePrint(CC_HELP, "Open the frame rate window.");
 		return true;
 	}
 
@@ -2290,9 +2281,9 @@ static void ConDumpCargoTypes()
 DEF_CONSOLE_CMD(ConDumpInfo)
 {
 	if (argc != 2) {
-		IConsoleHelp("Dump debugging information.");
-		IConsoleHelp("Usage: dump_info roadtypes|railtypes|cargotypes");
-		IConsoleHelp("  Show information about road/tram types, rail types or cargo types.");
+		IConsolePrint(CC_HELP, "Dump debugging information.");
+		IConsolePrint(CC_HELP, "Usage: 'dump_info roadtypes|railtypes|cargotypes'.");
+		IConsolePrint(CC_HELP, "  Show information about road/tram types, rail types or cargo types.");
 		return true;
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -273,7 +273,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 			uint32 result;
 			if (GetArgumentInteger(&result, argv[1])) {
 				if (result >= MapSize()) {
-					IConsolePrint(CC_ERROR, "Tile does not exist");
+					IConsolePrint(CC_ERROR, "Tile does not exist.");
 					return true;
 				}
 				ScrollMainWindowToTile((TileIndex)result);
@@ -286,7 +286,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 			uint32 x, y;
 			if (GetArgumentInteger(&x, argv[1]) && GetArgumentInteger(&y, argv[2])) {
 				if (x >= MapSizeX() || y >= MapSizeY()) {
-					IConsolePrint(CC_ERROR, "Tile does not exist");
+					IConsolePrint(CC_ERROR, "Tile does not exist.");
 					return true;
 				}
 				ScrollMainWindowToTile(TileXY(x, y));
@@ -593,7 +593,7 @@ DEF_CONSOLE_CMD(ConUnBan)
 		_network_ban_list.erase(_network_ban_list.begin() + index);
 	} else {
 		IConsolePrint(CC_DEFAULT, "Invalid list index or IP not in ban-list.");
-		IConsolePrint(CC_DEFAULT, "For a list of banned IP's, see the command 'banlist'");
+		IConsolePrint(CC_DEFAULT, "For a list of banned IP's, see the command 'banlist'.");
 	}
 
 	return true;
@@ -606,7 +606,7 @@ DEF_CONSOLE_CMD(ConBanList)
 		return true;
 	}
 
-	IConsolePrint(CC_DEFAULT, "Banlist: ");
+	IConsolePrint(CC_DEFAULT, "Banlist:");
 
 	uint i = 1;
 	for (const auto &entry : _network_ban_list) {
@@ -1018,7 +1018,7 @@ DEF_CONSOLE_CMD(ConScript)
 		if (_iconsole_output_file == nullptr) {
 			IConsolePrint(CC_ERROR, "Could not open console log file '{}'.", argv[1]);
 		} else {
-			IConsolePrint(CC_INFO, "Console log output started to: '{}'", argv[1]);
+			IConsolePrint(CC_INFO, "Console log output started to '{}'.", argv[1]);
 		}
 	}
 
@@ -1581,18 +1581,18 @@ DEF_CONSOLE_CMD(ConHelp)
 			return true;
 		}
 
-		IConsolePrint(CC_ERROR, "Command not found");
+		IConsolePrint(CC_ERROR, "Command not found.");
 		return true;
 	}
 
 	IConsolePrint(TC_LIGHT_BLUE, " ---- OpenTTD Console Help ---- ");
-	IConsolePrint(CC_DEFAULT, " - commands: [command to list all commands: list_cmds]");
+	IConsolePrint(CC_DEFAULT, " - commands: the command to list all commands is 'list_cmds'.");
 	IConsolePrint(CC_DEFAULT, " call commands with '<command> <arg2> <arg3>...'");
-	IConsolePrint(CC_DEFAULT, " - to assign strings, or use them as arguments, enclose it within quotes");
-	IConsolePrint(CC_DEFAULT, " like this: '<command> \"string argument with spaces\"'");
-	IConsolePrint(CC_DEFAULT, " - use 'help <command>' to get specific information");
-	IConsolePrint(CC_DEFAULT, " - scroll console output with shift + (up | down | pageup | pagedown)");
-	IConsolePrint(CC_DEFAULT, " - scroll console input history with the up or down arrows");
+	IConsolePrint(CC_DEFAULT, " - to assign strings, or use them as arguments, enclose it within quotes.");
+	IConsolePrint(CC_DEFAULT, " like this: '<command> \"string argument with spaces\"'.");
+	IConsolePrint(CC_DEFAULT, " - use 'help <command>' to get specific information.");
+	IConsolePrint(CC_DEFAULT, " - scroll console output with shift + (up | down | pageup | pagedown).");
+	IConsolePrint(CC_DEFAULT, " - scroll console input history with the up or down arrows.");
 	IConsolePrint(CC_DEFAULT, "");
 	return true;
 }
@@ -2070,7 +2070,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 			}
 		}
 		if (started > 0) {
-			IConsolePrint(CC_DEBUG, "Started profiling for GRFID{} {}", (started > 1) ? "s" : "", grfids);
+			IConsolePrint(CC_DEBUG, "Started profiling for GRFID{} {}.", (started > 1) ? "s" : "", grfids);
 			if (argc >= 3) {
 				int days = std::max(atoi(argv[2]), 1);
 				_newgrf_profile_end_date = _date + days;
@@ -2144,7 +2144,7 @@ DEF_CONSOLE_CMD(ConFramerateWindow)
 	}
 
 	if (_network_dedicated) {
-		IConsolePrint(CC_ERROR, "Can not open frame rate window on a dedicated server");
+		IConsolePrint(CC_ERROR, "Can not open frame rate window on a dedicated server.");
 		return false;
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -96,7 +96,7 @@ static ConsoleFileList _console_file_list; ///< File storage cache for the conso
 static inline bool NetworkAvailable(bool echo)
 {
 	if (!_network_available) {
-		if (echo) IConsoleError("You cannot use this command because there is no network available.");
+		if (echo) IConsolePrint(CC_ERROR, "You cannot use this command because there is no network available.");
 		return false;
 	}
 	return true;
@@ -111,7 +111,7 @@ DEF_CONSOLE_HOOK(ConHookServerOnly)
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
 	if (!_network_server) {
-		if (echo) IConsoleError("This command is only available to a network server.");
+		if (echo) IConsolePrint(CC_ERROR, "This command is only available to a network server.");
 		return CHR_DISALLOW;
 	}
 	return CHR_ALLOW;
@@ -126,7 +126,7 @@ DEF_CONSOLE_HOOK(ConHookClientOnly)
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
 	if (_network_server) {
-		if (echo) IConsoleError("This command is not available to a network server.");
+		if (echo) IConsolePrint(CC_ERROR, "This command is not available to a network server.");
 		return CHR_DISALLOW;
 	}
 	return CHR_ALLOW;
@@ -141,7 +141,7 @@ DEF_CONSOLE_HOOK(ConHookNeedNetwork)
 	if (!NetworkAvailable(echo)) return CHR_DISALLOW;
 
 	if (!_networking || (!_network_server && !MyClient::IsConnected())) {
-		if (echo) IConsoleError("Not connected. This command is only available in multiplayer.");
+		if (echo) IConsolePrint(CC_ERROR, "Not connected. This command is only available in multiplayer.");
 		return CHR_DISALLOW;
 	}
 	return CHR_ALLOW;
@@ -154,7 +154,7 @@ DEF_CONSOLE_HOOK(ConHookNeedNetwork)
 DEF_CONSOLE_HOOK(ConHookNoNetwork)
 {
 	if (_networking) {
-		if (echo) IConsoleError("This command is forbidden in multiplayer.");
+		if (echo) IConsolePrint(CC_ERROR, "This command is forbidden in multiplayer.");
 		return CHR_DISALLOW;
 	}
 	return CHR_ALLOW;
@@ -167,7 +167,7 @@ DEF_CONSOLE_HOOK(ConHookNoNetwork)
 DEF_CONSOLE_HOOK(ConHookServerOrNoNetwork)
 {
 	if (_networking && !_network_server) {
-		if (echo) IConsoleError("This command is only available to a network server.");
+		if (echo) IConsolePrint(CC_ERROR, "This command is only available to a network server.");
 		return CHR_DISALLOW;
 	}
 	return CHR_ALLOW;
@@ -177,7 +177,7 @@ DEF_CONSOLE_HOOK(ConHookNewGRFDeveloperTool)
 {
 	if (_settings_client.gui.newgrf_developer_tools) {
 		if (_game_mode == GM_MENU) {
-			if (echo) IConsoleError("This command is only available in-game and in the editor.");
+			if (echo) IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 			return CHR_DISALLOW;
 		}
 		return ConHookNoNetwork(echo);
@@ -222,12 +222,12 @@ DEF_CONSOLE_CMD(ConResetEnginePool)
 	}
 
 	if (_game_mode == GM_MENU) {
-		IConsoleError("This command is only available in-game and in the editor.");
+		IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 		return true;
 	}
 
 	if (!EngineOverrideManager::ResetToCurrentNewGRFConfig()) {
-		IConsoleError("This can only be done when there are no vehicles in the game.");
+		IConsolePrint(CC_ERROR, "This can only be done when there are no vehicles in the game.");
 		return true;
 	}
 
@@ -372,10 +372,10 @@ DEF_CONSOLE_CMD(ConLoad)
 			_file_to_saveload.SetName(FiosBrowseTo(item));
 			_file_to_saveload.SetTitle(item->title);
 		} else {
-			IConsolePrintF(CC_ERROR, "%s: Not a savegame.", file);
+			IConsolePrint(CC_ERROR, "'{}' is not a savegame.", file);
 		}
 	} else {
-		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		IConsolePrint(CC_ERROR, "'{}' cannot be found.", file);
 	}
 
 	return true;
@@ -396,10 +396,10 @@ DEF_CONSOLE_CMD(ConRemove)
 	const FiosItem *item = _console_file_list.FindItem(file);
 	if (item != nullptr) {
 		if (!FiosDelete(item->name)) {
-			IConsolePrintF(CC_ERROR, "%s: Failed to delete file", file);
+			IConsolePrint(CC_ERROR, "Failed to delete '{}'.", file);
 		}
 	} else {
-		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		IConsolePrint(CC_ERROR, "'{}' could not be found.", file);
 	}
 
 	_console_file_list.InvalidateFileList();
@@ -441,10 +441,10 @@ DEF_CONSOLE_CMD(ConChangeDirectory)
 			case FIOS_TYPE_DIR: case FIOS_TYPE_DRIVE: case FIOS_TYPE_PARENT:
 				FiosBrowseTo(item);
 				break;
-			default: IConsolePrintF(CC_ERROR, "%s: Not a directory.", file);
+			default: IConsolePrint(CC_ERROR, "{}: Not a directory.", file);
 		}
 	} else {
-		IConsolePrintF(CC_ERROR, "%s: No such file or directory.", file);
+		IConsolePrint(CC_ERROR, "{}: No such file or directory.", file);
 	}
 
 	_console_file_list.InvalidateFileList();
@@ -498,13 +498,13 @@ static bool ConKickOrBan(const char *argv, bool ban, const std::string &reason)
 		 * would be reading from and writing to after returning. So we would read or write data
 		 * from freed memory up till the segfault triggers. */
 		if (client_id == CLIENT_ID_SERVER || client_id == _redirect_console_to_client) {
-			IConsolePrintF(CC_ERROR, "ERROR: You can not %s yourself!", ban ? "ban" : "kick");
+			IConsolePrint(CC_ERROR, "You can not {} yourself!", ban ? "ban" : "kick");
 			return true;
 		}
 
 		NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(client_id);
 		if (ci == nullptr) {
-			IConsoleError("Invalid client");
+			IConsolePrint(CC_ERROR, "Invalid client ID.");
 			return true;
 		}
 
@@ -521,9 +521,9 @@ static bool ConKickOrBan(const char *argv, bool ban, const std::string &reason)
 	}
 
 	if (n == 0) {
-		IConsolePrint(CC_DEFAULT, ban ? "Client not online, address added to banlist" : "Client not found");
+		IConsolePrint(CC_DEFAULT, ban ? "Client not online, address added to banlist." : "Client not found.");
 	} else {
-		IConsolePrintF(CC_DEFAULT, "%sed %u client(s)", ban ? "Bann" : "Kick", n);
+		IConsolePrintF(CC_DEFAULT, "%sed %u client(s).", ban ? "Bann" : "Kick", n);
 	}
 
 	return true;
@@ -545,7 +545,7 @@ DEF_CONSOLE_CMD(ConKick)
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
 	if (kick_message_length >= 255) {
-		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered " PRINTF_SIZE " characters.", kick_message_length);
+		IConsolePrint(CC_ERROR, "Maximum kick message length is 254 characters. You entered {} characters.", kick_message_length);
 		return false;
 	} else {
 		return ConKickOrBan(argv[1], false, argv[2]);
@@ -569,7 +569,7 @@ DEF_CONSOLE_CMD(ConBan)
 	/* Reason for kicking supplied */
 	size_t kick_message_length = strlen(argv[2]);
 	if (kick_message_length >= 255) {
-		IConsolePrintF(CC_ERROR, "ERROR: Maximum kick message length is 254 characters. You entered " PRINTF_SIZE " characters.", kick_message_length);
+		IConsolePrint(CC_ERROR, "Maximum kick message length is 254 characters. You entered {} characters.", kick_message_length);
 		return false;
 	} else {
 		return ConKickOrBan(argv[1], true, argv[2]);
@@ -636,7 +636,7 @@ DEF_CONSOLE_CMD(ConPauseGame)
 	}
 
 	if (_game_mode == GM_MENU) {
-		IConsoleError("This command is only available in-game and in the editor.");
+		IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 		return true;
 	}
 
@@ -658,7 +658,7 @@ DEF_CONSOLE_CMD(ConUnpauseGame)
 	}
 
 	if (_game_mode == GM_MENU) {
-		IConsoleError("This command is only available in-game and in the editor.");
+		IConsolePrint(CC_ERROR, "This command is only available in-game and in the editor.");
 		return true;
 	}
 
@@ -731,24 +731,24 @@ DEF_CONSOLE_CMD(ConClientNickChange)
 	ClientID client_id = (ClientID)atoi(argv[1]);
 
 	if (client_id == CLIENT_ID_SERVER) {
-		IConsoleError("Please use the command 'name' to change your own name!");
+		IConsolePrint(CC_ERROR, "Please use the command 'name' to change your own name!");
 		return true;
 	}
 
 	if (NetworkClientInfo::GetByClientID(client_id) == nullptr) {
-		IConsoleError("Invalid client");
+		IConsolePrint(CC_ERROR, "Invalid client ID.");
 		return true;
 	}
 
 	std::string client_name(argv[2]);
 	StrTrimInPlace(client_name);
 	if (!NetworkIsValidClientName(client_name)) {
-		IConsoleError("Cannot give a client an empty name");
+		IConsolePrint(CC_ERROR, "Cannot give a client an empty name.");
 		return true;
 	}
 
 	if (!NetworkServerChangeClientName(client_id, client_name)) {
-		IConsoleError("Cannot give a client a duplicate name");
+		IConsolePrint(CC_ERROR, "Cannot give a client a duplicate name.");
 	}
 
 	return true;
@@ -766,28 +766,28 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 
 	/* Check we have a valid company id! */
 	if (!Company::IsValidID(company_id) && company_id != COMPANY_SPECTATOR) {
-		IConsolePrintF(CC_ERROR, "Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
+		IConsolePrint(CC_ERROR, "Company does not exist. Company-id must be between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
 	if (NetworkClientInfo::GetByClientID(_network_own_client_id)->client_playas == company_id) {
-		IConsoleError("You are already there!");
+		IConsolePrint(CC_ERROR, "You are already there!");
 		return true;
 	}
 
 	if (company_id == COMPANY_SPECTATOR && NetworkMaxSpectatorsReached()) {
-		IConsoleError("Cannot join spectators, maximum number of spectators reached.");
+		IConsolePrint(CC_ERROR, "Cannot join spectators, maximum number of spectators reached.");
 		return true;
 	}
 
 	if (company_id != COMPANY_SPECTATOR && !Company::IsHumanID(company_id)) {
-		IConsoleError("Cannot join AI company.");
+		IConsolePrint(CC_ERROR, "Cannot join AI company.");
 		return true;
 	}
 
 	/* Check if the company requires a password */
 	if (NetworkCompanyIsPassworded(company_id) && argc < 3) {
-		IConsolePrintF(CC_ERROR, "Company %d requires a password to join.", company_id + 1);
+		IConsolePrint(CC_ERROR, "Company {} requires a password to join.", company_id + 1);
 		return true;
 	}
 
@@ -814,27 +814,27 @@ DEF_CONSOLE_CMD(ConMoveClient)
 
 	/* check the client exists */
 	if (ci == nullptr) {
-		IConsoleError("Invalid client-id, check the command 'clients' for valid client-id's.");
+		IConsolePrint(CC_ERROR, "Invalid client-id, check the command 'clients' for valid client-id's.");
 		return true;
 	}
 
 	if (!Company::IsValidID(company_id) && company_id != COMPANY_SPECTATOR) {
-		IConsolePrintF(CC_ERROR, "Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
+		IConsolePrint(CC_ERROR, "Company does not exist. Company-id must be between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
 	if (company_id != COMPANY_SPECTATOR && !Company::IsHumanID(company_id)) {
-		IConsoleError("You cannot move clients to AI companies.");
+		IConsolePrint(CC_ERROR, "You cannot move clients to AI companies.");
 		return true;
 	}
 
 	if (ci->client_id == CLIENT_ID_SERVER && _network_dedicated) {
-		IConsoleError("You cannot move the server!");
+		IConsolePrint(CC_ERROR, "You cannot move the server!");
 		return true;
 	}
 
 	if (ci->client_playas == company_id) {
-		IConsoleError("You cannot move someone to where they already are!");
+		IConsolePrint(CC_ERROR, "You cannot move someone to where they already are!");
 		return true;
 	}
 
@@ -858,22 +858,22 @@ DEF_CONSOLE_CMD(ConResetCompany)
 
 	/* Check valid range */
 	if (!Company::IsValidID(index)) {
-		IConsolePrintF(CC_ERROR, "Company does not exist. Company-id must be between 1 and %d.", MAX_COMPANIES);
+		IConsolePrint(CC_ERROR, "Company does not exist. Company-id must be between 1 and {}.", MAX_COMPANIES);
 		return true;
 	}
 
 	if (!Company::IsHumanID(index)) {
-		IConsoleError("Company is owned by an AI.");
+		IConsolePrint(CC_ERROR, "Company is owned by an AI.");
 		return true;
 	}
 
 	if (NetworkCompanyHasClients(index)) {
-		IConsoleError("Cannot remove company: a client is connected to that company.");
+		IConsolePrint(CC_ERROR, "Cannot remove company: a client is connected to that company.");
 		return false;
 	}
 	const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
 	if (ci->client_playas == index) {
-		IConsoleError("Cannot remove company: the server is connected to that company.");
+		IConsolePrint(CC_ERROR, "Cannot remove company: the server is connected to that company.");
 		return true;
 	}
 
@@ -957,13 +957,13 @@ DEF_CONSOLE_CMD(ConExec)
 	FILE *script_file = FioFOpenFile(argv[1], "r", BASE_DIR);
 
 	if (script_file == nullptr) {
-		if (argc == 2 || atoi(argv[2]) != 0) IConsoleError("script file not found");
+		if (argc == 2 || atoi(argv[2]) != 0) IConsolePrint(CC_ERROR, "Script file '{}' not found.", argv[1]);
 		return true;
 	}
 
 	if (_script_current_depth == 11) {
 		FioFCloseFile(script_file);
-		IConsoleError("Maximum 'exec' depth reached; script A is calling script B is calling script C ... more than 10 times.");
+		IConsolePrint(CC_ERROR, "Maximum 'exec' depth reached; script A is calling script B is calling script C ... more than 10 times.");
 		return true;
 	}
 
@@ -988,7 +988,7 @@ DEF_CONSOLE_CMD(ConExec)
 	}
 
 	if (ferror(script_file)) {
-		IConsoleError("Encountered error while trying to read from script file");
+		IConsolePrint(CC_ERROR, "Encountered error while trying to read from script file '{}'.", argv[1]);
 	}
 
 	if (_script_current_depth == script_depth) _script_current_depth--;
@@ -1027,7 +1027,7 @@ DEF_CONSOLE_CMD(ConScript)
 
 		IConsolePrintF(CC_DEFAULT, "file output started to: %s", argv[1]);
 		_iconsole_output_file = fopen(argv[1], "ab");
-		if (_iconsole_output_file == nullptr) IConsoleError("could not open file");
+		if (_iconsole_output_file == nullptr) IConsolePrint(CC_ERROR, "Could not open file '{}'.", argv[1]);
 	}
 
 	return true;
@@ -1466,7 +1466,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 
 	if (argc > arg_index && strcmp(argv[arg_index], "no_con") == 0) {
 		if (type != SC_VIEWPORT) {
-			IConsoleError("'no_con' can only be used in combination with 'viewport'");
+			IConsolePrint(CC_ERROR, "'no_con' can only be used in combination with 'viewport'.");
 			return true;
 		}
 		IConsoleClose();
@@ -1476,7 +1476,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 	if (argc > arg_index + 2 && strcmp(argv[arg_index], "size") == 0) {
 		/* size <width> <height> */
 		if (type != SC_DEFAULTZOOM && type != SC_ZOOMEDIN) {
-			IConsoleError("'size' can only be used in combination with 'normal' or 'big'");
+			IConsolePrint(CC_ERROR, "'size' can only be used in combination with 'normal' or 'big'.");
 			return true;
 		}
 		GetArgumentInteger(&width, argv[arg_index + 1]);
@@ -1510,7 +1510,7 @@ DEF_CONSOLE_CMD(ConInfoCmd)
 
 	const IConsoleCmd *cmd = IConsole::CmdGet(argv[1]);
 	if (cmd == nullptr) {
-		IConsoleError("the given command was not found");
+		IConsolePrint(CC_ERROR, "The given command was not found.");
 		return true;
 	}
 
@@ -1589,7 +1589,7 @@ DEF_CONSOLE_CMD(ConHelp)
 			return true;
 		}
 
-		IConsoleError("command not found");
+		IConsolePrint(CC_ERROR, "Command not found");
 		return true;
 	}
 
@@ -1774,7 +1774,7 @@ DEF_CONSOLE_CMD(ConCompanyPassword)
 	}
 
 	if (!Company::IsValidHumanID(company_id)) {
-		IConsoleError(errormsg);
+		IConsolePrint(CC_ERROR, errormsg);
 		return false;
 	}
 
@@ -1881,7 +1881,7 @@ DEF_CONSOLE_CMD(ConContent)
 			 * to download every available package on BaNaNaS. This is not in
 			 * the spirit of this service. Additionally, these few people were
 			 * good for 70% of the consumed bandwidth of BaNaNaS. */
-			IConsoleError("'select all' is no longer supported since 1.11");
+			IConsolePrint(CC_ERROR, "'select all' is no longer supported since 1.11.");
 		} else {
 			_network_content_client.Select((ContentID)atoi(argv[2]));
 		}
@@ -1890,7 +1890,7 @@ DEF_CONSOLE_CMD(ConContent)
 
 	if (strcasecmp(argv[1], "unselect") == 0) {
 		if (argc <= 2) {
-			IConsoleError("You must enter the id.");
+			IConsolePrint(CC_ERROR, "You must enter the id.");
 			return false;
 		}
 		if (strcasecmp(argv[2], "all") == 0) {
@@ -2155,7 +2155,7 @@ DEF_CONSOLE_CMD(ConFramerateWindow)
 	}
 
 	if (_network_dedicated) {
-		IConsoleError("Can not open frame rate window on a dedicated server");
+		IConsolePrint(CC_ERROR, "Can not open frame rate window on a dedicated server");
 		return false;
 	}
 

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -47,7 +47,6 @@ static inline void IConsolePrint(TextColour colour_code, const T &format, A firs
 }
 
 void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...) WARN_FORMAT(2, 3);
-void IConsoleDebug(const char *dbg, const char *string);
 void IConsoleWarning(const char *string);
 void IConsoleError(const char *string);
 

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -46,8 +46,6 @@ static inline void IConsolePrint(TextColour colour_code, const T &format, A firs
 	IConsolePrint(colour_code, fmt::format(format, first_arg, other_args...));
 }
 
-void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...) WARN_FORMAT(2, 3);
-
 /* Parser */
 void IConsoleCmdExec(const char *cmdstr, const uint recurse_count = 0);
 

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -11,6 +11,7 @@
 #define CONSOLE_FUNC_H
 
 #include "console_type.h"
+#include "3rdparty/fmt/format.h"
 
 /* console modes */
 extern IConsoleModes _iconsole_mode;
@@ -21,7 +22,30 @@ void IConsoleFree();
 void IConsoleClose();
 
 /* console output */
-void IConsolePrint(TextColour colour_code, const char *string);
+void IConsolePrint(TextColour colour_code, const std::string &string);
+
+/**
+ * Handle the printing of text entered into the console or redirected there
+ * by any other means. Text can be redirected to other clients in a network game
+ * as well as to a logfile. If the network server is a dedicated server, all activities
+ * are also logged. All lines to print are added to a temporary buffer which can be
+ * used as a history to print them onscreen
+ * @param colour_code The colour of the command.
+ * @param format_string The formatting string to tell what to do with the remaining arguments.
+ * @param first_arg The first argument to the format.
+ * @param other_args The other arguments to the format.
+ * @tparam T The type of formatting parameter.
+ * @tparam A The type of the first argument.
+ * @tparam Args The types of the other arguments.
+ */
+template <typename T, typename A, typename ... Args>
+static inline void IConsolePrint(TextColour colour_code, const T &format, A first_arg, Args&&... other_args)
+{
+	/* The separate first_arg argument is added to aid overloading.
+	 * Otherwise the calls that do no need formatting will still use this function. */
+	IConsolePrint(colour_code, fmt::format(format, first_arg, other_args...));
+}
+
 void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...) WARN_FORMAT(2, 3);
 void IConsoleDebug(const char *dbg, const char *string);
 void IConsoleWarning(const char *string);

--- a/src/console_func.h
+++ b/src/console_func.h
@@ -47,8 +47,6 @@ static inline void IConsolePrint(TextColour colour_code, const T &format, A firs
 }
 
 void CDECL IConsolePrintF(TextColour colour_code, const char *format, ...) WARN_FORMAT(2, 3);
-void IConsoleWarning(const char *string);
-void IConsoleError(const char *string);
 
 /* Parser */
 void IConsoleCmdExec(const char *cmdstr, const uint recurse_count = 0);

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -401,7 +401,7 @@ void IConsoleGUIInit()
 
 	IConsolePrint(TC_LIGHT_BLUE, "OpenTTD Game Console Revision 7 - {}", _openttd_revision);
 	IConsolePrint(CC_WHITE, "------------------------------------");
-	IConsolePrint(CC_WHITE, "use \"help\" for more information");
+	IConsolePrint(CC_WHITE, "use \"help\" for more information.");
 	IConsolePrint(CC_WHITE, "");
 	IConsoleClearCommand();
 }

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -287,7 +287,7 @@ struct IConsoleWindow : Window
 				/* We always want the ] at the left side; we always force these strings to be left
 				 * aligned anyway. So enforce this in all cases by adding a left-to-right marker,
 				 * otherwise it will be drawn at the wrong side with right-to-left texts. */
-				IConsolePrintF(CC_COMMAND, LRM "] %s", _iconsole_cmdline.buf);
+				IConsolePrint(CC_COMMAND, LRM "] {}", _iconsole_cmdline.buf);
 				const char *cmd = IConsoleHistoryAdd(_iconsole_cmdline.buf);
 				IConsoleClearCommand();
 
@@ -399,10 +399,10 @@ void IConsoleGUIInit()
 	IConsoleLine::Reset();
 	memset(_iconsole_history, 0, sizeof(_iconsole_history));
 
-	IConsolePrintF(CC_WARNING, "OpenTTD Game Console Revision 7 - %s", _openttd_revision);
-	IConsolePrint(CC_WHITE,  "------------------------------------");
-	IConsolePrint(CC_WHITE,  "use \"help\" for more information");
-	IConsolePrint(CC_WHITE,  "");
+	IConsolePrint(TC_LIGHT_BLUE, "OpenTTD Game Console Revision 7 - {}", _openttd_revision);
+	IConsolePrint(CC_WHITE, "------------------------------------");
+	IConsolePrint(CC_WHITE, "use \"help\" for more information");
+	IConsolePrint(CC_WHITE, "");
 	IConsoleClearCommand();
 }
 

--- a/src/console_type.h
+++ b/src/console_type.h
@@ -23,6 +23,7 @@ enum IConsoleModes {
 static const TextColour CC_DEFAULT = TC_SILVER;      ///< Default colour of the console.
 static const TextColour CC_ERROR   = TC_RED;         ///< Colour for error lines.
 static const TextColour CC_WARNING = TC_LIGHT_BLUE;  ///< Colour for warning lines.
+static const TextColour CC_HELP    = TC_LIGHT_BLUE;  ///< Colour for help lines.
 static const TextColour CC_INFO    = TC_YELLOW;      ///< Colour for information lines.
 static const TextColour CC_DEBUG   = TC_LIGHT_BROWN; ///< Colour for debug output.
 static const TextColour CC_COMMAND = TC_GOLD;        ///< Colour for the console's commands.

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -135,8 +135,9 @@ void DebugPrint(const char *level, const std::string &message)
 #else
 		fputs(msg.c_str(), stderr);
 #endif
+
 		NetworkAdminConsole(level, message);
-		IConsoleDebug(level, message.c_str());
+		if (_settings_client.gui.developer >= 2) IConsolePrint(CC_DEBUG, "dbg: [{}] {}", level, message);
 	}
 }
 

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -399,10 +399,7 @@ void ShowErrorMessage(StringID summary_msg, StringID detailed_msg, WarningLevel 
 
 		if (textref_stack_size > 0) StopTextRefStackUsage();
 
-		switch (wl) {
-			case WL_WARNING: IConsolePrint(CC_WARNING, buf); break;
-			default:         IConsoleError(buf); break;
-		}
+		IConsolePrint(wl == WL_WARNING ? CC_WARNING : CC_ERROR, buf);
 	}
 
 	bool no_timeout = wl == WL_CRITICAL;

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -1076,6 +1076,6 @@ void ConPrintFramerate()
 	}
 
 	if (!printed_anything) {
-		IConsoleWarning("No performance measurements have been taken yet");
+		IConsolePrint(CC_ERROR, "No performance measurements have been taken yet.");
 	}
 }

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -1023,7 +1023,7 @@ void ConPrintFramerate()
 	const int count2 = NUM_FRAMERATE_POINTS / 4;
 	const int count3 = NUM_FRAMERATE_POINTS / 1;
 
-	IConsolePrintF(TC_SILVER, "Based on num. data points: %d %d %d", count1, count2, count3);
+	IConsolePrint(TC_SILVER, "Based on num. data points: {} {} {}", count1, count2, count3);
 
 	static const char *MEASUREMENT_NAMES[PFE_MAX] = {
 		"Game loop",
@@ -1050,7 +1050,7 @@ void ConPrintFramerate()
 	for (const PerformanceElement *e = rate_elements; e < rate_elements + lengthof(rate_elements); e++) {
 		auto &pf = _pf_data[*e];
 		if (pf.num_valid == 0) continue;
-		IConsolePrintF(TC_GREEN, "%s rate: %.2ffps  (expected: %.2ffps)",
+		IConsolePrint(TC_GREEN, "{} rate: {:.2f}fps  (expected: {:.2f}fps)",
 			MEASUREMENT_NAMES[*e],
 			pf.GetRate(),
 			pf.expected_rate);
@@ -1067,7 +1067,7 @@ void ConPrintFramerate()
 			seprintf(ai_name_buf, lastof(ai_name_buf), "AI %d %s", e - PFE_AI0 + 1, GetAIName(e - PFE_AI0)),
 			name = ai_name_buf;
 		}
-		IConsolePrintF(TC_LIGHT_BLUE, "%s times: %.2fms  %.2fms  %.2fms",
+		IConsolePrint(TC_LIGHT_BLUE, "{} times: {:.2f}ms  {:.2f}ms  {:.2f}ms",
 			name,
 			pf.GetAverageDurationMilliseconds(count1),
 			pf.GetAverageDurationMilliseconds(count2),

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -1109,7 +1109,7 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 static bool CmdDumpSMF(byte argc, char *argv[])
 {
 	if (argc == 0) {
-		IConsolePrint(CC_WARNING, "Write the current song to a Standard MIDI File. Usage: 'dumpsmf <filename>'");
+		IConsolePrint(CC_HELP, "Write the current song to a Standard MIDI File. Usage: 'dumpsmf <filename>'.");
 		return true;
 	}
 	if (argc != 2) {
@@ -1127,7 +1127,7 @@ static bool CmdDumpSMF(byte argc, char *argv[])
 		IConsolePrint(CC_ERROR, "Filename too long.");
 		return false;
 	}
-	IConsolePrintF(CC_INFO, "Dumping MIDI to: %s", fnbuf);
+	IConsolePrint(CC_INFO, "Dumping MIDI to '{}'.", fnbuf);
 
 	if (_midifile_instance->WriteSMF(fnbuf)) {
 		IConsolePrint(CC_INFO, "File written successfully.");

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -265,7 +265,7 @@ void NetworkTextMessage(NetworkAction action, TextColour colour, bool self_send,
 	GetString(msg_ptr, strid, lastof(message));
 
 	Debug(desync, 1, "msg: {:08x}; {:02x}; {}", _date, _date_fract, message);
-	IConsolePrintF(colour, "%s", message);
+	IConsolePrint(colour, message);
 	NetworkAddChatMessage((TextColour)colour, _settings_client.gui.network_chat_timeout, message);
 }
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1010,7 +1010,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMMAND(Packet 
 	cp.my_cmd   = p->Recv_bool();
 
 	if (err != nullptr) {
-		IConsolePrintF(CC_ERROR, "WARNING: %s from server, dropping...", err);
+		IConsolePrint(CC_WARNING, "Dropping server connection due to {}.", err);
 		return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 	}
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1160,7 +1160,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_RCON(Packet *p)
 
 	std::string rcon_out = p->Recv_string(NETWORK_RCONCOMMAND_LENGTH);
 
-	IConsolePrint(colour_code, rcon_out.c_str());
+	IConsolePrint(colour_code, rcon_out);
 
 	return NETWORK_RECV_STATUS_OKAY;
 }

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -95,12 +95,12 @@ uint32 NewGRFProfiler::Finish()
 	if (!this->active) return 0;
 
 	if (this->calls.empty()) {
-		IConsolePrintF(CC_DEBUG, "Finished profile of NewGRF [%08X], no events collected, not writing a file", BSWAP32(this->grffile->grfid));
+		IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{:08X}], no events collected, not writing a file.", BSWAP32(this->grffile->grfid));
 		return 0;
 	}
 
 	std::string filename = this->GetOutputFilename();
-	IConsolePrintF(CC_DEBUG, "Finished profile of NewGRF [%08X], writing %u events to %s", BSWAP32(this->grffile->grfid), (uint)this->calls.size(), filename.c_str());
+	IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{:08X}], writing {} events to '{}'.", BSWAP32(this->grffile->grfid), this->calls.size(), filename);
 
 	FILE *f = FioFOpenFile(filename, "wt", Subdirectory::NO_DIRECTORY);
 	FileCloser fcloser(f);
@@ -151,7 +151,7 @@ uint32 NewGRFProfiler::FinishAll()
 	}
 
 	if (total_microseconds > 0 && max_ticks > 0) {
-		IConsolePrintF(CC_DEBUG, "Total NewGRF callback processing: %u microseconds over %d ticks", total_microseconds, max_ticks);
+		IConsolePrint(CC_DEBUG, "Total NewGRF callback processing: {} microseconds over {} ticks.", total_microseconds, max_ticks);
 	}
 
 	_newgrf_profile_end_date = MAX_DAY;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1950,9 +1950,9 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 
 	if (!success) {
 		if (_network_server) {
-			IConsoleError("This command/variable is not available during network games.");
+			IConsolePrint(CC_ERROR, "This command/variable is not available during network games.");
 		} else {
-			IConsoleError("This command/variable is only available to a network server.");
+			IConsolePrint(CC_ERROR, "This command/variable is only available to a network server.");
 		}
 	}
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1929,7 +1929,7 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 {
 	const SettingDesc *sd = GetSettingFromName(name);
 	if (sd == nullptr) {
-		IConsolePrintF(CC_WARNING, "'%s' is an unknown setting.", name);
+		IConsolePrint(CC_ERROR, "'{}' is an unknown setting.", name);
 		return;
 	}
 
@@ -1941,7 +1941,7 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 		extern bool GetArgumentInteger(uint32 *value, const char *arg);
 		success = GetArgumentInteger(&val, value);
 		if (!success) {
-			IConsolePrintF(CC_ERROR, "'%s' is not an integer.", value);
+			IConsolePrint(CC_ERROR, "'{}' is not an integer.", value);
 			return;
 		}
 
@@ -1973,19 +1973,19 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
 {
 	const SettingDesc *sd = GetSettingFromName(name);
 	if (sd == nullptr) {
-		IConsolePrintF(CC_WARNING, "'%s' is an unknown setting.", name);
+		IConsolePrint(CC_ERROR, "'{}' is an unknown setting.", name);
 		return;
 	}
 
 	const void *object = (_game_mode == GM_MENU || force_newgame) ? &_settings_newgame : &_settings_game;
 
 	if (sd->IsStringSetting()) {
-		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s'", sd->name.c_str(), sd->AsStringSetting()->Read(object).c_str());
+		IConsolePrint(CC_INFO, "Current value for '{}' is '{}'.", sd->name, sd->AsStringSetting()->Read(object));
 	} else if (sd->IsIntSetting()) {
 		char value[20];
 		sd->FormatValue(value, lastof(value), object);
 		const IntSettingDesc *int_setting = sd->AsIntSetting();
-		IConsolePrintF(CC_WARNING, "Current value for '%s' is: '%s' (min: %s%d, max: %u)",
+		IConsolePrint(CC_INFO, "Current value for '{}' is '{}' (min: {}{}, max: {}).",
 			sd->name.c_str(), value, (sd->flags & SF_GUI_0_IS_SPECIAL) ? "(0) " : "", int_setting->min, int_setting->max);
 	}
 }
@@ -1997,17 +1997,17 @@ void IConsoleGetSetting(const char *name, bool force_newgame)
  */
 void IConsoleListSettings(const char *prefilter)
 {
-	IConsolePrintF(CC_WARNING, "All settings with their current value:");
+	IConsolePrint(CC_HELP, "All settings with their current value:");
 
 	for (auto &sd : _settings) {
 		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
 		if (prefilter != nullptr && sd->name.find(prefilter) == std::string::npos) continue;
 		char value[80];
 		sd->FormatValue(value, lastof(value), &GetGameSettings());
-		IConsolePrintF(CC_DEFAULT, "%s = %s", sd->name.c_str(), value);
+		IConsolePrint(CC_DEFAULT, "{} = {}", sd->name, value);
 	}
 
-	IConsolePrintF(CC_WARNING, "Use 'setting' command to change a value");
+	IConsolePrint(CC_HELP, "Use 'setting' command to change a value.");
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Where to start?
* Some warnings get "WARNING" added, others do not.
* Some errors get "ERROR" added, others do not.
* Some issues that mean a command cannot be run are shown as warnings, whereas other times they are called as errors.
* Some messages starting with "WARNING" are shown in the error color.
* Vast inconsistency in writing of messages.
* Pointless "-" in front of the help messages, but not for all of them.
* Some "warnings" (or rather issues that would prevent the command to be not run) would not get their "error" shown based on a setting.
* IConsoleError/IConsoleWarning/IConsoleDebug/IConsoleHelp "helper" functions did not support formatting of strings.
* IConsolePrint and IConsolePrintF were used interchangeably, well... IConsolePrintF was used when IConsolePrint could have been used.


## Description

* Consolidate all the console printing functions into IConsolePrint, which now has the same functionality as IConsolePrintF.
* Remove `IConsoleWarning(` in lieu of `IConsolePrint(CC_WARNING, `.
* Remove the filtering of some warning messages.
* Remove `IConsoleError(` in lieu of `IConsolePrint(CC_ERROR, `.
* Remove `IConsoleHelp(` in lieu of `IConsolePrint(CC_HELP, `.
* Add `CC_HELP` to distinguish between `CC_HELP` and `CC_WARNING`.
* Revisit all error messages on their writing and their "color", i.e. make some errors warnings and vice versa.

Feel free to propose other improvements to strings printed to the in-game console.

If this approach is taken over adding formatting functionality to IConsoleError/Warning, then this closes #8853 and closes #8894.


## Limitations

None I think, unless someone did matching on colors of strings, or was actually parsing the strings... as then those might now be broken in some cases.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
