### PR TITLE
Fix #9743: Rework macOS Touchbar.

### DIFF
--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -91,7 +91,7 @@ void GfxScroll(int left, int top, int width, int height, int xo, int yo);
 Dimension GetSpriteSize(SpriteID sprid, Point *offset = nullptr, ZoomLevel zoom = ZOOM_LVL_GUI);
 void DrawSpriteViewport(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub = nullptr);
 void DrawSprite(SpriteID img, PaletteID pal, int x, int y, const SubSprite *sub = nullptr, ZoomLevel zoom = ZOOM_LVL_GUI);
-std::unique_ptr<uint32[]> DrawSpriteToRgbaBuffer(SpriteID spriteId);
+std::unique_ptr<uint32[]> DrawSpriteToRgbaBuffer(SpriteID spriteId, ZoomLevel zoom = ZOOM_LVL_GUI);
 
 int DrawString(int left, int right, int top, const char *str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL);
 int DrawString(int left, int right, int top, const std::string &str, TextColour colour = TC_FROMSTRING, StringAlignment align = SA_LEFT, bool underline = false, FontSize fontsize = FS_NORMAL);

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -234,11 +234,15 @@ void VideoDriver_CocoaOpenGL::Stop()
 
 void VideoDriver_CocoaOpenGL::PopulateSystemSprites()
 {
+	VideoDriver_Cocoa::PopulateSystemSprites();
+
 	OpenGLBackend::Get()->PopulateCursorCache();
 }
 
 void VideoDriver_CocoaOpenGL::ClearSystemSprites()
 {
+	VideoDriver_Cocoa::ClearSystemSprites();
+
 	CGLSetCurrentContext(this->gl_context);
 	OpenGLBackend::Get()->ClearCursorCache();
 }

--- a/src/video/cocoa/cocoa_v.h
+++ b/src/video/cocoa/cocoa_v.h
@@ -22,7 +22,8 @@ extern bool _cocoa_video_started;
 
 class VideoDriver_Cocoa : public VideoDriver {
 private:
-	Dimension orig_res;   ///< Saved window size for non-fullscreen mode.
+	Dimension orig_res;       ///< Saved window size for non-fullscreen mode.
+	bool refresh_sys_sprites; ///< System sprites need refreshing.
 
 public:
 	bool setup; ///< Window is currently being created.
@@ -44,6 +45,9 @@ public:
 
 	bool ChangeResolution(int w, int h) override;
 	bool ToggleFullscreen(bool fullscreen) override;
+
+	void ClearSystemSprites() override;
+	void PopulateSystemSprites() override;
 
 	void EditBoxLostFocus() override;
 

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -99,6 +99,8 @@ VideoDriver_Cocoa::VideoDriver_Cocoa()
 	this->setup         = false;
 	this->buffer_locked = false;
 
+	this->refresh_sys_sprites = true;
+
 	this->window    = nil;
 	this->cocoaview = nil;
 	this->delegate  = nil;
@@ -219,6 +221,19 @@ bool VideoDriver_Cocoa::ToggleFullscreen(bool full_screen)
 	}
 
 	return false;
