### PR TITLE
Feature: join servers based on their invite code

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -702,6 +702,7 @@ DEF_CONSOLE_CMD(ConServerInfo)
 		return true;
 	}
 
+	IConsolePrint(CC_DEFAULT, "Invite code:                {}", _network_server_invite_code);
 	IConsolePrint(CC_DEFAULT, "Current/maximum clients:    {:3d}/{:3d}", _network_game_info.clients_on, _settings_client.network.max_clients);
 	IConsolePrint(CC_DEFAULT, "Current/maximum companies:  {:3d}/{:3d}", Company::GetNumItems(), _settings_client.network.max_companies);
 	IConsolePrint(CC_DEFAULT, "Current/maximum spectators: {:3d}/{:3d}", NetworkSpectatorCount(), _settings_client.network.max_spectators);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2045,12 +2045,12 @@ STR_NETWORK_SERVER_LIST_SEARCH_SERVER_INTERNET_TOOLTIP          :{BLACK}Search i
 STR_NETWORK_SERVER_LIST_SEARCH_SERVER_LAN                       :{BLACK}Search LAN
 STR_NETWORK_SERVER_LIST_SEARCH_SERVER_LAN_TOOLTIP               :{BLACK}Search local area network for servers
 STR_NETWORK_SERVER_LIST_ADD_SERVER                              :{BLACK}Add server
-STR_NETWORK_SERVER_LIST_ADD_SERVER_TOOLTIP                      :{BLACK}Adds a server to the list which will always be checked for running games
+STR_NETWORK_SERVER_LIST_ADD_SERVER_TOOLTIP                      :{BLACK}Adds a server to the list. This can either be a server address or an invite code
 STR_NETWORK_SERVER_LIST_START_SERVER                            :{BLACK}Start server
 STR_NETWORK_SERVER_LIST_START_SERVER_TOOLTIP                    :{BLACK}Start your own server
 
 STR_NETWORK_SERVER_LIST_PLAYER_NAME_OSKTITLE                    :{BLACK}Enter your name
-STR_NETWORK_SERVER_LIST_ENTER_IP                                :{BLACK}Enter the address of the host
+STR_NETWORK_SERVER_LIST_ENTER_SERVER_ADDRESS                    :{BLACK}Enter server address or invite code
 
 # Start new multiplayer server
 STR_NETWORK_START_SERVER_CAPTION                                :{WHITE}Start new multiplayer game
@@ -2136,6 +2136,8 @@ STR_NETWORK_CLIENT_LIST_SERVER_NAME_EDIT_TOOLTIP                :{BLACK}Edit the
 STR_NETWORK_CLIENT_LIST_SERVER_NAME_QUERY_CAPTION               :Name of the server
 STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY                       :{BLACK}Visibility
 STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY_TOOLTIP               :{BLACK}Whether other people can see your server in the public listing
+STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE                      :{BLACK}Invite code
+STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE_TOOLTIP              :{BLACK}Invite code other players can use to join this server
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE                  :{BLACK}Connection type
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TOOLTIP          :{BLACK}Whether and how your server can be reached by others
 STR_NETWORK_CLIENT_LIST_PLAYER                                  :{BLACK}Player

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -414,17 +414,22 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 }
 
 /**
- * Convert a string containing either "hostname" or "hostname:ip" to a
- * ServerAddress, where the string can be postfixed with "#company" to
+ * Convert a string containing either "hostname", "hostname:port" or invite code
+ * to a ServerAddress, where the string can be postfixed with "#company" to
  * indicate the requested company.
  *
  * @param connection_string The string to parse.
  * @param default_port The default port to set port to if not in connection_string.
- * @param company Pointer to the company variable to set iff indicted.
+ * @param company Pointer to the company variable to set iff indicated.
  * @return A valid ServerAddress of the parsed information.
  */
 /* static */ ServerAddress ServerAddress::Parse(const std::string &connection_string, uint16 default_port, CompanyID *company_id)
 {
+	if (StrStartsWith(connection_string, "+")) {
+		std::string_view invite_code = ParseCompanyFromConnectionString(connection_string, company_id);
+		return ServerAddress(SERVER_ADDRESS_INVITE_CODE, std::string(invite_code));
+	}
+
 	uint16 port = default_port;
 	std::string_view ip = ParseFullConnectionString(connection_string, port, company_id);
 	return ServerAddress(SERVER_ADDRESS_DIRECT, std::string(ip) + ":" + std::to_string(port));

--- a/src/network/core/address.cpp
+++ b/src/network/core/address.cpp
@@ -10,6 +10,7 @@
 #include "../../stdafx.h"
 
 #include "address.h"
+#include "../network_internal.h"
 #include "../../debug.h"
 
 #include "../../safeguards.h"
@@ -410,4 +411,21 @@ void NetworkAddress::Listen(int socktype, SocketList *sockets)
 	socklen_t addr_len = sizeof(addr);
 	getpeername(sock, (sockaddr *)&addr, &addr_len);
 	return NetworkAddress(addr, addr_len).GetAddressAsString();
+}
+
+/**
+ * Convert a string containing either "hostname" or "hostname:ip" to a
+ * ServerAddress, where the string can be postfixed with "#company" to
+ * indicate the requested company.
+ *
+ * @param connection_string The string to parse.
+ * @param default_port The default port to set port to if not in connection_string.
+ * @param company Pointer to the company variable to set iff indicted.
+ * @return A valid ServerAddress of the parsed information.
+ */
+/* static */ ServerAddress ServerAddress::Parse(const std::string &connection_string, uint16 default_port, CompanyID *company_id)
+{
+	uint16 port = default_port;
+	std::string_view ip = ParseFullConnectionString(connection_string, port, company_id);
+	return ServerAddress(SERVER_ADDRESS_DIRECT, std::string(ip) + ":" + std::to_string(port));
 }

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -185,6 +185,7 @@ public:
  */
 enum ServerAddressType {
 	SERVER_ADDRESS_DIRECT,      ///< Server-address is based on an hostname:port.
+	SERVER_ADDRESS_INVITE_CODE, ///< Server-address is based on an invite code.
 };
 
 /**

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -12,6 +12,7 @@
 
 #include "os_abstraction.h"
 #include "config.h"
+#include "../../company_type.h"
 #include "../../string_func.h"
 #include "../../core/smallmap_type.hpp"
 
@@ -175,6 +176,39 @@ public:
 	static const char *SocketTypeAsString(int socktype);
 	static const char *AddressFamilyAsString(int family);
 	static const std::string GetPeerName(SOCKET sock);
+};
+
+/**
+ * Types of server addresses we know.
+ *
+ * Sorting will prefer entries at the top of this list above ones at the bottom.
+ */
+enum ServerAddressType {
+	SERVER_ADDRESS_DIRECT,      ///< Server-address is based on an hostname:port.
+};
+
+/**
+ * Address to a game server.
+ *
+ * This generalises addresses which are based on different identifiers.
+ */
+class ServerAddress {
+private:
+	/**
+	 * Create a new ServerAddress object.
+	 *
+	 * Please use ServerAddress::Parse() instead of calling this directly.
+	 *
+	 * @param type The type of the ServerAdress.
+	 * @param connection_string The connection_string that belongs to this ServerAddress type.
+	 */
+	ServerAddress(ServerAddressType type, const std::string &connection_string) : type(type), connection_string(connection_string) {}
+
+public:
+	ServerAddressType type;        ///< The type of this ServerAddress.
+	std::string connection_string; ///< The connection string for this ServerAddress.
+
+	static ServerAddress Parse(const std::string &connection_string, uint16 default_port, CompanyID *company_id = nullptr);
 };
 
 #endif /* NETWORK_CORE_ADDRESS_H */

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -47,7 +47,7 @@ static const uint16 COMPAT_MTU                      = 1460;           ///< Numbe
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    4;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
-static const byte NETWORK_COORDINATOR_VERSION       =    1;           ///< What version of game-coordinator-protocol do we use?
+static const byte NETWORK_COORDINATOR_VERSION       =    2;           ///< What version of game-coordinator-protocol do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'
@@ -67,7 +67,10 @@ static const uint NETWORK_CONTENT_VERSION_LENGTH    =   16;           ///< The m
 static const uint NETWORK_CONTENT_URL_LENGTH        =   96;           ///< The maximum length of a content's url, in bytes including '\0'.
 static const uint NETWORK_CONTENT_DESC_LENGTH       =  512;           ///< The maximum length of a content's description, in bytes including '\0'.
 static const uint NETWORK_CONTENT_TAG_LENGTH        =   32;           ///< The maximum length of a content's tag, in bytes including '\0'.
