### PR TITLE
Fix: Indent production in industry window and resolve button issues.

### DIFF
--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -208,6 +208,17 @@ struct Rect {
 			? Rect {this->left, this->bottom - height + 1, this->right, this->bottom}
 			: Rect {this->left, this->top,                 this->right, this->top + height - 1};
 	}
+
+	/**
+	 * Test if a point falls inside this Rect.
+	 * @param pt the point to test.
+	 * @return true iif the point falls inside the Rect.
+	 */
+	inline bool Contains(const Point &pt) const
+	{
+		/* This is a local version of IsInsideMM, to avoid including math_func everywhere. */
+		return (uint)(pt.x - this->left) < (uint)(this->right - this->left) && (uint)(pt.y - this->top) < (uint)(this->bottom - this->top);
+	}
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Industry production used to be indented, although a different amount than the industry accepts list.

Additionally the cheat-mode production modifier buttons are insufficiently spaced and are always on the last side of the window, regardless of RTL.

## Description

The indent of cargo production is now added back, with the standard indent width.

The cheat-mode production modifier buttons now support RTL and the list height now takes account of the button height.

![image](https://user-images.githubusercontent.com/639850/202867760-7fbde5ae-0b77-455e-9c68-a50c85b6f0ec.png)

A Rect helper function `Contains()` has been added to check if a point is contained by a Rect, as using `IsInsideMM()` requires a temporary variable to fill both min and max parameters.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
