### PR TITLE
Fix 2183fd4d: [NewGRF] Use divide instead of right shift for signed numbers.

### DIFF
--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1189,7 +1189,7 @@ int GetEngineProperty(EngineID engine, PropertyID property, int orig_value, cons
 	if (callback != CALLBACK_FAILED) {
 		if (is_signed) {
 			/* Sign extend 15 bit integer */
-			return static_cast<int16>(callback << 1) >> 1;
+			return static_cast<int16>(callback << 1) / 2;
 		} else {
 			return callback;
 		}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -363,7 +363,7 @@ int Train::GetCurveSpeedLimit() const
 
 		/* Apply max_speed modifier (cached value is fixed-point binary with 8 fractional bits)
 		 * and clamp the result to an acceptable range. */
-		max_speed += (max_speed * this->tcache.cached_curve_speed_mod) >> 8;
+		max_speed += (max_speed * this->tcache.cached_curve_speed_mod) / 256;
 		max_speed = Clamp(max_speed, 2, absolute_max_speed);
 	}
 


### PR DESCRIPTION


## Motivation / Problem

> For negative a, the value of a >> b is implementation-defined (in most implementations, this performs arithmetic right shift, so that the result remains negative).

## Description

Change the bit shift to a proper divide to avoid implementation-defined behaviour. It can probably be assumed that the compiler will optimize the divide properly.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
