### PR TITLE
Add: [AI] Get the number of vehicles in a given group

### DIFF
--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -20,6 +20,7 @@
  * API additions:
  * \li AINewGRF
  * \li AINewGRFList
+ * \li AIGroup::GetNumVehicles
  *
  * \b 1.11.0
  *

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -106,6 +106,15 @@
 	return GetGroupNumEngines(ScriptObject::GetCompany(), group_id, engine_id);
 }
 
+/* static */ int32 ScriptGroup::GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type)
+{
+	bool valid_group = IsValidGroup(group_id);
+	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
+	if (!valid_group && (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR)) return -1;
+
+	return GetGroupNumVehicle(ScriptObject::GetCompany(), group_id, valid_group ? ::Group::Get(group_id)->vehicle_type : (::VehicleType)vehicle_type);
+}
+
 /* static */ bool ScriptGroup::MoveVehicle(GroupID group_id, VehicleID vehicle_id)
 {
 	EnforcePrecondition(false, IsValidGroup(group_id) || group_id == GROUP_DEFAULT);

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -129,6 +129,20 @@ public:
 	static int32 GetNumEngines(GroupID group_id, EngineID engine_id);
 
 	/**
+	 * Get the total number of vehicles in a given group and its sub-groups.
+	 * @param group_id The group to get the number of vehicles in.
+	 * @param vehicle_type The type of vehicle of the group.
+	 * @pre IsValidGroup(group_id) || group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
+	 * @pre IsValidGroup(group_id) || vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL ||
+	 *   vehicle_type == ScriptVehicle::VT_WATER || vehicle_type == ScriptVehicle::VT_AIR
+	 * @return The total number of vehicles in the group with id group_id and it's sub-groups.
+	 * @note If the group is valid (neither GROUP_ALL nor GROUP_DEFAULT), the value of
+	 *  vehicle_type is retrieved from the group itself and not from the input value.
+	 *  But if the group is GROUP_ALL or GROUP_DEFAULT, then vehicle_type must be valid.
+	 */
+	static int32 GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type);
+
+	/**
 	 * Move a vehicle to a group.
 	 * @param group_id The group to move the vehicle to.
 	 * @param vehicle_id The vehicle to move to the group.


### PR DESCRIPTION
## Motivation / Problem
Using `AIVehicleList_Group(group_id).Count()` tends to become more cpu intensive over time as the number of vehicles in the game increases, because it has to iterate over all vehicles to check which belong to the group. When an AI uses it constantly, slowdowns become noticeable.

If the intention is only to know how many vehicles are in a group, I thought of a less cpu intensive method, which is using the `GroupStatistics` own `num_vehicle`. For that, this PR comes up with a new function `AIGroup.GetNumVehicles(group_id, vehicle_type)`.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
With this function, instead of iterating over all vehicles just to get a count, it iterates over all groups. In normal circumstances, there's less groups than vehicles, so it is expected to be less intensive even when used repeatedly.
My own testings with my AI, with about 10k vehicles and 1600 groups, the ms peaks are much less noticeable. 

35.95 ms  `while(true) { AIGroup.GetNumVehicles(m_sentToDepotRoadGroup[1], AIVehicle.VT_ROAD); }`
3,179.86 ms `while(true) { AIVehicleList_Group(m_sentToDepotRoadGroup[1]).Count(); }`

![image](https://user-images.githubusercontent.com/43006711/128197607-0f602b25-98be-4fcd-802e-8d36ac693b89.png)

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
`AIGroup.GetNumVehicles(group_id, vehicle_type)` gets the number of total vehicles in the group and its sub-groups.
`AIVehicleList_Group(group_id).Count()` gets the number of total vehicles in that group only and creates a list with vehicle_ids of that group.

For my use case, since I don't use sub-groups and for the portion of the code I'm using it I have no need to know which vehicles they are, it's not an issue.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
