### PR TITLE
Fix #10032: Capacities of articulated vehicles in build window

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -161,41 +161,6 @@ CargoArray GetCapacityOfArticulatedParts(EngineID engine)
 }
 
 /**
- * Get the default cargoes and refits of an articulated vehicle.
- * The refits are linked to a cargo rather than an articulated part to prevent a long list of parts.
- * @param engine Model to investigate.
- * @param[out] cargoes Total amount of units that can be transported, summed by cargo.
- * @param[out] refits Whether a (possibly partial) refit for each cargo is possible.
- * @param cargo_type Selected refitted cargo type
- * @param cargo_capacity Capacity of selected refitted cargo type
- */
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint cargo_capacity)
-{
-	cargoes->Clear();
-	*refits = 0;
-
-	const Engine *e = Engine::Get(engine);
-
-	if (cargo_type < NUM_CARGO && cargo_capacity > 0) {
-		(*cargoes)[cargo_type] += cargo_capacity;
-		if (IsEngineRefittable(engine)) SetBit(*refits, cargo_type);
-	}
-
-	if (!e->IsGroundVehicle() || !HasBit(e->info.callback_mask, CBM_VEHICLE_ARTIC_ENGINE)) return;
-
-	for (uint i = 1; i < MAX_ARTICULATED_PARTS; i++) {
-		EngineID artic_engine = GetNextArticulatedPart(i, engine);
-		if (artic_engine == INVALID_ENGINE) break;
-
-		cargo_capacity = GetVehicleDefaultCapacity(artic_engine, &cargo_type);
-		if (cargo_type < NUM_CARGO && cargo_capacity > 0) {
-			(*cargoes)[cargo_type] += cargo_capacity;
-			if (IsEngineRefittable(artic_engine)) SetBit(*refits, cargo_type);
-		}
-	}
-}
-
-/**
  * Checks whether any of the articulated parts is refittable
  * @param engine the first part
  * @return true if refittable

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -346,7 +346,7 @@ static CommandCost BuildReplacementVehicle(Vehicle *old_veh, Vehicle **new_vehic
 
 	/* Build the new vehicle */
 	VehicleID new_veh_id;
-	std::tie(cost, new_veh_id, std::ignore, std::ignore) = Command<CMD_BUILD_VEHICLE>::Do(DC_EXEC | DC_AUTOREPLACE, old_veh->tile, e, true, CT_INVALID, INVALID_CLIENT_ID);
+	std::tie(cost, new_veh_id, std::ignore, std::ignore, std::ignore) = Command<CMD_BUILD_VEHICLE>::Do(DC_EXEC | DC_AUTOREPLACE, old_veh->tile, e, true, CT_INVALID, INVALID_CLIENT_ID);
 	if (cost.Failed()) return cost;
 
 	Vehicle *new_veh = Vehicle::Get(new_veh_id);

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -523,8 +523,7 @@ public:
 					const Engine *e = Engine::Get(this->sel_engine[side]);
 					TestedEngineDetails ted;
 					ted.cost = 0;
