### PR TITLE
Fix: Incorrect error messages on placing water on scenario editor

### DIFF
--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -477,8 +477,8 @@ CommandCost CmdBuildCanal(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 
 		bool water = IsWaterTile(current_tile);
 
-		/* can't make water of water! */
-		if (water && (!IsTileOwner(current_tile, OWNER_WATER) || wc == WATER_CLASS_SEA)) continue;
+		/* Outside the editor, prevent building canals over your own or OWNER_NONE owned canals */
+		if (water && IsCanal(current_tile) && _game_mode != GM_EDITOR && (IsTileOwner(current_tile, _current_company) || IsTileOwner(current_tile, OWNER_NONE))) continue;
 
 		ret = DoCommand(current_tile, 0, 0, flags, CMD_LANDSCAPE_CLEAR);
 		if (ret.Failed()) return ret;


### PR DESCRIPTION
## Motivation / Problem
I found some issues when placing sea/canal/river on scenario, the error messages don't always make sense and the behaviour is a little inconsistent when compared with each other. Listed below is the behaviour tested on 12.0-beta2.

On the scenario editor...
Building sea on sea: "Can't build canals here... already built"
Building sea on canal (owner none): "Can't build canals here... already built"
Building sea on canal (company owned): "Can't build canals here... already built"
Building sea on river: "Can't build canals here... already built"

Building canal on sea: builds with no error
Building canal on canal (owner none): "Can't build canals here... already built"
Building canal on canal (company owned): "Can't build canals here... already built"
Building canal on river: builds with no error

Building river on sea: builds with no error
Building river on canal (owner none): "Can't place rivers here... already built"
Building river on canal (company owned): "Can't place rivers here... already built"
Building river on river: overbuilds with no error

On a game...
Building canal on sea: builds with no error, cost £3,750
Building canal on canal (owner none): "Can't build canals here... already built"
Building canal on canal (self-owned): "Can't build canals here... already built"
Building canal on canal (other company): "Can't build canals here... already built"
Building canal on river: builds with no error, cost £3,750
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Below is the behaviour after the PR, which seem a bit better.

On the scenario editor...
Building sea on sea: overbuilds with no error
Building sea on canal (owner none): builds with no error
Building sea on canal (company owned): "Can't build canals here... owned by 'company'"
Building sea on river: builds with no error

Building canal on sea: builds with no error
Building canal on canal (owner none): overbuilds with no error
Building canal on canal (company owned): "Can't build canals here... owned by 'company'"
Building canal on river: builds with no error

Building river on sea: builds with no error
Building river on canal (owner none): builds with no error
Building river on canal (company owned): "Can't place rivers here... owned by 'company'"
Building river on river: overbuilds with no error

On a game...
Building canal on sea: builds with no error, cost £3,750
Building canal on canal (owner none): "Can't build canals here... already built"
Building canal on canal (self-owned): "Can't build canals here... already built"
Building canal on canal (other company): "Can't build canals here... owned by 'company'"
Building canal on river: builds with no error, cost £3,750
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Still incorrect error message for 'Building sea on canal (company owned)'
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
