### PR TITLE
Fix: Don't stop growth attempt if house is not allowed

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1593,8 +1593,6 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 		}
 
 		if (!TownCanGrowRoad(tile)) return;
-
-		_grow_town_result = GROWTH_SEARCH_STOPPED;
 	}
 
 	/* Return if a water tile */


### PR DESCRIPTION
## Motivation / Problem

When OpenTTD tries to build a house but is not allowed it stops the growth attempt completely even though it could've succeeded further down that road. AFACT there are two distinct cases that are affected (I'm using cmclient for screenshots since it shows stopped growth with the orange square):
- Blocking grid intersections with stations or one-way roads when towns are allowed to build roads;
![Screenshot from 2022-09-06 02-13-51](https://user-images.githubusercontent.com/413570/188520014-1cefbf39-aa55-4fb3-b831-dbc0bcdfd8ea.png)
- Using road types that don't allow houses
![Screenshot from 2022-09-06 02-15-01](https://user-images.githubusercontent.com/413570/188520015-79394683-8108-4e41-aed9-dfbc5277139b.png)

In both cases, it results in a drastic reduction of the effective growth speed as it needs to chance on a road tile when picking the house spot for it to fail early and the search to continue.

## Description

Simply don't set the growth stopping flag if the house spot was not allowed.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~The bug fix is important enough to be backported? (label: 'backport requested')~
* ~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ~ai_changelog.hpp, gs_changelog.hpp need updating.~
    * ~The compatibility wrappers (compat_*.nut) need updating.~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * ~newgrf_debug_data.h may need updating.~
    * ~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~
