### PR TITLE
Fix #8584: Vehicles with shared orders getting invalid or unexpected start dates

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4468,7 +4468,7 @@ STR_TIMETABLE_STATUS_NOT_STARTED                                :{BLACK}This tim
 STR_TIMETABLE_STATUS_START_AT                                   :{BLACK}This timetable will start at {STRING1}
 
 STR_TIMETABLE_STARTING_DATE                                     :{BLACK}Start date
-STR_TIMETABLE_STARTING_DATE_TOOLTIP                             :{BLACK}Select a date as starting point of this timetable. Ctrl+Click sets the starting point of this timetable and distributes all vehicles sharing this order evenly based on their relative order, if the order is completely timetabled
+STR_TIMETABLE_STARTING_DATE_TOOLTIP                             :{BLACK}Select a date as starting point of this timetable. Ctrl+Click distributes all vehicles sharing this order evenly from the given date based on their relative order, if the order is completely timetabled
 
 STR_TIMETABLE_CHANGE_TIME                                       :{BLACK}Change Time
 STR_TIMETABLE_WAIT_TIME_TOOLTIP                                 :{BLACK}Change the amount of time that the highlighted order should take


### PR DESCRIPTION
## Motivation / Problem

Filling simultaneously the start dates of all the vehicles sharing an order list often assigns a start date *before* the user-provided one to some of the vehicles, possibly several years in the past or even at a negative date.
It also bypasses the MAX_DAY bound check.

## Description

This PR changes the logic CmdSetTimetableStart so that the start dates of all vehicles of the shared orders group are after the user-provided start date. It also adds a check against MAX_DAY.

## Limitations

I had to reword STR_TIMETABLE_STARTING_DATE_TOOLTIP because the start date of the vehicle the user selected is no longer guaranteed to be the one the user provided, it will be given to the vehicle that is the closest to the first station instead (see VehicleTimetableSorter for the implementation details).


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
