### PR TITLE
Change: make lists in savegames consistent

### DIFF
--- a/src/saveload/animated_tile_sl.cpp
+++ b/src/saveload/animated_tile_sl.cpp
@@ -24,7 +24,7 @@ extern std::vector<TileIndex> _animated_tiles;
 static void Save_ANIT()
 {
 	SlSetLength(_animated_tiles.size() * sizeof(_animated_tiles.front()));
-	SlArray(_animated_tiles.data(), _animated_tiles.size(), SLE_UINT32);
+	SlCopy(_animated_tiles.data(), _animated_tiles.size(), SLE_UINT32);
 }
 
 /**
@@ -36,7 +36,7 @@ static void Load_ANIT()
 	if (IsSavegameVersionBefore(SLV_80)) {
 		/* In pre version 6, we has 16bit per tile, now we have 32bit per tile, convert it ;) */
 		TileIndex anim_list[256];
-		SlArray(anim_list, 256, IsSavegameVersionBefore(SLV_6) ? (SLE_FILE_U16 | SLE_VAR_U32) : SLE_UINT32);
+		SlCopy(anim_list, 256, IsSavegameVersionBefore(SLV_6) ? (SLE_FILE_U16 | SLE_VAR_U32) : SLE_UINT32);
 
 		for (int i = 0; i < 256; i++) {
 			if (anim_list[i] == 0) break;
@@ -48,7 +48,7 @@ static void Load_ANIT()
 	uint count = (uint)SlGetFieldLength() / sizeof(_animated_tiles.front());
 	_animated_tiles.clear();
 	_animated_tiles.resize(_animated_tiles.size() + count);
-	SlArray(_animated_tiles.data(), count, SLE_UINT32);
+	SlCopy(_animated_tiles.data(), count, SLE_UINT32);
 }
 
 /**

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -20,8 +20,8 @@ static void Load_PRIC()
 {
 	/* Old games store 49 base prices, very old games store them as int32 */
 	int vt = IsSavegameVersionBefore(SLV_65) ? SLE_FILE_I32 : SLE_FILE_I64;
-	SlArray(nullptr, 49, vt | SLE_VAR_NULL);
-	SlArray(nullptr, 49, SLE_FILE_U16 | SLE_VAR_NULL);
+	SlCopy(nullptr, 49, vt | SLE_VAR_NULL);
+	SlCopy(nullptr, 49, SLE_FILE_U16 | SLE_VAR_NULL);
 }
 
 /** Cargo payment rates in pre 126 savegames */
@@ -29,8 +29,8 @@ static void Load_CAPR()
 {
 	uint num_cargo = IsSavegameVersionBefore(SLV_55) ? 12 : IsSavegameVersionBefore(SLV_EXTEND_CARGOTYPES) ? 32 : NUM_CARGO;
 	int vt = IsSavegameVersionBefore(SLV_65) ? SLE_FILE_I32 : SLE_FILE_I64;
-	SlArray(nullptr, num_cargo, vt | SLE_VAR_NULL);
-	SlArray(nullptr, num_cargo, SLE_FILE_U16 | SLE_VAR_NULL);
+	SlCopy(nullptr, num_cargo, vt | SLE_VAR_NULL);
+	SlCopy(nullptr, num_cargo, SLE_FILE_U16 | SLE_VAR_NULL);
 }
 
 static const SaveLoad _economy_desc[] = {

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -156,7 +156,7 @@ static void Load_ENGS()
 	 * was always 256 entries. */
 	StringID names[256];
 
-	SlArray(names, lengthof(names), SLE_STRINGID);
+	SlCopy(names, lengthof(names), SLE_STRINGID);
 
 	/* Copy each string into the temporary engine array. */
 	for (EngineID engine = 0; engine < lengthof(names); engine++) {

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -53,7 +53,7 @@ static void Load_MAPT()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].type = buf[j];
 	}
 }
@@ -66,7 +66,7 @@ static void Save_MAPT()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].type;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -76,7 +76,7 @@ static void Load_MAPH()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].height = buf[j];
 	}
 }
@@ -89,7 +89,7 @@ static void Save_MAPH()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].height;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -99,7 +99,7 @@ static void Load_MAP1()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m1 = buf[j];
 	}
 }
@@ -112,7 +112,7 @@ static void Save_MAP1()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m1;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -122,7 +122,7 @@ static void Load_MAP2()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE,
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE,
 			/* In those versions the m2 was 8 bits */
 			IsSavegameVersionBefore(SLV_5) ? SLE_FILE_U8 | SLE_VAR_U16 : SLE_UINT16
 		);
@@ -138,7 +138,7 @@ static void Save_MAP2()
 	SlSetLength(size * sizeof(uint16));
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m2;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 	}
 }
 
