### PR TITLE
Codechange: [OSX] Use more exact enum names where introduced with the 10.12 SDK.

### DIFF
--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -191,13 +191,13 @@ const char *GetCurrentLocale(const char *)
 bool GetClipboardContents(char *buffer, const char *last)
 {
 	NSPasteboard *pb = [ NSPasteboard generalPasteboard ];
-	NSArray *types = [ NSArray arrayWithObject:NSStringPboardType ];
+	NSArray *types = [ NSArray arrayWithObject:NSPasteboardTypeString ];
 	NSString *bestType = [ pb availableTypeFromArray:types ];
 
 	/* Clipboard has no text data available. */
 	if (bestType == nil) return false;
 
-	NSString *string = [ pb stringForType:NSStringPboardType ];
+	NSString *string = [ pb stringForType:NSPasteboardTypeString ];
 	if (string == nil || [ string length ] == 0) return false;
 
 	strecpy(buffer, [ string UTF8String ], last);

--- a/src/os/macosx/osx_stdafx.h
+++ b/src/os/macosx/osx_stdafx.h
@@ -26,6 +26,10 @@
 #define HAVE_OSX_1011_SDK
 #endif
 
+#ifdef MAC_OS_X_VERSION_10_12
+#define HAVE_OSX_1012_SDK
+#endif
+
 /* It would seem that to ensure backward compatibility we have to ensure that we have defined MAC_OS_X_VERSION_10_x everywhere */
 #ifndef MAC_OS_X_VERSION_10_3
 #define MAC_OS_X_VERSION_10_3 1030

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -12,6 +12,8 @@
 #include "../../stdafx.h"
 #include "../../os/macosx/macos.h"
 
+#define GL_SILENCE_DEPRECATION
+
 #define Rect  OTTDRect
 #define Point OTTDPoint
 #import <Cocoa/Cocoa.h>

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -152,7 +152,6 @@ static bool _allowSoftware;
 {
 	if (self = [ super initWithFrame:frameRect ]) {
 		/* We manage our content updates ourselves. */
-		self.wantsBestResolutionOpenGLSurface = _allow_hidpi_window ? YES : NO;
 		self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawOnSetNeedsDisplay;
 
 		/* Create backing layer. */

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -32,7 +32,6 @@ extern NSString *OTTDMainLaunchGameEngine;
 @interface OTTD_CocoaWindow : NSWindow
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag driver:(VideoDriver_Cocoa *)drv;
 
-- (void)display;
 - (void)setFrame:(NSRect)frameRect display:(BOOL)flag;
 @end
 

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -406,23 +406,6 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 }
 
 /**
- * This method fires just before the window deminaturizes from the Dock.
- * We'll save the current visible surface, let the window manager redraw any
- * UI elements, and restore the surface. This way, no expose event
- * is required, and the deminiaturize works perfectly.
- */
-- (void)display
-{
-	/* save current visible surface */
-	[ self cacheImageInRect:[ driver->cocoaview frame ] ];
-
-	/* let the window manager redraw controls, border, etc */
-	[ super display ];
-
-	/* restore visible surface */
-	[ self restoreCachedImage ];
-}
-/**
  * Define the rectangle we draw our window in
  */
 - (void)setFrame:(NSRect)frameRect display:(BOOL)flag

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -22,6 +22,7 @@
 
 #define GL_GLEXT_PROTOTYPES
 #if defined(__APPLE__)
+#	define GL_SILENCE_DEPRECATION
 #	include <OpenGL/gl3.h>
 #else
 #	include <GL/gl.h>


### PR DESCRIPTION
## Motivation / Problem / Description

```
The enum values still have the exact same numerical values, but the 10.12
SDK introduced more explicit names (e.g. like NSEventTypeApplicationDefined
instead of NSApplicationDefined) for several enum constants.
Use them when available.
```

The OSX 10.12 SDK introduced various more logical and exact enum/constant names for various things.
As the old variants where marked deprecated, building for newer OSX versions produces compiler warnings.


## Limitations

I added `#ifdef`s where needed as master as of right now is still marked as 10.9 minimum. If the minimum ws bumped to 10.12, these wouldn't be needed. The pasteboard change is 10.6+.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
