### PR TITLE
Fix #9940: Print debuglevel parse errors to console when changed from console

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1587,7 +1587,7 @@ DEF_CONSOLE_CMD(ConDebugLevel)
 	if (argc == 1) {
 		IConsolePrint(CC_DEFAULT, "Current debug-level: '{}'", GetDebugString());
 	} else {
-		SetDebugString(argv[1]);
+		SetDebugString(argv[1], [](const char *err) { IConsolePrint(CC_ERROR, std::string(err)); });
 	}
 
 	return true;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -159,8 +159,9 @@ void DebugPrint(const char *level, const std::string &message)
  * For setting individual levels a string like \c "net=3,grf=6" should be used.
  * If the string starts with a number, the number is used as global debugging level.
  * @param s Text describing the wanted debugging levels.
+ * @param error_func The function to call if a parse error occurs.
  */
-void SetDebugString(const char *s)
+void SetDebugString(const char *s, void (*error_func)(const char *))
 {
 	int v;
 	char *end;
@@ -203,7 +204,8 @@ void SetDebugString(const char *s)
 		if (p != nullptr) {
 			*p = v;
 		} else {
-			ShowInfoF("Unknown debug level '%.*s'", (int)(s - t), t);
+			std::string error_string = fmt::format("Unknown debug level '{}'", std::string(t, s - t));
+			error_func(error_string.c_str());
 			return;
 		}
 	}

--- a/src/debug.h
+++ b/src/debug.h
@@ -57,7 +57,7 @@ extern int _debug_random_level;
 #endif
 
 char *DumpDebugFacilityNames(char *buf, char *last);
-void SetDebugString(const char *s);
+void SetDebugString(const char *s, void (*error_func)(const char *));
 const char *GetDebugString();
 
 /* Shorter form for passing filename and linenumber */

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -564,7 +564,7 @@ int openttd_main(int argc, char *argv[])
 			videodriver = "dedicated";
 			blitter = "null";
 			dedicated = true;
-			SetDebugString("net=4");
+			SetDebugString("net=4", ShowInfo);
 			if (mgo.opt != nullptr) {
 				scanner->dedicated_host = ParseFullConnectionString(mgo.opt, scanner->dedicated_port);
 			}
@@ -588,7 +588,7 @@ int openttd_main(int argc, char *argv[])
 #if defined(_WIN32)
 				CreateConsole();
 #endif
-				if (mgo.opt != nullptr) SetDebugString(mgo.opt);
+				if (mgo.opt != nullptr) SetDebugString(mgo.opt, ShowInfo);
 				break;
 			}
 		case 'e': _switch_mode = (_switch_mode == SM_LOAD_GAME || _switch_mode == SM_LOAD_SCENARIO ? SM_LOAD_SCENARIO : SM_EDITOR); break;


### PR DESCRIPTION
## Motivation / Problem

The `SetDebugString` function doesn't care if it gets called from a commandline parameter or from the internal console. It always uses error output as if it was called during startup where the GUI might not be available.


## Description

Make it take a callback for reporting parse errors.


## Limitations

Slightly more annoying to call, but it's only called from 3 places.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
