### PR TITLE
New industry creation/closure behavior

### DIFF
--- a/src/industry.h
+++ b/src/industry.h
@@ -55,8 +55,11 @@ enum IndustryControlFlags : byte {
 	 * Industry can not close regardless of production level or time since last delivery.
 	 * This does not prevent a closure already announced. */
 	INDCTL_NO_CLOSURE             = 1 << 2,
+	/**
+	 * Industry has been serviced at least one */
+	 INDCTL_SERVICED 			  = 1 << 3,
 	/** Mask of all flags set */
-	INDCTL_MASK = INDCTL_NO_PRODUCTION_DECREASE | INDCTL_NO_PRODUCTION_INCREASE | INDCTL_NO_CLOSURE,
+	INDCTL_MASK = INDCTL_NO_PRODUCTION_DECREASE | INDCTL_NO_PRODUCTION_INCREASE | INDCTL_NO_CLOSURE | INDCTL_SERVICED,
 };
 DECLARE_ENUM_AS_BIT_SET(IndustryControlFlags);
 
@@ -209,6 +212,8 @@ void ReleaseDisastersTargetingIndustry(IndustryID);
 
 bool IsTileForestIndustry(TileIndex tile);
 
+uint GetCurrentTotalNumberOfIndustries();
+
 /** Data for managing the number of industries of a single industry type. */
 struct IndustryTypeBuildData {
 	uint32 probability;  ///< Relative probability of building this industry.
@@ -228,6 +233,8 @@ struct IndustryTypeBuildData {
 struct IndustryBuildData {
 	IndustryTypeBuildData builddata[NUM_INDUSTRYTYPES]; ///< Industry build data for every industry type.
 	uint32 wanted_inds; ///< Number of wanted industries (bits 31-16), and a fraction (bits 15-0).
+	uint16 industry_target[NUM_INDUSTRYTYPES]; ///< Target count for each industry type set during game start
+	uint32 total_population; ///< Population when starting game
 
 	void Reset();
 

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -772,7 +772,7 @@ public:
 		this->SetupArrays();
 
 		const IndustrySpec *indsp = (this->selected_type == INVALID_INDUSTRYTYPE) ? nullptr : GetIndustrySpec(this->selected_type);
-		if (indsp == nullptr) this->enabled[this->selected_index] = _settings_game.difficulty.industry_density != ID_FUND_ONLY;
+		if (indsp == nullptr) this->enabled[this->selected_index] = _settings_game.difficulty.industry_creation != ICR_FUND_ONLY;
 		this->SetButtons();
 		this->SetDirty();
 	}
@@ -1235,6 +1235,9 @@ static const NWidgetPart _nested_industry_directory_widgets[] = {
 				NWidget(WWT_PANEL, COLOUR_BROWN), SetResize(1, 0), EndContainer(),
 			EndContainer(),
 			NWidget(WWT_PANEL, COLOUR_BROWN, WID_ID_INDUSTRY_LIST), SetDataTip(0x0, STR_INDUSTRY_DIRECTORY_LIST_CAPTION), SetResize(1, 1), SetScrollbar(WID_ID_SCROLLBAR), EndContainer(),
+			NWidget(WWT_PANEL, COLOUR_BROWN),
+				NWidget(WWT_TEXT, COLOUR_BROWN, WID_ID_INDUSTRY_TOTAL), SetPadding(2, 0, 2, 2), SetMinimalTextLines(1, 0), SetFill(1, 0), SetResize(1, 0), SetDataTip(STR_INDUSTRY_TOTAL, STR_NULL),
+			EndContainer(),
 		EndContainer(),
 		NWidget(NWID_VERTICAL),
 			NWidget(NWID_VSCROLLBAR, COLOUR_BROWN, WID_ID_SCROLLBAR),
@@ -1648,6 +1651,10 @@ public:
 
 			case WID_ID_FILTER_BY_PROD_CARGO:
 				SetDParam(0, this->cargo_filter_texts[this->produced_cargo_filter_criteria]);
+				break;
+				
+			case WID_ID_INDUSTRY_TOTAL:
+				SetDParam(0, GetCurrentTotalNumberOfIndustries());
 				break;
 		}
 	}

--- a/src/lang/afrikaans.txt
+++ b/src/lang/afrikaans.txt
@@ -1060,7 +1060,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}verander
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maksimum no. mededingers: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Geen
-STR_FUNDING_ONLY                                                :Befondsing alleen
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Befondsing alleen
 STR_MINIMAL                                                     :Minimale
 STR_NUM_VERY_LOW                                                :Baie laag
 STR_NUM_LOW                                                     :Laag

--- a/src/lang/arabic_egypt.txt
+++ b/src/lang/arabic_egypt.txt
@@ -1059,7 +1059,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}غير �
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}العدد الاقصى للمتنافسين: {ORANGE}{COMMA}
 
 STR_NONE                                                        :بدون
-STR_FUNDING_ONLY                                                :التمويل فقط
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :التمويل فقط
 STR_MINIMAL                                                     :الادنى
 STR_NUM_VERY_LOW                                                :منخفض جدا
 STR_NUM_LOW                                                     :قليل

--- a/src/lang/basque.txt
+++ b/src/lang/basque.txt
@@ -1025,7 +1025,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Dibisa p
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Gehienezko arerio kopurua: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ezer ez
-STR_FUNDING_ONLY                                                :Finantzazioa bakarrik
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Finantzazioa bakarrik
 STR_MINIMAL                                                     :Gutxienekoa
 STR_NUM_VERY_LOW                                                :Oso baxua
 STR_NUM_LOW                                                     :Baxua

--- a/src/lang/belarusian.txt
+++ b/src/lang/belarusian.txt
@@ -1370,7 +1370,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Зьмя
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Максымальная колькасьць канкурэнтаў: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Няма
-STR_FUNDING_ONLY                                                :Будаваць самому
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Будаваць самому
 STR_MINIMAL                                                     :Мінімальнае
 STR_NUM_VERY_LOW                                                :Вельмі мала
 STR_NUM_LOW                                                     :Мала

--- a/src/lang/brazilian_portuguese.txt
+++ b/src/lang/brazilian_portuguese.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Alterar 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Número máximo de concorrentes: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nenhum
-STR_FUNDING_ONLY                                                :Apenas financiamento
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Apenas financiamento
 STR_MINIMAL                                                     :Mínimo
 STR_NUM_VERY_LOW                                                :Muito baixo
 STR_NUM_LOW                                                     :Baixo

