### PR TITLE
Fix 5e413c9d: Last sprite offset in GRF file was not recorded

### DIFF
--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -592,6 +592,7 @@ void ReadGRFSpriteOffsets(SpriteFile &file)
 			}
 			file.SkipBytes(length);
 		}
+		if (prev_id != 0) _grf_sprite_offsets[prev_id] = offset;
 
 		/* Continue processing the data section. */
 		file.SeekTo(old_pos, SEEK_SET);


### PR DESCRIPTION
## Motivation / Problem

Last sprite offset in GRF file was not recorded.
This is noticeable as sprite 4626 (trees on road) from OpenGFX is missing on the title screen save.

## Description

A line was missed when preparing PR #9988, as this had been added in a commit prior to the one which the PR was immediately based on.
This PR adds the missing line.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
