### PR TITLE
News window zoom level fixes.

### DIFF
--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -520,6 +520,18 @@ struct NewsWindow : Window {
 		}
 	}
 
+	void OnResize() override
+	{
+		if (this->viewport != nullptr) {
+			NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_N_VIEWPORT);
+			nvp->UpdateViewportCoordinates(this);
+
+			if (ni->reftype1 != NR_VEHICLE) {
+				ScrollWindowToTile(GetReferenceTile(ni->reftype1, ni->ref1), this, true); // Re-center viewport.
+			}
+		}
+	}
+
 	/**
 	 * Some data on this window has become invalid.
 	 * @param data Information about the changed data.

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -267,6 +267,7 @@ struct NewsWindow : Window {
 	const NewsItem *ni;   ///< News item to display.
 	static int duration;  ///< Remaining time for showing the current news message (may only be access while a news item is displayed).
 
+	static const uint TIMER_INTERVAL = 210; ///< Scrolling interval, scaled by line text line height. This value chosen to maintain the 15ms at normal zoom.
 	GUITimer timer;
 
 	NewsWindow(WindowDesc *desc, const NewsItem *ni) : Window(desc), ni(ni)
@@ -277,8 +278,6 @@ struct NewsWindow : Window {
 		this->status_height = FindWindowById(WC_STATUS_BAR, 0)->height;
 
 		this->flags |= WF_DISABLE_VP_SCROLL;
-
-		this->timer.SetInterval(15);
 
 		this->CreateNestedTree();
 
@@ -321,6 +320,11 @@ struct NewsWindow : Window {
 		}
 
 		PositionNewsMessage(this);
+	}
+
+	void OnInit() override
+	{
+		this->timer.SetInterval(TIMER_INTERVAL / FONT_HEIGHT_NORMAL);
 	}
 
 	void DrawNewsBorder(const Rect &r) const


### PR DESCRIPTION
## Motivation / Problem

1. The viewport in the news window does not get updated if the zoom level is changed, causing screen corruption.
3. The news window takes longer to appear on high zoom levels as it only moves a fixed amount.

## Description

1. This is fixed by implementing the OnResize window event, based on other windows containing a viewport.
2. The refresh interval of the news window animation is now based on the font height, fixing this issue in the same way as was done for the credits window.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
