### PR TITLE
Change: Use colourblind-friendly gradient for linkgraph

### DIFF
--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -27,9 +27,9 @@
  * "overloaded".
  */
 const uint8 LinkGraphOverlay::LINK_COLOURS[] = {
-	0x0f, 0xd1, 0xd0, 0x57,
-	0x55, 0x53, 0xbf, 0xbd,
-	0xba, 0xb9, 0xb7, 0xb5
+	0x07, 0xc7, 0xc9, 0xcb,
+	0xcd, 0x99, 0x44, 0xbe,
+	0xbb, 0xb9, 0xb7, 0xb5
 };
 
 /**
@@ -285,7 +285,7 @@ void LinkGraphOverlay::DrawContent(Point pta, Point ptb, const LinkProperties &c
 		GfxDrawLine(pta.x, pta.y + offset_y, ptb.x, ptb.y + offset_y, colour, this->scale, dash);
 	}
 
-	GfxDrawLine(pta.x, pta.y, ptb.x, ptb.y, _colour_gradient[COLOUR_GREY][1], this->scale);
+	GfxDrawLine(pta.x, pta.y, ptb.x, ptb.y, _colour_gradient[COLOUR_GREY][2], this->scale);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Per #9168:

> [According to the NHS](https://www.nhs.uk/conditions/colour-vision-deficiency/), about 1 in 12 men and 1 in 200 women are red/green colourblind.
> 
> The linkgraph colours which show if a route is overloaded, saturated, or unused currently use a red-green colour scale. Additionally, the green "saturated" colour matches the temperate grass and is quite difficult to see.
>
> ![rhd](https://user-images.githubusercontent.com/55058389/116788933-4ed13e80-aa7a-11eb-8b2b-e75f37521e5b.png)

## Description

![linkgraph2](https://user-images.githubusercontent.com/55058389/131133951-2e188bdd-c176-4a05-ac56-dcb2e4a322a6.png)
_(screenshot of 2nd revision with lighter separation gray line)_

Changes to a new colour scheme using a blue-yellow-red diverging palette, as suggested by [ColorBrewer 2](https://colorbrewer2.org/#type=diverging&scheme=RdYlBu&n=11).

Additionally, the less-than-saturated scale is reversed so that Saturated is approximately in the middle of the colour gradient, instead of jumping from dark green to bright yellow as in the original. Unused is changed from white to gray so as to avoid confusion with the light blue Saturated.

This becomes the default colour scheme, ~~but a new setting is added so players can choose the original red-green scheme.~~ and no setting for the original red-green scheme is available.

The grey line which separates the linkgraph lines in each direction is lightened slightly for visibility against the darkest blue.

I closely based this off the [colorblind-friendly linkgraph colour schemes in JGRPP](https://github.com/JGRennison/OpenTTD-patches/commit/f26143f06319a56739e94ff3513c2909f49c108f), but his do not reverse the top half of the gradient.

Closes #9168.

## Limitations

I originally added a setting allowing players to choose the original green-red colour scheme, but glx22 suggested not adding a setting and simply changing the gradient, so I did that instead.

I did not incorporate any of the colour schemes from JGRPP, since this should work for all [types of colourblindness](https://www.visioncenter.org/conditions/types-of-color-blindness/) and is more visually attractive than his schemes, in my opinion.

The darkest blue of lightly-used links is hard to see on the minimap when the land colour is violet, however this is also true (and worse) when using the red-green palette on green land.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
