### PR TITLE
Add: [Script] ObjectType::ResolveNewGRFID to resolve object id from grfid and grf_local_id

### DIFF
--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -17,6 +17,8 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * \li AIObjectType::ResolveNewGRFID
+ *
  * \b 12.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -17,6 +17,8 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * \li GSObjectType::ResolveNewGRFID
+ *
  * \b 12.0
  *
  * API additions:

--- a/src/script/api/script_objecttype.cpp
+++ b/src/script/api/script_objecttype.cpp
@@ -43,3 +43,11 @@
 
 	return ScriptObject::DoCommand(tile, object_type, view, CMD_BUILD_OBJECT);
 }
+
+/* static */ ObjectType ScriptObjectType::ResolveNewGRFID(uint32 grfid, uint16 grf_local_id)
+{
+	EnforcePrecondition(INVALID_OBJECT_TYPE, IsInsideBS(grf_local_id, 0x00, NUM_OBJECTS_PER_GRF));
+
+	grfid = BSWAP32(grfid); // Match people's expectations.
+	return _object_mngr.GetID(grf_local_id, grfid);
+}

--- a/src/script/api/script_objecttype.hpp
+++ b/src/script/api/script_objecttype.hpp
@@ -52,6 +52,15 @@ public:
 	 * @return True if the object was successfully build.
 	 */
 	static bool BuildObject(ObjectType object_type, uint8 view, TileIndex tile);
+
+	/**
+	 * Get a specific object-type from a grf.
+	 * @param grf_id The ID of the NewGRF.
+	 * @param grf_local_id The ID of the object, local to the NewGRF.
+	 * @pre 0x00 <= grf_local_id < NUM_OBJECTS_PER_GRF.
+	 * @return the object-type ID, local to the current game (this diverges from the grf_local_id).
+	 */
+	static ObjectType ResolveNewGRFID(uint32 grfid, uint16 grf_local_id);
 };
 
 #endif /* SCRIPT_OBJECTTYPE_HPP */


### PR DESCRIPTION
…f_local_id

## Motivation / Problem

Describe here shortly
* For features or gameplay changes:
    * What was the motivation to develop this feature?
        * make more complete the GS -> objects API which was introduced by #9568.
    * Does this address any problem with the gameplay or interface?
        * No, it extends GS API.  
    * Which group of players do you think would enjoy this feature?
        * GS Authors.


## Description

Describe here shortly
* For features or gameplay changes:
    * What does this feature do?
        * permits resolving the grf-local ID of NewGRF Object to the ObjectType (ID) of an object in game.
        * the ObjectType in game is what GS works with for listing objects, building objects etc
        * this permits GS to work deterministically with objects, almost all of which come from NewGRF.
    * How does it improve/solve the situation described under 'motivation'.
        * without this, it's not possible to reliably and deterministically identify NewGRF objects across different games, therefore building or otherwise working with objects in GS is limited to unpredictable random effects.


## Limitations

Describe here
* Is the problem solved in all scenarios?
    * as far as I know yes.
* Is this feature complete? Are there things that could be added in the future?
    * as far as I know yes.   
* Are there things that are intentionally left out?
    * there's no inverse resolve method to get the grf-local-id and grfid from an ObjectType.
    * this may be needed, but it's not a clear case yet, and this PR does not block adding that method later.
* Do you know of a bug or corner case that does not work?
    * no.   


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
    * no. 
* This PR touches english.txt or translations? 
    * no. 
* This PR affects the save game format? (label 'savegame upgrade')
    * no. 
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
        * both done. 
    * The compatibility wrappers (compat_*.nut) need updating.
        * not needed, new method, no prior compatibility to maintain.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * no.