### PR TITLE
Allow Scripts to convert returned uint32 values to int64

### DIFF
--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -491,3 +491,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -466,3 +466,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -392,3 +392,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -482,3 +482,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -458,3 +458,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -434,3 +434,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -474,3 +474,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -243,3 +243,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -218,3 +218,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -186,3 +186,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -144,3 +144,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -210,3 +210,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -234,3 +234,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -226,3 +226,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -163,3 +163,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -81,3 +81,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -155,3 +155,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -147,3 +147,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -123,3 +123,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -171,3 +171,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -180,3 +180,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -118,3 +118,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -101,3 +101,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -19,3 +19,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -93,3 +93,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -61,3 +61,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -85,3 +85,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -109,3 +109,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -118,3 +118,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -101,3 +101,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -19,3 +19,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -93,3 +93,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -61,3 +61,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -85,3 +85,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -109,3 +109,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -132,3 +132,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -99,3 +99,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -123,3 +123,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -115,3 +115,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -107,3 +107,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -75,3 +75,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -33,3 +33,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -118,3 +118,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -101,3 +101,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -19,3 +19,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -93,3 +93,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -61,3 +61,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -85,3 +85,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -109,3 +109,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -118,3 +118,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -101,3 +101,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -19,3 +19,45 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -93,3 +93,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -61,3 +61,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -85,3 +85,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -109,3 +109,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -80,3 +80,11 @@ AIRoad.GetMaxSpeed <- function(road_type)
 	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return AIRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+AIEngine._GetMaximumOrderDistance <- AIEngine.GetMaximumOrderDistance
+AIEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!AIEngine.IsValidEngine(engine_id)) return 0;
+	return AIEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -48,3 +48,27 @@ AIBase.ChanceItem <- function(unused_param, out, max)
 {
 	return AIBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+AIAirport._GetMaintenanceCostFactor <- AIAirport.GetMaintenanceCostFactor
+AIAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!AIAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return AIAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+AIRail._GetMaintenanceCostFactor <- AIRail.GetMaintenanceCostFactor
+AIRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!AIRail.IsRailTypeAvailable(railtype)) return 0;
+	return AIRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+AIRoad._GetMaintenanceCostFactor <- AIRoad.GetMaintenanceCostFactor
+AIRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return AIRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -105,3 +105,11 @@ AITown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return AITown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+AIOrder._GetOrderDistance <- AIOrder.GetOrderDistance
+AIOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < AIVehicle.VT_RAIL || vehicle_type > AIVehicle.VT_AIR) return AIMap.DistanceManhattan(origin_tile, dest_tile);
+	return AIOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -6,3 +6,45 @@
  */
 
 AILog.Info("13 API compatibility in effect.");
