### PR TITLE
Codechange: Simplify FormatString

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -926,7 +926,8 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 			case SCC_NEWGRF_STRINL: {
 				StringID substr = Utf8Consume(&str);
-				buff = FormatString(buff, GetStringPtr(substr), args, last, case_index, game_script, dry_run);
+				buff = FormatString(buff, GetStringPtr(substr), args, last, next_substr_case_index, game_script, dry_run);
+				next_substr_case_index = 0;
 				break;
 			}
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -932,8 +932,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 			case SCC_NEWGRF_PRINT_WORD_STRING_ID: {
 				StringID substr = args->GetInt32(SCC_NEWGRF_PRINT_WORD_STRING_ID);
-				buff = FormatString(buff, GetStringPtr(substr), args, last, case_index, game_script, dry_run);
-				case_index = next_substr_case_index;
+				buff = FormatString(buff, GetStringPtr(substr), args, last, next_substr_case_index, game_script, dry_run);
 				next_substr_case_index = 0;
 				break;
 			}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -818,8 +818,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 	uint next_substr_case_index = 0;
 	char *buf_start = buff;
 	const char *current_str_arg = str_arg;
-	for (;;) {
-		if ((b = Utf8Consume(&current_str_arg)) == '\0') break;
+	while ((b = Utf8Consume(&current_str_arg)) != '\0') {
 		const char *&str = current_str_arg;
 
 		if (SCC_NEWGRF_FIRST <= b && b <= SCC_NEWGRF_LAST) {

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -817,7 +817,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 	WChar b = '\0';
 	uint next_substr_case_index = 0;
 	char *buf_start = buff;
-	const char* current_str_arg = str_arg;
+	const char *current_str_arg = str_arg;
 	for (;;) {
 		if ((b = Utf8Consume(&current_str_arg)) == '\0') break;
 		const char *&str = current_str_arg;


### PR DESCRIPTION

## Motivation / Problem

`FormatString` uses a stack to handle formatting of inlined strings.
This is overly complex and leads to unnecessary allocations in the drawing code of OpenTTD, 

## Description

Based on #9405, this PR simplifies `FormatString` by removing its stack and replacing it by recursion for the format codes  `SCC_NEWGRF_STRINL` and `SCC_NEWGRF_PRINT_WORD_STRING_ID`.
This change removes the use of temporary allocations in this function.
With this change, the overall temporary allocations are down by ~90% for the test case mentioned in #9405.

I am not sure why, but `SCC_NEWGRF_PRINT_WORD_STRING_ID` got triggered repeatedly in world generation.

## Limitations

I was unable to test the changes for the affected format code `SCC_NEWGRF_STRINL` as I couldn't find a NewGrf which uses it.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
