### PR TITLE
Fix #9492: show for what server a relay session is being created

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2163,7 +2163,7 @@ STR_NETWORK_CLIENT_LIST_ASK_COMPANY_RESET                       :{YELLOW}Are you
 STR_NETWORK_CLIENT_LIST_ASK_COMPANY_UNLOCK                      :{YELLOW}Are you sure you want to reset the password of company '{COMPANY}'?
 
 STR_NETWORK_ASK_RELAY_CAPTION                                   :{WHITE}Use relay?
-STR_NETWORK_ASK_RELAY_TEXT                                      :{YELLOW}Failed to establish a connection between you and the server.{}Would you like to relay this session via '{RAW_STRING}'?
+STR_NETWORK_ASK_RELAY_TEXT                                      :{YELLOW}Failed to establish a connection between you and server '{RAW_STRING}'.{}Would you like to relay this session via '{RAW_STRING}'?
 STR_NETWORK_ASK_RELAY_NO                                        :{BLACK}No
 STR_NETWORK_ASK_RELAY_YES_ONCE                                  :{BLACK}Yes, this once
 STR_NETWORK_ASK_RELAY_YES_ALWAYS                                :{BLACK}Yes, don't ask again

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -54,7 +54,7 @@
 class ClientNetworkCoordinatorSocketHandler : public NetworkCoordinatorSocketHandler {
 private:
 	std::chrono::steady_clock::time_point next_update; ///< When to send the next update (if server and public).
-	std::map<std::string, TCPServerConnecter *> connecter; ///< Based on tokens, the current connecters that are pending.
+	std::map<std::string, std::pair<std::string, TCPServerConnecter *>> connecter; ///< Based on tokens, the current (invite-code, connecter) that are pending.
 	std::map<std::string, TCPServerConnecter *> connecter_pre; ///< Based on invite codes, the current connecters that are pending.
 	std::map<std::string, std::map<int, std::unique_ptr<ClientNetworkStunSocketHandler>>> stun_handlers; ///< All pending STUN handlers, stored by token:family.
 	std::map<std::string, std::unique_ptr<ClientNetworkTurnSocketHandler>> turn_handlers; ///< Pending TURN handler (if any), stored by token.

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2361,13 +2361,18 @@ void ShowNetworkCompanyPasswordWindow(Window *parent)
 }
 
 /**
- * Window used for asking the user if he is okay using a TURN server.
+ * Window used for asking the user if he is okay using a relay server.
  */
 struct NetworkAskRelayWindow : public Window {
-	std::string connection_string; ///< The TURN server we want to connect to.
-	std::string token;             ///< The token for this connection.
+	std::string server_connection_string; ///< The game server we want to connect to.
+	std::string relay_connection_string;  ///< The relay server we want to connect to.
+	std::string token;                    ///< The token for this connection.
 
-	NetworkAskRelayWindow(WindowDesc *desc, Window *parent, const std::string &connection_string, const std::string &token) : Window(desc), connection_string(connection_string), token(token)
+	NetworkAskRelayWindow(WindowDesc *desc, Window *parent, const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token) :
+		Window(desc),
+		server_connection_string(server_connection_string),
+		relay_connection_string(relay_connection_string),
+		token(token)
 	{
 		this->parent = parent;
 		this->InitNested(0);
@@ -2400,7 +2405,8 @@ struct NetworkAskRelayWindow : public Window {
 	{
 		switch (widget) {
 			case WID_NAR_TEXT:
-				SetDParamStr(0, this->connection_string);
+				SetDParamStr(0, this->server_connection_string);
+				SetDParamStr(1, this->relay_connection_string);
 				break;
 		}
 	}
@@ -2451,13 +2457,14 @@ static WindowDesc _network_ask_relay_desc(
 
 /**
  * Show a modal confirmation window with "no" / "yes, once" / "yes, always" buttons.
- * @param connection_string The relay server we want to connect to.
+ * @param server_connection_string The game server we want to connect to.
+ * @param relay_connection_string The relay server we want to connect to.
  * @param token The token for this connection.
  */
-void ShowNetworkAskRelay(const std::string &connection_string, const std::string &token)
+void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token)
 {
 	CloseWindowByClass(WC_NETWORK_ASK_RELAY);
 
 	Window *parent = FindWindowById(WC_MAIN_WINDOW, 0);
-	new NetworkAskRelayWindow(&_network_ask_relay_desc, parent, connection_string, token);
+	new NetworkAskRelayWindow(&_network_ask_relay_desc, parent, server_connection_string, relay_connection_string, token);
 }

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -23,6 +23,7 @@ void ShowJoinStatusWindow();
 void ShowNetworkGameWindow();
 void ShowClientList();
 void ShowNetworkCompanyPasswordWindow(Window *parent);
+void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token);
 
 
 /** Company information stored at the client side */
@@ -37,6 +38,5 @@ struct NetworkCompanyInfo : NetworkCompanyStats {
 	std::string clients;      ///< The clients that control this company (Name1, name2, ..)
 };
 
-void ShowNetworkAskRelay(const std::string &connection_string, const std::string &token);
 
 #endif /* NETWORK_GUI_H */


### PR DESCRIPTION
## Motivation / Problem

When you open the Multiplayer window, all your old servers are being "refreshed" to give an up-to-date picture of how the server is doing. Imagine this as clicking on every server in your last, and hitting refresh.
To refresh a server, a TCP connection with the server is established, and the `GAME_INFO` is requested.
Currently, when that TCP connection is being relayed, you get the message that the session is being relayed. However, it doesn't tell for what server. And rightfully this is confusing to the user opening the Multiplayer, as: why am I getting this window?

This PR mitigates that issue a bit by showing what server the session is being relayed for, so the user can connect the dots between: look, this server doesn't have game-info, and I see it in this window named now. It is a stop-gap solution.

## Description

The "invite-code" was not tracked for connections, as it wasn't relevant information anymore. So I had to poke some holes to keep that information up to the point the window can appear.

## Limitations

- I am never sure if this means I should delete all the translations for this string, as I am changing the amount of parameters?

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
