### PR TITLE
Fix: [Actions] Switch source for 'gon' in macOS build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,8 +619,8 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: |
-        brew tap mitchellh/gon
-        brew install mitchellh/gon/gon
+        brew tap mistydemeo/gon
+        brew install mistydemeo/gon/gon
 
     - name: Notarize
       env:


### PR DESCRIPTION
## Motivation / Problem

The macOS builds on GitHub are broken.

## Description

Homebrew on the macOS action runner has been updated and the 'gon' package, which we use as part of the macOS code signing process, hasn't been updated to be compatible (see https://github.com/mitchellh/homebrew-gon/pull/1).

Another user has forked homebrew-gon with a fix for this, which solves the issue. Ideally the PR will be merged into the original branch at some point.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)