### PR TITLE
Fix #10309: [SDL] Uninitialized width and height when turning off full screen

### DIFF
--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -648,12 +648,11 @@ bool VideoDriver_SDL_Base::ChangeResolution(int w, int h)
 
 bool VideoDriver_SDL_Base::ToggleFullscreen(bool fullscreen)
 {
-	int w, h;
-
 	/* Remember current window size */
-	if (fullscreen) {
-		SDL_GetWindowSize(this->sdl_window, &w, &h);
+	int w, h;
+	SDL_GetWindowSize(this->sdl_window, &w, &h);
 
+	if (fullscreen) {
 		/* Find fullscreen window size */
 		SDL_DisplayMode dm;
 		if (SDL_GetCurrentDisplayMode(0, &dm) < 0) {


### PR DESCRIPTION
## Motivation / Problem

See #10309.


## Description

Just move the code to fill the width and height variables outside of the `if`, so the values will always be set regardless of the code paths.


## Limitations

I'm not sure how consistent the full screen toggling behaviour is compared to Windows/Mac OS X.
With SDL going to full screen will use the resolution of the current screen, which I think is generally fine. However, going away from full screen will use the resolution as screen size which might be too large when the full screen resolution was equal to or larger than the resolution that the OS sets after returning from the OpenTTD full screen. So, the main window is bigger than the screen.
However, that behaviour is definitely better than crashing and since nobody reported it I doubt many people switch between fullscreen and non-fullscreen so I'd see it as a tiny peeve that is not in the scope of this PR or the bug report.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
