### PR TITLE
Feature: Airport construction GUI displays infrastructure cost

### DIFF
--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -8,6 +8,7 @@
 /** @file airport_gui.cpp The GUI for airports. */
 
 #include "stdafx.h"
+#include "economy_func.h"
 #include "window_gui.h"
 #include "station_gui.h"
 #include "terraform_gui.h"
@@ -436,6 +437,13 @@ public:
 				/* show the noise of the selected airport */
 				SetDParam(0, as->noise_level);
 				DrawString(r.left, r.right, top, STR_STATION_BUILD_NOISE);
+				top += FONT_HEIGHT_NORMAL + ScaleGUITrad(WD_PAR_VSEP_NORMAL);
+			}
+
+			if (_settings_game.economy.infrastructure_maintenance) {
+				Money monthly = _price[PR_INFRASTRUCTURE_AIRPORT] * as->maintenance_cost >> 3;
+				SetDParam(0, monthly * 12);
+				DrawString(r.left, r.right, top, STR_STATION_BUILD_INFRASTRUCTURE_COST);
 				top += FONT_HEIGHT_NORMAL + ScaleGUITrad(WD_PAR_VSEP_NORMAL);
 			}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2630,6 +2630,7 @@ STR_STATION_BUILD_COVERAGE_AREA_OFF_TOOLTIP                     :{BLACK}Don't hi
 STR_STATION_BUILD_COVERAGE_AREA_ON_TOOLTIP                      :{BLACK}Highlight coverage area of proposed site
 STR_STATION_BUILD_ACCEPTS_CARGO                                 :{BLACK}Accepts: {GOLD}{CARGO_LIST}
 STR_STATION_BUILD_SUPPLIES_CARGO                                :{BLACK}Supplies: {GOLD}{CARGO_LIST}
+STR_STATION_BUILD_INFRASTRUCTURE_COST                           :{BLACK}Maintainance cost: {GOLD}{CURRENCY_SHORT}/yr
 
 # Join station window
 STR_JOIN_STATION_CAPTION                                        :{WHITE}Join station


### PR DESCRIPTION
## Motivation / Problem

New players are often unaware of the infrastructure costs of airports and there then confused that their seemingly profitable aircraft are not enough to avoid bankruptcy.

## Description

If infrastructure costs are enabled, display these costs in the airport construction GUI.
Players are more likely to notice that airports aren't just a one time cost. It will also help experienced players choose between differing sizes of airport.

![Screenshot from 2022-10-21 17-36-42](https://user-images.githubusercontent.com/7112446/197245836-7fff8fe9-4e77-4a48-b8d4-ea1eb0f698b0.png)

## Limitations

Other construction GUIs may also benefit from similar changes.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
