### PR TITLE
Feature: Allow disabling local authority control of company actions

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1256,8 +1256,8 @@ STR_CONFIG_SETTING_TRAIN_REVERSING_HELPTEXT                     :If enabled, tra
 STR_CONFIG_SETTING_DISASTERS                                    :Disasters: {STRING2}
 STR_CONFIG_SETTING_DISASTERS_HELPTEXT                           :Toggle disasters which may occasionally block or destroy vehicles or infrastructure
 
-STR_CONFIG_SETTING_CITY_APPROVAL                                :Town council's attitude towards area restructuring: {STRING2}
-STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT                       :Choose how much noise and environmental damage by companies affect their town rating and further construction actions in their area
+STR_CONFIG_SETTING_CITY_APPROVAL                                :Local authority attitude: {STRING2}
+STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT                       :Choose how much noise and environmental damage by companies affect their town rating and further construction actions in the town
 
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT                             :Map height limit: {STRING2}
 STR_CONFIG_SETTING_MAP_HEIGHT_LIMIT_HELPTEXT                    :Set the maximum height of the map terrain. With "(auto)" a good value will be picked after terrain generation

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1151,10 +1151,11 @@ STR_TERRAIN_TYPE_ALPINIST                                       :Alpinist
 STR_TERRAIN_TYPE_CUSTOM                                         :Custom height
 STR_TERRAIN_TYPE_CUSTOM_VALUE                                   :Custom height ({NUM})
 
-###length 3
-STR_CITY_APPROVAL_PERMISSIVE                                    :Permissive
+###length 4
+STR_CITY_APPROVAL_LENIENT                                       :Lenient
 STR_CITY_APPROVAL_TOLERANT                                      :Tolerant
 STR_CITY_APPROVAL_HOSTILE                                       :Hostile
+STR_CITY_APPROVAL_PERMISSIVE                                    :Permissive (no effect on company actions)
 
 STR_WARNING_NO_SUITABLE_AI                                      :{WHITE}No suitable AIs available...{}You can download several AIs via the 'Online Content' system
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -519,7 +519,7 @@ struct EconomySettings {
 	bool   allow_town_roads;                 ///< towns are allowed to build roads (always allowed when generating world / in SE)
 	TownFounding found_town;                 ///< town founding.
 	bool   station_noise_level;              ///< build new airports when the town noise level is still within accepted limits
-	uint16 town_noise_population[3];         ///< population to base decision on noise evaluation (@see town_council_tolerance)
+	uint16 town_noise_population[4];         ///< population to base decision on noise evaluation (@see town_council_tolerance)
 	bool   allow_town_level_crossings;       ///< towns are allowed to build level crossings
 	bool   infrastructure_maintenance;       ///< enable monthly maintenance fee for owner infrastructure
 };

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2258,7 +2258,7 @@ CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, byte airport_ty
 			authority_refuse_message = STR_ERROR_LOCAL_AUTHORITY_REFUSES_NOISE;
 			authority_refuse_town = nearest;
 		}
