### PR TITLE
Fix #10223: Crash when vehicle cloning fails on order cloning.

### DIFF
--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -958,7 +958,7 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlag flags, TileInde
 		if (result.Failed()) {
 			/* The vehicle has already been bought, so now it must be sold again. */
 			Command<CMD_SELL_VEHICLE>::Do(flags, w_front->index, true, false, INVALID_CLIENT_ID);
-			return { total_cost, INVALID_VEHICLE };
+			return { result, INVALID_VEHICLE };
 		}
 
 		/* Now clone the vehicle's name, if it has one. */


### PR DESCRIPTION
## Motivation / Problem

See #10223. Cloning a vehicle can crash when cloning the order list fails.


## Description / Limitations

This was caused by a misconversion in the command rewrite. #10223 mentions another line below, but that is correct as `CheckCompanyHasMoney` actually modifies the `CommandCost` parameter.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
