### PR TITLE
Change: make as many savegame chunks a CH_ARRAY as possible

### DIFF
--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -13,7 +13,7 @@
 #include "newgrf_config.h"
 
 /** The actions we log. */
-enum GamelogActionType {
+enum GamelogActionType : uint8 {
 	GLAT_START,        ///< Game created
 	GLAT_LOAD,         ///< Game loaded
 	GLAT_GRF,          ///< GRF changed

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -13,7 +13,7 @@
 #include "gamelog.h"
 
 /** Type of logged change */
-enum GamelogChangeType {
+enum GamelogChangeType : uint8 {
 	GLCT_MODE,        ///< Scenario editor x Game, different landscape
 	GLCT_REVISION,    ///< Changed game revision string
 	GLCT_OLDVER,      ///< Loaded from savegame without logged data

--- a/src/saveload/cheat_sl.cpp
+++ b/src/saveload/cheat_sl.cpp
@@ -44,6 +44,8 @@ static const SaveLoad _cheats_desc[] = {
  */
 static void Save_CHTS()
 {
+	SlSetArrayIndex(0);
+
 	SlSetLength(std::size(_cheats_desc));
 	SlObject(&_cheats, _cheats_desc);
 }
@@ -67,12 +69,14 @@ static void Load_CHTS()
 		if (count == 0) break;
 	}
 
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
 	SlObject(&_cheats, slt);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many CHTS entries");
 }
 
 /** Chunk handlers related to cheats. */
 static const ChunkHandler cheat_chunk_handlers[] = {
-	{ 'CHTS', Save_CHTS, Load_CHTS, nullptr, nullptr, CH_RIFF },
+	{ 'CHTS', Save_CHTS, Load_CHTS, nullptr, nullptr, CH_ARRAY },
 };
 
 extern const ChunkHandlerTable _cheat_chunk_handlers(cheat_chunk_handlers);

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -51,13 +51,17 @@ static const SaveLoad _economy_desc[] = {
 /** Economy variables */
 static void Save_ECMY()
 {
+	SlSetArrayIndex(0);
 	SlObject(&_economy, _economy_desc);
 }
 
 /** Economy variables */
 static void Load_ECMY()
 {
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
 	SlObject(&_economy, _economy_desc);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many ECMY entries");
+
 	StartupIndustryDailyChanges(IsSavegameVersionBefore(SLV_102));  // old savegames will need to be initialized
 }
 
@@ -98,7 +102,7 @@ static const ChunkHandler economy_chunk_handlers[] = {
 	{ 'CAPY', Save_CAPY, Load_CAPY, Ptrs_CAPY, nullptr, CH_ARRAY },
 	{ 'PRIC', nullptr,   Load_PRIC, nullptr,   nullptr, CH_RIFF  },
 	{ 'CAPR', nullptr,   Load_CAPR, nullptr,   nullptr, CH_RIFF  },
-	{ 'ECMY', Save_ECMY, Load_ECMY, nullptr,   nullptr, CH_RIFF  },
+	{ 'ECMY', Save_ECMY, Load_ECMY, nullptr,   nullptr, CH_ARRAY },
 };
 
 extern const ChunkHandlerTable _economy_chunk_handlers(economy_chunk_handlers);

--- a/src/saveload/economy_sl.cpp
+++ b/src/saveload/economy_sl.cpp
@@ -100,8 +100,8 @@ static void Ptrs_CAPY()
 
 static const ChunkHandler economy_chunk_handlers[] = {
 	{ 'CAPY', Save_CAPY, Load_CAPY, Ptrs_CAPY, nullptr, CH_ARRAY },
-	{ 'PRIC', nullptr,   Load_PRIC, nullptr,   nullptr, CH_RIFF  },
-	{ 'CAPR', nullptr,   Load_CAPR, nullptr,   nullptr, CH_RIFF  },
+	{ 'PRIC', nullptr,   Load_PRIC, nullptr,   nullptr, CH_READONLY  },
+	{ 'CAPR', nullptr,   Load_CAPR, nullptr,   nullptr, CH_READONLY  },
 	{ 'ECMY', Save_ECMY, Load_ECMY, nullptr,   nullptr, CH_ARRAY },
 };
 

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -196,7 +196,7 @@ static void Load_EIDS()
 static const ChunkHandler engine_chunk_handlers[] = {
 	{ 'EIDS', Save_EIDS, Load_EIDS, nullptr, nullptr, CH_ARRAY },
 	{ 'ENGN', Save_ENGN, Load_ENGN, nullptr, nullptr, CH_ARRAY },
-	{ 'ENGS', nullptr,   Load_ENGS, nullptr, nullptr, CH_RIFF  },
+	{ 'ENGS', nullptr,   Load_ENGS, nullptr, nullptr, CH_READONLY  },
 };
 
 extern const ChunkHandlerTable _engine_chunk_handlers(engine_chunk_handlers);

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -57,14 +57,14 @@ static void Load_GSDT()
 	/* Free all current data */
 	GameConfig::GetConfig(GameConfig::SSS_FORCE_GAME)->Change(nullptr);
 
-	if ((CompanyID)SlIterateArray() == (CompanyID)-1) return;
+	if (SlIterateArray() == -1) return;
 
 	_game_saveload_version = -1;
 	SlObject(nullptr, _game_script);
 
 	if (_networking && !_network_server) {
 		GameInstance::LoadEmpty();
-		if ((CompanyID)SlIterateArray() != (CompanyID)-1) SlErrorCorrupt("Too many GameScript configs");
+		if (SlIterateArray() != -1) SlErrorCorrupt("Too many GameScript configs");
 		return;
 	}
 
@@ -99,7 +99,7 @@ static void Load_GSDT()
 	Game::StartNew();
 	Game::Load(_game_saveload_version);
 
-	if ((CompanyID)SlIterateArray() != (CompanyID)-1) SlErrorCorrupt("Too many GameScript configs");
+	if (SlIterateArray() != -1) SlErrorCorrupt("Too many GameScript configs");
 }
 
 static void Save_GSDT()

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -15,147 +15,317 @@
 
 #include "../safeguards.h"
 
-static const SaveLoad _glog_action_desc[] = {
+
+class SlGamelogMode : public DefaultSaveLoadHandler<SlGamelogMode, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, mode.mode,         SLE_UINT8),
+		SLE_VAR(LoggedChange, mode.landscape,    SLE_UINT8),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_MODE) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogRevision : public DefaultSaveLoadHandler<SlGamelogRevision, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_ARR(LoggedChange, revision.text,     SLE_UINT8,  GAMELOG_REVISION_LENGTH),
+		SLE_VAR(LoggedChange, revision.newgrf,   SLE_UINT32),
+		SLE_VAR(LoggedChange, revision.slver,    SLE_UINT16),
+		SLE_VAR(LoggedChange, revision.modified, SLE_UINT8),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_REVISION) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogOldver : public DefaultSaveLoadHandler<SlGamelogOldver, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, oldver.type,       SLE_UINT32),
+		SLE_VAR(LoggedChange, oldver.version,    SLE_UINT32),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_OLDVER) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogSetting : public DefaultSaveLoadHandler<SlGamelogSetting, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_STR(LoggedChange, setting.name,      SLE_STR,    128),
+		SLE_VAR(LoggedChange, setting.oldval,    SLE_INT32),
+		SLE_VAR(LoggedChange, setting.newval,    SLE_INT32),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_SETTING) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, grfadd.grfid,      SLE_UINT32    ),
+		SLE_ARR(LoggedChange, grfadd.md5sum,     SLE_UINT8,  16),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_GRFADD) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, grfrem.grfid,      SLE_UINT32),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_GRFREM) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, grfcompat.grfid,   SLE_UINT32    ),
+		SLE_ARR(LoggedChange, grfcompat.md5sum,  SLE_UINT8,  16),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_GRFCOMPAT) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, grfparam.grfid,    SLE_UINT32),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_GRFPARAM) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, grfmove.grfid,     SLE_UINT32),
+		SLE_VAR(LoggedChange, grfmove.offset,    SLE_INT32),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_GRFMOVE) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedChange> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_VAR(LoggedChange, grfbug.data,       SLE_UINT64),
+		SLE_VAR(LoggedChange, grfbug.grfid,      SLE_UINT32),
+		SLE_VAR(LoggedChange, grfbug.bug,        SLE_UINT8),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_GRFBUG) return;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+static bool _is_emergency_save = true;
+
+class SlGamelogEmergency : public DefaultSaveLoadHandler<SlGamelogEmergency, LoggedChange> {
+public:
+	/* We need to store something, so store a "true" value. */
+	inline static const SaveLoad description[] = {
+		SLEG_CONDVAR(_is_emergency_save, SLE_BOOL, SLV_RIFF_TO_ARRAY, SL_MAX_VERSION),
+	};
+
+	void GenericSaveLoad(LoggedChange *lc) const
+	{
+		if (lc->ct != GLCT_EMERGENCY) return;
+
+		_is_emergency_save = true;
+		SlObject(lc, this->GetDescription());
+	}
+
+	void Save(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void Load(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+	void LoadCheck(LoggedChange *lc) const override { this->GenericSaveLoad(lc); }
+};
+
+class SlGamelogAction : public DefaultSaveLoadHandler<SlGamelogAction, LoggedAction> {
+public:
+	inline static const SaveLoad description[] = {
+		SLE_SAVEBYTE(LoggedChange, ct),
+		SLEG_STRUCT(SlGamelogMode),
+		SLEG_STRUCT(SlGamelogRevision),
+		SLEG_STRUCT(SlGamelogOldver),
+		SLEG_STRUCT(SlGamelogSetting),
+		SLEG_STRUCT(SlGamelogGrfadd),
+		SLEG_STRUCT(SlGamelogGrfrem),
+		SLEG_STRUCT(SlGamelogGrfcompat),
+		SLEG_STRUCT(SlGamelogGrfparam),
+		SLEG_STRUCT(SlGamelogGrfmove),
+		SLEG_STRUCT(SlGamelogGrfbug),
+		SLEG_STRUCT(SlGamelogEmergency),
+	};
+
+	void Save(LoggedAction *la) const override
+	{
+		SlSetStructListLength(la->changes);
+
+		const LoggedChange *lcend = &la->change[la->changes];
+		for (LoggedChange *lc = la->change; lc != lcend; lc++) {
+			assert((uint)lc->ct < GLCT_END);
+			SlObject(lc, this->GetDescription());
+		}
+	}
+
+	void Load(LoggedAction *la) const override
+	{
+		if (IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY)) {
+			byte type;
+			while ((type = SlReadByte()) != GLCT_NONE) {
+				if (type >= GLCT_END) SlErrorCorrupt("Invalid gamelog change type");
+				GamelogChangeType ct = (GamelogChangeType)type;
+
+				la->change = ReallocT(la->change, la->changes + 1);
+
+				LoggedChange *lc = &la->change[la->changes++];
+				memset(lc, 0, sizeof(*lc));
+				lc->ct = ct;
+
+				SlObject(lc, this->GetDescription());
+			}
+			return;
+		}
+
+		size_t length = SlGetStructListLength(UINT32_MAX);
+		la->change = ReallocT(la->change, length);
+
+		for (size_t i = 0; i < length; i++) {
+			LoggedChange *lc = &la->change[i];
+			memset(lc, 0, sizeof(*lc));
+
+			lc->ct = (GamelogChangeType)SlReadByte();
+			SlObject(lc, this->GetDescription());
+		}
+	}
+
+	void LoadCheck(LoggedAction *la) const override { this->Load(la); }
+};
+
+static const SaveLoad _gamelog_desc[] = {
+	SLE_CONDVAR(LoggedAction, at,            SLE_UINT8,   SLV_RIFF_TO_ARRAY, SL_MAX_VERSION),
 	SLE_VAR(LoggedAction, tick,              SLE_UINT16),
+	SLEG_STRUCTLIST(SlGamelogAction),
 };
-
-static const SaveLoad _glog_mode_desc[] = {
-	SLE_VAR(LoggedChange, mode.mode,         SLE_UINT8),
-	SLE_VAR(LoggedChange, mode.landscape,    SLE_UINT8),
-};
-
-static const SaveLoad _glog_revision_desc[] = {
-	SLE_ARR(LoggedChange, revision.text,     SLE_UINT8,  GAMELOG_REVISION_LENGTH),
-	SLE_VAR(LoggedChange, revision.newgrf,   SLE_UINT32),
-	SLE_VAR(LoggedChange, revision.slver,    SLE_UINT16),
-	SLE_VAR(LoggedChange, revision.modified, SLE_UINT8),
-};
-
-static const SaveLoad _glog_oldver_desc[] = {
-	SLE_VAR(LoggedChange, oldver.type,       SLE_UINT32),
-	SLE_VAR(LoggedChange, oldver.version,    SLE_UINT32),
-};
-
-static const SaveLoad _glog_setting_desc[] = {
-	SLE_STR(LoggedChange, setting.name,      SLE_STR,    128),
-	SLE_VAR(LoggedChange, setting.oldval,    SLE_INT32),
-	SLE_VAR(LoggedChange, setting.newval,    SLE_INT32),
-};
-
-static const SaveLoad _glog_grfadd_desc[] = {
-	SLE_VAR(LoggedChange, grfadd.grfid,      SLE_UINT32    ),
-	SLE_ARR(LoggedChange, grfadd.md5sum,     SLE_UINT8,  16),
-};
-
-static const SaveLoad _glog_grfrem_desc[] = {
-	SLE_VAR(LoggedChange, grfrem.grfid,      SLE_UINT32),
-};
-
-static const SaveLoad _glog_grfcompat_desc[] = {
-	SLE_VAR(LoggedChange, grfcompat.grfid,   SLE_UINT32    ),
-	SLE_ARR(LoggedChange, grfcompat.md5sum,  SLE_UINT8,  16),
-};
-
-static const SaveLoad _glog_grfparam_desc[] = {
-	SLE_VAR(LoggedChange, grfparam.grfid,    SLE_UINT32),
-};
-
-static const SaveLoad _glog_grfmove_desc[] = {
-	SLE_VAR(LoggedChange, grfmove.grfid,     SLE_UINT32),
-	SLE_VAR(LoggedChange, grfmove.offset,    SLE_INT32),
-};
-
-static const SaveLoad _glog_grfbug_desc[] = {
-	SLE_VAR(LoggedChange, grfbug.data,       SLE_UINT64),
-	SLE_VAR(LoggedChange, grfbug.grfid,      SLE_UINT32),
-	SLE_VAR(LoggedChange, grfbug.bug,        SLE_UINT8),
-};
-
-static const SaveLoad _glog_emergency_desc[] = {
-	SLE_CONDNULL(0, SL_MIN_VERSION, SL_MIN_VERSION), // Just an empty list, to keep the rest of the code easier.
-};
-
-static const SaveLoadTable _glog_desc[] = {
-	_glog_mode_desc,
-	_glog_revision_desc,
-	_glog_oldver_desc,
-	_glog_setting_desc,
-	_glog_grfadd_desc,
-	_glog_grfrem_desc,
-	_glog_grfcompat_desc,
-	_glog_grfparam_desc,
-	_glog_grfmove_desc,
-	_glog_grfbug_desc,
-	_glog_emergency_desc,
-};
-
-static_assert(lengthof(_glog_desc) == GLCT_END);
 
 static void Load_GLOG_common(LoggedAction *&gamelog_action, uint &gamelog_actions)
 {
 	assert(gamelog_action == nullptr);
 	assert(gamelog_actions == 0);
 
-	byte type;
-	while ((type = SlReadByte()) != GLAT_NONE) {
-		if (type >= GLAT_END) SlErrorCorrupt("Invalid gamelog action type");
-		GamelogActionType at = (GamelogActionType)type;
+	if (IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY)) {
+		byte type;
+		while ((type = SlReadByte()) != GLAT_NONE) {
+			if (type >= GLAT_END) SlErrorCorrupt("Invalid gamelog action type");
 
+			gamelog_action = ReallocT(gamelog_action, gamelog_actions + 1);
+			LoggedAction *la = &gamelog_action[gamelog_actions++];
+			memset(la, 0, sizeof(*la));
+
+			la->at = (GamelogActionType)type;
+			SlObject(la, _gamelog_desc);
+		}
+		return;
+	}
+
+	while (SlIterateArray() != -1) {
 		gamelog_action = ReallocT(gamelog_action, gamelog_actions + 1);
 		LoggedAction *la = &gamelog_action[gamelog_actions++];
+		memset(la, 0, sizeof(*la));
 
-		la->at = at;
-
-		SlObject(la, _glog_action_desc); // has to be saved after 'DATE'!
-		la->change = nullptr;
-		la->changes = 0;
-
-		while ((type = SlReadByte()) != GLCT_NONE) {
-			if (type >= GLCT_END) SlErrorCorrupt("Invalid gamelog change type");
-			GamelogChangeType ct = (GamelogChangeType)type;
-
-			la->change = ReallocT(la->change, la->changes + 1);
-
-			LoggedChange *lc = &la->change[la->changes++];
-			/* for SLE_STR, pointer has to be valid! so make it nullptr */
-			memset(lc, 0, sizeof(*lc));
-			lc->ct = ct;
-
-			SlObject(lc, _glog_desc[ct]);
-		}
+		SlObject(la, _gamelog_desc);
 	}
 }
 
 static void Save_GLOG()
 {
 	const LoggedAction *laend = &_gamelog_action[_gamelog_actions];
-	size_t length = 0;
 
-	for (const LoggedAction *la = _gamelog_action; la != laend; la++) {
-		const LoggedChange *lcend = &la->change[la->changes];
-		for (LoggedChange *lc = la->change; lc != lcend; lc++) {
-			assert((uint)lc->ct < lengthof(_glog_desc));
-			length += SlCalcObjLength(lc, _glog_desc[lc->ct]) + 1;
-		}
-		length += 4;
+	uint i = 0;
+	for (LoggedAction *la = _gamelog_action; la != laend; la++, i++) {
+		SlSetArrayIndex(i);
+		SlObject(la, _gamelog_desc);
 	}
-	length++;
-
-	SlSetLength(length);
-
-	for (LoggedAction *la = _gamelog_action; la != laend; la++) {
-		SlWriteByte(la->at);
-		SlObject(la, _glog_action_desc);
-
-		const LoggedChange *lcend = &la->change[la->changes];
-		for (LoggedChange *lc = la->change; lc != lcend; lc++) {
-			SlWriteByte(lc->ct);
-			assert((uint)lc->ct < GLCT_END);
-			SlObject(lc, _glog_desc[lc->ct]);
-		}
-		SlWriteByte(GLCT_NONE);
-	}
-	SlWriteByte(GLAT_NONE);
 }
 
 static void Load_GLOG()
@@ -169,7 +339,7 @@ static void Check_GLOG()
 }
 
 static const ChunkHandler gamelog_chunk_handlers[] = {
-	{ 'GLOG', Save_GLOG, Load_GLOG, nullptr, Check_GLOG, CH_RIFF }
+	{ 'GLOG', Save_GLOG, Load_GLOG, nullptr, Check_GLOG, CH_ARRAY }
 };
 
 extern const ChunkHandlerTable _gamelog_chunk_handlers(gamelog_chunk_handlers);

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -139,10 +139,19 @@ static const SaveLoad _industry_builder_desc[] = {
 	SLEG_VAR(_industry_builder.wanted_inds, SLE_UINT32),
 };
 
-/** Load/save industry builder. */
-static void LoadSave_IBLD()
+/** Save industry builder. */
+static void Save_IBLD()
 {
+	SlSetArrayIndex(0);
 	SlGlobList(_industry_builder_desc);
+}
+
+/** Load industry builder. */
+static void Load_IBLD()
+{
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
+	SlGlobList(_industry_builder_desc);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many IBLD entries");
 }
 
 /** Description of the data to save and load in #IndustryTypeBuildData. */
@@ -177,11 +186,11 @@ static void Load_ITBL()
 }
 
 static const ChunkHandler industry_chunk_handlers[] = {
-	{ 'INDY', Save_INDY,     Load_INDY,     Ptrs_INDY, nullptr, CH_ARRAY },
-	{ 'IIDS', Save_IIDS,     Load_IIDS,     nullptr,   nullptr, CH_ARRAY },
-	{ 'TIDS', Save_TIDS,     Load_TIDS,     nullptr,   nullptr, CH_ARRAY },
-	{ 'IBLD', LoadSave_IBLD, LoadSave_IBLD, nullptr,   nullptr, CH_RIFF  },
-	{ 'ITBL', Save_ITBL,     Load_ITBL,     nullptr,   nullptr, CH_ARRAY },
+	{ 'INDY', Save_INDY, Load_INDY, Ptrs_INDY, nullptr, CH_ARRAY },
+	{ 'IIDS', Save_IIDS, Load_IIDS, nullptr,   nullptr, CH_ARRAY },
+	{ 'TIDS', Save_TIDS, Load_TIDS, nullptr,   nullptr, CH_ARRAY },
+	{ 'IBLD', Save_IBLD, Load_IBLD, nullptr,   nullptr, CH_ARRAY },
+	{ 'ITBL', Save_ITBL, Load_ITBL, nullptr,   nullptr, CH_ARRAY },
 };
 
 extern const ChunkHandlerTable _industry_chunk_handlers(industry_chunk_handlers);

