### PR TITLE
Fix #10010: memory leak in IConsolePrint in non-dedicated case

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -123,6 +123,7 @@ void IConsolePrint(TextColour colour_code, const std::string &string)
 
 	IConsoleWriteToLogFile(str);
 	IConsoleGUIPrint(colour_code, str);
+	free(str);
 }
 
 /**

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -53,8 +53,8 @@ struct IConsoleLine {
 	 * @param buffer the data to print.
 	 * @param colour the colour of the line.
 	 */
-	IConsoleLine(const std::string &buffer, TextColour colour) :
-			buffer(buffer),
+	IConsoleLine(std::string buffer, TextColour colour) :
+			buffer(std::move(buffer)),
 			colour(colour),
 			time(0)
 	{


### PR DESCRIPTION
## Motivation / Problem

See #10010

## Description

Fix memory leak in IConsolePrint in non-dedicated case
Fix unnecessary string reallocation in IConsoleLine constructor

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
