### PR TITLE
Add: open Online Players GUI on starting/joining a server

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -868,6 +868,8 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_MAP_DONE(Packet
 	/* Say we received the map and loaded it correctly! */
 	SendMapOk();
 
+	ShowClientList();
+
 	/* New company/spectator (invalid company) or company we want to join is not active
 	 * Switch local company to spectator and await the server's judgement */
 	if (_network_join.company == COMPANY_NEW_COMPANY || !Company::IsValidID(_network_join.company)) {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -65,6 +65,7 @@
 #include "viewport_sprite_sorter.h"
 #include "framerate_type.h"
 #include "industry.h"
+#include "network/network_gui.h"
 
 #include "linkgraph/linkgraphschedule.h"
 
@@ -884,6 +885,8 @@ static void MakeNewGameDone()
 	CheckEngines();
 	CheckIndustries();
 	MarkWholeScreenDirty();
+
+	if (_network_server && !_network_dedicated) ShowClientList();
 }
 
 static void MakeNewGame(bool from_heightmap, bool reset_settings)


### PR DESCRIPTION
## Motivation / Problem

Basically everyone says: we should open the Online Players GUI when you join a server.

So .. here is the code to make that happen :)

## Description

Needed slightly more code, as by the time the window opens, you haven't received `ClientInfo` yet. So also make sure the GUI doesn't crash because of that.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
