### PR TITLE
Fix nullptr dereference when autoreplacing vehicle with no orders in GetIncompatibleRefitOrderIdForAutoreplace

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -207,6 +207,7 @@ static int GetIncompatibleRefitOrderIdForAutoreplace(const Vehicle *v, EngineID 
 	const Vehicle *u = (v->type == VEH_TRAIN) ? v->First() : v;
 
 	const OrderList *orders = u->orders.list;
+	if (orders == nullptr) return -1;
 	for (VehicleOrderID i = 0; i < orders->GetNumOrders(); i++) {
 		o = orders->GetOrderAt(i);
 		if (!o->IsRefit()) continue;


### PR DESCRIPTION
## Motivation / Problem

A null pointer dereference occurs when GetIncompatibleRefitOrderIdForAutoreplace is called on a vehicle with no orders, such that the order list is null.
(This also includes autoreplacing of free-wagon chains).

This was introduced in PR #8169.

## Description

Handle the case where the order list is null in GetIncompatibleRefitOrderIdForAutoreplace.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
