### PR TITLE
Add: mention you are a spectator in the status bar (if you are, ofc)

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -783,6 +783,8 @@ STR_STATUSBAR_PAUSED_LINK_GRAPH                                 :{ORANGE}*  *  P
 STR_STATUSBAR_AUTOSAVE                                          :{RED}AUTOSAVE
 STR_STATUSBAR_SAVING_GAME                                       :{RED}*  *  SAVING GAME  *  *
 
+STR_STATUSBAR_SPECATOR                                          :{WHITE}(spectator)
+
 # News message history
 STR_MESSAGE_HISTORY                                             :{WHITE}Message History
 STR_MESSAGE_HISTORY_TOOLTIP                                     :{BLACK}A list of the recent news messages

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -147,11 +147,15 @@ struct StatusBarWindow : Window {
 				break;
 
 			case WID_S_RIGHT: {
-				/* Draw company money, if any */
-				const Company *c = Company::GetIfValid(_local_company);
-				if (c != nullptr) {
-					SetDParam(0, c->money);
-					DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, text_top, STR_COMPANY_MONEY, TC_FROMSTRING, SA_HOR_CENTER);
+				if (_local_company == COMPANY_SPECTATOR) {
+					DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, text_top, STR_STATUSBAR_SPECATOR, TC_FROMSTRING, SA_HOR_CENTER);
+				} else {
+					/* Draw company money, if any */
+					const Company *c = Company::GetIfValid(_local_company);
+					if (c != nullptr) {
+						SetDParam(0, c->money);
+						DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, text_top, STR_COMPANY_MONEY, TC_FROMSTRING, SA_HOR_CENTER);
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

During talks about the new network flow on IRC it came up we don't mention in the statusbar that you are spectator. It sound like a good idea to hint that to the player.


## Description

Initially we considered `***SPECTATOR***` in the middle-part, but with news and everything that feels weird. So in the currency part seems better, as there is never any money there anyway.

The result:
![image](https://user-images.githubusercontent.com/1663690/129402790-e4042efc-5873-401a-b2ee-d56870b9a505.png)

This is up for vote if we like this or not.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