--- a/src/lang/bulgarian.txt
+++ b/src/lang/bulgarian.txt
@@ -1035,7 +1035,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Пром
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Максимален брой конкуренти: {ORANGE}{COMMA}
 
 STR_NONE                                                        :николко
-STR_FUNDING_ONLY                                                :Единствено финансиране
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Единствено финансиране
 STR_MINIMAL                                                     :Минимален
 STR_NUM_VERY_LOW                                                :Mн. малко
 STR_NUM_LOW                                                     :малко

--- a/src/lang/catalan.txt
+++ b/src/lang/catalan.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Canvia e
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Nombre màxim de competidors: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Cap
-STR_FUNDING_ONLY                                                :Cap, excepte finançades
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Cap, excepte finançades
 STR_MINIMAL                                                     :Mínim
 STR_NUM_VERY_LOW                                                :Molt baix
 STR_NUM_LOW                                                     :Baix

--- a/src/lang/croatian.txt
+++ b/src/lang/croatian.txt
@@ -1163,7 +1163,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Promijen
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Najveći broj natjecatelja: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ništa
-STR_FUNDING_ONLY                                                :Samo financiranje
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Samo financiranje
 STR_MINIMAL                                                     :Najmanje
 STR_NUM_VERY_LOW                                                :Vrlo nisko
 STR_NUM_LOW                                                     :Nisko

--- a/src/lang/czech.txt
+++ b/src/lang/czech.txt
@@ -1183,7 +1183,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Změnit 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximální počet protivníků: {ORANGE}{COMMA}
 
 STR_NONE                                                        :žádný
-STR_FUNDING_ONLY                                                :Pouze dotace
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Pouze dotace
 STR_MINIMAL                                                     :Nejmenší
 STR_NUM_VERY_LOW                                                :velmi nízké
 STR_NUM_LOW                                                     :nízké

--- a/src/lang/danish.txt
+++ b/src/lang/danish.txt
@@ -1095,7 +1095,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Skift br
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maksimalt antal modstandere: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ingen
-STR_FUNDING_ONLY                                                :Kun finansiering
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Kun finansiering
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Meget lav
 STR_NUM_LOW                                                     :Lav

--- a/src/lang/dutch.txt
+++ b/src/lang/dutch.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Aangepas
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximaal aantal tegenstanders: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Geen
-STR_FUNDING_ONLY                                                :Alleen gefinancierd
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Alleen gefinancierd
 STR_MINIMAL                                                     :Minimaal
 STR_NUM_VERY_LOW                                                :Zeer laag
 STR_NUM_LOW                                                     :Laag

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1096,7 +1096,6 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Change c
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximum no. competitors: {ORANGE}{COMMA}
 
 STR_NONE                                                        :None
-STR_FUNDING_ONLY                                                :Funding only
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Very Low
 STR_NUM_LOW                                                     :Low
@@ -1104,6 +1103,15 @@ STR_NUM_NORMAL                                                  :Normal
 STR_NUM_HIGH                                                    :High
 STR_NUM_CUSTOM                                                  :Custom
 STR_NUM_CUSTOM_NUMBER                                           :Custom ({NUM})
+
+STR_INDUSTRY_CREATION_FUNDING_ONLY                              :Funding only
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Original behavior
+STR_INDUSTRY_CREATION_KEEP_COUNT                                :Maintain stable number
+STR_INDUSTRY_CREATION_ADAPT_POP                                 :Adapt the industry number to the overall population
+
+STR_INDUSTRY_CLOSURE_ORIGINAL_BEHAVIOR                          :Original behavior
+STR_INDUSTRY_CLOSURE_KEEP_UNSERVICED                            :Keep industries with no service record
+STR_INDUSTRY_CLOSURE_KEEP_NORATING                              :Keep industries linked to towns with no player rating
 
 STR_VARIETY_NONE                                                :None
 STR_VARIETY_VERY_LOW                                            :Very Low
