### PR TITLE
Change: Big UFO disaster targets current location of a random train

### DIFF
--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -40,6 +40,7 @@
 #include "sound_func.h"
 #include "effectvehicle_func.h"
 #include "roadveh.h"
+#include "train.h"
 #include "ai/ai.hpp"
 #include "game/game.hpp"
 #include "company_base.h"
@@ -578,17 +579,34 @@ static bool DisasterTick_Big_Ufo(DisasterVehicle *v)
 		}
 		v->current_order.SetDestination(1);
 
-		TileIndex tile_org = RandomTile();
-		TileIndex tile = tile_org;
-		do {
-			if (IsPlainRailTile(tile) &&
-					Company::IsHumanID(GetTileOwner(tile))) {
+		const auto is_valid_target = [](const Train *t) {
+			return t->IsFrontEngine() // Only the engines
+				&& Company::IsHumanID(t->owner) // Don't break AIs
+				&& IsPlainRailTile(t->tile) // No tunnels
+				&& (t->vehstatus & VS_CRASHED) == 0; // Not crashed
+		};
+
+		uint n = 0; // Total number of targetable trains.
+		for (const Train *t : Train::Iterate()) {
+			if (is_valid_target(t)) n++;
+		}
+
+		if (n == 0) {
+			/* If there are no targetable trains, destroy the UFO. */
+			delete v;
+			return false;
+		}
+
+		n = RandomRange(n); // Choose one of them.
+		for (const Train *t : Train::Iterate()) {
+			/* Find (n+1)-th train. */
+			if (is_valid_target(t) && (n-- == 0)) {
+				/* Target it. */
+				v->dest_tile = t->tile;
+				v->age = 0;
 				break;
 			}
-			tile = TILE_MASK(tile + 1);
-		} while (tile != tile_org);
-		v->dest_tile = tile;
-		v->age = 0;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
## Motivation / Problem
See #10076
Closes #10076
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
As suggested, Big UFO now targets the current location of a random train.
Code largely copied from the standard UFO - differs in that it uses the current tile of the train, rather than the index, because we're not actively targeting a train

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Limited testing, because disasters are a pain to spawn. Potential feature: Cheat to spawn a disaster.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
