### PR TITLE
Fix #10140: [SDL2] Lock mouse while moving viewport

### DIFF
--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -88,6 +88,9 @@ private:
 	bool edit_box_focused;
 
 	int startup_display;
+
+	/** linked SDL library version - for backward compatibility workarounds */
+	int sdl_lib_major, sdl_lib_minor;
 };
 
 #endif /* VIDEO_SDL_H */


### PR DESCRIPTION
Setting viewport scroll behaviour does not affect mouse locking - mouse position is not locked. Mouse does not warp, when SDL RelativeMouseMode is false. This is workaround for SDL 2.24.0 (and hopefully next versions).

## Motivation / Problem
Fix of map scrolling with mouse position locked on Fedora 36
https://github.com/OpenTTD/OpenTTD/issues/10140

## Description
Setting of RelativeMouseMode in SDL solved this issue for me (Fedora 36). I am not sure what this change will do on other platforms.

## Limitations
Fix is used only with SDL library of version >= 2.24.0. 

## Checklist for review

* The bug fix is important enough to be backported? (label: 'backport requested')
