### PR TITLE
Feature: Add alternative setting for right-click close window option to exclude pinned windows

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1618,6 +1618,10 @@ STR_CONFIG_SETTING_RIGHT_MOUSE_BTN_EMU_OFF                      :Off
 
 STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE                        :Close window on right-click: {STRING2}
 STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_HELPTEXT               :Closes a window by right-clicking inside it. Disables the tooltip on right-click!
+###length 3
+STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_NO                     :No
+STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_YES                    :Yes
+STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_YES_EXCEPT_STICKY      :Yes, except sticky
 
 STR_CONFIG_SETTING_AUTOSAVE                                     :Autosave: {STRING2}
 STR_CONFIG_SETTING_AUTOSAVE_HELPTEXT                            :Select interval between automatic game saves

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -160,8 +160,8 @@ enum IniFileVersion : uint32_t {
 	IFV_GAME_TYPE,                                         ///< 2  PR#9515  Convert server_advertise to server_game_type.
 	IFV_LINKGRAPH_SECONDS,                                 ///< 3  PR#10610 Store linkgraph update intervals in seconds instead of days.
 	IFV_NETWORK_PRIVATE_SETTINGS,                          ///< 4  PR#10762 Move no_http_content_downloads / use_relay_service to private settings.
-
 	IFV_AUTOSAVE_RENAME,                                   ///< 5  PR#11143 Renamed values of autosave to be in minutes.
+	IFV_RIGHT_CLICK_CLOSE,                                 ///< 6  PR#10204 Add alternative right click to close windows setting.
 
 	IFV_MAX_VERSION,       ///< Highest possible ini-file version.
 };
@@ -1332,6 +1332,12 @@ void LoadFromConfig(bool startup)
 				case 4: _settings_client.gui.autosave_interval = std::chrono::minutes(120); break;
 				default: break;
 			}
+		}
+
+		/* Persist the right click close option from older versions. */
+		if (generic_version < IFV_RIGHT_CLICK_CLOSE && IsConversionNeeded(generic_ini, "gui", "right_mouse_wnd_close", "right_click_wnd_close", &old_item)) {
+			auto old_value = BoolSettingDesc::ParseSingleValue(old_item->value->c_str());
+			_settings_client.gui.right_click_wnd_close = old_value.value_or(false) ? RCC_YES : RCC_NO;
 		}
 
 		_grfconfig_newgame = GRFLoadConfig(generic_ini, "newgrf", false);

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1780,7 +1780,7 @@ static SettingsContainer &GetSettingsTree()
 				general->Add(new SettingEntry("gui.errmsg_duration"));
 				general->Add(new SettingEntry("gui.window_snap_radius"));
 				general->Add(new SettingEntry("gui.window_soft_limit"));
-				general->Add(new SettingEntry("gui.right_mouse_wnd_close"));
+				general->Add(new SettingEntry("gui.right_click_wnd_close"));
 			}
 
 			SettingsPage *viewports = interface->Add(new SettingsPage(STR_CONFIG_SETTING_INTERFACE_VIEWPORTS));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -77,6 +77,13 @@ enum ParticipateSurvey {
 	PS_YES,
 };
 
+/** Right-click to close window actions. */
+enum RightClickClose : uint8_t {
+	RCC_NO = 0,
+	RCC_YES,
+	RCC_YES_EXCEPT_STICKY,
+};
+
 /** Settings related to the difficulty of the game */
 struct DifficultySettings {
 	byte   competitor_start_time;            ///< Unused value, used to load old savegames.
@@ -154,7 +161,7 @@ struct GUISettings {
 	uint8_t  scrollwheel_scrolling;            ///< scrolling using the scroll wheel?
 	uint8_t  scrollwheel_multiplier;           ///< how much 'wheel' per incoming event from the OS?
 	bool   timetable_arrival_departure;      ///< show arrivals and departures in vehicle timetables
-	bool   right_mouse_wnd_close;            ///< close window with right click
+	RightClickClose  right_click_wnd_close;  ///< close window with right click
 	bool   pause_on_newgame;                 ///< whether to start new games paused or not
 	SignalGUISettings signal_gui_mode;       ///< select which signal types are shown in the signal GUI
 	SignalCycleSettings cycle_signal_types;  ///< Which signal types to cycle with the build signal tool.

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -18,6 +18,7 @@ static void SpriteZoomMinChanged(int32_t new_value);
 
 static constexpr std::initializer_list<const char*> _osk_activation{"disabled", "double", "single", "immediately"};
 static constexpr std::initializer_list<const char*> _savegame_date{"long", "short", "iso"};
+static constexpr std::initializer_list<const char*> _right_click_close{"no", "yes", "except sticky"};
 
 static const SettingVariant _gui_settings_table[] = {
 [post-amble]
@@ -128,12 +129,17 @@ def      = false
 str      = STR_CONFIG_SETTING_SMOOTH_SCROLLING
 strhelp  = STR_CONFIG_SETTING_SMOOTH_SCROLLING_HELPTEXT
 
-[SDTC_BOOL]
-var      = gui.right_mouse_wnd_close
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = false
+[SDTC_OMANY]
+var      = gui.right_click_wnd_close
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
+def      = RCC_NO
+min      = RCC_NO
+max      = RCC_YES_EXCEPT_STICKY
+full     = _right_click_close
 str      = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE
 strhelp  = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_HELPTEXT
+strval   = STR_CONFIG_SETTING_RIGHT_MOUSE_WND_CLOSE_NO
 cat      = SC_BASIC
 
 ; We might need to emulate a right mouse button on mac

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -819,8 +819,11 @@ static void DispatchRightClickEvent(Window *w, int x, int y)
 		if (w->OnRightClick(pt, wid->index)) return;
 	}
 
-	/* Right-click close is enabled and there is a closebox */
-	if (_settings_client.gui.right_mouse_wnd_close && (w->window_desc->flags & WDF_NO_CLOSE) == 0) {
+	/* Right-click close is enabled and there is a closebox. */
+	if (_settings_client.gui.right_click_wnd_close == RCC_YES && (w->window_desc->flags & WDF_NO_CLOSE) == 0) {
+		w->Close();
+	} else if (_settings_client.gui.right_click_wnd_close == RCC_YES_EXCEPT_STICKY && (w->flags & WF_STICKY) == 0 && (w->window_desc->flags & WDF_NO_CLOSE) == 0) {
+		/* Right-click close is enabled, but excluding sticky windows. */
 		w->Close();
 	} else if (_settings_client.gui.hover_delay_ms == 0 && !w->OnTooltip(pt, wid->index, TCC_RIGHT_CLICK) && wid->tool_tip != 0) {
 		GuiShowTooltips(w, wid->tool_tip, TCC_RIGHT_CLICK);


### PR DESCRIPTION
## Motivation / Problem

The right-click to close windows option is a great gameplay improvement, however it makes it very easy and common to close windows you don't intend to. 
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

My solution to this issue is to change the right-click to close windows setting to be a dropdown rather than a simple toggle, with a third option to exclude pinned windows. When set to this third mode, simply pin a window and right-click will no longer close the window.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

Since I changed the type of the config option from a `bool` to a `uint8` the game will give you a warning upon launching if you last saved settings from a version that did not make this change. This window can be easily dismissed and as far as I can tell there are no negative effects from this.

I've been looking into solutions for this, but modifying the setting loading code to smoothly change this format to the new type is not a satisfactory solution.

I'm also not very satisfied with my if condition in `window.cpp`, it's quite long, but I'm not sure of a better way to split it.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
