### PR TITLE
Change: Remove scrollbar from town authority actions panel

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3482,14 +3482,14 @@ STR_LOCAL_AUTHORITY_ACTION_EXCLUSIVE_TRANSPORT                  :Buy exclusive t
 STR_LOCAL_AUTHORITY_ACTION_BRIBE                                :Bribe the local authority
 
 ###length 8
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_SMALL_ADVERTISING            :{YELLOW}Initiate a small local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a small radius around the town centre.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_MEDIUM_ADVERTISING           :{YELLOW}Initiate a medium local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a medium radius around the town centre.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_LARGE_ADVERTISING            :{YELLOW}Initiate a large local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a large radius around the town centre.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ROAD_RECONSTRUCTION          :{YELLOW}Fund the reconstruction of the urban road network.{}Causes considerable disruption to road traffic for up to 6 months.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_STATUE_OF_COMPANY            :{YELLOW}Build a statue in honour of your company.{}Provides a permanent boost to station rating in this town.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_NEW_BUILDINGS                :{YELLOW}Fund the construction of new buildings in the town.{}Provides a temporary boost to town growth in this town.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_EXCLUSIVE_TRANSPORT          :{YELLOW}Buy 1 year's exclusive transport rights in town.{}Town authority will not allow passengers and cargo to use your competitors' stations.{}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{YELLOW}Bribe the local authority to increase your rating, at the risk of a severe penalty if caught.{}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_SMALL_ADVERTISING            :{PUSH_COLOUR}{YELLOW}Initiate a small local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a small radius around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_MEDIUM_ADVERTISING           :{PUSH_COLOUR}{YELLOW}Initiate a medium local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a medium radius around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_LARGE_ADVERTISING            :{PUSH_COLOUR}{YELLOW}Initiate a large local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a large radius around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ROAD_RECONSTRUCTION          :{PUSH_COLOUR}{YELLOW}Fund the reconstruction of the urban road network.{}Causes considerable disruption to road traffic for up to 6 months.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_STATUE_OF_COMPANY            :{PUSH_COLOUR}{YELLOW}Build a statue in honour of your company.{}Provides a permanent boost to station rating in this town.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_NEW_BUILDINGS                :{PUSH_COLOUR}{YELLOW}Fund the construction of new buildings in the town.{}Provides a temporary boost to town growth in this town.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_EXCLUSIVE_TRANSPORT          :{PUSH_COLOUR}{YELLOW}Buy 1 year's exclusive transport rights in town.{}Town authority will not allow passengers and cargo to use your competitors' stations.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_BRIBE                        :{PUSH_COLOUR}{YELLOW}Bribe the local authority to increase your rating, at the risk of a severe penalty if caught.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 
 # Goal window
 STR_GOALS_CAPTION                                               :{WHITE}{COMPANY} Goals

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -258,7 +258,7 @@
 	if (ScriptObject::GetCompany() == OWNER_DEITY) return false;
 	if (!IsValidTown(town_id)) return false;
 
-	return HasBit(::GetMaskOfTownActions(nullptr, ScriptObject::GetCompany(), ::Town::Get(town_id)), town_action);
+	return HasBit(::GetMaskOfTownActions(ScriptObject::GetCompany(), ::Town::Get(town_id)), town_action);
 }
 
 /* static */ bool ScriptTown::PerformTownAction(TownID town_id, TownAction town_action)

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -123,7 +123,7 @@ var      = economy.bribe
 def      = true
 str      = STR_CONFIG_SETTING_BRIBE
 strhelp  = STR_CONFIG_SETTING_BRIBE_HELPTEXT
-post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -132,7 +132,7 @@ from     = SLV_79
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_EXCLUSIVE
 strhelp  = STR_CONFIG_SETTING_ALLOW_EXCLUSIVE_HELPTEXT
-post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -141,7 +141,7 @@ from     = SLV_165
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS
 strhelp  = STR_CONFIG_SETTING_ALLOW_FUND_BUILDINGS_HELPTEXT
-post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]
@@ -150,7 +150,7 @@ from     = SLV_160
 def      = true
 str      = STR_CONFIG_SETTING_ALLOW_FUND_ROAD
 strhelp  = STR_CONFIG_SETTING_ALLOW_FUND_ROAD_HELPTEXT
-post_cb  = [](auto) { SetWindowClassesDirty(WC_TOWN_AUTHORITY); }
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_TOWN_AUTHORITY); }
 cat      = SC_BASIC
 
 [SDT_BOOL]

--- a/src/town.h
+++ b/src/town.h
@@ -200,18 +200,6 @@ Town *CalcClosestTownFromTile(TileIndex tile, uint threshold = UINT_MAX);
 
 void ResetHouses();
 
