### PR TITLE
Fix: don't complain when the sprite font is missing glyphs.

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2116,6 +2116,7 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 	if (bad_font) {
 		/* We found an unprintable character... lets try whether we can find
 		 * a fallback font that can print the characters in the current language. */
+		bool any_font_configured = !_freetype.medium.font.empty();
 		FreeTypeSettings backup = _freetype;
 
 		_freetype.mono.os_handle = nullptr;
@@ -2125,10 +2126,10 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 
 		_freetype = backup;
 
-		if (!bad_font) {
-			/* Show that we loaded fallback font. To do this properly we have
-			 * to set the colour of the string, otherwise we end up with a lot
-			 * of artifacts.* The colour 'character' might change in the
+		if (!bad_font && any_font_configured) {
+			/* If the user configured a bad font, and we found a better one,
+			 * show that we loaded the better font instead of the configured one.
+			 * The colour 'character' might change in the
 			 * future, so for safety we just Utf8 Encode it into the string,
 			 * which takes exactly three characters, so it replaces the "XXX"
 			 * with the colour marker. */


### PR DESCRIPTION
## Motivation / Problem

On start OpenTTD checks whether the loaded font supports all glyphs used by the current language pack.

If the font is lacking, it tries to find a suitable font itself, and shows an error message.

The error message is useful, if
* the user manually configured a bad font, and OpenTTD ignores this to pick a better one itself
* there is no suitable font at all.

However, the error is also shown if no font is configured (default), which is not useful at all.
All new players with non-latin-alphabet languages, see this message on start:
https://steamcommunity.com/sharedfiles/filedetails/?id=2443789429

## Description

| Font configured | Configured font is useable | Fallback font found | OpenTTD 12.1 | This PR |
| --------- | -------- | -------- | --------- | ------- |
| no | yes | N/A | ok | ok |
| no | no | yes | error | ok |
| no | no | no | error | error |
| yes | yes | N/A | ok | ok |
| yes | no | yes | error | error |
| yes | no | no | error | error |

## Limitations

The "font configured" is decided by the "medium"/"normal" font only.
It's assumed if the user knows how to configure that one, they also know about the other font sizes.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
