### PR TITLE
Fix a9a21e78: Depots aren't really stations.

### DIFF
--- a/src/depot_type.h
+++ b/src/depot_type.h
@@ -12,10 +12,10 @@
 
 #include "station_type.h"
 
-typedef StationID DepotID; ///< Type for the unique identifier of depots.
+typedef uint16 DepotID; ///< Type for the unique identifier of depots.
 struct Depot;
 
-static const DepotID INVALID_DEPOT = INVALID_STATION;
+static const DepotID INVALID_DEPOT = (DepotID)INVALID_STATION;
 
 static const uint MAX_LENGTH_DEPOT_NAME_CHARS = 32; ///< The maximum length of a depot name in characters including '\0'
 


### PR DESCRIPTION
## Motivation / Problem

Depots aren't actually stations, see https://github.com/OpenTTD/OpenTTD/pull/9959#pullrequestreview-1152104926


## Description

Revert the typedef to the original, we don't need that and yet can still use the same numerical value for invalid.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
