### PR TITLE
Fix #10206: Disable scripts in intro game

### DIFF
--- a/src/ai/ai_instance.cpp
+++ b/src/ai/ai_instance.cpp
@@ -61,6 +61,9 @@ void AIInstance::Died()
 {
 	ScriptInstance::Died();
 
+	/* Intro is not supposed to use AI, but it may have 'dummy' AI which instant dies. */
+	if (_game_mode == GM_MENU) return;
+
 	ShowAIDebugWindow(_current_company);
 
 	const AIInfo *info = AIConfig::GetConfig(_current_company, AIConfig::SSS_FORCE_GAME)->GetInfo();

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -10,6 +10,7 @@
 #include "../stdafx.h"
 #include "../debug.h"
 #include "../network/network.h"
+#include "../openttd.h"
 #include "../core/random_func.hpp"
 
 #include "../script/squirrel_class.hpp"
@@ -59,6 +60,11 @@ void AIScannerInfo::RegisterAPI(class Squirrel *engine)
 
 AIInfo *AIScannerInfo::SelectRandomAI() const
 {
+	if (_game_mode == GM_MENU) {
+		Debug(script, 0, "The intro game should not use AI, loading 'dummy' AI.");
+		return this->info_dummy;
+	}
+
 	uint num_random_ais = 0;
 	for (const auto &item : info_single_list) {
 		AIInfo *i = static_cast<AIInfo *>(item.second);

--- a/src/saveload/ai_sl.cpp
+++ b/src/saveload/ai_sl.cpp
@@ -77,7 +77,7 @@ struct AIPLChunkHandler : ChunkHandler {
 			_ai_saveload_version = -1;
 			SlObject(nullptr, slt);
 
-			if (_networking && !_network_server) {
+			if (_game_mode == GM_MENU || (_networking && !_network_server)) {
 				if (Company::IsValidAiID(index)) AIInstance::LoadEmpty();
 				continue;
 			}

--- a/src/saveload/game_sl.cpp
+++ b/src/saveload/game_sl.cpp
@@ -69,7 +69,7 @@ struct GSDTChunkHandler : ChunkHandler {
 		_game_saveload_version = -1;
 		SlObject(nullptr, slt);
 
-		if (_networking && !_network_server) {
+		if (_game_mode == GM_MENU || (_networking && !_network_server)) {
 			GameInstance::LoadEmpty();
 			if (SlIterateArray() != -1) SlErrorCorrupt("Too many GameScript configs");
 			return;


### PR DESCRIPTION
Fixes #10206

## Motivation / Problem
Using scripts in intro game can cause crashes.
We always said intro should not use scripts or newgrfs, but we only enforced the newgrf part (with broken save error because disabling newgrf in a running game is never a good idea).
Dedicated servers may also crash because of scripts during the load test as it's done in `GM_MENU` (unrelated but it's funny to see the broken save error when starting a dedicated server with `-g` and a save containing newgrf)
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Discard script data on load and skip starting of scripts (like it's done for network games).
As OpenTTD requires a script to be started for `is_ai` companies, prevent using any random ones (that may cause crash by accessing settings) by forcing Dummy AI for intro.
And don't show AIDebugWindow when an AI dies in intro (as Dummy AI will instant die).
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This also solves the crash reported in #9720 but starting scripts before the gamestate is ready is still an issue, and #9745 should handle that when done.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
