### PR TITLE
Feature: Allow Shift+Insert as paste in edit box

### DIFF
--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -475,6 +475,7 @@ HandleKeyPressResult Textbuf::HandleKeyPress(WChar key, uint16 keycode)
 		case WKC_RETURN: case WKC_NUM_ENTER: return HKPR_CONFIRM;
 
 		case (WKC_CTRL | 'V'):
+		case (WKC_SHIFT | WKC_INSERT):
 			edited = this->InsertClipboard();
 			break;
 


### PR DESCRIPTION
## Motivation / Problem

Though less famous than `Ctrl+V`, `Shift+Insert` is also often available for the paste operation in many programs. Left-handed players who actively drive the mouse in their left hand might prefer to do paste operations using their right hand if it were possible to do so.

## Description

This adds `Shift+Insert` to `Textbuf`'s key press handler to invoke `InsertClipboard()`, just like `Ctrl+V` does.

Interesting reading and other history:

- <https://en.wikipedia.org/wiki/Cut,_copy,_and_paste>
- <https://en.wikipedia.org/wiki/IBM_Common_User_Access>
- <https://defkey.com/what-means/shift-insert>
- <https://lifehacker.com/three-keyboard-shortcuts-left-handers-can-actually-use-1548841723>

## Limitations

There are no known limitations or negative interactions caused by this, as far as I could imagine.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
