### PR TITLE
Assorted C-string -> std::string conversions in network

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -231,7 +231,7 @@ GameStrings *LoadTranslations()
 	basename.erase(e + 1);
 
 	std::string filename = basename + "lang" PATHSEP "english.txt";
-	if (!FioCheckFileExists(filename.c_str() , GAME_DIR)) return nullptr;
+	if (!FioCheckFileExists(filename, GAME_DIR)) return nullptr;
 
 	auto ls = ReadRawLanguageStrings(filename);
 	if (!ls.IsValid()) return nullptr;

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -143,7 +143,7 @@ bool NetworkAddress::IsFamily(int family)
  * @note netmask without /n assumes all bits need to match.
  * @return true if this IP is within the netmask.
  */
-bool NetworkAddress::IsInNetmask(const char *netmask)
+bool NetworkAddress::IsInNetmask(const std::string &netmask)
 {
 	/* Resolve it if we didn't do it already */
 	if (!this->IsResolved()) this->GetAddress();
@@ -153,16 +153,15 @@ bool NetworkAddress::IsInNetmask(const char *netmask)
 	NetworkAddress mask_address;
 
 	/* Check for CIDR separator */
-	const char *chr_cidr = strchr(netmask, '/');
-	if (chr_cidr != nullptr) {
-		int tmp_cidr = atoi(chr_cidr + 1);
+	auto cidr_separator_location = netmask.find('/');
+	if (cidr_separator_location != std::string::npos) {
+		int tmp_cidr = atoi(netmask.substr(cidr_separator_location + 1).c_str());
 
 		/* Invalid CIDR, treat as single host */
 		if (tmp_cidr > 0 && tmp_cidr < cidr) cidr = tmp_cidr;
 
 		/* Remove the / so that NetworkAddress works on the IP portion */
-		std::string ip_str(netmask, chr_cidr - netmask);
-		mask_address = NetworkAddress(ip_str.c_str(), 0, this->address.ss_family);
+		mask_address = NetworkAddress(netmask.substr(0, cidr_separator_location), 0, this->address.ss_family);
 	} else {
 		mask_address = NetworkAddress(netmask, 0, this->address.ss_family);
 	}

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -19,7 +19,7 @@
  * IPv4 dotted representation is given.
  * @return the hostname
  */
-const char *NetworkAddress::GetHostname()
+const std::string &NetworkAddress::GetHostname()
 {
 	if (this->hostname.empty() && this->address.ss_family != AF_UNSPEC) {
 		assert(this->address_length != 0);
@@ -27,7 +27,7 @@ const char *NetworkAddress::GetHostname()
 		getnameinfo((struct sockaddr *)&this->address, this->address_length, buffer, sizeof(buffer), nullptr, 0, NI_NUMERICHOST);
 		this->hostname = buffer;
 	}
-	return this->hostname.c_str();
+	return this->hostname;
 }
 
 /**

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -116,7 +116,7 @@ public:
 	}
 
 	bool IsFamily(int family);
-	bool IsInNetmask(const char *netmask);
+	bool IsInNetmask(const std::string &netmask);
 
 	/**
 	 * Compare the address of this class with the address of another.

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -89,7 +89,6 @@ public:
 	}
 
 	const char *GetHostname();
-	void GetAddressAsString(char *buffer, const char *last, bool with_family = true);
 	std::string GetAddressAsString(bool with_family = true);
 	const sockaddr_storage *GetAddress();
 

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -88,7 +88,7 @@ public:
 		this->SetPort(port);
 	}
 
-	const char *GetHostname();
+	const std::string &GetHostname();
 	std::string GetAddressAsString(bool with_family = true);
 	const sockaddr_storage *GetAddress();
 

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -89,8 +89,8 @@ struct NetworkGameInfo : NetworkServerGameInfo {
 
 extern NetworkServerGameInfo _network_game_info;
 
-const char *GetNetworkRevisionString();
-bool IsNetworkCompatibleVersion(const char *other);
+std::string_view GetNetworkRevisionString();
+bool IsNetworkCompatibleVersion(std::string_view other);
 void CheckGameCompatibility(NetworkGameInfo &ngi);
 
 void FillStaticNetworkServerGameInfo();

--- a/src/network/core/os_abstraction.cpp
+++ b/src/network/core/os_abstraction.cpp
@@ -76,7 +76,7 @@ bool NetworkError::IsConnectInProgress() const
  * Get the string representation of the error message.
  * @return The string representation that will get overwritten by next calls.
  */
-const char *NetworkError::AsString() const
+const std::string &NetworkError::AsString() const
 {
 	if (this->message.empty()) {
 #if defined(_WIN32)
@@ -97,7 +97,7 @@ const char *NetworkError::AsString() const
 		this->message.assign(strerror(this->error));
 #endif
 	}
-	return this->message.c_str();
+	return this->message;
 }
 
 /**

--- a/src/network/core/os_abstraction.h
+++ b/src/network/core/os_abstraction.h
@@ -29,7 +29,7 @@ public:
 	bool WouldBlock() const;
 	bool IsConnectionReset() const;
 	bool IsConnectInProgress() const;
-	const char *AsString() const;
+	const std::string &AsString() const;
 
 	static NetworkError GetLast();
 };

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -183,7 +183,7 @@ void TCPConnecter::Resolve()
 	auto start = std::chrono::steady_clock::now();
 
 	addrinfo *ai;
-	int error = getaddrinfo(address.GetHostname(), port_name, &hints, &ai);
+	int error = getaddrinfo(address.GetHostname().c_str(), port_name, &hints, &ai);
 
 	auto end = std::chrono::steady_clock::now();
 	auto duration = std::chrono::duration_cast<std::chrono::seconds>(end - start);

--- a/src/network/core/tcp_http.h
+++ b/src/network/core/tcp_http.h
@@ -61,7 +61,7 @@ public:
 	void CloseSocket();
 
 	NetworkHTTPSocketHandler(SOCKET sock, HTTPCallback *callback,
-			const char *host, const char *url, const char *data, int depth);
+			const std::string &host, const char *url, const char *data, int depth);
 
 	~NetworkHTTPSocketHandler();
 
@@ -112,7 +112,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		new NetworkHTTPSocketHandler(s, this->callback, this->hostname.c_str(), this->url, this->data, this->depth);
+		new NetworkHTTPSocketHandler(s, this->callback, this->hostname, this->url, this->data, this->depth);
 		/* We've relinquished control of data now. */
 		this->data = nullptr;
 	}

--- a/src/network/core/tcp_listen.h
+++ b/src/network/core/tcp_listen.h
@@ -56,7 +56,7 @@ public:
 			/* Check if the client is banned */
 			bool banned = false;
 			for (const auto &entry : _network_ban_list) {
-				banned = address.IsInNetmask(entry.c_str());
+				banned = address.IsInNetmask(entry);
 				if (banned) {
 					Packet p(Tban_packet);
 					p.PrepareToSend();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -131,7 +131,7 @@ void BaseNetworkContentDownloadStatusWindow::DrawWidget(const Rect &r, int widge
 	StringID str;
 	if (this->downloaded_bytes == this->total_bytes) {
 		str = STR_CONTENT_DOWNLOAD_COMPLETE;
-	} else if (!StrEmpty(this->name)) {
+	} else if (!this->name.empty()) {
 		SetDParamStr(0, this->name);
 		SetDParam(1, this->downloaded_files);
 		SetDParam(2, this->total_files);
@@ -147,7 +147,7 @@ void BaseNetworkContentDownloadStatusWindow::DrawWidget(const Rect &r, int widge
 void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInfo *ci, int bytes)
 {
 	if (ci->id != this->cur_id) {
-		strecpy(this->name, ci->filename.c_str(), lastof(this->name));
+		this->name = ci->filename;
 		this->cur_id = ci->id;
 		this->downloaded_files++;
 	}

--- a/src/network/network_content_gui.h
+++ b/src/network/network_content_gui.h
@@ -22,8 +22,8 @@ protected:
 	uint total_files;      ///< Number of files to download
 	uint downloaded_files; ///< Number of files downloaded
 
-	uint32 cur_id; ///< The current ID of the downloaded file
-	char name[48]; ///< The current name of the downloaded file
+	uint32 cur_id;    ///< The current ID of the downloaded file
+	std::string name; ///< The current name of the downloaded file
 
 public:
 	/**

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1924,7 +1924,7 @@ void NetworkServerDailyLoop()
  * Get the IP address/hostname of the connected client.
  * @return The IP address.
  */
-const char *ServerNetworkGameSocketHandler::GetClientIP()
+const std::string &ServerNetworkGameSocketHandler::GetClientIP()
 {
 	return this->client_address.GetHostname();
 }
@@ -2094,7 +2094,7 @@ uint NetworkServerKickOrBanIP(const std::string &ip, bool ban, const std::string
 	for (NetworkClientSocket *cs : NetworkClientSocket::Iterate()) {
 		if (cs->client_id == CLIENT_ID_SERVER) continue;
 		if (cs->client_id == _redirect_console_to_client) continue;
-		if (cs->client_address.IsInNetmask(ip.c_str())) {
+		if (cs->client_address.IsInNetmask(ip)) {
 			NetworkServerKickClient(cs->client_id, reason);
 			n++;
 		}

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -878,7 +878,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_JOIN(Packet *p)
 	uint32 newgrf_version = p->Recv_uint32();
 
 	/* Check if the client has revision control enabled */
-	if (!IsNetworkCompatibleVersion(client_revision.c_str()) || _openttd_newgrf_version != newgrf_version) {
+	if (!IsNetworkCompatibleVersion(client_revision) || _openttd_newgrf_version != newgrf_version) {
 		/* Different revisions!! */
 		return this->SendError(NETWORK_ERROR_WRONG_REVISION);
 	}

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -115,7 +115,7 @@ public:
 		return "server";
 	}
 
-	const char *GetClientIP();
+	const std::string &GetClientIP();
 
 	static ServerNetworkGameSocketHandler *GetByClientID(ClientID client_id);
 };

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -79,7 +79,7 @@ public:
 
 	virtual Packet *ReceivePacket() override;
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
-	void GetClientName(char *client_name, const char *last) const;
+	std::string GetClientName() const;
 
 	void CheckNextClientToSendMap(NetworkClientSocket *ignore_cs = nullptr);
 

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -182,7 +182,7 @@ struct ScriptFileChecksumCreator : FileScanner {
 		byte tmp_md5sum[16];
 
 		/* Open the file ... */
-		FILE *f = FioFOpenFile(filename.c_str(), "rb", this->dir, &size);
+		FILE *f = FioFOpenFile(filename, "rb", this->dir, &size);
 		if (f == nullptr) return false;
 
 		/* ... calculate md5sum... */

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -708,7 +708,7 @@ static void IniSaveSettingList(IniFile *ini, const char *grpname, StringList &li
 	group->Clear();
 
 	for (const auto &iter : list) {
-		group->GetItem(iter.c_str(), true)->SetValue("");
+		group->GetItem(iter, true)->SetValue("");
 	}
 }
 
@@ -1272,7 +1272,7 @@ static void AILoadConfig(IniFile *ini, const char *grpname)
 				continue;
 			}
 		}
-		if (item->value.has_value()) config->StringToSettings(item->value->c_str());
+		if (item->value.has_value()) config->StringToSettings(*item->value);
 	}
 }
 
@@ -1299,7 +1299,7 @@ static void GameLoadConfig(IniFile *ini, const char *grpname)
 			return;
 		}
 	}
-	if (item->value.has_value()) config->StringToSettings(item->value->c_str());
+	if (item->value.has_value()) config->StringToSettings(*item->value);
 }
 
 /**

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -804,7 +804,7 @@ static void CloneVehicleName(const Vehicle *src, Vehicle *dst)
 
 		/* Check the name is unique. */
 		auto new_name = oss.str();
-		if (IsUniqueVehicleName(new_name.c_str())) {
+		if (IsUniqueVehicleName(new_name)) {
 			dst->name = new_name;
 			break;
 		}


### PR DESCRIPTION
## Motivation / Problem

The ongoing conversion of C-string to std::string.

## Description

All kinds of small, but scattered in networking code, changes to go from C-strings to std::string.
* Use fmt in the network address creation.
* Use std::string is IsInNetmask; https://godbolt.org/z/n8TTM5osz is a simple sort of unit test for this change.
* Let GetHostName/GetClientIP directly return the std::string reference instead of the C-string, to prevent converting is back to a std::string later on (e.g. in IsInNetmask), but also in other locations.
* Let NetworkError just return a reference to its std::string.
* Use fmt in HTTP request creation and pass the host as std::string reference.
* Use std::string_view for network compatability checks; https://godbolt.org/z/sj9Ya3q6W is a simple unit test for this change.
* Use std::string for returning the client name.
* Use std::string for (temporarily) storing the name of the downloading content.


## Limitations

Contains #9372.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
