### PR TITLE
Fix 81062163: for (really) old games, station bus/truck station cache was not updated

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1415,7 +1415,7 @@ bool AfterLoadGame()
 		c->avail_roadtypes = GetCompanyRoadTypes(c->index);
 	}
 
-	if (!IsSavegameVersionBefore(SLV_27)) AfterLoadStations();
+	AfterLoadStations();
 
 	/* Time starts at 0 instead of 1920.
 	 * Account for this in older games by adding an offset */


### PR DESCRIPTION
## Motivation / Problem

So I was doing the following:

For a huge set of savegames, ranging from 0.3 up til 1.11.2, do this:

- Save the old savegame, call it "main".
- Load the old savegame (call it "original"), run it for 256 ticks. Save the game, export as JSON.
- Load the "main", run it for 256 ticks. Save the game, export as JSON.
- Compare the JSON files. There should be no difference, in theory.

I did this to validate "Afterload", that we are doing the right thing in all cases.

Turns out .. 12 years ago we made a boo-boo, and we do not do the right thing in all cases :)


## Description

In 81062163 we introduced a station cache, where we know the area the bus/truck-stations are within. This cache is generated in `AfterloadStations`. Unaware to the writer of that change, `AfterloadStations` is not -always- loaded when loading old games. Specifically, if the version is pre-27, it is not executed. So for those savegames, the cache value was never correctly calculated.

This means that in the above example, you see, sometimes even after a few ticks, that road vehicles start to make different decisions. One thinks he reached the station, the other thinks he did not.

As it turns out, `AfterloadStations` is called in many other places too, mostly when there is any change to the NewGRF configuration. So clearly it is fine to call this function unconditionally, and indeed, by removing the version-check, the whole test-set validates a lot better. (still some issues, but not for this PR).

Version 27 is the 0.4.X series, for context.

## Limitations

- Ran the full test-suite again, and this solved 90% of the issues it found. The remaining ones are not for this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
