### PR TITLE
Feature: Build objects by area

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -186,6 +186,7 @@ enum Commands : uint16 {
 	CMD_REMOVE_SIGNALS,               ///< remove a signal
 	CMD_TERRAFORM_LAND,               ///< terraform a tile
 	CMD_BUILD_OBJECT,                 ///< build an object
+	CMD_BUILD_OBJECT_AREA,            ///< build an area of objects
 	CMD_BUILD_TUNNEL,                 ///< build a tunnel
 
 	CMD_REMOVE_FROM_RAIL_STATION,     ///< remove a (rectangle of) tiles from a rail station

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -87,6 +87,7 @@ struct CompanyProperties {
 	uint32 terraform_limit;          ///< Amount of tileheights we can (still) terraform (times 65536).
 	uint32 clear_limit;              ///< Amount of tiles we can (still) clear (times 65536).
 	uint32 tree_limit;               ///< Amount of trees we can (still) plant (times 65536).
+	uint32 build_object_limit;       ///< Amount of tiles we can (still) build objects on (times 65536).
 
 	/**
 	 * If \c true, the company is (also) controlled by the computer (a NoAI program).
@@ -110,7 +111,7 @@ struct CompanyProperties {
 		  face(0), money(0), money_fraction(0), current_loan(0), colour(0), block_preview(0),
 		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0),
 		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
-		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false), engine_renew_list(nullptr) {}
+		  terraform_limit(0), clear_limit(0), tree_limit(0), build_object_limit(0), is_ai(false), engine_renew_list(nullptr) {}
 };
 
 struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -63,9 +63,10 @@ Company::Company(uint16 name_1, bool is_ai)
 	this->name_1 = name_1;
 	this->location_of_HQ = INVALID_TILE;
 	this->is_ai = is_ai;
-	this->terraform_limit = (uint32)_settings_game.construction.terraform_frame_burst << 16;
-	this->clear_limit     = (uint32)_settings_game.construction.clear_frame_burst << 16;
-	this->tree_limit      = (uint32)_settings_game.construction.tree_frame_burst << 16;
+	this->terraform_limit    = (uint32)_settings_game.construction.terraform_frame_burst << 16;
+	this->clear_limit        = (uint32)_settings_game.construction.clear_frame_burst << 16;
+	this->tree_limit         = (uint32)_settings_game.construction.tree_frame_burst << 16;
+	this->build_object_limit = (uint32)_settings_game.construction.build_object_frame_burst << 16;
 
 	std::fill(this->share_owners.begin(), this->share_owners.end(), INVALID_OWNER);
 	InvalidateWindowData(WC_PERFORMANCE_DETAIL, 0, INVALID_COMPANY);
@@ -267,9 +268,10 @@ void SubtractMoneyFromCompanyFract(CompanyID company, const CommandCost &cst)
 void UpdateLandscapingLimits()
 {
 	for (Company *c : Company::Iterate()) {
-		c->terraform_limit = std::min<uint64>((uint64)c->terraform_limit + _settings_game.construction.terraform_per_64k_frames, (uint64)_settings_game.construction.terraform_frame_burst << 16);
-		c->clear_limit     = std::min<uint64>((uint64)c->clear_limit     + _settings_game.construction.clear_per_64k_frames,     (uint64)_settings_game.construction.clear_frame_burst << 16);
-		c->tree_limit      = std::min<uint64>((uint64)c->tree_limit      + _settings_game.construction.tree_per_64k_frames,      (uint64)_settings_game.construction.tree_frame_burst << 16);
+		c->terraform_limit    = std::min<uint64>((uint64)c->terraform_limit    + _settings_game.construction.terraform_per_64k_frames,    (uint64)_settings_game.construction.terraform_frame_burst << 16);
+		c->clear_limit        = std::min<uint64>((uint64)c->clear_limit        + _settings_game.construction.clear_per_64k_frames,        (uint64)_settings_game.construction.clear_frame_burst << 16);
+		c->tree_limit         = std::min<uint64>((uint64)c->tree_limit         + _settings_game.construction.tree_per_64k_frames,         (uint64)_settings_game.construction.tree_frame_burst << 16);
+		c->build_object_limit = std::min<uint64>((uint64)c->build_object_limit + _settings_game.construction.build_object_per_64k_frames, (uint64)_settings_game.construction.build_object_frame_burst << 16);
 	}
 }
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -378,7 +378,7 @@ STR_SCENEDIT_TOOLBAR_ROAD_CONSTRUCTION                          :{BLACK}Road con
 STR_SCENEDIT_TOOLBAR_TRAM_CONSTRUCTION                          :{BLACK}Tramway construction
 STR_SCENEDIT_TOOLBAR_PLANT_TREES                                :{BLACK}Plant trees. Shift toggles building/showing cost estimate
 STR_SCENEDIT_TOOLBAR_PLACE_SIGN                                 :{BLACK}Place sign
-STR_SCENEDIT_TOOLBAR_PLACE_OBJECT                               :{BLACK}Place object. Shift toggles building/showing cost estimate
+STR_SCENEDIT_TOOLBAR_PLACE_OBJECT                               :{BLACK}Place object. Ctrl selects the area diagonally. Shift toggles building/showing cost estimate
 
 # Scenario editor file menu
 ###length 7
@@ -2816,7 +2816,7 @@ STR_LANDSCAPING_TOOLTIP_PURCHASE_LAND                           :{BLACK}Purchase
 
 # Object construction window
 STR_OBJECT_BUILD_CAPTION                                        :{WHITE}Object Selection
-STR_OBJECT_BUILD_TOOLTIP                                        :{BLACK}Select object to build. Shift toggles building/showing cost estimate
+STR_OBJECT_BUILD_TOOLTIP                                        :{BLACK}Select object to build. Ctrl selects the area diagonally. Shift toggles building/showing cost estimate
 STR_OBJECT_BUILD_CLASS_TOOLTIP                                  :{BLACK}Select class of the object to build
 STR_OBJECT_BUILD_PREVIEW_TOOLTIP                                :{BLACK}Preview of the object
 STR_OBJECT_BUILD_SIZE                                           :{BLACK}Size: {GOLD}{NUM} x {NUM} tiles
@@ -4925,6 +4925,7 @@ STR_ERROR_OBJECT_IN_THE_WAY                                     :{WHITE}Object i
 STR_ERROR_COMPANY_HEADQUARTERS_IN                               :{WHITE}... company headquarters in the way
 STR_ERROR_CAN_T_PURCHASE_THIS_LAND                              :{WHITE}Can't purchase this land area...
 STR_ERROR_YOU_ALREADY_OWN_IT                                    :{WHITE}... you already own it!
+STR_ERROR_BUILD_OBJECT_LIMIT_REACHED                            :{WHITE}... object construction limit reached
 
 # Group related errors
 STR_ERROR_GROUP_CAN_T_CREATE                                    :{WHITE}Can't create group...

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4083,7 +4083,7 @@ static ChangeInfoResult ObjectChangeInfo(uint id, int numinfo, int prop, ByteRea
 				if (*ospec == nullptr) {
 					*ospec = CallocT<ObjectSpec>(1);
 					(*ospec)->views = 1; // Default for NewGRFs that don't set it.
-					(*ospec)->size = 0x11; // Default for NewGRFs that manage to not set it (1x1)
+					(*ospec)->size = OBJECT_SIZE_1X1; // Default for NewGRFs that manage to not set it (1x1)
 				}
 
 				/* Swap classid because we read it in BE. */
@@ -4111,7 +4111,7 @@ static ChangeInfoResult ObjectChangeInfo(uint id, int numinfo, int prop, ByteRea
 				spec->size = buf->ReadByte();
 				if (GB(spec->size, 0, 4) == 0 || GB(spec->size, 4, 4) == 0) {
 					grfmsg(0, "ObjectChangeInfo: Invalid object size requested (0x%x) for object id %u. Ignoring.", spec->size, id + i);
-					spec->size = 0x11; // 1x1
+					spec->size = OBJECT_SIZE_1X1;
 				}
 				break;
 

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -40,6 +40,8 @@ enum ObjectFlags {
 };
 DECLARE_ENUM_AS_BIT_SET(ObjectFlags)
 
+static const uint8 OBJECT_SIZE_1X1 = 0x11; ///< The value of a NewGRF's size property when the object is 1x1 tiles: low nibble for X, high nibble for Y.
+
 void ResetObjects();
 
 /** Class IDs for objects. */

--- a/src/object_cmd.h
+++ b/src/object_cmd.h
@@ -14,7 +14,9 @@
 #include "object_type.h"
 
 CommandCost CmdBuildObject(DoCommandFlag flags, TileIndex tile, ObjectType type, uint8 view);
+CommandCost CmdBuildObjectArea(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, ObjectType type, uint8 view, bool diagonal);
 
 DEF_CMD_TRAIT(CMD_BUILD_OBJECT, CmdBuildObject, CMD_DEITY | CMD_NO_WATER | CMD_AUTO, CMDT_LANDSCAPE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_BUILD_OBJECT_AREA, CmdBuildObjectArea, CMD_DEITY | CMD_NO_WATER | CMD_AUTO, CMDT_LANDSCAPE_CONSTRUCTION)
 
 #endif /* OBJECT_CMD_H */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -355,6 +355,8 @@ struct ConstructionSettings {
 	uint16 clear_frame_burst;                ///< how many tiles may, over a short period, be cleared?
 	uint32 tree_per_64k_frames;              ///< how many trees may, over a long period, be planted per 65536 frames?
 	uint16 tree_frame_burst;                 ///< how many trees may, over a short period, be planted?
+	uint32 build_object_per_64k_frames;      ///< how many tiles may, over a long period, have objects built on them per 65536 frames?
+	uint16 build_object_frame_burst;         ///< how many tiles may, over a short period, have objects built on them?
 };
 
 /** Settings related to the AI. */

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -415,6 +415,24 @@ max      = 1 << 15
 interval = 1
 cat      = SC_EXPERT
 
+[SDT_VAR]
+var      = construction.build_object_per_64k_frames
+type     = SLE_UINT32
+def      = 32 << 16
+min      = 0
+max      = 1 << 30
+interval = 1
+cat      = SC_EXPERT
+
+[SDT_VAR]
+var      = construction.build_object_frame_burst
+type     = SLE_UINT16
+def      = 2048
+min      = 0
+max      = 1 << 15
+interval = 1
+cat      = SC_EXPERT
+
 [SDT_BOOL]
 var      = construction.autoslope
 from     = SLV_75

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -123,6 +123,7 @@ enum ViewportDragDropSelectionProcess {
 	DDSP_CREATE_RIVER,         ///< Create rivers
 	DDSP_PLANT_TREES,          ///< Plant trees
 	DDSP_BUILD_BRIDGE,         ///< Bridge placement
+	DDSP_BUILD_OBJECT,         ///< Build an object
 
 	/* Rail specific actions */
 	DDSP_PLACE_RAIL,           ///< Rail placement


### PR DESCRIPTION
## Motivation / Problem

Building decorative objects one tile at a time is tedious.

JGRPP includes a feature to build objects by drag-and-drop, including diagonally by holding Ctrl.

## Description

Upstreams [JGR's commit](https://github.com/JGRennison/OpenTTD-patches/commit/f44d75eaf5cad16aa24617482a3ef3623036feb7), with modifications for vanilla.

Also includes a commit to [limit the rate of object construction](https://github.com/JGRennison/OpenTTD-patches/commit/2d350d26db8efe6a4b624a813237febf2d854443), to prevent griefing.


## Limitations

I haven't touched saveload upgrades in a while and JGRPP handles it differently, so please check this carefully!

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
