### PR TITLE
Add: Specify minimum version for macOS

### DIFF
--- a/os/macosx/Info.plist.in
+++ b/os/macosx/Info.plist.in
@@ -31,5 +31,7 @@
         <string>NSApplication</string>
         <key>NSHighResolutionCapable</key>
         <string>True</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>10.14.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Motivation / Problem

OpenTTD will open on macOS versions earlier than 10.14, but will crash.

Fixes #9688.

## Description

This adds a minimum version to the Info.plist so the Finder will not allow the application to launch. It will display a minimum version warning instead.

## Limitations

Tested on macOS 10.11 on my ancient MacBook Pro; with this patch it was greyed out and displayed a warning, without the patch it opened and crashed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
