### PR TITLE
Fix 68f2213: Don't use GetPoolSize() for end of pool iterator

### DIFF
--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -160,7 +160,11 @@ struct Pool : PoolBase {
 
 	private:
 		size_t index;
-		void ValidateIndex() { while (this->index < T::GetPoolSize() && !(T::IsValidID(this->index))) this->index++; }
+		void ValidateIndex()
+		{
+			while (this->index < T::GetPoolSize() && !(T::IsValidID(this->index))) this->index++;
+			if (this->index >= T::GetPoolSize()) this->index = T::Pool::MAX_SIZE;
+		}
 	};
 
 	/*
@@ -172,7 +176,7 @@ struct Pool : PoolBase {
 		size_t from;
 		IterateWrapper(size_t from = 0) : from(from) {}
 		PoolIterator<T> begin() { return PoolIterator<T>(this->from); }
-		PoolIterator<T> end() { return PoolIterator<T>(T::GetPoolSize()); }
+		PoolIterator<T> end() { return PoolIterator<T>(T::Pool::MAX_SIZE); }
 		bool empty() { return this->begin() == this->end(); }
 	};
 
@@ -201,7 +205,11 @@ struct Pool : PoolBase {
 	private:
 		size_t index;
 		F filter;
-		void ValidateIndex() { while (this->index < T::GetPoolSize() && !(T::IsValidID(this->index) && this->filter(this->index))) this->index++; }
+		void ValidateIndex()
+		{
+			while (this->index < T::GetPoolSize() && !(T::IsValidID(this->index) && this->filter(this->index))) this->index++;
+			if (this->index >= T::GetPoolSize()) this->index = T::Pool::MAX_SIZE;
+		}
 	};
 
 	/*
@@ -214,7 +222,7 @@ struct Pool : PoolBase {
 		F filter;
 		IterateWrapperFiltered(size_t from, F filter) : from(from), filter(filter) {}
 		PoolIteratorFiltered<T, F> begin() { return PoolIteratorFiltered<T, F>(this->from, this->filter); }
-		PoolIteratorFiltered<T, F> end() { return PoolIteratorFiltered<T, F>(T::GetPoolSize(), this->filter); }
+		PoolIteratorFiltered<T, F> end() { return PoolIteratorFiltered<T, F>(T::Pool::MAX_SIZE, this->filter); }
 		bool empty() { return this->begin() == this->end(); }
 	};
 


### PR DESCRIPTION
## Motivation / Problem
`GetPoolSize()` returned value can change during the pool iteration, so using it for `end()` was not a good idea.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use a constant (max size of the pool) for `end()`, and set `index` to this value whenever it reaches `GetPoolSize()`.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
