### PR TITLE
Use smart pointers for iterators

### DIFF
--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -126,9 +126,9 @@ public:
 		return *this;
 	}
 
-	virtual TileIterator *Clone() const
+	virtual std::unique_ptr<TileIterator> Clone() const
 	{
-		return new BitmapTileIterator(*this);
+		return std::make_unique<BitmapTileIterator>(*this);
 	}
 };
 

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -758,7 +758,7 @@ std::tuple<CommandCost, Money> CmdClearArea(DoCommandFlag flags, TileIndex tile,
 	const Company *c = (flags & (DC_AUTO | DC_BANKRUPT)) ? nullptr : Company::GetIfValid(_current_company);
 	int limit = (c == nullptr ? INT32_MAX : GB(c->clear_limit, 16, 16));
 
-	TileIterator *iter = diagonal ? (TileIterator *)new DiagonalTileIterator(tile, start_tile) : new OrthogonalTileIterator(tile, start_tile);
+	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
 	for (; *iter != INVALID_TILE; ++(*iter)) {
 		TileIndex t = *iter;
 		CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags & ~DC_EXEC, t);
@@ -774,7 +774,6 @@ std::tuple<CommandCost, Money> CmdClearArea(DoCommandFlag flags, TileIndex tile,
 		if (flags & DC_EXEC) {
 			money -= ret.GetCost();
 			if (ret.GetCost() > 0 && money < 0) {
-				delete iter;
 				return { cost, ret.GetCost() };
 			}
 			Command<CMD_LANDSCAPE_CLEAR>::Do(flags, t);
@@ -794,7 +793,6 @@ std::tuple<CommandCost, Money> CmdClearArea(DoCommandFlag flags, TileIndex tile,
 		cost.AddCost(ret);
 	}
 
-	delete iter;
 	return { had_success ? cost : last_error, 0 };
 }
 

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -58,9 +58,9 @@ public:
 		return this->att->gfx;
 	}
 
-	virtual AirportTileTableIterator *Clone() const
+	virtual std::unique_ptr<TileIterator> Clone() const
 	{
-		return new AirportTileTableIterator(*this);
+		return std::make_unique<AirportTileTableIterator>(*this);
 	}
 };
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -402,7 +402,7 @@ CommandCost CmdBuildObjectArea(DoCommandFlag flags, TileIndex tile, TileIndex st
 	const Company *c = Company::GetIfValid(_current_company);
 	int limit = (c == nullptr ? INT32_MAX : GB(c->build_object_limit, 16, 16));
 
-	TileIterator *iter = diagonal ? (TileIterator *)new DiagonalTileIterator(tile, start_tile) : new OrthogonalTileIterator(tile, start_tile);
+	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
 	for (; *iter != INVALID_TILE; ++(*iter)) {
 		TileIndex t = *iter;
 		CommandCost ret = Command<CMD_BUILD_OBJECT>::Do(flags & ~DC_EXEC, t, type, view);
@@ -426,7 +426,6 @@ CommandCost CmdBuildObjectArea(DoCommandFlag flags, TileIndex tile, TileIndex st
 		cost.AddCost(ret);
 	}
 
-	delete iter;
 	return had_success ? cost : last_error;
 }
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -443,9 +443,9 @@ int MacOSStringCompare(const char *s1, const char *s2)
 	return this->utf16_to_utf8[this->cur_pos];
 }
 
-/* static */ StringIterator *OSXStringIterator::Create()
+/* static */ std::unique_ptr<StringIterator> OSXStringIterator::Create()
 {
 	if (!MacOSVersionIsAtLeast(10, 5, 0)) return nullptr;
 
-	return new OSXStringIterator();
+	return std::make_unique<OSXStringIterator>();
 }

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -33,7 +33,7 @@ public:
 	size_t Next(IterType what) override;
 	size_t Prev(IterType what) override;
 
