### PR TITLE
Fix #10191: Incorrect refit highlight position.

### DIFF
--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -933,7 +933,7 @@ struct RefitWindow : public Window {
 		switch (widget) {
 			case WID_VR_VEHICLE_PANEL_DISPLAY: {
 				Vehicle *v = Vehicle::Get(this->window_number);
-				DrawVehicleImage(v, {this->sprite_left + WidgetDimensions::scaled.framerect.left, r.top, this->sprite_right - WidgetDimensions::scaled.framerect.right, r.bottom},
+				DrawVehicleImage(v, {this->sprite_left, r.top, this->sprite_right, r.bottom},
 					INVALID_VEHICLE, EIT_IN_DETAILS, this->hscroll != nullptr ? this->hscroll->GetPosition() : 0);
 
 				/* Highlight selected vehicles. */
@@ -946,6 +946,11 @@ struct RefitWindow : public Window {
 
 						int left = INT32_MIN;
 						int width = 0;
+
+						/* Determine top & bottom position of the highlight.*/
+						const int height = ScaleSpriteTrad(12);
+						const int highlight_top = CenterBounds(r.top, r.bottom, height);
+						const int highlight_bottom = highlight_top + height - 1;
 
 						for (Train *u = Train::From(v); u != nullptr; u = u->Next()) {
 							/* Start checking. */
@@ -967,12 +972,13 @@ struct RefitWindow : public Window {
 								left = std::max(0, left);
 
 								if (_current_text_dir == TD_RTL) {
-									right = this->GetWidget<NWidgetCore>(WID_VR_VEHICLE_PANEL_DISPLAY)->current_x - left;
+									right = r.Width() - left;
 									left = right - width;
 								}
 
 								if (left != right) {
-									DrawFrameRect(left, r.top + WidgetDimensions::scaled.framerect.top, right, r.top + WidgetDimensions::scaled.framerect.top + ScaleSpriteTrad(14) - 1, COLOUR_WHITE, FR_BORDERONLY);
+									Rect hr = {left, highlight_top, right, highlight_bottom};
+									DrawFrameRect(hr.Expand(WidgetDimensions::scaled.bevel), COLOUR_WHITE, FR_BORDERONLY);
 								}
 
 								left = INT32_MIN;


### PR DESCRIPTION
## Motivation / Problem

Refit highlight was not correct for non-power-of-2 interface scale.

![image](https://user-images.githubusercontent.com/639850/204140852-fbc7c32e-93bc-4d77-b3ad-afb57367d6d1.png)

## Description

Refit highlight position now uses similar method as regular highlight.

![image](https://user-images.githubusercontent.com/639850/204140873-b5b3bef6-2193-4f36-894e-1abc43c2f3f8.png)

Although this is a "Fix" it's more "oops I missed this bit".

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
