### PR TITLE
Fix 75b6051b: removing items from the ini could leave the group in a bad state

### DIFF
--- a/src/ini_load.cpp
+++ b/src/ini_load.cpp
@@ -112,8 +112,9 @@ void IniGroup::RemoveItem(const std::string &name)
 		if (item->name != name) continue;
 
 		*prev = item->next;
-		if (this->last_item == &this->item) {
-			this->last_item = &item->next;
+		/* "last_item" is a pointer to the "real-last-item"->next. */
+		if (this->last_item == &item->next) {
+			this->last_item = prev;
 		}
 
 		item->next = nullptr;


### PR DESCRIPTION
## Motivation / Problem

@LordAro had an ini-file that crashed the game upon save. Investigation showed I fucked up `IniGroup::RemoveItem` ;)


## Description

There are a few things going on here, but mostly `last_item` is a shitty name for a pointer to the `->next` of the real last item. I drew some wrong conclusions because of that, resulting in a broken implementation.

Now when the last item of a group is removed, `last_item` points to the `next` of the previous value, keeping the group in a valid state.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