-	} else {
+	} else if (_settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE) {
 		Town *t = ClosestTownFromTile(tile, UINT_MAX);
 		uint num = 0;
 		for (const Station *st : Station::Iterate()) {

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -265,11 +265,11 @@ from     = SLV_97
 flags    = SF_GUI_DROPDOWN
 def      = 0
 min      = 0
-max      = 2
+max      = 3
 interval = 1
 str      = STR_CONFIG_SETTING_CITY_APPROVAL
 strhelp  = STR_CONFIG_SETTING_CITY_APPROVAL_HELPTEXT
-strval   = STR_CITY_APPROVAL_PERMISSIVE
+strval   = STR_CITY_APPROVAL_LENIENT
 post_cb  = DifficultyNoiseChange
 
 [SDTG_VAR]

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -284,6 +284,14 @@ min      = 800
 max      = 65535
 cat      = SC_EXPERT
 
+[SDT_VAR]
+var      = economy.town_noise_population[3]
+type     = SLE_UINT16
+def      = 400
+min      = 100
+max      = 65535
+cat      = SC_EXPERT
+
 [SDT_BOOL]
 var      = economy.infrastructure_maintenance
 from     = SLV_166

--- a/src/town.h
+++ b/src/town.h
@@ -152,6 +152,13 @@ void ExpandTown(Town *t);
 
 void RebuildTownKdtree();
 
+/** Settings for town council attitudes. */
+enum TownCouncilAttitudes {
+	TOWN_COUNCIL_LENIENT    = 0,
+	TOWN_COUNCIL_TOLERANT   = 1,
+	TOWN_COUNCIL_HOSTILE    = 2,
+	TOWN_COUNCIL_PERMISSIVE = 3,
+};
 
 /**
  * Action types that a company must ask permission for to a town authority.

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -56,16 +56,18 @@ enum Ratings {
 
 	RATING_TUNNEL_BRIDGE_DOWN_STEP = -250, ///< penalty for removing town owned tunnel or bridge
 	RATING_TUNNEL_BRIDGE_MINIMUM   =    0, ///< minimum rating after removing tunnel or bridge
-	RATING_TUNNEL_BRIDGE_NEEDED_PERMISSIVE = 144, ///< rating needed, "Permissive" difficulty settings
-	RATING_TUNNEL_BRIDGE_NEEDED_NEUTRAL    = 208, ///< "Neutral"
-	RATING_TUNNEL_BRIDGE_NEEDED_HOSTILE    = 400, ///< "Hostile"
+	RATING_TUNNEL_BRIDGE_NEEDED_LENIENT    =            144, ///< rating needed, "Lenient" difficulty settings
+	RATING_TUNNEL_BRIDGE_NEEDED_NEUTRAL    =            208, ///< "Neutral"
+	RATING_TUNNEL_BRIDGE_NEEDED_HOSTILE    =            400, ///< "Hostile"
+	RATING_TUNNEL_BRIDGE_NEEDED_PERMISSIVE = RATING_MINIMUM, ///< "Permissive" (local authority disabled)
 
 	RATING_ROAD_DOWN_STEP_INNER =  -50, ///< removing a roadpiece in the middle
 	RATING_ROAD_DOWN_STEP_EDGE  =  -18, ///< removing a roadpiece at the edge
 	RATING_ROAD_MINIMUM         = -100, ///< minimum rating after removing town owned road
-	RATING_ROAD_NEEDED_PERMISSIVE =  16, ///< rating needed, "Permissive" difficulty settings
-	RATING_ROAD_NEEDED_NEUTRAL    =  64, ///< "Neutral"
-	RATING_ROAD_NEEDED_HOSTILE    = 112, ///< "Hostile"
+	RATING_ROAD_NEEDED_LENIENT    =             16, ///< rating needed, "Lenient" difficulty settings
+	RATING_ROAD_NEEDED_NEUTRAL    =             64, ///< "Neutral"
+	RATING_ROAD_NEEDED_HOSTILE    =            112, ///< "Hostile"
+	RATING_ROAD_NEEDED_PERMISSIVE = RATING_MINIMUM, ///< "Permissive" (local authority disabled)
 
 	RATING_HOUSE_MINIMUM  = RATING_MINIMUM,
 


### PR DESCRIPTION
## Motivation / Problem

Local authorities are a feature that are unpopular with some players, mostly due to their sensitivity to tree removal. Several Game Scripts effectively disable this feature by forcibly setting each company's rating to "Outstanding" on a regular basis. It would be better to have a way to fix this frustration within the game.

## Description

~~I added a new `Unrestricted` option in the existing `Town council's attitude towards area restructuring` setting.~~

Per @nielsmh's suggestion, I changed "Permissive" to "Lenient" and added a new "Permissive" option.

When chosen, the company's rating still changes with their actions, but the checks for a minimum rating to do certain actions are bypassed, either by requiring the minimum possible rating or ignoring the check entirely. This includes:
- Bulldozing roads
- Bulldozing houses
- Converting a NRT road to a different type
- Building a station
- Building more than 2 airports, if noise control is off*

*Note: If noise levels are on, they work as normal with new values half as restrictive as the "Lenient" attitude.

## Limitations

The values in the new "Permissive" airport noise setting are invented and not balanced for anything. I suspect few would play with both disabled local authority control and noise limits active, but I didn't want to silently bypass the separate noise level feature.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
