### PR TITLE
Fix: [Network] crash when last-joined server that is no longer available

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -249,15 +249,21 @@ protected:
 		this->servers.clear();
 
 		bool found_current_server = false;
+		bool found_last_joined = false;
 		for (NetworkGameList *ngl = _network_game_list; ngl != nullptr; ngl = ngl->next) {
 			this->servers.push_back(ngl);
 			if (ngl == this->server) {
 				found_current_server = true;
 			}
+			if (ngl == this->last_joined) {
+				found_last_joined = true;
+			}
 		}
 		/* A refresh can cause the current server to be delete; so unselect. */
+		if (!found_last_joined) {
+			this->last_joined = nullptr;
+		}
 		if (!found_current_server) {
-			if (this->server == this->last_joined) this->last_joined = nullptr;
 			this->server = nullptr;
 			this->list_pos = SLP_INVALID;
 		}


### PR DESCRIPTION
## Motivation / Problem

A crash that happened from time to time, but nobody could reproduce. Took me a long time staring at the traceback to figure out what causes it. But as written in the commit message:

```
If you update the server-list while not having last-joined selected
and it is no longer available, the game crashed.
```

## Description

We only removed `last_joined` selection in the GUI if it was selected and no longer available. Also remove it if it is not selected, as drawing it will obvious fail.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
