### PR TITLE
Biggest first

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -48,7 +48,7 @@ static const NWidgetPart _nested_group_widgets[] = {
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),
 		/* left part */
-		NWidget(NWID_VERTICAL),
+		NWidget(NWID_VERTICAL, NC_BIGFIRST),
 			NWidget(WWT_PANEL, COLOUR_GREY, WID_GL_ALL_VEHICLES), SetFill(1, 0), EndContainer(),
 			NWidget(WWT_PANEL, COLOUR_GREY, WID_GL_DEFAULT_VEHICLES), SetFill(1, 0), EndContainer(),
 			NWidget(NWID_HORIZONTAL),
@@ -383,26 +383,11 @@ public:
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
 	{
 		switch (widget) {
-			case WID_GL_LIST_GROUP: {
+			case WID_GL_LIST_GROUP:
 				size->width = this->ComputeGroupInfoSize();
 				resize->height = this->tiny_step_height;
-
-				/* Minimum height is the height of the list widget minus all and default vehicles... */
-				size->height = 4 * GetVehicleListHeight(this->vli.vtype, this->tiny_step_height);
-
-				/* ... minus the buttons at the bottom ... */
-				uint max_icon_height = GetSpriteSize(this->GetWidget<NWidgetCore>(WID_GL_CREATE_GROUP)->widget_data).height;
-				max_icon_height = std::max(max_icon_height, GetSpriteSize(this->GetWidget<NWidgetCore>(WID_GL_RENAME_GROUP)->widget_data).height);
-				max_icon_height = std::max(max_icon_height, GetSpriteSize(this->GetWidget<NWidgetCore>(WID_GL_DELETE_GROUP)->widget_data).height);
-				max_icon_height = std::max(max_icon_height, GetSpriteSize(this->GetWidget<NWidgetCore>(WID_GL_REPLACE_PROTECTION)->widget_data).height);
-
-				/* ... minus the height of the group info ... */
-				max_icon_height += (FONT_HEIGHT_NORMAL * 3) + WD_FRAMERECT_TOP + WD_FRAMERECT_BOTTOM;
-
-				/* Get a multiple of tiny_step_height of that amount */
-				size->height = Ceil(size->height - max_icon_height, tiny_step_height);
+				fill->height = this->tiny_step_height;
 				break;
-			}
 
 			case WID_GL_ALL_VEHICLES:
 			case WID_GL_DEFAULT_VEHICLES:

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1356,7 +1356,7 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, uint x, uint y, ui
 	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
 		uint hor_step = child_wid->GetHorizontalStepSize(sizing);
 		if (hor_step > 0) {
-			num_changing_childs++;
+			if (!(flags & NC_BIGFIRST)) num_changing_childs++;
 			biggest_stepsize = std::max(biggest_stepsize, hor_step);
 		} else {
 			child_wid->current_x = child_wid->smallest_x;
@@ -1364,6 +1364,16 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, uint x, uint y, ui
 
 		uint vert_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetVerticalStepSize(sizing);
 		child_wid->current_y = ComputeMaxSize(child_wid->smallest_y, given_height - child_wid->padding_top - child_wid->padding_bottom, vert_step);
+	}
+
+	/* First.5 loop: count how many children are of the biggest step size. */
+	if ((flags & NC_BIGFIRST) && biggest_stepsize > 0) {
+		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+			uint hor_step = child_wid->GetHorizontalStepSize(sizing);
+			if (hor_step == biggest_stepsize) {
+				num_changing_childs++;
+			}
+		}
 	}
 
 	/* Second loop: Allocate the additional horizontal space over the resizing children, starting with the biggest resize steps. */
@@ -1383,6 +1393,16 @@ void NWidgetHorizontal::AssignSizePosition(SizingType sizing, uint x, uint y, ui
 			next_biggest_stepsize = std::max(next_biggest_stepsize, hor_step);
 		}
 		biggest_stepsize = next_biggest_stepsize;
+
+		if (num_changing_childs == 0 && (flags & NC_BIGFIRST) && biggest_stepsize > 0) {
+			/* Second.5 loop: count how many children are of the updated biggest step size. */
+			for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+				uint hor_step = child_wid->GetHorizontalStepSize(sizing);
+				if (hor_step == biggest_stepsize) {
+					num_changing_childs++;
+				}
+			}
+		}
 	}
 	assert(num_changing_childs == 0);
 
