### PR TITLE
Change: Don't store not to be activated newGRFs in savegames

### DIFF
--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -81,7 +81,7 @@ struct NGRFChunkHandler : ChunkHandler {
 		int index = 0;
 
 		for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
-			if (HasBit(c->flags, GCF_STATIC)) continue;
+			if (HasBit(c->flags, GCF_STATIC) || HasBit(c->flags, GCF_INIT_ONLY)) continue;
 			SlSetArrayIndex(index++);
 			SlObject(c, _grfconfig_desc);
 		}


### PR DESCRIPTION
## Motivation / Problem
When a crash happens in intro menu, emergency save will contain the `newgame` grf config. But intro game can't have newgrfs, and loading the resulting `crash.sav` can cause other crashes, like any savegame with modified newgrf config.
See `crash.sav` from #9622.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
In intro menu, newgrf are only initialised and never activated, and it's indicated in the flags. So using that info it's easy to skip newgrfs from being stored in the savegame.
Of course checking `_game_mode` should work too, but I prefer the flags solution.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
