### PR TITLE
Fix #8971: Resize QueryStrings with interface scale change.

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -789,6 +789,11 @@ void QueryString::HandleEditBox(Window *w, int wid)
 	}
 }
 
+static int GetCaretWidth()
+{
+	return GetCharacterWidth(FS_NORMAL, '_');
+}
+
 void QueryString::DrawEditBox(const Window *w, int wid) const
 {
 	const NWidgetLeaf *wi = w->GetWidget<NWidgetLeaf>(wid);
@@ -821,7 +826,7 @@ void QueryString::DrawEditBox(const Window *w, int wid) const
 	/* We will take the current widget length as maximum width, with a small
 	 * space reserved at the end for the caret to show */
 	const Textbuf *tb = &this->text;
-	int delta = std::min(0, (fr.right - fr.left) - tb->pixels - 10);
+	int delta = std::min(0, (fr.right - fr.left) - tb->pixels - GetCaretWidth());
 
 	if (tb->caretxoffs + delta < 0) delta = -tb->caretxoffs;
 
@@ -858,7 +863,7 @@ Point QueryString::GetCaretPosition(const Window *w, int wid) const
 
 	/* Clamp caret position to be inside out current width. */
 	const Textbuf *tb = &this->text;
-	int delta = std::min(0, (r.right - r.left) - tb->pixels - 10);
+	int delta = std::min(0, (r.right - r.left) - tb->pixels - GetCaretWidth());
 	if (tb->caretxoffs + delta < 0) delta = -tb->caretxoffs;
 
 	Point pt = {r.left + tb->caretxoffs + delta, r.top};
@@ -887,7 +892,7 @@ Rect QueryString::GetBoundingRect(const Window *w, int wid, const char *from, co
 
 	/* Clamp caret position to be inside our current width. */
 	const Textbuf *tb = &this->text;
-	int delta = std::min(0, r.Width() - tb->pixels - 10);
+	int delta = std::min(0, r.Width() - tb->pixels - GetCaretWidth());
 	if (tb->caretxoffs + delta < 0) delta = -tb->caretxoffs;
 
 	/* Get location of first and last character. */
@@ -920,7 +925,7 @@ const char *QueryString::GetCharAtPosition(const Window *w, int wid, const Point
 
 	/* Clamp caret position to be inside our current width. */
 	const Textbuf *tb = &this->text;
-	int delta = std::min(0, r.Width() - tb->pixels - 10);
+	int delta = std::min(0, r.Width() - tb->pixels - GetCaretWidth());
 	if (tb->caretxoffs + delta < 0) delta = -tb->caretxoffs;
 
 	return ::GetCharAtPosition(tb->buf, pt.x - delta - r.left);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -355,6 +355,17 @@ QueryString *Window::GetQueryString(uint widnum)
 }
 
 /**
+ * Update size of all QueryStrings of this window.
+ */
+void Window::UpdateQueryStringSize()
+{
+	for (auto &qs : this->querystrings)
+	{
+		qs.second->text.UpdateSize();
+	}
+}
+
+/**
  * Get the current input text if an edit box has the focus.
  * @return The currently focused input text or nullptr if no input focused.
  */
@@ -3353,7 +3364,10 @@ void HideVitalWindows()
 void ReInitWindow(Window *w, bool zoom_changed)
 {
 	if (w == nullptr) return;
-	if (zoom_changed) w->nested_root->AdjustPaddingForZoom();
+	if (zoom_changed) {
+		w->nested_root->AdjustPaddingForZoom();
+		w->UpdateQueryStringSize();
+	}
 	w->ReInit();
 }
 

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -276,6 +276,7 @@ public:
 
 	const QueryString *GetQueryString(uint widnum) const;
 	QueryString *GetQueryString(uint widnum);
+	void UpdateQueryStringSize();
 
 	virtual const char *GetFocusedText() const;
 	virtual const char *GetCaret() const;


### PR DESCRIPTION
## Motivation / Problem

Closes #8971.

As per #8971, QueryString editboxes are incorrectly drawn after interface scale (or font size) is changed. This is because pixel positions are stored within the TextBuf.

This issue affects all editboxes, not just the Save Game window.

## Description

This is resolved by updating the size for all window querystrings when the interface scale (or font size) is changed.

Additionally the space available for the caret is was not scaled, so was cropped at larger scales.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
