### PR TITLE
Fix #10216: Initialise RoadStop caches before using them and don't try to teleport crashed vehicles

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3155,6 +3155,9 @@ bool AfterLoadGame()
 		}
 	}
 
+	/* Road stops is 'only' updating some caches, but they are needed for PF calls in SLV_MULTITRACK_LEVEL_CROSSINGS teleporting. */
+	AfterLoadRoadStops();
+
 	/* Road vehicles stopped on multitrack level crossings need teleporting to a depot
 	 * to avoid crashing into the side of the train they're waiting for. */
 	if (IsSavegameVersionBefore(SLV_MULTITRACK_LEVEL_CROSSINGS)) {
@@ -3165,6 +3168,9 @@ bool AfterLoadGame()
 
 			/* Ignore moving vehicles. */
 			if (rv->cur_speed > 0) continue;
+
+			/* Ignore crashed vehicles. */
+			if (rv->vehstatus & VS_CRASHED) continue;
 
 			/* Ignore vehicles not on level crossings. */
 			TileIndex cur_tile = rv->tile;
@@ -3207,8 +3213,6 @@ bool AfterLoadGame()
 		for (Station *st : Station::Iterate()) UpdateStationAcceptance(st, false);
 	}
 
-	/* Road stops is 'only' updating some caches */
-	AfterLoadRoadStops();
 	AfterLoadLabelMaps();
 	AfterLoadCompanyStats();
 	AfterLoadStoryBook();


### PR DESCRIPTION
## Motivation / Problem
When calling pathfinder to find closest depot during SLV_MULTITRACK_LEVEL_CROSSINGS conversion trying to prevent RV crashes it may traverse drive through road stops.
But the drive through road stops are not fully initialised yet and cause a crash.
After fixing this issue, the same savegame triggered an [assert](https://github.com/OpenTTD/OpenTTD/blob/master/src/track_func.h#L341) because it ran PF for a crashed vehicle.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Reorder some stuff to initialise RoadStops caches before use.
Ignore crashed vehicles when trying to teleport them.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
