### PR TITLE
Fix: Insufficient input validation for CmdIndustryCtrl.

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2118,7 +2118,7 @@ CommandCost CmdIndustryCtrl(TileIndex tile, DoCommandFlag flags, uint32 p1, uint
 		}
 
 		default:
-			NOT_REACHED();
+			return CMD_ERROR;
 	}
 
 	return CommandCost();


### PR DESCRIPTION
## Motivation / Problem / Description

An invalid action parameter to `CmdIndustryCtrl` could trigger a `NOT_REACHED`, ~~which a malicious client could use to crash a server.~~

Return `CMD_ERROR` instead to avoid this.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
