### PR TITLE
Fix: Don't let AIs to be 100% share owned

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2731,8 +2731,8 @@ struct CompanyWindow : Window
 
 			/* If all shares are owned by someone (none by nobody), disable buy button */
 			this->SetWidgetDisabledState(WID_C_BUY_SHARE, GetAmountOwnedBy(c, INVALID_OWNER) == 0 ||
-					/* Only 25% left to buy. If the company is human, disable buying it up.. TODO issues! */
-					(GetAmountOwnedBy(c, INVALID_OWNER) == 1 && !c->is_ai) ||
+					/* Only 25% left to buy. If the company is human, or we don't own 75% of it, disable buying it up.. TODO issues! */
+					(GetAmountOwnedBy(c, INVALID_OWNER) == 1 && (!c->is_ai || GetAmountOwnedBy(c, _local_company) < 3)) ||
 					/* Spectators cannot do anything of course */
 					_local_company == COMPANY_SPECTATOR);
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -2043,7 +2043,7 @@ CommandCost CmdBuyShareInCompany(DoCommandFlag flags, TileIndex tile, CompanyID 
 
 	if (GetAmountOwnedBy(c, INVALID_OWNER) == 1) {
 		if (!c->is_ai) return cost; //  We can not buy out a real company (temporarily). TODO: well, enable it obviously.
-
+		if (GetAmountOwnedBy(c, _current_company) < 3) return cost; // Can't buy the last 25% when we don't own 75% of it.
 		if (GetAmountOwnedBy(c, _current_company) == 3 && !MayCompanyTakeOver(_current_company, target_company)) return_cmd_error(STR_ERROR_TOO_MANY_VEHICLES_IN_GAME);
 	}
 


### PR DESCRIPTION
## Motivation / Problem
Alternative to #9905

AIs can be 100% share owned by other companies as shown in #9905.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This commit prevents that, limiting AIs to be 75% share owned by multiple companies, but still allowing a single company to buy it 100%, merging with it.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
