### PR TITLE
Fix a18188a: "Meaningful" is misspelled in landscape grid documentation.

### DIFF
--- a/docs/landscape_grid.html
+++ b/docs/landscape_grid.html
@@ -79,7 +79,7 @@ the array so you can quickly see what is used and what is not.
     <tr>
       <td rowspan="2">0</td>
       <td class="caption">ground</td>
-      <td class="bits" rowspan=27><span class="used" title="Tile type">XXXX</span> <span class="used" title="Presence and direction of bridge above">XX</span> <span class="used" title="Tropic Zone: only meaningfull in tropic climate. It contains the definition of the available zones">XX</span></td>
+      <td class="bits" rowspan=27><span class="used" title="Tile type">XXXX</span> <span class="used" title="Presence and direction of bridge above">XX</span> <span class="used" title="Tropic Zone: only meaningful in tropic climate. It contains the definition of the available zones">XX</span></td>
       <td class="bits" rowspan=27><span class="used" title="Tile height">XXXX XXXX</span></td>
       <td class="bits" rowspan=2><span class="free">OOO</span><span class="usable" title="Owner (always OWNER_NONE)">1 OOOO</span></td>
       <td class="bits"><span class="free">OOOO OOOO OOOO OOOO</span></td>


### PR DESCRIPTION
## Description

Meaningful is misspelled in landscape grid documentation.

My bad.
