### PR TITLE
Fix 11ab3c4: [NewGRF] Overflow when determining cargo mask for string code 9A 1E

### DIFF
--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -949,7 +949,7 @@ uint RemapNewGRFStringControlCode(uint scc, char *buf_start, char **buff, const 
 
 			case SCC_NEWGRF_PRINT_WORD_CARGO_NAME: {
 				CargoID cargo = GetCargoTranslation(_newgrf_textrefstack.PopUnsignedWord(), _newgrf_textrefstack.grffile);
-				*argv = cargo < NUM_CARGO ? 1 << cargo : 0;
+				*argv = cargo < NUM_CARGO ? 1ULL << cargo : 0;
 				break;
 			}
 		}


### PR DESCRIPTION
## Motivation / Problem

From coverity's scan:
```
1453026 Bad bit shift operation
The operation may have an undefined behavior or yield an unexpected result.

In RemapNewGRFStringControlCode(unsigned int, char *, char **, char const**, long long *, unsigned int, bool): 
A bit shift operation has a shift amount which is too large or has a negative value.
```

## Description

Make the 1 that is shifted 64 bits, so shifting with a cargo type > 32 will not result in a 0 value for the cargo mask to look up.


## Limitations

I haven't tested it as I have no idea which NewGRF uses this string code. Making a NewGRF for this is a bit out of my league.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
