### PR TITLE
Fix #10218: Sloped river tiles need water both up and downstream

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1176,9 +1176,9 @@ static bool RiverMakeWider(TileIndex tile, void *data)
 				Command<CMD_TERRAFORM_LAND>::Do(DC_EXEC | DC_AUTO, tile, to_change, true);
 			}
 		}
+		/* Update cur_slope after possibly terraforming. */
+		cur_slope = GetTileSlope(tile);
 	}
-	/* Update cur_slope after possibly terraforming. */
-	cur_slope = GetTileSlope(tile);
 
 	/* Sloped rivers need water both upstream and downstream. */
 	if (IsInclinedSlope(cur_slope)) {
@@ -1319,7 +1319,7 @@ static void River_FoundEndNode(AyStar *aystar, OpenListNode *current)
 			current_river_length = DistanceManhattan(data->spring, tile);
 			radius = std::min(3u, (current_river_length / (long_river_length / 3u)) + 1u);
 
-			if (radius > 1) CircularTileSearch(&tile, radius + RandomRange(1), RiverMakeWider, (void *)&path->node.tile);
+			if (radius > 1) CircularTileSearch(&tile, radius, RiverMakeWider, (void *)&path->node.tile);
 		}
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

When widening rivers, we use a CircularTileSearch to attempt to terraform and make river tiles within the river's radius. This determines the desired slope automatically based on whether the target tile is part of a continuous row of sloped river tiles. This was missing a check to ensure the river is actually sloping down to the sea, so the row of sloped tiles could end up propagating inland, as seen in #10218.

I don't know what's going on with coast tiles being drawn in #10218, but this also avoids that happening. 🙂 

## Description

Ensure that sloped tiles always have water both upstream and downstream from themselves.

New ocean tiles created by river terraforming will flood after river generation is complete, but on non-ocean tiles we can take a shortcut to create river tiles up and/or downstream, if they don't already exist.

Closes #10218.

A second commit moves a `cur_slope` update so it doesn't get run if no terraforming is needed, and gets rid of a `RandomRange(1)` (which always returns 0) that must be vestigial code from the patch's development which somehow snuck past review.

## Limitations

It's still possible for a long river paralleling a coast to have a wide row of sloped tiles down to the sea. But this looks much less wrong than #10218 and is more of a design choice than a bug. 😉 I'm hesitant to write a lot of code to solve this and potentially introduce other edge cases where multiple rivers flow into the ocean near each other. 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
 