### PR TITLE
Feature: Ctrl-click to bulk edit timetable speeds/waiting times

### DIFF
--- a/src/command_type.h
+++ b/src/command_type.h
@@ -331,6 +331,7 @@ enum Commands : uint16 {
 
 	CMD_MOVE_ORDER,                   ///< move an order
 	CMD_CHANGE_TIMETABLE,             ///< change the timetable for a vehicle
+	CMD_BULK_CHANGE_TIMETABLE,        ///< change the timetable for all orders of a vehicle
 	CMD_SET_VEHICLE_ON_TIME,          ///< set the vehicle on time feature (timetable)
 	CMD_AUTOFILL_TIMETABLE,           ///< autofill the timetable
 	CMD_SET_TIMETABLE_START,          ///< set the date that a timetable should start

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4526,7 +4526,7 @@ STR_TIMETABLE_RESET_LATENESS                                    :{BLACK}Reset La
 STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reset the lateness counter, so the vehicle will be on time
 
 STR_TIMETABLE_AUTOFILL                                          :{BLACK}Autofill
-STR_TIMETABLE_AUTOFILL_TOOLTIP                                  :{BLACK}Fill the timetable automatically with the values from the next journey (Ctrl+Click to try to keep waiting times)
+STR_TIMETABLE_AUTOFILL_TOOLTIP                                  :{BLACK}Fill the timetable automatically with the values from the next journey. Ctrl+Click to try to keep waiting times
 
 STR_TIMETABLE_EXPECTED                                          :{BLACK}Expected
 STR_TIMETABLE_SCHEDULED                                         :{BLACK}Scheduled

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4511,16 +4511,16 @@ STR_TIMETABLE_STARTING_DATE                                     :{BLACK}Start da
 STR_TIMETABLE_STARTING_DATE_TOOLTIP                             :{BLACK}Select a date as starting point of this timetable. Ctrl+Click distributes all vehicles sharing this order evenly from the given date based on their relative order, if the order is completely timetabled
 
 STR_TIMETABLE_CHANGE_TIME                                       :{BLACK}Change Time
-STR_TIMETABLE_WAIT_TIME_TOOLTIP                                 :{BLACK}Change the amount of time that the highlighted order should take
+STR_TIMETABLE_WAIT_TIME_TOOLTIP                                 :{BLACK}Change the amount of time that the highlighted order should take. Ctrl+Click sets the time for all orders
 
 STR_TIMETABLE_CLEAR_TIME                                        :{BLACK}Clear Time
-STR_TIMETABLE_CLEAR_TIME_TOOLTIP                                :{BLACK}Clear the amount of time for the highlighted order
+STR_TIMETABLE_CLEAR_TIME_TOOLTIP                                :{BLACK}Clear the amount of time for the highlighted order. Ctrl+Click clears the time for all orders
 
 STR_TIMETABLE_CHANGE_SPEED                                      :{BLACK}Change Speed Limit
-STR_TIMETABLE_CHANGE_SPEED_TOOLTIP                              :{BLACK}Change the maximum travel speed of the highlighted order
+STR_TIMETABLE_CHANGE_SPEED_TOOLTIP                              :{BLACK}Change the maximum travel speed of the highlighted order. Ctrl+Click sets the speed for all orders
 
 STR_TIMETABLE_CLEAR_SPEED                                       :{BLACK}Clear Speed Limit
-STR_TIMETABLE_CLEAR_SPEED_TOOLTIP                               :{BLACK}Clear the maximum travel speed of the highlighted order
+STR_TIMETABLE_CLEAR_SPEED_TOOLTIP                               :{BLACK}Clear the maximum travel speed of the highlighted order. Ctrl+Click clears the speed for all orders
 
 STR_TIMETABLE_RESET_LATENESS                                    :{BLACK}Reset Late Counter
 STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reset the lateness counter, so the vehicle will be on time

--- a/src/timetable_cmd.h
+++ b/src/timetable_cmd.h
@@ -13,13 +13,15 @@
 #include "command_type.h"
 
 CommandCost CmdChangeTimetable(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, ModifyTimetableFlags mtf, uint16 data);
+CommandCost CmdBulkChangeTimetable(DoCommandFlag flags, VehicleID veh, ModifyTimetableFlags mtf, uint16 data);
 CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh);
 CommandCost CmdAutofillTimetable(DoCommandFlag flags, VehicleID veh, bool autofill, bool preserve_wait_time);
 CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, Date start_date);
 
-DEF_CMD_TRAIT(CMD_CHANGE_TIMETABLE,    CmdChangeTimetable,   0, CMDT_ROUTE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_SET_VEHICLE_ON_TIME, CmdSetVehicleOnTime,  0, CMDT_ROUTE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_AUTOFILL_TIMETABLE,  CmdAutofillTimetable, 0, CMDT_ROUTE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_SET_TIMETABLE_START, CmdSetTimetableStart, 0, CMDT_ROUTE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_CHANGE_TIMETABLE,      CmdChangeTimetable,     0, CMDT_ROUTE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_BULK_CHANGE_TIMETABLE, CmdBulkChangeTimetable, 0, CMDT_ROUTE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_SET_VEHICLE_ON_TIME,   CmdSetVehicleOnTime,    0, CMDT_ROUTE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_AUTOFILL_TIMETABLE,    CmdAutofillTimetable,   0, CMDT_ROUTE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_SET_TIMETABLE_START,   CmdSetTimetableStart,   0, CMDT_ROUTE_MANAGEMENT)
 
 #endif /* TIMETABLE_CMD_H */


### PR DESCRIPTION
## Motivation / Problem

When using vanilla timetabling (which I've actually done recently), the generally-accepted method is to let Autofill populate running times between stations, add a bit of padding in either travel or station waiting times to allow vehicles to make up lost time, and Ctrl-click Start Date to spread out vehicles. The padding time lets vehicles get on schedule eventually, then maintain it.

In my experience, most stations can have the same waiting time (I usually use two days with Iron Horse loading speeds) and it would be quite convenient if all waiting times could be changed at once.

Yes, this is a "scratching my own personal itch" PR. 😃 

## Description

Holding Ctrl while clicking any of the timetable entry buttons (Change/Clear Speed Limit/Time) edits all entries in the list accordingly.

Upstreams two JGRPP commits with the necessary changes for the command changes which haven't flowed downstream:
* https://github.com/JGRennison/OpenTTD-patches/commit/c0cc72ad96162f6ae5f627191b03461077e403ff
* https://github.com/JGRennison/OpenTTD-patches/commit/9f82f00f7af991c3afe07c9137a3539f56194665

A second commit fixes a nearby tooltip which explains Ctrl+click in parenthesis rather than in a new sentence, as is standard.

## Limitations

I've seen a patch somewhere (maybe in #9084) which lets you add or subtract travel/waiting time from the existing number instead of simply setting whatever is in the text entry box. This makes it easier to add padding to travel time (although in my experience it doesn't matter if the padding is there or in station waiting time). This PR doesn't preclude adding a new button to do that, but it does claim Ctrl-click.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
