### PR TITLE
Fix/Feature: (re)introduce NewGRF names for (unknown) NewGRFs

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -47,7 +47,7 @@ static const uint16 TCP_MTU                         = 32767;          ///< Numbe
 static const uint16 COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
 
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
-static const byte NETWORK_GAME_INFO_VERSION         =    5;           ///< What version of game-info do we use?
+static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
 static const byte NETWORK_COORDINATOR_VERSION       =    3;           ///< What version of game-coordinator-protocol do we use?
 

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -49,7 +49,7 @@ static const uint16 COMPAT_MTU                      = 1460;           ///< Numbe
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
-static const byte NETWORK_COORDINATOR_VERSION       =    3;           ///< What version of game-coordinator-protocol do we use?
+static const byte NETWORK_COORDINATOR_VERSION       =    4;           ///< What version of game-coordinator-protocol do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -254,7 +254,7 @@ void SerializeNetworkGameInfo(Packet *p, const NetworkServerGameInfo *info, bool
  * @param p    the packet to read the data from.
  * @param info the NetworkGameInfo to deserialize into.
  */
-void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info)
+void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfoNewGRFLookupTable *newgrf_lookup_table)
 {
 	static const Date MAX_DATE = ConvertYMDToDate(MAX_YEAR, 11, 31); // December is month 11
 
@@ -299,6 +299,14 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info)
 					case NST_GRFID_MD5_NAME:
 						DeserializeGRFIdentifierWithName(p, &grf);
 						break;
+
+					case NST_LOOKUP_ID: {
+						if (newgrf_lookup_table == nullptr) return;
+						auto it = newgrf_lookup_table->find(p->Recv_uint32());
+						if (it == newgrf_lookup_table->end()) return;
+						grf = it->second;
+						break;
+					}
 
 					default:
 						NOT_REACHED();

--- a/src/network/core/tcp_coordinator.cpp
+++ b/src/network/core/tcp_coordinator.cpp
@@ -42,6 +42,7 @@ bool NetworkCoordinatorSocketHandler::HandlePacket(Packet *p)
 		case PACKET_COORDINATOR_GC_STUN_REQUEST:       return this->Receive_GC_STUN_REQUEST(p);
 		case PACKET_COORDINATOR_SERCLI_STUN_RESULT:    return this->Receive_SERCLI_STUN_RESULT(p);
 		case PACKET_COORDINATOR_GC_STUN_CONNECT:       return this->Receive_GC_STUN_CONNECT(p);
+		case PACKET_COORDINATOR_GC_NEWGRF_LOOKUP:      return this->Receive_GC_NEWGRF_LOOKUP(p);
 
 		default:
 			Debug(net, 0, "[tcp/coordinator] Received invalid packet type {}", type);
@@ -100,3 +101,4 @@ bool NetworkCoordinatorSocketHandler::Receive_GC_DIRECT_CONNECT(Packet *p) { ret
 bool NetworkCoordinatorSocketHandler::Receive_GC_STUN_REQUEST(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_STUN_REQUEST); }
 bool NetworkCoordinatorSocketHandler::Receive_SERCLI_STUN_RESULT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_SERCLI_STUN_RESULT); }
 bool NetworkCoordinatorSocketHandler::Receive_GC_STUN_CONNECT(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_STUN_CONNECT); }
+bool NetworkCoordinatorSocketHandler::Receive_GC_NEWGRF_LOOKUP(Packet *p) { return this->ReceiveInvalidPacket(PACKET_COORDINATOR_GC_NEWGRF_LOOKUP); }

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -41,6 +41,7 @@ enum PacketCoordinatorType {
 	PACKET_COORDINATOR_GC_STUN_REQUEST,       ///< Game Coordinator tells client/server to initiate a STUN request.
 	PACKET_COORDINATOR_SERCLI_STUN_RESULT,    ///< Client/server informs the Game Coordinator of the result of the STUN request.
 	PACKET_COORDINATOR_GC_STUN_CONNECT,       ///< Game Coordinator tells client/server to connect() reusing the STUN local address.
+	PACKET_COORDINATOR_GC_NEWGRF_LOOKUP,      ///< Game Coordinator informs client about NewGRF lookup table updates needed for GC_LISTING.
 	PACKET_COORDINATOR_END,                   ///< Must ALWAYS be on the end of this list!! (period)
 };
 
@@ -125,6 +126,7 @@ protected:
 	 *  uint8   Game Coordinator protocol version.
 	 *  uint8   Game-info version used by this client.
 	 *  string  Revision of the client.
+	 *  uint32  (Game Coordinator protocol >= 4) Cursor as received from GC_NEWGRF_LOOKUP, or zero.
 	 *
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
@@ -262,6 +264,29 @@ protected:
 	 * @return True upon success, otherwise false.
 	 */
 	virtual bool Receive_GC_STUN_CONNECT(Packet *p);
