### PR TITLE
Change: Automatic screenshot numbering

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1421,6 +1421,7 @@ DEF_CONSOLE_CMD(ConScreenShot)
 		IConsolePrint(CC_HELP, "  'minimap' makes a top-viewed minimap screenshot of the whole world which represents one tile by one pixel.");
 		IConsolePrint(CC_HELP, "  'no_con' hides the console to create the screenshot (only useful in combination with 'viewport').");
 		IConsolePrint(CC_HELP, "  'size' sets the width and height of the viewport to make a screenshot of (only useful in combination with 'normal' or 'big').");
+		IConsolePrint(CC_HELP, "  A filename ending in # will prevent overwriting existing files and will number files counting upwards.");
 		return true;
 	}
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -680,8 +680,18 @@ static const char *MakeScreenshotName(const char *default_fn, const char *ext, b
 		}
 	}
 
-	/* Add extension to screenshot file */
 	size_t len = strlen(_screenshot_name);
+
+	/* Handle user-specified filenames ending in %d with automatic numbering */
+	if (len >= 2) {
+		if (_screenshot_name[len - 2] == '%' && _screenshot_name[len - 1] == 'd') {
+			generate = true;
+			len -= 2;
+			_screenshot_name[len] = '\0';
+		}
+	}
+
+	/* Add extension to screenshot file */
 	seprintf(&_screenshot_name[len], lastof(_screenshot_name), ".%s", ext);
 
 	const char *screenshot_dir = crashlog ? _personal_dir.c_str() : FiosGetScreenshotDir();

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -683,12 +683,10 @@ static const char *MakeScreenshotName(const char *default_fn, const char *ext, b
 	size_t len = strlen(_screenshot_name);
 
 	/* Handle user-specified filenames ending in %d with automatic numbering */
-	if (len >= 2) {
-		if (_screenshot_name[len - 2] == '%' && _screenshot_name[len - 1] == 'd') {
-			generate = true;
-			len -= 2;
-			_screenshot_name[len] = '\0';
-		}
+	if (StrEndsWith(_screenshot_name, "%d")) {
+		generate = true;
+		len -= 2;
+		_screenshot_name[len] = '\0';
 	}
 
 	/* Add extension to screenshot file */

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -682,10 +682,10 @@ static const char *MakeScreenshotName(const char *default_fn, const char *ext, b
 
 	size_t len = strlen(_screenshot_name);
 
-	/* Handle user-specified filenames ending in %d with automatic numbering */
-	if (StrEndsWith(_screenshot_name, "%d")) {
+	/* Handle user-specified filenames ending in # with automatic numbering */
+	if (StrEndsWith(_screenshot_name, "#")) {
 		generate = true;
-		len -= 2;
+		len -= 1;
 		_screenshot_name[len] = '\0';
 	}
 


### PR DESCRIPTION
Invoking the `screenshot` console command with a filename ending in %d will cause it to be numbered automatically.

## Motivation / Problem

As part of running my OpenTTD server I use console scripts to capture a screenshot of the game periodically. I use these screenshots to make time-lapse videos of the game.

However, the default behavior of the console command `screenshot` with a user-provided filename will always save just to that filename, causing it to be overwritten if it exists. The only way to get a 'reel' of screenshots automatically is to omit the filename argument, in which case the screenshots will be saved as e.g. `screenshot.png`, `screenshot#1.png`, `screenshot#2.png`, etc.

## Description

The proposed change causes the automatic numbering to happen to any user provided filename that ends in `%d`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

* The `%d` token _must_ be at the end of the user provided filename.
* The automatically numbered files start with no number, and then count up from 1. This matches the existing behavior for generated filenames, where the first file generated is `screenshot.png`, followed by `screenshot#1.png`.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
