### PR TITLE
Fix #9740: Fix loading of gamelog change items from savegame ver >= 294

### DIFF
--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -328,6 +328,7 @@ public:
 
 		size_t length = SlGetStructListLength(UINT32_MAX);
 		la->change = ReallocT(la->change, length);
+		la->changes = (uint32)length;
 
 		for (size_t i = 0; i < length; i++) {
 			LoggedChange *lc = &la->change[i];


### PR DESCRIPTION
## Motivation / Problem

Fix #9740


## Description

See #9740 for description of problem


## Limitations

N/A


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
