### PR TITLE
Fix #9358: TarScanner no longer ignores empty files

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -541,9 +541,6 @@ bool TarScanner::AddFile(const std::string &filename, size_t basepath_length, co
 		switch (th.typeflag) {
 			case '\0':
 			case '0': { // regular file
-				/* Ignore empty files */
-				if (skip == 0) break;
-
 				if (strlen(name) == 0) break;
 
 				/* Store this entry in the list */


### PR DESCRIPTION
## Motivation / Problem
An AI requires a file with 0 bytes to be able to start, but the tar scanner skips empty files, causing the AI to fail with a "file not found" error.
See #9358 
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
The problem is solved by allowing tar scanner to add empty files.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
It was suggested to fix it this way, but there's some uncertainty about it. I'm not familiar with this code.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
