### PR TITLE
Fix #9867: Industry::stations_near not filled at industry creation

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1707,6 +1707,7 @@ static void PopulateStationsNearby(Industry *ind)
 
 	ForAllStationsAroundTiles(ind->location, [ind](Station *st, TileIndex tile) {
 		if (!IsTileType(tile, MP_INDUSTRY) || GetIndustryIndex(tile) != ind->index) return false;
+		ind->stations_near.insert(st);
 		st->AddIndustryToDeliver(ind, tile);
 		return false;
 	});


### PR DESCRIPTION
## Motivation / Problem

See #9867


## Description

Fix #9867
Restore insertion into Industry::stations_near incorrectly removed in 36bee83864ecffe526d7693dab8bb04fb3f6a4e2/#9536.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
