### PR TITLE
Codechange: Move Sound Driver paramater name listings

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -176,7 +176,7 @@ static void ShowHelp()
 		"\n"
 		"Command line options:\n"
 		"  -v drv              = Set video driver (see below)\n"
-		"  -s drv              = Set sound driver (see below) (param bufsize,hz)\n"
+		"  -s drv              = Set sound driver (see below)\n"
 		"  -m drv              = Set music driver (see below)\n"
 		"  -b drv              = Set the blitter to use (see below)\n"
 		"  -r res              = Set resolution (for instance 800x600)\n"

--- a/src/sound/allegro_s.h
+++ b/src/sound/allegro_s.h
@@ -26,7 +26,7 @@ public:
 /** Factory for the allegro sound driver. */
 class FSoundDriver_Allegro : public DriverFactoryBase {
 public:
-	FSoundDriver_Allegro() : DriverFactoryBase(Driver::DT_SOUND, 4, "allegro", "Allegro Sound Driver") {}
+	FSoundDriver_Allegro() : DriverFactoryBase(Driver::DT_SOUND, 4, "allegro", "Allegro Sound Driver (param hz,samples)") {}
 	/* virtual */ Driver *CreateInstance() const { return new SoundDriver_Allegro(); }
 };
 

--- a/src/sound/cocoa_s.h
+++ b/src/sound/cocoa_s.h
@@ -22,7 +22,7 @@ public:
 
 class FSoundDriver_Cocoa : public DriverFactoryBase {
 public:
-	FSoundDriver_Cocoa() : DriverFactoryBase(Driver::DT_SOUND, 10, "cocoa", "Cocoa Sound Driver") {}
+	FSoundDriver_Cocoa() : DriverFactoryBase(Driver::DT_SOUND, 10, "cocoa", "Cocoa Sound Driver (param hz)") {}
 	Driver *CreateInstance() const override { return new SoundDriver_Cocoa(); }
 };
 

--- a/src/sound/sdl_s.h
+++ b/src/sound/sdl_s.h
@@ -24,7 +24,7 @@ public:
 /** Factory for the SDL sound driver. */
 class FSoundDriver_SDL : public DriverFactoryBase {
 public:
-	FSoundDriver_SDL() : DriverFactoryBase(Driver::DT_SOUND, 5, "sdl", "SDL Sound Driver") {}
+	FSoundDriver_SDL() : DriverFactoryBase(Driver::DT_SOUND, 5, "sdl", "SDL Sound Driver (param hz,samples)") {}
 	Driver *CreateInstance() const override { return new SoundDriver_SDL(); }
 };
 

--- a/src/sound/win32_s.h
+++ b/src/sound/win32_s.h
@@ -24,7 +24,7 @@ public:
 /** Factory for the sound driver for Windows. */
 class FSoundDriver_Win32 : public DriverFactoryBase {
 public:
-	FSoundDriver_Win32() : DriverFactoryBase(Driver::DT_SOUND, 9, "win32", "Win32 WaveOut Sound Driver") {}
+	FSoundDriver_Win32() : DriverFactoryBase(Driver::DT_SOUND, 9, "win32", "Win32 WaveOut Sound Driver (param bufsize,hz)") {}
 	Driver *CreateInstance() const override { return new SoundDriver_Win32(); }
 };
 

--- a/src/sound/xaudio2_s.h
+++ b/src/sound/xaudio2_s.h
@@ -24,7 +24,7 @@ public:
 /** Factory for the XAudio2 sound driver. */
 class FSoundDriver_XAudio2 : public DriverFactoryBase {
 public:
-	FSoundDriver_XAudio2() : DriverFactoryBase(Driver::DT_SOUND, 10, "xaudio2", "XAudio2 Sound Driver") {}
+	FSoundDriver_XAudio2() : DriverFactoryBase(Driver::DT_SOUND, 10, "xaudio2", "XAudio2 Sound Driver (param bufsize,hz)") {}
 	Driver *CreateInstance() const override { return new SoundDriver_XAudio2(); }
 };
 


### PR DESCRIPTION
## Motivation / Problem

The various sound drivers don't take a consistent set of (optional) parameters.

## Description

This change places the list of accepted parameters for each sound driver on the line in the `openttd --help` to be with the individual sound drivers, rather than at the top.
EG:
From:
`-s drv              = Set sound driver (see below) (param bufsize,hz)`
...
`List of sound drivers:`
`               sdl: SDL Sound Driver`
`              null: Null Sound Driver`

To:
`-s drv              = Set sound driver (see below)`
...
`List of sound drivers:`
`               sdl: SDL Sound Driver (param hz,samples)`
`              null: Null Sound Driver`

## Limitations

None known.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