@@ -1463,7 +1471,13 @@ STR_CONFIG_SETTING_TERRAIN_TYPE                                 :Terrain type: {
 STR_CONFIG_SETTING_TERRAIN_TYPE_HELPTEXT                        :(TerraGenesis only) Hilliness of the landscape
 
 STR_CONFIG_SETTING_INDUSTRY_DENSITY                             :Industry density: {STRING2}
-STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Set how many industries should be generated and what level should be maintained during the game
+STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Set how many industries should be generated during map creation
+
+STR_CONFIG_SETTING_INDUSTRY_CREATION                            :Industry creation: {STRING2}
+STR_CONFIG_SETTING_INDUSTRY_CREATION_HELPTEXT                   :Defines how industries can be created in game
+
+STR_CONFIG_SETTING_INDUSTRY_CLOSURE                             :Industry closure: {STRING2}
+STR_CONFIG_SETTING_INDUSTRY_CLOSURE_HELPTEXT                    :Defines when a industry can be closed in game
 
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Maximum distance from edge for Oil industries: {STRING2}
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limit for how far from the map border oil refineries and oil rigs can be constructed. On island maps this ensures they are near the coast. On maps larger than 256 tiles, this value is scaled up.
@@ -3140,6 +3154,7 @@ STR_MAPGEN_BY                                                   :{BLACK}*
 STR_MAPGEN_NUMBER_OF_TOWNS                                      :{BLACK}No. of towns:
 STR_MAPGEN_DATE                                                 :{BLACK}Date:
 STR_MAPGEN_NUMBER_OF_INDUSTRIES                                 :{BLACK}No. of industries:
+STR_MAPGEN_BEHAVIOR_OF_INDUSTRIES                               :{BLACK}Industry creation:
 STR_MAPGEN_HEIGHTMAP_HEIGHT                                     :{BLACK}Highest peak:
 STR_MAPGEN_HEIGHTMAP_HEIGHT_UP                                  :{BLACK}Increase the maximum height of highest peak on the map by one
 STR_MAPGEN_HEIGHTMAP_HEIGHT_DOWN                                :{BLACK}Decrease the maximum height of highest peak on the map by one
@@ -3736,6 +3751,7 @@ STR_INDUSTRY_DIRECTORY_ACCEPTED_CARGO_FILTER                    :{BLACK}Accepted
 STR_INDUSTRY_DIRECTORY_PRODUCED_CARGO_FILTER                    :{BLACK}Produced cargo: {SILVER}{STRING}
 STR_INDUSTRY_DIRECTORY_FILTER_ALL_TYPES                         :All cargo types
 STR_INDUSTRY_DIRECTORY_FILTER_NONE                              :None
+STR_INDUSTRY_TOTAL                                              :{BLACK}Industry total: {COMMA}
 
 # Industry view
 STR_INDUSTRY_VIEW_CAPTION                                       :{WHITE}{INDUSTRY}

--- a/src/lang/english_AU.txt
+++ b/src/lang/english_AU.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Change c
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximum no. competitors: {ORANGE}{COMMA}
 
 STR_NONE                                                        :None
-STR_FUNDING_ONLY                                                :Funding only
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Funding only
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Very Low
 STR_NUM_LOW                                                     :Low

--- a/src/lang/english_US.txt
+++ b/src/lang/english_US.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Change c
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximum no. competitors: {ORANGE}{COMMA}
 
 STR_NONE                                                        :None
-STR_FUNDING_ONLY                                                :Funding only
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Funding only
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Very Low
 STR_NUM_LOW                                                     :Low

--- a/src/lang/esperanto.txt
+++ b/src/lang/esperanto.txt
@@ -1014,7 +1014,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Ŝanĝi 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maksimumo da konkurantoj: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Neniom
-STR_FUNDING_ONLY                                                :Funduso sola
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Funduso sola
 STR_MINIMAL                                                     :Malgrandeto
 STR_NUM_VERY_LOW                                                :Tre Malalte
 STR_NUM_LOW                                                     :Malalte

--- a/src/lang/estonian.txt
+++ b/src/lang/estonian.txt
@@ -1144,7 +1144,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Muuda pe
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Vastaseid kuni: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Pole
-STR_FUNDING_ONLY                                                :Ainult rahastatud
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Ainult rahastatud
 STR_MINIMAL                                                     :Vähene
 STR_NUM_VERY_LOW                                                :Väga madal
 STR_NUM_LOW                                                     :Madal

--- a/src/lang/faroese.txt
+++ b/src/lang/faroese.txt
@@ -1001,7 +1001,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Broyt pa
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Hægsta tali av kappingarneytum: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Einki
-STR_FUNDING_ONLY                                                :Fíggjing einans
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Fíggjing einans
 STR_MINIMAL                                                     :Minst
 STR_NUM_VERY_LOW                                                :Sera lágt
 STR_NUM_LOW                                                     :Lágt

--- a/src/lang/finnish.txt
+++ b/src/lang/finnish.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Vaihda o
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Vastustajien enimmäismäärä: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ei mitään
-STR_FUNDING_ONLY                                                :Vain rahoitetut
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Vain rahoitetut
 STR_MINIMAL                                                     :Minimi
 STR_NUM_VERY_LOW                                                :Erittäin alhainen
 STR_NUM_LOW                                                     :Matala

--- a/src/lang/french.txt
+++ b/src/lang/french.txt
@@ -1097,7 +1097,6 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Changer 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Nombre maximal de concurrents{NBSP}: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Aucune
-STR_FUNDING_ONLY                                                :Financement uniquement
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Très bas
 STR_NUM_LOW                                                     :Bas
@@ -1105,6 +1104,15 @@ STR_NUM_NORMAL                                                  :Normal
 STR_NUM_HIGH                                                    :Élevé
 STR_NUM_CUSTOM                                                  :Personnalisé
 STR_NUM_CUSTOM_NUMBER                                           :Personnalisé ({NUM})
+
+STR_INDUSTRY_CREATION_FUNDING_ONLY                              :Financement uniquement
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Comportement d'origine
+STR_INDUSTRY_CREATION_KEEP_COUNT                                :Maintenir nombre de départ
+STR_INDUSTRY_CREATION_ADAPT_POP                                 :Adapte le nombre d'industres à la population totale
+
+STR_INDUSTRY_CLOSURE_ORIGINAL_BEHAVIOR                          :Comportement d'origine
+STR_INDUSTRY_CLOSURE_KEEP_UNSERVICED                            :Garder les industries jamais desservies
+STR_INDUSTRY_CLOSURE_KEEP_NORATING                              :Garder les industries liées à des villes sans joueur
 
 STR_VARIETY_NONE                                                :Aucune
 STR_VARIETY_VERY_LOW                                            :Très basse
@@ -1464,7 +1472,13 @@ STR_CONFIG_SETTING_TERRAIN_TYPE                                 :Type de terrain
 STR_CONFIG_SETTING_TERRAIN_TYPE_HELPTEXT                        :(TerraGenesis only) Vallonnement du paysage
 
 STR_CONFIG_SETTING_INDUSTRY_DENSITY                             :Densité des industries{NBSP}: {STRING}
-STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Définit combien d'industries doivent être générée et quel niveau doit être maintenu pendant la partie
+STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT                    :Définit combien d'industries doivent être générées lors de la création de la carte
+
+STR_CONFIG_SETTING_INDUSTRY_CREATION                            :Création des industries {STRING}
+STR_CONFIG_SETTING_INDUSTRY_CREATION_HELPTEXT                   :Définit la manière dont les industries sont créées pendant le jeu
+
+STR_CONFIG_SETTING_INDUSTRY_CLOSURE                             :Fermeture des industries: {STRING}
+STR_CONFIG_SETTING_INDUSTRY_CLOSURE_HELPTEXT                    :Définit quand les industries peuvent être supprimées en cours de jeu
 
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE                        :Distance maximum depuis les bords pour les industries pétrolières{NBSP}: {STRING}
 STR_CONFIG_SETTING_OIL_REF_EDGE_DISTANCE_HELPTEXT               :Limite de distance par rapport au bord de la carte où les raffineries et les plateformes pétrolières peuvent être construites. Sur les cartes d'îles cela assure qu'elles sont près de la côte. Sur les cartes plus large que 256 tuiles, cette valeur est mise à l'échelle.
@@ -2917,6 +2931,7 @@ STR_INDUSTRY_CARGOES_SELECT_CARGO                               :{BLACK}Selectio
 STR_INDUSTRY_CARGOES_SELECT_CARGO_TOOLTIP                       :{BLACK}Choisir la marchandise à afficher
 STR_INDUSTRY_CARGOES_SELECT_INDUSTRY                            :{BLACK}Sélectionner l'industrie
 STR_INDUSTRY_CARGOES_SELECT_INDUSTRY_TOOLTIP                    :{BLACK}Choisir l'industrie à afficher
+STR_INDUSTRY_TOTAL                                              :{BLACK}Nombre d'industries: {COMMA}
 
 # Land area window
 STR_LAND_AREA_INFORMATION_CAPTION                               :{WHITE}Informations sur le terrain
@@ -3141,6 +3156,7 @@ STR_MAPGEN_BY                                                   :{BLACK}{NBSP}×
 STR_MAPGEN_NUMBER_OF_TOWNS                                      :{BLACK}Nb. de villes{NBSP}:
 STR_MAPGEN_DATE                                                 :{BLACK}Date{NBSP}:
 STR_MAPGEN_NUMBER_OF_INDUSTRIES                                 :{BLACK}Nb. d'industries{NBSP}:
+STR_MAPGEN_BEHAVIOR_OF_INDUSTRIES                               :{BLACK}Creation des industries:
 STR_MAPGEN_HEIGHTMAP_HEIGHT                                     :{BLACK}Sommet le plus élevé:
 STR_MAPGEN_HEIGHTMAP_HEIGHT_UP                                  :{BLACK}Augmenter la hauteur maximale du plus haut sommet de la carte de un
 STR_MAPGEN_HEIGHTMAP_HEIGHT_DOWN                                :{BLACK}Diminuer la hauteur maximale du plus haut sommet de la carte de un

--- a/src/lang/frisian.txt
+++ b/src/lang/frisian.txt
@@ -1034,7 +1034,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Feroarje
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maksimum oantal tsjinstanners: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Gjin
-STR_FUNDING_ONLY                                                :Allinnich finansierje
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Allinnich finansierje
 STR_MINIMAL                                                     :Minimaal
 STR_NUM_VERY_LOW                                                :Hiel leech
 STR_NUM_LOW                                                     :Leech

--- a/src/lang/gaelic.txt
+++ b/src/lang/gaelic.txt
@@ -1240,7 +1240,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Atharrai
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Àireamh as motha dhe cho-fharpaisich: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Chan eil gin
-STR_FUNDING_ONLY                                                :Le maoineachadh a-mhàin
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Le maoineachadh a-mhàin
 STR_MINIMAL                                                     :As lugha
 STR_NUM_VERY_LOW                                                :Gann
 STR_NUM_LOW                                                     :Beagan dhiubh

--- a/src/lang/galician.txt
+++ b/src/lang/galician.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Cambiar 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Nº máximo de opoñentes: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ningún
-STR_FUNDING_ONLY                                                :Só fundadas
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Só fundadas
 STR_MINIMAL                                                     :Mínimo
 STR_NUM_VERY_LOW                                                :Moi baixo
 STR_NUM_LOW                                                     :Baixo

--- a/src/lang/german.txt
+++ b/src/lang/german.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Paramete
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Max. Mitbewerber-Zahl: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Keine
-STR_FUNDING_ONLY                                                :Nur durch Spieler
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Nur durch Spieler
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Sehr niedrig
 STR_NUM_LOW                                                     :Niedrig

--- a/src/lang/greek.txt
+++ b/src/lang/greek.txt
@@ -1202,7 +1202,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Αλλα
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Μέγιστος αρ. ανταγωνιστών: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Κανένα
-STR_FUNDING_ONLY                                                :Χρηματοδότηση μονο
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Χρηματοδότηση μονο
 STR_MINIMAL                                                     :Ελάχιστο
 STR_NUM_VERY_LOW                                                :Πολύ χαμηλό
 STR_NUM_LOW                                                     :Χαμηλό

--- a/src/lang/hebrew.txt
+++ b/src/lang/hebrew.txt
@@ -1054,7 +1054,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}שנה �
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{ORANGE}{COMMA}{LTBLUE} : מספר מתחרים מירבי
 
 STR_NONE                                                        :ללא
