### PR TITLE
Change: Adjust saved viewport zoom level for HiDPI displays

### DIFF
--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -39,7 +39,7 @@ void SaveViewportBeforeSaveGame()
 	if (w != nullptr) {
 		_saved_scrollpos_x = w->viewport->scrollpos_x;
 		_saved_scrollpos_y = w->viewport->scrollpos_y;
-		_saved_scrollpos_zoom = w->viewport->zoom;
+		_saved_scrollpos_zoom = std::min(UnScaleZoomGUI(w->viewport->zoom), ZOOM_LVL_MAX);
 	}
 }
 
@@ -53,7 +53,7 @@ void ResetViewportAfterLoadGame()
 	w->viewport->dest_scrollpos_y = _saved_scrollpos_y;
 
 	Viewport *vp = w->viewport;
-	vp->zoom = std::min(_saved_scrollpos_zoom, ZOOM_LVL_MAX);
+	vp->zoom = ScaleZoomGUI(std::min(_saved_scrollpos_zoom, ZOOM_LVL_MAX));
 	vp->virtual_width = ScaleByZoom(vp->width, vp->zoom);
 	vp->virtual_height = ScaleByZoom(vp->height, vp->zoom);
 

--- a/src/zoom_func.h
+++ b/src/zoom_func.h
@@ -69,6 +69,26 @@ static inline int UnScaleGUI(int value)
 }
 
 /**
+ * Scale zoom level relative to GUI zoom.
+ * @param value zoom level to scale
+ * @return scaled zoom level
+ */
+static inline ZoomLevel ScaleZoomGUI(ZoomLevel value)
+{
+	return ZoomLevel(value + (ZOOM_LVL_GUI - ZOOM_LVL_OUT_4X));
+}
+
+/**
+ * UnScale zoom level relative to GUI zoom.
+ * @param value zoom level to scale
+ * @return un-scaled zoom level
+ */
+static inline ZoomLevel UnScaleZoomGUI(ZoomLevel value)
+{
+	return ZoomLevel(value - (ZOOM_LVL_GUI - ZOOM_LVL_OUT_4X));
+}
+
+/**
  * Scale traditional pixel dimensions to GUI zoom level.
  * @param value Pixel amount at #ZOOM_LVL_BASE (traditional "normal" interface size).
  * @return Pixel amount at #ZOOM_LVL_GUI (current interface size).


### PR DESCRIPTION
## Motivation / Problem

On HiDPI screens the zoom level is increased for detailed rendering. We store the current zoom level in save games. When such a savegame is loaded on a screen with different GUI zoom, the restored zoom level is changed, which is unexpected.

## Description

This PR is split off rom #9996, see also [this comment by @frosch123](https://github.com/OpenTTD/OpenTTD/pull/9996/files#r964112894).

- On save, we "un-scale" the current zoom; we adjust the zoom level for the GUI's zoom level.
- On load, we "scale" the savegame's zoom; we adjust the zoom level to the GUI's zoom level.
- Storing on HiDPI display would restore the expected zoom level on other HiDPI displays and normal displays.
- Storing on normals display would restore the expected zoom level on other normal and HiDPI displays.

## Limitations

- When viewed at the highest zoom level on a HiDPI screen (32x) we would like to store the equivalent zoom level for non-HiDPI screens (64x). As that zoom level doesn't exist, we store it capped at 32x. When loading such a savegame, we restore the zoom level incorrectly; one step zoomed in (16x).
- As we're changing the zoomlevel on-save, loading existing savegames on HiDPI screen will restore the viewport incorrectly; one step zoomed in.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.<s>
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)</s>