### PR TITLE
Add: Show video driver name in Game Options window

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -176,7 +176,7 @@ char *CrashLog::LogConfiguration(char *buffer, const char *last) const
 			SoundDriver::GetInstance() == nullptr ? "none" : SoundDriver::GetInstance()->GetName(),
 			BaseSounds::GetUsedSet() == nullptr ? "none" : BaseSounds::GetUsedSet()->name.c_str(),
 			BaseSounds::GetUsedSet() == nullptr ? UINT32_MAX : BaseSounds::GetUsedSet()->version,
-			VideoDriver::GetInstance() == nullptr ? "none" : VideoDriver::GetInstance()->GetName()
+			VideoDriver::GetInstance() == nullptr ? "none" : VideoDriver::GetInstance()->GetInfoString()
 	);
 
 	buffer += seprintf(buffer, last,

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1025,6 +1025,8 @@ STR_GAME_OPTIONS_VIDEO_ACCELERATION_RESTART                     :{WHITE}The sett
 STR_GAME_OPTIONS_VIDEO_VSYNC                                    :{BLACK}VSync
 STR_GAME_OPTIONS_VIDEO_VSYNC_TOOLTIP                            :{BLACK}Check this box to v-sync the screen. A changed setting will only be applied upon game restart. Only works with hardware acceleration enabled
 
+STR_GAME_OPTIONS_VIDEO_DRIVER_INFO                              :{BLACK}Current driver: {RAW_STRING}
+
 STR_GAME_OPTIONS_GUI_ZOOM_FRAME                                 :{BLACK}Interface size
 STR_GAME_OPTIONS_GUI_ZOOM_DROPDOWN_TOOLTIP                      :{BLACK}Select the interface element size to use
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -310,6 +310,7 @@ struct GameOptionsWindow : Window {
 			case WID_GO_BASE_SFX_DROPDOWN:     SetDParamStr(0, BaseSounds::GetUsedSet()->name); break;
 			case WID_GO_BASE_MUSIC_DROPDOWN:   SetDParamStr(0, BaseMusic::GetUsedSet()->name); break;
 			case WID_GO_BASE_MUSIC_STATUS:     SetDParam(0, BaseMusic::GetUsedSet()->GetNumInvalid()); break;
+			case WID_GO_VIDEO_DRIVER_INFO:     SetDParamStr(0, VideoDriver::GetInstance()->GetInfoString()); break;
 			case WID_GO_REFRESH_RATE_DROPDOWN: SetDParam(0, _settings_client.gui.refresh_rate); break;
 			case WID_GO_RESOLUTION_DROPDOWN: {
 				auto current_resolution = GetCurrentResolutionIndex();
@@ -690,6 +691,9 @@ static const NWidgetPart _nested_game_options_widgets[] = {
 						NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_GO_VIDEO_VSYNC_BUTTON), SetMinimalSize(21, 9), SetDataTip(STR_EMPTY, STR_GAME_OPTIONS_VIDEO_VSYNC_TOOLTIP),
 					EndContainer(),
 #endif
+					NWidget(NWID_HORIZONTAL),
+						NWidget(WWT_TEXT, COLOUR_GREY, WID_GO_VIDEO_DRIVER_INFO), SetMinimalSize(0, 12), SetFill(1, 0), SetDataTip(STR_GAME_OPTIONS_VIDEO_DRIVER_INFO, STR_NULL),
+					EndContainer(),
 				EndContainer(),
 			EndContainer(),
 		EndContainer(),

--- a/src/video/cocoa/cocoa_ogl.h
+++ b/src/video/cocoa/cocoa_ogl.h
@@ -18,11 +18,12 @@ class VideoDriver_CocoaOpenGL : public VideoDriver_Cocoa {
 	CGLContextObj gl_context;
 
 	uint8 *anim_buffer; ///< Animation buffer from OpenGL back-end.
+	std::string driver_info; ///< Information string about selected driver.
 
 	const char *AllocateContext(bool allow_software);
 
 public:
-	VideoDriver_CocoaOpenGL() : gl_context(nullptr), anim_buffer(nullptr) {}
+	VideoDriver_CocoaOpenGL() : gl_context(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
 
 	const char *Start(const StringList &param) override;
 	void Stop() override;
@@ -40,6 +41,8 @@ public:
 
 	/** Return driver name */
 	const char *GetName() const override { return "cocoa-opengl"; }
+
+	const char *GetInfoString() const override { return this->driver_info.c_str(); }
 
 	void AllocateBackingStore(bool force = false) override;
 

--- a/src/video/cocoa/cocoa_ogl.mm
+++ b/src/video/cocoa/cocoa_ogl.mm
@@ -203,6 +203,11 @@ const char *VideoDriver_CocoaOpenGL::Start(const StringList &param)
 		return err;
 	}
 
+	this->driver_info = GetName();
+	this->driver_info += " (";
+	this->driver_info += OpenGLBackend::Get()->GetDriverName();
+	this->driver_info += ")";
+
 	bool fullscreen = _fullscreen;
 	if (!this->MakeWindow(_cur_resolution.width, _cur_resolution.height)) {
 		this->Stop();

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -745,6 +745,16 @@ void OpenGLBackend::PrepareContext()
 	_glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
+std::string OpenGLBackend::GetDriverName()
+{
+	std::string res{};
+	/* Skipping GL_VENDOR as it tends to be "obvious" from the renderer and version data, and just makes the string pointlessly longer */
+	res += reinterpret_cast<const char *>(_glGetString(GL_RENDERER));
+	res += ", ";
+	res += reinterpret_cast<const char *>(_glGetString(GL_VERSION));
+	return res;
+}
+
 /**
  * Check a shader for compilation errors and log them if necessary.
  * @param shader Shader to check.

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -92,6 +92,8 @@ public:
 
 	void PrepareContext();
 
+	std::string GetDriverName();
+
 	void UpdatePalette(const Colour *pal, uint first, uint length);
 	bool Resize(int w, int h, bool force = false);
 	void Paint();

--- a/src/video/sdl2_opengl_v.cpp
+++ b/src/video/sdl2_opengl_v.cpp
@@ -64,6 +64,10 @@ const char *VideoDriver_SDL_OpenGL::Start(const StringList &param)
 		return error;
 	}
 
+	this->driver_info += " (";
+	this->driver_info += OpenGLBackend::Get()->GetDriverName();
+	this->driver_info += ")";
+
 	/* Now we have a OpenGL context, force a client-size-changed event,
 	 * so all buffers are allocated correctly. */
 	int w, h;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -540,6 +540,11 @@ const char *VideoDriver_SDL_Base::Start(const StringList &param)
 	const char *dname = SDL_GetCurrentVideoDriver();
 	Debug(driver, 1, "SDL2: using driver '{}'", dname);
 
+	this->driver_info = this->GetName();
+	this->driver_info += " (";
+	this->driver_info += dname;
+	this->driver_info += ")";
+
 	MarkWholeScreenDirty();
 
 	SDL_StopTextInput();

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -17,7 +17,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL_Base : public VideoDriver {
 public:
-	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false) {}
+	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false), driver_info(this->GetName()) {}
 
 	const char *Start(const StringList &param) override;
 
@@ -43,11 +43,14 @@ public:
 
 	const char *GetName() const override { return "sdl"; }
 
+	const char *GetInfoString() const override { return this->driver_info.c_str(); }
+
 protected:
 	struct SDL_Window *sdl_window; ///< Main SDL window.
 	Palette local_palette; ///< Current palette to use for drawing.
 	bool buffer_locked; ///< Video buffer was locked by the main thread.
 	Rect dirty_rect; ///< Rectangle encompassing the dirty area of the video buffer.
+	std::string driver_info; ///< Information string about selected driver.
 
 	Dimension GetScreenSize() const override;
 	void InputLoop() override;

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -178,6 +178,11 @@ public:
 		return ZOOM_LVL_OUT_4X;
 	}
 
+	virtual const char *GetInfoString() const
+	{
+		return this->GetName();
+	}
+
 	/**
 	 * Queue a function to be called on the main thread with game state
 	 * lock held and video buffer locked. Queued functions will be

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -1310,6 +1310,11 @@ const char *VideoDriver_Win32OpenGL::Start(const StringList &param)
 		return err;
 	}
 
+	this->driver_info = GetName();
+	this->driver_info += " (";
+	this->driver_info += OpenGLBackend::Get()->GetDriverName();
+	this->driver_info += ")";
+
 	this->ClientSizeChanged(this->width, this->height, true);
 	/* We should have a valid screen buffer now. If not, something went wrong and we should abort. */
 	if (_screen.dst_ptr == nullptr) {

--- a/src/video/win32_v.h
+++ b/src/video/win32_v.h
@@ -117,7 +117,7 @@ public:
 /** The OpenGL video driver for windows. */
 class VideoDriver_Win32OpenGL : public VideoDriver_Win32Base {
 public:
-	VideoDriver_Win32OpenGL() : dc(nullptr), gl_rc(nullptr), anim_buffer(nullptr) {}
+	VideoDriver_Win32OpenGL() : dc(nullptr), gl_rc(nullptr), anim_buffer(nullptr), driver_info(this->GetName()) {}
 
 	const char *Start(const StringList &param) override;
 
@@ -142,10 +142,13 @@ public:
 
 	const char *GetName() const override { return "win32-opengl"; }
 
+	const char *GetInfoString() const override { return this->driver_info.c_str(); }
+
 protected:
 	HDC    dc;          ///< Window device context.
 	HGLRC  gl_rc;       ///< OpenGL context.
 	uint8 *anim_buffer; ///< Animation buffer from OpenGL back-end.
+	std::string driver_info; ///< Information string about selected driver.
 
 	uint8 GetFullscreenBpp() override { return 32; } // OpenGL is always 32 bpp.
 

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -37,6 +37,7 @@ enum GameOptionsWidgets {
 	WID_GO_VIDEO_ACCEL_BUTTON,     ///< Toggle for video acceleration.
 	WID_GO_VIDEO_VSYNC_BUTTON,     ///< Toggle for video vsync.
 	WID_GO_REFRESH_RATE_DROPDOWN,  ///< Dropdown for all available refresh rates.
+	WID_GO_VIDEO_DRIVER_INFO,      ///< Label showing details about the current video driver.
 };
 
 /** Widgets of the #GameSettingsWindow class. */


### PR DESCRIPTION
## Motivation / Problem

It's difficult for users to be sure exactly what video driver is being used currently.

## Description

Let video drivers describe themselves and print the info in the Game Options window.

![image](https://user-images.githubusercontent.com/1062071/166107640-7fd9a5ad-c001-4397-b185-5657a3335eb1.png)

## Limitations

Some OpenGL drivers have really long names, which can make the window excessively wide


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
