### PR TITLE
Fix 977604ef: [Linkgraph] Add a special case for unknown travel times on link update

### DIFF
--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -74,6 +74,8 @@ void LinkGraph::Compress()
 			if (edge.capacity > 0) {
 				edge.capacity = std::max(1U, edge.capacity / 2);
 				edge.usage /= 2;
+			}
+			if (edge.travel_time_sum > 0) {
 				edge.travel_time_sum = std::max(1ULL, edge.travel_time_sum / 2);
 			}
 		}
@@ -279,14 +281,12 @@ void LinkGraph::Edge::Update(uint capacity, uint usage, uint32 travel_time, Edge
 		this->edge.capacity += capacity;
 		this->edge.usage += usage;
 	} else if (mode & EUM_REFRESH) {
-		/* If travel time is not provided, we scale the stored time based on
-		 * the capacity increase. */
-		if (capacity > this->edge.capacity && travel_time == 0) {
+		if (this->edge.travel_time_sum == 0) {
+			this->edge.capacity = std::max(this->edge.capacity, capacity);
+			this->edge.travel_time_sum = travel_time * this->edge.capacity;
+		} else if (capacity > this->edge.capacity) {
 			this->edge.travel_time_sum = this->edge.travel_time_sum / this->edge.capacity * capacity;
 			this->edge.capacity = capacity;
-		} else {
-			this->edge.capacity = std::max(this->edge.capacity, capacity);
-			this->edge.travel_time_sum = std::max<uint64>(this->edge.travel_time_sum, travel_time * capacity);
 		}
 		this->edge.usage = std::max(this->edge.usage, usage);
 	}


### PR DESCRIPTION
## Motivation / Problem

In my recently-merged PR #9457, the case of unknown (null) travel times is not properly handled everywhere. This can distort the calculation of the travel times of new links for a few months after their creation.

## Description

This PR adds simple checks to address the case of unknown travel times.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
