### PR TITLE
Update: Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /emsdk/upstream/emscripten/cache
         key: 2.0.31-${{ runner.os }}
@@ -174,7 +174,7 @@ jobs:
         echo "::set-output name=image::$ImageOS-$ImageVersion"
 
     - name: Enable vcpkg cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /usr/local/share/vcpkg/installed
         key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified
@@ -256,7 +256,7 @@ jobs:
         Write-Output "::set-output name=image::$env:ImageOS-$env:ImageVersion"
 
     - name: Enable vcpkg cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: vcpkg/installed
         key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup cache
       uses: actions/cache@v3
@@ -91,7 +91,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |
@@ -166,7 +166,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare cache key
       id: key
@@ -244,7 +244,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare cache key
       id: key
@@ -338,7 +338,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup MSYS2
       uses: msys2/setup-msys2@v2

--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 4
 

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -31,7 +31,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PREVIEW_GITHUB_TOKEN }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.client_payload.sha }}
 

--- a/.github/workflows/preview_build.yml
+++ b/.github/workflows/preview_build.yml
@@ -41,7 +41,7 @@ jobs:
         git checkout -b ${name}
 
     - name: Setup cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /emsdk/upstream/emscripten/cache
         key: 2.0.31-${{ runner.os }}

--- a/.github/workflows/preview_label.yml
+++ b/.github/workflows/preview_label.yml
@@ -59,7 +59,7 @@ jobs:
 
     - if: steps.core_developer.outcome == 'success'
       name: Trigger 'preview build'
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.PREVIEW_GITHUB_TOKEN }}
         event-type: "Preview build #${{ github.event.number }}"

--- a/.github/workflows/preview_push.yml
+++ b/.github/workflows/preview_push.yml
@@ -59,7 +59,7 @@ jobs:
 
     - if: toJson(fromJson(steps.earlier_preview.outputs.data)) != '[]' && contains(fromJson(steps.preview_label.outputs.data).*.name, 'preview')
       name: Trigger 'preview build'
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.PREVIEW_GITHUB_TOKEN }}
         event-type: "Preview build #${{ github.event.number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1086,7 +1086,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
 
     - name: Trigger 'New OpenTTD release'
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.DEPLOYMENT_TOKEN }}
         repository: OpenTTD/workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,14 +174,14 @@ jobs:
         echo "::endgroup::"
 
     - name: Store bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-source
         path: build/bundles/*
         retention-days: 5
 
     - name: Store source (for other jobs)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: internal-source
         path: source.tar.gz
@@ -258,7 +258,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Store bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-docs
         path: build/bundles/*.tar.xz
@@ -355,7 +355,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Store bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-linux-generic
         path: build/bundles
@@ -460,7 +460,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Store bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-linux-${{ matrix.bundle_name }}
         path: build/bundles
@@ -651,7 +651,7 @@ jobs:
         mv _CPack_Packages/*/Bundle/openttd-*.zip bundles/
 
     - name: Store bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-macos-universal
         path: build-x64/bundles
@@ -844,7 +844,7 @@ jobs:
         WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
 
     - name: Store bundles
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-windows-${{ matrix.arch }}
         path: build/bundles
@@ -1025,7 +1025,7 @@ jobs:
         SignTool sign /fd sha256 /a /f cert.pfx /p password "output\OpenTTD.appxbundle"
 
     - name: Store appx
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: openttd-windows-store
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,7 +497,7 @@ jobs:
         echo "::set-output name=image::$ImageOS-$ImageVersion"
 
     - name: Enable vcpkg cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /usr/local/share/vcpkg/installed
         key: ${{ steps.key.outputs.image }}-vcpkg-release-0 # Increase the number whenever dependencies are modified
@@ -700,7 +700,7 @@ jobs:
         Write-Output "::set-output name=image::$env:ImageOS-$env:ImageVersion"
 
     - name: Enable vcpkg cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: vcpkg/installed
         key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
 
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: internal-source
 
@@ -276,7 +276,7 @@ jobs:
 
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: internal-source
 
@@ -390,7 +390,7 @@ jobs:
 
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: internal-source
 
@@ -476,7 +476,7 @@ jobs:
 
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: internal-source
 
@@ -676,7 +676,7 @@ jobs:
 
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: internal-source
 
@@ -861,7 +861,7 @@ jobs:
 
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: internal-source
 
@@ -871,17 +871,17 @@ jobs:
         tar -xf source.tar.gz --strip-components=1
 
     - name: Download x86 build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x86
 
     - name: Download x64 build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: openttd-windows-x64
 
     - name: Download arm64 build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: openttd-windows-arm64
 
@@ -1054,7 +1054,7 @@ jobs:
 
     steps:
     - name: Download all bundles
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Calculate checksums
       run: |
@@ -1107,7 +1107,7 @@ jobs:
 
     steps:
     - name: Download all bundles
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Setup steamcmd
       uses: CyberAndrii/setup-steamcmd@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
     steps:
     - name: Checkout (Release)
       if: github.event_name == 'release'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We generate a changelog; for this we need the full git log.
         fetch-depth: 0
 
     - name: Checkout (Manual)
       if: github.event_name == 'workflow_dispatch'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.ref }}
         # We generate a changelog; for this we need the full git log.
@@ -44,7 +44,7 @@ jobs:
 
     - name: Checkout (Trigger)
       if: github.event_name == 'repository_dispatch'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.client_payload.ref }}
         # We generate a changelog; for this we need the full git log.

--- a/.github/workflows/unused-strings.yml
+++ b/.github/workflows/unused-strings.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Check for unused strings
       run: |


### PR DESCRIPTION
## Motivation / Problem

Current versions of GitHub Actions use Node 12 internally, which was EOL at the end of April and will no longer receive security updates.

## Description

This PR bumps GitHub Actions to their latest major versions, which use Node 16 internally.
Below are links to each actions respective changelog/release notes:

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Releases for `actions/cache` can be [found here](https://github.com/actions/cache/releases)
- Releases for `actions/upload-artifact` can be [found here](https://github.com/actions/upload-artifact/releases)
- Releases for `actions/download-artifact` can be [found here](https://github.com/actions/download-artifact/releases)
- Releases for `peter-evans/repository-dispatch` can be [found here](https://github.com/peter-evans/repository-dispatch/releases)

## Limitations

N/A


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
