### PR TITLE
Change: Deliver cargo to the closest industry first

### DIFF
--- a/src/cargomonitor.cpp
+++ b/src/cargomonitor.cpp
@@ -149,9 +149,9 @@ void AddCargoDelivery(CargoID cargo_type, CompanyID company, uint32 amount, Sour
 	if (iter != _cargo_deliveries.end()) iter->second += amount;
 
 	/* Industry delivery. */
-	for (Industry *ind : st->industries_near) {
-		if (ind->index != dest) continue;
-		CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, ind->index);
+	for (const auto &i : st->industries_near) {
+		if (i.industry->index != dest) continue;
+		CargoMonitorID num = EncodeCargoIndustryMonitor(company, cargo_type, i.industry->index);
 		CargoMonitorMap::iterator iter = _cargo_deliveries.find(num);
 		if (iter != _cargo_deliveries.end()) iter->second += amount;
 	}

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1040,9 +1040,10 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 
 	uint accepted = 0;
 
-	for (Industry *ind : st->industries_near) {
+	for (const auto &i : st->industries_near) {
 		if (num_pieces == 0) break;
 
+		Industry *ind = i.industry;
 		if (ind->index == source) continue;
 
 		uint cargo_index;

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -437,11 +437,18 @@ private:
 	}
 };
 
-struct IndustryCompare {
-	bool operator() (const Industry *lhs, const Industry *rhs) const;
+struct IndustryListEntry {
+	uint distance;
+	Industry *industry;
+
+	bool operator== (const IndustryListEntry &other) const { return this->distance == other.distance && this->industry == other.industry; };
 };
 
-typedef std::set<Industry *, IndustryCompare> IndustryList;
+struct IndustryCompare {
+	bool operator() (const IndustryListEntry &lhs, const IndustryListEntry &rhs) const;
+};
+
+typedef std::set<IndustryListEntry, IndustryCompare> IndustryList;
 
 /** Station data structure */
 struct Station FINAL : SpecializedStation<Station, false> {
@@ -500,7 +507,8 @@ public:
 	uint GetCatchmentRadius() const;
 	Rect GetCatchmentRect() const;
 	bool CatchmentCoversTown(TownID t) const;
-	void AddIndustryToDeliver(Industry *ind);
+	void AddIndustryToDeliver(Industry *ind, TileIndex tile);
+	void RemoveIndustryToDeliver(Industry *ind);
 	void RemoveFromAllNearbyLists();
 
 	inline bool TileIsInCatchment(TileIndex tile) const

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -600,9 +600,9 @@ bool CheckSubsidised(CargoID cargo_type, CompanyID company, SourceType src_type,
 		if (s->cargo_type == cargo_type && s->src_type == src_type && s->src == src && (!s->IsAwarded() || s->awarded == company)) {
 			switch (s->dst_type) {
 				case ST_INDUSTRY:
-					for (Industry *ind : st->industries_near) {
-						if (s->dst == ind->index) {
-							assert(ind->part_of_subsidy & POS_DST);
+					for (const auto &i : st->industries_near) {
+						if (s->dst == i.industry->index) {
+							assert(i.industry->part_of_subsidy & POS_DST);
 							subsidised = true;
 							if (!s->IsAwarded()) s->AwardTo(company);
 						}


### PR DESCRIPTION
## Motivation / Problem

Among other things, #7235 changed the way stations chose the industry to deliver cargo to. Before it, industries that are closer to the station had priority, after it those with lower id got it. And that proved to be problematic as there is no way to control or even see industry id in the game. A typical example would be another industry spawning next to the existing station and stealing all the production. With distance system you can manipulate station sign to solve (or even completely prevent) it. With index system you have to move entire station which may not even be feasible at that point. Also with index system you have to be careful not to include other industries that accept same cargo in your catchment area as you have no way of telling which one will get them.

## Description

Orders the nearby industry lists by DistanceMax to the nearest industry tile from station sign (as closest equivalent of previously used CircularTileSearch). 

## Limitations

Is somewhat less performant than before but mostly affects rebuilding nearest caches that don't seem to be anywhere near time-critical. Also the algorithm can be improved if needed (I actually started on it but abandoned due to excessive complexity of the change: https://gist.github.com/ldpl/2fe7ea9bf8931cdbe632222d058474c5).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~The bug fix is important enough to be backported? (label: 'backport requested')~
* ~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
