### PR TITLE
Replace master-server (UDP-based) with Game Coordinator (TCP-based)

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1995,7 +1995,7 @@ STR_FACE_TIE                                                    :Tie:
 STR_FACE_EARRING                                                :Earring:
 STR_FACE_TIE_EARRING_TOOLTIP                                    :{BLACK}Change tie or earring
 
-STR_NETWORK_SERVER_VISIBILITY_PRIVATE                           :Private
+STR_NETWORK_SERVER_VISIBILITY_LOCAL                             :Local
 STR_NETWORK_SERVER_VISIBILITY_PUBLIC                            :Public
 
 # Network server list
@@ -2136,6 +2136,8 @@ STR_NETWORK_CLIENT_LIST_SERVER_NAME_EDIT_TOOLTIP                :{BLACK}Edit the
 STR_NETWORK_CLIENT_LIST_SERVER_NAME_QUERY_CAPTION               :Name of the server
 STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY                       :{BLACK}Visibility
 STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY_TOOLTIP               :{BLACK}Whether other people can see your server in the public listing
+STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE                  :{BLACK}Connection type
+STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TOOLTIP          :{BLACK}Whether and how your server can be reached by others
 STR_NETWORK_CLIENT_LIST_PLAYER                                  :{BLACK}Player
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME                             :{BLACK}Name
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME_TOOLTIP                     :{BLACK}Your player name
@@ -2153,6 +2155,12 @@ STR_NETWORK_CLIENT_LIST_NEW_COMPANY_TOOLTIP                     :{BLACK}Create a
 STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP                :{BLACK}This is you
 STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP                :{BLACK}This is the host of the game
 STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT                    :{BLACK}{NUM} client{P "" s} / {NUM} compan{P y ies}
+
+############ Begin of ConnectionType
+STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_UNKNOWN          :{BLACK}Local
+STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_ISOLATED         :{RED}Remote players can't connect
+STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_DIRECT           :{BLACK}Public
+############ End of ConnectionType
 
 STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_KICK                       :Kick
 STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_BAN                        :Ban
@@ -2280,6 +2288,10 @@ STR_NETWORK_MESSAGE_GIVE_MONEY                                  :*** {RAW_STRING
 STR_NETWORK_MESSAGE_SERVER_SHUTDOWN                             :{WHITE}The server closed the session
 STR_NETWORK_MESSAGE_SERVER_REBOOT                               :{WHITE}The server is restarting...{}Please wait...
 STR_NETWORK_MESSAGE_KICKED                                      :*** {RAW_STRING} was kicked. Reason: ({RAW_STRING})
+
+STR_NETWORK_ERROR_COORDINATOR_REGISTRATION_FAILED               :{WHITE}Server registration failed
+STR_NETWORK_ERROR_COORDINATOR_ISOLATED                          :{WHITE}Your server doesn't allow remote connections
+STR_NETWORK_ERROR_COORDINATOR_ISOLATED_DETAIL                   :{WHITE}Other players won't be able to connect to your server
 
 # Content downloading window
 STR_CONTENT_TITLE                                               :{WHITE}Content downloading

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -14,6 +14,8 @@ add_files(
     network_content.h
     network_content_gui.cpp
     network_content_gui.h
+    network_coordinator.cpp
+    network_coordinator.h
     network_func.h
     network_gamelist.cpp
     network_gamelist.h

--- a/src/network/core/CMakeLists.txt
+++ b/src/network/core/CMakeLists.txt
@@ -20,6 +20,8 @@ add_files(
     tcp_content.cpp
     tcp_content.h
     tcp_content_type.h
+    tcp_coordinator.cpp
+    tcp_coordinator.h
     tcp_game.cpp
     tcp_game.h
     tcp_http.cpp

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -12,8 +12,6 @@
 #ifndef NETWORK_CORE_CONFIG_H
 #define NETWORK_CORE_CONFIG_H
 
-/** DNS hostname of the masterserver */
-static const char * const NETWORK_MASTER_SERVER_HOST            = "master.openttd.org";
 /** DNS hostname of the Game Coordinator server */
 static const char * const NETWORK_COORDINATOR_SERVER_HOST       = "coordinator.openttd.org";
 /** DNS hostname of the content server */
@@ -22,10 +20,7 @@ static const char * const NETWORK_CONTENT_SERVER_HOST           = "content.opent
 static const char * const NETWORK_CONTENT_MIRROR_HOST           = "binaries.openttd.org";
 /** URL of the HTTP mirror system */
 static const char * const NETWORK_CONTENT_MIRROR_URL            = "/bananas";
-/** Message sent to the masterserver to 'identify' this client as OpenTTD */
-static const char * const NETWORK_MASTER_SERVER_WELCOME_MESSAGE = "OpenTTDRegister";
 
-static const uint16 NETWORK_MASTER_SERVER_PORT      = 3978;           ///< The default port of the master server (UDP)
 static const uint16 NETWORK_COORDINATOR_SERVER_PORT = 3976;           ///< The default port of the Game Coordinator server (TCP)
 static const uint16 NETWORK_CONTENT_SERVER_PORT     = 3978;           ///< The default port of the content server (TCP)
 static const uint16 NETWORK_CONTENT_MIRROR_PORT     =   80;           ///< The default port of the content mirror (TCP)
@@ -54,7 +49,6 @@ static const uint16 COMPAT_MTU                      = 1460;           ///< Numbe
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    4;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
-static const byte NETWORK_MASTER_SERVER_VERSION     =    2;           ///< What version of master-server-protocol do we use?
 static const byte NETWORK_COORDINATOR_VERSION       =    1;           ///< What version of game-coordinator-protocol do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -14,6 +14,8 @@
 
 /** DNS hostname of the masterserver */
 static const char * const NETWORK_MASTER_SERVER_HOST            = "master.openttd.org";
+/** DNS hostname of the Game Coordinator server */
+static const char * const NETWORK_COORDINATOR_SERVER_HOST       = "coordinator.openttd.org";
 /** DNS hostname of the content server */
 static const char * const NETWORK_CONTENT_SERVER_HOST           = "content.openttd.org";
 /** DNS hostname of the HTTP-content mirror server */
@@ -23,14 +25,15 @@ static const char * const NETWORK_CONTENT_MIRROR_URL            = "/bananas";
 /** Message sent to the masterserver to 'identify' this client as OpenTTD */
 static const char * const NETWORK_MASTER_SERVER_WELCOME_MESSAGE = "OpenTTDRegister";
 
-static const uint16 NETWORK_MASTER_SERVER_PORT    = 3978;         ///< The default port of the master server (UDP)
-static const uint16 NETWORK_CONTENT_SERVER_PORT   = 3978;         ///< The default port of the content server (TCP)
-static const uint16 NETWORK_CONTENT_MIRROR_PORT   =   80;         ///< The default port of the content mirror (TCP)
-static const uint16 NETWORK_DEFAULT_PORT          = 3979;         ///< The default port of the game server (TCP & UDP)
-static const uint16 NETWORK_ADMIN_PORT            = 3977;         ///< The default port for admin network
-static const uint16 NETWORK_DEFAULT_DEBUGLOG_PORT = 3982;         ///< The default port debug-log is sent to (TCP)
+static const uint16 NETWORK_MASTER_SERVER_PORT      = 3978;           ///< The default port of the master server (UDP)
+static const uint16 NETWORK_COORDINATOR_SERVER_PORT = 3976;           ///< The default port of the Game Coordinator server (TCP)
+static const uint16 NETWORK_CONTENT_SERVER_PORT     = 3978;           ///< The default port of the content server (TCP)
+static const uint16 NETWORK_CONTENT_MIRROR_PORT     =   80;           ///< The default port of the content mirror (TCP)
+static const uint16 NETWORK_DEFAULT_PORT            = 3979;           ///< The default port of the game server (TCP & UDP)
+static const uint16 NETWORK_ADMIN_PORT              = 3977;           ///< The default port for admin network
+static const uint16 NETWORK_DEFAULT_DEBUGLOG_PORT   = 3982;           ///< The default port debug-log is sent to (TCP)
 
-static const uint16 UDP_MTU                       = 1460;         ///< Number of bytes we can pack in a single UDP packet
+static const uint16 UDP_MTU                         = 1460;           ///< Number of bytes we can pack in a single UDP packet
 /*
  * Technically a TCP packet could become 64kiB, however the high bit is kept so it becomes possible in the future
  * to go to (significantly) larger packets if needed. This would entail a strategy such as employed for UTF-8.
@@ -45,40 +48,42 @@ static const uint16 UDP_MTU                       = 1460;         ///< Number of
  * Send_uint16(GB(size, 16, 14) | 0b10 << 14)
  * Send_uint16(GB(size,  0, 16))
  */
-static const uint16 TCP_MTU                       = 32767;        ///< Number of bytes we can pack in a single TCP packet
-static const uint16 COMPAT_MTU                    = 1460;         ///< Number of bytes we can pack in a single packet for backward compatibility
+static const uint16 TCP_MTU                         = 32767;          ///< Number of bytes we can pack in a single TCP packet
+static const uint16 COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
 
-static const byte NETWORK_GAME_ADMIN_VERSION      =    1;         ///< What version of the admin network do we use?
-static const byte NETWORK_GAME_INFO_VERSION       =    4;         ///< What version of game-info do we use?
-static const byte NETWORK_COMPANY_INFO_VERSION    =    6;         ///< What version of company info is this?
-static const byte NETWORK_MASTER_SERVER_VERSION   =    2;         ///< What version of master-server-protocol do we use?
+static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
+static const byte NETWORK_GAME_INFO_VERSION         =    4;           ///< What version of game-info do we use?
+static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
+static const byte NETWORK_MASTER_SERVER_VERSION     =    2;           ///< What version of master-server-protocol do we use?
+static const byte NETWORK_COORDINATOR_VERSION       =    1;           ///< What version of game-coordinator-protocol do we use?
 
-static const uint NETWORK_NAME_LENGTH             =   80;         ///< The maximum length of the server name and map name, in bytes including '\0'
-static const uint NETWORK_COMPANY_NAME_LENGTH     =  128;         ///< The maximum length of the company name, in bytes including '\0'
-static const uint NETWORK_HOSTNAME_LENGTH         =   80;         ///< The maximum length of the host name, in bytes including '\0'
-static const uint NETWORK_HOSTNAME_PORT_LENGTH    =   80 + 6;     ///< The maximum length of the host name + port, in bytes including '\0'. The extra six is ":" + port number (with a max of 65536)
-static const uint NETWORK_SERVER_ID_LENGTH        =   33;         ///< The maximum length of the network id of the servers, in bytes including '\0'
-static const uint NETWORK_REVISION_LENGTH         =   33;         ///< The maximum length of the revision, in bytes including '\0'
-static const uint NETWORK_PASSWORD_LENGTH         =   33;         ///< The maximum length of the password, in bytes including '\0' (must be >= NETWORK_SERVER_ID_LENGTH)
-static const uint NETWORK_CLIENTS_LENGTH          =  200;         ///< The maximum length for the list of clients that controls a company, in bytes including '\0'
-static const uint NETWORK_CLIENT_NAME_LENGTH      =   25;         ///< The maximum length of a client's name, in bytes including '\0'
-static const uint NETWORK_RCONCOMMAND_LENGTH      =  500;         ///< The maximum length of a rconsole command, in bytes including '\0'
-static const uint NETWORK_GAMESCRIPT_JSON_LENGTH  = COMPAT_MTU-3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than COMPAT_MTU including header (3 bytes)
-static const uint NETWORK_CHAT_LENGTH             =  900;         ///< The maximum length of a chat message, in bytes including '\0'
-static const uint NETWORK_CONTENT_FILENAME_LENGTH =   48;         ///< The maximum length of a content's filename, in bytes including '\0'.
-static const uint NETWORK_CONTENT_NAME_LENGTH     =   32;         ///< The maximum length of a content's name, in bytes including '\0'.
-static const uint NETWORK_CONTENT_VERSION_LENGTH  =   16;         ///< The maximum length of a content's version, in bytes including '\0'.
-static const uint NETWORK_CONTENT_URL_LENGTH      =   96;         ///< The maximum length of a content's url, in bytes including '\0'.
-static const uint NETWORK_CONTENT_DESC_LENGTH     =  512;         ///< The maximum length of a content's description, in bytes including '\0'.
-static const uint NETWORK_CONTENT_TAG_LENGTH      =   32;         ///< The maximum length of a content's tag, in bytes including '\0'.
+static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
+static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'
+static const uint NETWORK_HOSTNAME_LENGTH           =   80;           ///< The maximum length of the host name, in bytes including '\0'
+static const uint NETWORK_HOSTNAME_PORT_LENGTH      =   80 + 6;       ///< The maximum length of the host name + port, in bytes including '\0'. The extra six is ":" + port number (with a max of 65536)
+static const uint NETWORK_SERVER_ID_LENGTH          =   33;           ///< The maximum length of the network id of the servers, in bytes including '\0'
+static const uint NETWORK_REVISION_LENGTH           =   33;           ///< The maximum length of the revision, in bytes including '\0'
+static const uint NETWORK_PASSWORD_LENGTH           =   33;           ///< The maximum length of the password, in bytes including '\0' (must be >= NETWORK_SERVER_ID_LENGTH)
+static const uint NETWORK_CLIENTS_LENGTH            =  200;           ///< The maximum length for the list of clients that controls a company, in bytes including '\0'
+static const uint NETWORK_CLIENT_NAME_LENGTH        =   25;           ///< The maximum length of a client's name, in bytes including '\0'
+static const uint NETWORK_RCONCOMMAND_LENGTH        =  500;           ///< The maximum length of a rconsole command, in bytes including '\0'
+static const uint NETWORK_GAMESCRIPT_JSON_LENGTH    = COMPAT_MTU - 3; ///< The maximum length of a gamescript json string, in bytes including '\0'. Must not be longer than COMPAT_MTU including header (3 bytes)
+static const uint NETWORK_CHAT_LENGTH               =  900;           ///< The maximum length of a chat message, in bytes including '\0'
+static const uint NETWORK_CONTENT_FILENAME_LENGTH   =   48;           ///< The maximum length of a content's filename, in bytes including '\0'.
+static const uint NETWORK_CONTENT_NAME_LENGTH       =   32;           ///< The maximum length of a content's name, in bytes including '\0'.
+static const uint NETWORK_CONTENT_VERSION_LENGTH    =   16;           ///< The maximum length of a content's version, in bytes including '\0'.
+static const uint NETWORK_CONTENT_URL_LENGTH        =   96;           ///< The maximum length of a content's url, in bytes including '\0'.
+static const uint NETWORK_CONTENT_DESC_LENGTH       =  512;           ///< The maximum length of a content's description, in bytes including '\0'.
+static const uint NETWORK_CONTENT_TAG_LENGTH        =   32;           ///< The maximum length of a content's tag, in bytes including '\0'.
+static const uint NETWORK_ERROR_DETAIL_LENGTH        = 100;           ///< The maximum length of the error detail, in bytes including '\0'
 
-static const uint NETWORK_GRF_NAME_LENGTH         =   80;         ///< Maximum length of the name of a GRF
+static const uint NETWORK_GRF_NAME_LENGTH           =   80;           ///< Maximum length of the name of a GRF
 
 /**
  * Maximum number of GRFs that can be sent.
  * This limit is reached when PACKET_UDP_SERVER_RESPONSE reaches the maximum size of UDP_MTU bytes.
  */
-static const uint NETWORK_MAX_GRF_COUNT           =   62;
+static const uint NETWORK_MAX_GRF_COUNT             =   62;
 
 /**
  * The number of landscapes in OpenTTD.
@@ -88,6 +93,6 @@ static const uint NETWORK_MAX_GRF_COUNT           =   62;
  * there is a compile assertion to check that this NUM_LANDSCAPE is equal
  * to NETWORK_NUM_LANDSCAPES.
  */
-static const uint NETWORK_NUM_LANDSCAPES          =    4;
+static const uint NETWORK_NUM_LANDSCAPES            =    4;
 
 #endif /* NETWORK_CORE_CONFIG_H */

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -31,6 +31,8 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet *p)
 		case PACKET_COORDINATOR_SERVER_REGISTER: return this->Receive_SERVER_REGISTER(p);
 		case PACKET_COORDINATOR_GC_REGISTER_ACK: return this->Receive_GC_REGISTER_ACK(p);
 		case PACKET_COORDINATOR_SERVER_UPDATE:   return this->Receive_SERVER_UPDATE(p);
+		case PACKET_COORDINATOR_CLIENT_LISTING:  return this->Receive_CLIENT_LISTING(p);
+		case PACKET_COORDINATOR_GC_LISTING:      return this->Receive_GC_LISTING(p);
 
 		default:
 			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
@@ -78,3 +80,5 @@ bool NetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet *p) { return this-
 bool NetworkCoordinatorSocketHandler::Receive_SERVER_REGISTER(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_REGISTER); }
 bool NetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_REGISTER_ACK); }
 bool NetworkCoordinatorSocketHandler::Receive_SERVER_UPDATE(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_UPDATE); }
