### PR TITLE
Fix #10304, fe30f66: [Scripts] Don't start GS in intro

### DIFF
--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -73,6 +73,9 @@
 {
 	if (Game::instance != nullptr) return;
 
+	/* Don't start GameScripts in intro */
+	if (_game_mode == GM_MENU) return;
+
 	/* Clients shouldn't start GameScripts */
 	if (_networking && !_network_server) return;
 


### PR DESCRIPTION
Fixes #10304

## Motivation / Problem
See #10304.
Before #9745, GS was started only during loading `GSDT` chunk, and there is a check for intro here.
Since #9745, GS is unconditionally started at the end of loading.

AIs are not affected because they are forced to use `dummy` in intro if one has to be started.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Check for intro when starting GS.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
