### PR TITLE
Fix: do not let shares in the company taking over another company disappear

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -324,13 +324,13 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 
 		/* Sell all the shares that people have on this company */
 		Backup<CompanyID> cur_company2(_current_company, FILE_LINE);
-		const Company *c = Company::Get(old_owner);
+		Company *c = Company::Get(old_owner);
 		for (i = 0; i < 4; i++) {
 			if (c->share_owners[i] == INVALID_OWNER) continue;
 
 			if (c->bankrupt_value == 0 && c->share_owners[i] == new_owner) {
 				/* You are the one buying the company; so don't sell the shares back to you. */
-				Company::Get(new_owner)->share_owners[i] = INVALID_OWNER;
+				c->share_owners[i] = INVALID_OWNER;
 			} else {
 				cur_company2.Change(c->share_owners[i]);
 				/* Sell the shares */


### PR DESCRIPTION
## Motivation / Problem

Shares of my company are owned by other companies. I take over another company. Nobody owns shares in my company!

Given [testcase.zip](https://github.com/OpenTTD/OpenTTD/files/7990270/testcase.zip), open your company window and the one of the red company. Now buy the last share of the red company. All shares in your company have gone.


## Description

Do not mess with shares of the new company, but rather "clear" the share for the old company. Although technically we might not even need to clear the status for the "old" company.


## Limitations

None? I'm not really sure why this code existed in this way. There is code to sell the shares of the to be removed company in other companies, but no idea why shares of the new company in the old company need to be sold/accounted for.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