+bool NetworkCoordinatorSocketHandler::Receive_CLIENT_LISTING(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_LISTING); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_LISTING); }

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -1,0 +1,80 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file tcp_coordinator.cpp Basic functions to receive and send Game Coordinator packets.
+ */
+
+#include "../../stdafx.h"
+#include "../../date_func.h"
+#include "../../debug.h"
+#include "tcp_coordinator.h"
+
+#include "../../safeguards.h"
+
+/**
+ * Handle the given packet, i.e. pass it to the right.
+ * parser receive command.
+ * @param p The packet to handle.
+ * @return True iff we should immediately handle further packets.
+ */
+bool NetworkCoordinatorSocketHandler::HandlePacket(Packet *p)
+{
+	PacketCoordinatorType type = (PacketCoordinatorType)p->Recv_uint8();
+
+	switch (type) {
+		case PACKET_COORDINATOR_GC_ERROR:        return this->Receive_GC_ERROR(p);
+		case PACKET_COORDINATOR_SERVER_REGISTER: return this->Receive_SERVER_REGISTER(p);
+		case PACKET_COORDINATOR_GC_REGISTER_ACK: return this->Receive_GC_REGISTER_ACK(p);
+		case PACKET_COORDINATOR_SERVER_UPDATE:   return this->Receive_SERVER_UPDATE(p);
+
+		default:
+			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
+			return false;
+	}
+}
+
+/**
+ * Receive a packet at TCP level.
+ * @return Whether at least one packet was received.
+ */
+bool NetworkCoordinatorSocketHandler::ReceivePackets()
+{
+	/*
+	 * We read only a few of the packets. This allows the GUI to update when
+	 * a large set of servers is being received. Otherwise the interface
+	 * "hangs" while the game is updating the server-list.
+	 *
+	 * What arbitrary number to choose is the ultimate question though.
+	 */
+	Packet *p;
+	static const int MAX_PACKETS_TO_RECEIVE = 42;
+	int i = MAX_PACKETS_TO_RECEIVE;
+	while (--i != 0 && (p = this->ReceivePacket()) != nullptr) {
+		bool cont = this->HandlePacket(p);
+		delete p;
+		if (!cont) return true;
+	}
+
+	return i != MAX_PACKETS_TO_RECEIVE - 1;
+}
+
+/**
+ * Helper for logging receiving invalid packets.
+ * @param type The received packet type.
+ * @return Always false, as it's an error.
+ */
+bool NetworkCoordinatorSocketHandler::ReceiveInvalidPacket(PacketCoordinatorType type)
+{
+	Debug(net, 0, "[tcp/coordinator] Received illegal packet type {}", type);
+	return false;
+}
+
+bool NetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_ERROR); }
+bool NetworkCoordinatorSocketHandler::Receive_SERVER_REGISTER(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_REGISTER); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_REGISTER_ACK); }
+bool NetworkCoordinatorSocketHandler::Receive_SERVER_UPDATE(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_UPDATE); }

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -29,6 +29,8 @@ enum PacketCoordinatorType {
 	PACKET_COORDINATOR_SERVER_REGISTER, ///< Server registration.
 	PACKET_COORDINATOR_GC_REGISTER_ACK, ///< Game Coordinator accepts the registration.
 	PACKET_COORDINATOR_SERVER_UPDATE,   ///< Server sends an set intervals an update of the server.
+	PACKET_COORDINATOR_CLIENT_LISTING,  ///< Client is requesting a listing of all public servers.
+	PACKET_COORDINATOR_GC_LISTING,      ///< Game Coordinator returns a listing of all public servers.
 	PACKET_COORDINATOR_END,             ///< Must ALWAYS be on the end of this list!! (period).
 };
 
@@ -100,6 +102,33 @@ protected:
 	 * @return True upon success, otherwise false.
 	 */
 	virtual bool Receive_SERVER_UPDATE(Packet *p);
