### PR TITLE
Fix #9853, 648ee88: incorrect merge of guiflags and flags for osk_activation

### DIFF
--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -185,11 +185,10 @@ strval   = STR_CONFIG_SETTING_HOVER_DELAY_VALUE
 [SDTC_OMANY]
 var      = gui.osk_activation
 type     = SLE_UINT8
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
 str      = STR_CONFIG_SETTING_OSK_ACTIVATION
 strhelp  = STR_CONFIG_SETTING_OSK_ACTIVATION_HELPTEXT
 strval   = STR_CONFIG_SETTING_OSK_ACTIVATION_DISABLED
-flags    = SF_GUI_DROPDOWN
 full     = _osk_activation
 def      = 1
 min      = 0


### PR DESCRIPTION
## Motivation / Problem
Having 2 `flags` elements when defining a setting doesn't work very well.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Merge the 2 `flags` into 1.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
