### PR TITLE
Fix #9463: [Win32] Try to work around XAudio2 crashes by catching SEH exceptions.

### DIFF
--- a/src/sound/xaudio2_s.cpp
+++ b/src/sound/xaudio2_s.cpp
@@ -117,6 +117,20 @@ static IXAudio2MasteringVoice* _mastering_voice = nullptr;
 static ComPtr<IXAudio2> _xaudio2;
 static StreamingVoiceContext* _voice_context = nullptr;
 
+/** Create XAudio2 context with SEH exception checking. */
+static HRESULT CreateXAudio(API_XAudio2Create xAudio2Create)
+{
+	HRESULT hr;
+	__try {
+		UINT32 flags = 0;
+		hr = xAudio2Create(_xaudio2.GetAddressOf(), flags, XAUDIO2_DEFAULT_PROCESSOR);
+	} __except (EXCEPTION_EXECUTE_HANDLER) {
+		hr = GetExceptionCode();
+	}
+
+	return hr;
+}
+
 /**
 * Initialises the XAudio2 driver.
 *
@@ -156,8 +170,7 @@ const char *SoundDriver_XAudio2::Start(const StringList &parm)
 	}
 
 	// Create the XAudio engine
-	UINT32 flags = 0;
-	hr = xAudio2Create(_xaudio2.GetAddressOf(), flags, XAUDIO2_DEFAULT_PROCESSOR);
+	hr = CreateXAudio(xAudio2Create);
 
 	if (FAILED(hr))
 	{


### PR DESCRIPTION
## Motivation / Problem

While it looks like the XAudio2 crashes reported e.g. in #9463 are caused by third-party components, users will still blame OpenTTD at first. As such, if we can do something, user experience is improved, especially as other audio drivers besides XAudio2 are available. 

## Description

The provided crash logs point to an illegal access exception during XAudio2 creation. Windows reports such errors using the SEH mechanism which can be caught by platform-specific code. If a SEH exception is encountered, just fail driver creation and let the system do the normal fallback.

The extra function is needed as SEH handling can't be used in contexts that rely on C++ unwinding.

## Limitations

As I don't have the suspected third-party software components, I can't verify if this PR actually fixes the reported issues.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
