### PR TITLE
Fix e740c24: Use correct command flag, not just DC_EXEC

### DIFF
--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -1373,7 +1373,7 @@ static CommandCost TerraformTile_Water(TileIndex tile, DoCommandFlag flags, int 
 	/* Canals can't be terraformed */
 	if (IsWaterTile(tile) && IsCanal(tile)) return_cmd_error(STR_ERROR_MUST_DEMOLISH_CANAL_FIRST);
 
-	return Command<CMD_LANDSCAPE_CLEAR>::Do(DC_EXEC, tile);
+	return Command<CMD_LANDSCAPE_CLEAR>::Do(flags, tile);
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

See #9822.

Per @nielsmh, the regression was introduced in https://github.com/OpenTTD/OpenTTD/commit/e740c24eb7a90bc771f5976d64d80639ee7576e5#diff-2435a884057fcf692871728ce3d0726330c4120b00d7b07514eaa0ec310b0fd5R1385-R1387

## Description

Use the flag passed to the command, not just DC_EXEC.

Closes #9822.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
