### PR TITLE
Fix 9e32c618: network revision was always empty

### DIFF
--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -43,7 +43,7 @@ std::string_view GetNetworkRevisionString()
 	static std::string network_revision;
 
 	if (network_revision.empty()) {
-		std::string network_revision = _openttd_revision;
+		network_revision = _openttd_revision;
 		if (_openttd_revision_tagged) {
 			/* Tagged; do not mangle further, though ensure it's not too long. */
 			if (network_revision.size() >= NETWORK_REVISION_LENGTH) network_revision.resize(NETWORK_REVISION_LENGTH - 1);


### PR DESCRIPTION


## Motivation / Problem

I was puzzled why nothing gave a version mismatch .. till I noticed all `master` servers were reporting as no version :D

"Oops" :)


## Description

```
Shadowing the variable you intend to write in tends to do that ;)
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
