### PR TITLE
Fix f7e390bd: freeaddrinfo() is not guaranteed to handle a nullptr graceful

### DIFF
--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -45,7 +45,7 @@ TCPConnecter::~TCPConnecter()
 	this->sockets.clear();
 	this->sock_to_address.clear();
 
-	freeaddrinfo(this->ai);
+	if (this->ai != nullptr) freeaddrinfo(this->ai);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Reported in a comment in #9017 . Could not confirm, as I cannot compile for Haiku.

## Description

Hopefully fix a crash on Haiku. Again, no way for me to confirm this :P

(and no, I do not know why it was reported as comment in #9017, as it already didn't contain that code at that point in time :P But I am happy to fix it ofc!)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
