### PR TITLE
Fix missing icon

### DIFF
--- a/media/baseset/CMakeLists.txt
+++ b/media/baseset/CMakeLists.txt
@@ -17,6 +17,7 @@ set(BASESET_OTHER_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/openttd.grf
         ${CMAKE_CURRENT_SOURCE_DIR}/opntitle.dat
         ${CMAKE_CURRENT_SOURCE_DIR}/orig_extra.grf
+        ${CMAKE_CURRENT_SOURCE_DIR}/../openttd.32.bmp
 )
 
 # Done by the subdirectories, if nforenum / grfcodec is installed


### PR DESCRIPTION
These are two fixes for small problems I noticed while preparing the Debian package
 - The openttd.32.bmp icon was no longer installed since the cmake conversion, but it is still referenced by the SDL driver.
 - ~~There was a super-long line that lintian complains about. Apparently super-long lines are discouraged because they might hinder other lintian checks and are generally a sign of bad code. There were some more complaints (about lang files, the changelog, a data uri in shell.html and the 3rdparty glext.h), but it did not seem appropriate or possible to change those, so I ignored those warnings instead.~~ Commit dropped, turned out the line was parsed and needs to stay one line.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? -> No
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md) -> No
* This PR affects the save game format? (label 'savegame upgrade') -> No
* This PR affects the GS/AI API? (label 'needs review: Script API') -> No (just touches a comment in the API)
* This PR affects the NewGRF API? (label 'needs review: NewGRF') -> No