### PR TITLE
Fix: Missing extra padding when drawing tooltip text.

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -656,7 +656,7 @@ void HideFillingPercent(TextEffectID *te_id)
 }
 
 static const NWidgetPart _nested_tooltips_widgets[] = {
-	NWidget(WWT_PANEL, COLOUR_GREY, WID_TT_BACKGROUND), SetMinimalSize(200, 32), EndContainer(),
+	NWidget(WWT_EMPTY, INVALID_COLOUR, WID_TT_BACKGROUND), EndContainer(),
 };
 
 static WindowDesc _tool_tips_desc(
@@ -722,8 +722,8 @@ struct TooltipsWindow : public Window
 		size->height = GetStringHeight(this->string_id, size->width);
 
 		/* Increase slightly to have some space around the box. */
-		size->width  += padding.width  + WidgetDimensions::scaled.fullbevel.Horizontal();
-		size->height += padding.height + WidgetDimensions::scaled.fullbevel.Vertical();
+		size->width  += WidgetDimensions::scaled.framerect.Horizontal()  + WidgetDimensions::scaled.fullbevel.Horizontal();
+		size->height += WidgetDimensions::scaled.framerect.Vertical()    + WidgetDimensions::scaled.fullbevel.Vertical();
 	}
 
 	void DrawWidget(const Rect &r, int widget) const override

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -735,7 +735,7 @@ struct TooltipsWindow : public Window
 		for (uint arg = 0; arg < this->paramcount; arg++) {
 			SetDParam(arg, this->params[arg]);
 		}
-		DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.framerect), this->string_id, TC_FROMSTRING, SA_CENTER);
+		DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.framerect).Shrink(WidgetDimensions::scaled.fullbevel), this->string_id, TC_FROMSTRING, SA_CENTER);
 	}
 
 	void OnMouseLoop() override


### PR DESCRIPTION
## Motivation / Problem

This padding is included when calculating the size of the tooltips, the difference causes a mismatch in height for some tooltips.

![image](https://user-images.githubusercontent.com/639850/204507322-fbcf59a1-1887-4f57-a022-3abbe392ed9d.png)

## Description

Apply padding when drawing.

![image](https://user-images.githubusercontent.com/639850/204507979-e7b5151b-1851-4f78-932c-8f82bdbf1c76.png)

Note that this tooltip wraps onto 4 lines because tooltips have a maximum width. While putting one word on the last line is arguable, the intention of this change is to make the padding consistent between sizing calculation and drawing.

The second commit changes the layout so that a grey panel isn't needlessly drawn underneath the tooltip.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
