### PR TITLE
Fix #9501: [Network] crash when more than one game-info query was pending

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -22,6 +22,8 @@ add_files(
     network_gui.cpp
     network_gui.h
     network_internal.h
+    network_query.cpp
+    network_query.h
     network_server.cpp
     network_server.h
     network_stun.cpp

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -14,6 +14,7 @@
 #include "../date_func.h"
 #include "network_admin.h"
 #include "network_client.h"
+#include "network_query.h"
 #include "network_server.h"
 #include "network_content.h"
 #include "network_udp.h"
@@ -638,9 +639,7 @@ public:
 
 	void OnConnect(SOCKET s) override
 	{
-		_networking = true;
-		new ClientNetworkGameSocketHandler(s, this->connection_string);
-		MyClient::SendInformationQuery();
+		QueryNetworkGameSocketHandler::QueryServer(s, this->connection_string);
 	}
 };
 
@@ -651,8 +650,6 @@ public:
 void NetworkQueryServer(const std::string &connection_string)
 {
 	if (!_network_available) return;
-
-	NetworkInitialize();
 
 	new TCPQueryConnecter(connection_string);
 }
@@ -1020,6 +1017,7 @@ void NetworkBackgroundLoop()
 	_network_coordinator_client.SendReceive();
 	TCPConnecter::CheckCallbacks();
 	NetworkHTTPSocketHandler::HTTPReceive();
+	QueryNetworkGameSocketHandler::SendReceive();
 
 	NetworkBackgroundUDPLoop();
 }

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -23,7 +23,6 @@
 #include "../gfx_func.h"
 #include "../error.h"
 #include "../rev.h"
-#include "core/game_info.h"
 #include "network.h"
 #include "network_base.h"
 #include "network_client.h"
@@ -328,17 +327,6 @@ static_assert(NETWORK_SERVER_ID_LENGTH == 16 * 2 + 1);
  *   DEF_CLIENT_SEND_COMMAND has no parameters
  ************/
 
-/**
- * Query the server for server information.
- */
-NetworkRecvStatus ClientNetworkGameSocketHandler::SendInformationQuery()
-{
-	my_client->status = STATUS_GAME_INFO;
-	my_client->SendPacket(new Packet(PACKET_CLIENT_GAME_INFO));
-
-	return NETWORK_RECV_STATUS_OKAY;
-}
-
 /** Tell the server we would like to join. */
 NetworkRecvStatus ClientNetworkGameSocketHandler::SendJoin()
 {
@@ -557,26 +545,6 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_BANNED(Packet *
 	return NETWORK_RECV_STATUS_SERVER_BANNED;
 }
 
-NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet *p)
-{
-	if (this->status != STATUS_GAME_INFO) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
-
-	NetworkGameList *item = NetworkGameListAddItem(this->connection_string);
-
-	/* Clear any existing GRFConfig chain. */
-	ClearGRFConfigList(&item->info.grfconfig);
-	/* Retrieve the NetworkGameInfo from the packet. */
-	DeserializeNetworkGameInfo(p, &item->info);
-	/* Check for compatability with the client. */
-	CheckGameCompatibility(item->info);
-	/* Ensure we consider the server online. */
-	item->online = true;
-
-	UpdateNetworkGameWindow();
-
-	return NETWORK_RECV_STATUS_CLOSE_QUERY;
-}
-
 /* This packet contains info about the client (playas and name)
  *  as client we save this in NetworkClientInfo, linked via 'client_id'
  *  which is always an unique number on a server. */
