### PR TITLE
Fix #9433: Use world generation seed from openttd.cfg if provided

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -93,7 +93,9 @@ static void _GenerateWorld()
 		_generating_world = true;
 		if (_network_dedicated) Debug(net, 3, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
-		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
+		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) {
+			_settings_game.game_creation.generation_seed = InteractiveRandom();
+		}
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
 		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -976,9 +976,6 @@ static void _ShowGenerateLandscape(GenerateLandscapeWindowMode mode)
 
 	CloseWindowByClass(WC_GENERATE_LANDSCAPE);
 
-	/* Generate a new seed when opening the window */
-	_settings_newgame.game_creation.generation_seed = InteractiveRandom();
-
 	if (mode == GLWM_HEIGHTMAP) {
 		/* If the function returns negative, it means there was a problem loading the heightmap */
 		if (!GetHeightmapDimensions(_file_to_saveload.detail_ftype, _file_to_saveload.name.c_str(), &x, &y)) return;


### PR DESCRIPTION
## Motivation / Problem
Fix #9433 

## Description

Code which overwrites user settings removed

## Limitations

none that I'm aware of

## Checklist for review

looks fine to me