### PR TITLE
Fix #9865: removing files with the console always failed

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -458,8 +458,8 @@ DEF_CONSOLE_CMD(ConRemove)
 	_console_file_list.ValidateFileList();
 	const FiosItem *item = _console_file_list.FindItem(file);
 	if (item != nullptr) {
-		if (!FiosDelete(item->name)) {
-			IConsolePrint(CC_ERROR, "Failed to delete '{}'.", file);
+		if (unlink(item->name) != 0) {
+			IConsolePrint(CC_ERROR, "Failed to delete '{}'.", item->name);
 		}
 	} else {
 		IConsolePrint(CC_ERROR, "'{}' could not be found.", file);


### PR DESCRIPTION
## Motivation / Problem

Fixes #9865.


## Description

In `ConRemove` OpenTTD already (seems to) work(s) with full file paths, but then it passes it to `FiosDelete` which inserts the `_fios_path` in front of the file name before removal. So, you end up with a (likely) non-existing path that is tried to be removed.

This is solved by simply `unlink`ing the file in `ConRemove` instead of going through `FiosDelete`. As added bonus the error message for failure is slightly improved by showing the actually resolved filename instead of what has been entered in the console.


## Limitations

Not yet tested on Windows/Mac OS. Maybe the path handling works slightly different there, so it should be tested there as well.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
