### PR TITLE
Fix #10242: Allow a space for text shadow when clipping WWT_EMPTY/WWT_TEXT.

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -2839,9 +2839,10 @@ void NWidgetLeaf::Draw(const Window *w)
 {
 	if (this->current_x == 0 || this->current_y == 0) return;
 
-	/* Setup a clipping rectangle... */
+	/* Setup a clipping rectangle... for WWT_EMPTY or WWT_TEXT, an extra scaled pixel is allowed vertically in case text shadow encroaches. */
+	int extra_y = (this->type == WWT_EMPTY || this->type == WWT_TEXT) ? ScaleGUITrad(1) : 0;
 	DrawPixelInfo new_dpi;
-	if (!FillDrawPixelInfo(&new_dpi, this->pos_x, this->pos_y, this->current_x, this->current_y)) return;
+	if (!FillDrawPixelInfo(&new_dpi, this->pos_x, this->pos_y, this->current_x, this->current_y + extra_y)) return;
 	/* ...but keep coordinates relative to the window. */
 	new_dpi.left += this->pos_x;
 	new_dpi.top += this->pos_y;


### PR DESCRIPTION
## Motivation / Problem

See #10242.

Text drawn inside WWT_EMPTY or WWT_TEXT widgets may have cropped shadows if the widget height is not additionally padded by the widget.

Other widget types are already 'padded' by a bevel, so they are not affected.

## Description

This is fixed by allowing extra vertical spacing when setting up the clipping area for a WWT_EMPTY or WWT_TEXT widget. There are still some conditions for this method to work, however it seems good enough in most cases.

Left is master, right is with this change applied.

![image](https://user-images.githubusercontent.com/639850/207961764-01410e53-6889-47e9-9015-e0967c0cf1cc.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
