### PR TITLE
Change: Cap docking tile occupancy penalty to a max of one ship

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -305,11 +305,8 @@ static void NPFMarkTile(TileIndex tile)
 
 static Vehicle *CountShipProc(Vehicle *v, void *data)
 {
-	uint *count = (uint *)data;
 	/* Ignore other vehicles (aircraft) and ships inside depot. */
-	if (v->type == VEH_SHIP && (v->vehstatus & VS_HIDDEN) == 0) (*count)++;
-
-	return nullptr;
+	return v->type == VEH_SHIP && (v->vehstatus & VS_HIDDEN) == 0 ? v : nullptr;
 }
 
 static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *parent)
@@ -331,7 +328,7 @@ static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *par
 	if (IsDockingTile(current->tile)) {
 		/* Check docking tile for occupancy */
 		uint count = 1;
-		HasVehicleOnPos(current->tile, &count, &CountShipProc);
+		if (HasVehicleOnPos(current->tile, nullptr, &CountShipProc)) count++;
 		cost += count * 3 * _trackdir_length[trackdir];
 	}
 

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -266,11 +266,8 @@ public:
 
 	static Vehicle *CountShipProc(Vehicle *v, void *data)
 	{
-		uint *count = (uint *)data;
 		/* Ignore other vehicles (aircraft) and ships inside depot. */
-		if (v->type == VEH_SHIP && (v->vehstatus & VS_HIDDEN) == 0) (*count)++;
-
-		return nullptr;
+		return v->type == VEH_SHIP && (v->vehstatus & VS_HIDDEN) == 0 ? v : nullptr;
 	}
 
 	/**
@@ -288,7 +285,7 @@ public:
 		if (IsDockingTile(n.GetTile())) {
 			/* Check docking tile for occupancy */
 			uint count = 1;
-			HasVehicleOnPos(n.GetTile(), &count, &CountShipProc);
+			if (HasVehicleOnPos(n.GetTile(), nullptr, &CountShipProc)) count++;
 			c += count * 3 * YAPF_TILE_LENGTH;
 		}
 


### PR DESCRIPTION
## Motivation / Problem
Main problem is that there is no cap to 'docking tile occupancy penalty' - if there are 50 ships on the docking tile, the cost is ~50 times higher.

The higher the penalty/cost, the more likely the chances for the pathfinder to report ship is lost for other ships that are part of this route. If there's lots of water near the docking tile which is also the pf's destination, it will start looking for those cheaper nodes first, resulting in more search nodes being needed to find a path.

It really seems like a waste to search nodes around the destination. It's understandable that the penalty is being used to help send the ships to other docking tiles of the same multi-dock station, but... oh well.

Also refer to #8001 

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This PR limits the penalty cost to a max of one ship in the docking tile. There's the cost of the tile being a docking tile which is 300 in YAPF, and then there's the cost of it being occupied by ships, which is also 300 in YAPF. So, at max, it's an added 600 cost now, instead of a cost that was dependent on the number of ships in the tile.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This PR may help mitigate 'ship is lost' messages which are triggered when the max number of search nodes is reached by the pf, but in all honesty, it feels insufficient still to what the game used to be before this penalty ever existed.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
