### PR TITLE
Change: Don't make wide rivers using original landscape generator

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1273,8 +1273,10 @@ static void River_FoundEndNode(AyStar *aystar, OpenListNode *current)
 		}
 	}
 
-	/* If the river is a main river, go back along the path to widen it. */
-	if (data->main_river) {
+	/* If the river is a main river, go back along the path to widen it.
+	 * Don't make wide rivers if we're using the original landscape generator.
+	 */
+	if (_settings_game.game_creation.land_generator != LG_ORIGINAL && data->main_river) {
 		const uint long_river_length = _settings_game.game_creation.min_river_length * 4;
 		uint current_river_length;
 		uint radius;


### PR DESCRIPTION
## Motivation / Problem

In [a comment on the Wide Rivers commit](https://github.com/OpenTTD/OpenTTD/commit/664771d085737f52838c6aa86e0e37bddf9dc47a#commitcomment-87469798), @Limyx826 suggested that maybe wide rivers shouldn't be built when using the original terrain generator.

## Description

Don't generate wide rivers when using original landscape generator.

(Yes, I'm aware that rivers didn't exist at all in TTD, but this change took me all of 5 minutes.)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
