### PR TITLE
Feature: allow the use of TURN to connect client and server together

### DIFF
--- a/docs/game_coordinator.md
+++ b/docs/game_coordinator.md
@@ -62,3 +62,22 @@ server can continue to talk to each other.
 Some NAT gateways do not allow this method; for those this attempt will fail,
 and this also means that it is not possible to create a connection between
 the client and server.
+
+## 3) Via TURN
+
+As a last resort, the Game Coordinator can decide to connect the client and
+server together via TURN. TURN is a relay service, relaying the messages
+between client and server.
+
+As the client and server can already connect to the Game Coordinator, it is
+very likely this is successful.
+
+It is important to note that a relay service has full view of the traffic
+send between client and server, and as such it is important that you trust
+the relay service used.
+For official binaries, this relay service is hosted by openttd.org. The relay
+service as hosted by openttd.org only validates it is relaying valid OpenTTD
+packets and does no further inspection of the payload itself.
+Although in our experience most patch-packs also use the services as offered
+by openttd.org, it is possible they use different services. Please be mindful
+about this.

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1439,6 +1439,12 @@ STR_CONFIG_SETTING_OSK_ACTIVATION_DOUBLE_CLICK                  :Double click
 STR_CONFIG_SETTING_OSK_ACTIVATION_SINGLE_CLICK_FOCUS            :Single click (when focussed)
 STR_CONFIG_SETTING_OSK_ACTIVATION_SINGLE_CLICK                  :Single click (immediately)
 
+STR_CONFIG_SETTING_USE_RELAY_SERVICE                            :Use relay service: {STRING2}
+STR_CONFIG_SETTING_USE_RELAY_SERVICE_HELPTEXT                   :If creating a connection to the server fails, one can use a relay service to create a connection. "Never" disallows this, "ask" will ask first, "allow" will allow it without asking
+STR_CONFIG_SETTING_USE_RELAY_SERVICE_NEVER                      :Never
+STR_CONFIG_SETTING_USE_RELAY_SERVICE_ASK                        :Ask
+STR_CONFIG_SETTING_USE_RELAY_SERVICE_ALLOW                      :Allow
+
 STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU                          :Right-click emulation: {STRING2}
 STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_HELPTEXT                 :Select the method to emulate right mouse-button clicks
 STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_COMMAND                  :Command+Click
@@ -1791,6 +1797,7 @@ STR_CONFIG_SETTING_ENVIRONMENT_INDUSTRIES                       :{ORANGE}Industr
 STR_CONFIG_SETTING_ENVIRONMENT_CARGODIST                        :{ORANGE}Cargo distribution
 STR_CONFIG_SETTING_AI                                           :{ORANGE}Competitors
 STR_CONFIG_SETTING_AI_NPC                                       :{ORANGE}Computer players
+STR_CONFIG_SETTING_NETWORK                                      :{ORANGE}Network
 
 STR_CONFIG_SETTING_PATHFINDER_NPF                               :NPF
 STR_CONFIG_SETTING_PATHFINDER_YAPF_RECOMMENDED                  :YAPF {BLUE}(Recommended)
@@ -2167,6 +2174,7 @@ STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_UNKNOWN          :{BLACK}Local
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_ISOLATED         :{RED}Remote players can't connect
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_DIRECT           :{BLACK}Public
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_STUN             :{BLACK}Behind NAT
+STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TURN             :{BLACK}Via relay
 ############ End of ConnectionType
 
 STR_NETWORK_CLIENT_LIST_ADMIN_CLIENT_KICK                       :Kick
@@ -2179,6 +2187,12 @@ STR_NETWORK_CLIENT_LIST_ASK_CLIENT_KICK                         :{YELLOW}Are you
 STR_NETWORK_CLIENT_LIST_ASK_CLIENT_BAN                          :{YELLOW}Are you sure you want to ban player '{RAW_STRING}'?
 STR_NETWORK_CLIENT_LIST_ASK_COMPANY_RESET                       :{YELLOW}Are you sure you want to delete company '{COMPANY}'?
 STR_NETWORK_CLIENT_LIST_ASK_COMPANY_UNLOCK                      :{YELLOW}Are you sure you want to reset the password of company '{COMPANY}'?
