### PR TITLE
Doc: Fix some spelling mistakes (to->two, tileindex->TileIndex).

### DIFF
--- a/src/map_func.h
+++ b/src/map_func.h
@@ -142,11 +142,11 @@ static inline uint ScaleByMapSize1D(uint n)
 }
 
 /**
- * An offset value between to tiles.
+ * An offset value between two tiles.
  *
  * This value is used for the difference between
- * two tiles. It can be added to a tileindex to get
- * the resulting tileindex of the start tile applied
+ * two tiles. It can be added to a TileIndex to get
+ * the resulting TileIndex of the start tile applied
  * with this saved difference.
  *
  * @see TileDiffXY(int, int)
@@ -168,7 +168,7 @@ static inline TileIndex TileXY(uint x, uint y)
 /**
  * Calculates an offset for the given coordinate(-offset).
  *
- * This function calculate an offset value which can be added to an
+ * This function calculate an offset value which can be added to a
  * #TileIndex. The coordinates can be negative.
  *
  * @param x The offset in x direction
@@ -218,7 +218,7 @@ static inline uint TileY(TileIndex tile)
 }
 
 /**
- * Return the offset between to tiles from a TileIndexDiffC struct.
+ * Return the offset between two tiles from a TileIndexDiffC struct.
  *
  * This function works like #TileDiffXY(int, int) and returns the
  * difference between two tiles.
@@ -235,7 +235,7 @@ static inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
 
 #ifndef _DEBUG
 	/**
-	 * Adds to tiles together.
+	 * Adds two tiles together.
 	 *
 	 * @param x One tile
 	 * @param y Another tile to add

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -37,11 +37,11 @@ struct TileExtended {
 };
 
 /**
- * An offset value between to tiles.
+ * An offset value between two tiles.
  *
  * This value is used for the difference between
- * to tiles. It can be added to a tileindex to get
- * the resulting tileindex of the start tile applied
+ * two tiles. It can be added to a TileIndex to get
+ * the resulting TileIndex of the start tile applied
  * with this saved difference.
  *
  * @see TileDiffXY(int, int)


### PR DESCRIPTION
## Description
Just simple changes in spelling in documentation of map functions.
