### PR TITLE
Feature: Technology progresses independently of game time

### DIFF
--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -127,8 +127,8 @@ uint64 GetMaskOfAllowedCurrencies()
 	for (i = 0; i < CURRENCY_END; i++) {
 		Year to_euro = _currency_specs[i].to_euro;
 
-		if (to_euro != CF_NOEURO && to_euro != CF_ISEURO && _cur_year >= to_euro) continue;
-		if (to_euro == CF_ISEURO && _cur_year < 2000) continue;
+		if (to_euro != CF_NOEURO && to_euro != CF_ISEURO && _technology_year >= to_euro) continue;
+		if (to_euro == CF_ISEURO && _technology_year < 2000) continue;
 		SetBit(mask, i);
 	}
 	SetBit(mask, CURRENCY_CUSTOM); // always allow custom currency
@@ -142,7 +142,7 @@ void CheckSwitchToEuro()
 {
 	if (_currency_specs[_settings_game.locale.currency].to_euro != CF_NOEURO &&
 			_currency_specs[_settings_game.locale.currency].to_euro != CF_ISEURO &&
-			_cur_year >= _currency_specs[_settings_game.locale.currency].to_euro) {
+			_technology_year >= _currency_specs[_settings_game.locale.currency].to_euro) {
 		_settings_game.locale.currency = 2; // this is the index of euro above.
 		AddNewsItem(STR_NEWS_EURO_INTRODUCTION, NT_ECONOMY, NF_NORMAL);
 	}

--- a/src/date_func.h
+++ b/src/date_func.h
@@ -18,6 +18,9 @@ extern Date      _date;
 extern DateFract _date_fract;
 extern uint16 _tick_counter;
 
+extern Year      _technology_year;
+extern Date      _technology_date;
+
 void SetDate(Date date, DateFract fract);
 void ConvertDateToYMD(Date date, YearMonthDay *ymd);
 Date ConvertYMDToDate(Year year, Month month, Day day);

--- a/src/date_type.h
+++ b/src/date_type.h
@@ -88,6 +88,13 @@ static const Year DEF_START_YEAR = 1950;
 /** The default scoring end year */
 static const Year DEF_END_YEAR = ORIGINAL_END_YEAR - 1;
 
+/** The default technology progress speed. */
+static const uint8 DEF_TECHNOLOGY_PROGRESS_SPEED = 1;
+/** Frozen technology progress speed. */
+static const uint8 FROZEN_TECHNOLOGY_PROGRESS_SPEED = 0;
+/** The slowest non-frozen technology progress speed, 1/255 times normal. */
+static const uint8 SLOWEST_TECHNOLOGY_PROGRESS_SPEED = 255;
+
 /**
  * MAX_YEAR, nicely rounded value of the number of years that can
  * be encoded in a single 32 bits date, about 2^31 / 366 years.

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -903,7 +903,7 @@ static void DoDisaster()
 
 	byte j = 0;
 	for (size_t i = 0; i != lengthof(_disasters); i++) {
-		if (_cur_year >= _disasters[i].min_year && _cur_year < _disasters[i].max_year) buf[j++] = (byte)i;
+		if (_technology_year >= _disasters[i].min_year && _technology_year < _disasters[i].max_year) buf[j++] = (byte)i;
 	}
 
 	if (j == 0) return;

--- a/src/economy_func.h
+++ b/src/economy_func.h
@@ -36,6 +36,7 @@ void LoadUnloadStation(Station *st);
 
 Money GetPrice(Price index, uint cost_factor, const struct GRFFile *grf_file, int shift = 0);
 
+void ResetInflation();
 void InitializeEconomy();
 void RecomputePrices();
 bool AddInflation(bool check_year = true);

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -124,6 +124,7 @@ static const NWidgetPart _nested_generate_landscape_widgets[] = {
 							NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_DESERT_COVERAGE, STR_NULL), SetFill(1, 1),
 						EndContainer(),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_DATE, STR_NULL), SetFill(1, 1),
+						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED, STR_NULL), SetFill(1, 1),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_SMOOTHNESS, STR_NULL), SetFill(1, 1),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_QUANTITY_OF_RIVERS, STR_NULL), SetFill(1, 1),
 						NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_GAME_OPTIONS_TOWN_NAMES_FRAME, STR_NULL), SetFill(1, 1),
@@ -148,6 +149,12 @@ static const NWidgetPart _nested_generate_landscape_widgets[] = {
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_START_DATE_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_BACKWARD), SetFill(0, 1),
 							NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_GL_START_DATE_TEXT), SetDataTip(STR_BLACK_DATE_LONG, STR_NULL), SetFill(1, 0),
 							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_START_DATE_UP), SetDataTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_FORWARD), SetFill(0, 1),
+						EndContainer(),
+						/* Technology progress speed */
+						NWidget(NWID_HORIZONTAL),
+							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_DECREASE_TECHNOLOGY_SPEED), SetFill(0, 1),
+							NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT), SetDataTip(STR_JUST_STRING, STR_NULL), SetFill(1, 0),
+							NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP), SetDataTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_TOOLTIP_INCREASE_TECHNOLOGY_SPEED), SetFill(0, 1),
 						EndContainer(),
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_SMOOTHNESS_PULLDOWN), SetDataTip(STR_JUST_STRING, STR_NULL), SetFill(1, 0),
 						NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_RIVER_PULLDOWN), SetDataTip(STR_JUST_STRING, STR_NULL), SetFill(1, 0),
@@ -246,6 +253,7 @@ static const NWidgetPart _nested_heightmap_load_widgets[] = {
 									NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_DESERT_COVERAGE, STR_NULL), SetFill(1, 1),
 								EndContainer(),
 								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_DATE, STR_NULL), SetFill(1, 1),
+								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED, STR_NULL), SetFill(1, 1),
 								NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_GAME_OPTIONS_TOWN_NAMES_FRAME, STR_NULL), SetFill(1, 1),
 							EndContainer(),
 							NWidget(NWID_VERTICAL, NC_EQUALSIZE), SetPIP(0, 4, 0),
@@ -270,6 +278,12 @@ static const NWidgetPart _nested_heightmap_load_widgets[] = {
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_START_DATE_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_BACKWARD), SetFill(0, 1),
 									NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_GL_START_DATE_TEXT), SetDataTip(STR_BLACK_DATE_LONG, STR_NULL), SetFill(1, 0),
 									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_START_DATE_UP), SetDataTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_FORWARD), SetFill(0, 1),
