### PR TITLE
Fix: connecting with the same name thrice hangs the server 

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1541,13 +1541,12 @@ static void NetworkAutoCleanCompanies()
 bool NetworkMakeClientNameUnique(std::string &name)
 {
 	bool is_name_unique = false;
-	uint number = 0;
 	std::string original_name = name;
 
-	while (!is_name_unique) {
+	for (uint number = 1; !is_name_unique && number <= MAX_CLIENTS; number++) {  // Something's really wrong when there're more names than clients
 		is_name_unique = true;
 		for (const NetworkClientInfo *ci : NetworkClientInfo::Iterate()) {
-			if (ci->client_name.compare(name) == 0) {
+			if (ci->client_name == name) {
 				/* Name already in use */
 				is_name_unique = false;
 				break;
@@ -1556,7 +1555,7 @@ bool NetworkMakeClientNameUnique(std::string &name)
 		/* Check if it is the same as the server-name */
 		const NetworkClientInfo *ci = NetworkClientInfo::GetByClientID(CLIENT_ID_SERVER);
 		if (ci != nullptr) {
-			if (ci->client_name.compare(name) == 0) is_name_unique = false; // name already in use
+			if (ci->client_name == name) is_name_unique = false; // name already in use
 		}
 
 		if (!is_name_unique) {


### PR DESCRIPTION
## Motivation / Problem

With conversion to std::sring in #9310 NetworkMakeClientNameUnique also lost a client # increment and infinite loop protection. So when connecting with the same name first client gets it as it is, second gets #0 and third hangs the server xD

## Description

Restructured code a bit making it clear that it assigns numbers correctly and can't become and infinite loop.
Also, while at it, changed `.compare() == 0` to regular `==` for better readability.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* **The bug fix is important enough to be backported? (label: 'backport requested')**
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
