### PR TITLE
Fix: Incorrect available height for dropdowns due to unsigned promotion.

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -388,12 +388,12 @@ void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button
 	bool above = false;
 
 	/* Available height below (or above, if the dropdown is placed above the widget). */
-	uint available_height = std::max(GetMainViewBottom() - top - WidgetDimensions::scaled.fullbevel.Vertical() * 2, 0U);
+	uint available_height = std::max(GetMainViewBottom() - top - (int)WidgetDimensions::scaled.fullbevel.Vertical() * 2, 0);
 
 	/* If the dropdown doesn't fully fit below the widget... */
 	if (height > available_height) {
 
-		uint available_height_above = std::max(w->top + wi_rect.top - GetMainViewTop() - WidgetDimensions::scaled.fullbevel.Vertical() * 2, 0U);
+		uint available_height_above = std::max(w->top + wi_rect.top - GetMainViewTop() - (int)WidgetDimensions::scaled.fullbevel.Vertical() * 2, 0);
 
 		/* Put the dropdown above if there is more available space. */
 		if (available_height_above > available_height) {


### PR DESCRIPTION
## Motivation / Problem

Dropdowns which are taller than the main window should automatically have a scrollbar added. This did not work for toolbar dropdown as the location near the top of the window resulted in an unsigned underflow.

![image](https://user-images.githubusercontent.com/639850/208681180-ef8cb643-f768-4ac8-a259-01f1b8ce25f3.png)

## Description

This is fixed by a simple cast to int.

![image](https://user-images.githubusercontent.com/639850/208682081-5b4d2e91-e3f5-437d-b000-08969a9619df.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
