### PR TITLE
Fix #9363: Rebuild client list on reinit event

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1714,6 +1714,11 @@ public:
 		this->FinishInitNested(window_number);
 	}
 
+	void OnInit() override
+	{
+		RebuildList();
+	}
+
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
 		this->RebuildList();


### PR DESCRIPTION
## Motivation / Problem

Fixes #9363 

## Description

Add an event handler for OnInit on the NetworkClientListWindow, rebuilding the list when the window is initialised.
Changing interface zoom level in the settings will reinitialise all open windows, rebuilding the client list window. 
This correctly re-sizes the buttons without having to reopen the window.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
