### PR TITLE
Change: Don't use special map gen for tropic

### DIFF
--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -467,6 +467,7 @@ static void HeightMapSineTransform(height_t h_min, height_t h_max)
 		switch (_settings_game.game_creation.landscape) {
 			case LT_TOYLAND:
 			case LT_TEMPERATE:
+			case LT_TROPIC:
 				/* Move and scale 0..1 into -1..+1 */
 				fheight = 2 * fheight - 1;
 				/* Sine transform */
@@ -492,27 +493,6 @@ static void HeightMapSineTransform(height_t h_min, height_t h_max)
 						fheight = sin(fheight * M_PI_2);
 						/* Get -1..1 back to 0..(1 - (1 - sine_upper_limit) / linear_compression) == 0.0..m */
 						fheight = 0.5 * (fheight + 1.0) * m;
-					}
-				}
-				break;
-
-			case LT_TROPIC:
-				{
-					/* Desert terrain needs special height distribution.
-					 * Half of tiles should be at lowest (0..25%) heights */
-					double sine_lower_limit = 0.5;
-					double linear_compression = 2;
-					if (fheight <= sine_lower_limit) {
-						/* Under the limit we do linear compression down */
-						fheight = fheight / linear_compression;
-					} else {
-						double m = sine_lower_limit / linear_compression;
-						/* Get sine_lower_limit..1 into -1..1 */
-						fheight = 2.0 * ((fheight - sine_lower_limit) / (1.0 - sine_lower_limit)) - 1.0;
-						/* Sine wave transform */
-						fheight = sin(fheight * M_PI_2);
-						/* Get -1..1 back to (sine_lower_limit / linear_compression)..1.0 */
-						fheight = 0.5 * ((1.0 - m) * fheight + (1.0 + m));
 					}
 				}
 				break;


### PR DESCRIPTION
## Motivation / Problem

Subtropic maps use different map generation than other climates (so does subarctic, but that's a different story) which makes it impossible to get mountainous terrain from generated maps. This limits the types of games which can be played, even as #8891 makes it possible to have all-rainforest maps. Want a hilly rainforest? Your only option is to use a heightmap.

Eliminating the special subtropic rules has been proposed before in #7340 and an associated [forum topic](https://www.tt-forums.net/viewtopic.php?f=33&t=74647&p=1165875&hilit=tropic+landscape#p1165875), but was closed by the stale bot. Now that landscape generation has been simplified in #8891, I think it's worth revisiting.

## Description

TGP uses separate rules for subtropic and subarctic:
* Subtropic: `Half of tiles should be at lowest (0..25%) heights`
* Subarctic: `Redistribute heights to have more tiles at highest (75%..100%) range`

As shown in https://github.com/OpenTTD/OpenTTD/pull/8891#issuecomment-807341140, this appears to drag down the peaks and make the entire map flatter.

Leaving alone subarctic for now, I don't see a need for separate subtropic rules to flatten maps. Players can just choose a flatter terrain type.

Generating a map with these settings:
![settings](https://user-images.githubusercontent.com/55058389/138129244-32885c0d-ab09-4ea1-8736-ee940d532de8.png)

Current subtropic generation:
![tropic_current](https://user-images.githubusercontent.com/55058389/138128982-8cf5848b-5092-4f00-8467-0ad0bfaa431d.png)

Proposed subtropic generation:
![tropic_new](https://user-images.githubusercontent.com/55058389/138128994-6154b4e7-9366-4587-b0c8-c9fa973538f1.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
