### PR TITLE
Fix #9937: Station industries_near incorrect after removing part moved sign

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -752,7 +752,6 @@ void Station::AfterStationTileSetChange(bool adding, StationType type)
 		InvalidateWindowData(WC_STATION_LIST, this->owner, 0);
 	} else {
 		MarkCatchmentTilesDirty();
-		this->RecomputeCatchment();
 	}
 
 	switch (type) {
@@ -776,6 +775,7 @@ void Station::AfterStationTileSetChange(bool adding, StationType type)
 		InvalidateWindowData(WC_SELECT_STATION, 0, 0);
 	} else {
 		DeleteStationIfEmpty(this);
+		this->RecomputeCatchment();
 	}
 
 }


### PR DESCRIPTION
## Motivation / Problem

Fix #9937.

## Description

RecomputeCatchment was being called before moving the sign tile instead of afterwards, such that distances in
Station::industries_near could be incorrect.
This could result in multiplayer desyncs, and triggered the checks in CheckCaches,

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
