### PR TITLE
Add: [InterfaceTutorial] show tutorial the first time you join any server 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,6 +205,9 @@ add_files(
     ini.cpp
     ini_load.cpp
     ini_type.h
+    interface_tutorial_gui.cpp
+    interface_tutorial_gui.h
+    interface_tutorial_type.h
     intro_gui.cpp
     landscape.cpp
     landscape.h

--- a/src/interface_tutorial_gui.cpp
+++ b/src/interface_tutorial_gui.cpp
@@ -1,0 +1,136 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file interface_tutorial_gui.cpp The GUI for the interface tutorials. */
+
+#include "stdafx.h"
+#include "gfx_func.h"
+#include "settings_type.h"
+#include "strings_func.h"
+#include "interface_tutorial_gui.h"
+#include "interface_tutorial_type.h"
+#include "window_gui.h"
+#include "window_func.h"
+
+#include "widgets/network_widget.h"
+
+#include "widgets/interface_tutorial_widget.h"
+
+#include "debug.h"
+
+#include "safeguards.h"
+
+struct InterfaceTutorialStepData {
+	InterfaceTutorialStep step;
+	StringID caption_string_id;
+	StringID text_string_id;
+	WindowClass window;
+	uint32 number;
+	uint8 widget;
+	bool *setting;
+};
+
+static const InterfaceTutorialStepData tutorial_steps[] = {
+	{
+		INTERFACE_TUTORIAL_MULTIPLAYER_JOIN,
+		STR_INTERFACE_TUTORIAL_MULTIPLAYER_JOIN_CAPTION,
+		STR_INTERFACE_TUTORIAL_MULTIPLAYER_JOIN_TEXT,
+		WC_CLIENT_LIST, 0,
+		WID_CL_MATRIX,
+		&_settings_client.tutorial.multiplayer_join
+	},
+};
+
+struct InterfaceTutorialWindow : Window {
+	const InterfaceTutorialStepData &data;
+
+	InterfaceTutorialWindow(WindowDesc *desc, const InterfaceTutorialStepData &data) : Window(desc), data(data)
+	{
+		this->InitNested();
+
+		Window *w = FindWindowById(this->data.window, this->data.number);
+		if (w != nullptr) {
+			w->SetWidgetHighlight(this->data.widget, TC_LIGHT_BLUE);
+		}
+	}
+
+	void Close() override
+	{
+		/* Mark this tutorial as seen, so it doesn't open next time. */
+		*this->data.setting = true;
+
+		Window *w = FindWindowById(this->data.window, this->data.number);
+		if (w != nullptr) {
+			w->SetWidgetHighlight(this->data.widget, TC_INVALID);
+		}
+
+		this->Window::Close();
+	}
+
+	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
+	{
+		if (widget == WID_IT_TEXT) {
+			*size = GetStringBoundingBox(STR_INTERFACE_TUTORIAL_TEXT);
+			size->height = GetStringHeight(STR_INTERFACE_TUTORIAL_TEXT, size->width - WD_FRAMETEXT_LEFT - WD_FRAMETEXT_RIGHT) + WD_FRAMETEXT_BOTTOM + WD_FRAMETEXT_TOP;
+		}
+	}
+
+	void SetStringParameters(int widget) const override
+	{
+		switch (widget) {
+			case WID_IT_CAPTION:
+				SetDParam(0, this->data.caption_string_id);
+				break;
+
+			case WID_IT_TEXT:
+				SetDParam(0, this->data.text_string_id);
+				break;
+		}
+	}
+
+	void DrawWidget(const Rect &r, int widget) const override
+	{
+		if (widget != WID_IT_TEXT) return;
+
+		DrawStringMultiLine(r.left + WD_FRAMETEXT_LEFT, r.right - WD_FRAMETEXT_RIGHT, r.top + WD_FRAMETEXT_TOP, r.bottom - WD_FRAMETEXT_BOTTOM, STR_INTERFACE_TUTORIAL_TEXT, TC_FROMSTRING, SA_CENTER);
+	}
+
+	void OnClick(Point pt, int widget, int click_count) override
+	{
+		switch (widget) {
+			case WID_IT_CLOSE:
+				this->Close();
+				break;
+		}
+	}
+};
+
+static const NWidgetPart _nested_interface_tutorial_widgets[] = {
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_CLOSEBOX, COLOUR_LIGHT_BLUE),
+		NWidget(WWT_CAPTION, COLOUR_LIGHT_BLUE, WID_IT_CAPTION), SetDataTip(STR_INTERFACE_TUTORIAL_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+	EndContainer(),
+	NWidget(WWT_PANEL, COLOUR_LIGHT_BLUE),
+		NWidget(WWT_TEXT, COLOUR_LIGHT_BLUE, WID_IT_TEXT), SetFill(1, 1),
+	EndContainer(),
+	NWidget(WWT_PUSHTXTBTN, COLOUR_LIGHT_BLUE, WID_IT_CLOSE), SetMinimalSize(71, 12), SetFill(1, 1), SetDataTip(STR_INTERFACE_TUTORIAL_CLOSE, STR_NULL),
+};
+
+static WindowDesc _interface_tutorial_desc(
+	WDP_CENTER, nullptr, 0, 0,
+	WC_INTERFACE_TUTORIAL, WC_NONE,
+	0,
+	_nested_interface_tutorial_widgets, lengthof(_nested_interface_tutorial_widgets)
+);
+
+void ShowInterfaceTutorial(InterfaceTutorialStep step)
+{
+	if (step >= INTERFACE_TUTORIAL_END) return;
+	if (*tutorial_steps[step].setting) return;
+
+	new InterfaceTutorialWindow(&_interface_tutorial_desc, tutorial_steps[step]);
+}

--- a/src/interface_tutorial_gui.h
+++ b/src/interface_tutorial_gui.h
@@ -1,0 +1,17 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file interface_tutorial_func.h Functions related to the interface tutorial. */
+
+#ifndef INTERFACE_TUTORIAL_FUNC_H
+#define INTERFACE_TUTORIAL_FUNC_H
+
+#include "interface_tutorial_type.h"
+
+void ShowInterfaceTutorial(InterfaceTutorialStep step);
+
+#endif /* INTERFACE_TUTORIAL_FUNC_H */

--- a/src/interface_tutorial_type.h
+++ b/src/interface_tutorial_type.h
@@ -1,0 +1,18 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file interface_tutorial_type.h Base types related to the interface tutorial. */
+
+#ifndef INTERFACE_TUTORIAL_TYPE_H
+#define INTERFACE_TUTORIAL_TYPE_H
+
+enum InterfaceTutorialStep {
+	INTERFACE_TUTORIAL_MULTIPLAYER_JOIN,
+	INTERFACE_TUTORIAL_END,
+};
+
+#endif /* INTERFACE_TUTORIAL_TYPE_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5251,3 +5251,10 @@ STR_PLANE                                                       :{BLACK}{PLANE}
 STR_SHIP                                                        :{BLACK}{SHIP}
 
 STR_TOOLBAR_RAILTYPE_VELOCITY                                   :{STRING} ({VELOCITY})
+
+STR_INTERFACE_TUTORIAL_CAPTION                                  :{BLACK}Tutorial: {STRING}
+STR_INTERFACE_TUTORIAL_TEXT                                     :{BLACK}{STRING}
+STR_INTERFACE_TUTORIAL_CLOSE                                    :{BLACK}Close
+
+STR_INTERFACE_TUTORIAL_MULTIPLAYER_JOIN_CAPTION                 :first time joining a server
+STR_INTERFACE_TUTORIAL_MULTIPLAYER_JOIN_TEXT                    :You always first join a server as spectator.{}As a spectator, you can look around, but not build.{}To start playing, use the "Online Players" window to either create your own company or join a friend's.

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -18,6 +18,7 @@
 #include "../company_func.h"
 #include "../company_base.h"
 #include "../company_gui.h"
+#include "../interface_tutorial_gui.h"
 #include "../core/random_func.hpp"
 #include "../date_func.h"
 #include "../gfx_func.h"
@@ -900,6 +901,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 			_network_join_status = NETWORK_JOIN_STATUS_REGISTERING;
 			ShowJoinStatusWindow();
 			NetworkSendCommand(0, CCA_NEW, 0, CMD_COMPANY_CTRL, nullptr, {}, _local_company);
+		} else {
+			/* If you join the game as spectator, possibly show tutorial. */
+			ShowInterfaceTutorial(INTERFACE_TUTORIAL_MULTIPLAYER_JOIN);
 		}
 	} else {
 		/* take control over an existing company */

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -887,6 +887,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 	/* Say we received the map and loaded it correctly! */
 	SendMapOk();
 
+	ShowClientList();
+
 	/* New company/spectator (invalid company) or company we want to join is not active
 	 * Switch local company to spectator and await the server's judgement */
 	if (_network_join.company == COMPANY_NEW_COMPANY || !Company::IsValidID(_network_join.company)) {

--- a/src/script/api/script_window.hpp.in
+++ b/src/script/api/script_window.hpp.in
@@ -38,6 +38,7 @@
 #include "../../widgets/highscore_widget.h"
 #include "../../widgets/industry_widget.h"
 #include "../../widgets/intro_widget.h"
+#include "../../widgets/interface_tutorial_widget.h"
 #include "../../widgets/main_widget.h"
 #include "../../widgets/misc_widget.h"
 #include "../../widgets/music_widget.h"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -96,6 +96,7 @@ static auto &PrivateSettingTables()
 {
 	static const SettingTable _private_setting_tables[] = {
 		_network_private_settings,
+		_tutorial_private_settings,
 	};
 	return _private_setting_tables;
 }

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -67,6 +67,7 @@ SettingTable _news_display_settings{ _news_display_settings_table };
 SettingTable _old_gameopt_settings{ _old_gameopt_settings_table };
 SettingTable _pathfinding_settings{ _pathfinding_settings_table };
 SettingTable _script_settings{ _script_settings_table };
+SettingTable _tutorial_private_settings{ _tutorial_private_settings_table };
 SettingTable _window_settings{ _window_settings_table };
 SettingTable _world_settings{ _world_settings_table };
 #if defined(_WIN32) && !defined(DEDICATED)

--- a/src/settings_table.h
+++ b/src/settings_table.h
@@ -32,6 +32,7 @@ extern SettingTable _news_display_settings;
 extern SettingTable _old_gameopt_settings;
 extern SettingTable _pathfinding_settings;
 extern SettingTable _script_settings;
+extern SettingTable _tutorial_private_settings;
 extern SettingTable _window_settings;
 extern SettingTable _world_settings;
 #if defined(_WIN32) && !defined(DEDICATED)

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -299,6 +299,11 @@ struct NetworkSettings {
 	UseRelayService use_relay_service;                        ///< Use relay service?
 };
 
+/** Settings to indicat eif user saw a piece of the tutorial. */
+struct TutorialSettings {
+	bool multiplayer_join;                   ///< Player has joined a multiplayer game before.
+};
+
 /** Settings related to the creation of games. */
 struct GameCreationSettings {
 	uint32 generation_seed;                  ///< noise seed for world generation
@@ -596,6 +601,7 @@ struct ClientSettings {
 	SoundSettings        sound;              ///< sound effect settings
 	MusicSettings        music;              ///< settings related to music/sound
 	NewsSettings         news_display;       ///< news display settings.
+	TutorialSettings     tutorial;           ///< Indications what part of the tutorial the player has seen.
 };
 
 /** The current settings for this game. */

--- a/src/table/settings/CMakeLists.txt
+++ b/src/table/settings/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TABLE_INI_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/old_gameopt_settings.ini
         ${CMAKE_CURRENT_SOURCE_DIR}/pathfinding_settings.ini
         ${CMAKE_CURRENT_SOURCE_DIR}/script_settings.ini
+        ${CMAKE_CURRENT_SOURCE_DIR}/tutorial_private_settings.ini
         ${CMAKE_CURRENT_SOURCE_DIR}/win32_settings.ini
         ${CMAKE_CURRENT_SOURCE_DIR}/window_settings.ini
         ${CMAKE_CURRENT_SOURCE_DIR}/world_settings.ini

--- a/src/table/settings/tutorial_private_settings.ini
+++ b/src/table/settings/tutorial_private_settings.ini
@@ -1,0 +1,38 @@
+; This file is part of OpenTTD.
+; OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+; OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+; See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+;
+
+; Tutorial settings as stored in the private configuration file ("private.cfg").
+
+[pre-amble]
+static const SettingVariant _tutorial_private_settings_table[] = {
+[post-amble]
+};
+[templates]
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+
+[validation]
+
+[defaults]
+flags    = SF_NONE
+interval = 0
+str      = STR_NULL
+strhelp  = STR_CONFIG_SETTING_NO_EXPLANATION_AVAILABLE_HELPTEXT
+strval   = STR_NULL
+pre_cb   = nullptr
+post_cb  = nullptr
+load     = nullptr
+from     = SL_MIN_VERSION
+to       = SL_MAX_VERSION
+cat      = SC_ADVANCED
+extra    = 0
+startup  = false
+
+
+[SDTC_BOOL]
+var      = tutorial.multiplayer_join
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = false
+cat      = SC_BASIC

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -25,6 +25,7 @@ add_files(
     group_widget.h
     highscore_widget.h
     industry_widget.h
+    interface_tutorial_widget.h
     intro_widget.h
     link_graph_legend_widget.h
     main_widget.h

--- a/src/widgets/interface_tutorial_widget.h
+++ b/src/widgets/interface_tutorial_widget.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file interface_tutorial_widget.h Types related to the tutorial widgets. */
+
+#ifndef WIDGETS_INTERFACE_TUTORIAL_WIDGET_H
+#define WIDGETS_INTERFACE_TUTORIAL_WIDGET_H
+
+/** Widgets of the #TutorialWindow class. */
+enum InterfaceTutorialWidgets {
+	WID_IT_CAPTION,               ///< Caption of the window.
+	WID_IT_TEXT,                  ///< Text in the window.
+	WID_IT_CLOSE,                 ///< "Close" button.
+};
+
+#endif /* WIDGETS_INTERFACE_TUTORIAL_WIDGET_H */

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -695,6 +695,12 @@ enum WindowClass {
 	 */
 	WC_SCREENSHOT,
 
+	/**
+	 * Interface tutorial window; %Window numbers:
+	 *   - 0 = #InterfaceTutorialWidgets
+	 */
+	WC_INTERFACE_TUTORIAL,
+
 	WC_INVALID = 0xFFFF, ///< Invalid window.
 };
 


### PR DESCRIPTION
Closes #9469.

## Motivation / Problem

With #9467 we can leave new players a bit lost in where to go next after joining a server. So after some talking to @nielsmh on IRC, we figured a tutorial would really help. Not only here, but on many more places in the game.

This is as alternative to #9469, which addresses the same issue, but via a MOTD. A tutorial might be more to the point, as it means the MOTD window doesn't share more than one purpose. Additionally, MOTD needs more work around text-editing / styling in OpenTTD before it becomes truly useful.

## Description

UPDATE: to make it more clear, renamed everything to "Interface Tutorial", as these tutorials are only meant for the interface parts. Not for gameplay. The caption still reads "Tutorial", as this is more a developers mindset, than something the user needs to know.

To start somewhere, this PR introduces a small tutorial framework for the multiplayer only. Over time we can extend this for other parts, but this gives us the opportunity to explore this a bit before going all-out with tutorials. In-game tutorials should still be done by GSes, but this covers the parts that a GS cannot cover. Basically, "how to use our interface" stuff.

Tutorials are only shown once, the first time you trigger it. In this case, only the first time you join any server. Never again after that. This information is saved in `private.cfg`, so people are less likely to give their tutorial status to other people when copying files.

I kept the framework really small, while still making it already a tiny bit generic. For example, future-work could add that "Close" can also be "Next", and that it chains several steps after each other. Think: "Here you can build trains" -> next -> "And here you can build road", etc. But this for now are only ideas.
It uses highlights to indicate where the user should look, just like a GS Can.

The text for this tutorial needs work, so suggestions are very welcome. Also (constructive) feedback on what you think about this tutorial system is welcome.

![image](https://user-images.githubusercontent.com/1663690/129413314-2276f91f-23c8-4744-9cd8-a308583d924c.png)

*!!!* Despite what the screenshot says, the text currently is:
```
You always first join a server as spectator.
As a spectator, you can look around, but not build.
To start playing, use the "Online Players" window to either create your own company or join a friend's.
```

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
