### PR TITLE
Fix: Don't assume engclass 2 should be elrail.

### DIFF
--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -597,16 +597,14 @@ void SettingsDisableElrail(int32 new_value)
 {
 	bool disable = (new_value != 0);
 
-	/* we will now walk through all electric train engines and change their railtypes if it is the wrong one*/
-	const RailType old_railtype = disable ? RAILTYPE_ELECTRIC : RAILTYPE_RAIL;
+	/* pick appropriate railtype for elrail engines depending on setting */
 	const RailType new_railtype = disable ? RAILTYPE_RAIL : RAILTYPE_ELECTRIC;
 
 	/* walk through all train engines */
 	for (Engine *e : Engine::IterateType(VEH_TRAIN)) {
 		RailVehicleInfo *rv_info = &e->u.rail;
-		/* if it is an electric rail engine and its railtype is the wrong one */
-		if (rv_info->engclass == 2 && rv_info->railtype == old_railtype) {
-			/* change it to the proper one */
+		/* update railtype of engines intended to use elrail */
+		if (rv_info->intended_railtype == RAILTYPE_ELECTRIC) {
 			rv_info->railtype = new_railtype;
 		}
 	}

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -43,7 +43,8 @@ struct RailVehicleInfo {
 	byte image_index;
 	RailVehicleTypes railveh_type;
 	byte cost_factor;               ///< Purchase cost factor;      For multiheaded engines the sum of both engine prices.
-	RailType railtype;
+	RailType railtype;              ///< Railtype, mangled if elrail is disabled.
+	RailType intended_railtype;     ///< Intended railtype, regardless of elrail being enabled or disabled.
 	uint16 max_speed;               ///< Maximum speed (1 unit = 1/1.6 mph = 1 km-ish/h)
 	uint16 power;                   ///< Power of engine (hp);      For multiheaded engines the sum of both engine powers.
 	uint16 weight;                  ///< Weight of vehicle (tons);  For multiheaded engines the weight of each single engine.

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9804,6 +9804,7 @@ static void AfterLoadGRFs()
 			e->info.climates = 0;
 		} else {
 			e->u.rail.railtype = railtype;
+			e->u.rail.intended_railtype = railtype;
 		}
 	}
 

--- a/src/table/engines.h
+++ b/src/table/engines.h
@@ -386,7 +386,7 @@ static const EngineInfo _orig_engine_info[] = {
  * Tractive effort coefficient by default is the same as TTDPatch, 0.30*256=76
  * Air drag value depends on the top speed of the vehicle.
  */
-#define RVI(a, b, c, d, e, f, g, h, i, j, k) { a, b, c, j, d, e, f, g, h, k, i, 0, 0, 0, VE_DEFAULT, 0, 76, 0, 0, 0 }
+#define RVI(a, b, c, d, e, f, g, h, i, j, k) { a, b, c, j, j, d, e, f, g, h, k, i, 0, 0, 0, VE_DEFAULT, 0, 76, 0, 0, 0 }
 #define M RAILVEH_MULTIHEAD
 #define W RAILVEH_WAGON
 #define G RAILVEH_SINGLEHEAD


### PR DESCRIPTION
## Motivation / Problem

When disabling/enabling elrail, there is an assumption that `engclass` of 2 means the engine will run on elrail. While this holds for default engines, NewGRFs can do other things.

Note that this disabling/enabling happens on new game, regardless of actually changing the setting.

## Description

To resolve this we store the intended railtype so that toggling elrail will restore to the correct type, instead of assuming RAIL should become ELRL

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