+
+	/**
+	 * Client requests a list of all public servers.
+	 *
+	 *  uint8   Game Coordinator protocol version.
+	 *  uint8   Game-info version used by this client.
+	 *  string  Revision of the client.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_CLIENT_LISTING(Packet *p);
+
+	/**
+	 * Game Coordinator replies with a list of all public servers. Multiple
+	 * of these packets are received after a request till all servers are
+	 * sent over. Last packet will have server count of 0.
+	 *
+	 *  uint16  Amount of public servers in this packet.
+	 *  For each server:
+	 *    string  Connection string for this server.
+	 *    Serialized NetworkGameInfo. See game_info.hpp for details.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_GC_LISTING(Packet *p);
 
 	bool HandlePacket(Packet *p);
 public:

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -1,0 +1,115 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file tcp_coordinator.h Basic functions to receive and send TCP packets to/from the Game Coordinator server.
+ */
+
+#ifndef NETWORK_CORE_TCP_COORDINATOR_H
+#define NETWORK_CORE_TCP_COORDINATOR_H
+
+#include "os_abstraction.h"
+#include "tcp.h"
+#include "packet.h"
+#include "game_info.h"
+
+/**
+ * Enum with all types of TCP Game Coordinator packets. The order MUST not be changed.
+ *
+ * GC     -> packets from Game Coordinator to either Client or Server.
+ * SERVER -> packets from Server to Game Coordinator.
+ * CLIENT -> packets from Client to Game Coordinator.
+ **/
+enum PacketCoordinatorType {
+	PACKET_COORDINATOR_GC_ERROR,        ///< Game Coordinator indicates there was an error.
+	PACKET_COORDINATOR_SERVER_REGISTER, ///< Server registration.
+	PACKET_COORDINATOR_GC_REGISTER_ACK, ///< Game Coordinator accepts the registration.
+	PACKET_COORDINATOR_SERVER_UPDATE,   ///< Server sends an set intervals an update of the server.
+	PACKET_COORDINATOR_END,             ///< Must ALWAYS be on the end of this list!! (period).
+};
+
+/**
+ * The type of connection the Game Coordinator can detect we have.
+ */
+enum ConnectionType {
+	CONNECTION_TYPE_UNKNOWN,  ///< The Game Coordinator hasn't informed us yet what type of connection we have.
+	CONNECTION_TYPE_ISOLATED, ///< The Game Coordinator failed to find a way to connect to your server. Nobody will be able to join.
+	CONNECTION_TYPE_DIRECT,   ///< The Game Coordinator can directly connect to your server.
+};
+
+/**
+ * The type of error from the Game Coordinator.
+ */
+enum NetworkCoordinatorErrorType {
+	NETWORK_COORDINATOR_ERROR_UNKNOWN,             ///< There was an unknown error.
+	NETWORK_COORDINATOR_ERROR_REGISTRATION_FAILED, ///< Your request for registration failed.
+};
+
+/** Base socket handler for all Game Coordinator TCP sockets. */
+class NetworkCoordinatorSocketHandler : public NetworkTCPSocketHandler {
+protected:
+	bool ReceiveInvalidPacket(PacketCoordinatorType type);
+
+	/**
+	 * Game Coordinator indicates there was an error. This can either be a
+	 * permanent error causing the connection to be dropped, or in response
+	 * to a request that is invalid.
+	 *
+	 *  uint8   Type of error (see NetworkCoordinatorErrorType).
+	 *  string  Details of the error.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_GC_ERROR(Packet *p);
+
+	/**
+	 * Server is starting a multiplayer game and wants to let the
+	 * Game Coordinator know.
+	 *
+	 *  uint8   Game Coordinator protocol version.
+	 *  uint8   Type of game (see ServerGameType).
+	 *  uint16  Local port of the server.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_SERVER_REGISTER(Packet *p);
+
+	/**
+	 * Game Coordinator acknowledges the registration.
+	 *
+	 *  uint8   Type of connection was detected (see ConnectionType).
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_GC_REGISTER_ACK(Packet *p);
+
+	/**
+	 * Send an update of the current state of the server to the Game Coordinator.
+	 *
+	 *  uint8   Game Coordinator protocol version.
+	 *  Serialized NetworkGameInfo. See game_info.hpp for details.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_SERVER_UPDATE(Packet *p);
+
+	bool HandlePacket(Packet *p);
+public:
+	/**
+	 * Create a new cs socket handler for a given cs.
+	 * @param s The socket we are connected with.
+	 */
+	NetworkCoordinatorSocketHandler(SOCKET s = INVALID_SOCKET) : NetworkTCPSocketHandler(s) {}
+
+	bool ReceivePackets();
+};
+
+#endif /* NETWORK_CORE_TCP_COORDINATOR_H */

--- a/src/network/core/udp.cpp
+++ b/src/network/core/udp.cpp
@@ -162,16 +162,6 @@ void NetworkUDPSocketHandler::HandleUDPPacket(Packet *p, NetworkAddress *client_
 	switch (this->HasClientQuit() ? PACKET_UDP_END : type) {
 		case PACKET_UDP_CLIENT_FIND_SERVER:   this->Receive_CLIENT_FIND_SERVER(p, client_addr);   break;
 		case PACKET_UDP_SERVER_RESPONSE:      this->Receive_SERVER_RESPONSE(p, client_addr);      break;
-		case PACKET_UDP_CLIENT_DETAIL_INFO:   this->Receive_CLIENT_DETAIL_INFO(p, client_addr);   break;
-		case PACKET_UDP_SERVER_DETAIL_INFO:   this->Receive_SERVER_DETAIL_INFO(p, client_addr);   break;
-		case PACKET_UDP_SERVER_REGISTER:      this->Receive_SERVER_REGISTER(p, client_addr);      break;
-		case PACKET_UDP_MASTER_ACK_REGISTER:  this->Receive_MASTER_ACK_REGISTER(p, client_addr);  break;
-		case PACKET_UDP_CLIENT_GET_LIST:      this->Receive_CLIENT_GET_LIST(p, client_addr);      break;
-		case PACKET_UDP_MASTER_RESPONSE_LIST: this->Receive_MASTER_RESPONSE_LIST(p, client_addr); break;
-		case PACKET_UDP_SERVER_UNREGISTER:    this->Receive_SERVER_UNREGISTER(p, client_addr);    break;
-		case PACKET_UDP_CLIENT_GET_NEWGRFS:   this->Receive_CLIENT_GET_NEWGRFS(p, client_addr);   break;
-		case PACKET_UDP_SERVER_NEWGRFS:       this->Receive_SERVER_NEWGRFS(p, client_addr);       break;
-		case PACKET_UDP_MASTER_SESSION_KEY:   this->Receive_MASTER_SESSION_KEY(p, client_addr);   break;
 
 		default:
 			if (this->HasClientQuit()) {
@@ -195,13 +185,3 @@ void NetworkUDPSocketHandler::ReceiveInvalidPacket(PacketUDPType type, NetworkAd
 
 void NetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_FIND_SERVER, client_addr); }
 void NetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_RESPONSE, client_addr); }
-void NetworkUDPSocketHandler::Receive_CLIENT_DETAIL_INFO(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_DETAIL_INFO, client_addr); }
-void NetworkUDPSocketHandler::Receive_SERVER_DETAIL_INFO(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_DETAIL_INFO, client_addr); }
-void NetworkUDPSocketHandler::Receive_SERVER_REGISTER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_REGISTER, client_addr); }
-void NetworkUDPSocketHandler::Receive_MASTER_ACK_REGISTER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_MASTER_ACK_REGISTER, client_addr); }
-void NetworkUDPSocketHandler::Receive_CLIENT_GET_LIST(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_GET_LIST, client_addr); }
-void NetworkUDPSocketHandler::Receive_MASTER_RESPONSE_LIST(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_MASTER_RESPONSE_LIST, client_addr); }
-void NetworkUDPSocketHandler::Receive_SERVER_UNREGISTER(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_UNREGISTER, client_addr); }
-void NetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_CLIENT_GET_NEWGRFS, client_addr); }
-void NetworkUDPSocketHandler::Receive_SERVER_NEWGRFS(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_SERVER_NEWGRFS, client_addr); }
-void NetworkUDPSocketHandler::Receive_MASTER_SESSION_KEY(Packet *p, NetworkAddress *client_addr) { this->ReceiveInvalidPacket(PACKET_UDP_MASTER_SESSION_KEY, client_addr); }

--- a/src/network/core/udp.h
+++ b/src/network/core/udp.h
@@ -19,26 +19,7 @@
 enum PacketUDPType {
 	PACKET_UDP_CLIENT_FIND_SERVER,   ///< Queries a game server for game information
 	PACKET_UDP_SERVER_RESPONSE,      ///< Reply of the game server with game information
-	PACKET_UDP_CLIENT_DETAIL_INFO,   ///< Queries a game server about details of the game, such as companies
-	PACKET_UDP_SERVER_DETAIL_INFO,   ///< Reply of the game server about details of the game, such as companies
-	PACKET_UDP_SERVER_REGISTER,      ///< Packet to register itself to the master server
-	PACKET_UDP_MASTER_ACK_REGISTER,  ///< Packet indicating registration has succeeded
-	PACKET_UDP_CLIENT_GET_LIST,      ///< Request for serverlist from master server
-	PACKET_UDP_MASTER_RESPONSE_LIST, ///< Response from master server with server ip's + port's
-	PACKET_UDP_SERVER_UNREGISTER,    ///< Request to be removed from the server-list
-	PACKET_UDP_CLIENT_GET_NEWGRFS,   ///< Requests the name for a list of GRFs (GRF_ID and MD5)
-	PACKET_UDP_SERVER_NEWGRFS,       ///< Sends the list of NewGRF's requested.
-	PACKET_UDP_MASTER_SESSION_KEY,   ///< Sends a fresh session key to the client
 	PACKET_UDP_END,                  ///< Must ALWAYS be on the end of this list!! (period)
-};
-
-/** The types of server lists we can get */
-enum ServerListType {
-	SLT_IPv4 = 0,   ///< Get the IPv4 addresses
-	SLT_IPv6 = 1,   ///< Get the IPv6 addresses
-	SLT_AUTODETECT, ///< Autodetect the type based on the connection
-
-	SLT_END = SLT_AUTODETECT, ///< End of 'arrays' marker
 };
 
 /** Base socket handler for all UDP sockets */
