### PR TITLE
Codechange: Don't store tree counter in the map array

### DIFF
--- a/docs/landscape.html
+++ b/docs/landscape.html
@@ -807,8 +807,6 @@
       </table>
      </li>
      <li>m2 bits 5..4: ground density</li>
-     <li>m2 bits 3..0: update counter, incremented on every periodic processing.<br>
-          on wraparound the growth status is updated (or, if it's <tt>3</tt>, a random action is taken)</li>
      <li>m3 bits 7..0: type of trees:
       <table>
        <tr>

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -588,7 +588,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
   SetName():            false
   GetLastErrorString(): ERR_NAME_IS_NOT_UNIQUE
   GetName():                         Regression
-  GetPresidentName():                E. McAlpine
+  GetPresidentName():                J. Green
   SetPresidentName():                true
   GetPresidentName():                Regression AI
   GetBankBalance():                  100000

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2334,8 +2334,7 @@ bool AfterLoadGame()
 			if (IsTileType(t, MP_TREES)) {
 				uint density = GB(_m[t].m2, 6, 2);
 				uint ground = GB(_m[t].m2, 4, 2);
-				uint counter = GB(_m[t].m2, 0, 4);
-				_m[t].m2 = ground << 6 | density << 4 | counter;
+				_m[t].m2 = ground << 6 | density << 4;
 			}
 		}
 	}
@@ -3187,6 +3186,15 @@ bool AfterLoadGame()
 					u->UpdatePosition();
 				}
 				RoadVehLeaveDepot(rv, false);
+			}
+		}
+
+		if (IsSavegameVersionBeforeOrAt(SLV_MULTITRACK_LEVEL_CROSSINGS)) {
+			/* Reset unused tree counters to reduce the savegame size. */
+			for (TileIndex t = 0; t < map_size; t++) {
+				if (IsTileType(t, MP_TREES)) {
+					SB(_m[t].m2, 0, 4, 0);
+				}
 			}
 		}
 

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -216,50 +216,6 @@ static inline void SetTreeGrowth(TileIndex t, uint g)
 }
 
 /**
- * Get the tick counter of a tree tile.
- *
- * Returns the saved tick counter of a given tile.
- *
- * @param t The tile to get the counter value from
- * @pre Tile must be of type MP_TREES
- */
-static inline uint GetTreeCounter(TileIndex t)
-{
-	assert(IsTileType(t, MP_TREES));
-	return GB(_m[t].m2, 0, 4);
-}
-
-/**
- * Add a value on the tick counter of a tree-tile
- *
- * This function adds a value on the tick counter of a tree-tile.
- *
- * @param t The tile to add the value on
- * @param a The value to add on the tick counter
- * @pre Tile must be of type MP_TREES
- */
-static inline void AddTreeCounter(TileIndex t, int a)
-{
-	assert(IsTileType(t, MP_TREES)); // XXX incomplete
-	_m[t].m2 += a;
-}
-
-/**
- * Set the tick counter for a tree-tile
- *
- * This function sets directly the tick counter for a tree-tile.
- *
- * @param t The tile to set the tick counter
- * @param c The new tick counter value
- * @pre Tile must be of type MP_TREES
- */
-static inline void SetTreeCounter(TileIndex t, uint c)
-{
-	assert(IsTileType(t, MP_TREES)); // XXX incomplete
-	SB(_m[t].m2, 0, 4, c);
-}
-
-/**
  * Make a tree-tile.
  *
  * This functions change the tile to a tile with trees and all information which belongs to it.


### PR DESCRIPTION
## Motivation / Problem

Trees add a lot of entropy to the map array drastically increasing the size of the save file.
According to my estimations, this change decreases the size by 10-15%.

## Description

The tree counter is just used to determine each 8th or 16th call to the `TileLoop_Trees` and that can easily be done without storing it in the map array. I plan to do some follow-up tree patches but this one is so free I decided to PR it separately.

## Limitations

It does change the order in which tiles are processed in the tile loop so it's not a perfect replica but it's ok as the rate is still the same. Regression tests had to be updated though as the random state blew up.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
