### PR TITLE
Copy server invite code to the clipboard automatically

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2346,6 +2346,7 @@ STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE                      :{BLACK}Invite c
 STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE_TOOLTIP              :{BLACK}Invite code other players can use to join this server
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE                  :{BLACK}Connection type
 STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TOOLTIP          :{BLACK}Whether and how your server can be reached by others
+STR_NETWORK_CLIENT_LIST_SERVER_COPY_TO_CLIPBOARD                :{BLACK}Copy to clipboard
 STR_NETWORK_CLIENT_LIST_PLAYER                                  :{BLACK}Player
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME                             :{BLACK}Name
 STR_NETWORK_CLIENT_LIST_PLAYER_NAME_TOOLTIP                     :{BLACK}Your player name

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -13,7 +13,6 @@
 #include "../rev.h"
 #include "../settings_type.h"
 #include "../strings_func.h"
-#include "../video/video_driver.hpp"
 #include "../window_func.h"
 #include "../window_type.h"
 #include "network.h"
@@ -194,7 +193,6 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet *p)
 	 * and _settings_client.network.server_invite_code contains the one we will
 	 * attempt to re-use when registering again. */
 	_network_server_invite_code = _settings_client.network.server_invite_code;
-	VideoDriver::GetInstance()->SetClipboardContents(_network_server_invite_code);
 
 	SetWindowDirty(WC_CLIENT_LIST, 0);
 

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -13,6 +13,7 @@
 #include "../rev.h"
 #include "../settings_type.h"
 #include "../strings_func.h"
+#include "../video/video_driver.hpp"
 #include "../window_func.h"
 #include "../window_type.h"
 #include "network.h"
@@ -193,6 +194,7 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_REGISTER_ACK(Packet *p)
 	 * and _settings_client.network.server_invite_code contains the one we will
 	 * attempt to re-use when registering again. */
 	_network_server_invite_code = _settings_client.network.server_invite_code;
+	VideoDriver::GetInstance()->SetClipboardContents(_network_server_invite_code);
 
 	SetWindowDirty(WC_CLIENT_LIST, 0);
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -30,6 +30,7 @@
 #include "../company_func.h"
 #include "../command_func.h"
 #include "../core/geometry_func.hpp"
+#include "../video/video_driver.hpp"
 #include "../genworld.h"
 #include "../map_type.h"
 #include "../guitimer_func.h"
@@ -1320,6 +1321,10 @@ static const NWidgetPart _nested_client_list_widgets[] = {
 						NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_SERVER_INVITE_CODE), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_RAW_STRING, STR_NETWORK_CLIENT_LIST_SERVER_INVITE_CODE_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
 					EndContainer(),
 					NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
+						NWidget(NWID_SPACER), SetMinimalSize(10, 0), SetFill(1, 0), SetResize(1, 0),
+						NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_CL_SERVER_COPY_TO_CLIPBOARD), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_COPY_TO_CLIPBOARD, STR_NETWORK_CLIENT_LIST_SERVER_COPY_TO_CLIPBOARD),
+					EndContainer(),
+					NWidget(NWID_HORIZONTAL), SetPIP(0, 3, 0),
 						NWidget(WWT_TEXT, COLOUR_GREY), SetMinimalTextLines(1, 0), SetDataTip(STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE, STR_NULL),
 						NWidget(NWID_SPACER), SetMinimalSize(10, 0),
 						NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_SERVER_CONNECTION_TYPE), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetDataTip(STR_BLACK_STRING, STR_NETWORK_CLIENT_LIST_SERVER_CONNECTION_TYPE_TOOLTIP), SetAlignment(SA_VERT_CENTER | SA_RIGHT),
@@ -1797,6 +1802,10 @@ public:
 				this->query_widget = WID_CL_CLIENT_NAME_EDIT;
 				SetDParamStr(0, _settings_client.network.client_name);
 				ShowQueryString(STR_JUST_RAW_STRING, STR_NETWORK_CLIENT_LIST_PLAYER_NAME_QUERY_CAPTION, NETWORK_CLIENT_NAME_LENGTH, this, CS_ALPHANUMERAL, QSF_LEN_IN_CHARS);
+				break;
+
+			case WID_CL_SERVER_COPY_TO_CLIPBOARD:
+				VideoDriver::GetInstance()->SetClipboardContents(_network_server_invite_code);
 				break;
 
 			case WID_CL_SERVER_VISIBILITY:

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -588,6 +588,11 @@ void VideoDriver_SDL_Base::InputLoop()
 		(keys[SDL_SCANCODE_DOWN]  ? 8 : 0);
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
+
+	if (!this->set_clipboard_text.empty()) {
+		SDL_SetClipboardText(this->set_clipboard_text.c_str());
+		this->set_clipboard_text = "";
+	}
 }
 
 void VideoDriver_SDL_Base::LoopOnce()

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -194,6 +194,14 @@ public:
 	void GameLoopPause();
 
 	/**
+	 * Set clipboard contents, the video thread will call the OS clipboard API
+	 */
+	void SetClipboardContents(const std::string &text)
+	{
+		this->set_clipboard_text = text;
+	}
+
+	/**
 	 * Get the currently active instance of the video driver.
 	 */
 	static VideoDriver *GetInstance() {
@@ -344,6 +352,7 @@ protected:
 
 	bool fast_forward_key_pressed; ///< The fast-forward key is being pressed.
 	bool fast_forward_via_key; ///< The fast-forward was enabled by key press.
+	std::string set_clipboard_text; ///< New clipboard contents to set
 
 	bool is_game_threaded;
 	std::thread game_thread;

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -83,6 +83,7 @@ enum ClientListWidgets {
 	WID_CL_SERVER_NAME_EDIT,           ///< Edit button for server name.
 	WID_CL_SERVER_VISIBILITY,          ///< Server visibility.
 	WID_CL_SERVER_INVITE_CODE,         ///< Invite code for this server.
+	WID_CL_SERVER_COPY_TO_CLIPBOARD,   ///< Copy invite code to clipboard.
 	WID_CL_SERVER_CONNECTION_TYPE,     ///< The type of connection the Game Coordinator detected for this server.
 	WID_CL_CLIENT_NAME,                ///< Client name.
 	WID_CL_CLIENT_NAME_EDIT,           ///< Edit button for client name.


### PR DESCRIPTION
## Motivation / Problem
When you create a server, you need to type the server invite code into email/chat letter by letter to send it to friends.

## Description
With this patch, the invite code is copied to the clipboard automatically when the server registers with the masterserver.

## Limitations
I am too lazy to add 'Copy to clipboard' button to the server info dialog, this is good enough for me.
This code works only with SDL2, other video backends will ignore the clipboard for now.

## Checklist for review

