### PR TITLE
Codechange: [MinGW] use pe-bigobj-x86-64 format for x64 debug builds

### DIFF
--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -44,8 +44,8 @@ macro(compile_flags)
             "$<$<NOT:$<CONFIG:Debug>>:-fstack-protector>" # Prevent undefined references when _FORTIFY_SOURCE > 0
         )
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-            add_link_options(
-                "$<$<CONFIG:Debug>:-Wl,--disable-dynamicbase,--disable-high-entropy-va,--default-image-base-low>" # ASLR somehow breaks linking for x64 Debug builds
+            add_compile_options(
+                "$<$<CONFIG:Debug>:-Wa,-mbig-obj>" # Switch to pe-bigobj-x86-64 as x64 Debug builds push pe-x86-64 to the limits (linking errors with ASLR, ...)
             )
         endif()
     endif()


### PR DESCRIPTION
## Motivation / Problem
When trying to understand why #10001 compilation was failing for MinGW x64 debug builds, I compared `objdump -t network_command.cpp.obj` from master and #10001.
```
objdump -t snippet for #10001
[85159](sec -32108)(fl 0x00)(ty    0)(scl   2) (nx 0) 0x0000000000000000 .refptr._Z19CmdClearOrderBackup13DoCommandFlag9TileIndex8ClientID
objdump -t snippet for master
[80970](sec 31671)(fl 0x00)(ty    0)(scl   2) (nx 0) 0x0000000000000000 .refptr._Z19CmdClearOrderBackup13DoCommandFlag9TileIndex8ClientID
```
I noticed a lot of negative section values in #10001, so I though maybe we have too many sections (even if the compiler doesn't complain about that). I then tried to enable pe-bigobj-x86-64 and that solved the issue for #10001.

Then I decided to test something and commented out the ASLR disabling, and #10001 still build fine.
So I tried the same on master, and it builds too.


So in the end it seems OpenTTD again managed to hit some compiler limits (remember the settings hell on macos).
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Add `-Wa,-mbig-obj` compile flag for MinGW x64 debug builds.
As a side effect, ASLR disabling in link options is not needed anymore, and removed.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
