### PR TITLE
Fix: [Network] show query errors in the server listing instead of error popup

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2046,6 +2046,8 @@ STR_NETWORK_SERVER_LIST_GAMESCRIPT                              :{SILVER}Game Sc
 STR_NETWORK_SERVER_LIST_PASSWORD                                :{SILVER}Password protected!
 STR_NETWORK_SERVER_LIST_SERVER_OFFLINE                          :{SILVER}SERVER OFFLINE
 STR_NETWORK_SERVER_LIST_SERVER_FULL                             :{SILVER}SERVER FULL
+STR_NETWORK_SERVER_LIST_SERVER_BANNED                           :{SILVER}SERVER BANNED YOU
+STR_NETWORK_SERVER_LIST_SERVER_TOO_OLD                          :{SILVER}SERVER TOO OLD
 STR_NETWORK_SERVER_LIST_VERSION_MISMATCH                        :{SILVER}VERSION MISMATCH
 STR_NETWORK_SERVER_LIST_GRF_MISMATCH                            :{SILVER}NEWGRF MISMATCH
 
@@ -2226,7 +2228,6 @@ STR_NETWORK_ERROR_TIMEOUT_COMPUTER                              :{WHITE}Your com
 STR_NETWORK_ERROR_TIMEOUT_MAP                                   :{WHITE}Your computer took too long to download the map
 STR_NETWORK_ERROR_TIMEOUT_JOIN                                  :{WHITE}Your computer took too long to join the server
 STR_NETWORK_ERROR_INVALID_CLIENT_NAME                           :{WHITE}Your player name is not valid
-STR_NETWORK_ERROR_SERVER_TOO_OLD                                :{WHITE}The queried server is too old for this client
 
 ############ Leave those lines in this order!!
 STR_NETWORK_ERROR_CLIENT_GENERAL                                :general error

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -632,7 +632,7 @@ public:
 	void OnFailure() override
 	{
 		NetworkGameList *item = NetworkGameListAddItem(connection_string);
-		item->online = false;
+		item->status = NGLS_OFFLINE;
 
 		UpdateNetworkGameWindow();
 	}

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -152,7 +152,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_ERROR(Packet *p)
 
 			/* Mark the server as offline. */
 			NetworkGameList *item = NetworkGameListAddItem(detail);
-			item->online = false;
+			item->status = NGLS_OFFLINE;
 
 			UpdateNetworkGameWindow();
 			return true;
@@ -257,7 +257,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet *p)
 		/* Check for compatability with the client. */
 		CheckGameCompatibility(item->info);
 		/* Mark server as online. */
-		item->online = true;
+		item->status = NGLS_ONLINE;
 		/* Mark the item as up-to-date. */
 		item->version = _network_game_list_version;
 	}

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -14,17 +14,26 @@
 #include "core/game_info.h"
 #include "network_type.h"
 
+/** The status a server can be in. */
+enum NetworkGameListStatus {
+	NGLS_OFFLINE, ///< Server is offline (or cannot be queried).
+	NGLS_ONLINE,  ///< Server is online.
+	NGLS_FULL,    ///< Server is full and cannot be queried.
+	NGLS_BANNED,  ///< You are banned from this server.
+	NGLS_TOO_OLD, ///< Server is too old to query.
+};
+
 /** Structure with information shown in the game list (GUI) */
 struct NetworkGameList {
 	NetworkGameList(const std::string &connection_string) : connection_string(connection_string) {}
 
-	NetworkGameInfo info = {};       ///< The game information of this server
-	std::string connection_string;   ///< Address of the server
-	bool online = false;             ///< False if the server did not respond (default status)
-	bool manually = false;           ///< True if the server was added manually
-	uint8 retries = 0;               ///< Number of retries (to stop requerying)
-	int version = 0;                 ///< Used to see which servers are no longer available on the Game Coordinator and can be removed.
-	NetworkGameList *next = nullptr; ///< Next pointer to make a linked game list
+	NetworkGameInfo info = {};                   ///< The game information of this server.
+	std::string connection_string;               ///< Address of the server.
+	NetworkGameListStatus status = NGLS_OFFLINE; ///< Stats of the server.
+	bool manually = false;                       ///< True if the server was added manually.
+	uint8 retries = 0;                           ///< Number of retries (to stop requerying).
+	int version = 0;                             ///< Used to see which servers are no longer available on the Game Coordinator and can be removed.
+	NetworkGameList *next = nullptr;             ///< Next pointer to make a linked game list.
 };
 
 extern NetworkGameList *_network_game_list;


### PR DESCRIPTION
Includes #9502.

## Motivation / Problem

While investigating solutions for #9490, and with the introduction of #9502, I realised how annoying the red popups are when querying servers. It makes much more sense (to me) to show the server status in the info dialog we have for it, similar to "offline".

## Description

As #9502 moved all the query code to its own file, it is a lot easier to add this. Making this PR pretty straight-forward.

![image](https://user-images.githubusercontent.com/1663690/130409401-693fdee4-897d-4caa-8a3b-065a9cbfcbe4.png)
![image](https://user-images.githubusercontent.com/1663690/130409409-19276f1a-66c5-4638-a0e2-afbfa176fb2b.png)

And similar for "Server too old".

To be clear, this is not the final solution for #9490, but at least makes it less icky.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
