### PR TITLE
Change: Double speed for speed rating at stations for road vehicle.

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1755,7 +1755,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 			case VEH_SHIP:
 			case VEH_ROAD:
 				/* cached_max_speed from ships and road vehicles are double in size when we fetch the values here
-				 * in order for road veichles to get speed bonus on station ratings we keep the values as is */
+				 * in order for road vehicles and ships to get speed bonus on station ratings we keep the values as is */
 				t = front->vcache.cached_max_speed;
 				break;
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1753,11 +1753,10 @@ static void LoadUnloadVehicle(Vehicle *front)
 		switch (front->type) {
 			case VEH_TRAIN:
 			case VEH_SHIP:
-				t = front->vcache.cached_max_speed;
-				break;
-
 			case VEH_ROAD:
-				t = front->vcache.cached_max_speed / 2;
+				/* cached_max_speed from ships and road vehicles are double in size when we fetch the values here
+				 * in order for road veichles to get speed bonus on station ratings we keep the values as is */
+				t = front->vcache.cached_max_speed;
 				break;
 
 			case VEH_AIRCRAFT:


### PR DESCRIPTION
## Motivation / Problem

Road vehicle never get any speed rating bonus on stations with current formula. Playing with only road vehicles it is impossible to reach the 80% needed to trigger the extra boost on industrial growth. 
With statue and the fastest road vehicle in late game only 79% is reached for cargo after the inital bonus for new vehicles have disapeared. But with trains you can breach the 80% even without statues. 
Beeing a sandbox focused game the players should have the oportunity to trigger all game mechanics using any type of transport. 

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
By doubling the road vehicle speed the same way that ships have a double bonus, road vehicles will follow the evolution that trains have very close if compared to the fastest type avaible each year:
![Station rating based on fastest avaible type_year](https://user-images.githubusercontent.com/1023885/196146101-d874300e-3286-442a-8f36-b0f9bd330db0.png)
Red line is current bonus, Yellow is after this patch. 

## Note

The speed for road vehicles are multiplied by 4 in the code and then divided by 2 here, and on the wiki it say that road vehicles speed is divided by 2 when used in the station rating. Making it so that people thinks that road vehicles have a bonus already of a factor of 2 for the rating formula. Or one might think that road vehicles have a penalty. 

The reality when looking at the numbers used here is that `t = front->vcache.cached_max_speed` is not the speed &times; 4 but the speed &times; 2 when it reaces this formula. So road vehicles have the same formula as trains. One might think that the intention from the beginning was to have road vehicles at &times; 2 because it looks like max_speed is set to &times; 4 but for some reason it is only &times; 2 when this math is done. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
