### PR TITLE
Change: [Admin] Bump admin port protocol due to command changes.

### DIFF
--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -47,7 +47,7 @@ static const uint16 UDP_MTU                         = 1460;           ///< Numbe
 static const uint16 TCP_MTU                         = 32767;          ///< Number of bytes we can pack in a single TCP packet
 static const uint16 COMPAT_MTU                      = 1460;           ///< Number of bytes we can pack in a single packet for backward compatibility
 
-static const byte NETWORK_GAME_ADMIN_VERSION        =    1;           ///< What version of the admin network do we use?
+static const byte NETWORK_GAME_ADMIN_VERSION        =    2;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
 static const byte NETWORK_COMPANY_INFO_VERSION      =    6;           ///< What version of company info is this?
 static const byte NETWORK_COORDINATOR_VERSION       =    6;           ///< What version of game-coordinator-protocol do we use?

--- a/src/network/core/tcp_admin.h
+++ b/src/network/core/tcp_admin.h
@@ -56,10 +56,11 @@ enum PacketAdminType {
 	ADMIN_PACKET_SERVER_RCON,            ///< The server's reply to a remove console command.
 	ADMIN_PACKET_SERVER_CONSOLE,         ///< The server gives the admin the data that got printed to its console.
 	ADMIN_PACKET_SERVER_CMD_NAMES,       ///< The server sends out the names of the DoCommands to the admins.
-	ADMIN_PACKET_SERVER_CMD_LOGGING,     ///< The server gives the admin copies of incoming command packets.
+	ADMIN_PACKET_SERVER_CMD_LOGGING_OLD, ///< Used to be the type ID of \c ADMIN_PACKET_SERVER_CMD_LOGGING in \c NETWORK_GAME_ADMIN_VERSION 1.
 	ADMIN_PACKET_SERVER_GAMESCRIPT,      ///< The server gives the admin information from the GameScript in JSON.
 	ADMIN_PACKET_SERVER_RCON_END,        ///< The server indicates that the remote console command has completed.
 	ADMIN_PACKET_SERVER_PONG,            ///< The server replies to a ping request from the admin.
+	ADMIN_PACKET_SERVER_CMD_LOGGING,     ///< The server gives the admin copies of incoming command packets.
 
 	INVALID_ADMIN_PACKET = 0xFF,         ///< An invalid marker for admin packets.
 };


### PR DESCRIPTION
## Motivation / Problem

```
docs/admin_network.md promised that information in an admin packet
is never removed. It does allow the possibility of using a new packet type
for changed data in combination with a bump of the admin port version.

As the recent command handling changes modified the contents of
ADMIN_PACKET_SERVER_CMD_LOGGING, do exactly that.
```


## Description / Limitations

Contents of `ADMIN_PACKET_SERVER_CMD_LOGGING` was changed in an incompatible way.  Bumping admin port protocol version is the least to indicate that format change.
One can probably argue whether the changed enum value of the packet is really needed given that admin_network.md has a special comment about the command logging packet.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
