### PR TITLE
Fix: File list mouse hover behaviour.

### DIFF
--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -721,11 +721,8 @@ public:
 		}
 	}
 
-	void OnMouseLoop() override
+	void OnMouseOver(Point pt, int widget) override
 	{
-		const Point pt{ _cursor.pos.x - this->left, _cursor.pos.y - this->top };
-		const int widget = GetWidgetFromPos(this, pt.x, pt.y);
-
 		if (widget == WID_SL_DRIVES_DIRECTORIES_LIST) {
 			int y = this->vscroll->GetScrolledRowFromWidget(pt.y, this, WID_SL_DRIVES_DIRECTORIES_LIST, WD_FRAMERECT_TOP);
 			if (y == INT_MAX) return;


### PR DESCRIPTION
## Motivation / Problem

File list mouse hover highlight is visible even if the mouse pointer was in a different window. 

## Description

Resolved by using OnMouseOver() instead of OnMouseLoop(), as done for the Online Players window.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
