### PR TITLE
Add: [Network] Keep the refresh button in lowered state while refreshing

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -635,6 +635,7 @@ public:
 	{
 		NetworkGameList *item = NetworkGameListAddItem(connection_string);
 		item->status = NGLS_OFFLINE;
+		item->refreshing = false;
 
 		UpdateNetworkGameWindow();
 	}
@@ -652,6 +653,10 @@ public:
 void NetworkQueryServer(const std::string &connection_string)
 {
 	if (!_network_available) return;
+
+	/* Mark the entry as refreshing, so the GUI can show the refresh is pending. */
+	NetworkGameList *item = NetworkGameListAddItem(connection_string);
+	item->refreshing = true;
 
 	new TCPQueryConnecter(connection_string);
 }

--- a/src/network/network_gamelist.h
+++ b/src/network/network_gamelist.h
@@ -31,7 +31,7 @@ struct NetworkGameList {
 	std::string connection_string;               ///< Address of the server.
 	NetworkGameListStatus status = NGLS_OFFLINE; ///< Stats of the server.
 	bool manually = false;                       ///< True if the server was added manually.
-	uint8 retries = 0;                           ///< Number of retries (to stop requerying).
+	bool refreshing = false;                     ///< Whether this server is being queried.
 	int version = 0;                             ///< Used to see which servers are no longer available on the Game Coordinator and can be removed.
 	NetworkGameList *next = nullptr;             ///< Next pointer to make a linked game list.
 };

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -613,6 +613,8 @@ public:
 				sel->info.clients_on >= sel->info.clients_max || // Server full
 				!sel->info.compatible); // Revision mismatch
 
+		this->SetWidgetLoweredState(WID_NG_REFRESH, sel != nullptr && sel->refreshing);
+
 		/* 'NewGRF Settings' button invisible if no NewGRF is used */
 		this->GetWidget<NWidgetStacked>(WID_NG_NEWGRF_SEL)->SetDisplayedPlane(sel == nullptr || sel->status != NGLS_ONLINE || sel->info.grfconfig == nullptr);
 		this->GetWidget<NWidgetStacked>(WID_NG_NEWGRF_MISSING_SEL)->SetDisplayedPlane(sel == nullptr || sel->status != NGLS_ONLINE || sel->info.grfconfig == nullptr || !sel->info.version_compatible || sel->info.compatible);
@@ -790,7 +792,7 @@ public:
 				break;
 
 			case WID_NG_REFRESH: // Refresh
-				if (this->server != nullptr) NetworkQueryServer(this->server->connection_string);
+				if (this->server != nullptr && !this->server->refreshing) NetworkQueryServer(this->server->connection_string);
 				break;
 
 			case WID_NG_NEWGRF: // NewGRF Settings

--- a/src/network/network_query.cpp
+++ b/src/network/network_query.cpp
@@ -79,6 +79,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_FULL(Packet *p)
 {
 	NetworkGameList *item = NetworkGameListAddItem(this->connection_string);
 	item->status = NGLS_FULL;
+	item->refreshing = false;
 
 	UpdateNetworkGameWindow();
 
@@ -89,6 +90,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_BANNED(Packet *p
 {
 	NetworkGameList *item = NetworkGameListAddItem(this->connection_string);
 	item->status = NGLS_BANNED;
+	item->refreshing = false;
 
 	UpdateNetworkGameWindow();
 
@@ -107,6 +109,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_GAME_INFO(Packet
 	CheckGameCompatibility(item->info);
 	/* Ensure we consider the server online. */
 	item->status = NGLS_ONLINE;
+	item->refreshing = false;
 
 	UpdateNetworkGameWindow();
 
@@ -128,6 +131,7 @@ NetworkRecvStatus QueryNetworkGameSocketHandler::Receive_SERVER_ERROR(Packet *p)
 	} else {
 		item->status = NGLS_OFFLINE;
 	}
+	item->refreshing = false;
 
 	UpdateNetworkGameWindow();
 


### PR DESCRIPTION


## Motivation / Problem

I noticed on the Game Coordinator usage statistics, that we see a lot of "Aborted" connections. This happens when a new connection to the same server is being created while another one is still pending. Initially I couldn't figure out when this happens, till I was looking into an unrelated but in the Game Coordinator:

Especially when you have a TURN-connection, one that doesn't allow STUN, refreshing a server takes a few seconds. There is no visual feedback in this GUI to tell you the refresh is still pending, as the button goes up directly after pressing it. This gives you the idea you misclicked or something else went wrong, so you press again. And again. And again.

This PR sets out to resolve this.

As written in the commit message:

```
This gives user visual feedback that the refresh is still pending, and
prevents people from clicking again and again thinking nothing is
happening. This is especially true for connections that fall back to
TURN, as that takes a few seconds to kick in.

Additionally, prevent clicking on the button again while a refresh
is pending. This is only delaying a successful result.
```


## Description

Simply track that the server is being refreshed, and keep the state lowered while this holds true. Additionally, prevent clicking on the button again to give a pretty solid UX experience.

`retries` wasn't used anymore, so I removed that variable while I was at it.



## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
