### PR TITLE
Add: ScriptCargo::GetWeight to get cargo weights

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -341,6 +341,7 @@ function Regression::Cargo()
 		print("    GetCargoIncome(10, 10):  " + AICargo.GetCargoIncome(i, 10, 10));
 		print("    GetCargoIncome(100, 10): " + AICargo.GetCargoIncome(i, 100, 10));
 		print("    GetCargoIncome(10, 100): " + AICargo.GetCargoIncome(i, 10, 100));
+		print("    GetWeight(100):          " + AICargo.GetWeight(i, 100));
 		print("    GetRoadVehicleTypeForCargo(): " + AIRoad.GetRoadVehicleTypeForCargo(i));
 	}
 }

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1118,6 +1118,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  -1
     GetCargoIncome(100, 10): -1
     GetCargoIncome(10, 100): -1
+    GetWeight(100):          -1
     GetRoadVehicleTypeForCargo(): 1
   Cargo 0
     IsValidCargo():          true
@@ -1130,6 +1131,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  3
     GetCargoIncome(100, 10): 38
     GetCargoIncome(10, 100): 3
+    GetWeight(100):          6
     GetRoadVehicleTypeForCargo(): 0
   Cargo 1
     IsValidCargo():          true
@@ -1142,6 +1144,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  7
     GetCargoIncome(100, 10): 71
     GetCargoIncome(10, 100): 6
+    GetWeight(100):          100
     GetRoadVehicleTypeForCargo(): 1
   Cargo 2
     IsValidCargo():          true
@@ -1154,6 +1157,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  5
     GetCargoIncome(100, 10): 55
     GetCargoIncome(10, 100): 5
+    GetWeight(100):          25
     GetRoadVehicleTypeForCargo(): 1
   Cargo 3
     IsValidCargo():          true
@@ -1166,6 +1170,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  5
     GetCargoIncome(100, 10): 53
     GetCargoIncome(10, 100): 5
+    GetWeight(100):          100
     GetRoadVehicleTypeForCargo(): 1
   Cargo 4
     IsValidCargo():          true
@@ -1178,6 +1183,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  5
     GetCargoIncome(100, 10): 52
     GetCargoIncome(10, 100): 4
+    GetWeight(100):          18
     GetRoadVehicleTypeForCargo(): 1
   Cargo 5
     IsValidCargo():          true
@@ -1190,6 +1196,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  7
     GetCargoIncome(100, 10): 74
     GetCargoIncome(10, 100): 6
+    GetWeight(100):          50
     GetRoadVehicleTypeForCargo(): 1
   Cargo 6
     IsValidCargo():          true
@@ -1202,6 +1209,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  5
     GetCargoIncome(100, 10): 58
     GetCargoIncome(10, 100): 4
+    GetWeight(100):          100
     GetRoadVehicleTypeForCargo(): 1
   Cargo 7
     IsValidCargo():          true
@@ -1214,6 +1222,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  6
     GetCargoIncome(100, 10): 60
     GetCargoIncome(10, 100): 5
+    GetWeight(100):          100
     GetRoadVehicleTypeForCargo(): 1
   Cargo 8
     IsValidCargo():          true
@@ -1226,6 +1235,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  6
     GetCargoIncome(100, 10): 62
     GetCargoIncome(10, 100): 5
+    GetWeight(100):          100
     GetRoadVehicleTypeForCargo(): 1
   Cargo 9
     IsValidCargo():          true
@@ -1238,6 +1248,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  6
     GetCargoIncome(100, 10): 69
     GetCargoIncome(10, 100): 6
+    GetWeight(100):          100
     GetRoadVehicleTypeForCargo(): 1
   Cargo 10
     IsValidCargo():          true
@@ -1250,6 +1261,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  9
     GetCargoIncome(100, 10): 90
     GetCargoIncome(10, 100): 7
+    GetWeight(100):          12
     GetRoadVehicleTypeForCargo(): 1
   Cargo 11
     IsValidCargo():          false
@@ -1262,6 +1274,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  -1
     GetCargoIncome(100, 10): -1
     GetCargoIncome(10, 100): -1
+    GetWeight(100):          -1
     GetRoadVehicleTypeForCargo(): 1
   Cargo 12
     IsValidCargo():          false
@@ -1274,6 +1287,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  -1
     GetCargoIncome(100, 10): -1
     GetCargoIncome(10, 100): -1
+    GetWeight(100):          -1
     GetRoadVehicleTypeForCargo(): 1
   Cargo 13
     IsValidCargo():          false
@@ -1286,6 +1300,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  -1
     GetCargoIncome(100, 10): -1
     GetCargoIncome(10, 100): -1
+    GetWeight(100):          -1
     GetRoadVehicleTypeForCargo(): 1
   Cargo 14
     IsValidCargo():          false
@@ -1298,6 +1313,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetCargoIncome(10, 10):  -1
     GetCargoIncome(100, 10): -1
     GetCargoIncome(10, 100): -1
+    GetWeight(100):          -1
     GetRoadVehicleTypeForCargo(): 1
 
 --CargoList--

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -17,6 +17,8 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li AICargo::GetWeight
  * \li AIIndustryType::ResolveNewGRFID
  * \li AIObjectType::ResolveNewGRFID
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -17,6 +17,8 @@
  *
  * This version is not yet released. The following changes are not set in stone yet.
  *
+ * API additions:
+ * \li GSCargo::GetWeight
  * \li GSIndustryType::ResolveNewGRFID
  * \li GSObjectType::ResolveNewGRFID
  *

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -81,3 +81,9 @@
 	if (!ScriptCargo::IsValidCargo(cargo_type)) return INVALID_DISTRIBUTION_TYPE;
 	return (ScriptCargo::DistributionType)_settings_game.linkgraph.GetDistributionType(cargo_type);
 }
+
+/* static */ int64 ScriptCargo::GetWeight(CargoID cargo_type, uint32 amount)
+{
+	if (!IsValidCargo(cargo_type)) return -1;
+	return ::CargoSpec::Get(cargo_type)->weight * static_cast<int64>(amount) / 16;
+}

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -153,6 +153,16 @@ public:
 	 * @return The cargo distribution type for the given cargo.
 	 */
 	static DistributionType GetDistributionType(CargoID cargo_type);
+
+	/**
+	 * Get the weight in tonnes for the given amount of
+	 *   cargo for the specified type.
+	 * @param cargo_type The cargo to check on.
+	 * @param amount The quantity of cargo.
+	 * @pre ScriptCargo::IsValidCargo(cargo_type).
+	 * @return The weight in tonnes for that quantity of cargo.
+	 */
+	static int64 GetWeight(CargoID cargo_type, uint32 amount);
 };
 
 #endif /* SCRIPT_CARGO_HPP */


### PR DESCRIPTION
## Motivation / Problem
There is no method to get how much a certain amount of cargo weight in tonnes.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add ScriptCargo::GetWeight(cargo_type, amount). It gets how much the amount given weights in tonnes, making use of the CargoSpec->weight property.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
It does not include the freight multiplier in the calculations.
When that is required, AIs can already know whether the cargo is freight with AICargo.IsFreight(cargo_type), and retrieve the multiplier with AIGameSettings.GetValue("freight_trains");
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
