### PR TITLE
Fix #9020: Update station coverage highlight when adding/removing tiles

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -744,9 +744,16 @@ static void DeleteStationIfEmpty(BaseStation *st)
 void Station::AfterStationTileSetChange(bool adding, StationType type)
 {
 	this->UpdateVirtCoord();
-	this->RecomputeCatchment();
 	DirtyCompanyInfrastructureWindows(this->owner);
-	if (adding) InvalidateWindowData(WC_STATION_LIST, this->owner, 0);
+
+	if (adding) {
+		this->RecomputeCatchment();
+		MarkCatchmentTilesDirty();
+		InvalidateWindowData(WC_STATION_LIST, this->owner, 0);
+	} else {
+		MarkCatchmentTilesDirty();
+		this->RecomputeCatchment();
+	}
 
 	switch (type) {
 		case STATION_RAIL:
@@ -1628,6 +1635,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, std::vector<T *> &affected_st
 		if (st->train_station.tile == INVALID_TILE) {
 			st->facilities &= ~FACIL_TRAIN;
 			SetWindowWidgetDirty(WC_STATION_VIEW, st->index, WID_SV_TRAINS);
+			MarkCatchmentTilesDirty();
 			st->UpdateVirtCoord();
 			DeleteStationIfEmpty(st);
 		}
@@ -1662,6 +1670,7 @@ CommandCost CmdRemoveFromRailStation(DoCommandFlag flags, TileIndex start, TileI
 
 		if (st->train_station.tile == INVALID_TILE) SetWindowWidgetDirty(WC_STATION_VIEW, st->index, WID_SV_TRAINS);
 		st->MarkTilesDirty(false);
+		MarkCatchmentTilesDirty();
 		st->RecomputeCatchment();
 	}
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3495,7 +3495,7 @@ CommandCost CmdScrollViewport(DoCommandFlag flags, TileIndex tile, ViewportScrol
 	return CommandCost();
 }
 
-static void MarkCatchmentTilesDirty()
+void MarkCatchmentTilesDirty()
 {
 	if (_viewport_highlight_town != nullptr) {
 		MarkWholeScreenDirty();

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -98,5 +98,6 @@ struct Town;
 
 void SetViewportCatchmentStation(const Station *st, bool sel);
 void SetViewportCatchmentTown(const Town *t, bool sel);
+void MarkCatchmentTilesDirty();
 
 #endif /* VIEWPORT_FUNC_H */


### PR DESCRIPTION
## Motivation / Problem

See #9020.

## Description

Marks catchment area tiles dirty whenever tiles are added or removed from a station.

I'd previously created a PR (#9793) to fix this bug and closed it after getting stuck and frustrated. After force-pushing my new commit to the branch, it wouldn't let me reopen the old PR. 

Closes #9020.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
