### PR TITLE
Fix d9c1d18f2: Wrong format string for console disconnect message.

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -1660,9 +1660,9 @@ void NetworkServer_Tick(bool send_frame)
 					/* Client did still not report in within the specified limit. */
 					IConsolePrint(CC_WARNING, cs->last_packet + std::chrono::milliseconds(lag * MILLISECONDS_PER_TICK) > std::chrono::steady_clock::now() ?
 							/* A packet was received in the last three game days, so the client is likely lagging behind. */
-								"Client #%u (IP: %s) is dropped because the client's game state is more than %d ticks behind." :
+								"Client #{} (IP: {}) is dropped because the client's game state is more than {} ticks behind." :
 							/* No packet was received in the last three game days; sounds like a lost connection. */
-								"Client #%u (IP: %s) is dropped because the client did not respond for more than %d ticks.",
+								"Client #{} (IP: {}) is dropped because the client did not respond for more than {} ticks.",
 							cs->client_id, cs->GetClientIP(), lag);
 					cs->SendError(NETWORK_ERROR_TIMEOUT_COMPUTER);
 					continue;


### PR DESCRIPTION
## Motivation / Problem / Description

Console message about dropped lagged client was not properly updated when changing formatting to use `fmt`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
