### PR TITLE
Fix: on startup, NewGRF scan could case race-condition

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -14,6 +14,7 @@
 #include "crashlog.h"
 #include <system_error>
 #include <thread>
+#include <mutex>
 
 /**
  * Sleep on the current thread for a defined time.
@@ -46,7 +47,17 @@ inline bool StartNewThread(std::thread *thr, const char *name, TFn&& _Fx, TArgs&
 {
 #ifndef NO_THREADS
 	try {
+		static std::mutex thread_startup_mutex;
+		std::lock_guard<std::mutex> lock(thread_startup_mutex);
+
 		std::thread t([] (const char *name, TFn&& F, TArgs&&... A) {
+				/* Delay starting the thread till the main thread is finished
+				 * with the administration. This prevent race-conditions on
+				 * startup. */
+				{
+					std::lock_guard<std::mutex> lock(thread_startup_mutex);
+				}
+
 				SetCurrentThreadName(name);
 				CrashLog::InitThread();
 				try {


### PR DESCRIPTION
## Motivation / Problem

NewGRF scan could trigger ThreadSanitizer (rightfully), because it tried to access a variable that wasn't fully prepared to be accessed yet.

## Description

```
Creating a thread was not thread-safe. The irony.

The video-driver has a function GameLoopPause() which first checks
if the thread is the game-thread or not. For this it needs access
to this->game_thread. This variable is set in StartNewThread().

However, due to timing, it is well possible GameLoopPause() is
called from the thread well before this->game_thread is assigned.

And so we have a race-condition!

Simply solve this by preventing a thread to start till we are
done with our bookkeeping.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
