### PR TITLE
Fix #8797: Use logical rail length when placing signals

### DIFF
--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -26,6 +26,9 @@
 #include <list>
 #include <map>
 
+const uint TILE_AXIAL_DISTANCE = 192;  // Logical length of the tile in any DiagDirection used in vehicle movement.
+const uint TILE_CORNER_DISTANCE = 128;  // Logical length of the tile corner crossing in any non-diagonal direction used in vehicle movement.
+
 /** Vehicle status bits in #Vehicle::vehstatus. */
 enum VehStatus {
 	VS_HIDDEN          = 0x01, ///< Vehicle is not visible.
@@ -426,7 +429,7 @@ public:
 	 */
 	inline uint GetAdvanceDistance()
 	{
-		return (this->direction & 1) ? 192 : 256;
+		return (this->direction & 1) ? TILE_AXIAL_DISTANCE : TILE_CORNER_DISTANCE * 2;
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

As described in #8797 signal placer uses some visual distance instead of logical distance to place signals requiring players who need a certain logical gap to place additional signals manually.

## Description

Interprets signal distance in the UI as the logical length of that many X/Y tiles of rail. And uses the logical length of the track pieces (i.e. 192 or 128 units) when calculating the distance between signals placed.

When "keep fixed distance" setting is off (i.e. minimize_gaps = true) ensures that gap between signals never exceeds the required signal distance except for when it's on a bridge or tunnel. 
Without minimize_gaps (i.e. "pretty" mode) just tries to place signals as soon as accumulated gap >= required distance regardless of whether it succeeds or not. 
![Nundinghall Transport, 15th Jan 2031](https://user-images.githubusercontent.com/413570/138607786-98ed4316-9c3f-41b6-93a6-d3e2878c0a34.png)

Also, this placer is mostly ready to work with segments of arbitrary logical length if that ever makes into the game.

## Limitations

* Does not account for train elongation on diagonals as there is nothing signal placer can do without knowing exact train stats.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
