### PR TITLE
Change: Set minimum macOS version to 10.13

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -162,7 +162,7 @@ jobs:
 
     runs-on: macos-latest
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.14
+      MACOSX_DEPLOYMENT_TARGET: 10.13
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,7 +469,7 @@ jobs:
 
     runs-on: macos-11
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.14
+      MACOSX_DEPLOYMENT_TARGET: 10.13
 
     steps:
     - name: Download source

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if (EMSCRIPTEN)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 
 # Use GNUInstallDirs to allow customisation
 # but set our own default data and bin dir

--- a/os/macosx/Info.plist.in
+++ b/os/macosx/Info.plist.in
@@ -32,6 +32,6 @@
         <key>NSHighResolutionCapable</key>
         <string>True</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.14.0</string>
+        <string>10.13.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Motivation / Problem

Following the addition of C++17 variants to the OpenTTD codebase, the deployment target and minimum system version for the game were set to 10.14. However, as testing seems to clearly show[^1][^2], `std::variant`s, along with the specific source of the problem - the `std::bad_variant_access` exceptions - do actually work on macOS 10.13 as well.

MacOS 10.13 is a milestone version, the last one to support Macs from 2009 (dropping, as a cursory search seems to show, no devices that 10.12 supported), and 10.14 only officially works with ones from 2012 onwards, with the exception of some Metal-capable desktop variants.[^3] This means that for little reason, three years' worth of perfectly good computers are being locked out of the game.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

This PR sets the macOS deployment targets and version limits to 10.13.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

It turns out that this PR is not even needed in the first place for the `openttd` executable generated by `make` to be launched from within the terminal.[^2] It is, however, essential to allow launching the game from within the .app.

Although these changes were enough for me in order to get the build working fine with LLVM Clang 15 from MacPorts, it might be the case that, say, Apple Clang in Xcode complains. If this were the case, adding `add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)` somewhere in the CMake setup would probably silence the error, but then it's not up to me to decide whether losing an oversensitive availability guard is too much to pay for potentially gaining a few players. If it's not obvious enough that I am quite biased... :)

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)

[^1]: https://stackoverflow.com/a/53868971
  In particular, I am referring to this part, and not the hackier workarounds:
  ![2a) ... and just use it](https://user-images.githubusercontent.com/1766353/208084513-81939dfc-03ee-408e-8017-b164874b8ab2.png)
[^2]: Apparently, a simple workaround for the version limit exists, even though it's not modifying the Info.plist: I unpacked the contents of the `MacOS` and `Resources` directories from the «incompatible» 12.2 OpenTTD.app into a single external directory, and ran `./openttd`. This is the result:
  ![Zrzut ekranu 2022-12-17 o 16 36 22](https://user-images.githubusercontent.com/1766353/208249537-1d61a2eb-4f4a-440d-8f70-005217ee6dad.png)
  Appears quite working to me, in contrast to the 10.12 crashes mentioned in #9689.
[^3]: Compare the compatibility charts: [10.12](https://support.apple.com/kb/sp742), [10.13](https://support.apple.com/kb/sp765), [10.14](https://support.apple.com/kb/sp777)