### PR TITLE
Change: Strip symbols from bundles except macOS

### DIFF
--- a/cmake/InstallAndPackage.cmake
+++ b/cmake/InstallAndPackage.cmake
@@ -118,10 +118,12 @@ endif()
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_MONOLITHIC_INSTALL YES)
 set(CPACK_PACKAGE_EXECUTABLES "openttd;OpenTTD")
-set(CPACK_STRIP_FILES NO)
+set(CPACK_STRIP_FILES YES)
 set(CPACK_OUTPUT_FILE_PREFIX "bundles")
 
 if(APPLE)
+    # Stripping would produce unreadable stacktraces.
+    set(CPACK_STRIP_FILES NO)
     set(CPACK_GENERATOR "Bundle")
     include(PackageBundle)
 


### PR DESCRIPTION
## Motivation / Problem

In #10071 stripping symbols from binaries was disabled to improve macOS stacktraces. However this caused the linux binaries to balloon, see [size comparison](https://github.com/OpenTTD/OpenTTD/pull/10071#issuecomment-1272268520).

## Description

On #openttd it was suggested to further tweak the stripping:

>  LordAro: @Bouke perhaps strip everything except macos?

So this PR disable stripping on all platforms except macOS.

## Limitations

- I'm not familiar with the stacktraces produced on Windows / Linux, and how stripping affects them. For Windows there are debug symbols (pdb) which would probably help, but I don't know what the situation on Linux is. Maybe we should produce something similar to a pdb for Linux, if that's even possible?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
<s>* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)</s>