@@ -148,7 +148,7 @@ static void Load_MAP3()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m3 = buf[j];
 	}
 }
@@ -161,7 +161,7 @@ static void Save_MAP3()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m3;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -171,7 +171,7 @@ static void Load_MAP4()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m4 = buf[j];
 	}
 }
@@ -184,7 +184,7 @@ static void Save_MAP4()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m4;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -194,7 +194,7 @@ static void Load_MAP5()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m5 = buf[j];
 	}
 }
@@ -207,7 +207,7 @@ static void Save_MAP5()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m5;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -219,7 +219,7 @@ static void Load_MAP6()
 	if (IsSavegameVersionBefore(SLV_42)) {
 		for (TileIndex i = 0; i != size;) {
 			/* 1024, otherwise we overflow on 64x64 maps! */
-			SlArray(buf.data(), 1024, SLE_UINT8);
+			SlCopy(buf.data(), 1024, SLE_UINT8);
 			for (uint j = 0; j != 1024; j++) {
 				_me[i++].m6 = GB(buf[j], 0, 2);
 				_me[i++].m6 = GB(buf[j], 2, 2);
@@ -229,7 +229,7 @@ static void Load_MAP6()
 		}
 	} else {
 		for (TileIndex i = 0; i != size;) {
-			SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _me[i++].m6 = buf[j];
 		}
 	}
@@ -243,7 +243,7 @@ static void Save_MAP6()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _me[i++].m6;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -253,7 +253,7 @@ static void Load_MAP7()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _me[i++].m7 = buf[j];
 	}
 }
@@ -266,7 +266,7 @@ static void Save_MAP7()
 	SlSetLength(size);
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _me[i++].m7;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 	}
 }
 
@@ -276,7 +276,7 @@ static void Load_MAP8()
 	TileIndex size = MapSize();
 
 	for (TileIndex i = 0; i != size;) {
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _me[i++].m8 = buf[j];
 	}
 }
@@ -289,7 +289,7 @@ static void Save_MAP8()
 	SlSetLength(size * sizeof(uint16));
 	for (TileIndex i = 0; i != size;) {
 		for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _me[i++].m8;
-		SlArray(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
+		SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 	}
 }
 

--- a/src/saveload/order_sl.cpp
+++ b/src/saveload/order_sl.cpp
@@ -141,7 +141,7 @@ static void Load_ORDR()
 			len /= sizeof(uint16);
 			uint16 *orders = MallocT<uint16>(len + 1);
 
