### PR TITLE
Fix #9971: Don't assert that time moves forward

### DIFF
--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -965,7 +965,7 @@ struct FrametimeGraphWindow : Window {
 					(int)Scinterlate<int64>(x_zero, x_max, 0, (int64)draw_horz_scale, (int64)draw_horz_scale - (int64)time_sum),
 					(int)Scinterlate<int64>(y_zero, y_max, 0, (int64)draw_vert_scale, (int64)value)
 				};
-				assert(newpoint.x <= lastpoint.x);
+				if (newpoint.x > lastpoint.x) continue; // don't draw backwards
 				GfxDrawLine(lastpoint.x, lastpoint.y, newpoint.x, newpoint.y, c_lines);
 				lastpoint = newpoint;
 


### PR DESCRIPTION
## Motivation / Problem

It seems that if simulation goes too fast, the tick time measurements can get inaccurate and produce measurements that appear to go backwards in time. Maybe it has to do with threads being migrated between CPU cores? No idea.

## Description

Just ignore measurements that appear to do time travel. Don't try to draw them.

## Limitations

I tried the reproduction given in #9971 and I can't make it crash with or without this patch. I did test with builds with asserts enabled, and reached about 1.3 million ticks/s.
It probably has to do with specific CPU models that have performance counters behaving in specific ways.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
