### PR TITLE
Codechange: [CMake] Pass API files list via a file to minimise command line length

### DIFF
--- a/cmake/scripts/SquirrelIncludes.cmake
+++ b/cmake/scripts/SquirrelIncludes.cmake
@@ -12,32 +12,11 @@ endif()
 if(NOT APIUC)
     message(FATAL_ERROR "Script needs APIUC defined")
 endif()
+if(NOT API_FILES)
+    message(FATAL_ERROR "Script needs API_FILES defined")
+endif()
 
-set(ARGC 1)
-set(ARG_READ NO)
-
-# For MSVC CMake runs this script from a batch file using || to detect errors,
-# depending on source path it may quote args, and cause cmd to not understand ||
-# and pass it as argument to ourself.
-# Read all the arguments given to CMake; we are looking for -- and everything
-# that follows, until ||. Those are our api files.
-while(ARGC LESS CMAKE_ARGC)
-    set(ARG ${CMAKE_ARGV${ARGC}})
-
-    if(ARG STREQUAL "||")
-        set(ARG_READ NO)
-    endif()
-
-    if(ARG_READ)
-        list(APPEND SCRIPT_API_BINARY_FILES "${ARG}")
-    endif()
-
-    if(ARG STREQUAL "--")
-        set(ARG_READ YES)
-    endif()
-
-    math(EXPR ARGC "${ARGC} + 1")
-endwhile()
+file(READ "${API_FILES}" SCRIPT_API_BINARY_FILES)
 
 foreach(FILE IN LISTS SCRIPT_API_BINARY_FILES)
     file(STRINGS "${FILE}" LINES REGEX "^void SQ${APIUC}.*_Register\\(Squirrel \\*engine\\)$")

--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -75,17 +75,19 @@ foreach(API "ai;AI" "game;GS" "template;Template")
     if(NOT "${APILC}" STREQUAL "template")
         list(APPEND SCRIPT_${APIUC}_BINARY_FILES "${CMAKE_CURRENT_SOURCE_DIR}/${APILC}/${APILC}_controller.hpp.sq")
         set(INCLUDES_BINARY_FILE "${CMAKE_BINARY_DIR}/generated/script/api/${APILC}/${APILC}_includes.hpp")
+        set(API_FILES "${CMAKE_CURRENT_BINARY_DIR}/${APILC}.files")
+        file(GENERATE OUTPUT ${API_FILES} CONTENT "${SCRIPT_${APIUC}_BINARY_FILES}")
         add_custom_command_timestamp(OUTPUT ${INCLUDES_BINARY_FILE}
                 COMMAND ${CMAKE_COMMAND}
                         -DINCLUDES_SOURCE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/script_includes.hpp.in
                         -DINCLUDES_BINARY_FILE=${INCLUDES_BINARY_FILE}
                         -DAPIUC=${APIUC}
                         -DAPILC=${APILC}
+                        -DAPI_FILES=${API_FILES}
                         -P ${CMAKE_SOURCE_DIR}/cmake/scripts/SquirrelIncludes.cmake
-                        --
-                        ${SCRIPT_${APIUC}_BINARY_FILES}
                 MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/script_includes.hpp.in
                 DEPENDS ${SCRIPT_${APIUC}_BINARY_FILES}
+                        ${API_FILES}
                         ${CMAKE_SOURCE_DIR}/cmake/scripts/SquirrelIncludes.cmake
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 COMMENT "Generating ${APILC}/${APILC}_includes.hpp"


### PR DESCRIPTION
## Motivation / Problem
When generating `ai_includes.hpp` and `game_includes.hpp`, all the included files full paths are passed to the script via command line.
Depending on build path this command line can be very long, (even if cmake creates a batch file to try to reduce it, and causing the `||` issue we fixed a long time ago).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Put the include files list into a file to be read by the script.
This hugely shortens the command line (cmake doesn't even need to create a batch file).

From 7738 chars (in the batch) to 878 chars (without batch) on my dev setup (build root being `D:/developpement/GitHub/glx22/OpenTTD/out/build/x64-Debug/`).
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