+
+STR_NETWORK_ASK_RELAY_CAPTION                                   :{WHITE}Use relay?
+STR_NETWORK_ASK_RELAY_TEXT                                      :{YELLOW}Failed to establish a connection between you and the server.{}Would you like to relay this session via '{RAW_STRING}'?
+STR_NETWORK_ASK_RELAY_NO                                        :{BLACK}No
+STR_NETWORK_ASK_RELAY_YES_ONCE                                  :{BLACK}Yes, this once
+STR_NETWORK_ASK_RELAY_YES_ALWAYS                                :{BLACK}Yes, don't ask again
 
 STR_NETWORK_SERVER                                              :Server
 STR_NETWORK_CLIENT                                              :Client

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -26,6 +26,8 @@ add_files(
     network_server.h
     network_stun.cpp
     network_stun.h
+    network_turn.cpp
+    network_turn.h
     network_type.h
     network_udp.cpp
     network_udp.h

--- a/src/network/core/CMakeLists.txt
+++ b/src/network/core/CMakeLists.txt
@@ -30,6 +30,8 @@ add_files(
     tcp_listen.h
     tcp_stun.cpp
     tcp_stun.h
+    tcp_turn.cpp
+    tcp_turn.h
     udp.cpp
     udp.h
 )

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -22,6 +22,7 @@ static const char * const NETWORK_CONTENT_MIRROR_URL            = "/bananas";
 
 static const uint16 NETWORK_COORDINATOR_SERVER_PORT = 3976;           ///< The default port of the Game Coordinator server (TCP)
 static const uint16 NETWORK_STUN_SERVER_PORT        = 3975;           ///< The default port of the STUN server (TCP)
+static const uint16 NETWORK_TURN_SERVER_PORT        = 3974;           ///< The default port of the TURN server (TCP)
 static const uint16 NETWORK_CONTENT_SERVER_PORT     = 3978;           ///< The default port of the content server (TCP)
 static const uint16 NETWORK_CONTENT_MIRROR_PORT     =   80;           ///< The default port of the content mirror (TCP)
 static const uint16 NETWORK_DEFAULT_PORT            = 3979;           ///< The default port of the game server (TCP & UDP)
@@ -49,7 +50,7 @@ static const uint16 COMPAT_MTU                      = 1460;           ///< Numbe
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
-static const byte NETWORK_COORDINATOR_VERSION       =    4;           ///< What version of game-coordinator-protocol do we use?
+static const byte NETWORK_COORDINATOR_VERSION       =    5;           ///< What version of game-coordinator-protocol do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -43,6 +43,7 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet *p)
 		case PACKET_COORDINATOR_SERCLI_STUN_RESULT:    return this->Receive_SERCLI_STUN_RESULT(p);
 		case PACKET_COORDINATOR_GC_STUN_CONNECT:       return this->Receive_GC_STUN_CONNECT(p);
 		case PACKET_COORDINATOR_GC_NEWGRF_LOOKUP:      return this->Receive_GC_NEWGRF_LOOKUP(p);
+		case PACKET_COORDINATOR_GC_TURN_CONNECT:       return this->Receive_GC_TURN_CONNECT(p);
 
 		default:
 			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
@@ -102,3 +103,4 @@ bool NetworkCoordinatorSocketHandler::Receive_GC_STUN_REQUEST(Packet *p) { retur
 bool NetworkCoordinatorSocketHandler::Receive_SERCLI_STUN_RESULT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERCLI_STUN_RESULT); }
 bool NetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_STUN_CONNECT); }
 bool NetworkCoordinatorSocketHandler::Receive_GC_NEWGRF_LOOKUP(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_NEWGRF_LOOKUP); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_TURN_CONNECT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_TURN_CONNECT); }

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -42,6 +42,7 @@ enum PacketCoordinatorType {
 	PACKET_COORDINATOR_SERCLI_STUN_RESULT,    ///< Client/server informs the Game Coordinator of the result of the STUN request.
 	PACKET_COORDINATOR_GC_STUN_CONNECT,       ///< Game Coordinator tells client/server to connect() reusing the STUN local address.
 	PACKET_COORDINATOR_GC_NEWGRF_LOOKUP,      ///< Game Coordinator informs client about NewGRF lookup table updates needed for GC_LISTING.
+	PACKET_COORDINATOR_GC_TURN_CONNECT,       ///< Game Coordinator tells client/server to connect to a specific TURN server.
 	PACKET_COORDINATOR_END,                   ///< Must ALWAYS be on the end of this list!! (period)
 };
 
