### PR TITLE
Fix #9386: use variant instead of unique_ptr to prevent compilers failing on the code generation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -157,7 +157,7 @@ jobs:
 
     runs-on: macos-latest
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: 10.14
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,7 +470,7 @@ jobs:
 
     runs-on: macos-10.15
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: 10.14
 
     steps:
     - name: Download source

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if (EMSCRIPTEN)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
 
 # Use GNUInstallDirs to allow customisation
 # but set our own default data and bin dir

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -795,7 +795,7 @@ bool NetworkClientConnectGame(const std::string &connection_string, CompanyID de
 	std::string resolved_connection_string = ParseGameConnectionString(connection_string, NETWORK_DEFAULT_PORT, &join_as).GetAddressAsString(false);
 
 	if (!_network_available) return false;
-	if (!NetworkValidateClientName()) return false;
+	if (!NetworkValidateOurClientName()) return false;
 
 	_network_join.connection_string = resolved_connection_string;
 	_network_join.company = join_as;

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1338,7 +1338,7 @@ bool NetworkValidateClientName(std::string &client_name)
  * See \c NetworkValidateClientName(char*) for details about the functionality.
  * @return True iff the client name is valid.
  */
-bool NetworkValidateClientName()
+bool NetworkValidateOurClientName()
 {
 	return NetworkValidateClientName(_settings_client.network.client_name);
 }

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -36,7 +36,7 @@ extern StringList _network_ban_list;
 
 byte NetworkSpectatorCount();
 bool NetworkIsValidClientName(const std::string_view client_name);
-bool NetworkValidateClientName();
+bool NetworkValidateOurClientName();
 bool NetworkValidateClientName(std::string &client_name);
 bool NetworkValidateServerName(std::string &server_name);
 void NetworkUpdateClientName(const std::string &client_name);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1263,7 +1263,7 @@ static WindowDesc _network_start_server_window_desc(
 
 static void ShowNetworkStartServerWindow()
 {
-	if (!NetworkValidateClientName()) return;
+	if (!NetworkValidateOurClientName()) return;
 
 	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);
 	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_LOBBY);
@@ -1557,7 +1557,7 @@ static WindowDesc _network_lobby_window_desc(
  */
 static void ShowNetworkLobbyWindow(NetworkGameList *ngl)
 {
-	if (!NetworkValidateClientName()) return;
+	if (!NetworkValidateOurClientName()) return;
 
 	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_START);
 	CloseWindowById(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -608,7 +608,7 @@ struct SaveLoad {
  * @param extra    Extra data to pass to the address callback function.
  * @note In general, it is better to use one of the SLE_* macros below.
  */
-#define SLE_GENERAL(cmd, base, variable, type, length, from, to, extra) {cmd, type, length, from, to, cpp_sizeof(base, variable), [] (void *b, size_t) -> void * { assert(b != nullptr); return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); }, extra, nullptr}
+#define SLE_GENERAL(cmd, base, variable, type, length, from, to, extra) SaveLoad {cmd, type, length, from, to, cpp_sizeof(base, variable), [] (void *b, size_t) -> void * { assert(b != nullptr); return const_cast<void *>(static_cast<const void *>(std::addressof(static_cast<base *>(b)->variable))); }, extra, nullptr}
 
 /**
  * Storage of a variable in some savegame versions.
@@ -744,7 +744,7 @@ struct SaveLoad {
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLE_CONDNULL(length, from, to) {SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
+#define SLE_CONDNULL(length, from, to) SaveLoad {SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
 
 /**
  * Only write byte during saving; never read it during loading.
@@ -768,7 +768,7 @@ struct SaveLoad {
  * @param extra    Extra data to pass to the address callback function.
  * @note In general, it is better to use one of the SLEG_* macros below.
  */
-#define SLEG_GENERAL(cmd, variable, type, length, from, to, extra) {cmd, type, length, from, to, sizeof(variable), [] (void *, size_t) -> void * { return static_cast<void *>(std::addressof(variable)); }, extra, nullptr}
+#define SLEG_GENERAL(cmd, variable, type, length, from, to, extra) SaveLoad {cmd, type, length, from, to, sizeof(variable), [] (void *, size_t) -> void * { return static_cast<void *>(std::addressof(variable)); }, extra, nullptr}
 
 /**
  * Storage of a global variable in some savegame versions.
@@ -823,7 +823,7 @@ struct SaveLoad {
  * @param from     First savegame version that has the struct.
  * @param to       Last savegame version that has the struct.
  */
-#define SLEG_CONDSTRUCT(handler, from, to) {SL_STRUCT, 0, 0, from, to, 0, nullptr, 0, new handler()}
+#define SLEG_CONDSTRUCT(handler, from, to) SaveLoad {SL_STRUCT, 0, 0, from, to, 0, nullptr, 0, new handler()}
 
 /**
  * Storage of a global reference list in some savegame versions.
@@ -849,7 +849,7 @@ struct SaveLoad {
  * @param from     First savegame version that has the list.
  * @param to       Last savegame version that has the list.
  */
-#define SLEG_CONDSTRUCTLIST(handler, from, to) {SL_STRUCTLIST, 0, 0, from, to, 0, nullptr, 0, new handler()}
+#define SLEG_CONDSTRUCTLIST(handler, from, to) SaveLoad {SL_STRUCTLIST, 0, 0, from, to, 0, nullptr, 0, new handler()}
 
 /**
  * Storage of a global variable in every savegame version.
@@ -918,7 +918,7 @@ struct SaveLoad {
  * @param from   First savegame version that has the empty space.
  * @param to     Last savegame version that has the empty space.
  */
-#define SLEG_CONDNULL(length, from, to) {SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
+#define SLEG_CONDNULL(length, from, to) SaveLoad {SL_NULL, SLE_FILE_U8 | SLE_VAR_NULL, length, from, to, 0, nullptr, 0, nullptr}
 
 /**
  * Checks whether the savegame is below \a major.\a minor.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -87,6 +87,7 @@ std::string _config_file; ///< Configuration file of OpenTTD
 typedef std::list<ErrorMessageData> ErrorList;
 static ErrorList _settings_error_list; ///< Errors while loading minimal settings.
 
+typedef span<const SettingVariant> SettingTable;
 
 typedef void SettingDescProc(IniFile *ini, const SettingTable &desc, const char *grpname, void *object, bool only_startup);
 typedef void SettingDescProcList(IniFile *ini, const char *grpname, StringList &list);
@@ -98,9 +99,9 @@ static bool IsSignedVarMemType(VarType vt);
  * @param desc The type of the iterator of the value in SettingTable.
  * @return The actual pointer to SettingDesc.
  */
-static const SettingDesc *GetSettingDesc(const std::unique_ptr<const SettingDesc> &desc)
+static constexpr const SettingDesc *GetSettingDesc(const SettingVariant &desc)
 {
-	return desc.get();
+	return std::visit([](auto&& arg) -> const SettingDesc * { return &arg; }, desc);
 }
 
 /**

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -833,7 +833,7 @@ static void UpdateConsists(int32 new_value)
 }
 
 /* Check service intervals of vehicles, newvalue is value of % or day based servicing */
-static void UpdateServiceInterval(int32 new_value)
+static void UpdateAllServiceInterval(int32 new_value)
 {
 	bool update_vehicles;
 	VehicleDefaultSettings *vds;

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -10,6 +10,7 @@
 #ifndef SETTINGS_INTERNAL_H
 #define SETTINGS_INTERNAL_H
 
+#include <variant>
 #include "saveload/saveload.h"
 
 enum SettingFlag : uint16 {
@@ -299,7 +300,7 @@ struct NullSettingDesc : SettingDesc {
 	bool IsSameValue(const IniItem *item, void *object) const override { NOT_REACHED(); }
 };
 
-typedef std::initializer_list<std::unique_ptr<const SettingDesc>> SettingTable;
+typedef std::variant<IntSettingDesc, BoolSettingDesc, OneOfManySettingDesc, ManyOfManySettingDesc, StringSettingDesc, ListSettingDesc, NullSettingDesc> SettingVariant;
 
 const SettingDesc *GetSettingFromName(const std::string_view name);
 void GetSettingSaveLoadByPrefix(const std::string_view prefix, std::vector<SaveLoad> &saveloads);

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -69,7 +69,7 @@ struct IniItem;
 
 /** Properties of config file settings. */
 struct SettingDesc {
-	SettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup) :
+	SettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup) :
 		name(name), flags(flags), startup(startup), save(save) {}
 	virtual ~SettingDesc() {}
 
@@ -140,7 +140,7 @@ struct IntSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(int32 value);
 
-	IntSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, int32 def,
+	IntSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, int32 def,
 			int32 min, uint32 max, int32 interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def), min(min), max(max), interval(interval),
@@ -182,7 +182,7 @@ private:
 
 /** Boolean setting. */
 struct BoolSettingDesc : IntSettingDesc {
-	BoolSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, bool def,
+	BoolSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, bool def,
 			StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		IntSettingDesc(save, name, flags, startup, def, 0, 1, 0, str, str_help, str_val, cat,
@@ -198,7 +198,7 @@ struct BoolSettingDesc : IntSettingDesc {
 struct OneOfManySettingDesc : IntSettingDesc {
 	typedef size_t OnConvert(const char *value); ///< callback prototype for conversion error
 
-	OneOfManySettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, int32 def,
+	OneOfManySettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, int32 def,
 			int32 max, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
 			std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -222,7 +222,7 @@ struct OneOfManySettingDesc : IntSettingDesc {
 
 /** Many of many setting. */
 struct ManyOfManySettingDesc : OneOfManySettingDesc {
-	ManyOfManySettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup,
+	ManyOfManySettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup,
 		int32 def, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 		PreChangeCheck pre_check, PostChangeCallback post_callback,
 		std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -251,7 +251,7 @@ struct StringSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(const std::string &value);
 
-	StringSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, const char *def,
+	StringSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, const char *def,
 			uint32 max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, name, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
 			pre_check(pre_check), post_callback(post_callback) {}
@@ -277,7 +277,7 @@ private:
 
 /** List/array settings. */
 struct ListSettingDesc : SettingDesc {
-	ListSettingDesc(SaveLoad save, const std::string &name, SettingFlag flags, bool startup, const char *def) :
+	ListSettingDesc(SaveLoad save, const char *name, SettingFlag flags, bool startup, const char *def) :
 		SettingDesc(save, name, flags, startup), def(def) {}
 	virtual ~ListSettingDesc() {}
 
@@ -291,7 +291,7 @@ struct ListSettingDesc : SettingDesc {
 /** Placeholder for settings that have been removed, but might still linger in the savegame. */
 struct NullSettingDesc : SettingDesc {
 	NullSettingDesc(SaveLoad save) :
-		SettingDesc(save, {}, SF_NOT_IN_CONFIG, false) {}
+		SettingDesc(save, "", SF_NOT_IN_CONFIG, false) {}
 	virtual ~NullSettingDesc() {}
 
 	void FormatValue(char *buf, const char *last, const void *object) const override { NOT_REACHED(); }

--- a/src/table/settings.h.preamble
+++ b/src/table/settings.h.preamble
@@ -54,7 +54,7 @@ static size_t ConvertLandscape(const char *value);
  * on the appropriate macro.
  */
 
-#define NSD(type, ...) std::unique_ptr<const SettingDesc>(new type##SettingDesc(__VA_ARGS__))
+#define NSD(type, ...) SettingVariant { std::in_place_type<type##SettingDesc>, __VA_ARGS__ }
 
 /* Macros for various objects to go in the configuration file.
  * This section is for global variables */

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -8,7 +8,7 @@
 ; company changes them, it changes for all players.
 
 [pre-amble]
-static void UpdateServiceInterval(int32 new_value);
+static void UpdateAllServiceInterval(int32 new_value);
 static bool CanUpdateServiceInterval(VehicleType type, int32 &new_value);
 static void UpdateServiceInterval(VehicleType type, int32 new_value);
 
@@ -77,7 +77,7 @@ var      = vehicle.servint_ispercent
 def      = false
 str      = STR_CONFIG_SETTING_SERVINT_ISPERCENT
 strhelp  = STR_CONFIG_SETTING_SERVINT_ISPERCENT_HELPTEXT
-post_cb  = UpdateServiceInterval
+post_cb  = UpdateAllServiceInterval
 
 [SDT_VAR]
 var      = vehicle.servint_trains

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -12,7 +12,7 @@ static void UpdateAllServiceInterval(int32 new_value);
 static bool CanUpdateServiceInterval(VehicleType type, int32 &new_value);
 static void UpdateServiceInterval(VehicleType type, int32 new_value);
 
-static const SettingTable _company_settings{
+static const SettingVariant _company_settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/currency_settings.ini
+++ b/src/table/settings/currency_settings.ini
@@ -7,7 +7,7 @@
 ; Settings for the in-game custom currency.
 
 [pre-amble]
-static const SettingTable _currency_settings{
+static const SettingVariant _currency_settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/gameopt_settings.ini
+++ b/src/table/settings/gameopt_settings.ini
@@ -33,7 +33,7 @@ static std::initializer_list<const char*> _osk_activation{"disabled", "double", 
 static std::initializer_list<const char*> _settings_profiles{"easy", "medium", "hard"};
 static std::initializer_list<const char*> _news_display{ "off", "summarized", "full"};
 
-static const SettingTable _gameopt_settings{
+static const SettingVariant _gameopt_settings[] = {
 /* In version 4 a new difficulty setting has been added to the difficulty settings,
  * town attitude towards demolishing. Needs special handling because some dimwit thought
  * it funny to have the GameDifficulty struct be an array while it is a struct of

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -20,7 +20,7 @@ extern bool _allow_hidpi_window;
 #define WITHOUT_COCOA
 #endif
 
-static const SettingTable _misc_settings{
+static const SettingVariant _misc_settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -1002,14 +1002,14 @@ post_cb  = MaxVehiclesChanged
 cat      = SC_BASIC
 
 [SDTG_BOOL]
-name     = {}
+name     = """"
 flags    = SF_NO_NETWORK
 var      = _old_vds.servint_ispercent
 def      = false
 to       = SLV_120
 
 [SDTG_VAR]
-name     = {}
+name     = """"
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_trains
@@ -1019,7 +1019,7 @@ max      = 800
 to       = SLV_120
 
 [SDTG_VAR]
-name     = {}
+name     = """"
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_roadveh
@@ -1029,7 +1029,7 @@ max      = 800
 to       = SLV_120
 
 [SDTG_VAR]
-name     = {}
+name     = """"
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_ships
@@ -1039,7 +1039,7 @@ max      = 800
 to       = SLV_120
 
 [SDTG_VAR]
-name     = {}
+name     = """"
 type     = SLE_UINT16
 flags    = SF_GUI_0_IS_SPECIAL
 var      = _old_vds.servint_aircraft

--- a/src/table/settings/settings.ini
+++ b/src/table/settings/settings.ini
@@ -49,7 +49,7 @@ static void UpdateClientConfigValues();
  * assigns its own value. If the setting was company-based, that would mean that
  * vehicles could decide on different moments that they are heading back to a
  * service depot, causing desyncs on a massive scale. */
-const SettingTable _settings{
+static const SettingVariant _settings[] = {
 [post-amble]
 };
 [templates]

--- a/src/table/settings/win32_settings.ini
+++ b/src/table/settings/win32_settings.ini
@@ -12,7 +12,7 @@
 #if defined(_WIN32) && !defined(DEDICATED)
 extern bool _window_maximize;
 
-static const SettingTable _win32_settings{
+static const SettingVariant _win32_settings[] = {
 [post-amble]
 };
 #endif /* _WIN32 */

--- a/src/table/settings/window_settings.ini
+++ b/src/table/settings/window_settings.ini
@@ -9,7 +9,7 @@
 
 [pre-amble]
 
-static const SettingTable _window_settings{
+static const SettingVariant _window_settings[] = {
 [post-amble]
 };
 [templates]


### PR DESCRIPTION
## Motivation / Problem

In the words of TB:
>MacOS said: BOOOO
GCC said: fuck this shit


## Description

Fixes #9386 by using `std::variant` to forego the need to generate code for a `new` and as such needing to bother with `delete` at a later stage.
The forwarding constructor of `std::variant` is quite picky (at least on MSVC). It does not like to resolve overloaded functions, so some functions needed to be renamed to be resolvable. Furthermore the 'naked' initializer for `SaveLoad` was causing issues at some places, so effectively 'name' it by adding `SaveLoad` to the SLE* macros.
Finally resolving from a variant to a type is not super trivial when you do not know the exact type, for this `std::visit` is used which helps but including that in a simple `iterator` is beyond my C++-foo, so fell back to a helper function to convert the type of the 'auto loop' to the needed/wanted `const SettingDesc *`.


## Limitations

`std::visit` requires Mac OS 10.14 or higher which has been out-of-support for half a year... and that causes deprecations warnings that I can't solve.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
