### PR TITLE
Fix #10377, Fix 94167df: bad sorting of rail vehicles when primary variant is missing

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1334,8 +1334,7 @@ struct BuildVehicleWindow : Window {
 	{
 		std::vector<EngineID> variants;
 		EngineID sel_id = INVALID_ENGINE;
-		int num_engines = 0;
-		int num_wagons  = 0;
+		size_t num_engines = 0;
 
 		list.clear();
 
@@ -1356,12 +1355,7 @@ struct BuildVehicleWindow : Window {
 
 			list.emplace_back(eid, e->info.variant_id, e->display_flags, 0);
 
-			if (rvi->railveh_type != RAILVEH_WAGON) {
-				num_engines++;
-			} else {
-				num_wagons++;
-			}
-
+			if (rvi->railveh_type != RAILVEH_WAGON) num_engines++;
 			if (e->info.variant_id != eid && e->info.variant_id != INVALID_ENGINE) variants.push_back(e->info.variant_id);
 			if (eid == this->sel_engine) sel_id = eid;
 		}
@@ -1371,6 +1365,7 @@ struct BuildVehicleWindow : Window {
 			if (std::find(list.begin(), list.end(), variant) == list.end()) {
 				const Engine *e = Engine::Get(variant);
 				list.emplace_back(variant, e->info.variant_id, e->display_flags | EngineDisplayFlags::Shaded, 0);
+				if (e->u.rail.railveh_type != RAILVEH_WAGON) num_engines++;
 			}
 		}
 
@@ -1388,7 +1383,7 @@ struct BuildVehicleWindow : Window {
 		EngList_SortPartial(&list, _engine_sort_functions[0][this->sort_criteria], 0, num_engines);
 
 		/* and finally sort wagons */
-		EngList_SortPartial(&list, _engine_sort_functions[0][this->sort_criteria], num_engines, num_wagons);
+		EngList_SortPartial(&list, _engine_sort_functions[0][this->sort_criteria], num_engines, list.size() - num_engines);
 	}
 
 	/* Figure out what road vehicle EngineIDs to put in the list */

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -337,7 +337,7 @@ void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare)
  * @param begin start of sorting
  * @param num_items count of items to be sorted
  */
-void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, uint begin, uint num_items)
+void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, size_t begin, size_t num_items)
 {
 	if (num_items < 2) return;
 	assert(begin < el->size());

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -32,7 +32,7 @@ typedef GUIList<GUIEngineListItem, CargoID> GUIEngineList;
 
 typedef bool EngList_SortTypeFunction(const GUIEngineListItem&, const GUIEngineListItem&); ///< argument type for #EngList_Sort.
 void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare);
-void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, uint begin, uint num_items);
+void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, size_t begin, size_t num_items);
 
 StringID GetEngineCategoryName(EngineID engine);
 StringID GetEngineInfoString(EngineID engine);


### PR DESCRIPTION
## Motivation / Problem

Fixes #10377.

The "broken" function first sorts on engine/wagon, and then the parts on the actually requested sort order. For this it counts the number of engine and wagons to know what to partially sort.
With the provided NewGRF in #10377 you will get 304 engines and 147 wagons for a total of 452 elements in the list. This is due to the fact that the code that ensures the primary engine of a variant group does not count the vehicles it adds to the list, so in this case the list is off-by-one and the 304th engine gets sorted somewhere among the wagons and the 147th wagon is always last.


## Description

Just count the engines in the special code where primary engines of variant groups get added. And because we got a `std::vector` backing the engine list, only count the engines and calculate the wagons based on the size of the vector minus the number of engines.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