-static const uint NETWORK_ERROR_DETAIL_LENGTH        = 100;           ///< The maximum length of the error detail, in bytes including '\0'
+static const uint NETWORK_ERROR_DETAIL_LENGTH       =  100;           ///< The maximum length of the error detail, in bytes including '\0'.
+static const uint NETWORK_INVITE_CODE_LENGTH        =   64;           ///< The maximum length of the invite code, in bytes including '\0'.
+static const uint NETWORK_INVITE_CODE_SECRET_LENGTH =   80;           ///< The maximum length of the invite code secret, in bytes including '\0'.
+static const uint NETWORK_TOKEN_LENGTH              =   64;           ///< The maximum length of a token, in bytes including '\0'.
 
 static const uint NETWORK_GRF_NAME_LENGTH           =   80;           ///< Maximum length of the name of a GRF
 

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -141,7 +141,11 @@ void FillStaticNetworkServerGameInfo()
  */
 const NetworkServerGameInfo *GetCurrentNetworkServerGameInfo()
 {
-	/* Client_on is used as global variable to keep track on the number of clients. */
+	/* These variables are updated inside _network_game_info as if they are global variables:
+	 *  - clients_on
+	 *  - invite_code
+	 * These don't need to be updated manually here.
+	 */
 	_network_game_info.companies_on  = (byte)Company::GetNumItems();
 	_network_game_info.spectators_on = NetworkSpectatorCount();
 	_network_game_info.game_date     = _date;

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -103,9 +103,14 @@ private:
 	void Connect(addrinfo *address);
 	bool CheckActivity();
 
+	/* We do not want any other derived classes from this class being able to
+	 * access these private members, but it is okay for TCPServerConnecter. */
+	friend class TCPServerConnecter;
+
 	static void ResolveThunk(TCPConnecter *connecter);
 
 public:
+	TCPConnecter() {};
 	TCPConnecter(const std::string &connection_string, uint16 default_port);
 	virtual ~TCPConnecter();
 
@@ -122,6 +127,13 @@ public:
 
 	static void CheckCallbacks();
 	static void KillAll();
+};
+
+class TCPServerConnecter : public TCPConnecter {
+public:
+	ServerAddress server_address; ///< Address we are connecting to.
+
+	TCPServerConnecter(const std::string &connection_string, uint16 default_port);
 };
 
 #endif /* NETWORK_CORE_TCP_H */

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -13,6 +13,7 @@
 #include "../../thread.h"
 
 #include "tcp.h"
+#include "../network_coordinator.h"
 #include "../network_internal.h"
 
 #include <deque>
