### PR TITLE
Change: remove the ability to control "max spectators"

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -698,14 +698,14 @@ DEF_CONSOLE_CMD(ConServerInfo)
 {
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "List current and maximum client/company limits. Usage 'server_info'.");
-		IConsolePrint(CC_HELP, "You can change these values by modifying settings 'network.max_clients', 'network.max_companies' and 'network.max_spectators'.");
+		IConsolePrint(CC_HELP, "You can change these values by modifying settings 'network.max_clients' and 'network.max_companies'.");
 		return true;
 	}
 
 	IConsolePrint(CC_DEFAULT, "Invite code:                {}", _network_server_invite_code);
 	IConsolePrint(CC_DEFAULT, "Current/maximum clients:    {:3d}/{:3d}", _network_game_info.clients_on, _settings_client.network.max_clients);
 	IConsolePrint(CC_DEFAULT, "Current/maximum companies:  {:3d}/{:3d}", Company::GetNumItems(), _settings_client.network.max_companies);
-	IConsolePrint(CC_DEFAULT, "Current/maximum spectators: {:3d}/{:3d}", NetworkSpectatorCount(), _settings_client.network.max_spectators);
+	IConsolePrint(CC_DEFAULT, "Current spectators:         {:3d}", NetworkSpectatorCount());
 
 	return true;
 }
@@ -762,11 +762,6 @@ DEF_CONSOLE_CMD(ConJoinCompany)
 
 	if (NetworkClientInfo::GetByClientID(_network_own_client_id)->client_playas == company_id) {
 		IConsolePrint(CC_ERROR, "You are already there!");
-		return true;
-	}
-
-	if (company_id == COMPANY_SPECTATOR && NetworkMaxSpectatorsReached()) {
-		IConsolePrint(CC_ERROR, "Cannot join spectators, maximum number of spectators reached.");
 		return true;
 	}
 
@@ -2422,7 +2417,6 @@ void IConsoleStdLibRegister()
 	IConsole::AliasRegister("server_port",           "setting server_port %+");
 	IConsole::AliasRegister("max_clients",           "setting max_clients %+");
 	IConsole::AliasRegister("max_companies",         "setting max_companies %+");
-	IConsole::AliasRegister("max_spectators",        "setting max_spectators %+");
 	IConsole::AliasRegister("max_join_time",         "setting max_join_time %+");
 	IConsole::AliasRegister("pause_on_join",         "setting pause_on_join %+");
 	IConsole::AliasRegister("autoclean_companies",   "setting autoclean_companies %+");

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2079,9 +2079,6 @@ STR_NETWORK_START_SERVER_NUMBER_OF_CLIENTS_TOOLTIP              :{BLACK}Choose t
 STR_NETWORK_START_SERVER_COMPANIES_SELECT                       :{BLACK}{NUM} compan{P y ies}
 STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES                    :{BLACK}Maximum number of companies:
 STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES_TOOLTIP            :{BLACK}Limit the server to a certain amount of companies
-STR_NETWORK_START_SERVER_SPECTATORS_SELECT                      :{BLACK}{NUM} spectator{P "" s}
-STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS                   :{BLACK}Maximum number of spectators:
-STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS_TOOLTIP           :{BLACK}Limit the server to a certain amount of spectators
 STR_NETWORK_START_SERVER_LANGUAGE_SPOKEN                        :{BLACK}Language spoken:
 STR_NETWORK_START_SERVER_LANGUAGE_TOOLTIP                       :{BLACK}Other players will know which language is spoken on the server
 

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -126,7 +126,6 @@ void FillStaticNetworkServerGameInfo()
 	_network_game_info.start_date     = ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1);
 	_network_game_info.clients_max    = _settings_client.network.max_clients;
 	_network_game_info.companies_max  = _settings_client.network.max_companies;
-	_network_game_info.spectators_max = _settings_client.network.max_spectators;
 	_network_game_info.map_width      = MapSizeX();
 	_network_game_info.map_height     = MapSizeY();
 	_network_game_info.landscape      = _settings_game.game_creation.landscape;
