### PR TITLE
Fix #9993: Handle DPI changes on macOS and Windows

### DIFF
--- a/os/windows/openttd.manifest
+++ b/os/windows/openttd.manifest
@@ -10,6 +10,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
     </windowsSettings>
   </application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/src/gfx_func.h
+++ b/src/gfx_func.h
@@ -80,6 +80,7 @@ void DrawMouseCursor();
 void ScreenSizeChanged();
 void GameSizeChanged();
 void UpdateGUIZoom();
+bool AdjustGUIZoom();
 void UndrawMouseCursor();
 
 /** Size of the buffer used for drawing strings. */

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -1269,8 +1269,12 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 /** Screen the window is on changed. */
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification
 {
+	bool did_adjust = AdjustGUIZoom();
+
 	/* Reallocate screen buffer if necessary. */
 	driver->AllocateBackingStore();
+
+	if (did_adjust) ReInitAllWindows(true);
 }
 
 /** Presentation options to use for full screen mode. */

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -38,6 +38,10 @@
 #define PM_QS_INPUT 0x20000
 #endif
 
+#ifndef WM_DPICHANGED
+#define WM_DPICHANGED 0x02E0
+#endif
+
 bool _window_maximize;
 static Dimension _bck_resolution;
 DWORD _imm_props;
@@ -668,6 +672,24 @@ LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 					break;
 			}
 			return TRUE;
+		}
+
+		case WM_DPICHANGED: {
+			auto did_adjust = AdjustGUIZoom();
+
+			/* Resize the window to match the new DPI setting. */
+			RECT *prcNewWindow = (RECT *)lParam;
+			SetWindowPos(hwnd,
+				NULL,
+				prcNewWindow->left,
+				prcNewWindow->top,
+				prcNewWindow->right - prcNewWindow->left,
+				prcNewWindow->bottom - prcNewWindow->top,
+				SWP_NOZORDER | SWP_NOACTIVATE);
+
+			if (did_adjust) ReInitAllWindows(true);
+
+			return 0;
 		}
 
 /* needed for wheel */

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3343,6 +3343,13 @@ void HideVitalWindows()
 	CloseWindowById(WC_STATUS_BAR, 0);
 }
 
+void ReInitWindow(Window *w, bool zoom_changed)
+{
+	if (w == nullptr) return;
+	if (zoom_changed) w->nested_root->AdjustPaddingForZoom();
+	w->ReInit();
+}
+
 /** Re-initialize all windows. */
 void ReInitAllWindows(bool zoom_changed)
 {
@@ -3352,9 +3359,13 @@ void ReInitAllWindows(bool zoom_changed)
 	extern void InitDepotWindowBlockSizes();
 	InitDepotWindowBlockSizes();
 
+	/* When _gui_zoom has changed, we need to resize toolbar and statusbar first,
+	 * so EnsureVisibleCaption uses the updated size information. */
+	ReInitWindow(FindWindowById(WC_MAIN_TOOLBAR, 0), zoom_changed);
+	ReInitWindow(FindWindowById(WC_STATUS_BAR, 0), zoom_changed);
 	for (Window *w : Window::Iterate()) {
-		if (zoom_changed) w->nested_root->AdjustPaddingForZoom();
-		w->ReInit();
+		if (w->window_class == WC_MAIN_TOOLBAR || w->window_class == WC_STATUS_BAR) continue;
+		ReInitWindow(w, zoom_changed);
 	}
 
 	void NetworkReInitChatBoxSize();

--- a/src/zoom_func.h
+++ b/src/zoom_func.h
@@ -37,6 +37,17 @@ static inline int UnScaleByZoom(int value, ZoomLevel zoom)
 }
 
 /**
+ * Adjust by zoom level; zoom < 0 shifts right, zoom >= 0 shifts left
+ * @param value value to shift
+ * @param zoom zoom level to shift to
+ * @return shifted value
+ */
+static inline int AdjustByZoom(int value, int zoom)
+{
+	return zoom < 0 ? UnScaleByZoom(value, ZoomLevel(-zoom)) : ScaleByZoom(value, ZoomLevel(zoom));
+}
+
+/**
  * Scale by zoom level, usually shift left (when zoom > ZOOM_LVL_NORMAL)
  * @param value value to shift
  * @param zoom  zoom level to shift to


### PR DESCRIPTION
## Motivation / Problem

Fixes #9993. When the application window is moved between retina and non-retina displays (macOS) or different DPI settings (Windows), the application should update the GUI zoom. Any opened windows should remain at their original position, but corrected for the new GUI zoom level.

## Description

When we determine that the window has moved to another display with a different scaling factor, we update `_gui_zoom` and apply the zoom scale factor to all internal `Window`s and their `viewport`. This is done by calling `UpdateGUIZoom()` and comparing the before and after value of `_gui_zoom`. A new zoom helper method `AdjustByZoom` scales any current value according to the difference in zoom (up/down). Then we allow the video driver to update the window/buffer and when that is done, we ReInit all windows to rerender them at the new zoom. This requires some specific ordering as the game tries to keep `Window`s visible: within the main window, below the toolbar and above the statusbar. My initial attempt didn't account for this and caused `Window`s to move around as a result.

On Windows we need to resize the window to match the new DPI configuration to keep the same size on-screen. Furthermore we opt-in to the [V2 DPI Awareness so that the _non-client area_ (title bar) is resized by the OS](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enablenonclientdpiscaling), on supported versions ([Windows 10, version 1607 and later](https://docs.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process#setting-default-awareness-with-the-application-manifest)).

Demo on macOS:
![fix0](https://user-images.githubusercontent.com/235882/188300054-5787bf25-90f6-4da7-87d4-5d884ef15e69.gif)

## Limitations

<s>- The fix is only implemented for the macOS video backend. The bug could be present on other systems, however I have no experience nor any setup to verify this. When this is the case, we might want to introduce a more generic hook to change `_gui_zoom`.

- When switching displays while on the main screen, the title "OpenTTD" is repositioned. This is not a new bug. Fixed in #9997.

- Sometimes the new scaling is not taking effect. I have not discovered how to reproduce.

- Station names get cut-off when the original display is non-retina. I _think_ this is caused by the max length calculation only being performed once.

- I need to make myself familiar with `_use_hidpi` / `_allow_hidpi_window` and see how that affects this PR.

- The initial GUI rescale doesn't apply when going from Retina -> non-Retina. I need to look into this. </s>

- The changes for Windows could use a critical pair of eyes. It appears to work fine in my VM when moving between displays with different DPI settings though.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.<s>
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)</s>
