### PR TITLE
Change: Suppress vehicle age warnings for stopped vehicles

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1392,8 +1392,8 @@ void AgeVehicle(Vehicle *v)
 
 	SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 
-	/* Don't warn about non-primary or not ours vehicles or vehicles that are crashed */
-	if (v->Previous() != nullptr || v->owner != _local_company || (v->vehstatus & VS_CRASHED) != 0) return;
+	/* Don't warn about vehicles which are non-primary (e.g., part of an articulated vehicle), don't belong to us, are crashed, or are stopped */
+	if (v->Previous() != nullptr || v->owner != _local_company || (v->vehstatus & VS_CRASHED) != 0 || (v->vehstatus & VS_STOPPED) != 0) return;
 
 	const Company *c = Company::Get(v->owner);
 	/* Don't warn if a renew is active */


### PR DESCRIPTION
## Motivation / Problem

Per #9700:

> When vehicle is manually stopped by player (either due to aesthetic purposes like first locomotive statue, or as timetable holder, or spare cars holder), its age should not bother - it affect only running vehicles.

The same goes for vehicles stopped in depots.

## Description

When a vehicle is stopped (red Stopped status bar, not speed == 0, obviously), don't send warnings about its age.

Closes #9700.

For a test savegame, see [old_vehicle_test.zip](https://github.com/OpenTTD/OpenTTD/files/7610905/old_vehicle_test.zip). Road vehicles 1 and 2 will hit the end of their lifespans within a month of loading the savegame. One is running, the other is stopped inside the depot.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
