### PR TITLE
Fix: use-after-free after ClientNetworkCoordinatorSocketHandler::CloseAllConnections()

### DIFF
--- a/src/network/network_stun.cpp
+++ b/src/network/network_stun.cpp
@@ -100,15 +100,21 @@ NetworkRecvStatus ClientNetworkStunSocketHandler::CloseConnection(bool error)
 {
 	NetworkStunSocketHandler::CloseConnection(error);
 
-	/* If our connecter is still pending, shut it down too. Otherwise the
-	 * callback of the connecter can call into us, and our object is most
-	 * likely about to be destroyed. */
+	/* Also make sure any pending connecter is killed ASAP. */
 	if (this->connecter != nullptr) {
 		this->connecter->Kill();
 		this->connecter = nullptr;
 	}
 
 	return NETWORK_RECV_STATUS_OKAY;
+}
+
+ClientNetworkStunSocketHandler::~ClientNetworkStunSocketHandler()
+{
+	if (this->connecter != nullptr) {
+		this->connecter->Kill();
+		this->connecter = nullptr;
+	}
 }
 
 /**

--- a/src/network/network_stun.h
+++ b/src/network/network_stun.h
@@ -24,6 +24,7 @@ public:
 	NetworkAddress local_addr;         ///< Local addresses of the socket.
 
 	NetworkRecvStatus CloseConnection(bool error = true) override;
+	~ClientNetworkStunSocketHandler() override;
 	void SendReceive();
 
 	void Connect(const std::string &token, uint8 family);

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -108,15 +108,21 @@ NetworkRecvStatus ClientNetworkTurnSocketHandler::CloseConnection(bool error)
 {
 	NetworkTurnSocketHandler::CloseConnection(error);
 
-	/* If our connecter is still pending, shut it down too. Otherwise the
-	 * callback of the connecter can call into us, and our object is most
-	 * likely about to be destroyed. */
+	/* Also make sure any pending connecter is killed ASAP. */
 	if (this->connecter != nullptr) {
 		this->connecter->Kill();
 		this->connecter = nullptr;
 	}
 
 	return NETWORK_RECV_STATUS_OKAY;
+}
+
+ClientNetworkTurnSocketHandler::~ClientNetworkTurnSocketHandler()
+{
+	if (this->connecter != nullptr) {
+		this->connecter->Kill();
+		this->connecter = nullptr;
+	}
 }
 
 /**

--- a/src/network/network_turn.h
+++ b/src/network/network_turn.h
@@ -30,6 +30,7 @@ public:
 	ClientNetworkTurnSocketHandler(const std::string &token, uint8 tracking_number, const std::string &connection_string) : token(token), tracking_number(tracking_number), connection_string(connection_string) {}
 
 	NetworkRecvStatus CloseConnection(bool error = true) override;
+	~ClientNetworkTurnSocketHandler() override;
 	void SendReceive();
 
 	void Connect();


### PR DESCRIPTION
## Motivation / Problem

While debugging a GC issue, I managed to cause a use-after-free. Example flow:

Start your own server, and while your server is being probed (takes ~3 seconds), kill the connection (for example by modifying the code or running your own GC that does this).

Possibly there are other ways to trigger a `CloseAllConnections`.

## Description

```
The function clears all stun-handlers. This causes all of those
objects to be destroyed.
A handler can have a pending connecter, which was only killed in
case CloseConnection() was called. This is never the case when
the object is destroyed. In result, the connecter could finish
and cause a use-after-free by calling into the (now deleted)
handler.
```

I have no clue why I initially wrote it in `CloseConnection()` with this comment, and that worries me a bit. I remember there was something special about these objects, but .. yeah, can't remember, and this seems to be the proper solution.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
