### PR TITLE
Change: Return 'New company/Spectate' option to company toolbar menu

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2107,6 +2107,8 @@ STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION                       :{WHITE}Company 
 
 # Network company list added strings
 STR_NETWORK_COMPANY_LIST_CLIENT_LIST                            :Online players
+STR_NETWORK_COMPANY_LIST_SPECTATE                               :Spectate
+STR_NETWORK_COMPANY_LIST_NEW_COMPANY                            :New company
 
 # Network client list
 STR_NETWORK_CLIENT_LIST_CAPTION                                 :{WHITE}Online Players


### PR DESCRIPTION
## Motivation / Problem

Somehow this option was removed in #9067 and since I couldn't find any reason for that change and I'm adding it back in cmclient anyway I thought I may as well PR it to vanilla. 

It's a convenient shortcut that was already there and doesn't have much to do with server lobby merging with the client list.

## Description

Returns "New company/Spectate" option to the company menu ("bald guy" button) in the main toolbar.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~The bug fix is important enough to be backported? (label: 'backport requested')~
* *This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)*
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
