### PR TITLE
Fix: Use of unstable sort when distributing cargo production can caus…

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -4080,7 +4080,7 @@ uint MoveGoodsToStation(CargoID type, uint amount, SourceType source_type, Sourc
 
 	/* If there is some cargo left due to rounding issues distribute it among the best rated stations. */
 	if (amount > moving) {
-		std::sort(used_stations.begin(), used_stations.end(), [type](const StationInfo &a, const StationInfo &b) {
+		std::stable_sort(used_stations.begin(), used_stations.end(), [type](const StationInfo &a, const StationInfo &b) {
 			return b.first->goods[type].rating < a.first->goods[type].rating;
 		});
 


### PR DESCRIPTION
## Motivation / Problem

Unstable `std::sort` is used to sort stations by rating so the order of stations with the same rating is not guaranteed and can differ between platforms so different stations receive leftover cargo causing desyncs. At least one platform is known to be affected so far (android): https://github.com/pelya/openttd-android/issues/12

## Description

Replacing `std::sort` with `std::stable_sort` should fix the issue as `used_stations` are guaranteed to b initially ordered by id due to std::set iteration.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* **The bug fix is important enough to be backported? (label: 'backport requested')**
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
