### PR TITLE
Fix #10343: Towns attempt and fail to extend disallowed roadtypes

### DIFF
--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -1362,6 +1362,20 @@ static inline bool RoadTypesAllowHouseHere(TileIndex t)
 	return !allow;
 }
 
+/** Test if town can grow road onto a specific tile.
+ * @param town Town that is building.
+ * @param tile Tile to build upon.
+ * @return true iff the tile's road type don't prevent extending the road.
+ */
+static bool TownCanGrowRoad(const Town *town, TileIndex tile)
+{
+	if (!IsTileType(tile, MP_ROAD)) return true;
+
+	/* Allow extending on roadtypes which can be built by town, or if the road type matches the type the town will build. */
+	RoadType rt = GetRoadTypeRoad(tile);
+	return HasBit(GetRoadTypeInfo(rt)->flags, ROTF_TOWN_BUILD) || GetTownRoadType(town) == rt;
+}
+
 /**
  * Grows the given town.
  * There are at the moment 3 possible way's for
@@ -1438,6 +1452,8 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 		}
 
 	} else if (target_dir < DIAGDIR_END && !(cur_rb & DiagDirToRoadBits(ReverseDiagDir(target_dir)))) {
+		if (!TownCanGrowRoad(t1, tile)) return;
+
 		/* Continue building on a partial road.
 		 * Should be always OK, so we only generate
 		 * the fitting RoadBits */
@@ -1556,6 +1572,8 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 			}
 			return;
 		}
+
+		if (!TownCanGrowRoad(t1, tile)) return;
 
 		_grow_town_result = GROWTH_SEARCH_STOPPED;
 	}


### PR DESCRIPTION
## Motivation / Problem

As per #10343, and also way back in #8506/#8535, towns are able to build road pieces for road types even if the the roadtype disallows it.

![image](https://user-images.githubusercontent.com/639850/212310672-780aec44-cee6-45d2-aa6d-ff93f5ef1cab.png)

## Description

This is resolved by checking if the tile currently has a non-buildable roadtype, and disallow building a road. This is slightly different from the fix in #8535 as that also inadvertently prevented building houses along non-buildable roadtypes, though that may be permitted.

![image](https://user-images.githubusercontent.com/639850/212309543-0c329c89-9fe7-4a9f-8f54-2b6dbdd976c1.png)

This also resolves and additional concern if a NewGRF disallows towns from building all roadtypes, by forcing the default ROADTYPE_ROAD slot to be town-buildable if no other roadtypes are town-buildable.

Closes #10343

## Limitations

Some NewGRFs maybe rely on the previously broken behaviour. Those NewGRFs can be fixed by the author.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
