### PR TITLE
Fix #10057: FallbackParagraphLayout fails to properly wrap

### DIFF
--- a/src/gfx_layout.cpp
+++ b/src/gfx_layout.cpp
@@ -552,8 +552,6 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 
 			next_run = this->buffer_begin + iter->first;
 			begin = this->buffer;
-
-			last_space = nullptr;
 		}
 
 		if (IsWhitespace(c)) last_space = this->buffer;
@@ -591,7 +589,7 @@ std::unique_ptr<const ParagraphLayouter::Line> FallbackParagraphLayout::NextLine
 		this->buffer++;
 	}
 
-	if (l->size() == 0 || last_char - begin != 0) {
+	if (l->size() == 0 || last_char - begin > 0) {
 		int w = l->GetWidth();
 		l->emplace_back(iter->second, begin, last_char - begin, w);
 	}


### PR DESCRIPTION
## Motivation / Problem

Fixes #10057.


## Description

The wrapping problem happens due to `last_space` getting set to `nullptr` when a new run (e.g. colour) is started. When it then finds that the word is too long for the line, it will break it at the character instead of the space because it thinks that it is the first word on the line.

It is solved by removing the resetting of `last_space`, and account for `last_char` being before the `begin` in which case it will not add an extra (sub) line to the created line. When starting creating the next line, it will happily continue with the start of the run.


## Limitations

The issue might be there for some of the other layouters, but #10057 does mention the fallback layouter specifically and one of the others isn't broken, so it might just be an implementation bug in our fallback.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
