### PR TITLE
Fix: reduce the amount of debug messages on -dsl=2

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -1918,7 +1918,8 @@ std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt)
 
 				auto sld_it = key_lookup.find(key);
 				if (sld_it == key_lookup.end()) {
-					Debug(sl, 2, "Field '{}' of type 0x{:02x} not found, skipping", key, type);
+					/* SLA_LOADCHECK triggers this debug statement a lot and is perfectly normal. */
+					Debug(sl, _sl.action == SLA_LOAD ? 2 : 6, "Field '{}' of type 0x{:02x} not found, skipping", key, type);
 
 					std::shared_ptr<SaveLoadHandler> handler = nullptr;
 					SaveLoadType slt;


### PR DESCRIPTION


## Motivation / Problem

I got annoyed while validating some new code about the output of `-dsl=2`.

## Description

```
LoadCheck makes it sound like something is really broken while
loading savegames, while it really is perfectly normal, as most
chunks do not implement LoadCheck.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