-					ted.cargo = e->GetDefaultCargoType();
-					ted.capacity = e->GetDisplayDefaultCapacity(&ted.mail_capacity);
+					ted.FillDefaultCapacities(e);
 
 					const Rect r = this->GetWidget<NWidgetBase>(side == 0 ? WID_RV_LEFT_DETAILS : WID_RV_RIGHT_DETAILS)->GetCurrentRect()
 							.Shrink(WidgetDimensions::scaled.frametext, WidgetDimensions::scaled.framerect);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1494,7 +1494,7 @@ static void HandleStationRefit(Vehicle *v, CargoArray &consist_capleft, Station 
 			if (st->goods[cid].cargo.HasCargoFor(next_station)) {
 				/* Try to find out if auto-refitting would succeed. In case the refit is allowed,
 				 * the returned refit capacity will be greater than zero. */
-				auto [cc, refit_capacity, mail_capacity] = Command<CMD_REFIT_VEHICLE>::Do(DC_QUERY_COST, v_start->index, cid, 0xFF, true, false, 1); // Auto-refit and only this vehicle including artic parts.
+				auto [cc, refit_capacity, mail_capacity, cargo_capacities] = Command<CMD_REFIT_VEHICLE>::Do(DC_QUERY_COST, v_start->index, cid, 0xFF, true, false, 1); // Auto-refit and only this vehicle including artic parts.
 				/* Try to balance different loadable cargoes between parts of the consist, so that
 				 * all of them can be loaded. Avoid a situation where all vehicles suddenly switch
 				 * to the first loadable cargo for which there is only one packet. If the capacities

--- a/src/engine_func.h
+++ b/src/engine_func.h
@@ -24,7 +24,6 @@ extern const uint8 _engine_offsets[4];
 
 bool IsEngineBuildable(EngineID engine, VehicleType type, CompanyID company);
 bool IsEngineRefittable(EngineID engine);
-void GetArticulatedVehicleCargoesAndRefits(EngineID engine, CargoArray *cargoes, CargoTypes *refits, CargoID cargo_type, uint cargo_capacity);
 void SetYearEngineAgingStops();
 void CalcEngineReliability(Engine *e, bool new_month);
 void StartupOneEngine(Engine *e, Date aging_date, uint32 seed);

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -94,7 +94,7 @@
 	if (!ScriptEngine::IsBuildable(engine_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 
-	auto [res, veh_id, refit_capacity, refit_mail] = ::Command<CMD_BUILD_VEHICLE>::Do(DC_QUERY_COST, depot, engine_id, true, cargo, INVALID_CLIENT_ID);
+	auto [res, veh_id, refit_capacity, refit_mail, cargo_capacities] = ::Command<CMD_BUILD_VEHICLE>::Do(DC_QUERY_COST, depot, engine_id, true, cargo, INVALID_CLIENT_ID);
 	return res.Succeeded() ? refit_capacity : -1;
 }
 
@@ -143,7 +143,7 @@
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
 
-	auto [res, refit_capacity, refit_mail] = ::Command<CMD_REFIT_VEHICLE>::Do(DC_QUERY_COST, vehicle_id, cargo, 0, false, false, 0);
+	auto [res, refit_capacity, refit_mail, cargo_capacities] = ::Command<CMD_REFIT_VEHICLE>::Do(DC_QUERY_COST, vehicle_id, cargo, 0, false, false, 0);
 	return res.Succeeded() ? refit_capacity : -1;
 }
 

--- a/src/train_cmd.h
+++ b/src/train_cmd.h
@@ -25,6 +25,6 @@ DEF_CMD_TRAIT(CMD_MOVE_RAIL_VEHICLE,       CmdMoveRailVehicle,       0, CMDT_VEH
 DEF_CMD_TRAIT(CMD_FORCE_TRAIN_PROCEED,     CmdForceTrainProceed,     0, CMDT_VEHICLE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_REVERSE_TRAIN_DIRECTION, CmdReverseTrainDirection, 0, CMDT_VEHICLE_MANAGEMENT)
 
-void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, TileIndex tile, EngineID, bool, CargoID, ClientID);
+void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, CargoArray, TileIndex tile, EngineID, bool, CargoID, ClientID);
 
 #endif /* TRAIN_CMD_H */

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -27,7 +27,7 @@
  * @param new_veh_id ID of the ne vehicle.
  * @param tile   The tile the command was executed on.
  */
-void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, TileIndex tile, EngineID, bool, CargoID, ClientID)
+void CcBuildWagon(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, CargoArray, TileIndex tile, EngineID, bool, CargoID, ClientID)
 {
 	if (result.Failed()) return;
 

--- a/src/vehicle_cmd.h
+++ b/src/vehicle_cmd.h
@@ -14,10 +14,11 @@
 #include "engine_type.h"
 #include "vehicle_type.h"
 #include "vehiclelist.h"
+#include "cargo_type.h"
 
-std::tuple<CommandCost, VehicleID, uint, uint16> CmdBuildVehicle(DoCommandFlag flags, TileIndex tile, EngineID eid, bool use_free_vehicles, CargoID cargo, ClientID client_id);
+std::tuple<CommandCost, VehicleID, uint, uint16, CargoArray> CmdBuildVehicle(DoCommandFlag flags, TileIndex tile, EngineID eid, bool use_free_vehicles, CargoID cargo, ClientID client_id);
 CommandCost CmdSellVehicle(DoCommandFlag flags, VehicleID v_id, bool sell_chain, bool backup_order, ClientID client_id);
-std::tuple<CommandCost, uint, uint16> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, byte new_subtype, bool auto_refit, bool only_this, uint8 num_vehicles);
+std::tuple<CommandCost, uint, uint16, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, byte new_subtype, bool auto_refit, bool only_this, uint8 num_vehicles);
 CommandCost CmdSendVehicleToDepot(DoCommandFlag flags, VehicleID veh_id, DepotCommand depot_cmd, const VehicleListIdentifier &vli);
 CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16 serv_int, bool is_custom, bool is_percent);
 CommandCost CmdRenameVehicle(DoCommandFlag flags, VehicleID veh_id, const std::string &text);