-void ClearTownHouse(Town *t, TileIndex tile);
-void UpdateTownMaxPass(Town *t);
-void UpdateTownRadius(Town *t);
-CommandCost CheckIfAuthorityAllowsNewStation(TileIndex tile, DoCommandFlag flags);
-Town *ClosestTownFromTile(TileIndex tile, uint threshold);
-void ChangeTownRating(Town *t, int add, int max, DoCommandFlag flags);
-HouseZonesBits GetTownRadiusGroup(const Town *t, TileIndex tile);
-void SetTownRatingTestMode(bool mode);
-uint GetMaskOfTownActions(int *nump, CompanyID cid, const Town *t);
-bool GenerateTowns(TownLayout layout);
-const CargoSpec *FindFirstCargoWithTownEffect(TownEffect effect);
-
 /** Town actions of a company. */
 enum TownActions {
 	TACT_NONE             = 0x00, ///< Empty action set.
@@ -233,6 +221,18 @@ enum TownActions {
 	TACT_ALL              = TACT_ADVERTISE | TACT_CONSTRUCTION | TACT_FUNDS,                     ///< All possible actions.
 };
 DECLARE_ENUM_AS_BIT_SET(TownActions)
+
+void ClearTownHouse(Town *t, TileIndex tile);
+void UpdateTownMaxPass(Town *t);
+void UpdateTownRadius(Town *t);
+CommandCost CheckIfAuthorityAllowsNewStation(TileIndex tile, DoCommandFlag flags);
+Town *ClosestTownFromTile(TileIndex tile, uint threshold);
+void ChangeTownRating(Town *t, int add, int max, DoCommandFlag flags);
+HouseZonesBits GetTownRadiusGroup(const Town *t, TileIndex tile);
+void SetTownRatingTestMode(bool mode);
+TownActions GetMaskOfTownActions(CompanyID cid, const Town *t);
+bool GenerateTowns(TownLayout layout);
+const CargoSpec *FindFirstCargoWithTownEffect(TownEffect effect);
 
 extern const byte _town_action_costs[TACT_COUNT];
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3293,21 +3293,19 @@ static TownActionProc * const _town_action_proc[] = {
 
 /**
  * Get a list of available actions to do at a town.
- * @param nump if not nullptr add put the number of available actions in it
  * @param cid the company that is querying the town
  * @param t the town that is queried
  * @return bitmasked value of enabled actions
  */
-uint GetMaskOfTownActions(int *nump, CompanyID cid, const Town *t)
+TownActions GetMaskOfTownActions(CompanyID cid, const Town *t)
 {
-	int num = 0;
 	TownActions buttons = TACT_NONE;
 
 	/* Spectators and unwanted have no options */
 	if (cid != COMPANY_SPECTATOR && !(_settings_game.economy.bribe && t->unwanted[cid])) {
 
-		/* Things worth more than this are not shown */
-		Money avail = Company::Get(cid)->money + _price[PR_STATION_VALUE] * 200;
+		/* Actions worth more than this are not able to be performed */
+		Money avail = Company::Get(cid)->money;
 
 		/* Check the action bits for validity and
 		 * if they are valid add them */
@@ -3331,12 +3329,10 @@ uint GetMaskOfTownActions(int *nump, CompanyID cid, const Town *t)
 
 			if (avail >= _town_action_costs[i] * _price[PR_TOWN_ACTION] >> 8) {
 				buttons |= cur;
-				num++;
 			}
 		}
 	}
 
-	if (nump != nullptr) *nump = num;
 	return buttons;
 }
 
@@ -3354,7 +3350,7 @@ CommandCost CmdDoTownAction(DoCommandFlag flags, TownID town_id, uint8 action)
 	Town *t = Town::GetIfValid(town_id);
 	if (t == nullptr || action >= lengthof(_town_action_proc)) return CMD_ERROR;
 
-	if (!HasBit(GetMaskOfTownActions(nullptr, _current_company, t), action)) return CMD_ERROR;
+	if (!HasBit(GetMaskOfTownActions(_current_company, t), action)) return CMD_ERROR;
 
 	CommandCost cost(EXPENSES_OTHER, _price[PR_TOWN_ACTION] * _town_action_costs[action] >> 8);
 


### PR DESCRIPTION
## Motivation / Problem

When a company has more than 4 actions available against a town authority, you must scroll down in a short window to access the later actions.

This can be annoying if you wish to do the same action to a number of different towns, or if you repeatedly close and open the local authority window to perform the same action periodically, such as 'Fund New Building' every few days when attempting to grow a town.

This will also enable players to quickly see which actions are available to them, instead of needing to scroll through the list to see if a certain action is an option.

I believe players that commonly deal with local authorities would enjoy this feature, as the interface is simpler (removed scrollbar) and easier to use (all actions available in one click).

## Description

Remove scrollbar from the actions panel of the local authority window, and instead resize the height of the panel to show the available options.

Only 2 actions available:
![image](https://user-images.githubusercontent.com/52927756/174459187-a03ba10d-a2da-46ba-9079-3a1a373aa0cc.png)

All 8 actions available:
![image](https://user-images.githubusercontent.com/52927756/174459190-d776b096-6cdb-4e58-8099-9a139402edb2.png)

## Limitations

Redrawing the local authority window can be slow if number of available actions rapidly changes (multiple times per second).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.

* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
  * ai_changelog.hpp, gs_changelog.hpp need updating.
  * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
  * newgrf_debug_data.h may need updating.
  * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