@@ -53,6 +54,7 @@ enum ConnectionType {
 	CONNECTION_TYPE_ISOLATED, ///< The Game Coordinator failed to find a way to connect to your server. Nobody will be able to join.
 	CONNECTION_TYPE_DIRECT,   ///< The Game Coordinator can directly connect to your server.
 	CONNECTION_TYPE_STUN,     ///< The Game Coordinator can connect to your server via a STUN request.
+	CONNECTION_TYPE_TURN,     ///< The Game Coordinator needs you to connect to a relay.
 };
 
 /**
@@ -287,6 +289,20 @@ protected:
 	 * @return True upon success, otherwise false.
 	 */
 	virtual bool Receive_GC_NEWGRF_LOOKUP(Packet *p);
+
+	/**
+	 * Game Coordinator requests that we make a connection to the indicated
+	 * peer, which is a TURN server.
+	 *
+	 *  string  Token to track the current connect request.
+	 *  uint8   Tracking number to track current connect request.
+	 *  string  Ticket to hand over to the TURN server.
+	 *  string  Connection string of the TURN server.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_GC_TURN_CONNECT(Packet *p);
 
 	bool HandlePacket(Packet *p);
 public:

--- a/src/network/core/tcp_turn.cpp
+++ b/src/network/core/tcp_turn.cpp
@@ -1,0 +1,71 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file tcp_turn.cpp Basic functions to receive and send TURN packets.
+ */
+
+#include "../../stdafx.h"
+#include "../../date_func.h"
+#include "../../debug.h"
+#include "tcp_turn.h"
+
+#include "../../safeguards.h"
+
+/**
+ * Handle the given packet, i.e. pass it to the right
+ * parser receive command.
+ * @param p the packet to handle
+ * @return true if we should immediately handle further packets, false otherwise
+ */
+bool NetworkTurnSocketHandler::HandlePacket(Packet *p)
+{
+	PacketTurnType type = (PacketTurnType)p->Recv_uint8();
+
+	switch (type) {
+		case PACKET_TURN_TURN_ERROR:     return this->Receive_TURN_ERROR(p);
+		case PACKET_TURN_SERCLI_CONNECT: return this->Receive_SERCLI_CONNECT(p);
+		case PACKET_TURN_TURN_CONNECTED: return this->Receive_TURN_CONNECTED(p);
+
+		default:
+			Debug(net, 0, "[tcp/turn] Received invalid packet type {}", type);
+			return false;
+	}
+}
+
+/**
+ * Receive a packet at TCP level
+ * @return Whether at least one packet was received.
+ */
+bool NetworkTurnSocketHandler::ReceivePackets()
+{
+	Packet *p;
+	static const int MAX_PACKETS_TO_RECEIVE = 4;
+	int i = MAX_PACKETS_TO_RECEIVE;
+	while (--i != 0 && (p = this->ReceivePacket()) != nullptr) {
+		bool cont = this->HandlePacket(p);
+		delete p;
+		if (!cont) return true;
+	}
+
+	return i != MAX_PACKETS_TO_RECEIVE - 1;
+}
+
+/**
+ * Helper for logging receiving invalid packets.
+ * @param type The received packet type.
+ * @return Always false, as it's an error.
+ */
+bool NetworkTurnSocketHandler::ReceiveInvalidPacket(PacketTurnType type)
+{
+	Debug(net, 0, "[tcp/turn] Received illegal packet type {}", type);
+	return false;
+}
+
+bool NetworkTurnSocketHandler::Receive_TURN_ERROR(Packet *p) { return this->ReceiveInvalidPacket(PACKET_TURN_TURN_ERROR); }
+bool NetworkTurnSocketHandler::Receive_SERCLI_CONNECT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_TURN_SERCLI_CONNECT); }
+bool NetworkTurnSocketHandler::Receive_TURN_CONNECTED(Packet *p) { return this->ReceiveInvalidPacket(PACKET_TURN_TURN_CONNECTED); }

