### PR TITLE
Fix #9020: Update station coverage highlight when adding/removing tiles

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -1286,7 +1286,7 @@ static void CheckCaches()
 
 		/* Check industries_near */
 		IndustryList industries_near = st->industries_near;
-		st->RecomputeCatchment();
+		st->RecomputeCatchment(false);
 		if (st->industries_near != industries_near) {
 			Debug(desync, 2, "station industries near mismatch: station {}", st->index);
 		}

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -402,8 +402,9 @@ bool Station::CatchmentCoversTown(TownID t) const
 /**
  * Recompute tiles covered in our catchment area.
  * This will additionally recompute nearby towns and industries.
+ * @param redraw Should we redraw the catchment area?
  */
-void Station::RecomputeCatchment()
+void Station::RecomputeCatchment(bool redraw)
 {
 	this->industries_near.clear();
 	this->RemoveFromAllNearbyLists();
@@ -465,6 +466,9 @@ void Station::RecomputeCatchment()
 			this->AddIndustryToDeliver(i);
 		}
 	}
+	/* Redraw the screen when building or removing stations, to update coverage highlights.
+	 * Note: We can't just redraw tiles in this->catchment_tiles, since this would exclude just-removed tiles.*/
+	if (redraw) MarkWholeScreenDirty();
 }
 
 /**
@@ -473,7 +477,7 @@ void Station::RecomputeCatchment()
  */
 /* static */ void Station::RecomputeCatchmentForAll()
 {
-	for (Station *st : Station::Iterate()) { st->RecomputeCatchment(); }
+	for (Station *st : Station::Iterate()) { st->RecomputeCatchment(false); }
 }
 
 /************************************************************************/

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -494,7 +494,7 @@ public:
 
 	uint GetPlatformLength(TileIndex tile, DiagDirection dir) const override;
 	uint GetPlatformLength(TileIndex tile) const override;
-	void RecomputeCatchment();
+	void RecomputeCatchment(bool redraw);
 	static void RecomputeCatchmentForAll();
 
 	uint GetCatchmentRadius() const;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -745,7 +745,7 @@ static void DeleteStationIfEmpty(BaseStation *st)
 void Station::AfterStationTileSetChange(bool adding, StationType type)
 {
 	this->UpdateVirtCoord();
-	this->RecomputeCatchment();
+	this->RecomputeCatchment(true);
 	DirtyCompanyInfrastructureWindows(this->owner);
 	if (adding) InvalidateWindowData(WC_STATION_LIST, this->owner, 0);
 
@@ -1663,7 +1663,7 @@ CommandCost CmdRemoveFromRailStation(DoCommandFlag flags, TileIndex start, TileI
 
 		if (st->train_station.tile == INVALID_TILE) SetWindowWidgetDirty(WC_STATION_VIEW, st->index, WID_SV_TRAINS);
 		st->MarkTilesDirty(false);
-		st->RecomputeCatchment();
+		st->RecomputeCatchment(true);
 	}
 
 	/* Now apply the rail cost to the number that we deleted */
@@ -1744,7 +1744,7 @@ static CommandCost RemoveRailStation(TileIndex tile, DoCommandFlag flags)
 	Station *st = Station::GetByTile(tile);
 	CommandCost cost = RemoveRailStation(st, flags, _price[PR_CLEAR_STATION_RAIL]);
 
-	if (flags & DC_EXEC) st->RecomputeCatchment();
+	if (flags & DC_EXEC) st->RecomputeCatchment(true);
 
 	return cost;
 }
@@ -4107,7 +4107,7 @@ void BuildOilRig(TileIndex tile)
 	st->rect.BeforeAddTile(tile, StationRect::ADD_FORCE);
 
 	st->UpdateVirtCoord();
-	st->RecomputeCatchment();
+	st->RecomputeCatchment(true);
 	UpdateStationAcceptance(st, false);
 }
 


### PR DESCRIPTION
## Motivation / Problem

See #9020.

## Description

Force a redraw of the entire screen whenever tiles are added or removed from a station.

Closes #9020.

## Limitations

I couldn't find a more targeted way of doing this, since the station's `catchment_tiles` won't include recently-removed tiles, nor could I find a way to check if the highlight is actually being shown. But adding and removing station tiles is a relatively rare operation, so I don't think this is too expensive. Suggestions welcome, of course.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
