### PR TITLE
Fix #9876: MacBook Touch Bar crash / render issues w/ 32bpp graphics

### DIFF
--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -53,6 +53,7 @@ inline void Blitter_32bppSSE4_Anim::Draw(const Blitter::BlitterParams *bp, ZoomL
 	const __m128i a_cm        = ALPHA_CONTROL_MASK;
 	const __m128i pack_low_cm = PACK_LOW_CONTROL_MASK;
 	const __m128i tr_nom_base = TRANSPARENT_NOM_BASE;
+	const __m128i a_am        = ALPHA_AND_MASK;
 
 	for (int y = bp->height; y != 0; y--) {
 		Colour *dst = dst_line;
@@ -144,7 +145,7 @@ inline void Blitter_32bppSSE4_Anim::Draw(const Blitter::BlitterParams *bp, ZoomL
 
 					/* Blend colours. */
 bmno_alpha_blend:
-					srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm);
+					srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm, a_am);
 bmno_full_opacity:
 					_mm_storel_epi64((__m128i *) dst, srcABCD);
 bmno_full_transparency:
@@ -171,7 +172,7 @@ bmno_full_transparency:
 						} else {
 							srcABCD = _mm_cvtsi32_si128(src->data);
 						}
-						dst->data = _mm_cvtsi128_si32(AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm));
+						dst->data = _mm_cvtsi128_si32(AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm, a_am));
 					}
 				}
 				break;
@@ -255,7 +256,7 @@ bmno_full_transparency:
 
 					/* Blend colours. */
 bmcr_alpha_blend:
-					srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm);
+					srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm, a_am);
 bmcr_full_opacity:
 					_mm_storel_epi64((__m128i *) dst, srcABCD);
 bmcr_full_transparency:
@@ -288,7 +289,7 @@ bmcr_full_transparency:
 						if (src->a < 255) {
 bmcr_alpha_blend_single:
 							__m128i dstABCD = _mm_cvtsi32_si128(dst->data);
-							srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm);
+							srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, a_cm, pack_low_cm, a_am);
 						}
 						dst->data = _mm_cvtsi128_si32(srcABCD);
 					}

