### PR TITLE
Fix #10224: Don't fast forward after autosave if tab key is no longer pressed

### DIFF
--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2920,9 +2920,11 @@ static inline void ClearSaveLoadState()
  */
 static void SaveFileStart()
 {
-	// If fast forward is via key, save normal game speed.
-	// If the key continues to be pressed, the graphics driver will continue to fast forward the game.
-	// If the key is released during autosave, the normal speed will be restored.
+	/**
+	 * If fast forward is via key, save normal game speed.
+	 * If the key continues to be pressed, the graphics driver will continue to fast forward the game.
+	 * If the key is released during autosave, the normal speed will be restored.
+	 */
 	_sl.game_speed = VideoDriver::GetInstance()->isFastForwardViaKey() ? 100 : _game_speed;
 	_game_speed = 100;
 	SetMouseCursorBusy(true);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2925,7 +2925,7 @@ static void SaveFileStart()
 	 * If the key continues to be pressed, the graphics driver will continue to fast forward the game.
 	 * If the key is released during autosave, the normal speed will be restored.
 	 */
-	_sl.game_speed = VideoDriver::GetInstance()->isFastForwardViaKey() ? 100 : _game_speed;
+	_sl.game_speed = VideoDriver::GetInstance()->IsFastForwardViaKey() ? 100 : _game_speed;
 	_game_speed = 100;
 	SetMouseCursorBusy(true);
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -2920,7 +2920,10 @@ static inline void ClearSaveLoadState()
  */
 static void SaveFileStart()
 {
-	_sl.game_speed = _game_speed;
+	// If fast forward is via key, save normal game speed.
+	// If the key continues to be pressed, the graphics driver will continue to fast forward the game.
+	// If the key is released during autosave, the normal speed will be restored.
+	_sl.game_speed = VideoDriver::GetInstance()->isFastForwardViaKey() ? 100 : _game_speed;
 	_game_speed = 100;
 	SetMouseCursorBusy(true);
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include "../video/video_driver.hpp"
 
 /** SaveLoad versions
  * Previous savegame versions, the trunk revision where they were

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -222,6 +222,9 @@ public:
 		bool unlock; ///< Stores if the lock did anything that has to be undone.
 	};
 
+	bool isFastForwardViaKey(){
+		return fast_forward_via_key;
+	}
 protected:
 	const uint ALLOWED_DRIFT = 5; ///< How many times videodriver can miss deadlines without it being overly compensated.
 

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -222,9 +222,11 @@ public:
 		bool unlock; ///< Stores if the lock did anything that has to be undone.
 	};
 
-	bool isFastForwardViaKey(){
-		return fast_forward_via_key;
+	bool IsFastForwardViaKey()
+	{
+		return this->fast_forward_via_key;
 	}
+
 protected:
 	const uint ALLOWED_DRIFT = 5; ///< How many times videodriver can miss deadlines without it being overly compensated.
 


### PR DESCRIPTION


If fast forward is via key press

## Motivation / Problem

Fix #10224


## Description

Upon autosave, we save game speed in order to restore fast forward upon completion of autosave.
This caused a bug in the case where fast forward was due to key press which was released during the autosave.
So if fast forward is due to key press, save normal game speed. The graphics driver will take care of game speed after the autosave completes just like it does during game-play based on the key being pressed or not. 


## Limitations

n/a

## Checklist for review