@@ -48,8 +49,7 @@ TCPServerConnecter::TCPServerConnecter(const std::string &connection_string, uin
 
 		case SERVER_ADDRESS_INVITE_CODE:
 			this->status = Status::CONNECTING;
-
-			// TODO -- The next commit will add this functionality.
+			_network_coordinator_client.ConnectToServer(this->server_address.connection_string, this);
 			break;
 
 		default:

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -33,6 +33,26 @@ TCPConnecter::TCPConnecter(const std::string &connection_string, uint16 default_
 	_tcp_connecters.push_back(this);
 }
 
+/**
+ * Create a new connecter for the server.
+ * @param connection_string The address to connect to.
+ * @param default_port If not indicated in connection_string, what port to use.
+ */
+TCPServerConnecter::TCPServerConnecter(const std::string &connection_string, uint16 default_port) :
+	server_address(ServerAddress::Parse(connection_string, default_port))
+{
+	switch (this->server_address.type) {
+		case SERVER_ADDRESS_DIRECT:
+			this->connection_string = this->server_address.connection_string;
+			break;
+
+		default:
+			NOT_REACHED();
+	}
+
+	_tcp_connecters.push_back(this);
+}
+
 TCPConnecter::~TCPConnecter()
 {
 	if (this->resolve_thread.joinable()) {

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -27,12 +27,18 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet *p)
 	PacketCoordinatorType type = (PacketCoordinatorType)p->Recv_uint8();
 
 	switch (type) {
-		case PACKET_COORDINATOR_GC_ERROR:        return this->Receive_GC_ERROR(p);
-		case PACKET_COORDINATOR_SERVER_REGISTER: return this->Receive_SERVER_REGISTER(p);
-		case PACKET_COORDINATOR_GC_REGISTER_ACK: return this->Receive_GC_REGISTER_ACK(p);
-		case PACKET_COORDINATOR_SERVER_UPDATE:   return this->Receive_SERVER_UPDATE(p);
-		case PACKET_COORDINATOR_CLIENT_LISTING:  return this->Receive_CLIENT_LISTING(p);
-		case PACKET_COORDINATOR_GC_LISTING:      return this->Receive_GC_LISTING(p);
+		case PACKET_COORDINATOR_GC_ERROR:              return this->Receive_GC_ERROR(p);
+		case PACKET_COORDINATOR_SERVER_REGISTER:       return this->Receive_SERVER_REGISTER(p);
+		case PACKET_COORDINATOR_GC_REGISTER_ACK:       return this->Receive_GC_REGISTER_ACK(p);
+		case PACKET_COORDINATOR_SERVER_UPDATE:         return this->Receive_SERVER_UPDATE(p);
+		case PACKET_COORDINATOR_CLIENT_LISTING:        return this->Receive_CLIENT_LISTING(p);
+		case PACKET_COORDINATOR_GC_LISTING:            return this->Receive_GC_LISTING(p);
+		case PACKET_COORDINATOR_CLIENT_CONNECT:        return this->Receive_CLIENT_CONNECT(p);
+		case PACKET_COORDINATOR_GC_CONNECTING:         return this->Receive_GC_CONNECTING(p);
+		case PACKET_COORDINATOR_SERCLI_CONNECT_FAILED: return this->Receive_SERCLI_CONNECT_FAILED(p);
+		case PACKET_COORDINATOR_GC_CONNECT_FAILED:     return this->Receive_GC_CONNECT_FAILED(p);
+		case PACKET_COORDINATOR_CLIENT_CONNECTED:      return this->Receive_CLIENT_CONNECTED(p);
+		case PACKET_COORDINATOR_GC_DIRECT_CONNECT:     return this->Receive_GC_DIRECT_CONNECT(p);
 
 		default:
 			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
@@ -82,3 +88,9 @@ bool NetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet *p) { retur
 bool NetworkCoordinatorSocketHandler::Receive_SERVER_UPDATE(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERVER_UPDATE); }
 bool NetworkCoordinatorSocketHandler::Receive_CLIENT_LISTING(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_LISTING); }
 bool NetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_LISTING); }
+bool NetworkCoordinatorSocketHandler::Receive_CLIENT_CONNECT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_CONNECT); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_CONNECTING(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_CONNECTING); }
+bool NetworkCoordinatorSocketHandler::Receive_SERCLI_CONNECT_FAILED(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERCLI_CONNECT_FAILED); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_CONNECT_FAILED(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_CONNECT_FAILED); }
+bool NetworkCoordinatorSocketHandler::Receive_CLIENT_CONNECTED(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_CLIENT_CONNECTED); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_DIRECT_CONNECT); }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -589,9 +589,13 @@ void NetworkClose(bool close_admins)
 		ServerNetworkAdminSocketHandler::CloseListeners();
 
 		_network_coordinator_client.CloseConnection();
-	} else if (MyClient::my_client != nullptr) {
-		MyClient::SendQuit();
-		MyClient::my_client->CloseConnection(NETWORK_RECV_STATUS_CLIENT_QUIT);
+	} else {
+		if (MyClient::my_client != nullptr) {
+			MyClient::SendQuit();
+			MyClient::my_client->CloseConnection(NETWORK_RECV_STATUS_CLIENT_QUIT);
+		}
+
+		_network_coordinator_client.CloseAllTokens();
 	}
 
 	TCPConnecter::KillAll();

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -532,23 +532,6 @@ NetworkAddress ParseConnectionString(const std::string &connection_string, uint1
 }
 
 /**
- * Convert a string containing either "hostname" or "hostname:ip" to a
- * NetworkAddress, where the string can be postfixed with "#company" to
- * indicate the requested company.
- *
- * @param connection_string The string to parse.
- * @param default_port The default port to set port to if not in connection_string.
- * @param company Pointer to the company variable to set iff indicted.
- * @return A valid NetworkAddress of the parsed information.
- */
-static NetworkAddress ParseGameConnectionString(const std::string &connection_string, uint16 default_port, CompanyID *company)
-{
-	uint16 port = default_port;
-	std::string_view ip = ParseFullConnectionString(connection_string, port, company);
-	return NetworkAddress(ip, port);
-}
-
-/**
  * Handle the accepting of a connection to the server.
  * @param s The socket of the new connection.
  * @param address The address of the peer.
@@ -624,12 +607,12 @@ static void NetworkInitialize(bool close_admins = true)
 }
 
 /** Non blocking connection to query servers for their game info. */
