### PR TITLE
Feature: Railways can be created "through" bridges, tunnels, stations…

### DIFF
--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -639,6 +639,29 @@ struct BuildRoadToolbarWindow : Window {
 				break;
 		}
 
+		/* Add special highlighting information for bridge and tunnel tiles */
+		if (!_ctrl_pressed) { // Only relevant for creation, not removal
+			const TileIndex start_tile = TileVirtXY(_thd.selstart.x, _thd.selstart.y);
+			const TileIndex end_tile = TileVirtXY(_thd.selend.x, _thd.selend.y);
+			const DiagDirection dir = DiagdirBetweenTiles(start_tile, end_tile);
+			if (dir != DiagDirection::INVALID_DIAGDIR) {
+				for (int step = 0; step < (int)DistanceManhattan(start_tile, end_tile) + 1; ++step) {
+					const TileIndex tile = start_tile + TileOffsByDiagDir(dir) * step;
+					if (IsValidTile(tile) && IsTileType(tile, MP_TUNNELBRIDGE)
+						&& GetTunnelBridgeTransportType(tile) == TransportType::TRANSPORT_ROAD && GetTunnelBridgeDirection(tile) == dir) {
+						const TileIndex other_bridge_end = GetOtherTunnelBridgeEnd(tile);
+						const int tunnel_bridge_length = GetTunnelBridgeLength(tile, other_bridge_end);
+						_thd.special_selection_tiles[tile] = SpecialTileHighLightInfo::SPECIAL_HL_DRAW_RECT;
+						_thd.special_selection_tiles[other_bridge_end] = SpecialTileHighLightInfo::SPECIAL_HL_DRAW_RECT;
+						for (int bridge_step = 0; bridge_step < tunnel_bridge_length; ++bridge_step) {
+							_thd.special_selection_tiles[tile + TileOffsByDiagDir(dir) * (1 + bridge_step)] = SpecialTileHighLightInfo::SPECIAL_HL_IGNORE;
+						}
+						step += tunnel_bridge_length + 1;
+					}
+				}
+			}
+		}
+
 		VpSelectTilesWithMethod(pt.x, pt.y, select_method);
 	}
 

--- a/src/tilehighlight_type.h
+++ b/src/tilehighlight_type.h
@@ -10,6 +10,8 @@
 #ifndef TILEHIGHLIGHT_TYPE_H
 #define TILEHIGHLIGHT_TYPE_H
 
+#include <unordered_map>
+
 #include "core/geometry_type.hpp"
 #include "window_type.h"
 #include "tile_type.h"
@@ -42,6 +44,13 @@ enum HighLightStyle {
 DECLARE_ENUM_AS_BIT_SET(HighLightStyle)
 
 
+enum SpecialTileHighLightInfo
+{
+	SPECIAL_HL_DRAW_RECT = 0, ///< To highlight tunnel/bridge entrances that were "entered" during selection
+	SPECIAL_HL_IGNORE = 1,    ///< Ignores the tile completely. Used for the middle of a bridge "entered" during selection
+	SPECIAL_HL_INVALID = -1,
+};
+
 /** Metadata about the current highlighting. */
 struct TileHighlightData {
 	Point pos;           ///< Location, in tile "units", of the northern tile of the selected area.
@@ -63,6 +72,8 @@ struct TileHighlightData {
 
 	HighLightStyle drawstyle;      ///< Lower bits 0-3 are reserved for detailed highlight information.
 	HighLightStyle next_drawstyle; ///< Queued, but not yet drawn style.
+
+	std::unordered_map<TileIndex, SpecialTileHighLightInfo> special_selection_tiles; ///< Additional information required for drawing
 
 	HighLightStyle place_mode;     ///< Method which is used to place the selection.
 	WindowClass window_class;      ///< The \c WindowClass of the window that is responsible for the selection mode.


### PR DESCRIPTION
…. And starting from depot tiles.

## Motivation / Problem

![RX3AJb1SRU](https://user-images.githubusercontent.com/68320206/137635133-fc96ed30-ef87-4a48-aa5c-ed51b2864c67.gif)

When laying track using the AutoRail tool, I often find myself accidentally starting on a bridge, tunnel or station tile. This invalidates the entire action and no rail is built. The other way around, i.e. starting at an empty tile and ending on say a station tile, that works just fine. This can be quite annoying for example when you are trying to create lots of bridges / tunnels in a crowded map.

## Description

My changes allow the user to start the AutoRail tool on train station tiles, train depot tiles, bridgehead tiles and tunnel entrance tiles. The user must drag in the right direction, or can be 45 degrees off.

In addition, the user can drag "through" a tunnel, bridge or station. This obviously doesn't apply to depots. If there are multiple tunnels or a tunnel + bridge above each other, we would follow the route that a train would take when driving along the dragged line. In other words, we simply enter the first tunnel or bridge, and exit out of the other end.

[EDIT] This now only applies when one is creating new track. When deleting track, basically we just "delete whatever we can". This approach is more in line with how we currently do things (before my changes).

Here's an impression of what all of this looks like:

![1RCFk94oG3](https://user-images.githubusercontent.com/68320206/137638449-572f6eb1-0800-4b0b-8509-97f5de142453.gif)

[EDIT] And now also for roads/trams:
![SJXEnptlxb](https://user-images.githubusercontent.com/68320206/138315833-2a75ed49-90cc-4b2c-9661-78139874e3cb.gif)


## Limitations

I like the visualization, but I need to jump through a number of hoops to get there. Worst case I can ditch the new visualization.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
