### PR TITLE
Fix: Wrong type cast for selected AI/GS script info in AIListWindow

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -142,11 +142,11 @@ struct AIListWindow : public Window {
 				break;
 			}
 			case WID_AIL_INFO_BG: {
-				AIInfo *selected_info = nullptr;
+				ScriptInfo *selected_info = nullptr;
 				int i = 0;
 				for (const auto &item : *this->info_list) {
 					i++;
-					if (this->selected == i - 1) selected_info = static_cast<AIInfo *>(item.second);
+					if (this->selected == i - 1) selected_info = static_cast<ScriptInfo *>(item.second);
 				}
 				/* Some info about the currently selected AI. */
 				if (selected_info != nullptr) {


### PR DESCRIPTION
## Motivation / Problem

Incorrect type used in static_cast in AI/GS list window, when getting info of selected item.

## Description

Use ScriptInfo*, instead of AIInfo*.
AIInfo* is not a valid pointer type for instances of type GameInfo.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
