### PR TITLE
Add: support filtering content entries for patchpacks

### DIFF
--- a/src/network/core/tcp_content.h
+++ b/src/network/core/tcp_content.h
@@ -26,7 +26,11 @@ protected:
 	/**
 	 * Client requesting a list of content info:
 	 *  byte    type
-	 *  uint32  openttd version
+	 *  uint32  openttd version (or 0xFFFFFFFF if using a list)
+	 * Only if the above value is 0xFFFFFFFF:
+	 *  uint8   count
+	 *  string  branch-name ("vanilla" for upstream OpenTTD)
+	 *  string  release version (like "12.0")
 	 * @param p The packet that was just received.
 	 * @return True upon success, otherwise false.
 	 */

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -207,7 +207,20 @@ void ClientNetworkContentSocketHandler::RequestContentList(ContentType type)
 
 	Packet *p = new Packet(PACKET_CONTENT_CLIENT_INFO_LIST);
 	p->Send_uint8 ((byte)type);
-	p->Send_uint32(_openttd_newgrf_version);
+	p->Send_uint32(0xffffffff);
+	p->Send_uint8 (1);
+	p->Send_string("vanilla");
+	p->Send_string(_openttd_content_version);
+
+	/* Patchpacks can extend the list with one. In BaNaNaS metadata you can
+	 * add a branch in the 'compatibility' list, to filter on this. If you want
+	 * your patchpack to be mentioned in the BaNaNaS web-interface, create an
+	 * issue on https://github.com/OpenTTD/bananas-api asking for this.
+
+	p->Send_string("patchpack"); // Or what-ever the name of your patchpack is.
+	p->Send_string(_openttd_content_version_patchpack);
+
+	*/
 
 	this->SendPacket(p);
 }

--- a/src/rev.cpp.in
+++ b/src/rev.cpp.in
@@ -73,6 +73,13 @@ const byte _openttd_revision_modified = ${REV_MODIFIED};
 const byte _openttd_revision_tagged = ${REV_ISTAG};
 
 /**
+ * To check compatibility of BaNaNaS content, this version string is used.
+ * It should never contain things like "beta", but only the release version
+ * we are compatible with.
+ */
+const char _openttd_content_version[] = "${REV_MAJOR}.${REV_MINOR}";
+
+/**
  * The NewGRF revision of OTTD:
  * bits  meaning.
  * 24-31 major version + 16

--- a/src/rev.h
+++ b/src/rev.h
@@ -16,6 +16,7 @@ extern const char _openttd_revision_hash[];
 extern const char _openttd_revision_year[];
 extern const byte _openttd_revision_modified;
 extern const byte _openttd_revision_tagged;
+extern const char _openttd_content_version[];
 extern const uint32 _openttd_newgrf_version;
 
 bool IsReleasedVersion();


### PR DESCRIPTION
## Motivation / Problem

Implement the client part to allow https://github.com/OpenTTD/BaNaNaS/issues/105. See for motivation etc there.

Closes https://github.com/OpenTTD/BaNaNaS/issues/105.

## Description

```
This changes nothing for us, but allows patchpacks to add the
right pieces of code to start filtering content entries on patchpack
only entries.
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
