### PR TITLE
Fix: Don't show screenshot GUI in screenshots

### DIFF
--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -12,6 +12,7 @@
 #include "viewport_func.h"
 #include "gfx_func.h"
 #include "screenshot.h"
+#include "screenshot_gui.h"
 #include "blitter/factory.hpp"
 #include "zoom_func.h"
 #include "core/endian_func.hpp"
@@ -909,8 +910,10 @@ static bool RealMakeScreenshot(ScreenshotType t, std::string name, uint32 width,
 		 * of the screenshot. This way the screenshot will always show the name
 		 * of the previous screenshot in the 'successful' message instead of the
 		 * name of the new screenshot (or an empty name). */
+		SetScreenshotWindowVisibility(true);
 		UndrawMouseCursor();
 		DrawDirtyBlocks();
+		SetScreenshotWindowVisibility(false);
 	}
 
 	_screenshot_name[0] = '\0';

--- a/src/screenshot_gui.cpp
+++ b/src/screenshot_gui.cpp
@@ -13,6 +13,7 @@
 #include "screenshot.h"
 #include "widgets/screenshot_widget.h"
 #include "table/strings.h"
+#include "gfx_func.h"
 
 struct ScreenshotWindow : Window {
 	ScreenshotWindow(WindowDesc *desc) : Window(desc)
@@ -71,4 +72,25 @@ void ShowScreenshotWindow()
 {
 	CloseWindowById(WC_SCREENSHOT, 0);
 	new ScreenshotWindow(&_screenshot_window_desc);
+}
+
+/**
+ * Set the visibility of the screenshot window when taking a screenshot.
+ * @param hide Are we hiding the window or showing it again after the screenshot is taken?
+ */
+void SetScreenshotWindowVisibility(bool hide)
+{
+	ScreenshotWindow *scw = (ScreenshotWindow *)FindWindowById(WC_SCREENSHOT, 0);
+
+	if (scw == nullptr) return;
+
+	if (hide) {
+		/* Set dirty the screen area where the window is covering (not the window itself), then move window off screen. */
+		scw->SetDirty();
+		scw->left += 2 * _screen.width;
+	} else {
+		/* Return window to original position. */
+		scw->left -= 2 * _screen.width;
+		scw->SetDirty();
+	}
 }

--- a/src/screenshot_gui.h
+++ b/src/screenshot_gui.h
@@ -11,5 +11,6 @@
 #define SCREENSHOT_GUI_H
 
 void ShowScreenshotWindow();
+void SetScreenshotWindowVisibility(bool hide);
 
 #endif /* SCREENSHOT_GUI_H */


### PR DESCRIPTION
## Motivation / Problem

Screenshots captured using the "Normal screenshot" button show the screenshot GUI. The other screenshot modes do not.

![Unnamed, 1920-11-20](https://user-images.githubusercontent.com/55058389/140597553-73035269-5a67-445e-acfc-10337ec07223.png)

I often see new players posting screenshots using this button on Discord, Reddit, etc., which is typically met with suggestions to use another screen capture tool which doesn't show the screenshot GUI.

I can imagine a player wanting to show other GUI elements like vehicle windows, the status bar ("look at how much money I have!"), and even the main toolbar at top. But I don't see a reason to show the screenshot GUI itself!

## Description

Upstreams [a JGRPP commit](https://github.com/JGRennison/OpenTTD-patches/commit/a65be9b7471753603ecc37f3234125fc06c40853) to hide the screenshot GUI when taking a screenshot.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
