### PR TITLE
Feature: Add use of Intel Intrinsics & RDTSC on e2k (MCST Elbrus 2000)

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -73,6 +73,18 @@ uint64 ottd_rdtsc()
 # define RDTSC_AVAILABLE
 #endif
 
+/* rdtsc for MCST Elbrus 2000 */
+#if defined(__e2k__) && !defined(RDTSC_AVAILABLE)
+uint64 ottd_rdtsc()
+{
+	uint64_t dst;
+# pragma asm_inline
+	asm("rrd %%clkr, %0" : "=r" (dst));
+	return dst;
+}
+# define RDTSC_AVAILABLE
+#endif
+
 #if defined(__EMSCRIPTEN__) && !defined(RDTSC_AVAILABLE)
 /* On emscripten doing TIC/TOC would be ill-advised */
 uint64 ottd_rdtsc() {return 0;}
@@ -130,6 +142,24 @@ void ottd_cpuid(int info[4], int type)
 			: "a" (type)
 	);
 #endif /* i386 PIC */
+}
+#elif defined(__e2k__) /* MCST Elbrus 2000*/
+void ottd_cpuid(int info[4], int type)
+{
+	info[0] = info[1] = info[2] = info[3] = 0;
+	if (type == 0) {
+		info[0] = 1;
+	} else if (type == 1) {
+#if defined(__SSE4_1__)
+		info[2] |= (1<<19); /* HasCPUIDFlag(1, 2, 19) */
+#endif
+#if defined(__SSSE3__)
+		info[2] |= (1<<9); /* HasCPUIDFlag(1, 2, 9) */
+#endif
+#if defined(__SSE2__)
+		info[3] |= (1<<26); /* HasCPUIDFlag(1, 3, 26) */
+#endif
+	}
 }
 #else
 void ottd_cpuid(int info[4], int type)


### PR DESCRIPTION
## Motivation / Problem
The e2k MCST-LСС (eLbrus Compiler Collection) compiler can cross-compile Intel Intrinsics into Elbrus Intrinsics. But to use this feature need to pretend to be an i386/x86_64 architecture (to use this code). To do this need to add Elbrus implementation to CPUID function.
Also, Elbrus support RDTSC.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Added use of Intel Intrinsics (SSE2, SSSE3, SSE4.1) & RDTSC on e2k architecture by default.
Co-authored-by: Alexander Troosh @troosh, Konstantin Ivlev @SSE4 and Dmitry Shcherbakov @crypto-das
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
No.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* ~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    ~* ai_changelog.hpp, gs_changelog.hpp need updating.~
    ~* The compatibility wrappers (compat_*.nut) need updating.~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * ~newgrf_debug_data.h may need updating.~
    * ~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~