### PR TITLE
Fix #9804: Only apply sprite_zoom_min setting when sprites available

### DIFF
--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -22,6 +22,13 @@ struct Sprite {
 	byte data[];   ///< Sprite data.
 };
 
+enum SpriteCacheCtrlFlags {
+	SCCF_ALLOW_ZOOM_MIN_1X_PAL    = 0, ///< Allow use of sprite min zoom setting at 1x in palette mode.
+	SCCF_ALLOW_ZOOM_MIN_1X_32BPP  = 1, ///< Allow use of sprite min zoom setting at 1x in 32bpp mode.
+	SCCF_ALLOW_ZOOM_MIN_2X_PAL    = 2, ///< Allow use of sprite min zoom setting at 2x in palette mode.
+	SCCF_ALLOW_ZOOM_MIN_2X_32BPP  = 3, ///< Allow use of sprite min zoom setting at 2x in 32bpp mode.
+};
+
 extern uint _sprite_cache_size;
 
 typedef void *AllocatorProc(size_t size);

--- a/src/spriteloader/grf.hpp
+++ b/src/spriteloader/grf.hpp
@@ -17,7 +17,7 @@ class SpriteLoaderGrf : public SpriteLoader {
 	byte container_ver;
 public:
 	SpriteLoaderGrf(byte container_ver) : container_ver(container_ver) {}
-	uint8 LoadSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp);
+	uint8 LoadSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags);
 };
 
 #endif /* SPRITELOADER_GRF_HPP */

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -72,9 +72,10 @@ public:
 	 * @param file_pos    The position within the file the image begins.
 	 * @param sprite_type The type of sprite we're trying to load.
 	 * @param load_32bpp  True if 32bpp sprites should be loaded, false for a 8bpp sprite.
+	 * @param control_flags Control flags, see SpriteCacheCtrlFlags.
 	 * @return Bit mask of the zoom levels successfully loaded or 0 if no sprite could be loaded.
 	 */
-	virtual uint8 LoadSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp) = 0;
+	virtual uint8 LoadSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags) = 0;
 
 	virtual ~SpriteLoader() { }
 };


### PR DESCRIPTION
## Motivation / Problem

See: #9804

## Description
Only discard sprite zoom levels when a suitable higher zoom level is defined in the same colour mode.

This is to avoid placeholder or empty sprites being used, causing visual artefacts.

Minimal port of: https://github.com/JGRennison/OpenTTD-patches/commit/309f1b47d29a377e24dd75071848d67d5c0c23f0

## Limitations

Only tested on a representative sample of GRFs.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
