### PR TITLE
Feature: Button to toggle showing advanced signal types

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2673,6 +2673,7 @@ STR_STATION_CLASS_WAYP                                          :Waypoints
 
 # Signal window
 STR_BUILD_SIGNAL_CAPTION                                        :{WHITE}Signal Selection
+STR_BUILD_SIGNAL_TOGGLE_ADVANCED_SIGNAL_TOOLTIP                 :{BLACK}Toggle showing advanced signal types
 STR_BUILD_SIGNAL_SEMAPHORE_NORM_TOOLTIP                         :{BLACK}Block Signal (semaphore){}This is the most basic type of signal, allowing only one train to be in the same block at the same time
 STR_BUILD_SIGNAL_SEMAPHORE_ENTRY_TOOLTIP                        :{BLACK}Entry Signal (semaphore){}Green as long as there is one or more green exit-signal from the following section of track. Otherwise it shows red
 STR_BUILD_SIGNAL_SEMAPHORE_EXIT_TOOLTIP                         :{BLACK}Exit Signal (semaphore){}Behaves in the same way as a block signal but is necessary to trigger the correct colour on entry & combo pre-signals

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1823,6 +1823,12 @@ public:
 				}
 				break;
 
+			case WID_BS_TOGGLE_SIZE:
+				_settings_client.gui.signal_gui_mode = (_settings_client.gui.signal_gui_mode == SIGNAL_GUI_ALL) ? SIGNAL_GUI_PATH : SIGNAL_GUI_ALL;
+				this->SetSignalUIMode();
+				this->ReInit();
+				break;
+
 			default: break;
 		}
 
@@ -1851,6 +1857,7 @@ static const NWidgetPart _nested_signal_builder_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_DARK_GREEN),
 		NWidget(WWT_CAPTION, COLOUR_DARK_GREEN, WID_BS_CAPTION), SetDataTip(STR_BUILD_SIGNAL_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_IMGBTN, COLOUR_DARK_GREEN, WID_BS_TOGGLE_SIZE), SetDataTip(SPR_LARGE_SMALL_WINDOW, STR_BUILD_SIGNAL_TOGGLE_ADVANCED_SIGNAL_TOOLTIP),
 	EndContainer(),
 	NWidget(NWID_VERTICAL, NC_EQUALSIZE),
 		NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -79,6 +79,7 @@ enum BuildRailStationWidgets {
 /** Widgets of the #BuildSignalWindow class. */
 enum BuildSignalWidgets {
 	WID_BS_CAPTION,            ///< Caption for the Signal Selection window.
+	WID_BS_TOGGLE_SIZE,        ///< Toggle showing advanced signal types.
 	WID_BS_SEMAPHORE_NORM,     ///< Build a semaphore normal block signal.
 	WID_BS_SEMAPHORE_ENTRY,    ///< Build a semaphore entry block signal.
 	WID_BS_SEMAPHORE_EXIT,     ///< Build a semaphore exit block signal.


### PR DESCRIPTION
## Motivation / Problem
The setting for showing the "advanced" pre & block signals is not the most obvious thing in the world.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add a toggle button, similar to the finance window, that just toggles the setting and reinitialises the window.

![](https://i.imgur.com/dQLuwoG.png)
![](https://i.imgur.com/irPWcL1.png)
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
If you hide advanced signals while block signals are still selected, block signals are still selected and you can still build them until you select something else. Technically no change from changing the setting via the settings window, but that was a bit harder to do..


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ~ai_changelog.hpp, gs_changelog.hpp need updating.~
    * ~The compatibility wrappers (compat_*.nut) need updating.~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * ~newgrf_debug_data.h may need updating.~
    * ~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~
