### PR TITLE
Fix 8706dcd9: [Script] Byte-swap grfids to match normal expectations.

### DIFF
--- a/src/script/api/script_newgrf.cpp
+++ b/src/script/api/script_newgrf.cpp
@@ -19,13 +19,15 @@ ScriptNewGRFList::ScriptNewGRFList()
 {
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC)) {
-			this->AddItem(c->ident.grfid);
+			this->AddItem(BSWAP32(c->ident.grfid));
 		}
 	}
 }
 
 /* static */ bool ScriptNewGRF::IsLoaded(uint32 grfid)
 {
+	grfid = BSWAP32(grfid); // Match people's expectations.
+
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
 			return true;
@@ -37,6 +39,8 @@ ScriptNewGRFList::ScriptNewGRFList()
 
 /* static */ uint32 ScriptNewGRF::GetVersion(uint32 grfid)
 {
+	grfid = BSWAP32(grfid); // Match people's expectations.
+
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
 			return c->version;
@@ -48,6 +52,8 @@ ScriptNewGRFList::ScriptNewGRFList()
 
 /* static */ char *ScriptNewGRF::GetName(uint32 grfid)
 {
+	grfid = BSWAP32(grfid); // Match people's expectations.
+
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
 			return ::stredup(c->GetName());

--- a/src/script/api/script_newgrf.hpp
+++ b/src/script/api/script_newgrf.hpp
@@ -45,7 +45,7 @@ public:
 	static uint32 GetVersion(uint32 grfid);
 
 	/**
-	 * Get the BridgeID of a bridge at a given tile.
+	 * Get the name of a loaded NewGRF.
 	 * @param grfid The NewGRF to query.
 	 * @pre ScriptNewGRF::IsLoaded(grfid).
 	 * @return The name of the NewGRF or nullptr if no name is defined.


### PR DESCRIPTION
## Motivation / Problem / Description

Grfids are generally expected to be presented in a big-endian format. Swap internal grfids in the script API to match expectations.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
