### PR TITLE
Change: prevent palette updates during copying to the video driver 

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1201,6 +1201,30 @@ void GfxInitPalettes()
 	DoPaletteAnimations();
 }
 
+/**
+ * Copy the current palette if the palette was updated.
+ * Used by video-driver to get a current up-to-date version of the palette,
+ * to avoid two threads accessing the same piece of memory (with a good chance
+ * one is already updating the palette while the other is drawing based on it).
+ * @param local_palette The location to copy the palette to.
+ * @param force_copy Whether to ignore if there is an update for the palette.
+ * @return True iff a copy was done.
+ */
+bool CopyPalette(Palette &local_palette, bool force_copy)
+{
+	if (!force_copy && _cur_palette.count_dirty == 0) return false;
+
+	local_palette = _cur_palette;
+	_cur_palette.count_dirty = 0;
+
+	if (force_copy) {
+		local_palette.first_dirty = 0;
+		local_palette.count_dirty = 256;
+	}
+
+	return true;
+}
+
 #define EXTR(p, q) (((uint16)(palette_animation_counter * (p)) * (q)) >> 16)
 #define EXTR2(p, q) (((uint16)(~palette_animation_counter * (p)) * (q)) >> 16)
 

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -121,6 +121,7 @@ void DrawDirtyBlocks();
 void AddDirtyBlock(int left, int top, int right, int bottom);
 void MarkWholeScreenDirty();
 
+bool CopyPalette(Palette &local_palette, bool force_copy = false);
 void GfxInitPalettes();
 void CheckBlitter();
 

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -37,6 +37,8 @@
 #import <OpenGL/OpenGL.h>
 #import <OpenGL/gl3.h>
 
+static Palette _local_palette; ///< Current palette to use for drawing.
+
 
 /**
  * Important notice regarding all modifications!!!!!!!
@@ -304,17 +306,15 @@ void VideoDriver_CocoaOpenGL::Paint()
 {
 	PerformanceMeasurer framerate(PFE_VIDEO);
 
-	if (_cur_palette.count_dirty != 0) {
+	if (CopyPalette(_local_palette)) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 
 		/* Always push a changed palette to OpenGL. */
 		CGLSetCurrentContext(this->gl_context);
-		OpenGLBackend::Get()->UpdatePalette(_cur_palette.palette, _cur_palette.first_dirty, _cur_palette.count_dirty);
+		OpenGLBackend::Get()->UpdatePalette(_local_palette.palette, _local_palette.first_dirty, _local_palette.count_dirty);
 		if (blitter->UsePaletteAnimation() == Blitter::PALETTE_ANIMATION_BLITTER) {
-			blitter->PaletteAnimate(_cur_palette);
+			blitter->PaletteAnimate(_local_palette);
 		}
-
-		_cur_palette.count_dirty = 0;
 	}
 
 	[ CATransaction begin ];

--- a/src/video/sdl2_default_v.cpp
+++ b/src/video/sdl2_default_v.cpp
@@ -62,9 +62,7 @@ void VideoDriver_SDL_Default::MakePalette()
 		if (_sdl_palette == nullptr) usererror("SDL2: Couldn't allocate palette: %s", SDL_GetError());
 	}
 
