### PR TITLE
Fix: reduce framerate overhead in Train::Tick

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3910,11 +3910,11 @@ Money Train::GetRunningCost() const
  */
 bool Train::Tick()
 {
-	PerformanceAccumulator framerate(PFE_GL_TRAINS);
-
 	this->tick_counter++;
 
 	if (this->IsFrontEngine()) {
+		PerformanceAccumulator framerate(PFE_GL_TRAINS);
+
 		if (!(this->vehstatus & VS_STOPPED) || this->cur_speed > 0) this->running_ticks++;
 
 		this->current_order_time++;


### PR DESCRIPTION
## Motivation / Problem

After profiling a save game with lots of trains (few hundred), I noticed 20% of `Train::Tick()` was spent on measuring the game loop. By moving the measurement to the only relevant case, I reduced the game loop duration by 25% (15ms to 12ms).

## Description

`Train::Tick()` is a noop for all but front-engine / crashed vehicles. Starting a `framerate` is rather cheap, but not free, and introduces a lot of overhead for such close loops. This PR changes `Train::Tick` to only start a `framerate` for the front engine. As `Train::Tick()` is a noop in other cases, in practice there should not be a difference to the actual generated measurements.

Before:
<img width="591" alt="Screenshot 2022-09-27 at 10 32 13" src="https://user-images.githubusercontent.com/235882/192572712-8410df3b-e11a-4cdf-aa60-8c13e4195c56.png">

After:
<img width="583" alt="Screenshot 2022-09-27 at 10 35 57" src="https://user-images.githubusercontent.com/235882/192572740-64bcf1ba-0a21-45f2-b8fa-5b4cce2f1ea6.png">

## Limitations

## Alternatives considered

Currently the frame rate is determined _per-vehicle_, but we could instead do this _per-type_. So for 100 trains we would do a single measurement combining 100 `Tick()`s instead of 100 measurements of a single `Tick()`. This would mean we have to enumerate the vehicles more, once per type (4 types + 1 'other'). A small experiment didn't yield improved noticeably.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
<s>* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)</s>
