### PR TITLE
Add: 'font' console command to configure fonts

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -23,6 +23,7 @@
 #include "settings_func.h"
 #include "fios.h"
 #include "fileio_func.h"
+#include "fontcache.h"
 #include "screenshot.h"
 #include "genworld.h"
 #include "strings_func.h"
@@ -1982,6 +1983,82 @@ DEF_CONSOLE_CMD(ConContent)
 }
 #endif /* defined(WITH_ZLIB) */
 
+DEF_CONSOLE_CMD(ConFont)
+{
+	if (argc == 0) {
+		IConsolePrint(CC_HELP, "Manage the fonts configuration.");
+		IConsolePrint(CC_HELP, "Usage 'font'.");
+		IConsolePrint(CC_HELP, "  Print out the fonts configuration.");
+		IConsolePrint(CC_HELP, "Usage 'font [medium|small|large|mono] [<name>] [<size>] [aa|noaa]'.");
+		IConsolePrint(CC_HELP, "  Change the configuration for a font.");
+		IConsolePrint(CC_HELP, "  Omitting an argument will keep the current value.");
+		IConsolePrint(CC_HELP, "  Set <name> to \"\" for the sprite font (size and aa have no effect on sprite font).");
+		return true;
+	}
+
+	FontSize argfs;
+	for (argfs = FS_BEGIN; argfs < FS_END; argfs++) {
+		if (argc > 1 && strcasecmp(argv[1], FontSizeToName(argfs)) == 0) break;
+	}
+
+	/* First argument must be a FontSize. */
+	if (argc > 1 && argfs == FS_END) return false;
+
+	if (argc > 2) {
+		FontCacheSubSetting *setting = GetFontCacheSubSetting(argfs);
+		std::string font = setting->font;
+		uint size = setting->size;
+		bool aa = setting->aa;
+
+		byte arg_index = 2;
+
+		if (argc > arg_index) {
+			/* We may encounter "aa" or "noaa" but it must be the last argument. */
+			if (strcasecmp(argv[arg_index], "aa") == 0 || strcasecmp(argv[arg_index], "noaa") == 0) {
+				aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
+				if (argc > arg_index) return false;
+			} else {
+				/* For <name> we want a string. */
+				uint v;
+				if (!GetArgumentInteger(&v, argv[arg_index])) {
+					font = argv[arg_index++];
+				}
+			}
+		}
+
+		if (argc > arg_index) {
+			/* For <size> we want a number. */
+			uint v;
+			if (GetArgumentInteger(&v, argv[arg_index])) {
+				size = v;
+				arg_index++;
+			}
+		}
+
+		if (argc > arg_index) {
+			/* Last argument must be "aa" or "noaa". */
+			if (strcasecmp(argv[arg_index], "aa") != 0 && strcasecmp(argv[arg_index], "noaa") != 0) return false;
+			aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
+			if (argc > arg_index) return false;
+		}
+
+		SetFont(argfs, font, size, aa);
+	}
+
+	for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
+		FontCache *fc = FontCache::Get(fs);
+		FontCacheSubSetting *setting = GetFontCacheSubSetting(fs);
+		/* Make sure all non sprite fonts are loaded. */
+		if (!setting->font.empty() && !fc->HasParent()) {
+			InitFontCache(fs == FS_MONO);
+			fc = FontCache::Get(fs);
+		}
+		IConsolePrint(CC_DEFAULT, "{}: \"{}\" {} {} [\"{}\" {} {}]", FontSizeToName(fs), fc->GetFontName(), fc->GetFontSize(), GetFontAAState(fs), setting->font, setting->size, setting->aa);
+	}
+
+	return true;
+}
+
 DEF_CONSOLE_CMD(ConSetting)
 {
 	if (argc == 0) {
@@ -2480,6 +2557,7 @@ void IConsoleStdLibRegister()
 	IConsole::CmdRegister("cd",                      ConChangeDirectory);
 	IConsole::CmdRegister("pwd",                     ConPrintWorkingDirectory);
 	IConsole::CmdRegister("clear",                   ConClearBuffer);
+	IConsole::CmdRegister("font",                    ConFont);
 	IConsole::CmdRegister("setting",                 ConSetting);
 	IConsole::CmdRegister("setting_newgame",         ConSettingNewgame);
 	IConsole::CmdRegister("list_settings",           ConListSettings);

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -13,6 +13,11 @@
 #include "blitter/factory.hpp"
 #include "gfx_layout.h"
 #include "fontcache/spritefontcache.h"
+#include "openttd.h"
+#include "settings_func.h"
+#include "strings_func.h"
+#include "viewport_func.h"
+#include "window_func.h"
 
 #include "safeguards.h"
 
@@ -71,6 +76,49 @@ bool GetFontAAState(FontSize size, bool check_blitter)
 	if (check_blitter && BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
 
 	return GetFontCacheSubSetting(size)->aa;
+}
+
+void SetFont(FontSize fontsize, const std::string& font, uint size, bool aa)
+{
+	FontCacheSubSetting *setting = GetFontCacheSubSetting(fontsize);
+	bool changed = false;
+
+	if (setting->font != font) {
+		setting->font = font;
+		changed = true;
+	}
+
+	if (setting->size != size) {
+		setting->size = size;
+		changed = true;
+	}
+
+	if (setting->aa != aa) {
+		setting->aa = aa;
+		changed = true;
+	}
+
+	if (!changed) return;
+
+	if (fontsize != FS_MONO) {
+		/* Try to reload only the modified font. */
+		FontCacheSettings backup = _fcsettings;
+		for (FontSize fs = FS_BEGIN; fs < FS_END; fs++) {
+			if (fs == fontsize) continue;
+			FontCache *fc = FontCache::Get(fs);
+			GetFontCacheSubSetting(fs)->font = fc->HasParent() ? fc->GetFontName() : "";
+		}
+		CheckForMissingGlyphs();
+		_fcsettings = backup;
+	} else {
+		InitFontCache(true);
+	}
+
+	LoadStringWidthTable();
+	UpdateAllVirtCoords();
+	ReInitAllWindows(true);
+
+	if (_save_config) SaveToConfig();
 }
 
 /**

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -70,15 +70,8 @@ bool GetFontAAState(FontSize size, bool check_blitter)
 	/* AA is only supported for 32 bpp */
 	if (check_blitter && BlitterFactory::GetCurrentBlitter()->GetScreenDepth() != 32) return false;
 
-	switch (size) {
-		default: NOT_REACHED();
-		case FS_NORMAL: return _fcsettings.medium.aa;
-		case FS_SMALL:  return _fcsettings.small.aa;
-		case FS_LARGE:  return _fcsettings.large.aa;
-		case FS_MONO:   return _fcsettings.mono.aa;
-	}
+	return GetFontCacheSubSetting(size)->aa;
 }
-
 
 /**
  * (Re)initialize the font cache related things, i.e. load the non-sprite fonts.

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -239,5 +239,6 @@ void UninitFontCache();
 bool HasAntialiasedFonts();
 
 bool GetFontAAState(FontSize size, bool check_blitter = true);
+void SetFont(FontSize fontsize, const std::string &font, uint size, bool aa);
 
 #endif /* FONTCACHE_H */

--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -218,6 +218,22 @@ struct FontCacheSettings {
 
 extern FontCacheSettings _fcsettings;
 
+/**
+ * Get the settings of a given font size.
+ * @param fs The font size to look up.
+ * @return The settings.
+ */
+static inline FontCacheSubSetting *GetFontCacheSubSetting(FontSize fs)
+{
+	switch (fs) {
+		default: NOT_REACHED();
+		case FS_SMALL:  return &_fcsettings.small;
+		case FS_NORMAL: return &_fcsettings.medium;
+		case FS_LARGE:  return &_fcsettings.large;
+		case FS_MONO:   return &_fcsettings.mono;
+	}
+}
+
 void InitFontCache(bool monospace);
 void UninitFontCache();
 bool HasAntialiasedFonts();

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -122,14 +122,7 @@ void FreeTypeFontCache::SetFontSize(FontSize fs, FT_Face face, int pixels)
  */
 void LoadFreeTypeFont(FontSize fs)
 {
-	FontCacheSubSetting *settings = nullptr;
-	switch (fs) {
-		default: NOT_REACHED();
-		case FS_SMALL:  settings = &_fcsettings.small;  break;
-		case FS_NORMAL: settings = &_fcsettings.medium; break;
-		case FS_LARGE:  settings = &_fcsettings.large;  break;
-		case FS_MONO:   settings = &_fcsettings.mono;   break;
-	}
+	FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
 
 	if (settings->font.empty()) return;
 
@@ -197,8 +190,7 @@ void LoadFreeTypeFont(FontSize fs)
 
 	FT_Done_Face(face);
 
-	static const char *SIZE_TO_NAME[] = { "medium", "small", "large", "mono" };
-	ShowInfoF("Unable to use '%s' for %s font, FreeType reported error 0x%X, using sprite font instead", font_name, SIZE_TO_NAME[fs], error);
+	ShowInfoF("Unable to use '%s' for %s font, FreeType reported error 0x%X, using sprite font instead", font_name, FontSizeToName(fs), error);
 	return;
 
 found_face:

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -214,6 +214,13 @@ enum FontSize {
 };
 DECLARE_POSTFIX_INCREMENT(FontSize)
 
+static inline const char *FontSizeToName(FontSize fs)
+{
+	static const char *SIZE_TO_NAME[] = { "medium", "small", "large", "mono" };
+	assert(fs < FS_END);
+	return SIZE_TO_NAME[fs];
+}
+
 /**
  * Used to only draw a part of the sprite.
  * Draw the subsprite in the rect (sprite_x_offset + left, sprite_y_offset + top) to (sprite_x_offset + right, sprite_y_offset + bottom).

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -350,16 +350,7 @@ const Sprite *CoreTextFontCache::InternalGetGlyph(GlyphID key, bool use_aa)
  */
 void LoadCoreTextFont(FontSize fs)
 {
-	static const char *SIZE_TO_NAME[] = { "medium", "small", "large", "mono" };
-
-	FontCacheSubSetting *settings = nullptr;
-	switch (fs) {
-		default: NOT_REACHED();
-		case FS_SMALL:  settings = &_fcsettings.small;  break;
-		case FS_NORMAL: settings = &_fcsettings.medium; break;
-		case FS_LARGE:  settings = &_fcsettings.large;  break;
-		case FS_MONO:   settings = &_fcsettings.mono;   break;
-	}
+	FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
 
 	if (settings->font.empty()) return;
 
@@ -395,7 +386,7 @@ void LoadCoreTextFont(FontSize fs)
 				font_ref.reset((CTFontDescriptorRef)CFArrayGetValueAtIndex(descs.get(), 0));
 				CFRetain(font_ref.get());
 			} else {
-				ShowInfoF("Unable to load file '%s' for %s font, using default OS font selection instead", settings->font.c_str(), SIZE_TO_NAME[fs]);
+				ShowInfoF("Unable to load file '%s' for %s font, using default OS font selection instead", settings->font.c_str(), FontSizeToName(fs));
 			}
 		}
 	}
@@ -419,7 +410,7 @@ void LoadCoreTextFont(FontSize fs)
 	}
 
 	if (!font_ref) {
-		ShowInfoF("Unable to use '%s' for %s font, using sprite font instead", settings->font.c_str(), SIZE_TO_NAME[fs]);
+		ShowInfoF("Unable to use '%s' for %s font, using sprite font instead", settings->font.c_str(), FontSizeToName(fs));
 		return;
 	}
 

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -378,7 +378,6 @@ Win32FontCache::Win32FontCache(FontSize fs, const LOGFONT &logfont, int pixels) 
 {
 	this->dc = CreateCompatibleDC(nullptr);
 	this->SetFontSize(fs, pixels);
-	this->fontname = FS2OTTD(this->logfont.lfFaceName);
 }
 
 Win32FontCache::~Win32FontCache()
