### PR TITLE
Fix #10114: Wonky depot layout.

### DIFF
--- a/src/aircraft_gui.cpp
+++ b/src/aircraft_gui.cpp
@@ -73,12 +73,10 @@ void DrawAircraftDetails(const Aircraft *v, const Rect &r)
 /**
  * Draws an image of an aircraft
  * @param v         Front vehicle
- * @param left      The minimum horizontal position
- * @param right     The maximum horizontal position
- * @param y         Vertical position to draw at
+ * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
  */
-void DrawAircraftImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type)
+void DrawAircraftImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type)
 {
 	bool rtl = _current_text_dir == TD_RTL;
 
@@ -90,25 +88,27 @@ void DrawAircraftImage(const Vehicle *v, int left, int right, int y, VehicleID s
 
 	int width = UnScaleGUI(rect.Width());
 	int x_offs = UnScaleGUI(rect.left);
-	int x = rtl ? right - width - x_offs : left - x_offs;
+	int x = rtl ? r.right - width - x_offs : r.left - x_offs;
+	/* This magic -1 offset is related to the sprite_y_offsets in build_vehicle_gui.cpp */
+	int y = ScaleSpriteTrad(-1) + CenterBounds(r.top, r.bottom, 0);
 	bool helicopter = v->subtype == AIR_HELICOPTER;
 
-	int y_offs = ScaleSpriteTrad(10);
 	int heli_offs = 0;
 
 	PaletteID pal = (v->vehstatus & VS_CRASHED) ? PALETTE_CRASH : GetVehiclePalette(v);
-	seq.Draw(x, y + y_offs, pal, (v->vehstatus & VS_CRASHED) != 0);
+	seq.Draw(x, y, pal, (v->vehstatus & VS_CRASHED) != 0);
 	if (helicopter) {
 		const Aircraft *a = Aircraft::From(v);
 		VehicleSpriteSeq rotor_seq;
 		GetCustomRotorSprite(a, image_type, &rotor_seq);
 		if (!rotor_seq.IsValid()) rotor_seq.Set(SPR_ROTOR_STOPPED);
 		heli_offs = ScaleSpriteTrad(5);
-		rotor_seq.Draw(x, y + y_offs - heli_offs, PAL_NONE, false);
+		rotor_seq.Draw(x, y - heli_offs, PAL_NONE, false);
 	}
 	if (v->index == selection) {
 		x += x_offs;
-		y += UnScaleGUI(rect.top) + y_offs - heli_offs;
-		DrawFrameRect(x - 1, y - 1, x + width + 1, y + UnScaleGUI(rect.Height()) + heli_offs + 1, COLOUR_WHITE, FR_BORDERONLY);
+		y += UnScaleGUI(rect.top) - heli_offs;
+		Rect hr = {x, y, x + width - 1, y + UnScaleGUI(rect.Height()) + heli_offs - 1};
+		DrawFrameRect(hr.Expand(WidgetDimensions::scaled.bevel), COLOUR_WHITE, FR_BORDERONLY);
 	}
 }

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -29,6 +29,7 @@
 #include "depot_cmd.h"
 #include "train_cmd.h"
 #include "vehicle_cmd.h"
+#include "core/geometry_func.hpp"
 
 #include "widgets/depot_widget.h"
 
@@ -303,18 +304,15 @@ struct DepotWindow : Window {
 	/**
 	 * Draw a vehicle in the depot window in the box with the top left corner at x,y.
 	 * @param v     Vehicle to draw.
-	 * @param left  Left side of the box to draw in.
-	 * @param right Right side of the box to draw in.
-	 * @param y     Top of the box to draw in.
+	 * @param r     Rect to draw in.
 	 */
-	void DrawVehicleInDepot(const Vehicle *v, int left, int right, int y) const
+	void DrawVehicleInDepot(const Vehicle *v, const Rect &r) const
 	{
 		bool free_wagon = false;
-		int sprite_y = y + (this->resize.step_height - ScaleSpriteTrad(GetVehicleHeight(v->type))) / 2;
 
 		bool rtl = _current_text_dir == TD_RTL;
-		int image_left  = rtl ? left  + this->count_width  : left  + this->header_width;
-		int image_right = rtl ? right - this->header_width : right - this->count_width;
+		Rect text = r.Shrink(RectPadding::zero, WidgetDimensions::scaled.matrix);       /* Ract for text elements, horizontal is already applied. */
+		Rect image = r.Indent(this->header_width, rtl).Indent(this->count_width, !rtl); /* Rect for vehicle images */
 
 		switch (v->type) {
 			case VEH_TRAIN: {
@@ -325,42 +323,42 @@ struct DepotWindow : Window {
 						ScaleSpriteTrad(_consistent_train_width != 0 ? _consistent_train_width : TRAININFO_DEFAULT_VEHICLE_WIDTH) :
 						0;
 
-				DrawTrainImage(u, image_left + (rtl ? 0 : x_space), image_right - (rtl ? x_space : 0), sprite_y,
-						this->sel, EIT_IN_DEPOT, free_wagon ? 0 : this->hscroll->GetPosition(), this->vehicle_over);
+				DrawTrainImage(u, image.Indent(x_space, rtl), this->sel, EIT_IN_DEPOT, free_wagon ? 0 : this->hscroll->GetPosition(), this->vehicle_over);
 
 				/* Length of consist in tiles with 1 fractional digit (rounded up) */
 				SetDParam(0, CeilDiv(u->gcache.cached_total_length * 10, TILE_SIZE));
 				SetDParam(1, 1);
-				DrawString(rtl ? left : right - this->count_width, rtl ? left + this->count_width : right, y + (this->resize.step_height - FONT_HEIGHT_SMALL) / 2, STR_TINY_BLACK_DECIMAL, TC_FROMSTRING, SA_RIGHT); // Draw the counter
+				Rect count = text.WithWidth(this->count_width - WidgetDimensions::scaled.hsep_normal, !rtl);
+				DrawString(count.left, count.right, count.bottom - FONT_HEIGHT_SMALL + 1, STR_TINY_BLACK_DECIMAL, TC_FROMSTRING, SA_RIGHT); // Draw the counter
 				break;
 			}
 
-			case VEH_ROAD:     DrawRoadVehImage( v, image_left, image_right, sprite_y, this->sel, EIT_IN_DEPOT); break;
-			case VEH_SHIP:     DrawShipImage(    v, image_left, image_right, sprite_y, this->sel, EIT_IN_DEPOT); break;
-			case VEH_AIRCRAFT: DrawAircraftImage(v, image_left, image_right, sprite_y, this->sel, EIT_IN_DEPOT); break;
+			case VEH_ROAD:     DrawRoadVehImage( v, image, this->sel, EIT_IN_DEPOT); break;
+			case VEH_SHIP:     DrawShipImage(    v, image, this->sel, EIT_IN_DEPOT); break;
+			case VEH_AIRCRAFT: DrawAircraftImage(v, image, this->sel, EIT_IN_DEPOT); break;
 			default: NOT_REACHED();
 		}
 
 		uint diff_x, diff_y;
 		if (v->IsGroundVehicle()) {
 			/* Arrange unitnumber and flag horizontally */
-			diff_x = this->flag_width;
-			diff_y = (this->resize.step_height - this->flag_height) / 2;
+			diff_x = this->flag_size.width + WidgetDimensions::scaled.hsep_normal;
+			diff_y = WidgetDimensions::scaled.matrix.top;
 		} else {
 			/* Arrange unitnumber and flag vertically */
 			diff_x = 0;
-			diff_y = FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal;
+			diff_y = WidgetDimensions::scaled.matrix.top + FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal;
 		}
-		int text_left  = rtl ? right - this->header_width - 1 : left + diff_x;
-		int text_right = rtl ? right - diff_x : left + this->header_width - 1;
 
+		text = text.WithWidth(this->header_width - WidgetDimensions::scaled.hsep_normal, rtl).WithHeight(FONT_HEIGHT_NORMAL).Indent(diff_x, rtl);
 		if (free_wagon) {
-			DrawString(text_left, text_right, y + WidgetDimensions::scaled.framerect.top, STR_DEPOT_NO_ENGINE);
+			DrawString(text, STR_DEPOT_NO_ENGINE);
 		} else {
-			DrawSprite((v->vehstatus & VS_STOPPED) ? SPR_FLAG_VEH_STOPPED : SPR_FLAG_VEH_RUNNING, PAL_NONE, rtl ? right - this->flag_width : left + WidgetDimensions::scaled.framerect.left, y + diff_y);
+			Rect flag = r.WithWidth(this->flag_size.width, rtl).WithHeight(this->flag_size.height).Translate(0, diff_y);
+			DrawSpriteIgnorePadding((v->vehstatus & VS_STOPPED) ? SPR_FLAG_VEH_STOPPED : SPR_FLAG_VEH_RUNNING, PAL_NONE, flag, false, SA_CENTER);
 
 			SetDParam(0, v->unitnumber);
-			DrawString(text_left, text_right, y + WidgetDimensions::scaled.framerect.top, (uint16)(v->max_age - DAYS_IN_LEAP_YEAR) >= v->age ? STR_BLACK_COMMA : STR_RED_COMMA);
+			DrawString(text, (uint16)(v->max_age - DAYS_IN_LEAP_YEAR) >= v->age ? STR_BLACK_COMMA : STR_RED_COMMA);
 		}
 	}
 
@@ -373,7 +371,10 @@ struct DepotWindow : Window {
 		/* Set the row and number of boxes in each row based on the number of boxes drawn in the matrix */
 		const NWidgetCore *wid = this->GetWidget<NWidgetCore>(WID_D_MATRIX);
 
-		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
+		/* Set up rect for each cell */
+		Rect ir = r.WithHeight(this->resize.step_height);
+		if (this->num_columns != 1) ir = ir.WithWidth(this->resize.step_width, rtl);
+		ir = ir.Shrink(WidgetDimensions::scaled.framerect, RectPadding::zero);
 
 		/* Draw vertical separators at whole tiles.
 		 * This only works in two cases:
@@ -383,15 +384,14 @@ struct DepotWindow : Window {
 		if (this->type == VEH_TRAIN && _consistent_train_width != 0) {
 			int w = ScaleSpriteTrad(2 * _consistent_train_width);
 			int col = _colour_gradient[wid->colour][4];
-			int image_left  = rtl ? ir.left  + this->count_width  : ir.left  + this->header_width;
-			int image_right = rtl ? ir.right - this->header_width : ir.right - this->count_width;
+			Rect image = ir.Indent(this->header_width, rtl).Indent(this->count_width, !rtl);
 			int first_line = w + (-this->hscroll->GetPosition()) % w;
 			if (rtl) {
-				for (int x = image_right - first_line; x >= image_left; x -= w) {
+				for (int x = image.right - first_line; x >= image.left; x -= w) {
 					GfxDrawLine(x, r.top, x, r.bottom, col, ScaleGUITrad(1), ScaleGUITrad(3));
 				}
 			} else {
-				for (int x = image_left + first_line; x <= image_right; x += w) {
+				for (int x = image.left + first_line; x <= image.right; x += w) {
 					GfxDrawLine(x, r.top, x, r.bottom, col, ScaleGUITrad(1), ScaleGUITrad(3));
 				}
 			}
@@ -401,26 +401,22 @@ struct DepotWindow : Window {
 
 		uint num = this->vscroll->GetPosition() * this->num_columns;
 		uint maxval = static_cast<uint>(std::min<size_t>(this->vehicle_list.size(), num + (rows_in_display * this->num_columns)));
-		int y;
-		for (y = r.top; num < maxval; y += this->resize.step_height) { // Draw the rows
+		for (; num < maxval; ir = ir.Translate(0, this->resize.step_height)) { // Draw the rows
+			Rect cell = ir; /* Keep track of horizontal cells */
 			for (uint i = 0; i < this->num_columns && num < maxval; i++, num++) {
 				/* Draw all vehicles in the current row */
 				const Vehicle *v = this->vehicle_list[num];
-				if (this->num_columns == 1) {
-					this->DrawVehicleInDepot(v, ir.left, ir.right, y);
-				} else {
-					int x = ir.left + (rtl ? (this->num_columns - i - 1) : i) * this->resize.step_width;
-					this->DrawVehicleInDepot(v, x, x + this->resize.step_width - 1 - WidgetDimensions::scaled.framerect.Horizontal(), y);
-				}
+				this->DrawVehicleInDepot(v, cell);
+				cell = cell.Translate(rtl ? -(int)this->resize.step_width : (int)this->resize.step_width, 0);
 			}
 		}
 
 		maxval = static_cast<uint>(std::min<size_t>(this->vehicle_list.size() + this->wagon_list.size(), (this->vscroll->GetPosition() * this->num_columns) + (rows_in_display * this->num_columns)));
 
 		/* Draw the train wagons without an engine in front. */
-		for (; num < maxval; num++, y += this->resize.step_height) {
+		for (; num < maxval; num++, ir = ir.Translate(0, this->resize.step_height)) {
 			const Vehicle *v = this->wagon_list[num - this->vehicle_list.size()];
-			this->DrawVehicleInDepot(v, ir.left, ir.right, y);
+			this->DrawVehicleInDepot(v, ir);
 		}
 	}
 
@@ -503,12 +499,12 @@ struct DepotWindow : Window {
 					FALLTHROUGH;
 
 				case VEH_ROAD:
-					if (xm <= this->flag_width) return MODE_START_STOP;
+					if (xm <= this->flag_size.width) return MODE_START_STOP;
 					break;
 
 				case VEH_SHIP:
 				case VEH_AIRCRAFT:
-					if (xm <= this->flag_width && ym >= (uint)(FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal)) return MODE_START_STOP;
+					if (xm <= this->flag_size.width && ym >= (uint)(FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal)) return MODE_START_STOP;
 					break;
 
 				default: NOT_REACHED();
@@ -645,10 +641,16 @@ struct DepotWindow : Window {
 		}
 	}
 
-	uint count_width;
-	uint header_width;
-	uint flag_width;
-	uint flag_height;
+	uint count_width;          ///< Width of length count, including separator.
+	uint header_width;         ///< Width of unit number and flag, including separator.
+	Dimension flag_size;       ///< Size of start/stop flag.
+	VehicleCellSize cell_size; ///< Vehicle sprite cell size.
+
+	void OnInit() override
+	{
+		this->cell_size = GetVehicleImageCellSize(this->type, EIT_IN_DEPOT);
+		this->flag_size = maxdim(GetScaledSpriteSize(SPR_FLAG_VEH_STOPPED), GetScaledSpriteSize(SPR_FLAG_VEH_RUNNING));
+	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
 	{
@@ -659,33 +661,30 @@ struct DepotWindow : Window {
 				if (this->type == VEH_TRAIN) {
 					SetDParamMaxValue(0, 1000, 0, FS_SMALL);
 					SetDParam(1, 1);
-					this->count_width = GetStringBoundingBox(STR_TINY_BLACK_DECIMAL).width + WidgetDimensions::scaled.framerect.Horizontal();
+					this->count_width = GetStringBoundingBox(STR_TINY_BLACK_DECIMAL).width + WidgetDimensions::scaled.hsep_normal;
 				} else {
 					this->count_width = 0;
 				}
 
 				SetDParamMaxDigits(0, this->unitnumber_digits);
 				Dimension unumber = GetStringBoundingBox(STR_BLACK_COMMA);
-				const Sprite *spr = GetSprite(SPR_FLAG_VEH_STOPPED, ST_NORMAL);
-				this->flag_width  = UnScaleGUI(spr->width) + WidgetDimensions::scaled.framerect.right;
-				this->flag_height = UnScaleGUI(spr->height);
 
 				if (this->type == VEH_TRAIN || this->type == VEH_ROAD) {
-					min_height = std::max<uint>(unumber.height + WidgetDimensions::scaled.matrix.top, UnScaleGUI(spr->height));
-					this->header_width = unumber.width + this->flag_width + WidgetDimensions::scaled.framerect.left;
+					min_height = std::max<uint>(unumber.height, this->flag_size.height);
+					this->header_width = unumber.width + WidgetDimensions::scaled.hsep_normal + this->flag_size.width + WidgetDimensions::scaled.hsep_normal;
 				} else {
-					min_height = unumber.height + UnScaleGUI(spr->height) + padding.height + WidgetDimensions::scaled.vsep_normal;
-					this->header_width = std::max<uint>(unumber.width, this->flag_width) + WidgetDimensions::scaled.framerect.right;
+					min_height = unumber.height + WidgetDimensions::scaled.vsep_normal + this->flag_size.height;
+					this->header_width = std::max<uint>(unumber.width, this->flag_size.width) + WidgetDimensions::scaled.hsep_normal;
 				}
-				int base_width = this->count_width + this->header_width;
+				int base_width = this->count_width + this->header_width + padding.width;
 
-				resize->height = std::max<uint>(GetVehicleImageCellSize(this->type, EIT_IN_DEPOT).height, min_height);
+				resize->height = std::max<uint>(this->cell_size.height, min_height + padding.height);
 				if (this->type == VEH_TRAIN) {
 					resize->width = 1;
 					size->width = base_width + 2 * ScaleSpriteTrad(29); // about 2 parts
 					size->height = resize->height * 6;
 				} else {
-					resize->width = base_width + GetVehicleImageCellSize(this->type, EIT_IN_DEPOT).extend_left + GetVehicleImageCellSize(this->type, EIT_IN_DEPOT).extend_right;
+					resize->width = base_width + this->cell_size.extend_left + this->cell_size.extend_right;
 					size->width = resize->width * (this->type == VEH_ROAD ? 5 : 3);
 					size->height = resize->height * (this->type == VEH_ROAD ? 5 : 3);
 				}

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -434,7 +434,7 @@ struct NewGRFInspectWindow : Window {
 				GrfSpecFeature f = GetFeatureNum(this->window_number);
 				int h = GetVehicleImageCellSize((VehicleType)(VEH_TRAIN + (f - GSF_TRAINS)), EIT_IN_DEPOT).height;
 				int y = CenterBounds(br.top, br.bottom, h);
-				DrawVehicleImage(v->First(), br.left, br.right, y + 1, INVALID_VEHICLE, EIT_IN_DETAILS, skip);
+				DrawVehicleImage(v->First(), br, INVALID_VEHICLE, EIT_IN_DETAILS, skip);
 
 				/* Highlight the articulated part (this is different to the whole-vehicle highlighting of DrawVehicleImage */
 				if (_current_text_dir == TD_RTL) {

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -120,28 +120,28 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 /**
  * Draws an image of a road vehicle chain
  * @param v         Front vehicle
- * @param left      The minimum horizontal position
- * @param right     The maximum horizontal position
- * @param y         Vertical position to draw at
+ * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
  * @param skip      Number of pixels to skip at the front (for scrolling)
  */
-void DrawRoadVehImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip)
+void DrawRoadVehImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip)
 {
 	bool rtl = _current_text_dir == TD_RTL;
 	Direction dir = rtl ? DIR_E : DIR_W;
 	const RoadVehicle *u = RoadVehicle::From(v);
 
 	DrawPixelInfo tmp_dpi, *old_dpi;
-	int max_width = right - left + 1;
+	int max_width = r.Width();
 
-	if (!FillDrawPixelInfo(&tmp_dpi, left, y, max_width, ScaleSpriteTrad(14))) return;
+	if (!FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) return;
 
 	old_dpi = _cur_dpi;
 	_cur_dpi = &tmp_dpi;
 
 	int px = rtl ? max_width + skip : -skip;
-	for (; u != nullptr && (rtl ? px > 0 : px < max_width); u = u->Next()) {
+	int y = r.Height() / 2;
+	for (; u != nullptr && (rtl ? px > 0 : px < max_width); u = u->Next())
+	{
 		Point offset;
 		int width = u->GetDisplayImageWidth(&offset);
 
@@ -149,15 +149,17 @@ void DrawRoadVehImage(const Vehicle *v, int left, int right, int y, VehicleID se
 			PaletteID pal = (u->vehstatus & VS_CRASHED) ? PALETTE_CRASH : GetVehiclePalette(u);
 			VehicleSpriteSeq seq;
 			u->GetImage(dir, image_type, &seq);
-			seq.Draw(px + (rtl ? -offset.x : offset.x), ScaleSpriteTrad(6) + offset.y, pal, (u->vehstatus & VS_CRASHED) != 0);
+			seq.Draw(px + (rtl ? -offset.x : offset.x), y + offset.y, pal, (u->vehstatus & VS_CRASHED) != 0);
 		}
 
 		px += rtl ? -width : width;
 	}
 
-	if (v->index == selection) {
-		DrawFrameRect((rtl ? px : 0), 0, (rtl ? max_width : px) - 1, ScaleSpriteTrad(13) - 1, COLOUR_WHITE, FR_BORDERONLY);
-	}
-
 	_cur_dpi = old_dpi;
+
+	if (v->index == selection) {
+		int height = ScaleSpriteTrad(12);
+		Rect hr = {(rtl ? px : 0), 0, (rtl ? max_width : px) - 1, height - 1};
+		DrawFrameRect(hr.Translate(r.left, CenterBounds(r.top, r.bottom, height)).Expand(WidgetDimensions::scaled.bevel), COLOUR_WHITE, FR_BORDERONLY);
+	}
 }

--- a/src/ship_gui.cpp
+++ b/src/ship_gui.cpp
@@ -24,12 +24,10 @@
 /**
  * Draws an image of a ship
  * @param v         Front vehicle
- * @param left      The minimum horizontal position
- * @param right     The maximum horizontal position
- * @param y         Vertical position to draw at
+ * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
  */
-void DrawShipImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type)
+void DrawShipImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type)
 {
 	bool rtl = _current_text_dir == TD_RTL;
 
@@ -41,15 +39,17 @@ void DrawShipImage(const Vehicle *v, int left, int right, int y, VehicleID selec
 
 	int width = UnScaleGUI(rect.Width());
 	int x_offs = UnScaleGUI(rect.left);
-	int x = rtl ? right - width - x_offs : left - x_offs;
+	int x = rtl ? r.right - width - x_offs : r.left - x_offs;
+	/* This magic -1 offset is related to the sprite_y_offsets in build_vehicle_gui.cpp */
+	int y = ScaleSpriteTrad(-1) + CenterBounds(r.top, r.bottom, 0);
 
-	y += ScaleSpriteTrad(10);
 	seq.Draw(x, y, GetVehiclePalette(v), false);
 
 	if (v->index == selection) {
 		x += x_offs;
 		y += UnScaleGUI(rect.top);
-		DrawFrameRect(x - 1, y - 1, x + width + 1, y + UnScaleGUI(rect.Height()) + 1, COLOUR_WHITE, FR_BORDERONLY);
+		Rect hr = {x, y, x + width - 1, y + UnScaleGUI(rect.Height()) - 1};
+		DrawFrameRect(hr.Expand(WidgetDimensions::scaled.bevel), COLOUR_WHITE, FR_BORDERONLY);
 	}
 }
 

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -933,8 +933,8 @@ struct RefitWindow : public Window {
 		switch (widget) {
 			case WID_VR_VEHICLE_PANEL_DISPLAY: {
 				Vehicle *v = Vehicle::Get(this->window_number);
-				DrawVehicleImage(v, this->sprite_left + WidgetDimensions::scaled.framerect.left, this->sprite_right - WidgetDimensions::scaled.framerect.right,
-					r.top + WidgetDimensions::scaled.framerect.top, INVALID_VEHICLE, EIT_IN_DETAILS, this->hscroll != nullptr ? this->hscroll->GetPosition() : 0);
+				DrawVehicleImage(v, {this->sprite_left + WidgetDimensions::scaled.framerect.left, r.top, this->sprite_right - WidgetDimensions::scaled.framerect.right, r.bottom},
+					INVALID_VEHICLE, EIT_IN_DETAILS, this->hscroll != nullptr ? this->hscroll->GetPosition() : 0);
 
 				/* Highlight selected vehicles. */
 				if (this->order != INVALID_VEH_ORDER_ID) break;
@@ -1590,19 +1590,17 @@ static void DrawSmallOrderList(const Order *order, int left, int right, int y, u
 /**
  * Draws an image of a vehicle chain
  * @param v         Front vehicle
- * @param left      The minimum horizontal position
- * @param right     The maximum horizontal position
- * @param y         Vertical position to draw at
+ * @param r         Rect to draw at
  * @param selection Selected vehicle to draw a frame around
  * @param skip      Number of pixels to skip at the front (for scrolling)
  */
-void DrawVehicleImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip)
+void DrawVehicleImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip)
 {
 	switch (v->type) {
-		case VEH_TRAIN:    DrawTrainImage(Train::From(v), left, right, y, selection, image_type, skip); break;
-		case VEH_ROAD:     DrawRoadVehImage(v, left, right, y, selection, image_type, skip);  break;
-		case VEH_SHIP:     DrawShipImage(v, left, right, y, selection, image_type);     break;
-		case VEH_AIRCRAFT: DrawAircraftImage(v, left, right, y, selection, image_type); break;
+		case VEH_TRAIN:    DrawTrainImage(Train::From(v), r, selection, image_type, skip); break;
+		case VEH_ROAD:     DrawRoadVehImage(v, r, selection, image_type, skip);  break;
+		case VEH_SHIP:     DrawShipImage(v, r, selection, image_type);     break;
+		case VEH_AIRCRAFT: DrawAircraftImage(v, r, selection, image_type); break;
 		default: NOT_REACHED();
 	}
 }
@@ -1647,7 +1645,6 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 
 	int image_left  = (rtl && show_orderlist) ? olr.right : tr.left;
 	int image_right = (!rtl && show_orderlist) ? olr.left : tr.right;
-	int image_height = ScaleSpriteTrad(GetVehicleHeight(this->vli.vtype));
 
 	int vehicle_button_x = rtl ? ir.right - profit.width : ir.left;
 
@@ -1670,7 +1667,7 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 					DrawSprite(SPR_WARNING_SIGN, PAL_NONE, vehicle_button_x, ir.top + FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal + profit.height);
 				}
 
-				DrawVehicleImage(v, image_left, image_right, CenterBounds(ir.top, ir.bottom, image_height), selected_vehicle, EIT_IN_LIST, 0);
+				DrawVehicleImage(v, {image_left, ir.top, image_right, ir.bottom}, selected_vehicle, EIT_IN_LIST, 0);
 
 				if (!v->name.empty()) {
 					/* The vehicle got a name so we will print it */
@@ -1701,7 +1698,7 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 
 				for (int i = 0; i < static_cast<int>(vehgroup.NumVehicles()); ++i) {
 					if (image_left + WidgetDimensions::scaled.hsep_wide * i >= image_right) break; // Break if there is no more space to draw any more vehicles anyway.
-					DrawVehicleImage(vehgroup.vehicles_begin[i], image_left + WidgetDimensions::scaled.hsep_wide * i, image_right, CenterBounds(ir.top, ir.bottom, image_height), selected_vehicle, EIT_IN_LIST, 0);
+					DrawVehicleImage(vehgroup.vehicles_begin[i], {image_left + WidgetDimensions::scaled.hsep_wide * i, ir.top, image_right, ir.bottom}, selected_vehicle, EIT_IN_LIST, 0);
 				}
 
 				if (show_orderlist) DrawSmallOrderList((vehgroup.vehicles_begin[0])->GetFirstOrder(), olr.left, olr.right, ir.top, this->order_arrow_width);
@@ -2501,10 +2498,10 @@ struct VehicleDetailsWindow : Window {
 
 				/* Articulated road vehicles use a complete line. */
 				if (v->type == VEH_ROAD && v->HasArticulatedPart()) {
-					DrawVehicleImage(v, tr.left, tr.right, tr.top, INVALID_VEHICLE, EIT_IN_DETAILS, 0);
+					DrawVehicleImage(v, tr, INVALID_VEHICLE, EIT_IN_DETAILS, 0);
 				} else {
 					Rect sr = tr.WithWidth(sprite_width, rtl);
-					DrawVehicleImage(v, sr.left, sr.right, sr.top, INVALID_VEHICLE, EIT_IN_DETAILS, 0);
+					DrawVehicleImage(v, sr, INVALID_VEHICLE, EIT_IN_DETAILS, 0);
 				}
 
 				DrawVehicleDetails(v, tr.Indent(sprite_width, rtl), 0, 0, this->tab);

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -45,10 +45,10 @@ struct TestedEngineDetails {
 
 int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, TestedEngineDetails &te);
 
-void DrawTrainImage(const Train *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip, VehicleID drag_dest = INVALID_VEHICLE);
-void DrawRoadVehImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip = 0);
-void DrawShipImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type);
-void DrawAircraftImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type);
+void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip, VehicleID drag_dest = INVALID_VEHICLE);
+void DrawRoadVehImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip = 0);
+void DrawShipImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type);
+void DrawAircraftImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type);
 
 void ShowBuildVehicleWindow(TileIndex tile, VehicleType type);
 
@@ -106,7 +106,7 @@ void StartStopVehicle(const Vehicle *v, bool texteffect);
 
 Vehicle *CheckClickOnVehicle(const struct Viewport *vp, int x, int y);
 
-void DrawVehicleImage(const Vehicle *v, int left, int right, int y, VehicleID selection, EngineImageType image_type, int skip);
+void DrawVehicleImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip);
 void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type);
 
 #endif /* VEHICLE_GUI_H */


### PR DESCRIPTION

## Motivation / Problem

Depot layout is incorrect since #10114. Flag and unit number overlap in train and roadveh depots, and the cell sizes are not large enough.

![image](https://user-images.githubusercontent.com/639850/203434527-e1feb6a5-fd0e-472d-8d8d-835e5151d140.png)

## Description

Depot lists internal layout was not handled well. This is improved by throwing more Rects at it:
- Vehicle images are now be vertically centred in the rect.
- Image clipping is relaxed to cover the rect, improving larger sprites.
- Outline highlight is now aware of bevel thickness.

Picture = Words * 1000:

![image](https://user-images.githubusercontent.com/639850/203434573-5cfcfd7c-ffed-4aac-beaf-ac2a8c7a8b6d.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
