### PR TITLE
Change: Log AI/GS Squirrel crashes in white text for readability

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -1166,7 +1166,7 @@ struct AIDebugWindow : public Window {
 					TextColour colour;
 					switch (log->type[pos]) {
 						case ScriptLog::LOG_SQ_INFO:  colour = TC_BLACK;  break;
-						case ScriptLog::LOG_SQ_ERROR: colour = TC_RED;    break;
+						case ScriptLog::LOG_SQ_ERROR: colour = TC_WHITE;    break;
 						case ScriptLog::LOG_INFO:     colour = TC_BLACK;  break;
 						case ScriptLog::LOG_WARNING:  colour = TC_YELLOW; break;
 						case ScriptLog::LOG_ERROR:    colour = TC_RED;    break;


### PR DESCRIPTION
## Motivation / Problem

* improve legibility of errors in AI / GS debug log

## Description

* white on grey is more legible than red on grey

## Limitations

* probably someone will disagree

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
No
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* No
* This PR affects the save game format? (label 'savegame upgrade')
* No
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
 Not really
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
No