### PR TITLE
Fix #10151: Use otmAscent instead of otmTextMetrics.tmAscent [Windows]

### DIFF
--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -185,8 +185,8 @@ void Win32FontCache::SetFontSize(int pixels)
 	GetOutlineTextMetrics(this->dc, otmSize, otm);
 
 	this->units_per_em = otm->otmEMSquare;
-	this->ascender = otm->otmTextMetrics.tmAscent;
-	this->descender = otm->otmTextMetrics.tmDescent;
+	this->ascender = otm->otmAscent;
+	this->descender = -otm->otmDescent;
 	this->height = this->ascender + this->descender;
 	this->glyph_size.cx = otm->otmTextMetrics.tmMaxCharWidth;
 	this->glyph_size.cy = otm->otmTextMetrics.tmHeight;


### PR DESCRIPTION
## Motivation / Problem

Windows font rendering provides two sets of metrics for ascent and descent.

We have always used otmTextMetrics.tmAscent and otmTextMetrics.tmDescent, however an alternative is to use otmAscent and otmDescent instead. 

![image](https://user-images.githubusercontent.com/639850/209004694-284f7e80-6f09-4098-b667-315178f28d7f.png)

## Description

These metrics actually more closely match the the sprite font, but do result in a more cramped line-height.

![image](https://user-images.githubusercontent.com/639850/209004447-f8483fd8-7617-4fd8-bf41-847a6d425394.png)

These screenshots also show the viewport sign padding change, although it's also different due to the metrics change.

## Limitations

Use of these metrics probably doesn't match macOS and Freetype rendering, but I can't confirm this.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
