### PR TITLE
Add various user folders to the file browser windows

### DIFF
--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -47,6 +47,16 @@ extern bool FiosGetDiskFreeSpace(const char *path, uint64 *tot);
 extern void GetOldSaveGameName(const std::string &file, char *title, const char *last);
 
 /**
+ * Construct a FiosItem from std::string values for name and title.
+ */
+FiosItem::FiosItem(FiosType type, const std::string &name, const std::string &title, uint64 mtime) :
+	type(type), mtime(mtime)
+{
+	strecpy(this->name, name.c_str(), lastof(this->name));
+	strecpy(this->title, title.c_str(), lastof(this->title));
+}
+
+/**
  * Compare two FiosItem's. Used with sort when sorting the file list.
  * @param other The FiosItem to compare to.
  * @return for ascending order: returns true if da < db. Vice versa for descending order.

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -420,6 +420,21 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 
 	std::sort(file_list.begin() + sort_start, file_list.end());
 
+	/* Show default directories */
+	if (callback_proc == &FiosGetSavegameListCallback) {
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(SAVE_DIR), GetString(STR_SAVELOAD_SAVEGAMES_DIRECTORY));
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(AUTOSAVE_DIR), GetString(STR_SAVELOAD_AUTOSAVES_DIRECTORY));
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(SCENARIO_DIR), GetString(STR_SAVELOAD_SCENARIOS_DIRECTORY));
+	} else if (callback_proc == &FiosGetScenarioListCallback) {
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(SCENARIO_DIR), GetString(STR_SAVELOAD_SCENARIOS_DIRECTORY));
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(SAVE_DIR), GetString(STR_SAVELOAD_SAVEGAMES_DIRECTORY));
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(HEIGHTMAP_DIR), GetString(STR_SAVELOAD_HEIGHTMAPS_DIRECTORY));
+	} else if (callback_proc == &FiosGetHeightmapListCallback) {
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(HEIGHTMAP_DIR), GetString(STR_SAVELOAD_HEIGHTMAPS_DIRECTORY));
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(SCENARIO_DIR), GetString(STR_SAVELOAD_SCENARIOS_DIRECTORY));
+		file_list.emplace_back(FIOS_TYPE_DRIVE, FioFindDirectory(SAVE_DIR), GetString(STR_SAVELOAD_SAVEGAMES_DIRECTORY));
+	}
+
 	/* Show drives */
 	FiosGetDrives(file_list);
 
@@ -515,7 +530,7 @@ void FiosGetSavegameList(SaveLoadOperation fop, FileList &file_list)
  * @see FiosGetFileList
  * @see FiosGetScenarioList
  */
