### PR TITLE
Fix 3c047b1: AIGroup.GetProfitLastYear could get values different than those displayed in GUI

### DIFF
--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -423,6 +423,11 @@ static CommandCost CopyHeadSpecificThings(Vehicle *old_head, Vehicle *new_head, 
 		/* Copy other things which cannot be copied by a command and which shall not stay resetted from the build vehicle command */
 		new_head->CopyVehicleConfigAndStatistics(old_head);
 
+		GroupStatistics &stats_all = GroupStatistics::GetAllGroup(new_head);
+		GroupStatistics &stats = GroupStatistics::Get(new_head);
+		stats_all.profit_last_year += new_head->GetDisplayProfitLastYear();
+		stats.profit_last_year += new_head->GetDisplayProfitLastYear();
+
 		/* Switch vehicle windows/news to the new vehicle, so they are not closed/deleted when the old vehicle is sold */
 		ChangeVehicleViewports(old_head->index, new_head->index);
 		ChangeVehicleViewWindow(old_head->index, new_head->index);

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -422,11 +422,7 @@ static CommandCost CopyHeadSpecificThings(Vehicle *old_head, Vehicle *new_head, 
 	if (cost.Succeeded() && old_head != new_head && (flags & DC_EXEC) != 0) {
 		/* Copy other things which cannot be copied by a command and which shall not stay resetted from the build vehicle command */
 		new_head->CopyVehicleConfigAndStatistics(old_head);
-
-		GroupStatistics &stats_all = GroupStatistics::GetAllGroup(new_head);
-		GroupStatistics &stats = GroupStatistics::Get(new_head);
-		stats_all.profit_last_year += new_head->GetDisplayProfitLastYear();
-		stats.profit_last_year += new_head->GetDisplayProfitLastYear();
+		GroupStatistics::AddProfitLastYear(new_head);
 
 		/* Switch vehicle windows/news to the new vehicle, so they are not closed/deleted when the old vehicle is sold */
 		ChangeVehicleViewports(old_head->index, new_head->index);

--- a/src/group.h
+++ b/src/group.h
@@ -24,13 +24,14 @@ extern GroupPool _group_pool; ///< Pool of groups.
 /** Statistics and caches on the vehicles in a group. */
 struct GroupStatistics {
 	uint16 num_vehicle;                     ///< Number of vehicles.
+	Money profit_last_year;                 ///< Sum of profits for all vehicles.
 	uint16 *num_engines;                    ///< Caches the number of engines of each type the company owns.
 
 	bool autoreplace_defined;               ///< Are any autoreplace rules set?
 	bool autoreplace_finished;              ///< Have all autoreplacement finished?
 
 	uint16 num_profit_vehicle;              ///< Number of vehicles considered for profit statistics;
-	Money profit_last_year;                 ///< Sum of profits for all vehicles.
+	Money profit_last_year_min_age;         ///< Sum of profits for considered vehicles.
 
 	GroupStatistics();
 	~GroupStatistics();
@@ -41,6 +42,7 @@ struct GroupStatistics {
 	{
 		this->num_profit_vehicle = 0;
 		this->profit_last_year = 0;
+		this->profit_last_year_min_age = 0;
 	}
 
 	void ClearAutoreplace()
@@ -105,7 +107,7 @@ static inline bool IsAllGroupID(GroupID id_g)
 uint GetGroupNumEngines(CompanyID company, GroupID id_g, EngineID id_e);
 uint GetGroupNumVehicle(CompanyID company, GroupID id_g, VehicleType type);
 uint GetGroupNumProfitVehicle(CompanyID company, GroupID id_g, VehicleType type);
-Money GetGroupProfitLastYear(CompanyID company, GroupID id_g, VehicleType type);
+Money GetGroupProfitLastYearMinAge(CompanyID company, GroupID id_g, VehicleType type);
 
 void SetTrainGroupID(Train *v, GroupID grp);
 void UpdateTrainGroupID(Train *v);

--- a/src/group.h
+++ b/src/group.h
@@ -23,15 +23,13 @@ extern GroupPool _group_pool; ///< Pool of groups.
 
 /** Statistics and caches on the vehicles in a group. */
 struct GroupStatistics {
-	uint16 num_vehicle;                     ///< Number of vehicles.
 	Money profit_last_year;                 ///< Sum of profits for all vehicles.
+	Money profit_last_year_min_age;         ///< Sum of profits for vehicles considered for profit statistics.
 	uint16 *num_engines;                    ///< Caches the number of engines of each type the company owns.
-
+	uint16 num_vehicle;                     ///< Number of vehicles.
+	uint16 num_vehicle_min_age;             ///< Number of vehicles considered for profit statistics;
 	bool autoreplace_defined;               ///< Are any autoreplace rules set?
 	bool autoreplace_finished;              ///< Have all autoreplacement finished?
-
-	uint16 num_vehicle_min_age;             ///< Number of vehicles considered for profit statistics;
-	Money profit_last_year_min_age;         ///< Sum of profits for considered vehicles.
 
 	GroupStatistics();
 	~GroupStatistics();

--- a/src/group.h
+++ b/src/group.h
@@ -57,6 +57,7 @@ struct GroupStatistics {
 
 	static void CountVehicle(const Vehicle *v, int delta);
 	static void CountEngine(const Vehicle *v, int delta);
+	static void AddProfitLastYear(const Vehicle *v);
 	static void VehicleReachedProfitAge(const Vehicle *v);
 
 	static void UpdateProfits();

--- a/src/group.h
+++ b/src/group.h
@@ -30,7 +30,7 @@ struct GroupStatistics {
 	bool autoreplace_defined;               ///< Are any autoreplace rules set?
 	bool autoreplace_finished;              ///< Have all autoreplacement finished?
 
-	uint16 num_profit_vehicle;              ///< Number of vehicles considered for profit statistics;
+	uint16 num_vehicle_min_age;             ///< Number of vehicles considered for profit statistics;
 	Money profit_last_year_min_age;         ///< Sum of profits for considered vehicles.
 
 	GroupStatistics();
@@ -40,8 +40,9 @@ struct GroupStatistics {
 
 	void ClearProfits()
 	{
-		this->num_profit_vehicle = 0;
 		this->profit_last_year = 0;
+
+		this->num_vehicle_min_age = 0;
 		this->profit_last_year_min_age = 0;
 	}
 
@@ -58,7 +59,7 @@ struct GroupStatistics {
 	static void CountVehicle(const Vehicle *v, int delta);
 	static void CountEngine(const Vehicle *v, int delta);
 	static void AddProfitLastYear(const Vehicle *v);
-	static void VehicleReachedProfitAge(const Vehicle *v);
+	static void VehicleReachedMinAge(const Vehicle *v);
 
 	static void UpdateProfits();
 	static void UpdateAfterLoad();
@@ -107,7 +108,7 @@ static inline bool IsAllGroupID(GroupID id_g)
 
 uint GetGroupNumEngines(CompanyID company, GroupID id_g, EngineID id_e);
 uint GetGroupNumVehicle(CompanyID company, GroupID id_g, VehicleType type);
-uint GetGroupNumProfitVehicle(CompanyID company, GroupID id_g, VehicleType type);
+uint GetGroupNumVehicleMinAge(CompanyID company, GroupID id_g, VehicleType type);
 Money GetGroupProfitLastYearMinAge(CompanyID company, GroupID id_g, VehicleType type);
 
 void SetTrainGroupID(Train *v, GroupID grp);

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -162,6 +162,18 @@ void GroupStatistics::Clear()
 }
 
 /**
+ * Add a vehicle's last year profit to the profit sum of its group.
+ */
+/* static */ void GroupStatistics::AddProfitLastYear(const Vehicle *v)
+{
+	GroupStatistics &stats_all = GroupStatistics::GetAllGroup(v);
+	GroupStatistics &stats = GroupStatistics::Get(v);
+
+	stats_all.profit_last_year += v->GetDisplayProfitLastYear();
+	stats.profit_last_year += v->GetDisplayProfitLastYear();
+}
+
+/**
  * Add a vehicle to the profit sum of its group.
  */
 /* static */ void GroupStatistics::VehicleReachedProfitAge(const Vehicle *v)
@@ -195,12 +207,7 @@ void GroupStatistics::Clear()
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
 		if (v->IsPrimaryVehicle()) {
-			GroupStatistics &stats_all = GroupStatistics::GetAllGroup(v);
-			GroupStatistics &stats = GroupStatistics::Get(v);
-
-			stats_all.profit_last_year += v->GetDisplayProfitLastYear();
-			stats.profit_last_year += v->GetDisplayProfitLastYear();
-
+			GroupStatistics::AddProfitLastYear(v);
 			if (v->age > VEHICLE_PROFIT_MIN_AGE) GroupStatistics::VehicleReachedProfitAge(v);
 		}
 	}

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -43,9 +43,9 @@ GroupStatistics::~GroupStatistics()
 void GroupStatistics::Clear()
 {
 	this->num_vehicle = 0;
-	this->num_profit_vehicle = 0;
-	this->profit_last_year_min_age = 0;
 	this->profit_last_year = 0;
+	this->num_vehicle_min_age = 0;
+	this->profit_last_year_min_age = 0;
 
 	/* This is also called when NewGRF change. So the number of engines might have changed. Reallocate. */
 	free(this->num_engines);
@@ -142,9 +142,9 @@ void GroupStatistics::Clear()
 	stats.profit_last_year += v->GetDisplayProfitLastYear() * delta;
 
 	if (v->age > VEHICLE_PROFIT_MIN_AGE) {
-		stats_all.num_profit_vehicle += delta;
+		stats_all.num_vehicle_min_age += delta;
 		stats_all.profit_last_year_min_age += v->GetDisplayProfitLastYear() * delta;
-		stats.num_profit_vehicle += delta;
+		stats.num_vehicle_min_age += delta;
 		stats.profit_last_year_min_age += v->GetDisplayProfitLastYear() * delta;
 	}
 }
@@ -176,14 +176,14 @@ void GroupStatistics::Clear()
 /**
  * Add a vehicle to the profit sum of its group.
  */
-/* static */ void GroupStatistics::VehicleReachedProfitAge(const Vehicle *v)
+/* static */ void GroupStatistics::VehicleReachedMinAge(const Vehicle *v)
 {
 	GroupStatistics &stats_all = GroupStatistics::GetAllGroup(v);
 	GroupStatistics &stats = GroupStatistics::Get(v);
 
-	stats_all.num_profit_vehicle++;
+	stats_all.num_vehicle_min_age++;
 	stats_all.profit_last_year_min_age += v->GetDisplayProfitLastYear();
-	stats.num_profit_vehicle++;
+	stats.num_vehicle_min_age++;
 	stats.profit_last_year_min_age += v->GetDisplayProfitLastYear();
 }
 
@@ -208,7 +208,7 @@ void GroupStatistics::Clear()
 	for (const Vehicle *v : Vehicle::Iterate()) {
 		if (v->IsPrimaryVehicle()) {
 			GroupStatistics::AddProfitLastYear(v);
-			if (v->age > VEHICLE_PROFIT_MIN_AGE) GroupStatistics::VehicleReachedProfitAge(v);
+			if (v->age > VEHICLE_PROFIT_MIN_AGE) GroupStatistics::VehicleReachedMinAge(v);
 		}
 	}
 }
@@ -807,13 +807,13 @@ uint GetGroupNumVehicle(CompanyID company, GroupID id_g, VehicleType type)
  * @param type The vehicle type of the group
  * @return The number of vehicles above profit minimum age in the group
  */
-uint GetGroupNumProfitVehicle(CompanyID company, GroupID id_g, VehicleType type)
+uint GetGroupNumVehicleMinAge(CompanyID company, GroupID id_g, VehicleType type)
 {
 	uint count = 0;
 	for (const Group *g : Group::Iterate()) {
-		if (g->parent == id_g) count += GetGroupNumProfitVehicle(company, g->index, type);
+		if (g->parent == id_g) count += GetGroupNumVehicleMinAge(company, g->index, type);
 	}
-	return count + GroupStatistics::Get(company, id_g, type).num_profit_vehicle;
+	return count + GroupStatistics::Get(company, id_g, type).num_vehicle_min_age;
 }
 
 /**

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -303,7 +303,7 @@ private:
 		x = rtl ? x - WidgetDimensions::scaled.hsep_normal - this->column_size[VGC_PROFIT].width : x + WidgetDimensions::scaled.hsep_normal + this->column_size[VGC_AUTOREPLACE].width;
 		SpriteID spr;
 		uint num_profit_vehicle = GetGroupNumProfitVehicle(this->vli.company, g_id, this->vli.vtype);
-		Money profit_last_year = GetGroupProfitLastYear(this->vli.company, g_id, this->vli.vtype);
+		Money profit_last_year = GetGroupProfitLastYearMinAge(this->vli.company, g_id, this->vli.vtype);
 		if (num_profit_vehicle == 0) {
 			spr = SPR_PROFIT_NA;
 		} else if (profit_last_year < 0) {

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -302,13 +302,13 @@ private:
 		/* draw the profit icon */
 		x = rtl ? x - WidgetDimensions::scaled.hsep_normal - this->column_size[VGC_PROFIT].width : x + WidgetDimensions::scaled.hsep_normal + this->column_size[VGC_AUTOREPLACE].width;
 		SpriteID spr;
-		uint num_profit_vehicle = GetGroupNumProfitVehicle(this->vli.company, g_id, this->vli.vtype);
-		Money profit_last_year = GetGroupProfitLastYearMinAge(this->vli.company, g_id, this->vli.vtype);
-		if (num_profit_vehicle == 0) {
+		uint num_vehicle_min_age = GetGroupNumVehicleMinAge(this->vli.company, g_id, this->vli.vtype);
+		Money profit_last_year_min_age = GetGroupProfitLastYearMinAge(this->vli.company, g_id, this->vli.vtype);
+		if (num_vehicle_min_age == 0) {
 			spr = SPR_PROFIT_NA;
-		} else if (profit_last_year < 0) {
+		} else if (profit_last_year_min_age < 0) {
 			spr = SPR_PROFIT_NEGATIVE;
-		} else if (profit_last_year < VEHICLE_PROFIT_THRESHOLD * num_profit_vehicle) {
+		} else if (profit_last_year_min_age < VEHICLE_PROFIT_THRESHOLD * num_vehicle_min_age) {
 			spr = SPR_PROFIT_SOME;
 		} else {
 			spr = SPR_PROFIT_LOT;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1379,7 +1379,7 @@ void AgeVehicle(Vehicle *v)
 {
 	if (v->age < MAX_DAY) {
 		v->age++;
-		if (v->IsPrimaryVehicle() && v->age == VEHICLE_PROFIT_MIN_AGE + 1) GroupStatistics::VehicleReachedProfitAge(v);
+		if (v->IsPrimaryVehicle() && v->age == VEHICLE_PROFIT_MIN_AGE + 1) GroupStatistics::VehicleReachedMinAge(v);
 	}
 
 	if (!v->IsPrimaryVehicle() && (v->type != VEH_TRAIN || !Train::From(v)->IsEngine())) return;


### PR DESCRIPTION
## Motivation / Problem
`AIGroup.GetProfitLastYear` was only accounting profits of vehicles which had an age higher than `VEHICLE_PROFIT_MIN_AGE`, which is different than what is displayed on group_gui widget `WID_GL_INFO`

`GroupStatistics::profit_last_year` is only used for displaying the colour of the profit icons in the vehicle list window, but for the AI API method, it should be expected to account for all vehicles in the group, and it doesn't.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
The proposed solution is to create another `GroupStatistics` profit that includes all vehicles and which would match the value  from `WID_GL_INFO`:
The original `GroupStatistics::profit_last_year` is renamed to `GroupStatistics::profit_last_year_min_age`, and a second `GroupStatistics::profit_last_year` replaces the original.
The resulting `GroupStatistics::profit_last_year_min_age` is to be used for the icon purposes in vehicle group lists and the new `GroupStatistics::profit_last_year` is to be used for the `AIGroup.GetProfitLastYear` method. No actual changes to the AI code is necessary then.
For clarity, `GroupStatistics::num_profit_vehicle` is renamed to `GroupStatistics::num_vehicle_min_age` as well as a few other items related to this, to try make it easier to understand what they refer to.

With the addition of the new profit, autoreplace posed an issue when trying to copy group and vehicle statistics from the old vehicle to the new vehicle. The group was getting the last year profit of the new vehicle which was still 0, before the profit was updated over from the old vehicle. The end result after autoreplace was completed, was that the group statistics didn't account for the missing profit. It was only copied between vehicles, but not when updating the group. This is solved by cirurgically updating the last year profits of the affected groups in `CopyVehicleConfigAndStatistics`
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
