### PR TITLE
Cleanup: remove some references to the old master-server

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -94,14 +94,4 @@ static const uint NETWORK_GRF_NAME_LENGTH           =   80;           ///< Maxim
  */
 static const uint NETWORK_MAX_GRF_COUNT             =   255;
 
-/**
- * The number of landscapes in OpenTTD.
- * This number must be equal to NUM_LANDSCAPE, but as this number is used
- * within the network code and that the network code is shared with the
- * masterserver/updater, it has to be declared in here too. In network.cpp
- * there is a compile assertion to check that this NUM_LANDSCAPE is equal
- * to NETWORK_NUM_LANDSCAPES.
- */
-static const uint NETWORK_NUM_LANDSCAPES            =    4;
-
 #endif /* NETWORK_CORE_CONFIG_H */

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -352,7 +352,7 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfo
 			info->landscape      = p->Recv_uint8 ();
 			info->dedicated      = p->Recv_bool  ();
 
-			if (info->landscape >= NETWORK_NUM_LANDSCAPES) info->landscape = 0;
+			if (info->landscape >= NUM_LANDSCAPE) info->landscape = 0;
 	}
 }
 

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -78,8 +78,6 @@ uint32 _sync_frame;                   ///< The frame to perform the sync check.
 bool _network_first_time;             ///< Whether we have finished joining or not.
 CompanyMask _network_company_passworded; ///< Bitmask of the password status of all companies.
 
-/* Check whether NETWORK_NUM_LANDSCAPES is still in sync with NUM_LANDSCAPE */
-static_assert((int)NETWORK_NUM_LANDSCAPES == (int)NUM_LANDSCAPE);
 static_assert((int)NETWORK_COMPANY_NAME_LENGTH == MAX_LENGTH_COMPANY_NAME_CHARS * MAX_CHAR_LENGTH);
 
 /** The amount of clients connected */

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -483,7 +483,7 @@ public:
 		this->filter_editbox.cancel_button = QueryString::ACTION_CLEAR;
 		this->SetFocusedWidget(WID_NG_FILTER);
 
-		/* As the master-server doesn't support "websocket" servers yet, we
+		/* As the Game Coordinator doesn't support "websocket" servers yet, we
 		 * let "os/emscripten/pre.js" hardcode a list of servers people can
 		 * join. This means the serverlist is curated for now, but it is the
 		 * best we can offer. */


### PR DESCRIPTION
## Motivation / Problem

There are some reference to he old master-server, which is not used anymore. And even references to the building of the old-old master-server. That is not needed anymore, so anything that "helped" with that is not needed anymore.


## Description

Remove them, or replace them with Game Coordinator where appropriate.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
