### PR TITLE
Fix: Trains only considered railtype-poweredness, and mostly ignored railtype-compatibility.

### DIFF
--- a/src/ground_vehicle.cpp
+++ b/src/ground_vehicle.cpp
@@ -56,12 +56,14 @@ void GroundVehicle<T, Type>::PowerChanged()
 
 	this->gcache.cached_air_drag = air_drag + 3 * air_drag * number_of_parts / 20;
 
+	if (total_power == 0) {
+		/* Ensure that vehicles are never completely stuck */
+		total_power = 1;
+	}
+
 	max_te *= GROUND_ACCELERATION; // Tractive effort in (tonnes * 1000 * 9.8 =) N.
 	max_te /= 256;  // Tractive effort is a [0-255] coefficient.
 	if (this->gcache.cached_power != total_power || this->gcache.cached_max_te != max_te) {
-		/* Stop the vehicle if it has no power. */
-		if (total_power == 0) this->vehstatus |= VS_STOPPED;
-
 		this->gcache.cached_power = total_power;
 		this->gcache.cached_max_te = max_te;
 		SetWindowDirty(WC_VEHICLE_DETAILS, this->index);

--- a/src/rail_type.h
+++ b/src/rail_type.h
@@ -49,6 +49,7 @@ enum RailTypes : uint64 {
 	RAILTYPES_ELECTRIC = 1 << RAILTYPE_ELECTRIC, ///< Electrified rails
 	RAILTYPES_MONO     = 1 << RAILTYPE_MONO,     ///< Monorail!
 	RAILTYPES_MAGLEV   = 1 << RAILTYPE_MAGLEV,   ///< Ever fast maglev
+	RAILTYPES_ALL      = UINT64_MAX,             ///< All railtypes
 	INVALID_RAILTYPES  = UINT64_MAX,             ///< Invalid railtypes
 };
 DECLARE_ENUM_AS_BIT_SET(RailTypes)


### PR DESCRIPTION
## Motivation / Problem

Consider Andy's train:

| Vehicle | Compatible | Powered |
| --- | --- | --- |
| Engine 1 | RAIL, ELRL, HIGH | ELRL |
| Engine 2 | RAIL, HIGH | HIGH |

Expected behavior:
* Train can only run on HIGH tracks.
    * All engines are compatible with RAIL and HIGH; but only some with ELRL.
    * Some engines are powered on ELRL, some on HIGH; but none on just RAIL.

Actual behavior:
* Compatibilty is ignored.
* The train runs on ELRL and HIGH tracks.

Secondary issue:
* If different engines of a train are powered on different railtypes, a train may get stranded when transitioning between railtypes.
    * Engines in the front may lose power when entering the new railtype.
    * Engines in the back may not yet have entered the new railtype, so are not powered either.
* If trains have enough momentum they can safely transition these power gaps.
* If a train stops due to signals, breakdowns, ... it is stuck with zero power.

## Description

Primary issue:
* Trains are allowed to enter tracks, if
    * All vehicles of the consist are compatible.
    * At least one engine is powered.

Secondary issue:
* Passengers can now be drafted to push the train, providing a minimum of 1 hp in all cases.

## Limitations

PBS path reservation/freeing sometimes uses `v->compatible_railtypes` instead of `GetRailTypeInfo(v->railtype)->compatible_railtypes`. This needs checking.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
