### PR TITLE
Fix: removing long roads doesn't prioritize refusal of local authority over other errors

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -1113,8 +1113,14 @@ std::tuple<CommandCost, Money> CmdRemoveLongRoad(DoCommandFlag flags, TileIndex 
 				cost.AddCost(ret);
 				had_success = true;
 			} else {
-				/* Ownership errors are more important. */
-				if (last_error.GetErrorMessage() != STR_ERROR_OWNED_BY) last_error = ret;
+				/* Some errors are more equal than others. */
+				switch (last_error.GetErrorMessage()) {
+					case STR_ERROR_OWNED_BY:
+					case STR_ERROR_LOCAL_AUTHORITY_REFUSES_TO_ALLOW_THIS:
+						break;
+					default:
+						last_error = ret;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #9820

## Motivation / Problem

Some errors are more equal than others. Ownership errors already were. Now local authority errors are too. See #9820 for example.

## Description

See patch. Can't explain it in more words.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
