### PR TITLE
Fix #9811, 9156d7b: Use the NewGRF-defined vehicle center when dragging ships and aircraft.

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -3186,6 +3186,7 @@ void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type)
 	int total_width = 0;
 	int y_offset = 0;
 	bool rotor_seq = false; // Whether to draw the rotor of the vehicle in this step.
+	bool is_ground_vehicle = v->IsGroundVehicle();
 
 	while (v != nullptr) {
 		if (total_width >= ScaleGUITrad(2 * (int)VEHICLEINFO_FULL_VEHICLE_WIDTH)) break;
@@ -3221,10 +3222,13 @@ void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type)
 		}
 	}
 
-	int offs = (ScaleGUITrad(VEHICLEINFO_FULL_VEHICLE_WIDTH) - total_width) / 2;
-	if (rtl) offs = -offs;
-	for (uint i = 0; i < _cursor.sprite_count; ++i) {
-		_cursor.sprite_pos[i].x += offs;
+	if (is_ground_vehicle) {
+		/* Center trains and road vehicles on the front vehicle */
+		int offs = (ScaleGUITrad(VEHICLEINFO_FULL_VEHICLE_WIDTH) - total_width) / 2;
+		if (rtl) offs = -offs;
+		for (uint i = 0; i < _cursor.sprite_count; ++i) {
+			_cursor.sprite_pos[i].x += offs;
+		}
 	}
 
 	UpdateCursorSize();


### PR DESCRIPTION
## Motivation / Problem

#9811 

## Description

NewGRF define the center of a vehicle using the sprite offsets.
Originally this was also used to define the "mouse position" when dragging vehicles using the vehicle sprite as mouse cursor.

9156d7b fixed dragging of articulated trains and road vehicles to draw the whole articulated vehicle (limited to some max width), instead of just the first articulated part (which may be a partial/broken vehicle or even invisible).

9156d7b was designed to put the "mouse position" to the front of the vehicle chain, which felt more natural than some center of a wagon chain.

However, this also affected ships and aircraft, which essentially resulted in the "mouse position" always being at the border of the sprite.

This reverts the change from 9156d7b for aircraft and ships.

## Limitations

This PR fixes the behavior for NewGRF like FISH.

The "sailing ships" NewGRF from the original issue #9811 however has such broken offsets, that it is wrong in any case.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
