### PR TITLE
Fix: Every 16th client never reconnects after server restart

### DIFF
--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1055,9 +1055,9 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_NEWGAME(Packet 
 	 * care about the server shutting down. */
 	if (this->status >= STATUS_JOIN) {
 		/* To throttle the reconnects a bit, every clients waits its
-		 * Client ID modulo 16. This way reconnects should be spread
-		 * out a bit. */
-		_network_reconnect = _network_own_client_id % 16;
+		 * Client ID modulo 16 + 1 (value 0 means no reconnect).
+		 * This way reconnects should be spread out a bit. */
+		_network_reconnect = _network_own_client_id % 16 + 1;
 		ShowErrorMessage(STR_NETWORK_MESSAGE_SERVER_REBOOT, INVALID_STRING_ID, WL_CRITICAL);
 	}
 


### PR DESCRIPTION
## Motivation / Problem

If client id is divisible by 16 he gets stuck with "server is restarting message" when the server restarts and never attempts to reconnect.

## Steps to reproduce 

0. Start the server.
1. Connect the client so his id is divisible by 16 (refreshing server a bunch of times helps to get it faster).
2. Type `newgame` in server console.
3. Client gets the server restarting message but never reconnects

## Description

Add +1 to _network_reconnect as value 0 means no reconnect.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* **The bug fix is important enough to be backported? (label: 'backport requested')**
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
