### PR TITLE
Feature: Multi-track level crossings

### DIFF
--- a/src/pbs.cpp
+++ b/src/pbs.cpp
@@ -105,8 +105,7 @@ bool TryReserveRailTrack(TileIndex tile, Track t, bool trigger_stations)
 		case MP_ROAD:
 			if (IsLevelCrossing(tile) && !HasCrossingReservation(tile)) {
 				SetCrossingReservation(tile, true);
-				BarCrossing(tile);
-				MarkTileDirtyByTile(tile); // crossing barred, make tile dirty
+				UpdateLevelCrossing(tile, false);
 				return true;
 			}
 			break;

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -548,6 +548,7 @@ CommandCost CmdBuildSingleRail(DoCommandFlag flags, TileIndex tile, RailType rai
 					if (flags & DC_EXEC) {
 						MakeRoadCrossing(tile, road_owner, tram_owner, _current_company, (track == TRACK_X ? AXIS_Y : AXIS_X), railtype, roadtype_road, roadtype_tram, GetTownIndex(tile));
 						UpdateLevelCrossing(tile, false);
+						MarkDirtyAdjacentLevelCrossingTiles(tile, GetCrossingRoadAxis(tile));
 						Company::Get(_current_company)->infrastructure.rail[railtype] += LEVELCROSSING_TRACKBIT_FACTOR;
 						DirtyCompanyInfrastructureWindows(_current_company);
 						if (num_new_road_pieces > 0 && Company::IsValidID(road_owner)) {
@@ -649,6 +650,8 @@ CommandCost CmdRemoveSingleRail(DoCommandFlag flags, TileIndex tile, Track track
 			cost.AddCost(RailClearCost(GetRailType(tile)));
 
 			if (flags & DC_EXEC) {
+				MarkDirtyAdjacentLevelCrossingTiles(tile, GetCrossingRoadAxis(tile));
+
 				if (HasReservedTracks(tile, trackbit)) {
 					v = GetTrainForReservation(tile, track);
 					if (v != nullptr) FreeTrainTrackReservation(v);

--- a/src/road_func.h
+++ b/src/road_func.h
@@ -153,7 +153,8 @@ RoadTypes GetCompanyRoadTypes(CompanyID company, bool introduces = true);
 RoadTypes GetRoadTypes(bool introduces);
 RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, Date date);
 
-void UpdateLevelCrossing(TileIndex tile, bool sound = true);
+void UpdateLevelCrossing(TileIndex tile, bool sound = true, bool force_bar = false);
+void MarkDirtyAdjacentLevelCrossingTiles(TileIndex tile, Axis road_axis);
 void UpdateCompanyRoadInfrastructure(RoadType rt, Owner o, int count);
 
 struct TileInfo;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -1004,7 +1004,7 @@ struct RoadDriveEntry {
 
 #include "table/roadveh_movement.h"
 
-static bool RoadVehLeaveDepot(RoadVehicle *v, bool first)
+bool RoadVehLeaveDepot(RoadVehicle *v, bool first)
 {
 	/* Don't leave unless v and following wagons are in the depot. */
 	for (const RoadVehicle *u = v; u != nullptr; u = u->Next()) {

--- a/src/roadveh_cmd.h
+++ b/src/roadveh_cmd.h
@@ -14,6 +14,8 @@
 #include "engine_type.h"
 #include "vehicle_type.h"
 
+bool RoadVehLeaveDepot(RoadVehicle *v, bool first);
+
 CommandCost CmdBuildRoadVehicle(DoCommandFlag flags, TileIndex tile, const Engine *e, Vehicle **v);
 
 CommandCost CmdTurnRoadVeh(DoCommandFlag flags, VehicleID veh_id);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -342,6 +342,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_REPAIR_OBJECT_DOCKING_TILES,        ///< 299  PR#9594 v12.0  Fixing issue with docking tiles overlapping objects.
 	SLV_U64_TICK_COUNTER,                   ///< 300  PR#10035 Make _tick_counter 64bit to avoid wrapping.
 	SLV_LAST_LOADING_TICK,                  ///< 301  PR#9693 Store tick of last loading for vehicles.
+	SLV_MULTITRACK_LEVEL_CROSSINGS,         ///< 302  PR#9931 Multi-track level crossings.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/table/road_land.h
+++ b/src/table/road_land.h
@@ -53,6 +53,46 @@ static const DrawTileSprites _crossing_layout = {
 	{0, PAL_NONE}, _crossing_layout_ALL
 };
 
+static const DrawTileSeqStruct _crossing_layout_SW_ALL[] = {
+	TILE_SEQ_LINE(6, PAL_NONE, 13,  0, 3, 3)
+	TILE_SEQ_LINE(8, PAL_NONE, 13, 13, 3, 3)
+	TILE_SEQ_END()
+};
+
+static const DrawTileSprites _crossing_layout_SW = {
+	{0, PAL_NONE}, _crossing_layout_SW_ALL
+};
+
+static const DrawTileSeqStruct _crossing_layout_NW_ALL[] = {
+	TILE_SEQ_LINE(2, PAL_NONE,  0,  0, 3, 3)
+	TILE_SEQ_LINE(6, PAL_NONE, 13,  0, 3, 3)
+	TILE_SEQ_END()
+};
+
+static const DrawTileSprites _crossing_layout_NW = {
+	{0, PAL_NONE}, _crossing_layout_NW_ALL
+};
+
+static const DrawTileSeqStruct _crossing_layout_NE_ALL[] = {
+	TILE_SEQ_LINE(2, PAL_NONE,  0,  0, 3, 3)
+	TILE_SEQ_LINE(4, PAL_NONE,  0, 13, 3, 3)
+	TILE_SEQ_END()
+};
+
+static const DrawTileSprites _crossing_layout_NE = {
+	{0, PAL_NONE}, _crossing_layout_NE_ALL
+};
+
+static const DrawTileSeqStruct _crossing_layout_SE_ALL[] = {
+	TILE_SEQ_LINE(4, PAL_NONE,  0, 13, 3, 3)
+	TILE_SEQ_LINE(8, PAL_NONE, 13, 13, 3, 3)
+	TILE_SEQ_END()
+};
+
+static const DrawTileSprites _crossing_layout_SE = {
+	{0, PAL_NONE}, _crossing_layout_SE_ALL
+};
+
 #undef TILE_SEQ_LINE
 #undef TILE_SEQ_END
 


### PR DESCRIPTION
## Motivation / Problem

Multiple-track level crossings in vanilla OpenTTD are unsafe since road vehicle protection is per-track and not for the entire crossing. Vehicles will happily stop on the near track to wait for a train to pass on the far track, and then get smushed by a train.

## Description

![single_sided](https://user-images.githubusercontent.com/55058389/175394421-1feb172a-c024-434b-a8f8-98b64f2d03c4.png)
_(NewGRFs: U&RaTT roads and U&ReRMM rails, both by Ufiby)_

JGRPP includes several improvements to level crossings. This PR only includes some features, starting with Eddi's original [patch](https://www.tt-forums.net/viewtopic.php?p=836749#p836749) and various improvements by JGR including code improvements and a feature to only draw crossing signals (when sprites are provided by NewGRF) on the edges of a multi-track crossing.

What this PR includes:

- When an approaching train causes a level crossing to be barred, adjacent tracks are also blocked.
- Road vehicles are always allowed to exit blocked crossings even if that means crossing multiple tracks.
- When using a NewGRF railtype which includes custom crossing signal sprites, only the crossing signals at the edges of the crossing are drawn.

What this PR does NOT include from JGRPP:
- Safer level crossings (trains cannot reserve a path over a level crossing unless it is clear of road vehicles) ([commit](https://github.com/JGRennison/OpenTTD-patches/commit/0073c4e71eefa6ff499082ff1fc05d40c983f232))
- Road vehicles cannot be manually stopped on level crossings ([commit](https://github.com/JGRennison/OpenTTD-patches/commit/0acb4fdd2f94fa4a241600500f4b08552188e10e))
- Settings to enable or disable multi-track crossings

There is a saveload conversion for savegames where road vehicles may be stopped on a level crossing waiting for a train. Any road vehicle stopped on a level crossing is teleported to the nearest depot, if one exists. (If no depot is reachable, it'll still get smashed.) The conversion then iterates through every tile on the map to update level crossings and block adjacent tiles if necessary. I tried looking only at tiles reserved by trains, but couldn't find an easy way to do this. Iterating through every tile is a bit more expensive but as a one-time saveload conversion I hope it's okay.

Closes #8444 (draft PR of the same patch)

## Limitations

- ~~In savegames where a road vehicle is sitting on an open level crossing, stopped at a barred level crossing on the next track (behavior which this PR bans), if another train reserves the crossing where this vehicle sets, it will start driving and crash into the side of the train on the next track.~~ Now fixed. Savegame for demonstration: [rv_smash.zip](https://github.com/OpenTTD/OpenTTD/files/8970738/rv_smash.zip)
- During saveload conversion, if a vehicle stopped on a level crossing cannot find a depot, it will not get teleported and will likely get smashed. This should be rare, but is still possible.
- Vanilla level crossings are drawn using a single sprite, so a NewGRF railtype which includes custom crossing signal sprites is required to only show crossing signals on the crossing edges
- Level crossings are still unsafe if you're using block signals, or if your road vehicles take a long time to clear the crossing. Path signals should be placed far in advance of the crossing to cause it to activate and allow road vehicles to clear the crossing before the train arrives. This is existing behavior, with the only change being that the more tracks you have, the longer the time it takes to clear.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
