### PR TITLE
Fix: Industry layouts with zero regular tiles should be invalid

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -27,6 +27,7 @@
 #include "newgrf_sound.h"
 #include "newgrf_station.h"
 #include "industrytype.h"
+#include "industry_map.h"
 #include "newgrf_canal.h"
 #include "newgrf_townname.h"
 #include "newgrf_industries.h"
@@ -3374,15 +3375,22 @@ static ChangeInfoResult IgnoreIndustryProperty(int prop, ByteReader *buf)
 static bool ValidateIndustryLayout(const IndustryTileLayout &layout)
 {
 	const size_t size = layout.size();
+	if (size == 0) return false;
+
+	size_t valid_regular_tiles = 0;
+
 	for (size_t i = 0; i < size - 1; i++) {
 		for (size_t j = i + 1; j < size; j++) {
 			if (layout[i].ti.x == layout[j].ti.x &&
 					layout[i].ti.y == layout[j].ti.y) {
 				return false;
 			}
+			if (layout[i].gfx != GFX_WATERTILE_SPECIALCHECK) {
+				++valid_regular_tiles;
+			}
 		}
 	}
-	return true;
+	return valid_regular_tiles > 0;
 }
 
 /**
@@ -3533,7 +3541,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint indid, int numinfo, int prop, 
 								/* Declared as been valid, can be used */
 								it.gfx = tempid;
 							}
-						} else if (it.gfx == 0xFF) {
+						} else if (it.gfx == GFX_WATERTILE_SPECIALCHECK) {
 							it.ti.x = (int8)GB(it.ti.x, 0, 8);
 							it.ti.y = (int8)GB(it.ti.y, 0, 8);
 


### PR DESCRIPTION
## Motivation / Problem

Industry tile layouts are not checked for being empty, despite that causing various problems.
First, it triggers a loop running `(size_t)-1` iterations loop which takes quite a while.
Second, industries with zero regular tiles are useless, they can't accept or produce cargo, and can't be clicked on the map.

## Description

Check the layout for being empty, and check for it having non-watertilecheck graphics tiles.

## Limitations

Only smoke tested. It can start a game with some FIRS 4 version.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
