### PR TITLE
Fix: Open scenario editor date query once.

### DIFF
--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -1152,7 +1152,6 @@ static CallBackFunction ToolbarScenDatePanel(Window *w)
 {
 	SetDParam(0, _settings_game.game_creation.starting_year);
 	ShowQueryString(STR_JUST_INT, STR_MAPGEN_START_DATE_QUERY_CAPT, 8, w, CS_NUMERAL, QSF_ENABLE_DEFAULT);
-	_left_button_clicked = false;
 	return CBF_NONE;
 }
 


### PR DESCRIPTION
## Motivation / Problem

Click and holding on the scenario editor start date widget causes the query text window to be repeatedly opened until the mouse button is released.

Clearing `_left_button_clicked` causes the button callback to be fired constantly while the mouse button is held.

## Description

This is resolved by removing clearing `_left_button_clicked`, which turns the button into a regular one-shot.

This is probably a leftover from the year decrement/increment buttons which do need this cleared.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
