### PR TITLE
Change: Remove land generator setting from World Generation GUI

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3144,7 +3144,6 @@ STR_MAPGEN_DESERT_COVERAGE                                      :{BLACK}Desert c
 STR_MAPGEN_DESERT_COVERAGE_UP                                   :{BLACK}Increase desert coverage by ten percent
 STR_MAPGEN_DESERT_COVERAGE_DOWN                                 :{BLACK}Decrease desert coverage by ten percent
 STR_MAPGEN_DESERT_COVERAGE_TEXT                                 :{BLACK}{NUM}%
-STR_MAPGEN_LAND_GENERATOR                                       :{BLACK}Land generator:
 STR_MAPGEN_TERRAIN_TYPE                                         :{BLACK}Terrain type:
 STR_MAPGEN_SEA_LEVEL                                            :{BLACK}Sea level:
 STR_MAPGEN_QUANTITY_OF_RIVERS                                   :{BLACK}Rivers:


### PR DESCRIPTION
## Motivation / Problem

In a Discord discussion about #10092, @JGRennison and @LordAro suggested removing the original map generator code entirely. I'm not willing to die on that hill, but there's no reason the setting needs to be in the already-cluttered World Generation GUI.

## Description

![worldgen](https://user-images.githubusercontent.com/55058389/201400246-0e6c2596-ab1f-46c6-b10d-a40e7723d54e.png)

Removes the dropdown selector from the World Generation GUI.

Players who wish to select the original land generator can do so in Settings.

## Limitations

- "We should not be simplifying the game to appeal to new players," etc...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
