### PR TITLE
Change: [strgen] 'warnings' for translations are now 'infos' unless invoked with -w or -t

### DIFF
--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -46,7 +46,11 @@ void CDECL strgen_warning(const char *s, ...)
 	va_start(va, s);
 	vseprintf(buf, lastof(buf), s, va);
 	va_end(va);
-	fprintf(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, buf);
+	if (_show_todo > 0) {
+		fprintf(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, buf);
+	} else {
+		fprintf(stderr, LINE_NUM_FMT("info"), _file, _cur_line, buf);
+	}
 	_warnings++;
 }
 

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -818,8 +818,12 @@ void StringReader::ParseFile()
 	char buf[2048];
 	_warnings = _errors = 0;
 
-	_translation = this->master || this->translation;
+	_translation = this->translation;
 	_file = this->file;
+
+	/* Abusing _show_todo to replace "warning" with "info" for translations. */
+	_show_todo &= 3;
+	if (!this->translation) _show_todo |= 4;
 
 	/* For each new file we parse, reset the genders, and language codes. */
 	MemSetT(&_lang, 0);


### PR DESCRIPTION
## Motivation / Problem
A change in gcc-problem-matcher made it pickup strgen warnings for translations. These are usually handled by eints later.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use `info` for translation warnings, unless `-w` or `-t` switches are used.
This is done by abusing `_show_todo`.
Tested on #9017 (see output [here](https://github.com/glx22/OpenTTD/runs/2944908462?check_suite_focus=true)).
I also tested locally to be sure `english.txt` still always generate `warning` and not `info`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
