### PR TITLE
Cleanup 'info_view' parameter.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -188,7 +188,7 @@ void GetRotorImage(const Aircraft *v, EngineImageType image_type, VehicleSpriteS
 
 	const Aircraft *w = v->Next()->Next();
 	if (is_custom_sprite(v->spritenum)) {
-		GetCustomRotorSprite(v, false, image_type, result);
+		GetCustomRotorSprite(v, image_type, result);
 		if (result->IsValid()) return;
 	}
 

--- a/src/aircraft_gui.cpp
+++ b/src/aircraft_gui.cpp
@@ -100,7 +100,7 @@ void DrawAircraftImage(const Vehicle *v, int left, int right, int y, VehicleID s
 	if (helicopter) {
 		const Aircraft *a = Aircraft::From(v);
 		VehicleSpriteSeq rotor_seq;
-		GetCustomRotorSprite(a, true, image_type, &rotor_seq);
+		GetCustomRotorSprite(a, image_type, &rotor_seq);
 		if (!rotor_seq.IsValid()) rotor_seq.Set(SPR_ROTOR_STOPPED);
 		heli_offs = ScaleGUITrad(5);
 		rotor_seq.Draw(x, y + y_offs - heli_offs, PAL_NONE, false);

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -1103,7 +1103,7 @@ void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction directio
 }
 
 
-void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, bool info_view, EngineImageType image_type, VehicleSpriteSeq *result)
+void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, EngineImageType image_type, VehicleSpriteSeq *result)
 {
 	const Engine *e = Engine::Get(engine);
 
@@ -1111,6 +1111,7 @@ void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, bool info
 	assert(e->type == VEH_AIRCRAFT);
 	assert(!(e->u.air.subtype & AIR_CTOL));
 
+	bool info_view = image_type != EIT_ON_MAP;
 	VehicleResolverObject object(engine, v, VehicleResolverObject::WO_SELF, info_view, CBID_NO_CALLBACK);
 	result->Clear();
 	uint rotor_pos = v == nullptr || info_view ? 0 : v->Next()->Next()->state;

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -22,17 +22,17 @@
 struct VehicleScopeResolver : public ScopeResolver {
 	const struct Vehicle *v; ///< The vehicle being resolved.
 	EngineID self_type;      ///< Type of the vehicle.
-	bool info_view;          ///< Indicates if the item is being drawn in an info window.
+	bool rotor_in_gui;       ///< Helicopter rotor is drawn in GUI.
 
 	/**
 	 * Scope resolver of a single vehicle.
 	 * @param ro Surrounding resolver.
 	 * @param engine_type Engine type
 	 * @param v %Vehicle being resolved.
-	 * @param info_view Indicates if the item is being drawn in an info window.
+	 * @param rotor_in_gui Helicopter rotor is drawn in GUI.
 	 */
-	VehicleScopeResolver(ResolverObject &ro, EngineID engine_type, const Vehicle *v, bool info_view)
-		: ScopeResolver(ro), v(v), self_type(engine_type), info_view(info_view)
+	VehicleScopeResolver(ResolverObject &ro, EngineID engine_type, const Vehicle *v, bool rotor_in_gui)
+		: ScopeResolver(ro), v(v), self_type(engine_type), rotor_in_gui(rotor_in_gui)
 	{
 	}
 
@@ -59,7 +59,7 @@ struct VehicleResolverObject : public ResolverObject {
 	VehicleScopeResolver relative_scope; ///< Scope resolver for an other vehicle in the chain.
 	byte cached_relative_count;          ///< Relative position of the other vehicle.
 
-	VehicleResolverObject(EngineID engine_type, const Vehicle *v, WagonOverride wagon_override, bool info_view = false,
+	VehicleResolverObject(EngineID engine_type, const Vehicle *v, WagonOverride wagon_override, bool rotor_in_gui = false,
 			CallbackID callback = CBID_NO_CALLBACK, uint32 callback_param1 = 0, uint32 callback_param2 = 0);
 
 	ScopeResolver *GetScope(VarSpriteGroupScope scope = VSG_SCOPE_SELF, byte relative = 0) override;

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -84,9 +84,9 @@ void GetCustomEngineSprite(EngineID engine, const Vehicle *v, Direction directio
 #define GetCustomVehicleSprite(v, direction, image_type, result) GetCustomEngineSprite(v->engine_type, v, direction, image_type, result)
 #define GetCustomVehicleIcon(et, direction, image_type, result) GetCustomEngineSprite(et, nullptr, direction, image_type, result)
 
-void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, bool info_view, EngineImageType image_type, VehicleSpriteSeq *result);
-#define GetCustomRotorSprite(v, i, image_type, result) GetRotorOverrideSprite(v->engine_type, v, i, image_type, result)
-#define GetCustomRotorIcon(et, image_type, result) GetRotorOverrideSprite(et, nullptr, true, image_type, result)
+void GetRotorOverrideSprite(EngineID engine, const struct Aircraft *v, EngineImageType image_type, VehicleSpriteSeq *result);
+#define GetCustomRotorSprite(v, image_type, result) GetRotorOverrideSprite(v->engine_type, v, image_type, result)
+#define GetCustomRotorIcon(et, image_type, result) GetRotorOverrideSprite(et, nullptr, image_type, result)
 
 /* Forward declaration of GRFFile, to avoid unnecessary inclusion of newgrf.h
  * elsewhere... */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3191,7 +3191,7 @@ void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type)
 		VehicleSpriteSeq seq;
 
 		if (rotor_seq) {
-			GetCustomRotorSprite(Aircraft::From(v), true, image_type, &seq);
+			GetCustomRotorSprite(Aircraft::From(v), image_type, &seq);
 			if (!seq.IsValid()) seq.Set(SPR_ROTOR_STOPPED);
 			y_offset = - ScaleGUITrad(5);
 		} else {


### PR DESCRIPTION
## Motivation / Problem

Everytime 'GetRotorOverrideSprite' comes up, 'info_view' confuses me.
It turns out:
* 'info_view' is redundant and can be derived from the easier-to-understand 'image_type'.
* 'info_view' is only used for aircraft helicopter, so the name is quite stupid.
* When comparing with TTDPatch behavior, 'info_view' is mostly bollocks.

## Description

* Remove the 'info_view' parameter from function signatures and calls, and derive it from 'image_type'.
* Rename the NewGRF-code internal 'info_view' flag to 'rotor_in_gui', since that is what it means.
* Add some comments about the bollocks.

## Limitations

When it comes to NewGRF rotor sprites, OpenTTD actually differs a lot from TTDPatch.
I have to guess that 'info_view' was added to make the behavior similar to TTDPatch at some point.
But now NewGRF probably rely on the observable behavior of OpenTTD, so it no longer makes sense to adjust the behavior to match TTDPatch, even though TTDPatch exposes "more" internal 80+x variables, that some NewGRF may exploit. ("more" as in "more, but apparently unneeded")

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
