### PR TITLE
Fix #8252: Remove duplicate functionality in `screenshot.cpp`

### DIFF
--- a/src/smallmap_gui.h
+++ b/src/smallmap_gui.h
@@ -27,6 +27,15 @@ void ShowSmallMap();
 void BuildLandLegend();
 void BuildOwnerLegend();
 
+/** Enum for how to include the heightmap pixels/colours in small map related functions */
+enum class IncludeHeightmap {
+	Never,      ///< Never include the heightmap
+	IfEnabled,  ///< Only include the heightmap if its enabled in the gui by the player
+	Always      ///< Always include the heightmap
+};
+
+uint32 GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap include_heightmap);
+
 /** Structure for holding relevant data for legends in small map */
 struct LegendAndColour {
 	uint8 colour;              ///< Colour of the item on the map.


### PR DESCRIPTION
## Motivation / Problem
Fixes #8252 by removing all duplicate (small map tile related) functionality in [`screenshot.cpp`](https://github.com/OpenTTD/OpenTTD/blob/73e5c57e6ba3d49f2ecd4c781d8e4ff128764c2d/src/screenshot.cpp#L1004).

## Description
This fix completely removes the [`GetMinimapOwner(...)`](https://github.com/OpenTTD/OpenTTD/blob/73e5c57e6ba3d49f2ecd4c781d8e4ff128764c2d/src/screenshot.cpp#L1004) function and the first half of the [`MinimapScreenCallback(...)`](https://github.com/OpenTTD/OpenTTD/blob/73e5c57e6ba3d49f2ecd4c781d8e4ff128764c2d/src/screenshot.cpp#L1025) function, as both duplicated functionality already present within [`GetSmallMapOwnerPixels(...)`](https://github.com/OpenTTD/OpenTTD/blob/73e5c57e6ba3d49f2ecd4c781d8e4ff128764c2d/src/smallmap_gui.cpp#L563) in `smallmap_gui.cpp`. `MinimapScreenCallback(...)` now just reuses `GetSmallMapOwnerPixels(...)` with a byte mask to get the palette colour.

`GetSmallMapOwnerPixels(...)` had to be changed for this however (since screenshots don't include the heightmap while the minimap does) and thus was given a new enum parameter: `include_heightmap`. It determines if and how the minimap pixels should include the heightmap/contour. In `screenshot.cpp` (specifically  `MinimapScreenCallback(...)`), this parameter is set to `IH_NEVER` so that the heightmap will never be shown regardless and thus the pixels will always be the default land color. In `smallmap_gui.cpp`, this parameter is set to `IH_IF_ENABLED` so that the heightmap will only be shown if the user presses the button to enable it in the minimap GUI. Critically, I made this parameter an enum and not a boolean because:
1. I wanted the parameter to be more clear to developers than just a boolean. In my opinion, an enum value of `IH_NEVER` seems more clear than just a true/false, and the source code of the function (not to mention the function itself) is generally easier to read.
2. I wanted developers to have more control over how the function handles heightmap colours/pixels without having to change the function. If in the future, a developer ever wants to re-use the function again, they can easily specify how the heightmap colours should be handled so that it better matches the intended functionality. 
3. I wanted developers to be able to add any values in the future to the enum, so that one could easily add ways to handle the small map heightmap, without having to change the function prototype.

Importantly, there is also a third, currently unused option: `IH_ALWAYS`, which always shows the heightmap colours/pixels regardless of any player input. While this option may seem unnecessary (since it's unused right now), I put it in anyway for future-proofing. I wanted to add this functionality/value because it could be used for future features; A good example of such a feature would be taking a minimap screenshot with the contour/heightmap showing as well. This idea is also a good example of my reasoning for making this parameter an enum in the first place.

## Limitations

While **all parts of the commit that actually fix the issue don't have any limitations or problems**, the new parameter for `GetSmallMapOwnerPixels(...)` does have a small caveat with the `IH_ALWAYS` option (which again, is not a problem right now since it's currently unused). 

If `IH_ALWAYS` is passed, the function may return a 32-bit palette colour or a heightmap colour. Thus, any function that wants to always include the heightmap, but also use the palette colours when a heightmap colour isn't returned, has to manually determine if the return value is a palette colour or a heightmap colour. An example of such function would be if `MinimapScreenCallback(...)` wanted to always show the heightmap, i.e. if you wanted to take a minimap screenshot with the heightmap shown. While I could've corrected this by significantly changing `GetSmallMapOwnerPixels(...)`, I intentionally did not. I do not know how any future developers will/would use `IH_ALWAYS` (or more specifically, how they will use `GetSmallMapOwnerPixels(...)`); Thus, I did not want to remove any possibly desired functionality (maybe developers would want both palette colours and heightmap colours returned), since I really don't know what exact behavior future developers would want. Also, I think that significantly changing the function for an option that has yet to be used is not ideal. I will leave it up to developers using the function to handle and check the return value as they wish. Of course, if this is disagreed upon, I can change the function to be more clear about which type of value/colour it returns (e.g. changing the function to also indicate if the returned value is a heightmap or palette colour). Hopefully this all makes sense; I know that it's a very niche caveat and may never even come up, but I thought I might as well talk about it for reference.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
