### PR TITLE
Codechange: do not use all upper case enumerators in a scoped enum

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1324,10 +1324,10 @@ protected:
 	static CargoID produced_cargo_filter;
 
 	enum class SorterType : uint8 {
-		IDW_SORT_BY_NAME,                       ///< Sorter type to sort by name
-		IDW_SORT_BY_TYPE,                       ///< Sorter type to sort by type
-		IDW_SORT_BY_PRODUCTION,                 ///< Sorter type to sort by production amount
-		IDW_SORT_BY_TRANSPORTED,                ///< Sorter type to sort by transported percentage
+		ByName,        ///< Sorter type to sort by name
+		ByType,        ///< Sorter type to sort by type
+		ByProduction,  ///< Sorter type to sort by production amount
+		ByTransported, ///< Sorter type to sort by transported percentage
 	};
 
 	/**
@@ -1552,9 +1552,9 @@ protected:
 		}
 
 		switch (static_cast<IndustryDirectoryWindow::SorterType>(this->industries.SortType())) {
-			case IndustryDirectoryWindow::SorterType::IDW_SORT_BY_NAME:
-			case IndustryDirectoryWindow::SorterType::IDW_SORT_BY_TYPE:
-			case IndustryDirectoryWindow::SorterType::IDW_SORT_BY_PRODUCTION:
+			case IndustryDirectoryWindow::SorterType::ByName:
+			case IndustryDirectoryWindow::SorterType::ByType:
+			case IndustryDirectoryWindow::SorterType::ByProduction:
 				/* Sort by descending production, then descending transported */
 				std::sort(cargos.begin(), cargos.end(), [](const CargoInfo &a, const CargoInfo &b) {
 					if (a.production != b.production) return a.production > b.production;
@@ -1562,7 +1562,7 @@ protected:
 				});
 				break;
 
-			case IndustryDirectoryWindow::SorterType::IDW_SORT_BY_TRANSPORTED:
+			case IndustryDirectoryWindow::SorterType::ByTransported:
 				/* Sort by descending transported, then descending production */
 				std::sort(cargos.begin(), cargos.end(), [](const CargoInfo &a, const CargoInfo &b) {
 					if (a.transported != b.transported) return a.transported > b.transported;

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -78,15 +78,15 @@ private:
 	 * lock on the game-state.
 	 */
 	enum class Status {
-		INIT,       ///< TCPConnecter is created but resolving hasn't started.
-		RESOLVING,  ///< The hostname is being resolved (threaded).
-		FAILURE,    ///< Resolving failed.
-		CONNECTING, ///< We are currently connecting.
-		CONNECTED,  ///< The connection is established.
+		Init,       ///< TCPConnecter is created but resolving hasn't started.
+		Resolving,  ///< The hostname is being resolved (threaded).
+		Failure,    ///< Resolving failed.
+		Connecting, ///< We are currently connecting.
+		Connected,  ///< The connection is established.
 	};
 
 	std::thread resolve_thread;                         ///< Thread used during resolving.
-	std::atomic<Status> status = Status::INIT;          ///< The current status of the connecter.
+	std::atomic<Status> status = Status::Init;          ///< The current status of the connecter.
 	std::atomic<bool> killed = false;                   ///< Whether this connecter is marked as killed.
 
 	addrinfo *ai = nullptr;                             ///< getaddrinfo() allocated linked-list of resolved addresses.

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -52,7 +52,7 @@ TCPServerConnecter::TCPServerConnecter(const std::string &connection_string, uin
 			break;
 
 		case SERVER_ADDRESS_INVITE_CODE:
-			this->status = Status::CONNECTING;
+			this->status = Status::Connecting;
 			_network_coordinator_client.ConnectToServer(this->server_address.connection_string, this);
 			break;
 
@@ -254,14 +254,14 @@ void TCPConnecter::Resolve()
 
 	if (error != 0) {
 		Debug(net, 0, "Failed to resolve DNS for {}", this->connection_string);
-		this->status = Status::FAILURE;
+		this->status = Status::Failure;
 		return;
 	}
 
 	this->ai = ai;
 	this->OnResolved(ai);
 
-	this->status = Status::CONNECTING;
+	this->status = Status::Connecting;
 }
 
 /**
@@ -281,11 +281,11 @@ bool TCPConnecter::CheckActivity()
 	if (this->killed) return true;
 
 	switch (this->status) {
-		case Status::INIT:
+		case Status::Init:
 			/* Start the thread delayed, so the vtable is loaded. This allows classes
 			 * to overload functions used by Resolve() (in case threading is disabled). */
 			if (StartNewThread(&this->resolve_thread, "ottd:resolve", &TCPConnecter::ResolveThunk, this)) {
-				this->status = Status::RESOLVING;
+				this->status = Status::Resolving;
 				return false;
 			}
 
@@ -296,18 +296,18 @@ bool TCPConnecter::CheckActivity()
 			 * connection. The rest of this function handles exactly that. */
 			break;
 
-		case Status::RESOLVING:
+		case Status::Resolving:
 			/* Wait till Resolve() comes back with an answer (in case it runs threaded). */
 			return false;
 
-		case Status::FAILURE:
+		case Status::Failure:
 			/* Ensure the OnFailure() is called from the game-thread instead of the
 			 * resolve-thread, as otherwise we can get into some threading issues. */
 			this->OnFailure();
 			return true;
 
-		case Status::CONNECTING:
-		case Status::CONNECTED:
+		case Status::Connecting:
+		case Status::Connected:
 			break;
 	}
 
@@ -403,7 +403,7 @@ bool TCPConnecter::CheckActivity()
 	}
 
 	this->OnConnect(connected_socket);
-	this->status = Status::CONNECTED;
+	this->status = Status::Connected;
 	return true;
 }
 
@@ -422,11 +422,11 @@ bool TCPServerConnecter::CheckActivity()
 		case SERVER_ADDRESS_INVITE_CODE:
 			/* Check if a result has come in. */
 			switch (this->status) {
-				case Status::FAILURE:
+				case Status::Failure:
 					this->OnFailure();
 					return true;
 
-				case Status::CONNECTED:
+				case Status::Connected:
 					this->OnConnect(this->socket);
 					return true;
 
@@ -451,7 +451,7 @@ void TCPServerConnecter::SetConnected(SOCKET sock)
 	assert(sock != INVALID_SOCKET);
 
 	this->socket = sock;
-	this->status = Status::CONNECTED;
+	this->status = Status::Connected;
 }
 
 /**
@@ -459,7 +459,7 @@ void TCPServerConnecter::SetConnected(SOCKET sock)
  */
 void TCPServerConnecter::SetFailure()
 {
-	this->status = Status::FAILURE;
+	this->status = Status::Failure;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Inconsistency in the way of writing of enumerators for scoped enums.


## Description

Consensus in [#9725](https://github.com/OpenTTD/OpenTTD/pull/9725#discussion_r762459739) seemed to be that for scoped enums we should not use all uppercase but rather CamelCase.


## Limitations

Deviates from the coding style in https://wiki.openttd.org/en/Development/Coding%20style. But that's where https://github.com/OpenTTD/wiki-data/pull/15 is for.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
