### PR TITLE
Fix #10009: bad overflow protection when taking out loans

### DIFF
--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -176,6 +176,9 @@ public:
 	inline constexpr bool operator <= (const int other) const { return !(*this > other); }
 
 	inline constexpr operator T () const { return this->m_value; }
+
+	static inline constexpr OverflowSafeInt<T> max() { return T_MAX; }
+	static inline constexpr OverflowSafeInt<T> min() { return T_MIN; }
 };
 
 

--- a/src/misc_cmd.cpp
+++ b/src/misc_cmd.cpp
@@ -60,8 +60,10 @@ CommandCost CmdIncreaseLoan(DoCommandFlag flags, LoanCommand cmd, Money amount)
 			break;
 	}
 
-	/* Overflow protection */
-	if (c->money + c->current_loan + loan < c->money) return CMD_ERROR;
+	/* In case adding the loan triggers the overflow protection of Money,
+	 * we would essentially be losing money as taking and repaying the loan
+	 * immediately would not get us back to the same bank balance anymore. */
+	if (c->money > Money::max() - loan) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
 		c->money        += loan;


### PR DESCRIPTION
## Motivation / Problem

Fixes #10009. The old code is explictly looking for signs of an overflow. However, since `Money` is an overflow safe integer now, it will never overflow and as such the protection simply fails.


## Description

First introduces a way to create overflow safe integers with the minimum and maximum value.
When taking out a new loan check whether the money you have plus the loan would be triggering the overflow protection in `Money`, and if so return an error "Can't borrow any more money".


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
