### PR TITLE
Fix: Uninitialized variable in Income/Expence summary

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -260,7 +260,7 @@ static Money DrawYearCategory (const Rect &r, int start_y, ExpensesList list, co
 static void DrawYearColumn(const Rect &r, int year, const Money (*tbl)[EXPENSES_END])
 {
 	int y = r.top;
-	Money sum;
+	Money sum = 0;
 
 	/* Year header */
 	SetDParam(0, year);


### PR DESCRIPTION

## Motivation / Problem

While browsing in the code I found an uninitialized variable in the Income/Expence summary that could lead to wrongly calculated yearly total sum.



## Description




## Limitations




## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