+
+/* 14 Rand no longer returns negative values */
+AIBase._Rand <- AIBase.Rand;
+AIBase.Rand <- function()
+{
+	local r = AIBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+AIBase.RandItem <- function(unused_param)
+{
+	return AIBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+AIBase._RandRange <- AIBase.RandRange
+AIBase.RandRange <- function(max)
+{
+	local r = AIBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+AIBase.RandRangeItem <- function(unused_param, max)
+{
+	return AIBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+AIBase._Chance <- AIBase.Chance
+AIBase.Chance <- function(out, max)
+{
+	if (out > max) return AIBase._Chance(out, max);
+	return AIBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+AIBase.ChanceItem <- function(unused_param, out, max)
+{
+	return AIBase.Chance(out, max);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -72,3 +72,11 @@ AIRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!AIRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return AIRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+AIRoad._GetMaxSpeed <- AIRoad.GetMaxSpeed
+AIRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!AIRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return AIRoad._GetMaxSpeed(road_type);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -88,3 +88,11 @@ AIEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!AIEngine.IsValidEngine(engine_id)) return 0;
 	return AIEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+AIVehicle._GetMaximumOrderDistance <- AIVehicle.GetMaximumOrderDistance
+AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -96,3 +96,12 @@ AIVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!AIVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return AIVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+AITown._GetCargoGoal <- AITown.GetCargoGoal
+AITown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!AITown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!AICargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return AITown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -108,3 +108,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -92,3 +92,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -26,3 +26,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -68,3 +68,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -125,3 +125,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -116,3 +116,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -100,3 +100,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -93,3 +93,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -61,3 +61,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -19,3 +19,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -109,3 +109,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -101,3 +101,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -85,3 +85,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -118,3 +118,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -114,3 +114,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -147,3 +147,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -138,3 +138,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -122,3 +122,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -90,3 +90,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -48,3 +48,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -130,3 +130,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -114,3 +114,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -147,3 +147,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -138,3 +138,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -122,3 +122,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -90,3 +90,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -48,3 +48,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -130,3 +130,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -106,3 +106,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -82,3 +82,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -130,3 +130,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -40,3 +40,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -122,3 +122,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -114,3 +114,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -139,3 +139,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -75,3 +75,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -107,3 +107,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -99,3 +99,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -132,3 +132,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -115,3 +115,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -33,3 +33,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -123,3 +123,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -75,3 +75,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -107,3 +107,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -99,3 +99,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -132,3 +132,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -115,3 +115,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -33,3 +33,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -123,3 +123,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -75,3 +75,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -107,3 +107,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -99,3 +99,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -132,3 +132,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -115,3 +115,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -33,3 +33,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -123,3 +123,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -75,3 +75,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -107,3 +107,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -99,3 +99,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -132,3 +132,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -115,3 +115,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -33,3 +33,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -123,3 +123,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -108,3 +108,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -92,3 +92,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -26,3 +26,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -68,3 +68,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -125,3 +125,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -116,3 +116,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -100,3 +100,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -93,3 +93,11 @@ GSRoad.GetMaxSpeed <- function(road_type)
 	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
 	return GSRoad._GetMaxSpeed(road_type);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -61,3 +61,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -19,3 +19,45 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -109,3 +109,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -101,3 +101,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -85,3 +85,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a max speed of -1 for unavailable road types */
+GSRoad._GetMaxSpeed <- GSRoad.GetMaxSpeed
+GSRoad.GetMaxSpeed <- function(road_type)
+{
+	if (!GSRoad.IsRoadTypeAvailable(road_type)) return 0;
+	return GSRoad._GetMaxSpeed(road_type);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -118,3 +118,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -6,3 +6,45 @@
  */
 
 GSLog.Info("13 API compatibility in effect.");
+
+/* 14 Rand no longer returns negative values */
+GSBase._Rand <- GSBase.Rand;
+GSBase.Rand <- function()
+{
+	local r = GSBase._Rand();
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandItem no longer returns negative values */
+GSBase.RandItem <- function(unused_param)
+{
+	return GSBase.Rand();
+}
+
+/* 14 RandRange no longer returns negative values */
+GSBase._RandRange <- GSBase.RandRange
+GSBase.RandRange <- function(max)
+{
+	local r = GSBase._RandRange(max);
+	return (r & 1 << 31) != 0 ? r | ~((1 << 31) - 1) : r;
+}
+
+/* 14 RandRangeItem no longer returns negative values */
+GSBase.RandRangeItem <- function(unused_param, max)
+{
+	return GSBase.RandRange(max);
+}
+
+/* 14 Chance no longer compares against randomized negative values */
+GSBase._Chance <- GSBase.Chance
+GSBase.Chance <- function(out, max)
+{
+	if (out > max) return GSBase._Chance(out, max);
+	return GSBase.RandRange(max) < out;
+}
+
+/* 14 ChanceItem no longer compares against randomized negative values */
+GSBase.ChanceItem <- function(unused_param, out, max)
+{
+	return GSBase.Chance(out, max);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -72,3 +72,11 @@ GSRoad.GetMaintenanceCostFactor <- function(roadtype)
 	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
 	return GSRoad._GetMaintenanceCostFactor(roadtype);
 }
+
+/* 14 returns a distance of -1 for invalid engines */
+GSEngine._GetMaximumOrderDistance <- GSEngine.GetMaximumOrderDistance
+GSEngine.GetMaximumOrderDistance <- function (engine_id)
+{
+	if (!GSEngine.IsValidEngine(engine_id)) return 0;
+	return GSEngine._GetMaximumOrderDistance(engine_id);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -88,3 +88,12 @@ GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
 	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
 	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
 }
+
+/* 14 returns -1 for invalid towns and invalid town effect ids */
+GSTown._GetCargoGoal <- GSTown.GetCargoGoal
+GSTown.GetCargoGoal <- function(town_id, towneffect_id)
+{
+	if (!GSTown.IsValidTown(town_id)) return 0xFFFFFFFF;
+	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
+	return GSTown._GetCargoGoal(town_id, towneffect_id);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -80,3 +80,11 @@ GSEngine.GetMaximumOrderDistance <- function (engine_id)
 	if (!GSEngine.IsValidEngine(engine_id)) return 0;
 	return GSEngine._GetMaximumOrderDistance(engine_id);
 }
+
+/* 14 returns a distance of -1 for invalid vehicles */
+GSVehicle._GetMaximumOrderDistance <- GSVehicle.GetMaximumOrderDistance
+GSVehicle.GetMaximumOrderDistance <- function(vehicle_id)
+{
+	if (!GSVehicle.IsValidVehicle(vehicle_id)) return 0;
+	return GSVehicle._GetMaximumOrderDistance(vehicle_id);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -48,3 +48,27 @@ GSBase.ChanceItem <- function(unused_param, out, max)
 {
 	return GSBase.Chance(out, max);
 }
+
+/* 14 airport maintenance cost factor returns -1 for unavailable airports */
+GSAirport._GetMaintenanceCostFactor <- GSAirport.GetMaintenanceCostFactor
+GSAirport.GetMaintenanceCostFactor <- function(type)
+{
+	if (!GSAirport.IsAirportInformationAvailable(type)) return 0xFFFF;
+	return GSAirport._GetMaintenanceCostFactor(type);
+}
+
+/* 14 railtype maintenance cost factor returns -1 for unavailable railtypes */
+GSRail._GetMaintenanceCostFactor <- GSRail.GetMaintenanceCostFactor
+GSRail.GetMaintenanceCostFactor <- function(railtype)
+{
+	if (!GSRail.IsRailTypeAvailable(railtype)) return 0;
+	return GSRail._GetMaintenanceCostFactor(railtype);
+}
+
+/* 14 roadtype maintenance cost factor returns -1 for unavailable roadtypes */
+GSRoad._GetMaintenanceCostFactor <- GSRoad.GetMaintenanceCostFactor
+GSRoad.GetMaintenanceCostFactor <- function(roadtype)
+{
+	if (!GSRoad.IsRoadTypeAvailable(roadtype)) return 0;
+	return GSRoad._GetMaintenanceCostFactor(roadtype);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -97,3 +97,11 @@ GSTown.GetCargoGoal <- function(town_id, towneffect_id)
 	if (!GSCargo.IsValidTownEffect(towneffect_id)) return 0xFFFFFFFF;
 	return GSTown._GetCargoGoal(town_id, towneffect_id);
 }
+
+/* 14 tests whether the vehicle type is valid */
+GSOrder._GetOrderDistance <- GSOrder.GetOrderDistance
+GSOrder.GetOrderDistance <- function(vehicle_type, origin_tile, dest_tile)
+{
+	if (vehicle_type < GSVehicle.VT_RAIL || vehicle_type > GSVehicle.VT_AIR) return GSMap.DistanceManhattan(origin_tile, dest_tile);
+	return GSOrder._GetOrderDistance(vehicle_type, origin_tile, dest_tile);
+}

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1040,7 +1040,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetMinLength():     -1
   Valid Bridges:        10
   IsBridgeTile():       false
-  GetBridgeID():        -1
+  GetBridgeID():        4294967295
   RemoveBridge():       false
   GetLastErrorString(): ERR_PRECONDITION_FAILED
   GetOtherBridgeEnd():  -1

--- a/regression/regression/result.txt
+++ b/regression/regression/result.txt
@@ -1040,7 +1040,7 @@ ERROR: IsEnd() is invalid as Begin() is never called
     GetMinLength():     -1
   Valid Bridges:        10
   IsBridgeTile():       false
-  GetBridgeID():        4294967295
+  GetBridgeID():        -1
   RemoveBridge():       false
   GetLastErrorString(): ERR_PRECONDITION_FAILED
   GetOtherBridgeEnd():  -1

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -20,6 +20,7 @@
  * API additions:
  * \li AITown::ROAD_LAYOUT_RANDOM
  * \li AIVehicle::IsPrimaryVehicle
+ * \li AIBridge::BRIDGE_INVALID
  *
  * API removals:
  * \li AIError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -25,6 +25,11 @@
  * API removals:
  * \li AIError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
  *
+ * Other changes:
+ * \li AIAirport::GetMaintenanceCostFactor returns -1 for unavailable airport information instead of 65535
+ * \li AIRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
+ * \li AIRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
+ *
  * \b 13.0
  *
  * API additions:

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -29,6 +29,7 @@
  * \li AIAirport::GetMaintenanceCostFactor returns -1 for unavailable airport information instead of 65535
  * \li AIRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
  * \li AIRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
+ * \li AIRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
  *
  * \b 13.0
  *

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -30,6 +30,7 @@
  * \li AIRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
  * \li AIRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
  * \li AIRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
+ * \li AIEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
  *
  * \b 13.0
  *

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -33,6 +33,7 @@
  * \li AIEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
  * \li AIVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
  * \li AITown::GetCargoGoal returns -1 for invalid towns or invalid town effects instead of UINT32_MAX
+ * \li AIOrder::GetOrderDistance now tests the validity of the vehicle type, returning -1 for invalid vehicle types
  *
  * \b 13.0
  *

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -32,6 +32,7 @@
  * \li AIRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
  * \li AIEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
  * \li AIVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
+ * \li AITown::GetCargoGoal returns -1 for invalid towns or invalid town effects instead of UINT32_MAX
  *
  * \b 13.0
  *

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -31,6 +31,7 @@
  * \li AIRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
  * \li AIRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
  * \li AIEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
+ * \li AIVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
  *
  * \b 13.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -32,6 +32,7 @@
  * \li GSRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
  * \li GSEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
  * \li GSVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
+ * \li GSTown::GetCargoGoal returns -1 for invalid towns or invalid town effects instead of UINT32_MAX
  *
  * \b 13.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -25,6 +25,11 @@
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
  *
+ * Other changes:
+ * \li GSAirport::GetMaintenanceCostFactor returns -1 for unavailable airport information instead of 65535
+ * \li GSRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
+ * \li GSRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
+ *
  * \b 13.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -20,6 +20,7 @@
  * API additions:
  * \li GSTown::ROAD_LAYOUT_RANDOM
  * \li GSVehicle::IsPrimaryVehicle
+ * \li GSBridge::BRIDGE_INVALID
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -31,6 +31,7 @@
  * \li GSRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
  * \li GSRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
  * \li GSEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
+ * \li GSVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
  *
  * \b 13.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -33,6 +33,7 @@
  * \li GSEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
  * \li GSVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
  * \li GSTown::GetCargoGoal returns -1 for invalid towns or invalid town effects instead of UINT32_MAX
+ * \li GSOrder::GetOrderDistance now tests the validity of the vehicle type, returning -1 for invalid vehicle types
  *
  * \b 13.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -29,6 +29,7 @@
  * \li GSAirport::GetMaintenanceCostFactor returns -1 for unavailable airport information instead of 65535
  * \li GSRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
  * \li GSRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
+ * \li GSRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
  *
  * \b 13.0
  *

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -30,6 +30,7 @@
  * \li GSRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
  * \li GSRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
  * \li GSRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
+ * \li GSEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
  *
  * \b 13.0
  *

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -156,9 +156,9 @@
 	return AirportGetNearestTown(as, AirportTileTableIterator(as->table[0], tile), dist)->index;
 }
 
-/* static */ uint16 ScriptAirport::GetMaintenanceCostFactor(AirportType type)
+/* static */ int ScriptAirport::GetMaintenanceCostFactor(AirportType type)
 {
-	if (!IsAirportInformationAvailable(type)) return INVALID_TOWN;
+	if (!IsAirportInformationAvailable(type)) return -1;
 
 	return AirportSpec::Get(type)->maintenance_cost;
 }

--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -198,7 +198,7 @@ public:
 	 * @pre IsAirportInformationAvailable(type)
 	 * @return Maintenance cost factor of the airport type.
 	 */
-	static uint16 GetMaintenanceCostFactor(AirportType type);
+	static int GetMaintenanceCostFactor(AirportType type);
 
 	/**
 	 * Get the monthly maintenance cost of an airport type.

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -23,7 +23,7 @@
 
 /* static */ bool ScriptBridge::IsValidBridge(BridgeID bridge_id)
 {
-	return bridge_id < MAX_BRIDGES && ::GetBridgeSpec(bridge_id)->avail_year <= _cur_year;
+	return (::BridgeID)bridge_id < MAX_BRIDGES && ::GetBridgeSpec((::BridgeID)bridge_id)->avail_year <= _cur_year;
 }
 
 /* static */ bool ScriptBridge::IsBridgeTile(TileIndex tile)
@@ -32,9 +32,9 @@
 	return ::IsBridgeTile(tile);
 }
 
-/* static */ BridgeID ScriptBridge::GetBridgeID(TileIndex tile)
+/* static */ ScriptBridge::BridgeID ScriptBridge::GetBridgeID(TileIndex tile)
 {
-	if (!IsBridgeTile(tile)) return (BridgeID)-1;
+	if (!IsBridgeTile(tile)) return BRIDGE_INVALID;
 	return (BridgeID)::GetBridgeType(tile);
 }
 
@@ -84,11 +84,11 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 		case ScriptVehicle::VT_ROAD:
 			ScriptObject::SetCallbackVariable(0, start);
 			ScriptObject::SetCallbackVariable(1, end);
-			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(&::_DoCommandReturnBuildBridge1, end, start, TRANSPORT_ROAD, bridge_id, ScriptRoad::GetCurrentRoadType());
+			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(&::_DoCommandReturnBuildBridge1, end, start, TRANSPORT_ROAD, (::BridgeID)bridge_id, ScriptRoad::GetCurrentRoadType());
 		case ScriptVehicle::VT_RAIL:
-			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_RAIL, bridge_id, ScriptRail::GetCurrentRailType());
+			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_RAIL, (::BridgeID)bridge_id, ScriptRail::GetCurrentRailType());
 		case ScriptVehicle::VT_WATER:
-			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_WATER, bridge_id, 0);
+			return ScriptObject::Command<CMD_BUILD_BRIDGE>::Do(end, start, TRANSPORT_WATER, (::BridgeID)bridge_id, 0);
 		default: NOT_REACHED();
 	}
 }
@@ -129,35 +129,35 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	EnforcePrecondition(nullptr, vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER);
 	if (!IsValidBridge(bridge_id)) return nullptr;
 
-	return GetString(vehicle_type == ScriptVehicle::VT_WATER ? STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT : ::GetBridgeSpec(bridge_id)->transport_name[vehicle_type]);
+	return GetString(vehicle_type == ScriptVehicle::VT_WATER ? STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT : ::GetBridgeSpec((::BridgeID)bridge_id)->transport_name[vehicle_type]);
 }
 
 /* static */ int32 ScriptBridge::GetMaxSpeed(BridgeID bridge_id)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
