### PR TITLE
Cleanup: Fix typo in overflowsafe_type comment

### DIFF
--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -22,8 +22,8 @@
 
 /**
  * Overflow safe template for integers, i.e. integers that will never overflow
- * you multiply the maximum value with 2, or add 2, or subtract something from
- * the minimum value, etc.
+ * when you multiply the maximum value with 2, or add 2, or subtract something
+ * from the minimum value, etc.
  * @param T     the type these integers are stored with.
  */
 template <class T>


### PR DESCRIPTION
## Motivation / Problem

Per #9681, typo in the doxygen header.

## Description

Fix typo.

Closes #9681.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)