### PR TITLE
Fix #9440: negative cargo payments not being handled right

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -61,7 +61,7 @@ struct CargoSpec {
 	uint8 rating_colour;
 	uint8 weight;                    ///< Weight of a single unit of this cargo type in 1/16 ton (62.5 kg).
 	uint16 multiplier;               ///< Capacity multiplier for vehicles. (8 fractional bits)
-	uint32 initial_payment;          ///< Initial payment rate before inflation is applied.
+	int32 initial_payment;           ///< Initial payment rate before inflation is applied.
 	uint8 transit_days[2];
 
 	bool is_freight;                 ///< Cargo type is considered to be freight (affects train freight multiplier).

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -803,7 +803,7 @@ void RecomputePrices()
 
 	/* Setup cargo payment */
 	for (CargoSpec *cs : CargoSpec::Iterate()) {
-		cs->current_payment = ((int64)cs->initial_payment * _economy.inflation_payment) >> 16;
+		cs->current_payment = (cs->initial_payment * (int64)_economy.inflation_payment) >> 16;
 	}
 
 	SetWindowClassesDirty(WC_BUILD_VEHICLE);

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -34,7 +34,7 @@ struct Economy {
 	uint32 industry_daily_change_counter; ///< Bits 31-16 are number of industry to be performed, 15-0 are fractional collected daily
 	uint32 industry_daily_increment;      ///< The value which will increment industry_daily_change_counter. Computed value. NOSAVE
 	uint64 inflation_prices;              ///< Cumulated inflation of prices since game start; 16 bit fractional part
-	uint64 inflation_payment;             ///< Cumulated inflation of cargo paypent since game start; 16 bit fractional part
+	uint64 inflation_payment;             ///< Cumulated inflation of cargo payment since game start; 16 bit fractional part
 
 	/* Old stuff for savegame conversion only */
 	Money old_max_loan_unround;           ///< Old: Unrounded max loan


### PR DESCRIPTION
## Motivation / Problem

Fixes #9440; negative cargo payments causing huge payments.


## Description

```
Cargo payments were stored as unsigned integer, but cast to int64 during
application of inflation. However, then being multiplied with a uint64
making the result uint64. So in the end the payment that should have been
negative becomes hugely positive.
```


## Limitations

First and major question is whether it is wanted that cargo payments can be negative. The specifications do not seem to be very clear about it, though the custom cargo calculation allowing negative factors might imply that the cargo payments themselves can be negative.

So, this makes it possible and seemingly work for the graphs and actual payment, but I'm far from certain it should be this way. So closing this PR and #9440 as not-a-bug would be a valid solution as well.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
