### PR TITLE
Fix: ensure no more than the allowed number of NewGRFs are loaded from the configuration

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -956,6 +956,7 @@ static GRFConfig *GRFLoadConfig(IniFile &ini, const char *grpname, bool is_stati
 
 	if (group == nullptr) return nullptr;
 
+	uint num_grfs = 0;
 	for (item = group->item; item != nullptr; item = item->next) {
 		GRFConfig *c = nullptr;
 
@@ -1030,8 +1031,14 @@ static GRFConfig *GRFLoadConfig(IniFile &ini, const char *grpname, bool is_stati
 			continue;
 		}
 
-		/* Mark file as static to avoid saving in savegame. */
-		if (is_static) SetBit(c->flags, GCF_STATIC);
+		if (is_static) {
+			/* Mark file as static to avoid saving in savegame. */
+			SetBit(c->flags, GCF_STATIC);
+		} else if (++num_grfs > NETWORK_MAX_GRF_COUNT) {
+			/* Check we will not load more non-static NewGRFs than allowed. This could trigger issues for game servers. */
+			ShowErrorMessage(STR_CONFIG_ERROR, STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED, WL_CRITICAL);
+			break;
+		}
 
 		/* Add item to list */
 		*curr = c;


### PR DESCRIPTION
## Motivation / Problem

When loading OpenTTD with a configuration that has more than NETWORK_MAX_GRF_COUNT NewGRFs configured bad things might happen.

The UI limits the user from entering more than that amount, but loading the configuration does not perform such sanity checks.

With older versions, including 1.11.2, this can cause an assertion or when assertions are disabled a buffer overrun when advertising to the master server.

With versions since the packet rewrite this causes only the assertion as the buffer will automatically resize if needed. However, the packets might be interpreted incorrectly by others, especially the UDP packets.

With any, but more likely for #9428, this could lead to an overflow of the number of NewGRFs in the packet, meaning the clients see 0 NewGRFs when the server actually has 256.


## Description

The issue is solved by limiting the number of non-static NewGRFs that are loaded from the configuration file.


## Limitations

Saving the configuration will now remove any NewGRFs over the limit from the configuration, so going back and forth between stable and post #9428 might loose NewGRFs in the configuration if you have set more than 62.

This change doesn't magically fix the problem of loading valid post #9428 settings files in 1.11. That requires this PR to be backported.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