-	return ::GetBridgeSpec(bridge_id)->speed; // km-ish/h
+	return ::GetBridgeSpec((::BridgeID)bridge_id)->speed; // km-ish/h
 }
 
 /* static */ Money ScriptBridge::GetPrice(BridgeID bridge_id, uint length)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
-	return ::CalcBridgeLenCostFactor(length) * _price[PR_BUILD_BRIDGE] * ::GetBridgeSpec(bridge_id)->price >> 8;
+	return ::CalcBridgeLenCostFactor(length) * _price[PR_BUILD_BRIDGE] * ::GetBridgeSpec((::BridgeID)bridge_id)->price >> 8;
 }
 
 /* static */ int32 ScriptBridge::GetMaxLength(BridgeID bridge_id)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
-	return std::min(::GetBridgeSpec(bridge_id)->max_length, _settings_game.construction.max_bridge_length) + 2;
+	return std::min(::GetBridgeSpec((::BridgeID)bridge_id)->max_length, _settings_game.construction.max_bridge_length) + 2;
 }
 
 /* static */ int32 ScriptBridge::GetMinLength(BridgeID bridge_id)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
-	return ::GetBridgeSpec(bridge_id)->min_length + 2;
+	return ::GetBridgeSpec((::BridgeID)bridge_id)->min_length + 2;
 }
 
 /* static */ TileIndex ScriptBridge::GetOtherBridgeEnd(TileIndex tile)

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -19,6 +19,13 @@
 class ScriptBridge : public ScriptObject {
 public:
 	/**
+	 * The types of bridges available in the game.
+	 */
+	enum BridgeID {
+		BRIDGE_INVALID = -1, ///< Invalid Bridge ID.
+	};
+
+	/**
 	 * All bridge related error messages.
 	 */
 	enum ErrorMessages {

--- a/src/script/api/script_bridgelist.cpp
+++ b/src/script/api/script_bridgelist.cpp
@@ -17,15 +17,15 @@
 ScriptBridgeList::ScriptBridgeList()
 {
 	for (byte j = 0; j < MAX_BRIDGES; j++) {
-		if (ScriptBridge::IsValidBridge(j)) this->AddItem(j);
+		if (ScriptBridge::IsValidBridge((ScriptBridge::BridgeID)j)) this->AddItem(j);
 	}
 }
 
 ScriptBridgeList_Length::ScriptBridgeList_Length(uint length)
 {
 	for (byte j = 0; j < MAX_BRIDGES; j++) {
-		if (ScriptBridge::IsValidBridge(j)) {
-			if (length >= (uint)ScriptBridge::GetMinLength(j) && length <= (uint)ScriptBridge::GetMaxLength(j)) this->AddItem(j);
+		if (ScriptBridge::IsValidBridge((ScriptBridge::BridgeID)j)) {
+			if (length >= (uint)ScriptBridge::GetMinLength((ScriptBridge::BridgeID)j) && length <= (uint)ScriptBridge::GetMaxLength((ScriptBridge::BridgeID)j)) this->AddItem(j);
 		}
 	}
 }

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -265,13 +265,13 @@
 	return (ScriptAirport::PlaneType)::AircraftVehInfo(engine_id)->subtype;
 }
 
-/* static */ uint ScriptEngine::GetMaximumOrderDistance(EngineID engine_id)
+/* static */ int64 ScriptEngine::GetMaximumOrderDistance(EngineID engine_id)
 {
-	if (!IsValidEngine(engine_id)) return 0;
+	if (!IsValidEngine(engine_id)) return -1;
 
 	switch (GetVehicleType(engine_id)) {
 		case ScriptVehicle::VT_AIR:
-			return ::Engine::Get(engine_id)->GetRange() * ::Engine::Get(engine_id)->GetRange();
+			return (uint32)::Engine::Get(engine_id)->GetRange() * (uint32)::Engine::Get(engine_id)->GetRange();
 
 		default:
 			return 0;

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -286,7 +286,7 @@ public:
 	 *         not be compared with map distances
 	 * @see ScriptOrder::GetOrderDistance
 	 */
-	static uint GetMaximumOrderDistance(EngineID engine_id);
+	static int64 GetMaximumOrderDistance(EngineID engine_id);
 
 	/**
 	 * Allows a company to use an engine before its intro date or after retirement.

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -183,7 +183,7 @@
 	return ::Group::Get(group_id)->statistics.profit_last_year;
 }
 
-/* static */ uint32 ScriptGroup::GetCurrentUsage(GroupID group_id)
+/* static */ int32 ScriptGroup::GetCurrentUsage(GroupID group_id)
 {
 	if (!IsValidGroup(group_id)) return -1;
 

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -225,7 +225,7 @@ public:
 	 * @pre IsValidGroup(group_id).
 	 * @return The current usage of the group.
 	 */
-	static uint32 GetCurrentUsage(GroupID group_id);
+	static int32 GetCurrentUsage(GroupID group_id);
 
 	/**
 	 * Set primary colour for a group.

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -666,8 +666,10 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, 0);
 }
 
-/* static */ uint ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)
+/* static */ int ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)
 {
+	if (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR) return -1;
+
 	if (vehicle_type == ScriptVehicle::VT_AIR) {
 		if (ScriptTile::IsStationTile(origin_tile)) {
 			Station *orig_station = ::Station::GetByTile(origin_tile);

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -595,13 +595,15 @@ public:
 	 * @param vehicle_type The vehicle type to get the distance for.
 	 * @param origin_tile Origin, can be any tile or a tile of a specific station.
 	 * @param dest_tile Destination, can be any tile or a tile of a specific station.
+	 * @pre vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL ||
+	 *   vehicle_type == ScriptVehicle::VT_WATER || vehicle_type == ScriptVehicle::VT_AIR
 	 * @return The distance between the origin and the destination for a
 	 *         vehicle of the given vehicle type.
 	 * @note   The unit of the order distances is unspecified and should
 	 *         not be compared with map distances
 	 * @see ScriptEngine::GetMaximumOrderDistance and ScriptVehicle::GetMaximumOrderDistance
 	 */
-	static uint GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile);
+	static int GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile);
 };
 DECLARE_ENUM_AS_BIT_SET(ScriptOrder::ScriptOrderFlags)
 

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -511,9 +511,9 @@ static bool IsValidSignalType(int signal_type)
 	return ::GetRailTypeInfo((::RailType)railtype)->max_speed;
 }
 
-/* static */ uint16 ScriptRail::GetMaintenanceCostFactor(RailType railtype)
+/* static */ int ScriptRail::GetMaintenanceCostFactor(RailType railtype)
 {
-	if (!ScriptRail::IsRailTypeAvailable(railtype)) return 0;
+	if (!ScriptRail::IsRailTypeAvailable(railtype)) return -1;
 
 	return ::GetRailTypeInfo((::RailType)railtype)->maintenance_multiplier;
 }

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -494,7 +494,7 @@ public:
 	 * @pre IsRailTypeAvailable(railtype)
 	 * @return Maintenance cost factor of the railtype.
 	 */
-	static uint16 GetMaintenanceCostFactor(RailType railtype);
+	static int GetMaintenanceCostFactor(RailType railtype);
 };
 
 #endif /* SCRIPT_RAIL_HPP */

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -627,7 +627,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ int32 ScriptRoad::GetMaxSpeed(RoadType road_type)
 {
-	if (!ScriptRoad::IsRoadTypeAvailable(road_type)) return 0;
+	if (!ScriptRoad::IsRoadTypeAvailable(road_type)) return -1;
 
 	return GetRoadTypeInfo((::RoadType)road_type)->max_speed;
 }

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -632,9 +632,9 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 	return GetRoadTypeInfo((::RoadType)road_type)->max_speed;
 }
 
