### PR TITLE
Fix: Wrong string used to determine size of zoomed out station sign.

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -424,7 +424,7 @@ void Station::UpdateVirtCoord()
 
 	SetDParam(0, this->index);
 	SetDParam(1, this->facilities);
-	this->sign.UpdatePosition(pt.x, pt.y, STR_VIEWPORT_STATION);
+	this->sign.UpdatePosition(pt.x, pt.y, STR_VIEWPORT_STATION, STR_VIEWPORT_STATION_TINY);
 
 	_viewport_sign_kdtree.Insert(ViewportSignKdtreeItem::MakeStation(this->index));
 


### PR DESCRIPTION
## Motivation / Problem

Station signs use `STR_VIEWPORT_STATION_TINY` rather than `STR_VIEWPORT_STATION` when zoomed out. This was not reflected in the call to `UpdatePosition` that updates the sign dimensions.

This has no real effect by default as the small font doesn't have glyphs for the `STATION_FEATURES` string code, but it is possible to add those glyphs, and the facility is there to provide different strings, so it makes sense to use it.

## Description

Resolved by adding the appropriate string for the `str_small` parameter of `UpdatePosition`.

## Limitations

None.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
