### PR TITLE
Fix: report reuse of invite-code and switch to local game-type

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2285,6 +2285,7 @@ STR_NETWORK_MESSAGE_SERVER_REBOOT                               :{WHITE}The serv
 STR_NETWORK_MESSAGE_KICKED                                      :*** {RAW_STRING} was kicked. Reason: ({RAW_STRING})
 
 STR_NETWORK_ERROR_COORDINATOR_REGISTRATION_FAILED               :{WHITE}Server registration failed
+STR_NETWORK_ERROR_COORDINATOR_REUSE_OF_INVITE_CODE              :{WHITE}Another server with the same invite-code registered itself. Switching to "local" game-type.
 STR_NETWORK_ERROR_COORDINATOR_ISOLATED                          :{WHITE}Your server doesn't allow remote connections
 STR_NETWORK_ERROR_COORDINATOR_ISOLATED_DETAIL                   :{WHITE}Other players won't be able to connect to your server
 

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -50,7 +50,7 @@ static const uint16 COMPAT_MTU                      = 1460;           ///< Numbe
 static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
-static const byte NETWORK_COORDINATOR_VERSION       =    5;           ///< What version of game-coordinator-protocol do we use?
+static const byte NETWORK_COORDINATOR_VERSION       =    6;           ///< What version of game-coordinator-protocol do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'

--- a/src/network/core/tcp_coordinator.h
+++ b/src/network/core/tcp_coordinator.h
@@ -61,9 +61,10 @@ enum ConnectionType {
  * The type of error from the Game Coordinator.
  */
 enum NetworkCoordinatorErrorType {
-	NETWORK_COORDINATOR_ERROR_UNKNOWN,             ///< There was an unknown error.
-	NETWORK_COORDINATOR_ERROR_REGISTRATION_FAILED, ///< Your request for registration failed.
-	NETWORK_COORDINATOR_ERROR_INVALID_INVITE_CODE, ///< The invite code given is invalid.
+	NETWORK_COORDINATOR_ERROR_UNKNOWN,              ///< There was an unknown error.
+	NETWORK_COORDINATOR_ERROR_REGISTRATION_FAILED,  ///< Your request for registration failed.
+	NETWORK_COORDINATOR_ERROR_INVALID_INVITE_CODE,  ///< The invite code given is invalid.
+	NETWORK_COORDINATOR_ERROR_REUSE_OF_INVITE_CODE, ///< The invite code is used by another (newer) server.
 };
 
 /** Base socket handler for all Game Coordinator TCP sockets. */

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -135,7 +135,6 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet *p)
 			return false;
 
 		case NETWORK_COORDINATOR_ERROR_REGISTRATION_FAILED:
-			SetDParamStr(0, detail);
 			ShowErrorMessage(STR_NETWORK_ERROR_COORDINATOR_REGISTRATION_FAILED, STR_JUST_RAW_STRING, WL_ERROR);
 
 			/* To prevent that we constantly try to reconnect, switch to local game. */
@@ -158,6 +157,15 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet *p)
 			UpdateNetworkGameWindow();
 			return true;
 		}
+
+		case NETWORK_COORDINATOR_ERROR_REUSE_OF_INVITE_CODE:
+			ShowErrorMessage(STR_NETWORK_ERROR_COORDINATOR_REUSE_OF_INVITE_CODE, STR_JUST_RAW_STRING, WL_ERROR);
+
+			/* To prevent that we constantly battle for the same invite-code, switch to local game. */
+			_settings_client.network.server_game_type = SERVER_GAME_TYPE_LOCAL;
+
+			this->CloseConnection();
+			return false;
 
 		default:
 			Debug(net, 0, "Invalid error type {} received from Game Coordinator", error);


### PR DESCRIPTION


## Motivation / Problem

Two servers can announce themselves with the same invite-code. It does mean both servers also know the secret, so it is most likely the same user starting their server on different ports.

Currently, those two will battle for who owns the invite-code, kicking the other off constantly.

## Description

Instead of letting this battle go, the GC sends (since protocol version 6) an error indicating that this situation happen. To prevent the fighting going on, switch the old server to `local` game-type.

The server operator should be able to pick up from this, and realise he is using the same invite-code for both games.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
