### PR TITLE
Add #7889: Company rating via Server Admin Port

### DIFF
--- a/src/company_base.h
+++ b/src/company_base.h
@@ -79,6 +79,8 @@ struct CompanyProperties {
 
 	Year inaugurated_year;           ///< Year of starting the company.
 
+	byte rating;                     ///< Ranking nth of the company with 1st being best performing according to performance history.
+
 	byte months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?
 	int16 bankrupt_timeout;          ///< If bigger than \c 0, amount of time to wait for an answer on an offer to buy this company.
@@ -108,7 +110,7 @@ struct CompanyProperties {
 	CompanyProperties()
 		: name_2(0), name_1(0), president_name_1(0), president_name_2(0),
 		  face(0), money(0), money_fraction(0), current_loan(0), colour(0), block_preview(0),
-		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0),
+		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0), rating(0),
 		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
 		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false), engine_renew_list(nullptr) {}
 };

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -79,8 +79,6 @@ struct CompanyProperties {
 
 	Year inaugurated_year;           ///< Year of starting the company.
 
-	byte rating;                     ///< Ranking nth of the company with 1st being best performing according to performance history.
-
 	byte months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?
 	int16 bankrupt_timeout;          ///< If bigger than \c 0, amount of time to wait for an answer on an offer to buy this company.
@@ -110,7 +108,7 @@ struct CompanyProperties {
 	CompanyProperties()
 		: name_2(0), name_1(0), president_name_1(0), president_name_2(0),
 		  face(0), money(0), money_fraction(0), current_loan(0), colour(0), block_preview(0),
-		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0), rating(0),
+		  location_of_HQ(0), last_build_coordinate(0), share_owners(), inaugurated_year(0),
 		  months_of_bankruptcy(0), bankrupt_asked(0), bankrupt_timeout(0), bankrupt_value(0),
 		  terraform_limit(0), clear_limit(0), tree_limit(0), is_ai(false), engine_renew_list(nullptr) {}
 };

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -332,7 +332,7 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company
 	p->Send_uint8 (CeilDiv(c->months_of_bankruptcy, 3)); // send as quarters_of_bankruptcy
 
 	for (auto owner : c->share_owners) {
-	  p->Send_uint8(owner);
+		p->Send_uint8(owner);
 	}
 
 

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -335,20 +335,11 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendCompanyInfo(const Company
 	  p->Send_uint8(owner);
 	}
 
-	std::vector<Company *> companies;
-	for(Company* company: Company::Iterate()){
-	  companies.emplace_back(company);
-	}
 
-	std::sort(companies.begin(), companies.end(), [](Company * const &c1, Company * const &c2){
-	  return c2->old_economy[0].performance_history < c1->old_economy[0].performance_history;
-	});
+	uint8 rating = std::count_if(Company::Iterate().begin(), Company::Iterate().end(), [&](auto company){
+	return c->old_economy[0].performance_history < company->old_economy[0].performance_history;});
 
-	for(size_t t = 0; t < companies.size(); t++){
-	  companies[t]->rating = t+1;
-	}
-
-	p->Send_uint8 (c->rating);
+	p->Send_uint8 (rating);
 
 	this->SendPacket(p);
 


### PR DESCRIPTION
## Motivation / Problem
Enhancing the admin port by sending company 'ranking' information as well. 

## Description

The ranking is according to the performance history of the company, the same as the company league table. The company rating is modified by calling _SendCompanyInfo_.

## Limitations
- Modifies company objects
- Duplicates sorting functionality with the company league table

I originally attempted to reuse the sorting done from the company league table GUI class, but then the admin port would have to wait for the player to open it up before getting rating information.

This is also my first PR for any project so there are definitely more things to be called out here, please do that. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
