### PR TITLE
Feature: Make large UFO destination a bit more random

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -580,10 +580,11 @@ static bool DisasterTick_Big_Ufo(DisasterVehicle *v)
 
 		TileIndex tile_org = RandomTile();
 		TileIndex tile = tile_org;
+		int num = GB(Random(), 0, 8);
 		do {
 			if (IsPlainRailTile(tile) &&
 					Company::IsHumanID(GetTileOwner(tile))) {
-				break;
+				if (--num == 0) break;
 			}
 			tile = TILE_MASK(tile + 1);
 		} while (tile != tile_org);


### PR DESCRIPTION
## Motivation / Problem

When a large UFO appears, it picks a random tile, and looks for the next rail tile. on usual networks, this often results in the same rail tile being picked, as some rail tiles "stick out" more than others, and there is a heavy bias towards those tiles

## Description

With this PR, a random number of rail tiles is skipped after the first one, hopefully evening out some of these biases


## Limitations

I haven't actually had time to run a test playthrough with disasters enabled


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
