### PR TITLE
Change: [Emscripten] update to 2.0.34 and use Release over RelWithDebInfo

### DIFF
--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -76,7 +76,7 @@ jobs:
         echo "::group::CMake"
         emcmake cmake .. \
           -DHOST_BINARY_DIR=../build-host \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_BUILD_TYPE=Release \
           # EOF
         echo "::endgroup::"
 

--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:2.0.31
+FROM emscripten/emsdk:2.0.34
 
 COPY emsdk-liblzma.patch /
 RUN cd /emsdk/upstream/emscripten && patch -p1 < /emsdk-liblzma.patch

--- a/os/emscripten/README.md
+++ b/os/emscripten/README.md
@@ -24,7 +24,7 @@ Next, build the game with emscripten:
 
 ```
   mkdir build
-  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-lzma emcmake cmake .. -DHOST_BINARY_DIR=$(pwd)/build-host -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPTION_USE_ASSERTS=OFF
+  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-lzma emcmake cmake .. -DHOST_BINARY_DIR=../build-host -DCMAKE_BUILD_TYPE=Release -DOPTION_USE_ASSERTS=OFF
   docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-lzma emmake make -j5
 ```
 


### PR DESCRIPTION
## Motivation / Problem

I noticed preview binaries were huge. Had to investigate .. found the issue. Got sad.

## Description

```
It turns out that having "-g" in the compile-statement causes
Emscripten to pick -g3, which makes for very big binaries. This
is very likely not your intention when building Emscripten, as
smaller really is better.

For comparison, with RelWithDebInfo the binary is ~80MB. With
Release it is ~7.4MB.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
