### PR TITLE
Fix #9989: £0 Net Profit is neither negative nor positive

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -214,9 +214,11 @@ static void DrawCategories(const Rect &r)
 static void DrawPrice(Money amount, int left, int right, int top, TextColour colour)
 {
 	StringID str = STR_FINANCES_NEGATIVE_INCOME;
-	if (amount < 0) {
+	if (amount == 0) {
+		str = STR_FINANCES_ZERO_INCOME;
+	} else if (amount < 0) {
 		amount = -amount;
-		str++;
+		str = STR_FINANCES_POSITIVE_INCOME;
 	}
 	SetDParam(0, amount);
 	DrawString(left, right, top, str, colour, SA_RIGHT);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3641,6 +3641,7 @@ STR_FINANCES_SECTION_LOAN_INTEREST                              :{GOLD}Loan Inte
 STR_FINANCES_SECTION_OTHER                                      :{GOLD}Other
 
 STR_FINANCES_NEGATIVE_INCOME                                    :-{CURRENCY_LONG}
+STR_FINANCES_ZERO_INCOME                                        :{CURRENCY_LONG}
 STR_FINANCES_POSITIVE_INCOME                                    :+{CURRENCY_LONG}
 STR_FINANCES_NET_PROFIT                                         :{WHITE}Net Profit
 STR_FINANCES_BANK_BALANCE_TITLE                                 :{WHITE}Bank Balance


### PR DESCRIPTION
## Motivation / Problem

See #9989:

> "Net Profit" shows "-£0" as if the value "0" is interpreted as negative (even though it's neither negative or positive).


## Description

If the amount to draw is 0, use a string without a negative or positive sign.

Fixes #9989.

## Limitations

`DrawPrice()` and its callers are a bit odd in how they use the amount, where a negative `amount` is actually positive income and vice versa. But untangling that is out of scope here. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
