### PR TITLE
Fix: Various Wide River issues

### DIFF
--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1093,7 +1093,7 @@ static bool RiverMakeWider(TileIndex tile, void *data)
 	/* If the tile is at height 0 after terraforming but the ocean hasn't flooded yet, don't build river. */
 	if (GetTileMaxZ(tile) == 0) return false;
 
-	TileIndex origin_tile = *(TileIndex *)data;;
+	TileIndex origin_tile = *(TileIndex *)data;
 	Slope cur_slope = GetTileSlope(tile);
 	Slope desired_slope = GetTileSlope(origin_tile); // Initialize matching the origin tile as a shortcut if no terraforming is needed.
 
@@ -1131,7 +1131,7 @@ static bool RiverMakeWider(TileIndex tile, void *data)
 					}
 				}
 				/* If we find an adjacent river tile, remember it. We'll terraform to match it later if we don't find a slope. */
-				if (IsTileFlat(tile)) flat_river_found = true;
+				if (IsTileFlat(other_tile)) flat_river_found = true;
 			}
 		}
 		/* We didn't find either an inclined or flat river, so we're climbing the wrong slope. Bail out. */
@@ -1203,6 +1203,11 @@ static bool RiverMakeWider(TileIndex tile, void *data)
 			if (GetTileSlope(downstream_tile) != SLOPE_FLAT) return false;
 
 			MakeRiver(downstream_tile, Random());
+			MarkTileDirtyByTile(downstream_tile);
+
+			/* Remove desert directly around the river tile. */
+			TileIndex cur_tile = downstream_tile;
+			CircularTileSearch(&cur_tile, RIVER_OFFSET_DESERT_DISTANCE, RiverModifyDesertZone, nullptr);
 		}
 
 		/* If upstream is dry and flat, try making it a river tile. */
@@ -1211,16 +1216,21 @@ static bool RiverMakeWider(TileIndex tile, void *data)
 			if (GetTileSlope(upstream_tile) != SLOPE_FLAT) return false;
 
 			MakeRiver(upstream_tile, Random());
+			MarkTileDirtyByTile(upstream_tile);
+
+			/* Remove desert directly around the river tile. */
+			TileIndex cur_tile = upstream_tile;
+			CircularTileSearch(&cur_tile, RIVER_OFFSET_DESERT_DISTANCE, RiverModifyDesertZone, nullptr);
 		}
 	}
 
 	/* If the tile slope matches the desired slope, add a river tile. */
 	if (cur_slope == desired_slope) {
 		MakeRiver(tile, Random());
+		MarkTileDirtyByTile(tile);
 
 		/* Remove desert directly around the river tile. */
 		TileIndex cur_tile = tile;
-		MarkTileDirtyByTile(cur_tile);
 		CircularTileSearch(&cur_tile, RIVER_OFFSET_DESERT_DISTANCE, RiverModifyDesertZone, nullptr);
 	}
 
@@ -1493,6 +1503,9 @@ static void CreateRivers()
 			if (std::get<0>(FlowRiver(t, t, _settings_game.game_creation.min_river_length))) break;
 		}
 	}
+
+	/* Widening rivers may have left some tiles requiring to be watered. */
+	ConvertGroundTilesIntoWaterTiles();
 
 	/* Run tile loop to update the ground density. */
 	for (uint i = 0; i != 256; i++) {


### PR DESCRIPTION
## Motivation / Problem

@SamuXarick identified several issues with Wide Rivers and suggested improvements.

## Description

### Cleanup
1. Fixed an accidental double semicolon.
2. One usage of `MarkTileDirtyByTile()` used the iterator for a `CircularTileSearch()` which worked since it was initialized to the current tile, but should just reference the current tile to be less...weird.

### Fixes
1. Looking for adjacent river tiles to determine the desired slope accidentally called `tile` instead of `other_tile` -- see the check directly above it for a sloped tile to see how it was intended. As it was, that `if` path was never taken. I've tested the fix briefly and it seems to not really affect anything, but it might be more efficient.
2. Adding upstream or downstream water tiles did not convert desert tiles or mark tiles dirty.

### Changes
1. After rivers are widened, some ocean tiles might not have flooded yet due to terraforming. Force a flood check to allow #8492 to work properly.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
