### PR TITLE
Feature: allow setting (game) coordinator and content server connection strings using environment variables

### DIFF
--- a/src/network/core/CMakeLists.txt
+++ b/src/network/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_files(
     address.cpp
     address.h
+    config.cpp
     config.h
     core.cpp
     core.h

--- a/src/network/core/config.cpp
+++ b/src/network/core/config.cpp
@@ -1,0 +1,59 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file config.cpp Configuration of the connection strings for network stuff using environment variables.
+ */
+
+#include "../../stdafx.h"
+
+#include <cstdlib>
+#include "../../string_func.h"
+
+#include "../../safeguards.h"
+
+/**
+ * Get the environment variable using std::getenv and when it is an empty string (or nullptr), return a fallback value instead.
+ * @param variable The environment variable to read from.
+ * @param fallback The fallback in case the environment variable is not set.
+ * @return The environment value, or when that does not exist the given fallback value.
+ */
+static const char *GetEnv(const char *variable, const char *fallback)
+{
+	const char *value = std::getenv(variable);
+	return StrEmpty(value) ? fallback : value;
+}
+
+/**
+ * Get the connection string for the game coordinator from the environment variable OTTD_COORDINATOR_CS,
+ * or when it has not been set a hard coded default DNS hostname of the production server.
+ * @return The game coordinator's connection string.
+ */
+const char *NetworkCoordinatorConnectionString()
+{
+	return GetEnv("OTTD_COORDINATOR_CS", "coordinator.openttd.org");
+}
+
+/**
+ * Get the connection string for the content server from the environment variable OTTD_CONTENT_SERVER_CS,
+ * or when it has not been set a hard coded default DNS hostname of the production server.
+ * @return The game coordinator's connection string.
+ */
+const char *NetworkContentServerConnectionString()
+{
+	return GetEnv("OTTD_CONTENT_SERVER_CS", "content.openttd.org");
+}
+
+/**
+ * Get the connection string for the content mirror from the environment variable OTTD_CONTENT_MIRROR_CS,
+ * or when it has not been set a hard coded default DNS hostname of the production server.
+ * @return The game coordinator's connection string.
+ */
+const char *NetworkContentMirrorConnectionString()
+{
+	return GetEnv("OTTD_CONTENT_MIRROR_CS", "binaries.openttd.org");
+}

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -12,12 +12,10 @@
 #ifndef NETWORK_CORE_CONFIG_H
 #define NETWORK_CORE_CONFIG_H
 
-/** DNS hostname of the Game Coordinator server */
-static const char * const NETWORK_COORDINATOR_SERVER_HOST       = "coordinator.openttd.org";
-/** DNS hostname of the content server */
-static const char * const NETWORK_CONTENT_SERVER_HOST           = "content.openttd.org";
-/** DNS hostname of the HTTP-content mirror server */
-static const char * const NETWORK_CONTENT_MIRROR_HOST           = "binaries.openttd.org";
+const char *NetworkCoordinatorConnectionString();
+const char *NetworkContentServerConnectionString();
+const char *NetworkContentMirrorConnectionString();
+
 /** URL of the HTTP mirror system */
 static const char * const NETWORK_CONTENT_MIRROR_URL            = "/bananas";
 

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -342,7 +342,7 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const Conten
 
 	this->http_response_index = -1;
 
-	new NetworkHTTPContentConnecter(NETWORK_CONTENT_MIRROR_HOST, this, NETWORK_CONTENT_MIRROR_URL, content_request);
+	new NetworkHTTPContentConnecter(NetworkContentMirrorConnectionString(), this, NETWORK_CONTENT_MIRROR_URL, content_request);
 	/* NetworkHTTPContentConnecter takes over freeing of content_request! */
 }
 
@@ -774,7 +774,7 @@ void ClientNetworkContentSocketHandler::Connect()
 {
 	if (this->sock != INVALID_SOCKET || this->isConnecting) return;
 	this->isConnecting = true;
-	new NetworkContentConnecter(NETWORK_CONTENT_SERVER_HOST);
+	new NetworkContentConnecter(NetworkContentServerConnectionString());
 }
 
 /**

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -159,7 +159,7 @@ void ClientNetworkCoordinatorSocketHandler::Connect()
 	this->connecting = true;
 	this->last_activity = std::chrono::steady_clock::now();
 
-	new NetworkCoordinatorConnecter(NETWORK_COORDINATOR_SERVER_HOST);
+	new NetworkCoordinatorConnecter(NetworkCoordinatorConnectionString());
 }
 
 NetworkRecvStatus ClientNetworkCoordinatorSocketHandler::CloseConnection(bool error)


### PR DESCRIPTION
## Motivation / Problem

Someone was complaining that it requires recompiling to test new networking features against a staging server.


## Description

Add functionality to read the game coordinator and content server connection strings from an environment variable.
* OTTD_COORDINATOR_CS for the game coordinator defaults to coordinator.openttd.org:3976
* OTTD_CONTENT_SERVER_CS for the content server defaults to content.openttd.org:3978
* OTTD_CONTENT_MIRROR_CS for the content mirror server defaults to binaries.openttd.org:80

The `TCPConnecter` already expected a connection string (`ip:port`) where the port might be omitted, in which case it gets replaced with the default port number of that type of connection.

## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
