### PR TITLE
Fix: Improve performance when calculating company value

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -101,6 +101,8 @@ Economy _economy;
 Prices _price;
 static PriceMultipliers _price_base_multiplier;
 
+extern int GetAmountOwnedBy(const Company *c, Owner owner);
+
 /**
  * Calculate the value of the company. That is the value of all
  * assets (vehicles, stations, shares) and money minus the loan,
@@ -115,13 +117,7 @@ Money CalculateCompanyValue(const Company *c, bool including_loan)
 	Money owned_shares_value = 0;
 
 	for (const Company *co : Company::Iterate()) {
-		uint8 shares_owned = 0;
-
-		for (uint8 i = 0; i < 4; i++) {
-			if (co->share_owners[i] == c->index) {
-				shares_owned++;
-			}
-		}
+		int shares_owned = GetAmountOwnedBy(co, c->index);
 
 		if (shares_owned > 0) owned_shares_value += (CalculateCompanyValueExcludingShares(co) / 4) * shares_owned;
 	}
@@ -2017,8 +2013,6 @@ static void DoAcquireCompany(Company *c)
 
 	delete c;
 }
-
-extern int GetAmountOwnedBy(const Company *c, Owner owner);
 
 /**
  * Acquire shares in an opposing company.

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -123,10 +123,10 @@ Money CalculateCompanyValue(const Company *c, bool including_loan)
 			}
 		}
 
-		owned_shares_value += (CalculateCompanyValueExcludingShares(co) / 4) * shares_owned;
+		if (shares_owned > 0) owned_shares_value += (CalculateCompanyValueExcludingShares(co) / 4) * shares_owned;
 	}
 
-	return std::max<Money>(owned_shares_value + CalculateCompanyValueExcludingShares(c), 1);
+	return owned_shares_value + CalculateCompanyValueExcludingShares(c);
 }
 
 Money CalculateCompanyValueExcludingShares(const Company *c, bool including_loan)


### PR DESCRIPTION
## Motivation / Problem
Commit 1:
Some scripts make heavy use of CalculateCompanyValue and AI companies can't own shares of other AIs anyway, so there is no point calculating company values just to multiply it by zero in the end.

Commit 2:
`GetAmountOwnedBy` can do the same functionality as that for loop it replaces.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Commit 1:
Don't compute the value of the other company when the shares a company has on the other company is zero.

Commit 2:
N/A
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
