### PR TITLE
Fix: Maximum space for engine preview image was never scaled.

### DIFF
--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -24,6 +24,7 @@
 #include "ship.h"
 #include "aircraft.h"
 #include "engine_cmd.h"
+#include "zoom_func.h"
 
 #include "widgets/engine_widget.h"
 
@@ -94,7 +95,7 @@ struct EnginePreviewWindow : Window {
 			case VEH_SHIP:     GetShipSpriteSize(    engine, x, y, x_offs, y_offs, image_type); break;
 			case VEH_AIRCRAFT: GetAircraftSpriteSize(engine, x, y, x_offs, y_offs, image_type); break;
 		}
-		this->vehicle_space = std::max<int>(40, y - y_offs);
+		this->vehicle_space = std::max<int>(ScaleSpriteTrad(40), y - y_offs);
 
 		size->width = std::max(size->width, x - x_offs);
 		SetDParam(0, GetEngineCategoryName(engine));


### PR DESCRIPTION
## Motivation / Problem

Maximum vertical space for engine preview image is fixed at 40 pixels, regardless of interface scaling.

This has never been scaled, even before the recent changes.

## Description

As this is drawing a sprite, this is resolved by scaling the maximum vertical space with `ScaleSpriteTrad()`

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
