### PR TITLE
Feature: Allow AI/GS to be fully modified in scenario editor

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -575,9 +575,10 @@ private:
 	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
 		return _game_mode == GM_MENU
-			|| ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot))
-			|| (config_item.flags & SCRIPTCONFIG_INGAME) != 0
-			|| _settings_client.gui.ai_developer_tools;
+		    || _game_mode == GM_EDITOR
+		    || ((this->slot != OWNER_DEITY) && !Company::IsValidID(this->slot))
+		    || (config_item.flags & SCRIPTCONFIG_INGAME) != 0
+		    || _settings_client.gui.ai_developer_tools;
 	}
 
 	void SetValue(int value)

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -442,7 +442,10 @@ struct GSConfigWindow : public Window {
 private:
 	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
-		return _game_mode == GM_MENU || (config_item.flags & SCRIPTCONFIG_INGAME) != 0;
+		return _game_mode == GM_MENU
+		    || _game_mode == GM_EDITOR
+		    || (config_item.flags & SCRIPTCONFIG_INGAME) != 0
+		    || _settings_client.gui.ai_developer_tools;
 	}
 
 	void SetValue(int value)

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -187,7 +187,7 @@ struct GUISettings {
 	uint8  developer;                        ///< print non-fatal warnings in console (>= 1), copy debug output to console (== 2)
 	bool   show_date_in_logs;                ///< whether to show dates in console logs
 	bool   newgrf_developer_tools;           ///< activate NewGRF developer tools and allow modifying NewGRFs in an existing game
-	bool   ai_developer_tools;               ///< activate AI developer tools
+	bool   ai_developer_tools;               ///< activate AI/GS developer tools
 	bool   scenario_developer;               ///< activate scenario developer: allow modifying NewGRFs in an existing game
 	uint8  settings_restriction_mode;        ///< selected restriction mode in adv. settings GUI. @see RestrictionMode
 	bool   newgrf_show_old_versions;         ///< whether to show old versions in the NewGRF list


### PR DESCRIPTION
## Motivation / Problem
There is no way to edit non-editable GS/AI Script parameters in the scenario editor, even though they should since they are not an existing save. You can currently change the script itself in the scenario editor, but not any of its settings/parameters. This problem is also partially outlined in #8895. Currently the workaround is to set `CONFIG_INGAME`, but that is not a good solution for obvious reasons. 

## Description
This change simply allows all GS and AI script parameters to be modified in the scenario editor. This PR is also another partial solution to the problems outlined in #8895.

As a side note, I've also changed out the tabs for spaces in the checks for if a setting is editable to better align them.

## Limitations
The `scenario_developer` setting is intentionally ignored, since I feel being able to modify the AI/GS parameters should be the default behavior for the scenario editor, and I don't think `scenario_developer` applies to this. This can easily be changed it need be however.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
