### PR TITLE
Fix 44f2ef1: [strgen] Allow gender for {CARGO_SHORT}

### DIFF
--- a/src/table/strgen_tables.h
+++ b/src/table/strgen_tables.h
@@ -74,7 +74,7 @@ static const CmdStruct _cmd_structs[] = {
 	{"STATION_FEATURES",  EmitSingleChar, SCC_STATION_FEATURES,   1, -1, C_NONE}, // station features string, icons of the features
 	{"INDUSTRY",          EmitSingleChar, SCC_INDUSTRY_NAME,      1, -1, C_CASE | C_GENDER}, // industry, takes an industry #, can have cases
 	{"CARGO_LONG",        EmitSingleChar, SCC_CARGO_LONG,         2,  1, C_NONE | C_GENDER},
-	{"CARGO_SHORT",       EmitSingleChar, SCC_CARGO_SHORT,        2,  1, C_NONE}, // short cargo description, only ### tons, or ### litres
+	{"CARGO_SHORT",       EmitSingleChar, SCC_CARGO_SHORT,        2,  1, C_NONE | C_GENDER}, // short cargo description, only ### tons, or ### litres
 	{"CARGO_TINY",        EmitSingleChar, SCC_CARGO_TINY,         2,  1, C_NONE}, // tiny cargo description with only the amount, not a specifier for the amount or the actual cargo name
 	{"CARGO_LIST",        EmitSingleChar, SCC_CARGO_LIST,         1, -1, C_CASE},
 	{"POWER",             EmitSingleChar, SCC_POWER,              1,  0, C_NONE},


### PR DESCRIPTION
## Motivation / Problem
As noticed in https://github.com/OpenTTD/eints/issues/67, genders are already supported for `{CARGO_LONG}` commands.

So I did some tests after allowing them for `{CARGO_SHORT}`, I added `{G 0 "m" "m2" "f"}` to `STR_STATION_VIEW_WAITING_CARGO` and `STR_STATION_VIEW_FROM_HERE`  in french translation, then added some `{G=...}` to `STR_UNITS_WEIGHT_LONG_XXX` (fake genders just to test, not grammatically correct).

Resulting screenshots show it works as expected.
![image](https://user-images.githubusercontent.com/2952192/164996602-1ad09dde-6aa5-443b-97b1-4f7d91b966c5.png)
![image](https://user-images.githubusercontent.com/2952192/164996620-3a0ebaad-cb61-4138-b471-12786eb9a576.png)
![image](https://user-images.githubusercontent.com/2952192/164996641-c96ea541-4377-467d-bfa0-bcc1c718e2f7.png)
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Just adding the `C_GENDER` flag to enable gender support for `{CARGO_SHORT}` commands. 
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
An change is required in [eints](https://github.com/OpenTTD/eints) to allow the translators to use genders with `{CARGO_SHORT}`.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
