### PR TITLE
Fix #9535: Maintain a reverse dependency map of network content

### DIFF
--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -12,6 +12,7 @@
 
 #include "core/tcp_content.h"
 #include "core/tcp_http.h"
+#include <unordered_map>
 
 /** Vector with content info */
 typedef std::vector<ContentInfo *> ContentVector;
@@ -68,6 +69,7 @@ protected:
 	std::vector<ContentCallback *> callbacks;     ///< Callbacks to notify "the world"
 	ContentIDList requested;                      ///< ContentIDs we already requested (so we don't do it again)
 	ContentVector infos;                          ///< All content info we received
+	std::unordered_multimap<ContentID, ContentID> reverse_dependency_map; ///< Content reverse dependency map
 	std::vector<char> http_response;              ///< The HTTP response to the requests we've been doing
 	int http_response_index;                      ///< Where we are, in the response, with handling it
 
@@ -81,7 +83,7 @@ protected:
 	bool Receive_SERVER_INFO(Packet *p) override;
 	bool Receive_SERVER_CONTENT(Packet *p) override;
 
-	ContentInfo *GetContent(ContentID cid);
+	ContentInfo *GetContent(ContentID cid) const;
 	void DownloadContentInfo(ContentID cid);
 
 	void OnConnect(bool success) override;


### PR DESCRIPTION
## Motivation / Problem

This fixes the performance issues in #9535 with dependency lookup when retrieving the content list from the content server.

## Description

Instead of iterating all content to find reverse dependencies, maintain an iteratively built reverse dependency map.
When a new content item arrives, instead of calling `CheckDependencyState` on all content items, only call it on the reverse tree dependencies of the newly received item.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
