### PR TITLE
Fix: [Squirrel] Enforce comma usage in function calls

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -1702,9 +1702,9 @@ function Regression::Vehicle()
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 0));
 	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 1));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 1));
-	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17 2));
+	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 2));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 2));
-	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17 3));
+	print("  GetWagonEngineType(): " + AIVehicle.GetWagonEngineType(17, 3));
 	print("  GetWagonAge():        " + AIVehicle.GetWagonAge(17, 3));
 
 	print("  --Refit--");

--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -784,6 +784,7 @@ public:
 				 Lex();
 				 if(_token == ')') Error("expression expected, found ')'");
 			 }
+			 else if(_token != ')') Error("')' or ',' expected, found expression");
 		 }
 		 Lex();
 		 for(SQInteger i = 0; i < (nargs - 1); i++) _fs->PopTarget();


### PR DESCRIPTION
## Motivation / Problem
Squirrel errors for `call(a, b, c,)` with `expression expected, found ')'`, but accepts `call(a b c)`.
I think it's inconsistent, and it should enforce `,` usage.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Added a check to enforce `,` in function calls. And found 2 missing ones in regression test :)

I tried to respect Squirrel coding style.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Existing AIs may fail to compile if they miss some `,` in function calls.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
