### PR TITLE
Fix #9756: Network command unpack proc was not generated in all cases.

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -409,12 +409,14 @@ template <typename T> struct CommandFunctionTraitHelper;
 template <typename... Targs>
 struct CommandFunctionTraitHelper<CommandCost(*)(DoCommandFlag, Targs...)> {
 	using Args = std::tuple<std::decay_t<Targs>...>;
+	using RetTypes = void;
 	using CbArgs = Args;
 	using CbProcType = void(*)(Commands, const CommandCost &);
 };
 template <template <typename...> typename Tret, typename... Tretargs, typename... Targs>
 struct CommandFunctionTraitHelper<Tret<CommandCost, Tretargs...>(*)(DoCommandFlag, Targs...)> {
 	using Args = std::tuple<std::decay_t<Targs>...>;
+	using RetTypes = std::tuple<std::decay_t<Tretargs>...>;
 	using CbArgs = std::tuple<std::decay_t<Tretargs>..., std::decay_t<Targs>...>;
 	using CbProcType = void(*)(Commands, const CommandCost &, Tretargs...);
 };
@@ -426,6 +428,7 @@ template <Commands Tcmd> struct CommandTraits;
 	template<> struct CommandTraits<cmd_> { \
 		using ProcType = decltype(&proc_); \
 		using Args = typename CommandFunctionTraitHelper<ProcType>::Args; \
+		using RetTypes = typename CommandFunctionTraitHelper<ProcType>::RetTypes; \
 		using CbArgs = typename CommandFunctionTraitHelper<ProcType>::CbArgs; \
 		using RetCallbackProc = typename CommandFunctionTraitHelper<ProcType>::CbProcType; \
 		static constexpr Commands cmd = cmd_; \

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -136,7 +136,10 @@ constexpr UnpackNetworkCommandProc MakeUnpackNetworkCommandCallback() noexcept
 {
 	/* Check if the callback matches with the command arguments. If not, don't generate an Unpack proc. */
 	using Tcallback = std::tuple_element_t<Tcb, decltype(_callback_tuple)>;
-	if constexpr (std::is_same_v<Tcallback, CommandCallback * const> || std::is_same_v<Tcallback, CommandCallbackData * const> || std::is_same_v<typename CommandTraits<Tcmd>::CbArgs, typename CallbackArgsHelper<Tcallback>::Args>) {
+	if constexpr (std::is_same_v<Tcallback, CommandCallback * const> || // Callback type is CommandCallback.
+			std::is_same_v<Tcallback, CommandCallbackData * const> || // Callback type is CommandCallbackData.
+			std::is_same_v<typename CommandTraits<Tcmd>::CbArgs, typename CallbackArgsHelper<Tcallback>::Args> || // Callback proc takes all command return values and parameters.
+			(!std::is_void_v<typename CommandTraits<Tcmd>::RetTypes> && std::is_same_v<typename CallbackArgsHelper<typename CommandTraits<Tcmd>::RetCallbackProc const>::Args, typename CallbackArgsHelper<Tcallback>::Args>)) { // Callback return is more than CommandCost and the proc takes all return values.
 		return &UnpackNetworkCommand<Tcmd, Tcb>;
 	} else {
 		return nullptr;


### PR DESCRIPTION
## Motivation / Problem

Fixes #9756 


## Description

The network command unpack function was not generated for the case when the command has additional return values and the callback proc takes all of them but none of the command parameters.

This is only directly visible as an assert on server-generated commands as commands incoming from the network would have the command be rejected due to an "invalid" callback.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
