### PR TITLE
Fix #10177: company list password padlock showed after switching to single player

### DIFF
--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -609,6 +609,7 @@ void NetworkClose(bool close_admins)
 
 	delete[] _network_company_states;
 	_network_company_states = nullptr;
+	_network_company_passworded = 0;
 
 	InitializeNetworkPools(close_admins);
 }


### PR DESCRIPTION
## Motivation / Problem

Fixes #10177. `NetworkCompanyIsPassworded` could return `true` values after the network game had stopped, yielding in weird behaviour most notably by showing the padlock in the single player company list dropdown from the toolbar.


## Description

Reset the password state upon closing the connection / releasing the `_network_company_states`.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