@@ -59,126 +40,11 @@ protected:
 	virtual void Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr);
 
 	/**
-	 * Return of server information to the client.
-	 * Serialized NetworkGameInfo. See game_info.h for details.
+	 * Response to a query letting the client know we are here.
 	 * @param p           The received packet.
 	 * @param client_addr The origin of the packet.
 	 */
 	virtual void Receive_SERVER_RESPONSE(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * Query for detailed information about companies.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_CLIENT_DETAIL_INFO(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * Reply with detailed company information.
-	 * uint8   Version of the packet.
-	 * uint8   Number of companies.
-	 * For each company:
-	 *   uint8   ID of the company.
-	 *   string  Name of the company.
-	 *   uint32  Year the company was inaugurated.
-	 *   uint64  Value.
-	 *   uint64  Money.
-	 *   uint64  Income.
-	 *   uint16  Performance (last quarter).
-	 *   bool    Company is password protected.
-	 *   uint16  Number of trains.
-	 *   uint16  Number of lorries.
-	 *   uint16  Number of busses.
-	 *   uint16  Number of planes.
-	 *   uint16  Number of ships.
-	 *   uint16  Number of train stations.
-	 *   uint16  Number of lorry stations.
-	 *   uint16  Number of bus stops.
-	 *   uint16  Number of airports and heliports.
-	 *   uint16  Number of harbours.
-	 *   bool    Company is an AI.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_SERVER_DETAIL_INFO(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * Registers the server to the master server.
-	 * string  The "welcome" message to root out other binary packets.
-	 * uint8   Version of the protocol.
-	 * uint16  The port to unregister.
-	 * uint64  The session key.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_SERVER_REGISTER(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * The master server acknowledges the registration.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_MASTER_ACK_REGISTER(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * The client requests a list of servers.
-	 * uint8   The protocol version.
-	 * uint8   The type of server to look for: IPv4, IPv6 or based on the received packet.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_CLIENT_GET_LIST(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * The server sends a list of servers.
-	 * uint8   The protocol version.
-	 * For each server:
-	 *   4 or 16 bytes of IPv4 or IPv6 address.
-	 *   uint8   The port.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_MASTER_RESPONSE_LIST(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * A server unregisters itself at the master server.
-	 * uint8   Version of the protocol.
-	 * uint16  The port to unregister.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_SERVER_UNREGISTER(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * The client requests information about some NewGRFs.
-	 * uint8   The number of NewGRFs information is requested about.
-	 * For each NewGRF:
-	 *   uint32      The GRFID.
-	 *   16 * uint8  MD5 checksum of the GRF.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_CLIENT_GET_NEWGRFS(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * The server returns information about some NewGRFs.
-	 * uint8   The number of NewGRFs information is requested about.
-	 * For each NewGRF:
-	 *   uint32      The GRFID.
-	 *   16 * uint8  MD5 checksum of the GRF.
-	 *   string      The name of the NewGRF.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_SERVER_NEWGRFS(Packet *p, NetworkAddress *client_addr);
-
-	/**
-	 * The master server sends us a session key.
-	 * uint64  The session key.
-	 * @param p           The received packet.
-	 * @param client_addr The origin of the packet.
-	 */
-	virtual void Receive_MASTER_SESSION_KEY(Packet *p, NetworkAddress *client_addr);
 
 	void HandleUDPPacket(Packet *p, NetworkAddress *client_addr);
 public:

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -61,7 +61,6 @@ bool _is_network_server;  ///< Does this client wants to be a network-server?
 NetworkCompanyState *_network_company_states = nullptr; ///< Statistics about some companies.
 ClientID _network_own_client_id;      ///< Our client identifier.
 ClientID _redirect_console_to_client; ///< If not invalid, redirect the console output to a client.
-bool _network_need_advertise;         ///< Whether we need to advertise.
 uint8 _network_reconnect;             ///< Reconnect timeout
 StringList _network_bind_list;        ///< The addresses to bind on.
 StringList _network_host_list;        ///< The servers we know.
@@ -944,10 +943,6 @@ bool NetworkServerStart()
 	/* if the server is dedicated ... add some other script */
 	if (_network_dedicated) IConsoleCmdExec("exec scripts/on_dedicated.scr 0");
 
-	/* Try to register us to the master server */
-	_network_need_advertise = true;
-	NetworkUDPAdvertise();
-
 	/* welcome possibly still connected admins - this can only happen on a dedicated server. */
 	if (_network_dedicated) ServerNetworkAdminSocketHandler::WelcomeAll();
 
@@ -995,8 +990,6 @@ void NetworkDisconnect(bool blocking, bool close_admins)
 			}
 		}
 	}
-
-	if (_settings_client.network.server_advertise) NetworkUDPRemoveAdvertise(blocking);
 
 	CloseWindowById(WC_NETWORK_STATUS_WINDOW, WN_NETWORK_STATUS_WINDOW_JOIN);
 
@@ -1269,7 +1262,6 @@ void NetworkStartUp()
 	/* Network is available */
 	_network_available = NetworkCoreInitialize();
 	_network_dedicated = false;
-	_network_need_advertise = true;
 
 	/* Generate an server id when there is none yet */
 	if (_settings_client.network.network_id.empty()) NetworkGenerateServerId();

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -699,9 +699,11 @@ void NetworkQueryLobbyServer(const std::string &connection_string)
  * the list. If you use this function, the games will be marked
  * as manually added.
  * @param connection_string The IP:port of the server to add.
+ * @param manually Whether the enter should be marked as manual added.
+ * @param never_expire Whether the entry can expire (removed when no longer found in the public listing).
  * @return The entry on the game list.
  */
-NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually)
+NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually, bool never_expire)
 {
 	if (connection_string.empty()) return nullptr;
 
@@ -717,6 +719,7 @@ NetworkGameList *NetworkAddServer(const std::string &connection_string, bool man
 	}
 
 	if (manually) item->manually = true;
+	if (never_expire) item->version = INT32_MAX;
 
 	return item;
 }
@@ -1288,7 +1291,7 @@ extern "C" {
 
 void CDECL em_openttd_add_server(const char *connection_string)
 {
-	NetworkAddServer(connection_string, false);
+	NetworkAddServer(connection_string, false, true);
 }
 
 }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -19,6 +19,7 @@
 #include "network_udp.h"
 #include "network_gamelist.h"
 #include "network_base.h"
+#include "network_coordinator.h"
 #include "core/udp.h"
 #include "core/host.h"
 #include "network_gui.h"
@@ -591,6 +592,8 @@ void NetworkClose(bool close_admins)
 		}
 		ServerNetworkGameSocketHandler::CloseListeners();
 		ServerNetworkAdminSocketHandler::CloseListeners();
+
+		_network_coordinator_client.CloseConnection();
 	} else if (MyClient::my_client != nullptr) {
 		MyClient::SendQuit();
 		MyClient::my_client->CloseConnection(NETWORK_RECV_STATUS_CLIENT_QUIT);
@@ -932,6 +935,10 @@ bool NetworkServerStart()
 
 	NetworkInitGameInfo();
 
+	if (_settings_client.network.server_advertise) {
+		_network_coordinator_client.Register();
+	}
+
 	/* execute server initialization script */
 	IConsoleCmdExec("exec scripts/on_server.scr 0");
 	/* if the server is dedicated ... add some other script */
@@ -1032,6 +1039,7 @@ static void NetworkSend()
 void NetworkBackgroundLoop()
 {
 	_network_content_client.SendReceive();
+	_network_coordinator_client.SendReceive();
 	TCPConnecter::CheckCallbacks();
 	NetworkHTTPSocketHandler::HTTPReceive();
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -590,7 +590,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packe
 	item->online = true;
 
 	/* It could be either window, but only one is open, so redraw both. */
-	SetWindowDirty(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME);
+	UpdateNetworkGameWindow();
 	SetWindowDirty(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_LOBBY);
 
 	/* We will receive company info next, so keep connection open. */

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -1,0 +1,234 @@
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_coordinator.cpp Game Coordinator sending/receiving part of the network protocol. */
+
+#include "../stdafx.h"
+#include "../debug.h"
+#include "../error.h"
+#include "../rev.h"
+#include "../settings_type.h"
+#include "../strings_func.h"
+#include "../window_func.h"
+#include "../window_type.h"
+#include "network.h"
+#include "network_coordinator.h"
+#include "network_gamelist.h"
+#include "table/strings.h"
+
+#include "../safeguards.h"
+
+static const auto NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES = std::chrono::seconds(30); ///< How many time between updates the server sends to the Game Coordinator.
+ClientNetworkCoordinatorSocketHandler _network_coordinator_client; ///< The connection to the Game Coordinator.
+ConnectionType _network_server_connection_type = CONNECTION_TYPE_UNKNOWN; ///< What type of connection the Game Coordinator detected we are on.
+
+/** Connect to the Game Coordinator server. */
+class NetworkCoordinatorConnecter : TCPConnecter {
+public:
+	/**
+	 * Initiate the connecting.
+	 * @param address The address of the Game Coordinator server.
+	 */
+	NetworkCoordinatorConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_COORDINATOR_SERVER_PORT) {}
+
+	void OnFailure() override
+	{
+		_network_coordinator_client.connecting = false;
+		_network_coordinator_client.CloseConnection(true);
+	}
+
+	void OnConnect(SOCKET s) override
+	{
+		assert(_network_coordinator_client.sock == INVALID_SOCKET);
+
+		_network_coordinator_client.sock = s;
+		_network_coordinator_client.connecting = false;
+	}
+};
+
+bool ClientNetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet *p)
+{
+	NetworkCoordinatorErrorType error = (NetworkCoordinatorErrorType)p->Recv_uint8();
+	std::string detail = p->Recv_string(NETWORK_ERROR_DETAIL_LENGTH);
+
+	switch (error) {
+		case NETWORK_COORDINATOR_ERROR_UNKNOWN:
+			this->CloseConnection();
+			return false;
+
+		case NETWORK_COORDINATOR_ERROR_REGISTRATION_FAILED:
+			SetDParamStr(0, detail);
+			ShowErrorMessage(STR_NETWORK_ERROR_COORDINATOR_REGISTRATION_FAILED, STR_JUST_RAW_STRING, WL_ERROR);
+
+			/* To prevent that we constantly try to reconnect, switch to private game. */
+			_settings_client.network.server_advertise = false;
+
+			this->CloseConnection();
+			return false;
+
+		default:
+			Debug(net, 0, "Invalid error type {} received from Game Coordinator", error);
+			this->CloseConnection();
+			return false;
+	}
+}
+
+bool ClientNetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet *p)
+{
+	/* Schedule sending an update. */
+	this->next_update = std::chrono::steady_clock::now();
+
+	_network_server_connection_type = (ConnectionType)p->Recv_uint8();
+
+	if (_network_server_connection_type == CONNECTION_TYPE_ISOLATED) {
+		ShowErrorMessage(STR_NETWORK_ERROR_COORDINATOR_ISOLATED, STR_NETWORK_ERROR_COORDINATOR_ISOLATED_DETAIL, WL_ERROR);
+	}
+
+	SetWindowDirty(WC_CLIENT_LIST, 0);
+
+	if (_network_dedicated) {
+		std::string connection_type;
+		switch (_network_server_connection_type) {
+			case CONNECTION_TYPE_ISOLATED: connection_type = "Remote players can't connect"; break;
+			case CONNECTION_TYPE_DIRECT:   connection_type = "Public"; break;
+
+			case CONNECTION_TYPE_UNKNOWN: // Never returned from Game Coordinator.
+			default: connection_type = "Unknown"; break; // Should never happen, but don't fail if it does.
+		}
+
+		Debug(net, 3, "----------------------------------------");
+		Debug(net, 3, "Your server is now registered with the Game Coordinator:");
+		Debug(net, 3, "  Game type:       Public");
+		Debug(net, 3, "  Connection type: {}", connection_type);
+		Debug(net, 3, "----------------------------------------");
+	}
+
+	return true;
+}
+
+void ClientNetworkCoordinatorSocketHandler::Connect()
+{
+	/* We are either already connected or are trying to connect. */
+	if (this->sock != INVALID_SOCKET || this->connecting) return;
+
+	this->Reopen();
+
+	this->connecting = true;
+	new NetworkCoordinatorConnecter(NETWORK_COORDINATOR_SERVER_HOST);
+}
+
+NetworkRecvStatus ClientNetworkCoordinatorSocketHandler::CloseConnection(bool error)
+{
+	NetworkCoordinatorSocketHandler::CloseConnection(error);
+
+	this->CloseSocket();
+	this->connecting = false;
+
+	_network_server_connection_type = CONNECTION_TYPE_UNKNOWN;
+	this->next_update = {};
+
+	SetWindowDirty(WC_CLIENT_LIST, 0);
+
+	return NETWORK_RECV_STATUS_OKAY;
+}
+
+/**
+ * Register our server to receive our join-key.
+ */
+void ClientNetworkCoordinatorSocketHandler::Register()
+{
+	_network_server_connection_type = CONNECTION_TYPE_UNKNOWN;
+	this->next_update = {};
+
+	SetWindowDirty(WC_CLIENT_LIST, 0);
+
+	this->Connect();
+
+	Packet *p = new Packet(PACKET_COORDINATOR_SERVER_REGISTER);
+	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
+	p->Send_uint8(SERVER_GAME_TYPE_PUBLIC);
+	p->Send_uint16(_settings_client.network.server_port);
+
+	this->SendPacket(p);
+}
+
+/**
+ * Send an update of our server status to the Game Coordinator.
+ */
+void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
+{
+	Debug(net, 6, "Sending server update to Game Coordinator");
+	this->next_update = std::chrono::steady_clock::now() + NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES;
+
+	Packet *p = new Packet(PACKET_COORDINATOR_SERVER_UPDATE);
+	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
+	SerializeNetworkGameInfo(p, GetCurrentNetworkServerGameInfo());
+
+	this->SendPacket(p);
+}
+
+/**
+ * Check whether we received/can send some data from/to the Game Coordinator server and
+ * when that's the case handle it appropriately.
+ */
+void ClientNetworkCoordinatorSocketHandler::SendReceive()
+{
+	/* Private games are not listed via the Game Coordinator. */
+	if (_network_server && !_settings_client.network.server_advertise) {
+		if (this->sock != INVALID_SOCKET) {
+			this->CloseConnection();
+		}
+		return;
+	}
+
+	static int last_attempt_backoff = 1;
+	static bool first_reconnect = true;
+
+	if (this->sock == INVALID_SOCKET) {
+		static std::chrono::steady_clock::time_point last_attempt = {};
+
+		/* Don't auto-reconnect when we are not a server. */
+		if (!_network_server) return;
+		/* Don't reconnect if we are connecting. */
+		if (this->connecting) return;
+		/* Throttle how often we try to reconnect. */
+		if (std::chrono::steady_clock::now() < last_attempt + std::chrono::seconds(1) * last_attempt_backoff) return;
+
+		last_attempt = std::chrono::steady_clock::now();
+		/* Delay reconnecting with up to 32 seconds. */
+		if (last_attempt_backoff < 32) {
+			last_attempt_backoff *= 2;
+		}
+
+		/* Do not reconnect on the first attempt, but only initialize the
+		 * last_attempt variables.  Otherwise after an outage all servers
+		 * reconnect at the same time, potentially overwhelming the
+		 * Game Coordinator. */
+		if (first_reconnect) {
+			first_reconnect = false;
+			return;
+		}
+
+		Debug(net, 1, "Connection with Game Coordinator lost; reconnecting...");
+		this->Register();
+		return;
+	}
+
+	last_attempt_backoff = 1;
+	first_reconnect = true;
+
+	if (_network_server && _network_server_connection_type != CONNECTION_TYPE_UNKNOWN && std::chrono::steady_clock::now() > this->next_update) {
+		this->SendServerUpdate();
+	}
+
+	if (this->CanSendReceive()) {
+		this->ReceivePackets();
+	}
+
+	this->SendPackets();
+}

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -21,6 +21,10 @@
  *  - Game Coordinator probes server to check if it can directly connect.
  *  - Game Coordinator sends GC_REGISTER_ACK with type of connection.
  *  - Server sends every 30 seconds SERVER_UPDATE.
+ *
+ * For clients (listing):
+ *  - Client sends CLIENT_LISTING.
+ *  - Game Coordinator returns the full list of public servers via GC_LISTING (multiple packets).
  */
 
 /** Class for handling the client side of the Game Coordinator connection. */
@@ -31,8 +35,13 @@ private:
 protected:
 	bool Receive_GC_ERROR(Packet *p) override;
 	bool Receive_GC_REGISTER_ACK(Packet *p) override;
+	bool Receive_GC_LISTING(Packet *p) override;
 
 public:
+	/** The idle timeout; when to close the connection because it's idle. */
+	static constexpr std::chrono::seconds IDLE_TIMEOUT = std::chrono::seconds(60);
+
+	std::chrono::steady_clock::time_point last_activity;  ///< The last time there was network activity.
 	bool connecting; ///< Are we connecting to the Game Coordinator?
 
 	ClientNetworkCoordinatorSocketHandler() : connecting(false) {}
@@ -44,6 +53,7 @@ public:
 
 	void Register();
 	void SendServerUpdate();
+	void GetListing();
 };
 
 extern ClientNetworkCoordinatorSocketHandler _network_coordinator_client;

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -1,0 +1,51 @@
+
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_coordinator.h Part of the network protocol handling Game Coordinator requests. */
+
+#ifndef NETWORK_COORDINATOR_H
+#define NETWORK_COORDINATOR_H
+
+#include "core/tcp_coordinator.h"
+
+/**
+ * Game Coordinator communication.
+ *
+ * For servers:
+ *  - Server sends SERVER_REGISTER.
+ *  - Game Coordinator probes server to check if it can directly connect.
+ *  - Game Coordinator sends GC_REGISTER_ACK with type of connection.
+ *  - Server sends every 30 seconds SERVER_UPDATE.
+ */
+
+/** Class for handling the client side of the Game Coordinator connection. */
+class ClientNetworkCoordinatorSocketHandler : public NetworkCoordinatorSocketHandler {
+private:
+	std::chrono::steady_clock::time_point next_update; ///< When to send the next update (if server and public).
+
+protected:
+	bool Receive_GC_ERROR(Packet *p) override;
+	bool Receive_GC_REGISTER_ACK(Packet *p) override;
+
+public:
+	bool connecting; ///< Are we connecting to the Game Coordinator?
+
+	ClientNetworkCoordinatorSocketHandler() : connecting(false) {}
+
+	NetworkRecvStatus CloseConnection(bool error = true) override;
+	void SendReceive();
+
+	void Connect();
+
+	void Register();
+	void SendServerUpdate();
+};
+
+extern ClientNetworkCoordinatorSocketHandler _network_coordinator_client;
+
+#endif /* NETWORK_COORDINATOR_H */

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -28,7 +28,6 @@ extern NetworkCompanyState *_network_company_states;
 
 extern ClientID _network_own_client_id;
 extern ClientID _redirect_console_to_client;
