### PR TITLE
Fix: [Network] don't show GameScript " (v0)" for old servers

### DIFF
--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -43,6 +43,7 @@ NetworkGameList *NetworkGameListAddItem(const std::string &connection_string)
 	}
 
 	item = new NetworkGameList(resolved_connection_string);
+	item->info.gamescript_version = -1;
 	item->version = _network_game_list_version;
 
 	if (prev_item == nullptr) {


### PR DESCRIPTION
## Motivation / Problem

Found a bug during playtesting. When a 1.11.2 server doesn't have a GS, it is shown as ` (v0)`.

## Description

```
Old servers don't tell the GameScript they are running, so nothing
should be shown.
All values in NetworkGameInfo initialize as 0/empty, except for GS
version. Someone has to be different from the rest, I guess.
```

This happens because if you do send the NetworkGameInfo as v4 or earlier, the GS version remained its initial value (0), which makes it show up like that. For GS version, the default value should be `-1`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
