### PR TITLE
Fix #9407: desync when founding a town nearby a station

### DIFF
--- a/src/station_base.h
+++ b/src/station_base.h
@@ -565,6 +565,9 @@ void RebuildStationKdtree();
 template<typename Func>
 void ForAllStationsAroundTiles(const TileArea &ta, Func func)
 {
+	/* There are no stations, so we will never find anything. */
+	if (Station::GetNumItems() == 0) return;
+
 	/* Not using, or don't have a nearby stations list, so we need to scan. */
 	std::set<StationID> seen_stations;
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2310,12 +2310,10 @@ static void MakeTownHouse(TileIndex t, Town *town, byte counter, byte stage, Hou
 	if (size & BUILDING_2_TILES_X)   ClearMakeHouseTile(t + TileDiffXY(1, 0), town, counter, stage, ++type, random_bits);
 	if (size & BUILDING_HAS_4_TILES) ClearMakeHouseTile(t + TileDiffXY(1, 1), town, counter, stage, ++type, random_bits);
 
-	if (!_generating_world) {
-		ForAllStationsAroundTiles(TileArea(t, (size & BUILDING_2_TILES_X) ? 2 : 1, (size & BUILDING_2_TILES_Y) ? 2 : 1), [town](Station *st, TileIndex tile) {
-			town->stations_near.insert(st);
-			return true;
-		});
-	}
+	ForAllStationsAroundTiles(TileArea(t, (size & BUILDING_2_TILES_X) ? 2 : 1, (size & BUILDING_2_TILES_Y) ? 2 : 1), [town](Station *st, TileIndex tile) {
+		town->stations_near.insert(st);
+		return true;
+	});
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

When a town is founded during a game, we misuse `_generating_world` to bypass a bunch of validation that normally should happen when towns grow etc.
This is also done to skip updating `stations_near`, as it is a pretty expensive operation, and when generating a new map there is of course never a station around a town to start with. So this is safe to skip in that scenario. Not when founding a new town.

As I wrote in the commit message:

```
"stations_near" wasn't updated when founding a town near
a station. As this variable is not saved, any client joining
after the town is founded has a different value for
"stations_near", potentially causing desyncs.
```

This was reported in #9407.

## Description

JGR also made a solution for this (https://github.com/JGRennison/OpenTTD-patches/commit/b23ba0c6c0f5be9ea4d4239478b39be42fe81ee6), and although effective, it felt a bit like bringing a gun to a pillow fight.
I was also mostly wondering why `_generating_world` was misused like this, and why it would skip the `stations_near` update.

Long story short: the check on `_generating_world` is an optimization, to avoid wasting a lot of CPU on something that is never going to happen during map generation. So I looked for the next-best-thing that does the same but differently, and settled on checking if there is any station at all. During map generation of course there isn't.

In result, after this PR the code does the same for new map generation (skipping the expensive station check), but fixes the bug in #9407.

JGR's solution is also a fine solution, but it introduces several globals and more complexity that can break over time. On the other hand, his solution might fix issues we were not even aware of. I leave it to the reviewer to balance this.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
