### PR TITLE
Fix #9995: Adjust viewport zoom level for HiDPI displays

### DIFF
--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -837,7 +837,7 @@ public:
 
 		this->InitNested(window_number);
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_IV_VIEWPORT);
-		nvp->InitializeViewport(this, Industry::Get(window_number)->location.GetCenterTile(), ZOOM_LVL_INDUSTRY);
+		nvp->InitializeViewport(this, Industry::Get(window_number)->location.GetCenterTile(), ScaleZoomGUI(ZOOM_LVL_INDUSTRY));
 
 		this->InvalidateData();
 	}

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -222,7 +222,7 @@ struct MainWindow : Window
 		ResizeWindow(this, _screen.width, _screen.height);
 
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_M_VIEWPORT);
-		nvp->InitializeViewport(this, TileXY(32, 32), ZOOM_LVL_VIEWPORT);
+		nvp->InitializeViewport(this, TileXY(32, 32), ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
 
 		this->viewport->overlay = new LinkGraphOverlay(this, WID_M_VIEWPORT, 0, 0, 3);
 		this->refresh.SetInterval(LINKGRAPH_DELAY);

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -310,7 +310,7 @@ struct NewsWindow : Window {
 		/* Initialize viewport if it exists. */
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_N_VIEWPORT);
 		if (nvp != nullptr) {
-			nvp->InitializeViewport(this, ni->reftype1 == NR_VEHICLE ? 0x80000000 | ni->ref1 : (uint32)GetReferenceTile(ni->reftype1, ni->ref1), ZOOM_LVL_NEWS);
+			nvp->InitializeViewport(this, ni->reftype1 == NR_VEHICLE ? 0x80000000 | ni->ref1 : (uint32)GetReferenceTile(ni->reftype1, ni->ref1),ScaleZoomGUI(ZOOM_LVL_NEWS));
 			if (this->ni->flags & NF_NO_TRANSPARENT) nvp->disp_flags |= ND_NO_TRANSPARENCY;
 			if ((this->ni->flags & NF_INCOLOUR) == 0) {
 				nvp->disp_flags |= ND_SHADE_GREY;

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -40,6 +40,7 @@
 #include "table/strings.h"
 
 #include "safeguards.h"
+#include "zoom_func.h"
 
 TownKdtree _town_local_authority_kdtree(&Kdtree_TownXYFunc);
 
@@ -331,7 +332,7 @@ public:
 
 		this->flags |= WF_DISABLE_VP_SCROLL;
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_TV_VIEWPORT);
-		nvp->InitializeViewport(this, this->town->xy, ZOOM_LVL_NEWS);
+		nvp->InitializeViewport(this, this->town->xy, ScaleZoomGUI(ZOOM_LVL_TOWN));
 
 		/* disable renaming town in network games if you are not the server */
 		this->SetWidgetDisabledState(WID_TV_CHANGE_NAME, _networking && !_network_server);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2736,7 +2736,7 @@ public:
 		}
 		this->FinishInitNested(window_number);
 		this->owner = v->owner;
-		this->GetWidget<NWidgetViewport>(WID_VV_VIEWPORT)->InitializeViewport(this, this->window_number | (1 << 31), _vehicle_view_zoom_levels[v->type]);
+		this->GetWidget<NWidgetViewport>(WID_VV_VIEWPORT)->InitializeViewport(this, this->window_number | (1 << 31), ScaleZoomGUI(_vehicle_view_zoom_levels[v->type]));
 
 		this->GetWidget<NWidgetCore>(WID_VV_START_STOP)->tool_tip       = STR_VEHICLE_VIEW_TRAIN_STATUS_START_STOP_TOOLTIP + v->type;
 		this->GetWidget<NWidgetCore>(WID_VV_RENAME)->tool_tip           = STR_VEHICLE_DETAILS_TRAIN_RENAME + v->type;

--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -57,8 +57,8 @@ public:
 		this->InitNested(window_number);
 
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_EV_VIEWPORT);
-		nvp->InitializeViewport(this, 0, ZOOM_LVL_VIEWPORT);
-		if (_settings_client.gui.zoom_min == ZOOM_LVL_VIEWPORT) this->DisableWidget(WID_EV_ZOOM_IN);
+		nvp->InitializeViewport(this, 0, ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
+		if (_settings_client.gui.zoom_min == viewport->zoom) this->DisableWidget(WID_EV_ZOOM_IN);
 
 		Point pt;
 		if (tile == INVALID_TILE) {

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -27,6 +27,7 @@
 #include "table/strings.h"
 
 #include "safeguards.h"
+#include "zoom_func.h"
 
 /** GUI for accessing waypoints and buoys. */
 struct WaypointWindow : Window {
@@ -70,7 +71,7 @@ public:
 		this->flags |= WF_DISABLE_VP_SCROLL;
 
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_W_VIEWPORT);
-		nvp->InitializeViewport(this, this->GetCenterTile(), ZOOM_LVL_VIEWPORT);
+		nvp->InitializeViewport(this, this->GetCenterTile(), ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
 
 		this->OnInvalidateData(0);
 	}

--- a/src/zoom_func.h
+++ b/src/zoom_func.h
@@ -80,6 +80,26 @@ static inline int UnScaleGUI(int value)
 }
 
 /**
+ * Scale zoom level relative to GUI zoom.
+ * @param value zoom level to scale
+ * @return scaled zoom level
+ */
+static inline ZoomLevel ScaleZoomGUI(ZoomLevel value)
+{
+	return std::clamp(ZoomLevel(value + (ZOOM_LVL_GUI - ZOOM_LVL_OUT_4X)), ZOOM_LVL_MIN, ZOOM_LVL_MAX);
+}
+
+/**
+ * UnScale zoom level relative to GUI zoom.
+ * @param value zoom level to scale
+ * @return un-scaled zoom level
+ */
+static inline ZoomLevel UnScaleZoomGUI(ZoomLevel value)
+{
+	return std::clamp(ZoomLevel(value - (ZOOM_LVL_GUI - ZOOM_LVL_OUT_4X)), ZOOM_LVL_MIN, ZOOM_LVL_MAX);
+}
+
+/**
  * Scale traditional pixel dimensions to GUI zoom level.
  * @param value Pixel amount at #ZOOM_LVL_BASE (traditional "normal" interface size).
  * @return Pixel amount at #ZOOM_LVL_GUI (current interface size).

--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -35,7 +35,7 @@ enum ZoomLevel : byte {
 	ZOOM_LVL_VIEWPORT = ZOOM_LVL_OUT_4X, ///< Default zoom level for viewports.
 	ZOOM_LVL_NEWS     = ZOOM_LVL_OUT_4X, ///< Default zoom level for the news messages.
 	ZOOM_LVL_INDUSTRY = ZOOM_LVL_OUT_8X, ///< Default zoom level for the industry view.
-	ZOOM_LVL_TOWN     = ZOOM_LVL_OUT_8X, ///< Default zoom level for the town view.
+	ZOOM_LVL_TOWN     = ZOOM_LVL_OUT_4X, ///< Default zoom level for the town view.
 	ZOOM_LVL_AIRCRAFT = ZOOM_LVL_OUT_4X, ///< Default zoom level for the aircraft view.
 	ZOOM_LVL_SHIP     = ZOOM_LVL_OUT_4X, ///< Default zoom level for the ship view.
 	ZOOM_LVL_TRAIN    = ZOOM_LVL_OUT_4X, ///< Default zoom level for the train view.


### PR DESCRIPTION
## Motivation / Problem

Fixes #9995.

## Description

On HiDPI screens the zoom level is increased for detailed rendering. This causes hard-coded zoom levels to be off by this adjustment. To fix these default zoom levels, we adjust based on `_gui_zoom`.

Expected viewport zoom:
![OpenTTD 9996 002](https://user-images.githubusercontent.com/235882/196039193-37094b36-ae8a-4612-ba5d-441d40c830ae.png)

Actual viewport zoom:
![OpenTTD 9996 003](https://user-images.githubusercontent.com/235882/196039198-f496095f-5e9a-4eaa-8d03-209493212996.png)

Fixed viewport zoom:
![OpenTTD 9996 fix 003](https://user-images.githubusercontent.com/235882/196039240-3e95dc9e-e1ee-4eab-8150-54ca3b8a44ae.png)

I've tested with all viewports: trains, buses, airplanes, ships, towns, news, industries, waypoint, extra viewport.

The change is also applied to savegames, when saving them we save current zoom, but un-adjust it for the current `_gui_zoom`. This means that regardless of the user's display scaling, loading the game will restore the viewport at the same experienced viewport.

## Limitations

- Savegames saved from by a HiDPI prior to this PR will restore with a zoomed-out viewport, as we now regard the saved zoom level as display-independent. This allows for a consistent viewport restoration regardless of display dpi settings.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.<s>
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)</s>
