### PR TITLE
Fix #9241: Grove and forest tree brushes also create rainforests

### DIFF
--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -301,9 +301,10 @@ void PlaceTreesRandomly()
  * @param treetype  Type of trees to place. Must be a valid tree type for the climate.
  * @param radius    Maximum distance (on each axis) from tile to place trees.
  * @param count     Maximum number of trees to place.
+ * @param set_zone  Whether to create a rainforest zone when placing rainforest trees.
  * @return Number of trees actually placed.
  */
-uint PlaceTreeGroupAroundTile(TileIndex tile, TreeType treetype, uint radius, uint count)
+uint PlaceTreeGroupAroundTile(TileIndex tile, TreeType treetype, uint radius, uint count, bool set_zone)
 {
 	assert(treetype < TREE_TOYLAND + TREE_COUNT_TOYLAND);
 	const bool allow_desert = treetype == TREE_CACTUS;
@@ -331,6 +332,12 @@ uint PlaceTreeGroupAroundTile(TileIndex tile, TreeType treetype, uint radius, ui
 				MarkTileDirtyByTile(tile_to_plant, 0);
 				planted++;
 			}
+		}
+	}
+
+	if (set_zone && IsInsideMM(treetype, TREE_RAINFOREST, TREE_CACTUS)) {
+		for (TileIndex t : TileArea(tile).Expand(radius)) {
+			if (GetTileType(t) != MP_VOID && DistanceSquare(tile, t) < radius * radius) SetTropicZone(t, TROPICZONE_RAINFOREST);
 		}
 	}
 

--- a/src/tree_gui.cpp
+++ b/src/tree_gui.cpp
@@ -29,7 +29,7 @@
 #include "safeguards.h"
 
 void PlaceTreesRandomly();
-uint PlaceTreeGroupAroundTile(TileIndex tile, TreeType treetype, uint radius, uint count);
+uint PlaceTreeGroupAroundTile(TileIndex tile, TreeType treetype, uint radius, uint count, bool set_zone);
 
 /** Tree Sprites with their palettes */
 const PalSpriteID tree_sprites[] = {
@@ -133,7 +133,8 @@ class BuildTreesWindow : public Window
 		}
 		const uint radius = this->mode == PM_FOREST_LG ? 12 : 5;
 		const uint count = this->mode == PM_FOREST_LG ? 12 : 5;
-		PlaceTreeGroupAroundTile(tile, treetype, radius, count);
+		// Create tropic zones only when the tree type is selected by the user and not picked randomly.
+		PlaceTreeGroupAroundTile(tile, treetype, radius, count, this->tree_to_plant != TREE_INVALID);
 	}
 
 public:


### PR DESCRIPTION
## Motivation / Problem

Creating rainforest in the scenario editor is exceptionally hard. The only way to make a rainforest is to plant a rainforest tree with the single-tile tree brush. See also https://github.com/OpenTTD/OpenTTD/issues/9241

## Description

This PR allows larger tree brushes to also create rainforest tiles. The behavior of random-tree brushes remains unchanged.

## Limitations

Currently, the implementation simply makes the behavior of the larger tree brushes match that of the single-tile brush. However, the zoning could be more complex (such as planting cacti also creates desert or such).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
