### PR TITLE
Change: Scale towns/industries by amount of land tiles.

### DIFF
--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -139,11 +139,13 @@ static void _GenerateWorld()
 			if (_game_mode != GM_MENU) FlatEmptyWorld(_settings_game.game_creation.se_flat_world_height);
 
 			ConvertGroundTilesIntoWaterTiles();
+			Map::CountLandTiles();
 			IncreaseGeneratingWorldProgress(GWP_OBJECT);
 
 			_settings_game.game_creation.snow_line_height = DEF_SNOWLINE_HEIGHT;
 		} else {
 			GenerateClearTile();
+			Map::CountLandTiles();
 
 			/* Only generate towns, tree and industries in newgame mode. */
 			if (_game_mode != GM_EDITOR) {

--- a/src/genworld.h
+++ b/src/genworld.h
@@ -64,7 +64,8 @@ enum GenWorldProgress : uint8_t {
 	GWP_RIVER,       ///< Create the rivers
 	GWP_ROUGH_ROCKY, ///< Make rough and rocky areas
 	GWP_TOWN,        ///< Generate towns
-	GWP_INDUSTRY,    ///< Generate industries
+	GWP_LAND_INDUSTRY, ///< Generate industries
+	GWP_WATER_INDUSTRY, ///< Generate industries
 	GWP_OBJECT,      ///< Generate objects (radio tower, light houses)
 	GWP_TREE,        ///< Generate trees
 	GWP_GAME_INIT,   ///< Initialize the game

--- a/src/genworld_gui.cpp
+++ b/src/genworld_gui.cpp
@@ -1340,7 +1340,8 @@ static const StringID _generation_class_table[]  = {
 	STR_GENERATION_RIVER_GENERATION,
 	STR_GENERATION_CLEARING_TILES,
 	STR_GENERATION_TOWN_GENERATION,
-	STR_GENERATION_INDUSTRY_GENERATION,
+	STR_GENERATION_LAND_INDUSTRY_GENERATION,
+	STR_GENERATION_WATER_INDUSTRY_GENERATION,
 	STR_GENERATION_OBJECT_GENERATION,
 	STR_GENERATION_TREE_GENERATION,
 	STR_GENERATION_SETTINGUP_GAME,
@@ -1448,7 +1449,7 @@ void ShowGenerateWorldProgress()
 
 static void _SetGeneratingWorldProgress(GenWorldProgress cls, uint progress, uint total)
 {
-	static const int percent_table[] = {0, 5, 14, 17, 20, 40, 60, 65, 80, 85, 95, 99, 100 };
+	static const int percent_table[] = {0, 5, 14, 17, 20, 40, 55, 60, 65, 80, 85, 95, 99, 100 };
 	static_assert(lengthof(percent_table) == GWP_CLASS_COUNT + 1);
 	assert(cls < GWP_CLASS_COUNT);
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -45,6 +45,7 @@
 #include "industry_cmd.h"
 #include "landscape_cmd.h"
 #include "terraform_cmd.h"
+#include "map_func.h"
 #include "timer/timer.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
@@ -2353,7 +2354,7 @@ static uint GetNumberOfIndustries()
 
 	if (difficulty == ID_CUSTOM) return std::min<uint>(IndustryPool::MAX_SIZE, _settings_game.game_creation.custom_industry_number);
 
-	return std::min<uint>(IndustryPool::MAX_SIZE, Map::ScaleBySize(numof_industry_table[difficulty]));
+	return std::min<uint>(IndustryPool::MAX_SIZE, Map::ScaleByLandProportion(Map::ScaleBySize(numof_industry_table[difficulty])));
 }
 
 /**

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2283,12 +2283,15 @@ static Industry *CreateNewIndustry(TileIndex tile, IndustryType type, IndustryAv
 /**
  * Compute the appearance probability for an industry during map creation.
  * @param it Industry type to compute.
+ * @param water Whether to get probability of land-based, water-based, (or both, if std::nullopt), industry types.
  * @param[out] force_at_least_one Returns whether at least one instance should be forced on map creation.
  * @return Relative probability for the industry to appear.
  */
-static uint32_t GetScaledIndustryGenerationProbability(IndustryType it, bool *force_at_least_one)
+static uint32_t GetScaledIndustryGenerationProbability(IndustryType it, std::optional<bool> water, bool *force_at_least_one)
 {
 	const IndustrySpec *ind_spc = GetIndustrySpec(it);
+	if (water.has_value() && ind_spc->behaviour.Test(IndustryBehaviour::BuiltOnWater) != *water) return 0;
+
 	uint32_t chance = ind_spc->appear_creation[to_underlying(_settings_game.game_creation.landscape)];
 	if (!ind_spc->enabled || ind_spc->layouts.empty() ||
 			(_game_mode != GM_EDITOR && _settings_game.difficulty.industry_density == ID_FUND_ONLY) ||
@@ -2354,7 +2357,7 @@ static uint GetNumberOfIndustries()
 
 	if (difficulty == ID_CUSTOM) return std::min<uint>(IndustryPool::MAX_SIZE, _settings_game.game_creation.custom_industry_number);
 
-	return std::min<uint>(IndustryPool::MAX_SIZE, Map::ScaleByLandProportion(Map::ScaleBySize(numof_industry_table[difficulty])));
+	return std::min<uint>(IndustryPool::MAX_SIZE, Map::ScaleBySize(numof_industry_table[difficulty]));
 }
 
 /**
@@ -2380,11 +2383,11 @@ static Industry *PlaceIndustry(IndustryType type, IndustryAvailabilityCallType c
  * @param type IndustryType of the desired industry
  * @param try_hard Try very hard to find a place. (Used to place at least one industry per type)
  */
-static void PlaceInitialIndustry(IndustryType type, bool try_hard)
+static void PlaceInitialIndustry(IndustryType type, bool water, bool try_hard)
 {
 	Backup<CompanyID> cur_company(_current_company, OWNER_NONE);
 
-	IncreaseGeneratingWorldProgress(GWP_INDUSTRY);
+	IncreaseGeneratingWorldProgress(water ? GWP_WATER_INDUSTRY : GWP_LAND_INDUSTRY);
 	PlaceIndustry(type, IACT_MAPGENERATION, try_hard);
 
 	cur_company.Restore();
@@ -2438,6 +2441,31 @@ void IndustryBuildData::EconomyMonthlyLoop()
 	}
 }
 
+struct IndustryGenerationProbabilities {
+	std::array<uint32_t, NUM_INDUSTRYTYPES> probs{};
+	std::array<bool, NUM_INDUSTRYTYPES> force_one{};
+	uint64_t total = 0;
+	uint num_forced = 0;
+};
+
+/**
+ * Get scaled industry generation probabilities.
+ * @param water Whether to get land or water industry probabilities.
+ * @returns Probability information.
+ */
+static IndustryGenerationProbabilities GetScaledProbabilities(bool water)
+{
+	IndustryGenerationProbabilities p{};
+
+	for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
+		p.probs[it] = GetScaledIndustryGenerationProbability(it, water, &p.force_one[it]);
+		p.total += p.probs[it];;
+		if (p.force_one[it]) p.num_forced++;
+	}
+
+	return p;
+}
+
 /**
  * This function will create random industries during game creation.
  * It will scale the amount of industries by mapsize and difficulty level.
@@ -2446,46 +2474,54 @@ void GenerateIndustries()
 {
 	if (_game_mode != GM_EDITOR && _settings_game.difficulty.industry_density == ID_FUND_ONLY) return; // No industries in the game.
 
-	uint32_t industry_probs[NUM_INDUSTRYTYPES];
-	bool force_at_least_one[NUM_INDUSTRYTYPES];
-	uint32_t total_prob = 0;
-	uint num_forced = 0;
+	/* Get the probabilities for all industries. This is done first as we need the total of
+	 * both land and water for scaling later. */
+	IndustryGenerationProbabilities lprob = GetScaledProbabilities(false);
+	IndustryGenerationProbabilities wprob = GetScaledProbabilities(true);
 
-	for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
-		industry_probs[it] = GetScaledIndustryGenerationProbability(it, force_at_least_one + it);
-		total_prob += industry_probs[it];
-		if (force_at_least_one[it]) num_forced++;
-	}
+	/* Run generation twice, for land and water industries in turn. */
+	for (bool water = false;; water = true) {
+		auto &p = water ? wprob : lprob;
 
-	uint total_amount = GetNumberOfIndustries();
-	if (total_prob == 0 || total_amount < num_forced) {
-		/* Only place the forced ones */
-		total_amount = num_forced;
-	}
+		/* Total number of industries scaled by land/water proportion. */
+		uint total_amount = p.total * GetNumberOfIndustries() / (lprob.total + wprob.total);
 
-	SetGeneratingWorldProgress(GWP_INDUSTRY, total_amount);
+		/* Scale land-based industries to the land proportion. */
+		if (!water) total_amount = Map::ScaleByLandProportion(total_amount);
 
-	/* Try to build one industry per type independent of any probabilities */
-	for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
-		if (force_at_least_one[it]) {
-			assert(total_amount > 0);
-			total_amount--;
-			PlaceInitialIndustry(it, true);
+		/* Ensure that forced industries are generated even if the scaled amounts are too low. */
+		if (p.total == 0 || total_amount < p.num_forced) {
+			/* Only place the forced ones */
+			total_amount = p.num_forced;
 		}
+
+		SetGeneratingWorldProgress(water ? GWP_WATER_INDUSTRY : GWP_LAND_INDUSTRY, total_amount);
+
+		/* Try to build one industry per type independent of any probabilities */
+		for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
+			if (p.force_one[it]) {
+				assert(total_amount > 0);
+				total_amount--;
+				PlaceInitialIndustry(it, water, true);
+			}
+		}
+
+		/* Add the remaining industries according to their probabilities */
+		for (uint i = 0; i < total_amount; i++) {
+			uint32_t r = RandomRange(p.total);
+			IndustryType it = 0;
+			while (r >= p.probs[it]) {
+				r -= p.probs[it];
+				it++;
+				assert(it < NUM_INDUSTRYTYPES);
+			}
+			assert(p.probs[it] > 0);
+			PlaceInitialIndustry(it, water, false);
+		}
+
+		if (water) break;
 	}
 
-	/* Add the remaining industries according to their probabilities */
-	for (uint i = 0; i < total_amount; i++) {
-		uint32_t r = RandomRange(total_prob);
-		IndustryType it = 0;
-		while (r >= industry_probs[it]) {
-			r -= industry_probs[it];
-			it++;
-			assert(it < NUM_INDUSTRYTYPES);
-		}
-		assert(industry_probs[it] > 0);
-		PlaceInitialIndustry(it, false);
-	}
 	_industry_builder.Reset();
 }
 
@@ -3112,7 +3148,7 @@ void CheckIndustries()
 		if (Industry::GetIndustryTypeCount(it) > 0) continue; // Types of existing industries can be skipped.
 
 		bool force_at_least_one;
-		uint32_t chance = GetScaledIndustryGenerationProbability(it, &force_at_least_one);
+		uint32_t chance = GetScaledIndustryGenerationProbability(it, std::nullopt, &force_at_least_one);
 		if (chance == 0 || !force_at_least_one) continue; // Types that are not available can be skipped.
 
 		const IndustrySpec *is = GetIndustrySpec(it);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3463,7 +3463,8 @@ STR_GENERATION_LANDSCAPE_GENERATION                             :{BLACK}Landscap
 STR_GENERATION_RIVER_GENERATION                                 :{BLACK}River generation
 STR_GENERATION_CLEARING_TILES                                   :{BLACK}Rough and rocky area generation
 STR_GENERATION_TOWN_GENERATION                                  :{BLACK}Town generation
-STR_GENERATION_INDUSTRY_GENERATION                              :{BLACK}Industry generation
+STR_GENERATION_LAND_INDUSTRY_GENERATION                         :{BLACK}Land industry generation
+STR_GENERATION_WATER_INDUSTRY_GENERATION                        :{BLACK}Water industry generation
 STR_GENERATION_OBJECT_GENERATION                                :{BLACK}Object generation
 STR_GENERATION_TREE_GENERATION                                  :{BLACK}Tree generation
 STR_GENERATION_SETTINGUP_GAME                                   :{BLACK}Setting up game

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -23,6 +23,8 @@
 /* static */ uint Map::size;      ///< The number of tiles on the map
 /* static */ uint Map::tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
+/* static */ uint Map::initial_land_count; ///< Initial number of land tiles on the map.
+
 /* static */ std::unique_ptr<Tile::TileBase[]> Tile::base_tiles; ///< Base tiles of the map
 /* static */ std::unique_ptr<Tile::TileExtended[]> Tile::extended_tiles; ///< Extended tiles of the map
 
@@ -56,6 +58,20 @@
 	Tile::extended_tiles = std::make_unique<Tile::TileExtended[]>(Map::size);
 
 	AllocateWaterRegions();
+}
+
+/* static */ void Map::CountLandTiles()
+{
+	/* Count number of tiles that are land. */
+	Map::initial_land_count = 0;
+	for (const auto tile : Map::Iterate()) {
+		Map::initial_land_count += IsWaterTile(tile) ? 0 : 1;
+	}
+
+	/* Compensate for default values being set for (or users are most familiar with) at least
+	 * very low sea level. Dividing by 12 adds roughly 8%. */
+	Map::initial_land_count += Map::initial_land_count / 12;
+	Map::initial_land_count = std::min(Map::initial_land_count, Map::size);
 }
 
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -239,8 +239,11 @@ private:
 	static uint size;      ///< The number of tiles on the map
 	static uint tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
