### PR TITLE
Fix #10117: Decrement object burst limit after build check

### DIFF
--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -408,7 +408,7 @@ CommandCost CmdBuildObjectArea(DoCommandFlag flags, TileIndex tile, TileIndex st
 		CommandCost ret = Command<CMD_BUILD_OBJECT>::Do(flags & ~DC_EXEC, t, type, view);
 
 		/* If we've reached the limit, stop building (or testing). */
-		if (c != nullptr && --limit <= 0) break;
+		if (c != nullptr && limit-- <= 0) break;
 
 		if (ret.Failed()) {
 			last_error = ret;


### PR DESCRIPTION
## Motivation / Problem

When building multiple objects or buying multiple tiles at once, the limit is one less than the `build_object_frame_burst` setting, because the limit is decremented before the build check. A simple `--limit` which should be `limit--`.

## Description

Closes #10117.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