+								EndContainer(),
+								/* Technology progress speed */
+								NWidget(NWID_HORIZONTAL),
+									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_DECREASE_TECHNOLOGY_SPEED), SetFill(0, 1),
+									NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT), SetDataTip(STR_JUST_STRING, STR_NULL), SetFill(1, 0),
+									NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP), SetDataTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_TOOLTIP_INCREASE_TECHNOLOGY_SPEED), SetFill(0, 1),
 								EndContainer(),
 								NWidget(WWT_DROPDOWN, COLOUR_ORANGE, WID_GL_TOWNNAME_DROPDOWN), SetDataTip(STR_BLACK_STRING, STR_GAME_OPTIONS_TOWN_NAMES_DROPDOWN_TOOLTIP), SetFill(1, 0),
 							EndContainer(),
@@ -390,6 +404,15 @@ struct GenerateLandscapeWindow : public Window {
 	{
 		switch (widget) {
 			case WID_GL_START_DATE_TEXT:      SetDParam(0, ConvertYMDToDate(_settings_newgame.game_creation.starting_year, 0, 1)); break;
+			case WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT:
+				if (_settings_newgame.economy.technology_progress_speed == FROZEN_TECHNOLOGY_PROGRESS_SPEED) {
+					SetDParam(0, STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED_FROZEN);
+					SetDParam(1, _settings_newgame.economy.technology_progress_speed);
+				} else {
+					SetDParam(0, STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED);
+					SetDParam(1, _settings_newgame.economy.technology_progress_speed);
+				}
+				break;
 			case WID_GL_MAPSIZE_X_PULLDOWN:   SetDParam(0, 1LL << _settings_newgame.game_creation.map_x); break;
 			case WID_GL_MAPSIZE_Y_PULLDOWN:   SetDParam(0, 1LL << _settings_newgame.game_creation.map_y); break;
 			case WID_GL_HEIGHTMAP_HEIGHT_TEXT: SetDParam(0, _settings_newgame.game_creation.heightmap_height); break;
@@ -514,6 +537,8 @@ struct GenerateLandscapeWindow : public Window {
 		}
 		this->SetWidgetDisabledState(WID_GL_START_DATE_DOWN, _settings_newgame.game_creation.starting_year <= MIN_YEAR);
 		this->SetWidgetDisabledState(WID_GL_START_DATE_UP,   _settings_newgame.game_creation.starting_year >= MAX_YEAR);
+		this->SetWidgetDisabledState(WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN, _settings_newgame.economy.technology_progress_speed <= FROZEN_TECHNOLOGY_PROGRESS_SPEED);
+		this->SetWidgetDisabledState(WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP, _settings_newgame.economy.technology_progress_speed >= SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
 		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_DOWN, _settings_newgame.game_creation.snow_coverage <= 0 || _settings_newgame.game_creation.landscape != LT_ARCTIC);
 		this->SetWidgetDisabledState(WID_GL_SNOW_COVERAGE_UP,   _settings_newgame.game_creation.snow_coverage >= 100 || _settings_newgame.game_creation.landscape != LT_ARCTIC);
 		this->SetWidgetDisabledState(WID_GL_DESERT_COVERAGE_DOWN, _settings_newgame.game_creation.desert_coverage <= 0 || _settings_newgame.game_creation.landscape != LT_TROPIC);
@@ -543,6 +568,11 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_START_DATE_TEXT:
 				SetDParam(0, ConvertYMDToDate(MAX_YEAR, 0, 1));
 				*size = maxdim(*size, GetStringBoundingBox(STR_BLACK_DATE_LONG));
+				break;
+
+			case WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT:
+				SetDParam(0, SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
+				*size = maxdim(*size, GetStringBoundingBox(STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED_FROZEN));
 				break;
 
 			case WID_GL_MAPSIZE_X_PULLDOWN:
@@ -723,6 +753,24 @@ struct GenerateLandscapeWindow : public Window {
 				ShowQueryString(STR_JUST_INT, STR_MAPGEN_START_DATE_QUERY_CAPT, 8, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
 				break;
 
+			case WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN:
+			case WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP: // Technology progress speed buttons
+				/* Don't allow too fast scrolling */
+				if (!(this->flags & WF_TIMEOUT) || this->timeout_timer <= 1) {
+					this->HandleButtonClick(widget);
+
+					_settings_newgame.economy.technology_progress_speed = Clamp(_settings_newgame.economy.technology_progress_speed + widget - WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT, FROZEN_TECHNOLOGY_PROGRESS_SPEED, SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
+					this->InvalidateData();
+				}
+				_left_button_clicked = false;
+				break;
+
+			case WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT: // Technology progress speed text
+				this->widget_id = WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT;
+				SetDParam(0, _settings_newgame.economy.technology_progress_speed);
+				ShowQueryString(STR_JUST_INT, STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED_CAPT, 4, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
+				break;
+
 			case WID_GL_SNOW_COVERAGE_DOWN:
 			case WID_GL_SNOW_COVERAGE_UP: // Snow coverage buttons
 				/* Don't allow too fast scrolling */
@@ -824,8 +872,8 @@ struct GenerateLandscapeWindow : public Window {
 
 	void OnTimeout() override
 	{
-		static const int newgame_raise_widgets[] = {WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN, WIDGET_LIST_END};
-		static const int heightmap_raise_widgets[] = {WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN, WIDGET_LIST_END};
+		static const int newgame_raise_widgets[] = {WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN, WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN, WIDGET_LIST_END};
+		static const int heightmap_raise_widgets[] = {WID_GL_HEIGHTMAP_HEIGHT_DOWN, WID_GL_HEIGHTMAP_HEIGHT_UP, WID_GL_START_DATE_DOWN, WID_GL_START_DATE_UP, WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN, WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP, WID_GL_SNOW_COVERAGE_UP, WID_GL_SNOW_COVERAGE_DOWN, WID_GL_DESERT_COVERAGE_UP, WID_GL_DESERT_COVERAGE_DOWN, WIDGET_LIST_END};
 
 		const int *widget = (mode == GLWM_HEIGHTMAP) ? heightmap_raise_widgets : newgame_raise_widgets;
 
@@ -908,6 +956,7 @@ struct GenerateLandscapeWindow : public Window {
 			switch (this->widget_id) {
 				case WID_GL_HEIGHTMAP_HEIGHT_TEXT: value = MAP_HEIGHT_LIMIT_AUTO_MINIMUM; break;
 				case WID_GL_START_DATE_TEXT: value = DEF_START_YEAR; break;
+				case WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT: value = DEF_TECHNOLOGY_PROGRESS_SPEED; break;
 				case WID_GL_SNOW_COVERAGE_TEXT: value = DEF_SNOW_COVERAGE; break;
 				case WID_GL_DESERT_COVERAGE_TEXT: value = DEF_DESERT_COVERAGE; break;
 				case WID_GL_TOWN_PULLDOWN: value = 1; break;
@@ -926,6 +975,11 @@ struct GenerateLandscapeWindow : public Window {
 			case WID_GL_START_DATE_TEXT:
 				this->SetWidgetDirty(WID_GL_START_DATE_TEXT);
 				_settings_newgame.game_creation.starting_year = Clamp(value, MIN_YEAR, MAX_YEAR);
+				break;
+
+			case WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT:
+				this->SetWidgetDirty(WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT);
+				_settings_newgame.economy.technology_progress_speed = Clamp(value, FROZEN_TECHNOLOGY_PROGRESS_SPEED, SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
 				break;
 
 			case WID_GL_SNOW_COVERAGE_TEXT:
@@ -1043,6 +1097,17 @@ struct CreateScenarioWindow : public Window
 				SetDParam(0, ConvertYMDToDate(_settings_newgame.game_creation.starting_year, 0, 1));
 				break;
 
+			case WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT:
+				if (_settings_newgame.economy.technology_progress_speed == FROZEN_TECHNOLOGY_PROGRESS_SPEED) {
+					SetDParam(0, STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED_FROZEN);
+					SetDParam(1, _settings_newgame.economy.technology_progress_speed);
+				}
+				else {
+					SetDParam(0, STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED);
+					SetDParam(1, _settings_newgame.economy.technology_progress_speed);
+				}
+				break;
+
 			case WID_CS_MAPSIZE_X_PULLDOWN:
 				SetDParam(0, 1LL << _settings_newgame.game_creation.map_x);
 				break;
@@ -1061,6 +1126,8 @@ struct CreateScenarioWindow : public Window
 	{
 		this->SetWidgetDisabledState(WID_CS_START_DATE_DOWN,       _settings_newgame.game_creation.starting_year <= MIN_YEAR);
 		this->SetWidgetDisabledState(WID_CS_START_DATE_UP,         _settings_newgame.game_creation.starting_year >= MAX_YEAR);
+		this->SetWidgetDisabledState(WID_CS_TECHNOLOGY_PROGRESS_SPEED_DOWN, _settings_newgame.economy.technology_progress_speed <= FROZEN_TECHNOLOGY_PROGRESS_SPEED);
+		this->SetWidgetDisabledState(WID_CS_TECHNOLOGY_PROGRESS_SPEED_UP,   _settings_newgame.economy.technology_progress_speed >= SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
 		this->SetWidgetDisabledState(WID_CS_FLAT_LAND_HEIGHT_DOWN, _settings_newgame.game_creation.se_flat_world_height <= 0);
 		this->SetWidgetDisabledState(WID_CS_FLAT_LAND_HEIGHT_UP,   _settings_newgame.game_creation.se_flat_world_height >= GetMapHeightLimit());
 
@@ -1079,6 +1146,11 @@ struct CreateScenarioWindow : public Window
 			case WID_CS_START_DATE_TEXT:
 				SetDParam(0, ConvertYMDToDate(MAX_YEAR, 0, 1));
 				str = STR_BLACK_DATE_LONG;
+				break;
+
+			case WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT:
+				SetDParam(0, SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
+				*size = maxdim(*size, GetStringBoundingBox(STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED_FROZEN));
 				break;
 
 			case WID_CS_MAPSIZE_X_PULLDOWN:
@@ -1140,7 +1212,25 @@ struct CreateScenarioWindow : public Window
 			case WID_CS_START_DATE_TEXT: // Year text
 				this->widget_id = WID_CS_START_DATE_TEXT;
 				SetDParam(0, _settings_newgame.game_creation.starting_year);
-				ShowQueryString(STR_JUST_INT, STR_MAPGEN_START_DATE_QUERY_CAPT, 8, this, CS_NUMERAL, QSF_NONE);
+				ShowQueryString(STR_JUST_INT, STR_MAPGEN_START_DATE_QUERY_CAPT, 8, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
+				break;
+
+			case WID_CS_TECHNOLOGY_PROGRESS_SPEED_DOWN:
+			case WID_CS_TECHNOLOGY_PROGRESS_SPEED_UP: // Technology progress speed buttons
+				/* Don't allow too fast scrolling */
+				if (!(this->flags & WF_TIMEOUT) || this->timeout_timer <= 1) {
+					this->HandleButtonClick(widget);
+
+					_settings_newgame.economy.technology_progress_speed = Clamp(_settings_newgame.economy.technology_progress_speed + widget - WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT, FROZEN_TECHNOLOGY_PROGRESS_SPEED, SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
+					this->InvalidateData();
+				}
+				_left_button_clicked = false;
+				break;
+
+			case WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT: // Technology progress speed text
+				this->widget_id = WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT;
+				SetDParam(0, _settings_newgame.economy.technology_progress_speed);
+				ShowQueryString(STR_JUST_INT, STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED_CAPT, 4, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
 				break;
 
 			case WID_CS_FLAT_LAND_HEIGHT_DOWN:
@@ -1165,7 +1255,7 @@ struct CreateScenarioWindow : public Window
 
 	void OnTimeout() override
 	{
-		static const int raise_widgets[] = {WID_CS_START_DATE_DOWN, WID_CS_START_DATE_UP, WID_CS_FLAT_LAND_HEIGHT_DOWN, WID_CS_FLAT_LAND_HEIGHT_UP, WIDGET_LIST_END};
+		static const int raise_widgets[] = { WID_CS_START_DATE_DOWN, WID_CS_START_DATE_UP, WID_CS_TECHNOLOGY_PROGRESS_SPEED_DOWN, WID_CS_TECHNOLOGY_PROGRESS_SPEED_UP, WID_CS_FLAT_LAND_HEIGHT_DOWN, WID_CS_FLAT_LAND_HEIGHT_UP, WIDGET_LIST_END };
 		for (const int *widget = raise_widgets; *widget != WIDGET_LIST_END; widget++) {
 			if (this->IsWidgetLowered(*widget)) {
 				this->RaiseWidget(*widget);
@@ -1185,23 +1275,40 @@ struct CreateScenarioWindow : public Window
 
 	void OnQueryTextFinished(char *str) override
 	{
+		/* Was 'cancel' pressed? */
+		if (str == nullptr) return;
+
+		int32 value;
 		if (!StrEmpty(str)) {
-			int32 value = atoi(str);
-
-			switch (this->widget_id) {
-				case WID_CS_START_DATE_TEXT:
-					this->SetWidgetDirty(WID_CS_START_DATE_TEXT);
-					_settings_newgame.game_creation.starting_year = Clamp(value, MIN_YEAR, MAX_YEAR);
-					break;
-
-				case WID_CS_FLAT_LAND_HEIGHT_TEXT:
-					this->SetWidgetDirty(WID_CS_FLAT_LAND_HEIGHT_TEXT);
-					_settings_newgame.game_creation.se_flat_world_height = Clamp(value, 0, GetMapHeightLimit());
-					break;
-			}
-
-			this->SetDirty();
+			value = atoi(str);
 		}
+		else {
+			/* An empty string means revert to the default */
+			switch (this->widget_id) {
+				case WID_CS_START_DATE_TEXT: value = DEF_START_YEAR; break;
+				case WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT: value = DEF_TECHNOLOGY_PROGRESS_SPEED; break;
+				default: NOT_REACHED();
+			}
+		}
+
+		switch (this->widget_id) {
+			case WID_CS_START_DATE_TEXT:
+				this->SetWidgetDirty(WID_CS_START_DATE_TEXT);
+				_settings_newgame.game_creation.starting_year = Clamp(value, MIN_YEAR, MAX_YEAR);
+				break;
+
+			case WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT:
+				this->SetWidgetDirty(WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT);
+				_settings_newgame.economy.technology_progress_speed = Clamp(value, FROZEN_TECHNOLOGY_PROGRESS_SPEED, SLOWEST_TECHNOLOGY_PROGRESS_SPEED);
+				break;
+
+			case WID_CS_FLAT_LAND_HEIGHT_TEXT:
+				this->SetWidgetDirty(WID_CS_FLAT_LAND_HEIGHT_TEXT);
+				_settings_newgame.game_creation.se_flat_world_height = Clamp(value, 0, GetMapHeightLimit());
+				break;
+		}
+
+		this->SetDirty();
 	}
 };
 
@@ -1242,6 +1349,14 @@ static const NWidgetPart _nested_create_scenario_widgets[] = {
 					NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_CS_START_DATE_DOWN), SetFill(0, 1), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_BACKWARD),
 					NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_CS_START_DATE_TEXT), SetDataTip(STR_BLACK_DATE_LONG, STR_NULL),
 					NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_CS_START_DATE_UP), SetFill(0, 1), SetDataTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_FORWARD),
+				EndContainer(),
+				/* Technology progress speed. */
+				NWidget(NWID_HORIZONTAL),
+					NWidget(WWT_TEXT, COLOUR_ORANGE), SetDataTip(STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED, STR_NULL), SetPadding(1, 0, 0, 0),
+					NWidget(NWID_SPACER), SetMinimalSize(6, 0), SetFill(1, 0),
+					NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_CS_TECHNOLOGY_PROGRESS_SPEED_DOWN), SetFill(0, 1), SetDataTip(SPR_ARROW_DOWN, STR_SCENEDIT_TOOLBAR_TOOLTIP_DECREASE_TECHNOLOGY_SPEED),
+					NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT), SetFill(1, 0), SetDataTip(STR_JUST_STRING, STR_NULL),
+					NWidget(WWT_IMGBTN, COLOUR_ORANGE, WID_CS_TECHNOLOGY_PROGRESS_SPEED_UP), SetFill(0, 1), SetDataTip(SPR_ARROW_UP, STR_SCENEDIT_TOOLBAR_TOOLTIP_INCREASE_TECHNOLOGY_SPEED),
 				EndContainer(),
 				/* Flat map height. */
 				NWidget(NWID_HORIZONTAL),

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2177,8 +2177,8 @@ static uint16 GetIndustryGamePlayProbability(IndustryType it, byte *min_number)
 	const IndustrySpec *ind_spc = GetIndustrySpec(it);
 	byte chance = ind_spc->appear_ingame[_settings_game.game_creation.landscape];
 	if (!ind_spc->enabled || ind_spc->layouts.empty() ||
-			((ind_spc->behaviour & INDUSTRYBEH_BEFORE_1950) && _cur_year > 1950) ||
-			((ind_spc->behaviour & INDUSTRYBEH_AFTER_1960) && _cur_year < 1960) ||
+			((ind_spc->behaviour & INDUSTRYBEH_BEFORE_1950) && _technology_year > 1950) ||
+			((ind_spc->behaviour & INDUSTRYBEH_AFTER_1960) && _technology_year < 1960) ||
 			(chance = GetIndustryProbabilityCallback(it, IACT_RANDOMCREATION, chance)) == 0) {
 		*min_number = 0;
 		return 0;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -370,6 +370,10 @@ STR_SCENEDIT_TOOLBAR_SCENARIO_EDITOR                            :{YELLOW}Scenari
 STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_BACKWARD    :{BLACK}Move the starting date backward 1 year
 STR_SCENEDIT_TOOLBAR_TOOLTIP_MOVE_THE_STARTING_DATE_FORWARD     :{BLACK}Move the starting date forward 1 year
 STR_SCENEDIT_TOOLBAR_TOOLTIP_SET_DATE                           :{BLACK}Click to enter the starting year
+STR_SCENEDIT_TOOLBAR_TOOLTIP_DECREASE_TECHNOLOGY_SPEED          :{BLACK}Decrease the technology progress speed
+STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED                   :{BLACK}1/{NUM}
+STR_SCENEDIT_TOOLBAR_TOOLTIP_TECHNOLOGY_SPEED_FROZEN            :{BLACK}Frozen
+STR_SCENEDIT_TOOLBAR_TOOLTIP_INCREASE_TECHNOLOGY_SPEED          :{BLACK}Increase the technology progress speed
 STR_SCENEDIT_TOOLBAR_TOOLTIP_DISPLAY_MAP_TOWN_DIRECTORY         :{BLACK}Display map, town directory
 STR_SCENEDIT_TOOLBAR_LANDSCAPE_GENERATION                       :{BLACK}Landscape generation
 STR_SCENEDIT_TOOLBAR_TOWN_GENERATION                            :{BLACK}Town generation
@@ -1415,6 +1419,16 @@ STR_CONFIG_SETTING_WARN_INCOME_LESS_HELPTEXT                    :When enabled, a
 
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES                        :Vehicles never expire: {STRING2}
 STR_CONFIG_SETTING_NEVER_EXPIRE_VEHICLES_HELPTEXT               :When enabled, all vehicle models remain available forever after their introduction
+
+STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED                    :Technology progress speed: {STRING2}
+STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED_HELPTEXT           :Choose the rate of technological progression, which determines availability of vehicle models, houses, etc, independently of the actual game year.
+STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED_VALUE              :1/{NUM}
+###setting-zero-is-special
+STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED_FROZEN             :Frozen
+
+STR_CONFIG_SETTING_TECHNOLOGY_YEAR                              :Technology year: {STRING2}
+STR_CONFIG_SETTING_TECHNOLOGY_YEAR_HELPTEXT                     :Choose the technology year of the game, which determines availability of vehicle models, houses, etc, independently of the actual game year.
+STR_CONFIG_SETTING_TECHNOLOGY_YEAR_VALUE                        :{NUM}
 
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE                            :Autorenew vehicle when it gets old: {STRING2}
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT                   :When enabled, a vehicle nearing its end of life gets automatically replaced when the renew conditions are fulfilled
@@ -3131,6 +3145,7 @@ STR_MAPGEN_MAPSIZE_TOOLTIP                                      :{BLACK}Select t
 STR_MAPGEN_BY                                                   :{BLACK}*
 STR_MAPGEN_NUMBER_OF_TOWNS                                      :{BLACK}No. of towns:
 STR_MAPGEN_DATE                                                 :{BLACK}Date:
+STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED                            :{BLACK}Technology progress speed:
 STR_MAPGEN_NUMBER_OF_INDUSTRIES                                 :{BLACK}No. of industries:
 STR_MAPGEN_HEIGHTMAP_HEIGHT                                     :{BLACK}Highest peak:
 STR_MAPGEN_HEIGHTMAP_HEIGHT_UP                                  :{BLACK}Increase the maximum height of highest peak on the map by one
@@ -3173,6 +3188,7 @@ STR_MAPGEN_HEIGHTMAP_HEIGHT_QUERY_CAPT                          :{WHITE}Highest 
 STR_MAPGEN_SNOW_COVERAGE_QUERY_CAPT                             :{WHITE}Snow coverage (in %)
 STR_MAPGEN_DESERT_COVERAGE_QUERY_CAPT                           :{WHITE}Desert coverage (in %)
 STR_MAPGEN_START_DATE_QUERY_CAPT                                :{WHITE}Change starting year
+STR_MAPGEN_TECHNOLOGY_PROGRESS_SPEED_CAPT                       :{WHITE}Change technology progress speed
 
 # SE Map generation
 STR_SE_MAPGEN_CAPTION                                           :{WHITE}Scenario Type

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -73,7 +73,15 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	_newgrf_profilers.clear();
 
 	if (reset_date) {
-		SetDate(ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1), 0);
+		/* Start with the technology date synced with the chosen starting year, no matter what. */
+		_settings_game.economy.technology_year = _settings_game.game_creation.starting_year;
+
+		/* If using a non-default technology progress speed, start game at year 1. */
+		if (_settings_game.economy.technology_progress_speed != DEF_TECHNOLOGY_PROGRESS_SPEED) {
+			SetDate(ConvertYMDToDate(1, 0, 1), 0); // Year 1.
+		} else {
+			SetDate(ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1), 0); // Use the actual year.
+		}
 		InitializeOldNames();
 	}
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -6385,6 +6385,14 @@ bool GetGlobalVariable(byte param, uint32 *value, const GRFFile *grffile)
 			*value = _cur_year;
 			return true;
 
+		case 0x25: // technology date
+			*value = _technology_date;
+			return true;
+
+		case 0x26: // technology year
+			*value = _technology_year;
+			return true;
+
 		default: return false;
 	}
 }

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -124,9 +124,9 @@ AirportSpec AirportSpec::specs[NUM_AIRPORTS]; ///< Airport specifications.
 bool AirportSpec::IsAvailable() const
 {
 	if (!this->enabled) return false;
-	if (_cur_year < this->min_year) return false;
+	if (_technology_year < this->min_year) return false;
 	if (_settings_game.station.never_expire_airports) return true;
-	return _cur_year <= this->max_year;
+	return _technology_year <= this->max_year;
 }
 
 /**

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -68,7 +68,7 @@ bool ObjectSpec::IsEverAvailable() const
  */
 bool ObjectSpec::WasEverAvailable() const
 {
-	return this->IsEverAvailable() && _date > this->introduction_date;
+	return this->IsEverAvailable() && _technology_date > this->introduction_date;
 }
 
 /**
@@ -78,7 +78,7 @@ bool ObjectSpec::WasEverAvailable() const
 bool ObjectSpec::IsAvailable() const
 {
 	return this->WasEverAvailable() &&
-			(_date < this->end_of_life_date || this->end_of_life_date < this->introduction_date + 365);
+			(_technology_date < this->end_of_life_date || this->end_of_life_date < this->introduction_date + DAYS_IN_YEAR);
 }
 
 /**

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -789,7 +789,7 @@ NewsItem::NewsItem(StringID string_id, NewsType type, NewsFlag flags, NewsRefere
 	string_id(string_id), date(_date), type(type), flags(flags), reftype1(reftype1), reftype2(reftype2), ref1(ref1), ref2(ref2), data(data)
 {
 	/* show this news message in colour? */
-	if (_cur_year >= _settings_client.gui.coloured_news_year) this->flags |= NF_INCOLOUR;
+	if (_technology_year >= _settings_client.gui.coloured_news_year) this->flags |= NF_INCOLOUR;
 	CopyOutDParam(this->params, 0, lengthof(this->params));
 }
 

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -256,7 +256,7 @@ RailTypes GetCompanyRailtypes(CompanyID company, bool introduces)
 		const EngineInfo *ei = &e->info;
 
 		if (HasBit(ei->climates, _settings_game.game_creation.landscape) &&
-				(HasBit(e->company_avail, company) || _date >= e->intro_date + DAYS_IN_YEAR)) {
+				(HasBit(e->company_avail, company) || _technology_date >= e->intro_date + DAYS_IN_YEAR)) {
 			const RailVehicleInfo *rvi = &e->u.rail;
 
 			if (rvi->railveh_type != RAILVEH_WAGON) {
@@ -270,7 +270,7 @@ RailTypes GetCompanyRailtypes(CompanyID company, bool introduces)
 		}
 	}
 
-	if (introduces) return AddDateIntroducedRailTypes(rts, _date);
+	if (introduces) return AddDateIntroducedRailTypes(rts, _technology_date);
 	return rts;
 }
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -248,7 +248,7 @@ static void GenericPlaceSignals(TileIndex tile)
 			Command<CMD_BUILD_SIGNALS>::Post(_convert_signal_button ? STR_ERROR_SIGNAL_CAN_T_CONVERT_SIGNALS_HERE : STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
 				tile, track, _cur_signal_type, _cur_signal_variant, _convert_signal_button, false, _ctrl_pressed, cycle_start, SIGTYPE_LAST, 0, 0);
 		} else {
-			SignalVariant sigvar = _cur_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC;
+			SignalVariant sigvar = _technology_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC;
 			Command<CMD_BUILD_SIGNALS>::Post(STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
 				tile, track, SIGTYPE_PBS_ONEWAY, sigvar, false, false, _ctrl_pressed, cycle_start, SIGTYPE_LAST, 0, 0);
 
@@ -397,7 +397,7 @@ static void HandleAutoSignalPlacement()
 	} else {
 		bool sig_gui = FindWindowById(WC_BUILD_SIGNAL, 0) != nullptr;
 		SignalType sigtype = sig_gui ? _cur_signal_type : SIGTYPE_PBS_ONEWAY;
-		SignalVariant sigvar = sig_gui ? _cur_signal_variant : (_cur_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
+		SignalVariant sigvar = sig_gui ? _cur_signal_variant : (_technology_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
 		Command<CMD_BUILD_SIGNAL_TRACK>::Post(STR_ERROR_CAN_T_BUILD_SIGNALS_HERE, CcPlaySound_CONSTRUCTION_RAIL,
 				TileVirtXY(_thd.selstart.x, _thd.selstart.y), TileVirtXY(_thd.selend.x, _thd.selend.y), track, sigtype, sigvar, false, _ctrl_pressed, !_settings_client.gui.drag_signals_fixed_distance, _settings_client.gui.drag_signals_density);
 	}
@@ -2178,7 +2178,7 @@ static void SetDefaultRailGui()
  */
 void ResetSignalVariant(int32 new_value)
 {
-	SignalVariant new_variant = (_cur_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
+	SignalVariant new_variant = (_technology_year < _settings_client.gui.semaphore_build_before ? SIG_SEMAPHORE : SIG_ELECTRIC);
 
 	if (new_variant != _cur_signal_variant) {
 		Window *w = FindWindowById(WC_BUILD_SIGNAL, 0);

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -193,7 +193,7 @@ RoadTypes GetCompanyRoadTypes(CompanyID company, bool introduces)
 		const EngineInfo *ei = &e->info;
 
 		if (HasBit(ei->climates, _settings_game.game_creation.landscape) &&
-				(HasBit(e->company_avail, company) || _date >= e->intro_date + DAYS_IN_YEAR)) {
+				(HasBit(e->company_avail, company) || _technology_date >= e->intro_date + DAYS_IN_YEAR)) {
 			const RoadVehicleInfo *rvi = &e->u.road;
 			assert(rvi->roadtype < ROADTYPE_END);
 			if (introduces) {
@@ -204,7 +204,7 @@ RoadTypes GetCompanyRoadTypes(CompanyID company, bool introduces)
 		}
 	}
 
-	if (introduces) return AddDateIntroducedRoadTypes(rts, _date);
+	if (introduces) return AddDateIntroducedRoadTypes(rts, _technology_date);
 	return rts;
 }
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1330,7 +1330,7 @@ DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, b
 DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 {
 	RoadTypes avail_roadtypes = GetRoadTypes(false);
-	avail_roadtypes = AddDateIntroducedRoadTypes(avail_roadtypes, _date);
+	avail_roadtypes = AddDateIntroducedRoadTypes(avail_roadtypes, _technology_date);
 	RoadTypes used_roadtypes = GetRoadTypes(true);
 
 	/* Filter listed road types */

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -17,6 +17,10 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSDate::GetTechnologyYear
+ * \li GSDate::GetTechnologyDate
+ *
  * \b 12.0
  *
  * API additions:

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -23,7 +23,7 @@
 
 /* static */ bool ScriptBridge::IsValidBridge(BridgeID bridge_id)
 {
-	return bridge_id < MAX_BRIDGES && ::GetBridgeSpec(bridge_id)->avail_year <= _cur_year;
+	return bridge_id < MAX_BRIDGES && ::GetBridgeSpec(bridge_id)->avail_year <= _technology_year;
 }
 
 /* static */ bool ScriptBridge::IsBridgeTile(TileIndex tile)

--- a/src/script/api/script_date.cpp
+++ b/src/script/api/script_date.cpp
@@ -67,3 +67,13 @@
 	time(&t);
 	return t;
 }
+
+/* static */ int32 ScriptDate::GetTechnologyYear()
+{
+	return (ScriptDate::Date)_technology_year;
+}
+
+/* static */ ScriptDate::Date ScriptDate::GetTechnologyDate()
+{
+	return (ScriptDate::Date)_technology_date;
+}

--- a/src/script/api/script_date.hpp
+++ b/src/script/api/script_date.hpp
@@ -87,6 +87,18 @@ public:
 	 * @note This uses the clock of the host system, which can skew or be set back. Use with caution.
 	 */
 	static int32 GetSystemTime();
+
+	/**
+	 * Get the technology year, which governs the availability of vehicles, houses, industries, etc., independently of the actual game year.
+	 * @return The technology year of the game. If technology progress speed is 1/1, this will be the actual game year.
+	 */
+	static int32 GetTechnologyYear();
+
+	/**
+	 * Get the technology date, which governs the availability of vehicles, houses, industries, etc., independently of the actual game date.
+	 * @return The technology date of the game. If technology progress speed is 1/1, this will be the actual game date.
+	 */
+	static Date GetTechnologyDate();
 };
 
 #endif /* SCRIPT_DATE_HPP */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1761,6 +1761,8 @@ static SettingsContainer &GetSettingsTree()
 
 		SettingsPage *genworld = main->Add(new SettingsPage(STR_CONFIG_SETTING_GENWORLD));
 		{
+			genworld->Add(new SettingEntry("economy.technology_progress_speed"));
+			genworld->Add(new SettingEntry("economy.technology_year"));
 			genworld->Add(new SettingEntry("game_creation.landscape"));
 			genworld->Add(new SettingEntry("game_creation.land_generator"));
 			genworld->Add(new SettingEntry("difficulty.terrain_type"));

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -43,6 +43,7 @@
 #include "smallmap_gui.h"
 #include "roadveh.h"
 #include "vehicle_func.h"
+#include "engine_func.h"
 #include "void_map.h"
 
 #include "table/strings.h"
@@ -471,6 +472,21 @@ static void UpdateClientConfigValues()
 {
 	NetworkServerUpdateGameInfo();
 	if (_network_server) NetworkServerSendConfigUpdate();
+}
+
+/* The technology freeze year has changed; update technology date and recalculate vehicle availability and other things. */
+static void TechnologyFreezeYearChanged(int32 new_value)
+{
+	_technology_date = ConvertYMDToDate(_settings_game.economy.technology_year, 0, 1);
+	_technology_year = _settings_game.economy.technology_year;
+
+	StartupEngines();
+	ResetSignalVariant();
+
+	_economy.inflation_prices = _economy.inflation_payment = 1 << 16;
+	ResetInflation();
+
+	if (_settings_client.gui.auto_euro) CheckSwitchToEuro();
 }
 
 /* End - Callback Functions */

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -520,6 +520,8 @@ struct EconomySettings {
 	uint16 town_noise_population[3];         ///< population to base decision on noise evaluation (@see town_council_tolerance)
 	bool   allow_town_level_crossings;       ///< towns are allowed to build level crossings
 	bool   infrastructure_maintenance;       ///< enable monthly maintenance fee for owner infrastructure
+	uint8  technology_progress_speed;        ///< the rate of technological progress, in 1/n times normal speed.
+	Year   technology_year;                  ///< choose the technology year, which decides availability of vehicles, houses, road/railtypes, etc.
 };
 
 struct LinkGraphSettings {

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -9,6 +9,7 @@
 
 [pre-amble]
 static void TownFoundingChanged(int32 new_value);
+static void TechnologyFreezeYearChanged(int32 new_value);
 
 static const SettingVariant _economy_settings_table[] = {
 [post-amble]
@@ -291,4 +292,31 @@ def      = false
 str      = STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE
 strhelp  = STR_CONFIG_SETTING_INFRASTRUCTURE_MAINTENANCE_HELPTEXT
 post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY_INFRASTRUCTURE); }
+cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.technology_progress_speed
+type     = SLE_UINT8
+flags    = SF_NO_NETWORK | SF_GUI_0_IS_SPECIAL
+def      = DEF_TECHNOLOGY_PROGRESS_SPEED
+min      = FROZEN_TECHNOLOGY_PROGRESS_SPEED
+max      = SLOWEST_TECHNOLOGY_PROGRESS_SPEED
+interval = 1
+str      = STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED
+strhelp  = STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED_HELPTEXT
+strval   = STR_CONFIG_SETTING_TECHNOLOGY_PROGRESS_SPEED_VALUE
+cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.technology_year
+type     = SLE_INT32
+flags    = SF_NO_NETWORK
+def      = DEF_START_YEAR
+min      = MIN_YEAR
+max      = MAX_YEAR
+interval = 1
+str      = STR_CONFIG_SETTING_TECHNOLOGY_YEAR
+strhelp  = STR_CONFIG_SETTING_TECHNOLOGY_YEAR_HELPTEXT
+strval   = STR_CONFIG_SETTING_TECHNOLOGY_YEAR_VALUE
+post_cb  = TechnologyFreezeYearChanged
 cat      = SC_BASIC

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -871,7 +871,7 @@ RoadType GetTownRoadType(const Town *t)
 		if (!HasBit(rti->flags, ROTF_TOWN_BUILD)) continue;
 
 		/* Not yet introduced at this date. */
-		if (IsInsideMM(rti->introduction_date, 0, MAX_DAY) && rti->introduction_date > _date) continue;
+		if (IsInsideMM(rti->introduction_date, 0, MAX_DAY) && rti->introduction_date > _technology_date) continue;
 
 		if (best != nullptr) {
 			if ((rti->max_speed == 0 ? assume_max_speed : rti->max_speed) < (best->max_speed == 0 ? assume_max_speed : best->max_speed)) continue;
@@ -2585,7 +2585,7 @@ static bool BuildTownHouse(Town *t, TileIndex tile)
 			continue;
 		}
 
-		if (_cur_year < hs->min_year || _cur_year > hs->max_year) continue;
+		if (_technology_year < hs->min_year || _technology_year > hs->max_year) continue;
 
 		/* Special houses that there can be only one of. */
 		uint oneof = 0;

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -207,7 +207,7 @@ CommandCost CheckBridgeAvailability(BridgeType bridge_type, uint bridge_len, DoC
 	if (bridge_type >= MAX_BRIDGES) return CMD_ERROR;
 
 	const BridgeSpec *b = GetBridgeSpec(bridge_type);
-	if (b->avail_year > _cur_year) return CMD_ERROR;
+	if (b->avail_year > _technology_year) return CMD_ERROR;
 
 	uint max = std::min(b->max_length, _settings_game.construction.max_bridge_length);
 

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -34,6 +34,10 @@ enum GenerateLandscapeWidgets {
 	WID_GL_START_DATE_TEXT,             ///< Start year.
 	WID_GL_START_DATE_UP,               ///< Increase start year.
 
+	WID_GL_TECHNOLOGY_PROGRESS_SPEED_DOWN, ///< Decrease technology progress speed
+	WID_GL_TECHNOLOGY_PROGRESS_SPEED_TEXT, ///< Technology progress speed
+	WID_GL_TECHNOLOGY_PROGRESS_SPEED_UP,   ///< Increase technology progress speed
+
 	WID_GL_SNOW_COVERAGE_DOWN,          ///< Decrease snow coverage.
 	WID_GL_SNOW_COVERAGE_TEXT,          ///< Snow coverage.
 	WID_GL_SNOW_COVERAGE_UP,            ///< Increase snow coverage.
@@ -77,6 +81,11 @@ enum CreateScenarioWidgets {
 	WID_CS_START_DATE_DOWN,        ///< Decrease start year (start earlier).
 	WID_CS_START_DATE_TEXT,        ///< Clickable start date value.
 	WID_CS_START_DATE_UP,          ///< Increase start year (start later).
+
+	WID_CS_TECHNOLOGY_PROGRESS_SPEED_DOWN, ///< Decrease technology progress speed
+	WID_CS_TECHNOLOGY_PROGRESS_SPEED_TEXT, ///< Technology progress speed
+	WID_CS_TECHNOLOGY_PROGRESS_SPEED_UP,   ///< Increase technology progress speed
+
 	WID_CS_FLAT_LAND_HEIGHT_DOWN,  ///< Decrease flat land height.
 	WID_CS_FLAT_LAND_HEIGHT_TEXT,  ///< Clickable flat land height value.
 	WID_CS_FLAT_LAND_HEIGHT_UP,    ///< Increase flat land height.


### PR DESCRIPTION
## Motivation / Problem

In the [daylength](https://github.com/OpenTTD/OpenTTD/discussions/8397#discussioncomment-224382) discussion, @andythenorth gives motivations for players to configure how fast technology progresses in OpenTTD:

> Play 1960 trains forever!
> 
> For many players, the game seems to progress quickly. A new generation of vehicles appears, so we upgrade and tune our networks. Then just as we finish, boom! A new generation of vehicles appears.
> 
> On busy or large maps it can be hard to keep up.
> 
> Slower progression of vehicles would make a more relaxing games for some players.

Additional usecases might be:

* A GS freezes technology progress and advances it when the player completes transport goals ("research" in many games).
* Early-year games such as the American Wild West can actually reach a late-game network size and bank account without cheating time and money — without this, by the time a large network can be built, the era is long past.
* Industry sets can be designed for frozen progression without regard to supporting realistic technological progression, and can offer industry chains which were phased out long ago. Imagine sending ships to hunt whales, delivering coal to gasworks for town gas production, and harvesting ice from frozen lakes to ship around the world. Currently, the NewGRF author can either choose to force these industries to close, frustrating the player, or keep them around forever, which feels silly.


## Description

This PR decouples technology date from game time. The availability of content such as vehicles, houses, bridges, etc., as well as date-sensitive game settings like coloured newspapers, automatic selection of semaphore vs light signals, etc., is based on a new _technology date_ which advances according to a new `Technology progress speed` setting. The current, and default, speed is 1/1, but this can be slowed up to 1/255 normal speed.

Other than content availability, the rest of the game mechanics continue to use the actual game date which progresses normally and independently of the technology date — so this is not "daylength" in any way.

### Is this daylength?

No, this is not daylength. Daylength generally changes the speed of the economic engine, for instance [the _Slow Pace_ implementation](https://github.com/OpenTTD/OpenTTD/discussions/8397#discussioncomment-1879306) by @kaomoneus. If years go by slower, the technology naturally progresses slower, but this is a side effect and not the point. It is also impossible to freeze technology progress entirely with a daylength approach. 

### Does this prevent daylength in the future?

I believe this could coexist alongside a daylength implementation like _Slow Pace_, giving players separate control over technology and economic time, respectively. I don't see a global reduction of tick speed as a viable, understandable, or desirable implementation. Two parallel controls seem like the way to go, to me.

I've looked through the code in _Slow Pace_, and don't believe there is any code overlap with this PR.

### How does the player choose the technology progress speed?

The world generation screen (all three of them, including the heightmap GUI and the mini generator screen in Scenario Editor) gains a `Technology progress speed` setting. This is given in 1/n (like plane speed factor), where 0 is `Frozen`, the current speed (also default) is 1/1, and increasing the setting makes the speed slower, up to 1/255 of normal speed.

The technology year always starts synced with the chosen start year. If normal speed is selected, it silently mirrors the game year and the player has no idea they are different variables. However, if a game is started with any other technology progression speed, the game year starts at 1, counting up the calendar years played instead of the technology year, since they are no longer synced. This is how the same feature works in Transport Fever 2, and I think it's quite elegant.

I am open to suggestions and debate about whether and how the technology year should be displayed in the toolbar somewhere.

If the player wishes to adjust the technology progress speed, or manually change the technology year, both are available in Settings. Changing the technology year resets the availability of vehicles, road/railtypes, airports, bridges, etc., as well as the current inflation rate. Otherwise, it works like the date cheat where objects (vehicles, objects, etc) already in the game world are not affected.

### How does this work in multiplayer?

No differently than singleplayer. Like many settings, the technology progress speed cannot be changed in a running game, nor can the technology year be changed manually.

If we go forward with this PR, the technology date will likely replace the actual date in the server list, while the server detail window will be modified to show the same `Date` and `Years` fields instead of `Start date` and `Current date`. I haven't implemented this yet since network and game coordinator code is quite complex, and I want to see if there's even interest in this PR before tackling that.

### What about NewGRF global variables?

The global variables for `current_date/year/month/etc` continue to use the actual game date, to avoid breaking anything. 

New variables are added for `_technology_date` and `_technology_year` to allow NewGRF authors to update their creations. If this is merged, I will make PRs to add the variables to NML.

In my experience with NewGRF, the only time I've seen the date variables used are for depot graphics which choose a sprite based on the build year, or for automatic vehicle liveries. These would need to be modified to use the new variables, but I don't see this as a deal-breaker since the NewGRFs will still work with technology progress speed 1/1 — they aren't broken, they just don't support the new feature.

## Questions & Limitations

* I have not touched network code yet, but if we go forward with this PR, the technology date will likely replace the actual date in the server list, while the server detail window will be modified to show the same `Date` and `Years` fields instead of `Start date` and `Current date`. I haven't implemented this yet since network and game coordinator code is quite complex, and I want to see if there's even interest in this PR before tackling that.
* Can a GS change the technology year and technology progress speed settings using the existing GSGameSettings::SetValue() method, or do I need to add new functions to change these?
* I didn't touch `oldloader_sl` for loading non-OpenTTD saves and determining which vehicles are available. Do I need to, or are the intro dates overwritten later?
* Do I need to create or add to any regression tests?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
