### PR TITLE
Codechange: Rework 'start_date' parameter for AIs as a game setting

### DIFF
--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -23,12 +23,14 @@ public:
 	 * The default months AIs start after each other.
 	 */
 	enum StartNext {
-		START_NEXT_EASY   = DAYS_IN_YEAR * 2,
-		START_NEXT_MEDIUM = DAYS_IN_YEAR,
-		START_NEXT_HARD   = DAYS_IN_YEAR / 2,
-		START_NEXT_MIN    = 0,
-		START_NEXT_MAX    = 3600,
+		START_NEXT           = DAYS_IN_YEAR * 2,
+		START_NEXT_EASY      = DAYS_IN_YEAR * 2,
+		START_NEXT_MEDIUM    = DAYS_IN_YEAR,
+		START_NEXT_HARD      = DAYS_IN_YEAR / 2,
+		START_NEXT_MIN       = 0,
+		START_NEXT_MAX       = 3600,
 		START_NEXT_DEVIATION = 60,
+		START_NEXT_STEP_SIZE = 30
 	};
 
 	/**

--- a/src/ai/ai.hpp
+++ b/src/ai/ai.hpp
@@ -24,9 +24,6 @@ public:
 	 */
 	enum StartNext {
 		START_NEXT           = DAYS_IN_YEAR * 2,
-		START_NEXT_EASY      = DAYS_IN_YEAR * 2,
-		START_NEXT_MEDIUM    = DAYS_IN_YEAR,
-		START_NEXT_HARD      = DAYS_IN_YEAR / 2,
 		START_NEXT_MIN       = 0,
 		START_NEXT_MAX       = 3600,
 		START_NEXT_DEVIATION = 60,

--- a/src/ai/ai_config.cpp
+++ b/src/ai/ai_config.cpp
@@ -9,38 +9,11 @@
 
 #include "../stdafx.h"
 #include "../settings_type.h"
-#include "../string_func.h"
 #include "ai.hpp"
 #include "ai_config.hpp"
 #include "ai_info.hpp"
 
 #include "../safeguards.h"
-
-/** Configuration for AI start date, every AI has this setting. */
-ScriptConfigItem _start_date_config = {
-	"start_date",
-	"", // STR_AI_SETTINGS_START_DELAY
-	AI::START_NEXT_MIN,
-	AI::START_NEXT_MAX,
-	AI::START_NEXT_MEDIUM,
-	AI::START_NEXT_EASY,
-	AI::START_NEXT_MEDIUM,
-	AI::START_NEXT_HARD,
-	AI::START_NEXT_DEVIATION,
-	30,
-	SCRIPTCONFIG_NONE,
-	nullptr,
-	false
-};
-
-AIConfig::AIConfig(const AIConfig *config) : ScriptConfig(config)
-{
-	/* Override start_date as per AIConfig::AddRandomDeviation().
-	 * This is necessary because the ScriptConfig constructor will instead call
-	 * ScriptConfig::AddRandomDeviation(). */
-	int start_date = config->GetSetting("start_date");
-	this->SetSetting("start_date", start_date != 0 ? std::max(1, this->GetSetting("start_date")) : 0);
-}
 
 /* static */ AIConfig *AIConfig::GetConfig(CompanyID company, ScriptSettingSource source)
 {
@@ -68,71 +41,4 @@ bool AIConfig::ResetInfo(bool force_exact_match)
 {
 	this->info = (ScriptInfo *)AI::FindInfo(this->name, force_exact_match ? this->version : -1, force_exact_match);
 	return this->info != nullptr;
-}
-
-void AIConfig::PushExtraConfigList()
-{
-	this->config_list->push_back(_start_date_config);
-}
-
-void AIConfig::ClearConfigList()
-{
-	/* The special casing for start_date is here to ensure that the
-	 *  start_date setting won't change even if you chose another Script. */
-	int start_date = this->GetSetting("start_date");
-
-	ScriptConfig::ClearConfigList();
-
-	this->SetSetting("start_date", start_date);
-}
-
-int AIConfig::GetSetting(const char *name) const
-{
-	if (this->info == nullptr) {
-		SettingValueList::const_iterator it = this->settings.find(name);
-		if (it == this->settings.end()) {
-			assert(strcmp("start_date", name) == 0);
-			switch (GetGameSettings().script.settings_profile) {
-				case SP_EASY:   return AI::START_NEXT_EASY;
-				case SP_MEDIUM: return AI::START_NEXT_MEDIUM;
-				case SP_HARD:   return AI::START_NEXT_HARD;
-				case SP_CUSTOM: return AI::START_NEXT_MEDIUM;
-				default: NOT_REACHED();
-			}
-		}
-
-		return (*it).second;
-	}
-
-	return ScriptConfig::GetSetting(name);
-}
-
-void AIConfig::SetSetting(const char *name, int value)
-{
-	if (this->info == nullptr) {
-		if (strcmp("start_date", name) != 0) return;
-		value = Clamp(value, AI::START_NEXT_MIN, AI::START_NEXT_MAX);
-
-		SettingValueList::iterator it = this->settings.find(name);
-		if (it != this->settings.end()) {
-			(*it).second = value;
-		} else {
-			this->settings[stredup(name)] = value;
-		}
-
-		return;
-	}
-
-	ScriptConfig::SetSetting(name, value);
-}
-
-void AIConfig::AddRandomDeviation()
-{
-	int start_date = this->GetSetting("start_date");
-
-	ScriptConfig::AddRandomDeviation();
-
-	/* start_date = 0 is a special case, where random deviation does not occur.
-	 * If start_date was not already 0, then a minimum value of 1 must apply. */
-	this->SetSetting("start_date", start_date != 0 ? std::max(1, this->GetSetting("start_date")) : 0);
 }

--- a/src/ai/ai_config.hpp
+++ b/src/ai/ai_config.hpp
@@ -24,13 +24,11 @@ public:
 		ScriptConfig()
 	{}
 
-	AIConfig(const AIConfig *config);
+	AIConfig(const AIConfig *config) :
+		ScriptConfig(config)
+	{}
 
 	class AIInfo *GetInfo() const;
-
-	int GetSetting(const char *name) const override;
-	void SetSetting(const char *name, int value) override;
-	void AddRandomDeviation() override;
 
 	/**
 	 * When ever the AI Scanner is reloaded, all infos become invalid. This
@@ -43,8 +41,6 @@ public:
 	bool ResetInfo(bool force_exact_match);
 
 protected:
-	void PushExtraConfigList() override;
-	void ClearConfigList() override;
 	ScriptInfo *FindInfo(const char *name, int version, bool force_exact_match) override;
 };
 

--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -69,11 +69,6 @@ template <> const char *GetClassName<AIInfo, ST_AI>() { return "AIInfo"; }
 	SQInteger res = ScriptInfo::Constructor(vm, info);
 	if (res != 0) return res;
 
-	ScriptConfigItem config = _start_date_config;
-	config.name = stredup(config.name);
-	config.description = stredup(config.description);
-	info->config_list.push_front(config);
-
 	if (info->engine->MethodExists(*info->SQ_instance, "MinVersionToLoad")) {
 		if (!info->engine->CallIntegerMethod(*info->SQ_instance, "MinVersionToLoad", &info->min_loadable_version, MAX_GET_OPS)) return SQ_ERROR;
 	} else {

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -727,13 +727,14 @@ void OnTick_Companies()
 
 	if (_game_mode != GM_MENU && AI::CanStartNew() && --_next_competitor_start == 0) {
 		/* Allow multiple AIs to possibly start in the same tick. */
-		do {
+		for (;;) {
 			if (!MaybeStartNewCompany()) break;
+			if (_settings_game.ai.ai_start_next != 0) break;
 
 			/* In networking mode, we can only send a command to start but it
 			 * didn't execute yet, so we cannot loop. */
 			if (_networking) break;
-		} while (AI::GetStartNextTime() == 0);
+		}
 	}
 
 	_cur_company_tick_index = (_cur_company_tick_index + 1) % MAX_COMPANIES;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4635,7 +4635,6 @@ STR_AI_SETTINGS_CAPTION_GAMESCRIPT                              :Game Script
 STR_AI_SETTINGS_CLOSE                                           :{BLACK}Close
 STR_AI_SETTINGS_RESET                                           :{BLACK}Reset
 STR_AI_SETTINGS_SETTING                                         :{RAW_STRING}: {ORANGE}{STRING1}
-STR_AI_SETTINGS_START_DELAY                                     :Number of days to start this AI after the previous one (give or take): {ORANGE}{STRING1}
 
 
 # Textfile window

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4589,6 +4589,8 @@ STR_AI_CONFIG_HUMAN_PLAYER                                      :Human player
 STR_AI_CONFIG_RANDOM_AI                                         :Random AI
 STR_AI_CONFIG_NONE                                              :(none)
 STR_AI_CONFIG_MAX_COMPETITORS                                   :{LTBLUE}Maximum no. competitors: {ORANGE}{COMMA}
+STR_AI_CONFIG_START_NEXT                                        :{LTBLUE}Start delay between AIs (give or take): {ORANGE}{STRING1}
+STR_AI_CONFIG_START_NEXT_TOOLTIP                                :{BLACK}Number of days to wait before starting an AI, or subsequent AI(s) after the previous one.{}If the number of days is different than zero, a random deviation of 60 days is added, and the actual value in-game will be 'number_of_days + random(-60 days, 60 days)', with a minimum of 1 day and a maximum of 3600 days.{}If the number of days is zero, the AI(s) will start immediately.
 
 STR_AI_CONFIG_MOVE_UP                                           :{BLACK}Move Up
 STR_AI_CONFIG_MOVE_UP_TOOLTIP                                   :{BLACK}Move selected AI up in the list

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1704,6 +1704,10 @@ STR_CONFIG_SETTING_AI_PROFILE_HARD                              :Hard
 STR_CONFIG_SETTING_AI_IN_MULTIPLAYER                            :Allow AIs in multiplayer: {STRING2}
 STR_CONFIG_SETTING_AI_IN_MULTIPLAYER_HELPTEXT                   :Allow AI computer players to participate in multiplayer games
 
+STR_CONFIG_SETTING_AI_START_NEXT                                :Start delay between AIs (give or take): {STRING2}
+STR_CONFIG_SETTING_AI_START_NEXT_HELPTEXT                       :Number of days to wait before starting an AI, or subsequent AI(s) after the previous one.{}If the number of days is different than zero, a random deviation of 60 days is added, and the actual value in-game will be 'number_of_days + random(-60 days, 60 days)', with a minimum of 1 day and a maximum of 3600 days
+STR_CONFIG_SETTING_AI_START_NEXT_VALUE                          :{COMMA}{NBSP}day{P 0 "" s}
+
 STR_CONFIG_SETTING_SCRIPT_MAX_OPCODES                           :#opcodes before scripts are suspended: {STRING2}
 STR_CONFIG_SETTING_SCRIPT_MAX_OPCODES_HELPTEXT                  :Maximum number of computation steps that a script can take in one turn
 STR_CONFIG_SETTING_SCRIPT_MAX_MEMORY                            :Max memory usage per script: {STRING2}

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -389,9 +389,6 @@ void MakeNewgameSettingsLive()
 		_settings_game.ai_config[c] = nullptr;
 		if (_settings_newgame.ai_config[c] != nullptr) {
 			_settings_game.ai_config[c] = new AIConfig(_settings_newgame.ai_config[c]);
-			if (!AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->HasScript()) {
-				AIConfig::GetConfig(c, AIConfig::SSS_FORCE_GAME)->Change(nullptr);
-			}
 		}
 	}
 	_settings_game.game_config = nullptr;

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3203,6 +3203,10 @@ bool AfterLoadGame()
 		}
 	}
 
