### PR TITLE
Change: Disable AI and Game Script when loading the title game

### DIFF
--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -82,6 +82,15 @@ struct AIPLChunkHandler : ChunkHandler {
 				continue;
 			}
 
+			/* If on the main menu, i.e. loading the title game, disable all AIs */
+			if (_game_mode == GM_MENU) {
+				if (Company::IsValidAiID(index)) {
+					AIInstance::LoadEmpty();
+					Company::Get(index)->is_ai = false;
+				}
+				continue;
+			}
+
 			AIConfig *config = AIConfig::GetConfig(index, AIConfig::SSS_FORCE_GAME);
 			if (_ai_saveload_name.empty()) {
 				/* A random AI. */

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -69,7 +69,8 @@ struct GSDTChunkHandler : ChunkHandler {
 		_game_saveload_version = -1;
 		SlObject(nullptr, slt);
 
-		if (_networking && !_network_server) {
+		/* Network clients don't run the game script, and neither does the title screen game */
+		if ((_networking && !_network_server) || _game_mode == GM_MENU) {
 			GameInstance::LoadEmpty();
 			if (SlIterateArray() != -1) SlErrorCorrupt("Too many GameScript configs");
 			return;


### PR DESCRIPTION
## Motivation / Problem

AI players and game scripts can be valuable tools for producing a title screen game, but having to take them out/disable them before shipping the title game is a big hassle. Let's just pretend the AI/GS isn't there when loading the game instead.

## Description

Don't load the Game Script data, don't load AI data, and turn AI players into "human" players, when loading a save game and the game mode is menu.

## Limitations

I hope this doesn't break detection of missing AI/GS in the Load Game window... as far as I can tell there isn't anything to break there, so it doesn't.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