--- a/src/blitter/32bpp_anim_sse4.cpp
+++ b/src/blitter/32bpp_anim_sse4.cpp
@@ -367,6 +367,12 @@ IGNORE_UNINITIALIZED_WARNING_STOP
  */
 void Blitter_32bppSSE4_Anim::Draw(Blitter::BlitterParams *bp, BlitterMode mode, ZoomLevel zoom)
 {
+	if (_screen_disable_anim) {
+		/* This means our output is not to the screen, so we can't be doing any animation stuff, so use our parent Draw() */
+		Blitter_32bppSSE4::Draw(bp, mode, zoom);
+		return;
+	}
+
 	const Blitter_32bppSSE_Base::SpriteFlags sprite_flags = ((const Blitter_32bppSSE_Base::SpriteData *) bp->sprite)->flags;
 	switch (mode) {
 		default: {

--- a/src/blitter/32bpp_anim_sse4.hpp
+++ b/src/blitter/32bpp_anim_sse4.hpp
@@ -32,7 +32,7 @@
 #define MARGIN_NORMAL_THRESHOLD 4
 
 /** The SSE4 32 bpp blitter with palette animation. */
-class Blitter_32bppSSE4_Anim FINAL : public Blitter_32bppSSE2_Anim, public Blitter_32bppSSE_Base {
+class Blitter_32bppSSE4_Anim FINAL : public Blitter_32bppSSE2_Anim, public Blitter_32bppSSE4 {
 private:
 
 public:
@@ -43,13 +43,14 @@ public:
 		return Blitter_32bppSSE_Base::Encode(sprite, allocator);
 	}
 	const char *GetName() override { return "32bpp-sse4-anim"; }
+	using Blitter_32bppSSE2_Anim::LookupColourInPalette;
 };
 
 /** Factory for the SSE4 32 bpp blitter (with palette animation). */
 class FBlitter_32bppSSE4_Anim: public BlitterFactory {
 public:
 	FBlitter_32bppSSE4_Anim() : BlitterFactory("32bpp-sse4-anim", "32bpp SSE4 Blitter (palette animation)", HasCPUIDFlag(1, 2, 19)) {}
-	Blitter *CreateInstance() override { return new Blitter_32bppSSE4_Anim(); }
+	Blitter *CreateInstance() override { return static_cast<Blitter_32bppSSE2_Anim *>(new Blitter_32bppSSE4_Anim()); }
 };
 
 #endif /* WITH_SSE */

--- a/src/blitter/32bpp_sse_func.hpp
+++ b/src/blitter/32bpp_sse_func.hpp
@@ -65,27 +65,33 @@ static inline __m128i DistributeAlpha(const __m128i from, const __m128i &mask)
 {
 #if (SSE_VERSION == 2)
 	__m128i alphaAB = _mm_shufflelo_epi16(from, 0x3F); // PSHUFLW, put alpha1 in front of each rgb1
-	return _mm_shufflehi_epi16(alphaAB, 0x3F);         // PSHUFHW, put alpha2 in front of each rgb2
+	alphaAB = _mm_shufflehi_epi16(alphaAB, 0x3F);      // PSHUFHW, put alpha2 in front of each rgb2
+	alphaAB = _mm_or_si128(alphaAB, mask);             // POR, set alpha fields to all 1
+	return _mm_xor_si128(alphaAB, mask);               // PXOR, set alpha fields to 0
 #else
 	return _mm_shuffle_epi8(from, mask);
 #endif
 }
 
 GNU_TARGET(SSE_TARGET)
-static inline __m128i AlphaBlendTwoPixels(__m128i src, __m128i dst, const __m128i &distribution_mask, const __m128i &pack_mask)
+static inline __m128i AlphaBlendTwoPixels(__m128i src, __m128i dst, const __m128i &distribution_mask, const __m128i &pack_mask, const __m128i &alpha_mask)
 {
 	__m128i srcAB = _mm_unpacklo_epi8(src, _mm_setzero_si128());   // PUNPCKLBW, expand each uint8 into uint16
 	__m128i dstAB = _mm_unpacklo_epi8(dst, _mm_setzero_si128());
 
-	__m128i alphaAB = _mm_cmpgt_epi16(srcAB, _mm_setzero_si128()); // PCMPGTW, if (alpha > 0) a++;
-	alphaAB = _mm_srli_epi16(alphaAB, 15);
-	alphaAB = _mm_add_epi16(alphaAB, srcAB);
+	__m128i alphaMaskAB = _mm_cmpgt_epi16(srcAB, _mm_setzero_si128()); // PCMPGTW (alpha > 0) ? 0xFFFF : 0
+	__m128i alphaAB = _mm_srli_epi16(alphaMaskAB, 15);
+	alphaAB = _mm_add_epi16(alphaAB, srcAB);                           // if (alpha > 0) a++;
 	alphaAB = DistributeAlpha(alphaAB, distribution_mask);
 
 	srcAB = _mm_sub_epi16(srcAB, dstAB);     // PSUBW,    (r - Cr)
 	srcAB = _mm_mullo_epi16(srcAB, alphaAB); // PMULLW, a*(r - Cr)
 	srcAB = _mm_srli_epi16(srcAB, 8);        // PSRLW,  a*(r - Cr)/256
 	srcAB = _mm_add_epi16(srcAB, dstAB);     // PADDW,  a*(r - Cr)/256 + Cr
+
+	alphaMaskAB = _mm_and_si128(alphaMaskAB, alpha_mask); // PAND, set non alpha fields to 0
+	srcAB = _mm_or_si128(srcAB, alphaMaskAB);             // POR, set alpha fields to 0xFFFF is src alpha was > 0
+
 	return PackUnsaturated(srcAB, pack_mask);
 }
 
@@ -227,9 +233,11 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 	const MapValue *src_mv = src_mv_line;
 
 	/* Load these variables into register before loop. */
+	const __m128i alpha_and   = ALPHA_AND_MASK;
+	#define ALPHA_BLEND_PARAM_3 alpha_and
 #if (SSE_VERSION == 2)
 	const __m128i clear_hi    = CLEAR_HIGH_BYTE_MASK;
-	#define ALPHA_BLEND_PARAM_1 clear_hi
+	#define ALPHA_BLEND_PARAM_1 alpha_and
 	#define ALPHA_BLEND_PARAM_2 clear_hi
 	#define DARKEN_PARAM_1      tr_nom_base
 	#define DARKEN_PARAM_2      tr_nom_base
@@ -275,7 +283,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 				for (uint x = (uint) effective_width / 2; x > 0; x--) {
 					__m128i srcABCD = _mm_loadl_epi64((const __m128i*) src);
 					__m128i dstABCD = _mm_loadl_epi64((__m128i*) dst);
-					_mm_storel_epi64((__m128i*) dst, AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2));
+					_mm_storel_epi64((__m128i*) dst, AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2, ALPHA_BLEND_PARAM_3));
 					src += 2;
 					dst += 2;
 				}
@@ -283,7 +291,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 				if ((bt_last == BT_NONE && effective_width & 1) || bt_last == BT_ODD) {
 					__m128i srcABCD = _mm_cvtsi32_si128(src->data);
 					__m128i dstABCD = _mm_cvtsi32_si128(dst->data);
-					dst->data = _mm_cvtsi128_si32(AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2));
+					dst->data = _mm_cvtsi128_si32(AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2, ALPHA_BLEND_PARAM_3));
 				}
 				break;
 