--- a/src/network/core/tcp_turn.h
+++ b/src/network/core/tcp_turn.h
@@ -1,0 +1,79 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file tcp_turn.h Basic functions to receive and send TCP packets to/from the TURN server.
+ */
+
+#ifndef NETWORK_CORE_TCP_TURN_H
+#define NETWORK_CORE_TCP_TURN_H
+
+#include "os_abstraction.h"
+#include "tcp.h"
+#include "packet.h"
+#include "game_info.h"
+
+/** Enum with all types of TCP TURN packets. The order MUST not be changed. **/
+enum PacketTurnType {
+	PACKET_TURN_TURN_ERROR,     ///< TURN server is unable to relay.
+	PACKET_TURN_SERCLI_CONNECT, ///< Client or server is connecting to the TURN server.
+	PACKET_TURN_TURN_CONNECTED, ///< TURN server indicates the socket is now being relayed.
+	PACKET_TURN_END,            ///< Must ALWAYS be on the end of this list!! (period)
+};
+
+/** Base socket handler for all TURN TCP sockets. */
+class NetworkTurnSocketHandler : public NetworkTCPSocketHandler {
+protected:
+	bool ReceiveInvalidPacket(PacketTurnType type);
+
+	/**
+	 * TURN server was unable to connect the client or server based on the
+	 * token. Most likely cause is an invalid token or the other side that
+	 * hasn't connected in a reasonable amount of time.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_TURN_ERROR(Packet *p);
+
+	/**
+	 * Client or servers wants to connect to the TURN server (on request by
+	 * the Game Coordinator).
+	 *
+	 *  uint8   Game Coordinator protocol version.
+	 *  string  Token to track the current TURN request.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_SERCLI_CONNECT(Packet *p);
+
+	/**
+	 * TURN server has connected client and server together and will now relay
+	 * all packets to each other. No further TURN packets should be send over
+	 * this socket, and the socket should be handed over to the game protocol.
+	 *
+	 *  string  Hostname of the peer. This can be used to check if a client is not banned etc.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_TURN_CONNECTED(Packet *p);
+
+	bool HandlePacket(Packet *p);
+public:
+	/**
+	 * Create a new cs socket handler for a given cs.
+	 * @param s  the socket we are connected with.
+	 * @param address IP etc. of the client.
+	 */
+	NetworkTurnSocketHandler(SOCKET s = INVALID_SOCKET) : NetworkTCPSocketHandler(s) {}
+
+	bool ReceivePackets();
+};
+
+#endif /* NETWORK_CORE_TCP_TURN_H */

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -595,7 +595,7 @@ void NetworkClose(bool close_admins)
 			MyClient::my_client->CloseConnection(NETWORK_RECV_STATUS_CLIENT_QUIT);
 		}
 
-		_network_coordinator_client.CloseAllTokens();
+		_network_coordinator_client.CloseAllConnections();
 	}
 
 	TCPConnecter::KillAll();

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -86,7 +86,7 @@ public:
 
 	void Connect();
 	void CloseToken(const std::string &token);
