### PR TITLE
Fix #10214: Various scriptable league table minor issues

### DIFF
--- a/src/league_cmd.h
+++ b/src/league_cmd.h
@@ -20,7 +20,7 @@ CommandCost CmdUpdateLeagueTableElementData(DoCommandFlag flags, LeagueTableElem
 CommandCost CmdUpdateLeagueTableElementScore(DoCommandFlag flags, LeagueTableElementID element, int64 rating, const std::string &score);
 CommandCost CmdRemoveLeagueTableElement(DoCommandFlag flags, LeagueTableElementID element);
 
-DEF_CMD_TRAIT(CMD_CREATE_LEAGUE_TABLE, CmdCreateLeagueTable, CMD_DEITY, CMDT_OTHER_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_CREATE_LEAGUE_TABLE, CmdCreateLeagueTable, CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_CREATE_LEAGUE_TABLE_ELEMENT, CmdCreateLeagueTableElement, CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_UPDATE_LEAGUE_TABLE_ELEMENT_DATA, CmdUpdateLeagueTableElementData, CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_UPDATE_LEAGUE_TABLE_ELEMENT_SCORE, CmdUpdateLeagueTableElementScore, CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -52,6 +52,8 @@ struct LEAEChunkHandler : ChunkHandler {
 
 static const SaveLoad _league_tables_desc[] = {
 	SLE_SSTR(LeagueTable, title, SLE_STR | SLF_ALLOW_CONTROL),
+	SLE_SSTR(LeagueTable, header, SLE_STR | SLF_ALLOW_CONTROL),
+	SLE_SSTR(LeagueTable, footer, SLE_STR | SLF_ALLOW_CONTROL),
 };
 
 struct LEATChunkHandler : ChunkHandler {

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -716,7 +716,7 @@ static CallBackFunction ToolbarGraphsClick(Window *w)
 
 	if (_toolbar_mode != TB_NORMAL) AddDropDownLeagueTableOptions(list);
 
-	ShowDropDownList(w, std::move(list), 0, WID_TN_GRAPHS, 140, true, true);
+	ShowDropDownList(w, std::move(list), GRMN_OPERATING_PROFIT_GRAPH, WID_TN_GRAPHS, 140, true, true);
 	if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 
 	return CBF_NONE;
@@ -728,7 +728,8 @@ static CallBackFunction ToolbarLeagueClick(Window *w)
 
 	AddDropDownLeagueTableOptions(list);
 
-	ShowDropDownList(w, std::move(list), 0, WID_TN_LEAGUE, 140, true, true);
+	int selected = list[0]->result;
+	ShowDropDownList(w, std::move(list), selected, WID_TN_LEAGUE, 140, true, true);
 	if (_settings_client.sound.click_beep) SndPlayFx(SND_15_BEEP);
 
 	return CBF_NONE;


### PR DESCRIPTION
## Motivation / Problem

Fix #10214 

## Description

Fix:
* Header and footer missing from league table saveload
* League and graph buttons in toolbar not having a default action
* CMD_CREATE_LEAGUE_TABLE not setting CMD_STR_CTRL, (which broke script indirect text references in multiplayer)

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
