### PR TITLE
Added widget showing company slots remaining

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2370,6 +2370,7 @@ STR_NETWORK_CLIENT_LIST_NEW_COMPANY                             :(New company)
 STR_NETWORK_CLIENT_LIST_NEW_COMPANY_TOOLTIP                     :{BLACK}Create a new company and join it
 STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP                :{BLACK}This is you
 STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP                :{BLACK}This is the host of the game
+STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_REMAINING                :{BLACK}{NUM} open slot{P "" s}
 STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT                    :{BLACK}{NUM} client{P "" s} / {NUM} compan{P y ies}
 
 # Matches ConnectionType

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1341,6 +1341,7 @@ static const NWidgetPart _nested_client_list_widgets[] = {
 		NWidget(NWID_VERTICAL),
 			NWidget(WWT_MATRIX, COLOUR_GREY, WID_CL_MATRIX), SetMinimalSize(180, 0), SetResize(1, 1), SetFill(1, 1), SetMatrixDataTip(1, 0, STR_NULL), SetScrollbar(WID_CL_SCROLLBAR),
 			NWidget(WWT_PANEL, COLOUR_GREY),
+				NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_CLIENT_COMPANY_REMAINING), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetPadding(2, 1, 2, 1), SetAlignment(SA_CENTER), SetDataTip(STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_REMAINING, STR_NULL),
 				NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_CLIENT_COMPANY_COUNT), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetPadding(2, 1, 2, 1), SetAlignment(SA_CENTER), SetDataTip(STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT, STR_NULL),
 			EndContainer(),
 		EndContainer(),
@@ -1784,6 +1785,10 @@ public:
 				SetDParamStr(0, own_ci != nullptr ? own_ci->client_name : _settings_client.network.client_name);
 				break;
 			}
+
+			case WID_CL_CLIENT_COMPANY_REMAINING:
+				SetDParam(0, _settings_client.network.max_companies - Company::GetNumItems());
+				break;
 
 			case WID_CL_CLIENT_COMPANY_COUNT:
 				SetDParam(0, NetworkClientInfo::GetNumItems());

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -89,6 +89,7 @@ enum ClientListWidgets {
 	WID_CL_MATRIX,                     ///< Company/client list.
 	WID_CL_SCROLLBAR,                  ///< Scrollbar for company/client list.
 	WID_CL_COMPANY_JOIN,               ///< Used for QueryWindow when a company has a password.
+	WID_CL_CLIENT_COMPANY_REMAINING,   ///< Number of companies that can still be formed.
 	WID_CL_CLIENT_COMPANY_COUNT,       ///< Count of clients and companies.
 };
 


### PR DESCRIPTION
## Motivation / Problem
I've seen a few new players join and try to create a company, not realizing that the game has reached the maximum amount of companies, e.g #9703 , which is easier to see at a glance. 

## Description
Adds a single line above company/client count to display the amount of remaining companies that can be created.

## Limitations
The addition simply shows the amount of existing companies minus the max amount of companies. Can be changed from '0 company slots' to 'FULL' if desired

Closes #9703 - edit 2TT

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
