### PR TITLE
Codechange: Remove objectspec `enabled` flag and shuffle members.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4113,7 +4113,6 @@ static ChangeInfoResult ObjectChangeInfo(uint id, int numinfo, int prop, ByteRea
 				/* Swap classid because we read it in BE. */
 				uint32 classid = buf->ReadDWord();
 				(*ospec)->cls_id = ObjectClass::Allocate(BSWAP32(classid));
-				(*ospec)->enabled = true;
 				break;
 			}
 
@@ -9283,7 +9282,7 @@ static void FinaliseObjectsArray()
 		ObjectSpec **&objectspec = file->objectspec;
 		if (objectspec != nullptr) {
 			for (int i = 0; i < NUM_OBJECTS_PER_GRF; i++) {
-				if (objectspec[i] != nullptr && objectspec[i]->grf_prop.grffile != nullptr && objectspec[i]->enabled) {
+				if (objectspec[i] != nullptr && objectspec[i]->grf_prop.grffile != nullptr && objectspec[i]->IsEnabled()) {
 					_object_mngr.SetEntitySpec(objectspec[i]);
 				}
 			}

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -58,7 +58,7 @@ ObjectSpec _object_specs[NUM_OBJECTS];
  */
 bool ObjectSpec::IsEverAvailable() const
 {
-	return this->enabled && HasBit(this->climate, _settings_game.game_creation.landscape) &&
+	return this->IsEnabled() && HasBit(this->climate, _settings_game.game_creation.landscape) &&
 			(this->flags & ((_game_mode != GM_EDITOR && !_generating_world) ? OBJECT_FLAG_ONLY_IN_SCENEDIT : OBJECT_FLAG_ONLY_IN_GAME)) == 0;
 }
 

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -21,7 +21,7 @@
 #include "newgrf_commons.h"
 
 /** Various object behaviours. */
-enum ObjectFlags {
+enum ObjectFlags : uint16 {
 	OBJECT_FLAG_NONE               =       0, ///< Just nothing.
 	OBJECT_FLAG_ONLY_IN_SCENEDIT   = 1 <<  0, ///< Object can only be constructed in the scenario editor.
 	OBJECT_FLAG_CANNOT_REMOVE      = 1 <<  1, ///< Object can not be removed.
@@ -45,7 +45,7 @@ static const uint8 OBJECT_SIZE_1X1 = 0x11; ///< The value of a NewGRF's size pro
 void ResetObjects();
 
 /** Class IDs for objects. */
-enum ObjectClassID {
+enum ObjectClassID : uint8 {
 	OBJECT_CLASS_BEGIN   =    0, ///< The lowest valid value
 	OBJECT_CLASS_MAX     = 0xFF, ///< Maximum number of classes.
 	INVALID_OBJECT_CLASS = 0xFF, ///< Class for the less fortunate.
@@ -60,6 +60,7 @@ DECLARE_POSTFIX_INCREMENT(ObjectClassID)
 struct ObjectSpec {
 	/* 2 because of the "normal" and "buy" sprite stacks. */
 	GRFFilePropsBase<2> grf_prop; ///< Properties related the the grf file
+	AnimationInfo animation;      ///< Information about the animation.
 	ObjectClassID cls_id;         ///< The class to which this spec belongs.
 	StringID name;                ///< The name for this object.
 
@@ -70,12 +71,16 @@ struct ObjectSpec {
 	Date introduction_date;       ///< From when can this object be built.
 	Date end_of_life_date;        ///< When can't this object be built anymore.
 	ObjectFlags flags;            ///< Flags/settings related to the object.
-	AnimationInfo animation;      ///< Information about the animation.
 	uint16 callback_mask;         ///< Bitmask of requested/allowed callbacks.
 	uint8 height;                 ///< The height of this structure, in heightlevels; max MAX_TILE_HEIGHT.
 	uint8 views;                  ///< The number of views.
 	uint8 generate_amount;        ///< Number of objects which are attempted to be generated per 256^2 map during world generation.
-	bool enabled;                 ///< Is this spec enabled?
+
+	/**
+	 * Test if this object is enabled.
+	 * @return True iif this object is enabled.
+	 */
+	bool IsEnabled() const { return this->views > 0; }
 
 	/**
 	 * Get the cost for building a structure of this type.

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -437,7 +437,7 @@ static void DrawTile_Object(TileInfo *ti)
 	const ObjectSpec *spec = ObjectSpec::Get(type);
 
 	/* Fall back for when the object doesn't exist anymore. */
-	if (!spec->enabled) type = OBJECT_TRANSMITTER;
+	if (!spec->IsEnabled()) type = OBJECT_TRANSMITTER;
 
 	if ((spec->flags & OBJECT_FLAG_HAS_NO_FOUNDATION) == 0) DrawFoundation(ti, GetFoundation_Object(ti->tile, ti->tileh));
 
@@ -906,7 +906,7 @@ static CommandCost TerraformTile_Object(TileIndex tile, DoCommandFlag flags, int
 				/* If the callback fails, allow autoslope. */
 				uint16 res = GetObjectCallback(CBID_OBJECT_AUTOSLOPE, 0, 0, spec, Object::GetByTile(tile), tile);
 				if (res == CALLBACK_FAILED || !ConvertBooleanCallback(spec->grf_prop.grffile, CBID_OBJECT_AUTOSLOPE, res)) return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_FOUNDATION]);
-			} else if (spec->enabled) {
+			} else if (spec->IsEnabled()) {
 				/* allow autoslope */
 				return CommandCost(EXPENSES_CONSTRUCTION, _price[PR_BUILD_FOUNDATION]);
 			}

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -121,7 +121,7 @@ static const DrawTileSprites _object_hq[] = {
 
 #undef TILE_SPRITE_LINE
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) { GRFFilePropsBase<2>(), INVALID_OBJECT_CLASS, name, climate, size, build_cost_multiplier, clear_cost_multiplier, 0, MAX_DAY + 1, flags, {0, 0, 0, 0}, 0, height, 1, gen_amount, true }
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) { GRFFilePropsBase<2>(), {0, 0, 0, 0}, INVALID_OBJECT_CLASS, name, climate, size, build_cost_multiplier, clear_cost_multiplier, 0, MAX_DAY + 1, flags, 0, height, 1, gen_amount }
 
 /* Climates
  * T = Temperate


### PR DESCRIPTION
## Motivation / Problem

We currently statically allocate space for 64000 ObjectSpecs. On my system ObjectSpec is 72 bytes, so 4608000 bytes are allocated.

## Description

ObjectSpec has some members that are large and affect alignment, so `animation` is moved to the front.

Its `enabled` bool uses 4 bytes alone, so is replaced with `IsEnabled()` which simply checks if `views` is non-zero.

The ObjectFlags and ObjectClassID enums are now sized to uint16 and uint8.

On my system this reduces ObjectSpec to 64 bytes. Unfortunately `grf_prop` takes up 32 bytes by itself, so there's no more saving to be done.

However this saves 64000 * 8 = 512000 bytes of memory allocation.

[It would also be better to not allocate 64000 ObjectSpecs, but that is a WIP :-)]

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