-			SlArray(orders, len, SLE_UINT16);
+			SlCopy(orders, len, SLE_UINT16);
 
 			for (size_t i = 0; i < len; ++i) {
 				Order *o = new (i) Order();
@@ -153,7 +153,7 @@ static void Load_ORDR()
 			len /= sizeof(uint32);
 			uint32 *orders = MallocT<uint32>(len + 1);
 
-			SlArray(orders, len, SLE_UINT32);
+			SlCopy(orders, len, SLE_UINT32);
 
 			for (size_t i = 0; i < len; ++i) {
 				new (i) Order(orders[i]);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1590,6 +1590,34 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 }
 
 /**
+ * Set the length of this list.
+ * @param The length of the list.
+ */
+void SlSetStructListLength(size_t length)
+{
+	/* Automatically calculate the length? */
+	if (_sl.need_length != NL_NONE) {
+		SlSetLength(SlGetArrayLength(length));
+		if (_sl.need_length == NL_CALCLENGTH) return;
+	}
+
+	SlWriteArrayLength(length);
+}
+
+/**
+ * Get the length of this list; if it exceeds the limit, error out.
+ * @param limit The maximum size the list can be.
+ * @return The length of the list.
+ */
+size_t SlGetStructListLength(size_t limit)
+{
+	size_t length = SlReadArrayLength();
+	if (length > limit) SlErrorCorrupt("List exceeds storage size");
+
+	return length;
+}
+
+/**
  * Main SaveLoad function.
  * @param object The object that is being saved or loaded.
  * @param slt The SaveLoad table with objects to save/load.

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1261,7 +1261,7 @@ public:
 
 		const SlStorageT *list = static_cast<const SlStorageT *>(storage);
 
-		int type_size = SlCalcConvFileLen(SLE_FILE_U32); // Size of the length of the list.
+		int type_size = SlGetArrayLength(list->size());
 		int item_size = SlCalcConvFileLen(cmd == SL_VAR ? conv : (VarType)SLE_FILE_U32);
 		return list->size() * item_size + type_size;
 	}
@@ -1290,7 +1290,7 @@ public:
 
 		switch (_sl.action) {
 			case SLA_SAVE:
-				SlWriteUint32((uint32)list->size());
+				SlWriteArrayLength(list->size());
 
 				for (auto &item : *list) {
 					SlSaveLoadMember(cmd, &item, conv);
@@ -1301,8 +1301,8 @@ public:
 			case SLA_LOAD: {
 				size_t length;
 				switch (cmd) {
-					case SL_VAR: length = SlReadUint32(); break;
-					case SL_REF: length = IsSavegameVersionBefore(SLV_69) ? SlReadUint16() : SlReadUint32(); break;
+					case SL_VAR: length = IsSavegameVersionBefore(SLV_SAVELOAD_LIST_LENGTH) ? SlReadUint32() : SlReadArrayLength(); break;
+					case SL_REF: length = IsSavegameVersionBefore(SLV_69) ? SlReadUint16() : IsSavegameVersionBefore(SLV_SAVELOAD_LIST_LENGTH) ? SlReadUint32() : SlReadArrayLength(); break;
 					default: NOT_REACHED();
 				}
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1069,6 +1069,12 @@ void SlArray(void *array, size_t length, VarType conv)
 		if (_sl.need_length == NL_CALCLENGTH) return;
 	}
 
+	if (GetVarMemType(conv) == SLE_VAR_NULL) {
+		assert(_sl.action != SLA_SAVE); // Use SL_NULL if you want to write null-bytes
+		SlSkipBytes(SlCalcArrayLen(length, conv));
+		return;
+	}
+
 	/* NOTICE - handle some buggy stuff, in really old versions everything was saved
 	 * as a byte-type. So detect this, and adjust array size accordingly */
 	if (_sl.action != SLA_SAVE && _sl_version == 0) {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -1008,7 +1008,7 @@ byte SlReadByte();
 void SlWriteByte(byte b);
 
 void SlGlobList(const SaveLoadTable &slt);
-void SlArray(void *array, size_t length, VarType conv);
+void SlCopy(void *object, size_t length, VarType conv);
 void SlObject(void *object, const SaveLoadTable &slt);
 void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
 void NORETURN SlErrorCorrupt(const char *msg);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -326,9 +326,11 @@ enum SaveLoadVersion : uint16 {
 	SLV_GS_INDUSTRY_CONTROL,                ///< 287  PR#7912 and PR#8115 GS industry control.
 	SLV_VEH_MOTION_COUNTER,                 ///< 288  PR#8591 Desync safe motion counter
 	SLV_INDUSTRY_TEXT,                      ///< 289  PR#8576 v1.11.0-RC1  Additional GS text for industries.
+
 	SLV_MAPGEN_SETTINGS_REVAMP,             ///< 290  PR#8891 v1.11  Revamp of some mapgen settings (snow coverage, desert coverage, heightmap height, custom terrain type).
 	SLV_GROUP_REPLACE_WAGON_REMOVAL,        ///< 291  PR#7441 Per-group wagon removal flag.
 	SLV_CUSTOM_SUBSIDY_DURATION,            ///< 292  PR#9081 Configurable subsidy duration.
+	SLV_SAVELOAD_LIST_LENGTH,               ///< 293  PR#9374 Consistency in list length with SL_STRUCT / SL_STRUCTLIST / SL_DEQUE / SL_REFLIST.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
@@ -991,6 +993,9 @@ void WriteValue(void *ptr, VarType conv, int64 val);
 
 void SlSetArrayIndex(uint index);
 int SlIterateArray();
+
+void SlSetStructListLength(size_t length);
+size_t SlGetStructListLength(size_t limit);
 
 void SlAutolength(AutolengthProc *proc, void *arg);
 size_t SlGetFieldLength();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -573,6 +573,7 @@ enum SaveLoadType : byte {
 	SL_STRUCT      =  7, ///< Save/load a struct.
 	SL_STRUCTLIST  =  8, ///< Save/load a list of structs.
 	SL_SAVEBYTE    =  9, ///< Save (but not load) a byte.
+	SL_NULL        = 10, ///< Save null-bytes and load to nowhere.
 };
 
 typedef void *SaveLoadAddrProc(void *base, size_t extra);
@@ -737,7 +738,7 @@ struct SaveLoad {
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLE_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
+#define SLE_CONDNULL(length, from, to) {SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
 
 /**
  * Only write byte during saving; never read it during loading.
@@ -895,7 +896,7 @@ struct SaveLoad {
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLEG_CONDNULL(length, from, to) {SL_ARR, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
+#define SLEG_CONDNULL(length, from, to) {SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
 
 /**
  * Checks whether the savegame is below \a major.\a minor.

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -124,7 +124,7 @@ static void Load_NAME()
 		if (index >= NUM_OLD_STRINGS) SlErrorCorrupt("Invalid old name index");
 		if (SlGetFieldLength() > (uint)LEN_OLD_STRINGS) SlErrorCorrupt("Invalid old name length");
 
-		SlArray(&_old_name_array[LEN_OLD_STRINGS * index], SlGetFieldLength(), SLE_UINT8);
+		SlCopy(&_old_name_array[LEN_OLD_STRINGS * index], SlGetFieldLength(), SLE_UINT8);
 		/* Make sure the old name is null terminated */
 		_old_name_array[LEN_OLD_STRINGS * index + LEN_OLD_STRINGS - 1] = '\0';
 	}

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -365,7 +365,7 @@ static const SaveLoad _script_byte[] = {
 			sq_getinteger(vm, index, &res);
 			if (!test) {
 				int value = (int)res;
-				SlArray(&value, 1, SLE_INT32);
+				SlCopy(&value, 1, SLE_INT32);
 			}
 			return true;
 		}
@@ -385,7 +385,7 @@ static const SaveLoad _script_byte[] = {
 			if (!test) {
 				_script_sl_byte = (byte)len;
 				SlObject(nullptr, _script_byte);
-				SlArray(const_cast<char *>(buf), len, SLE_CHAR);
+				SlCopy(const_cast<char *>(buf), len, SLE_CHAR);
 			}
 			return true;
 		}
@@ -565,7 +565,7 @@ bool ScriptInstance::IsPaused()
 	switch (_script_sl_byte) {
 		case SQSL_INT: {
 			int value;
-			SlArray(&value, 1, SLE_INT32);
+			SlCopy(&value, 1, SLE_INT32);
 			if (vm != nullptr) sq_pushinteger(vm, (SQInteger)value);
 			return true;
 		}
@@ -573,7 +573,7 @@ bool ScriptInstance::IsPaused()
 		case SQSL_STRING: {
 			SlObject(nullptr, _script_byte);
 			static char buf[std::numeric_limits<decltype(_script_sl_byte)>::max()];
-			SlArray(buf, _script_sl_byte, SLE_CHAR);
+			SlCopy(buf, _script_sl_byte, SLE_CHAR);
 			StrMakeValidInPlace(buf, buf + _script_sl_byte);
 			if (vm != nullptr) sq_pushstring(vm, buf, -1);
 			return true;

--- a/src/table/settings/gameopt_settings.ini
+++ b/src/table/settings/gameopt_settings.ini
@@ -41,7 +41,7 @@ static const SettingTable _gameopt_settings{
  * XXX - To save file-space and since values are never bigger than about 10? only
  * save the first 16 bits in the savegame. Question is why the values are still int32
  * and why not byte for example?
- * 'SLE_FILE_I16 | SLE_VAR_U16' in "diff_custom" is needed to get around SlArray() hack
+ * 'SLE_FILE_I16 | SLE_VAR_U16' in "diff_custom" is needed to get around SlCopy() hack
  * for savegames version 0 - though it is an array, it has to go through the byteswap process */
 [post-amble]
 };


### PR DESCRIPTION
## Motivation / Problem

We have a bunch of different lists, which are all done slightly different.

- We have a "fixed-length" list, where the code dictates the length. No validation is done if that same value was also used when writing to disk, which means we have plenty of savegame bumps for cases where it did.
- We have lists like `SL_REFLIST` that have a 32bit length indicator.
- We have all kind of custom stuff with `SL_STRUCTLIST`, where sometimes the length is stored in the parent blob, saved/loaded to a global. But sometimes totally different solutions are used.

This makes self-described savegames really hard (the ultimate goal of this set of PRs, see #9322), but also means savegame-readers need to be really aware of what they are reading, and support a lot of different savegame-versions to do the right thing.

## Description

So .. as you might expect, I set out to fix that problem. Now the rules are simple:

- Any list, no matter who/what you are, has a gamma before the list to indicate how many entries are in the list.

In most cases this means you know the length. For `SL_STRUCT` this is not the case, and as such you need to know what struct is stored to figure out the length. This will be addressed in a later PR.

As using `SL_STRUCT` is normally only useful if it is an optional field (why else bother making it in a new struct, and not just embed it in the parent?), internally it is a `SL_STRUCTLIST` of either 0 or 1 in length. So if it is empty (nothing saved), the length-field is 0. Otherwise, length-field is 1.

## Limitations

- A lot of testing is involved, see #9339 and #9322 for details. So no known issues or limitations.
- Other solutions have been considered, instead of a length-field, like for example a "type", where the last entry is an empty one indicating "end". But given the current state of the code, that is vastly more work.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
