### PR TITLE
Change: Don't pay Property Maintenance on stations when Infrastructure Maintenance is disabled

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -652,13 +652,8 @@ static void CompaniesGenStatistics()
 
 	Backup<CompanyID> cur_company(_current_company, FILE_LINE);
 
-	if (!_settings_game.economy.infrastructure_maintenance) {
-		for (const Station *st : Station::Iterate()) {
-			cur_company.Change(st->owner);
-			CommandCost cost(EXPENSES_PROPERTY, _price[PR_STATION_VALUE] >> 1);
-			SubtractMoneyFromCompany(cost);
-		}
-	} else {
+	/* Pay Infrastructure Maintenance, if enabled */
+	if (_settings_game.economy.infrastructure_maintenance) {
 		/* Improved monthly infrastructure costs. */
 		for (const Company *c : Company::Iterate()) {
 			cur_company.Change(c->index);


### PR DESCRIPTION
## Motivation / Problem

When Infrastructure Maintenance is off, I would expect to not pay Property Maintenance. However, we still pay Property Maintenance on stations.

Posts on [reddit](https://www.reddit.com/r/openttd/comments/szwf6j/whats_the_difference_between_property_maintenance/) and [TT-Forums](https://www.tt-forums.net/viewtopic.php?t=76716) assume the same thing.

This appears to be a holdover from the days before Infrastructure Maintenance was added to OpenTTD, when station tiles were the only contributor toward Property Maintenance.

## Description

Only pay Property Maintenance on stations when Infrastructure Maintenance is enabled. Otherwise, pay no property costs.

This may be a controversial change, but I think it brings the game's behavior into line with what the player expects.

## Limitations

* Savegames with Infrastructure Maintenance disabled will have slightly lower expenses. I would be impressed if anyone manages to play OpenTTD with a small enough profit margin that this has any meaningful effect.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