@@ -1512,7 +1532,7 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, uint x, uint y, uint
 	for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
 		uint vert_step = child_wid->GetVerticalStepSize(sizing);
 		if (vert_step > 0) {
-			num_changing_childs++;
+			if (!(flags & NC_BIGFIRST)) num_changing_childs++;
 			biggest_stepsize = std::max(biggest_stepsize, vert_step);
 		} else {
 			child_wid->current_y = child_wid->smallest_y;
@@ -1520,6 +1540,16 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, uint x, uint y, uint
 
 		uint hor_step = (sizing == ST_SMALLEST) ? 1 : child_wid->GetHorizontalStepSize(sizing);
 		child_wid->current_x = ComputeMaxSize(child_wid->smallest_x, given_width - child_wid->padding_left - child_wid->padding_right, hor_step);
+	}
+
+	/* First.5 loop: count how many children are of the biggest step size. */
+	if ((this->flags & NC_BIGFIRST) && biggest_stepsize > 0) {
+		for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+			uint vert_step = child_wid->GetVerticalStepSize(sizing);
+			if (vert_step == biggest_stepsize) {
+				num_changing_childs++;
+			}
+		}
 	}
 
 	/* Second loop: Allocate the additional vertical space over the resizing children, starting with the biggest resize steps. */
@@ -1539,6 +1569,16 @@ void NWidgetVertical::AssignSizePosition(SizingType sizing, uint x, uint y, uint
 			next_biggest_stepsize = std::max(next_biggest_stepsize, vert_step);
 		}
 		biggest_stepsize = next_biggest_stepsize;
+
+		if (num_changing_childs == 0 && (flags & NC_BIGFIRST) && biggest_stepsize > 0) {
+			/* Second.5 loop: count how many children are of the updated biggest step size. */
+			for (NWidgetBase *child_wid = this->head; child_wid != nullptr; child_wid = child_wid->next) {
+				uint vert_step = child_wid->GetVerticalStepSize(sizing);
+				if (vert_step == biggest_stepsize) {
+					num_changing_childs++;
+				}
+			}
+		}
 	}
 	assert(num_changing_childs == 0);
 

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -458,9 +458,11 @@ public:
 /** Nested widget container flags, */
 enum NWidContainerFlags {
 	NCB_EQUALSIZE = 0, ///< Containers should keep all their (resizing) children equally large.
+	NCB_BIGFIRST  = 1, ///< Allocate space to biggest resize first.
 
 	NC_NONE = 0,                       ///< All flags cleared.
 	NC_EQUALSIZE = 1 << NCB_EQUALSIZE, ///< Value of the #NCB_EQUALSIZE flag.
+	NC_BIGFIRST  = 1 << NCB_BIGFIRST,  ///< Value of the #NCB_BIGFIRST flag.
 };
 DECLARE_ENUM_AS_BIT_SET(NWidContainerFlags)
 


### PR DESCRIPTION
## Motivation / Problem

Group window manually calculates sizes of other widgets to determine how large to make the group list widget. This is clumsy, and error-prone when making window adjustments.

## Description

This PR solves this by adding a flag to NWidgetPIPContainers to indicate that space should be allocated to larger resize_step widgets first.

Rather than the current behaviour where space is allocated equally, this causes the group list widget to fill as much as possible first, and then any leftover remaining is allocated to the smaller information panel.

This seems 'cleaner' to me however it is actually quite some extra code compared to the amount removed...

Added as a flag so that the existing behaviour is retained for other windows, however I'm not sure that's really needed.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
