### PR TITLE
Fix: Link variants to parents when finalising engines.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1329,7 +1329,7 @@ static ChangeInfoResult RailVehicleChangeInfo(uint engine, int numinfo, int prop
 				break;
 
 			case 0x2F: // Engine variant
-				ei->variant_id = GetNewEngineID(_cur.grffile, VEH_TRAIN, buf->ReadWord());
+				ei->variant_id = buf->ReadWord();
 				break;
 
 			case 0x30: // Extra miscellaneous flags
@@ -1531,7 +1531,7 @@ static ChangeInfoResult RoadVehicleChangeInfo(uint engine, int numinfo, int prop
 			}
 
 			case 0x26: // Engine variant
-				ei->variant_id = GetNewEngineID(_cur.grffile, VEH_ROAD, buf->ReadWord());
+				ei->variant_id = buf->ReadWord();
 				break;
 
 			case 0x27: // Extra miscellaneous flags
@@ -1711,7 +1711,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint engine, int numinfo, int prop
 			}
 
 			case 0x20: // Engine variant
-				ei->variant_id = GetNewEngineID(_cur.grffile, VEH_SHIP, buf->ReadWord());
+				ei->variant_id = buf->ReadWord();
 				break;
 
 			case 0x21: // Extra miscellaneous flags
@@ -1873,7 +1873,7 @@ static ChangeInfoResult AircraftVehicleChangeInfo(uint engine, int numinfo, int 
 				break;
 
 			case 0x20: // Engine variant
-				ei->variant_id = GetNewEngineID(_cur.grffile, VEH_AIRCRAFT, buf->ReadWord());
+				ei->variant_id = buf->ReadWord();
 				break;
 
 			case 0x21: // Extra miscellaneous flags
@@ -9001,12 +9001,15 @@ static void FinaliseEngineArray()
 			}
 		}
 
-		if (!HasBit(e->info.climates, _settings_game.game_creation.landscape)) continue;
-
-		/* Set appropriate flags on variant engine */
+		/* Do final mapping on variant engine ID and set appropriate flags on variant engine */
 		if (e->info.variant_id != INVALID_ENGINE) {
-			Engine::Get(e->info.variant_id)->display_flags |= EngineDisplayFlags::HasVariants | EngineDisplayFlags::IsFolded;
+			e->info.variant_id = GetNewEngineID(e->grf_prop.grffile, e->type, e->info.variant_id);
+			if (e->info.variant_id != INVALID_ENGINE) {
+				Engine::Get(e->info.variant_id)->display_flags |= EngineDisplayFlags::HasVariants | EngineDisplayFlags::IsFolded;
+			}
 		}
+
+		if (!HasBit(e->info.climates, _settings_game.game_creation.landscape)) continue;
 
 		/* Skip wagons, there livery is defined via the engine */
 		if (e->type != VEH_TRAIN || e->u.rail.railveh_type != RAILVEH_WAGON) {


### PR DESCRIPTION
## Motivation / Problem

It is currently not possible to define a variant whose parent is defined later in the NewGRF.

In this example TE10 is the parent of several variants, but is defined later:

![image](https://user-images.githubusercontent.com/639850/212390800-fb01d3f0-715c-41e8-adbd-f2a4f64ba40c.png)

## Description

This is resolved by deferring mapping variant IDs to the engine finalisation stage. This ensures that definition-order of engines within the NewGRF does not matter.

![image](https://user-images.githubusercontent.com/639850/212390874-64580a25-85b3-46a3-86d2-3983c2cf26ca.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
