### PR TITLE
Remove: artificial "random" limit on number of statically loaded NewGRFs

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -80,7 +80,6 @@ static uint32 _ttdpatch_flags[8];
 GRFLoadedFeatures _loaded_newgrf_features;
 
 static const uint MAX_SPRITEGROUP = UINT8_MAX; ///< Maximum GRF-local ID for a spritegroup.
-static const uint MAX_GRF_COUNT = 128; ///< Maximum number of NewGRF files that could be loaded.
 
 /** Temporary data during loading of GRFs */
 struct GrfProcessingState {
@@ -9853,14 +9852,6 @@ void LoadNewGRF(uint load_index, uint num_baseset)
 				}
 				num_non_static++;
 			}
-
-			if (num_grfs >= MAX_GRF_COUNT) {
-				Debug(grf, 0, "'{}' is not loaded as the maximum number of file slots has been reached", c->filename);
-				c->status = GCS_DISABLED;
-				c->error  = new GRFError(STR_NEWGRF_ERROR_MSG_FATAL, STR_NEWGRF_ERROR_TOO_MANY_NEWGRFS_LOADED);
-				continue;
-			}
-			num_grfs++;
 
 			LoadNewGRFFile(c, stage, subdir, false);
 			if (stage == GLS_RESERVE) {


### PR DESCRIPTION
## Motivation / Problem

Playing with #9428 I noticed that only an actual 253 NewGRFs could be loaded, so I concluded that MAX_GRF_COUNT must be larger than NETWORK_MAX_GRF_COUNT.

The maximum number of statically loaded NewGRFs is currently limited to 128 minus the number of base set NewGRFs (2) and the number of loaded NewGRFs (2-62), so the number of static NewGRFs is in the range of 64 to 126. With #9428 that would be changed from 2 - 253.

It makes little sense to limit the number of statically loaded NewGRFs, except for when thinking about the insanity of the players. Previously this was an index into a statically allocated array of loaded files, but now this is all dynamic there is no practical limit on them anymore.


## Description

Get rid of the artificial limitation on the number of static NewGRFs loaded. It adds no real purpose, and enforcing is would add more logic that is essentially not needed.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
