### PR TITLE
Fix/incorrect company values

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -69,7 +69,7 @@ that comes with vcpkg. After that, you can run something similar to this:
 ```powershell
 mkdir build
 cd build
-cmake.exe .. -G'Visual Studio 16 2019' -DCMAKE_TOOLCHAIN_FILE="<location of vcpkg>\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows-static"
+cmake.exe .. -G"Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE="<location of vcpkg>\vcpkg\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows-static"
 ```
 
 Change `<location of vcpkg>` to where you have installed vcpkg. After this

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -166,6 +166,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 };
 
 Money CalculateCompanyValue(const Company *c, bool including_loan = true);
+Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan = true);
 
 extern uint _next_competitor_start;
 extern uint _cur_company_tick_index;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -112,23 +112,47 @@ static PriceMultipliers _price_base_multiplier;
  */
 Money CalculateCompanyValue(const Company *c, bool including_loan)
 {
+	Money value = 0;
+
+	Money companyValues[8];
+
+	for (const Company* co : Company::Iterate()) {
+	  companyValues[co->index]	= CalculateCompanyValueExcludingShares(co);
+	}
+
+	for (const Company* co : Company::Iterate()) {
+
+		for (int i = 0; i < 4; i++)
+		{
+			if (co->share_owners[i] == c->index)
+			{
+				value += (companyValues[co->index] / 4);
+			}
+		}
+	}
+
+	return std::max<Money>(value + companyValues[c->index], 1);
+}
+
+Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan)
+{
 	Owner owner = c->index;
 
 	uint num = 0;
 
-	for (const Station *st : Station::Iterate()) {
+	for (const Station* st : Station::Iterate()) {
 		if (st->owner == owner) num += CountBits((byte)st->facilities);
 	}
 
 	Money value = num * _price[PR_STATION_VALUE] * 25;
 
-	for (const Vehicle *v : Vehicle::Iterate()) {
+	for (const Vehicle* v : Vehicle::Iterate()) {
 		if (v->owner != owner) continue;
 
 		if (v->type == VEH_TRAIN ||
-				v->type == VEH_ROAD ||
-				(v->type == VEH_AIRCRAFT && Aircraft::From(v)->IsNormalAircraft()) ||
-				v->type == VEH_SHIP) {
+			v->type == VEH_ROAD ||
+			(v->type == VEH_AIRCRAFT && Aircraft::From(v)->IsNormalAircraft()) ||
+			v->type == VEH_SHIP) {
 			value += v->value * 3 >> 1;
 		}
 	}

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -103,35 +103,32 @@ static PriceMultipliers _price_base_multiplier;
 
 /**
  * Calculate the value of the company. That is the value of all
- * assets (vehicles, stations, etc) and money minus the loan,
+ * assets (vehicles, stations, shares) and money minus the loan,
  * except when including_loan is \c false which is useful when
  * we want to calculate the value for bankruptcy.
- * @param c              the company to get the value of.
+ * @param c the company to get the value of.
  * @param including_loan include the loan in the company value.
  * @return the value of the company.
  */
 Money CalculateCompanyValue(const Company *c, bool including_loan)
 {
-	Money value = 0;
+	Money companyValue = 0;
 
-	Money companyValues[8];
+	Money companyValuesExcludingShares[MAX_COMPANIES];
 
 	for (const Company* co : Company::Iterate()) {
-	  companyValues[co->index]	= CalculateCompanyValueExcludingShares(co);
+	  companyValuesExcludingShares[co->index]	= CalculateCompanyValueExcludingShares(co);
 	}
 
 	for (const Company* co : Company::Iterate()) {
-
-		for (int i = 0; i < 4; i++)
-		{
-			if (co->share_owners[i] == c->index)
-			{
-				value += (companyValues[co->index] / 4);
+		for (int i = 0; i < 4; i++){
+			if (co->share_owners[i] == c->index) {
+				companyValue += (companyValuesExcludingShares[co->index] / 4);
 			}
 		}
 	}
 
-	return std::max<Money>(value + companyValues[c->index], 1);
+	return std::max<Money>(companyValue + companyValuesExcludingShares[c->index], 1);
 }
 
 Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan)
@@ -157,8 +154,10 @@ Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan
 		}
 	}
 
-	/* Add real money value */
 	if (including_loan) value -= c->current_loan;
+
+	/* Add real money value */
+
 	value += c->money;
 
 	return std::max<Money>(value, 1);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -116,7 +116,7 @@ Money CalculateCompanyValue(const Company *c, bool including_loan)
 
 	int sharesOwned = 0;
 
-	for (const Company* co : Company::Iterate()) {
+	for (const Company *co : Company::Iterate()) {
 
 		sharesOwned = 0;
 
@@ -141,13 +141,13 @@ Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan
 
 	uint num = 0;
 
-	for (const Station* st : Station::Iterate()) {
+	for (const Station *st : Station::Iterate()) {
 		if (st->owner == owner) num += CountBits((byte)st->facilities);
 	}
 
 	Money value = num * _price[PR_STATION_VALUE] * 25;
 
-	for (const Vehicle* v : Vehicle::Iterate()) {
+	for (const Vehicle *v : Vehicle::Iterate()) {
 		if (v->owner != owner) continue;
 
 		if (v->type == VEH_TRAIN ||

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -112,27 +112,26 @@ static PriceMultipliers _price_base_multiplier;
  */
 Money CalculateCompanyValue(const Company *c, bool including_loan)
 {
-	Money companySharesValue = 0;
+	Money owned_shares_value = 0;
 
-	int sharesOwned = 0;
+	uint shares_owned = 0;
 
 	for (const Company *co : Company::Iterate()) {
 
-		sharesOwned = 0;
+		shares_owned = 0;
 
 		for (int i = 0; i < 4; i++){
 			if (co->share_owners[i] == c->index) {
-				sharesOwned++;
+				shares_owned++;
 			}
 		}
 
-		if (sharesOwned > 0)
-		{
-			companySharesValue += (CalculateCompanyValueExcludingShares(co) / 4) * sharesOwned;
+		if (shares_owned > 0){
+			owned_shares_value += (CalculateCompanyValueExcludingShares(co) / 4) * shares_owned;
 		}
 	}
 	
-	return std::max<Money>(companySharesValue + CalculateCompanyValueExcludingShares(c), 1);
+	return std::max<Money>(owned_shares_value + CalculateCompanyValueExcludingShares(c), 1);
 }
 
 Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan)

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -114,13 +114,13 @@ Money CalculateCompanyValue(const Company *c, bool including_loan)
 {
 	Money owned_shares_value = 0;
 
-	uint shares_owned = 0;
+	uint8 shares_owned = 0;
 
 	for (const Company *co : Company::Iterate()) {
 
 		shares_owned = 0;
 
-		for (int i = 0; i < 4; i++){
+		for (uint8 i = 0; i < 4; i++){
 			if (co->share_owners[i] == c->index) {
 				shares_owned++;
 			}

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -117,7 +117,6 @@ Money CalculateCompanyValue(const Company *c, bool including_loan)
 	uint8 shares_owned = 0;
 
 	for (const Company *co : Company::Iterate()) {
-
 		shares_owned = 0;
 
 		for (uint8 i = 0; i < 4; i++){
@@ -150,9 +149,9 @@ Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan
 		if (v->owner != owner) continue;
 
 		if (v->type == VEH_TRAIN ||
-			v->type == VEH_ROAD ||
-			(v->type == VEH_AIRCRAFT && Aircraft::From(v)->IsNormalAircraft()) ||
-			v->type == VEH_SHIP) {
+				v->type == VEH_ROAD ||
+				(v->type == VEH_AIRCRAFT && Aircraft::From(v)->IsNormalAircraft()) ||
+				v->type == VEH_SHIP) {
 			value += v->value * 3 >> 1;
 		}
 	}
@@ -160,7 +159,6 @@ Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan
 	if (including_loan) value -= c->current_loan;
 
 	/* Add real money value */
-
 	value += c->money;
 
 	return std::max<Money>(value, 1);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -112,23 +112,27 @@ static PriceMultipliers _price_base_multiplier;
  */
 Money CalculateCompanyValue(const Company *c, bool including_loan)
 {
-	Money companyValue = 0;
+	Money companySharesValue = 0;
 
-	Money companyValuesExcludingShares[MAX_COMPANIES];
-
-	for (const Company* co : Company::Iterate()) {
-	  companyValuesExcludingShares[co->index]	= CalculateCompanyValueExcludingShares(co);
-	}
+	int sharesOwned = 0;
 
 	for (const Company* co : Company::Iterate()) {
+
+		sharesOwned = 0;
+
 		for (int i = 0; i < 4; i++){
 			if (co->share_owners[i] == c->index) {
-				companyValue += (companyValuesExcludingShares[co->index] / 4);
+				sharesOwned++;
 			}
 		}
-	}
 
-	return std::max<Money>(companyValue + companyValuesExcludingShares[c->index], 1);
+		if (sharesOwned > 0)
+		{
+			companySharesValue += (CalculateCompanyValueExcludingShares(co) / 4) * sharesOwned;
+		}
+	}
+	
+	return std::max<Money>(companySharesValue + CalculateCompanyValueExcludingShares(c), 1);
 }
 
 Money CalculateCompanyValueExcludingShares(const Company* c, bool including_loan)


### PR DESCRIPTION
## Motivation / Problem

Company value calculation is missing the value of the company's shares in other companies

Discussed as issue 1 below:

https://github.com/OpenTTD/OpenTTD/discussions/9765

I view this as a defect.

## Description

The problem is solved by first calculating all of the company values without including value of shares in other companies, then adding in the value of the shares which now is known. I do not think this causes issues with bankruptcy or buying/selling shares; it does affect those of course since they now use the new company values.

Note that when buying shares, the company value does not change, since instead of holding the cash it now holds the shares of an equivalent value. 

Note that when selling shares, the company value does not change, since instead of holding the shares it now holds cash of an equivalent value. 

## Limitations

I think this PR includes a commit that was already merged (the first commit), I'm not sure how to remove that from this PR. 

I haven't tested multiplayer, this works fine on saved games in single player.

I am not a C++ programmer so my change should be thoroughly reviewed. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