+	static uint initial_land_count; ///< Initial number of land tiles on the map.
+
 public:
 	static void Allocate(uint size_x, uint size_y);
+	static void CountLandTiles();
 
 	/**
 	 * Logarithm of the map size along the X side.
@@ -307,6 +310,16 @@ public:
 		return Map::SizeY() - 1;
 	}
 
+	/**
+	 * Scales the given value by the number of water tiles.
+	 * @param n the value to scale
+	 * @return the scaled size
+	 */
+	static inline uint ScaleByLandProportion(uint n)
+	{
+		/* Use 64-bit arithmetic to avoid overflow. */
+		return static_cast<uint>(static_cast<uint64_t>(n) * Map::initial_land_count / Map::size);
+	}
 
 	/**
 	 * 'Wraps' the given "tile" so it is within the map.

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -55,6 +55,7 @@
 #include "road_cmd.h"
 #include "terraform_cmd.h"
 #include "tunnelbridge_cmd.h"
+#include "map_func.h"
 #include "timer/timer.h"
 #include "timer/timer_game_calendar.h"
 #include "timer/timer_game_economy.h"
@@ -2419,9 +2420,9 @@ bool GenerateTowns(TownLayout layout, std::optional<uint> number)
 	if (number.has_value()) {
 		total = number.value();
 	} else if (_settings_game.difficulty.number_towns == static_cast<uint>(CUSTOM_TOWN_NUMBER_DIFFICULTY)) {
-		total = GetDefaultTownsForMapSize();
+		total = Map::ScaleByLandProportion(GetDefaultTownsForMapSize());
 	} else {
-		total = GetDefaultTownsForMapSize() + (Random() & 7);
+		total = Map::ScaleByLandProportion(GetDefaultTownsForMapSize() + (Random() & 7));
 	}
 
 	total = std::min<uint>(TownPool::MAX_SIZE, total);


### PR DESCRIPTION
## Motivation / Problem

During generation of a map with a large amount of water, the number of towns and industries does not take this water into account.

This results in a map with towns and industries crammed together, even when towns and industries are set to Very Low.

## Description

This change counts the amount of water/land, and turns it into a percentage so that town and industry generation can be directly scaled, after scaling by map size.

When no. of towns is a custom amount, this is not scaled.

## Limitations

The scaling is linear, so this might well be a bit extreme.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
