### PR TITLE
Feature: Improved finance window

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -91,7 +91,7 @@ struct Aircraft FINAL : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 
 	void MarkDirty();
 	void UpdateDeltaXY();
-	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_AIRCRAFT_INC : EXPENSES_AIRCRAFT_RUN; }
+	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_AIRCRAFT_REVENUE : EXPENSES_AIRCRAFT_RUN; }
 	bool IsPrimaryVehicle() const                  { return this->IsNormalAircraft(); }
 	void GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const;
 	int GetDisplaySpeed() const    { return this->cur_speed; }

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -219,17 +219,17 @@ static void SubtractMoneyFromAnyCompany(Company *c, const CommandCost &cost)
 	c->money -= cost.GetCost();
 	c->yearly_expenses[0][cost.GetExpensesType()] += cost.GetCost();
 
-	if (HasBit(1 << EXPENSES_TRAIN_INC    |
-	           1 << EXPENSES_ROADVEH_INC  |
-	           1 << EXPENSES_AIRCRAFT_INC |
-	           1 << EXPENSES_SHIP_INC, cost.GetExpensesType())) {
+	if (HasBit(1 << EXPENSES_TRAIN_REVENUE    |
+	           1 << EXPENSES_ROADVEH_REVENUE  |
+	           1 << EXPENSES_AIRCRAFT_REVENUE |
+	           1 << EXPENSES_SHIP_REVENUE, cost.GetExpensesType())) {
 		c->cur_economy.income -= cost.GetCost();
 	} else if (HasBit(1 << EXPENSES_TRAIN_RUN    |
 	                  1 << EXPENSES_ROADVEH_RUN  |
 	                  1 << EXPENSES_AIRCRAFT_RUN |
 	                  1 << EXPENSES_SHIP_RUN     |
 	                  1 << EXPENSES_PROPERTY     |
-	                  1 << EXPENSES_LOAN_INT, cost.GetExpensesType())) {
+	                  1 << EXPENSES_LOAN_INTEREST, cost.GetExpensesType())) {
 		c->cur_economy.expenses -= cost.GetCost();
 	}
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -831,7 +831,7 @@ static void CompaniesPayInterest()
 		Money up_to_previous_month = yearly_fee * _cur_month / 12;
 		Money up_to_this_month = yearly_fee * (_cur_month + 1) / 12;
 
