### PR TITLE
Codechange: Make RoadScopeResolver constructor inlineable.

### DIFF
--- a/src/newgrf_roadtype.cpp
+++ b/src/newgrf_roadtype.cpp
@@ -74,19 +74,6 @@ uint32 RoadTypeResolverObject::GetDebugID() const
 }
 
 /**
- * Constructor of the roadtype scope resolvers.
- * @param ro Surrounding resolver.
- * @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
- * @param context Are we resolving sprites for the upper halftile, or on a bridge?
- */
-RoadTypeScopeResolver::RoadTypeScopeResolver(ResolverObject &ro, const RoadTypeInfo *rti, TileIndex tile, TileContext context) : ScopeResolver(ro)
-{
-	this->tile = tile;
-	this->context = context;
-	this->rti = rti;
-}
-
-/**
  * Resolver object for road types.
  * @param rti Roadtype. nullptr in NewGRF Inspect window.
  * @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.

--- a/src/newgrf_roadtype.h
+++ b/src/newgrf_roadtype.h
@@ -20,7 +20,17 @@ struct RoadTypeScopeResolver : public ScopeResolver {
 	TileContext context; ///< Are we resolving sprites for the upper halftile, or on a bridge?
 	const RoadTypeInfo *rti;
 
-	RoadTypeScopeResolver(ResolverObject &ro, const RoadTypeInfo *rti, TileIndex tile, TileContext context);
+	/**
+	* Constructor of the roadtype scope resolvers.
+	* @param ro Surrounding resolver.
+	* @param rti Associated RoadTypeInfo.
+	* @param tile %Tile containing the track. For track on a bridge this is the southern bridgehead.
+	* @param context Are we resolving sprites for the upper halftile, or on a bridge?
+	*/
+	RoadTypeScopeResolver(ResolverObject &ro, const RoadTypeInfo *rti, TileIndex tile, TileContext context)
+		: ScopeResolver(ro), tile(tile), context(context), rti(rti)
+	{
+	}
 
 	/* virtual */ uint32 GetRandomBits() const;
 	/* virtual */ uint32 GetVariable(byte variable, uint32 parameter, bool *available) const;


### PR DESCRIPTION
## Description
[(svn r27984)](https://github.com/OpenTTD/OpenTTD/commit/d9d669dcf855e444a77141b4b96e5df1f13c7203) made constructors of ScopeResolvers inlineable.
When roadtypes were introduced after r27984, its ScopeResolver didn't take that into account.

Maybe it is worth RoadScopeResolver could be inlineable too.

## Limitations
I haven't done any profiling.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
