### PR TITLE
CodeQL triggered clean ups

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -513,7 +513,7 @@ void RefTable::AllocNodes(SQUnsignedInteger size)
 		bucks[n] = nullptr;
 		temp->refs = 0;
 		new (&temp->obj) SQObjectPtr;
-		temp->next = temp+1;
+		temp->next = &temp[1];
 		temp++;
 	}
 	bucks[n] = nullptr;

--- a/src/blitter/32bpp_anim.cpp
+++ b/src/blitter/32bpp_anim.cpp
@@ -383,7 +383,7 @@ void Blitter_32bppAnim::CopyFromBuffer(void *video, const void *src, int width, 
 		dst += _screen.pitch;
 		/* Copy back the anim-buffer */
 		memcpy(anim_line, usrc, width * sizeof(uint16));
-		usrc = (const uint32 *)((const uint16 *)usrc + width);
+		usrc = (const uint32 *)&((const uint16 *)usrc)[width];
 		anim_line += this->anim_buf_pitch;
 
 		/* Okay, it is *very* likely that the image we stored is using
@@ -422,7 +422,7 @@ void Blitter_32bppAnim::CopyToBuffer(const void *video, void *dst, int width, in
 		udst += width;
 		/* Copy the anim-buffer */
 		memcpy(udst, anim_line, width * sizeof(uint16));
-		udst = (uint32 *)((uint16 *)udst + width);
+		udst = (uint32 *)&((uint16 *)udst)[width];
 		anim_line += this->anim_buf_pitch;
 	}
 }

