### PR TITLE
Fix #10114: Incorrect drag-highlight position with non-power-of-2 scaling.

### DIFF
--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -53,11 +53,12 @@ void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id,
  * Highlight the position where a rail vehicle is dragged over by drawing a light gray background.
  * @param px        The current x position to draw from.
  * @param max_width The maximum space available to draw.
+ * @param y         The vertical centre position to draw from.
  * @param selection Selected vehicle that is dragged.
  * @param chain     Whether a whole chain is dragged.
  * @return The width of the highlight mark.
  */
-static int HighlightDragPosition(int px, int max_width, VehicleID selection, bool chain)
+static int HighlightDragPosition(int px, int max_width, int y, VehicleID selection, bool chain)
 {
 	bool rtl = _current_text_dir == TD_RTL;
 
@@ -72,8 +73,11 @@ static int HighlightDragPosition(int px, int max_width, VehicleID selection, boo
 	int drag_hlight_width = std::max(drag_hlight_right - drag_hlight_left + 1, 0);
 
 	if (drag_hlight_width > 0) {
-		GfxFillRect(drag_hlight_left + WidgetDimensions::scaled.framerect.left, WidgetDimensions::scaled.framerect.top + 1,
-				drag_hlight_right - WidgetDimensions::scaled.framerect.right, ScaleSpriteTrad(13) - WidgetDimensions::scaled.framerect.bottom, _colour_gradient[COLOUR_GREY][7]);
+		int height = ScaleSpriteTrad(12);
+		int top = y - height / 2;
+		Rect r = {drag_hlight_left, top, drag_hlight_right, top + height - 1};
+		/* Sprite-scaling is used here as the area is from sprite size */
+		GfxFillRect(r.Shrink(ScaleSpriteTrad(1)), _colour_gradient[COLOUR_GREY][7]);
 	}
 
 	return drag_hlight_width;
@@ -111,7 +115,7 @@ void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineIm
 	for (; v != nullptr && (rtl ? px > 0 : px < max_width); v = v->Next()) {
 		if (dragging && !drag_at_end_of_train && drag_dest == v->index) {
 			/* Highlight the drag-and-drop destination inside the train. */
-			int drag_hlight_width = HighlightDragPosition(px, max_width, selection, _cursor.vehchain);
+			int drag_hlight_width = HighlightDragPosition(px, max_width, y, selection, _cursor.vehchain);
 			px += rtl ? -drag_hlight_width : drag_hlight_width;
 		}
 
@@ -145,7 +149,7 @@ void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineIm
 
 	if (dragging && drag_at_end_of_train) {
 		/* Highlight the drag-and-drop destination at the end of the train. */
-		HighlightDragPosition(px, max_width, selection, _cursor.vehchain);
+		HighlightDragPosition(px, max_width, y, selection, _cursor.vehchain);
 	}
 
 	_cur_dpi = old_dpi;


### PR DESCRIPTION
## Motivation / Problem

![image](https://user-images.githubusercontent.com/639850/205387695-d680d24a-fa9f-48f4-9d7d-a29855a2af6f.png)

Drag highlight didn't take account of vertical offset.

## Description

![image](https://user-images.githubusercontent.com/639850/205388458-43584aed-65f8-4740-9316-4c29266fd4da.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
