### PR TITLE
Fix #9774: CmdBuildRoadStop updated station acceptance in estimate mode

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1918,10 +1918,10 @@ CommandCost CmdBuildRoadStop(DoCommandFlag flags, TileIndex tile, uint8 width, u
 
 			MarkTileDirtyByTile(cur_tile);
 		}
-	}
 
-	if (st != nullptr) {
-		st->AfterStationTileSetChange(true, is_truck_stop ? STATION_TRUCK: STATION_BUS);
+		if (st != nullptr) {
+			st->AfterStationTileSetChange(true, is_truck_stop ? STATION_TRUCK: STATION_BUS);
+		}
 	}
 	return cost;
 }


### PR DESCRIPTION
## Motivation / Problem

Fix #9774

## Description

Only call Station::AfterStationTileSetChange when DC_EXEC is set.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
