### PR TITLE
Fix: Don't give focus to text filter when opening Object GUI

### DIFF
--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -117,7 +117,6 @@ public:
 		NWidgetMatrix *matrix = this->GetWidget<NWidgetMatrix>(WID_BO_SELECT_MATRIX);
 		matrix->SetScrollbar(this->GetScrollbar(WID_BO_SELECT_SCROLL));
 
-		this->SetFocusedWidget(WID_BO_FILTER);
 		this->GetWidget<NWidgetMatrix>(WID_BO_OBJECT_MATRIX)->SetCount(4);
 
 		ResetObjectToPlace();


### PR DESCRIPTION
## Motivation / Problem

When opening the object window to build NewGRF objects, the text filter box is automatically given focus, so any hotkeys are typed into the textbox.

The same problem with the rail station filter [in a comment on the feature PR](https://github.com/OpenTTD/OpenTTD/pull/8706#issuecomment-803176613) and again in #8875, and fixed in #8885.

Text filters in other GUIs like the Town directory do not get focus upon opening the GUI, setting a further precedent to remove this auto-focus, especially now that we have a hotkey (#8908) to give focus to the textbox.

## Description

The text filter does not automatically get focus upon opening the object GUI.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
