### PR TITLE
Fix: Two favorite face bugs

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -847,7 +847,7 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 
 				/* In network games, we need to try setting the company manager face here to sync it to all clients.
 				 * If a favorite company manager face is selected, choose it. Otherwise, use a random face. */
-				if (_company_manager_face != 0) Command<CMD_SET_COMPANY_MANAGER_FACE>::Post(_company_manager_face);
+				if (_company_manager_face != 0) Command<CMD_SET_COMPANY_MANAGER_FACE>::SendNet(STR_NULL, c->index, _company_manager_face);
 
 				/* Now that we have a new company, broadcast our company settings to
 				 * all clients so everything is in sync */

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -564,8 +564,8 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 	c->inaugurated_year = _cur_year;
 
 	/* If starting a player company in singleplayer and a favorite company manager face is selected, choose it. Otherwise, use a random face.
-	 * In a network game, we'll choose the favorite face later in CmdCompanyCtrl to sync it to all clients. */
-	if (_company_manager_face != 0 && !is_ai && !_networking) {
+	 * In a network game, we'll choose the favorite face later in CmdCompanyCtrl to sync it to all clients, but we choose it here for the first (host) company. */
+	if (_company_manager_face != 0 && !is_ai) {
 		c->face = _company_manager_face;
 	} else {
 		RandomCompanyManagerFaceBits(c->face, (GenderEthnicity)Random(), false, false);


### PR DESCRIPTION
## Motivation / Problem

As described in #10016, my changes in ca19a0d / #9895 causes an assertion failure when creating a new company in network games.

When testing the fix for that, I discovered that network hosts weren't getting their favorite face chosen.

## Description

- Send the network command properly to avoid an assert.
- Allow network hosts to load their favorite face.

Closes #10016.

## Limitations

Creating a new company in network games loads the favorite face twice for all clients except the host. This is probably cheaper than checking if the client is the host.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
