### PR TITLE
Fix #10038: Missing upper bounds check when loading custom playlists

### DIFF
--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -127,11 +127,11 @@ void MusicSystem::BuildPlaylists()
 	/* Load custom playlists
 	 * Song index offsets are 1-based, zero indicates invalid/end-of-list value */
 	for (uint i = 0; i < NUM_SONGS_PLAYLIST; i++) {
-		if (_settings_client.music.custom_1[i] > 0) {
+		if (_settings_client.music.custom_1[i] > 0 && _settings_client.music.custom_1[i] <= NUM_SONGS_AVAILABLE) {
 			PlaylistEntry entry(set, _settings_client.music.custom_1[i] - 1);
 			if (entry.IsValid()) this->standard_playlists[PLCH_CUSTOM1].push_back(entry);
 		}
-		if (_settings_client.music.custom_2[i] > 0) {
+		if (_settings_client.music.custom_2[i] > 0 && _settings_client.music.custom_2[i] <= NUM_SONGS_AVAILABLE) {
 			PlaylistEntry entry(set, _settings_client.music.custom_2[i] - 1);
 			if (entry.IsValid()) this->standard_playlists[PLCH_CUSTOM2].push_back(entry);
 		}


### PR DESCRIPTION
## Motivation / Problem

OpenTTD only allows for a limited number of songs, but does not check for this limit when loading the custom playlists from configuration. This leads to an invalid read.

## Description

This is solved by ignoring values greater than `NUM_SONGS_AVAILABLE`. <= is used here as the value is then subtracted by one.

## Limitations

Limitation disturbs me very songs. Goes it throw out limitation?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
