### PR TITLE
Fix #10274: Use after free when rescanning scripts with GS selected

### DIFF
--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -199,6 +199,7 @@
 	InvalidateWindowData(WC_AI_LIST, 0, 1);
 	SetWindowClassesDirty(WC_AI_DEBUG);
 	InvalidateWindowClassesData(WC_AI_SETTINGS);
+	InvalidateWindowClassesData(WC_GAME_OPTIONS);
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

#10274

## Description

WC_GAME_OPTIONS windows were not properly invalidated.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
