### PR TITLE
Add: [NewGRF] Map seed as global variable.

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -93,7 +93,6 @@ static void _GenerateWorld()
 		_generating_world = true;
 		if (_network_dedicated) Debug(net, 3, "Generating map, please wait...");
 		/* Set the Random() seed to generation_seed so we produce the same map with the same seed */
-		if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
 		_random.SetSeed(_settings_game.game_creation.generation_seed);
 		SetGeneratingWorldProgress(GWP_MAP_INIT, 2);
 		SetObjectToPlace(SPR_CURSOR_ZZZ, PAL_NONE, HT_NONE, WC_MAIN_WINDOW, 0);
@@ -301,6 +300,8 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 
 		_settings_game.construction.map_height_limit = std::max(MAP_HEIGHT_LIMIT_AUTO_MINIMUM, std::min(MAX_MAP_HEIGHT_LIMIT, estimated_height + MAP_HEIGHT_LIMIT_AUTO_CEILING_ROOM));
 	}
+
+	if (_settings_game.game_creation.generation_seed == GENERATE_NEW_SEED) _settings_game.game_creation.generation_seed = _settings_newgame.game_creation.generation_seed = InteractiveRandom();
 
 	/* Load the right landscape stuff, and the NewGRFs! */
 	GfxLoadSprites();

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -7046,6 +7046,10 @@ static uint32 GetPatchVariable(uint8 param)
 		case 0x16:
 			return SPR_SHORE_BASE;
 
+		/* Game map seed */
+		case 0x17:
+			return _settings_game.game_creation.generation_seed;
+
 		default:
 			grfmsg(2, "ParamSet: Unknown Patch variable 0x%02X.", param);
 			return 0;


### PR DESCRIPTION
## Motivation / Problem

NewGRF lacks access to a stable random value that is both global and fixed during runtime of a game.

```
This is useful to provide a feature-agnostic, stable random value that differs between games.
One of the possible uses is to e.g. use it to create pseudo-random regions for towns or industries.
```

## Description

The map game seed is (usually) a random value and stable, so we can just expose it as an Action 2 global variable.
Game seed is stored as a setting and doesn't change, so it should be desync-safe.

## Limitations

Global variables in OTTD are handled identical for both Action 2 and Action 6/7/9, but the game seed is not yet set when Action 6/7/9 are executed. A similar problem is present with var 0x20, which is documented to be only usable in Act 2 (reads game settings as well), but can be happily read (possibly with a different value) in Act 6/7/9 as OTTD does not check this.

As such, a documentation only limit seems to have been acceptable in the past.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
