### PR TITLE
Remove: includes to network/core/config.h from headers when only three cpp files need it

### DIFF
--- a/src/network/network_type.h
+++ b/src/network/network_type.h
@@ -10,8 +10,6 @@
 #ifndef NETWORK_TYPE_H
 #define NETWORK_TYPE_H
 
-#include "core/config.h"
-
 /** How many clients can we have */
 static const uint MAX_CLIENTS = 255;
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -38,7 +38,7 @@
 #include "strings_func.h"
 #include "date_func.h"
 #include "string_func.h"
-#include "network/network.h"
+#include "network/core/config.h"
 #include <map>
 #include "smallmap_gui.h"
 #include "genworld.h"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -28,6 +28,7 @@
 #include "currency.h"
 #include "network/network.h"
 #include "network/network_func.h"
+#include "network/core/config.h"
 #include "command_func.h"
 #include "console_func.h"
 #include "genworld.h"

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -15,6 +15,7 @@
 #include "screenshot.h"
 #include "network/network.h"
 #include "network/network_func.h"
+#include "network/core/config.h"
 #include "pathfinder/pathfinder_type.h"
 #include "genworld.h"
 #include "train.h"

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -14,7 +14,6 @@
 #include "economy_type.h"
 #include "town_type.h"
 #include "transport_type.h"
-#include "network/core/config.h"
 #include "network/network_type.h"
 #include "company_type.h"
 #include "cargotype.h"


### PR DESCRIPTION
## Motivation / Problem

Changing something in network/core/config.h took ages to recompile as many .cpp files included it indirectly via settings_type.h or network_type.h even when those .h files did not need it.


## Description

Remove network/core/config.h includes from two .h files and add it two three .cpp files that actually need it.

Now changing config.h requires 50 files to be recompiled, compared to 298 before this change.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
