### PR TITLE
Fix #10154: Don't inconsistently set random company face in network games

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -569,8 +569,8 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 	c->inaugurated_year = _cur_year;
 
 	/* If starting a player company in singleplayer and a favorite company manager face is selected, choose it. Otherwise, use a random face.
-	 * In a network game, we'll choose the favorite face later in CmdCompanyCtrl to sync it to all clients, but we choose it here for the first (host) company. */
-	if (_company_manager_face != 0 && !is_ai) {
+	 * In a network game, we'll choose the favorite face later in CmdCompanyCtrl to sync it to all clients. */
+	if (_company_manager_face != 0 && !is_ai && !_networking) {
 		c->face = _company_manager_face;
 	} else {
 		RandomCompanyManagerFaceBits(c->face, (GenderEthnicity)Random(), false, false);


### PR DESCRIPTION
## Motivation / Problem

In #10025 I fixed network hosts not loading their favorite company face by removing a check on networking games.

This caused #10154.

## Description

Before #9895 we consistently randomized the facebits for everyone in the game and had no problems. Since the correct way to load a favorite face is in a network-safe command in `CmdCompanyCtrl()`, we shouldn't inconsistently do Random() things outside that command.

Closes #10154.

## Limitations

Network hosts don't load their saved favorite face automatically, reverting to pre-#10025 behavior. This is because their company is generated outside of `CmdCompanyCtrl()` where we safely load saved faces and sync to all clients.

I imagine it's possible to check if a company is the host and determine whether it's safe to load their face, but I can see too many corner cases that would continue to break things. I think it's TMWFTLB for a pretty silly feature anyway.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
