### PR TITLE
Codechange: use the C++ std::getenv over the POSIX/C getenv

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -822,7 +822,7 @@ static std::string GetHomeDir()
 	find_directory(B_USER_SETTINGS_DIRECTORY, &path);
 	return std::string(path.Path());
 #else
-	const char *home_env = getenv("HOME"); // Stack var, shouldn't be freed
+	const char *home_env = std::getenv("HOME"); // Stack var, shouldn't be freed
 	if (home_env != nullptr) return std::string(home_env);
 
 	const struct passwd *pw = getpwuid(getuid());
@@ -840,7 +840,7 @@ void DetermineBasePaths(const char *exe)
 	std::string tmp;
 	const std::string homedir = GetHomeDir();
 #ifdef USE_XDG
-	const char *xdg_data_home = getenv("XDG_DATA_HOME");
+	const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
 	if (xdg_data_home != nullptr) {
 		tmp = xdg_data_home;
 		tmp += PATHSEP;
@@ -971,7 +971,7 @@ void DeterminePaths(const char *exe, bool only_local_path)
 #ifdef USE_XDG
 	std::string config_home;
 	const std::string homedir = GetHomeDir();
-	const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+	const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
 	if (xdg_config_home != nullptr) {
 		config_home = xdg_config_home;
 		config_home += PATHSEP;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1850,18 +1850,18 @@ const char *GetCurrentLocale(const char *param)
 {
 	const char *env;
 
-	env = getenv("LANGUAGE");
+	env = std::getenv("LANGUAGE");
 	if (env != nullptr) return env;
 
-	env = getenv("LC_ALL");
+	env = std::getenv("LC_ALL");
 	if (env != nullptr) return env;
 
 	if (param != nullptr) {
-		env = getenv(param);
+		env = std::getenv(param);
 		if (env != nullptr) return env;
 	}
 
-	return getenv("LANG");
+	return std::getenv("LANG");
 }
 #else
 const char *GetCurrentLocale(const char *param);


### PR DESCRIPTION
## Motivation / Problem

The C++ std::getenv is guaranteed thread-safe by the C++11 specification,
whereas the POSIX/C getenv might not be thread-safe by the C11 specification.


## Description

`s/getenv/std::getenv/`. There is no usage of `setenv`, `putenv` or `unsetenv` in our code, so that caveat in the specification should not apply to us.


## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
