### PR TITLE
Remove: COMPANY_INFO packets and related code

### DIFF
--- a/src/network/core/core.h
+++ b/src/network/core/core.h
@@ -71,8 +71,6 @@ public:
 	 * Reopen the socket so we can send/receive stuff again.
 	 */
 	void Reopen() { this->has_quit = false; }
-
-	void SendCompanyInformation(Packet *p, const struct Company *c, const struct NetworkCompanyStats *stats, uint max_len = NETWORK_COMPANY_NAME_LENGTH);
 };
 
 #endif /* NETWORK_CORE_CORE_H */

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -73,8 +73,6 @@ NetworkRecvStatus NetworkGameSocketHandler::HandlePacket(Packet *p)
 		case PACKET_SERVER_ERROR:                 return this->Receive_SERVER_ERROR(p);
 		case PACKET_CLIENT_GAME_INFO:             return this->Receive_CLIENT_GAME_INFO(p);
 		case PACKET_SERVER_GAME_INFO:             return this->Receive_SERVER_GAME_INFO(p);
-		case PACKET_CLIENT_COMPANY_INFO:          return this->Receive_CLIENT_COMPANY_INFO(p);
-		case PACKET_SERVER_COMPANY_INFO:          return this->Receive_SERVER_COMPANY_INFO(p);
 		case PACKET_SERVER_CLIENT_INFO:           return this->Receive_SERVER_CLIENT_INFO(p);
 		case PACKET_SERVER_NEED_GAME_PASSWORD:    return this->Receive_SERVER_NEED_GAME_PASSWORD(p);
 		case PACKET_SERVER_NEED_COMPANY_PASSWORD: return this->Receive_SERVER_NEED_COMPANY_PASSWORD(p);
