### PR TITLE
Fix: when DNS didn't resolve any IPs, the debug message was misleading

### DIFF
--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -205,9 +205,13 @@ void TCPConnecter::OnResolved(addrinfo *ai)
 	}
 
 	if (_debug_net_level >= 6) {
-		Debug(net, 6, "{} resolved in:", this->connection_string);
-		for (const auto &address : this->addresses) {
-			Debug(net, 6, "- {}", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
+		if (this->addresses.size() == 0) {
+			Debug(net, 6, "{} did not resolve", this->connection_string);
+		} else {
+			Debug(net, 6, "{} resolved in:", this->connection_string);
+			for (const auto &address : this->addresses) {
+				Debug(net, 6, "- {}", NetworkAddress(address->ai_addr, (int)address->ai_addrlen).GetAddressAsString());
+			}
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

A user reported some logs to me of which at first I was like: huh?


## Description

If you do not have IPv6, resolving `stun.openttd.org` forced on IPv6 returns an empty list. We reported this as:
```
dbg: [net] stun.openttd.org:3975 resolved in:
dbg: [net] stun.openttd.org:3975 resolved in:
dbg: [net] - 3.120.34.250:3975 (IPv4)
dbg: [net] - 18.185.47.230:3975 (IPv4)
```

As those prints happen in a thread, it can also look like this:
```
dbg: [net] stun.openttd.org:3975 resolved in:
dbg: [net] - 3.120.34.250:3975 (IPv4)
dbg: [net] stun.openttd.org:3975 resolved in:
dbg: [net] - 18.185.47.230:3975 (IPv4)
```

That was throwing me off at first. So if the list is empty, be a bit more verbose about that fact. Saves me running in a circle :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
