### PR TITLE
Change: Vanilla industry tiles have 8/8 acceptance by default

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -411,14 +411,16 @@ static Foundation GetFoundation_Industry(TileIndex tile, Slope tileh)
 static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, CargoTypes &always_accepted)
 {
 	IndustryGfx gfx = GetIndustryGfx(tile);
-	const IndustryTileSpec *itspec = GetIndustryTileSpec(gfx);
 	const Industry *ind = Industry::GetByTile(tile);
+	const IndustryTileSpec *itspec = GetIndustryTileSpec(gfx);
+	const IndustrySpec *indspec = GetIndustrySpec(ind->type);
 
 	/* Starting point for acceptance */
 	auto accepts_cargo = itspec->accepts_cargo;
 	auto cargo_acceptance = itspec->acceptance;
 
-	if (itspec->special_flags.Test(IndustryTileSpecialFlag::AcceptsAllCargo)) {
+	/* Default (non-NewGRF) industry tiles might accept all cargoes. */
+	if (itspec->special_flags.Test(IndustryTileSpecialFlag::AcceptsAllCargo) || (!_settings_game.economy.traditional_industry_acceptance && !indspec->grf_prop.HasGrfFile() && !itspec->grf_prop.HasGrfFile())) {
 		/* Copy all accepted cargoes from industry itself */
 		for (const auto &a : ind->accepted) {
 			auto pos = std::ranges::find(accepts_cargo, a.cargo);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1431,6 +1431,9 @@ STR_CONFIG_SETTING_INDUSTRY_PLATFORM_HELPTEXT                   :Amount of flat 
 STR_CONFIG_SETTING_MULTIPINDTOWN                                :Allow multiple similar industries per town: {STRING2}
 STR_CONFIG_SETTING_MULTIPINDTOWN_HELPTEXT                       :Normally, a town does not want more than one industry of each type. With this setting, it will allow several industries of the same type in the same town
 
+STR_CONFIG_SETTING_TRADITIONAL_INDUSTRY_ACCEPTANCE              :Traditional industry tile acceptance
+STR_CONFIG_SETTING_TRADITIONAL_INDUSTRY_ACCEPTANCE_HELPTEXT     :When enabled, only some tiles of the default Oil Refinery, Power Station, and Sawmill accept cargo
+
 STR_CONFIG_SETTING_SIGNALSIDE                                   :Show signals: {STRING2}
 STR_CONFIG_SETTING_SIGNALSIDE_HELPTEXT                          :Select on which side of the track to place signals
 ###length 3

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -798,6 +798,11 @@ bool AfterLoadGame()
 		_settings_game.linkgraph.recalc_time     *= CalendarTime::SECONDS_PER_DAY;
 	}
 
+	/* Keep existing industry tile cargo acceptance. */
+	if (IsSavegameVersionBefore(SLV_TRADITIONAL_INDTILE_ACCEPTANCE)) {
+		_settings_game.economy.traditional_industry_acceptance = true;
+	}
+
 	/* Load the sprites */
 	GfxLoadSprites();
 	LoadStringWidthTable();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -415,6 +415,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_SIGN_TEXT_COLOURS,                  ///< 363  PR#14743 Configurable sign text colors in scenario editor.
 	SLV_BUOYS_AT_0_0,                       ///< 364  PR#14983 Allow to build buoys at (0x0).
 
+	SLV_TRADITIONAL_INDTILE_ACCEPTANCE,     ///< 365  PR#9832  Setting for vanilla industries to accept cargo on all tiles.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/settingentry_gui.cpp
+++ b/src/settingentry_gui.cpp
@@ -843,6 +843,7 @@ SettingsContainer &GetSettingsTree()
 				industries->Add(new SettingEntry("construction.raw_industry_construction"));
 				industries->Add(new SettingEntry("construction.industry_platform"));
 				industries->Add(new SettingEntry("economy.multiple_industry_per_town"));
+				industries->Add(new SettingEntry("economy.traditional_industry_acceptance"));
 				industries->Add(new SettingEntry("game_creation.oil_refinery_limit"));
 				industries->Add(new SettingEntry("economy.type"));
 				industries->Add(new SettingEntry("station.serve_neutral_industries"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -578,6 +578,7 @@ struct EconomySettings {
 	bool give_money; ///< allow giving other companies money
 	bool mod_road_rebuild; ///< roadworks remove unnecessary RoadBits
 	bool multiple_industry_per_town; ///< allow many industries of the same type per town
+	bool traditional_industry_acceptance; ///< default industries don't accept cargo on all tiles
 	uint8_t town_growth_rate; ///< town growth rate
 	uint8_t larger_towns; ///< the number of cities to build. These start off larger and grow twice as fast
 	uint8_t initial_city_size; ///< multiplier for the initial size of the cities compared to towns

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -142,6 +142,13 @@ str      = STR_CONFIG_SETTING_MULTIPINDTOWN
 strhelp  = STR_CONFIG_SETTING_MULTIPINDTOWN_HELPTEXT
 
 [SDT_BOOL]
+var      = economy.traditional_industry_acceptance
+def      = false
+str      = STR_CONFIG_SETTING_TRADITIONAL_INDUSTRY_ACCEPTANCE
+strhelp  = STR_CONFIG_SETTING_TRADITIONAL_INDUSTRY_ACCEPTANCE_HELPTEXT
+cat      = SC_ADVANCED
+
+[SDT_BOOL]
 var      = economy.bribe
 def      = true
 str      = STR_CONFIG_SETTING_BRIBE


### PR DESCRIPTION
## Motivation / Problem

In the vanilla industry set, the Sawmill, Oil Refinery, and Power Station don't have 8/8 cargo acceptance on each tile. All other industries do.

This is behavior copied from TTD (or so the story goes), but as discussed in #9791, it doesn't really add anything to the game and often confuses players.

## Description

Give 8/8 cargo acceptance to vanilla Sawmill, Oil Refinery, and Power Station tiles.

Add a setting for traditional tile acceptance behavior, used by existing savegames automatically.

Do not change tiles provided by a NewGRF, even if they just inherit vanilla tiles (these will keep their original acceptance, unchanged by this PR).

Closes #9791.

## Limitations

* Oil Rigs have strange cargo acceptance, with one tile accepting 8/8 Passengers and another accepting 8/8 Mail, both in the second cargo slot. But the built-in station seems to circumvent the problem of players finding the right place to build a station.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