-extern bool _network_need_advertise;
 extern uint8 _network_reconnect;
 extern StringList _network_bind_list;
 extern StringList _network_host_list;

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -23,45 +23,6 @@
 NetworkGameList *_network_game_list = nullptr; ///< Game list of this client.
 int _network_game_list_version = 0; ///< Current version of all items in the list.
 
-/** The games to insert when the GUI thread has time for us. */
-static std::atomic<NetworkGameList *> _network_game_delayed_insertion_list(nullptr);
-
-/**
- * Add a new item to the linked gamelist, but do it delayed in the next tick
- * or so to prevent race conditions.
- * @param item the item to add. Will be freed once added.
- */
-void NetworkGameListAddItemDelayed(NetworkGameList *item)
-{
-	item->next = _network_game_delayed_insertion_list.load(std::memory_order_relaxed);
-	while (!_network_game_delayed_insertion_list.compare_exchange_weak(item->next, item, std::memory_order_acq_rel)) {}
-}
-
-/** Perform the delayed (thread safe) insertion into the game list */
-static void NetworkGameListHandleDelayedInsert()
-{
-	while (true) {
-		NetworkGameList *ins_item = _network_game_delayed_insertion_list.load(std::memory_order_relaxed);
-		while (ins_item != nullptr && !_network_game_delayed_insertion_list.compare_exchange_weak(ins_item, ins_item->next, std::memory_order_acq_rel)) {}
-		if (ins_item == nullptr) break; // No item left.
-
-		NetworkGameList *item = NetworkGameListAddItem(ins_item->connection_string);
-
-		if (item != nullptr) {
-			if (item->info.server_name.empty()) {
-				ClearGRFConfigList(&item->info.grfconfig);
-				item->info = {};
-				item->info.server_name = ins_item->info.server_name;
-				item->online = false;
-			}
-			item->manually |= ins_item->manually;
-			if (item->manually) NetworkRebuildHostList();
-			UpdateNetworkGameWindow();
-		}
-		delete ins_item;
-	}
-}
-
 /**
  * Add a new item to the linked gamelist. If the IP and Port match
  * return the existing item instead of adding it again
@@ -147,31 +108,6 @@ void NetworkGameListRemoveExpired()
 	}
 
 	UpdateNetworkGameWindow();
-}
-
-static const uint MAX_GAME_LIST_REQUERY_COUNT  = 10; ///< How often do we requery in number of times per server?
-static const uint REQUERY_EVERY_X_GAMELOOPS    = 60; ///< How often do we requery in time?
-static const uint REFRESH_GAMEINFO_X_REQUERIES = 50; ///< Refresh the game info itself after REFRESH_GAMEINFO_X_REQUERIES * REQUERY_EVERY_X_GAMELOOPS game loops
-
-/** Requeries the (game) servers we have not gotten a reply from */
-void NetworkGameListRequery()
-{
-	NetworkGameListHandleDelayedInsert();
-
-	static uint8 requery_cnt = 0;
-
-	if (++requery_cnt < REQUERY_EVERY_X_GAMELOOPS) return;
-	requery_cnt = 0;
-
-	for (NetworkGameList *item = _network_game_list; item != nullptr; item = item->next) {
-		item->retries++;
-		if (item->retries < REFRESH_GAMEINFO_X_REQUERIES && (item->online || item->retries >= MAX_GAME_LIST_REQUERY_COUNT)) continue;
-
-		/* item gets mostly zeroed by NetworkUDPQueryServer */
-		uint8 retries = item->retries;
-		NetworkUDPQueryServer(item->connection_string);
-		item->retries = (retries >= REFRESH_GAMEINFO_X_REQUERIES) ? 0 : retries;
-	}
 }
 
 /**

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -33,10 +33,8 @@ struct NetworkGameList {
 extern NetworkGameList *_network_game_list;
 extern int _network_game_list_version;
 
-void NetworkGameListAddItemDelayed(NetworkGameList *item);
 NetworkGameList *NetworkGameListAddItem(const std::string &connection_string);
 void NetworkGameListRemoveItem(NetworkGameList *remove);
 void NetworkGameListRemoveExpired();
-void NetworkGameListRequery();
 
 #endif /* NETWORK_GAMELIST_H */

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -16,10 +16,7 @@
 
 /** Structure with information shown in the game list (GUI) */
 struct NetworkGameList {
-	NetworkGameList(const std::string &connection_string, bool manually = false) :
-		connection_string(connection_string), manually(manually)
-	{
-	}
+	NetworkGameList(const std::string &connection_string) : connection_string(connection_string) {}
 
 	NetworkGameInfo info = {};       ///< The game information of this server
 	std::string connection_string;   ///< Address of the server

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -26,15 +26,17 @@ struct NetworkGameList {
 	bool online = false;             ///< False if the server did not respond (default status)
 	bool manually = false;           ///< True if the server was added manually
 	uint8 retries = 0;               ///< Number of retries (to stop requerying)
+	int version = 0;                 ///< Used to see which servers are no longer available on the Game Coordinator and can be removed.
 	NetworkGameList *next = nullptr; ///< Next pointer to make a linked game list
 };
 
-/** Game list of this client */
 extern NetworkGameList *_network_game_list;
+extern int _network_game_list_version;
 
 void NetworkGameListAddItemDelayed(NetworkGameList *item);
 NetworkGameList *NetworkGameListAddItem(const std::string &connection_string);
 void NetworkGameListRemoveItem(NetworkGameList *remove);
+void NetworkGameListRemoveExpired();
 void NetworkGameListRequery();
 
 #endif /* NETWORK_GAMELIST_H */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -62,7 +62,7 @@ static CompanyID _admin_company_id = INVALID_COMPANY; ///< For what company a co
  * do not.
  */
 static const StringID _server_visibility_dropdown[] = {
-	STR_NETWORK_SERVER_VISIBILITY_PRIVATE,
+	STR_NETWORK_SERVER_VISIBILITY_LOCAL,
 	STR_NETWORK_SERVER_VISIBILITY_PUBLIC,
 	INVALID_STRING_ID
 };
@@ -1607,21 +1607,26 @@ static const NWidgetPart _nested_client_list_widgets[] = {
 			NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER, STR_NULL), SetPadding(4, 4, 0, 4), SetPIP(0, 2, 0),
 				NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 					NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_NAME, STR_NULL),
