### PR TITLE
 Fix #9918: Reset industy last production year on scenario start 

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -844,6 +844,11 @@ static void OnStartScenario()
 {
 	/* Reset engine pool to simplify changing engine NewGRFs in scenario editor. */
 	EngineOverrideManager::ResetToCurrentNewGRFConfig();
+
+	/* Make sure all industries were built "this year", to avoid too early closures. (#9918) */
+	for (Industry *i : Industry::Iterate()) {
+		i->last_prod_year = _cur_year;
+	}
 }
 
 /**

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -838,6 +838,15 @@ void HandleExitGameRequest()
 }
 
 /**
+ * Triggers everything required to set up a saved scenario for a new game.
+ */
+static void OnStartScenario()
+{
+	/* Reset engine pool to simplify changing engine NewGRFs in scenario editor. */
+	EngineOverrideManager::ResetToCurrentNewGRFConfig();
+}
+
+/**
  * Triggers everything that should be triggered when starting a game.
  * @param dedicated_server Whether this is a dedicated server or not.
  */
@@ -1049,8 +1058,7 @@ void SwitchToMode(SwitchMode new_mode)
 				ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_ERROR);
 			} else {
 				if (_file_to_saveload.abstract_ftype == FT_SCENARIO) {
-					/* Reset engine pool to simplify changing engine NewGRFs in scenario editor. */
-					EngineOverrideManager::ResetToCurrentNewGRFConfig();
+					OnStartScenario();
 				}
 				OnStartGame(_network_dedicated);
 				/* Decrease pause counter (was increased from opening load dialog) */


### PR DESCRIPTION
## Motivation / Problem

Fix #9918
All industries at the start of a game should have the same risk of closing (from inactivity/low production) whether they were built automatically by the map generator, or manually in the scenario editor.
However, if the scenario starting date is changed after building an industry, the industry might have a risk of closing very soon after scenario start, instead of the usual grace period of 5 years from its construction.


## Description

When the player starts a new game from a scenario, change the "last production year" for all industries to the actual starting year. This makes them behave as if they were built by the map generator.


## Limitations

None, as far as I know.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