-STR_FUNDING_ONLY                                                :מימון בלבד
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :מימון בלבד
 STR_MINIMAL                                                     :מזערי
 STR_NUM_VERY_LOW                                                :נמוך מאוד
 STR_NUM_LOW                                                     :נמוך

--- a/src/lang/hungarian.txt
+++ b/src/lang/hungarian.txt
@@ -1160,7 +1160,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}A saját
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Ellenfelek száma legfeljebb: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Semmi
-STR_FUNDING_ONLY                                                :Csak finanszírozás
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Csak finanszírozás
 STR_MINIMAL                                                     :Minimális
 STR_NUM_VERY_LOW                                                :Nagyon kevés
 STR_NUM_LOW                                                     :Kevés

--- a/src/lang/icelandic.txt
+++ b/src/lang/icelandic.txt
@@ -1000,7 +1000,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Breyta s
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Hámarksfjöldi keppinauta: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Engin
-STR_FUNDING_ONLY                                                :Með fjármögnun
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Með fjármögnun
 STR_MINIMAL                                                     :Lágmark
 STR_NUM_VERY_LOW                                                :Mjög Lágt
 STR_NUM_LOW                                                     :Fáir

--- a/src/lang/indonesian.txt
+++ b/src/lang/indonesian.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Ubah sen
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Jumlah pesaing maksimal: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Tidak ada
-STR_FUNDING_ONLY                                                :Hanya pendanaan
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Hanya pendanaan
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Sangat Sedikit
 STR_NUM_LOW                                                     :Sedikit

--- a/src/lang/irish.txt
+++ b/src/lang/irish.txt
@@ -1095,7 +1095,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Athraigh
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Uaslíon na n-iomaitheoirí: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ceann ar bith
-STR_FUNDING_ONLY                                                :Maoiniú amháin
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Maoiniú amháin
 STR_MINIMAL                                                     :Íosmhéid
 STR_NUM_VERY_LOW                                                :An íseal
 STR_NUM_LOW                                                     :Íseal

--- a/src/lang/italian.txt
+++ b/src/lang/italian.txt
@@ -1098,7 +1098,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Cambia i
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Numero massimo di avversari: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nessuno
-STR_FUNDING_ONLY                                                :Solo finanziate
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Solo finanziate
 STR_MINIMAL                                                     :Minimo
 STR_MINIMAL.mp                                                  :Minimi
 STR_MINIMAL.fs                                                  :Minima

--- a/src/lang/japanese.txt
+++ b/src/lang/japanese.txt
@@ -1095,7 +1095,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}カス�
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}最大競争会社数: {ORANGE}{COMMA}
 
 STR_NONE                                                        :なし
