### PR TITLE
Codechange: Minor cleanups to Windows font handling

### DIFF
--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -440,10 +440,6 @@ void Win32FontCache::ClearFontCache()
 	DWORD size = GetGlyphOutline(this->dc, key, GGO_GLYPH_INDEX | (aa ? GGO_GRAY8_BITMAP : GGO_BITMAP), &gm, 0, nullptr, &mat);
 	if (size == GDI_ERROR) usererror("Unable to render font glyph");
 
-	/* Call GetGlyphOutline again with size to actually render the glyph. */
-	byte *bmp = AllocaM(byte, size);
-	GetGlyphOutline(this->dc, key, GGO_GLYPH_INDEX | (aa ? GGO_GRAY8_BITMAP : GGO_BITMAP), &gm, size, bmp, &mat);
-
 	/* Add 1 scaled pixel for the shadow on the medium font. Our sprite must be at least 1x1 pixel. */
 	uint shadow = (this->fs == FS_NORMAL) ? ScaleGUITrad(1) : 0;
 	uint width = std::max(1U, (uint)gm.gmBlackBoxX + shadow);
@@ -451,6 +447,10 @@ void Win32FontCache::ClearFontCache()
 
 	/* Limit glyph size to prevent overflows later on. */
 	if (width > MAX_GLYPH_DIM || height > MAX_GLYPH_DIM) usererror("Font glyph is too large");
+
+	/* Call GetGlyphOutline again with size to actually render the glyph. */
+	byte *bmp = AllocaM(byte, size);
+	GetGlyphOutline(this->dc, key, GGO_GLYPH_INDEX | (aa ? GGO_GRAY8_BITMAP : GGO_BITMAP), &gm, size, bmp, &mat);
 
 	/* GDI has rendered the glyph, now we allocate a sprite and copy the image into it. */
 	SpriteLoader::Sprite sprite;


### PR DESCRIPTION
## Motivation / Problem

* Fallback font list uses custom C-style list allocation.
* Glyph rendering attempts to guess memory size required for a glyph to prevent two calls to `GetGlyphOutline`.
* Trying to render a glyph that is too large can fail at the `AllocaM` stage before width & height are checked.

## Description

* Simplify by using `std::vector` and `std::wstring` for fallback font list instead.
* The `GetGlyphOutline` API basically is intended to be called twice. Removing the guesswork simplifies the flow.
* Due to the above, we know the glyph width & height before trying to allocate, so do this check first. Gives a better error.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
