### PR TITLE
Change: Add configurable docking tile occupied penalty for NPF and YAPF

### DIFF
--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -332,7 +332,7 @@ static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *par
 		/* Check docking tile for occupancy */
 		uint count = 0;
 		HasVehicleOnPos(current->tile, &count, &CountShipProc);
-		cost += count * 3 * _trackdir_length[trackdir];
+		cost += count * _settings_game.pf.npf.npf_docking_tile_occupied_penalty;
 	}
 
 	/* @todo More penalties? */

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -289,7 +289,7 @@ public:
 			/* Check docking tile for occupancy */
 			uint count = 0;
 			HasVehicleOnPos(n.GetTile(), &count, &CountShipProc);
-			c += count * 3 * YAPF_TILE_LENGTH;
+			c += count * Yapf().PfGetSettings().ship_docking_tile_occupied_penalty;
 		}
 
 		/* Skipped tile cost for aqueducts. */

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -338,6 +338,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_TABLE_CHUNKS,                       ///< 295  PR#9322 Introduction of CH_TABLE and CH_SPARSE_TABLE.
 	SLV_SCRIPT_INT64,                       ///< 296  PR#9415 SQInteger is 64bit but was saved as 32bit.
 	SLV_LINKGRAPH_TRAVEL_TIME,              ///< 297  PR#9457 Store travel time in the linkgraph.
+	SLV_SHIP_DOCKING_PENALTY,               ///< 298  PR#9553 Configurable docking tile occupied penalties for NPF and YAPF.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -395,6 +395,7 @@ struct NPFSettings {
 	uint32 npf_road_drive_through_penalty;   ///< the penalty for going through a drive-through road stop
 	uint32 npf_road_dt_occupied_penalty;     ///< the penalty multiplied by the fill percentage of a drive-through road stop
 	uint32 npf_road_bay_occupied_penalty;    ///< the penalty multiplied by the fill percentage of a road bay
+	uint32 npf_docking_tile_occupied_penalty; ///< the penalty multiplied by the number of ships on a docking tile
 };
 
 /** Settings related to the yet another pathfinder. */
@@ -437,6 +438,7 @@ struct YAPFSettings {
 	uint32 rail_shorter_platform_per_tile_penalty; ///< penalty for shorter station platform than train (per tile)
 	uint32 ship_curve45_penalty;                   ///< penalty for 45-deg curve for ships
 	uint32 ship_curve90_penalty;                   ///< penalty for 90-deg curve for ships
+	uint32 ship_docking_tile_occupied_penalty;     ///< penalty multiplied by the number of ships on a docking tile
 };
 
 /** Settings related to all pathfinders. */

--- a/src/table/settings/pathfinding_settings.ini
+++ b/src/table/settings/pathfinding_settings.ini
@@ -308,6 +308,15 @@ max      = 100000
 cat      = SC_EXPERT
 
 [SDT_VAR]
+var      = pf.npf.npf_docking_tile_occupied_penalty
+type     = SLE_UINT
+from     = SLV_SHIP_DOCKING_PENALTY
+def      = 3 * NPF_TILE_LENGTH
+min      = 0
+max      = 100000
+cat      = SC_EXPERT
+
+[SDT_VAR]
 var      = pf.npf.maximum_go_to_depot_penalty
 type     = SLE_UINT
 from     = SLV_131
@@ -612,6 +621,15 @@ var      = pf.yapf.ship_curve90_penalty
 type     = SLE_UINT
 from     = SLV_SHIP_CURVE_PENALTY
 def      = 6 * YAPF_TILE_LENGTH
+min      = 0
+max      = 1000000
+cat      = SC_EXPERT
+
+[SDT_VAR]
+var      = pf.yapf.ship_docking_tile_occupied_penalty
+type     = SLE_UINT
+from     = SLV_SHIP_DOCKING_PENALTY
+def      = 3 * YAPF_TILE_LENGTH
 min      = 0
 max      = 1000000
 cat      = SC_EXPERT


### PR DESCRIPTION
## Motivation / Problem
Personally, I'd like to be able to configure docking tile occupied penalty to 0, so that there is a way to make the pathfinder behave more like it used to before this penalty was introduced. ship_curve45_penalty and ship_curve90_penalty were introduced recently and are configurable, so why not the docking tile?
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add configurable docking tile occupied penalty for NPF and YAPF
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
