### PR TITLE
Fix: title positioning on HiDPI displays

### DIFF
--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -248,8 +248,8 @@ struct MainWindow : Window
 		this->DrawWidgets();
 		if (_game_mode == GM_MENU) {
 			static const SpriteID title_sprites[] = {SPR_OTTD_O, SPR_OTTD_P, SPR_OTTD_E, SPR_OTTD_N, SPR_OTTD_T, SPR_OTTD_T, SPR_OTTD_D};
-			static const uint LETTER_SPACING = 10;
-			int name_width = (lengthof(title_sprites) - 1) * LETTER_SPACING;
+			uint letter_spacing = ScaleGUITrad(10);
+			int name_width = (lengthof(title_sprites) - 1) * letter_spacing;
 
 			for (uint i = 0; i < lengthof(title_sprites); i++) {
 				name_width += GetSpriteSize(title_sprites[i]).width;
@@ -257,8 +257,8 @@ struct MainWindow : Window
 			int off_x = (this->width - name_width) / 2;
 
 			for (uint i = 0; i < lengthof(title_sprites); i++) {
-				DrawSprite(title_sprites[i], PAL_NONE, off_x, 50);
-				off_x += GetSpriteSize(title_sprites[i]).width + LETTER_SPACING;
+				DrawSprite(title_sprites[i], PAL_NONE, off_x, ScaleGUITrad(50));
+				off_x += GetSpriteSize(title_sprites[i]).width + letter_spacing;
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation / Problem

The title positioning on the main screen is incorrect on HiDPI displays; the offsets/padding isn't adjusted for the zoom. This causes the title to display at a different position when the window is shown on a retina vs non-retina display (macOS).

## Description

![fix2](https://user-images.githubusercontent.com/235882/188314578-4371bba0-d23b-42f0-a9ad-58e4b4082310.gif)

## Limitations

None afaik.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
