### PR TITLE
Fix: FreeBSD crash on multiplayer

### DIFF
--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -220,6 +220,8 @@ bool NetworkTCPSocketHandler::CanSendReceive()
 	fd_set read_fd, write_fd;
 	struct timeval tv;
 
+	if (this->sock == -1)
+		return false;
 	FD_ZERO(&read_fd);
 	FD_ZERO(&write_fd);
 


### PR DESCRIPTION
On FreeBSD at least, FD_SET(-1, ptr); either causes a segfault or
writes outside of the bounds of ptr.  Since -1 is returned when
socket() fails, this is always in valid and can never be read or
written, so always return false in this case.

## Motivation / Problem

Fixes crash on (at least) FreeBSD

## Description

```
Thread 7 received signal SIGBUS, Bus error.
Address not present.
[Switching to LWP 100805 of process 32847]
0x0000000000bb44b4 in NetworkTCPSocketHandler::CanSendReceive (this=0x807fcc488) at /usr/ports/games/openttd/work/openttd-12.1/src/network/core/tcp.cpp:226
226		FD_SET(this->sock, &read_fd);
(gdb) print this->sock
$1 = -1
(gdb) bt
#0  0x0000000000bb44b4 in NetworkTCPSocketHandler::CanSendReceive (this=0x807fcc488)
    at /usr/ports/games/openttd/work/openttd-12.1/src/network/core/tcp.cpp:226
#1  0x0000000000c318a6 in QueryNetworkGameSocketHandler::Receive (this=0x807fcc480)
    at /usr/ports/games/openttd/work/openttd-12.1/src/network/network_query.cpp:53
#2  0x0000000000c31ca1 in QueryNetworkGameSocketHandler::SendReceive ()
    at /usr/ports/games/openttd/work/openttd-12.1/src/network/network_query.cpp:147
#3  0x0000000000bd3f61 in NetworkBackgroundLoop ()
    at /usr/ports/games/openttd/work/openttd-12.1/src/network/network.cpp:1027
#4  0x000000000104e9d9 in GameLoop () at /usr/ports/games/openttd/work/openttd-12.1/src/openttd.cpp:1454
#5  0x0000000000da9d5e in VideoDriver::GameLoop (this=0x803694c00)
    at /usr/ports/games/openttd/work/openttd-12.1/src/video/video_driver.cpp:37
#6  0x0000000000da9dcb in VideoDriver::GameThread (this=0x803694c00)
    at /usr/ports/games/openttd/work/openttd-12.1/src/video/video_driver.cpp:44
#7  0x0000000000da9f05 in VideoDriver::GameThreadThunk (drv=0x803694c00)
    at /usr/ports/games/openttd/work/openttd-12.1/src/video/video_driver.cpp:81
#8  0x0000000000daba14 in StartNewThread<void (*)(VideoDriver*), VideoDriver*>(std::__1::thread*, char const*, void (*&&)(VideoDriver*), VideoDriver*&&)::{lambda(char const*, void (*&&)(VideoDriver*), VideoDriver*&&)#1}::operator()(char const*, void (*&&)(VideoDriver*), VideoDriver*&&) const (this=0x82ac66fa0, name=0x5e2bcd "ottd:game", 
    F=@0x82ac66fb0: 0xda9ef0 <VideoDriver::GameThreadThunk(VideoDriver*)>, A=@0x82ac66fb8: 0x803694c00)
    at /usr/ports/games/openttd/work/openttd-12.1/src/video/../thread.h:65
#9  0x0000000000dab8cf in std::__1::__invoke<StartNewThread<void (*)(VideoDriver*), VideoDriver*>(std::__1::thread*, char const*, void (*&&)(VideoDriver*), VideoDriver*&&)::{lambda(char const*, void (*&&)(VideoDriver*), VideoDriver*&&)#1}, char const*, void (*)(VideoDriver*), VideoDriver*> (__f=..., __args=@0x82ac66fb8: 0x803694c00, 
    __args=@0x82ac66fb8: 0x803694c00, __args=@0x82ac66fb8: 0x803694c00) at /usr/include/c++/v1/type_traits:3539
#10 0x0000000000dab830 in std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, StartNewThread<void (*)(VideoDriver*), VideoDriver*>(std::__1::thread*, char const*, void (*&&)(VideoDriver*), VideoDriver*&&)::{lambda(char const*, void (*&&)(VideoDriver*), VideoDriver*&&)#1}, char const*, void (*)(VideoDriver*), VideoDriver*, 2ul, 3ul, 4ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, StartNewThread<void (*)(VideoDriver*), VideoDriver*>(std::__1::thread*, char const*, void (*&&)(VideoDriver*), VideoDriver*&&)::{lambda(char const*, void (*&&)(VideoDriver*), VideoDriver*&&)#1}, char const*, void (*)(VideoDriver*), VideoDriver*>&, std::__1::__tuple_indices<2ul, 3ul, 4ul>)
    (__t=...) at /usr/include/c++/v1/thread:273
#11 0x0000000000dab486 in std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, StartNewThread<void (*)(VideoDriver*), VideoDriver*>(std::__1::thread*, char const*, void (*&&)(VideoDriver*), VideoDriver*&&)::{lambda(char const*, void (*&&)(VideoDriver*), VideoDriver*&&)#1}, char const*, void (*)(VideoDriver*), VideoDriver*> >(void*) (__vp=0x82ac66fa0)
    at /usr/include/c++/v1/thread:284
#12 0x0000000801cbcfac in ?? () from /lib/libthr.so.3
#13 0x0000000000000000 in ?? ()
Backtrace stopped: Cannot access memory at address 0x7fffdf5f9000
```

## Limitations

None

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
