### PR TITLE
Change: Rivers may start in desert when no rainforest exists

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1021,8 +1021,8 @@ static bool FindSpring(TileIndex tile, void *user_data)
 	int referenceHeight;
 	if (!IsTileFlat(tile, &referenceHeight) || IsWaterTile(tile)) return false;
 
-	/* In the tropics rivers start in the rainforest. */
-	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) != TROPICZONE_RAINFOREST) return false;
+	/* In the tropics rivers start in the rainforest, unless there is no rainforest. */
+	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) != TROPICZONE_RAINFOREST && _settings_game.game_creation.desert_coverage < 100) return false;
 
 	/* Are there enough higher tiles to warrant a 'spring'? */
 	uint num = 0;
@@ -1056,7 +1056,7 @@ static bool MakeLake(TileIndex tile, void *user_data)
 {
 	uint height = *(uint*)user_data;
 	if (!IsValidTile(tile) || TileHeight(tile) != height || !IsTileFlat(tile)) return false;
-	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) == TROPICZONE_DESERT) return false;
+	if (_settings_game.game_creation.landscape == LT_TROPIC && GetTropicZone(tile) == TROPICZONE_DESERT && _settings_game.game_creation.desert_coverage < 100) return false;
 
 	for (DiagDirection d = DIAGDIR_BEGIN; d < DIAGDIR_END; d++) {
 		TileIndex t2 = tile + TileOffsByDiagDir(d);


### PR DESCRIPTION
## Motivation / Problem

Rivers cannot currently start in the desert. This is normally fine, but when the desert percentage is 100%, it is impossible for rivers to generate since the only non-desert surrounds ocean and isn't wide enough to fit the minimum length river starting at a higher elevation.

## Description

When the desert percentage is 100, allow rivers to start in the desert. Lakes are also allowed to generate, as the game already generates inland sea as oases into which rivers can flow.

Not that OpenTTD always reflects reality, but the real-world precedent for rivers starting in the desert would be water emerging from an underground spring like those which feed [qanats](https://en.wikipedia.org/wiki/Qanat).

If a player wants a 100% desert map without rivers, they can set rivers to "none".

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