-					NWidget(NWID_SPACER), SetMinimalSize(20, 0),
+					NWidget(NWID_SPACER), SetMinimalSize(10, 0),
 					NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_SERVER_NAME), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_RAW_STRING, STR_NETWORK_CLIENT_LIST_SERVER_NAME_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
 					NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_CL_SERVER_NAME_EDIT), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_NETWORK_CLIENT_LIST_SERVER_NAME_EDIT_TOOLTIP),
 				EndContainer(),
 				NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 					NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY, STR_NULL),
-					NWidget(NWID_SPACER), SetMinimalSize(20, 0), SetFill(1, 0), SetResize(1, 0),
+					NWidget(NWID_SPACER), SetMinimalSize(10, 0), SetFill(1, 0), SetResize(1, 0),
 					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_CL_SERVER_VISIBILITY), SetDataTip(STR_BLACK_STRING, STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY_TOOLTIP),
+				EndContainer(),
+				NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
+					NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE, STR_NULL),
+					NWidget(NWID_SPACER), SetMinimalSize(10, 0),
+					NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_SERVER_CONNECTION_TYPE), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_STRING, STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
 				EndContainer(),
 			EndContainer(),
 		EndContainer(),
 		NWidget(WWT_FRAME, COLOUR_GREY), SetDataTip(STR_NETWORK_CLIENT_LIST_PLAYER, STR_NULL), SetPadding(4, 4, 4, 4), SetPIP(0, 2, 0),
 			NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 				NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_PLAYER_NAME, STR_NULL),
-				NWidget(NWID_SPACER), SetMinimalSize(20, 0),
+				NWidget(NWID_SPACER), SetMinimalSize(10, 0),
 				NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_CLIENT_NAME), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_RAW_STRING, STR_NETWORK_CLIENT_LIST_PLAYER_NAME_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
 				NWidget(WWT_PUSHIMGBTN, COLOUR_GREY, WID_CL_CLIENT_NAME_EDIT), SetMinimalSize(12, 14), SetDataTip(SPR_RENAME, STR_NETWORK_CLIENT_LIST_PLAYER_NAME_EDIT_TOOLTIP),
 			EndContainer(),
@@ -2048,6 +2053,10 @@ public:
 
 			case WID_CL_SERVER_VISIBILITY:
 				SetDParam(0, _server_visibility_dropdown[_settings_client.network.server_advertise]);
+				break;
+
+			case WID_CL_SERVER_CONNECTION_TYPE:
+				SetDParam(0, STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_UNKNOWN + _network_server_connection_type);
 				break;
 
 			case WID_CL_CLIENT_NAME:

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -18,6 +18,7 @@
 #include "network_base.h"
 #include "network_content.h"
 #include "network_server.h"
+#include "network_coordinator.h"
 #include "../gui.h"
 #include "network_udp.h"
 #include "../window_func.h"
@@ -53,6 +54,8 @@
 
 static void ShowNetworkStartServerWindow();
 static void ShowNetworkLobbyWindow(NetworkGameList *ngl);
+
+static const int NETWORK_LIST_REFRESH_DELAY = 30; ///< Time, in seconds, between updates of the network list.
 
 static ClientID _admin_client_id = INVALID_CLIENT_ID; ///< For what client a confirmation window is open.
 static CompanyID _admin_company_id = INVALID_COMPANY; ///< For what company a confirmation window is open.
@@ -219,14 +222,15 @@ protected:
 	static GUIGameServerList::SortFunction * const sorter_funcs[];
 	static GUIGameServerList::FilterFunction * const filter_funcs[];
 
-	NetworkGameList *server;      ///< selected server
-	NetworkGameList *last_joined; ///< the last joined server
-	GUIGameServerList servers;    ///< list with game servers.
-	ServerListPosition list_pos;  ///< position of the selected server
-	Scrollbar *vscroll;           ///< vertical scrollbar of the list of servers
-	QueryString name_editbox;     ///< Client name editbox.
-	QueryString filter_editbox;   ///< Editbox for filter on servers
-	GUITimer requery_timer;       ///< Timer for network requery
+	NetworkGameList *server;        ///< Selected server.
+	NetworkGameList *last_joined;   ///< The last joined server.
+	GUIGameServerList servers;      ///< List with game servers.
+	ServerListPosition list_pos;    ///< Position of the selected server.
+	Scrollbar *vscroll;             ///< Vertical scrollbar of the list of servers.
+	QueryString name_editbox;       ///< Client name editbox.
+	QueryString filter_editbox;     ///< Editbox for filter on servers.
+	GUITimer requery_timer;         ///< Timer for network requery.
+	bool searched_internet = false; ///< Did we ever press "Search Internet" button?
 
 	int lock_offset; ///< Left offset for lock icon.
 	int blot_offset; ///< Left offset for green/yellow/red compatibility icon.
@@ -244,8 +248,18 @@ protected:
 		/* Create temporary array of games to use for listing */
 		this->servers.clear();
 
+		bool found_current_server = false;
 		for (NetworkGameList *ngl = _network_game_list; ngl != nullptr; ngl = ngl->next) {
 			this->servers.push_back(ngl);
+			if (ngl == this->server) {
+				found_current_server = true;
+			}
+		}
+		/* A refresh can cause the current server to be delete; so unselect. */
+		if (!found_current_server) {
+			if (this->server == this->last_joined) this->last_joined = nullptr;
+			this->server = nullptr;
+			this->list_pos = SLP_INVALID;
 		}
 
 		/* Apply the filter condition immediately, if a search string has been provided. */
@@ -479,7 +493,7 @@ public:
 		this->last_joined = NetworkAddServer(_settings_client.network.last_joined, false);
 		this->server = this->last_joined;
 
-		this->requery_timer.SetInterval(MILLISECONDS_PER_TICK);
+		this->requery_timer.SetInterval(NETWORK_LIST_REFRESH_DELAY * 1000);
 
 		this->servers.SetListing(this->last_sorting);
 		this->servers.SetSortFuncs(this->sorter_funcs);
@@ -725,7 +739,8 @@ public:
 			}
 
 			case WID_NG_SEARCH_INTERNET:
-				NetworkUDPQueryMasterServer();
+				_network_coordinator_client.GetListing();
+				this->searched_internet = true;
 				break;
 
 			case WID_NG_SEARCH_LAN:
@@ -841,10 +856,11 @@ public:
 
 	void OnRealtimeTick(uint delta_ms) override
 	{
+		if (!this->searched_internet) return;
 		if (!this->requery_timer.Elapsed(delta_ms)) return;
-		this->requery_timer.SetInterval(MILLISECONDS_PER_TICK);
+		this->requery_timer.SetInterval(NETWORK_LIST_REFRESH_DELAY * 1000);
 
-		NetworkGameListRequery();
+		_network_coordinator_client.GetListing();
 	}
 };
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -11,6 +11,7 @@
 #define NETWORK_INTERNAL_H
 
 #include "network_func.h"
+#include "core/tcp_coordinator.h"
 #include "core/tcp_game.h"
 
 #include "../command_type.h"
@@ -82,6 +83,7 @@ extern NetworkJoinStatus _network_join_status;
 extern uint8 _network_join_waiting;
 extern uint32 _network_join_bytes;
 extern uint32 _network_join_bytes_total;
+extern ConnectionType _network_server_connection_type;
 
 extern uint8 _network_reconnect;
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -91,7 +91,7 @@ void NetworkQueryServer(const std::string &connection_string);
 void NetworkQueryLobbyServer(const std::string &connection_string);
 
 void GetBindAddresses(NetworkAddressList *addresses, uint16 port);
-struct NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually = true);
+struct NetworkGameList *NetworkAddServer(const std::string &connection_string, bool manually = true, bool never_expire = false);
 void NetworkRebuildHostList();
 void UpdateNetworkGameWindow();
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1879,9 +1879,6 @@ void NetworkServer_Tick(bool send_frame)
 #endif
 		}
 	}
-
-	/* See if we need to advertise */
-	NetworkUDPAdvertise();
 }
 
 /** Yearly "callback". Called whenever the year changes. */

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -35,6 +35,15 @@ enum NetworkVehicleType {
 	NETWORK_VEH_END
 };
 