-	void CloseAllTokens();
+	void CloseAllConnections();
 	void CloseStunHandler(const std::string &token, uint8 family = AF_UNSPEC);
 
 	void Register();

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -39,5 +39,6 @@ struct NetworkCompanyInfo : NetworkCompanyStats {
 
 NetworkCompanyInfo *GetLobbyCompanyInfo(CompanyID company);
 NetworkGameList *GetLobbyGameInfo();
+void ShowNetworkAskRelay(const std::string &connection_string, const std::string &token);
 
 #endif /* NETWORK_GUI_H */

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -1,0 +1,135 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_turn.cpp TURN sending/receiving part of the network protocol. */
+
+#include "../stdafx.h"
+#include "../debug.h"
+#include "../error.h"
+#include "../strings_func.h"
+#include "network_coordinator.h"
+#include "network_turn.h"
+
+#include "table/strings.h"
+
+#include "../safeguards.h"
+
+/** Connect to the TURN server. */
+class NetworkTurnConnecter : public TCPConnecter {
+private:
+	ClientNetworkTurnSocketHandler *handler;
+
+public:
+	/**
+	 * Initiate the connecting.
+	 * @param connection_string The address of the TURN server.
+	 */
+	NetworkTurnConnecter(ClientNetworkTurnSocketHandler *handler, const std::string &connection_string) : TCPConnecter(connection_string, NETWORK_TURN_SERVER_PORT), handler(handler) {}
+
+	void OnFailure() override
+	{
+		this->handler->connecter = nullptr;
+
+		this->handler->ConnectFailure();
+	}
+
+	void OnConnect(SOCKET s) override
+	{
+		this->handler->connecter = nullptr;
+
+		handler->sock = s;
+	}
+};
+
+bool ClientNetworkTurnSocketHandler::Receive_TURN_ERROR(Packet *p)
+{
+	this->ConnectFailure();
+
+	return false;
+}
+
+bool ClientNetworkTurnSocketHandler::Receive_TURN_CONNECTED(Packet *p)
+{
+	std::string hostname = p->Recv_string(NETWORK_HOSTNAME_LENGTH);
+
+	/* Act like we no longer have a socket, as we are handing it over to the
+	 * game handler. */
+	SOCKET game_sock = this->sock;
+	this->sock = INVALID_SOCKET;
+
+	NetworkAddress address = NetworkAddress(hostname, NETWORK_DEFAULT_PORT);
+	_network_coordinator_client.ConnectSuccess(this->token, game_sock, address);
+
+	return false;
+}
+
+/**
+ * Connect to the TURN server.
+ */
+void ClientNetworkTurnSocketHandler::Connect()
+{
+	this->connect_started = true;
+	this->connecter = new NetworkTurnConnecter(this, this->connection_string);
+}
+
+/**
+ * Prepare a TURN connection.
+ * Not until you run Connect() on the resulting instance will it start setting
+ * up the TURN connection.
+ * @param token The token as received from the Game Coordinator.
+ * @param tracking_number The tracking number as recieved from the Game Coordinator.
+ * @param ticket The ticket as received from the Game Coordinator.
+ * @param connection_string Connection string of the TURN server.
+ * @return The handler for this TURN connection.
+ */
+/* static */ std::unique_ptr<ClientNetworkTurnSocketHandler> ClientNetworkTurnSocketHandler::Turn(const std::string &token, uint8 tracking_number, const std::string &ticket, const std::string &connection_string)
+{
+	auto turn_handler = std::make_unique<ClientNetworkTurnSocketHandler>(token, tracking_number, connection_string);
+
+	Packet *p = new Packet(PACKET_TURN_SERCLI_CONNECT);
+	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
+	p->Send_string(ticket);
+
+	turn_handler->SendPacket(p);
+
+	return turn_handler;
+}
+
+void ClientNetworkTurnSocketHandler::ConnectFailure()
+{
+	_network_coordinator_client.ConnectFailure(this->token, this->tracking_number);
+}
+
+NetworkRecvStatus ClientNetworkTurnSocketHandler::CloseConnection(bool error)
+{
+	NetworkTurnSocketHandler::CloseConnection(error);
+
+	/* If our connecter is still pending, shut it down too. Otherwise the
+	 * callback of the connecter can call into us, and our object is most
+	 * likely about to be destroyed. */
+	if (this->connecter != nullptr) {
+		this->connecter->Kill();
+		this->connecter = nullptr;
+	}
+
+	return NETWORK_RECV_STATUS_OKAY;
+}
+
+/**
+ * Check whether we received/can send some data from/to the TURN server and
+ * when that's the case handle it appropriately
+ */
+void ClientNetworkTurnSocketHandler::SendReceive()
+{
+	if (this->sock == INVALID_SOCKET) return;
+
+	if (this->CanSendReceive()) {
+		this->ReceivePackets();
+	}
+
+	this->SendPackets();
+}

--- a/src/network/network_turn.h
+++ b/src/network/network_turn.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_turn.h Part of the network protocol handling TURN requests. */
+
+#ifndef NETWORK_TURN_H
+#define NETWORK_TURN_H
+
+#include "core/tcp_turn.h"
+
+/** Class for handling the client side of the TURN connection. */
+class ClientNetworkTurnSocketHandler : public NetworkTurnSocketHandler {
+private:
+	std::string token;             ///< Token of this connection.
+	uint8 tracking_number;         ///< Tracking number of this connection.
+	std::string connection_string; ///< The connection string of the TURN server we are connecting to.
+
+protected:
+	bool Receive_TURN_ERROR(Packet *p) override;
+	bool Receive_TURN_CONNECTED(Packet *p) override;
+
+public:
+	TCPConnecter *connecter = nullptr; ///< Connecter instance.
+	bool connect_started = false;      ///< Whether we started the connection.
+
+	ClientNetworkTurnSocketHandler(const std::string &token, uint8 tracking_number, const std::string &connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}
+
+	NetworkRecvStatus CloseConnection(bool error = true) override;
+	void SendReceive();
+
+	void Connect();
+	void ConnectFailure();
+
+	static std::unique_ptr<ClientNetworkTurnSocketHandler> Turn(const std::string &token, uint8 tracking_number, const std::string &ticket, const std::string &connection_string);
+};
+
+#endif /* NETWORK_TURN_H */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1846,6 +1846,11 @@ static SettingsContainer &GetSettingsTree()
 			ai->Add(new SettingEntry("economy.min_years_for_shares"));
 		}
 
