### PR TITLE
Fix #10212: [Script] Nested ScriptAccounting scopes are not restored properly.

### DIFF
--- a/regression/regression/main.nut
+++ b/regression/regression/main.nut
@@ -562,6 +562,25 @@ function Regression::Prices()
 	print("  BT_CLEAR_WATER:  " + AITile.GetBuildCost(AITile.BT_CLEAR_WATER));
 }
 
+function Regression::Commands()
+{
+	print("");
+	print("--Commands--");
+
+	print(" -Command accounting-");
+	local test = AITestMode();
+	local costs = AIAccounting();
+	AITile.DemolishTile(2834);
+	print("  Command cost:              " + costs.GetCosts());
+	{
+		local inner = AIAccounting();
+		print("  New inner cost scope:      " + costs.GetCosts());
+		AITile.DemolishTile(2835);
+		print("  Further command cost:      " + costs.GetCosts());
+	}
+	print("  Saved cost of outer scope: " + costs.GetCosts());
+}
+
 function cost_callback(old_path, new_tile, new_direction, self) { if (old_path == null) return 0; return old_path.GetCost() + 1; }
 function estimate_callback(tile, direction, goals, self) { return goals[0] - tile; }
 function neighbours_callback(path, cur_tile, self) { return [[cur_tile + 1, 1]]; }
@@ -1940,6 +1959,7 @@ function Regression::Start()
 	/* Do this first as it gains maximum loan (which is faked to quite a lot). */
 	this.Company();
 
+	this.Commands();
 	this.Airport();
 	this.Bridge();
 	this.BridgeList();

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -788,6 +788,13 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetQuarterlyPerformanceRating(): 0
     GetQuarterlyCompanyValue():      0
 
+--Commands--
+ -Command accounting-
+  Command cost:              7500
+  New inner cost scope:      0
+  Further command cost:      30
+  Saved cost of outer scope: 7500
+
 --AIAirport--
   IsHangarTile():       false
   IsAirportTile():      false

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -103,7 +103,7 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 
 /* static */ void ScriptObject::SetDoCommandCosts(Money value)
 {
-	GetStorage()->costs = CommandCost(value);
+	GetStorage()->costs = CommandCost(INVALID_EXPENSES, value); // Expense type is never read.
 }
 
 /* static */ void ScriptObject::IncreaseDoCommandCosts(Money value)


### PR DESCRIPTION
## Motivation / Problem

As reported in #10212 `ScriptObject::SetDoCommandCosts` doesn't actually set any command costs as the called `CommandCost` constructor is not the one taking a cost.

The only user of this function is the script `ScriptAccounting` class, which uses it to enter and exit nested scopes.
Entering a scope sets the cost to 0, which is the default anyway and works even with this bug, but exiting a nested scope doesn't restore the old tracked cost value.


## Description

Use the proper constructor so when a cost scoped is left, we don't restore a cost of 0.

While at it, add a regression function that would detect this bug.


## Limitations

It is not known if any existing script relies on the broken behaviour, but I'd guess that nesting `ScriptAccounting` scopes is somewhat obscure.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