@@ -39,7 +40,7 @@ DEF_CMD_TRAIT(CMD_MASS_START_STOP,         CmdMassStartStopVehicle, 0,          
 DEF_CMD_TRAIT(CMD_DEPOT_SELL_ALL_VEHICLES, CmdDepotSellAllVehicles, 0,             CMDT_VEHICLE_CONSTRUCTION)
 DEF_CMD_TRAIT(CMD_DEPOT_MASS_AUTOREPLACE,  CmdDepotMassAutoReplace, 0,             CMDT_VEHICLE_CONSTRUCTION)
 
-void CcBuildPrimaryVehicle(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16);
+void CcBuildPrimaryVehicle(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, CargoArray);
 void CcStartStopVehicle(Commands cmd, const CommandCost &result, VehicleID veh_id, bool);
 
 template <typename Tcont, typename Titer>
@@ -51,6 +52,23 @@ inline EndianBufferWriter<Tcont, Titer> &operator <<(EndianBufferWriter<Tcont, T
 inline EndianBufferReader &operator >>(EndianBufferReader &buffer, VehicleListIdentifier &vli)
 {
 	return buffer >> vli.type >> vli.vtype >> vli.company >> vli.index;
+}
+
+template <typename Tcont, typename Titer>
+inline EndianBufferWriter<Tcont, Titer> &operator <<(EndianBufferWriter<Tcont, Titer> &buffer, const CargoArray &cargo_array)
+{
+	for (CargoID c = 0; c < NUM_CARGO; c++) {
+		buffer << cargo_array[c];
+	}
+	return buffer;
+}
+
+inline EndianBufferReader &operator >>(EndianBufferReader &buffer, CargoArray &cargo_array)
+{
+	for (CargoID c = 0; c < NUM_CARGO; c++) {
+		buffer >> cargo_array[c];
+	}
+	return buffer;
 }
 
 #endif /* VEHICLE_CMD_H */

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -892,7 +892,7 @@ struct RefitWindow : public Window {
 	StringID GetCapacityString(RefitOption *option) const
 	{
 		assert(_current_company == _local_company);
-		auto [cost, refit_capacity, mail_capacity] = Command<CMD_REFIT_VEHICLE>::Do(DC_QUERY_COST, this->selected_vehicle, option->cargo, option->subtype, this->auto_refit, false, this->num_vehicles);
+		auto [cost, refit_capacity, mail_capacity, cargo_capacities] = Command<CMD_REFIT_VEHICLE>::Do(DC_QUERY_COST, this->selected_vehicle, option->cargo, option->subtype, this->auto_refit, false, this->num_vehicles);
 
 		if (cost.Failed()) return INVALID_STRING_ID;
 
@@ -3356,7 +3356,7 @@ void StopGlobalFollowVehicle(const Vehicle *v)
  * @param result indicates completion (or not) of the operation
  * @param new_veh_id ID of the new vehicle.
  */
-void CcBuildPrimaryVehicle(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16)
+void CcBuildPrimaryVehicle(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, CargoArray)
 {
 	if (result.Failed()) return;
 

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -43,6 +43,9 @@ struct TestedEngineDetails {
 	CargoID cargo;        ///< Cargo type
 	uint capacity;        ///< Cargo capacity
 	uint16 mail_capacity; ///< Mail capacity if available
+	CargoArray all_capacities; ///< Capacities for all cargoes
+
+	void FillDefaultCapacities(const Engine *e);
 };
 
 int DrawVehiclePurchaseInfo(int left, int right, int y, EngineID engine_number, TestedEngineDetails &te);


### PR DESCRIPTION
## Motivation / Problem

#10032 and #9954
Fixes #9954

## Description

GetArticulatedVehicleCargoesAndRefits is incorrect, remove it.
Correctly handle capacities of articulated vehicles, including the refitting case, and multiple cargoes.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
