### PR TITLE
Fix: thread safety issue during exiting the game

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -41,7 +41,7 @@ bool _right_button_down;    ///< Is right mouse button pressed?
 bool _right_button_clicked; ///< Is right mouse button clicked?
 DrawPixelInfo _screen;
 bool _screen_disable_anim = false;   ///< Disable palette animation (important for 32bpp-anim blitter during giant screenshot)
-bool _exit_game;
+std::atomic<bool> _exit_game;
 GameMode _game_mode;
 SwitchMode _switch_mode;  ///< The next mainloop command.
 PauseMode _pause_mode;

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -10,6 +10,7 @@
 #ifndef OPENTTD_H
 #define OPENTTD_H
 
+#include <atomic>
 #include "core/enum_type.hpp"
 
 /** Mode which defines the state of the game. */
@@ -52,7 +53,7 @@ enum DisplayOptions {
 
 extern GameMode _game_mode;
 extern SwitchMode _switch_mode;
-extern bool _exit_game;
+extern std::atomic<bool> _exit_game;
 extern bool _save_config;
 
 /** Modes of pausing we've got */


### PR DESCRIPTION
## Motivation / Problem

ThreadSantizer was complaining on exiting the game. It is a bit silly, as it is a boolean value .. but making it a `std::atomic` is also a small effort.

## Description

```
_exit_game is read by the draw-thread to know when to exit, but
most of the time written by the game-thread.
```

Most likely we could change all the loads and stores to `memory_order_relaxed`, as I doubt it really matters honestly. We are pretty resilient against `_exit_game` being flipped at the weirdest places.

The reason I didn't do it, is because there are roughly 30 places where we load/store `_exit_game`. That maybe highlights a completely different issue in our codebase :P

## Limitations

- I am never all to sure about the performance impact of making something into a `std::atomic`. I would think it doesn't matter (at all) in this case, but I would love to be told wrong here :)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
