### PR TITLE
Enable CodeQL code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: openttd
+queries:
+- uses: security-and-quality
+query-filters:
+- exclude:
+    id:
+    # Only feasible way is to move away from fopen; fopen_s is optional C11 and not implemented on most platforms.
+    - cpp/world-writable-file-creation
+    # Basically OpenTTD's coding style for adding things like ..._INVALID to enumerations
+    - cpp/irregular-enum-init

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,78 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+    - master
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        echo "::group::Update apt"
+        sudo apt-get update
+        echo "::endgroup::"
+
+        echo "::group::Install dependencies"
+        sudo apt-get install -y --no-install-recommends \
+          liballegro4-dev \
+          libfontconfig-dev \
+          libicu-dev \
+          liblzma-dev \
+          liblzo2-dev \
+          libsdl2-dev \
+          zlib1g-dev \
+          # EOF
+        echo "::endgroup::"
+      env:
+        DEBIAN_FRONTEND: noninteractive
+
+    - name: Set number of make jobs
+      run: |
+        echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: cpp
+        config-file: ./.github/codeql/codeql-config.yml
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: /language:cpp
+        upload: False
+        output: sarif-results
+
+    - name: Filter out table & generated code
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          +**/*.*
+          -**/table/*.*
+          -**/generated/**/*.*
+        input: sarif-results/cpp.sarif
+        output: sarif-results/cpp.sarif
+
+    - name: Upload results
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: sarif-results/cpp.sarif


### PR DESCRIPTION
## Motivation / Problem

There used to be a website called lgtm.com, but that has been deprecated in favour of this solution.
The goal is to resolve potential code issues before an actual release, and this way it should even be able to do it with pull requests.


## Description

Just followed the manual at https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository#setting-up-code-scanning-manually though disabled Javascript testing.


## Limitations

Compiling will be slower, as CodeQL building takes about 45 minutes (MinGW takes about 30 minutes). There are three "configurations" that are supported out of the box:
- default: 50 high security alerts -> https://github.com/rubidium42/OpenTTD/pull/2/checks?check_run_id=10378139264
- security-extended: 83 high security alerts -> https://github.com/rubidium42/OpenTTD/pull/3/checks?check_run_id=10378116897
- security-and-quality: 83 high security alerts, 38 errors, 106 warnings and 3151 notes -> https://github.com/rubidium42/OpenTTD/pull/4/checks?check_run_id=10378214008

Someone needs to go through the errors and warnings first, to either dismiss them or fix them in a separate PR. However, I'm not sure whether people without merge rights will be able to dismiss warnings in their PRs and how that will look.

Furthermore there's a question whether some of the warnings/notes might be too noisy for OpenTTD's coding style. So, the first question would be... which configuration do we want to use?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
