### PR TITLE
Feature: parse the console settings the same way as config settings

### DIFF
--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -117,7 +117,7 @@ Last updated:    2011-02-16
  - If you want to be on the server-list, make your server public. You can do
    this either from the Start Server GUI, via the in-game Online Players GUI,
    or by typing in the console:
-   'set server_game_type 1'.
+   'set server_game_type public'.
 
  - You can protect your server with a password via the console: 'set server_pw',
    or via the Start Server menu.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1635,15 +1635,14 @@ void IConsoleSetSetting(const char *name, const char *value, bool force_newgame)
 	if (sd->IsStringSetting()) {
 		success = SetSettingValue(sd->AsStringSetting(), value, force_newgame);
 	} else if (sd->IsIntSetting()) {
-		uint32 val;
-		extern bool GetArgumentInteger(uint32 *value, const char *arg);
-		success = GetArgumentInteger(&val, value);
-		if (!success) {
-			IConsolePrint(CC_ERROR, "'{}' is not an integer.", value);
+		const IntSettingDesc *isd = sd->AsIntSetting();
+		size_t val = isd->ParseValue(value);
+		if (!_settings_error_list.empty()) {
+			IConsolePrint(CC_ERROR, "'{}' is not a valid value for this setting.", value);
+			_settings_error_list.clear();
 			return;
 		}
-
-		success = SetSettingValue(sd->AsIntSetting(), val, force_newgame);
+		success = SetSettingValue(isd, (int32)val, force_newgame);
 	}
 
 	if (!success) {


### PR DESCRIPTION
## Motivation / Problem

`set server_game_type` in the in-game console shows the string representation (like local and public).
The configuration file uses local and public for the value of server_game_type.
But `set server_game_type public` cannot be done as public is not an integer.


## Description

Use the parse logic from the settings instead of the integer parsing from the console to parse the setting. This way it gets unified.


## Limitations

Technically there is a more useful error message that the parse function puts onto the error list. However, extracting that requires a lot of extra effort and adds a single translated string to the console output, whereas all other errors are not translated. So, I rather leave it with this simple error message.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