-STR_FUNDING_ONLY                                                :出資のみ
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :出資のみ
 STR_MINIMAL                                                     :最小
 STR_NUM_VERY_LOW                                                :特に低い
 STR_NUM_LOW                                                     :低い

--- a/src/lang/korean.txt
+++ b/src/lang/korean.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}사용�
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}최대 경쟁자수: {ORANGE}{COMMA}
 
 STR_NONE                                                        :없음
-STR_FUNDING_ONLY                                                :투자만 가능
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :투자만 가능
 STR_MINIMAL                                                     :최소
 STR_NUM_VERY_LOW                                                :매우 적음
 STR_NUM_LOW                                                     :낮음

--- a/src/lang/latin.txt
+++ b/src/lang/latin.txt
@@ -1237,7 +1237,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Mutare p
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Numerus competitorum maximus: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nullae
-STR_FUNDING_ONLY                                                :Modo conditu
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Modo conditu
 STR_MINIMAL                                                     :Minimus
 STR_NUM_VERY_LOW                                                :Minor
 STR_NUM_LOW                                                     :Parvus

--- a/src/lang/latvian.txt
+++ b/src/lang/latvian.txt
@@ -1098,7 +1098,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Mainīt 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maksimālais sāncenšu daudzums: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nav
-STR_FUNDING_ONLY                                                :Tikai līdzekļu piešķiršana
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Tikai līdzekļu piešķiršana
 STR_MINIMAL                                                     :Minimāls
 STR_NUM_VERY_LOW                                                :Ļoti zems
 STR_NUM_LOW                                                     :Zems

--- a/src/lang/lithuanian.txt
+++ b/src/lang/lithuanian.txt
@@ -1296,7 +1296,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Keisti p
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Didžiausias priešininkų skaičius: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nėra
-STR_FUNDING_ONLY                                                :Tik finansavimas
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Tik finansavimas
 STR_MINIMAL                                                     :Mažiausias
 STR_NUM_VERY_LOW                                                :Labai mažas
 STR_NUM_LOW                                                     :Žemas

--- a/src/lang/luxembourgish.txt
+++ b/src/lang/luxembourgish.txt
@@ -1095,7 +1095,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Änner W
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximal Unzuel vu Géigner: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Keng
-STR_FUNDING_ONLY                                                :Nëmmen finanzéiren
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Nëmmen finanzéiren
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Ganz niddreg
 STR_NUM_LOW                                                     :Wéineg

--- a/src/lang/malay.txt
+++ b/src/lang/malay.txt
@@ -1010,7 +1010,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Tukar pa
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Jumlah maksimum pesaing: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Tiada
-STR_FUNDING_ONLY                                                :Melalui pembiayaan sahaja
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Melalui pembiayaan sahaja
 STR_MINIMAL                                                     :Minimum
 STR_NUM_VERY_LOW                                                :Sangat Rendah
 STR_NUM_LOW                                                     :Rendah

--- a/src/lang/norwegian_bokmal.txt
+++ b/src/lang/norwegian_bokmal.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Endre eg
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maks antall motstandere: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ingen
-STR_FUNDING_ONLY                                                :Kun finansiering
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Kun finansiering
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Veldig lavt
 STR_NUM_LOW                                                     :Lavt

--- a/src/lang/norwegian_nynorsk.txt
+++ b/src/lang/norwegian_nynorsk.txt
@@ -1037,7 +1037,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Byt eige
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maks. antal konkurrentar: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ingen
-STR_FUNDING_ONLY                                                :Kun finansiering
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Kun finansiering
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Særs lågt
 STR_NUM_LOW                                                     :Lite

--- a/src/lang/persian.txt
+++ b/src/lang/persian.txt
@@ -1023,7 +1023,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}تغیی
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}حد اکثر تعداد رقبا :{ORANGE}{COMMA}
 
 STR_NONE                                                        :هیچکدام
-STR_FUNDING_ONLY                                                :فقط سرمایه گذاری
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :فقط سرمایه گذاری
 STR_MINIMAL                                                     :کمینه
 STR_NUM_VERY_LOW                                                :خیلی کم
 STR_NUM_LOW                                                     :کم

--- a/src/lang/polish.txt
+++ b/src/lang/polish.txt
@@ -1476,7 +1476,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Zmień p
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maksymalna liczba przeciwników: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Brak
-STR_FUNDING_ONLY                                                :Tylko sponsorowanie
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Tylko sponsorowanie
 STR_MINIMAL                                                     :Minimum
 STR_NUM_VERY_LOW                                                :Bardzo mało
 STR_NUM_LOW                                                     :Mało

--- a/src/lang/portuguese.txt
+++ b/src/lang/portuguese.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Mudar pa
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Número máximo de oponentes: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nenhum
-STR_FUNDING_ONLY                                                :Financiamento apenas
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Financiamento apenas
 STR_MINIMAL                                                     :Mínimo
 STR_NUM_VERY_LOW                                                :Muito Baixo
 STR_NUM_LOW                                                     :Baixo

--- a/src/lang/romanian.txt
+++ b/src/lang/romanian.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Schimbă
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Numărul maxim de companii concurente: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nimic
-STR_FUNDING_ONLY                                                :Doar finanțare
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Doar finanțare
 STR_MINIMAL                                                     :Minim
 STR_NUM_VERY_LOW                                                :Foarte scăzut
 STR_NUM_LOW                                                     :Scăzut

--- a/src/lang/russian.txt
+++ b/src/lang/russian.txt
@@ -1241,7 +1241,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Изме
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Максимальное количество конкурентов: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Нет
-STR_FUNDING_ONLY                                                :Строить самому
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Строить самому
 STR_MINIMAL                                                     :Минимальное
 STR_NUM_VERY_LOW                                                :Очень малое
 STR_NUM_LOW                                                     :Малое

--- a/src/lang/serbian.txt
+++ b/src/lang/serbian.txt
@@ -1290,7 +1290,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Promena 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Najveći broj suparnika: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Nijedan
-STR_FUNDING_ONLY                                                :Samo finansiranje
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Samo finansiranje
 STR_MINIMAL                                                     :Najmanji
 STR_NUM_VERY_LOW                                                :Veoma mali
 STR_NUM_LOW                                                     :Mali

--- a/src/lang/simplified_chinese.txt
+++ b/src/lang/simplified_chinese.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}改变�
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}最大竞争对手个数：{ORANGE}{COMMA}
 
 STR_NONE                                                        :没有
