### PR TITLE
Remove some logically dead code

### DIFF
--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -618,9 +618,9 @@ const Sprite *FreeTypeFontCache::InternalGetGlyph(GlyphID key, bool aa)
 	if (this->fs == FS_NORMAL && !aa) {
 		for (uint y = 0; y < (uint)slot->bitmap.rows; y++) {
 			for (uint x = 0; x < (uint)slot->bitmap.width; x++) {
-				if (aa ? (slot->bitmap.buffer[x + y * slot->bitmap.pitch] > 0) : HasBit(slot->bitmap.buffer[(x / 8) + y * slot->bitmap.pitch], 7 - (x % 8))) {
+				if (HasBit(slot->bitmap.buffer[(x / 8) + y * slot->bitmap.pitch], 7 - (x % 8))) {
 					sprite.data[1 + x + (1 + y) * sprite.width].m = SHADOW_COLOUR;
-					sprite.data[1 + x + (1 + y) * sprite.width].a = aa ? slot->bitmap.buffer[x + y * slot->bitmap.pitch] : 0xFF;
+					sprite.data[1 + x + (1 + y) * sprite.width].a = 0xFF;
 				}
 			}
 		}

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -963,7 +963,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 			bool lowered = !HasBit(_legend_excluded_cargo, cs->Index());
 
 			/* Redraw box if lowered */
-			if (lowered) DrawFrameRect(r.left, y, r.right, y + this->line_height - 1, COLOUR_BROWN, lowered ? FR_LOWERED : FR_NONE);
+			if (lowered) DrawFrameRect(r.left, y, r.right, y + this->line_height - 1, COLOUR_BROWN, FR_LOWERED);
 
 			byte clk_dif = lowered ? 1 : 0;
 			int rect_x = clk_dif + (rtl ? r.right - this->legend_width - WD_FRAMERECT_RIGHT : r.left + WD_FRAMERECT_LEFT);


### PR DESCRIPTION
## Motivation / Problem

From coverity: Logically dead code. The indicated dead code may have performed some action; that action will never occur.
* In FreeTypeFontCache::​InternalGetGlyph(unsigned int, bool): Code can never be reached because of a logical contradiction (CWE-561)
* In PaymentRatesGraphWindow::​DrawWidget(Rect const&, int): Code can never be reached because of a logical contradiction (CWE-561)


## Description

Practically in a branch of `if (expr)` any ternary that looks like `expr ? A : B` can be collapsed to `A` as `expr` is known to be true at that point. Note that in some of the cases it's more like `if (!expr)` with `expr ? A : B`, so `B` is chosen there.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
