### PR TITLE
Add the Simulation subcategory to openttd.desktop

### DIFF
--- a/media/openttd.desktop
+++ b/media/openttd.desktop
@@ -6,6 +6,6 @@ Name=OpenTTD
 Icon=${BINARY_NAME}
 Exec=${BINARY_NAME}
 Terminal=false
-Categories=Game;
+Categories=Game;Simulation;
 Keywords=game;simulation;transport;tycoon;deluxe;economics;multiplayer;money;train;ship;bus;truck;aircraft;cargo;
 @Comment_STR_DESKTOP_SHORTCUT_COMMENT@


### PR DESCRIPTION
## Motivation / Problem

OpenTTD unnecessarily clutters up the top level of the Games section of my launcher menu unless I manually reorganize the menu after installing it... in some desktop environments, this requires seeking out a third-party desktop entry editor tool or manually copying the `.desktop` file into `~/.local/share/applications` and editing it.

## Description

Launcher menus such as KDE Plasma's Application Menu Plasmoid are capable of automatically subcategorizing entries. (eg. To group games into genres)

This is accomplished by complementing the primary category (`Game`) with one of the associated [Additional Categories](https://specifications.freedesktop.org/menu-spec/latest/apas02.html) from the XDG Menu Specification.

For a game like OpenTTD, the relevant additional category is `Simulation`.

## Limitations

There should be none.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
