### PR TITLE
Codechange: Improve LineCache queries

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -888,6 +888,12 @@ Layouter::LineCacheItem &Layouter::GetCachedParagraphLayout(const char *str, siz
 		linecache = new LineCache();
 	}
 
+	if (auto match = linecache->find(LineCacheQuery{state, std::string_view{str, len}});
+		match != linecache->end()) {
+		return match->second;
+	}
+
+	/* Create missing entry */
 	LineCacheKey key;
 	key.state_before = state;
 	key.str.assign(str, len);


### PR DESCRIPTION
## Motivation / Problem

After #9416, one major source of temporary allocations is `GetCachedParagraphLayout`.
The key of the `std::map` contains a `std::string`, while the cache access uses a `const char* + size`.
The current version constructs the key to query the linecache, which needs to allocate and copy the string for each query.

With C++14, some queries of `std::map` allow to query using a different type than key using a transparent comparator. 

## Description

This PR adds the support to query the linecache without copying the string.

Building pieces are:
* A non-owning type of the cacheline key using a `std::string_view`
* A transparent comparator
* A 2 phase query algorithm. First query with the lightweight query type. Then insert using the key type if needed.

After this PR and #9416, the allocations are dominated by the SpriteSorter.

## Limitations

_none_

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
