### PR TITLE
Fix: if vehicles only refit to cargo-slots >= 32, the default cargo was wrong.

### DIFF
--- a/src/core/bitmath_func.cpp
+++ b/src/core/bitmath_func.cpp
@@ -24,7 +24,7 @@ const uint8 _ffb_64[64] = {
 };
 
 /**
- * Search the first set bit in a 32 bit variable.
+ * Search the first set bit in a 64 bit variable.
  *
  * This algorithm is a static implementation of a log
  * congruence search algorithm. It checks the first half
@@ -34,7 +34,7 @@ const uint8 _ffb_64[64] = {
  * @param x The value to search
  * @return The position of the first bit set
  */
-uint8 FindFirstBit(uint32 x)
+uint8 FindFirstBit(uint64 x)
 {
 	if (x == 0) return 0;
 	/* The macro FIND_FIRST_BIT is better to use when your x is
@@ -42,11 +42,12 @@ uint8 FindFirstBit(uint32 x)
 
 	uint8 pos = 0;
 
-	if ((x & 0x0000ffff) == 0) { x >>= 16; pos += 16; }
-	if ((x & 0x000000ff) == 0) { x >>= 8;  pos += 8;  }
-	if ((x & 0x0000000f) == 0) { x >>= 4;  pos += 4;  }
-	if ((x & 0x00000003) == 0) { x >>= 2;  pos += 2;  }
-	if ((x & 0x00000001) == 0) { pos += 1; }
+	if ((x & 0xffffffffULL) == 0) { x >>= 32; pos += 32; }
+	if ((x & 0x0000ffffULL) == 0) { x >>= 16; pos += 16; }
+	if ((x & 0x000000ffULL) == 0) { x >>= 8;  pos += 8;  }
+	if ((x & 0x0000000fULL) == 0) { x >>= 4;  pos += 4;  }
+	if ((x & 0x00000003ULL) == 0) { x >>= 2;  pos += 2;  }
+	if ((x & 0x00000001ULL) == 0) { pos += 1; }
 
 	return pos;
 }

--- a/src/core/bitmath_func.hpp
+++ b/src/core/bitmath_func.hpp
@@ -222,7 +222,7 @@ static inline uint8 FindFirstBit2x64(const int value)
 	}
 }
 
-uint8 FindFirstBit(uint32 x);
+uint8 FindFirstBit(uint64 x);
 uint8 FindLastBit(uint64 x);
 
 /**


### PR DESCRIPTION
## Motivation / Problem

If vehicles are only refittable to cargo-slots >= 32, their default cargo would say "passengers".

## Description

In this case the default cargo uses the first refittable-cargo.
The refit-mask is a uint64, but FindFirstBit truncated that to uint32.
Apprently if "no bit is set", FindFirstBit returns 0 (= passengers), instead of asserting.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
