### PR TITLE
Fix 3046a6ce: [Preview] building preview failed to patch LZMA

### DIFF
--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -13,8 +13,6 @@ jobs:
     container:
       # If you change this version, change the number in the cache step too.
       image: emscripten/emsdk:2.0.31
-      # uid=1001(runner) gid=121(docker)
-      options: -u 1001:121
 
     steps:
     - name: Update deployment status to in progress


### PR DESCRIPTION


## Motivation / Problem

In 3046a6ce I assumed that the CI job and preview job would work the same way. It didn't.


## Description

As by commit message:
```
The job was started under a non-priv user, which did not have
permission to patch the emscripten files required to make LZMA
work.
```


## Limitations

There is no real way of testing this anymore, other than it now did build on my fork. But the publishing part etc can only be checked after merging. Tagging this PR with "preview" doesn't work, as this change needs to be in master before it is picked up. (security blabla).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
