### PR TITLE
Fix: Wrong cargo line position in IndustryCargo window.

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2021,11 +2021,7 @@ struct CargoesField {
 		assert(this->type == CFT_CARGO);
 		int n = this->u.cargo.num_cargoes;
 
-		if (n % 2 == 0) {
-			return xpos + cargo_field_width / 2 - (CargoesField::cargo_line.width + CargoesField::cargo_space.width / 2) * (n / 2);
-		} else {
-			return xpos + cargo_field_width / 2 - CargoesField::cargo_line.width / 2 - (CargoesField::cargo_line.width + CargoesField::cargo_space.width) * (n / 2);
-		}
+		return xpos + cargo_field_width / 2 - (CargoesField::cargo_line.width * n + CargoesField::cargo_space.width * (n - 1)) / 2;
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

Cargo line position in industry cargo window was incorrect when many cargo types are present. This was noticed with the OTIS NewGRF at https://www.tt-forums.net/viewtopic.php?p=1242719#p1242719

## Description

Resolved by changing calculation to determine the offset based on centring the cargo lines in the available space.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