+/**
+ * Game type the server can be using.
+ * Used on the network protocol to communicate with Game Coordinator.
+ */
+enum ServerGameType : uint8 {
+	SERVER_GAME_TYPE_LOCAL = 0,
+	SERVER_GAME_TYPE_PUBLIC,
+};
+
 /** 'Unique' identifier to be given to clients */
 enum ClientID : uint32 {
 	INVALID_CLIENT_ID = 0, ///< Client is not part of anything

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -23,12 +23,10 @@
 #include "network.h"
 #include "../core/endian_func.hpp"
 #include "../company_base.h"
-#include "../thread.h"
 #include "../rev.h"
 #include "../newgrf_text.h"
 #include "../strings_func.h"
 #include "table/strings.h"
-#include <mutex>
 
 #include "core/udp.h"
 
@@ -40,70 +38,25 @@ static uint16 _network_udp_broadcast;    ///< Timeout for the UDP broadcasts.
 /** Some information about a socket, which exists before the actual socket has been created to provide locking and the likes. */
 struct UDPSocket {
 	const std::string name;                     ///< The name of the socket.
-	std::mutex mutex;                           ///< Mutex for everything that (indirectly) touches the sockets within the handler.
 	NetworkUDPSocketHandler *socket;            ///< The actual socket, which may be nullptr when not initialized yet.
-	std::atomic<int> receive_iterations_locked; ///< The number of receive iterations the mutex was locked.
 
-	UDPSocket(const std::string &name_) : name(name_), socket(nullptr) {}
+	UDPSocket(const std::string &name) : name(name), socket(nullptr) {}
 
 	void CloseSocket()
 	{
-		std::lock_guard<std::mutex> lock(mutex);
-		socket->CloseSocket();
-		delete socket;
-		socket = nullptr;
+		this->socket->CloseSocket();
+		delete this->socket;
+		this->socket = nullptr;
 	}
 
 	void ReceivePackets()
 	{
-		std::unique_lock<std::mutex> lock(mutex, std::defer_lock);
-		if (!lock.try_lock()) {
-			if (++receive_iterations_locked % 32 == 0) {
-				Debug(net, 0, "{} background UDP loop processing appears to be blocked. Your OS may be low on UDP send buffers.", name);
-			}
-			return;
-		}
-
-		receive_iterations_locked.store(0);
-		socket->ReceivePackets();
+		this->socket->ReceivePackets();
 	}
 };
 
 static UDPSocket _udp_client("Client"); ///< udp client socket
 static UDPSocket _udp_server("Server"); ///< udp server socket
-
-/**
- * Helper function doing the actual work for querying the server.
- * @param connection_string The address of the server.
- * @param needs_mutex Whether we need to acquire locks when sending the packet or not.
- * @param manually Whether the address was entered manually.
- */
-static void DoNetworkUDPQueryServer(const std::string &connection_string, bool needs_mutex, bool manually)
-{
-	/* Clear item in gamelist */
-	NetworkGameList *item = new NetworkGameList(connection_string, manually);
-	item->info.server_name = connection_string;
-	NetworkGameListAddItemDelayed(item);
-
-	std::unique_lock<std::mutex> lock(_udp_client.mutex, std::defer_lock);
-	if (needs_mutex) lock.lock();
-	/* Init the packet */
-	NetworkAddress address = NetworkAddress(ParseConnectionString(connection_string, NETWORK_DEFAULT_PORT));
-	Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
-	if (_udp_client.socket != nullptr) _udp_client.socket->SendPacket(&p, &address);
-}
-
-/**
- * Query a specific server.
- * @param connection_string The address of the server.
- * @param manually Whether the address was entered manually.
- */
-void NetworkUDPQueryServer(const std::string &connection_string, bool manually)
-{
-	if (!StartNewThread(nullptr, "ottd:udp-query", &DoNetworkUDPQueryServer, std::move(connection_string), true, std::move(manually))) {
-		DoNetworkUDPQueryServer(connection_string, true, manually);
-	}
-}
 
 ///*** Communication with clients (we are server) ***/
 
@@ -111,8 +64,6 @@ void NetworkUDPQueryServer(const std::string &connection_string, bool manually)
 class ServerNetworkUDPSocketHandler : public NetworkUDPSocketHandler {
 protected:
 	void Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr) override;
-	void Receive_CLIENT_DETAIL_INFO(Packet *p, NetworkAddress *client_addr) override;
-	void Receive_CLIENT_GET_NEWGRFS(Packet *p, NetworkAddress *client_addr) override;
 public:
 	/**
 	 * Create the socket.
@@ -124,135 +75,10 @@ public:
 
 void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr)
 {
-	/* Just a fail-safe.. should never happen */
-	if (!_network_udp_server) {
-		return;
-	}
-
 	Packet packet(PACKET_UDP_SERVER_RESPONSE);
-	SerializeNetworkGameInfo(&packet, GetCurrentNetworkServerGameInfo());
-
-	/* Let the client know that we are here */
 	this->SendPacket(&packet, client_addr);
 
 	Debug(net, 7, "Queried from {}", client_addr->GetHostname());
-}
-
-void ServerNetworkUDPSocketHandler::Receive_CLIENT_DETAIL_INFO(Packet *p, NetworkAddress *client_addr)
-{
-	/* Just a fail-safe.. should never happen */
-	if (!_network_udp_server) return;
-
-	Packet packet(PACKET_UDP_SERVER_DETAIL_INFO);
-
-	/* Send the amount of active companies */
-	packet.Send_uint8 (NETWORK_COMPANY_INFO_VERSION);
-	packet.Send_uint8 ((uint8)Company::GetNumItems());
-
-	/* Fetch the latest version of the stats */
-	NetworkCompanyStats company_stats[MAX_COMPANIES];
-	NetworkPopulateCompanyStats(company_stats);
-
-	/* The minimum company information "blob" size. */
-	static const uint MIN_CI_SIZE = 54;
-	uint max_cname_length = NETWORK_COMPANY_NAME_LENGTH;
-
-	if (!packet.CanWriteToPacket(Company::GetNumItems() * (MIN_CI_SIZE + NETWORK_COMPANY_NAME_LENGTH))) {
-		/* Assume we can at least put the company information in the packets. */
-		assert(packet.CanWriteToPacket(Company::GetNumItems() * MIN_CI_SIZE));
-
-		/* At this moment the company names might not fit in the
-		 * packet. Check whether that is really the case. */
-
-		for (;;) {
-			size_t required = 0;
-			for (const Company *company : Company::Iterate()) {
-				char company_name[NETWORK_COMPANY_NAME_LENGTH];
-				SetDParam(0, company->index);
-				GetString(company_name, STR_COMPANY_NAME, company_name + max_cname_length - 1);
-				required += MIN_CI_SIZE;
-				required += strlen(company_name);
-			}
-			if (packet.CanWriteToPacket(required)) break;
-
-			/* Try again, with slightly shorter strings. */
-			assert(max_cname_length > 0);
-			max_cname_length--;
-		}
-	}
-
-	/* Go through all the companies */
-	for (const Company *company : Company::Iterate()) {
-		/* Send the information */
-		this->SendCompanyInformation(&packet, company, &company_stats[company->index], max_cname_length);
-	}
-
-	this->SendPacket(&packet, client_addr);
-}
-
-/**
- * A client has requested the names of some NewGRFs.
- *
- * Replying this can be tricky as we have a limit of UDP_MTU bytes
- * in the reply packet and we can send up to 100 bytes per NewGRF
- * (GRF ID, MD5sum and NETWORK_GRF_NAME_LENGTH bytes for the name).
- * As UDP_MTU is _much_ less than 100 * NETWORK_MAX_GRF_COUNT, it
- * could be that a packet overflows. To stop this we only reply
- * with the first N NewGRFs so that if the first N + 1 NewGRFs
- * would be sent, the packet overflows.
- * in_reply and in_reply_count are used to keep a list of GRFs to
- * send in the reply.
- */
-void ServerNetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, NetworkAddress *client_addr)
-{
-	uint8 num_grfs;
-	uint i;
-
-	const GRFConfig *in_reply[NETWORK_MAX_GRF_COUNT];
-	uint8 in_reply_count = 0;
-	size_t packet_len = 0;
-
-	Debug(net, 7, "NewGRF data request from {}", client_addr->GetAddressAsString());
-
-	num_grfs = p->Recv_uint8 ();
-	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
-
-	for (i = 0; i < num_grfs; i++) {
-		GRFIdentifier c;
-		const GRFConfig *f;
-
-		DeserializeGRFIdentifier(p, &c);
-
-		/* Find the matching GRF file */
-		f = FindGRFConfig(c.grfid, FGCM_EXACT, c.md5sum);
-		if (f == nullptr) continue; // The GRF is unknown to this server
-
-		/* If the reply might exceed the size of the packet, only reply
-		 * the current list and do not send the other data.
-		 * The name could be an empty string, if so take the filename. */
-		packet_len += sizeof(c.grfid) + sizeof(c.md5sum) +
-				std::min(strlen(f->GetName()) + 1, (size_t)NETWORK_GRF_NAME_LENGTH);
-		if (packet_len > UDP_MTU - 4) { // 4 is 3 byte header + grf count in reply
-			break;
-		}
-		in_reply[in_reply_count] = f;
-		in_reply_count++;
-	}
-
-	if (in_reply_count == 0) return;
-
-	Packet packet(PACKET_UDP_SERVER_NEWGRFS);
-	packet.Send_uint8(in_reply_count);
-	for (i = 0; i < in_reply_count; i++) {
-		char name[NETWORK_GRF_NAME_LENGTH];
-
-		/* The name could be an empty string, if so take the filename */
-		strecpy(name, in_reply[i]->GetName(), lastof(name));
-		SerializeGRFIdentifier(&packet, &in_reply[i]->ident);
-		packet.Send_string(name);
-	}
-
-	this->SendPacket(&packet, client_addr);
 }
 
 ///*** Communication with servers (we are client) ***/
