### PR TITLE
Block unsafe use of SetDParamStr

### DIFF
--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -203,6 +203,7 @@ void SetDParamMaxDigits(uint n, uint count, FontSize size = FS_NORMAL);
 
 void SetDParamStr(uint n, const char *str);
 void SetDParamStr(uint n, const std::string &str);
+void SetDParamStr(uint n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
 
 void CopyInDParam(int offs, const uint64 *src, int num);
 void CopyOutDParam(uint64 *dst, int offs, int num);


### PR DESCRIPTION
## Motivation / Problem

#10130 fixes a single case of incorrect usage of SetDParamStr.

## Description

This PR deletes the problematic overload/implicit conversion, so issues like #10130 no longer compile:

GCC and derivates:
```
src/settings.cpp: In function ‘GRFConfig* GRFLoadConfig(IniFile&, const char*, bool)’:
src/settings.cpp:1019:62: error: use of deleted function ‘void SetDParamStr(uint, std::string&&)’
 1019 |    SetDParamStr(0, StrEmpty(filename) ? item->name : filename);
      |                                                              ^
In file included from src/ai/../script/../textfile_gui.h:14,
                 from src/ai/../script/script_config.hpp:18,
                 from src/ai/ai_config.hpp:13,
                 from src/settings.cpp:42:
src/ai/../script/../strings_func.h:206:6: note: declared here
  206 | void SetDParamStr(uint n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
      |      ^~~~~~~~~~~~
```

Clang and derivates:
```
Error: src/settings.cpp:1019:4: error: call to deleted function 'SetDParamStr'
                          SetDParamStr(0, StrEmpty(filename) ? item->name : filename);
                          ^~~~~~~~~~~~
  src/strings_func.h:206:6: note: candidate function has been explicitly deleted
  void SetDParamStr(uint n, std::string &&str) = delete; // block passing temporaries to SetDParamStr
       ^
  src/strings_func.h:205:6: note: candidate function
  void SetDParamStr(uint n, const std::string &str);
       ^
  src/strings_func.h:204:6: note: candidate function not viable: no known conversion from 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>') to 'const char *' for 2nd argument
  void SetDParamStr(uint n, const char *str);
       ^
```


MSVC
```
  Error: src\settings.cpp(1019): error C2280: 'void SetDParamStr(uint,std::string &&)': attempting to reference a deleted function
  src\strings_func.h(206): note: see declaration of 'SetDParamStr'
  src\strings_func.h(206): note: 'void SetDParamStr(uint,std::string &&)': function was explicitly deleted
```


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
