### PR TITLE
Codechange: ensure OnConnect() always gets called with a valid socket

### DIFF
--- a/src/network/core/tcp.cpp
+++ b/src/network/core/tcp.cpp
@@ -217,6 +217,8 @@ Packet *NetworkTCPSocketHandler::ReceivePacket()
  */
 bool NetworkTCPSocketHandler::CanSendReceive()
 {
+	assert(this->sock != INVALID_SOCKET);
+
 	fd_set read_fd, write_fd;
 	struct timeval tv;
 

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -451,6 +451,8 @@ bool TCPServerConnecter::CheckActivity()
  */
 void TCPServerConnecter::SetConnected(SOCKET sock)
 {
+	assert(sock != INVALID_SOCKET);
+
 	this->socket = sock;
 	this->status = Status::CONNECTED;
 }

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -566,6 +566,8 @@ void ClientNetworkCoordinatorSocketHandler::ConnectFailure(const std::string &to
  */
 void ClientNetworkCoordinatorSocketHandler::ConnectSuccess(const std::string &token, SOCKET sock, NetworkAddress &address)
 {
+	assert(sock != INVALID_SOCKET);
+
 	/* Connecter will destroy itself. */
 	this->game_connecter = nullptr;
 

--- a/src/network/network_turn.cpp
+++ b/src/network/network_turn.cpp
@@ -41,7 +41,7 @@ public:
 	{
 		this->handler->connecter = nullptr;
 
-		handler->sock = s;
+		this->handler->sock = s;
 	}
 };
 


### PR DESCRIPTION

## Motivation / Problem

The backtrace in #9728 is odd to me. The only reason I can think of that `this->sock` is `INVALID_SOCKET` is when the `OnConnect` already indicated this. That should never happen, but two flows in the code didn't validate for it (where the other two we have did). Neither should ever be `INVALID_SOCKET`, but should/would/could.

## Description

```
This should already be the case, but now assert()s will tell us
if this isn't.
```

This might help uncover where in #9728 the socket becomes `INVALID_SOCKET`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
