### PR TITLE
Fix: pathfinders always tried to avoid docking tiles (even if nothing was on them)

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -330,7 +330,7 @@ static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *par
 
 	if (IsDockingTile(current->tile)) {
 		/* Check docking tile for occupancy */
-		uint count = 1;
+		uint count = 0;
 		HasVehicleOnPos(current->tile, &count, &CountShipProc);
 		cost += count * 3 * _trackdir_length[trackdir];
 	}

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -287,7 +287,7 @@ public:
 
 		if (IsDockingTile(n.GetTile())) {
 			/* Check docking tile for occupancy */
-			uint count = 1;
+			uint count = 0;
 			HasVehicleOnPos(n.GetTile(), &count, &CountShipProc);
 			c += count * 3 * YAPF_TILE_LENGTH;
 		}


### PR DESCRIPTION
## Motivation / Problem

While reading up on #9514 (and being confused about what it tries to address) and checking out #8001 and getting a bit annoyed by the fact people confuse cause with causality, I looked into the multi-dock stuff for pathfinders.

A few things I figured out I did not know:
- A "Docking Tile" are the tiles around a docking point. Not the docking point itself. For example, an oilrig has 12 docking tiles around itself.
- The pathfinder gives a penalty for when a ship is on a docking tile, meaning it tries to avoid it. This would mean if there are ships just passing through them, it would still avoid it. Basically, it is a small beginning of making ships avoid each other on the open waters. Just only for docking tiles
- If a path is found, only the next 32 tiles are cached. After that, the PF is called again. This repeats till we are 16 from destination; at that point we evaluate every tile. Also, the PF doesn't cache anything.

But mainly, and that is the reason for this PR: I noticed that even if a tile is empty, it was being avoided. Basically the pathfinder always tried to avoid going through a docking tile, empty or not.

## Description

There is something to say for avoiding docking tiles in general, as it is a bad thing for a ship to enter such tiles. Sadly, in the way our ship pathfinder works, this is not something that will result in good routes. Also, it is kinda weird we do this for docking tiles, and not for ships in general. As that would of course be the ultimate dream, that ships don't go over the same tile at the same time.

So personally, I consider ships avoiding docking tiles that are empty a bug, and this PR sets out to resolve that.

In more detail:

When a ship navigates through open waters with a lot of oilrigs / depots, it is not only avoiding the rig / depot, but it also tries to stay away from the docking tiles. In fact, if the best route would be through a docking tile, it scans for 3 more tiles in the width of its path, making it scan a lot more tiles for a better route. This, I guess, is an unintentional side-effect of 31db4f8d5e .

As I wrote in the commit message:

```
When coming across any docking tile (for example, all tiles around
an oilrig are docking tiles), it always at least added a penalty
of 3 times a normal tile, even when there are no ships on them.

In result, the pathfinder got suggested to always go around docking
tiles. This was most likely not the intention of the change made in
31db4f8d5e.
```

This makes routes that were "barely cutting it" in the allowed amount of nodes we can scan to "surely not going to make it". This means people get "ship is lost" in situations they didn't get before.
This PR mitigates "ship is lost" slightly by reducing the amount of nodes we need to scan to before 31db4f8d5e in case no ship occupies any of those docking tiles. If any ship does, it still does the same stuff, and can still give "ship is lost".

In the screenshots below you can see this happening because of the depot. The ship has to navigate around it, but instead of going 1 around it in search-space, it checks out 3 wide, because of this additional penalty. Despite there not being any ship.

This means this PR addresses the original savegame in #8001, and basically makes the game similar to before 31db4f8d5e for those savegames (while still having the benefits of that change). However, there are still many cases where you get "ship is lost". This is not a solution to that; this is only addressing the regression created by 31db4f8d5e for the most common use-case. And it is solving the fact that I think it is wrong ships avoid a perfectly valid tile to pass through, just because it can also be used as docking tile ;)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