-	static StringIterator *Create();
+	static std::unique_ptr<StringIterator> Create();
 };
 
 /**

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -1548,7 +1548,7 @@ CommandCost CmdConvertRail(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 	CommandCost error = CommandCost(STR_ERROR_NO_SUITABLE_RAILROAD_TRACK); // by default, there is no track to convert.
 	bool found_convertible_track = false; // whether we actually did convert some track (see bug #7633)
 
-	TileIterator *iter = diagonal ? (TileIterator *)new DiagonalTileIterator(area_start, area_end) : new OrthogonalTileIterator(area_start, area_end);
+	std::unique_ptr<TileIterator> iter = TileIterator::Create(area_start, area_end, diagonal);
 	for (; (tile = *iter) != INVALID_TILE; ++(*iter)) {
 		TileType tt = GetTileType(tile);
 
@@ -1745,7 +1745,6 @@ CommandCost CmdConvertRail(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 		}
 	}
 
-	delete iter;
 	return found_convertible_track ? cost : error;
 }
 

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -2400,7 +2400,7 @@ CommandCost CmdConvertRoad(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 	CommandCost error = CommandCost((rtt == RTT_TRAM) ? STR_ERROR_NO_SUITABLE_TRAMWAY : STR_ERROR_NO_SUITABLE_ROAD); // by default, there is no road to convert.
 	bool found_convertible_road = false; // whether we actually did convert any road/tram (see bug #7633)
 
-	TileIterator *iter = new OrthogonalTileIterator(area_start, area_end);
+	std::unique_ptr<TileIterator> iter = std::make_unique<OrthogonalTileIterator>(area_start, area_end);
 	for (; (tile = *iter) != INVALID_TILE; ++(*iter)) {
 		/* Is road present on tile? */
 		if (!MayHaveRoad(tile)) continue;
@@ -2556,7 +2556,6 @@ CommandCost CmdConvertRoad(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 		}
 	}
 
-	delete iter;
 	return found_convertible_road ? cost : error;
 }
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -555,9 +555,9 @@ public:
 		return *this;
 	}
 
-	virtual TileIterator *Clone() const
+	virtual std::unique_ptr<TileIterator> Clone() const
 	{
-		return new AirportTileIterator(*this);
+		return std::make_unique<AirportTileIterator>(*this);
 	}
 };
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -765,9 +765,9 @@ int strnatcmp(const char *s1, const char *s2, bool ignore_garbage_at_front)
 
 #ifdef WITH_UNISCRIBE
 
-/* static */ StringIterator *StringIterator::Create()
+/* static */ std::unique_ptr<StringIterator> StringIterator::Create()
 {
-	return new UniscribeStringIterator();
+	return std::make_unique<UniscribeStringIterator>();
 }
 
 #elif defined(WITH_ICU_I18N)
@@ -921,9 +921,9 @@ public:
 	}
 };
 
-/* static */ StringIterator *StringIterator::Create()
+/* static */ std::unique_ptr<StringIterator> StringIterator::Create()
 {
-	return new IcuStringIterator();
+	return std::make_unique<IcuStringIterator>();
 }
 
 #else
@@ -1032,17 +1032,17 @@ public:
 };
 
 #if defined(WITH_COCOA) && !defined(STRGEN) && !defined(SETTINGSGEN)
-/* static */ StringIterator *StringIterator::Create()
+/* static */ std::unique_ptr<StringIterator> StringIterator::Create()
 {
-	StringIterator *i = OSXStringIterator::Create();
+	std::unique_ptr<StringIterator> i = OSXStringIterator::Create();
 	if (i != nullptr) return i;
 
-	return new DefaultStringIterator();
+	return std::make_unique<DefaultStringIterator>();
 }
 #else
-/* static */ StringIterator *StringIterator::Create()
+/* static */ std::unique_ptr<StringIterator> StringIterator::Create()
 {
-	return new DefaultStringIterator();
+	return std::make_unique<DefaultStringIterator>();
 }
 #endif /* defined(WITH_COCOA) && !defined(STRGEN) && !defined(SETTINGSGEN) */
 

--- a/src/string_base.h
+++ b/src/string_base.h
@@ -26,7 +26,7 @@ public:
 	 * Create a new iterator instance.
 	 * @return New iterator instance.
 	 */
-	static StringIterator *Create();
+	static std::unique_ptr<StringIterator> Create();
 
 	virtual ~StringIterator() {}
 

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -361,7 +361,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlag flags, Tile
 	if (limit == 0) return { CommandCost(STR_ERROR_TERRAFORM_LIMIT_REACHED), 0, INVALID_TILE };
 
 	TileIndex error_tile = INVALID_TILE;
-	TileIterator *iter = diagonal ? (TileIterator *)new DiagonalTileIterator(tile, start_tile) : new OrthogonalTileIterator(tile, start_tile);
+	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
 	for (; *iter != INVALID_TILE; ++(*iter)) {
 		TileIndex t = *iter;
 		uint curh = TileHeight(t);
@@ -379,7 +379,6 @@ std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlag flags, Tile
 			if (flags & DC_EXEC) {
 				money -= ret.GetCost();
 				if (money < 0) {
-					delete iter;
 					return { cost, ret.GetCost(), error_tile };
 				}
 				Command<CMD_TERRAFORM_LAND>::Do(flags, t, SLOPE_N, curh <= h);
@@ -403,7 +402,6 @@ std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlag flags, Tile
 		if (limit <= 0) break;
 	}
 
-	delete iter;
 	CommandCost cc_ret = had_success ? cost : last_error;
 	return { cc_ret, 0, cc_ret.Succeeded() ? tile : error_tile };
 }

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -369,12 +369,10 @@ bool Textbuf::MovePos(uint16 keycode)
  * @param max_chars maximum size in chars, including terminating '\0'
  */
 Textbuf::Textbuf(uint16 max_bytes, uint16 max_chars)
