### PR TITLE
Add: allow setting your server visibility to "invite-only"

### DIFF
--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -48,6 +48,10 @@ Last updated:    2011-02-16
     - click add server
     - type in the ip address or hostname
     - if you want to add a port use :<port>
+ - If you want to play and you have the invite code of the game server you
+   want connect to.
+    - click add server
+    - type in the invite code
  - Now you can select a company and press: "Join company", to help that company
     - Or you can press "Spectate game", to spectate the game
     - Or you can press "New company", and start your own company (if there are
@@ -110,9 +114,10 @@ Last updated:    2011-02-16
  - You can let your server automatically restart a map when, let's say, year 2030
    is reached. See 'set restart_game_date' for detail.
 
- - If you want to be on the server-list, enable Advertising. To do this, select
-   'Internet (advertise)' in the Start Server menu, or type in console:
-   'set server_advertise 1'.
+ - If you want to be on the server-list, make your server public. You can do
+   this either from the Start Server GUI, via the in-game Online Players GUI,
+   or by typing in the console:
+   'set server_game_type 1'.
 
  - You can protect your server with a password via the console: 'set server_pw',
    or via the Start Server menu.

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2420,7 +2420,6 @@ void IConsoleStdLibRegister()
 	IConsole::AliasRegister("name",                  "setting client_name %+");
 	IConsole::AliasRegister("server_name",           "setting server_name %+");
 	IConsole::AliasRegister("server_port",           "setting server_port %+");
-	IConsole::AliasRegister("server_advertise",      "setting server_advertise %+");
 	IConsole::AliasRegister("max_clients",           "setting max_clients %+");
 	IConsole::AliasRegister("max_companies",         "setting max_companies %+");
 	IConsole::AliasRegister("max_spectators",        "setting max_spectators %+");

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1995,8 +1995,11 @@ STR_FACE_TIE                                                    :Tie:
 STR_FACE_EARRING                                                :Earring:
 STR_FACE_TIE_EARRING_TOOLTIP                                    :{BLACK}Change tie or earring
 
+############ Next lines match ServerGameType
 STR_NETWORK_SERVER_VISIBILITY_LOCAL                             :Local
 STR_NETWORK_SERVER_VISIBILITY_PUBLIC                            :Public
+STR_NETWORK_SERVER_VISIBILITY_INVITE_ONLY                       :Invite only
+############ End of leave-in-this-order
 
 # Network server list
 STR_NETWORK_SERVER_LIST_CAPTION                                 :{WHITE}Multiplayer

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -934,7 +934,7 @@ bool NetworkServerStart()
 
 	NetworkInitGameInfo();
 
-	if (_settings_client.network.server_advertise) {
+	if (_settings_client.network.server_game_type != SERVER_GAME_TYPE_LOCAL) {
 		_network_coordinator_client.Register();
 	}
 
@@ -997,6 +997,29 @@ void NetworkDisconnect(bool blocking, bool close_admins)
 
 	/* Reinitialize the UDP stack, i.e. close all existing connections. */
 	NetworkUDPInitialize();
+}
+
+/**
+ * The setting server_game_type was updated; possibly we need to take some
+ * action.
+ */
+void NetworkUpdateServerGameType()
+{
+	if (!_networking) return;
+
+	switch (_settings_client.network.server_game_type) {
+		case SERVER_GAME_TYPE_LOCAL:
+			_network_coordinator_client.CloseConnection();
+			break;
+
+		case SERVER_GAME_TYPE_INVITE_ONLY:
+		case SERVER_GAME_TYPE_PUBLIC:
+			_network_coordinator_client.Register();
+			break;
+
+		default:
+			NOT_REACHED();
+	}
 }
 
 /**

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -39,6 +39,7 @@ bool NetworkValidateOurClientName();
 bool NetworkValidateClientName(std::string &client_name);
 bool NetworkValidateServerName(std::string &server_name);
 void NetworkUpdateClientName(const std::string &client_name);
+void NetworkUpdateServerGameType();
 bool NetworkCompanyHasClients(CompanyID company);
 std::string NetworkChangeCompanyPassword(CompanyID company_id, std::string password);
 void NetworkReboot();

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -61,22 +61,23 @@ static ClientID _admin_client_id = INVALID_CLIENT_ID; ///< For what client a con
 static CompanyID _admin_company_id = INVALID_COMPANY; ///< For what company a confirmation window is open.
 
 /**
- * Visibility of the server. Public servers advertise, where private servers
- * do not.
- */
-static const StringID _server_visibility_dropdown[] = {
-	STR_NETWORK_SERVER_VISIBILITY_LOCAL,
-	STR_NETWORK_SERVER_VISIBILITY_PUBLIC,
-	INVALID_STRING_ID
-};
-
-/**
  * Update the network new window because a new server is
  * found on the network.
  */
 void UpdateNetworkGameWindow()
 {
 	InvalidateWindowData(WC_NETWORK_WINDOW, WN_NETWORK_WINDOW_GAME, 0);
+}
+
+static DropDownList BuildVisibilityDropDownList()
+{
+	DropDownList list;
+
+	list.emplace_back(new DropDownListStringItem(STR_NETWORK_SERVER_VISIBILITY_LOCAL, SERVER_GAME_TYPE_LOCAL, false));
+	list.emplace_back(new DropDownListStringItem(STR_NETWORK_SERVER_VISIBILITY_INVITE_ONLY, SERVER_GAME_TYPE_INVITE_ONLY, false));
+	list.emplace_back(new DropDownListStringItem(STR_NETWORK_SERVER_VISIBILITY_PUBLIC, SERVER_GAME_TYPE_PUBLIC, false));
+
+	return list;
 }
 
 typedef GUIList<NetworkGameList*, StringFilter&> GUIGameServerList;
@@ -1015,7 +1016,7 @@ struct NetworkStartServerWindow : public Window {
 	{
 		switch (widget) {
 			case WID_NSS_CONNTYPE_BTN:
-				SetDParam(0, _server_visibility_dropdown[_settings_client.network.server_advertise]);
+				SetDParam(0, STR_NETWORK_SERVER_VISIBILITY_LOCAL + _settings_client.network.server_game_type);
 				break;
 
 			case WID_NSS_CLIENTS_TXT:
@@ -1036,7 +1037,7 @@ struct NetworkStartServerWindow : public Window {
 	{
 		switch (widget) {
 			case WID_NSS_CONNTYPE_BTN:
-				*size = maxdim(GetStringBoundingBox(_server_visibility_dropdown[0]), GetStringBoundingBox(_server_visibility_dropdown[1]));
+				*size = maxdim(maxdim(GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_LOCAL), GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_PUBLIC)), GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_INVITE_ONLY));
 				size->width += padding.width;
 				size->height += padding.height;
 				break;
@@ -1066,7 +1067,7 @@ struct NetworkStartServerWindow : public Window {
 				break;
 
 			case WID_NSS_CONNTYPE_BTN: // Connection type
-				ShowDropDownMenu(this, _server_visibility_dropdown, _settings_client.network.server_advertise, WID_NSS_CONNTYPE_BTN, 0, 0); // do it for widget WID_NSS_CONNTYPE_BTN
+				ShowDropDownList(this, BuildVisibilityDropDownList(), _settings_client.network.server_game_type, WID_NSS_CONNTYPE_BTN);
 				break;
 
 			case WID_NSS_CLIENTS_BTND:    case WID_NSS_CLIENTS_BTNU:    // Click on up/down button for number of clients
@@ -1144,7 +1145,7 @@ struct NetworkStartServerWindow : public Window {
 	{
 		switch (widget) {
 			case WID_NSS_CONNTYPE_BTN:
-				_settings_client.network.server_advertise = (index != 0);
+				_settings_client.network.server_game_type = (ServerGameType)index;
 				break;
 			default:
 				NOT_REACHED();
@@ -2041,7 +2042,7 @@ public:
 	{
 		switch (widget) {
 			case WID_CL_SERVER_VISIBILITY:
-				*size = maxdim(GetStringBoundingBox(_server_visibility_dropdown[0]), GetStringBoundingBox(_server_visibility_dropdown[1]));
+				*size = maxdim(maxdim(GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_LOCAL), GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_PUBLIC)), GetStringBoundingBox(STR_NETWORK_SERVER_VISIBILITY_INVITE_ONLY));
 				size->width += padding.width;
 				size->height += padding.height;
 				break;
@@ -2073,7 +2074,7 @@ public:
 				break;
 
 			case WID_CL_SERVER_VISIBILITY:
-				SetDParam(0, _server_visibility_dropdown[_settings_client.network.server_advertise]);
+				SetDParam(0, STR_NETWORK_SERVER_VISIBILITY_LOCAL + _settings_client.network.server_game_type);
 				break;
 
 			case WID_CL_SERVER_INVITE_CODE: {
@@ -2117,7 +2118,7 @@ public:
 			case WID_CL_SERVER_VISIBILITY:
 				if (!_network_server) break;
 
-				ShowDropDownMenu(this, _server_visibility_dropdown, _settings_client.network.server_advertise, WID_CL_SERVER_VISIBILITY, 0, 0);
+				ShowDropDownList(this, BuildVisibilityDropDownList(), _settings_client.network.server_game_type, WID_CL_SERVER_VISIBILITY);
 				break;
 
 			case WID_CL_MATRIX: {
@@ -2183,7 +2184,8 @@ public:
 			case WID_CL_SERVER_VISIBILITY:
 				if (!_network_server) break;
 
-				_settings_client.network.server_advertise = (index != 0);
+				_settings_client.network.server_game_type = (ServerGameType)index;
+				NetworkUpdateServerGameType();
 				break;
 
 			case WID_CL_MATRIX: {

--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -42,6 +42,7 @@ enum NetworkVehicleType {
 enum ServerGameType : uint8 {
 	SERVER_GAME_TYPE_LOCAL = 0,
 	SERVER_GAME_TYPE_PUBLIC,
+	SERVER_GAME_TYPE_INVITE_ONLY,
 };
 
 /** 'Unique' identifier to be given to clients */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -15,6 +15,7 @@
 #include "town_type.h"
 #include "transport_type.h"
 #include "network/core/config.h"
+#include "network/network_type.h"
 #include "company_type.h"
 #include "cargotype.h"
 #include "linkgraph/linkgraph_type.h"
@@ -266,6 +267,7 @@ struct NetworkSettings {
 	uint16      server_port;                              ///< port the server listens on
 	uint16      server_admin_port;                        ///< port the server listens on for the admin network
 	bool        server_admin_chat;                        ///< allow private chat for the server to be distributed to the admin network
+	ServerGameType server_game_type;                      ///< Server type: local / public / invite-only.
 	std::string server_invite_code;                       ///< Invite code to use when registering as server.
 	std::string server_invite_code_secret;                ///< Secret to proof we got this invite code from the Game Coordinator.
 	std::string server_name;                              ///< name of the server

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -9,14 +9,18 @@
 [pre-amble]
 static void UpdateClientConfigValues();
 
+static std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
+
 static const SettingVariant _network_settings_table[] = {
 [post-amble]
 };
 [templates]
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
+SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 SDTC_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 
 [defaults]
@@ -159,10 +163,16 @@ flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = true
 cat      = SC_EXPERT
 
-[SDTC_BOOL]
-var      = network.server_advertise
+[SDTC_OMANY]
+var      = network.server_game_type
+type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
-def      = false
+def      = SERVER_GAME_TYPE_LOCAL
+min      = SERVER_GAME_TYPE_LOCAL
+max      = SERVER_GAME_TYPE_INVITE_ONLY
+full     = _server_game_type
+post_cb  = [](auto) { NetworkUpdateServerGameType(); }
+cat      = SC_BASIC
 
 [SDTC_BOOL]
 var      = network.autoclean_companies


### PR DESCRIPTION
## Motivation / Problem

As you can join based on invite codes now, it allows for servers to be registered but not public. In other words: invite-only. If you know the invite code you can join, but otherwise it won't be visible in the server-listing.

This might not seem all that useful now, as you could as well give someone your IP+port. But invite-codes are shorter, and where IPs can change, invite-codes do not.

And of course, if STUN lands, it becomes even more clear why this is useful :)


## Description

```
In this mode you do register to the Game Coordinator, but your
server will not show up in the public server listing. You can give
your friends the invite code of the server with which they can
join.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
