### PR TITLE
Fix #9491: reword "no connection" error message

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2202,7 +2202,7 @@ STR_NETWORK_CHAT_OSKTITLE                                       :{BLACK}Enter te
 # Network messages
 STR_NETWORK_ERROR_NOTAVAILABLE                                  :{WHITE}No network devices found
 STR_NETWORK_ERROR_NOSERVER                                      :{WHITE}Could not find any network games
-STR_NETWORK_ERROR_NOCONNECTION                                  :{WHITE}The server didn't answer the request
+STR_NETWORK_ERROR_NOCONNECTION                                  :{WHITE}Connection to the server timed out or was refused
 STR_NETWORK_ERROR_NEWGRF_MISMATCH                               :{WHITE}Could not connect due to NewGRF mismatch
 STR_NETWORK_ERROR_DESYNC                                        :{WHITE}Network-Game synchronisation failed
 STR_NETWORK_ERROR_LOSTCONNECTION                                :{WHITE}Network-Game connection lost


### PR DESCRIPTION
## Motivation / Problem

When the connection to the server couldn't be established, you get this weird error `The server didn't answer the request`. It is non-descriptive and misleading. #9491 also shows this can cause ?!?! with people.

## Description

Instead of having this generic message nobody knows how to deal with, be a bit more specific. The error happens that, if for what-ever reason, the "connector" couldn't establish a connection to the server. This basically means a wide range of errors:

- DNS failure
- TCP connect timeout
- TCP connect refused

And everything you can imagine up to just before the point of the connection being established. So I summarized it in other words in this PR. I am open for alternatives.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
