### PR TITLE
Fix: DrawStringMultiLine() could overdraw

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -819,7 +819,7 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, const char *st
 	for (const auto &line : layout) {
 
 		int line_height = line->GetLeading();
-		if (y >= top && y < bottom) {
+		if (y >= top && y + line_height - 1 <= bottom) {
 			last_line = y + line_height;
 			if (first_line > y) first_line = y;
 


### PR DESCRIPTION
## Motivation / Problem

DrawStringMultiLine() will overdraw below the bottom bound if it falls between text rows, as it does not take the line height into account when checking position.

![image](https://user-images.githubusercontent.com/639850/189451157-7fc68d96-16e5-4956-b1df-6136dc2b544a.png)

## Description

This is resolved by taking the line height into account when testing the bottom bound.

![image](https://user-images.githubusercontent.com/639850/189451244-8fa893e4-eaad-4f3b-ab12-b907d944b169.png)

## Limitations

Some windows may exploit this bug and use DrawPixelInfo to crop the partially overdrawn text. These will now not overdraw. IMHO such instances should be fixed to ensure the bottom bound leaves enough room.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
