### PR TITLE
CVE-2022-30292 fix

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqbaselib.cpp
@@ -816,6 +816,7 @@ static SQInteger thread_call(HSQUIRRELVM v)
 	SQObjectPtr o = stack_get(v,1);
 	if(type(o) == OT_THREAD) {
 		SQInteger nparams = sq_gettop(v);
+		sq_reservestack(_thread(o), nparams + 3);
 		_thread(o)->Push(_thread(o)->_roottable);
 		for(SQInteger i = 2; i<(nparams+1); i++)
 			sq_move(_thread(o),v,i);


### PR DESCRIPTION
## Motivation / Problem

This is the fix for CVE-2022-30292 which is the critical Squirrel vulnerability:
- [Security advisory](https://github.com/sprushed/CVE-2022-30292)
- [MITRE reference](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-30292)