### PR TITLE
Fix #10333, c53f29d: Only show industry prospecting errors to local company

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2064,7 +2064,7 @@ CommandCost CmdBuildIndustry(DoCommandFlag flags, TileIndex tile, IndustryType i
 				}
 				cur_company.Restore();
 			}
-			if (ret.Failed()) {
+			if (ret.Failed() && IsLocalCompany()) {
 				if (prospect_success) {
 					ShowErrorMessage(STR_ERROR_CAN_T_PROSPECT_INDUSTRY, STR_ERROR_NO_SUITABLE_PLACES_FOR_PROSPECTING, WL_INFO);
 				} else {


### PR DESCRIPTION
## Motivation / Problem

Since #10202, when a player attempts to prospect an industry and it fails, they receive an error message. When this happens in a network game, all clients connected to the game (including spectators) are shown the error message.

## Description

Only players in the local company receive the message. This includes all members of the company, not just the player who performed the action, to be consistent with the error which is shown to all players in the company when a local authority bribe fails and is discovered by investigators.

Closes #10333.

## Limitations

Perhaps this and the bribe failure should only be shown to the player who initiated the action, but that's arguably a design decision.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
