### PR TITLE
Fix: [NewGRF] Default value of RailVehicleInfo::railveh_type was inconsistent with other default properties.

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -76,6 +76,8 @@ Engine::Engine(VehicleType type, EngineID base)
 
 	/* Check if this base engine is within the original engine data range */
 	if (base >= _engine_counts[type]) {
+		/* 'power' defaults to zero, so we also have to default to 'wagon' */
+		if (type == VEH_TRAIN) this->u.rail.railveh_type = RAILVEH_WAGON;
 		/* Set model life to maximum to make wagons available */
 		this->info.base_life = 0xFF;
 		/* Set road vehicle tractive effort to the default value */


### PR DESCRIPTION
## Motivation / Problem

If a NewGRF (or Andy by proxy) assigned neither "power" nor "dual-headed" properties of a train vehicle, then "railveh_type" defaulted to "singlehead-engine", while "power=0" said "it's a wagon".

This results in inconsistent behavior in some places, like the "wagon" using a "engine livery".

## Description

While NewGRF are "officially" required to set all properties, defaulting to inconsistent property values creates corner-cases which otherwise would not exist.

This PR fixes the inconsistency by defaulting "railveh_type" to a value, which is consistent with the default value for "power".

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