@@ -664,15 +632,6 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_ERROR(Packet *p
 	static_assert(lengthof(network_error_strings) == NETWORK_ERROR_END);
 
 	NetworkErrorCode error = (NetworkErrorCode)p->Recv_uint8();
-
-	/* If we query a server that is 1.11.1 or older, we get an
-	 * NETWORK_ERROR_NOT_EXPECTED on requesting the game info. Show a special
-	 * error popup in that case.
-	 */
-	if (error == NETWORK_ERROR_NOT_EXPECTED && this->status == STATUS_GAME_INFO) {
-		ShowErrorMessage(STR_NETWORK_ERROR_SERVER_TOO_OLD, INVALID_STRING_ID, WL_CRITICAL);
-		return NETWORK_RECV_STATUS_CLOSE_QUERY;
-	}
 
 	StringID err = STR_NETWORK_ERROR_LOSTCONNECTION;
 	if (error < (ptrdiff_t)lengthof(network_error_strings)) err = network_error_strings[error];

--- a/src/network/network_client.h
+++ b/src/network/network_client.h
@@ -22,7 +22,6 @@ private:
 	/** Status of the connection with the server. */
 	enum ServerStatus {
 		STATUS_INACTIVE,      ///< The client is not connected nor active.
-		STATUS_GAME_INFO,     ///< We are trying to get the game information.
 		STATUS_JOIN,          ///< We are trying to join a server.
 		STATUS_NEWGRFS_CHECK, ///< Last action was checking NewGRFs.
 		STATUS_AUTH_GAME,     ///< Last action was requesting game (server) password.
@@ -44,7 +43,6 @@ protected:
 	NetworkRecvStatus Receive_SERVER_FULL(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_BANNED(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_ERROR(Packet *p) override;
-	NetworkRecvStatus Receive_SERVER_GAME_INFO(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_CLIENT_INFO(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_NEED_GAME_PASSWORD(Packet *p) override;
 	NetworkRecvStatus Receive_SERVER_NEED_COMPANY_PASSWORD(Packet *p) override;
@@ -79,8 +77,6 @@ public:
 
 	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
 	void ClientError(NetworkRecvStatus res);
-
-	static NetworkRecvStatus SendInformationQuery();
 
 	static NetworkRecvStatus SendJoin();
 	static NetworkRecvStatus SendCommand(const CommandPacket *cp);

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -1,0 +1,145 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_query.cpp Query part of the network protocol. */
+
+#include "../stdafx.h"
+#include "core/game_info.h"
+#include "network_query.h"
+#include "network_gamelist.h"
+#include "../error.h"
+
+#include "table/strings.h"
+
+#include "../safeguards.h"
+
+std::vector<std::unique_ptr<QueryNetworkGameSocketHandler>> QueryNetworkGameSocketHandler::queries = {};
+
+NetworkRecvStatus QueryNetworkGameSocketHandler::CloseConnection(NetworkRecvStatus status)
+{
+	assert(status != NETWORK_RECV_STATUS_OKAY);
+	assert(this->sock != INVALID_SOCKET);
+
+	return status;
+}
+
+/**
+ * Check the connection's state, i.e. is the connection still up?
+ */
+bool QueryNetworkGameSocketHandler::CheckConnection()
+{
+	std::chrono::steady_clock::duration lag = std::chrono::steady_clock::now() - this->last_packet;
+
+	/* If there was no response in 5 seconds, terminate the query. */
+	if (lag > std::chrono::seconds(5)) {
+		this->CloseConnection(NETWORK_RECV_STATUS_CONNECTION_LOST);
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Check whether we received/can send some data from/to the server and
+ * when that's the case handle it appropriately.
+ * @return true when everything went okay.
+ */
+bool QueryNetworkGameSocketHandler::Receive()
+{
+	if (this->CanSendReceive()) {
+		NetworkRecvStatus res = this->ReceivePackets();
+		if (res != NETWORK_RECV_STATUS_OKAY) {
+			this->CloseConnection(res);
+			return false;
+		}
+	}
+	return true;
+}
+
+/** Send the packets of this socket handler. */
+void QueryNetworkGameSocketHandler::Send()
+{
+	this->SendPackets();
+}
+
+/**
+ * Query the server for server information.
+ */
+NetworkRecvStatus QueryNetworkGameSocketHandler::SendGameInfo()
+{
+	this->SendPacket(new Packet(PACKET_CLIENT_GAME_INFO));
+	return NETWORK_RECV_STATUS_OKAY;
+}
+
+NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_FULL(Packet *p)
+{
+	/* We try to join a server which is full */
+	ShowErrorMessage(STR_NETWORK_ERROR_SERVER_FULL, INVALID_STRING_ID, WL_CRITICAL);
+	return NETWORK_RECV_STATUS_SERVER_FULL;
+}
+
+NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_BANNED(Packet *p)
+{
+	/* We try to join a server where we are banned */
+	ShowErrorMessage(STR_NETWORK_ERROR_SERVER_BANNED, INVALID_STRING_ID, WL_CRITICAL);
+	return NETWORK_RECV_STATUS_SERVER_BANNED;
+}
+
+NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet *p)
+{
+	NetworkGameList *item = NetworkGameListAddItem(this->connection_string);
+
+	/* Clear any existing GRFConfig chain. */
+	ClearGRFConfigList(&item->info.grfconfig);
+	/* Retrieve the NetworkGameInfo from the packet. */
+	DeserializeNetworkGameInfo(p, &item->info);
+	/* Check for compatability with the client. */
+	CheckGameCompatibility(item->info);
+	/* Ensure we consider the server online. */
+	item->online = true;
+
+	UpdateNetworkGameWindow();
+
+	return NETWORK_RECV_STATUS_CLOSE_QUERY;
+}
+
+NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_ERROR(Packet *p)
+{
+	NetworkErrorCode error = (NetworkErrorCode)p->Recv_uint8();
+
+	/* If we query a server that is 1.11.1 or older, we get an
+	 * NETWORK_ERROR_NOT_EXPECTED on requesting the game info. Show a special
+	 * error popup in that case.
+	 */
+	if (error == NETWORK_ERROR_NOT_EXPECTED) {
+		ShowErrorMessage(STR_NETWORK_ERROR_SERVER_TOO_OLD, INVALID_STRING_ID, WL_CRITICAL);
+		return NETWORK_RECV_STATUS_CLOSE_QUERY;
+	}
+
+	ShowErrorMessage(STR_NETWORK_ERROR_LOSTCONNECTION, INVALID_STRING_ID, WL_CRITICAL);
+	return NETWORK_RECV_STATUS_SERVER_ERROR;
+}
+
+/**
+ * Check if any query needs to send or receive.
+ */
+/* static */ void QueryNetworkGameSocketHandler::SendReceive()
+{
+	for (auto it = QueryNetworkGameSocketHandler::queries.begin(); it != QueryNetworkGameSocketHandler::queries.end(); /* nothing */) {
+		if (!(*it)->Receive()) {
+			it = QueryNetworkGameSocketHandler::queries.erase(it);
+		} else if (!(*it)->CheckConnection()) {
+			it = QueryNetworkGameSocketHandler::queries.erase(it);
+		} else {
+			it++;
+		}
+	}
+
+	for (auto &query : QueryNetworkGameSocketHandler::queries) {
+		query->Send();
+	}
+}

--- a/src/network/network_query.h
+++ b/src/network/network_query.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_query.h Query part of the network protocol. */
+
+#ifndef NETWORK_QUERY_H
+#define NETWORK_QUERY_H
+
+#include "network_internal.h"
+
+/** Class for handling the client side of quering a game server. */
+class QueryNetworkGameSocketHandler : public ZeroedMemoryAllocator, public NetworkGameSocketHandler {
+private:
+	static std::vector<std::unique_ptr<QueryNetworkGameSocketHandler>> queries; ///< Pending queries.
+	std::string connection_string; ///< Address we are connected to.
+
+protected:
+	NetworkRecvStatus Receive_SERVER_FULL(Packet *p) override;
+	NetworkRecvStatus Receive_SERVER_BANNED(Packet *p) override;
+	NetworkRecvStatus Receive_SERVER_ERROR(Packet *p) override;
+	NetworkRecvStatus Receive_SERVER_GAME_INFO(Packet *p) override;
+
+	NetworkRecvStatus SendGameInfo();
+
+	bool CheckConnection();
+	void Send();
+	bool Receive();
+
+public:
+	/**
+	 * Create a new socket for the client side of quering game server.
+	 * @param s The socket to connect with.
+	 * @param connection_string The connection string of the server.
+	 */
+	QueryNetworkGameSocketHandler(SOCKET s, const std::string &connection_string) : NetworkGameSocketHandler(s), connection_string(connection_string) {}
+
+	/**
+	 * Start to query a server based on an open socket.
+	 * @param s The socket to connect with.
+	 * @param connection_string The connection string of the server.
+	 */
+	static void QueryServer(SOCKET s, const std::string &connection_string)
+	{
+		auto query = std::make_unique<QueryNetworkGameSocketHandler>(s, connection_string);
+		query->SendGameInfo();
+
+		QueryNetworkGameSocketHandler::queries.push_back(std::move(query));
+	}
+
+	static void SendReceive();
+
+	NetworkRecvStatus CloseConnection(NetworkRecvStatus status) override;
+};
+
+#endif /* NETWORK_QUERY_H */


### PR DESCRIPTION
## Motivation / Problem

When you have more than one query-for-game-info pending, the game crashes. This is easiest reproduced by starting a local server, and adding `127.0.0.1` and `127.0.0.2` to your server-list. Close the game, restart it, click Multiplayer. Now two queries will be send out at the exact same time.

## Description

We piggy-backed on the client code to, after establishing a TCP connection, query the server. The client code only has a very weird and annoying to follow singleton called `my_client`. As it turns out, when it is being asked to query two different servers at the same time, it panics.

To resolve the situation in a more robust way, I cut out the game-info query part from the client code, and moved it to `network_query`. This part is now responsible solely for querying the game-info of a server, and can have as many parallel connection as needed. It self-registers and self-destroys.

As an additional bonus, this means we can also handle errors from servers in a bit nicer way for when a query fails. This is best seen about the code removed from the client code.

As the protocol reuses other packages to indicate issues, the server can send back 4 different packets depending on the situation on a game-info request:
- `game-info`, what we are after.
- `error`, when something weird went wrong. For example, when it never saw your game-info request packet .. it will hit a timeout and close your connection. But this is really unlikely to ever happen.
- `banned`, when your IP is banned (you won't be able to query the server in that case either; only seems fair).
- `full`, which is already a bug on our bugtracker, but currently at a very early moment in time we validate if the server has room for you. If not, you get this packet back, and refresh fails. This of course has to be resolved, but as for now, this is still happening.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
