### PR TITLE
Change: Explicitly specify SHA1 for legacy code signing on Windows

### DIFF
--- a/os/windows/sign.bat
+++ b/os/windows/sign.bat
@@ -12,7 +12,7 @@ REM URL of the timestamp server
 IF NOT DEFINED SIGNTOOL_TIMESTAMP_URL (SET SIGNTOOL_TIMESTAMP_URL=http://timestamp.digicert.com)
 
 REM Sign with SHA-1 for Windows 7 and below
-"%SIGNTOOL_PATH%" sign -v -n %2 -t %SIGNTOOL_TIMESTAMP_URL% %1
+"%SIGNTOOL_PATH%" sign -v -n %2 -t %SIGNTOOL_TIMESTAMP_URL% -fd sha1 %1
 
 REM Sign with SHA-256 for Windows 8 and above
 "%SIGNTOOL_PATH%" sign -v -n %2 -tr %SIGNTOOL_TIMESTAMP_URL% -fd sha256 -td sha256 -as %1


### PR DESCRIPTION
## Motivation / Problem

Due to an upgrade of the Windows SDK used on the GitHub Actions virtual environments, an error is printing when attempting to code sign:

```
SignTool Error: No file digest algorithm specified. Please specify the digest algorithm with the /fd flag. Using /fd SHA256 is recommended and more secure than SHA1. Calling signtool with /fd sha1 is equivalent to the previous behavior. In order to select the hash algorithm used in the signing certificate's signature, use the /fd certHash option.
```

This means the certificate is only being SHA-256 timestamped, but the SHA-1 timestamping is failing. While this doesn't really matter for modern versions of Windows, Windows Vista and possibly 7 pre-SP1 only support SHA-1.

## Description

This patch updates the syntax of the SignTool call to be explicit about the digest algorithm we want to use.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)