@@ -261,168 +87,26 @@ void ServerNetworkUDPSocketHandler::Receive_CLIENT_GET_NEWGRFS(Packet *p, Networ
 class ClientNetworkUDPSocketHandler : public NetworkUDPSocketHandler {
 protected:
 	void Receive_SERVER_RESPONSE(Packet *p, NetworkAddress *client_addr) override;
-	void Receive_MASTER_RESPONSE_LIST(Packet *p, NetworkAddress *client_addr) override;
-	void Receive_SERVER_NEWGRFS(Packet *p, NetworkAddress *client_addr) override;
 public:
 	virtual ~ClientNetworkUDPSocketHandler() {}
 };
 
 void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAddress *client_addr)
 {
-	NetworkGameList *item;
-
-	/* Just a fail-safe.. should never happen */
-	if (_network_udp_server) return;
-
 	Debug(net, 3, "Server response from {}", client_addr->GetAddressAsString());
 
-	/* Find next item */
-	item = NetworkGameListAddItem(client_addr->GetAddressAsString(false));
-
-	/* Clear any existing GRFConfig chain. */
-	ClearGRFConfigList(&item->info.grfconfig);
-	/* Retrieve the NetworkGameInfo from the packet. */
-	DeserializeNetworkGameInfo(p, &item->info);
-	/* Check for compatability with the client. */
-	CheckGameCompatibility(item->info);
-	/* Ensure we consider the server online. */
-	item->online = true;
-	/* Make sure this entry never expires. */
-	item->version = INT32_MAX;
-
-	{
-		/* Checks whether there needs to be a request for names of GRFs and makes
-		 * the request if necessary. GRFs that need to be requested are the GRFs
-		 * that do not exist on the clients system and we do not have the name
-		 * resolved of, i.e. the name is still UNKNOWN_GRF_NAME_PLACEHOLDER.
-		 * The in_request array and in_request_count are used so there is no need
-		 * to do a second loop over the GRF list, which can be relatively expensive
-		 * due to the string comparisons. */
-		const GRFConfig *in_request[NETWORK_MAX_GRF_COUNT];
-		const GRFConfig *c;
-		uint in_request_count = 0;
-
-		for (c = item->info.grfconfig; c != nullptr; c = c->next) {
-			if (c->status != GCS_NOT_FOUND || strcmp(c->GetName(), UNKNOWN_GRF_NAME_PLACEHOLDER) != 0) continue;
-			in_request[in_request_count] = c;
-			in_request_count++;
-		}
-
-		if (in_request_count > 0) {
-			/* There are 'unknown' GRFs, now send a request for them */
-			uint i;
-			Packet packet(PACKET_UDP_CLIENT_GET_NEWGRFS);
-
-			packet.Send_uint8(in_request_count);
-			for (i = 0; i < in_request_count; i++) {
-				SerializeGRFIdentifier(&packet, &in_request[i]->ident);
-			}
-
-			NetworkAddress address = NetworkAddress(ParseConnectionString(item->connection_string, NETWORK_DEFAULT_PORT));
-			this->SendPacket(&packet, &address);
-		}
-	}
-
-	if (client_addr->GetAddress()->ss_family == AF_INET6) {
-		item->info.server_name.append(" (IPv6)");
-	}
-
-	UpdateNetworkGameWindow();
-}
-
-void ClientNetworkUDPSocketHandler::Receive_MASTER_RESPONSE_LIST(Packet *p, NetworkAddress *client_addr)
-{
-	/* packet begins with the protocol version (uint8)
-	 * then an uint16 which indicates how many
-	 * ip:port pairs are in this packet, after that
-	 * an uint32 (ip) and an uint16 (port) for each pair.
-	 */
-
-	ServerListType type = (ServerListType)(p->Recv_uint8() - 1);
-
-	if (type < SLT_END) {
-		for (int i = p->Recv_uint16(); i != 0 ; i--) {
-			sockaddr_storage addr_storage;
-			memset(&addr_storage, 0, sizeof(addr_storage));
-
-			if (type == SLT_IPv4) {
-				addr_storage.ss_family = AF_INET;
-				((sockaddr_in*)&addr_storage)->sin_addr.s_addr = TO_LE32(p->Recv_uint32());
-			} else {
-				assert(type == SLT_IPv6);
-				addr_storage.ss_family = AF_INET6;
-				byte *addr = (byte*)&((sockaddr_in6*)&addr_storage)->sin6_addr;
-				for (uint i = 0; i < sizeof(in6_addr); i++) *addr++ = p->Recv_uint8();
-			}
-			NetworkAddress addr(addr_storage, type == SLT_IPv4 ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
-			addr.SetPort(p->Recv_uint16());
-
-			/* Somehow we reached the end of the packet */
-			if (this->HasClientQuit()) return;
-
-			DoNetworkUDPQueryServer(addr.GetAddressAsString(false), false, false);
-		}
-	}
-}
-
-/** The return of the client's request of the names of some NewGRFs */
-void ClientNetworkUDPSocketHandler::Receive_SERVER_NEWGRFS(Packet *p, NetworkAddress *client_addr)
-{
-	uint8 num_grfs;
-	uint i;
-
-	Debug(net, 7, "NewGRF data reply from {}", client_addr->GetAddressAsString());
-
-	num_grfs = p->Recv_uint8 ();
-	if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
-
-	for (i = 0; i < num_grfs; i++) {
-		GRFIdentifier c;
-
-		DeserializeGRFIdentifier(p, &c);
-		std::string name = p->Recv_string(NETWORK_GRF_NAME_LENGTH);
-
-		/* An empty name is not possible under normal circumstances
-		 * and causes problems when showing the NewGRF list. */
-		if (name.empty()) continue;
-
-		/* Try to find the GRFTextWrapper for the name of this GRF ID and MD5sum tuple.
-		 * If it exists and not resolved yet, then name of the fake GRF is
-		 * overwritten with the name from the reply. */
-		GRFTextWrapper unknown_name = FindUnknownGRFName(c.grfid, c.md5sum, false);
-		if (unknown_name && strcmp(GetGRFStringFromGRFText(unknown_name), UNKNOWN_GRF_NAME_PLACEHOLDER) == 0) {
-			AddGRFTextToList(unknown_name, name);
-		}
-	}
+	NetworkAddServer(client_addr->GetAddressAsString(false), false, true);
 }
 
 /** Broadcast to all ips */
 static void NetworkUDPBroadCast(NetworkUDPSocketHandler *socket)
 {
 	for (NetworkAddress &addr : _broadcast_list) {
-		Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
-
 		Debug(net, 5, "Broadcasting to {}", addr.GetHostname());
 
+		Packet p(PACKET_UDP_CLIENT_FIND_SERVER);
 		socket->SendPacket(&p, &addr, true, true);
 	}
-}
-
-
-/** Request the the server-list from the master server */
-void NetworkUDPQueryMasterServer()
-{
-	Packet p(PACKET_UDP_CLIENT_GET_LIST);
-	NetworkAddress out_addr(NETWORK_MASTER_SERVER_HOST, NETWORK_MASTER_SERVER_PORT);
-
-	/* packet only contains protocol version */
-	p.Send_uint8(NETWORK_MASTER_SERVER_VERSION);
-	p.Send_uint8(SLT_AUTODETECT);
-
-	std::lock_guard<std::mutex> lock(_udp_client.mutex);
-	_udp_client.socket->SendPacket(&p, &out_addr, true);
-
-	Debug(net, 6, "Master server queried at {}", out_addr.GetAddressAsString());
 }
 
 /** Find all servers */
@@ -446,8 +130,6 @@ void NetworkUDPInitialize()
 	Debug(net, 3, "Initializing UDP listeners");
 	assert(_udp_client.socket == nullptr && _udp_server.socket == nullptr);
 
-	std::scoped_lock lock(_udp_client.mutex, _udp_server.mutex);
-
 	_udp_client.socket = new ClientNetworkUDPSocketHandler();
 
 	NetworkAddressList server;
@@ -461,7 +143,6 @@ void NetworkUDPInitialize()
 /** Start the listening of the UDP server component. */
 void NetworkUDPServerListen()
 {
-	std::lock_guard<std::mutex> lock(_udp_server.mutex);
 	_network_udp_server = _udp_server.socket->Listen();
 }
 

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -327,6 +327,8 @@ void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAd
 	CheckGameCompatibility(item->info);
 	/* Ensure we consider the server online. */
 	item->online = true;
+	/* Make sure this entry never expires. */
+	item->version = INT32_MAX;
 
 	{
 		/* Checks whether there needs to be a request for names of GRFs and makes

--- a/src/network/network_udp.h
+++ b/src/network/network_udp.h
@@ -16,8 +16,6 @@ void NetworkUDPInitialize();
 void NetworkUDPSearchGame();
 void NetworkUDPQueryMasterServer();
 void NetworkUDPQueryServer(const std::string &connection_string, bool manually = false);
-void NetworkUDPAdvertise();
-void NetworkUDPRemoveAdvertise(bool blocking);
 void NetworkUDPClose();
 void NetworkUDPServerListen();
 void NetworkBackgroundUDPLoop();

--- a/src/network/network_udp.h
+++ b/src/network/network_udp.h
@@ -14,8 +14,6 @@
 
 void NetworkUDPInitialize();
 void NetworkUDPSearchGame();
-void NetworkUDPQueryMasterServer();
-void NetworkUDPQueryServer(const std::string &connection_string, bool manually = false);
 void NetworkUDPClose();
 void NetworkUDPServerListen();
 void NetworkBackgroundUDPLoop();

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -270,7 +270,7 @@ struct NetworkSettings {
 	std::string server_password;                          ///< password for joining this server
 	std::string rcon_password;                            ///< password for rconsole (server side)
 	std::string admin_password;                           ///< password for the admin network
-	bool        server_advertise;                         ///< advertise the server to the masterserver
+	bool        server_advertise;                         ///< Advertise the server to the game coordinator.
 	std::string client_name;                              ///< name of the player (as client)
 	std::string default_company_pass;                     ///< default password for new companies in encrypted form
 	std::string connect_to_ip;                            ///< default for the "Add server" query

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -101,6 +101,7 @@ enum ClientListWidgets {
 	WID_CL_SERVER_NAME,                ///< Server name.
 	WID_CL_SERVER_NAME_EDIT,           ///< Edit button for server name.
 	WID_CL_SERVER_VISIBILITY,          ///< Server visibility.
+	WID_CL_SERVER_CONNECTION_TYPE,     ///< The type of connection the Game Coordinator detected for this server.
 	WID_CL_CLIENT_NAME,                ///< Client name.
 	WID_CL_CLIENT_NAME_EDIT,           ///< Edit button for client name.
 	WID_CL_MATRIX,                     ///< Company/client list.


### PR DESCRIPTION
## Motivation / Problem

This is a part of #9017.

Currently OpenTTD communicates over UDP with the master-server to register itself, and the master-server uses UDP to polls the server for game-state. This has several disadvantages, as we noticed over the years:

- The users that do manage to setup a port-forwarding, often only manage to do this for TCP. Doing it for UDP too, is often either difficult in routers, or just not something they understand. As such, people have a lot of trouble setting up portforwarding in such a way the master-server can see the server. But to make matters worse, without UDP port-forwarding, people can join a server via the direct IP. This is frustrating to users.
- UDP is, by definition, unreliable. So we have a lot of code to retry several times and trying to recover.
- UDP has a hard MTU-size, as fragmentation is impossible. We try to be on the safe-side with the MTU we picked, but there are known scenarios where you cannot host OpenTTD because the connection doesn't allow such large UDP packets to travel through it. (mostly GRE links etc) Explaining this to users is very very difficult.
- #9017 works towards adding STUN support. For this we need a persistent connection between something on the openttd.org infra and the server, so we can push messages to the server of which we know they arrive safely. In theory we could use UDP for this, and with some smart keep-alive etc we can keep a bi-direction connection alive .. but it is tricky. More-over, most infrastructure, also on our hosting side, is more aimed at TCP connections than UDP connections, and several issues are to be expected.
- Pretty sure I miss a few arguments here.

In total, it became pretty clear we should just stop using UDP, and switch completely to TCP. Well, I say completely .. local LAN discovery is and always will be UDP based. That is just how multicasts work ;)

To be clear, this doesn't mean OpenTTD will always be using TCP. It is surely an option to use some library like https://github.com/ValveSoftware/GameNetworkingSockets that does resilient connections over UDP. Either way, we first have to change to a single way of doing stuff, before we can think about changing it all to something else. And this is far out of scope of this PR.

## Description

This removes all master-server communication and all UDP-related code from OpenTTD, and replaces it with a TCP-based Game Coordinator code.
Again, the local LAN discovery still uses UDP and remains.

Why the change of name? To keep it clear that this is a completely different component. And in the future the Game Coordinator will be tasked with many other tasks, like join-keys, STUN, TURN, etc. It much more takes on the role of a coordinator, and no longer "just" lists the servers.
In the background, master-server and Game Coordinator communicate with each other, so the server-listing will be a combination of both for 1.12+. 1.11 will only see 1.11 and older servers.

The way it works is like this (and yes, this is documented in `network_coordinator.cpp`, just to beat LordAro to the punch :P):

```cpp
/**
 * Game Coordinator communication.
 *
 * For servers:
 *  - Server sends CLIENT_REGISTER.
 *  - GC probes server to check if it can directly connect.
 *  - GC sends SERVER_REGISTER_ACK with type of connection.
 *  - Server sends every 30 seconds CLIENT_UPDATE.
 *
 * For clients (listing):
 *  - Client sends CLIENT_LISTING.
 *  - GC returns the full list of public servers via SERVER_LISTING (multiple packets).
 */
```

Basically this means as soon as the client clicks "Search Internet", it gets the full list of servers, including their details. It no longer has to send a flood of UDP packets to all servers.

`Private` is renamed to `Local`, as there is no such thing as `Private` .. a server is either accessible locally (or by the IP if you happen  to know that), or publicly listed. This change makes the later addition of `Invite Only` a lot more sensible to the user.

Future PRs will extend this functionality with invite-codes, STUN, TURN, ... But, baby-steps.

## Limitations

Currently there are a few rough edged, but further PRs will address those.  For example:

- The `CLIENT_UPDATE` sends all the NewGRF data every time. But as they can never change, this is a waste of bandwidth.
- Currently servers can only register via either IPv4 or IPv6, not both. This is because future PR will use the STUN requests to discover the IPs. I could strictly seen already add this in this PR, but that would increase the change drastically. And solving it differently is rather wasting my time a lot, as I have to create something I have to remove a few PRs later.
- Currently servers registering via IPv6 will be told that they do not have their firewall open. This might not be true, but the Game Coordinator can't query IPv6 yet.
- Currently servers using 1.11.2 or earlier are not showing up in the server listing. This will be addressed before 1.12.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
