### PR TITLE
Cleanup #9725: Clean up Doxygen docs and fix typo.

### DIFF
--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -659,7 +659,6 @@ static void SetGroupFlag(Group *g, GroupFlags flag, bool set, bool children)
 /**
  * (Un)set group flag from a group
  * @param flags type of operation
- * @param tile unused
  * @param group_id index of group array
  * @param flag flag to set, by value not bit.
  * @param value value to set the flag to.

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -729,7 +729,6 @@ uint GetOrderDistance(const Order *prev, const Order *cur, const Vehicle *v, int
 /**
  * Add an order to the orderlist of a vehicle.
  * @param flags operation to perform
- * @param p1 various bitstuffed elements
  * @param veh ID of the vehicle
  * @param sel_ord the selected order (if any). If the last order is given,
  *                        the order will be inserted before that one

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -958,7 +958,6 @@ CommandCost CmdRemoveRailroadTrack(DoCommandFlag flags, TileIndex tile, TileInde
  * @param tile position of the train depot
  * @param railtype rail type
  * @param dir entrance direction
- * @param text unused
  * @return the cost of this operation or an error
  *
  * @todo When checking for the tile slope,

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -2782,12 +2782,9 @@ const CargoSpec *FindFirstCargoWithTownEffect(TownEffect effect)
 /**
  * Change the cargo goal of a town.
  * @param flags Type of operation.
- * @param tile Unused.
- * @param p1 various bitstuffed elements
  * @param town_id Town ID to cargo game of.
  * @param te TownEffect to change the game of.
  * @param goal The new goal value.
- * @param text Unused.
  * @return Empty cost or an error.
  */
 CommandCost CmdTownCargoGoal(DoCommandFlag flags, TownID town_id, TownEffect te, uint32 goal)

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -198,11 +198,10 @@ std::tuple<CommandCost, VehicleID, uint, uint16> CmdBuildVehicle(DoCommandFlag f
 /**
  * Sell a vehicle.
  * @param flags for command.
- * @aram v_id vehicle ID being sold.
+ * @param v_id vehicle ID being sold.
  * @param sell_chain sell the vehicle and all vehicles following it in the chain.
  * @param backup_order make a backup of the vehicle's order (if an engine).
  * @param client_id User.
- * @param text unused.
  * @return the cost of this operation or an error.
  */
 CommandCost CmdSellVehicle(DoCommandFlag flags, VehicleID v_id, bool sell_chain, bool backup_order, ClientID client_id)


### PR DESCRIPTION
## Motivation / Problem
There are leftovers of some parameters and a typo in doc.

## Limitations
Please, don't forget to review commit message. 
