### PR TITLE
Codechange: replace magic numbers and C-style arrays with C++-style array for share owners

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -17,6 +17,7 @@
 #include "settings_type.h"
 #include "group.h"
 #include <string>
+#include <array>
 
 /** Statistics about the economy. */
 struct CompanyEconomyEntry {
@@ -74,7 +75,7 @@ struct CompanyProperties {
 	TileIndex location_of_HQ;        ///< Northern tile of HQ; #INVALID_TILE when there is none.
 	TileIndex last_build_coordinate; ///< Coordinate of the last build thing by this company.
 
-	Owner share_owners[4];           ///< Owners of the 4 shares of the company. #INVALID_OWNER if nobody has bought them yet.
+	std::array<Owner, MAX_COMPANY_SHARE_OWNERS> share_owners; ///< Owners of the shares of the company. #INVALID_OWNER if nobody has bought them yet.
 
 	Year inaugurated_year;           ///< Year of starting the company.
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -67,7 +67,7 @@ Company::Company(uint16 name_1, bool is_ai)
 	this->clear_limit     = (uint32)_settings_game.construction.clear_frame_burst << 16;
 	this->tree_limit      = (uint32)_settings_game.construction.tree_frame_burst << 16;
 
-	for (uint j = 0; j < 4; j++) this->share_owners[j] = INVALID_OWNER;
+	std::fill(this->share_owners.begin(), this->share_owners.end(), INVALID_OWNER);
 	InvalidateWindowData(WC_PERFORMANCE_DETAIL, 0, INVALID_COMPANY);
 }
 
@@ -557,7 +557,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 
 	c->money = c->current_loan = (std::min<int64>(INITIAL_LOAN, _economy.max_loan) * _economy.inflation_prices >> 16) / 50000 * 50000;
 
-	c->share_owners[0] = c->share_owners[1] = c->share_owners[2] = c->share_owners[3] = INVALID_OWNER;
+	std::fill(c->share_owners.begin(), c->share_owners.end(), INVALID_OWNER);
 
 	c->avail_railtypes = GetCompanyRailtypes(c->index);
 	c->avail_roadtypes = GetCompanyRoadTypes(c->index);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2195,10 +2195,8 @@ static const NWidgetPart _nested_company_widgets[] = {
 
 int GetAmountOwnedBy(const Company *c, Owner owner)
 {
-	return (c->share_owners[0] == owner) +
-				 (c->share_owners[1] == owner) +
-				 (c->share_owners[2] == owner) +
-				 (c->share_owners[3] == owner);
+	auto share_owned_by = [owner](auto share_owner) { return share_owner == owner; };
+	return std::count_if(c->share_owners.begin(), c->share_owners.end(), share_owned_by);
 }
 
 /** Strings for the company vehicle counts */
@@ -2275,13 +2273,8 @@ struct CompanyWindow : Window
 			}
 
 			/* Owners of company */
-			plane = SZSP_HORIZONTAL;
-			for (uint i = 0; i < lengthof(c->share_owners); i++) {
-				if (c->share_owners[i] != INVALID_COMPANY) {
-					plane = 0;
-					break;
-				}
-			}
+			auto invalid_owner = [](auto owner) { return owner == INVALID_COMPANY; };
+			plane = std::all_of(c->share_owners.begin(), c->share_owners.end(), invalid_owner) ? SZSP_HORIZONTAL : 0;
 			wi = this->GetWidget<NWidgetStacked>(WID_C_SELECT_DESC_OWNERS);
 			if (plane != wi->shown_plane) {
 				wi->SetDisplayedPlane(plane);

--- a/src/company_type.h
+++ b/src/company_type.h
@@ -40,6 +40,7 @@ static const uint MAX_LENGTH_PRESIDENT_NAME_CHARS = 32; ///< The maximum length 
 static const uint MAX_LENGTH_COMPANY_NAME_CHARS   = 32; ///< The maximum length of a company name in characters including '\0'
 
 static const uint MAX_HISTORY_QUARTERS            = 24; ///< The maximum number of quarters kept as performance's history
+static const uint MAX_COMPANY_SHARE_OWNERS        =  4; ///< The maximum number of shares of a company that can be owned by another company.
 
 /** Define basic enum properties */
 template <> struct EnumPropsT<Owner> : MakeEnumPropsT<Owner, byte, OWNER_BEGIN, OWNER_END, INVALID_OWNER> {};

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -332,8 +332,8 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company
 	p->Send_bool  (c->is_ai);
 	p->Send_uint8 (CeilDiv(c->months_of_bankruptcy, 3)); // send as quarters_of_bankruptcy
 
-	for (size_t i = 0; i < lengthof(c->share_owners); i++) {
-		p->Send_uint8(c->share_owners[i]);
+	for (auto owner : c->share_owners) {
+		p->Send_uint8(owner);
 	}
 
 	this->SendPacket(p);
@@ -359,8 +359,8 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyUpdate(const Compa
 	p->Send_bool  (NetworkCompanyIsPassworded(c->index));
 	p->Send_uint8 (CeilDiv(c->months_of_bankruptcy, 3)); // send as quarters_of_bankruptcy
 
-	for (size_t i = 0; i < lengthof(c->share_owners); i++) {
-		p->Send_uint8(c->share_owners[i]);
+	for (auto owner : c->share_owners) {
+		p->Send_uint8(owner);
 	}
 
 	this->SendPacket(p);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1755,10 +1755,9 @@ bool AfterLoadGame()
 		 * 2) shares that are owned by inactive companies or self
 		 *     (caused by cheating clients in earlier revisions) */
 		for (Company *c : Company::Iterate()) {
-			for (uint i = 0; i < 4; i++) {
-				CompanyID company = c->share_owners[i];
-				if (company == INVALID_COMPANY) continue;
-				if (!Company::IsValidID(company) || company == c->index) c->share_owners[i] = INVALID_COMPANY;
+			for (auto &share_owner : c->share_owners) {
+				if (share_owner == INVALID_COMPANY) continue;
+				if (!Company::IsValidID(share_owner) || share_owner == c->index) share_owner = INVALID_COMPANY;
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

I was looking at some PR, saw magic numbers related to share owners and thought this could be done nicer/clearer with C++-style arrays and algorithms.


## Description

Should be a 1:1 functional code change that replaces C-style arrays, magic numbers and lengthof with C++ algorithms and for loops.


## Limitations

None... although with C++20 ranges it could be even simpler.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
