### PR TITLE
Change: Vertically centre sprite font relative to TrueType font.

### DIFF
--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -29,11 +29,11 @@ protected:
 	int descender;                    ///< The descender value of the font.
 	int units_per_em;                 ///< The units per EM value of the font.
 
-	static int GetDefaultFontHeight(FontSize fs);
-
 public:
 	FontCache(FontSize fs);
 	virtual ~FontCache();
+
+	static int GetDefaultFontHeight(FontSize fs);
 
 	/**
 	 * Get the FontSize of the font.

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -65,14 +65,14 @@ void FreeTypeFontCache::SetFontSize(FontSize fs, FT_Face face, int pixels)
 {
 	if (pixels == 0) {
 		/* Try to determine a good height based on the minimal height recommended by the font. */
-		int scaled_height = ScaleGUITrad(this->GetDefaultFontHeight(this->fs));
+		int scaled_height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
 		pixels = scaled_height;
 
 		TT_Header *head = (TT_Header *)FT_Get_Sfnt_Table(this->face, ft_sfnt_head);
 		if (head != nullptr) {
 			/* Font height is minimum height plus the difference between the default
 			 * height for this font size and the small size. */
-			int diff = scaled_height - ScaleGUITrad(this->GetDefaultFontHeight(FS_SMALL));
+			int diff = scaled_height - ScaleGUITrad(FontCache::GetDefaultFontHeight(FS_SMALL));
 			/* Clamp() is not used as scaled_height could be greater than MAX_FONT_SIZE, which is not permitted in Clamp(). */
 			pixels = std::min(std::max(std::min<int>(head->Lowest_Rec_PPEM, MAX_FONT_MIN_REC_SIZE) + diff, scaled_height), MAX_FONT_SIZE);
 		}

--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -28,8 +28,8 @@ static const int ASCII_LETTERSTART = 32; ///< First printable ASCII letter.
 SpriteFontCache::SpriteFontCache(FontSize fs) : FontCache(fs), glyph_to_spriteid_map(nullptr)
 {
 	this->InitializeUnicodeGlyphMap();
-	this->height = ScaleGUITrad(this->GetDefaultFontHeight(this->fs));
-	this->ascender = (this->height - ScaleSpriteTrad(this->GetDefaultFontHeight(this->fs))) / 2;
+	this->height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
+	this->ascender = (this->height - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
 }
 
 /**
@@ -105,8 +105,8 @@ void SpriteFontCache::ClearGlyphToSpriteMap()
 void SpriteFontCache::ClearFontCache()
 {
 	Layouter::ResetFontCache(this->fs);
-	this->height = ScaleGUITrad(this->GetDefaultFontHeight(this->fs));
-	this->ascender = (this->height - ScaleSpriteTrad(this->GetDefaultFontHeight(this->fs))) / 2;
+	this->height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
+	this->ascender = (this->height - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
 }
 
 const Sprite *SpriteFontCache::GetGlyph(GlyphID key)

--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -11,6 +11,7 @@
 #include "gfx_layout.h"
 #include "string_func.h"
 #include "strings_func.h"
+#include "zoom_func.h"
 #include "debug.h"
 
 #include "table/control_codes.h"
@@ -345,11 +346,11 @@ FallbackParagraphLayout::FallbackVisualRun::FallbackVisualRun(Font *font, const 
 	for (int i = 0; i < this->glyph_count; i++) {
 		this->glyphs[i] = font->fc->MapCharToGlyph(chars[i]);
 		if (isbuiltin) {
-			this->positions[2 * i + 1] = font->fc->GetAscender();                                                   // Apply sprite font's ascender.
+			this->positions[2 * i + 1] = font->fc->GetAscender(); // Apply sprite font's ascender.
 		} else if (chars[i] >= SCC_SPRITE_START && chars[i] <= SCC_SPRITE_END) {
-			this->positions[2 * i + 1] = font->fc->GetAscender() - font->fc->GetGlyph(this->glyphs[i])->height - 1; // Align sprite glyphs to font baseline.
+			this->positions[2 * i + 1] = (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2; // Align sprite font to centre
 		} else {
-			this->positions[2 * i + 1] = 0;                                                                         // No ascender adjustment.
+			this->positions[2 * i + 1] = 0;                       // No ascender adjustment.
 		}
 		this->positions[2 * i + 2] = this->positions[2 * i] + font->fc->GetGlyphWidth(this->glyphs[i]);
 		this->glyph_to_char[i] = i;

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -173,7 +173,7 @@ void CoreTextFontCache::SetFontSize(int pixels)
 {
 	if (pixels == 0) {
 		/* Try to determine a good height based on the height recommended by the font. */
-		int scaled_height = ScaleGUITrad(this->GetDefaultFontHeight(this->fs));
+		int scaled_height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
 		pixels = scaled_height;
 
 		CFAutoRelease<CTFontRef> font(CTFontCreateWithFontDescriptor(this->font_desc.get(), 0.0f, nullptr));
@@ -197,7 +197,7 @@ void CoreTextFontCache::SetFontSize(int pixels)
 
 			/* Font height is minimum height plus the difference between the default
 			 * height for this font size and the small size. */
-			int diff = scaled_height - ScaleGUITrad(this->GetDefaultFontHeight(FS_SMALL));
+			int diff = scaled_height - ScaleGUITrad(FontCache::GetDefaultFontHeight(FS_SMALL));
 			/* Clamp() is not used as scaled_height could be greater than MAX_FONT_SIZE, which is not permitted in Clamp(). */
 			pixels = std::min(std::max(std::min<int>(min_size, MAX_FONT_MIN_REC_SIZE) + diff, scaled_height), MAX_FONT_SIZE);
 		}

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -13,6 +13,7 @@
 #include "../../strings_func.h"
 #include "../../table/control_codes.h"
 #include "../../fontcache.h"
