### PR TITLE
Fix: [Script] Ensure building/removing rail lines can't be backwards and allow building/removing rail lines coming from or heading to the void

### DIFF
--- a/bin/ai/compat_0.7.nut
+++ b/bin/ai/compat_0.7.nut
@@ -392,3 +392,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -144,3 +144,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -81,3 +81,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -19,3 +19,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -19,3 +19,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -33,3 +33,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -19,3 +19,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -19,3 +19,88 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -6,3 +6,88 @@
  */
 
 AILog.Info("13 API compatibility in effect.");
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = AIMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < AIMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (AIMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - AIMap.GetTileX(t_valid)) + abs(ty(t_void) - AIMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - AIMap.GetTileX(t_valid)) - abs(ty(t_void) - AIMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (AICompany.ResolveCompanyID(AICompany.COMPANY_SELF) != AICompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && AIMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			AIRail.IsRailTypeAvailable(AIRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (AIMap.IsValidTile(from) && AIMap.IsValidTile(to)) {
+			if (from == to ||
+					(AIMap.GetTileX(from) == AIMap.GetTileX(tile) && AIMap.GetTileX(tile) == AIMap.GetTileX(to) &&
+					AIMap.GetTileY(from) - AIMap.GetTileY(tile) == -(AIMap.GetTileY(tile) - AIMap.GetTileY(to)) / abs(AIMap.GetTileY(tile) - AIMap.GetTileY(to))) ||
+					(AIMap.GetTileY(from) == AIMap.GetTileY(tile) && AIMap.GetTileY(tile) == AIMap.GetTileY(to) &&
+					AIMap.GetTileX(from) - AIMap.GetTileX(tile) == -(AIMap.GetTileX(tile) - AIMap.GetTileX(to)) / abs(AIMap.GetTileX(tile) - AIMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+AIRail._BuildRail <- AIRail.BuildRail
+AIRail.BuildRail <- function(from, tile, to)
+{
+	return AIRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+AIRail._RemoveRail <- AIRail.RemoveRail
+AIRail.RemoveRail <- function(from, tile, to)
+{
+	return AIRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -26,3 +26,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -19,3 +19,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -48,3 +48,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -48,3 +48,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -40,3 +40,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -33,3 +33,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -33,3 +33,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -33,3 +33,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -33,3 +33,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -26,3 +26,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -19,3 +19,88 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -6,3 +6,88 @@
  */
 
 GSLog.Info("13 API compatibility in effect.");
+
+/* 14 ensures rail can't be built or removed backwards and allows
+ * 'from' and 'to' tiles to be invalid, as long as they're void tiles. */
+__BuildRemoveRailHelper <- function(from, tile, to)
+{
+	local map_log_x = function()
+	{
+		local x = GSMap.GetMapSizeX();
+		local pos = 0;
+
+		if ((x & 0xFFFFFFFF) == 0) { x = x >> 32; pos += 32; }
+		if ((x & 0x0000FFFF) == 0) { x = x >> 16; pos += 16; }
+		if ((x & 0x000000FF) == 0) { x = x >> 8;  pos += 8;  }
+		if ((x & 0x0000000F) == 0) { x = x >> 4;  pos += 4;  }
+		if ((x & 0x00000003) == 0) { x = x >> 2;  pos += 2;  }
+		if ((x & 0x00000001) == 0) { pos += 1; }
+
+		return pos;
+	};
+
+	/* Workaround to circumvent IsValidTile. We want to give a pass to void tiles */
+	local is_tile_inside_map = function(t)
+	{
+		return t >= 0 && t < GSMap.GetMapSize();
+	};
+
+	/* Workaround to circumvent GetTileX which tests IsValidTile */
+	local tile_x = function(t)
+	{
+		return t & (GSMap.GetMapSizeX() - 1);
+	};
+
+	/* Workaround to circumvent GetTileY which tests IsValidTile */
+	local tile_y = function(t, maplogx = map_log_x)
+	{
+		return t >> maplogx();
+	};
+
+	/* Workaround to circumvent DistanceManhattan which tests IsValidTile */
+	local distance_manhattan = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(tx(t_void) - GSMap.GetTileX(t_valid)) + abs(ty(t_void) - GSMap.GetTileY(t_valid));
+	};
+
+	local diag_offset = function(t_void, t_valid, tx = tile_x, ty = tile_y)
+	{
+		return abs(abs(tx(t_void) - GSMap.GetTileX(t_valid)) - abs(ty(t_void) - GSMap.GetTileY(t_valid)));
+	};
+
+	/* Run common tests to both API versions */
+	if (GSCompany.ResolveCompanyID(GSCompany.COMPANY_SELF) != GSCompany.COMPANY_INVALID &&
+			is_tile_inside_map(from) && GSMap.IsValidTile(tile) && is_tile_inside_map(to) &&
+			distance_manhattan(from, tile) == 1 && distance_manhattan(to, tile) >= 1 &&
+			GSRail.IsRailTypeAvailable(GSRail.GetCurrentRailType()) && (diag_offset(to, tile) <= 1 ||
+			(tile_x(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == tile_x(to)) ||
+			(tile_y(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == tile_y(to)))) {
+		/* Run tests which differ from version 14 */
+		if (GSMap.IsValidTile(from) && GSMap.IsValidTile(to)) {
+			if (from == to ||
+					(GSMap.GetTileX(from) == GSMap.GetTileX(tile) && GSMap.GetTileX(tile) == GSMap.GetTileX(to) &&
+					GSMap.GetTileY(from) - GSMap.GetTileY(tile) == -(GSMap.GetTileY(tile) - GSMap.GetTileY(to)) / abs(GSMap.GetTileY(tile) - GSMap.GetTileY(to))) ||
+					(GSMap.GetTileY(from) == GSMap.GetTileY(tile) && GSMap.GetTileY(tile) == GSMap.GetTileY(to) &&
+					GSMap.GetTileX(from) - GSMap.GetTileX(tile) == -(GSMap.GetTileX(tile) - GSMap.GetTileX(to)) / abs(GSMap.GetTileX(tile) - GSMap.GetTileX(to)))) {
+				/* Adjust 'from' to simulate pre-14 behaviour */
+				from = tile + (tile - from);
+			}
+		} else {
+			/* Provoke a precondition fail to simulate pre-14 behaviour */
+			from = tile;
+		}
+	}
+	return from;
+}
+
+GSRail._BuildRail <- GSRail.BuildRail
+GSRail.BuildRail <- function(from, tile, to)
+{
+	return GSRail._BuildRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}
+
+GSRail._RemoveRail <- GSRail.RemoveRail
+GSRail.RemoveRail <- function(from, tile, to)
+{
+	return GSRail._RemoveRail(__BuildRemoveRailHelper(from, tile, to), tile, to);
+}

--- a/src/script/api/ai_changelog.hpp
+++ b/src/script/api/ai_changelog.hpp
@@ -24,6 +24,12 @@
  * API removals:
  * \li AIError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
  *
+ * Other changes:
+ * \li AIRail::BuildRail preconditions changed to allow rail coming from and heading
+ *     to the void. Also ensure going from a tile to another doesn't change direction.
+ * \li AIRail::RemoveRail preconditions changed to allow rail coming from and heading
+ *     to the void. Also ensure going from a tile to another doesn't change direction.
+ *
  * \b 13.0
  *
  * API additions:

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -24,6 +24,12 @@
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.
  *
+ * Other changes:
+ * \li GSRail::BuildRail preconditions changed to allow rail coming from and heading
+ *     to the void. Also ensure going from a tile to another doesn't change direction.
+ * \li GSRail::RemoveRail preconditions changed to allow rail coming from and heading
+ *     to the void. Also ensure going from a tile to another doesn't change direction.
+ *
  * \b 13.0
  *
  * API additions:

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -353,16 +353,16 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 /* static */ bool ScriptRail::BuildRail(TileIndex from, TileIndex tile, TileIndex to)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
-	EnforcePrecondition(false, ::IsValidTile(from));
+	EnforcePrecondition(false, from != to);
+	EnforcePrecondition(false, from < ScriptMap::GetMapSize());
 	EnforcePrecondition(false, ::IsValidTile(tile));
-	EnforcePrecondition(false, ::IsValidTile(to));
+	EnforcePrecondition(false, to < ScriptMap::GetMapSize());
 	EnforcePrecondition(false, ::DistanceManhattan(from, tile) == 1);
-	EnforcePrecondition(false, ::DistanceManhattan(tile, to) >= 1);
+	EnforcePrecondition(false, ::DistanceManhattan(to, tile) >= 1);
 	EnforcePrecondition(false, IsRailTypeAvailable(GetCurrentRailType()));
 	int diag_offset = abs(abs((int)::TileX(to) - (int)::TileX(tile)) - abs((int)::TileY(to) - (int)::TileY(tile)));
 	EnforcePrecondition(false, diag_offset <= 1 ||
-			(::TileX(from) == ::TileX(tile) && ::TileX(tile) == ::TileX(to)) ||
-			(::TileY(from) == ::TileY(tile) && ::TileY(tile) == ::TileY(to)));
+			::DiagdirBetweenTiles(from, tile) == ::DiagdirBetweenTiles(tile, to));
 
 	Track track = SimulateDrag(from, tile, &to);
 	return ScriptObject::Command<CMD_BUILD_RAILROAD_TRACK>::Do(to, tile, (::RailType)ScriptRail::GetCurrentRailType(), track, false, true);
@@ -371,15 +371,15 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 /* static */ bool ScriptRail::RemoveRail(TileIndex from, TileIndex tile, TileIndex to)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
-	EnforcePrecondition(false, ::IsValidTile(from));
+	EnforcePrecondition(false, from != to);
+	EnforcePrecondition(false, from < ScriptMap::GetMapSize());
 	EnforcePrecondition(false, ::IsValidTile(tile));
-	EnforcePrecondition(false, ::IsValidTile(to));
+	EnforcePrecondition(false, to < ScriptMap::GetMapSize());
 	EnforcePrecondition(false, ::DistanceManhattan(from, tile) == 1);
-	EnforcePrecondition(false, ::DistanceManhattan(tile, to) >= 1);
+	EnforcePrecondition(false, ::DistanceManhattan(to, tile) >= 1);
 	int diag_offset = abs(abs((int)::TileX(to) - (int)::TileX(tile)) - abs((int)::TileY(to) - (int)::TileY(tile)));
 	EnforcePrecondition(false, diag_offset <= 1 ||
-			(::TileX(from) == ::TileX(tile) && ::TileX(tile) == ::TileX(to)) ||
-			(::TileY(from) == ::TileY(tile) && ::TileY(tile) == ::TileY(to)));
+			::DiagdirBetweenTiles(from, tile) == ::DiagdirBetweenTiles(tile, to));
 
 	Track track = SimulateDrag(from, tile, &to);
 	return ScriptObject::Command<CMD_REMOVE_RAILROAD_TRACK>::Do(to, tile, track);

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -397,12 +397,11 @@ public:
 	 * @param tile The first tile to build on.
 	 * @param to The tile just after the last tile to build on.
 	 * @pre from != to.
-	 * @pre ScriptMap::DistanceManhattan(from, tile) == 1.
-	 * @pre ScriptMap::DistanceManhattan(to, tile) >= 1.
-	 * @pre (abs(abs(ScriptMap::GetTileX(to) - ScriptMap::GetTileX(tile)) -
-	 *          abs(ScriptMap::GetTileY(to) - ScriptMap::GetTileY(tile))) <= 1) ||
-	 *      (ScriptMap::GetTileX(from) == ScriptMap::GetTileX(tile) && ScriptMap::GetTileX(tile) == ScriptMap::GetTileX(to)) ||
-	 *      (ScriptMap::GetTileY(from) == ScriptMap::GetTileY(tile) && ScriptMap::GetTileY(tile) == ScriptMap::GetTileY(to)).
+	 * @pre ::DistanceManhattan(from, tile) == 1.
+	 * @pre ::DistanceManhattan(to, tile) >= 1.
+	 * @pre (abs(abs((int)::TileX(to) - (int)::TileX(tile)) -
+	 *          abs((int)::TileY(to) - (int)::TileY(tile))) <= 1 ||
+	 *      (::DiagdirBetweenTiles(from, tile) == ::DiagdirBetweenTiles(tile, to))).
 	 * @pre IsRailTypeAvailable(GetCurrentRailType()).
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
@@ -421,12 +420,11 @@ public:
 	 * @param tile The first tile to remove rail from.
 	 * @param to The tile just after the last tile to remove rail from.
 	 * @pre from != to.
-	 * @pre ScriptMap::DistanceManhattan(from, tile) == 1.
-	 * @pre ScriptMap::DistanceManhattan(to, tile) >= 1.
-	 * @pre (abs(abs(ScriptMap::GetTileX(to) - ScriptMap::GetTileX(tile)) -
-	 *          abs(ScriptMap::GetTileY(to) - ScriptMap::GetTileY(tile))) <= 1) ||
-	 *      (ScriptMap::GetTileX(from) == ScriptMap::GetTileX(tile) && ScriptMap::GetTileX(tile) == ScriptMap::GetTileX(to)) ||
-	 *      (ScriptMap::GetTileY(from) == ScriptMap::GetTileY(tile) && ScriptMap::GetTileY(tile) == ScriptMap::GetTileY(to)).
+	 * @pre ::DistanceManhattan(from, tile) == 1.
+	 * @pre ::DistanceManhattan(to, tile) >= 1.
+	 * @pre (abs(abs((int)::TileX(to) - (int)::TileX(tile)) -
+	 *          abs((int)::TileY(to) - (int)::TileY(tile))) <= 1 ||
+	 *      (::DiagdirBetweenTiles(from, tile) == ::DiagdirBetweenTiles(tile, to))).
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether the rail has been/can be removed or not.


### PR DESCRIPTION
## Motivation / Problem
It is possible to build and remove a rail line backwards, using `ScriptRail.BuildRail` and `ScriptRail.RemoveRail`.
It is not possible to build or remove a rail line that is facing the void.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Add the missing precondition that forbids `from` tile to be the same as `to` tile.
- For lines longer than 1 piece which makes the value of `diag_offset` to be 2 or more, the test was incomplete. It was not checking the direction going from a tile to another. The code below would solve it, but it would be difficult to describe in the documentation, so I opted for `DiagdirBetweenTiles`.
```
EnforcePrecondition(false, diag_offset <= 1 ||
			(::TileX(from) == ::TileX(tile) && ::TileX(tile) == ::TileX(to) && (int)::TileY(from) - (int)::TileY(tile) == ((int)::TileY(tile) - (int)::TileY(to)) / abs((int)::TileY(tile) - (int)::TileY(to))) ||
			(::TileY(from) == ::TileY(tile) && ::TileY(tile) == ::TileY(to) && (int)::TileX(from) - (int)::TileX(tile) == ((int)::TileX(tile) - (int)::TileX(to)) / abs((int)::TileX(tile) - (int)::TileX(to))));
```
- Replace the checks that test `IsValidTile` for `from` and `to` with a `MapSize` check. This allows building or removing rail facing the void.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
If the void tiles on top left and top right are disabled, then the edge tiles are always ocean that can't be cleared. So there should be no worries about placing rail tiles there.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
