### PR TITLE
Add: inform clients what game-script a server is running

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2033,6 +2033,7 @@ STR_NETWORK_SERVER_LIST_SERVER_VERSION                          :{SILVER}Server 
 STR_NETWORK_SERVER_LIST_SERVER_ADDRESS                          :{SILVER}Server address: {WHITE}{RAW_STRING}
 STR_NETWORK_SERVER_LIST_START_DATE                              :{SILVER}Start date: {WHITE}{DATE_SHORT}
 STR_NETWORK_SERVER_LIST_CURRENT_DATE                            :{SILVER}Current date: {WHITE}{DATE_SHORT}
+STR_NETWORK_SERVER_LIST_GAMESCRIPT                              :{SILVER}Game Script: {WHITE}{RAW_STRING} (v{NUM})
 STR_NETWORK_SERVER_LIST_PASSWORD                                :{SILVER}Password protected!
 STR_NETWORK_SERVER_LIST_SERVER_OFFLINE                          :{SILVER}SERVER OFFLINE
 STR_NETWORK_SERVER_LIST_SERVER_FULL                             :{SILVER}SERVER FULL

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -45,7 +45,7 @@ static const uint16 TCP_MTU                         = 32767;          ///< Numbe
 static const uint16 COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
-static const byte NETWORK_GAME_INFO_VERSION         =    4;           ///< What version of game-info do we use?
+static const byte NETWORK_GAME_INFO_VERSION         =    5;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
 static const byte NETWORK_COORDINATOR_VERSION       =    2;           ///< What version of game-coordinator-protocol do we use?
 

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -76,6 +76,8 @@ struct NetworkServerGameInfo {
 	byte spectators_on;          ///< How many spectators do we have?
 	byte spectators_max;         ///< Max spectators allowed on server
 	byte landscape;              ///< The used landscape
+	int gamescript_version;      ///< Version of the gamescript.
+	std::string gamescript_name; ///< Name of the gamescript.
 };
 
 /**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -675,6 +675,13 @@ public:
 			DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_CURRENT_DATE); // current date
 			y += FONT_HEIGHT_NORMAL;
 
+			if (sel->info.gamescript_version != -1) {
+				SetDParamStr(0, sel->info.gamescript_name);
+				SetDParam(1, sel->info.gamescript_version);
+				DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_NETWORK_SERVER_LIST_GAMESCRIPT); // gamescript name and version
+				y += FONT_HEIGHT_NORMAL;
+			}
+
 			y += WD_PAR_VSEP_NORMAL;
 
 			if (!sel->info.compatible) {


### PR DESCRIPTION
Note: this is only deployed on staging; please use `OTTD_COORDINATOR_CS="coordinator.openttd.org:4976"` for testing. After approval and before merging this will be deployed to production.

## Motivation / Problem

#9234 introduces the ability to send/receive game-script info in the server listing. This sounds like a very useful addition.

Closes #9234.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR takes #9234, and makes it compatible with master. I also approaches some things slightly different from a coding perspective.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
