### PR TITLE
Fix eb4ba1991: Signal icons incorrectly positioned in UI.

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1678,7 +1678,7 @@ private:
 		Point offset;
 		Dimension sprite_size = GetSpriteSize(image, &offset);
 		Rect ir = r.Shrink(WidgetDimensions::scaled.imgbtn);
-		int x = CenterBounds(ir.left, ir.right, sprite_size.width - offset.x); // centered
+		int x = CenterBounds(ir.left, ir.right, sprite_size.width - offset.x) - offset.x; // centered
 		int y = ir.top - sig_sprite_bottom_offset +
 				(ir.Height() + sig_sprite_size.height) / 2; // aligned to bottom
 


### PR DESCRIPTION
## Motivation / Problem

![image](https://user-images.githubusercontent.com/639850/204364282-1bc488b9-11a3-40b3-a5e2-294008d57522.png)

I broke signal sprite offsets.

## Description
 
![image](https://user-images.githubusercontent.com/639850/204364191-703b413d-31d9-4132-9a15-4906359f6fae.png)

I fix signal sprite offsets.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
