### PR TITLE
Change: add a timestamp in name of crash files

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -325,6 +325,25 @@ char *CrashLog::LogRecentNews(char *buffer, const char *last) const
 }
 
 /**
+ * Create a timestamped filename.
+ * @param filename      The begin where to write at.
+ * @param filename_last The last position in the buffer to write to.
+ * @param ext           The extension for the filename.
+ * @param with_dir      Whether to prepend the filename with the personal directory.
+ * @return the number of added characters.
+ */
+int CrashLog::CreateFileName(char *filename, const char *filename_last, const char *ext, bool with_dir) const
+{
+	static std::string crashname;
+
+	if (crashname.empty()) {
+		UTCTime::Format(filename, filename_last, "crash%Y%m%d%H%M%S");
+		crashname = filename;
+	}
+	return seprintf(filename, filename_last, "%s%s%s", with_dir ? _personal_dir.c_str() : "", crashname.c_str(), ext);
+}
+
+/**
  * Fill the crash log buffer with all data of a crash log.
  * @param buffer The begin where to write at.
  * @param last   The last position in the buffer to write to.
@@ -366,7 +385,7 @@ char *CrashLog::FillCrashLog(char *buffer, const char *last) const
  */
 bool CrashLog::WriteCrashLog(const char *buffer, char *filename, const char *filename_last) const
 {
-	seprintf(filename, filename_last, "%scrash.log", _personal_dir.c_str());
+	this->CreateFileName(filename, filename_last, ".log");
 
 	FILE *file = FioFOpenFile(filename, "w", NO_DIRECTORY);
 	if (file == nullptr) return false;
@@ -401,7 +420,7 @@ bool CrashLog::WriteSavegame(char *filename, const char *filename_last) const
 	try {
 		GamelogEmergency();
 
-		seprintf(filename, filename_last, "%scrash.sav", _personal_dir.c_str());
+		this->CreateFileName(filename, filename_last, ".sav");
 
 		/* Don't do a threaded saveload. */
 		return SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, NO_DIRECTORY, false) == SL_OK;
@@ -423,7 +442,9 @@ bool CrashLog::WriteScreenshot(char *filename, const char *filename_last) const
 	/* Don't draw when we have invalid screen size */
 	if (_screen.width < 1 || _screen.height < 1 || _screen.dst_ptr == nullptr) return false;
 
-	bool res = MakeScreenshot(SC_CRASHLOG, "crash");
+	this->CreateFileName(filename, filename_last, "", false);
+	bool res = MakeScreenshot(SC_CRASHLOG, filename);
+	filename[0] = '\0';
 	if (res) strecpy(filename, _full_screenshot_name, filename_last);
 	return res;
 }

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -85,6 +85,8 @@ protected:
 	char *LogGamelog(char *buffer, const char *last) const;
 	char *LogRecentNews(char *buffer, const char *list) const;
 
+	int CreateFileName(char *filename, const char *filename_last, const char *ext, bool with_dir = true) const;
+
 public:
 	/** Stub destructor to silence some compilers. */
 	virtual ~CrashLog() {}

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -186,7 +186,7 @@ public:
 			ret = false;
 		}
 
-		printf("Writing crash savegame...\n");
+		printf("Writing crash screenshot...\n");
 		if (!this->WriteScreenshot(filename_screenshot, lastof(filename_screenshot))) {
 			filename_screenshot[0] = '\0';
 			ret = false;

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -490,7 +490,7 @@ char *CrashLogWindows::AppendDecodedStacktrace(char *buffer, const char *last) c
 				CONST PMINIDUMP_CALLBACK_INFORMATION);
 		MiniDumpWriteDump_t funcMiniDumpWriteDump = dbghelp.GetProcAddress("MiniDumpWriteDump");
 		if (funcMiniDumpWriteDump != nullptr) {
-			seprintf(filename, filename_last, "%scrash.dmp", _personal_dir.c_str());
+			this->CreateFileName(filename, filename_last, ".dmp");
 			HANDLE file  = CreateFile(OTTD2FS(filename).c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, 0);
 			HANDLE proc  = GetCurrentProcess();
 			DWORD procid = GetCurrentProcessId();


### PR DESCRIPTION
## Motivation / Problem
When a crash happens, it overwrites previous crash files.
But different crash may happen before a player decides to open an issue, and they can have very different causes.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add a timestamp to the filenames, so newer crashes don't overwrite maybe useful data from previous crashes.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
