### PR TITLE
Remove: [Actions] Ubuntu Bionic and Debian Buster from release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,17 +371,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - container_image: "ubuntu:18.04"
-          bundle_name: "bionic"
-          compiler: "g++-8"
         - container_image: "ubuntu:20.04"
           bundle_name: "focal"
           compiler: "g++"
         - container_image: "ubuntu:22.04"
           bundle_name: "jammy"
-          compiler: "g++"
-        - container_image: "debian:buster"
-          bundle_name: "buster"
           compiler: "g++"
         - container_image: "debian:bullseye"
           bundle_name: "bullseye"


### PR DESCRIPTION
## Motivation / Problem

Ubuntu Bionic and Debian Buster can't build OpenTTD master as of now.
Targets with newer compilers don't have this problem.


## Description

Both targets are quite old and are or are going to be out-of-support soon, so just drop them.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