-static FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
+FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
 {
 	/* Show scenario files
 	 * .SCN OpenTTD style scenario file
@@ -556,7 +571,7 @@ void FiosGetScenarioList(SaveLoadOperation fop, FileList &file_list)
 	FiosGetFileList(fop, &FiosGetScenarioListCallback, subdir, file_list);
 }
 
-static FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
+FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last)
 {
 	/* Show heightmap files
 	 * .PNG PNG Based heightmap files

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -151,10 +151,8 @@ const char *FiosBrowseTo(const FiosItem *item)
 {
 	switch (item->type) {
 		case FIOS_TYPE_DRIVE:
-#if defined(_WIN32) || defined(__OS2__)
 			assert(_fios_path != nullptr);
-			*_fios_path = std::string{ item->title[0] } + ":" PATHSEP;
-#endif
+			*_fios_path = std::string{ item->name };
 			break;
 
 		case FIOS_TYPE_INVALID:

--- a/src/fios.h
+++ b/src/fios.h
@@ -124,6 +124,8 @@ std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);
 
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
+FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
+FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 
 void ScanScenarios();
 const char *FindScenario(const ContentInfo *ci, bool md5sum);

--- a/src/fios.h
+++ b/src/fios.h
@@ -89,6 +89,10 @@ struct FiosItem {
 	uint64 mtime;
 	char title[64];
 	char name[MAX_PATH];
+
+	FiosItem() = default;
+	FiosItem(FiosType type, const std::string &name, const std::string &title, uint64 mtime = 0);
+
 	bool operator< (const FiosItem &other) const;
 };
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3134,6 +3134,10 @@ STR_SAVELOAD_OVERWRITE_TITLE                                    :{WHITE}Overwrit
 STR_SAVELOAD_OVERWRITE_WARNING                                  :{YELLOW}Are you sure you want to overwrite the existing file?
 STR_SAVELOAD_DIRECTORY                                          :{RAW_STRING} (Directory)
 STR_SAVELOAD_PARENT_DIRECTORY                                   :{RAW_STRING} (Parent directory)
+STR_SAVELOAD_SAVEGAMES_DIRECTORY                                :OpenTTD Saved Games
+STR_SAVELOAD_AUTOSAVES_DIRECTORY                                :OpenTTD Automatically Saved Games
+STR_SAVELOAD_SCENARIOS_DIRECTORY                                :OpenTTD Scenarios
+STR_SAVELOAD_HEIGHTMAPS_DIRECTORY                               :OpenTTD Heightmaps
 
 STR_SAVELOAD_OSKTITLE                                           :{BLACK}Enter a name for the savegame
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3134,6 +3134,7 @@ STR_SAVELOAD_OVERWRITE_TITLE                                    :{WHITE}Overwrit
 STR_SAVELOAD_OVERWRITE_WARNING                                  :{YELLOW}Are you sure you want to overwrite the existing file?
 STR_SAVELOAD_DIRECTORY                                          :{RAW_STRING} (Directory)
 STR_SAVELOAD_PARENT_DIRECTORY                                   :{RAW_STRING} (Parent directory)
+STR_SAVELOAD_DRIVE_VOLUMELABEL                                  :{RAW_STRING} ({RAW_STRING})
 STR_SAVELOAD_SAVEGAMES_DIRECTORY                                :OpenTTD Saved Games
 STR_SAVELOAD_AUTOSAVES_DIRECTORY                                :OpenTTD Automatically Saved Games
 STR_SAVELOAD_SCENARIOS_DIRECTORY                                :OpenTTD Scenarios

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -81,6 +81,7 @@ void FiosGetDrives(FileList &file_list)
 			snprintf(fios->name, lengthof(fios->name),  "%c:", disk);
 #endif
 			strecpy(fios->title, fios->name, lastof(fios->title));
+			strecat(fios->name, PATHSEP, lastof(fios->name));
 		}
 	}
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -62,10 +62,12 @@ bool FiosIsRoot(const char *path)
 	return path[1] == '\0';
 }
 
+#ifndef __APPLE__
 void FiosGetDrives(FileList &file_list)
 {
 	return;
 }
+#endif
 
 bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
 {

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -177,6 +177,7 @@ bool FiosIsRoot(const char *file)
 
 void FiosGetDrives(FileList &file_list)
 {
+	/* Add drive letters */
 	wchar_t drives[256];
 	const wchar_t *s;
 
@@ -185,8 +186,8 @@ void FiosGetDrives(FileList &file_list)
 		FiosItem *fios = &file_list.emplace_back();
 		fios->type = FIOS_TYPE_DRIVE;
 		fios->mtime = 0;
-		seprintf(fios->name, lastof(fios->name),  "%c:", s[0] & 0xFF);
-		strecpy(fios->title, fios->name, lastof(fios->title));
+		seprintf(fios->title, lastof(fios->title),  "%c:", s[0] & 0xFF);
+		seprintf(fios->name, lastof(fios->name), "%c:" PATHSEP, s[0] & 0xFF);
 		while (*s++ != '\0') { /* Nothing */ }
 	}
 }

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -12,10 +12,10 @@
 
 #if defined(_WIN32)
 	/* MinGW defaults to Windows 7 if none of these are set, and they must be set before any MinGW header is included */
-#	define NTDDI_VERSION NTDDI_WINXP // Windows XP
-#	define _WIN32_WINNT 0x501        // Windows XP
-#	define _WIN32_WINDOWS 0x501      // Windows XP
-#	define WINVER 0x0501             // Windows XP
+#	define NTDDI_VERSION NTDDI_VISTA // Windows Vista
+#	define _WIN32_WINNT 0x600        // Windows Vista
+#	define _WIN32_WINDOWS 0x600      // Windows Vista
+#	define WINVER 0x0600             // Windows Vista
 #	define _WIN32_IE_ 0x0600         // 6.0 (XP+)
 #endif
 


### PR DESCRIPTION
## Motivation / Problem

Most users don't organize their files by drive letters any more, but use the OS-provided special folders (Desktop, Documents, Downloads, etc), but finding those folders in the file browser in OpenTTD is rather troublesome.

## Description

Extend the idea of "drive letters" in the FIOS code to actually mean "any link to a special folder that requires absolute navigation".
On Windows, add a selection of known user folders, when available.

To do:
- [x] Add known user folders on Windows
- [x] Add some of the known in-game folders (the default savegame folder) on all operating systems
- [x] Add known user folders on macOS
- [x] Add known user folders on Unix-y systems (Freedesktop 'basedir' spec?)

![image](https://user-images.githubusercontent.com/1062071/187067218-075c3c68-1005-4b97-99f7-38531e7e07f6.png)

## Limitations

The interface used requires bumping the Windows version to minimum Vista.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