--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -287,6 +287,7 @@ static void Load_LGRJ()
  */
 static void Save_LGRS()
 {
+	SlSetArrayIndex(0);
 	SlObject(&LinkGraphSchedule::instance, GetLinkGraphScheduleDesc());
 }
 
@@ -295,7 +296,9 @@ static void Save_LGRS()
  */
 static void Load_LGRS()
 {
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
 	SlObject(&LinkGraphSchedule::instance, GetLinkGraphScheduleDesc());
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many LGRS entries");
 }
 
 /**
@@ -309,7 +312,7 @@ static void Ptrs_LGRS()
 static const ChunkHandler linkgraph_chunk_handlers[] = {
 	{ 'LGRP', Save_LGRP, Load_LGRP, nullptr,   nullptr, CH_ARRAY },
 	{ 'LGRJ', Save_LGRJ, Load_LGRJ, nullptr,   nullptr, CH_ARRAY },
-	{ 'LGRS', Save_LGRS, Load_LGRS, Ptrs_LGRS, nullptr, CH_RIFF  }
+	{ 'LGRS', Save_LGRS, Load_LGRS, Ptrs_LGRS, nullptr, CH_ARRAY },
 };
 
 extern const ChunkHandlerTable _linkgraph_chunk_handlers(linkgraph_chunk_handlers);

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -20,7 +20,7 @@
 static uint32 _map_dim_x;
 static uint32 _map_dim_y;
 
-static const SaveLoad _map_dimensions[] = {
+static const SaveLoad _map_desc[] = {
 	SLEG_CONDVAR(_map_dim_x, SLE_UINT32, SLV_6, SL_MAX_VERSION),
 	SLEG_CONDVAR(_map_dim_y, SLE_UINT32, SLV_6, SL_MAX_VERSION),
 };
@@ -29,18 +29,26 @@ static void Save_MAPS()
 {
 	_map_dim_x = MapSizeX();
 	_map_dim_y = MapSizeY();
-	SlGlobList(_map_dimensions);
+
+	SlSetArrayIndex(0);
+	SlGlobList(_map_desc);
 }
 
 static void Load_MAPS()
 {
-	SlGlobList(_map_dimensions);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
+	SlGlobList(_map_desc);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many MAPS entries");
+
 	AllocateMap(_map_dim_x, _map_dim_y);
 }
 
 static void Check_MAPS()
 {
-	SlGlobList(_map_dimensions);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
+	SlGlobList(_map_desc);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many MAPS entries");
+
 	_load_check_data.map_size_x = _map_dim_x;
 	_load_check_data.map_size_y = _map_dim_y;
 }
@@ -295,7 +303,7 @@ static void Save_MAP8()
 
 
 static const ChunkHandler map_chunk_handlers[] = {
-	{ 'MAPS', Save_MAPS, Load_MAPS, nullptr, Check_MAPS, CH_RIFF },
+	{ 'MAPS', Save_MAPS, Load_MAPS, nullptr, Check_MAPS, CH_ARRAY },
 	{ 'MAPT', Save_MAPT, Load_MAPT, nullptr, nullptr,    CH_RIFF },
 	{ 'MAPH', Save_MAPH, Load_MAPH, nullptr, nullptr,    CH_RIFF },
 	{ 'MAPO', Save_MAP1, Load_MAP1, nullptr, nullptr,    CH_RIFF },

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -118,14 +118,28 @@ static const SaveLoad _date_check_desc[] = {
 
 /* Save load date related variables as well as persistent tick counters
  * XXX: currently some unrelated stuff is just put here */
