### PR TITLE
Feature: Alternative linkgraph colour schemes

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1527,6 +1527,14 @@ STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_GREEN                   :Green
 STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_DARK_GREEN              :Dark green
 STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_VIOLET                  :Violet
 
+STR_CONFIG_SETTING_LINKGRAPH_COLOURS                            :Cargo flow overlay colours: {STRING2}
+STR_CONFIG_SETTING_LINKGRAPH_COLOURS_HELPTEXT                   :Set the colour scheme used for the cargo flow overlay.
+###length 4
+STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREEN_TO_RED               :Green to red (original)
+STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREEN_TO_BLUE              :Green to blue
+STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREY_TO_RED                :Grey to red
+STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREYSCALE                  :Greyscale
+
 STR_CONFIG_SETTING_SCROLLMODE                                   :Viewport scroll behaviour: {STRING2}
 STR_CONFIG_SETTING_SCROLLMODE_HELPTEXT                          :Behaviour when scrolling the map
 ###length 4

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -26,10 +26,27 @@
  * Colours for the various "load" states of links. Ordered from "unused" to
  * "overloaded".
  */
-const uint8 LinkGraphOverlay::LINK_COLOURS[] = {
+const uint8 LinkGraphOverlay::LINK_COLOURS[][12] = {
+{
 	0x0f, 0xd1, 0xd0, 0x57,
 	0x55, 0x53, 0xbf, 0xbd,
 	0xba, 0xb9, 0xb7, 0xb5
+},
+{
+	0x0f, 0xd1, 0xd0, 0x57,
+	0x55, 0x53, 0x96, 0x95,
+	0x94, 0x93, 0x92, 0x91
+},
+{
+	0x0f, 0x0b, 0x09, 0x07,
+	0x05, 0x03, 0xbf, 0xbd,
+	0xba, 0xb9, 0xb7, 0xb5
+},
+{
+	0x0f, 0x0b, 0x0a, 0x09,
+	0x08, 0x07, 0x06, 0x05,
+	0x04, 0x03, 0x02, 0x01
+}
 };
 
 /**
@@ -271,7 +288,7 @@ void LinkGraphOverlay::DrawLinks(const DrawPixelInfo *dpi) const
 void LinkGraphOverlay::DrawContent(Point pta, Point ptb, const LinkProperties &cargo) const
 {
 	uint usage_or_plan = std::min(cargo.capacity * 2 + 1, std::max(cargo.usage, cargo.planned));
-	int colour = LinkGraphOverlay::LINK_COLOURS[usage_or_plan * lengthof(LinkGraphOverlay::LINK_COLOURS) / (cargo.capacity * 2 + 2)];
+	int colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][usage_or_plan * lengthof(LinkGraphOverlay::LINK_COLOURS[0]) / (cargo.capacity * 2 + 2)];
 	int dash = cargo.shared ? this->scale * 4 : 0;
 
 	/* Move line a bit 90° against its dominant direction to prevent it from
@@ -379,7 +396,7 @@ NWidgetBase *MakeCompanyButtonRowsLinkGraphGUI(int *biggest_index)
 NWidgetBase *MakeSaturationLegendLinkGraphGUI(int *biggest_index)
 {
 	NWidgetVertical *panel = new NWidgetVertical(NC_EQUALSIZE);
-	for (uint i = 0; i < lengthof(LinkGraphOverlay::LINK_COLOURS); ++i) {
+	for (uint i = 0; i < lengthof(LinkGraphOverlay::LINK_COLOURS[0]); ++i) {
 		NWidgetBackground * wid = new NWidgetBackground(WWT_PANEL, COLOUR_DARK_GREEN, i + WID_LGL_SATURATION_FIRST);
 		wid->SetMinimalSize(50, 0);
 		wid->SetMinimalTextLines(1, 0, FS_SMALL);
@@ -456,7 +473,7 @@ static const NWidgetPart _nested_linkgraph_legend_widgets[] = {
 };
 
 static_assert(WID_LGL_SATURATION_LAST - WID_LGL_SATURATION_FIRST ==
-		lengthof(LinkGraphOverlay::LINK_COLOURS) - 1);
+		lengthof(LinkGraphOverlay::LINK_COLOURS[0]) - 1);
 
 static WindowDesc _linkgraph_legend_desc(
 	WDP_AUTO, "toolbar_linkgraph", 0, 0,
@@ -538,7 +555,8 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 		DrawCompanyIcon(cid, (r.left + r.right + 1 - sprite_size.width) / 2, (r.top + r.bottom + 1 - sprite_size.height) / 2);
 	}
 	if (IsInsideMM(widget, WID_LGL_SATURATION_FIRST, WID_LGL_SATURATION_LAST + 1)) {
-		GfxFillRect(r.left + 1, r.top + 1, r.right - 1, r.bottom - 1, LinkGraphOverlay::LINK_COLOURS[widget - WID_LGL_SATURATION_FIRST]);
+		uint8 colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][widget - WID_LGL_SATURATION_FIRST];
+		GfxFillRect(r.left + 1, r.top + 1, r.right - 1, r.bottom - 1, colour);
 		StringID str = STR_NULL;
 		if (widget == WID_LGL_SATURATION_FIRST) {
 			str = STR_LINKGRAPH_LEGEND_UNUSED;
@@ -547,7 +565,9 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 		} else if (widget == (WID_LGL_SATURATION_LAST + WID_LGL_SATURATION_FIRST) / 2) {
 			str = STR_LINKGRAPH_LEGEND_SATURATED;
 		}
-		if (str != STR_NULL) DrawString(r.left, r.right, (r.top + r.bottom + 1 - FONT_HEIGHT_SMALL) / 2, str, TC_FROMSTRING, SA_HOR_CENTER);
+		if (str != STR_NULL) {
+			DrawString(r.left, r.right, (r.top + r.bottom + 1 - FONT_HEIGHT_SMALL) / 2, str, GetContrastColour(colour) | TC_FORCED, SA_HOR_CENTER);
+		}
 	}
 	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
 		if (this->IsWidgetDisabled(widget)) return;

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -40,7 +40,7 @@ public:
 	typedef std::map<StationID, StationLinkMap> LinkMap;
 	typedef std::vector<std::pair<StationID, uint> > StationSupplyList;
 
-	static const uint8 LINK_COLOURS[];
+	static const uint8 LINK_COLOURS[][12];
 
 	/**
 	 * Create a link graph overlay for the specified window.

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1573,6 +1573,7 @@ static SettingsContainer &GetSettingsTree()
 			graphics->Add(new SettingEntry("gui.zoom_max"));
 			graphics->Add(new SettingEntry("gui.sprite_zoom_min"));
 			graphics->Add(new SettingEntry("gui.smallmap_land_colour"));
+			graphics->Add(new SettingEntry("gui.linkgraph_colours"));
 			graphics->Add(new SettingEntry("gui.graph_line_thickness"));
 		}
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -103,6 +103,13 @@ static void RedrawSmallmap(int32 new_value)
 	SetWindowClassesDirty(WC_SMALLMAP);
 }
 
+/** Redraw linkgraph links after a colour scheme change. */
+static void UpdateLinkgraphColours(int32 new_value)
+{
+	BuildLinkStatsLegend();
+	MarkWholeScreenDirty();
+}
+
 static void StationSpreadChanged(int32 p1)
 {
 	InvalidateWindowData(WC_SELECT_STATION, 0);

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -116,6 +116,7 @@ struct GUISettings {
 	uint16 hover_delay_ms;                   ///< time required to activate a hover event, in milliseconds
 	bool   link_terraform_toolbar;           ///< display terraform toolbar when displaying rail, road, water and airport toolbars
 	uint8  smallmap_land_colour;             ///< colour used for land and heightmap at the smallmap
+	uint8  linkgraph_colours;                ///< linkgraph overlay colours
 	uint8  scroll_mode;                      ///< viewport scroll mode
 	bool   smooth_scroll;                    ///< smooth scroll viewports
 	bool   measure_tooltip;                  ///< show a permanent tooltip when dragging tools

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -216,7 +216,7 @@ void BuildLinkStatsLegend()
 
 	for (; i < _smallmap_cargo_count + lengthof(_linkstat_colours_in_legenda); ++i) {
 		_legend_linkstats[i].legend = STR_EMPTY;
-		_legend_linkstats[i].colour = LinkGraphOverlay::LINK_COLOURS[_linkstat_colours_in_legenda[i - _smallmap_cargo_count]];
+		_legend_linkstats[i].colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][_linkstat_colours_in_legenda[i - _smallmap_cargo_count]];
 		_legend_linkstats[i].show_on_map = true;
 	}
 

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -10,6 +10,7 @@
 static void v_PositionMainToolbar(int32 new_value);
 static void v_PositionStatusbar(int32 new_value);
 static void RedrawSmallmap(int32 new_value);
+static void UpdateLinkgraphColours(int32 new_value);
 static void InvalidateCompanyLiveryWindow(int32 new_value);
 static void InvalidateNewGRFChangeWindows(int32 new_value);
 static void ZoomMinMaxChanged(int32 new_value);
@@ -310,6 +311,19 @@ str      = STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR
 strhelp  = STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_HELPTEXT
 strval   = STR_CONFIG_SETTING_SMALLMAP_LAND_COLOUR_GREEN
 post_cb  = RedrawSmallmap
+
+[SDTC_VAR]
+var      = gui.linkgraph_colours
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = 0
+min      = 0
+max      = 3
+str      = STR_CONFIG_SETTING_LINKGRAPH_COLOURS
+strhelp  = STR_CONFIG_SETTING_LINKGRAPH_COLOURS_HELPTEXT
+strval   = STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREEN_TO_RED
+post_cb  = UpdateLinkgraphColours
+cat      = SC_BASIC
 
 [SDTC_VAR]
 var      = gui.liveries


### PR DESCRIPTION
## Motivation / Problem

Per #9168:

> [According to the NHS](https://www.nhs.uk/conditions/colour-vision-deficiency/), about 1 in 12 men and 1 in 200 women are red/green colourblind.
> 
> The linkgraph colours which show if a route is overloaded, saturated, or unused currently use a red-green colour scale. Additionally, the green "saturated" colour matches the temperate grass and is quite difficult to see.
>
> ![rhd](https://user-images.githubusercontent.com/55058389/116788933-4ed13e80-aa7a-11eb-8b2b-e75f37521e5b.png)

## Description

In conversations in #9513 and on Reddit, a number of colourblind users stated their preference for other information besides colour to convey information and for the game to offer them a choice of colour schemes.

I think #9760 adds the other information, and this commit adds more colour scheme choices. Specifically, it upstreams a JGRPP [commit](https://github.com/JGRennison/OpenTTD-patches/commit/f26143f06319a56739e94ff3513c2909f49c108f) to add three additional colour schemes:

- Green to red (original)
- Green to blue
- Grey to red
- Greyscale

Closes #9168 
Alternative to #9513

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
