### PR TITLE
Fix: No longer open a duplicate multiplayer window upon canceling password entry

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -2218,7 +2218,6 @@ struct NetworkJoinStatusWindow : Window {
 	{
 		if (StrEmpty(str)) {
 			NetworkDisconnect();
-			ShowNetworkGameWindow();
 			return;
 		}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes: #9736



## Description

When OnQueryTextFinished() is called and no password has been filled, we call ShowNetworkGameWindow() causing a new network game window to appear.
But this is unnecessary as the original window is still there too.


## Limitations

~~Since there are no game servers running on master, I was only able to test this change on release 12.1 17dfc6e28aac5ad2290e849b03893a416be97b03 (to avoid version mismatch).
If there's a way I can work around a version mismatch to test on master I'd be glad to do so.~~
Never mind, I figured out how I can test this feature based on master: I hosted my own server locally and ran a second instance of openttd in parallel.
The fix worked as expected there too.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
