### PR TITLE
Fix #9702: Revert old behaviour in group GUI when not using shared orders

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -746,17 +746,23 @@ public:
 						NOT_REACHED();
 				}
 				if (v) {
-					if (_ctrl_pressed) {
-						if (this->grouping == GB_NONE) {
-							this->SelectGroup(v->group_id);
-						} else {
-							ShowOrdersWindow(v);
-						}
+					if (_ctrl_pressed && this->grouping == GB_SHARED_ORDERS) {
+						ShowOrdersWindow(v);
 					} else {
 						this->vehicle_sel = v->index;
+
+						if (_ctrl_pressed && this->grouping == GB_NONE) {
+							/*
+							 * It only makes sense to select a group if not using shared orders
+							 * since two vehicles sharing orders can be from different groups.
+							 */
+							this->SelectGroup(v->group_id);
+						}
+
 						SetObjectToPlaceWnd(SPR_CURSOR_MOUSE, PAL_NONE, HT_DRAG, this);
 						SetMouseCursorVehicle(v, EIT_IN_LIST);
 						_cursor.vehchain = true;
+
 						this->SetDirty();
 					}
 				}


### PR DESCRIPTION
## Motivation / Problem

This PR is a fix for #9702.

## Description

The group GUI now only opens the shared order list if the dropdown is set to shared orders AND the Ctrl key is pressed.  In other situations, we use the original behaviour.

When grouped by shared orders, the Ctrl key does not need to be pressed when doing a drag-and-drop operation - all vehicles that share those orders will be moved to the new group, regardless of the state of the Ctrl key when releasing the mouse.  This has already been the behaviour before the bug was introduced.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
