### PR TITLE
Change: [Actions] Switch back to primary source for 'gon' in macOS build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,8 +619,8 @@ jobs:
         HOMEBREW_NO_AUTO_UPDATE: 1
         HOMEBREW_NO_INSTALL_CLEANUP: 1
       run: |
-        brew tap mistydemeo/gon
-        brew install mistydemeo/gon/gon
+        brew tap mitchellh/gon
+        brew install mitchellh/gon/gon
 
     - name: Notarize
       env:


### PR DESCRIPTION
This reverts commit 7a97a33598774faf65576b55e5d1322716859de6 (PR #9840).

## Motivation / Problem

The day after I switched to an unofficial mirror of 'gon' (used in the macOS build signing), the PR that fixed the official gon package was finally accepted, so it would be best to switch back to it.

## Description

As above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
