### PR TITLE
Add: [Script] IndustryType::ResolveNewGRFID to resolve industry id from grf_local_id and grfid

### DIFF
--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -17,6 +17,7 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * \li AIIndustryType::ResolveNewGRFID
  * \li AIObjectType::ResolveNewGRFID
  *
  * \b 12.0

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -17,6 +17,7 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * \li GSIndustryType::ResolveNewGRFID
  * \li GSObjectType::ResolveNewGRFID
  *
  * \b 12.0

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -154,3 +154,11 @@
 
 	return (::GetIndustrySpec(industry_type)->behaviour & INDUSTRYBEH_AI_AIRSHIP_ROUTES) != 0;
 }
+
+/* static */ IndustryType ScriptIndustryType::ResolveNewGRFID(uint32 grfid, uint16 grf_local_id)
+{
+	EnforcePrecondition(INVALID_INDUSTRYTYPE, IsInsideBS(grf_local_id, 0x00, NUM_INDUSTRYTYPES_PER_GRF));
+
+	grfid = BSWAP32(grfid); // Match people's expectations.
+	return _industry_mngr.GetID(grf_local_id, grfid);
+}

--- a/src/script/api/script_industrytype.hpp
+++ b/src/script/api/script_industrytype.hpp
@@ -181,6 +181,15 @@ public:
 	 * @return True when this type has a dock.
 	 */
 	static bool HasDock(IndustryType industry_type);
+
+	/**
+	 * Get a specific industry-type from a grf.
+	 * @param grf_id The ID of the NewGRF.
+	 * @param grf_local_id The ID of the industry, local to the NewGRF.
+	 * @pre 0x00 <= grf_local_id < NUM_INDUSTRYTYPES_PER_GRF.
+	 * @return the industry-type ID, local to the current game (this diverges from the grf_local_id).
+	 */
+	static IndustryType ResolveNewGRFID(uint32 grfid, uint16 grf_local_id);
 };
 
 #endif /* SCRIPT_INDUSTRYTYPE_HPP */


### PR DESCRIPTION
## Motivation / Problem

Describe here shortly
* For features or gameplay changes:
    * What was the motivation to develop this feature?
        * make more complete the GS -> industry API, following similar addition for objects in #9795
    * Does this address any problem with the gameplay or interface?
        * No, it extends GS API.  
    * Which group of players do you think would enjoy this feature?
        * GS Authors.


## Description

Describe here shortly
* For features or gameplay changes:
    * What does this feature do?
        * permits resolving the grf-local ID of NewGRF industry to the IndustryType (ID) of an industry in game.
        * the IndustryType in game is what GS works with for listing industries, building industries etc
        * this permits GS to work deterministically with industries, which frequently come from NewGRF.
    * How does it improve/solve the situation described under 'motivation'.
        * without this, it's not possible to reliably and deterministically identify NewGRF industries across different games, except via cargo fingerprinting, which is crude and inelegant

## Limitations

Describe here
* Is the problem solved in all scenarios?
    * as far as I know yes.
* Is this feature complete? Are there things that could be added in the future?
    * as far as I know it's complete.   
* Are there things that are intentionally left out?
    * there's no inverse resolve method to get the grf-local-id and grfid from an IndustryType.
    * this may be needed, but it's not a clear case yet, and this PR does not block adding that method later.
* Do you know of a bug or corner case that does not work?
    * no.   


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
    * no. 
* This PR touches english.txt or translations? 
    * no. 
* This PR affects the save game format? (label 'savegame upgrade')
    * no. 
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
        * both done. 
    * The compatibility wrappers (compat_*.nut) need updating.
        * not needed, new method, no prior compatibility to maintain.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * no.