### PR TITLE
Feature: raise the maximum NewGRF limit to 255

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -73,9 +73,20 @@ static const uint NETWORK_GRF_NAME_LENGTH           =   80;           ///< Maxim
 
 /**
  * Maximum number of GRFs that can be sent.
- * This limit is reached when PACKET_UDP_SERVER_RESPONSE reaches the maximum size of UDP_MTU bytes.
+ *
+ * This limit exists to avoid that the SERVER_INFO packet exceeding the
+ * maximum MTU. At the time of writing this limit is 32767 (TCP_MTU).
+ *
+ * In the SERVER_INFO packet is the NetworkGameInfo struct, which is
+ * 142 bytes + 100 per NewGRF (under the assumption strings are used to
+ * their max). This brings us to roughly 326 possible NewGRFs. Round it
+ * down so people don't freak out because they see a weird value, and you
+ * get the limit: 255.
+ *
+ * PS: in case you ever want to raise this number, please be mindful that
+ * "amount of NewGRFs" in NetworkGameInfo is currently an uint8.
  */
-static const uint NETWORK_MAX_GRF_COUNT             =   62;
+static const uint NETWORK_MAX_GRF_COUNT             =   255;
 
 /**
  * The number of landscapes in OpenTTD.

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -205,7 +205,7 @@ void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
 	Debug(net, 6, "Sending server update to Game Coordinator");
 	this->next_update = std::chrono::steady_clock::now() + NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES;
 
-	Packet *p = new Packet(PACKET_COORDINATOR_SERVER_UPDATE);
+	Packet *p = new Packet(PACKET_COORDINATOR_SERVER_UPDATE, TCP_MTU);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
 	SerializeNetworkGameInfo(p, GetCurrentNetworkServerGameInfo());
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -354,7 +354,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendClientInfo(NetworkClientIn
 /** Send the client information about the server. */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendGameInfo()
 {
-	Packet *p = new Packet(PACKET_SERVER_GAME_INFO);
+	Packet *p = new Packet(PACKET_SERVER_GAME_INFO, TCP_MTU);
 	SerializeNetworkGameInfo(p, GetCurrentNetworkServerGameInfo());
 
 	this->SendPacket(p);
@@ -470,7 +470,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendError(NetworkErrorCode err
 /** Send the check for the NewGRFs. */
 NetworkRecvStatus ServerNetworkGameSocketHandler::SendNewGRFCheck()
 {
-	Packet *p = new Packet(PACKET_SERVER_CHECK_NEWGRFS);
+	Packet *p = new Packet(PACKET_SERVER_CHECK_NEWGRFS, TCP_MTU);
 	const GRFConfig *c;
 	uint grf_count = 0;
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9853,6 +9853,8 @@ void LoadNewGRF(uint load_index, uint num_baseset)
 				num_non_static++;
 			}
 
+			num_grfs++;
+
 			LoadNewGRFFile(c, stage, subdir, false);
 			if (stage == GLS_RESERVE) {
 				SetBit(c->flags, GCF_RESERVED);


### PR DESCRIPTION
## Motivation / Problem

Every limit is one limit too many! WE WANT MORE NEWGRFS! MOAR! MMOOAAARRRR!


## Description

As the Game Info now travels via TCP, we can increase the MTU limit on both sides to allow more NewGRFs. So .. I did exactly that.

I tested it with up to 209 NewGRFs .. that was all I had on disk :P

![image](https://user-images.githubusercontent.com/1663690/125176431-89bac580-e1d3-11eb-9083-b5f96379de7d.png)

Picture to proof it!

## Limitations

- 255 isn't enough. But .. a problem for another day ;)


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
