### PR TITLE
Fix: Dereference of past-the-end iterator in linkgraph overlay tooltip

### DIFF
--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -379,16 +379,20 @@ bool LinkGraphOverlay::ShowTooltip(Point pt, TooltipCloseCondition close_cond)
 				char *buf_end = buf;
 				buf[0] = 0;
 				/* Fill buf with more information if this is a bidirectional link. */
+				uint32 back_time = 0;
 				auto k = this->cached_links[j->first].find(i->first);
-				const auto &back = k->second;
-				if (k != this->cached_links[j->first].end() && back.Usage() > 0) {
-					SetDParam(0, back.cargo);
-					SetDParam(1, back.Usage());
-					SetDParam(2, back.Usage() * 100 / (back.capacity + 1));
-					buf_end = GetString(buf, STR_LINKGRAPH_STATS_TOOLTIP_RETURN_EXTENSION, lastof(buf));
+				if (k != this->cached_links[j->first].end()) {
+					const auto &back = k->second;
+					back_time = back.time;
+					if (back.Usage() > 0) {
+						SetDParam(0, back.cargo);
+						SetDParam(1, back.Usage());
+						SetDParam(2, back.Usage() * 100 / (back.capacity + 1));
+						buf_end = GetString(buf, STR_LINKGRAPH_STATS_TOOLTIP_RETURN_EXTENSION, lastof(buf));
+					}
 				}
 				/* Add information about the travel time if known. */
-				const auto time = link.time ? back.time ? ((link.time + back.time) / 2) : link.time : back.time;
+				const auto time = link.time ? back_time ? ((link.time + back_time) / 2) : link.time : back_time;
 				if (time > 0) {
 					SetDParam(0, time);
 					buf_end = GetString(buf_end, STR_LINKGRAPH_STATS_TOOLTIP_TIME_EXTENSION, lastof(buf));


### PR DESCRIPTION
## Motivation / Problem

The link graph tooltip (#9760) dereferences a past-the-end iterator when getting the travel time of the reverse direction of a unidirectional link.
This is UB and triggers an abort when using checking iterators and/or memory checkers.

## Description

Fix the above.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
