### PR TITLE
Fix: add back 'Spectate' option to company toolbar menu

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2323,6 +2323,7 @@ STR_NETWORK_NEED_COMPANY_PASSWORD_CAPTION                       :{WHITE}Company 
 
 # Network company list added strings
 STR_NETWORK_COMPANY_LIST_CLIENT_LIST                            :Online players
+STR_NETWORK_COMPANY_LIST_SPECTATE                               :Spectate
 
 # Network client list
 STR_NETWORK_CLIENT_LIST_CAPTION                                 :{WHITE}Online Players

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -204,7 +204,8 @@ static void PopupMainToolbMenu(Window *w, int widget, StringID string, int count
 
 /** Enum for the Company Toolbar's network related buttons */
 static const int CTMN_CLIENT_LIST = -1; ///< Show the client list
-static const int CTMN_SPECTATOR   = -2; ///< Show a company window as spectator
+static const int CTMN_SPECTATE    = -2; ///< Become spectator
+static const int CTMN_SPECTATOR   = -3; ///< Show a company window as spectator
 
 /**
  * Pop up a generic company list menu.
@@ -222,8 +223,11 @@ static void PopupMainCompanyToolbMenu(Window *w, int widget, int grey = 0)
 
 			/* Add the client list button for the companies menu */
 			list.emplace_back(new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_CLIENT_LIST, CTMN_CLIENT_LIST, false));
-			break;
 
+			if (_local_company != COMPANY_SPECTATOR) {
+				list.emplace_back(new DropDownListStringItem(STR_NETWORK_COMPANY_LIST_SPECTATE, CTMN_SPECTATE, false));
+			}
+			break;
 		case WID_TN_STORY:
 			list.emplace_back(new DropDownListStringItem(STR_STORY_BOOK_SPECTATOR, CTMN_SPECTATOR, false));
 			break;
@@ -602,6 +606,15 @@ static CallBackFunction MenuClickCompany(int index)
 		switch (index) {
 			case CTMN_CLIENT_LIST:
 				ShowClientList();
+				return CBF_NONE;
+
+			case CTMN_SPECTATE:
+				if (_network_server) {
+					NetworkServerDoMove(CLIENT_ID_SERVER, COMPANY_SPECTATOR);
+					MarkWholeScreenDirty();
+				} else {
+					NetworkClientRequestMove(COMPANY_SPECTATOR);
+				}
 				return CBF_NONE;
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

People have been using the "Spectate" in the menu as a quick way to mark themselves as "away" in multiplayer games. As we have no alternative for this flow, reinstate this button.

More details here: https://github.com/OpenTTD/OpenTTD/pull/9532#issuecomment-913108471

## Description

This is a cherry-pick of the work of JGRPP: https://github.com/JGRennison/OpenTTD-patches/commit/40a6181a16302fbd9f96d6e1730ece0ca0cb2f0b
Which is a partial cherry-pick of #9532.
Closes #9532.

As by commit message:
```
This was removed in ce7406f88b, but people used this to quickly
mark themselves as away.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
