### PR TITLE
Fix: don't allow deleting SettingDesc to prevent compilers getting confused

### DIFF
--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -11,6 +11,7 @@
 #define SETTINGS_INTERNAL_H
 
 #include "saveload/saveload.h"
+#include "core/span_type.hpp"
 
 enum SettingFlag : uint16 {
 	SF_NONE = 0,
@@ -299,7 +300,7 @@ struct NullSettingDesc : SettingDesc {
 	bool IsSameValue(const IniItem *item, void *object) const override { NOT_REACHED(); }
 };
 
-typedef std::initializer_list<std::unique_ptr<const SettingDesc>> SettingTable;
+using SettingTable = span<const SettingDesc * const>;
 
 const SettingDesc *GetSettingFromName(const std::string_view name);
 void GetSettingSaveLoadByPrefix(const std::string_view prefix, std::vector<SaveLoad> &saveloads);

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -54,7 +54,7 @@ static size_t ConvertLandscape(const char *value);
  * on the appropriate macro.
  */
 
-#define NSD(type, ...) std::unique_ptr<const SettingDesc>(new type##SettingDesc(__VA_ARGS__))
+#define NSD(type, ...) new type##SettingDesc(__VA_ARGS__)
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -12,7 +12,7 @@ static void UpdateServiceInterval(int32 new_value);
 static bool CanUpdateServiceInterval(VehicleType type, int32 &new_value);
 static void UpdateServiceInterval(VehicleType type, int32 new_value);
 
-static const SettingTable _company_settings{
+static const SettingDesc * const _company_settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -7,7 +7,7 @@
 ; Settings for the in-game custom currency.
 
 [pre-amble]
-static const SettingTable _currency_settings{
+static const SettingDesc * const _currency_settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/gameopt_settings.ini
+++ b/src/table/settings/gameopt_settings.ini
@@ -33,7 +33,7 @@ static std::initializer_list<const char*> _osk_activation{"disabled", "double", 
 static std::initializer_list<const char*> _settings_profiles{"easy", "medium", "hard"};
 static std::initializer_list<const char*> _news_display{ "off", "summarized", "full"};
 
-static const SettingTable _gameopt_settings{
+static const SettingDesc * const _gameopt_settings[] = {
 /* In version 4 a new difficulty setting has been added to the difficulty settings,
  * town attitude towards demolishing. Needs special handling because some dimwit thought
  * it funny to have the GameDifficulty struct be an array while it is a struct of

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -20,7 +20,7 @@ extern bool _allow_hidpi_window;
 #define WITHOUT_COCOA
 #endif
 
-static const SettingTable _misc_settings{
+static const SettingDesc * const _misc_settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -49,7 +49,7 @@ static void UpdateClientConfigValues();
  * assigns its own value. If the setting was company-based, that would mean that
  * vehicles could decide on different moments that they are heading back to a
  * service depot, causing desyncs on a massive scale. */
-const SettingTable _settings{
+static const SettingDesc * const _settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/win32_settings.ini
+++ b/src/table/settings/win32_settings.ini
@@ -12,7 +12,7 @@
 #if defined(_WIN32) && !defined(DEDICATED)
 extern bool _window_maximize;
 
-static const SettingTable _win32_settings{
+static const SettingDesc * const _win32_settings[] = {
 [post-amble]
 };
 #endif /* _WIN32 */

--- a/src/table/settings/window_settings.ini
+++ b/src/table/settings/window_settings.ini
@@ -9,7 +9,7 @@
 
 [pre-amble]
 
-static const SettingTable _window_settings{
+static const SettingDesc * const _window_settings[] = {
 [post-amble]
 };
 [templates]


### PR DESCRIPTION
Fixes #9386.
Alternative to #9389. Closes #9389.

## Motivation / Problem

MacOS said: BOOOO
GCC said: fuck this shit

Similar to #9389, this shows that the core problem is not so much the `std::string`, but more the default dtor.

## Description

Please don't accept this PR. I just wanted it here to list it for history, and hopefully someone can discover a proper solution. This triggers a bunch of warnings, and is just a bit nasty.

And no, you cannot do `~SettingDesc() = delete`, as then sub-classes cannot use the ctor of `SettingDesc` to create its object.

The first commit removes `unique_ptr` from the code-base, and might in general be a good idea to accept in the code-base. I can create a separate PR for that if this is wanted.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