@@ -234,7 +233,7 @@ void SerializeNetworkGameInfo(Packet *p, const NetworkServerGameInfo *info, bool
 	/* NETWORK_GAME_INFO_VERSION = 2 */
 	p->Send_uint8 (info->companies_max);
 	p->Send_uint8 (info->companies_on);
-	p->Send_uint8 (info->spectators_max);
+	p->Send_uint8 (info->clients_max); // Used to be max-spectators
 
 	/* NETWORK_GAME_INFO_VERSION = 1 */
 	p->Send_string(info->server_name);
@@ -331,7 +330,7 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfo
 		case 2:
 			info->companies_max  = p->Recv_uint8 ();
 			info->companies_on   = p->Recv_uint8 ();
-			info->spectators_max = p->Recv_uint8 ();
+			p->Recv_uint8(); // Used to contain max-spectators.
 			FALLTHROUGH;
 
 		case 1:

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -105,7 +105,6 @@ struct NetworkServerGameInfo {
 	byte companies_on;           ///< How many started companies do we have
 	byte companies_max;          ///< Max companies allowed on server
 	byte spectators_on;          ///< How many spectators do we have?
-	byte spectators_max;         ///< Max spectators allowed on server
 	byte landscape;              ///< The used landscape
 	int gamescript_version;      ///< Version of the gamescript.
 	std::string gamescript_name; ///< Name of the gamescript.

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -314,8 +314,6 @@ static std::string _password_server_id;
 
 /** Maximum number of companies of the currently joined server. */
 static uint8 _network_server_max_companies;
-/** Maximum number of spectators of the currently joined server. */
-static uint8 _network_server_max_spectators;
 
 /** Information about the game to join to. */
 NetworkJoinInfo _network_join;
@@ -1189,7 +1187,6 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CONFIG_UPDATE(P
 	if (this->status < STATUS_ACTIVE) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
 	_network_server_max_companies = p->Recv_uint8();
-	_network_server_max_spectators = p->Recv_uint8();
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -1405,13 +1402,4 @@ bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio)
 bool NetworkMaxCompaniesReached()
 {
 	return Company::GetNumItems() >= (_network_server ? _settings_client.network.max_companies : _network_server_max_companies);
-}
-
-/**
- * Check if max_spectatos has been reached on the server (local check only).
- * @return true if the max value has been reached or exceeded, false otherwise.
- */
-bool NetworkMaxSpectatorsReached()
-{
-	return NetworkSpectatorCount() >= (_network_server ? _settings_client.network.max_spectators : _network_server_max_spectators);
 }

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -60,7 +60,6 @@ void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const 
 bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio);
 bool NetworkCompanyIsPassworded(CompanyID company_id);
 bool NetworkMaxCompaniesReached();
-bool NetworkMaxSpectatorsReached();
 void NetworkPrintClients();
 void NetworkHandlePauseChange(PauseMode prev_mode, PauseMode changed_mode);
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1033,10 +1033,6 @@ struct NetworkStartServerWindow : public Window {
 			case WID_NSS_COMPANIES_TXT:
 				SetDParam(0, _settings_client.network.max_companies);
 				break;
-
-			case WID_NSS_SPECTATORS_TXT:
-				SetDParam(0, _settings_client.network.max_spectators);
-				break;
 		}
 	}
 
