### PR TITLE
Fix 55a11710: Curly braces need to be double-escaped for (std::)fmt.

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1073,7 +1073,7 @@ void NetworkGameLoop()
 					if (sync_state[0] == _random.state[0] && sync_state[1] == _random.state[1]) {
 						Debug(desync, 0, "Sync check: {:08x}; {:02x}; match", _date, _date_fract);
 					} else {
-						Debug(desync, 0, "Sync check: {:08x}; {:02x}; mismatch expected {{:08x}, {:08x}}, got {{:08x}, {:08x}}",
+						Debug(desync, 0, "Sync check: {:08x}; {:02x}; mismatch expected {{{:08x}, {:08x}}}, got {{{:08x}, {:08x}}}",
 									_date, _date_fract, sync_state[0], sync_state[1], _random.state[0], _random.state[1]);
 						NOT_REACHED();
 					}


### PR DESCRIPTION
## Motivation / Problem / Description

When converting `Debug` to use `(std::)fmt`, one string for `DEBUG_DUMP_COMMANDS` was misconverted. It contains curly braces to be printed which need to be double escaped.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
