### PR TITLE
Fix: Inconsistent error message when overbuilding canal on a lock/ship depot tile

### DIFF
--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -475,10 +475,11 @@ CommandCost CmdBuildCanal(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 			return_cmd_error(STR_ERROR_FLAT_LAND_REQUIRED);
 		}
 
-		/* can't make water of water! */
-		if (IsTileType(current_tile, MP_WATER) && (!IsTileOwner(current_tile, OWNER_WATER) || wc == WATER_CLASS_SEA)) continue;
-
 		bool water = IsWaterTile(current_tile);
+
+		/* can't make water of water! */
+		if (water && (!IsTileOwner(current_tile, OWNER_WATER) || wc == WATER_CLASS_SEA)) continue;
+
 		ret = DoCommand(current_tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -479,7 +479,7 @@ CommandCost CmdBuildCanal(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 		if (IsTileType(current_tile, MP_WATER) && (!IsTileOwner(current_tile, OWNER_WATER) || wc == WATER_CLASS_SEA)) continue;
 
 		bool water = IsWaterTile(current_tile);
-		ret = DoCommand(current_tile, 0, 0, flags | DC_FORCE_CLEAR_TILE, CMD_LANDSCAPE_CLEAR);
+		ret = DoCommand(current_tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;
 
 		if (!water) cost.AddCost(ret);


### PR DESCRIPTION
## Motivation / Problem
This is a delicate issue.
It originated when my AI was overbuilding a canal on the entry/exit of a lock tile. If the waterclass was canal, I would get a 'Can't build canals here... ... already built' error message, but if the waterclass was sea, I would get 'Can't build canals here... Building must be demolished first'.

https://github.com/OpenTTD/OpenTTD/blob/d38ad7d80ca592612ce7bc98e770e40ae778fd04/src/water_cmd.cpp#L478-L485

First I discovered that `IsTileType(current_tile, MP_WATER)` can't be used here, due to Ship Depots and Locks also being tiles of the same type `MP_WATER `as Canals. I changed to `IsWaterTile(current_tile)` and I thought that would be enough to fix the problem, but it wasn't.

Now I was getting 'Can't build canals here... Must demolish canal first'.

I found that `DC_FORCE_CLEAR_TILE` was in the way. It would end up doing these checks:
https://github.com/OpenTTD/OpenTTD/blob/d38ad7d80ca592612ce7bc98e770e40ae778fd04/src/landscape.cpp#L696-L702

I still tried adding some extra checks to line 698, to exclude locks and ship depots, but that would mean I was going against the purpose of `DC_FORCE_CLEAR_TILE`.

Went back to the origin of this flag, at line 482 of water_cmd.cpp. Decided to remove the flag, and that finally solved the issue.

Now, the error message is consistent, regardless of waterclass: 'Can't build canals here... Building must be demolished first'. They reach `ClearTile_Water` to get the error string.

There is however, behaviour changes when experimenting with tiles of type `MP_OBJECT`. I Loaded NewGRF 'OpenGFX+ Landscape 1.1.2'. When we have a canal, and a rocky land on the canal, overbuilding the canal no longer comes up with an error message saying 'Can't build canals here... ... Must demolish canal first'. Now it overbuilds with no error. Also, if we build a canal on top of a rocky land on sea, the price is also different. It doesn't include the price of clearing sea.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
