### PR TITLE
Fix #9579: Object and HQ construction is Construction cost, not Property Ma…

### DIFF
--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -639,7 +639,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetQuarterlyCompanyValue():      -1
   Quarter: 0
     GetQuarterlyIncome():            0
-    GetQuarterlyExpenses():          -210
+    GetQuarterlyExpenses():          0
     GetQuarterlyCargoDelivered():    0
     GetQuarterlyPerformanceRating(): -1
     GetQuarterlyCompanyValue():      1

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -204,7 +204,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags);
  */
 CommandCost CmdBuildObject(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32 p2, const std::string &text)
 {
-	CommandCost cost(EXPENSES_PROPERTY);
+	CommandCost cost(EXPENSES_CONSTRUCTION);
 
 	ObjectType type = (ObjectType)GB(p1, 0, 16);
 	if (type >= NUM_OBJECTS) return CMD_ERROR;
@@ -526,7 +526,7 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags)
 			}
 
 			/* cost of relocating company is 1% of company value */
-			cost = CommandCost(EXPENSES_PROPERTY, CalculateCompanyValue(c) / 100);
+			cost = CommandCost(EXPENSES_CONSTRUCTION, CalculateCompanyValue(c) / 100);
 			break;
 		}
 


### PR DESCRIPTION
…intenance

## Motivation / Problem

Per #9579:

> ### Expected result
> The costs of building objects and moving the headquarters are included in the "Construction" or "Other" sections, which do not affect the company's operating profit.
> 
> ### Actual result
> The cost of building objects and relocating the company's seat are included in the property maintenance costs.

The cost of clearing objects is already counted under Construction.

## Description

Building objects and moving the company HQ is now considered under Construction, not Property Maintenance.

Closes #9579

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
