### PR TITLE
Add: [Script] Basic information about loaded NewGRFs for scripts.

### DIFF
--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -179,6 +179,7 @@ add_files(
     script_log.hpp
     script_map.hpp
     script_marine.hpp
+    script_newgrf.hpp
     script_news.hpp
     script_object.hpp
     script_order.hpp
@@ -246,6 +247,7 @@ add_files(
     script_log.cpp
     script_map.cpp
     script_marine.cpp
+    script_newgrf.cpp
     script_news.cpp
     script_object.cpp
     script_order.cpp

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -17,6 +17,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li AINewGRF
+ * \li AINewGRFList
+ *
  * \b 1.11.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -17,6 +17,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSNewGRF
+ * \li GSNewGRFList
+ *
  * \b 1.11.0
  *
  * API additions:

--- a/src/script/api/script_newgrf.cpp
+++ b/src/script/api/script_newgrf.cpp
@@ -1,0 +1,58 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_newgrf.cpp Implementation of ScriptNewGRF and friends. */
+
+#include "../../stdafx.h"
+#include "script_newgrf.hpp"
+#include "../../core/bitmath_func.hpp"
+#include "../../newgrf_config.h"
+#include "../../string_func.h"
+
+#include "../../safeguards.h"
+
+ScriptNewGRFList::ScriptNewGRFList()
+{
+	for (auto c = _grfconfig; c != nullptr; c = c->next) {
+		if (!HasBit(c->flags, GCF_STATIC)) {
+			this->AddItem(c->ident.grfid);
+		}
+	}
+}
+
+/* static */ bool ScriptNewGRF::IsLoaded(uint32 grfid)
+{
+	for (auto c = _grfconfig; c != nullptr; c = c->next) {
+		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* static */ uint32 ScriptNewGRF::GetVersion(uint32 grfid)
+{
+	for (auto c = _grfconfig; c != nullptr; c = c->next) {
+		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
+			return c->version;
+		}
+	}
+
+	return 0;
+}
+
+/* static */ char *ScriptNewGRF::GetName(uint32 grfid)
+{
+	for (auto c = _grfconfig; c != nullptr; c = c->next) {
+		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
+			return ::stredup(c->GetName());
+		}
+	}
+
+	return nullptr;
+}

--- a/src/script/api/script_newgrf.hpp
+++ b/src/script/api/script_newgrf.hpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_newgrf.hpp NewGRF info for scripts. */
+
+#ifndef SCRIPT_NEWGRF_HPP
+#define SCRIPT_NEWGRF_HPP
+
+#include "script_list.hpp"
+
+/**
+ * Create a list of loaded NewGRFs.
+ * @api ai game
+ * @ingroup ScriptList
+ */
+class ScriptNewGRFList : public ScriptList {
+public:
+	ScriptNewGRFList();
+};
+
+
+/**
+ * Class that handles all NewGRF related functions.
+ * @api ai game
+ */
+class ScriptNewGRF : public ScriptObject {
+public:
+	/**
+	 * Check if a NewGRF with a given grfid is loaded.
+	 * @param grfid The grfid to check.
+	 * @return True if and only if a NewGRF with the given grfid is loaded in the game.
+	 */
+	static bool IsLoaded(uint32 grfid);
+
+	/**
+	 * Get the version of a loaded NewGRF.
+	 * @param grfid The NewGRF to query.
+	 * @pre ScriptNewGRF::IsLoaded(grfid).
+	 * @return Version of the NewGRF or 0 if the NewGRF specifies no version.
+	 */
+	static uint32 GetVersion(uint32 grfid);
+
+	/**
+	 * Get the BridgeID of a bridge at a given tile.
+	 * @param grfid The NewGRF to query.
+	 * @pre ScriptNewGRF::IsLoaded(grfid).
+	 * @return The name of the NewGRF or nullptr if no name is defined.
+	 */
+	static char *GetName(uint32 grfid);
+};
+
+#endif /* SCRIPT_NEWGRF_HPP */


### PR DESCRIPTION
## Motivation / Problem

Currently, scripts use various heuristics to detect loaded NewGRFs that are inherently unreliable and prone to break.

At the same time, the list of loaded NewGRFs is easily accessible to a human player. Thus, giving scripts the same basic information is consistent with the approach to not give scripts any information advantage over a human player.


## Description

This PR allows AIs and GS to get the most basic information about loaded NewGRFs. Static NewGRFs are hidden from scripts.
Right now there are no APIs that would allow a script to get more insight into what a NewGRF actually provides and changes (which matches the human experience).

Whether any other information should be exposed to scripts is up for discussion.


## Limitations

The implementation is quite inefficient as the active NewGRF config is only kept in a non-indexable linked list.
Also, there is no way for a script to be informed about changes to loaded NewGRFs after game start.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
