### PR TITLE
Add: [Network] On join, log the ClientID + IP + Name clearly

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -281,7 +281,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::CloseConnection(NetworkRecvSta
 	}
 
 	NetworkAdminClientError(this->client_id, NETWORK_ERROR_CONNECTION_LOST);
-	Debug(net, 3, "Closed client connection {}", this->client_id);
+	Debug(net, 3, "[{}] Client #{} closed connection", ServerNetworkGameSocketHandler::GetName(), this->client_id);
 
 	/* We just lost one client :( */
 	if (this->status >= STATUS_AUTHORIZED) _network_game_info.clients_on--;
@@ -947,6 +947,8 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::Receive_CLIENT_MAP_OK(Packet *
 
 		NetworkTextMessage(NETWORK_ACTION_JOIN, CC_DEFAULT, false, client_name, "", this->client_id);
 		InvalidateWindowData(WC_CLIENT_LIST, 0);
+
+		Debug(net, 3, "[{}] Client #{} ({}) joined as {}", ServerNetworkGameSocketHandler::GetName(), this->client_id, this->GetClientIP(), client_name);
 
 		/* Mark the client as pre-active, and wait for an ACK
 		 *  so we know it is done loading and in sync with us */


### PR DESCRIPTION
Closes #9105.

## Motivation / Problem

#9105 asks for better ability to match clientid + ip + username. Currently there isn't a single place this is logged, so tools etc can't pick up on this without difficult complexity on their side.

## Description

Where #9105 presents some of this information via chat, of which I am not a fan (See https://github.com/OpenTTD/OpenTTD/pull/9105#issuecomment-922253286 for details), instead this PR presents the log in a single message.

Another difference to #9105 has to do with how loud we want connects to be. With this PR, this is what a normal connect looks like:

```
[2021-09-18 12:04:53] dbg: [net] [server] Client connected from 172.31.242.231 on frame 243
[2021-09-18 12:04:53] dbg: [net] [server] Client #2 closed connection
[2021-09-18 12:04:54] dbg: [net] [server] Client connected from 172.31.242.231 on frame 282
[2021-09-18 12:04:55] ‎*** TrueBrain #1 has joined the game (Client #3)
[2021-09-18 12:04:55] dbg: [net] [server] Client #3 (172.31.242.231) joined as TrueBrain #1
```

The first 2 lines are the server being queried by the client. The last 3 lines is a client joining (and has not left yet).

I went for only logging the "joined" when the name was known, so there is a single log message stating the client ID, the client IP and the client name. #9105 also adds a log message when the connection is assigned to a client ID, adding another message for only stating client ID + client IP. I can see the use of that, but it also makes the logs even more verbose. I am fully open to be convinced that is a good idea however :)

I also changed the "closed connection" message, to make the connect, join, and close message look alike. This should make it easier on tooling to deal with this.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
