### PR TITLE
Fix #10023: Allow negative input in text fields when needed

### DIFF
--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2288,10 +2288,13 @@ struct GameSettingsWindow : Window {
 				/* Show the correct currency-translated value */
 				if (sd->flags & SF_GUI_CURRENCY) value64 *= _currency->rate;
 
+				CharSetFilter charset_filter = CS_NUMERAL; //default, only numeric input allowed
+				if (sd->min < 0) charset_filter = CS_NUMERAL_SIGNED; // special case, also allow '-' sign for negative input
+
 				this->valuewindow_entry = pe;
 				SetDParam(0, value64);
 				/* Limit string length to 14 so that MAX_INT32 * max currency rate doesn't exceed MAX_INT64. */
-				ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, 15, this, CS_NUMERAL, QSF_ENABLE_DEFAULT);
+				ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, 15, this, charset_filter, QSF_ENABLE_DEFAULT);
 			}
 			this->SetDisplayedHelpText(pe);
 		}

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -494,12 +494,13 @@ bool strtolower(std::string &str, std::string::size_type offs)
 bool IsValidChar(WChar key, CharSetFilter afilter)
 {
 	switch (afilter) {
-		case CS_ALPHANUMERAL:  return IsPrintable(key);
-		case CS_NUMERAL:       return (key >= '0' && key <= '9');
-		case CS_NUMERAL_SPACE: return (key >= '0' && key <= '9') || key == ' ';
-		case CS_ALPHA:         return IsPrintable(key) && !(key >= '0' && key <= '9');
-		case CS_HEXADECIMAL:   return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
-		default: NOT_REACHED();
+	case CS_ALPHANUMERAL:   return IsPrintable(key);
+	case CS_NUMERAL:        return (key >= '0' && key <= '9');
+	case CS_NUMERAL_SPACE:  return (key >= '0' && key <= '9') || key == ' ';
+	case CS_NUMERAL_SIGNED: return (key >= '0' && key <= '9') || key == '-';
+	case CS_ALPHA:          return IsPrintable(key) && !(key >= '0' && key <= '9');
+	case CS_HEXADECIMAL:    return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
+	default: NOT_REACHED();
 	}
 }
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -494,13 +494,13 @@ bool strtolower(std::string &str, std::string::size_type offs)
 bool IsValidChar(WChar key, CharSetFilter afilter)
 {
 	switch (afilter) {
-	case CS_ALPHANUMERAL:   return IsPrintable(key);
-	case CS_NUMERAL:        return (key >= '0' && key <= '9');
-	case CS_NUMERAL_SPACE:  return (key >= '0' && key <= '9') || key == ' ';
-	case CS_NUMERAL_SIGNED: return (key >= '0' && key <= '9') || key == '-';
-	case CS_ALPHA:          return IsPrintable(key) && !(key >= '0' && key <= '9');
-	case CS_HEXADECIMAL:    return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
-	default: NOT_REACHED();
+	    case CS_ALPHANUMERAL:   return IsPrintable(key);
+	    case CS_NUMERAL:        return (key >= '0' && key <= '9');
+	    case CS_NUMERAL_SPACE:  return (key >= '0' && key <= '9') || key == ' ';
+	    case CS_NUMERAL_SIGNED: return (key >= '0' && key <= '9') || key == '-';
+	    case CS_ALPHA:          return IsPrintable(key) && !(key >= '0' && key <= '9');
+	    case CS_HEXADECIMAL:    return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
+	    default: NOT_REACHED();
 	}
 }
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -494,13 +494,13 @@ bool strtolower(std::string &str, std::string::size_type offs)
 bool IsValidChar(WChar key, CharSetFilter afilter)
 {
 	switch (afilter) {
-	    case CS_ALPHANUMERAL:   return IsPrintable(key);
-	    case CS_NUMERAL:        return (key >= '0' && key <= '9');
-	    case CS_NUMERAL_SPACE:  return (key >= '0' && key <= '9') || key == ' ';
-	    case CS_NUMERAL_SIGNED: return (key >= '0' && key <= '9') || key == '-';
-	    case CS_ALPHA:          return IsPrintable(key) && !(key >= '0' && key <= '9');
-	    case CS_HEXADECIMAL:    return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
-	    default: NOT_REACHED();
+		case CS_ALPHANUMERAL:   return IsPrintable(key);
+		case CS_NUMERAL:        return (key >= '0' && key <= '9');
+		case CS_NUMERAL_SPACE:  return (key >= '0' && key <= '9') || key == ' ';
+		case CS_NUMERAL_SIGNED: return (key >= '0' && key <= '9') || key == '-';
+		case CS_ALPHA:          return IsPrintable(key) && !(key >= '0' && key <= '9');
+		case CS_HEXADECIMAL:    return (key >= '0' && key <= '9') || (key >= 'a' && key <= 'f') || (key >= 'A' && key <= 'F');
+		default: NOT_REACHED();
 	}
 }
 

--- a/src/string_type.h
+++ b/src/string_type.h
@@ -27,6 +27,7 @@ enum CharSetFilter {
 	CS_ALPHANUMERAL,      ///< Both numeric and alphabetic and spaces and stuff
 	CS_NUMERAL,           ///< Only numeric ones
 	CS_NUMERAL_SPACE,     ///< Only numbers and spaces
+	CS_NUMERAL_SIGNED,    ///< Only numbers and '-' for negative values
 	CS_ALPHA,             ///< Only alphabetic values
 	CS_HEXADECIMAL,       ///< Only hexadecimal characters
 };


### PR DESCRIPTION

## Motivation / Problem
Some settings like "Autorenew when vehicle is X months after maximum age" have negative values in the valid range and should therefore allow negative sign ('-') in the text field.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Only in a few rare cases settings span between positive and negative values in the valid range. 
For example "Autorenew when vehicle is X months after max age" have [-12,12] as a valid range. 
In these cases also negative sign ('-')  will be allowed in the text field with this fix.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
