### PR TITLE
Feature: add setting to hide news about competitors vehicle crash

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1329,7 +1329,6 @@ static void CrashAirplane(Aircraft *v)
 	const Station *st = GetTargetAirportIfValid(v);
 	StringID newsitem;
 	TileIndex vt;
-	NewsType newstype = NT_ACCIDENT;
 	if (st == nullptr) {
 		newsitem = STR_NEWS_PLANE_CRASH_OUT_OF_FUEL;
 		vt = TileVirtXY(v->x_pos, v->y_pos);
@@ -1342,6 +1341,7 @@ static void CrashAirplane(Aircraft *v)
 	AI::NewEvent(v->owner, new ScriptEventVehicleCrashed(v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING));
 	Game::NewEvent(new ScriptEventVehicleCrashed(v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING));
 
+	NewsType newstype = NT_ACCIDENT;
 	if (v->owner != _local_company) {
 		newstype = NT_ACCIDENT_OTHER;
 	}

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1329,6 +1329,7 @@ static void CrashAirplane(Aircraft *v)
 	const Station *st = GetTargetAirportIfValid(v);
 	StringID newsitem;
 	TileIndex vt;
+	NewsType newstype = NT_ACCIDENT;
 	if (st == nullptr) {
 		newsitem = STR_NEWS_PLANE_CRASH_OUT_OF_FUEL;
 		vt = TileVirtXY(v->x_pos, v->y_pos);
@@ -1341,7 +1342,11 @@ static void CrashAirplane(Aircraft *v)
 	AI::NewEvent(v->owner, new ScriptEventVehicleCrashed(v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING));
 	Game::NewEvent(new ScriptEventVehicleCrashed(v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING));
 
-	AddTileNewsItem(newsitem, NT_ACCIDENT, vt, nullptr, st != nullptr ? st->index : INVALID_STATION);
+	if (v->owner != _local_company) {
+		newstype = NT_ACCIDENT_OTHER;
+	}
+
+	AddTileNewsItem(newsitem, newstype, vt, nullptr, st != nullptr ? st->index : INVALID_STATION);
 
 	ModifyStationRatingAround(vt, v->owner, -160, 30);
 	if (_settings_client.sound.disaster) SndPlayVehicleFx(SND_12_EXPLOSION, v);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1743,6 +1743,9 @@ STR_CONFIG_SETTING_NEWS_ARRIVAL_FIRST_VEHICLE_OTHER_HELPTEXT    :Display a newsp
 STR_CONFIG_SETTING_NEWS_ACCIDENTS_DISASTERS                     :Accidents / disasters: {STRING2}
 STR_CONFIG_SETTING_NEWS_ACCIDENTS_DISASTERS_HELPTEXT            :Display a newspaper when accidents or disasters occur
 
+STR_CONFIG_SETTING_NEWS_ACCIDENT_OTHER                          :Accidents of competitor's vehicles: {STRING2}
+STR_CONFIG_SETTING_NEWS_ACCIDENT_OTHER_HELPTEXT                 :Display a newspaper about crashed vehicles for competitors
+
 STR_CONFIG_SETTING_NEWS_COMPANY_INFORMATION                     :Company information: {STRING2}
 STR_CONFIG_SETTING_NEWS_COMPANY_INFORMATION_HELPTEXT            :Display a newspaper when a new company starts, or when companies are risking to bankrupt
 

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -231,6 +231,7 @@ static NewsTypeData _news_type_data[] = {
 	NewsTypeData("news_display.arrival_player",    60, SND_1D_APPLAUSE ),  ///< NT_ARRIVAL_COMPANY
 	NewsTypeData("news_display.arrival_other",     60, SND_1D_APPLAUSE ),  ///< NT_ARRIVAL_OTHER
 	NewsTypeData("news_display.accident",          90, SND_BEGIN       ),  ///< NT_ACCIDENT
+	NewsTypeData("news_display.accident_other",    90, SND_BEGIN       ),  ///< NT_ACCIDENT_OTHER
 	NewsTypeData("news_display.company_info",      60, SND_BEGIN       ),  ///< NT_COMPANY_INFO
 	NewsTypeData("news_display.open",              90, SND_BEGIN       ),  ///< NT_INDUSTRY_OPEN
 	NewsTypeData("news_display.close",             90, SND_BEGIN       ),  ///< NT_INDUSTRY_CLOSE

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -22,6 +22,7 @@ enum NewsType {
 	NT_ARRIVAL_COMPANY, ///< First vehicle arrived for company
 	NT_ARRIVAL_OTHER,   ///< First vehicle arrived for competitor
 	NT_ACCIDENT,        ///< An accident or disaster has occurred
+	NT_ACCIDENT_OTHER,  ///< An accident or disaster has occurred
 	NT_COMPANY_INFO,    ///< Company info (new companies, bankruptcy messages)
 	NT_INDUSTRY_OPEN,   ///< Opening of industries
 	NT_INDUSTRY_CLOSE,  ///< Closing of industries

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -553,7 +553,13 @@ static void RoadVehCrash(RoadVehicle *v)
 
 	SetDParam(0, pass);
 	StringID newsitem = (pass == 1) ? STR_NEWS_ROAD_VEHICLE_CRASH_DRIVER : STR_NEWS_ROAD_VEHICLE_CRASH;
-	AddTileNewsItem(newsitem, NT_ACCIDENT, v->tile);
+	NewsType newstype = NT_ACCIDENT;
+
+	if (v->owner != _local_company) {
+		newstype = NT_ACCIDENT_OTHER;
+	}
+
+	AddTileNewsItem(newsitem, newstype, v->tile);
 
 	ModifyStationRatingAround(v->tile, v->owner, -160, 22);
 	if (_settings_client.sound.disaster) SndPlayVehicleFx(SND_12_EXPLOSION, v);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1648,6 +1648,7 @@ static SettingsContainer &GetSettingsTree()
 			advisors->Add(new SettingEntry("news_display.general"));
 			advisors->Add(new SettingEntry("news_display.new_vehicles"));
 			advisors->Add(new SettingEntry("news_display.accident"));
+			advisors->Add(new SettingEntry("news_display.accident_other"));
 			advisors->Add(new SettingEntry("news_display.company_info"));
 			advisors->Add(new SettingEntry("news_display.acceptance"));
 			advisors->Add(new SettingEntry("news_display.arrival_player"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -242,6 +242,7 @@ struct NewsSettings {
 	uint8 arrival_player;                                 ///< NewsDisplay of vehicles arriving at new stations of current player
 	uint8 arrival_other;                                  ///< NewsDisplay of vehicles arriving at new stations of other players
 	uint8 accident;                                       ///< NewsDisplay of accidents that occur
+	uint8 accident_other;                                 ///< NewsDisplay if a vehicle from another company is involved in an accident
 	uint8 company_info;                                   ///< NewsDisplay of general company information
 	uint8 open;                                           ///< NewsDisplay on new industry constructions
 	uint8 close;                                          ///< NewsDisplay about closing industries

--- a/src/table/settings/news_display_settings.ini
+++ b/src/table/settings/news_display_settings.ini
@@ -68,6 +68,17 @@ strhelp  = STR_CONFIG_SETTING_NEWS_ACCIDENTS_DISASTERS_HELPTEXT
 strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
 
 [SDTC_OMANY]
+var      = news_display.accident_other
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = 2
+max      = 2
+full     = _news_display
+str      = STR_CONFIG_SETTING_NEWS_ACCIDENT_OTHER
+strhelp  = STR_CONFIG_SETTING_NEWS_ACCIDENT_OTHER_HELPTEXT
+strval   = STR_CONFIG_SETTING_NEWS_MESSAGES_OFF
+
+[SDTC_OMANY]
 var      = news_display.company_info
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN


### PR DESCRIPTION
## Motivation / Problem

During a game of OpenTTD with many competitors, we can receive a lot of news regarding competitors vehicles involved in accidents. This is especially true when vehicles have low reliability and are rarely replaced:
- road vehicles breaking down on a rail crossing then being crashed by a train,
- airplanes failing to land on an airport and crashing.

This PR addresses the issue of receiving too many news regarding competitors vehicle crash where it doesn't bring any value or meaning to the main player. As a OpenTTD player, I want to know when my vehicles are involved in a crash but I may choose to not receive notification if competitors vehicles are destroyed.

## Description

A new setting has been added "Accidents of competitor's vehicles". It's "Full" by default. When turned off, no news will be generated when a competitor vehicle is involved in a crash. When it's "Summary", only the short version will be displayed at the bottom of the screen.
A crash, in the context of this PR, is when a road vehicle is hit by a train or when an airplane misses landing at an airport.

- Full: A news item is generated when setting is Full (by default) and a competitor vehicle is crashed (in this example, a plane crash):
![image](https://user-images.githubusercontent.com/16795616/138574752-65cf20e3-9e73-4e35-a6d3-8d90b1dd63a0.png)

- Summary: Short news are generated when setting is "Summary" and a competitor vehicle (red) is crashed by a train:
![image](https://user-images.githubusercontent.com/16795616/138574704-a6af3633-62aa-4f81-8158-459ad12af3ef.png)

- Off: no news are generated when a competitor vehicle is crashed when settings is "Off"
![image](https://user-images.githubusercontent.com/16795616/138574780-9d3edfad-3ee5-4653-9843-b58f85384d4f.png)


## Limitations

- other crashes, such as UFOs and similar events are ignored as part of this PR. This has been left out because it's rare enough to cause a disruption to the player. That being said, one could argue we could update this in this PR and I could update it (probably in another PR) if requested.

## Checklist for review

- This PR adds a new translation in english.txt file. From the [documentation](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md#i-want-to-add-a-new-string), nothing else is required at this stage.