+		SettingsPage *network = main->Add(new SettingsPage(STR_CONFIG_SETTING_NETWORK));
+		{
+			network->Add(new SettingEntry("network.use_relay_service"));
+		}
+
 		main->Init();
 	}
 	return *main;

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -59,6 +59,13 @@ enum IndustryDensity {
 	ID_END,       ///< Number of industry density settings.
 };
 
+/** Possible values for "userelayservice" setting. */
+enum UseRelayService {
+	URS_NEVER = 0,
+	URS_ASK,
+	URS_ALLOW,
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	byte   competitor_start_time;            ///< Unused value, used to load old savegames.
@@ -290,6 +297,7 @@ struct NetworkSettings {
 	bool        reload_cfg;                               ///< reload the config file before restarting
 	std::string last_joined;                              ///< Last joined server
 	bool        no_http_content_downloads;                ///< do not do content downloads over HTTP
+	UseRelayService use_relay_service;                        ///< Use relay service?
 };
 
 /** Settings related to the creation of games. */

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -10,6 +10,7 @@
 static void UpdateClientConfigValues();
 
 static std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
+static std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
 
 static const SettingVariant _network_settings_table[] = {
 [post-amble]
@@ -261,3 +262,16 @@ var      = network.no_http_content_downloads
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
 cat      = SC_EXPERT
+
+[SDTC_OMANY]
+var      = network.use_relay_service
+type     = SLE_UINT8
+flags    = SF_GUI_DROPDOWN | SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = URS_ASK
+min      = URS_NO
+max      = URS_ALLOW
+full     = _use_relay_service
+str      = STR_CONFIG_SETTING_USE_RELAY_SERVICE
+strhelp  = STR_CONFIG_SETTING_USE_RELAY_SERVICE_HELPTEXT
+strval   = STR_CONFIG_SETTING_USE_RELAY_SERVICE_NEVER
+cat      = SC_BASIC

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -128,4 +128,13 @@ enum NetworkCompanyPasswordWidgets {
 	WID_NCP_OK,                       ///< Safe the password etc.
 };
 
+/** Widgets of the #NetworkAskRelayWindow class. */
+enum NetworkAskRelayWidgets {
+	WID_NAR_CAPTION,    ///< Caption of the window.
+	WID_NAR_TEXT,       ///< Text in the window.
+	WID_NAR_NO,         ///< "No" button.
+	WID_NAR_YES_ONCE,   ///< "Yes, once" button.
+	WID_NAR_YES_ALWAYS, ///< "Yes, always" button.
+};
+
 #endif /* WIDGETS_NETWORK_WIDGET_H */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1332,6 +1332,7 @@ static uint GetWindowZPriority(WindowClass wc)
 
 		case WC_ERRMSG:
 		case WC_CONFIRM_POPUP_QUERY:
+		case WC_NETWORK_ASK_RELAY:
 		case WC_MODAL_PROGRESS:
 		case WC_NETWORK_STATUS_WINDOW:
 		case WC_SAVE_PRESET:

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -479,6 +479,12 @@ enum WindowClass {
 	WC_NETWORK_STATUS_WINDOW,
 
 	/**
+	 * Network ask relay window; %Window numbers:
+	 *   - 0 - #NetworkAskRelayWidgets
+	 */
+	WC_NETWORK_ASK_RELAY,
+
+	/**
 	 * Chatbox; %Window numbers:
 	 *   - #DestType = #NetWorkChatWidgets
 	 */


### PR DESCRIPTION
Note: this is currently only deployed on staging. To test it out:
- Host your server on a port that you do NOT forward (you do not want to have a Public server).
- We "disable" STUN by using a server that doesn't exist ("localhost"). This will give a connection error, that is fully expected.
- Start the game like: `OTTD_COORDINATOR_CS="coordinator.openttd.org:4976" OTTD_STUN_CS="localhost" ./openttd`
- Host a server, join as client .. there is a 2 second delay till it switched  to TURN. This is because it is expecting STUN, but as we "disabled" that, it will fail. There is a 2 second timeout on waiting for STUN, hence the delay.

## Motivation / Problem

As final piece of #9017, this introduces TURN support in the OpenTTD client. This is meant to allow connecting those clients and servers that we cannot connect in any other way.

With this, it should be possible in nearly all situations for player A to play with player B, without any configuration in their network. The situations where it won't be possible are most properly extremes: those who do not have (stable) Internet, or those that have very poor peering and cannot connect to our TURN servers.

## Description

```
TURN is a last resort, used only if all other methods failed.
TURN is a relay approach to connect client and server together, where
openttd.org (by default) is the middleman.

It is very unlikely either the client or server cannot connect to
the STUN server, as they are both already connected to the Game
Coordinator. But in the odd case it does fail, estabilishing the
connection fails without any further possibility to recover.
```

For OpenTTD TURN is expensive, as we are paying for the relaying (bandwidth cost), and as such the Game Coordinator does its at-most to find any other means first.

Additional, our TURN-servers are not off-the-shelves TURN-servers, but instead they validate the protocol they are relaying. This avoids us being used as TURN-server for any other purpose other than relaying OpenTTD.

Future work extends TURN-servers to allow Websockets, meaning we can provide full network support for our Emscripten builds. But this is kept out of this PR for now.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
