### PR TITLE
Fix 9aef7b8c: Don't dispatch hover event if already hovering.

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2966,7 +2966,7 @@ void HandleMouseEvents()
 			hover_pos = _cursor.pos;
 			hover_time = std::chrono::steady_clock::now();
 			_mouse_hovering = false;
-		} else {
+		} else if (!_mouse_hovering) {
 			if (std::chrono::steady_clock::now() > hover_time + std::chrono::milliseconds(_settings_client.gui.hover_delay_ms)) {
 				click = MC_HOVER;
 				_input_events_this_tick++;


### PR DESCRIPTION
## Motivation / Problem

When using timed tooltips, the tooltip window is destroyed and recreated every frame. This is invisible but unnecessary.

## Description

`MC_HOVER` is dispatched every mouse loop, with triggers GuiShowTooltips() which heartlessly destroys its window and creates another one.

This is fixed by not dispatching the `MC_HOVER` event if already hovering.

## Limitations

This also affects the `OnHover()` window event, however this is not ever used so there's no impact.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
