### PR TITLE
Fix: [Actions] Ubuntu 18.04 by default has a compiler too old for OpenTTD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,14 +373,19 @@ jobs:
         include:
         - container_image: "ubuntu:18.04"
           bundle_name: "bionic"
+          compiler: "g++-8"
         - container_image: "ubuntu:20.04"
           bundle_name: "focal"
+          compiler: "g++"
         - container_image: "ubuntu:20.10"
           bundle_name: "groovy"
+          compiler: "g++"
         - container_image: "debian:buster"
           bundle_name: "buster"
+          compiler: "g++"
         - container_image: "debian:bullseye"
           bundle_name: "bullseye"
+          compiler: "g++"
 
     runs-on: ubuntu-20.04
     container:
@@ -406,7 +411,7 @@ jobs:
         apt-get install -y --no-install-recommends \
           cmake \
           debhelper \
-          g++ \
+          ${{ matrix.compiler }} \
           git \
           make \
           openssl \
@@ -432,7 +437,7 @@ jobs:
         cd build
 
         echo "::group::CMake"
-        cmake ${GITHUB_WORKSPACE} \
+        CXX=${{ matrix.compiler }} cmake ${GITHUB_WORKSPACE} \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_INSTALL_PREFIX=/usr \
           # EOF


### PR DESCRIPTION
## Motivation / Problem

We  have known this for a long time, but nobody seemed to care enough to fix it. So now here I am, moment before release, finding out nobody fixed it :(

## Description

Allow every Linux target to tell what the `CXX` is going to be. Should address the issue.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
