### PR TITLE
Change #10077: make maximum loan a positive multiple of the loan interval

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -560,7 +560,8 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY)
 	ResetCompanyLivery(c);
 	_company_colours[c->index] = (Colours)c->colour;
 
-	c->money = c->current_loan = (std::min<int64>(INITIAL_LOAN, _economy.max_loan) * _economy.inflation_prices >> 16) / 50000 * 50000;
+	/* Scale the initial loan based on the inflation rounded down to the loan interval. The maximum loan has already been inflation adjusted. */
+	c->money = c->current_loan = std::min<int64>((INITIAL_LOAN * _economy.inflation_prices >> 16) / LOAN_INTERVAL * LOAN_INTERVAL, _economy.max_loan);
 
 	std::fill(c->share_owners.begin(), c->share_owners.end(), INVALID_OWNER);
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -757,8 +757,8 @@ bool AddInflation(bool check_year)
  */
 void RecomputePrices()
 {
-	/* Setup maximum loan */
-	_economy.max_loan = ((uint64)_settings_game.difficulty.max_loan * _economy.inflation_prices >> 16) / 50000 * 50000;
+	/* Setup maximum loan as a rounded down multiple of LOAN_INTERVAL. */
+	_economy.max_loan = ((uint64)_settings_game.difficulty.max_loan * _economy.inflation_prices >> 16) / LOAN_INTERVAL * LOAN_INTERVAL;
 
 	/* Setup price bases */
 	for (Price i = PR_BEGIN; i < PR_END; i++) {

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1206,6 +1206,9 @@ STR_CONFIG_SETTING_HORIZONTAL_POS_RIGHT                         :Right
 
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN                         :Maximum initial loan: {STRING2}
 STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT                :Maximum amount a company can loan (without taking inflation into account)
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE                   :{CURRENCY_LONG}
+###setting-zero-is-special
+STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_DISABLED                :No loan {RED}Requires Game Script to provide initial funds
 
 STR_CONFIG_SETTING_INTEREST_RATE                                :Interest rate: {STRING2}
 STR_CONFIG_SETTING_INTEREST_RATE_HELPTEXT                       :Loan interest rate; also controls inflation, if enabled

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -89,7 +89,7 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_TRAINS
 strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
+pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 
 [SDT_VAR]
@@ -102,7 +102,7 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES
 strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
+pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 
 [SDT_VAR]
@@ -115,7 +115,7 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_SHIPS
 strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
+pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 
 [SDT_VAR]
@@ -128,5 +128,5 @@ max      = 800
 str      = STR_CONFIG_SETTING_SERVINT_AIRCRAFT
 strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
+pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -98,9 +98,10 @@ type     = SLE_UINT32
 from     = SLV_97
 flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_CURRENCY
 def      = 300000
-min      = 0
+min      = LOAN_INTERVAL
 max      = 2000000000
-interval = 50000
+pre_cb   = [](auto &new_value) { new_value = (new_value + LOAN_INTERVAL / 2) / LOAN_INTERVAL * LOAN_INTERVAL; return true; }
+interval = LOAN_INTERVAL
 str      = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN
 strhelp  = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT
 strval   = STR_JUST_CURRENCY_LONG

--- a/src/table/settings/difficulty_settings.ini
+++ b/src/table/settings/difficulty_settings.ini
@@ -96,7 +96,7 @@ cat      = SC_BASIC
 var      = difficulty.max_loan
 type     = SLE_UINT32
 from     = SLV_97
-flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_CURRENCY
+flags    = SF_NEWGAME_ONLY | SF_SCENEDIT_TOO | SF_GUI_CURRENCY | SF_GUI_0_IS_SPECIAL
 def      = 300000
 min      = LOAN_INTERVAL
 max      = 2000000000
@@ -104,7 +104,7 @@ pre_cb   = [](auto &new_value) { new_value = (new_value + LOAN_INTERVAL / 2) / L
 interval = LOAN_INTERVAL
 str      = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN
 strhelp  = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_HELPTEXT
-strval   = STR_JUST_CURRENCY_LONG
+strval   = STR_CONFIG_SETTING_MAXIMUM_INITIAL_LOAN_VALUE
 cat      = SC_BASIC
 
 [SDT_VAR]


### PR DESCRIPTION
## Motivation / Problem

Fixes #10077 as far as I am aware. Lots of small issues related to the maximum loan setting.


## Description

First and foremost problem is that you can set the maximum loan below the first multiple of the interval for maximum loan. In the original code this would be 50 000, so setting it to 20 000 means you would have to wait quite a while in 1920 before you can actually take out a loan. 
Furthermore setting it to 0 means you can never get a loan. However, a loan of 0 can be useful if there is a Game Script that will provide you with funds. So, allow 0 but round everything 1 GBP up to loan interval GBP and show a warning in the setting that a Game Script is required.
![screenshot](https://user-images.githubusercontent.com/13785744/212967798-b94de4dd-9819-4ddd-a202-df33a19ac82e.png)

The second issue is that you can enter any random amount, but the maximum loan shown in the game will still be a multiple of the interval for maximum loan. I added a pre check callback, so when the user enters it in the user interface the setting will get (silently) rounding towards the nearest multiple of the interval for maximum loan.

A third issue, that was not noted in #10077, is that the initial money/loan at company start is applying inflation twice to the maximum loan; it got minimum of the default initial loan and inflation corrected maximum loan, and then inflation corrected that minimum. When the inflation corrected maximum loan was less than the initial loan, then the initial money/loan of the company would be more than allowed by the maximum loan shown in the company finances window.

Finally I changed the maximum loan interval to the interval of taking out a loan. This means more granularity for the person setting the maximum loan, and allows slightly more loan when inflation sets in due to rising earlier to say 310 000 instead of waiting until 350 000 before the first increase in maximum loanx.


## Limitations

Loading the configuration from savegame/settings.ini will not clamp the maximum loan setting to a multiple of the interval for maximum loan.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
