### PR TITLE
Fix #10065: Remove problematic inline specifier

### DIFF
--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -562,7 +562,7 @@ static inline uint32 GetSmallMapVegetationPixels(TileIndex tile, TileType t)
  * @param include_heightmap Whether to return the heightmap/contour colour of this tile (instead of the default land tile colour)
  * @return The colour of tile in the small map in mode "Owner"
  */
-inline uint32 GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap include_heightmap)
+uint32 GetSmallMapOwnerPixels(TileIndex tile, TileType t, IncludeHeightmap include_heightmap)
 {
 	Owner o;
 


### PR DESCRIPTION
## Motivation / Problem
#10065 created a regression since I forgot to remove the inline specifier for `GetSmallMapOwnerPixels`. This causes various build/linker problems depending on the compiler and the optimization settings.

## Description
The `inline` specifier here should be removed since it causes said problems. Not to mention, the `GetSmallMapOwnerPixels` function should probably not be hinted as inline now anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* ~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~
* ~This PR affects the save game format? (label 'savegame upgrade')~
* ~This PR affects the GS/AI API? (label 'needs review: Script API')~
    * ~ai_changelog.hpp, gs_changelog.hpp need updating.~
    * ~The compatibility wrappers (compat_*.nut) need updating.~
* ~This PR affects the NewGRF API? (label 'needs review: NewGRF')~
    * ~newgrf_debug_data.h may need updating.~
    * ~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~