-static void SaveLoad_DATE()
+static void Save_DATE()
 {
+	SlSetArrayIndex(0);
 	SlGlobList(_date_desc);
+}
+
+static void Load_DATE_common(const SaveLoadTable &slt)
+{
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
+	SlGlobList(slt);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many DATE entries");
+}
+
+static void Load_DATE()
+{
+	Load_DATE_common(_date_desc);
 }
 
 static void Check_DATE()
 {
-	SlGlobList(_date_check_desc);
+	Load_DATE_common(_date_check_desc);
+
 	if (IsSavegameVersionBefore(SLV_31)) {
 		_load_check_data.current_date += DAYS_TILL_ORIGINAL_BASE_YEAR;
 	}
@@ -140,14 +154,22 @@ static const SaveLoad _view_desc[] = {
 	    SLEG_VAR(_saved_scrollpos_zoom, SLE_UINT8),
 };
 
-static void SaveLoad_VIEW()
+static void Save_VIEW()
 {
+	SlSetArrayIndex(0);
 	SlGlobList(_view_desc);
 }
 
+static void Load_VIEW()
+{
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
+	SlGlobList(_view_desc);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many DATE entries");
+}
+
 static const ChunkHandler misc_chunk_handlers[] = {
-	{ 'DATE', SaveLoad_DATE, SaveLoad_DATE, nullptr, Check_DATE, CH_RIFF },
-	{ 'VIEW', SaveLoad_VIEW, SaveLoad_VIEW, nullptr, nullptr,    CH_RIFF },
+	{ 'DATE', Save_DATE, Load_DATE, nullptr, Check_DATE, CH_ARRAY },
+	{ 'VIEW', Save_VIEW, Load_VIEW, nullptr, nullptr,    CH_ARRAY },
 };
 
 extern const ChunkHandlerTable _misc_chunk_handlers(misc_chunk_handlers);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1897,10 +1897,10 @@ static void SlLoadCheckChunk(const ChunkHandler &ch)
  */
 static void SlSaveChunk(const ChunkHandler &ch)
 {
-	ChunkSaveLoadProc *proc = ch.save_proc;
+	if (ch.type == CH_READONLY) return;
 
-	/* Don't save any chunk information if there is no save handler. */
-	if (proc == nullptr) return;
+	ChunkSaveLoadProc *proc = ch.save_proc;
+	assert(proc != nullptr);
 
 	SlWriteUint32(ch.id);
 	Debug(sl, 2, "Saving chunk {:c}{:c}{:c}{:c}", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -44,6 +44,7 @@
 #include "../error.h"
 #include <atomic>
 #include <deque>
+#include <vector>
 #include <string>
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>
@@ -1452,6 +1453,48 @@ static void SlDeque(void *deque, VarType conv)
 	}
 }
 
+/**
+ * Return the size in bytes of a std::vector.
+ * @param vector The std::vector to find the size of
+ * @param conv VarType type of variable that is used for calculating the size
+ */
+static inline size_t SlCalcVectorLen(const void *vector, VarType conv)
+{
+	switch (GetVarMemType(conv)) {
+		case SLE_VAR_BL: NOT_REACHED(); // Not supported
+		case SLE_VAR_I8: return SlStorageHelper<std::vector, int8>::SlCalcLen(vector, conv);
+		case SLE_VAR_U8: return SlStorageHelper<std::vector, uint8>::SlCalcLen(vector, conv);
+		case SLE_VAR_I16: return SlStorageHelper<std::vector, int16>::SlCalcLen(vector, conv);
+		case SLE_VAR_U16: return SlStorageHelper<std::vector, uint16>::SlCalcLen(vector, conv);
+		case SLE_VAR_I32: return SlStorageHelper<std::vector, int32>::SlCalcLen(vector, conv);
+		case SLE_VAR_U32: return SlStorageHelper<std::vector, uint32>::SlCalcLen(vector, conv);
+		case SLE_VAR_I64: return SlStorageHelper<std::vector, int64>::SlCalcLen(vector, conv);
+		case SLE_VAR_U64: return SlStorageHelper<std::vector, uint64>::SlCalcLen(vector, conv);
+		default: NOT_REACHED();
+	}
+}
+
+/**
+ * Save/load a std::vector.
+ * @param vector The std::vector being manipulated
+ * @param conv VarType type of variable that is used for calculating the size
+ */
+static void SlVector(void *vector, VarType conv)
+{
+	switch (GetVarMemType(conv)) {
+		case SLE_VAR_BL: NOT_REACHED(); // Not supported
+		case SLE_VAR_I8: SlStorageHelper<std::vector, int8>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_U8: SlStorageHelper<std::vector, uint8>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_I16: SlStorageHelper<std::vector, int16>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_U16: SlStorageHelper<std::vector, uint16>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_I32: SlStorageHelper<std::vector, int32>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_U32: SlStorageHelper<std::vector, uint32>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_I64: SlStorageHelper<std::vector, int64>::SlSaveLoad(vector, conv); break;
+		case SLE_VAR_U64: SlStorageHelper<std::vector, uint64>::SlSaveLoad(vector, conv); break;
+		default: NOT_REACHED();
+	}
+}
+
 /** Are we going to save this object or not? */
 static inline bool SlIsObjectValidInSavegame(const SaveLoad &sld)
 {
@@ -1488,6 +1531,7 @@ size_t SlCalcObjMemberLength(const void *object, const SaveLoad &sld)
 		case SL_STR: return SlCalcStringLen(GetVariableAddress(object, sld), sld.length, sld.conv);
 		case SL_REFLIST: return SlCalcRefListLen(GetVariableAddress(object, sld), sld.conv);
 		case SL_DEQUE: return SlCalcDequeLen(GetVariableAddress(object, sld), sld.conv);
+		case SL_VECTOR: return SlCalcVectorLen(GetVariableAddress(object, sld), sld.conv);
 		case SL_STDSTR: return SlCalcStdStringLen(GetVariableAddress(object, sld));
 		case SL_SAVEBYTE: return 1; // a byte is logically of size 1
 		case SL_NULL: return SlCalcConvFileLen(sld.conv) * sld.length;
@@ -1583,6 +1627,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 		case SL_STR:
 		case SL_REFLIST:
 		case SL_DEQUE:
+		case SL_VECTOR:
 		case SL_STDSTR: {
 			void *ptr = GetVariableAddress(object, sld);
 
@@ -1593,6 +1638,7 @@ static bool SlObjectMember(void *object, const SaveLoad &sld)
 				case SL_STR: SlString(ptr, sld.length, sld.conv); break;
 				case SL_REFLIST: SlRefList(ptr, conv); break;
 				case SL_DEQUE: SlDeque(ptr, conv); break;
+				case SL_VECTOR: SlVector(ptr, conv); break;
 				case SL_STDSTR: SlStdString(ptr, sld.conv); break;
 				default: NOT_REACHED();
 			}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -565,15 +565,19 @@ typedef uint32 VarType;
 enum SaveLoadType : byte {
 	SL_VAR         =  0, ///< Save/load a variable.
 	SL_REF         =  1, ///< Save/load a reference.
-	SL_ARR         =  2, ///< Save/load a fixed-size array of #SL_VAR elements.
+	SL_STRUCT      =  2, ///< Save/load a struct.
+
 	SL_STR         =  3, ///< Save/load a string.
-	SL_REFLIST     =  4, ///< Save/load a list of #SL_REF elements.
-	SL_DEQUE       =  5, ///< Save/load a deque of #SL_VAR elements.
-	SL_STDSTR      =  6, ///< Save/load a \c std::string.
-	SL_STRUCT      =  7, ///< Save/load a struct.
-	SL_STRUCTLIST  =  8, ///< Save/load a list of structs.
-	SL_SAVEBYTE    =  9, ///< Save (but not load) a byte.
-	SL_NULL        = 10, ///< Save null-bytes and load to nowhere.
+	SL_STDSTR      =  4, ///< Save/load a \c std::string.
+
+	SL_ARR         =  5, ///< Save/load a fixed-size array of #SL_VAR elements.
+	SL_DEQUE       =  6, ///< Save/load a deque of #SL_VAR elements.
+	SL_VECTOR      =  7, ///< Save/load a vector of #SL_VAR elements.
+	SL_REFLIST     =  8, ///< Save/load a list of #SL_REF elements.
+	SL_STRUCTLIST  =  9, ///< Save/load a list of structs.
+
+	SL_SAVEBYTE    = 10, ///< Save (but not load) a byte.
+	SL_NULL        = 11, ///< Save null-bytes and load to nowhere.
 };
 
 typedef void *SaveLoadAddrProc(void *base, size_t extra);
@@ -829,6 +833,15 @@ struct SaveLoad {
 #define SLEG_CONDREFLIST(variable, type, from, to) SLEG_GENERAL(SL_REFLIST, variable, type, 0, from, to, 0)
 
 /**
+ * Storage of a global vector of #SL_VAR elements in some savegame versions.
+ * @param variable Name of the global variable.
+ * @param type     Storage of the data in memory and in the savegame.
+ * @param from     First savegame version that has the list.
+ * @param to       Last savegame version that has the list.
+ */
+#define SLEG_CONDVECTOR(variable, type, from, to) SLEG_GENERAL(SL_VECTOR, variable, type, 0, from, to, 0)
+
+/**
  * Storage of a list of structs in some savegame versions.
  * @param handler  SaveLoadHandler for the list of structs.
  * @param from     First savegame version that has the list.
@@ -883,6 +896,13 @@ struct SaveLoad {
  * @param type     Storage of the data in memory and in the savegame.
  */
 #define SLEG_REFLIST(variable, type) SLEG_CONDREFLIST(variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
+
+/**
+ * Storage of a global vector of #SL_VAR elements in every savegame version.
+ * @param variable Name of the global variable.
+ * @param type     Storage of the data in memory and in the savegame.
+ */
+#define SLEG_VECTOR(variable, type) SLEG_CONDVECTOR(variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
  * Storage of a list of structs in every savegame version.

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -331,6 +331,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_GROUP_REPLACE_WAGON_REMOVAL,        ///< 291  PR#7441 Per-group wagon removal flag.
 	SLV_CUSTOM_SUBSIDY_DURATION,            ///< 292  PR#9081 Configurable subsidy duration.
 	SLV_SAVELOAD_LIST_LENGTH,               ///< 293  PR#9374 Consistency in list length with SL_STRUCT / SL_STRUCTLIST / SL_DEQUE / SL_REFLIST.
+	SLV_RIFF_TO_ARRAY,                      ///< 294  PR#9375 Changed many CH_RIFF chunks to CH_ARRAY chunks.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -388,6 +388,7 @@ enum ChunkType {
 	CH_RIFF = 0,
 	CH_ARRAY = 1,
 	CH_SPARSE_ARRAY = 2,
+	CH_READONLY, ///< Chunk is never saved.
 };
 
 /** Handlers and description of chunk. */

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -703,7 +703,7 @@ static void Ptrs_ROADSTOP()
 }
 
 static const ChunkHandler station_chunk_handlers[] = {
-	{ 'STNS', nullptr,       Load_STNS,     Ptrs_STNS,     nullptr, CH_ARRAY },
+	{ 'STNS', nullptr,       Load_STNS,     Ptrs_STNS,     nullptr, CH_READONLY },
 	{ 'STNN', Save_STNN,     Load_STNN,     Ptrs_STNN,     nullptr, CH_ARRAY },
 	{ 'ROAD', Save_ROADSTOP, Load_ROADSTOP, Ptrs_ROADSTOP, nullptr, CH_ARRAY },
 };

--- a/src/saveload/strings_sl.cpp
+++ b/src/saveload/strings_sl.cpp
@@ -132,7 +132,7 @@ static void Load_NAME()
 
 /** Chunk handlers related to strings. */
 static const ChunkHandler name_chunk_handlers[] = {
-	{ 'NAME', nullptr, Load_NAME, nullptr, nullptr, CH_ARRAY },
+	{ 'NAME', nullptr, Load_NAME, nullptr, nullptr, CH_READONLY },
 };
 
 extern const ChunkHandlerTable _name_chunk_handlers(name_chunk_handlers);

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -225,7 +225,7 @@ static void Ptrs_WAYP()
 }
 
 static const ChunkHandler waypoint_chunk_handlers[] = {
-	{ 'CHKP', nullptr, Load_WAYP, Ptrs_WAYP, nullptr, CH_ARRAY },
+	{ 'CHKP', nullptr, Load_WAYP, Ptrs_WAYP, nullptr, CH_READONLY },
 };
 
 extern const ChunkHandlerTable _waypoint_chunk_handlers(waypoint_chunk_handlers);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2045,7 +2045,9 @@ static void LoadSettings(const SettingTable &settings, void *object)
 {
 	const std::vector<SaveLoad> slt = GetSettingsDesc(settings, true);
 
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() == -1) return;
 	SlObject(object, slt);
