### PR TITLE
Fix #9361, a2051ba: [Network] Off by one in CanWriteToPacket

### DIFF
--- a/src/network/core/packet.cpp
+++ b/src/network/core/packet.cpp
@@ -98,7 +98,7 @@ void Packet::PrepareToSend()
  */
 bool Packet::CanWriteToPacket(size_t bytes_to_write)
 {
-	return this->Size() + bytes_to_write < this->limit;
+	return this->Size() + bytes_to_write <= this->limit;
 }
 
 /*


### PR DESCRIPTION
## Motivation / Problem

Fixes #9361. Also partly fixing a2051ba, though it was also wrong before as well in some parts.

The old implementation (pre a2051ba) of `Send_uint*`/`Send_bool` function of `Packet` did `assert(this->size < SEND_MTU - sizeof(data));`. After a2051ba this effectively became `assert(this->size + sizeof(data) < SEND_MTU);`, which is still the same functionality wise, and that was the logic `CanWriteToPacket` was based upon.
However, other functions such as `Send_string` and custom checks in other places did things like `assert(this->size + strlen(data) + 1 <= SEND_MTU);`. In a2051ba they lost the `=` of `<=`, whereas the `Send_uint` ones should have actually gained the `=` as they were wrong/off-by-one.

Note: this is an off-by-one in the safe direction, as it would just prevent the last valid byte of the packet to be used by `Send_uint*`. It is NOT writing beyond its buffer.


## Description

Change `bytes_in_packet + bytes_to_add < MAX_BYTES_IN_PACKET` to `bytes_in_packet + bytes_to_add <= MAX_BYTES_IN_PACKET`. Presume `bytes_in_packet` to be 1, `bytes_to_add` to be 2 and `MAX_BYTES_IN_PACKET` to be 3. Then the two bytes can be written to the packet, whereas the previous `CanWriteToPacket` would not allow it anymore.

## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
