### PR TITLE
Fix: Don't try to rename OWNER_DEITY signs in-game

### DIFF
--- a/src/signs.cpp
+++ b/src/signs.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "landscape.h"
+#include "company_func.h"
 #include "signs_base.h"
 #include "signs_func.h"
 #include "strings_func.h"
@@ -60,4 +61,15 @@ void UpdateAllSignVirtCoords()
 	for (Sign *si : Sign::Iterate()) {
 		si->UpdateVirtCoord();
 	}
+}
+
+/**
+ * Check if the current company can rename a given sign.
+ * @param *si The sign in question.
+ * @return true if the sign can be renamed, else false.
+ */
+bool CompanyCanRenameSign(const Sign *si)
+{
+	if (si->owner == OWNER_DEITY && _current_company != OWNER_DEITY && _game_mode != GM_EDITOR) return false;
+	return true;
 }

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -79,7 +79,7 @@ CommandCost CmdRenameSign(TileIndex tile, DoCommandFlag flags, uint32 p1, uint32
 {
 	Sign *si = Sign::GetIfValid(p1);
 	if (si == nullptr) return CMD_ERROR;
-	if (si->owner == OWNER_DEITY && _current_company != OWNER_DEITY && _game_mode != GM_EDITOR) return CMD_ERROR;
+	if (!CompanyCanRenameSign(si)) return CMD_ERROR;
 
 	/* Rename the signs when empty, otherwise remove it */
 	if (!text.empty()) {

--- a/src/signs_func.h
+++ b/src/signs_func.h
@@ -18,6 +18,7 @@ extern SignID _new_sign_id;
 
 void UpdateAllSignVirtCoords();
 void PlaceProc_Sign(TileIndex tile);
+bool CompanyCanRenameSign(const Sign *si);
 
 /* signs_gui.cpp */
 void ShowRenameSignWindow(const Sign *si);

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -565,10 +565,14 @@ static WindowDesc _query_sign_edit_desc(
  */
 void HandleClickOnSign(const Sign *si)
 {
+	/* If we can't rename the sign, don't even open the rename GUI. */
+	if (!CompanyCanRenameSign(si)) return;
+
 	if (_ctrl_pressed && (si->owner == _local_company || (si->owner == OWNER_DEITY && _game_mode == GM_EDITOR))) {
 		RenameSign(si->index, "");
 		return;
 	}
+
 	ShowRenameSignWindow(si);
 }
 


### PR DESCRIPTION
## Motivation / Problem

Many city builder Game Scripts use a sign below the town name to show the current growth rate. Players can click on this sign which brings up the GUI to edit the sign, but they are actually blocked from renaming the sign. The same goes for signs created by other players.

Why show the rename GUI if we're not allowed to do anything with it?

![sign_error](https://user-images.githubusercontent.com/55058389/143176598-b6a0de99-6420-4248-b204-9c78d1748a20.png)

## Description

If we're not allowed to rename a sign, don't even open the rename GUI.

The exception is if we're in Scenario Editor, which can open savegames by changing the file extension, and needs to be allowed to edit anything including signs.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
