### PR TITLE
Fix: "Search LAN games" used the socket after it was closed

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -615,7 +615,6 @@ void NetworkClose(bool close_admins)
 static void NetworkInitialize(bool close_admins = true)
 {
 	InitializeNetworkPools(close_admins);
-	NetworkUDPInitialize();
 
 	_sync_frame = 0;
 	_network_first_time = true;
@@ -907,6 +906,7 @@ bool NetworkServerStart()
 
 	NetworkDisconnect(false, false);
 	NetworkInitialize(false);
+	NetworkUDPInitialize();
 	Debug(net, 5, "Starting listeners for clients");
 	if (!ServerNetworkGameSocketHandler::Listen(_settings_client.network.server_port)) return false;
 
@@ -1292,6 +1292,7 @@ void NetworkStartUp()
 	_network_game_info = {};
 
 	NetworkInitialize();
+	NetworkUDPInitialize();
 	Debug(net, 3, "Network online, multiplayer available");
 	NetworkFindBroadcastIPs(&_broadcast_list);
 }


### PR DESCRIPTION
## Motivation / Problem

GCC sanitizer complained when I pressed "Search LAN games". I don't like it when it does that!


## Description

```
Every outgoing connection, either TCP or UDP, triggered
NetworkInitialize(), which triggered NetworkUDPInitialize() which
first closes all connections.

Now the problem was that "Search LAN games" found a server, added
it to the list, after which (over TCP) it quries the server. This
closes all UDP sockets (as that makes sense, I guess?), while the
UDP was still reading from it.

Solve this by simply stop initializing UDP every time we make an
outgoing TCP connection; instead only do it on start-up.
```

In general, this code is just weird .. seems overly pedantic what it is doing .. but I didn't want to go down the rabbit hole too much, so I just patched what I saw on the surface :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
