### PR TITLE
Fix #10368, Fix 994bf19: server restarting game caused clients to hit assertion

### DIFF
--- a/src/highscore_gui.cpp
+++ b/src/highscore_gui.cpp
@@ -126,7 +126,7 @@ struct EndGameWindow : EndGameHighScoreBaseWindow {
 	void Close() override
 	{
 		if (!_networking) Command<CMD_PAUSE>::Post(PM_PAUSED_NORMAL, false); // unpause
-		ShowHighscoreTable(this->window_number, this->rank);
+		if (_game_mode != GM_MENU) ShowHighscoreTable(this->window_number, this->rank);
 		this->EndGameHighScoreBaseWindow::Close();
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes #10368.

Cause: Upon closing the `EndGameWindow`, triggered from `UnInitWindowSystem`, the `HighScoreWindow` would be opened and `_z_windows` would not be empty.


## Description

When closing the EndGameWindow check whether `_game_mode` is not `GM_MENU` before opening the window.


## Limitations

Solves this situation, but there might be others lurking...
However, the only thing I can think of that would trigger `UnInitWindowSystem` from there, besides the server restarting, is shutting down the game. However, you never get to the "Do you want to close OpenTTD" window until you closed both the end game and high score windows, and then this issue trigger.
Neither can you open the console, so that does not seem a part to trigger `UnInitWindowSystem`.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
