### PR TITLE
Fix: Too many braces make old gcc sad.

### DIFF
--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -149,7 +149,7 @@ constexpr UnpackNetworkCommandProc MakeUnpackNetworkCommandCallback() noexcept
 template <Commands Tcmd, size_t... i>
 constexpr UnpackDispatchT MakeUnpackNetworkCommand(std::index_sequence<i...>) noexcept
 {
-	return UnpackDispatchT{{ {MakeUnpackNetworkCommandCallback<Tcmd, i>()}...}};
+	return UnpackDispatchT{{ MakeUnpackNetworkCommandCallback<Tcmd, i>()...}};
 }
 
 template <typename T, T... i, size_t... j>


### PR DESCRIPTION
## Motivation / Problem / Description / Limitations

Some version of GCC 8 complain about an abundance of braces. Remove them to make GCC happy.

This is strictly speaking not needed anymore as any target  that still uses GCC 8 was removed by  #10115 .

Nevertheless, all current compilers seem to be happy with less braces as well, so we might as well do some code cleanup here.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