-	: buf(MallocT<char>(max_bytes))
+	: buf(MallocT<char>(max_bytes)), char_iter(StringIterator::Create())
 {
 	assert(max_bytes != 0);
 	assert(max_chars != 0);
-
-	this->char_iter = StringIterator::Create();
 
 	this->afilter    = CS_ALPHANUMERAL;
 	this->max_bytes  = max_bytes;
@@ -385,7 +383,6 @@ Textbuf::Textbuf(uint16 max_bytes, uint16 max_chars)
 
 Textbuf::~Textbuf()
 {
-	delete this->char_iter;
 	free(this->buf);
 }
 

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -67,7 +67,7 @@ struct Textbuf {
 	void DiscardMarkedText(bool update = true);
 
 private:
-	StringIterator *char_iter;
+	std::unique_ptr<StringIterator> char_iter;
 
 	bool CanDelChar(bool backspace);
 

--- a/src/tilearea.cpp
+++ b/src/tilearea.cpp
@@ -280,3 +280,18 @@ TileIterator &DiagonalTileIterator::operator++()
 	if (this->b_max == this->b_cur) this->tile = INVALID_TILE;
 	return *this;
 }
+
+/**
+ * Create either an OrthogonalTileIterator or DiagonalTileIterator given the diagonal parameter.
+ * @param corner1 Tile from where to begin iterating.
+ * @param corner2 Tile where to end the iterating.
+ * @param diagonal Whether to create a DiagonalTileIterator or OrthogonalTileIterator.
+ * @return unique_ptr to the allocated TileIterator.
+ */
+/* static */ std::unique_ptr<TileIterator> TileIterator::Create(TileIndex corner1, TileIndex corner2, bool diagonal)
+{
+	if (diagonal) {
+		return std::make_unique<DiagonalTileIterator>(corner1, corner2);
+	}
+	return std::make_unique<OrthogonalTileIterator>(corner1, corner2);
+}

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -177,6 +177,8 @@ public:
 	{
 		return this->tile != rhs;
 	}
+
+	static std::unique_ptr<TileIterator> Create(TileIndex corner1, TileIndex corner2, bool diagonal);
 };
 
 /** Iterator to iterate over a tile area (rectangle) of the map. */

--- a/src/tilearea_type.h
+++ b/src/tilearea_type.h
@@ -146,7 +146,7 @@ public:
 	/**
 	 * Allocate a new iterator that is a copy of this one.
 	 */
-	virtual TileIterator *Clone() const = 0;
+	virtual std::unique_ptr<TileIterator> Clone() const = 0;
 
 	/**
 	 * Equality comparison.
@@ -225,9 +225,9 @@ public:
 		return *this;
 	}
 
-	virtual TileIterator *Clone() const
+	virtual std::unique_ptr<TileIterator> Clone() const
 	{
-		return new OrthogonalTileIterator(*this);
+		return std::make_unique<OrthogonalTileIterator>(*this);
 	}
 };
 
@@ -264,9 +264,9 @@ public:
 
 	TileIterator& operator ++();
 
-	virtual TileIterator *Clone() const
+	virtual std::unique_ptr<TileIterator> Clone() const
 	{
-		return new DiagonalTileIterator(*this);
+		return std::make_unique<DiagonalTileIterator>(*this);
 	}
 };
 

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -445,13 +445,7 @@ CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_t
 
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 
-	std::unique_ptr<TileIterator> iter;
-	if (diagonal) {
-		iter = std::make_unique<DiagonalTileIterator>(tile, start_tile);
-	} else {
-		iter = std::make_unique<OrthogonalTileIterator>(tile, start_tile);
-	}
-
+	std::unique_ptr<TileIterator> iter = TileIterator::Create(tile, start_tile, diagonal);
 	for (; *iter != INVALID_TILE; ++(*iter)) {
 		TileIndex current_tile = *iter;
 		CommandCost ret;


### PR DESCRIPTION
## Motivation / Problem

Seeing manual memory management and duplicated code.


## Description

There are some Iterators that use `new` and `delete` to manually manage memory, with `delete` in some early returns.

For some TileIterators there is a choice between Orthogonal and Diagonal. The would yield quite a bit of duplicated code, so there is not a helper function to construct either an orthogonal or diagonal TileIterator based on a boolean.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
