### PR TITLE
Fix: Update last servicing dates when using the date cheat

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -14,6 +14,7 @@
 #include "company_func.h"
 #include "date_func.h"
 #include "saveload/saveload.h"
+#include "vehicle_base.h"
 #include "textbuf_gui.h"
 #include "window_gui.h"
 #include "string_func.h"
@@ -106,6 +107,7 @@ static int32 ClickChangeDateCheat(int32 p1, int32 p2)
 	if (p1 == _cur_year) return _cur_year;
 
 	Date new_date = ConvertYMDToDate(p1, ymd.month, ymd.day);
+	for (auto v : Vehicle::Iterate()) v->ShiftDates(new_date - _date);
 	LinkGraphSchedule::instance.ShiftDates(new_date - _date);
 	SetDate(new_date, _date_fract);
 	EnginesMonthlyLoop();

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -211,7 +211,7 @@ static void OnNewYear()
 		_cur_year--;
 		days_this_year = IsLeapYear(_cur_year) ? DAYS_IN_LEAP_YEAR : DAYS_IN_YEAR;
 		_date -= days_this_year;
-		for (Vehicle *v : Vehicle::Iterate()) v->date_of_last_service -= days_this_year;
+		for (Vehicle *v : Vehicle::Iterate()) v->ShiftDates(-days_this_year);
 		for (LinkGraph *lg : LinkGraph::Iterate()) lg->ShiftDates(-days_this_year);
 
 		/* Because the _date wraps here, and text-messages expire by game-days, we have to clean out

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -764,6 +764,16 @@ uint32 Vehicle::GetGRFID() const
 }
 
 /**
+ * Shift all dates by given interval.
+ * This is useful if the date has been modified with the cheat menu.
+ * @param interval Number of days to be added or substracted.
+ */
+void Vehicle::ShiftDates(int interval)
+{
+	this->date_of_last_service += interval;
+}
+
+/**
  * Handle the pathfinding result, especially the lost status.
  * If the vehicle is now lost and wasn't previously fire an
  * event to the AIs and a news message to the user. If the

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -545,6 +545,8 @@ public:
 	 */
 	virtual void OnNewDay() {};
 
+	void ShiftDates(int interval);
+
 	/**
 	 * Crash the (whole) vehicle chain.
 	 * @param flooded whether the cause of the crash is flooding or not.


### PR DESCRIPTION
## Motivation / Problem

The dates of last service are not shifted after changing the current year with the cheat menu. This has several consequences, mainly if service intervals are in days and a vehicle has a service order.
- If the cheat was used to go back in time, the date of last service may become in the future, in which case the vehicle will not service for a long time
- If the date was advanced by n years, it adds n years to the time since last service of the vehicle (`_date - date_of_last_service`), so it will go to depot n years early

To reproduce this bug, create a vehicle with a service order and a servicing interval of e.g. 120 days, decrement the date by one year and observe that the vehicle waits 120 days + 1 year before going to a depot.

## Description

This PR introduces a `Vehicle::ShiftDates()` function that works like `LinkGraph::ShiftDates()`. This method is called for all vehicles when the maximum year is reached (this case was already handled before) and when the cheat menu is used. This function will also be useful for #9093 and #9693.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
