### PR TITLE
Fix: Company values do not properly account for shares

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -167,6 +167,7 @@ struct Company : CompanyProperties, CompanyPool::PoolItem<&_company_pool> {
 };
 
 Money CalculateCompanyValue(const Company *c, bool including_loan = true);
+Money CalculateCompanyValueExcludingShares(const Company *c, bool including_loan = true);
 
 extern uint _next_competitor_start;
 extern uint _cur_company_tick_index;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -103,14 +103,33 @@ static PriceMultipliers _price_base_multiplier;
 
 /**
  * Calculate the value of the company. That is the value of all
- * assets (vehicles, stations, etc) and money minus the loan,
+ * assets (vehicles, stations, shares) and money minus the loan,
  * except when including_loan is \c false which is useful when
  * we want to calculate the value for bankruptcy.
- * @param c              the company to get the value of.
+ * @param c the company to get the value of.
  * @param including_loan include the loan in the company value.
  * @return the value of the company.
  */
 Money CalculateCompanyValue(const Company *c, bool including_loan)
+{
+	Money owned_shares_value = 0;
+
+	for (const Company *co : Company::Iterate()) {
+		uint8 shares_owned = 0;
+
+		for (uint8 i = 0; i < 4; i++) {
+			if (co->share_owners[i] == c->index) {
+				shares_owned++;
+			}
+		}
+
+		owned_shares_value += (CalculateCompanyValueExcludingShares(co) / 4) * shares_owned;
+	}
+
+	return std::max<Money>(owned_shares_value + CalculateCompanyValueExcludingShares(c), 1);
+}
+
+Money CalculateCompanyValueExcludingShares(const Company *c, bool including_loan)
 {
 	Owner owner = c->index;
 


### PR DESCRIPTION
## Motivation / Problem

This is a redo of

https://github.com/OpenTTD/OpenTTD/pull/9768

to have everything into 1 commit. Had some rebase conflicts with prior PR. 

Company value calculation is missing the value of the company's shares in other companies

Discussed as issue 1 below:

https://github.com/OpenTTD/OpenTTD/discussions/9765

## Description

The problem is solved by first calculating all of the company values without including value of shares in other companies, then adding in the value of the shares which now is known. I do not think this causes issues with bankruptcy or buying/selling shares; it does affect those of course since they now use the new company values.

Note that when buying shares, the company value does not change, since instead of holding the cash it now holds the shares of an equivalent value.

Note that when selling shares, the company value does not change, since instead of holding the shares it now holds cash of an equivalent value.


## Limitations

I haven't tested multiplayer, this works fine on saved games in single player.

I am not a C++ programmer so my change should be thoroughly reviewed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
