### PR TITLE
Change: [Win32] Set the console codepage to UTF-8

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -128,13 +128,7 @@ void DebugPrint(const char *level, const std::string &message)
 #endif
 	} else {
 		std::string msg = fmt::format("{}dbg: [{}] {}\n", GetLogPrefix(), level, message);
-#if defined(_WIN32)
-		wchar_t system_buf[512];
-		convert_to_fs(msg.c_str(), system_buf, lengthof(system_buf));
-		fputws(system_buf, stderr);
-#else
 		fputs(msg.c_str(), stderr);
-#endif
 
 		NetworkAdminConsole(level, message);
 		if (_settings_client.gui.developer >= 2) IConsolePrint(CC_DEBUG, "dbg: [{}] {}", level, message);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -626,6 +626,7 @@ int openttd_main(int argc, char *argv[])
 			if (res != SL_OK || _load_check_data.HasErrors()) {
 				fprintf(stderr, "Failed to open savegame\n");
 				if (_load_check_data.HasErrors()) {
+					InitializeLanguagePacks(); // A language pack is needed for GetString()
 					char buf[256];
 					SetDParamStr(0, _load_check_data.error_data);
 					GetString(buf, _load_check_data.error, lastof(buf));

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -393,6 +393,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	 * be available between subsequent calls to FS2OTTD(). */
 	char *cmdline = stredup(FS2OTTD(GetCommandLine()).c_str());
 
+	/* Set the console codepage to UTF-8. */
+	SetConsoleOutputCP(CP_UTF8);
+
 #if defined(_DEBUG)
 	CreateConsole();
 #endif


### PR DESCRIPTION
## Motivation / Problem
When doing tests for #9443, I noticed weird output in the console.

After some digging and testing, it appears we convert internal UTF-8 strings to UTF-16 before outputting them. And it seems the output just stops on the first "invalid" char for the console codepage (I tried many codepage and was never able to print a string from greek translation).

While testing stuff, I also notice a nice crash with `-q` switch.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Setting the console codepage to UTF-8 allows us to directly print the string without any conversion. Even if chars are not displayable by the console font, the string itself will be fully printed.

I also fixed the `-q` issue.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
