### PR TITLE
Add: [YAPF] Rail depot penalty based on the number of trains waiting in it

### DIFF
--- a/src/depot_base.h
+++ b/src/depot_base.h
@@ -24,6 +24,7 @@ struct Depot : DepotPool::PoolItem<&_depot_pool> {
 	Town *town = nullptr;
 	std::string name{};
 	TimerGameCalendar::Date build_date{}; ///< Date of construction
+	uint running_vehicles = 0; ///< Number of vehicles currently entering or waiting to leave the depot
 
 	Depot() {}
 	Depot(TileIndex xy) : xy(xy), build_date(TimerGameCalendar::date) {}
@@ -45,5 +46,7 @@ struct Depot : DepotPool::PoolItem<&_depot_pool> {
 		return GetTileType(d->xy) == GetTileType(this->xy);
 	}
 };
+
+void RebuildDepotOccupancyCache(VehicleType type);
 
 #endif /* DEPOT_BASE_H */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -53,6 +53,7 @@
 #include "rev.h"
 #include "highscore.h"
 #include "station_base.h"
+#include "depot_base.h"
 #include "crashlog.h"
 #include "engine_func.h"
 #include "core/random_func.hpp"
@@ -1250,6 +1251,7 @@ void StateGameLoop()
 			SaveOrLoad(name, SLO_SAVE, DFT_GAME_FILE, AUTOSAVE_DIR, false);
 		}
 
+		RebuildDepotOccupancyCache(VEH_TRAIN);
 		CheckCaches();
 
 		/* All these actions has to be done from OWNER_NONE

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -11,6 +11,7 @@
 #define YAPF_COSTRAIL_HPP
 
 
+#include "../../depot_base.h"
 #include "../../pbs.h"
 #include "../follow_track.hpp"
 #include "../pathfinder_type.h"
@@ -400,6 +401,13 @@ no_entry_cost: // jump here at the beginning if the node has no parent (it is th
 			} else if (IsRailDepotTile(cur.tile)) {
 				/* We will end in this pass (depot is possible target) */
 				end_segment_reason.Set(EndSegmentReason::Depot);
+				/* Add a penalty for each non-stopped train in the depot.
+				 * The penalty is capped at 8 trains. */
+				const Depot *d = Depot::GetByTile(cur.tile);
+				if (d) {
+					const uint count = std::min(d->running_vehicles, 8u);
+					segment_cost += Yapf().PfGetSettings().rail_pbs_cross_penalty * count;
+				}
 
 			} else if (cur.tile_type == MP_STATION && IsRailWaypoint(cur.tile)) {
 				if (v->current_order.IsType(OT_GOTO_WAYPOINT) &&


### PR DESCRIPTION
## Motivation / Problem

Non-stopped trains waiting in depot are not taken into account in YAPF cost calculations, because they may not have any track reserved. This can for instance be a problem for 'go to nearest depot' orders, as a train may choose to go to a depot full of waiting trains when it could go to a slightly more distant empty depot instead.

## Description

This PR adds a penalty for trains in depot to YAPF.
`rail_pbs_cross_penalty` seemed to be the most relevant penalty as it is used for reserved tracks.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