@@ -441,7 +440,9 @@ void Win32FontCache::SetFontSize(FontSize fs, int pixels)
 	this->glyph_size.cx = otm->otmTextMetrics.tmMaxCharWidth;
 	this->glyph_size.cy = otm->otmTextMetrics.tmHeight;
 
-	Debug(fontcache, 2, "Loaded font '{}' with size {}", FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFullName)), pixels);
+	this->fontname = FS2OTTD((LPWSTR)((BYTE *)otm + (ptrdiff_t)otm->otmpFaceName));
+
+	Debug(fontcache, 2, "Loaded font '{}' with size {}", this->fontname, pixels);
 }
 
 /**

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -580,16 +580,7 @@ void Win32FontCache::ClearFontCache()
  */
 void LoadWin32Font(FontSize fs)
 {
-	static const char *SIZE_TO_NAME[] = { "medium", "small", "large", "mono" };
-
-	FontCacheSubSetting *settings = nullptr;
-	switch (fs) {
-		case FS_SMALL:  settings = &_fcsettings.small;  break;
-		case FS_NORMAL: settings = &_fcsettings.medium; break;
-		case FS_LARGE:  settings = &_fcsettings.large;  break;
-		case FS_MONO:   settings = &_fcsettings.mono;   break;
-		default: NOT_REACHED();
-	}
+	FontCacheSubSetting *settings = GetFontCacheSubSetting(fs);
 
 	if (settings->font.empty()) return;
 
@@ -647,7 +638,7 @@ void LoadWin32Font(FontSize fs)
 					logfont.lfWeight = strcasestr(font_name, " bold") != nullptr || strcasestr(font_name, "-bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
 				}
 			} else {
-				ShowInfoF("Unable to load file '%s' for %s font, using default windows font selection instead", font_name, SIZE_TO_NAME[fs]);
+				ShowInfoF("Unable to load file '%s' for %s font, using default windows font selection instead", font_name, FontSizeToName(fs));
 			}
 		}
 	}