+#include "../../zoom_func.h"
 #include "macos.h"
 
 #include <CoreFoundation/CoreFoundation.h>
@@ -245,7 +246,7 @@ CoreTextParagraphLayout::CoreTextVisualRun::CoreTextVisualRun(CTRunRef run, Font
 		if (buff[this->glyph_to_char[i]] >= SCC_SPRITE_START && buff[this->glyph_to_char[i]] <= SCC_SPRITE_END) {
 			this->glyphs[i] = font->fc->MapCharToGlyph(buff[this->glyph_to_char[i]]);
 			this->positions[i * 2 + 0] = pts[i].x;
-			this->positions[i * 2 + 1] = font->fc->GetAscender() - font->fc->GetGlyph(this->glyphs[i])->height - 1; // Align sprite glyphs to font baseline.
+			this->positions[i * 2 + 1] = (font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(font->fc->GetSize()))) / 2; // Align sprite font to centre
 		} else {
 			this->glyphs[i] = gl[i];
 			this->positions[i * 2 + 0] = pts[i].x;

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -392,7 +392,7 @@ void Win32FontCache::SetFontSize(FontSize fs, int pixels)
 {
 	if (pixels == 0) {
 		/* Try to determine a good height based on the minimal height recommended by the font. */
-		int scaled_height = ScaleGUITrad(this->GetDefaultFontHeight(this->fs));
+		int scaled_height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
 		pixels = scaled_height;
 
 		HFONT temp = CreateFontIndirect(&this->logfont);
@@ -405,7 +405,7 @@ void Win32FontCache::SetFontSize(FontSize fs, int pixels)
 
 			/* Font height is minimum height plus the difference between the default
 			 * height for this font size and the small size. */
-			int diff = scaled_height - ScaleGUITrad(this->GetDefaultFontHeight(FS_SMALL));
+			int diff = scaled_height - ScaleGUITrad(FontCache::GetDefaultFontHeight(FS_SMALL));
 			/* Clamp() is not used as scaled_height could be greater than MAX_FONT_SIZE, which is not permitted in Clamp(). */
 			pixels = std::min(std::max(std::min<int>(otm->otmusMinimumPPEM, MAX_FONT_MIN_REC_SIZE) + diff, scaled_height), MAX_FONT_SIZE);
 

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -14,6 +14,7 @@
 #include "../../strings_func.h"
 #include "../../string_func.h"
 #include "../../table/control_codes.h"
+#include "../../zoom_func.h"
 #include "win32.h"
 #include <vector>
 
@@ -195,7 +196,7 @@ static bool UniscribeShapeRun(const UniscribeParagraphLayoutFactory::CharType *b
 					if (buff[range.pos + i] >= SCC_SPRITE_START && buff[range.pos + i] <= SCC_SPRITE_END) {
 						auto pos = range.char_to_glyph[i];
 						range.ft_glyphs[pos] = range.font->fc->MapCharToGlyph(buff[range.pos + i]);
-						range.offsets[pos].dv = range.font->fc->GetAscender() - range.font->fc->GetGlyph(range.ft_glyphs[pos])->height - 1; // Align sprite glyphs to font baseline.
+						range.offsets[pos].dv = (range.font->fc->GetHeight() - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(range.font->fc->GetSize()))) / 2; // Align sprite font to centre
 						range.advances[pos] = range.font->fc->GetGlyphWidth(range.ft_glyphs[pos]);
 					}
 				}


### PR DESCRIPTION
## Motivation / Problem

Currently we try to draw the sprite font aligned to the base line of the TrueType font, however this has some issues:
1. Individual sprite height is used but y_offs is ignored so sprites are not aligned correctly. This is noticeable with OpenGFX.
2. If the TrueType font is smaller than the sprite font it overflows above the font.
3. Since variable scaling, the sprite font is centred within the scaled font height when not using TrueType fonts.

## Description

These are mostly resolved here by:
1. Using the scaled sprite font height rather than individual sprite sizes. Alignment is always correct.
2. & 3. Vertically centring the sprite within the TrueType font's height. This avoids overflowing above the font (it can still overflow, but this will be shared top & bottom), and makes the alignment consistent between TrueType and non-TrueType rendering.

Change when using Liberation Sans size 10 at 2x, old vs new:
![image](https://user-images.githubusercontent.com/639850/208270761-2a6e9051-391f-4365-834c-4f37db941e71.png)

Change when using Liberation Sans size 10 at 3x, old vs new:
![image](https://user-images.githubusercontent.com/639850/208271037-04ed5886-e4ef-49bc-abea-9b52b24a543d.png)

Change in station label using Liberation Sans size 6 as 2x, old vs new:
![image](https://user-images.githubusercontent.com/639850/208271195-5b71f4ed-f601-4306-a7e9-138db8a51338.png)
![image](https://user-images.githubusercontent.com/639850/208271254-a90806ba-546e-4fc0-ad58-b3ca760fe142.png)

(In these screenshots, it is the bus glyph that is incorrectly positioned before this change)

This change also fixes users of static function GetDefaultFontHeight() to call it properly.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
