### PR TITLE
Fix bf500c3: reduce the amount of vars to track by using std::string_view

### DIFF
--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -37,7 +37,7 @@
 
 	if ((sd->flags & SF_NO_NETWORK_SYNC) != 0) return false;
 
-	return ScriptObject::DoCommand(0, 0, value, CMD_CHANGE_SETTING, sd->name.c_str());
+	return ScriptObject::DoCommand(0, 0, value, CMD_CHANGE_SETTING, sd->name.data());
 }
 
 /* static */ bool ScriptGameSettings::IsDisabledVehicleType(ScriptVehicle::VehicleType vehicle_type)

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -69,14 +69,14 @@ struct IniItem;
 
 /** Properties of config file settings. */
 struct SettingDesc {
-	SettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup) :
+	SettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup) :
 		name(name), flags(flags), startup(startup), save(save) {}
 	virtual ~SettingDesc() {}
 
-	std::string name;   ///< Name of the setting. Used in configuration file and for console.
-	SettingFlag flags;  ///< Handles how a setting would show up in the GUI (text/currency, etc.).
-	bool startup;       ///< Setting has to be loaded directly at startup?.
-	SaveLoad save;      ///< Internal structure (going to savegame, parts to config).
+	const std::string_view name; ///< Name of the setting. Used in configuration file and for console.
+	SettingFlag flags;           ///< Handles how a setting would show up in the GUI (text/currency, etc.).
+	bool startup;                ///< Setting has to be loaded directly at startup?.
+	SaveLoad save;               ///< Internal structure (going to savegame, parts to config).
 
 	bool IsEditable(bool do_command = false) const;
 	SettingType GetType() const;
@@ -140,7 +140,7 @@ struct IntSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(int32 value);
 
-	IntSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, int32 def,
+	IntSettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup, int32 def,
 			int32 min, uint32 max, int32 interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def), min(min), max(max), interval(interval),
@@ -182,7 +182,7 @@ private:
 
 /** Boolean setting. */
 struct BoolSettingDesc : IntSettingDesc {
-	BoolSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, bool def,
+	BoolSettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup, bool def,
 			StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		IntSettingDesc(save, name, flags, startup, def, 0, 1, 0, str, str_help, str_val, cat,
@@ -198,7 +198,7 @@ struct BoolSettingDesc : IntSettingDesc {
 struct OneOfManySettingDesc : IntSettingDesc {
 	typedef size_t OnConvert(const char *value); ///< callback prototype for conversion error
 
-	OneOfManySettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, int32 def,
+	OneOfManySettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup, int32 def,
 			int32 max, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
 			std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -222,7 +222,7 @@ struct OneOfManySettingDesc : IntSettingDesc {
 
 /** Many of many setting. */
 struct ManyOfManySettingDesc : OneOfManySettingDesc {
-	ManyOfManySettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup,
+	ManyOfManySettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup,
 		int32 def, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 		PreChangeCheck pre_check, PostChangeCallback post_callback,
 		std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -251,7 +251,7 @@ struct StringSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(const std::string &value);
 
-	StringSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, const char *def,
+	StringSettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup, const char *def,
 			uint32 max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
 			pre_check(pre_check), post_callback(post_callback) {}
@@ -277,7 +277,7 @@ private:
 
 /** List/array settings. */
 struct ListSettingDesc : SettingDesc {
-	ListSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, const char *def) :
+	ListSettingDesc(SaveLoad save, const std::string_view name, SettingFlag flags, bool startup, const char *def) :
 		SettingDesc(save, name, flags, startup), def(def) {}
 	virtual ~ListSettingDesc() {}
 


### PR DESCRIPTION
Fixes #9386.
Alternative to #9390. Closes #9390.

## Motivation / Problem

MacOS said: BOOOO
GCC said: fuck this shit

See #9386 for details and triage. But basically, since we changed a `const char *` into `std::string`, more than one compiler went apeshit on us. I present a (possibly temporary) solution: replace it with `const std::string_view`.

## Description

I do not really know why compilers start to track the `std::string` like this, or let alone why it blows up optimizations (GCC, from what I understand, tracks 50M vars before giving up .. that sounds like an insane alot for the few settings we have). Either way, on a hunch I replaced `std::string` with `const std::string` .. no change. So what about `const std::string_view`? Fixes the issue. Riggghhtttttt....

So to be clear, I have no clue why. I do know it is (most likely) a save operation, as the string itself will be stored in the data-segment, and the `string_view` will be a thin wrapper around that.

Sadly, this means in a few places where we were replacing `const char *` with `std::string`, I revert that situation a bit, as I cheeky use `.data()` to get this compiling again. By default a `std::string_view` cannot be casted to a `std::string`. But I mostly think this indicates places where we should change the `std::string` to `std::string_view`  instead of the other way around. Either way, I pushed this outside the scope of this PR, to keep this "fix" to its core element.

The commit message:
```
GCC complaints with:
  note: variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without

clang on MacOS just crashes (with bus error 10, read: out of memory).

This started to happen after introducing std::string to each setting.
As these are static strings that never change, there is no need to
use std::string. Instead, we can use std::string_view for this. This
seems to make both compilers really happy (as they basically still
only store a "const char *" as it was before this commit).
```


## Limitations

- I have 0 clues why this fixes the issue, or why the original code was an issue in the first place. This by no means tells us the root-problem. It just seems to fix the issue so everything is happy again. Any insights to what is going on here exactly would be greatly appreciated.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
