### PR TITLE
Small clean ups due to the introduction of GC

### DIFF
--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -166,10 +166,7 @@ static void HandleIncomingNetworkGameInfoGRFConfig(GRFConfig *config)
 	/* Find the matching GRF file */
 	const GRFConfig *f = FindGRFConfig(config->ident.grfid, FGCM_EXACT, config->ident.md5sum);
 	if (f == nullptr) {
-		/* Don't know the GRF, so mark game incompatible and the (possibly)
-		 * already resolved name for this GRF (another server has sent the
-		 * name of the GRF already */
-		config->name = FindUnknownGRFName(config->ident.grfid, config->ident.md5sum, true);
+		AddGRFTextToList(config->name, GetString(STR_CONFIG_ERROR_INVALID_GRF_UNKNOWN));
 		config->status = GCS_NOT_FOUND;
 	} else {
 		config->filename = f->filename;

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -25,6 +25,9 @@
  * Version: Bytes:  Description:
  *   all      1       the version of this packet's structure
  *
+ *   5+       4       version number of the Game Script (-1 is case none is selected).
+ *   5+       var     string with the name of the Game Script.
+ *
  *   4+       1       number of GRFs attached (n)
  *   4+       n * 20  unique identifier for GRF files. Consists of:
  *                     - one 4 byte variable with the GRF ID

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -125,10 +125,7 @@ void NetworkAfterNewGRFScan()
 
 			const GRFConfig *f = FindGRFConfig(c->ident.grfid, FGCM_EXACT, c->ident.md5sum);
 			if (f == nullptr) {
-				/* Don't know the GRF, so mark game incompatible and the (possibly)
-				 * already resolved name for this GRF (another server has sent the
-				 * name of the GRF already. */
-				c->name = FindUnknownGRFName(c->ident.grfid, c->ident.md5sum, true);
+				/* Don't know the GRF (anymore), so mark game incompatible. */
 				c->status = GCS_NOT_FOUND;
 
 				/* If we miss a file, we're obviously incompatible. */

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -753,53 +753,6 @@ const GRFConfig *FindGRFConfig(uint32 grfid, FindGRFConfigMode mode, const uint8
 	return best;
 }
 
-/** Structure for UnknownGRFs; this is a lightweight variant of GRFConfig */
-struct UnknownGRF : public GRFIdentifier {
-	GRFTextWrapper name; ///< Name of the GRF.
-
-	UnknownGRF() = default;
-	UnknownGRF(const UnknownGRF &other) = default;
-	UnknownGRF(UnknownGRF &&other) = default;
-	UnknownGRF(uint32 grfid, const uint8 *_md5sum) : GRFIdentifier(grfid, _md5sum), name(new GRFTextList) {}
-};
-
-/**
- * Finds the name of a NewGRF in the list of names for unknown GRFs. An
- * unknown GRF is a GRF where the .grf is not found during scanning.
- *
- * The names are resolved via UDP calls to servers that should know the name,
- * though the replies may not come. This leaves "<Unknown>" as name, though
- * that shouldn't matter _very_ much as they need GRF crawler or so to look
- * up the GRF anyway and that works better with the GRF ID.
- *
- * @param grfid  the GRF ID part of the 'unique' GRF identifier
- * @param md5sum the MD5 checksum part of the 'unique' GRF identifier
- * @param create whether to create a new GRFConfig if the GRFConfig did not
- *               exist in the fake list of GRFConfigs.
- * @return The GRFTextWrapper of the name of the GRFConfig with the given GRF ID
- *         and MD5 checksum or nullptr when it does not exist and create is false.
- *         This value must NEVER be freed by the caller.
- */
-GRFTextWrapper FindUnknownGRFName(uint32 grfid, uint8 *md5sum, bool create)
-{
-	static std::vector<UnknownGRF> unknown_grfs;
-
-	for (const auto &grf : unknown_grfs) {
-		if (grf.grfid == grfid) {
-			if (memcmp(md5sum, grf.md5sum, sizeof(grf.md5sum)) == 0) return grf.name;
-		}
-	}
-
-	if (!create) return nullptr;
-
-	unknown_grfs.emplace_back(grfid, md5sum);
-	UnknownGRF &grf = unknown_grfs.back();
-
-	AddGRFTextToList(grf.name, UNKNOWN_GRF_NAME_PLACEHOLDER);
-
-	return grf.name;
-}
-
 /**
  * Retrieve a NewGRF from the current config by its grfid.
  * @param grfid grf to look for.

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -234,10 +234,6 @@ char *GRFBuildParamList(char *dst, const GRFConfig *c, const char *last);
 /* In newgrf_gui.cpp */
 void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFConfig **config);
 
-/** For communication about GRFs over the network */
-#define UNKNOWN_GRF_NAME_PLACEHOLDER "<Unknown>"
-GRFTextWrapper FindUnknownGRFName(uint32 grfid, uint8 *md5sum, bool create);
-
 void UpdateNewGRFScanStatus(uint num, const char *name);
 void UpdateNewGRFConfigPalette(int32 new_value = 0);
 


### PR DESCRIPTION
## Motivation / Problem

Effectively dead code since 8a2da49.
Out-of-date documentation since c921f6d.


## Description

```
Remove: the concept of UnknownGRFs

These were filled with "<Unknown>" (before 8a2da49) and later their name would get filled via UDP requests to the server.
These UDP packets do not exist anymore, so they will always remain "<Unknown>".
Remove that logic and just use the generic translated error GRF UNKNOWN string instead.
```

And update the documentation of the GameInfo packet with the Game Script fields / for version 5.

## Limitations

None. Well, the NewGRFs will now always be called "Unknown" (or whatever the translation is). Later updates to the Game Info protocol and the GC should remedy this problem in the near future (if all goes to plan).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