@@ -659,7 +650,7 @@ void LoadWin32Font(FontSize fs)
 
 	HFONT font = CreateFontIndirect(&logfont);
 	if (font == nullptr) {
-		ShowInfoF("Unable to use '%s' for %s font, Win32 reported error 0x%lX, using sprite font instead", font_name, SIZE_TO_NAME[fs], GetLastError());
+		ShowInfoF("Unable to use '%s' for %s font, Win32 reported error 0x%lX, using sprite font instead", font_name, FontSizeToName(fs), GetLastError());
 		return;
 	}
 	DeleteObject(font);

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -21,7 +21,7 @@ private:
 	HDC dc = nullptr;     ///< Cached GDI device context.
 	HGDIOBJ old_font;     ///< Old font selected into the GDI context.
 	SIZE glyph_size;      ///< Maximum size of regular glyphs.
-	std::string fontname; ///< Cached copy of this->logfont.lfFaceName
+	std::string fontname; ///< Cached copy of loaded font facename
 
 	void SetFontSize(FontSize fs, int pixels);
 


### PR DESCRIPTION
Closes #8596.

## Motivation / Problem
Configuring fonts requires multiple iterations of 
- editing `openttd.cfg`
- start OpenTTD to see the result
- close OpenTTD

So a console command to do the same from a running OpenTTD will be an improvement.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
I implemented `font` console command.
The command allows to list loaded fonts, with indication of the config as loaded font may differ (fallback mechanism ...).

Usually fonts are initialised before the command is accessible, but `FS_MONO` has to be different as it's not loaded unless a TextFile is displayed. So I included a mechanism to make sure all non sprite fonts are loaded when listing them.

For "normal" fonts I used `CheckForMissingGlyphs()` to initialise and check the modified font, but for "monospace" I directly `InitFontCache(true)` because the validation is only done when loading a file in a TextFile window, but that should at least validate the user selected font could work.

Fallback mechanism is also a huge annoyance as it reinitialises the fonts and may invalidate a perfectly fine font for a given size.
I tried to work around this by temporary storing in the config the fonts currently loaded for other `FontSize` when changing config for a font. That way if other sizes use fallback font they will still use it while validating the new font.
Of course if the new font is not valid and a fallback is searched, other sizes, which might have been valid while not being the fallback font, will end up using the fallback font.
We really need a per character fallback mechanism instead of the global one we currently have, but that will be another journey.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I tested only with non freetype windows, but I think it should work for other platforms as long as `FontCache::GetFontName()` overrides return a sensible value.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
