### PR TITLE
Fix travel times stored in the linkgraph 

### DIFF
--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -72,11 +72,14 @@ void LinkGraph::Compress()
 		for (NodeID node2 = 0; node2 < this->Size(); ++node2) {
 			BaseEdge &edge = this->edges[node1][node2];
 			if (edge.capacity > 0) {
-				edge.capacity = std::max(1U, edge.capacity / 2);
+				uint new_capacity = std::max(1U, edge.capacity / 2);
+				if (edge.capacity < (1 << 16)) {
+					edge.travel_time_sum = edge.travel_time_sum * new_capacity / edge.capacity;
+				} else if (edge.travel_time_sum != 0) {
+					edge.travel_time_sum = std::max(1ULL, edge.travel_time_sum / 2);
+				}
+				edge.capacity = new_capacity;
 				edge.usage /= 2;
-			}
-			if (edge.travel_time_sum > 0) {
-				edge.travel_time_sum = std::max(1ULL, edge.travel_time_sum / 2);
 			}
 		}
 	}

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -210,6 +210,8 @@ void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 			uint cargo_quantity = this->capacities[c];
 			if (cargo_quantity == 0) continue;
 
+			if (this->vehicle->GetDisplayMaxSpeed() == 0) continue;
+
 			/* If not allowed to merge link graphs, make sure the stations are
 			 * already in the same link graph. */
 			if (!this->allow_merge && st->goods[c].link_graph != st_to->goods[c].link_graph) {

--- a/src/linkgraph/refresh.cpp
+++ b/src/linkgraph/refresh.cpp
@@ -203,6 +203,7 @@ void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 	StationID next_station = next->GetDestination();
 	Station *st = Station::GetIfValid(cur->GetDestination());
 	if (st != nullptr && next_station != INVALID_STATION && next_station != st->index) {
+		Station *st_to = Station::Get(next_station);
 		for (CargoID c = 0; c < NUM_CARGO; c++) {
 			/* Refresh the link and give it a minimum capacity. */
 
@@ -211,19 +212,17 @@ void LinkRefresher::RefreshStats(const Order *cur, const Order *next)
 
 			/* If not allowed to merge link graphs, make sure the stations are
 			 * already in the same link graph. */
-			if (!this->allow_merge && st->goods[c].link_graph != Station::Get(next_station)->goods[c].link_graph) {
+			if (!this->allow_merge && st->goods[c].link_graph != st_to->goods[c].link_graph) {
 				continue;
 			}
 
 			/* A link is at least partly restricted if a vehicle can't load at its source. */
 			EdgeUpdateMode restricted_mode = (cur->GetLoadType() & OLFB_NO_LOAD) == 0 ?
 						EUM_UNRESTRICTED : EUM_RESTRICTED;
-			Station *st_to = Station::GetIfValid(next_station);
 			/* This estimates the travel time of the link as the time needed
 			 * to travel between the stations at half the max speed of the consist.
 			 * The result is in tiles/tick (= 2048 km-ish/h). */
-			uint32 time_estimate = (st_to != nullptr) ?
-				DistanceManhattan(st->xy, st_to->xy) * 4096U / this->vehicle->GetDisplayMaxSpeed() : 0;
+			uint32 time_estimate = DistanceManhattan(st->xy, st_to->xy) * 4096U / this->vehicle->GetDisplayMaxSpeed();
 
 			/* If the vehicle is currently full loading, increase the capacities at the station
 			 * where it is loading by an estimate of what it would have transported if it wasn't

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3148,6 +3148,13 @@ bool AfterLoadGame()
 		}
 	}
 
+	/* Use current order time to approximate last loading time */
+	if (IsSavegameVersionBefore(SLV_LAST_LOADING_TICK)) {
+		for (Vehicle *v : Vehicle::Iterate()) {
+			v->last_loading_tick = std::max(_tick_counter, static_cast<uint64>(v->current_order_time)) - v->current_order_time;
+		}
+	}
+
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -341,6 +341,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_DOCK_DOCKINGTILES,                  ///< 298  PR#9578 All tiles around docks may be docking tiles.
 	SLV_REPAIR_OBJECT_DOCKING_TILES,        ///< 299  PR#9594 v12.0  Fixing issue with docking tiles overlapping objects.
 	SLV_U64_TICK_COUNTER,                   ///< 300  PR#10035 Make _tick_counter 64bit to avoid wrapping.
+	SLV_LAST_LOADING_TICK,                  ///< 301  PR#9693 Store tick of last loading for vehicles.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -705,6 +705,7 @@ public:
 		SLE_CONDVAR(Vehicle, group_id,              SLE_UINT16,                  SLV_60, SL_MAX_VERSION),
 
 		SLE_CONDVAR(Vehicle, current_order_time,    SLE_UINT32,                  SLV_67, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, last_loading_tick,     SLE_UINT64,                   SLV_LAST_LOADING_TICK, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, lateness_counter,      SLE_INT32,                   SLV_67, SL_MAX_VERSION),
 	};
 #if defined(_MSC_VER) && (_MSC_VER == 1915 || _MSC_VER == 1916)

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2114,7 +2114,7 @@ void Vehicle::BeginLoading()
 {
 	assert(IsTileType(this->tile, MP_STATION) || this->type == VEH_SHIP);
 
-	uint32 travel_time = this->current_order_time;
+	Ticks travel_time = _tick_counter - this->last_loading_tick;
 	if (this->current_order.IsType(OT_GOTO_STATION) &&
 			this->current_order.GetDestination() == this->last_station_visited) {
 		this->DeleteUnreachedImplicitOrders();
@@ -2279,6 +2279,7 @@ void Vehicle::LeaveStation()
 
 			/* if the vehicle could load here or could stop with cargo loaded set the last loading station */
 			this->last_loading_station = this->last_station_visited;
+			this->last_loading_tick = _tick_counter;
 		} else {
 			/* if the vehicle couldn't load and had to unload or transfer everything
 			 * set the last loading station to invalid as it will leave empty. */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -315,6 +315,7 @@ public:
 
 	StationID last_station_visited;     ///< The last station we stopped at.
 	StationID last_loading_station;     ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
+	uint64_t last_loading_tick;         ///< Last time (relative to _tick_counter) the vehicle has stopped at a station and could possibly leave with any cargo loaded.
 
 	CargoID cargo_type;                 ///< type of cargo this vehicle is carrying
 	byte cargo_subtype;                 ///< Used for livery refits (NewGRF variations)


### PR DESCRIPTION
## Motivation / Problem

This PR fixes a few problems with travel times in the linkgraph (#9457).
- The first commit is a tiny code cleanup.
- The second commit fixes a small loss of precision that can happen (rarely) on linkgraph compression for low-capacity links.
- The third commit fixes #9665.

## Description

To fix #9665, I added a member variable `BaseConsist::time_since_last_loading` that is incremented whenever `current_order_time` is, and that is reset when the vehicle loads cargo at a station, just like `last_loading_station`.

This fully fixes the travel times in the example savegame of #9665. I also tested with a go to depot order and with a basic conditional order.

## Limitations

This PR needs a savegame upgrade.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
