### PR TITLE
Change: Don't show vehicle reliability when breakdowns disabled

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -928,10 +928,12 @@ int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, 
 		DrawString(left, right, y, STR_PURCHASE_INFO_DESIGNED_LIFE);
 		y += FONT_HEIGHT_NORMAL;
 
-		/* Reliability */
-		SetDParam(0, ToPercent16(e->reliability));
-		DrawString(left, right, y, STR_PURCHASE_INFO_RELIABILITY);
-		y += FONT_HEIGHT_NORMAL;
+		/* Reliability, if breakdowns are enabled */
+		if (_settings_game.difficulty.vehicle_breakdowns != 0) {
+			SetDParam(0, ToPercent16(e->reliability));
+			DrawString(left, right, y, STR_PURCHASE_INFO_RELIABILITY);
+			y += FONT_HEIGHT_NORMAL;
+		}
 	}
 
 	if (refittable) y = ShowRefitOptionsList(left, right, y, engine_number);
@@ -1115,7 +1117,8 @@ struct BuildVehicleWindow : Window {
 		widget->tool_tip    = STR_SHOW_HIDDEN_ENGINES_VEHICLE_TRAIN_TOOLTIP + type;
 		widget->SetLowered(this->show_hidden_engines);
 
-		this->details_height = ((this->vehicle_type == VEH_TRAIN) ? 10 : 9);
+		this->details_height = ((this->vehicle_type == VEH_TRAIN) ? 9 : 8);
+		if (_settings_game.difficulty.vehicle_breakdowns != 0) this->details_height++; // Only show a line for max reliability if breakdowns are enabled
 
 		this->FinishInitNested(tile == INVALID_TILE ? (int)type : (int)tile);
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -247,6 +247,15 @@ static void RoadVehSlopeSteepnessChanged(int32 new_value)
 	}
 }
 
+/**
+ *Vehicle breakdown setting changed, redraw vehicle and buy menu GUIs to show / hide reliability info
+ * @param new_value Unused
+ */
+static void VehicleBreakdownsChanged(int32 new_value)
+{
+	ReInitAllWindows(false);
+}
+
 static void TownFoundingChanged(int32 new_value)
 {
 	if (_game_mode != GM_EDITOR && _settings_game.economy.found_town == TF_FORBIDDEN) {

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -15,6 +15,7 @@ uint8 _old_diff_level;                                 ///< Old difficulty level
 
 static void DifficultyNoiseChange(int32 new_value);
 static void MaxNoAIsChange(int32 new_value);
+static void VehicleBreakdownsChanged(int32 new_value);
 
 static const SettingVariant _difficulty_settings_table[] = {
 [post-amble]
@@ -168,6 +169,7 @@ interval = 1
 str      = STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS
 strhelp  = STR_CONFIG_SETTING_VEHICLE_BREAKDOWNS_HELPTEXT
 strval   = STR_DISASTER_NONE
+post_cb  = VehicleBreakdownsChanged
 cat      = SC_BASIC
 
 [SDT_VAR]

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2185,7 +2185,9 @@ struct VehicleDetailsWindow : Window {
 		switch (widget) {
 			case WID_VD_TOP_DETAILS: {
 				Dimension dim = { 0, 0 };
-				size->height = WD_FRAMERECT_TOP + 4 * FONT_HEIGHT_NORMAL + WD_FRAMERECT_BOTTOM;
+				/* Only make space for reliability and breakdown info if breakdowns are enabled. */
+				uint num_info_strings = (_settings_game.difficulty.vehicle_breakdowns == 0) ? 3 : 4;
+				size->height = WD_FRAMERECT_TOP + num_info_strings * FONT_HEIGHT_NORMAL + WD_FRAMERECT_BOTTOM;
 
 				for (uint i = 0; i < 4; i++) SetDParamMaxValue(i, INT16_MAX);
 				static const StringID info_strings[] = {
@@ -2346,10 +2348,12 @@ struct VehicleDetailsWindow : Window {
 				DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_VEHICLE_INFO_PROFIT_THIS_YEAR_LAST_YEAR);
 				y += FONT_HEIGHT_NORMAL;
 
-				/* Draw breakdown & reliability */
-				SetDParam(0, ToPercent16(v->reliability));
-				SetDParam(1, v->breakdowns_since_last_service);
-				DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS);
+				/* Draw breakdown & reliability, if breakdowns are enabled. */
+				if (_settings_game.difficulty.vehicle_breakdowns != 0) {
+					SetDParam(0, ToPercent16(v->reliability));
+					SetDParam(1, v->breakdowns_since_last_service);
+					DrawString(r.left + WD_FRAMERECT_LEFT, r.right - WD_FRAMERECT_RIGHT, y, STR_VEHICLE_INFO_RELIABILITY_BREAKDOWNS);
+				}
 				break;
 			}
 


### PR DESCRIPTION
## Motivation / Problem

The build vehicle GUI and vehicle details GUI are full of useful information, but they're also...full. 

It would be nice to hide useless information, like reliability and breakdown information when breakdowns are disabled.

## Description

![reliability](https://user-images.githubusercontent.com/55058389/199577457-338619d3-afba-40f0-947a-bbbfb1e2ecbb.png)

Hide these lines of text and make the GUIs smaller when breakdowns are disabled. If the setting is changed while a GUI is open, it will grow to fit the content.

## Limitations

If you repeatedly enable and disable breakdowns while a train details window is open, the details window will lose lines until it's only three lines high. This does not break anything and I don't expect many people to do this, but I'm also not sure why it happens. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