-		SubtractMoneyFromCompany(CommandCost(EXPENSES_LOAN_INT, up_to_this_month - up_to_previous_month));
+		SubtractMoneyFromCompany(CommandCost(EXPENSES_LOAN_INTEREST, up_to_this_month - up_to_previous_month));
 
 		SubtractMoneyFromCompany(CommandCost(EXPENSES_OTHER, _price[PR_STATION_VALUE] >> 2));
 	}

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -162,11 +162,11 @@ enum ExpensesType : byte {
 	EXPENSES_AIRCRAFT_RUN,        ///< Running costs aircraft.
 	EXPENSES_SHIP_RUN,            ///< Running costs ships.
 	EXPENSES_PROPERTY,            ///< Property costs.
-	EXPENSES_TRAIN_INC,           ///< Income from trains.
-	EXPENSES_ROADVEH_INC,         ///< Income from road vehicles.
-	EXPENSES_AIRCRAFT_INC,        ///< Income from aircraft.
-	EXPENSES_SHIP_INC,            ///< Income from ships.
-	EXPENSES_LOAN_INT,            ///< Interest payments over the loan.
+	EXPENSES_TRAIN_REVENUE,       ///< Revenue from trains.
+	EXPENSES_ROADVEH_REVENUE,     ///< Revenue from road vehicles.
+	EXPENSES_AIRCRAFT_REVENUE,    ///< Revenue from aircraft.
+	EXPENSES_SHIP_REVENUE,        ///< Revenue from ships.
+	EXPENSES_LOAN_INTEREST,       ///< Interest payments over the loan.
 	EXPENSES_OTHER,               ///< Other expenses.
 	EXPENSES_END,                 ///< Number of expense types.
 	INVALID_EXPENSES      = 0xFF, ///< Invalid expense type.

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1635,9 +1635,6 @@ STR_CONFIG_SETTING_SHOW_TRACK_RESERVATION_HELPTEXT              :Give reserved t
 STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS                     :Keep building tools active after usage: {STRING2}
 STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS_HELPTEXT            :Keep the building tools for bridges, tunnels, etc. open after use
 
-STR_CONFIG_SETTING_EXPENSES_LAYOUT                              :Group expenses in company finance window: {STRING2}
-STR_CONFIG_SETTING_EXPENSES_LAYOUT_HELPTEXT                     :Define the layout for the company expenses window
-
 STR_CONFIG_SETTING_AUTO_REMOVE_SIGNALS                          :Automatically remove signals during rail construction: {STRING2}
 STR_CONFIG_SETTING_AUTO_REMOVE_SIGNALS_HELPTEXT                 :Automatically remove signals during rail construction if the signals are in the way. Note that this can potentially lead to train crashes.
 
@@ -3610,29 +3607,36 @@ STR_EDIT_WAYPOINT_NAME                                          :{WHITE}Edit way
 
 # Finances window
 STR_FINANCES_CAPTION                                            :{WHITE}{COMPANY} Finances {BLACK}{COMPANY_NUM}
-STR_FINANCES_EXPENDITURE_INCOME_TITLE                           :{WHITE}Expenditure/Income
 STR_FINANCES_YEAR                                               :{WHITE}{NUM}
+
+###length 3
+STR_FINANCES_REVENUE_TITLE                                      :{WHITE}Revenue
+STR_FINANCES_OPERATING_EXPENSES_TITLE                           :{WHITE}Operating Expenses
+STR_FINANCES_CAPITAL_EXPENSES_TITLE                             :{WHITE}Capital Expenses
+
 
 ###length 13
 STR_FINANCES_SECTION_CONSTRUCTION                               :{GOLD}Construction
 STR_FINANCES_SECTION_NEW_VEHICLES                               :{GOLD}New Vehicles
-STR_FINANCES_SECTION_TRAIN_RUNNING_COSTS                        :{GOLD}Train Running Costs
-STR_FINANCES_SECTION_ROAD_VEHICLE_RUNNING_COSTS                 :{GOLD}Road Vehicle Running Costs
-STR_FINANCES_SECTION_AIRCRAFT_RUNNING_COSTS                     :{GOLD}Aircraft Running Costs
-STR_FINANCES_SECTION_SHIP_RUNNING_COSTS                         :{GOLD}Ship Running Costs
-STR_FINANCES_SECTION_PROPERTY_MAINTENANCE                       :{GOLD}Property Maintenance
-STR_FINANCES_SECTION_TRAIN_INCOME                               :{GOLD}Train Income
-STR_FINANCES_SECTION_ROAD_VEHICLE_INCOME                        :{GOLD}Road Vehicle Income
-STR_FINANCES_SECTION_AIRCRAFT_INCOME                            :{GOLD}Aircraft Income
-STR_FINANCES_SECTION_SHIP_INCOME                                :{GOLD}Ship Income
+STR_FINANCES_SECTION_TRAIN_RUNNING_COSTS                        :{GOLD}Trains
+STR_FINANCES_SECTION_ROAD_VEHICLE_RUNNING_COSTS                 :{GOLD}Road Vehicles
+STR_FINANCES_SECTION_AIRCRAFT_RUNNING_COSTS                     :{GOLD}Aircraft
+STR_FINANCES_SECTION_SHIP_RUNNING_COSTS                         :{GOLD}Ships
+STR_FINANCES_SECTION_INFRASTRUCTURE                             :{GOLD}Infrastructure
+STR_FINANCES_SECTION_TRAIN_REVENUE                              :{GOLD}Trains
+STR_FINANCES_SECTION_ROAD_VEHICLE_REVENUE                       :{GOLD}Road Vehicles
+STR_FINANCES_SECTION_AIRCRAFT_REVENUE                           :{GOLD}Aircraft
+STR_FINANCES_SECTION_SHIP_REVENUE                               :{GOLD}Ships
 STR_FINANCES_SECTION_LOAN_INTEREST                              :{GOLD}Loan Interest
 STR_FINANCES_SECTION_OTHER                                      :{GOLD}Other
 
-STR_FINANCES_NEGATIVE_INCOME                                    :{BLACK}-{CURRENCY_LONG}
-STR_FINANCES_POSITIVE_INCOME                                    :{BLACK}+{CURRENCY_LONG}
-STR_FINANCES_TOTAL_CAPTION                                      :{WHITE}Total:
+STR_FINANCES_NEGATIVE_INCOME                                    :-{CURRENCY_LONG}
+STR_FINANCES_POSITIVE_INCOME                                    :+{CURRENCY_LONG}
+STR_FINANCES_NET_PROFIT                                         :{WHITE}Net Profit
 STR_FINANCES_BANK_BALANCE_TITLE                                 :{WHITE}Bank Balance
+STR_FINANCES_OWN_FUNDS_TITLE                                    :{WHITE}Own Funds
 STR_FINANCES_LOAN_TITLE                                         :{WHITE}Loan
+STR_FINANCES_INTEREST_RATE                                      :{WHITE}Loan Interest: {BLACK}{NUM}%
 STR_FINANCES_MAX_LOAN                                           :{WHITE}Maximum Loan: {BLACK}{CURRENCY_LONG}
 STR_FINANCES_TOTAL_CURRENCY                                     :{BLACK}{CURRENCY_LONG}
 STR_FINANCES_BORROW_BUTTON                                      :{BLACK}Borrow {CURRENCY_LONG}

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -126,7 +126,7 @@ struct RoadVehicle FINAL : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 
 	void MarkDirty();
 	void UpdateDeltaXY();
-	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_ROADVEH_INC : EXPENSES_ROADVEH_RUN; }
+	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_ROADVEH_REVENUE : EXPENSES_ROADVEH_RUN; }
 	bool IsPrimaryVehicle() const { return this->IsFrontEngine(); }
 	void GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const;
 	int GetDisplaySpeed() const { return this->gcache.last_speed / 2; }

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -100,20 +100,20 @@ public:
 	 * @api -ai
 	 */
 	enum ExpensesType : byte {
-		EXPENSES_CONSTRUCTION = ::EXPENSES_CONSTRUCTION, ///< Construction costs.
-		EXPENSES_NEW_VEHICLES = ::EXPENSES_NEW_VEHICLES, ///< New vehicles.
-		EXPENSES_TRAIN_RUN    = ::EXPENSES_TRAIN_RUN,    ///< Running costs trains.
-		EXPENSES_ROADVEH_RUN  = ::EXPENSES_ROADVEH_RUN,  ///< Running costs road vehicles.
-		EXPENSES_AIRCRAFT_RUN = ::EXPENSES_AIRCRAFT_RUN, ///< Running costs aircraft.
-		EXPENSES_SHIP_RUN     = ::EXPENSES_SHIP_RUN,     ///< Running costs ships.
-		EXPENSES_PROPERTY     = ::EXPENSES_PROPERTY,     ///< Property costs.
-		EXPENSES_TRAIN_INC    = ::EXPENSES_TRAIN_INC,    ///< Income from trains.
-		EXPENSES_ROADVEH_INC  = ::EXPENSES_ROADVEH_INC,  ///< Income from road vehicles.
-		EXPENSES_AIRCRAFT_INC = ::EXPENSES_AIRCRAFT_INC, ///< Income from aircraft.
-		EXPENSES_SHIP_INC     = ::EXPENSES_SHIP_INC,     ///< Income from ships.
-		EXPENSES_LOAN_INT     = ::EXPENSES_LOAN_INT,     ///< Interest payments over the loan.
-		EXPENSES_OTHER        = ::EXPENSES_OTHER,        ///< Other expenses.
-		EXPENSES_INVALID      = ::INVALID_EXPENSES,      ///< Invalid expense type.
+		EXPENSES_CONSTRUCTION = ::EXPENSES_CONSTRUCTION,     ///< Construction costs.
+		EXPENSES_NEW_VEHICLES = ::EXPENSES_NEW_VEHICLES,     ///< New vehicles.
+		EXPENSES_TRAIN_RUN    = ::EXPENSES_TRAIN_RUN,        ///< Running costs trains.
+		EXPENSES_ROADVEH_RUN  = ::EXPENSES_ROADVEH_RUN,      ///< Running costs road vehicles.
+		EXPENSES_AIRCRAFT_RUN = ::EXPENSES_AIRCRAFT_RUN,     ///< Running costs aircraft.
+		EXPENSES_SHIP_RUN     = ::EXPENSES_SHIP_RUN,         ///< Running costs ships.
+		EXPENSES_PROPERTY     = ::EXPENSES_PROPERTY,         ///< Property costs.
+		EXPENSES_TRAIN_INC    = ::EXPENSES_TRAIN_REVENUE,    ///< Revenue from trains.
+		EXPENSES_ROADVEH_INC  = ::EXPENSES_ROADVEH_REVENUE,  ///< Revenue from road vehicles.
+		EXPENSES_AIRCRAFT_INC = ::EXPENSES_AIRCRAFT_REVENUE, ///< Revenue from aircraft.
+		EXPENSES_SHIP_INC     = ::EXPENSES_SHIP_REVENUE,     ///< Revenue from ships.
+		EXPENSES_LOAN_INT     = ::EXPENSES_LOAN_INTEREST,    ///< Interest payments over the loan.
+		EXPENSES_OTHER        = ::EXPENSES_OTHER,            ///< Other expenses.
+		EXPENSES_INVALID      = ::INVALID_EXPENSES,          ///< Invalid expense type.
 	};
 
 	/**

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1638,7 +1638,6 @@ static SettingsContainer &GetSettingsTree()
 			interface->Add(new SettingEntry("gui.advanced_vehicle_list"));
 			interface->Add(new SettingEntry("gui.timetable_in_ticks"));
 			interface->Add(new SettingEntry("gui.timetable_arrival_departure"));
-			interface->Add(new SettingEntry("gui.expenses_layout"));
 			interface->Add(new SettingEntry("gui.show_newgrf_name"));
 		}
 

--- a/src/ship.h
+++ b/src/ship.h
@@ -37,7 +37,7 @@ struct Ship FINAL : public SpecializedVehicle<Ship, VEH_SHIP> {
 
 	void MarkDirty();
 	void UpdateDeltaXY();
-	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_SHIP_INC : EXPENSES_SHIP_RUN; }
+	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_SHIP_REVENUE : EXPENSES_SHIP_RUN; }
 	void PlayLeaveStationSound() const;
 	bool IsPrimaryVehicle() const { return true; }
 	void GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const;

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -657,14 +657,6 @@ str      = STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS
 strhelp  = STR_CONFIG_SETTING_PERSISTENT_BUILDINGTOOLS_HELPTEXT
 cat      = SC_BASIC
 
-[SDTC_BOOL]
-var      = gui.expenses_layout
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = true
-str      = STR_CONFIG_SETTING_EXPENSES_LAYOUT
-strhelp  = STR_CONFIG_SETTING_EXPENSES_LAYOUT_HELPTEXT
-post_cb  = [](auto) { MarkWholeScreenDirty(); }
-
 [SDTC_VAR]
 var      = gui.station_gui_group_order
 type     = SLE_UINT8

--- a/src/train.h
+++ b/src/train.h
@@ -109,7 +109,7 @@ struct Train FINAL : public GroundVehicle<Train, VEH_TRAIN> {
 
 	void MarkDirty();
 	void UpdateDeltaXY();
-	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_TRAIN_INC : EXPENSES_TRAIN_RUN; }
+	ExpensesType GetExpenseType(bool income) const { return income ? EXPENSES_TRAIN_REVENUE : EXPENSES_TRAIN_RUN; }
 	void PlayLeaveStationSound() const;
 	bool IsPrimaryVehicle() const { return this->IsFrontEngine(); }
 	void GetImage(Direction direction, EngineImageType image_type, VehicleSpriteSeq *result) const;

--- a/src/widgets/company_widget.h
+++ b/src/widgets/company_widget.h
@@ -68,9 +68,9 @@ enum CompanyFinancesWidgets {
 	WID_CF_SEL_MAXLOAN,    ///< Selection of maxloan column.
 	WID_CF_BALANCE_VALUE,  ///< Bank balance value.
 	WID_CF_LOAN_VALUE,     ///< Loan.
-	WID_CF_LOAN_LINE,      ///< Line for summing bank balance and loan.
-	WID_CF_TOTAL_VALUE,    ///< Total.
-	WID_CF_MAXLOAN_GAP,    ///< Gap above max loan widget.
+	WID_CF_BALANCE_LINE,   ///< Available cash.
+	WID_CF_OWN_VALUE,      ///< Own funds, not including loan.
+	WID_CF_INTEREST_RATE,  ///< Loan interest rate.
 	WID_CF_MAXLOAN_VALUE,  ///< Max loan widget.
 	WID_CF_SEL_BUTTONS,    ///< Selection of buttons.
 	WID_CF_INCREASE_LOAN,  ///< Increase loan.


### PR DESCRIPTION
## Motivation / Problem

![fianances_old](https://user-images.githubusercontent.com/55058389/155381706-5f1ff825-045a-41a8-a448-673592408cc6.png)

`Group expenses in company finance window` has been on by default since #8463. Even so, the window is cluttered with redundant text ("Income" and "Running Costs") and a whole bunch of black numbers.

Additionally, the "Income" is incorrectly used to describe "Revenue" — income is revenue minus expenses.

## Description

![financeGUI](https://user-images.githubusercontent.com/55058389/165000806-b59348f7-4bc9-42ff-b2d1-ebd6bf01441c.png)

I've reworked the window inspired by a design by @LC-Zorg [on TT-Forums](https://www.tt-forums.net/viewtopic.php?t=86948). Each category gained a title with an indented breakdown below.

Per discussion here and on Discord, the total was kept below the category instead of being in-line with the title, as I originally proposed.

The expense/revenue names have been significantly simplified, both for vehicle types as well as "Property Maintenance" becoming "Infrastructure".

Income is renamed to Revenue in several places, both in strings and source code. The script API has been left unchanged.

The balance sheet at bottom left has been reorganized to emphasize the bank balance available for construction, not the company's own funds, which would be negative until the bank balance is higher than the loan.

I have also added the loan interest above the maximum loan. Both of these are purely informational, as the loan interest currently cannot be changed during a game.

## Limitations

The un-grouped finance window no longer exists, a casualty of how I've rewritten the window. It was awful and needed to disappear anyway.

The new names for Revenue, Operating Expenses, and Capital Expenses are American English. Feel free to tell me I'm a silly yank if the terms are different in the UK. 😄 

LC-Zorg's proposal includes a slider to change how much loan is borrowed or repaid per click. I don't consider that in scope for this PR.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
