### PR TITLE
Change: Try making Scripts usage of Random more predictable

### DIFF
--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -11,6 +11,7 @@
 #include "script_company.hpp"
 #include "script_error.hpp"
 #include "script_companymode.hpp"
+#include "script_base.hpp"
 #include "../../company_func.h"
 #include "../../company_base.h"
 #include "../../company_manager_face.h"
@@ -24,6 +25,7 @@
 #include "../../misc_cmd.h"
 #include "../../object_cmd.h"
 #include "../../settings_cmd.h"
+#include "../../network/network.h"
 #include "table/strings.h"
 
 #include "../../safeguards.h"
@@ -98,8 +100,8 @@
 	EnforcePrecondition(false, GetPresidentGender(ScriptCompany::COMPANY_SELF) != gender);
 
 	CompanyManagerFace cmf;
-	GenderEthnicity ge = (GenderEthnicity)((gender == GENDER_FEMALE ? (1 << ::GENDER_FEMALE) : 0) | (::InteractiveRandom() & (1 << ETHNICITY_BLACK)));
-	RandomCompanyManagerFaceBits(cmf, ge, false);
+	GenderEthnicity ge = (GenderEthnicity)((gender == GENDER_FEMALE ? (1 << ::GENDER_FEMALE) : 0) | (ScriptBase::Rand() & (1 << ETHNICITY_BLACK)));
+	RandomCompanyManagerFaceBits(cmf, ge, false, _networking);
 
 	return ScriptObject::Command<CMD_SET_COMPANY_MANAGER_FACE>::Do(cmf);
 }

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -11,10 +11,10 @@
 #include "script_industrytype.hpp"
 #include "script_map.hpp"
 #include "script_error.hpp"
+#include "script_base.hpp"
 #include "../../strings_func.h"
 #include "../../industry.h"
 #include "../../newgrf_industries.h"
-#include "../../core/random_func.hpp"
 #include "../../industry_cmd.h"
 
 #include "../../safeguards.h"
@@ -121,8 +121,8 @@
 	EnforcePrecondition(false, CanBuildIndustry(industry_type));
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
-	uint32 seed = ::InteractiveRandom();
-	uint32 layout_index = ::InteractiveRandomRange((uint32)::GetIndustrySpec(industry_type)->layouts.size());
+	uint32 seed = ScriptBase::Rand();
+	uint32 layout_index = ScriptBase::RandRange((uint32)::GetIndustrySpec(industry_type)->layouts.size());
 	return ScriptObject::Command<CMD_BUILD_INDUSTRY>::Do(tile, industry_type, layout_index, true, seed);
 }
 
@@ -130,7 +130,7 @@
 {
 	EnforcePrecondition(false, CanProspectIndustry(industry_type));
 
-	uint32 seed = ::InteractiveRandom();
+	uint32 seed = ScriptBase::Rand();
 	return ScriptObject::Command<CMD_BUILD_INDUSTRY>::Do(0, industry_type, 0, false, seed);
 }
 

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -18,6 +18,7 @@
 #include "../../station_base.h"
 #include "../../landscape.h"
 #include "../../town_cmd.h"
+#include "../../network/network.h"
 #include "table/strings.h"
 
 #include "../../safeguards.h"
@@ -301,7 +302,7 @@
 		EnforcePreconditionCustomError(false, ::Utf8StringLength(text) < MAX_LENGTH_TOWN_NAME_CHARS, ScriptError::ERR_PRECONDITION_STRING_TOO_LONG);
 	}
 	uint32 townnameparts;
-	if (!GenerateTownName(&townnameparts)) {
+	if (!GenerateTownName(&townnameparts, nullptr, !_networking)) {
 		ScriptObject::SetLastError(ScriptError::ERR_NAME_IS_NOT_UNIQUE);
 		return false;
 	}

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -9,7 +9,7 @@
 
 #include "../stdafx.h"
 #include "../settings_type.h"
-#include "../core/random_func.hpp"
+#include "script_base.hpp"
 #include "script_info.hpp"
 #include "../textfile_gui.h"
 #include "../string_func.h"
@@ -35,7 +35,7 @@ void ScriptConfig::Change(const char *name, int version, bool force_exact_match,
 		 *  for the Script that have the random flag to a random value. */
 		for (const auto &item : *this->info->GetConfigList()) {
 			if (item.flags & SCRIPTCONFIG_RANDOM) {
-				this->SetSetting(item.name, InteractiveRandomRange(item.max_value + 1 - item.min_value) + item.min_value);
+				this->SetSetting(item.name, ScriptBase::RandRange(item.max_value + 1 - item.min_value) + item.min_value);
 			}
 		}
 
@@ -157,7 +157,7 @@ void ScriptConfig::AddRandomDeviation()
 {
 	for (const auto &item : *this->GetConfigList()) {
 		if (item.random_deviation != 0) {
-			this->SetSetting(item.name, InteractiveRandomRange(item.random_deviation * 2 + 1) - item.random_deviation + this->GetSetting(item.name));
+			this->SetSetting(item.name, ScriptBase::RandRange(item.random_deviation * 2 + 1) - item.random_deviation + this->GetSetting(item.name));
 		}
 	}
 }

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -114,9 +114,10 @@ bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names)
  * Generates valid town name.
  * @param townnameparts if a name is generated, it's stored there
  * @param town_names if a name is generated, check its uniqueness with the set
+ * @param force_random whether to force the use of Random() over InteractiveRandom()
  * @return true iff a name was generated
  */
-bool GenerateTownName(uint32 *townnameparts, TownNames *town_names)
+bool GenerateTownName(uint32 *townnameparts, TownNames *town_names, bool force_random)
 {
 	TownNameParams par(_settings_game.game_creation.town_name);
 
@@ -130,7 +131,7 @@ bool GenerateTownName(uint32 *townnameparts, TownNames *town_names)
 	 * the other towns may take considerable amount of time (10000 is
 	 * too much). */
 	for (int i = 1000; i != 0; i--) {
-		uint32 r = _generating_world ? Random() : InteractiveRandom();
+		uint32 r = (_generating_world || force_random) ? Random() : InteractiveRandom();
 		if (!VerifyTownName(r, &par, town_names)) continue;
 
 		*townnameparts = r;

--- a/src/townname_func.h
+++ b/src/townname_func.h
@@ -16,6 +16,6 @@ char *GenerateTownNameString(char *buf, const char *last, size_t lang, uint32 se
 char *GetTownName(char *buff, const TownNameParams *par, uint32 townnameparts, const char *last);
 char *GetTownName(char *buff, const Town *t, const char *last);
 bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names = nullptr);
-bool GenerateTownName(uint32 *townnameparts, TownNames *town_names = nullptr);
+bool GenerateTownName(uint32 *townnameparts, TownNames *town_names = nullptr, bool force_random = false);
 
 #endif /* TOWNNAME_FUNC_H */


### PR DESCRIPTION
## Motivation / Problem
The use of InteractiveRandom in Script based functions means that when attempting to reproduce the same game play they could not repeat the same events.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Make AIs or GSs do the same thing when the games are restarted in single player wherever possible.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Note that there are certain limitations though where reproduceability isn't garanteed, such as GS's ability to modify game settings, but those are not dealt with in here.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
