### PR TITLE
Reduce allocations in string handling

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -800,15 +800,14 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 	WChar b = '\0';
 	uint next_substr_case_index = 0;
 	char *buf_start = buff;
-	std::stack<const char *, std::vector<const char *>> str_stack;
-	str_stack.push(str_arg);
+	const char * next_str_arg = str_arg;
 
 	for (;;) {
-		while (!str_stack.empty() && (b = Utf8Consume(&str_stack.top())) == '\0') {
-			str_stack.pop();
+		if (next_str_arg != nullptr && (b = Utf8Consume(next_str_arg)) == '\0') {
+			next_str_arg = nullptr;
 		}
-		if (str_stack.empty()) break;
-		const char *&str = str_stack.top();
+		if (next_str_arg == nullptr) break;
+		const char *str = next_str_arg;
 
 		if (SCC_NEWGRF_FIRST <= b && b <= SCC_NEWGRF_LAST) {
 			/* We need to pass some stuff as it might be modified; oh boy. */
@@ -915,13 +914,13 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 			case SCC_NEWGRF_STRINL: {
 				StringID substr = Utf8Consume(&str);
-				str_stack.push(GetStringPtr(substr));
+				next_str_arg = GetStringPtr(substr);
 				break;
 			}
 
 			case SCC_NEWGRF_PRINT_WORD_STRING_ID: {
 				StringID substr = args->GetInt32(SCC_NEWGRF_PRINT_WORD_STRING_ID);
-				str_stack.push(GetStringPtr(substr));
+				next_str_arg = GetStringPtr(substr);
 				case_index = next_substr_case_index;
 				next_substr_case_index = 0;
 				break;


### PR DESCRIPTION
## Motivation / Problem

I often use OpenTTD to get accustomed with new tools. This time I used heaptrack to analyse and locate allocations in the code.

There are some places in string handling that reallocate temporary char buffers per call. As OpenTTD has to format quite a few strings per frame, this accumulates quickly.

## Description

_edit: skip this part_

> Proxy functions often follow this pattern:
> 1. Allocate char buffer
> 2. Populate char buffer with a string
> 3. Process the string
> I marked these buffers as static to prevent unnecessary allocations. The content will simply be overwritten by the population function.

Next is the `FormatString` function. Currently, this function uses a stack to keep track of the remaining string.
This is not necessary as this stack can never reach 2 values. (Correct me if I am wrong.) Hence using a pointer suffices and prevents allocations altogether.

I used the first 30s of [this savegame](https://www.tt-forums.net/viewtopic.php?f=60&t=49307) to analyse the differences. I am using the sdl(_opengl) drivers.
The overall temporary allocations are down by ~90% and FormatString now doesn't allocate at all.
`ViewportDrawStrings` + Callers is now responsible for 26% of total temporary allocation (48k), which was 67% (413k).

Temp allocation hotspots after this PR are:
* `Layouter::GetCachedParagraphLayout` ~ 25%
* `ViewportSortParentSpritesSSE41`~ 34%
Main allocation hotspot is `ViewportSortParentSpritesSSE41` with ~85% of all allocations.

I am not sure how much this translates to FPS improvement. The 512 samples are not capable of smoothening out the frame time jitter on my dev system. Maybe a reviewer can give this a try.

## Limitations

_none_

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
