### PR TITLE
Fix #9903: Don't build houses around half-tile roads after a bridge or tunnel

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1622,6 +1622,9 @@ static TownGrowthResult GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, Dia
 			return TownGrowthResult::Continue;
 		}
 
+		/* Don't build houses around half-tile roads in the rare case we ended up on one. */
+		if (HasExactlyOneBit(cur_rb)) allow_house = false;
+
 		/* Possibly extend the road in a direction.
 		 * Randomize a direction and if it has a road, bail out. */
 		target_dir = RandomDiagDir();


### PR DESCRIPTION
## Motivation / Problem

Closes #9903

## Description

Adds a check for the half-tile road before building a house. 
AFACT only matters if it's the end of the tunnel/bridge or starting tile. 
Didn't check for `_settings_game.economy.allow_town_roads` as that seems irrelevant since towns don't build half-tile roads anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* ~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ~ai_changelog.hpp, gs_changelog.hpp need updating.~
    * ~The compatibility wrappers (compat_*.nut) need updating.~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * ~newgrf_debug_data.h may need updating.~
    * ~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~
