### PR TITLE
Fix #9810: 'Rebuilding' a through road stop costs money.

### DIFF
--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -191,6 +191,21 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 
 	if (distant_join && (!_settings_game.station.distant_join_stations || !Waypoint::IsValidID(station_to_join))) return CMD_ERROR;
 
+	TileArea new_location(start_tile, width, height);
+
+	/* only AddCost for non-existing waypoints */
+	CommandCost cost(EXPENSES_CONSTRUCTION);
+	bool success = false;
+	for (TileIndex cur_tile : new_location) {
+		if (!IsRailWaypointTile(cur_tile)) {
+			cost.AddCost(_price[PR_BUILD_WAYPOINT_RAIL]);
+			success = true;
+		}
+	}
+	if (!success) {
+		return_cmd_error(STR_ERROR_ALREADY_BUILT);
+	}
+
 	/* Make sure the area below consists of clear tiles. (OR tiles belonging to a certain rail station) */
 	StationID est = INVALID_STATION;
 
@@ -203,7 +218,6 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 	}
 
 	Waypoint *wp = nullptr;
-	TileArea new_location(start_tile, width, height);
 	CommandCost ret = FindJoiningWaypoint(est, station_to_join, adjacent, new_location, &wp);
 	if (ret.Failed()) return ret;
 
@@ -279,7 +293,7 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 		DirtyCompanyInfrastructureWindows(wp->owner);
 	}
 
-	return CommandCost(EXPENSES_CONSTRUCTION, count * _price[PR_BUILD_WAYPOINT_RAIL]);
+	return cost;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

Issue #9810 and comments: Overbuilding of road stops, rail stations, and rail waypoints on pre-existing buildings of same type charge money.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->
For road stops:
Tiles that already have a road stop do not contribute to the build cost anymore.
Non-through road stops can be rotated by overbuilding for free.
Through road stops cannot be rotated by overbuilding since there is already an error if the underlying road is in the wrong orientation.
If no new road stops are built or rotated, the command returns  a STR_ERROR_ALREADY_BUILT error.

For rail stations:
Tiles that already have a rail station of the same orientation do not contribute to the build cost anymore, even if the station gfx is changed by the command.
Rail stations cost money to rotate since they rebuild the underlying rail as well.
If no new rail stations are built or rotated, the command returns  a STR_ERROR_ALREADY_BUILT error.

For rail waypoints:
If there already is a rail waypoint, the command returns a STR_ERROR_ALREADY_BUILT error.

These changes mean overbuilding either errors or charges only for significant changes and not for pre-existing stations.

Closes #9810 - edit 2TT

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
I decided to use STR_ERROR_ALREADY_BUILT as the error, but as seen in the comments of issue #9810, there's still a bit of inconsistency with other overbuilding building errors.
The cost calculations for road stops and rail stations use two new entire functions, one for each type.
The costs for all changed building are calculated before placements. No actual placement updating code was changed. This means the actual tile changes still happen as before.
The waypoint building interface seems to allow areas of selection, but in-game only allows single tile placements. The code change accounts for areas, but effectively only errors for waypoint overbuilding.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