+}
+
+void VideoDriver_Cocoa::ClearSystemSprites()
+{
+	this->refresh_sys_sprites = true;
+}
+
+void VideoDriver_Cocoa::PopulateSystemSprites()
+{
+	if (this->refresh_sys_sprites && this->window != nil) {
+		[ this->window refreshSystemSprites ];
+		this->refresh_sys_sprites = false;
+	}
 }
 
 /**

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -11,8 +11,6 @@
 #define COCOA_WND_H
 
 #import <Cocoa/Cocoa.h>
-#include "toolbar_gui.h"
-#include "table/sprites.h"
 
 #ifdef MAC_OS_X_VERSION_10_12_2
 #	define HAVE_TOUCHBAR_SUPPORT
@@ -33,58 +31,6 @@ extern NSString *OTTDMainLaunchGameEngine;
 @interface NSCursor (OTTD_QuickdrawCursor)
 + (NSCursor *) clearCocoaCursor;
 @end
-
-#ifdef HAVE_TOUCHBAR_SUPPORT
-/* 9 items can be displayed on the touch bar when using default buttons. */
-static NSArray *touchBarButtonIdentifiers = @[
-	@"openttd.pause",
-	@"openttd.fastforward",
-	@"openttd.zoom_in",
-	@"openttd.zoom_out",
-	@"openttd.build_rail",
-	@"openttd.build_road",
-	@"openttd.build_tram",
-	@"openttd.build_docks",
-	@"openttd.build_airport",
-	NSTouchBarItemIdentifierOtherItemsProxy
-];
-
-static NSDictionary *touchBarButtonSprites = @{
-	@"openttd.pause":           [NSNumber numberWithInt:SPR_IMG_PAUSE],
-	@"openttd.fastforward":     [NSNumber numberWithInt:SPR_IMG_FASTFORWARD],
-	@"openttd.zoom_in":         [NSNumber numberWithInt:SPR_IMG_ZOOMIN],
-	@"openttd.zoom_out":        [NSNumber numberWithInt:SPR_IMG_ZOOMOUT],
-	@"openttd.build_rail":      [NSNumber numberWithInt:SPR_IMG_BUILDRAIL],
-	@"openttd.build_road":      [NSNumber numberWithInt:SPR_IMG_BUILDROAD],
-	@"openttd.build_tram":      [NSNumber numberWithInt:SPR_IMG_BUILDTRAMS],
-	@"openttd.build_docks":     [NSNumber numberWithInt:SPR_IMG_BUILDWATER],
-	@"openttd.build_airport":   [NSNumber numberWithInt:SPR_IMG_BUILDAIR],
-};
-
-static NSDictionary *touchBarButtonActions = @{
-	@"openttd.pause":           [NSNumber numberWithInt:MTHK_PAUSE],
-	@"openttd.fastforward":     [NSNumber numberWithInt:MTHK_FASTFORWARD],
-	@"openttd.zoom_in":         [NSNumber numberWithInt:MTHK_ZOOM_IN],
-	@"openttd.zoom_out":        [NSNumber numberWithInt:MTHK_ZOOM_OUT],
-	@"openttd.build_rail":      [NSNumber numberWithInt:MTHK_BUILD_RAIL],
-	@"openttd.build_road":      [NSNumber numberWithInt:MTHK_BUILD_ROAD],
-	@"openttd.build_tram":      [NSNumber numberWithInt:MTHK_BUILD_TRAM],
-	@"openttd.build_docks":     [NSNumber numberWithInt:MTHK_BUILD_DOCKS],
-	@"openttd.build_airport":   [NSNumber numberWithInt:MTHK_BUILD_AIRPORT],
-};
-
-static NSDictionary *touchBarFallbackText = @{
-	@"openttd.pause":           @"Pause",
-	@"openttd.fastforward":     @"Fast Forward",
-	@"openttd.zoom_in":         @"Zoom In",
-	@"openttd.zoom_out":        @"Zoom Out",
-	@"openttd.build_rail":      @"Rail",
-	@"openttd.build_road":      @"Road",
-	@"openttd.build_tram":      @"Tram",
-	@"openttd.build_docks":     @"Docks",
-	@"openttd.build_airport":   @"Airport",
-};
-#endif
 
 /** Subclass of NSWindow to cater our special needs */
 @interface OTTD_CocoaWindow : NSWindow

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -95,6 +95,8 @@ static NSDictionary *touchBarFallbackText = @{
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag driver:(VideoDriver_Cocoa *)drv;
 
 - (void)setFrame:(NSRect)frameRect display:(BOOL)flag;
+
+- (void)refreshSystemSprites;
 @end
 
 /** Subclass of NSView to support mouse awareness and text input. */

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -90,8 +90,6 @@ static NSDictionary *touchBarFallbackText = @{
 @interface OTTD_CocoaWindow : NSWindow
 #ifdef HAVE_TOUCHBAR_SUPPORT
 	<NSTouchBarDelegate>
-
-- (NSImage *)generateImage:(int)spriteId;
 #endif
 
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag driver:(VideoDriver_Cocoa *)drv;

--- a/src/video/cocoa/cocoa_wnd.h
+++ b/src/video/cocoa/cocoa_wnd.h
@@ -14,6 +14,10 @@
 #include "toolbar_gui.h"
 #include "table/sprites.h"
 
+#ifdef MAC_OS_X_VERSION_10_12_2
+#	define HAVE_TOUCHBAR_SUPPORT
+#endif
+
 class VideoDriver_Cocoa;
 
 /* Right Mouse Button Emulation enum */
@@ -30,7 +34,7 @@ extern NSString *OTTDMainLaunchGameEngine;
 + (NSCursor *) clearCocoaCursor;
 @end
 
-#ifdef HAVE_OSX_1015_SDK
+#ifdef HAVE_TOUCHBAR_SUPPORT
 /* 9 items can be displayed on the touch bar when using default buttons. */
 static NSArray *touchBarButtonIdentifiers = @[
 	@"openttd.pause",
@@ -83,12 +87,11 @@ static NSDictionary *touchBarFallbackText = @{
 #endif
 
 /** Subclass of NSWindow to cater our special needs */
-#ifdef HAVE_OSX_1015_SDK
-@interface OTTD_CocoaWindow : NSWindow <NSTouchBarDelegate>
-@property (strong) NSSet *touchbarItems;
-- (NSImage*)generateImage:(int)spriteId;
-#else
 @interface OTTD_CocoaWindow : NSWindow
+#ifdef HAVE_TOUCHBAR_SUPPORT
+	<NSTouchBarDelegate>
+
+- (NSImage *)generateImage:(int)spriteId;
 #endif
 
 - (instancetype)initWithContentRect:(NSRect)contentRect styleMask:(NSUInteger)styleMask backing:(NSBackingStoreType)backingType defer:(BOOL)flag driver:(VideoDriver_Cocoa *)drv;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -179,7 +179,7 @@ static NSImage *NSImageFromSprite(SpriteID sprite_id, ZoomLevel zoom)
 	/* Fetch the sprite and create a new bitmap */
 	Dimension dim = GetSpriteSize(sprite_id, nullptr, zoom);
 	std::unique_ptr<uint32[]> buffer = DrawSpriteToRgbaBuffer(sprite_id, zoom);
-	if (!buffer) return nullptr; // failed to blit sprite or we're using an 8bpp blitter.
+	if (!buffer) return nullptr; // Failed to blit sprite for some reason.
 
 	CFAutoRelease<CGDataProvider> data(CGDataProviderCreateWithData(nullptr, buffer.release(), dim.width * dim.height * 4, &CGDataFreeCallback));
 	if (!data) return nullptr;


### PR DESCRIPTION
## Motivation / Problem

The current touch bar implementation has several problems, see #9743, and is also needlessly limited to macOS 10.15+.


## Description

Touchbar sprites are now (re-)created by using the existing `PopulateSystemSprites/ClearSystemSprites` functionality which ensures sprites are only accessed when loaded and are re-created on graphics changes.
Sprites are created using the highest available zoom level, which should avoid crashes on reduced zoom ranges but still provide the best possible image resolution.

While at it, do some code cleanup and extend `DrawSpriteToRgbaBuffer` to work for 8bpp blitters as well.

(Side note: The first commit is mainly so I could even test this.)


## Limitations

The button texts for no/invalid sprites are not translated, but as they should never be shown with an intact baseset, I consider translating them just busywork. If requested, changing this would not be too difficult, though.

Only tested using the Xcode touchbar simulator on 10.14, not with any real hardware. As the original implementation was 10.15+ only, I can't compare if my changes introduce any graphical or functional differences.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
