### PR TITLE
Revert 7ca1793: Using Trackdir keyed node is not required, Exitdir keyed node still have the correct trackdir

### DIFF
--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -337,16 +337,6 @@ struct CYapfShip1 : CYapfT<CYapfShip_TypesT<CYapfShip1, CFollowTrackWater    , C
 /* YAPF type 2 - uses TileIndex/DiagDirection as Node key */
 struct CYapfShip2 : CYapfT<CYapfShip_TypesT<CYapfShip2, CFollowTrackWater    , CShipNodeListExitDir > > {};
 
-static inline bool RequireTrackdirKey()
-{
-	/* If the two curve penalties are not equal, then it is not possible to use the
-	 * ExitDir keyed node list, as it there will be key overlap. Using Trackdir keyed
-	 * nodes means potentially more paths are tested, which would be wasteful if it's
-	 * not necessary.
-	 */
-	return _settings_game.pf.yapf.ship_curve45_penalty != _settings_game.pf.yapf.ship_curve90_penalty;
-}
-
 /** Ship controller helper - path finder invoker */
 Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir, TrackBits tracks, bool &path_found, ShipPathCache &path_cache)
 {
@@ -355,7 +345,7 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, DiagDirection enterdir,
 	PfnChooseShipTrack pfnChooseShipTrack = CYapfShip2::ChooseShipTrack; // default: ExitDir
 
 	/* check if non-default YAPF type needed */
-	if (_settings_game.pf.yapf.disable_node_optimization || RequireTrackdirKey()) {
+	if (_settings_game.pf.yapf.disable_node_optimization) {
 		pfnChooseShipTrack = &CYapfShip1::ChooseShipTrack; // Trackdir
 	}
 
@@ -373,7 +363,7 @@ bool YapfShipCheckReverse(const Ship *v)
 	PfnCheckReverseShip pfnCheckReverseShip = CYapfShip2::CheckShipReverse; // default: ExitDir
 
 	/* check if non-default YAPF type needed */
-	if (_settings_game.pf.yapf.disable_node_optimization || RequireTrackdirKey()) {
+	if (_settings_game.pf.yapf.disable_node_optimization) {
 		pfnCheckReverseShip = &CYapfShip1::CheckShipReverse; // Trackdir
 	}
 


### PR DESCRIPTION
## Motivation / Problem
Trackdir keyed nodes are forced when 45° and 90° penalties for ships differ (and they differ when using default values).
That implies a lot more nodes are opened when pathfinding, which implies more closed node, and when enough nodes are closed (default 10K), pathfinding just stops and ship says "can't reach destination".
But using trackdir keyed nodes for different curve penalties is not required at all, because even for exitdir keyed nodes the correct trackdir is still available (and already used to determine next tile).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Revert the commit introducing the forced switch to trackdir keyed nodes.
Hugely decreases the number of nodes opened to find a path, which increases the chance to actually find one where using trackdirs would bail out before finding it.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Found paths may be a little different, but in most cases they are the same.
Using trackdir keyed nodes:
![trackdir](https://user-images.githubusercontent.com/2952192/134809452-3f7980d1-a589-406c-811b-3b8f4f1e902e.png)
Using exitdir keyed nodes:
![exitdir](https://user-images.githubusercontent.com/2952192/134809445-616539dd-8c6c-47bb-8eba-1b3a8be1884b.png)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status
)
