### PR TITLE
Feature: Persistant rotation of numbered autosave after restart

### DIFF
--- a/src/fios.h
+++ b/src/fios.h
@@ -125,4 +125,16 @@ std::string FiosMakeSavegameName(const char *name);
 
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 
+/**
+ * A savegame name automatically numbered.
+ */
+struct FiosNumberedSaveName {
+	FiosNumberedSaveName(const std::string &prefix);
+	std::string Filename();
+	std::string Extension();
+private:
+	std::string prefix;
+	int number;
+};
+
 #endif /* FIOS_H */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -132,8 +132,8 @@ struct PacketReader : LoadFilter {
  */
 void ClientNetworkEmergencySave()
 {
-	static int _netsave_ctr = 0;
-	DoAutoOrNetsave(_netsave_ctr, true);
+	static FiosNumberedSaveName _netsave_ctr("netsave");
+	DoAutoOrNetsave(_netsave_ctr);
 }
 
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1392,7 +1392,7 @@ void StateGameLoop()
  */
 static void DoAutosave()
 {
-	static int _autosave_ctr = 0;
+	static FiosNumberedSaveName _autosave_ctr("autosave");
 	DoAutoOrNetsave(_autosave_ctr);
 }
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -3328,26 +3328,15 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
  * @param counter A reference to the counter variable to be used for rotating the file name.
  * @param netsave Indicates if this is a regular autosave or a netsave.
  */
-void DoAutoOrNetsave(int &counter, bool netsave)
+void DoAutoOrNetsave(FiosNumberedSaveName &counter)
 {
 	char buf[MAX_PATH];
 
 	if (_settings_client.gui.keep_all_autosave) {
 		GenerateDefaultSaveName(buf, lastof(buf));
-		if (!netsave) {
-			strecat(buf, ".sav", lastof(buf));
-		} else {
-			strecat(buf, "-netsave.sav", lastof(buf));
-		}
+		strecat(buf, counter.Extension().c_str(), lastof(buf));
 	} else {
-		/* Generate a savegame name and number according to _settings_client.gui.max_num_autosaves. */
-		if (!netsave) {
-			seprintf(buf, lastof(buf), "autosave%d.sav", counter);
-		} else {
-			seprintf(buf, lastof(buf), "netsave%d.sav", counter);
-		}
-
-		if (++counter >= _settings_client.gui.max_num_autosaves) counter = 0;
+		strecpy(buf, counter.Filename().c_str(), lastof(buf));
 	}
 
 	Debug(sl, 2, "Autosaving to '{}'", buf);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -11,6 +11,7 @@
 #define SAVELOAD_H
 
 #include "../fileio_type.h"
+#include "../fios.h"
 #include "../strings_type.h"
 #include "../core/span_type.hpp"
 #include <optional>
@@ -381,7 +382,7 @@ void WaitTillSaved();
 void ProcessAsyncSaveFinish();
 void DoExitSave();
 
-void DoAutoOrNetsave(int &counter, bool netsave = false);
+void DoAutoOrNetsave(FiosNumberedSaveName &counter);
 
 SaveOrLoadResult SaveWithFilter(struct SaveFilter *writer, bool threaded);
 SaveOrLoadResult LoadWithFilter(struct LoadFilter *reader);


### PR DESCRIPTION
Fixes #9396

## Motivation / Problem
Autosave numbering always starts from 0 when OpenTTD is started.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Retrieve the number of the most recent autosave and use it as a base for the next one.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
If more than one OpenTTD instance is running, and if they share the same `autosave` directory, they will still overwrite each other savegames.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
