### PR TITLE
Codechange: Remove CargoSpec::multipliertowngrowth which is unused

### DIFF
--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -66,7 +66,6 @@ struct CargoSpec {
 
 	bool is_freight;                 ///< Cargo type is considered to be freight (affects train freight multiplier).
 	TownEffect town_effect;          ///< The effect that delivering this cargo type has on towns. Also affects destination of subsidies.
-	uint16 multipliertowngrowth;     ///< Size of the effect.
 	uint8 callback_mask;             ///< Bitmask of cargo callbacks that have to be called
 
 	StringID name;                   ///< Name of this type of cargo.

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3019,7 +3019,7 @@ static ChangeInfoResult CargoChangeInfo(uint cid, int numinfo, int prop, ByteRea
 			}
 
 			case 0x19: // Town growth coefficient
-				cs->multipliertowngrowth = buf->ReadWord();
+				buf->ReadWord();
 				break;
 
 			case 0x1A: // Bitmask of callbacks to use

--- a/src/table/cargo_const.h
+++ b/src/table/cargo_const.h
@@ -44,7 +44,7 @@
  * @param classes      Classes of this cargo type. @see CargoClass
  */
 #define MK(bt, label, colour, weight, mult, ip, td1, td2, freight, te, str_plural, str_singular, str_volume, classes) \
-		{bt, label, colour, colour, weight, mult, ip, {td1, td2}, freight, te, 0, 0, \
+		{bt, label, colour, colour, weight, mult, ip, {td1, td2}, freight, te, 0, \
 		MK_STR_CARGO_PLURAL(str_plural), MK_STR_CARGO_SINGULAR(str_singular), str_volume, MK_STR_QUANTITY(str_plural), MK_STR_ABBREV(str_plural), \
 		MK_SPRITE(str_plural), classes, nullptr, nullptr, 0}
 


### PR DESCRIPTION
## Motivation / Problem

CargoSpec::multipliertowngrowth was added in 3d581f4f, but no readers have been added since then.
It seems unlikely that readers will be added in the near future.

CargoSpec::multipliertowngrowth is set by cargo property 19.
Cargo property 19 is only implemented in TTDPatch.

The name looks enticing to NewGRF authors, but they are then confused and disappointed when setting it seems to do nothing.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
