### PR TITLE
Codechange: Remove shift as fast-forward key when _DEBUG is defined

### DIFF
--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -467,13 +467,9 @@ void VideoDriver_Allegro::InputLoop()
 	_ctrl_pressed  = !!(key_shifts & KB_CTRL_FLAG);
 	_shift_pressed = !!(key_shifts & KB_SHIFT_FLAG);
 
-#if defined(_DEBUG)
-	this->fast_forward_key_pressed = _shift_pressed;
-#else
 	/* Speedup when pressing tab, except when using ALT+TAB
 	 * to switch to another application. */
 	this->fast_forward_key_pressed = key[KEY_TAB] && (key_shifts & KB_ALT_FLAG) == 0;
-#endif
 
 	/* Determine which directional keys are down. */
 	_dirkeys =

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -484,11 +484,7 @@ void VideoDriver_Cocoa::InputLoop()
 	_ctrl_pressed = (cur_mods & ( _settings_client.gui.right_mouse_btn_emulation != RMBE_CONTROL ? NSEventModifierFlagControl : NSEventModifierFlagCommand)) != 0;
 	_shift_pressed = (cur_mods & NSEventModifierFlagShift) != 0;
 
-#if defined(_DEBUG)
-	this->fast_forward_key_pressed = _shift_pressed;
-#else
 	this->fast_forward_key_pressed = _tab_is_down;
-#endif
 
 	if (old_ctrl_pressed != _ctrl_pressed) HandleCtrlChanged();
 }

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -577,13 +577,9 @@ void VideoDriver_SDL_Base::InputLoop()
 	_ctrl_pressed  = !!(mod & KMOD_CTRL);
 	_shift_pressed = !!(mod & KMOD_SHIFT);
 
-#if defined(_DEBUG)
-	this->fast_forward_key_pressed = _shift_pressed;
-#else
 	/* Speedup when pressing tab, except when using ALT+TAB
 	 * to switch to another application. */
 	this->fast_forward_key_pressed = keys[SDL_SCANCODE_TAB] && (mod & KMOD_ALT) == 0;
-#endif /* defined(_DEBUG) */
 
 	/* Determine which directional keys are down. */
 	_dirkeys =

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -624,13 +624,9 @@ void VideoDriver_SDL::InputLoop()
 	_ctrl_pressed  = !!(mod & KMOD_CTRL);
 	_shift_pressed = !!(mod & KMOD_SHIFT);
 
-#if defined(_DEBUG)
-	this->fast_forward_key_pressed = _shift_pressed;
-#else
 	/* Speedup when pressing tab, except when using ALT+TAB
 	 * to switch to another application. */
 	this->fast_forward_key_pressed = keys[SDLK_TAB] && (mod & KMOD_ALT) == 0;
-#endif /* defined(_DEBUG) */
 
 	/* Determine which directional keys are down. */
 	_dirkeys =

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -844,13 +844,9 @@ void VideoDriver_Win32Base::InputLoop()
 	_ctrl_pressed = this->has_focus && GetAsyncKeyState(VK_CONTROL) < 0;
 	_shift_pressed = this->has_focus && GetAsyncKeyState(VK_SHIFT) < 0;
 
-#if defined(_DEBUG)
-	this->fast_forward_key_pressed = _shift_pressed;
-#else
 	/* Speedup when pressing tab, except when using ALT+TAB
 	 * to switch to another application. */
 	this->fast_forward_key_pressed = this->has_focus && GetAsyncKeyState(VK_TAB) < 0 && GetAsyncKeyState(VK_MENU) >= 0;
-#endif
 
 	/* Determine which directional keys are down. */
 	if (this->has_focus) {


### PR DESCRIPTION
## Motivation / Problem

Changing hotkeys when debugging appears to have been an unintentional change as part of c3dc27e37e.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Revert change to hotkey mapping.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Perhaps user-configurable hotkeys should be a thing?
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
