### PR TITLE
Change: Make pf.yapf.rail_firstred_twoway_eol on by default

### DIFF
--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -334,7 +334,7 @@ cat      = SC_EXPERT
 [SDT_BOOL]
 var      = pf.yapf.rail_firstred_twoway_eol
 from     = SLV_28
-def      = false
+def      = true
 cat      = SC_EXPERT
 
 [SDT_VAR]


### PR DESCRIPTION
## Motivation / Problem

I think it's a perfect time to change the default as #8688 now officially makes block signals an advanced feature for advanced players and those advanced players play with twoway_eol on xD

Jokes aside it's a useful feature that allows a number of cool techniques so changing the default will let players use them on servers even if the server owner is not aware (or forgot) of such setting and didn't specifically enable it. And help avoid confusion when trying to copy those techniques from the wiki or other players. As for the only argument against it that I know of it no longer stands (that it makes broken newbie networks even more broken).

More info on twoway eol can be found here: http://web.archive.org/web/20191223024422/http://wiki.openttdcoop.org/Two-way_end_of_line

## Description

Just changed the default value of `pf.yapf.rail_firstred_twoway_eol` from `false` to `true`.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