@@ -1079,7 +1075,6 @@ struct NetworkStartServerWindow : public Window {
 
 			case WID_NSS_CLIENTS_BTND:    case WID_NSS_CLIENTS_BTNU:    // Click on up/down button for number of clients
 			case WID_NSS_COMPANIES_BTND:  case WID_NSS_COMPANIES_BTNU:  // Click on up/down button for number of companies
-			case WID_NSS_SPECTATORS_BTND: case WID_NSS_SPECTATORS_BTNU: // Click on up/down button for number of spectators
 				/* Don't allow too fast scrolling. */
 				if (!(this->flags & WF_TIMEOUT) || this->timeout_timer <= 1) {
 					this->HandleButtonClick(widget);
@@ -1091,9 +1086,6 @@ struct NetworkStartServerWindow : public Window {
 							break;
 						case WID_NSS_COMPANIES_BTND: case WID_NSS_COMPANIES_BTNU:
 							_settings_client.network.max_companies  = Clamp(_settings_client.network.max_companies  + widget - WID_NSS_COMPANIES_TXT,  1, MAX_COMPANIES);
-							break;
-						case WID_NSS_SPECTATORS_BTND: case WID_NSS_SPECTATORS_BTNU:
-							_settings_client.network.max_spectators = Clamp(_settings_client.network.max_spectators + widget - WID_NSS_SPECTATORS_TXT, 0, MAX_CLIENTS);
 							break;
 					}
 				}
@@ -1110,12 +1102,6 @@ struct NetworkStartServerWindow : public Window {
 				this->widget_id = WID_NSS_COMPANIES_TXT;
 				SetDParam(0, _settings_client.network.max_companies);
 				ShowQueryString(STR_JUST_INT, STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES,  3, this, CS_NUMERAL, QSF_NONE);
-				break;
-
-			case WID_NSS_SPECTATORS_TXT: // Click on number of spectators
-				this->widget_id = WID_NSS_SPECTATORS_TXT;
-				SetDParam(0, _settings_client.network.max_spectators);
-				ShowQueryString(STR_JUST_INT, STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS, 4, this, CS_NUMERAL, QSF_NONE);
 				break;
 
 			case WID_NSS_GENERATE_GAME: // Start game
@@ -1172,7 +1158,7 @@ struct NetworkStartServerWindow : public Window {
 
 	void OnTimeout() override
 	{
-		static const int raise_widgets[] = {WID_NSS_CLIENTS_BTND, WID_NSS_CLIENTS_BTNU, WID_NSS_COMPANIES_BTND, WID_NSS_COMPANIES_BTNU, WID_NSS_SPECTATORS_BTND, WID_NSS_SPECTATORS_BTNU, WIDGET_LIST_END};
+		static const int raise_widgets[] = {WID_NSS_CLIENTS_BTND, WID_NSS_CLIENTS_BTNU, WID_NSS_COMPANIES_BTND, WID_NSS_COMPANIES_BTNU, WIDGET_LIST_END};
 		for (const int *widget = raise_widgets; *widget != WIDGET_LIST_END; widget++) {
 			if (this->IsWidgetLowered(*widget)) {
 				this->RaiseWidget(*widget);
@@ -1194,7 +1180,6 @@ struct NetworkStartServerWindow : public Window {
 				default: NOT_REACHED();
 				case WID_NSS_CLIENTS_TXT:    _settings_client.network.max_clients    = Clamp(value, 2, MAX_CLIENTS); break;
 				case WID_NSS_COMPANIES_TXT:  _settings_client.network.max_companies  = Clamp(value, 1, MAX_COMPANIES); break;
-				case WID_NSS_SPECTATORS_TXT: _settings_client.network.max_spectators = Clamp(value, 0, MAX_CLIENTS); break;
 			}
 		}
 
@@ -1244,15 +1229,6 @@ static const NWidgetPart _nested_network_start_server_window_widgets[] = {
 						NWidget(WWT_IMGBTN, COLOUR_LIGHT_BLUE, WID_NSS_COMPANIES_BTND), SetMinimalSize(12, 12), SetFill(0, 1), SetDataTip(SPR_ARROW_DOWN, STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES_TOOLTIP),
 						NWidget(WWT_PUSHTXTBTN, COLOUR_LIGHT_BLUE, WID_NSS_COMPANIES_TXT), SetFill(1, 0), SetDataTip(STR_NETWORK_START_SERVER_COMPANIES_SELECT, STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES_TOOLTIP),
 						NWidget(WWT_IMGBTN, COLOUR_LIGHT_BLUE, WID_NSS_COMPANIES_BTNU), SetMinimalSize(12, 12), SetFill(0, 1), SetDataTip(SPR_ARROW_UP, STR_NETWORK_START_SERVER_NUMBER_OF_COMPANIES_TOOLTIP),
-					EndContainer(),
-				EndContainer(),
-
-				NWidget(NWID_VERTICAL), SetPIP(0, 1, 0),
-					NWidget(WWT_TEXT, COLOUR_LIGHT_BLUE, WID_NSS_SPECTATORS_LABEL), SetFill(1, 0), SetDataTip(STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS, STR_NULL),
-					NWidget(NWID_HORIZONTAL),
-						NWidget(WWT_IMGBTN, COLOUR_LIGHT_BLUE, WID_NSS_SPECTATORS_BTND), SetMinimalSize(12, 12), SetFill(0, 1), SetDataTip(SPR_ARROW_DOWN, STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS_TOOLTIP),
-						NWidget(WWT_PUSHTXTBTN, COLOUR_LIGHT_BLUE, WID_NSS_SPECTATORS_TXT), SetFill(1, 0), SetDataTip(STR_NETWORK_START_SERVER_SPECTATORS_SELECT, STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS_TOOLTIP),
-						NWidget(WWT_IMGBTN, COLOUR_LIGHT_BLUE, WID_NSS_SPECTATORS_BTNU), SetMinimalSize(12, 12), SetFill(0, 1), SetDataTip(SPR_ARROW_UP, STR_NETWORK_START_SERVER_NUMBER_OF_SPECTATORS_TOOLTIP),
 					EndContainer(),
 				EndContainer(),
 			EndContainer(),
@@ -1369,8 +1345,6 @@ struct NetworkLobbyWindow : public Window {
 		this->SetWidgetDisabledState(WID_NL_JOIN, this->company == INVALID_COMPANY || GetLobbyCompanyInfo(this->company)->ai);
 		/* Cannot start new company if there are too many. */
 		this->SetWidgetDisabledState(WID_NL_NEW, gi->companies_on >= gi->companies_max);
-		/* Cannot spectate if there are too many spectators. */
-		this->SetWidgetDisabledState(WID_NL_SPECTATE, gi->spectators_on >= gi->spectators_max);
 
 		this->vscroll->SetCount(gi->companies_on);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -820,7 +820,6 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendConfigUpdate()
 	Packet *p = new Packet(PACKET_SERVER_CONFIG_UPDATE);
 
 	p->Send_uint8(_settings_client.network.max_companies);
-	p->Send_uint8(_settings_client.network.max_spectators);
 	this->SendPacket(p);
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -890,9 +889,6 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_JOIN(Packet *p)
 			}
 			break;
 		case COMPANY_SPECTATOR: // Spectator
-			if (NetworkSpectatorCount() >= _settings_client.network.max_spectators) {
-				return this->SendError(NETWORK_ERROR_FULL);
-			}
 			break;
 		default: // Join another company (companies 1-8 (index 0-7))
 			if (!Company::IsValidHumanID(playas)) {

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -291,7 +291,6 @@ struct NetworkSettings {
 	uint8       autoclean_novehicles;                     ///< remove companies with no vehicles after this many months
 	uint8       max_companies;                            ///< maximum amount of companies
 	uint8       max_clients;                              ///< maximum amount of clients
-	uint8       max_spectators;                           ///< maximum amount of spectators
 	Year        restart_game_year;                        ///< year the server restarts
 	uint8       min_active_clients;                       ///< minimum amount of active clients to unpause the game
 	bool        reload_cfg;                               ///< reload the config file before restarting

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -225,16 +225,6 @@ post_cb  = [](auto) { UpdateClientConfigValues(); }
 cat      = SC_BASIC
 
 [SDTC_VAR]
-var      = network.max_spectators
-type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
-def      = 15
-min      = 0
-max      = MAX_CLIENTS
-post_cb  = [](auto) { UpdateClientConfigValues(); }
-cat      = SC_BASIC
-
-[SDTC_VAR]
 var      = network.restart_game_year
 type     = SLE_INT32
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_0_IS_SPECIAL | SF_NETWORK_ONLY

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -66,10 +66,6 @@ enum NetworkStartServerWidgets {
 	WID_NSS_COMPANIES_BTND,    ///< 'Max companies' downarrow.
 	WID_NSS_COMPANIES_TXT,     ///< 'Max companies' text.
 	WID_NSS_COMPANIES_BTNU,    ///< 'Max companies' uparrow.
-	WID_NSS_SPECTATORS_LABEL,  ///< Label for 'max spectators'.
-	WID_NSS_SPECTATORS_BTND,   ///< 'Max spectators' downarrow.
-	WID_NSS_SPECTATORS_TXT,    ///< 'Max spectators' text.
-	WID_NSS_SPECTATORS_BTNU,   ///< 'Max spectators' uparrow.
 
 	WID_NSS_GENERATE_GAME,     ///< New game button.
 	WID_NSS_LOAD_GAME,         ///< Load game button.


### PR DESCRIPTION
## Motivation / Problem

We want to remove the "lobby" window, as it is just an annoying window. As replacement, the "Join Game" button will join the game as spectator, from which you can move to a (new) company.

In order to get there, we need to remove "max spectators", as if you set spectators to 0, it would mean nobody can join.

Honestly, I am not sure "max spectators" has ever been useful.

## Description

Removed max-spectators. For master-server info, replaced it with "max-clients" for now, as that is basically the next value .. you can never have more spectators than "max-clients" :D

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