-STR_FUNDING_ONLY                                                :不生成
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :不生成
 STR_MINIMAL                                                     :每种仅一个
 STR_NUM_VERY_LOW                                                :非常低
 STR_NUM_LOW                                                     :低

--- a/src/lang/slovak.txt
+++ b/src/lang/slovak.txt
@@ -1163,7 +1163,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Zmeniť 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Maximálny počet konkurentov: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Žiadny
-STR_FUNDING_ONLY                                                :Iba financovanie
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Iba financovanie
 STR_MINIMAL                                                     :Minimálny
 STR_NUM_VERY_LOW                                                :Veľmi nízky
 STR_NUM_LOW                                                     :Nízky

--- a/src/lang/slovenian.txt
+++ b/src/lang/slovenian.txt
@@ -1193,7 +1193,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Zamenjaj
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Največje število tekmecev: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Brez
-STR_FUNDING_ONLY                                                :Samo financiranje
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Samo financiranje
 STR_MINIMAL                                                     :Minimalno
 STR_NUM_VERY_LOW                                                :Zelo malo
 STR_NUM_LOW                                                     :Malo

--- a/src/lang/spanish.txt
+++ b/src/lang/spanish.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Cambiar 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Núm. máximo de jugadores: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ninguno
-STR_FUNDING_ONLY                                                :Solo fundadas
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Solo fundadas
 STR_MINIMAL                                                     :Mínimo
 STR_NUM_VERY_LOW                                                :Muy Bajo
 STR_NUM_LOW                                                     :Bajo

--- a/src/lang/spanish_MX.txt
+++ b/src/lang/spanish_MX.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Cambiar 
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Núm. máximo de jugadores: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ninguno
-STR_FUNDING_ONLY                                                :Solo fundadas
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Solo fundadas
 STR_MINIMAL                                                     :Mínimo
 STR_NUM_VERY_LOW                                                :Muy bajo
 STR_NUM_LOW                                                     :Bajo

--- a/src/lang/swedish.txt
+++ b/src/lang/swedish.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Ändra v
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Max antal motståndare: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Ingen
-STR_FUNDING_ONLY                                                :Endast finansiering
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Endast finansiering
 STR_MINIMAL                                                     :Minimal
 STR_NUM_VERY_LOW                                                :Väldigt låg
 STR_NUM_LOW                                                     :Låg

--- a/src/lang/tamil.txt
+++ b/src/lang/tamil.txt
@@ -1053,7 +1053,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}பய�
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}அதிகபட்ச போட்டியாளர்கள்: {ORANGE}{COMMA}
 
 STR_NONE                                                        :ஒன்றுமில்லை
-STR_FUNDING_ONLY                                                :நிதியளிப்பு மட்டும்
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :நிதியளிப்பு மட்டும்
 STR_MINIMAL                                                     :குறைந்தபட்சம்
 STR_NUM_VERY_LOW                                                :மிகவும் குறைவு
 STR_NUM_LOW                                                     :குறைவு

--- a/src/lang/thai.txt
+++ b/src/lang/thai.txt
@@ -1054,7 +1054,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}เป�
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}จำนวนผู้ร่วมแข่งขันสูงสุด: {ORANGE}{COMMA}
 
 STR_NONE                                                        :ไม่มี
-STR_FUNDING_ONLY                                                :ระดมทุนเท่านั้น
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :ระดมทุนเท่านั้น
 STR_MINIMAL                                                     :ขั้นต่ำ
 STR_NUM_VERY_LOW                                                :ต่ำมาก
 STR_NUM_LOW                                                     :ต่ำ

--- a/src/lang/traditional_chinese.txt
+++ b/src/lang/traditional_chinese.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}修改�
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}競爭對手數目上限：{ORANGE}{COMMA}
 
 STR_NONE                                                        :無
-STR_FUNDING_ONLY                                                :只挹注資金
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :只挹注資金
 STR_MINIMAL                                                     :最小
 STR_NUM_VERY_LOW                                                :非常少
 STR_NUM_LOW                                                     :低

--- a/src/lang/turkish.txt
+++ b/src/lang/turkish.txt
@@ -1097,7 +1097,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Özel pa
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}En fazla rakip: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Hiç
-STR_FUNDING_ONLY                                                :Yalnızca yatırım
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Yalnızca yatırım
 STR_MINIMAL                                                     :En düşük
 STR_NUM_VERY_LOW                                                :Çok Az
 STR_NUM_LOW                                                     :Düşük

--- a/src/lang/ukrainian.txt
+++ b/src/lang/ukrainian.txt
@@ -1223,7 +1223,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Нала
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Кількість конкурентів: {ORANGE}{COMMA}
 
 STR_NONE                                                        :нема
-STR_FUNDING_ONLY                                                :засновувати власноруч
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :засновувати власноруч
 STR_MINIMAL                                                     :мінімально
 STR_NUM_VERY_LOW                                                :дуже мало
 STR_NUM_LOW                                                     :мало

--- a/src/lang/urdu.txt
+++ b/src/lang/urdu.txt
@@ -996,7 +996,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}اپنی
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}مدمقابلوں کی زیادہ سے زیادہ تعداد: {ORANGE}{COMMA}
 
 STR_NONE                                                        :کوئی نہیں
-STR_FUNDING_ONLY                                                :صرف فنڈنگ
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :صرف فنڈنگ
 STR_MINIMAL                                                     :کم از کم
 STR_NUM_VERY_LOW                                                :بہت نیچا
 STR_NUM_LOW                                                     :نیچا

--- a/src/lang/vietnamese.txt
+++ b/src/lang/vietnamese.txt
@@ -1096,7 +1096,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Sửa th
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Số đối thủ cạnh tranh tối đa: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Không Có
-STR_FUNDING_ONLY                                                :Chỉ Cấp Vốn
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Chỉ Cấp Vốn
 STR_MINIMAL                                                     :Tối Thiểu
 STR_NUM_VERY_LOW                                                :Ít Nhất
 STR_NUM_LOW                                                     :Ít

--- a/src/lang/welsh.txt
+++ b/src/lang/welsh.txt
@@ -1039,7 +1039,7 @@ STR_CURRENCY_CHANGE_PARAMETER                                   :{BLACK}Newid pa
 STR_DIFFICULTY_LEVEL_SETTING_MAXIMUM_NO_COMPETITORS             :{LTBLUE}Uchafswm nifer y cystadleuwyr: {ORANGE}{COMMA}
 
 STR_NONE                                                        :Dim
