### PR TITLE
Change: GetQuarterlyExpenses now returns the additive inverse of the value

### DIFF
--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -379,3 +379,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -131,3 +131,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -68,3 +68,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -6,3 +6,10 @@
  */
 
 AILog.Info("1.10 API compatibility in effect.");
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -6,3 +6,10 @@
  */
 
 AILog.Info("1.11 API compatibility in effect.");
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -20,3 +20,10 @@ AIGroup.CreateGroup <- function(vehicle_type)
 {
 	return AIGroup._CreateGroup(vehicle_type, AIGroup.GROUP_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -6,3 +6,10 @@
  */
 
 AILog.Info("1.9 API compatibility in effect.");
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -6,3 +6,10 @@
  */
 
 AILog.Info("12 API compatibility in effect.");
+
+/* 13 returns the additive inverse of the value. */
+AICompany._GetQuarterlyExpenses <- AICompany.GetQuarterlyExpenses
+AICompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -AICompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -13,3 +13,11 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}
+

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -6,3 +6,10 @@
  */
 
 GSLog.Info("1.11 API compatibility in effect.");
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -35,3 +35,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -35,3 +35,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -28,3 +28,9 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
 
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -20,3 +20,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -20,3 +20,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -20,3 +20,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -20,3 +20,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -13,3 +13,10 @@ GSCompany.ChangeBankBalance <- function(company, delta, expenses_type)
 {
 	return GSCompany._ChangeBankBalance(company, delta, expenses_type, GSMap.TILE_INVALID);
 }
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -6,3 +6,10 @@
  */
 
 GSLog.Info("12 API compatibility in effect.");
+
+/* 13 returns the additive inverse of the value. */
+GSCompany._GetQuarterlyExpenses <- GSCompany.GetQuarterlyExpenses
+GSCompany.GetQuarterlyExpenses <- function(company, quarter)
+{
+	return -GSCompany._GetQuarterlyExpenses(company, quarter);
+}

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -20,6 +20,9 @@
  * \li AIIndustryType::ResolveNewGRFID
  * \li AIObjectType::ResolveNewGRFID
  *
+ * Other changes:
+ * \li AICompany::GetQuarterlyExpenses now returns the additive inverse of the value
+ *
  * \b 12.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -20,6 +20,9 @@
  * \li GSIndustryType::ResolveNewGRFID
  * \li GSObjectType::ResolveNewGRFID
  *
+ * Other changes:
+ * \li GSCompany::GetQuarterlyExpenses now returns the additive inverse of the value
+ *
  * \b 12.0
  *
  * API additions:

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -132,9 +132,9 @@
 	if (quarter > EARLIEST_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
-		return ::Company::Get(company)->cur_economy.expenses;
+		return -::Company::Get(company)->cur_economy.expenses;
 	}
-	return ::Company::Get(company)->old_economy[quarter - 1].expenses;
+	return -::Company::Get(company)->old_economy[quarter - 1].expenses;
 }
 
 /* static */ int32 ScriptCompany::GetQuarterlyCargoDelivered(ScriptCompany::CompanyID company, uint32 quarter)


### PR DESCRIPTION
This ensures that the value '-1' always refer to an invalid result, while values '>= 0' as valid values.

## Motivation / Problem
GetQuarterlyExpenses could return '-1' for invalid and valid results, because expenses are retrieved as negative values.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This ensures that the value '-1' always refer to an invalid result, while values '>= 0' as valid values.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Old behaviour is mainained for old scripts, before 13, always a negative value for valid expenses. New behaviour is always a positive value for valid expenses.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
