### PR TITLE
Fix: Original music playback rate was slightly too fast

### DIFF
--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -525,8 +525,8 @@ struct MpsMachine {
 	Channel channels[16];         ///< playback status for each MIDI channel
 	std::vector<uint32> segments; ///< pointers into songdata to repeatable data segments
 	int16 tempo_ticks;            ///< ticker that increments when playing a frame, decrements before playing a frame
-	int16 current_tempo;         ///< threshold for actually playing a frame
-	int16 initial_tempo;         ///< starting tempo of song
+	int16 current_tempo;          ///< threshold for actually playing a frame
+	int16 initial_tempo;          ///< starting tempo of song
 	bool shouldplayflag;          ///< not-end-of-song flag
 
 	static const int TEMPO_RATE;
@@ -787,10 +787,11 @@ struct MpsMachine {
 	bool PlayInto()
 	{
 		/* Tempo seems to be handled as TEMPO_RATE = 148 ticks per second.
-		 * Use this as the tickdiv, and define the tempo to be one second (1M microseconds) per tickdiv.
+		 * Use this as the tickdiv, and define the tempo to be somewhat less than one second (1M microseconds) per quarter note.
+		 * This value was found experimentally to give a very close approximation of the correct playback speed.
 		 * MIDI software loading exported files will show a bogus tempo, but playback will be correct. */
 		this->target.tickdiv = TEMPO_RATE;
-		this->target.tempos.push_back(MidiFile::TempoChange(0, 1000000));
+		this->target.tempos.push_back(MidiFile::TempoChange(0, 980500));
 
 		/* Initialize playback simulation */
 		this->RestartSong();


### PR DESCRIPTION
## Motivation / Problem

Music loaded from the DOS music data is played slightly too fast tempo.

## Description

I experimentally found a playback rate that gets very close to the correct tempo. The new speed gives an error of less than 0.01 seconds per minute of playback.

Also fix indentation of comments on two lines.

## Limitations

It's a magic number.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
