### PR TITLE
Fix a99ac62: fmt's include of cassert breaks our assert logic

### DIFF
--- a/src/3rdparty/fmt/format-inl.h
+++ b/src/3rdparty/fmt/format-inl.h
@@ -8,7 +8,7 @@
 #ifndef FMT_FORMAT_INL_H_
 #define FMT_FORMAT_INL_H_
 
-#include <cassert>
+/* Do not include cassert as that breaks our own asserts. */
 #include <cctype>
 #include <climits>
 #include <cmath>


### PR DESCRIPTION
## Motivation / Problem

Including `<cassert>` breaks our asserts and that could lead to e.g. the pool checks to fail as in some cases the side effects of asserts are ran, and in others they are not.


## Description

Remove `<cassert>` from being included in "format-inl.h" and add a comment there so we are unlikely to re add it when updating fmt.


## Limitations

None as far as I know.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
