### PR TITLE
Fix: depot-related commands did not validate depot tiles properly

### DIFF
--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -634,6 +634,7 @@ CommandCost CmdMassStartStopVehicle(DoCommandFlag flags, TileIndex tile, bool do
 	if (vehicle_list_window) {
 		if (!GenerateVehicleSortList(&list, vli)) return CMD_ERROR;
 	} else {
+		if (!IsDepotTile(tile) || !IsTileOwner(tile, _current_company)) return CMD_ERROR;
 		/* Get the list of vehicles in the depot */
 		BuildDepotVehicleList(vli.vtype, tile, &list, nullptr);
 	}
@@ -666,6 +667,7 @@ CommandCost CmdDepotSellAllVehicles(DoCommandFlag flags, TileIndex tile, Vehicle
 	CommandCost cost(EXPENSES_NEW_VEHICLES);
 
 	if (!IsCompanyBuildableVehicleType(vehicle_type)) return CMD_ERROR;
+	if (!IsDepotTile(tile) || !IsTileOwner(tile, _current_company)) return CMD_ERROR;
 
 	/* Get the list of vehicles in the depot */
 	BuildDepotVehicleList(vehicle_type, tile, &list, &list);

--- a/src/vehiclelist.cpp
+++ b/src/vehiclelist.cpp
@@ -80,20 +80,20 @@ void BuildDepotVehicleList(VehicleType type, TileIndex tile, VehicleList *engine
 			case VEH_TRAIN: {
 				const Train *t = Train::From(v);
 				if (t->IsArticulatedPart() || t->IsRearDualheaded()) continue;
-				if (t->track != TRACK_BIT_DEPOT) continue;
+				if (!t->IsInDepot()) continue;
 				if (wagons != nullptr && t->First()->IsFreeWagon()) {
 					if (individual_wagons || t->IsFreeWagon()) wagons->push_back(t);
 					continue;
 				}
+				if (!t->IsPrimaryVehicle()) continue;
 				break;
 			}
 
 			default:
+				if (!v->IsPrimaryVehicle()) continue;
 				if (!v->IsInDepot()) continue;
 				break;
 		}
-
-		if (!v->IsPrimaryVehicle()) continue;
 
 		engines->push_back(v);
 	}


### PR DESCRIPTION
## Motivation / Problem

Fuzzing commands indicated a crash on commands like `CmdDepotMassAutoReplace` and friends.


## Description
```
The bug comes in two slices:

1) the functions never actually checked if "tile" was a depot tile.
   This allowed executing the function on tile 0, where are the
   things like shadows of aircrafts are.
2) BuildDepotVehicleList() first checked if a vehicle is in a depot
   before checking if it was a primary vehicle. This is invalid
   for aircraft.

Fixing the first hides the second, and fixing the second makes the
first non-exploitable. But, fixing both felt like the best thing
to do.
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
