### PR TITLE
Fix #9909, 13528bf: Left-over unused parameter breaks overload resolution

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -2023,10 +2023,10 @@ extern int GetAmountOwnedBy(const Company *c, Owner owner);
 /**
  * Acquire shares in an opposing company.
  * @param flags type of operation
- * @param p1 company to buy the shares from
+ * @param target_company company to buy the shares from
  * @return the cost of this operation or an error
  */
-CommandCost CmdBuyShareInCompany(DoCommandFlag flags, TileIndex tile, CompanyID target_company)
+CommandCost CmdBuyShareInCompany(DoCommandFlag flags, CompanyID target_company)
 {
 	CommandCost cost(EXPENSES_OTHER);
 	Company *c = Company::GetIfValid(target_company);

--- a/src/economy_cmd.h
+++ b/src/economy_cmd.h
@@ -13,7 +13,7 @@
 #include "command_type.h"
 #include "company_type.h"
 
-CommandCost CmdBuyShareInCompany(DoCommandFlag flags, TileIndex tile, CompanyID target_company);
+CommandCost CmdBuyShareInCompany(DoCommandFlag flags, CompanyID target_company);
 CommandCost CmdSellShareInCompany(DoCommandFlag flags, CompanyID target_company);
 CommandCost CmdBuyCompany(DoCommandFlag flags, CompanyID target_company);
 


### PR DESCRIPTION
## Motivation / Problem
`Post()` on https://github.com/OpenTTD/OpenTTD/blob/master/src/company_gui.cpp#L2642 is translated to https://github.com/OpenTTD/OpenTTD/blob/master/src/command_func.h#L195 while it should use https://github.com/OpenTTD/OpenTTD/blob/master/src/command_func.h#L183.

This is because `CmdBuyShareInCompany()` signature doesn't match `Command<CMD_BUY_SHARE_IN_COMPANY>::Post()` signature.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Removed the unused parameter.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
