### PR TITLE
Fix #9490: [Network] a full server couldn't be queried either

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -305,7 +305,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 /* static */ bool ServerNetworkGameSocketHandler::AllowConnection()
 {
 	extern byte _network_clients_connected;
-	bool accept = _network_clients_connected < MAX_CLIENTS && _network_game_info.clients_on < _settings_client.network.max_clients;
+	bool accept = _network_clients_connected < MAX_CLIENTS;
 
 	/* We can't go over the MAX_CLIENTS limit here. However, the
 	 * pool must have place for all clients and ourself. */
@@ -803,6 +803,11 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_JOIN(Packet *p)
 	if (this->status != STATUS_INACTIVE) {
 		/* Illegal call, return error and ignore the packet */
 		return this->SendError(NETWORK_ERROR_NOT_EXPECTED);
+	}
+
+	if (_network_game_info.clients_on >= _settings_client.network.max_clients) {
+		/* Turns out we are full. Inform the user about this. */
+		return this->SendError(NETWORK_ERROR_FULL);
 	}
 
 	std::string client_revision = p->Recv_string(NETWORK_REVISION_LENGTH);


### PR DESCRIPTION
## Motivation / Problem

#9490 shows that querying a full server wasn't possible. In most cases there isn't really a reason to not allow this.

## Description

```
You can now still query a full server, as long as the maximum
amount of allowed connections isn't reached. This means that as
long as there are not 255 clients connected to a server, you can
always connect to query.
```

Basically, you are now allowed to do a `GAME_INFO` packet despite the server being full. `CLIENT_JOIN` is the first packet checking if the server is really full (and drops the connection if it is). All other packets require that `CLIENT_JOIN` was successful, and otherwise they return a `NOT_EXPECTED` error.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
