### PR TITLE
Change: increase vehicle sprite stack from 4 layers to 8

### DIFF
--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -130,7 +130,7 @@ struct VehicleCache {
 
 /** Sprite sequence for a vehicle part. */
 struct VehicleSpriteSeq {
-	PalSpriteID seq[4];
+	PalSpriteID seq[8];
 	uint count;
 
 	bool operator==(const VehicleSpriteSeq &other) const


### PR DESCRIPTION
## Motivation / Problem

* newgrf vehicles can be optionally composed from a stack of sprites 
* this was introduced by frosch in https://github.com/OpenTTD/OpenTTD/commit/117e73751c9aeea9f9663c15226c52541d2c8723#diff-de51c778900aa0c3c7f050dc793c51f52e300a2f348c1d280ce9ac1cedb30748R1035
* the sprite stack is currently limited to 4 layers
* the sprite stack has proven useful; although sprites can be pre-composed before compiling a grf, this can be combinatorially very complicated. For example vehicle with 2 colour schemes, and 40 sets of cargo sprites requires generating 80 spriterows without spritelayers; by using 2 sprite layers it only requires 42 spriterows.
* it would now be helpful to have more than 4 layers available

## Description

* this PR increases the sprite stack to 8 layers
* it's a single digit change
* I've tested it with a local grf, and it worked as expected
* I didn't spot any cases where 8 layers will consume more bits than we have available e.g. callback results etc 
* grfcodec and nmlc do not appear to need updating for this, both compiled more than 4 layers happily (this is expected)
* the docs need updating in 2 places for nfo (vehicle action 2) and nml (vehicles properties etc)
* I don't have a meaningful test of performance impact; as far as I can tell the extra layers will only be evaluated if used, so existing savegames won't offer any real information
*  for what it's worth (not much) there was no obvious FPS impact simply from increasing the number to 8

## Limitations

* unsure of performance impact
* I didn't include any provision for grfs expecting 8 layers to fail gracefully or notify with older OpenTTD that only has 4.  I'm not very concerned by that, grfs can make their own arrangements using OpenTTD minimum version.
* frosch might ask "are you sure 8 is enough, how about 256?" 🙉 😃 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

Yes the NewGRF API is affected.  I don't know if newgrf_debug_data.h needs updating.  I will update the newgrf wiki and API tracker if this one is approved.