### PR TITLE
Fix #9484: update locale currencies settings mapping

### DIFF
--- a/src/table/settings/game_settings.ini
+++ b/src/table/settings/game_settings.ini
@@ -9,7 +9,7 @@
 ; Game settings are everything related to vehicles, stations, orders, etc.
 
 [pre-amble]
-static std::initializer_list<const char*> _roadsides{"left", "right"};
+static constexpr std::initializer_list<const char*> _roadsides{"left", "right"};
 
 static void StationSpreadChanged(int32 new_value);
 static void UpdateConsists(int32 new_value);

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -15,9 +15,9 @@ static void InvalidateNewGRFChangeWindows(int32 new_value);
 static void ZoomMinMaxChanged(int32 new_value);
 static void SpriteZoomMinChanged(int32 new_value);
 
-static std::initializer_list<const char*> _autosave_interval{"off", "monthly", "quarterly", "half year", "yearly"};
-static std::initializer_list<const char*> _osk_activation{"disabled", "double", "single", "immediately"};
-static std::initializer_list<const char*> _savegame_date{"long", "short", "iso"};
+static constexpr std::initializer_list<const char*> _autosave_interval{"off", "monthly", "quarterly", "half year", "yearly"};
+static constexpr std::initializer_list<const char*> _osk_activation{"disabled", "double", "single", "immediately"};
+static constexpr std::initializer_list<const char*> _savegame_date{"long", "short", "iso"};
 
 static const SettingVariant _gui_settings_table[] = {
 [post-amble]

--- a/src/table/settings/locale_settings.ini
+++ b/src/table/settings/locale_settings.ini
@@ -10,8 +10,10 @@
 [pre-amble]
 uint8 _old_units;                                      ///< Old units from old savegames
 
-static std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "YEN", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "YTL", "SKK", "BRL", "EEK", "custom"};
-static std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits"};
+static constexpr std::initializer_list<const char*> _locale_currencies{"GBP", "USD", "EUR", "JPY", "ATS", "BEF", "CHF", "CZK", "DEM", "DKK", "ESP", "FIM", "FRF", "GRD", "HUF", "ISK", "ITL", "NLG", "NOK", "PLN", "RON", "RUR", "SIT", "SEK", "TRY", "SKK", "BRL", "EEK", "LTL", "KRW", "ZAR", "custom", "GEL", "IRR", "RUB", "MXN", "NTD", "CNY", "HKD", "INR", "IDR", "MYR"};
+static constexpr std::initializer_list<const char*> _locale_units{"imperial", "metric", "si", "gameunits"};
+
+static_assert(_locale_currencies.size() == CURRENCY_END);
 
 static const SettingVariant _locale_settings_table[] = {
 [post-amble]

--- a/src/table/settings/misc_settings.ini
+++ b/src/table/settings/misc_settings.ini
@@ -10,8 +10,8 @@
 [pre-amble]
 extern std::string _config_language_file;
 
-static std::initializer_list<const char*> _support8bppmodes{"no", "system" , "hardware"};
-static std::initializer_list<const char*> _display_opt_modes{"SHOW_TOWN_NAMES", "SHOW_STATION_NAMES", "SHOW_SIGNS", "FULL_ANIMATION", "", "FULL_DETAIL", "WAYPOINTS", "SHOW_COMPETITOR_SIGNS"};
+static constexpr std::initializer_list<const char*> _support8bppmodes{"no", "system", "hardware"};
+static constexpr std::initializer_list<const char*> _display_opt_modes{"SHOW_TOWN_NAMES", "SHOW_STATION_NAMES", "SHOW_SIGNS", "FULL_ANIMATION", "", "FULL_DETAIL", "WAYPOINTS", "SHOW_COMPETITOR_SIGNS"};
 
 #ifdef WITH_COCOA
 extern bool _allow_hidpi_window;

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -9,8 +9,8 @@
 [pre-amble]
 static void UpdateClientConfigValues();
 
-static std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
-static std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
+static constexpr std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
+static constexpr std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
 
 static const SettingVariant _network_settings_table[] = {
 [post-amble]

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -7,7 +7,7 @@
 ; News display settings as stored in the main configuration file ("openttd.cfg").
 
 [pre-amble]
-static std::initializer_list<const char*> _news_display{ "off", "summarized", "full"};
+static constexpr std::initializer_list<const char*> _news_display{ "off", "summarized", "full"};
 
 static const SettingVariant _news_display_settings_table[] = {
 [post-amble]

--- a/src/table/settings/old_gameopt_settings.ini
+++ b/src/table/settings/old_gameopt_settings.ini
@@ -14,8 +14,8 @@
 ; be saved in their new place.
 
 [pre-amble]
-static std::initializer_list<const char*> _town_names{"english", "french", "german", "american", "latin", "silly", "swedish", "dutch", "finnish", "polish", "slovak", "norwegian", "hungarian", "austrian", "romanian", "czech", "swiss", "danish", "turkish", "italian", "catalan"};
-static std::initializer_list<const char*> _climates{"temperate", "arctic", "tropic", "toyland"};
+static constexpr std::initializer_list<const char*> _town_names{"english", "french", "german", "american", "latin", "silly", "swedish", "dutch", "finnish", "polish", "slovak", "norwegian", "hungarian", "austrian", "romanian", "czech", "swiss", "danish", "turkish", "italian", "catalan"};
+static constexpr std::initializer_list<const char*> _climates{"temperate", "arctic", "tropic", "toyland"};
 
 static const SettingVariant _old_gameopt_settings_table[] = {
 /* In version 4 a new difficulty setting has been added to the difficulty settings,

--- a/src/table/settings/script_settings.ini
+++ b/src/table/settings/script_settings.ini
@@ -8,7 +8,7 @@
 ; and in the savegame PATS chunk.
 
 [pre-amble]
-static std::initializer_list<const char*> _settings_profiles{"easy", "medium", "hard"};
+static constexpr std::initializer_list<const char*> _settings_profiles{"easy", "medium", "hard"};
 
 static const SettingVariant _script_settings_table[] = {
 [post-amble]


### PR DESCRIPTION
## Motivation / Problem

See #9484 for bug description.

## Description

Updated the table.

## Limitations

If people use either `YEN` or `YTL`, their locale currency will reset. This might not be ideal, but to leave code to fix that for ever and ever is much worse imo.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
