### PR TITLE
Refactor some CodeQL warnings away

### DIFF
--- a/src/3rdparty/fmt/core.h
+++ b/src/3rdparty/fmt/core.h
@@ -529,7 +529,6 @@ void check_format_string(S);
 
 struct error_handler {
   constexpr error_handler() = default;
-  constexpr error_handler(const error_handler&) = default;
 
   // This function is intentionally not constexpr to give a compile-time error.
   FMT_NORETURN FMT_API void on_error(const char* message);

--- a/src/3rdparty/squirrel/squirrel/sqclass.h
+++ b/src/3rdparty/squirrel/squirrel/sqclass.h
@@ -10,6 +10,7 @@ struct SQClassMember {
 		val = o.val;
 		attrs = o.attrs;
 	}
+	SQClassMember& operator=(SQClassMember &o) = delete;
 	SQObjectPtr val;
 	SQObjectPtr attrs;
 };

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -25,7 +25,7 @@ class CommandCost {
 	ExpensesType expense_type; ///< the type of expence as shown on the finances view
 	Money cost;       ///< The cost of this action
 	StringID message; ///< Warning message for when success is unset
-	bool success;     ///< Whether the comment went fine up to this moment
+	bool success;     ///< Whether the command went fine up to this moment
 	const GRFFile *textref_stack_grffile; ///< NewGRF providing the #TextRefStack content.
 	uint textref_stack_size;   ///< Number of uint32 values to put on the #TextRefStack for the error message.
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -286,7 +286,11 @@ DEF_CONSOLE_CMD(ConZoomToLevel)
 		case 2: {
 			uint32 level;
 			if (GetArgumentInteger(&level, argv[1])) {
-				if (level < ZOOM_LVL_MIN) {
+				/* In case ZOOM_LVL_MIN is more than 0, the next if statement needs to be amended.
+				 * A simple check for less than ZOOM_LVL_MIN does not work here because we are
+				 * reading an unsigned integer from the console, so just check for a '-' char. */
+				static_assert(ZOOM_LVL_MIN == 0);
+				if (argv[1][0] == '-') {
 					IConsolePrint(CC_ERROR, "Zoom-in levels below {} are not supported.", ZOOM_LVL_MIN);
 				} else if (level < _settings_client.gui.zoom_min) {
 					IConsolePrint(CC_ERROR, "Current client settings do not allow zooming in below level {}.", _settings_client.gui.zoom_min);
@@ -2012,18 +2016,15 @@ DEF_CONSOLE_CMD(ConFont)
 		bool aa = setting->aa;
 
 		byte arg_index = 2;
-
-		if (argc > arg_index) {
-			/* We may encounter "aa" or "noaa" but it must be the last argument. */
-			if (strcasecmp(argv[arg_index], "aa") == 0 || strcasecmp(argv[arg_index], "noaa") == 0) {
-				aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
-				if (argc > arg_index) return false;
-			} else {
-				/* For <name> we want a string. */
-				uint v;
-				if (!GetArgumentInteger(&v, argv[arg_index])) {
-					font = argv[arg_index++];
-				}
+		/* We may encounter "aa" or "noaa" but it must be the last argument. */
+		if (strcasecmp(argv[arg_index], "aa") == 0 || strcasecmp(argv[arg_index], "noaa") == 0) {
+			aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
+			if (argc > arg_index) return false;
+		} else {
+			/* For <name> we want a string. */
+			uint v;
+			if (!GetArgumentInteger(&v, argv[arg_index])) {
+				font = argv[arg_index++];
 			}
 		}
 

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -281,14 +281,14 @@ void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfo
 		}
 
 		case 4: {
-			GRFConfig **dst = &info->grfconfig;
-			uint i;
+			/* Ensure that the maximum number of NewGRFs and the field in the network
+			 * protocol are matched to eachother. If that is not the case anymore a
+			 * check must be added to ensure the received data is still valid. */
+			static_assert(std::numeric_limits<uint8>::max() == NETWORK_MAX_GRF_COUNT);
 			uint num_grfs = p->Recv_uint8();
 
-			/* Broken/bad data. It cannot have that many NewGRFs. */
-			if (num_grfs > NETWORK_MAX_GRF_COUNT) return;
-
-			for (i = 0; i < num_grfs; i++) {
+			GRFConfig **dst = &info->grfconfig;
+			for (uint i = 0; i < num_grfs; i++) {
 				NamedGRFIdentifier grf;
 				switch (newgrf_serialisation) {
 					case NST_GRFID_MD5:


### PR DESCRIPTION
## Motivation / Problem

CodeQL warnings about not following "Rule of Two" and "Comparison result is always the same".


## Description

The "Rule of Two" is about that if you declare a copy-constructor you should also declare a ssignment and vice versa, so you do not get conflicts between the default and custom behaviour. In case of sqclass.h the assignment is explicitly deleted. In case of fmt/core.h I did a check of more recent versions and the copy-constructor got removed. Since it's declared to be the default implementation, this should not be a problem for us either.

The "Comparison result is always the same" are more funky. In console_cmds.cpp's zoomto function the GetArgumentInteger always gets an unsigned number and since `ZOOM_LVL_MIN` is 0, checking for the parameter to be less than makes no sense. I wanted to opt to remove it, but then users can try negative numbers and they will get an error that the value is too large. So I just check for the minus-character instead and added a `static_assert` in case `ZOOM_LVL_MIN` ever becomes a positive number.
Also in console_cmds.cpp there is a check in the font function for the argument index being less than the number of arguments, but it already checked for argument index + 1 before. On the other hand the code looked more consistent before.
In network/core/game_info.cpp there is a check for the number of NewGRFs to not exceed `NETWORK_MAX_GRF_COUNT`, however the value being read it an uint8 and the value it is checked against is > 255. That can obviously never happen, and as such the check is pointless. However, to prevent handy people only changing `NETWORK_MAX_GRF_COUNT` to get more NewGRFs a `static_assert` is added to at least be triggered to check the network protocol.

And a small typo as bonus.


## Limitations

None as far as I know.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
