### PR TITLE
Feature: Added hotkeys to tooltips and dropdown menu's

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,6 +212,7 @@ add_files(
     language.h
     livery.h
     main_gui.cpp
+    main_gui.h
     map.cpp
     map_func.h
     map_type.h

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -1102,6 +1102,7 @@ struct AIDebugWindow : public Window {
 
 		this->SelectValidDebugCompany();
 		this->InvalidateData(-1);
+		this->AssociateHotkeysByWidgetIndex(desc);
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -72,6 +72,7 @@ struct BuildAirToolbarWindow : Window {
 	{
 		this->InitNested(window_number);
 		this->OnInvalidateData();
+		this->AssociateHotkeysByWidgetIndex(desc);
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 		this->last_user_action = WIDGET_LIST_END;
 	}

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -98,6 +98,7 @@ struct BuildDocksToolbarWindow : Window {
 		this->last_clicked_widget = WID_DT_INVALID;
 		this->InitNested(window_number);
 		this->OnInvalidateData();
+		this->AssociateHotkeysByWidgetIndex(desc);
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
 
@@ -388,7 +389,8 @@ static WindowDesc _build_docks_scen_toolbar_desc(
 	WDP_AUTO, "toolbar_water_scen", 0, 0,
 	WC_SCEN_BUILD_TOOLBAR, WC_NONE,
 	WDF_CONSTRUCTION,
-	_nested_build_docks_scen_toolbar_widgets, lengthof(_nested_build_docks_scen_toolbar_widgets)
+	_nested_build_docks_scen_toolbar_widgets, lengthof(_nested_build_docks_scen_toolbar_widgets),
+	& BuildDocksToolbarWindow::hotkeys
 );
 
 /**

--- a/src/hotkeys.h
+++ b/src/hotkeys.h
@@ -30,6 +30,8 @@ struct Hotkey {
 	std::vector<uint16> keycodes;
 };
 
+std::string AppendHotkeyToString(const std::string& input, const Hotkey* hotkey);
+
 #define HOTKEY_LIST_END Hotkey((uint16)0, nullptr, -1)
 
 struct IniFile;
@@ -47,6 +49,7 @@ struct HotkeyList {
 	void Save(IniFile *ini) const;
 
 	int CheckMatch(uint16 keycode, bool global_only = false) const;
+	const Hotkey* GetHotkeyByNum(int num) const;
 
 	GlobalHotkeyHandlerFunc global_hotkey_handler;
 private:

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -8,6 +8,7 @@
 /** @file main_gui.cpp Handling of the main viewport. */
 
 #include "stdafx.h"
+#include "main_gui.h"
 #include "currency.h"
 #include "spritecache.h"
 #include "window_gui.h"
@@ -178,33 +179,7 @@ static const struct NWidgetPart _nested_main_window_widgets[] = {
 	NWidget(NWID_VIEWPORT, INVALID_COLOUR, WID_M_VIEWPORT), SetResize(1, 1),
 };
 
-enum {
-	GHK_QUIT,
-	GHK_ABANDON,
-	GHK_CONSOLE,
-	GHK_BOUNDING_BOXES,
-	GHK_DIRTY_BLOCKS,
-	GHK_CENTER,
-	GHK_CENTER_ZOOM,
-	GHK_RESET_OBJECT_TO_PLACE,
-	GHK_DELETE_WINDOWS,
-	GHK_DELETE_NONVITAL_WINDOWS,
-	GHK_DELETE_ALL_MESSAGES,
-	GHK_REFRESH_SCREEN,
-	GHK_CRASH,
-	GHK_MONEY,
-	GHK_UPDATE_COORDS,
-	GHK_TOGGLE_TRANSPARENCY,
-	GHK_TOGGLE_INVISIBILITY = GHK_TOGGLE_TRANSPARENCY + 9,
-	GHK_TRANSPARENCY_TOOLBAR = GHK_TOGGLE_INVISIBILITY + 8,
-	GHK_TRANSPARANCY,
-	GHK_CHAT,
-	GHK_CHAT_ALL,
-	GHK_CHAT_COMPANY,
-	GHK_CHAT_SERVER,
-	GHK_CLOSE_NEWS,
-	GHK_CLOSE_ERROR,
-};
+
 
 struct MainWindow : Window
 {
@@ -361,7 +336,7 @@ struct MainWindow : Window
 				break;
 
 			case GHK_TRANSPARENCY_TOOLBAR:
-				ShowTransparencyToolbar();
+				ShowTransparencyToolbar(hotkeys);
 				break;
 
 			case GHK_TRANSPARANCY:
@@ -558,7 +533,7 @@ void SetupColoursAndInitialWindow()
  */
 void ShowVitalWindows()
 {
-	AllocateToolbar();
+	AllocateToolbar(MainWindow::hotkeys);
 
 	/* Status bad only for normal games */
 	if (_game_mode == GM_EDITOR) return;

--- a/src/main_gui.h
+++ b/src/main_gui.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file main_gui.h Stuff related to the main gui. */
+
+#ifndef MAIN_GUI_H
+#define MAIN_GUI_H
+
+#include "hotkeys.h"
+
+enum MainGuiHotkeys {
+	GHK_QUIT,
+	GHK_ABANDON,
+	GHK_CONSOLE,
+	GHK_BOUNDING_BOXES,
+	GHK_DIRTY_BLOCKS,
+	GHK_CENTER,
+	GHK_CENTER_ZOOM,
+	GHK_RESET_OBJECT_TO_PLACE,
+	GHK_DELETE_WINDOWS,
+	GHK_DELETE_NONVITAL_WINDOWS,
+	GHK_DELETE_ALL_MESSAGES,
+	GHK_REFRESH_SCREEN,
+	GHK_CRASH,
+	GHK_MONEY,
+	GHK_UPDATE_COORDS,
+	GHK_TOGGLE_TRANSPARENCY,
+	GHK_TOGGLE_INVISIBILITY = GHK_TOGGLE_TRANSPARENCY + 9,
+	GHK_TRANSPARENCY_TOOLBAR = GHK_TOGGLE_INVISIBILITY + 8,
+	GHK_TRANSPARANCY,
+	GHK_CHAT,
+	GHK_CHAT_ALL,
+	GHK_CHAT_COMPANY,
+	GHK_CHAT_SERVER,
+	GHK_CLOSE_NEWS,
+	GHK_CLOSE_ERROR,
+};
+
+#endif /* MAIN_GUI_H */

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -434,6 +434,8 @@ struct BuildRailToolbarWindow : Window {
 		this->DisableWidget(WID_RAT_REMOVE);
 		this->last_user_action = WIDGET_LIST_END;
 
+		this->AssociateHotkeysByWidgetIndex(desc);
+
 		if (_settings_client.gui.link_terraform_toolbar) ShowTerraformToolbar(this);
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -276,6 +276,9 @@ struct BuildRoadToolbarWindow : Window {
 	{
 		this->Initialize(_cur_roadtype);
 		this->InitNested(window_number);
+
+		this->AssociateHotkeysByWidgetIndex(desc);
+
 		this->SetupRoadToolbar();
 		this->SetWidgetDisabledState(WID_ROT_REMOVE, true);
 

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -157,6 +157,7 @@ struct TerraformToolbarWindow : Window {
 		/* This is needed as we like to have the tree available on OnInit. */
 		this->CreateNestedTree();
 		this->FinishInitNested(window_number);
+		this->AssociateHotkeysByWidgetIndex(desc);
 		this->last_user_action = WIDGET_LIST_END;
 	}
 

--- a/src/toolbar_gui.h
+++ b/src/toolbar_gui.h
@@ -10,6 +10,8 @@
 #ifndef TOOLBAR_GUI_H
 #define TOOLBAR_GUI_H
 
+#include "hotkeys.h"
+
 enum MainToolbarHotkeys {
 	MTHK_PAUSE,
 	MTHK_FASTFORWARD,
@@ -53,7 +55,7 @@ enum MainToolbarHotkeys {
 	MTHK_SIGN_LIST
 };
 
-void AllocateToolbar();
+void AllocateToolbar(const HotkeyList& hotkeys);
 void ToggleBoundingBoxes();
 void ToggleDirtyBlocks();
 

--- a/src/transparency_gui.h
+++ b/src/transparency_gui.h
@@ -10,6 +10,8 @@
 #ifndef TRANSPARENCY_GUI_H
 #define TRANSPARENCY_GUI_H
 
-void ShowTransparencyToolbar();
+#include "hotkeys.h"
+
+void ShowTransparencyToolbar(const HotkeyList& hotkeys);
 
 #endif /* TRANSPARENCY_GUI_H */

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -2642,7 +2642,7 @@ void UpdateTileSelection()
 static inline void ShowMeasurementTooltips(StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_cond = TCC_EXIT_VIEWPORT)
 {
 	if (!_settings_client.gui.measure_tooltip) return;
-	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, params, close_cond);
+	GuiShowTooltips(_thd.GetCallbackWnd(), str, paramcount, params, close_cond, nullptr);
 }
 
 static void HideMeasurementTooltips()

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -933,12 +933,13 @@ void NWidgetResizeBase::AssignSizePosition(SizingType sizing, uint x, uint y, ui
  * @param widget_data Data component of the widget. @see Widget::data
  * @param tool_tip    Tool tip of the widget. @see Widget::tooltips
  */
-NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y, uint32 widget_data, StringID tool_tip) : NWidgetResizeBase(tp, fill_x, fill_y)
+NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y, uint32 widget_data, StringID tool_tip, const Hotkey* hotkey) : NWidgetResizeBase(tp, fill_x, fill_y)
 {
 	this->colour = colour;
 	this->index = -1;
 	this->widget_data = widget_data;
 	this->tool_tip = tool_tip;
+	this->hotkey = hotkey;
 	this->scrollbar_index = -1;
 	this->text_colour = TC_FROMSTRING;
 	this->align = SA_CENTER;
@@ -2315,7 +2316,7 @@ Dimension NWidgetLeaf::dropdown_dimension   = {0, 0};
  * @param data   Data of the widget.
  * @param tip    Tooltip of the widget.
  */
-NWidgetLeaf::NWidgetLeaf(WidgetType tp, Colours colour, int index, uint32 data, StringID tip) : NWidgetCore(tp, colour, 1, 1, data, tip)
+NWidgetLeaf::NWidgetLeaf(WidgetType tp, Colours colour, int index, uint32 data, StringID tip, const Hotkey* hotkey) : NWidgetCore(tp, colour, 1, 1, data, tip, hotkey)
 {
 	assert(index >= 0 || tp == WWT_LABEL || tp == WWT_TEXT || tp == WWT_CAPTION || tp == WWT_RESIZEBOX || tp == WWT_SHADEBOX || tp == WWT_DEFSIZEBOX || tp == WWT_DEBUGBOX || tp == WWT_STICKYBOX || tp == WWT_CLOSEBOX);
 	if (index >= 0) this->SetIndex(index);

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -16,6 +16,7 @@
 #include "strings_type.h"
 #include "gfx_type.h"
 #include "window_type.h"
+#include "hotkeys.h"
 
 static const int WIDGET_LIST_END = -1; ///< indicate the end of widgets' list for vararg functions
 
@@ -310,7 +311,7 @@ DECLARE_ENUM_AS_BIT_SET(NWidgetDisplay)
  */
 class NWidgetCore : public NWidgetResizeBase {
 public:
-	NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y, uint32 widget_data, StringID tool_tip);
+	NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y, uint32 widget_data, StringID tool_tip, const Hotkey* hotkey = nullptr);
 
 	void SetIndex(int index);
 	void SetDataTip(uint32 widget_data, StringID tool_tip);
@@ -334,6 +335,7 @@ public:
 	int index;                 ///< Index of the nested widget in the widget array of the window (\c -1 means 'not used').
 	uint32 widget_data;        ///< Data of the widget. @see Widget::data
 	StringID tool_tip;         ///< Tooltip of the widget. @see Widget::tootips
+	const Hotkey* hotkey;
 	int scrollbar_index;       ///< Index of an attached scrollbar.
 	TextColour highlight_colour; ///< Colour of highlight.
 	TextColour text_colour;    ///< Colour of text within widget.
@@ -814,7 +816,7 @@ private:
  */
 class NWidgetLeaf : public NWidgetCore {
 public:
-	NWidgetLeaf(WidgetType tp, Colours colour, int index, uint32 data, StringID tip);
+	NWidgetLeaf(WidgetType tp, Colours colour, int index, uint32 data, StringID tip, const Hotkey* hotkey = nullptr);
 
 	void SetupSmallestSize(Window *w, bool init_array) override;
 	void Draw(const Window *w) override;

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -32,14 +32,12 @@ void DropDownListItem::Draw(int left, int right, int top, int bottom, bool sel, 
 
 uint DropDownListStringItem::Width() const
 {
-	char buffer[512];
-	GetString(buffer, this->String(), lastof(buffer));
-	return GetStringBoundingBox(buffer).width;
+	return GetStringBoundingBox(AppendHotkeyToString(GetString(this->String()), this->hotkey)).width;
 }
 
 void DropDownListStringItem::Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const
 {
-	DrawString(left + WD_FRAMERECT_LEFT, right - WD_FRAMERECT_RIGHT, top, this->String(), sel ? TC_WHITE : TC_BLACK);
+	DrawString(left + WD_FRAMERECT_LEFT, right - WD_FRAMERECT_RIGHT, top, AppendHotkeyToString(GetString(this->String()), this->hotkey), sel ? TC_WHITE : TC_BLACK);
 }
 
 /**
@@ -89,7 +87,8 @@ void DropDownListIconItem::Draw(int left, int right, int top, int bottom, bool s
 {
 	bool rtl = _current_text_dir == TD_RTL;
 	DrawSprite(this->sprite, this->pal, rtl ? right - this->dim.width - WD_FRAMERECT_RIGHT : left + WD_FRAMERECT_LEFT, CenterBounds(top, bottom, this->sprite_y));
-	DrawString(left + WD_FRAMERECT_LEFT + (rtl ? 0 : (this->dim.width + WD_FRAMERECT_LEFT)), right - WD_FRAMERECT_RIGHT - (rtl ? (this->dim.width + WD_FRAMERECT_RIGHT) : 0), CenterBounds(top, bottom, FONT_HEIGHT_NORMAL), this->String(), sel ? TC_WHITE : TC_BLACK);
+	DrawString(left + WD_FRAMERECT_LEFT + (rtl ? 0 : (this->dim.width + WD_FRAMERECT_LEFT)), right - WD_FRAMERECT_RIGHT - (rtl ? (this->dim.width + WD_FRAMERECT_RIGHT) : 0),
+		CenterBounds(top, bottom, FONT_HEIGHT_NORMAL), AppendHotkeyToString(GetString(this->String()), this->hotkey), sel ? TC_WHITE : TC_BLACK);
 }
 
 void DropDownListIconItem::SetDimension(Dimension d)
@@ -477,13 +476,14 @@ void ShowDropDownList(Window *w, DropDownList &&list, int selected, int button, 
  * @param hidden_mask   Bitmask for hidden items (items with their bit set are not copied to the dropdown list).
  * @param width         Width of the dropdown menu. If \c 0, use the width of parent widget \a button.
  */
-void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32 disabled_mask, uint32 hidden_mask, uint width)
+void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32 disabled_mask, uint32 hidden_mask, uint width, const Hotkey* hotkeys[])
 {
 	DropDownList list;
 
 	for (uint i = 0; strings[i] != INVALID_STRING_ID; i++) {
 		if (!HasBit(hidden_mask, i)) {
-			list.emplace_back(new DropDownListStringItem(strings[i], i, HasBit(disabled_mask, i)));
+			const Hotkey* hotkey = hotkeys ? hotkeys[i] : nullptr;
+			list.emplace_back(new DropDownListStringItem(strings[i], i, HasBit(disabled_mask, i), hotkey));
 		}
 	}
 

--- a/src/widgets/dropdown_func.h
+++ b/src/widgets/dropdown_func.h
@@ -11,9 +11,10 @@
 #define WIDGETS_DROPDOWN_FUNC_H
 
 #include "../window_gui.h"
+#include "hotkeys.h"
 
 /* Show drop down menu containing a fixed list of strings */
-void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32 disabled_mask, uint32 hidden_mask, uint width = 0);
+void ShowDropDownMenu(Window *w, const StringID *strings, int selected, int button, uint32 disabled_mask, uint32 hidden_mask, uint width = 0, const Hotkey* hotkey[] = nullptr);
 
 /* Hide drop down menu of a parent window */
 int HideDropDownMenu(Window *pw);

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -12,6 +12,7 @@
 
 #include "../window_type.h"
 #include "../gfx_func.h"
+#include "../hotkeys.h"
 #include "../core/smallvec_type.hpp"
 #include "table/strings.h"
 
@@ -39,13 +40,16 @@ public:
 class DropDownListStringItem : public DropDownListItem {
 public:
 	StringID string; ///< String ID of item
+	const Hotkey *hotkey; ///< Hotkey of the item
 
-	DropDownListStringItem(StringID string, int result, bool masked) : DropDownListItem(result, masked), string(string) {}
+	DropDownListStringItem(StringID string, int result, bool masked, const Hotkey* hotkey = nullptr)
+		: DropDownListItem(result, masked), string(string), hotkey(hotkey)  {}
 
 	bool Selectable() const override { return true; }
 	uint Width() const override;
 	void Draw(int left, int right, int top, int bottom, bool sel, Colours bg_colour) const override;
 	virtual StringID String() const { return this->string; }
+	void SetHotkey(const Hotkey* hotkey) { this->hotkey = hotkey;  }
 
 	static bool NatSortFunc(std::unique_ptr<const DropDownListItem> const &first, std::unique_ptr<const DropDownListItem> const &second);
 };

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -104,7 +104,7 @@ std::string _windows_file;
 /** Window description constructor. */
 WindowDesc::WindowDesc(WindowPosition def_pos, const char *ini_key, int16 def_width_trad, int16 def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32 flags,
-			const NWidgetPart *nwid_parts, int16 nwid_length, HotkeyList *hotkeys) :
+			const NWidgetPart *nwid_parts, int16 nwid_length, const HotkeyList *hotkeys) :
 	default_pos(def_pos),
 	cls(window_class),
 	parent_cls(parent_class),
@@ -808,7 +808,7 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 	if (_settings_client.gui.right_mouse_wnd_close && w->nested_root->GetWidgetOfType(WWT_CLOSEBOX)) {
 		w->Close();
 	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->tool_tip != 0) {
-		GuiShowTooltips(w, wid->tool_tip, 0, nullptr, TCC_RIGHT_CLICK);
+		GuiShowTooltips(w, wid->tool_tip, 0, nullptr, TCC_RIGHT_CLICK, wid->hotkey);
 	}
 }
 
@@ -829,7 +829,7 @@ static void DispatchHoverEvent(Window *w, int x, int y)
 
 	/* Show the tooltip if there is any */
 	if (!w->OnTooltip(pt, wid->index, TCC_HOVER) && wid->tool_tip != 0) {
-		GuiShowTooltips(w, wid->tool_tip);
+		GuiShowTooltips(w, wid->tool_tip, 0, nullptr, TCC_HOVER, wid->hotkey);
 		return;
 	}
 
@@ -1790,6 +1790,20 @@ void Window::InitNested(WindowNumber window_number)
 {
 	this->CreateNestedTree(false);
 	this->FinishInitNested(window_number);
+}
+
+/**
+ * Associates hotkeys with the widgets simply by looking at the order in which they were added.
+ */
+void Window::AssociateHotkeysByWidgetIndex(WindowDesc* desc)
+{
+	for (uint index = 0; index < this->nested_array_size; ++index) {
+		auto* widget = this->GetWidget<NWidgetBase>(index);
+		if (widget) {
+			auto* widget_core = dynamic_cast<NWidgetCore*>(widget);
+			if (widget_core) widget_core->hotkey = desc->hotkeys->GetHotkeyByNum(index);
+		}
+	}
 }
 
 /**

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -20,6 +20,7 @@
 #include "core/smallvec_type.hpp"
 #include "core/smallmap_type.hpp"
 #include "string_type.h"
+#include "hotkeys.h"
 
 /**
  * Flags to describe the look of the frame
@@ -169,7 +170,7 @@ struct WindowDesc : ZeroedMemoryAllocator {
 
 	WindowDesc(WindowPosition default_pos, const char *ini_key, int16 def_width_trad, int16 def_height_trad,
 			WindowClass window_class, WindowClass parent_class, uint32 flags,
-			const NWidgetPart *nwid_parts, int16 nwid_length, HotkeyList *hotkeys = nullptr);
+			const NWidgetPart *nwid_parts, int16 nwid_length, const HotkeyList *hotkeys = nullptr);
 
 	~WindowDesc();
 
@@ -180,7 +181,7 @@ struct WindowDesc : ZeroedMemoryAllocator {
 	uint32 flags;                  ///< Flags. @see WindowDefaultFlag
 	const NWidgetPart *nwid_parts; ///< Nested widget parts describing the window.
 	int16 nwid_length;             ///< Length of the #nwid_parts array.
-	HotkeyList *hotkeys;           ///< Hotkeys for the window.
+	const HotkeyList *hotkeys;     ///< Hotkeys for the window.
 
 	bool pref_sticky;              ///< Preferred stickyness.
 	int16 pref_width;              ///< User-preferred width of the window. Zero if unset.
@@ -353,6 +354,8 @@ public:
 	void InitNested(WindowNumber number = 0);
 	void CreateNestedTree(bool fill_nested = true);
 	void FinishInitNested(WindowNumber window_number = 0);
+
+	void AssociateHotkeysByWidgetIndex(WindowDesc *desc);
 
 	/**
 	 * Set the timeout flag of the window and initiate the timer.
@@ -946,7 +949,7 @@ Wcls *AllocateWindowDescFront(WindowDesc *desc, int window_number, bool return_e
 
 void RelocateAllWindows(int neww, int newh);
 
-void GuiShowTooltips(Window *parent, StringID str, uint paramcount = 0, const uint64 params[] = nullptr, TooltipCloseCondition close_tooltip = TCC_HOVER);
+void GuiShowTooltips(Window *parent, StringID str, uint paramcount = 0, const uint64 params[] = nullptr, TooltipCloseCondition close_tooltip = TCC_HOVER, const Hotkey* hotkey = nullptr);
 
 /* widget.cpp */
 int GetWidgetFromPos(const Window *w, int x, int y);


### PR DESCRIPTION
## Motivation / Problem

OpenTTD is full of useful hotkeys, but these are never shown to the user. Having these hotkeys visible makes it much easier to learn about them.

## Description

![image](https://user-images.githubusercontent.com/68320206/144748228-fc955019-3d7e-4325-acf8-203595c845dc.png)
Tooltips

![image](https://user-images.githubusercontent.com/68320206/144748236-9bb5b213-35b1-4810-a00f-c3f07daf7491.png)
Dropdown menu's

The hotkeys have been added to:
- Main toolbar
- Dropdowns of main toolbar
- Transparancy window
- Order window
- All other toolbars that have hotkeys: rail toolbar, road toolbar, etc
- Scenario editor
- Probably some other places that I forgot...

## Limitations

- The widget system and the hotkey system are completely independent, and making an association between the two was much harder than I anticipated. I eventually got things working but the solution feels a little convoluted in certain areas. If anyone has ideas for a more straightforward solution, feel free to start the discussion.
- I had to use some platform specific voodoo to fetch the character of the "toggle console" hotkey, `~ on a US keyboard. Since I only have access to a Windows machine, I could not write an implementation for other platforms (at least not one I can test).
- For some hotkeys the text becomes a little ambigious, see the image below. Which hotkey does F3 refer to? I might be able to solve this with a string control command and parameters, but I haven't gone down that rabbit hole just yet.

![image](https://user-images.githubusercontent.com/68320206/144748300-68cfbe3d-2a49-46fa-874d-c8ca5d1d009e.png)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
