### PR TITLE
Fix #9870: Don't update infrastructure totals when overbuilding object on canal

### DIFF
--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -495,11 +495,14 @@ CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_t
 					FALLTHROUGH;
 
 				default:
-					MakeCanal(current_tile, _current_company, Random());
-					if (Company::IsValidID(_current_company)) {
+					/* If we overbuild a water object with a canal, don't update the infrastructure total. */
+					bool is_existing_canal = IsTileType(current_tile, MP_WATER) && IsCanal(current_tile);
+					if (Company::IsValidID(_current_company) && !is_existing_canal) {
 						Company::Get(_current_company)->infrastructure.water++;
 						DirtyCompanyInfrastructureWindows(_current_company);
 					}
+
+					MakeCanal(current_tile, _current_company, Random());
 					break;
 			}
 			MarkTileDirtyByTile(current_tile);


### PR DESCRIPTION
## Motivation / Problem

When a water-based object (e.g. AuzWaterObjects, available on Bananas) is placed on a canal and then a canal tile is overbuilt atop the object, the object is deleted to become an empty canal tile.

This incorrectly adds another canal tile to the company's infrastructure total.

## Description

If a canal already exists on that tile, don't add to the infrastructure total.

Closes #9870.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
