### PR TITLE
Feature: [Linkgraph] Show a tooltip with statistics when hovering a link

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2617,6 +2617,11 @@ STR_LINKGRAPH_LEGEND_UNUSED                                     :{TINY_FONT}{BLA
 STR_LINKGRAPH_LEGEND_SATURATED                                  :{TINY_FONT}{BLACK}saturated
 STR_LINKGRAPH_LEGEND_OVERLOADED                                 :{TINY_FONT}{BLACK}overloaded
 
+# Linkgraph tooltip
+STR_LINKGRAPH_STATS_TOOLTIP                                     :{BLACK}{CARGO_LONG} to be transported per month from {STATION} to {STATION} ({COMMA}% of capacity){RAW_STRING}
+STR_LINKGRAPH_STATS_TOOLTIP_RETURN_EXTENSION                    :{}{CARGO_LONG} to be transported back ({COMMA}% of capacity)
+STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION                      :{}Average travel time: {NUM}{NBSP}day{P "" s}
+
 # Base for station construction window(s)
 STR_STATION_BUILD_COVERAGE_AREA_TITLE                           :{BLACK}Coverage area highlight
 STR_STATION_BUILD_COVERAGE_OFF                                  :{BLACK}Off

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -435,6 +435,12 @@ struct MainWindow : Window
 		}
 	}
 
+	bool OnTooltip(Point pt, int widget, TooltipCloseCondition close_cond) override
+	{
+		if (widget != WID_M_VIEWPORT) return false;
+		return this->viewport->overlay->ShowTooltip(pt, close_cond);
+	}
+
 	/**
 	 * Some data on this window has become invalid.
 	 * @param data Information about the changed data.

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -673,7 +673,7 @@ struct TooltipsWindow : public Window
 {
 	StringID string_id;               ///< String to display as tooltip.
 	byte paramcount;                  ///< Number of string parameters in #string_id.
-	uint64 params[5];                 ///< The string parameters.
+	uint64 params[8];                 ///< The string parameters.
 	TooltipCloseCondition close_cond; ///< Condition for closing the window.
 
 	TooltipsWindow(Window *parent, StringID str, uint paramcount, const uint64 params[], TooltipCloseCondition close_tooltip) : Window(&_tool_tips_desc)
@@ -682,6 +682,10 @@ struct TooltipsWindow : public Window
 		this->string_id = str;
 		static_assert(sizeof(this->params[0]) == sizeof(params[0]));
 		assert(paramcount <= lengthof(this->params));
+		if (params == nullptr) {
+			_global_string_params.offset = 0;
+			params = _global_string_params.GetDataPointer();
+		}
 		if (paramcount > 0) memcpy(this->params, params, sizeof(this->params[0]) * paramcount);
 		this->paramcount = paramcount;
 		this->close_cond = close_tooltip;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2882,27 +2882,25 @@ static void MouseLoop(MouseClick click, int mousewheel)
 		}
 	}
 
-	if (vp == nullptr || (w->flags & WF_DISABLE_VP_SCROLL)) {
-		switch (click) {
-			case MC_LEFT:
-			case MC_DOUBLE_LEFT:
-				DispatchLeftClickEvent(w, x - w->left, y - w->top, click == MC_DOUBLE_LEFT ? 2 : 1);
-				return;
+	switch (click) {
+		case MC_LEFT:
+		case MC_DOUBLE_LEFT:
+			DispatchLeftClickEvent(w, x - w->left, y - w->top, click == MC_DOUBLE_LEFT ? 2 : 1);
+			return;
 
-			default:
-				if (!scrollwheel_scrolling || w == nullptr || w->window_class != WC_SMALLMAP) break;
-				/* We try to use the scrollwheel to scroll since we didn't touch any of the buttons.
-				 * Simulate a right button click so we can get started. */
-				FALLTHROUGH;
+		default:
+			if (!scrollwheel_scrolling || w == nullptr || w->window_class != WC_SMALLMAP) break;
+			/* We try to use the scrollwheel to scroll since we didn't touch any of the buttons.
+			 * Simulate a right button click so we can get started. */
+			FALLTHROUGH;
 
-			case MC_RIGHT:
-				DispatchRightClickEvent(w, x - w->left, y - w->top);
-				return;
+		case MC_RIGHT:
+			DispatchRightClickEvent(w, x - w->left, y - w->top);
+			return;
 
-			case MC_HOVER:
-				DispatchHoverEvent(w, x - w->left, y - w->top);
-				break;
-		}
+		case MC_HOVER:
+			DispatchHoverEvent(w, x - w->left, y - w->top);
+			break;
 	}
 
 	/* We're not doing anything with 2D scrolling, so reset the value.  */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2873,6 +2873,7 @@ static void MouseLoop(MouseClick click, int mousewheel)
 					_scrolling_viewport = true;
 					_cursor.fix_at = (_settings_client.gui.scroll_mode == VSM_VIEWPORT_RMB_FIXED ||
 							_settings_client.gui.scroll_mode == VSM_MAP_RMB_FIXED);
+					DispatchRightClickEvent(w, x - w->left, y - w->top);
 					return;
 				}
 				break;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2969,6 +2969,7 @@ void HandleMouseEvents()
 				click = MC_HOVER;
 				_input_events_this_tick++;
 				_mouse_hovering = true;
+				hover_time = std::chrono::steady_clock::now();
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

Cargodist considers many parameters to determine how cargo should be routed.
These parameters are not all exposed to the player:
the linkgraph overlay shows the saturation of links, but there is nothing
for the capacities, or for the travel times.

## Description

This PR shows a tooltip when a link of the overlay is hovered.
The tooltip contains the source and destination stations, the link capacity, its usage and its average travel time.
For bidirectional links, data are shown for both directions of travel.

I believe this could be useful for various reasons:
- The station names help differentiate close but distinct links, and clarify which color corresponds to each direction, mitigating #9167.
- The link usage is expressed as a percentage, which is more precise than the color code. It mitigates #9168 too.
- When e.g. adding a vehicle to a saturated route, it is interesting to see how the capacity of the link evolves.
- Travel times can help players update their timetables after replacing vehicles.
- It can help debugging linkgraph code (that was actually my motivation to write the first version of this patch a few months ago)

## Limitations

### Corner cases

- The tooltip is only shown if only one cargo type is selected. Showing information for all cargo types would need a huge tooltip.
- For the same reason, in case several links cross, the tooltip only shows information for one of them.
- As all cargo types are always shown in the minimap, it does not benefit from this feature.

### Limitations

I had to declare a C-like string as static because TooltipsWindow segfaults if its given string has a temporary RAW_STRING argument that does not outlive the TooltipsWindow.

A possible alternative would be to add a GetString call in the constructor of TooltipsWindow and store the resulting string once and for all in a buffer. This is how JGR's patch pack solves the same problem.

### Alternatives

A window would be more flexible than a tooltip, but it would raise many questions about its layout, etc.
I preferred to keep this PR relatively simple.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
