### PR TITLE
Fix #9588, 140a96b: [Squirrel] Reaching memory limit during script registration could prevent further script detections

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqobject.h
+++ b/src/3rdparty/squirrel/squirrel/sqobject.h
@@ -62,6 +62,24 @@ struct SQRefCounted
 	SQUnsignedInteger _uiRef;
 	struct SQWeakRef *_weakref;
 	virtual void Release()=0;
+
+	/* Placement new/delete to prevent memory leaks if constructor throws an exception. */
+	inline void *operator new(size_t size, SQRefCounted *place)
+	{
+		place->size = size;
+		return place;
+	}
+
+	inline void operator delete(void *ptr, SQRefCounted *place)
+	{
+		SQ_FREE(ptr, place->size);
+	}
+
+	/* Never used but required. */
+	inline void operator delete(void *ptr) { NOT_REACHED(); }
+
+private:
+	size_t size;
 };
 
 struct SQWeakRef : SQRefCounted


### PR DESCRIPTION
## Motivation / Problem
When a script's `info.nut` triggers `Maximum memory allocation exceeded`, it can prevent the detection of other scripts of the same type.
This happens because the memory allocation triggering the limit is still accounted in the allocator for all other detections.
And that means this memory is also never freed.

Once the `allocated_size` issue was fixed, another issue appeared, a script failing to register due to memory limit would still be available ingame (and possibly other scripts that should have failed memory check). That's because scripts are scanned multiple times, and the error was not properly reset.

Finally another memory leak exists, when the memory limit is triggered in a constructor and using placement new.

Regarding the reported crash, it's because `DummyAI` registration triggers the memory limit due to a previous failing script and incomplete cleaning between registrations.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Properly count allocated memory, and free memory not referenced by squirrel before it's lost.
I added an assert to ensure all allocated memory is managed by squirrel and its garbage collector, or is taken care of otherwise.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
As now the engine is properly reset, the failing scripts are now reported multiple times in debug console, because many rescan happen during startup.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
