### PR TITLE
Fix: do not allow more palette colours than there are indices for the colours

### DIFF
--- a/src/bmp.cpp
+++ b/src/bmp.cpp
@@ -367,7 +367,12 @@ bool BmpReadHeader(BmpBuffer *buffer, BmpInfo *info, BmpData *data)
 			info->palette_size = ReadDword(buffer); // number of colours in palette
 			SkipBytes(buffer, header_size - 16);    // skip the end of info header
 		}
-		if (info->palette_size == 0) info->palette_size = 1 << info->bpp;
+
+		uint maximum_palette_size = 1U << info->bpp;
+		if (info->palette_size == 0) info->palette_size = maximum_palette_size;
+
+		/* More palette colours than palette indices is not supported. */
+		if (info->palette_size > maximum_palette_size) return false;
 
 		data->palette = CallocT<Colour>(info->palette_size);
 


### PR DESCRIPTION
## Motivation / Problem

CodeQL check says that an unchecked size is passed into memory allocation. This is true.
If you set the BMP to have 4 or 8 bits per pixel, then it will try to read the palette. For this it reads the palette size from the file, and without any validation passes it to CallocT.

Technically this could trigger a write beyond buffer if in a 32 bit binary and the palette size * 4 overflows 32 bits. For example a palette size of `1 + (1U << 30)` would yield 4 with unsigned 32 bits integers. Then 4 bytes get allocated, and the further logic begins writing bytes for about 1 billion colours, thus writing way outside of the bounds.


## Description

Simply limit the number of palette entries to `1U << bits_per_pixel`, which would be at most 256 for 8 bpp images.


## Limitations

BMPs with malformed palette size might not be opened anymore.
I don't have a library of 4 or 8 bpp BMP images to test this change with, so I generated some by exporting BMPs with GIMP.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