+
+	/**
+	 * Game Coordinator informs the client of updates for the NewGRFs lookup table
+	 * as used by the NewGRF deserialization in GC_LISTING.
+	 * This packet is sent after a CLIENT_LISTING request, but before GC_LISTING.
+	 *
+	 *  uint32   Lookup table cursor.
+	 *  uint16   Number of NewGRFs in the packet, with for each of the NewGRFs:
+	 *      uint32   Lookup table index for the NewGRF.
+	 *      uint32   Unique NewGRF ID.
+	 *      byte[16] MD5 checksum of the NewGRF
+	 *      string   Name of the NewGRF.
+	 *
+	 * The lookup table built using these packets are used by the deserialisation
+	 * of the NewGRFs for servers in the GC_LISTING. These updates are additive,
+	 * i.e. each update will add NewGRFs but never remove them. However, this
+	 * lookup table is specific to the connection with the Game Coordinator, and
+	 * should be considered invalid after disconnecting from the Game Coordinator.
+	 *
+	 * @param p The packet that was just received.
+	 * @return True upon success, otherwise false.
+	 */
+	virtual bool Receive_GC_NEWGRF_LOOKUP(Packet *p);
 
 	bool HandlePacket(Packet *p);
 public:

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -410,13 +410,14 @@ void ClientNetworkCoordinatorSocketHandler::Register()
 void ClientNetworkCoordinatorSocketHandler::SendServerUpdate()
 {
 	Debug(net, 6, "Sending server update to Game Coordinator");
-	this->next_update = std::chrono::steady_clock::now() + NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES;
 
 	Packet *p = new Packet(PACKET_COORDINATOR_SERVER_UPDATE, TCP_MTU);
 	p->Send_uint8(NETWORK_COORDINATOR_VERSION);
-	SerializeNetworkGameInfo(p, GetCurrentNetworkServerGameInfo());
+	SerializeNetworkGameInfo(p, GetCurrentNetworkServerGameInfo(), this->next_update.time_since_epoch() != std::chrono::nanoseconds::zero());
 
 	this->SendPacket(p);
+
+	this->next_update = std::chrono::steady_clock::now() + NETWORK_COORDINATOR_DELAY_BETWEEN_UPDATES;
 }
 
 /**

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -54,6 +54,9 @@ private:
 	std::map<std::string, std::map<int, std::unique_ptr<ClientNetworkStunSocketHandler>>> stun_handlers; ///< All pending STUN handlers, stored by token:family.
 	TCPConnecter *game_connecter = nullptr; ///< Pending connecter to the game server.
 
+	uint32 newgrf_lookup_table_cursor = 0; ///< Last received cursor for the #GameInfoNewGRFLookupTable updates.
+	GameInfoNewGRFLookupTable newgrf_lookup_table; ///< Table to look up NewGRFs in the GC_LISTING packets.
+
 protected:
 	bool Receive_GC_ERROR(Packet *p) override;
 	bool Receive_GC_REGISTER_ACK(Packet *p) override;
@@ -63,6 +66,7 @@ protected:
 	bool Receive_GC_DIRECT_CONNECT(Packet *p) override;
 	bool Receive_GC_STUN_REQUEST(Packet *p) override;
 	bool Receive_GC_STUN_CONNECT(Packet *p) override;
+	bool Receive_GC_NEWGRF_LOOKUP(Packet *p) override;
 
 public:
 	/** The idle timeout; when to close the connection because it's idle. */


### PR DESCRIPTION
Note: this is currently only deployed on staging. Use `OTTD_COORDINATOR_CS="coordinator.openttd.org:4976" OTTD_STUN_CS="stun.staging.openttd.org:4975"` to test this PR.

## Motivation / Problem

With the removal of the UDP packets in lieu of the Game Coordinator listing, the ability to get the names for unknown NewGRFs for a server was lost.


## Description

Introduce a new version for the Game Info packet that allows to specify the way the NewGRFs are serialized. This could be only GRF ID + MD5 checksum, GRF ID + MD5 checksum + name, or an index into a lookup table (more details later). For clients requesting information from a server, the names of the NewGRFs will automatically be sent.
Updates of a game server to the Game Coordinator will not send the names, except for the first registration of that game.

A new version of the Game Coordinator protocol was added so the Game Coordinator can provide a lookup table for the NewGRF ID + MD5 checksum + name for the NewGRFs in the listing. Upon further requests for the listing, in the same connection with the Game Coordinator, only minimal updates for the lookup table need to be sent.

Assuming about 500 unique NewGRFs used by all the servers combined, and 3000 server-NewGRF combinations this will save about 25 kB for the initial listing and 45 kB for subsequent listings.

```
Saving 3000*16 bytes = 48 kB in the listing.
    replacing GRF ID + MD5 checksum with index reduces 16 bytes per server-NewGRF combination.
Adding at most 500*(4+16+80) = 50 kB in the lookup table.
   GRF ID + MD5 checksum + maximum length of GRF name.
However, the average number characters of unique BaNaNaS NewGRF names is about 20.5 characters long (21.5 with '\0'),
so it costs closer to 21-25 kB in the first lookup table update. Updates after that only need to send new NewGRFs, 
which will usually 0 NewGRFs or at most a few NewGRFs.
```


## Limitations

* Slightly more load for the Game Coordinator.
* Clients get names of NewGRFs that they might not need as they have the NewGRF locally.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