+	if (IsSavegameVersionBefore(SLV_AI_START_NEXT)) {
+		_settings_game.ai.ai_start_next = AI::START_NEXT;
+	}
+
 	/* Compute station catchment areas. This is needed here in case UpdateStationAcceptance is called below. */
 	Station::RecomputeCatchmentForAll();
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -345,6 +345,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_MULTITRACK_LEVEL_CROSSINGS,         ///< 302  PR#9931 v13.0  Multi-track level crossings.
 	SLV_NEWGRF_ROAD_STOPS,                  ///< 303  PR#10144 NewGRF road stops.
 	SLV_LINKGRAPH_EDGES,                    ///< 304  PR#10314 Explicitly store link graph edges destination, PR#10471 int64 instead of uint64 league rating
+	SLV_AI_START_NEXT,                      ///< 305  PR#10330 Rework AI "start_date" setting as game setting.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -51,8 +51,6 @@ struct ScriptConfigItem {
 
 typedef std::list<ScriptConfigItem> ScriptConfigItemList; ///< List of ScriptConfig items.
 
-extern ScriptConfigItem _start_date_config;
-
 /**
  * Script settings.
  */

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -373,14 +373,8 @@ struct ScriptSettingsWindow : public Window {
 			TextColour colour;
 			uint idx = 0;
 			if (StrEmpty(config_item.description)) {
-				if (this->slot != OWNER_DEITY && !strcmp(config_item.name, "start_date")) {
-					/* Build-in translation */
-					str = STR_AI_SETTINGS_START_DELAY;
-					colour = TC_LIGHT_BLUE;
-				} else {
-					str = STR_JUST_STRING;
-					colour = TC_ORANGE;
-				}
+				str = STR_JUST_STRING;
+				colour = TC_ORANGE;
 			} else {
 				str = STR_AI_SETTINGS_SETTING;
 				colour = TC_LIGHT_BLUE;

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1880,6 +1880,7 @@ static SettingsContainer &GetSettingsTree()
 				npc->Add(new SettingEntry("script.script_max_memory_megabytes"));
 				npc->Add(new SettingEntry("difficulty.competitor_speed"));
 				npc->Add(new SettingEntry("ai.ai_in_multiplayer"));
+				npc->Add(new SettingEntry("ai.ai_start_next"));
 				npc->Add(new SettingEntry("ai.ai_disable_veh_train"));
 				npc->Add(new SettingEntry("ai.ai_disable_veh_roadveh"));
 				npc->Add(new SettingEntry("ai.ai_disable_veh_aircraft"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -368,6 +368,7 @@ struct ConstructionSettings {
 /** Settings related to the AI. */
 struct AISettings {
 	bool   ai_in_multiplayer;                ///< so we allow AIs in multiplayer
+	uint16 ai_start_next;                    ///< days AIs start after each other
 	bool   ai_disable_veh_train;             ///< disable types for AI
 	bool   ai_disable_veh_roadveh;           ///< disable types for AI
 	bool   ai_disable_veh_aircraft;          ///< disable types for AI

--- a/src/table/settings/script_settings.ini
+++ b/src/table/settings/script_settings.ini
@@ -110,3 +110,17 @@ var      = ai.ai_disable_veh_ship
 def      = false
 str      = STR_CONFIG_SETTING_AI_BUILDS_SHIPS
 strhelp  = STR_CONFIG_SETTING_AI_BUILDS_SHIPS_HELPTEXT
+
+[SDT_VAR]
+var      = ai.ai_start_next
+type     = SLE_UINT16
+from     = SLV_AI_START_NEXT
+def      = AI::START_NEXT
+min      = AI::START_NEXT_MIN
+max      = AI::START_NEXT_MAX
+interval = AI::START_NEXT_STEP_SIZE
+str      = STR_CONFIG_SETTING_AI_START_NEXT
+strhelp  = STR_CONFIG_SETTING_AI_START_NEXT_HELPTEXT
+strval   = STR_CONFIG_SETTING_AI_START_NEXT_VALUE
+post_cb  = [](auto) { InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_AI); }
+cat      = SC_BASIC

--- a/src/widgets/ai_widget.h
+++ b/src/widgets/ai_widget.h
@@ -15,6 +15,9 @@
 /** Widgets of the #AIConfigWindow class. */
 enum AIConfigWidgets {
 	WID_AIC_BACKGROUND,       ///< Window background.
+	WID_AIC_SN_DECREASE,      ///< Decrease the AI start delay.
+	WID_AIC_SN_INCREASE,      ///< Increase the AI start delay.
+	WID_AIC_START_NEXT,       ///< Days to wait before starting an AI.
 	WID_AIC_DECREASE,         ///< Decrease the number of AIs.
 	WID_AIC_INCREASE,         ///< Increase the number of AIs.
 	WID_AIC_NUMBER,           ///< Number of AIs.


### PR DESCRIPTION
## Motivation / Problem
The point of the PR is to eliminate the need to control when "start_date" parameter is pushed into an AI config, then control when it's to be randomized or deviated, also to make it more predictable when loading from a savegame, what it initializes to, make the savegame thus more reproducible. By making it a game setting, it is removed from the AI config, no more need to babysit it.

See #7515, #7486, #8051, #6460
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
![StartDelay](https://user-images.githubusercontent.com/43006711/211921808-f6183de9-e81e-4c19-b5e3-f3a78a00dcfe.png)

`start_date` is removed from the list of AI parameters, and is added as `ai_start_next` on the list of game settings and on AI settings where you setup which AIs to start.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Moves 'start_date' AI parameter away from scripts losing its "per-AI" customization, into a game setting. It is now a "one for all" approach for the feature.
Default value was set to that of Easy Preset.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