+	if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many settings entries");
 
 	/* Ensure all IntSettings are valid (min/max could have changed between versions etc). */
 	for (auto &sd : settings) {
@@ -2070,6 +2072,7 @@ static void SaveSettings(const SettingTable &settings, void *object)
 {
 	const std::vector<SaveLoad> slt = GetSettingsDesc(settings, false);
 
+	SlSetArrayIndex(0);
 	SlObject(object, slt);
 }
 
@@ -2102,8 +2105,8 @@ static void Save_PATS()
 }
 
 static const ChunkHandler setting_chunk_handlers[] = {
-	{ 'OPTS', nullptr,   Load_OPTS, nullptr, nullptr,    CH_RIFF },
-	{ 'PATS', Save_PATS, Load_PATS, nullptr, Check_PATS, CH_RIFF },
+	{ 'OPTS', nullptr,   Load_OPTS, nullptr, nullptr,    CH_RIFF  },
+	{ 'PATS', Save_PATS, Load_PATS, nullptr, Check_PATS, CH_ARRAY },
 };
 
 extern const ChunkHandlerTable _setting_chunk_handlers(setting_chunk_handlers);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2105,7 +2105,7 @@ static void Save_PATS()
 }
 
 static const ChunkHandler setting_chunk_handlers[] = {
-	{ 'OPTS', nullptr,   Load_OPTS, nullptr, nullptr,    CH_RIFF  },
+	{ 'OPTS', nullptr,   Load_OPTS, nullptr, nullptr,    CH_READONLY },
 	{ 'PATS', Save_PATS, Load_PATS, nullptr, Check_PATS, CH_ARRAY },
 };
 


### PR DESCRIPTION
## Motivation / Problem

Weird goal, I know right? But hear me out.

#9322 sets out to make to make our savegame self-descriptive (see motivation for that there). But in order to do that, we need to make all chunks a table.

The first step in making anything a table, is to first make it an array. And so we come to the motivation of this PR: to make that possible.

## Description

Most `CH_RIFF`s in fact are just an array of length 1. So it might seem silly at first, but that is exactly what this PR does: make those chunks into an array of length 1.

The exception was the `GLOG` chunk. That required some more love and attention.

After this PR, only the map-chunks are `CH_RIFF`. Those could be made into `CH_ARRAY`, but that is not really useful, as they cannot become self-describing for now anyway.

Lastly, the chunk table tells how chunks are stored on disk. Chunks that are no longer stored were still marked by their old type. This was often confusing. So I sneaked that change in here, to mark those as `CH_READONLY`, making it more clear that it is not by accident.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