@@ -161,8 +159,6 @@ NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_JOIN(Packet *p) { ret
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_ERROR(Packet *p) { return this->ReceiveInvalidPacket(PACKET_SERVER_ERROR); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_GAME_INFO(Packet *p) { return this->ReceiveInvalidPacket(PACKET_CLIENT_GAME_INFO); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet *p) { return this->ReceiveInvalidPacket(PACKET_SERVER_GAME_INFO); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_CLIENT_COMPANY_INFO(Packet *p) { return this->ReceiveInvalidPacket(PACKET_CLIENT_COMPANY_INFO); }
-NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_COMPANY_INFO(Packet *p) { return this->ReceiveInvalidPacket(PACKET_SERVER_COMPANY_INFO); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_CLIENT_INFO(Packet *p) { return this->ReceiveInvalidPacket(PACKET_SERVER_CLIENT_INFO); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_NEED_GAME_PASSWORD(Packet *p) { return this->ReceiveInvalidPacket(PACKET_SERVER_NEED_GAME_PASSWORD); }
 NetworkRecvStatus NetworkGameSocketHandler::Receive_SERVER_NEED_COMPANY_PASSWORD(Packet *p) { return this->ReceiveInvalidPacket(PACKET_SERVER_NEED_COMPANY_PASSWORD); }

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -38,9 +38,9 @@ enum PacketGameType {
 	PACKET_CLIENT_JOIN,                  ///< The client telling the server it wants to join.
 	PACKET_SERVER_ERROR,                 ///< Server sending an error message to the client.
 
-	/* Packets used for the pre-game lobby (unused, but remain for backward/forward compatibility). */
-	PACKET_CLIENT_COMPANY_INFO,          ///< Request information about all companies.
-	PACKET_SERVER_COMPANY_INFO,          ///< Information about a single company.
+	/* Unused packet types, formerly used for the pre-game lobby. */
+	PACKET_CLIENT_UNUSED,                ///< Unused.
+	PACKET_SERVER_UNUSED,                ///< Unused.
 
 	/* Packets used to get the game info. */
 	PACKET_SERVER_GAME_INFO,             ///< Information about the server.
@@ -199,40 +199,6 @@ protected:
 	 * @param p The packet that was just received.
 	 */
 	virtual NetworkRecvStatus Receive_SERVER_GAME_INFO(Packet *p);
-
-	/**
-	 * Request company information (in detail).
-	 * @param p The packet that was just received.
-	 */
-	virtual NetworkRecvStatus Receive_CLIENT_COMPANY_INFO(Packet *p);
-
-	/**
-	 * Sends information about the companies (one packet per company):
-	 * uint8   Version of the structure of this packet (NETWORK_COMPANY_INFO_VERSION).
-	 * bool    Contains data (false marks the end of updates).
-	 * uint8   ID of the company.
-	 * string  Name of the company.
-	 * uint32  Year the company was inaugurated.
-	 * uint64  Value.
-	 * uint64  Money.
-	 * uint64  Income.
-	 * uint16  Performance (last quarter).
-	 * bool    Company is password protected.
-	 * uint16  Number of trains.
-	 * uint16  Number of lorries.
-	 * uint16  Number of busses.
-	 * uint16  Number of planes.
-	 * uint16  Number of ships.
-	 * uint16  Number of train stations.
-	 * uint16  Number of lorry stations.
-	 * uint16  Number of bus stops.
-	 * uint16  Number of airports and heliports.
-	 * uint16  Number of harbours.
-	 * bool    Company is an AI.
-	 * string  Client names (comma separated list)
-	 * @param p The packet that was just received.
-	 */
-	virtual NetworkRecvStatus Receive_SERVER_COMPANY_INFO(Packet *p);
 
 	/**
 	 * Send information about a client:

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -640,7 +640,7 @@ public:
 	{
 		_networking = true;
 		new ClientNetworkGameSocketHandler(s, this->connection_string);
-		MyClient::SendInformationQuery(false);
+		MyClient::SendInformationQuery();
 	}
 };
 

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -23,7 +23,6 @@ private:
 	enum ServerStatus {
 		STATUS_INACTIVE,      ///< The client is not connected nor active.
 		STATUS_GAME_INFO,     ///< We are trying to get the game information.
-		STATUS_COMPANY_INFO,  ///< We are trying to get company information.
 		STATUS_JOIN,          ///< We are trying to join a server.
 		STATUS_NEWGRFS_CHECK, ///< Last action was checking NewGRFs.
 		STATUS_AUTH_GAME,     ///< Last action was requesting game (server) password.
@@ -46,7 +45,6 @@ protected:
 	NetworkRecvStatus Receive_SERVER_BANNED(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_ERROR(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_GAME_INFO(Packet *p) override;
-	NetworkRecvStatus Receive_SERVER_COMPANY_INFO(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_NEED_GAME_PASSWORD(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_NEED_COMPANY_PASSWORD(Packet *p) override;
@@ -82,7 +80,7 @@ public:
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
 	void ClientError(NetworkRecvStatus res);
 
-	static NetworkRecvStatus SendInformationQuery(bool request_company_info);
+	static NetworkRecvStatus SendInformationQuery();
 
 	static NetworkRecvStatus SendJoin();
 	static NetworkRecvStatus SendCommand(const CommandPacket *cp);

--- a/src/network/network_server.h
+++ b/src/network/network_server.h
@@ -25,7 +25,6 @@ class ServerNetworkGameSocketHandler : public NetworkClientSocketPool::PoolItem<
 protected:
 	NetworkRecvStatus Receive_CLIENT_JOIN(Packet *p) override;
 	NetworkRecvStatus Receive_CLIENT_GAME_INFO(Packet *p) override;
-	NetworkRecvStatus Receive_CLIENT_COMPANY_INFO(Packet *p) override;
 	NetworkRecvStatus Receive_CLIENT_GAME_PASSWORD(Packet *p) override;
 	NetworkRecvStatus Receive_CLIENT_COMPANY_PASSWORD(Packet *p) override;
 	NetworkRecvStatus Receive_CLIENT_GETMAP(Packet *p) override;
@@ -42,7 +41,6 @@ protected:
 	NetworkRecvStatus Receive_CLIENT_MOVE(Packet *p) override;
 
 	NetworkRecvStatus SendGameInfo();
-	NetworkRecvStatus SendCompanyInfo();
 	NetworkRecvStatus SendNewGRFCheck();
 	NetworkRecvStatus SendWelcome();
 	NetworkRecvStatus SendNeedGamePassword();


### PR DESCRIPTION
## Motivation / Problem

#9467 asked if we could remove the `COMPANY_INFO` packets, as they are now unused (by our clients).


## Description

To get a bit of visual what it involves, I created this PR. I have several reservations whether this is a good idea or not.

- This also removes any other (custom) client to get company info. But to counter that, #7268 has a good point that showing company info on a private server is a bit weird .. and not really what you expect in 2021. So removing this would also work towards resolving #7268.
- `COMPANY_INFO` is part of the DO NOT CHANGE THIS .. which makes me wonder if there is anything I am overlooking, why this would be bad. I noticed I failed to estimate the impact of this.
- Currently you can gather this information from every server in the public listing. That might not have been the intention of this packet, but this removes that ability. It has to be noted that the admin port still has the ability to get the company info, but this of course requires authorization.
- Servers might use this on a banner to show who is on their server, how many trains, etc. They really should be using the admin port for that, but one cannot guarantee someone is using this.

We can also do everything "in between". Only remove the client-side, only remove the server-side, leave it alone.

I am rather conflicted about this, but I just present this PR so we can have a talk.

Edit: the more I think about it, the more I think all cases I mention where people might be using this packet, are illegal use of the packet. Additionally, #7268 really points out this packet should not exist in this form. So I do think we should remove it. Means we can also safely close #7268, as with this PR (combined with all the other work done on multiplayer) it is sufficiently addressed in my opinion.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
