### PR TITLE
Change: Allow building canal by area outside editor

### DIFF
--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -192,7 +192,7 @@ struct BuildDocksToolbarWindow : Window {
 	{
 		switch (this->last_clicked_widget) {
 			case WID_DT_CANAL: // Build canal button
-				VpStartPlaceSizing(tile, (_game_mode == GM_EDITOR) ? VPM_X_AND_Y : VPM_X_OR_Y, DDSP_CREATE_WATER);
+				VpStartPlaceSizing(tile, VPM_X_AND_Y, DDSP_CREATE_WATER);
 				break;
 
 			case WID_DT_LOCK: // Build lock button

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -443,12 +443,6 @@ CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_t
 	/* Outside of the editor you can only build canals, not oceans */
 	if (wc != WATER_CLASS_CANAL && _game_mode != GM_EDITOR) return CMD_ERROR;
 
-	/* Outside the editor you can only drag canals, and not areas */
-	if (_game_mode != GM_EDITOR) {
-		TileArea ta(tile, start_tile);
-		if (ta.w != 1 && ta.h != 1) return CMD_ERROR;
-	}
-
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 
 	std::unique_ptr<TileIterator> iter;


### PR DESCRIPTION
## Motivation / Problem

In Scenario Editor, we can build canals by area, but in-game we are restricted to building a single-tile-wide canal in one action.

This restriction feels arbitrary and makes building things like this slower:

![canal](https://user-images.githubusercontent.com/55058389/201742860-85900948-0e10-4d8d-86b1-6bca37706e78.png)

## Description

Remove the arbitrary restriction on building an area of canal tiles outside Scenario Editor.

I believe this follows a precedent set by #9709 and #10027 where we make it easier for players to build more objects or purchased tiles at once.

I can't think of an exploit that limiting canal construction could be trying to prevent, that wouldn't be an issue with other terraforming.

## Limitations

It is not possible to build canals diagonally with Ctrl like rivers in Scenario Editor, because the Ctrl key is already used to modify the canal tool to flood dry tiles into sea, when in Scenario Editor on dry sea-level tiles.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
