### PR TITLE
Codechange: [Actions] set-output is deprecated

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Prepare cache key
       id: key
       run: |
-        echo "::set-output name=image::$ImageOS-$ImageVersion"
+        echo "name=image::$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
 
     - name: Enable vcpkg cache
       uses: actions/cache@v3
@@ -253,7 +253,7 @@ jobs:
         # Work around caching failure with GNU tar
         New-Item -Type Junction -Path vcpkg -Target c:\vcpkg
 
-        Write-Output "::set-output name=image::$env:ImageOS-$env:ImageVersion"
+        Write-Output "name=image::$env:ImageOS-$env:ImageVersion" >> $GITHUB_OUTPUT
 
     - name: Enable vcpkg cache
       uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,10 +138,10 @@ jobs:
         echo "Folder on CDN: ${FOLDER}"
         echo "Workflow trigger: ${TRIGGER_TYPE}"
 
-        echo "::set-output name=version::$(cat .version)"
-        echo "::set-output name=is_tag::${IS_TAG}"
-        echo "::set-output name=folder::${FOLDER}"
-        echo "::set-output name=trigger_type::${TRIGGER_TYPE}"
+        echo "name=version::$(cat .version)" >> $GITHUB_OUTPUT
+        echo "name=is_tag::${IS_TAG}" >> $GITHUB_OUTPUT
+        echo "name=folder::${FOLDER}" >> $GITHUB_OUTPUT
+        echo "name=trigger_type::${TRIGGER_TYPE}" >> $GITHUB_OUTPUT
       env:
         NIGHTLIES_BRANCH: master
         FOLDER_RELEASES: openttd-releases
@@ -497,7 +497,7 @@ jobs:
     - name: Prepare cache key
       id: key
       run: |
-        echo "::set-output name=image::$ImageOS-$ImageVersion"
+        echo "name=image::$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
 
     - name: Enable vcpkg cache
       uses: actions/cache@v3
@@ -700,7 +700,7 @@ jobs:
         # Work around caching failure with GNU tar
         New-Item -Type Junction -Path vcpkg -Target c:\vcpkg
 
-        Write-Output "::set-output name=image::$env:ImageOS-$env:ImageVersion"
+        Write-Output "name=image::$env:ImageOS-$env:ImageVersion" >> $GITHUB_OUTPUT
 
     - name: Enable vcpkg cache
       uses: actions/cache@v3


### PR DESCRIPTION
## Motivation / Problem
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
