### PR TITLE
Fix #9562: Crash with invalid NewGRF

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5168,6 +5168,11 @@ static void NewSpriteGroup(ByteReader *buf)
 					grfmsg(6, "NewSpriteGroup: New SpriteGroup 0x%02X, %u loaded, %u loading",
 							setid, num_loaded, num_loading);
 
+					if (num_loaded + num_loading == 0) {
+						grfmsg(1, "NewSpriteGroup: no result, skipping invalid RealSpriteGroup");
+						break;
+					}
+
 					if (num_loaded + num_loading == 1) {
 						/* Avoid creating 'Real' sprite group if only one option. */
 						uint16 spriteid = buf->ReadWord();


### PR DESCRIPTION
## Motivation / Problem

Since #9344, invalid NewGRFs could crash OpenTTD with a new spritegroup if both num_loading and num_loaded are zero.

## Description

This is resolved by detecting this case and skipping creation of a sprite group.

## Limitations

The invalid NewGRF may behave differently than before this (and #9344) however the NewGRF is still invalid, but it won't crash OpenTTD.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