-class TCPQueryConnecter : TCPConnecter {
+class TCPQueryConnecter : TCPServerConnecter {
 private:
 	std::string connection_string;
 
 public:
-	TCPQueryConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
+	TCPQueryConnecter(const std::string &connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
 
 	void OnFailure() override
 	{
@@ -661,12 +644,12 @@ void NetworkQueryServer(const std::string &connection_string)
 }
 
 /** Non blocking connection to query servers for their game and company info. */
-class TCPLobbyQueryConnecter : TCPConnecter {
+class TCPLobbyQueryConnecter : TCPServerConnecter {
 private:
 	std::string connection_string;
 
 public:
-	TCPLobbyQueryConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
+	TCPLobbyQueryConnecter(const std::string &connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
 
 	void OnFailure() override
 	{
@@ -756,12 +739,12 @@ void NetworkRebuildHostList()
 }
 
 /** Non blocking connection create to actually connect to servers */
-class TCPClientConnecter : TCPConnecter {
+class TCPClientConnecter : TCPServerConnecter {
 private:
 	std::string connection_string;
 
 public:
-	TCPClientConnecter(const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
+	TCPClientConnecter(const std::string &connection_string) : TCPServerConnecter(connection_string, NETWORK_DEFAULT_PORT), connection_string(connection_string) {}
 
 	void OnFailure() override
 	{
@@ -797,7 +780,7 @@ public:
 bool NetworkClientConnectGame(const std::string &connection_string, CompanyID default_company, const std::string &join_server_password, const std::string &join_company_password)
 {
 	CompanyID join_as = default_company;
-	std::string resolved_connection_string = ParseGameConnectionString(connection_string, NETWORK_DEFAULT_PORT, &join_as).GetAddressAsString(false);
+	std::string resolved_connection_string = ServerAddress::Parse(connection_string, NETWORK_DEFAULT_PORT, &join_as).connection_string;
 
 	if (!_network_available) return false;
 	if (!NetworkValidateOurClientName()) return false;

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -1,4 +1,3 @@
-
 /*
  * This file is part of OpenTTD.
  * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
@@ -12,6 +11,7 @@
 #define NETWORK_COORDINATOR_H
 
 #include "core/tcp_coordinator.h"
+#include <map>
 
 /**
  * Game Coordinator communication.
@@ -25,17 +25,32 @@
  * For clients (listing):
  *  - Client sends CLIENT_LISTING.
  *  - Game Coordinator returns the full list of public servers via GC_LISTING (multiple packets).
+ *
+ * For clients (connecting):
+ *  - Client sends CLIENT_CONNECT.
+ *  - Game Coordinator checks what type of connections the servers supports:
+ *    1) Direct connect?
+ *        - Send the client a GC_CONNECT with the peer address.
+ *        - a) Client connects, client sends CLIENT_CONNECTED to Game Coordinator.
+ *        - b) Client connect fails, client sends CLIENT_CONNECT_FAILED to Game Coordinator.
+ *  - If all fails, Game Coordinator sends GC_CONNECT_FAILED to indicate no connection is possible.
  */
 
 /** Class for handling the client side of the Game Coordinator connection. */
 class ClientNetworkCoordinatorSocketHandler : public NetworkCoordinatorSocketHandler {
 private:
 	std::chrono::steady_clock::time_point next_update; ///< When to send the next update (if server and public).
+	std::map<std::string, TCPServerConnecter *> connecter; ///< Based on tokens, the current connecters that are pending.
+	std::map<std::string, TCPServerConnecter *> connecter_pre; ///< Based on invite codes, the current connecters that are pending.
+	TCPConnecter *game_connecter = nullptr; ///< Pending connecter to the game server.
 
 protected:
 	bool Receive_GC_ERROR(Packet *p) override;
 	bool Receive_GC_REGISTER_ACK(Packet *p) override;
 	bool Receive_GC_LISTING(Packet *p) override;
+	bool Receive_GC_CONNECTING(Packet *p) override;
+	bool Receive_GC_CONNECT_FAILED(Packet *p) override;
+	bool Receive_GC_DIRECT_CONNECT(Packet *p) override;
 
 public:
 	/** The idle timeout; when to close the connection because it's idle. */
@@ -49,11 +64,18 @@ public:
 	NetworkRecvStatus CloseConnection(bool error = true) override;
 	void SendReceive();
 
+	void ConnectFailure(const std::string &token, uint8 tracking_number);
+	void ConnectSuccess(const std::string &token, SOCKET sock);
+
 	void Connect();
+	void CloseToken(const std::string &token);
+	void CloseAllTokens();
 
 	void Register();
 	void SendServerUpdate();
 	void GetListing();
+
+	void ConnectToServer(const std::string &invite_code, TCPServerConnecter *connecter);
 };
 
 extern ClientNetworkCoordinatorSocketHandler _network_coordinator_client;

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -26,7 +26,7 @@ int _network_game_list_version = 0; ///< Current version of all items in the lis
 /**
  * Add a new item to the linked gamelist. If the IP and Port match
  * return the existing item instead of adding it again
- * @param address the address of the to-be added item
+ * @param connection_string the address of the to-be added item
  * @return a point to the newly added or already existing item
  */
 NetworkGameList *NetworkGameListAddItem(const std::string &connection_string)
@@ -34,7 +34,7 @@ NetworkGameList *NetworkGameListAddItem(const std::string &connection_string)
 	NetworkGameList *item, *prev_item;
 
 	/* Parse the connection string to ensure the default port is there. */
-	const std::string resolved_connection_string = ParseConnectionString(connection_string, NETWORK_DEFAULT_PORT).GetAddressAsString(false);
+	const std::string resolved_connection_string = ServerAddress::Parse(connection_string, NETWORK_DEFAULT_PORT).connection_string;
 
 	prev_item = nullptr;
 	for (item = _network_game_list; item != nullptr; item = item->next) {

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -751,7 +751,7 @@ public:
 				SetDParamStr(0, _settings_client.network.connect_to_ip);
 				ShowQueryString(
 					STR_JUST_RAW_STRING,
-					STR_NETWORK_SERVER_LIST_ENTER_IP,
+					STR_NETWORK_SERVER_LIST_ENTER_SERVER_ADDRESS,
 					NETWORK_HOSTNAME_PORT_LENGTH,  // maximum number of characters including '\0'
 					this, CS_ALPHANUMERAL, QSF_ACCEPT_UNCHANGED);
 				break;
@@ -1633,6 +1633,11 @@ static const NWidgetPart _nested_client_list_widgets[] = {
 					NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_CL_SERVER_VISIBILITY), SetDataTip(STR_BLACK_STRING, STR_NETWORK_CLIENT_LIST_SERVER_VISIBILITY_TOOLTIP),
 				EndContainer(),
 				NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
+					NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE, STR_NULL),
+					NWidget(NWID_SPACER), SetMinimalSize(10, 0),
+					NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_SERVER_INVITE_CODE), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_RAW_STRING, STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
+				EndContainer(),
+				NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 					NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE, STR_NULL),
 					NWidget(NWID_SPACER), SetMinimalSize(10, 0),
 					NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_SERVER_CONNECTION_TYPE), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_STRING, STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
@@ -2070,6 +2075,12 @@ public:
 			case WID_CL_SERVER_VISIBILITY:
 				SetDParam(0, _server_visibility_dropdown[_settings_client.network.server_advertise]);
 				break;
+
+			case WID_CL_SERVER_INVITE_CODE: {
+				static std::string empty = {};
+				SetDParamStr(0, _network_server_connection_type == CONNECTION_TYPE_UNKNOWN ? empty : _network_server_invite_code);
+				break;
+			}
 
 			case WID_CL_SERVER_CONNECTION_TYPE:
 				SetDParam(0, STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_UNKNOWN + _network_server_connection_type);

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -84,6 +84,7 @@ extern uint8 _network_join_waiting;
 extern uint32 _network_join_bytes;
 extern uint32 _network_join_bytes_total;
 extern ConnectionType _network_server_connection_type;
+extern std::string _network_server_invite_code;
 
 extern uint8 _network_reconnect;
 

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -122,6 +122,7 @@ StringID GetNetworkErrorMsg(NetworkErrorCode err);
 bool NetworkMakeClientNameUnique(std::string &new_name);
 std::string GenerateCompanyPasswordHash(const std::string &password, const std::string &password_server_id, uint32 password_game_seed);
 
+std::string_view ParseCompanyFromConnectionString(const std::string &connection_string, CompanyID *company_id);
 NetworkAddress ParseConnectionString(const std::string &connection_string, uint16 default_port);
 std::string NormalizeConnectionString(const std::string &connection_string, uint16 default_port);
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -266,6 +266,8 @@ struct NetworkSettings {
 	uint16      server_port;                              ///< port the server listens on
 	uint16      server_admin_port;                        ///< port the server listens on for the admin network
 	bool        server_admin_chat;                        ///< allow private chat for the server to be distributed to the admin network
+	std::string server_invite_code;                       ///< Invite code to use when registering as server.
+	std::string server_invite_code_secret;                ///< Secret to proof we got this invite code from the Game Coordinator.
 	std::string server_name;                              ///< name of the server
 	std::string server_password;                          ///< password for joining this server
 	std::string rcon_password;                            ///< password for rconsole (server side)

--- a/src/table/settings/network_secrets_settings.ini
+++ b/src/table/settings/network_secrets_settings.ini
@@ -74,3 +74,17 @@ type     = SLE_STR
 length   = NETWORK_SERVER_ID_LENGTH
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = nullptr
+
+[SDTC_SSTR]
+var      = network.server_invite_code
+type     = SLE_STR
+length   = NETWORK_INVITE_CODE_LENGTH
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
+def      = nullptr
+
+[SDTC_SSTR]
+var      = network.server_invite_code_secret
+type     = SLE_STR
+length   = NETWORK_INVITE_CODE_SECRET_LENGTH
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
+def      = nullptr

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -101,6 +101,7 @@ enum ClientListWidgets {
 	WID_CL_SERVER_NAME,                ///< Server name.
 	WID_CL_SERVER_NAME_EDIT,           ///< Edit button for server name.
 	WID_CL_SERVER_VISIBILITY,          ///< Server visibility.
+	WID_CL_SERVER_INVITE_CODE,         ///< Invite code for this server.
 	WID_CL_SERVER_CONNECTION_TYPE,     ///< The type of connection the Game Coordinator detected for this server.
 	WID_CL_CLIENT_NAME,                ///< Client name.
 	WID_CL_CLIENT_NAME_EDIT,           ///< Edit button for client name.


### PR DESCRIPTION
!!WARNING!!
This is currently only working with staging. See `Testing` how to test this PR!

## Motivation / Problem

Currently joining a server requires you to have either of these two:

- Know the hostname + port of the server.
- Find the server in the (huge) list of public servers.

This is often annoying if you want your friend to join the same server.

Additionally, this allows for several other future additions, that without a system like this would be impossible:
- "invite only" games: games that are open but not listed. Via an invite code you can join such games.
- STUN / TURN support, where you no longer need to port-forward in order to play.

## Description

There are now two type of connection-strings:
- server address. This connection-string is of the form `hostname:port`.
- invite code. This connection-string always starts with a `+`.

The `+` of the connection-string to indicate invite codes is part of the network protocol, and the Game Coordinator can either give a server address or an invite code per server. This is done for backwards compatibility, allowing you to still see servers from 1.11 and before. These are always server address based, ofc.

As using an invite code means you do not know the `hostname:port` of the server, several packets are needed to talk to the Game Coordinator to discover this information. The idea is very simple:

1) you tell the GC you want to connect to an indicate invite code
2) the GC tells you how to reach that server, currently the only supported thing is a "direct-ip", where it gives you the `hostname:port` of the server. (in the future, STUN and TURN will be added)
3) you connect to that address.
4) you tell the GC the outcome: could you connect or not.
5) the GC might offer an alternative way of connecting to the server.
6) if all methods are exhausted, the GC tells you there is no way for you to connect to the server.

## Testing

This is deployed on staging as of now, and you can test that by starting OpenTTD with:

`OTTD_COORDINATOR_CS="coordinator.openttd.org:4976" ./openttd`

It will NOT (!) work on production, so starting this PR unmodified will result in a non-functional multiplayer experience!

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
