### PR TITLE
Fix #10164: Incorrect slider handle position in RTL.

### DIFF
--- a/src/widgets/slider.cpp
+++ b/src/widgets/slider.cpp
@@ -63,8 +63,9 @@ void DrawSliderWidget(Rect r, int min_value, int max_value, int value, const std
 	}
 
 	/* Draw a slider handle indicating current value. */
+	value -= min_value;
 	if (_current_text_dir == TD_RTL) value = max_value - value;
-	x = r.left + ((value - min_value) * (r.right - r.left - sw) / max_value);
+	x = r.left + (value * (r.right - r.left - sw) / max_value);
 	DrawFrameRect(x, r.top, x + sw, r.bottom, COLOUR_GREY, FR_NONE);
 }
 


### PR DESCRIPTION
## Motivation / Problem

As per #10164, the slider widget handle is incorrectly positioned in RTL.

## Description

This is because `max_value` already had `min_value` removed to get the slider's range. Therefore `min_value` needs to be taken from `value` before adjusting for RTL.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
