### PR TITLE
Fix #9925: Industry tile layout validation for layouts of only one tile

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -3377,20 +3377,24 @@ static bool ValidateIndustryLayout(const IndustryTileLayout &layout)
 	const size_t size = layout.size();
 	if (size == 0) return false;
 
-	size_t valid_regular_tiles = 0;
-
 	for (size_t i = 0; i < size - 1; i++) {
 		for (size_t j = i + 1; j < size; j++) {
 			if (layout[i].ti.x == layout[j].ti.x &&
 					layout[i].ti.y == layout[j].ti.y) {
 				return false;
 			}
-			if (layout[i].gfx != GFX_WATERTILE_SPECIALCHECK) {
-				++valid_regular_tiles;
-			}
 		}
 	}
-	return valid_regular_tiles > 0;
+
+	bool have_regular_tile = false;
+	for (size_t i = 0; i < size; i++) {
+		if (layout[i].gfx != GFX_WATERTILE_SPECIALCHECK) {
+			have_regular_tile = true;
+			break;
+		}
+	}
+
+	return have_regular_tile;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Fix #9925, incorrect validation of industry tile layouts which contain only one tile in #9902.

## Description

Perform valid tile check separately from tile coordinate duplication check due to different loop bounds.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
