### PR TITLE
Fix #9712: Cap town bridge length at original 11-tile limit

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1185,15 +1185,16 @@ static bool GrowTownWithBridge(const Town *t, const TileIndex tile, const DiagDi
 	if (!(GetTownRoadBits(TileAddByDiagDir(tile, ReverseDiagDir(bridge_dir))) & DiagDirToRoadBits(bridge_dir))) return false;
 
 	/* We are in the right direction */
-	int bridge_length = 0;      // This value stores the length of the possible bridge
+	uint bridge_length = 0;       // This value stores the length of the possible bridge
 	TileIndex bridge_tile = tile; // Used to store the other waterside
 
 	const int delta = TileOffsByDiagDir(bridge_dir);
 
 	/* To prevent really small towns from building disproportionately
 	 * long bridges, make the max a function of its population. */
-	int base_bridge_length = 5;
-	int max_bridge_length = t->cache.population / 1000 + base_bridge_length;
+	const uint TOWN_BRIDGE_LENGTH_CAP = 11;
+	uint base_bridge_length = 5;
+	uint max_bridge_length = std::min(t->cache.population / 1000 + base_bridge_length, TOWN_BRIDGE_LENGTH_CAP);
 
 	if (slope == SLOPE_FLAT) {
 		/* Bridges starting on flat tiles are only allowed when crossing rivers, rails or one-way roads. */


### PR DESCRIPTION
## Motivation / Problem

In #8439, the bridge length limit was made a function of the town's population: a minimum of 4 plus 1 for each 1,000 population, rounded down.

With large cities, this allows bridges much, much longer than the original 11-tile limit, as reported in #9712:

![bridges](https://user-images.githubusercontent.com/67662046/142782935-4279fc88-b1ba-403a-b12b-788918f2b433.png)

## Description

To me, #8439 seems intended to limit smaller towns, not empower large cities:

> Really small towns can build disproportionately long bridges, all the way up to 11 tiles. To make it more realistic, the max number of tiles for a built bridge should be a function of its population.

This PR caps the maximum bridge length at the old limit of 11 (actually two end tiles plus ten elevated tiles in between) to keep his improvements to small towns while preventing large cities from building the nonsense seen above.

Closes #9712.

Related, but with a larger scope (which I'm working on separately as #9891): #9299

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
