### PR TITLE
Doc: Spelling mistake and grammatical correction in CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,8 +212,8 @@ When it comes to gameplay features there are at least these groups of interests:
 - *Control freak:* micromanagement like conditional orders, refitting and loading etc.
 - *Casual:* automatisation like cargodist, path based signalling etc.
 
-To please everyone, the official branch tries to stay close to the original gameplay; after all, that is what everyone brought here.
-The preferred method to alter and extent the gameplay is via add-ons like NewGRF and GameScripts.
+To please everyone, the official branch tries to stay close to the original gameplay; after all, that is what brought everyone here.
+The preferred method to alter and extend the gameplay is via add-ons like NewGRF and GameScripts.
 
 For a long time, the official branch was also open to features which could be enabled/disabled, but the corner-cases that came with some configurations have rendered some parts of the code very complicated.
 Today, new features have to work with all the already existing features, which is not only challenging in corner cases, but also requires spending considerable more work than just "making it work in the game mode that I play".


### PR DESCRIPTION
## Motivation / Problem

There was a typo and a grammatical error in the "Project Goals" section, as raised in the OpenTTD forums at https://www.tt-forums.net/viewtopic.php?t=90344


## Description

As mentioned in the forum thread, in the "Project Goals" section of CONTRIBUTING.md, I noticed two errors - a spelling mistake ('extent' used, 'extend' meant) and a grammatical error ('that is what everyone brought here', used, 'that is what brought everyone here'

## Limitations

No limitations known, as this affects a documentation file, nothing in-game.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