@@ -328,7 +336,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 					}
 
 					/* Blend colours. */
-					_mm_storel_epi64((__m128i *) dst, AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2));
+					_mm_storel_epi64((__m128i *) dst, AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2, ALPHA_BLEND_PARAM_3));
 					dst += 2;
 					src += 2;
 					src_mv += 2;
@@ -357,7 +365,7 @@ inline void Blitter_32bppSSE4::Draw(const Blitter::BlitterParams *bp, ZoomLevel 
 						if (src->a < 255) {
 bmcr_alpha_blend_single:
 							__m128i dstABCD = _mm_cvtsi32_si128(dst->data);
-							srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2);
+							srcABCD = AlphaBlendTwoPixels(srcABCD, dstABCD, ALPHA_BLEND_PARAM_1, ALPHA_BLEND_PARAM_2, ALPHA_BLEND_PARAM_3);
 						}
 						dst->data = _mm_cvtsi128_si32(srcABCD);
 					}

--- a/src/blitter/32bpp_sse_type.h
+++ b/src/blitter/32bpp_sse_type.h
@@ -51,6 +51,7 @@ typedef union ALIGN(16) um128i {
 #define OVERBRIGHT_VALUE_MASK       _mm_setr_epi8(-1,  0, -1,  0, -1,  0,  0,  0, -1,  0, -1,  0, -1,  0,  0,  0)
 #define OVERBRIGHT_CONTROL_MASK     _mm_setr_epi8( 0,  1,  0,  1,  0,  1,  7,  7,  2,  3,  2,  3,  2,  3,  7,  7)
 #define TRANSPARENT_NOM_BASE        _mm_setr_epi16(256, 256, 256, 256, 256, 256, 256, 256)
+#define ALPHA_AND_MASK              _mm_setr_epi16(  0,   0,   0,  -1,   0,   0,   0,  -1)
 
 #endif /* WITH_SSE */
 #endif /* BLITTER_32BPP_SSE_TYPE_H */


### PR DESCRIPTION
## Motivation / Problem

Rendering of the MacBook Touch Bar is incorrect on SSE-based blitters when using 32bpp base graphics and software rendering. The following problems related to Touch Bar rendering have been found:

Blitter|Result
-|-
32bpp-sse2|wrong (washed out colors)
32bpp-sse2-anim|correct (doesn't use `Blitter_32bppSSE_Base::Encode`)
32bpp-sse4|wrong (black buttons)
32bpp-sse4-anim|crash: #9876
32bpp-ssse3|wrong (black buttons)

## Description

The crash using `32bpp-sse4` is caused by trying to use the animation buffer while not rendering to the screen. Similar to `Blitter_40bppAnim::Draw` we need to forward to a non-animating `Draw()`. `Blitter_32bppSSE4_Anim` encodes sprites using `Blitter_32bppSSE_Base::Encode` but didn't inherit from a non-animating blitter, so it now inherits from `Blitter_32bppSSE4` to allow calling `Blitter_32bppSSE4::Draw` when a non-animated sprite is requested.

To fix the incorrect rendering @JGRennison had a look at the alpha channel rendering in the SSE blitters. My original patch (incorrectly) covered over the problems by disabling translucency altogether. The SSE blitters didn't set the alpha values to anything in particular. AlphaBlendTwoPixels are now adjusted so that the alpha output is as expected (i.e. it matches ComposeColourRGBA).

32bpp-simple (reference):
<img width="1085" alt="32bpp-simple" src="https://user-images.githubusercontent.com/235882/192853749-9a840c5e-a3bc-4f30-a2cc-c2984e93be1c.png">

32bpp-sse2 (washed out):
<img width="1085" alt="32bpp-sse2" src="https://user-images.githubusercontent.com/235882/192853792-abbcd7f3-3eac-4293-b7a2-b90185b5bb92.png">

32bpp-ssse3 (black):
<img width="1085" alt="32bpp-ssse3" src="https://user-images.githubusercontent.com/235882/192854026-c5839bbc-a3f6-4567-b31b-31ef9ad68e0b.png">

32bpp-ssse3 (with fix):
<img width="1085" alt="32bpp-ssse3-fixed-jgr" src="https://user-images.githubusercontent.com/235882/192960507-87578338-e669-4435-91b4-9a34962cb105.png">

@glx22, @JGRennison and @frosch123 contributed to this PR by debugging and/or blitter / C++ support.

## Limitations

?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
<s>* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)</s>