-STR_FUNDING_ONLY                                                :Ariannu'n unig
+STR_INDUSTRY_CREATION_ORIGINAL_BEHAVIOR                         :Ariannu'n unig
 STR_MINIMAL                                                     :Lleiafsymol
 STR_NUM_VERY_LOW                                                :Isel Iawn
 STR_NUM_LOW                                                     :Isel

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3148,6 +3148,19 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_INDUSTRY_CREATION)) {
+		//set industry creation if previous save was using ID_FUND_ONLY
+		//no need to change industry_density as it doesn't have any effect on the current game.
+		if (_settings_game.difficulty.industry_density == 0) { // previously ID_FUND_ONLY, equal to 0
+			_settings_game.difficulty.industry_creation = ICR_FUND_ONLY;
+		}
+		else {
+			_settings_game.difficulty.industry_creation = ICR_ORIGINAL;
+		}
+
+        _settings_game.difficulty.industry_closure = ICL_ORIGINAL;
+	}
+
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3158,8 +3158,15 @@ bool AfterLoadGame()
 			_settings_game.difficulty.industry_creation = ICR_ORIGINAL;
 		}
 
-        _settings_game.difficulty.industry_closure = ICL_ORIGINAL;
+		_settings_game.difficulty.industry_closure = ICL_ORIGINAL;
+
+		//set if no value loaded, to allow switching to new settings with old save
+		for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
+			if (_industry_builder.industry_target[it] == 0 ) _industry_builder.industry_target[it] = Industry::GetIndustryTypeCount(it);
+		}
+		if (_industry_builder.total_population == 0) _industry_builder.total_population = GetWorldPopulation();
 	}
+
 
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();