-	_cur_palette.first_dirty = 0;
-	_cur_palette.count_dirty = 256;
-	this->local_palette = _cur_palette;
+	CopyPalette(this->local_palette, true);
 	this->UpdatePalette();
 
 	if (_sdl_surface != _sdl_real_surface) {
@@ -96,9 +94,9 @@ void VideoDriver_SDL_Default::Paint()
 {
 	PerformanceMeasurer framerate(PFE_VIDEO);
 
-	if (IsEmptyRect(this->dirty_rect) && _cur_palette.count_dirty == 0) return;
+	if (IsEmptyRect(this->dirty_rect) && this->local_palette.count_dirty == 0) return;
 
-	if (_cur_palette.count_dirty != 0) {
+	if (this->local_palette.count_dirty != 0) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 
 		switch (blitter->UsePaletteAnimation()) {
@@ -117,7 +115,7 @@ void VideoDriver_SDL_Default::Paint()
 			default:
 				NOT_REACHED();
 		}
-		_cur_palette.count_dirty = 0;
+		this->local_palette.count_dirty = 0;
 	}
 
 	SDL_Rect r = { this->dirty_rect.left, this->dirty_rect.top, this->dirty_rect.right - this->dirty_rect.left, this->dirty_rect.bottom - this->dirty_rect.top };

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -146,9 +146,7 @@ bool VideoDriver_SDL_OpenGL::AllocateBackingStore(int w, int h, bool force)
 	SDL_GL_SwapWindow(this->sdl_window);
 	_screen.dst_ptr = this->GetVideoPointer();
 
-	_cur_palette.first_dirty = 0;
-	_cur_palette.count_dirty = 256;
-	this->local_palette = _cur_palette;
+	CopyPalette(this->local_palette, true);
 
 	return res;
 }
@@ -173,7 +171,7 @@ void VideoDriver_SDL_OpenGL::Paint()
 {
 	PerformanceMeasurer framerate(PFE_VIDEO);
 
-	if (_cur_palette.count_dirty != 0) {
+	if (this->local_palette.count_dirty != 0) {
 		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 
 		/* Always push a changed palette to OpenGL. */
@@ -182,7 +180,7 @@ void VideoDriver_SDL_OpenGL::Paint()
 			blitter->PaletteAnimate(this->local_palette);
 		}
 
-		_cur_palette.count_dirty = 0;
+		this->local_palette.count_dirty = 0;
 	}
 
 	OpenGLBackend::Get()->Paint();

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -43,9 +43,7 @@ void VideoDriver_SDL_Base::MakeDirty(int left, int top, int width, int height)
 
 void VideoDriver_SDL_Base::CheckPaletteAnim()
 {
-	if (_cur_palette.count_dirty == 0) return;
-
-	this->local_palette = _cur_palette;
+	if (!CopyPalette(this->local_palette)) return;
 	this->MakeDirty(0, 0, _screen.width, _screen.height);
 }
 
@@ -131,10 +129,7 @@ void VideoDriver_SDL_Base::ClientSizeChanged(int w, int h, bool force)
 {
 	/* Allocate backing store of the new size. */
 	if (this->AllocateBackingStore(w, h, force)) {
-		/* Mark all palette colours dirty. */
-		_cur_palette.first_dirty = 0;
-		_cur_palette.count_dirty = 256;
-		this->local_palette = _cur_palette;
+		CopyPalette(this->local_palette, true);
 
 		BlitterFactory::GetCurrentBlitter()->PostResize();
 

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -45,7 +45,7 @@ public:
 
 protected:
 	struct SDL_Window *sdl_window; ///< Main SDL window.
-	Palette local_palette; ///< Copy of _cur_palette.
+	Palette local_palette; ///< Current palette to use for drawing.
 	bool buffer_locked; ///< Video buffer was locked by the main thread.
 	Rect dirty_rect; ///< Rectangle encompassing the dirty area of the video buffer.
 

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -106,35 +106,30 @@ static void UpdatePalette(bool init = false)
 
 static void InitPalette()
 {
-	_local_palette = _cur_palette;
-	_local_palette.first_dirty = 0;
-	_local_palette.count_dirty = 256;
+	CopyPalette(_local_palette, true);
 	UpdatePalette(true);
 }
 
 void VideoDriver_SDL::CheckPaletteAnim()
 {
-	_local_palette = _cur_palette;
+	if (!CopyPalette(_local_palette)) return;
 
-	if (_cur_palette.count_dirty != 0) {
-		Blitter *blitter = BlitterFactory::GetCurrentBlitter();
+	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
 
-		switch (blitter->UsePaletteAnimation()) {
-			case Blitter::PALETTE_ANIMATION_VIDEO_BACKEND:
-				UpdatePalette();
-				break;
+	switch (blitter->UsePaletteAnimation()) {
+		case Blitter::PALETTE_ANIMATION_VIDEO_BACKEND:
+			UpdatePalette();
+			break;
 
-			case Blitter::PALETTE_ANIMATION_BLITTER:
-				blitter->PaletteAnimate(_local_palette);
-				break;
+		case Blitter::PALETTE_ANIMATION_BLITTER:
+			blitter->PaletteAnimate(_local_palette);
+			break;
 
-			case Blitter::PALETTE_ANIMATION_NONE:
-				break;
+		case Blitter::PALETTE_ANIMATION_NONE:
+			break;
 
-			default:
-				NOT_REACHED();
-		}
-		_cur_palette.count_dirty = 0;
+		default:
+			NOT_REACHED();
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

CLang's ThreadSanitizer complained a lot about our way of doing palettes. Turns out, depending on the video driver, it is also a bit of a mess how it is used.

## Description

This PR does two things:

1) first, it fixes the discrepancy between the video-drivers. Although not strictly needed to use `_local_palette` for the ones that weren't using it, as the `_cur_palette` is only used in that function, having everything the same does make the next commit a lot easier.

2) set a mutex-guard on `_cur_palette` access, so only one thread is accessing it at any given time.

This is a bit of an extreme solution in the sense that it possibly could be implemented in a more lightweight variant. `count_dirty` is used as event to notify the draw-thread a new palette is available. This means that guarding this would be sufficient, but it is also less clear that this is the case. So I didn't go for this solution, but it is something we can talk about.

## Limitations

- There are other places accessing `_cur_palette`, but they seem to all be done from the game-thread, which is all perfectly fine ofc.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
