### PR TITLE
Codechange: Don't explicitly unset _generating_world outside of genworld.cpp

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -608,9 +608,9 @@ public:
 			ShowErrorMessage(STR_ERROR_CAN_T_GENERATE_INDUSTRIES, STR_ERROR_MUST_FOUND_TOWN_FIRST, WL_INFO);
 		} else {
 			extern void GenerateIndustries();
-			_generating_world = true;
+			Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
 			GenerateIndustries();
-			_generating_world = false;
+			old_generating_world.Restore();
 		}
 	}
 
@@ -712,15 +712,15 @@ public:
 			}
 
 			Backup<CompanyID> cur_company(_current_company, OWNER_NONE, FILE_LINE);
-			_generating_world = true;
+			Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
 			_ignore_restrictions = true;
 
 			DoCommandP(tile, (layout_index << 8) | this->selected_type, seed,
 					CMD_BUILD_INDUSTRY | CMD_MSG(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY), &CcBuildIndustry);
 
 			cur_company.Restore();
+			old_generating_world.Restore();
 			_ignore_restrictions = false;
-			_generating_world = false;
 		} else {
 			success = DoCommandP(tile, (layout_index << 8) | this->selected_type, seed, CMD_BUILD_INDUSTRY | CMD_MSG(STR_ERROR_CAN_T_CONSTRUCT_THIS_INDUSTRY));
 		}

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -16,6 +16,7 @@
 #include "object_base.h"
 #include "company_base.h"
 #include "company_func.h"
+#include "core/backup_type.hpp"
 
 #include "table/strings.h"
 
@@ -279,8 +280,8 @@ CommandCost CmdTerraformLand(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 			bool indirectly_cleared = coa != nullptr && coa->first_tile != t;
 
 			/* Check tiletype-specific things, and add extra-cost */
-			const bool curr_gen = _generating_world;
-			if (_game_mode == GM_EDITOR) _generating_world = true; // used to create green terraformed land
+			Backup<bool> old_generating_world(_generating_world, FILE_LINE);
+			if (_game_mode == GM_EDITOR) old_generating_world.Change(true); // used to create green terraformed land
 			DoCommandFlag tile_flags = flags | DC_AUTO | DC_FORCE_CLEAR_TILE;
 			if (pass == 0) {
 				tile_flags &= ~DC_EXEC;
@@ -292,7 +293,7 @@ CommandCost CmdTerraformLand(TileIndex tile, DoCommandFlag flags, uint32 p1, uin
 			} else {
 				cost = _tile_type_procs[GetTileType(t)]->terraform_tile_proc(t, tile_flags, z_min, tileh);
 			}
-			_generating_world = curr_gen;
+			old_generating_world.Restore();
 			if (cost.Failed()) {
 				_terraform_err_tile = t;
 				return cost;

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -8,6 +8,7 @@
 /** @file terraform_gui.cpp GUI related to terraforming the map. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "clear_map.h"
 #include "company_func.h"
 #include "company_base.h"
@@ -54,7 +55,7 @@ static void GenerateDesertArea(TileIndex end, TileIndex start)
 {
 	if (_game_mode != GM_EDITOR) return;
 
-	_generating_world = true;
+	Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
 
 	TileArea ta(start, end);
 	for (TileIndex tile : ta) {
@@ -62,7 +63,7 @@ static void GenerateDesertArea(TileIndex end, TileIndex start)
 		DoCommandP(tile, 0, 0, CMD_LANDSCAPE_CLEAR);
 		MarkTileDirtyByTile(tile);
 	}
-	_generating_world = false;
+	old_generating_world.Restore();
 	InvalidateWindowClassesData(WC_TOWN_VIEW, 0);
 }
 
@@ -497,7 +498,7 @@ static void ResetLandscapeConfirmationCallback(Window *w, bool confirmed)
 	if (confirmed) {
 		/* Set generating_world to true to get instant-green grass after removing
 		 * company property. */
-		_generating_world = true;
+		Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
 
 		/* Delete all companies */
 		for (Company *c : Company::Iterate()) {
@@ -505,7 +506,7 @@ static void ResetLandscapeConfirmationCallback(Window *w, bool confirmed)
 			delete c;
 		}
 
-		_generating_world = false;
+		old_generating_world.Restore();
 
 		/* Delete all station signs */
 		for (BaseStation *st : BaseStation::Iterate()) {

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -27,6 +27,7 @@
 #include "querystring_gui.h"
 #include "window_func.h"
 #include "townname_func.h"
+#include "core/backup_type.hpp"
 #include "core/geometry_func.hpp"
 #include "genworld.h"
 #include "stringfilter_type.h"
@@ -1185,15 +1186,16 @@ public:
 				this->SetFocusedWidget(WID_TF_TOWN_NAME_EDITBOX);
 				break;
 
-			case WID_TF_MANY_RANDOM_TOWNS:
-				_generating_world = true;
+			case WID_TF_MANY_RANDOM_TOWNS: {
+				Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
 				UpdateNearestTownForRoadTiles(true);
 				if (!GenerateTowns(this->town_layout)) {
 					ShowErrorMessage(STR_ERROR_CAN_T_GENERATE_TOWN, STR_ERROR_NO_SPACE_FOR_TOWN, WL_INFO);
 				}
 				UpdateNearestTownForRoadTiles(false);
-				_generating_world = false;
+				old_generating_world.Restore();
 				break;
+			}
 
 			case WID_TF_SIZE_SMALL: case WID_TF_SIZE_MEDIUM: case WID_TF_SIZE_LARGE: case WID_TF_SIZE_RANDOM:
 				this->town_size = (TownSize)(widget - WID_TF_SIZE_SMALL);


### PR DESCRIPTION
## Motivation / Problem
While trying to understand the cause for #9407, I noticed some 
```
...
_generating_world = true;
DoStuff();
_generating_world = false;
...
```
They are relatively safe (mainly used in GUI code), but I think it can (and should) be done safer.
The only place `_generating_world` can be explicitly set to `false` is in `_GenerateWorld()`, ie during the real generation.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I just followed the idea of https://github.com/OpenTTD/OpenTTD/commit/ffec9b41e8d2efb539d5e24593249bc60baffd13, and used `Backup` to replace all direct writes to `_generating_world` from outside `_GenerateWorld()`.
One place was already doing a proper backup, but without using `Backup`, so I updated it too.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