-/* static */ uint16 ScriptRoad::GetMaintenanceCostFactor(RoadType roadtype)
+/* static */ int ScriptRoad::GetMaintenanceCostFactor(RoadType roadtype)
 {
-	if (!ScriptRoad::IsRoadTypeAvailable(roadtype)) return 0;
+	if (!ScriptRoad::IsRoadTypeAvailable(roadtype)) return -1;
 
 	return GetRoadTypeInfo((::RoadType)roadtype)->maintenance_multiplier;
 }

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -569,7 +569,7 @@ public:
 	 * @pre IsRoadTypeAvailable(roadtype)
 	 * @return Maintenance cost factor of the roadtype.
 	 */
-	static uint16 GetMaintenanceCostFactor(RoadType roadtype);
+	static int GetMaintenanceCostFactor(RoadType roadtype);
 
 private:
 

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -131,10 +131,10 @@
 	return ScriptObject::Command<CMD_TOWN_CARGO_GOAL>::Do(town_id, (::TownEffect)towneffect_id, goal);
 }
 
-/* static */ uint32 ScriptTown::GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id)
+/* static */ int64 ScriptTown::GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id)
 {
-	if (!IsValidTown(town_id)) return UINT32_MAX;
-	if (!ScriptCargo::IsValidTownEffect(towneffect_id)) return UINT32_MAX;
+	if (!IsValidTown(town_id)) return -1;
+	if (!ScriptCargo::IsValidTownEffect(towneffect_id)) return -1;
 
 	const Town *t = ::Town::Get(town_id);
 

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -251,7 +251,7 @@ public:
 	 * @note Goals can change over time. For example with a changing snowline, or
 	 *  with a growing town.
 	 */
-	static uint32 GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id);
+	static int64 GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id);
 
 	/**
 	 * Set the amount of days between town growth.

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -473,9 +473,9 @@
 	return ::ToPercent16(v->reliability);
 }
 
-/* static */ uint ScriptVehicle::GetMaximumOrderDistance(VehicleID vehicle_id)
+/* static */ int64 ScriptVehicle::GetMaximumOrderDistance(VehicleID vehicle_id)
 {
-	if (!IsPrimaryVehicle(vehicle_id)) return 0;
+	if (!IsPrimaryVehicle(vehicle_id)) return -1;
 
 	const ::Vehicle *v = ::Vehicle::Get(vehicle_id);
 	switch (v->type) {

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -609,7 +609,7 @@ public:
 	 *         not be compared with map distances
 	 * @see ScriptOrder::GetOrderDistance
 	 */
-	static uint GetMaximumOrderDistance(VehicleID vehicle_id);
+	static int64 GetMaximumOrderDistance(VehicleID vehicle_id);
 
 private:
 	/**

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -44,7 +44,7 @@ namespace SQConvert {
 
 	template <> struct Return<uint8>        { static inline int Set(HSQUIRRELVM vm, uint8 res)       { sq_pushinteger(vm, (int32)res); return 1; } };
 	template <> struct Return<uint16>       { static inline int Set(HSQUIRRELVM vm, uint16 res)      { sq_pushinteger(vm, (int32)res); return 1; } };
-	template <> struct Return<uint32>       { static inline int Set(HSQUIRRELVM vm, uint32 res)      { sq_pushinteger(vm, (int32)res); return 1; } };
+	template <> struct Return<uint32>       { static inline int Set(HSQUIRRELVM vm, uint32 res)      { sq_pushinteger(vm, (int64)res); return 1; } };
 	template <> struct Return<int8>         { static inline int Set(HSQUIRRELVM vm, int8 res)        { sq_pushinteger(vm, res); return 1; } };
 	template <> struct Return<int16>        { static inline int Set(HSQUIRRELVM vm, int16 res)       { sq_pushinteger(vm, res); return 1; } };
 	template <> struct Return<int32>        { static inline int Set(HSQUIRRELVM vm, int32 res)       { sq_pushinteger(vm, res); return 1; } };


### PR DESCRIPTION
## Motivation / Problem
~~ScriptBase Rand functions returns values that are negative at times, while the documentation about them mentions that they should be in a range starting from 0 to their max.~~

~~As a quick fix to that problem,~~ I allowed Scripts to convert returned any uint32 values to int64. But such fix was traversal to the entire API, I quickly realized some values could now be returning different results. One such case that was detected by regression test was the return of an invalid BridgeID. BridgeID itself is a uint. Multiple conversions were occurring before the final result was delivered.

`return (BridgeID)-1` was actually doing 2 conversions. -1 to uint = 4 294 967 295, then from uint to int32 =  4 294 967 295 to -1 and that was the final result it was being delivered. But now that the final conversion is to int64, the new result is 4 294 967 295 again, and that's what regression caught on.

I knew then that there could be more functions which could now be returning wrong values, so I went with a search or every API function returning uint32's and made changes accordingly.

I also took the liberty to fix some related bugs along the way, mainly if they didn't match their documentation, such as when they should return -1 for invalid parameters. I also created compatibility functions so that older scripts, would still behave as they did previously to the changes.

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
 * ~~ScriptBase::Rand now correctly returns a value between 0 and MAX(uint32)~~
 * ~~Script::RandItem now correctly returns a value between 0 and MAX(uint32)~~
 * ~~ScriptBase::RandRange now correctly returns a value between 0 and 'max - 1'~~
 * ~~ScriptBase::RandRangeItem now correctly returns a value between 0 and 'max - 1'~~
 * ~~ScriptBase::Chance randomized 'max' value is now in the correct range when compared with 'out'~~
 * ~~ScriptBase::ChanceItem randomized 'max' value is now in the correct range when compared with 'out'~~
~~All 6 above were fixed by converting returned uint32 values as int64 instead of int32.~~
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptBridge::GetBridgeID now returns BRIDGE_INVALID for invalid bridge ids, which is still -1.
Instead of returning 4 294 967 295 after the conversion fix, I created a BridgeID enum containing BRIDGE_INVALID = -1. Since now there's ::BridgeID and ScriptBridge::BridgeID, parts of the code were modified accordingly to use the correct type around.
No actual compatibility functions are necessary.

 * ScriptGroup::GetCurrentUsage could not return -1
It shared the same fate as the previous one. Since it was uint, after the conversion fix, returning -1 would mean 4 294 967 295, so i turned the function as a int to solve the issue.
No actual compatibility functions are necessary.

 * ScriptAirport::GetMaintenanceCostFactor returns -1 for unavailable airport information instead of 65535
When airport information was unavailable, it was erroneously returning INVALID_TOWN (65535). I decided -1 was an appropriate value to return, because I wanted to diferentiate it from the only positive values that cost factors could return.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptRail::GetMaintenanceCostFactor returns -1 for unavailable rail types instead of 0
I decided -1 was an appropriate value to return, because I wanted to diferentiate it from the only positive values that cost factors could return.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptRoad::GetMaintenanceCostFactor returns -1 for unavailable road types instead of 0
I decided -1 was an appropriate value to return, because I wanted to diferentiate it from the only positive values that cost factors could return.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptRoad::GetMaxSpeed now correctly returns -1 for invalid road types instead of 0
I decided -1 was an appropriate value to return, because 0 is used for unlimited speed.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptEngine::GetMaximumOrderDistance returns -1 for invalid engines instead of 0
I decided -1 was an appropriate value to return, because 0 is used for unlimited distance.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptVehicle::GetMaximumOrderDistance returns -1 for invalid vehicles instead of 0
I decided -1 was an appropriate value to return, because 0 is used for unlimited distance.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptTown::GetCargoGoal returns -1 for invalid towns or invalid town effects instead of UINT32_MAX
I decided -1 was an appropriate value to return, because UINT32_MAX could be misinterpreted as an actual goal requirement.
Compatibility functions were added to the older APIs to maintain old behaviour.

 * ScriptOrder::GetOrderDistance now tests the validity of the vehicle type, returning -1 for invalid vehicle types
There was no check in place to test the vehicle type. Testing for invalid tiles was attempting to return -1 (which would become 4 294 967 295 as this function was returning uint)
Compatibility functions were added to the older APIs to maintain old behaviour.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I could have missed some API functions that disguisely return uint32's. If you can spot some, please alert me.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