--- a/src/blitter/32bpp_optimized.cpp
+++ b/src/blitter/32bpp_optimized.cpp
@@ -316,8 +316,9 @@ template <bool Tpal_to_rgb> Sprite *Blitter_32bppOptimized::EncodeInternal(const
 		const SpriteLoader::CommonPixel *src = (const SpriteLoader::CommonPixel *)src_orig->data;
 
 		for (uint y = src_orig->height; y > 0; y--) {
-			Colour *dst_px = (Colour *)(dst_px_ln + 1);
-			uint16 *dst_n = (uint16 *)(dst_n_ln + 1);
+			/* Index 0 of dst_px and dst_n is left as space to save the length of the row to be filled later. */
+			Colour *dst_px = (Colour *)&dst_px_ln[1];
+			uint16 *dst_n = (uint16 *)&dst_n_ln[1];
 
 			uint16 *dst_len = dst_n++;
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -636,7 +636,7 @@ private:
 		const Company *c;
 		const Livery *livery, *default_livery = nullptr;
 		bool primary = widget == WID_SCL_PRI_COL_DROPDOWN;
-		byte default_col;
+		byte default_col = 0;
 
 		/* Disallow other company colours for the primary colour */
 		if (this->livery_class < LC_GROUP_RAIL && HasBit(this->sel, LS_DEFAULT) && primary) {

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -227,7 +227,7 @@ static void DrawPrice(Money amount, int left, int right, int top, TextColour col
  * Draw a category of expenses/revenues in the year column.
  * @return The income sum of the category.
  */
-static Money DrawYearCategory (const Rect &r, int start_y, ExpensesList list, const Money(*tbl)[EXPENSES_END])
+static Money DrawYearCategory (const Rect &r, int start_y, ExpensesList list, const Money(&tbl)[EXPENSES_END])
 {
 	int y = start_y;
 	ExpensesType et;
@@ -235,7 +235,7 @@ static Money DrawYearCategory (const Rect &r, int start_y, ExpensesList list, co
 
 	for (uint i = 0; i < list.length; i++) {
 		et = list.et[i];
-		Money cost = (*tbl)[et];
+		Money cost = tbl[et];
 		sum += cost;
 		if (cost != 0) DrawPrice(cost, r.left, r.right, y, TC_BLACK);
 		y += FONT_HEIGHT_NORMAL;
@@ -255,10 +255,10 @@ static Money DrawYearCategory (const Rect &r, int start_y, ExpensesList list, co
  * Draw a column with prices.
  * @param r    Available space for drawing.
  * @param year Year being drawn.
- * @param tbl  Pointer to table of amounts for \a year.
+ * @param tbl  Reference to table of amounts for \a year.
  * @note The environment must provide padding at the left and right of \a r.
  */
-static void DrawYearColumn(const Rect &r, int year, const Money (*tbl)[EXPENSES_END])
+static void DrawYearColumn(const Rect &r, int year, const Money (&tbl)[EXPENSES_END])
 {
 	int y = r.top;
 	Money sum;
@@ -435,7 +435,7 @@ struct CompanyFinancesWindow : Window {
 				int age = std::min(_cur_year - c->inaugurated_year, 2);
 				int wid_offset = widget - WID_CF_EXPS_PRICE1;
 				if (wid_offset <= age) {
-					DrawYearColumn(r, _cur_year - (age - wid_offset), c->yearly_expenses + (age - wid_offset));
+					DrawYearColumn(r, _cur_year - (age - wid_offset), c->yearly_expenses[age - wid_offset]);
 				}
 				break;
 			}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -392,7 +392,7 @@ public:
 		}
 
 		size_t num_cargo = this->GetNumCargo();
-		for (CargoID i = 0; i < num_cargo; i++) {
+		for (size_t i = 0; i < num_cargo; i++) {
 			GoodsEntry *ge = &st->goods[i];
 			SlObject(ge, this->GetLoadDescription());
 			if (IsSavegameVersionBefore(SLV_183)) {

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -148,7 +148,7 @@ public:
 	void Load(Town *t) const override
 	{
 		size_t num_cargo = this->GetNumCargo();
-		for (CargoID i = 0; i < num_cargo; i++) {
+		for (size_t i = 0; i < num_cargo; i++) {
 			SlObject(&t->supplied[i], this->GetLoadDescription());
 		}
 	}

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -449,7 +449,7 @@ static bool IsValidSignalType(int signal_type)
 	EnforcePrecondition(false, ::IsValidSignalType(signal));
 
 	Track track = INVALID_TRACK;
-	uint signal_cycles;
+	uint signal_cycles = 0;
 
 	int data_index = 2 + (::TileX(front) - ::TileX(tile)) + 2 * (::TileY(front) - ::TileY(tile));
 	for (int i = 0; i < NUM_TRACK_DIRECTIONS; i++) {

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -988,12 +988,8 @@ static void GfxInitSpriteCache()
 		_allocated_sprite_cache_size = target_size;
 
 		do {
-			try {
-				/* Try to allocate 50% more to make sure we do not allocate almost all available. */
-				_spritecache_ptr = reinterpret_cast<MemBlock *>(new byte[_allocated_sprite_cache_size + _allocated_sprite_cache_size / 2]);
-			} catch (std::bad_alloc &) {
-				_spritecache_ptr = nullptr;
-			}
+			/* Try to allocate 50% more to make sure we do not allocate almost all available. */
+			_spritecache_ptr = reinterpret_cast<MemBlock *>(new(std::nothrow) byte[_allocated_sprite_cache_size + _allocated_sprite_cache_size / 2]);
 
 			if (_spritecache_ptr != nullptr) {
 				/* Allocation succeeded, but we wanted less. */

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -310,13 +310,13 @@ struct TimetableWindow : Window {
 			bool disable = true;
 			if (selected != -1) {
 				const Order *order = v->GetOrder(((selected + 1) / 2) % v->GetNumOrders());
-				if (selected % 2 == 1) {
+				if (selected % 2 != 0) {
 					disable = order != nullptr && (order->IsType(OT_CONDITIONAL) || order->IsType(OT_IMPLICIT));
 				} else {
 					disable = order == nullptr || ((!order->IsType(OT_GOTO_STATION) || (order->GetNonStopType() & ONSF_NO_STOP_AT_DESTINATION_STATION)) && !order->IsType(OT_CONDITIONAL));
 				}
 			}
-			bool disable_speed = disable || selected % 2 != 1 || v->type == VEH_AIRCRAFT;
+			bool disable_speed = disable || selected % 2 == 0 || v->type == VEH_AIRCRAFT;
 
 			this->SetWidgetDisabledState(WID_VT_CHANGE_TIME, disable);
 			this->SetWidgetDisabledState(WID_VT_CLEAR_TIME, disable);
@@ -505,7 +505,7 @@ struct TimetableWindow : Window {
 	static inline std::tuple<VehicleOrderID, ModifyTimetableFlags> PackTimetableArgs(const Vehicle *v, uint selected, bool speed)
 	{
 		uint order_number = (selected + 1) / 2;
-		ModifyTimetableFlags mtf = (selected % 2 == 1) ? (speed ? MTF_TRAVEL_SPEED : MTF_TRAVEL_TIME) : MTF_WAIT_TIME;
+		ModifyTimetableFlags mtf = (selected % 2 != 0) ? (speed ? MTF_TRAVEL_SPEED : MTF_TRAVEL_TIME) : MTF_WAIT_TIME;
 
 		if (order_number >= v->GetNumOrders()) order_number = 0;
 
@@ -543,7 +543,7 @@ struct TimetableWindow : Window {
 				StringID current = STR_EMPTY;
 
 				if (order != nullptr) {
-					uint time = (selected % 2 == 1) ? order->GetTravelTime() : order->GetWaitTime();
+					uint time = (selected % 2 != 0) ? order->GetTravelTime() : order->GetWaitTime();
 					if (!_settings_client.gui.timetable_in_ticks) time /= DAY_TICKS;
 
 					if (time != 0) {

--- a/src/video/sdl2_v.h
+++ b/src/video/sdl2_v.h
@@ -17,7 +17,7 @@
 /** The SDL video driver. */
 class VideoDriver_SDL_Base : public VideoDriver {
 public:
-	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false), driver_info(this->GetName()) {}
+	VideoDriver_SDL_Base() : sdl_window(nullptr), buffer_locked(false) {}
 
 	const char *Start(const StringList &param) override;
 
@@ -40,8 +40,6 @@ public:
 	void EditBoxLostFocus() override;
 
 	std::vector<int> GetListOfMonitorRefreshRates() override;
-
-	const char *GetName() const override { return "sdl"; }
 
 	const char *GetInfoString() const override { return this->driver_info.c_str(); }
 


### PR DESCRIPTION
## Motivation / Problem

CodeQL is complaining about the code's security.


## Description

Does not add any functionality, besides silencing some of CodeQL's security errors by means of some minor code changes. 

The code itself is not actually broken in the way it is used here, but it is better to solve the error than to dismiss it. Just to ensure that we do not dismiss an alert that might in the future become an actual issue, due to some constants being made larger.


## Limitations

None as far as I am aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
