### PR TITLE
Codechange: replace InjectDParam/ShiftParameters

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -84,16 +84,6 @@ int64 StringParameters::GetInt64(WChar type)
 }
 
 /**
- * Shift all data in the data array by the given amount to make
- * room for some extra parameters.
- */
-void StringParameters::ShiftParameters(uint amount)
-{
-	assert(amount <= this->num_param);
-	MemMoveT(this->data + amount, this->data, this->num_param - amount);
-}
-
-/**
  * Set DParam n to some number that is suitable for string size computations.
  * @param n Index of the string parameter.
  * @param max_value The biggest value which shall be displayed.
@@ -317,15 +307,6 @@ void SetDParamStr(uint n, const char *str)
 void SetDParamStr(uint n, const std::string &str)
 {
 	SetDParamStr(n, str.c_str());
-}
-
-/**
- * Shift the string parameters in the global string parameter array by \a amount positions, making room at the beginning.
- * @param amount Number of positions to shift.
- */
-void InjectDParam(uint amount)
-{
-	_global_string_params.ShiftParameters(amount);
 }
 
 /**

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -122,8 +122,6 @@ public:
 		return (int32)this->GetInt64(type);
 	}
 
-	void ShiftParameters(uint amount);
-
 	/** Get a pointer to the current element in the data array. */
 	uint64 *GetDataPointer() const
 	{
@@ -178,8 +176,6 @@ const char *GetStringPtr(StringID string);
 
 uint ConvertKmhishSpeedToDisplaySpeed(uint speed);
 uint ConvertDisplaySpeedToKmhishSpeed(uint speed);
-
-void InjectDParam(uint amount);
 
 /**
  * Set a string parameter \a v at index \a n in a given array \a s.

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -47,8 +47,7 @@ void Subsidy::AwardTo(CompanyID company)
 	NewsStringData *company_name = new NewsStringData(GetString(STR_COMPANY_NAME));
 
 	/* Add a news item */
-	std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(this, SubsidyDecodeParamType::NewsAwarded);
-	InjectDParam(1);
+	std::pair<NewsReferenceType, NewsReferenceType> reftype = SetupSubsidyDecodeParam(this, SubsidyDecodeParamType::NewsAwarded, 1);
 
 	SetDParamStr(0, company_name->string);
 	AddNewsItem(
@@ -67,9 +66,10 @@ void Subsidy::AwardTo(CompanyID company)
  * Setup the string parameters for printing the subsidy at the screen, and compute the news reference for the subsidy.
  * @param s %Subsidy being printed.
  * @param mode Type of subsidy news message to decide on parameter format.
+ * @param parameter_offset The location/index in the String DParams to start decoding the subsidy's parameters. Defaults to 0.
  * @return Reference of the subsidy in the news system.
  */
-std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Subsidy *s, SubsidyDecodeParamType mode)
+std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset)
 {
 	NewsReferenceType reftype1 = NR_NONE;
 	NewsReferenceType reftype2 = NR_NONE;
@@ -77,40 +77,40 @@ std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const Su
 	/* Choose whether to use the singular or plural form of the cargo name based on how we're printing the subsidy */
 	const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
 	if (mode == SubsidyDecodeParamType::Gui || mode == SubsidyDecodeParamType::NewsWithdrawn) {
-		SetDParam(0, cs->name);
+		SetDParam(parameter_offset, cs->name);
 	} else {
-		SetDParam(0, cs->name_single);
+		SetDParam(parameter_offset, cs->name_single);
 	}
 
 	switch (s->src_type) {
 		case ST_INDUSTRY:
 			reftype1 = NR_INDUSTRY;
-			SetDParam(1, STR_INDUSTRY_NAME);
+			SetDParam(parameter_offset + 1, STR_INDUSTRY_NAME);
 			break;
 		case ST_TOWN:
 			reftype1 = NR_TOWN;
-			SetDParam(1, STR_TOWN_NAME);
+			SetDParam(parameter_offset + 1, STR_TOWN_NAME);
 			break;
 		default: NOT_REACHED();
 	}
-	SetDParam(2, s->src);
+	SetDParam(parameter_offset + 2, s->src);
 
 	switch (s->dst_type) {
 		case ST_INDUSTRY:
 			reftype2 = NR_INDUSTRY;
-			SetDParam(4, STR_INDUSTRY_NAME);
+			SetDParam(parameter_offset + 4, STR_INDUSTRY_NAME);
 			break;
 		case ST_TOWN:
 			reftype2 = NR_TOWN;
-			SetDParam(4, STR_TOWN_NAME);
+			SetDParam(parameter_offset + 4, STR_TOWN_NAME);
 			break;
 		default: NOT_REACHED();
 	}
-	SetDParam(5, s->dst);
+	SetDParam(parameter_offset + 5, s->dst);
 
 	/* If the subsidy is being offered or awarded, the news item mentions the subsidy duration. */
 	if (mode == SubsidyDecodeParamType::NewsOffered || mode == SubsidyDecodeParamType::NewsAwarded) {
-		SetDParam(7, _settings_game.difficulty.subsidy_duration);
+		SetDParam(parameter_offset + 7, _settings_game.difficulty.subsidy_duration);
 	}
 
 	return std::pair<NewsReferenceType, NewsReferenceType>(reftype1, reftype2);

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -17,7 +17,7 @@
 #include "news_type.h"
 #include "subsidy_base.h"
 
-std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode);
+std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const struct Subsidy *s, SubsidyDecodeParamType mode, uint parameter_offset = 0);
 void DeleteSubsidyWith(SourceType type, SourceID index);
 bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type, SourceID src, const Station *st);
 void RebuildSubsidisedSourceAndDestinationCache();

--- a/src/subsidy_func.h
+++ b/src/subsidy_func.h
@@ -21,6 +21,5 @@ std::pair<NewsReferenceType, NewsReferenceType> SetupSubsidyDecodeParam(const st
 void DeleteSubsidyWith(SourceType type, SourceID index);
 bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type, SourceID src, const Station *st);
 void RebuildSubsidisedSourceAndDestinationCache();
-void DeleteSubsidy(struct Subsidy *s);
 
 #endif /* SUBSIDY_FUNC_H */


### PR DESCRIPTION
## Motivation / Problem

ShiftParameters, and due to that InjectDParam use MemMoveT to move the parameters around. Since this only updates the parameters, but not the types associated with the parameters it cannot be used when types are used.

While doing this also spotted a declaration of a function that was not defined, so that will be removed as well.

## Description

Just set the right parameter indices in one subsidy function to be able to get rid of both ShiftParameters and InjectDParam.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
