### PR TITLE
Codechange: Use std::vector for station speclist

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -62,8 +62,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	Owner owner;                    ///< The owner of this station
 	StationFacility facilities;     ///< The facilities that this station has
 
-	uint8 num_specs;                ///< Number of specs in the speclist
-	StationSpecList *speclist;      ///< List of station specs of this station
+	std::vector<StationSpecList> speclist; ///< List of rail station specs of this station.
 
 	Date build_date;                ///< Date of construction
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -51,8 +51,6 @@ void RebuildStationKdtree()
 
 BaseStation::~BaseStation()
 {
-	free(this->speclist);
-
 	if (CleaningPool()) return;
 
 	CloseWindowById(WC_TRAINS_LIST,   VehicleListIdentifier(VL_STATION_LIST, VEH_TRAIN,    this->owner, this->index).Pack());
@@ -227,7 +225,7 @@ void Station::MarkTilesDirty(bool cargo_change) const
 		/* Don't waste time updating if there are no custom station graphics
 		 * that might change. Even if there are custom graphics, they might
 		 * not change. Unfortunately we have no way of telling. */
-		if (this->num_specs == 0) return;
+		if (this->speclist.size() == 0) return;
 	}
 
 	for (h = 0; h < train_station.h; h++) {


### PR DESCRIPTION
## Motivation / Problem

Station `speclist` is a manually allocated array with separate variable for size. Who even does manual memory management now?

## Description

Use `std::vector` for `speclist`. This removes manual memory allocation and separate size variable, although we still manage the list size in roughly the same way.

Saveload now requires a temporary variable between loading the station and loading the speclist, this is held inside the `SlStationSpecList` class to avoid more global variables.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
