### PR TITLE
Add: Commandline option to skip NewGRF scanning

### DIFF
--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -575,6 +575,10 @@ compatible_grf:
 	return res;
 }
 
+
+/** Set this flag to prevent any NewGRF scanning from being done. */
+int _skip_all_newgrf_scanning = 0;
+
 /** Helper for scanning for files with GRF as extension */
 class GRFFileScanner : FileScanner {
 	std::chrono::steady_clock::time_point next_update; ///< The next moment we do update the screen.
@@ -591,6 +595,11 @@ public:
 	/** Do the scan for GRFs. */
 	static uint DoScan()
 	{
+		if (_skip_all_newgrf_scanning > 0) {
+			if (_skip_all_newgrf_scanning == 1) _skip_all_newgrf_scanning = 0;
+			return 0;
+		}
+
 		GRFFileScanner fs;
 		int ret = fs.Scan(".grf", NEWGRF_DIR);
 		/* The number scanned and the number returned may not be the same;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -201,6 +201,8 @@ static void ShowHelp()
 		"  -x                  = Never save configuration changes to disk\n"
 		"  -X                  = Don't use global folders to search for files\n"
 		"  -q savegame         = Write some information about the savegame and exit\n"
+		"  -Q                  = Don't scan for/load NewGRF files on startup\n"
+		"  -QQ                 = Disable NewGRF scanning/loading entirely\n"
 		"\n",
 		lastof(buf)
 	);
@@ -512,6 +514,7 @@ static const OptionData _options[] = {
 	 GETOPT_SHORT_NOVAL('X'),
 	 GETOPT_SHORT_VALUE('q'),
 	 GETOPT_SHORT_NOVAL('h'),
+	 GETOPT_SHORT_NOVAL('Q'),
 	GETOPT_END()
 };
 
@@ -639,6 +642,11 @@ int openttd_main(int argc, char *argv[])
 
 			WriteSavegameInfo(title);
 			return ret;
+		}
+		case 'Q': {
+			extern int _skip_all_newgrf_scanning;
+			_skip_all_newgrf_scanning += 1;
+			break;
 		}
 		case 'G': scanner->generation_seed = strtoul(mgo.opt, nullptr, 10); break;
 		case 'c': _config_file = mgo.opt; break;


### PR DESCRIPTION
## Motivation / Problem

Sometimes when testing stuff, waiting for the NewGRF scanning just takes annoyingly long time, and you don't need NewGRFs anyway for what you're testing. But you also don't want to switch to a different config/file structure.


## Description

Add a commandline option `-Q` (for Quick) that skips all scanning for NewGRF files.


## Limitations

Haven't tested how this behaves with the in-game content downloading UI or anything like that.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