--- a/src/saveload/compat/industry_sl_compat.h
+++ b/src/saveload/compat/industry_sl_compat.h
@@ -58,6 +58,8 @@ const SaveLoadCompat _industry_sl_compat[] = {
 /** Original field order for _industry_builder_desc. */
 const SaveLoadCompat _industry_builder_sl_compat[] = {
 	SLC_VAR("wanted_inds"),
+	SLC_VAR("industry_target"),
+    SLC_VAR("total_population"),
 };
 
 /** Original field order for _industrytype_builder_desc. */

--- a/src/saveload/compat/industry_sl_compat.h
+++ b/src/saveload/compat/industry_sl_compat.h
@@ -58,8 +58,6 @@ const SaveLoadCompat _industry_sl_compat[] = {
 /** Original field order for _industry_builder_desc. */
 const SaveLoadCompat _industry_builder_sl_compat[] = {
 	SLC_VAR("wanted_inds"),
-	SLC_VAR("industry_target"),
-    SLC_VAR("total_population"),
 };
 
 /** Original field order for _industrytype_builder_desc. */

--- a/src/saveload/compat/settings_sl_compat.h
+++ b/src/saveload/compat/settings_sl_compat.h
@@ -31,7 +31,6 @@ const SaveLoadCompat _settings_sl_compat[] = {
 	SLC_VAR("difficulty.max_no_competitors"),
 	SLC_NULL(1, SLV_97, SLV_110),
 	SLC_VAR("difficulty.number_towns"),
-	SLC_VAR("difficulty.industry_density"),
 	SLC_VAR("difficulty.max_loan"),
 	SLC_VAR("difficulty.initial_interest"),
 	SLC_VAR("difficulty.vehicle_costs"),

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -13,8 +13,10 @@
 #include "compat/industry_sl_compat.h"
 
 #include "../industry.h"
+#include "../town.h"
 #include "newgrf_sl.h"
 
+#include "../debug.h"
 #include "../safeguards.h"
 
 static OldPersistentStorage _old_ind_persistent_storage;
@@ -141,10 +143,12 @@ struct IBLDChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		if (_game_mode == GM_EDITOR) {
-			/// udpate industry count to save correct values.
+			/// udpate industry count and world population to save correct values.
 			for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
 				_industry_builder.industry_target[it] = Industry::GetIndustryTypeCount(it);
 			}
+
+			_industry_builder.total_population = GetWorldPopulation();
 		}
 
 		SlTableHeader(_industry_builder_desc);

--- a/src/saveload/industry_sl.cpp
+++ b/src/saveload/industry_sl.cpp
@@ -130,6 +130,8 @@ struct TIDSChunkHandler : NewGRFMappingChunkHandler {
 /** Description of the data to save and load in #IndustryBuildData. */
 static const SaveLoad _industry_builder_desc[] = {
 	SLEG_VAR("wanted_inds", _industry_builder.wanted_inds, SLE_UINT32),
+	SLEG_ARR("industry_target", _industry_builder.industry_target, SLE_UINT16),
+	SLEG_VAR("total_population", _industry_builder.total_population, SLE_UINT32)
 };
 
 /** Industry builder. */
@@ -138,6 +140,13 @@ struct IBLDChunkHandler : ChunkHandler {
 
 	void Save() const override
 	{
+		if (_game_mode == GM_EDITOR) {
+			/// udpate industry count to save correct values.
+			for (IndustryType it = 0; it < NUM_INDUSTRYTYPES; it++) {
+				_industry_builder.industry_target[it] = Industry::GetIndustryTypeCount(it);
+			}
+		}
+
 		SlTableHeader(_industry_builder_desc);
 
 		SlSetArrayIndex(0);

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -341,6 +341,8 @@ enum SaveLoadVersion : uint16 {
 	SLV_DOCK_DOCKINGTILES,                  ///< 298  PR#9578 All tiles around docks may be docking tiles.
 	SLV_REPAIR_OBJECT_DOCKING_TILES,        ///< 299  PR#9594 v12.0  Fixing issue with docking tiles overlapping objects.
 	SLV_U64_TICK_COUNTER,                   ///< 300  PR#10035 Make _tick_counter 64bit to avoid wrapping.
+	SLV_INDUSTRY_CREATION,					///< 301  New option to control industry creation
+	SLV_INDUSTRY_CLOSURE,					///< 302  New option to control industry closure
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1812,6 +1812,8 @@ static SettingsContainer &GetSettingsTree()
 				industries->Add(new SettingEntry("economy.multiple_industry_per_town"));
 				industries->Add(new SettingEntry("game_creation.oil_refinery_limit"));
 				industries->Add(new SettingEntry("economy.type"));
+				industries->Add(new SettingEntry("difficulty.industry_creation"));
+				industries->Add(new SettingEntry("difficulty.industry_closure"));
 				industries->Add(new SettingEntry("station.serve_neutral_industries"));
 			}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -51,7 +51,6 @@ enum SettingsProfile {
 
 /** Available industry map generation densities. */
 enum IndustryDensity {
-	ID_FUND_ONLY, ///< The game does not build industries.
 	ID_MINIMAL,   ///< Start with just the industries that must be present.
 	ID_VERY_LOW,  ///< Very few industries at game start.
 	ID_LOW,       ///< Few industries at game start.
@@ -59,6 +58,25 @@ enum IndustryDensity {
 	ID_HIGH,      ///< Many industries at game start.
 
 	ID_END,       ///< Number of industry density settings.
+};
+
+/** In game industry creation behavior */
+enum IndustryCreation {
+	ICR_FUND_ONLY, 	///< The game does not build industries.
+	ICR_ORIGINAL,	///< Original game behavior
+	ICR_KEEP_COUNT,	///< Sticks to the number of industries at map creation. By type. With small variations.
+	ICR_ADAPT_POP,	///< Adapts the amount of industries to the population on the map
+
+	ICR_END			///< Number of industry creation settings.
+};
+
+/** In game industry closure behavior */
+enum IndustryClosure {
+	ICL_ORIGINAL,	///< Original game behavior
+	ICL_UNSERVICED,	///< Never remove unservided industries
+	ICL_NO_RATINGS,	///< Never remove an instry whose town never had player ratings
+
+	ICL_END			///< Number of industry closure settings.
 };
 
 /** Possible values for "userelayservice" setting. */
@@ -76,6 +94,8 @@ struct DifficultySettings {
 	byte   max_no_competitors;               ///< the number of competitors (AIs)
 	byte   number_towns;                     ///< the amount of towns
 	byte   industry_density;                 ///< The industry density. @see IndustryDensity
+	byte   industry_creation;                ///< The industry creation behavior. @see IndustryCreation
+	byte   industry_closure;                 ///< The industry closure behavior. @see IndustryCreation
 	uint32 max_loan;                         ///< the maximum initial loan
 	byte   initial_interest;                 ///< amount of interest (to pay over the loan)
 	byte   vehicle_costs;                    ///< amount of money spent on vehicle running cost

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -89,8 +89,35 @@ max      = ID_END - 1
 interval = 1
 str      = STR_CONFIG_SETTING_INDUSTRY_DENSITY
 strhelp  = STR_CONFIG_SETTING_INDUSTRY_DENSITY_HELPTEXT
-strval   = STR_FUNDING_ONLY
+strval   = STR_MINIMAL
 cat      = SC_BASIC
+
+[SDT_VAR]
+var      = difficulty.industry_creation
+type     = SLE_UINT8
+from     = SLV_INDUSTRY_CREATION
+flags    = SF_GUI_DROPDOWN
+def      = 1
+min      = 0
+max      = ICR_END - 1
+interval = 1
+str      = STR_CONFIG_SETTING_INDUSTRY_CREATION
+strhelp  = STR_CONFIG_SETTING_INDUSTRY_CREATION_HELPTEXT
+strval   = STR_INDUSTRY_CREATION_FUNDING_ONLY
+cat      = SC_BASIC
+
+[SDT_VAR]
+var      = difficulty.industry_closure
+type     = SLE_UINT8
+from     = SLV_INDUSTRY_CLOSURE
+flags    = SF_GUI_DROPDOWN
+def      = 0
+min      = 0
+max      = ICL_END - 1
+interval = 1
+str      = STR_CONFIG_SETTING_INDUSTRY_CLOSURE
+strhelp  = STR_CONFIG_SETTING_INDUSTRY_CLOSURE_HELPTEXT
+strval   = STR_INDUSTRY_CLOSURE_ORIGINAL_BEHAVIOR
 
 [SDT_VAR]
 var      = difficulty.max_loan

--- a/src/widgets/genworld_widget.h
+++ b/src/widgets/genworld_widget.h
@@ -22,7 +22,8 @@ enum GenerateLandscapeWidgets {
 
 	WID_GL_TOWN_PULLDOWN,               ///< Dropdown 'No. of towns'.
 	WID_GL_TOWNNAME_DROPDOWN,           ///< Dropdown 'Townnames'.
-	WID_GL_INDUSTRY_PULLDOWN,           ///< Dropdown 'No. of industries'.
+	WID_GL_INDUSTRY_DENSITY_PULLDOWN,   ///< Dropdown 'No. of industries'.
+	WID_GL_INDUSTRY_CREATION_PULLDOWN,  ///< Dropdown 'Industries creation behavior'.
 
 	WID_GL_GENERATE_BUTTON,             ///< 'Generate' button.
 

--- a/src/widgets/industry_widget.h
+++ b/src/widgets/industry_widget.h
@@ -39,6 +39,7 @@ enum IndustryDirectoryWidgets {
 	WID_ID_FILTER_BY_PROD_CARGO, ///< Produced cargo filter dropdown list.
 	WID_ID_INDUSTRY_LIST,        ///< Industry list.
 	WID_ID_SCROLLBAR,            ///< Scrollbar of the list.
+	WID_ID_INDUSTRY_TOTAL		 ///< Total Number of industries in the map
 };
 
 /** Widgets of the #IndustryCargoesWindow class */


### PR DESCRIPTION
## Motivation / Problem

This branch brings two new options in the game: "Industry creation behavior" and "Industry Closure Behavior", to better manage industry creations (default behavior is always increasing the number of industries until the map is full), and industry closures (prevent unserviced industries from closing)


## Description

Subject was discussed here: https://www.tt-forums.net/viewtopic.php?t=90314
The branch adds a new "Industry creation" parameter, with four options: Original/Keep stable count/ Adapt to population / Funding Only. (the latter disappearing from industry density, which becomes a map generation option only)
The other parameter, "industry closure", allows the player to prevent an industry from closing if Unserviced or Linked to a town without player ratings.
Also, industries with an active subsidies won't close.


## Limitations

I have tested with several tests cases (new game, load old save, load scenario), no pitfall.
Untested with newgrf industries.


## Checklist for review

Save is impacted. New save version has been added, with compatibility in afterload.
Translation files are altered. I have modified english.txt and also done french for the new string I added. Since I have changed the FUNDING_ONLY choice, moving from industry_density to industry_creation, I have modified all language files to reflect the change.

