### PR TITLE
Hide Tile and TileExtended implementation details inside Map structure

### DIFF
--- a/src/bridge_map.h
+++ b/src/bridge_map.h
@@ -21,10 +21,10 @@
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return true if the structure is a bridge one
  */
-static inline bool IsBridge(TileIndex t)
+static inline bool IsBridge(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
-	return HasBit(_m[t].m5, 7);
+	return HasBit(t.m5(), 7);
 }
 
 /**
@@ -32,7 +32,7 @@ static inline bool IsBridge(TileIndex t)
  * @param t The tile to analyze
  * @return true if a bridge is present
  */
-static inline bool IsBridgeTile(TileIndex t)
+static inline bool IsBridgeTile(Tile t)
 {
 	return IsTileType(t, MP_TUNNELBRIDGE) && IsBridge(t);
 }
@@ -42,9 +42,9 @@ static inline bool IsBridgeTile(TileIndex t)
  * @param t The tile to analyze
  * @return true if a bridge is detected above
  */
-static inline bool IsBridgeAbove(TileIndex t)
+static inline bool IsBridgeAbove(Tile t)
 {
-	return GB(_m[t].type, 2, 2) != 0;
+	return GB(t.type(), 2, 2) != 0;
 }
 
 /**
@@ -53,10 +53,10 @@ static inline bool IsBridgeAbove(TileIndex t)
  * @pre IsBridgeTile(t)
  * @return The bridge type
  */
-static inline BridgeType GetBridgeType(TileIndex t)
+static inline BridgeType GetBridgeType(Tile t)
 {
 	assert(IsBridgeTile(t));
-	return GB(_me[t].m6, 2, 4);
+	return GB(t.m6(), 2, 4);
 }
 
 /**
@@ -65,10 +65,10 @@ static inline BridgeType GetBridgeType(TileIndex t)
  * @pre IsBridgeAbove(t)
  * @return the above mentioned axis
  */
-static inline Axis GetBridgeAxis(TileIndex t)
+static inline Axis GetBridgeAxis(Tile t)
 {
 	assert(IsBridgeAbove(t));
-	return (Axis)(GB(_m[t].type, 2, 2) - 1);
+	return (Axis)(GB(t.type(), 2, 2) - 1);
 }
 
 TileIndex GetNorthernBridgeEnd(TileIndex t);
@@ -91,16 +91,16 @@ static inline int GetBridgePixelHeight(TileIndex tile)
  * @param t the tile to remove the bridge from
  * @param a the axis of the bridge to remove
  */
-static inline void ClearSingleBridgeMiddle(TileIndex t, Axis a)
+static inline void ClearSingleBridgeMiddle(Tile t, Axis a)
 {
-	ClrBit(_m[t].type, 2 + a);
+	ClrBit(t.type(), 2 + a);
 }
 
 /**
  * Removes bridges from the given, that is bridges along the X and Y axis.
  * @param t the tile to remove the bridge from
  */
-static inline void ClearBridgeMiddle(TileIndex t)
+static inline void ClearBridgeMiddle(Tile t)
 {
 	ClearSingleBridgeMiddle(t, AXIS_X);
 	ClearSingleBridgeMiddle(t, AXIS_Y);
@@ -111,9 +111,9 @@ static inline void ClearBridgeMiddle(TileIndex t)
  * @param t the tile to add the bridge to
  * @param a the axis of the bridge to add
  */
-static inline void SetBridgeMiddle(TileIndex t, Axis a)
+static inline void SetBridgeMiddle(Tile t, Axis a)
 {
-	SetBit(_m[t].type, 2 + a);
+	SetBit(t.type(), 2 + a);
 }
 
 /**
@@ -125,18 +125,18 @@ static inline void SetBridgeMiddle(TileIndex t, Axis a)
  * @param tt         the transport type of the bridge
  * @note this function should not be called directly.
  */
-static inline void MakeBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt)
+static inline void MakeBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, TransportType tt)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);
 	SetDockingTile(t, false);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = INVALID_ROADTYPE;
-	_m[t].m5 = 1 << 7 | tt << 2 | d;
-	SB(_me[t].m6, 2, 4, bridgetype);
-	_me[t].m7 = 0;
-	_me[t].m8 = INVALID_ROADTYPE << 6;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = INVALID_ROADTYPE;
+	t.m5() = 1 << 7 | tt << 2 | d;
+	SB(t.m6(), 2, 4, bridgetype);
+	t.m7() = 0;
+	t.m8() = INVALID_ROADTYPE << 6;
 }
 
 /**
@@ -150,7 +150,7 @@ static inline void MakeBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, D
  * @param road_rt    the road type of the bridge
  * @param tram_rt    the tram type of the bridge
  */
-static inline void MakeRoadBridgeRamp(TileIndex t, Owner o, Owner owner_road, Owner owner_tram, BridgeType bridgetype, DiagDirection d, RoadType road_rt, RoadType tram_rt)
+static inline void MakeRoadBridgeRamp(Tile t, Owner o, Owner owner_road, Owner owner_tram, BridgeType bridgetype, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {
 	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_ROAD);
 	SetRoadOwner(t, RTT_ROAD, owner_road);
@@ -166,7 +166,7 @@ static inline void MakeRoadBridgeRamp(TileIndex t, Owner o, Owner owner_road, Ow
  * @param d          the direction this ramp must be facing
  * @param rt         the rail type of the bridge
  */
-static inline void MakeRailBridgeRamp(TileIndex t, Owner o, BridgeType bridgetype, DiagDirection d, RailType rt)
+static inline void MakeRailBridgeRamp(Tile t, Owner o, BridgeType bridgetype, DiagDirection d, RailType rt)
 {
 	MakeBridgeRamp(t, o, bridgetype, d, TRANSPORT_RAIL);
 	SetRailType(t, rt);
@@ -178,7 +178,7 @@ static inline void MakeRailBridgeRamp(TileIndex t, Owner o, BridgeType bridgetyp
  * @param o          the new owner of the bridge ramp
  * @param d          the direction this ramp must be facing
  */
-static inline void MakeAqueductBridgeRamp(TileIndex t, Owner o, DiagDirection d)
+static inline void MakeAqueductBridgeRamp(Tile t, Owner o, DiagDirection d)
 {
 	MakeBridgeRamp(t, o, 0, d, TRANSPORT_WATER);
 }

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -32,10 +32,10 @@ enum ClearGround {
  * @pre IsTileType(t, MP_CLEAR)
  * @return whether the tile is covered with snow.
  */
-static inline bool IsSnowTile(TileIndex t)
+static inline bool IsSnowTile(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
-	return HasBit(_m[t].m3, 4);
+	return HasBit(t.m3(), 4);
 }
 
 /**
@@ -44,10 +44,10 @@ static inline bool IsSnowTile(TileIndex t)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the ground type
  */
-static inline ClearGround GetRawClearGround(TileIndex t)
+static inline ClearGround GetRawClearGround(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
-	return (ClearGround)GB(_m[t].m5, 2, 3);
+	return (ClearGround)GB(t.m5(), 2, 3);
 }
 
 /**
@@ -56,7 +56,7 @@ static inline ClearGround GetRawClearGround(TileIndex t)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the ground type
  */
-static inline ClearGround GetClearGround(TileIndex t)
+static inline ClearGround GetClearGround(Tile t)
 {
 	if (IsSnowTile(t)) return CLEAR_SNOW;
 	return GetRawClearGround(t);
@@ -68,7 +68,7 @@ static inline ClearGround GetClearGround(TileIndex t)
  * @param ct the ground type
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline bool IsClearGround(TileIndex t, ClearGround ct)
+static inline bool IsClearGround(Tile t, ClearGround ct)
 {
 	return GetClearGround(t) == ct;
 }
@@ -80,10 +80,10 @@ static inline bool IsClearGround(TileIndex t, ClearGround ct)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the density
  */
-static inline uint GetClearDensity(TileIndex t)
+static inline uint GetClearDensity(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
-	return GB(_m[t].m5, 0, 2);
+	return GB(t.m5(), 0, 2);
 }
 
 /**
@@ -92,10 +92,10 @@ static inline uint GetClearDensity(TileIndex t)
  * @param d the amount to increment the density with
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void AddClearDensity(TileIndex t, int d)
+static inline void AddClearDensity(Tile t, int d)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
-	_m[t].m5 += d;
+	t.m5() += d;
 }
 
 /**
@@ -104,10 +104,10 @@ static inline void AddClearDensity(TileIndex t, int d)
  * @param d the new density
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void SetClearDensity(TileIndex t, uint d)
+static inline void SetClearDensity(Tile t, uint d)
 {
 	assert(IsTileType(t, MP_CLEAR));
-	SB(_m[t].m5, 0, 2, d);
+	SB(t.m5(), 0, 2, d);
 }
 
 
@@ -117,10 +117,10 @@ static inline void SetClearDensity(TileIndex t, uint d)
  * @pre IsTileType(t, MP_CLEAR)
  * @return the value of the counter
  */
-static inline uint GetClearCounter(TileIndex t)
+static inline uint GetClearCounter(Tile t)
 {
 	assert(IsTileType(t, MP_CLEAR));
-	return GB(_m[t].m5, 5, 3);
+	return GB(t.m5(), 5, 3);
 }
 
 /**
@@ -129,10 +129,10 @@ static inline uint GetClearCounter(TileIndex t)
  * @param c the amount to increment the counter with
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void AddClearCounter(TileIndex t, int c)
+static inline void AddClearCounter(Tile t, int c)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
-	_m[t].m5 += c << 5;
+	t.m5() += c << 5;
 }
 
 /**
@@ -141,10 +141,10 @@ static inline void AddClearCounter(TileIndex t, int c)
  * @param c the amount to set the counter to
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void SetClearCounter(TileIndex t, uint c)
+static inline void SetClearCounter(Tile t, uint c)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
-	SB(_m[t].m5, 5, 3, c);
+	SB(t.m5(), 5, 3, c);
 }
 
 
@@ -155,10 +155,10 @@ static inline void SetClearCounter(TileIndex t, uint c)
  * @param density the density of the ground tile
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void SetClearGroundDensity(TileIndex t, ClearGround type, uint density)
+static inline void SetClearGroundDensity(Tile t, ClearGround type, uint density)
 {
 	assert(IsTileType(t, MP_CLEAR)); // XXX incomplete
-	_m[t].m5 = 0 << 5 | type << 2 | density;
+	t.m5() = 0 << 5 | type << 2 | density;
 }
 
 
@@ -168,10 +168,10 @@ static inline void SetClearGroundDensity(TileIndex t, ClearGround type, uint den
  * @pre GetClearGround(t) == CLEAR_FIELDS
  * @return the field type
  */
-static inline uint GetFieldType(TileIndex t)
+static inline uint GetFieldType(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	return GB(_m[t].m3, 0, 4);
+	return GB(t.m3(), 0, 4);
 }
 
 /**
@@ -180,10 +180,10 @@ static inline uint GetFieldType(TileIndex t)
  * @param f the field type
  * @pre GetClearGround(t) == CLEAR_FIELDS
  */
-static inline void SetFieldType(TileIndex t, uint f)
+static inline void SetFieldType(Tile t, uint f)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS); // XXX incomplete
-	SB(_m[t].m3, 0, 4, f);
+	SB(t.m3(), 0, 4, f);
 }
 
 /**
@@ -192,10 +192,10 @@ static inline void SetFieldType(TileIndex t, uint f)
  * @pre GetClearGround(t) == CLEAR_FIELDS
  * @return the industry that made the field
  */
-static inline IndustryID GetIndustryIndexOfField(TileIndex t)
+static inline IndustryID GetIndustryIndexOfField(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	return(IndustryID) _m[t].m2;
+	return(IndustryID) t.m2();
 }
 
 /**
@@ -204,10 +204,10 @@ static inline IndustryID GetIndustryIndexOfField(TileIndex t)
  * @param i the industry that made the field
  * @pre GetClearGround(t) == CLEAR_FIELDS
  */
-static inline void SetIndustryIndexOfField(TileIndex t, IndustryID i)
+static inline void SetIndustryIndexOfField(Tile t, IndustryID i)
 {
 	assert(GetClearGround(t) == CLEAR_FIELDS);
-	_m[t].m2 = i;
+	t.m2() = i;
 }
 
 
@@ -218,15 +218,15 @@ static inline void SetIndustryIndexOfField(TileIndex t, IndustryID i)
  * @pre IsClearGround(t, CLEAR_FIELDS)
  * @return 0 if there is no fence, otherwise the fence type
  */
-static inline uint GetFence(TileIndex t, DiagDirection side)
+static inline uint GetFence(Tile t, DiagDirection side)
 {
 	assert(IsClearGround(t, CLEAR_FIELDS));
 	switch (side) {
 		default: NOT_REACHED();
-		case DIAGDIR_SE: return GB(_m[t].m4, 2, 3);
-		case DIAGDIR_SW: return GB(_m[t].m4, 5, 3);
-		case DIAGDIR_NE: return GB(_m[t].m3, 5, 3);
-		case DIAGDIR_NW: return GB(_me[t].m6, 2, 3);
+		case DIAGDIR_SE: return GB(t.m4(), 2, 3);
+		case DIAGDIR_SW: return GB(t.m4(), 5, 3);
+		case DIAGDIR_NE: return GB(t.m3(), 5, 3);
+		case DIAGDIR_NW: return GB(t.m6(), 2, 3);
 	}
 }
 
@@ -237,15 +237,15 @@ static inline uint GetFence(TileIndex t, DiagDirection side)
  * @param h 0 if there is no fence, otherwise the fence type
  * @pre IsClearGround(t, CLEAR_FIELDS)
  */
-static inline void SetFence(TileIndex t, DiagDirection side, uint h)
+static inline void SetFence(Tile t, DiagDirection side, uint h)
 {
 	assert(IsClearGround(t, CLEAR_FIELDS));
 	switch (side) {
 		default: NOT_REACHED();
-		case DIAGDIR_SE: SB(_m[t].m4, 2, 3, h); break;
-		case DIAGDIR_SW: SB(_m[t].m4, 5, 3, h); break;
-		case DIAGDIR_NE: SB(_m[t].m3, 5, 3, h); break;
-		case DIAGDIR_NW: SB(_me[t].m6, 2, 3, h); break;
+		case DIAGDIR_SE: SB(t.m4(), 2, 3, h); break;
+		case DIAGDIR_SW: SB(t.m4(), 5, 3, h); break;
+		case DIAGDIR_NE: SB(t.m3(), 5, 3, h); break;
+		case DIAGDIR_NW: SB(t.m6(), 2, 3, h); break;
 	}
 }
 
@@ -256,18 +256,18 @@ static inline void SetFence(TileIndex t, DiagDirection side, uint h)
  * @param g       the type of ground
  * @param density the density of the grass/snow/desert etc
  */
-static inline void MakeClear(TileIndex t, ClearGround g, uint density)
+static inline void MakeClear(Tile t, ClearGround g, uint density)
 {
 	SetTileType(t, MP_CLEAR);
-	_m[t].m1 = 0;
+	t.m1() = 0;
 	SetTileOwner(t, OWNER_NONE);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0 << 5 | 0 << 2;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0 << 5 | 0 << 2;
 	SetClearGroundDensity(t, g, density); // Sets m5
-	_me[t].m6 = 0;
-	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	t.m6() = 0;
+	t.m7() = 0;
+	t.m8() = 0;
 }
 
 
@@ -277,18 +277,18 @@ static inline void MakeClear(TileIndex t, ClearGround g, uint density)
  * @param field_type the 'growth' level of the field
  * @param industry   the industry this tile belongs to
  */
-static inline void MakeField(TileIndex t, uint field_type, IndustryID industry)
+static inline void MakeField(Tile t, uint field_type, IndustryID industry)
 {
 	SetTileType(t, MP_CLEAR);
-	_m[t].m1 = 0;
+	t.m1() = 0;
 	SetTileOwner(t, OWNER_NONE);
-	_m[t].m2 = industry;
-	_m[t].m3 = field_type;
-	_m[t].m4 = 0 << 5 | 0 << 2;
+	t.m2() = industry;
+	t.m3() = field_type;
+	t.m4() = 0 << 5 | 0 << 2;
 	SetClearGroundDensity(t, CLEAR_FIELDS, 3);
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
+	t.m8() = 0;
 }
 
 /**
@@ -297,10 +297,10 @@ static inline void MakeField(TileIndex t, uint field_type, IndustryID industry)
  * @param density The density of snowiness.
  * @pre GetClearGround(t) != CLEAR_SNOW
  */
-static inline void MakeSnow(TileIndex t, uint density = 0)
+static inline void MakeSnow(Tile t, uint density = 0)
 {
 	assert(GetClearGround(t) != CLEAR_SNOW);
-	SetBit(_m[t].m3, 4);
+	SetBit(t.m3(), 4);
 	if (GetRawClearGround(t) == CLEAR_FIELDS) {
 		SetClearGroundDensity(t, CLEAR_GRASS, density);
 	} else {
@@ -313,10 +313,10 @@ static inline void MakeSnow(TileIndex t, uint density = 0)
  * @param t the tile to clear of snow
  * @pre GetClearGround(t) == CLEAR_SNOW
  */
-static inline void ClearSnow(TileIndex t)
+static inline void ClearSnow(Tile t)
 {
 	assert(GetClearGround(t) == CLEAR_SNOW);
-	ClrBit(_m[t].m3, 4);
+	ClrBit(t.m3(), 4);
 	SetClearDensity(t, 3);
 }
 

--- a/src/depot_map.h
+++ b/src/depot_map.h
@@ -15,7 +15,7 @@
 /**
  * Check if a tile is a depot and it is a depot of the given type.
  */
-static inline bool IsDepotTypeTile(TileIndex tile, TransportType type)
+static inline bool IsDepotTypeTile(Tile tile, TransportType type)
 {
 	switch (type) {
 		default: NOT_REACHED();
@@ -38,7 +38,7 @@ static inline bool IsDepotTypeTile(TileIndex tile, TransportType type)
  * @param tile the tile to check
  * @return true if and only if there is a depot on the tile.
  */
-static inline bool IsDepotTile(TileIndex tile)
+static inline bool IsDepotTile(Tile tile)
 {
 	return IsRailDepotTile(tile) || IsRoadDepotTile(tile) || IsShipDepotTile(tile) || IsHangarTile(tile);
 }
@@ -49,11 +49,11 @@ static inline bool IsDepotTile(TileIndex tile)
  * @pre IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t)
  * @return DepotID
  */
-static inline DepotID GetDepotIndex(TileIndex t)
+static inline DepotID GetDepotIndex(Tile t)
 {
 	/* Hangars don't have a Depot class, thus store no DepotID. */
 	assert(IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t));
-	return _m[t].m2;
+	return t.m2();
 }
 
 /**
@@ -62,7 +62,7 @@ static inline DepotID GetDepotIndex(TileIndex t)
  * @pre IsDepotTile(t)
  * @return the type of vehicles that can use the depot
  */
-static inline VehicleType GetDepotVehicleType(TileIndex t)
+static inline VehicleType GetDepotVehicleType(Tile t)
 {
 	switch (GetTileType(t)) {
 		default: NOT_REACHED();

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -103,7 +103,7 @@ void ResetIndustries()
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return general type for this industry, as defined in industry.h
  */
-IndustryType GetIndustryType(TileIndex tile)
+IndustryType GetIndustryType(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
 

--- a/src/industry_map.h
+++ b/src/industry_map.h
@@ -60,10 +60,10 @@ enum IndustryGraphics {
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return the industry ID
  */
-static inline IndustryID GetIndustryIndex(TileIndex t)
+static inline IndustryID GetIndustryIndex(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
-	return _m[t].m2;
+	return t.m2();
 }
 
 /**
@@ -72,23 +72,23 @@ static inline IndustryID GetIndustryIndex(TileIndex t)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return true if and only if the industry tile is fully built
  */
-static inline bool IsIndustryCompleted(TileIndex t)
+static inline bool IsIndustryCompleted(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
-	return HasBit(_m[t].m1, 7);
+	return HasBit(t.m1(), 7);
 }
 
-IndustryType GetIndustryType(TileIndex tile);
+IndustryType GetIndustryType(Tile tile);
 
 /**
  * Set if the industry that owns the tile as under construction or not
  * @param tile the tile to query
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryCompleted(TileIndex tile)
+static inline void SetIndustryCompleted(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(_m[tile].m1, 7, 1, 1);
+	SB(tile.m1(), 7, 1, 1);
 }
 
 /**
@@ -97,10 +97,10 @@ static inline void SetIndustryCompleted(TileIndex tile)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return the construction stage
  */
-static inline byte GetIndustryConstructionStage(TileIndex tile)
+static inline byte GetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return IsIndustryCompleted(tile) ? (byte)INDUSTRY_COMPLETED : GB(_m[tile].m1, 0, 2);
+	return IsIndustryCompleted(tile) ? (byte)INDUSTRY_COMPLETED : GB(tile.m1(), 0, 2);
 }
 
 /**
@@ -109,10 +109,10 @@ static inline byte GetIndustryConstructionStage(TileIndex tile)
  * @param value the new construction stage
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryConstructionStage(TileIndex tile, byte value)
+static inline void SetIndustryConstructionStage(Tile tile, byte value)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(_m[tile].m1, 0, 2, value);
+	SB(tile.m1(), 0, 2, value);
 }
 
 /**
@@ -122,10 +122,10 @@ static inline void SetIndustryConstructionStage(TileIndex tile, byte value)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return the gfx ID
  */
-static inline IndustryGfx GetCleanIndustryGfx(TileIndex t)
+static inline IndustryGfx GetCleanIndustryGfx(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
-	return _m[t].m5 | (GB(_me[t].m6, 2, 1) << 8);
+	return t.m5() | (GB(t.m6(), 2, 1) << 8);
 }
 
 /**
@@ -134,7 +134,7 @@ static inline IndustryGfx GetCleanIndustryGfx(TileIndex t)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @return the gfx ID
  */
-static inline IndustryGfx GetIndustryGfx(TileIndex t)
+static inline IndustryGfx GetIndustryGfx(Tile t)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
 	return GetTranslatedIndustryTileID(GetCleanIndustryGfx(t));
@@ -146,11 +146,11 @@ static inline IndustryGfx GetIndustryGfx(TileIndex t)
  * @pre IsTileType(t, MP_INDUSTRY)
  * @param gfx the graphics ID
  */
-static inline void SetIndustryGfx(TileIndex t, IndustryGfx gfx)
+static inline void SetIndustryGfx(Tile t, IndustryGfx gfx)
 {
 	assert(IsTileType(t, MP_INDUSTRY));
-	_m[t].m5 = GB(gfx, 0, 8);
-	SB(_me[t].m6, 2, 1, GB(gfx, 8, 1));
+	t.m5() = GB(gfx, 0, 8);
+	SB(t.m6(), 2, 1, GB(gfx, 8, 1));
 }
 
 /**
@@ -159,10 +159,10 @@ static inline void SetIndustryGfx(TileIndex t, IndustryGfx gfx)
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return the construction counter
  */
-static inline byte GetIndustryConstructionCounter(TileIndex tile)
+static inline byte GetIndustryConstructionCounter(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return GB(_m[tile].m1, 2, 2);
+	return GB(tile.m1(), 2, 2);
 }
 
 /**
@@ -171,10 +171,10 @@ static inline byte GetIndustryConstructionCounter(TileIndex tile)
  * @param value the new value for the construction counter
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryConstructionCounter(TileIndex tile, byte value)
+static inline void SetIndustryConstructionCounter(Tile tile, byte value)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(_m[tile].m1, 2, 2, value);
+	SB(tile.m1(), 2, 2, value);
 }
 
 /**
@@ -184,11 +184,11 @@ static inline void SetIndustryConstructionCounter(TileIndex tile, byte value)
  * @param tile the tile to query
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void ResetIndustryConstructionStage(TileIndex tile)
+static inline void ResetIndustryConstructionStage(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(_m[tile].m1, 0, 4, 0);
-	SB(_m[tile].m1, 7, 1, 0);
+	SB(tile.m1(), 0, 4, 0);
+	SB(tile.m1(), 7, 1, 0);
 }
 
 /**
@@ -196,10 +196,10 @@ static inline void ResetIndustryConstructionStage(TileIndex tile)
  * @param tile the tile to get the animation loop number of
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline byte GetIndustryAnimationLoop(TileIndex tile)
+static inline byte GetIndustryAnimationLoop(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return _m[tile].m4;
+	return tile.m4();
 }
 
 /**
@@ -208,63 +208,63 @@ static inline byte GetIndustryAnimationLoop(TileIndex tile)
  * @param count the new animation frame number
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryAnimationLoop(TileIndex tile, byte count)
+static inline void SetIndustryAnimationLoop(Tile tile, byte count)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	_m[tile].m4 = count;
+	tile.m4() = count;
 }
 
 /**
  * Get the random bits for this tile.
  * Used for grf callbacks
- * @param tile TileIndex of the tile to query
+ * @param tile the tile to query
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested bits
  */
-static inline byte GetIndustryRandomBits(TileIndex tile)
+static inline byte GetIndustryRandomBits(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return _m[tile].m3;
+	return tile.m3();
 }
 
 /**
  * Set the random bits for this tile.
  * Used for grf callbacks
- * @param tile TileIndex of the tile to query
+ * @param tile the tile to query
  * @param bits the random bits
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryRandomBits(TileIndex tile, byte bits)
+static inline void SetIndustryRandomBits(Tile tile, byte bits)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	_m[tile].m3 = bits;
+	tile.m3() = bits;
 }
 
 /**
  * Get the activated triggers bits for this industry tile
  * Used for grf callbacks
- * @param tile TileIndex of the tile to query
+ * @param tile the tile to query
  * @pre IsTileType(tile, MP_INDUSTRY)
  * @return requested triggers
  */
-static inline byte GetIndustryTriggers(TileIndex tile)
+static inline byte GetIndustryTriggers(Tile tile)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	return GB(_me[tile].m6, 3, 3);
+	return GB(tile.m6(), 3, 3);
 }
 
 
 /**
  * Set the activated triggers bits for this industry tile
  * Used for grf callbacks
- * @param tile TileIndex of the tile to query
+ * @param tile the tile to query
  * @param triggers the triggers to set
  * @pre IsTileType(tile, MP_INDUSTRY)
  */
-static inline void SetIndustryTriggers(TileIndex tile, byte triggers)
+static inline void SetIndustryTriggers(Tile tile, byte triggers)
 {
 	assert(IsTileType(tile, MP_INDUSTRY));
-	SB(_me[tile].m6, 3, 3, triggers);
+	SB(tile.m6(), 3, 3, triggers);
 }
 
 /**
@@ -275,17 +275,17 @@ static inline void SetIndustryTriggers(TileIndex tile, byte triggers)
  * @param random the random value
  * @param wc     the water class for this industry; only useful when build on water
  */
-static inline void MakeIndustry(TileIndex t, IndustryID index, IndustryGfx gfx, uint8 random, WaterClass wc)
+static inline void MakeIndustry(Tile t, IndustryID index, IndustryGfx gfx, uint8 random, WaterClass wc)
 {
 	SetTileType(t, MP_INDUSTRY);
-	_m[t].m1 = 0;
-	_m[t].m2 = index;
+	t.m1() = 0;
+	t.m2() = index;
 	SetIndustryRandomBits(t, random); // m3
-	_m[t].m4 = 0;
+	t.m4() = 0;
 	SetIndustryGfx(t, gfx); // m5, part of m6
 	SetIndustryTriggers(t, 0); // rest of m6
 	SetWaterClass(t, wc);
-	_me[t].m7 = 0;
+	t.m7() = 0;
 }
 
 #endif /* INDUSTRY_MAP_H */

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -27,8 +27,8 @@ extern "C" _CRTIMP void __cdecl _assert(void *, void *, unsigned);
 /* static */ uint Map::size;      ///< The number of tiles on the map
 /* static */ uint Map::tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
-TileBase *_m = nullptr;          ///< Tiles of the map
-TileExtended *_me = nullptr; ///< Extended Tiles of the map
+/* static */ Tile::TileBase *Tile::base_tiles = nullptr;         ///< Base tiles of the map
+/* static */ Tile::TileExtended *Tile::extended_tiles = nullptr; ///< Extended tiles of the map
 
 
 /**
@@ -56,11 +56,11 @@ TileExtended *_me = nullptr; ///< Extended Tiles of the map
 	Map::size = size_x * size_y;
 	Map::tile_mask = Map::size - 1;
 
-	free(_m);
-	free(_me);
+	free(Tile::base_tiles);
+	free(Tile::extended_tiles);
 
-	_m = CallocT<TileBase>(Map::size);
-	_me = CallocT<TileExtended>(Map::size);
+	Tile::base_tiles = CallocT<Tile::TileBase>(Map::size);
+	Tile::extended_tiles = CallocT<Tile::TileExtended>(Map::size);
 }
 
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -27,7 +27,7 @@ extern "C" _CRTIMP void __cdecl _assert(void *, void *, unsigned);
 /* static */ uint Map::size;      ///< The number of tiles on the map
 /* static */ uint Map::tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
-Tile *_m = nullptr;          ///< Tiles of the map
+TileBase *_m = nullptr;          ///< Tiles of the map
 TileExtended *_me = nullptr; ///< Extended Tiles of the map
 
 
@@ -59,7 +59,7 @@ TileExtended *_me = nullptr; ///< Extended Tiles of the map
 	free(_m);
 	free(_me);
 
-	_m = CallocT<Tile>(Map::size);
+	_m = CallocT<TileBase>(Map::size);
 	_me = CallocT<TileExtended>(Map::size);
 }
 

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -16,22 +16,6 @@
 #include "direction_func.h"
 
 /**
- * Pointer to the tile-array.
- *
- * This variable points to the tile-array which contains the tiles of
- * the map.
- */
-extern TileBase *_m;
-
-/**
- * Pointer to the extended tile-array.
- *
- * This variable points to the extended tile-array which contains the tiles
- * of the map.
- */
-extern TileExtended *_me;
-
-/**
  * Wrapper class to abstract away the way the tiles are stored. It is
  * intended to be used to access the "map" data of a single tile.
  *
@@ -40,6 +24,36 @@ extern TileExtended *_me;
  */
 class Tile {
 private:
+	friend struct Map;
+	/**
+	 * Data that is stored per tile. Also used TileExtended for this.
+	 * Look at docs/landscape.html for the exact meaning of the members.
+	 */
+	struct TileBase {
+		byte   type;   ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
+		byte   height; ///< The height of the northern corner.
+		uint16 m2;     ///< Primarily used for indices to towns, industries and stations
+		byte   m1;     ///< Primarily used for ownership information
+		byte   m3;     ///< General purpose
+		byte   m4;     ///< General purpose
+		byte   m5;     ///< General purpose
+	};
+
+	static_assert(sizeof(TileBase) == 8);
+
+	/**
+	 * Data that is stored per tile. Also used TileBase for this.
+	 * Look at docs/landscape.html for the exact meaning of the members.
+	 */
+	struct TileExtended {
+		byte m6;   ///< General purpose
+		byte m7;   ///< Primarily used for newgrf support
+		uint16 m8; ///< General purpose
+	};
+
+	static TileBase *base_tiles;         ///< Pointer to the tile-array.
+	static TileExtended *extended_tiles; ///< Pointer to the extended tile-array.
+
 	TileIndex tile; ///< The tile to access the map data for.
 
 public:
@@ -74,7 +88,7 @@ public:
 	 */
 	debug_inline byte &type()
 	{
-		return _m[tile].type;
+		return base_tiles[tile].type;
 	}
 
 	/**
@@ -86,7 +100,7 @@ public:
 	 */
 	debug_inline byte &height()
 	{
-		return _m[tile].height;
+		return base_tiles[tile].height;
 	}
 
 	/**
@@ -98,7 +112,7 @@ public:
 	 */
 	debug_inline byte &m1()
 	{
-		return _m[tile].m1;
+		return base_tiles[tile].m1;
 	}
 
 	/**
@@ -110,7 +124,7 @@ public:
 	 */
 	debug_inline uint16 &m2()
 	{
-		return _m[tile].m2;
+		return base_tiles[tile].m2;
 	}
 
 	/**
@@ -122,7 +136,7 @@ public:
 	 */
 	debug_inline byte &m3()
 	{
-		return _m[tile].m3;
+		return base_tiles[tile].m3;
 	}
 
 	/**
@@ -134,7 +148,7 @@ public:
 	 */
 	debug_inline byte &m4()
 	{
-		return _m[tile].m4;
+		return base_tiles[tile].m4;
 	}
 
 	/**
@@ -146,7 +160,7 @@ public:
 	 */
 	debug_inline byte &m5()
 	{
-		return _m[tile].m5;
+		return base_tiles[tile].m5;
 	}
 
 	/**
@@ -158,7 +172,7 @@ public:
 	 */
 	debug_inline byte &m6()
 	{
-		return _me[tile].m6;
+		return extended_tiles[tile].m6;
 	}
 
 	/**
@@ -170,7 +184,7 @@ public:
 	 */
 	debug_inline byte &m7()
 	{
-		return _me[tile].m7;
+		return extended_tiles[tile].m7;
 	}
 
 	/**
@@ -182,7 +196,7 @@ public:
 	 */
 	debug_inline uint16 &m8()
 	{
-		return _me[tile].m8;
+		return extended_tiles[tile].m8;
 	}
 };
 
@@ -339,7 +353,7 @@ public:
 	 */
 	static bool IsInitialized()
 	{
-		return _m != nullptr;
+		return Tile::base_tiles != nullptr;
 	}
 
 	/**

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -32,6 +32,155 @@ extern TileBase *_m;
 extern TileExtended *_me;
 
 /**
+ * Wrapper class to abstract away the way the tiles are stored. It is
+ * intended to be used to access the "map" data of a single tile.
+ *
+ * The wrapper is expected to be fully optimized away by the compiler, even
+ * with low optimization levels except when completely disabling it.
+ */
+class Tile {
+private:
+	TileIndex tile; ///< The tile to access the map data for.
+
+public:
+	/**
+	 * Create the tile wrapper for the given tile.
+	 * @param tile The tile to access the map for.
+	 */
+	debug_inline Tile(TileIndex tile) : tile(tile) {}
+
+	/**
+	 * Implicit conversion to the TileIndex.
+	 */
+	debug_inline constexpr operator TileIndex() const { return tile; }
+
+	/**
+	 * Implicit conversion to the uint for bounds checking.
+	 */
+	debug_inline constexpr operator uint() const { return tile; }
+
+	/**
+	 * The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &type()
+	{
+		return _m[tile].type;
+	}
+
+	/**
+	 * The height of the northern corner
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the height for.
+	 * @return reference to the byte holding the height.
+	 */
+	debug_inline byte &height()
+	{
+		return _m[tile].height;
+	}
+
+	/**
+	 * Primarily used for ownership information
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &m1()
+	{
+		return _m[tile].m1;
+	}
+
+	/**
+	 * Primarily used for indices to towns, industries and stations
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the uint16 holding the data.
+	 */
+	debug_inline uint16 &m2()
+	{
+		return _m[tile].m2;
+	}
+
+	/**
+	 * General purpose
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &m3()
+	{
+		return _m[tile].m3;
+	}
+
+	/**
+	 * General purpose
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &m4()
+	{
+		return _m[tile].m4;
+	}
+
+	/**
+	 * General purpose
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &m5()
+	{
+		return _m[tile].m5;
+	}
+
+	/**
+	 * General purpose
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &m6()
+	{
+		return _me[tile].m6;
+	}
+
+	/**
+	 * Primarily used for newgrf support
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the byte holding the data.
+	 */
+	debug_inline byte &m7()
+	{
+		return _me[tile].m7;
+	}
+
+	/**
+	 * General purpose
+	 *
+	 * Look at docs/landscape.html for the exact meaning of the data.
+	 * @param tile The tile to get the data for.
+	 * @return reference to the uint16 holding the data.
+	 */
+	debug_inline uint16 &m8()
+	{
+		return _me[tile].m8;
+	}
+};
+
+/**
  * Size related data of the map.
  */
 struct Map {

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -21,7 +21,7 @@
  * This variable points to the tile-array which contains the tiles of
  * the map.
  */
-extern Tile *_m;
+extern TileBase *_m;
 
 /**
  * Pointer to the extended tile-array.

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -50,6 +50,12 @@ public:
 	debug_inline Tile(TileIndex tile) : tile(tile) {}
 
 	/**
+	 * Create the tile wrapper for the given tile.
+	 * @param tile The tile to access the map for.
+	 */
+	Tile(uint tile) : tile(tile) {}
+
+	/**
 	 * Implicit conversion to the TileIndex.
 	 */
 	debug_inline constexpr operator TileIndex() const { return tile; }
@@ -189,16 +195,16 @@ private:
 	 * Iterator to iterate all Tiles
 	 */
 	struct Iterator {
-		typedef TileIndex value_type;
-		typedef TileIndex *pointer;
-		typedef TileIndex &reference;
+		typedef Tile value_type;
+		typedef Tile *pointer;
+		typedef Tile &reference;
 		typedef size_t difference_type;
 		typedef std::forward_iterator_tag iterator_category;
 
 		explicit Iterator(TileIndex index) : index(index) {}
 		bool operator==(const Iterator &other) const { return this->index == other.index; }
 		bool operator!=(const Iterator &other) const { return !(*this == other); }
-		TileIndex operator*() const { return this->index; }
+		Tile operator*() const { return this->index; }
 		Iterator & operator++() { this->index++; return *this; }
 	private:
 		TileIndex index;

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -36,6 +36,34 @@ extern TileExtended *_me;
  */
 struct Map {
 private:
+	/**
+	 * Iterator to iterate all Tiles
+	 */
+	struct Iterator {
+		typedef TileIndex value_type;
+		typedef TileIndex *pointer;
+		typedef TileIndex &reference;
+		typedef size_t difference_type;
+		typedef std::forward_iterator_tag iterator_category;
+
+		explicit Iterator(TileIndex index) : index(index) {}
+		bool operator==(const Iterator &other) const { return this->index == other.index; }
+		bool operator!=(const Iterator &other) const { return !(*this == other); }
+		TileIndex operator*() const { return this->index; }
+		Iterator & operator++() { this->index++; return *this; }
+	private:
+		TileIndex index;
+	};
+
+	/*
+	 * Iterable ensemble of all Tiles
+	 */
+	struct IterateWrapper {
+		Iterator begin() { return Iterator(0); }
+		Iterator end() { return Iterator(Map::Size()); }
+		bool empty() { return false; }
+	};
+
 	static uint log_x;     ///< 2^_map_log_x == _map_size_x
 	static uint log_y;     ///< 2^_map_log_y == _map_size_y
 	static uint size_x;    ///< Size of the map along the X
@@ -158,6 +186,12 @@ public:
 	{
 		return _m != nullptr;
 	}
+
+	/**
+	 * Returns an iterable ensemble of all Tiles
+	 * @return an iterable ensemble of all Tiles
+	 */
+	static IterateWrapper Iterate() { return IterateWrapper(); }
 };
 
 /**

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -11,32 +11,6 @@
 #define MAP_TYPE_H
 
 /**
- * Data that is stored per tile. Also used TileExtended for this.
- * Look at docs/landscape.html for the exact meaning of the members.
- */
-struct TileBase {
-	byte   type;        ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
-	byte   height;      ///< The height of the northern corner.
-	uint16 m2;          ///< Primarily used for indices to towns, industries and stations
-	byte   m1;          ///< Primarily used for ownership information
-	byte   m3;          ///< General purpose
-	byte   m4;          ///< General purpose
-	byte   m5;          ///< General purpose
-};
-
-static_assert(sizeof(TileBase) == 8);
-
-/**
- * Data that is stored per tile. Also used TileBase for this.
- * Look at docs/landscape.html for the exact meaning of the members.
- */
-struct TileExtended {
-	byte m6;   ///< General purpose
-	byte m7;   ///< Primarily used for newgrf support
-	uint16 m8; ///< General purpose
-};
-
-/**
  * An offset value between two tiles.
  *
  * This value is used for the difference between

--- a/src/map_type.h
+++ b/src/map_type.h
@@ -14,7 +14,7 @@
  * Data that is stored per tile. Also used TileExtended for this.
  * Look at docs/landscape.html for the exact meaning of the members.
  */
-struct Tile {
+struct TileBase {
 	byte   type;        ///< The type (bits 4..7), bridges (2..3), rainforest/desert (0..1)
 	byte   height;      ///< The height of the northern corner.
 	uint16 m2;          ///< Primarily used for indices to towns, industries and stations
@@ -24,10 +24,10 @@ struct Tile {
 	byte   m5;          ///< General purpose
 };
 
-static_assert(sizeof(Tile) == 8);
+static_assert(sizeof(TileBase) == 8);
 
 /**
- * Data that is stored per tile. Also used Tile for this.
+ * Data that is stored per tile. Also used TileBase for this.
  * Look at docs/landscape.html for the exact meaning of the members.
  */
 struct TileExtended {

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -107,7 +107,7 @@ public:
 		}
 	}
 
-	LandInfoWindow(TileIndex tile) : Window(&_land_info_desc), tile(tile)
+	LandInfoWindow(Tile tile) : Window(&_land_info_desc), tile(tile)
 	{
 		this->InitNested();
 
@@ -117,16 +117,16 @@ public:
 #	define LANDINFOD_LEVEL 1
 #endif
 		Debug(misc, LANDINFOD_LEVEL, "TILE: {:#x} ({},{})", tile, TileX(tile), TileY(tile));
-		Debug(misc, LANDINFOD_LEVEL, "type   = {:#x}", _m[tile].type);
-		Debug(misc, LANDINFOD_LEVEL, "height = {:#x}", _m[tile].height);
-		Debug(misc, LANDINFOD_LEVEL, "m1     = {:#x}", _m[tile].m1);
-		Debug(misc, LANDINFOD_LEVEL, "m2     = {:#x}", _m[tile].m2);
-		Debug(misc, LANDINFOD_LEVEL, "m3     = {:#x}", _m[tile].m3);
-		Debug(misc, LANDINFOD_LEVEL, "m4     = {:#x}", _m[tile].m4);
-		Debug(misc, LANDINFOD_LEVEL, "m5     = {:#x}", _m[tile].m5);
-		Debug(misc, LANDINFOD_LEVEL, "m6     = {:#x}", _me[tile].m6);
-		Debug(misc, LANDINFOD_LEVEL, "m7     = {:#x}", _me[tile].m7);
-		Debug(misc, LANDINFOD_LEVEL, "m8     = {:#x}", _me[tile].m8);
+		Debug(misc, LANDINFOD_LEVEL, "type   = {:#x}", tile.type());
+		Debug(misc, LANDINFOD_LEVEL, "height = {:#x}", tile.height());
+		Debug(misc, LANDINFOD_LEVEL, "m1     = {:#x}", tile.m1());
+		Debug(misc, LANDINFOD_LEVEL, "m2     = {:#x}", tile.m2());
+		Debug(misc, LANDINFOD_LEVEL, "m3     = {:#x}", tile.m3());
+		Debug(misc, LANDINFOD_LEVEL, "m4     = {:#x}", tile.m4());
+		Debug(misc, LANDINFOD_LEVEL, "m5     = {:#x}", tile.m5());
+		Debug(misc, LANDINFOD_LEVEL, "m6     = {:#x}", tile.m6());
+		Debug(misc, LANDINFOD_LEVEL, "m7     = {:#x}", tile.m7());
+		Debug(misc, LANDINFOD_LEVEL, "m8     = {:#x}", tile.m8());
 #undef LANDINFOD_LEVEL
 	}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -61,7 +61,7 @@ uint16 Object::counts[NUM_OBJECTS];
  * @pre IsTileType(t, MP_OBJECT)
  * @return the type.
  */
-ObjectType GetObjectType(TileIndex t)
+ObjectType GetObjectType(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
 	return Object::GetByTile(t)->type;

--- a/src/object_map.h
+++ b/src/object_map.h
@@ -13,7 +13,7 @@
 #include "water_map.h"
 #include "object_type.h"
 
-ObjectType GetObjectType(TileIndex t);
+ObjectType GetObjectType(Tile t);
 
 /**
  * Check whether the object on a tile is of a specific type.
@@ -22,7 +22,7 @@ ObjectType GetObjectType(TileIndex t);
  * @pre IsTileType(t, MP_OBJECT)
  * @return True if type matches.
  */
-static inline bool IsObjectType(TileIndex t, ObjectType type)
+static inline bool IsObjectType(Tile t, ObjectType type)
 {
 	return GetObjectType(t) == type;
 }
@@ -33,7 +33,7 @@ static inline bool IsObjectType(TileIndex t, ObjectType type)
  * @param type Type to test.
  * @return True if type matches.
  */
-static inline bool IsObjectTypeTile(TileIndex t, ObjectType type)
+static inline bool IsObjectTypeTile(Tile t, ObjectType type)
 {
 	return IsTileType(t, MP_OBJECT) && GetObjectType(t) == type;
 }
@@ -44,10 +44,10 @@ static inline bool IsObjectTypeTile(TileIndex t, ObjectType type)
  * @pre IsTileType(t, MP_OBJECT)
  * @return The ObjectID of the object.
  */
-static inline ObjectID GetObjectIndex(TileIndex t)
+static inline ObjectID GetObjectIndex(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
-	return _m[t].m2 | _m[t].m5 << 16;
+	return t.m2() | t.m5() << 16;
 }
 
 /**
@@ -56,10 +56,10 @@ static inline ObjectID GetObjectIndex(TileIndex t)
  * @pre IsTileType(t, MP_OBJECT)
  * @return The random bits.
  */
-static inline byte GetObjectRandomBits(TileIndex t)
+static inline byte GetObjectRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_OBJECT));
-	return _m[t].m3;
+	return t.m3();
 }
 
 
@@ -71,17 +71,17 @@ static inline byte GetObjectRandomBits(TileIndex t)
  * @param wc     Water class for this object.
  * @param random Random data to store on the tile
  */
-static inline void MakeObject(TileIndex t, Owner o, ObjectID index, WaterClass wc, byte random)
+static inline void MakeObject(Tile t, Owner o, ObjectID index, WaterClass wc, byte random)
 {
 	SetTileType(t, MP_OBJECT);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
-	_m[t].m2 = index;
-	_m[t].m3 = random;
-	_m[t].m4 = 0;
-	_m[t].m5 = index >> 16;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = index;
+	t.m3() = random;
+	t.m4() = 0;
+	t.m5() = index >> 16;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 }
 
 #endif /* OBJECT_MAP_H */

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -144,7 +144,7 @@ static uint NPFHash(uint key1, uint key2)
 	uint part2 = TileY(key1) & NPF_HASH_HALFMASK;
 
 	assert(IsValidTrackdir((Trackdir)key2));
-	assert(IsValidTile(key1));
+	assert(IsValidTile((TileIndex)key1));
 	return ((part1 << NPF_HASH_HALFBITS | part2) + (NPF_HASH_SIZE * key2 / TRACKDIR_END)) % NPF_HASH_SIZE;
 }
 

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -152,7 +152,7 @@ extern const TrackdirBits _uphill_trackdirs[] = {
 /**
  * Return the rail type of tile, or INVALID_RAILTYPE if this is no rail tile.
  */
-RailType GetTileRailType(TileIndex tile)
+RailType GetTileRailType(Tile tile)
 {
 	switch (GetTileType(tile)) {
 		case MP_RAILWAY:

--- a/src/rail_map.h
+++ b/src/rail_map.h
@@ -33,10 +33,10 @@ enum RailTileType {
  * @pre IsTileType(t, MP_RAILWAY)
  * @return the RailTileType
  */
-debug_inline static RailTileType GetRailTileType(TileIndex t)
+debug_inline static RailTileType GetRailTileType(Tile t)
 {
 	assert(IsTileType(t, MP_RAILWAY));
-	return (RailTileType)GB(_m[t].m5, 6, 2);
+	return (RailTileType)GB(t.m5(), 6, 2);
 }
 
 /**
@@ -46,7 +46,7 @@ debug_inline static RailTileType GetRailTileType(TileIndex t)
  * @pre IsTileType(t, MP_RAILWAY)
  * @return true if and only if the tile is normal rail (with or without signals)
  */
-debug_inline static bool IsPlainRail(TileIndex t)
+debug_inline static bool IsPlainRail(Tile t)
 {
 	RailTileType rtt = GetRailTileType(t);
 	return rtt == RAIL_TILE_NORMAL || rtt == RAIL_TILE_SIGNALS;
@@ -57,7 +57,7 @@ debug_inline static bool IsPlainRail(TileIndex t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is normal rail (with or without signals)
  */
-debug_inline static bool IsPlainRailTile(TileIndex t)
+debug_inline static bool IsPlainRailTile(Tile t)
 {
 	return IsTileType(t, MP_RAILWAY) && IsPlainRail(t);
 }
@@ -69,7 +69,7 @@ debug_inline static bool IsPlainRailTile(TileIndex t)
  * @pre IsTileType(t, MP_RAILWAY)
  * @return true if and only if the tile has signals
  */
-static inline bool HasSignals(TileIndex t)
+static inline bool HasSignals(Tile t)
 {
 	return GetRailTileType(t) == RAIL_TILE_SIGNALS;
 }
@@ -80,10 +80,10 @@ static inline bool HasSignals(TileIndex t)
  * @param signals whether the rail tile should have signals or not
  * @pre IsPlainRailTile(tile)
  */
-static inline void SetHasSignals(TileIndex tile, bool signals)
+static inline void SetHasSignals(Tile tile, bool signals)
 {
 	assert(IsPlainRailTile(tile));
-	SB(_m[tile].m5, 6, 1, signals);
+	SB(tile.m5(), 6, 1, signals);
 }
 
 /**
@@ -92,7 +92,7 @@ static inline void SetHasSignals(TileIndex tile, bool signals)
  * @pre IsTileType(t, MP_RAILWAY)
  * @return true if and only if the tile is a rail depot
  */
-debug_inline static bool IsRailDepot(TileIndex t)
+debug_inline static bool IsRailDepot(Tile t)
 {
 	return GetRailTileType(t) == RAIL_TILE_DEPOT;
 }
@@ -102,7 +102,7 @@ debug_inline static bool IsRailDepot(TileIndex t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail depot
  */
-debug_inline static bool IsRailDepotTile(TileIndex t)
+debug_inline static bool IsRailDepotTile(Tile t)
 {
 	return IsTileType(t, MP_RAILWAY) && IsRailDepot(t);
 }
@@ -112,9 +112,9 @@ debug_inline static bool IsRailDepotTile(TileIndex t)
  * @param t the tile to get the rail type from
  * @return the rail type of the tile
  */
-static inline RailType GetRailType(TileIndex t)
+static inline RailType GetRailType(Tile t)
 {
-	return (RailType)GB(_me[t].m8, 0, 6);
+	return (RailType)GB(t.m8(), 0, 6);
 }
 
 /**
@@ -122,9 +122,9 @@ static inline RailType GetRailType(TileIndex t)
  * @param t the tile to set the rail type of
  * @param r the new rail type for the tile
  */
-static inline void SetRailType(TileIndex t, RailType r)
+static inline void SetRailType(Tile t, RailType r)
 {
-	SB(_me[t].m8, 0, 6, r);
+	SB(t.m8(), 0, 6, r);
 }
 
 
@@ -133,10 +133,10 @@ static inline void SetRailType(TileIndex t, RailType r)
  * @param tile the tile to get the track bits from
  * @return the track bits of the tile
  */
-static inline TrackBits GetTrackBits(TileIndex tile)
+static inline TrackBits GetTrackBits(Tile tile)
 {
 	assert(IsPlainRailTile(tile));
-	return (TrackBits)GB(_m[tile].m5, 0, 6);
+	return (TrackBits)GB(tile.m5(), 0, 6);
 }
 
 /**
@@ -144,10 +144,10 @@ static inline TrackBits GetTrackBits(TileIndex tile)
  * @param t the tile to set the track bits of
  * @param b the new track bits for the tile
  */
-static inline void SetTrackBits(TileIndex t, TrackBits b)
+static inline void SetTrackBits(Tile t, TrackBits b)
 {
 	assert(IsPlainRailTile(t));
-	SB(_m[t].m5, 0, 6, b);
+	SB(t.m5(), 0, 6, b);
 }
 
 /**
@@ -157,7 +157,7 @@ static inline void SetTrackBits(TileIndex t, TrackBits b)
  * @pre IsPlainRailTile(tile)
  * @return true if and only if the given track exists on the tile
  */
-static inline bool HasTrack(TileIndex tile, Track track)
+static inline bool HasTrack(Tile tile, Track track)
 {
 	return HasBit(GetTrackBits(tile), track);
 }
@@ -168,9 +168,9 @@ static inline bool HasTrack(TileIndex tile, Track track)
  * @pre IsRailDepotTile(t)
  * @return the direction the depot is facing
  */
-static inline DiagDirection GetRailDepotDirection(TileIndex t)
+static inline DiagDirection GetRailDepotDirection(Tile t)
 {
-	return (DiagDirection)GB(_m[t].m5, 0, 2);
+	return (DiagDirection)GB(t.m5(), 0, 2);
 }
 
 /**
@@ -179,7 +179,7 @@ static inline DiagDirection GetRailDepotDirection(TileIndex t)
  * @param t the tile to get the depot track from
  * @return the track of the depot
  */
-static inline Track GetRailDepotTrack(TileIndex t)
+static inline Track GetRailDepotTrack(Tile t)
 {
 	return DiagDirToDiagTrack(GetRailDepotDirection(t));
 }
@@ -191,13 +191,13 @@ static inline Track GetRailDepotTrack(TileIndex t)
  * @param t the tile to query
  * @return the track bits
  */
-static inline TrackBits GetRailReservationTrackBits(TileIndex t)
+static inline TrackBits GetRailReservationTrackBits(Tile t)
 {
 	assert(IsPlainRailTile(t));
-	byte track_b = GB(_m[t].m2, 8, 3);
+	byte track_b = GB(t.m2(), 8, 3);
 	Track track = (Track)(track_b - 1);    // map array saves Track+1
 	if (track_b == 0) return TRACK_BIT_NONE;
-	return (TrackBits)(TrackToTrackBits(track) | (HasBit(_m[t].m2, 11) ? TrackToTrackBits(TrackToOppositeTrack(track)) : 0));
+	return (TrackBits)(TrackToTrackBits(track) | (HasBit(t.m2(), 11) ? TrackToTrackBits(TrackToOppositeTrack(track)) : 0));
 }
 
 /**
@@ -206,14 +206,14 @@ static inline TrackBits GetRailReservationTrackBits(TileIndex t)
  * @param t the tile to change
  * @param b the track bits
  */
-static inline void SetTrackReservation(TileIndex t, TrackBits b)
+static inline void SetTrackReservation(Tile t, TrackBits b)
 {
 	assert(IsPlainRailTile(t));
 	assert(b != INVALID_TRACK_BIT);
 	assert(!TracksOverlap(b));
 	Track track = RemoveFirstTrack(&b);
-	SB(_m[t].m2, 8, 3, track == INVALID_TRACK ? 0 : track + 1);
-	SB(_m[t].m2, 11, 1, (byte)(b != TRACK_BIT_NONE));
+	SB(t.m2(), 8, 3, track == INVALID_TRACK ? 0 : track + 1);
+	SB(t.m2(), 11, 1, (byte)(b != TRACK_BIT_NONE));
 }
 
 /**
@@ -223,7 +223,7 @@ static inline void SetTrackReservation(TileIndex t, TrackBits b)
  * @param t the rack to reserve
  * @return true if successful
  */
-static inline bool TryReserveTrack(TileIndex tile, Track t)
+static inline bool TryReserveTrack(Tile tile, Track t)
 {
 	assert(HasTrack(tile, t));
 	TrackBits bits = TrackToTrackBits(t);
@@ -241,7 +241,7 @@ static inline bool TryReserveTrack(TileIndex tile, Track t)
  * @param tile the tile
  * @param t the track to free
  */
-static inline void UnreserveTrack(TileIndex tile, Track t)
+static inline void UnreserveTrack(Tile tile, Track t)
 {
 	assert(HasTrack(tile, t));
 	TrackBits res = GetRailReservationTrackBits(tile);
@@ -255,10 +255,10 @@ static inline void UnreserveTrack(TileIndex tile, Track t)
  * @param t the depot tile
  * @return reservation state
  */
-static inline bool HasDepotReservation(TileIndex t)
+static inline bool HasDepotReservation(Tile t)
 {
 	assert(IsRailDepot(t));
-	return HasBit(_m[t].m5, 4);
+	return HasBit(t.m5(), 4);
 }
 
 /**
@@ -267,10 +267,10 @@ static inline bool HasDepotReservation(TileIndex t)
  * @param t the depot tile
  * @param b the reservation state
  */
-static inline void SetDepotReservation(TileIndex t, bool b)
+static inline void SetDepotReservation(Tile t, bool b)
 {
 	assert(IsRailDepot(t));
-	SB(_m[t].m5, 4, 1, (byte)b);
+	SB(t.m5(), 4, 1, (byte)b);
 }
 
 /**
@@ -279,7 +279,7 @@ static inline void SetDepotReservation(TileIndex t, bool b)
  * @param t the tile
  * @return reserved track bits
  */
-static inline TrackBits GetDepotReservationTrackBits(TileIndex t)
+static inline TrackBits GetDepotReservationTrackBits(Tile t)
 {
 	return HasDepotReservation(t) ? TrackToTrackBits(GetRailDepotTrack(t)) : TRACK_BIT_NONE;
 }
@@ -290,58 +290,58 @@ static inline bool IsPbsSignal(SignalType s)
 	return s == SIGTYPE_PBS || s == SIGTYPE_PBS_ONEWAY;
 }
 
-static inline SignalType GetSignalType(TileIndex t, Track track)
+static inline SignalType GetSignalType(Tile t, Track track)
 {
 	assert(GetRailTileType(t) == RAIL_TILE_SIGNALS);
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
-	return (SignalType)GB(_m[t].m2, pos, 3);
+	return (SignalType)GB(t.m2(), pos, 3);
 }
 
-static inline void SetSignalType(TileIndex t, Track track, SignalType s)
+static inline void SetSignalType(Tile t, Track track, SignalType s)
 {
 	assert(GetRailTileType(t) == RAIL_TILE_SIGNALS);
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 0;
-	SB(_m[t].m2, pos, 3, s);
-	if (track == INVALID_TRACK) SB(_m[t].m2, 4, 3, s);
+	SB(t.m2(), pos, 3, s);
+	if (track == INVALID_TRACK) SB(t.m2(), 4, 3, s);
 }
 
-static inline bool IsPresignalEntry(TileIndex t, Track track)
+static inline bool IsPresignalEntry(Tile t, Track track)
 {
 	return GetSignalType(t, track) == SIGTYPE_ENTRY || GetSignalType(t, track) == SIGTYPE_COMBO;
 }
 
-static inline bool IsPresignalExit(TileIndex t, Track track)
+static inline bool IsPresignalExit(Tile t, Track track)
 {
 	return GetSignalType(t, track) == SIGTYPE_EXIT || GetSignalType(t, track) == SIGTYPE_COMBO;
 }
 
 /** One-way signals can't be passed the 'wrong' way. */
-static inline bool IsOnewaySignal(TileIndex t, Track track)
+static inline bool IsOnewaySignal(Tile t, Track track)
 {
 	return GetSignalType(t, track) != SIGTYPE_PBS;
 }
 
-static inline void CycleSignalSide(TileIndex t, Track track)
+static inline void CycleSignalSide(Tile t, Track track)
 {
 	byte sig;
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 4 : 6;
 
-	sig = GB(_m[t].m3, pos, 2);
+	sig = GB(t.m3(), pos, 2);
 	if (--sig == 0) sig = IsPbsSignal(GetSignalType(t, track)) ? 2 : 3;
-	SB(_m[t].m3, pos, 2, sig);
+	SB(t.m3(), pos, 2, sig);
 }
 
-static inline SignalVariant GetSignalVariant(TileIndex t, Track track)
+static inline SignalVariant GetSignalVariant(Tile t, Track track)
 {
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
-	return (SignalVariant)GB(_m[t].m2, pos, 1);
+	return (SignalVariant)GB(t.m2(), pos, 1);
 }
 
-static inline void SetSignalVariant(TileIndex t, Track track, SignalVariant v)
+static inline void SetSignalVariant(Tile t, Track track, SignalVariant v)
 {
 	byte pos = (track == TRACK_LOWER || track == TRACK_RIGHT) ? 7 : 3;
-	SB(_m[t].m2, pos, 1, v);
-	if (track == INVALID_TRACK) SB(_m[t].m2, 7, 1, v);
+	SB(t.m2(), pos, 1, v);
+	if (track == INVALID_TRACK) SB(t.m2(), 7, 1, v);
 }
 
 /**
@@ -349,9 +349,9 @@ static inline void SetSignalVariant(TileIndex t, Track track, SignalVariant v)
  * @param tile  the tile to set the states for
  * @param state the new state
  */
-static inline void SetSignalStates(TileIndex tile, uint state)
+static inline void SetSignalStates(Tile tile, uint state)
 {
-	SB(_m[tile].m4, 4, 4, state);
+	SB(tile.m4(), 4, 4, state);
 }
 
 /**
@@ -359,9 +359,9 @@ static inline void SetSignalStates(TileIndex tile, uint state)
  * @param tile  the tile to set the states for
  * @return the state of the signals
  */
-static inline uint GetSignalStates(TileIndex tile)
+static inline uint GetSignalStates(Tile tile)
 {
-	return GB(_m[tile].m4, 4, 4);
+	return GB(tile.m4(), 4, 4);
 }
 
 /**
@@ -370,7 +370,7 @@ static inline uint GetSignalStates(TileIndex tile)
  * @param signalbit the signal
  * @return the state of the signal
  */
-static inline SignalState GetSingleSignalState(TileIndex t, byte signalbit)
+static inline SignalState GetSingleSignalState(Tile t, byte signalbit)
 {
 	return (SignalState)HasBit(GetSignalStates(t), signalbit);
 }
@@ -380,9 +380,9 @@ static inline SignalState GetSingleSignalState(TileIndex t, byte signalbit)
  * @param tile    the tile to set the present signals for
  * @param signals the signals that have to be present
  */
-static inline void SetPresentSignals(TileIndex tile, uint signals)
+static inline void SetPresentSignals(Tile tile, uint signals)
 {
-	SB(_m[tile].m3, 4, 4, signals);
+	SB(tile.m3(), 4, 4, signals);
 }
 
 /**
@@ -390,9 +390,9 @@ static inline void SetPresentSignals(TileIndex tile, uint signals)
  * @param tile the tile to get the present signals for
  * @return the signals that are present
  */
-static inline uint GetPresentSignals(TileIndex tile)
+static inline uint GetPresentSignals(Tile tile)
 {
-	return GB(_m[tile].m3, 4, 4);
+	return GB(tile.m3(), 4, 4);
 }
 
 /**
@@ -401,7 +401,7 @@ static inline uint GetPresentSignals(TileIndex tile)
  * @param signalbit the signal
  * @return true if and only if the signal is present
  */
-static inline bool IsSignalPresent(TileIndex t, byte signalbit)
+static inline bool IsSignalPresent(Tile t, byte signalbit)
 {
 	return HasBit(GetPresentSignals(t), signalbit);
 }
@@ -410,7 +410,7 @@ static inline bool IsSignalPresent(TileIndex t, byte signalbit)
  * Checks for the presence of signals (either way) on the given track on the
  * given rail tile.
  */
-static inline bool HasSignalOnTrack(TileIndex tile, Track track)
+static inline bool HasSignalOnTrack(Tile tile, Track track)
 {
 	assert(IsValidTrack(track));
 	return GetRailTileType(tile) == RAIL_TILE_SIGNALS && (GetPresentSignals(tile) & SignalOnTrack(track)) != 0;
@@ -423,7 +423,7 @@ static inline bool HasSignalOnTrack(TileIndex tile, Track track)
  * Along meaning if you are currently driving on the given trackdir, this is
  * the signal that is facing us (for which we stop when it's red).
  */
-static inline bool HasSignalOnTrackdir(TileIndex tile, Trackdir trackdir)
+static inline bool HasSignalOnTrackdir(Tile tile, Trackdir trackdir)
 {
 	assert (IsValidTrackdir(trackdir));
 	return GetRailTileType(tile) == RAIL_TILE_SIGNALS && GetPresentSignals(tile) & SignalAlongTrackdir(trackdir);
@@ -435,7 +435,7 @@ static inline bool HasSignalOnTrackdir(TileIndex tile, Trackdir trackdir)
  * Along meaning if you are currently driving on the given trackdir, this is
  * the signal that is facing us (for which we stop when it's red).
  */
-static inline SignalState GetSignalStateByTrackdir(TileIndex tile, Trackdir trackdir)
+static inline SignalState GetSignalStateByTrackdir(Tile tile, Trackdir trackdir)
 {
 	assert(IsValidTrackdir(trackdir));
 	assert(HasSignalOnTrack(tile, TrackdirToTrack(trackdir)));
@@ -446,7 +446,7 @@ static inline SignalState GetSignalStateByTrackdir(TileIndex tile, Trackdir trac
 /**
  * Sets the state of the signal along the given trackdir.
  */
-static inline void SetSignalStateByTrackdir(TileIndex tile, Trackdir trackdir, SignalState state)
+static inline void SetSignalStateByTrackdir(Tile tile, Trackdir trackdir, SignalState state)
 {
 	if (state == SIGNAL_STATE_GREEN) { // set 1
 		SetSignalStates(tile, GetSignalStates(tile) | SignalAlongTrackdir(trackdir));
@@ -460,7 +460,7 @@ static inline void SetSignalStateByTrackdir(TileIndex tile, Trackdir trackdir, S
  * @param tile the tile to check
  * @param td the trackdir to check
  */
-static inline bool HasPbsSignalOnTrackdir(TileIndex tile, Trackdir td)
+static inline bool HasPbsSignalOnTrackdir(Tile tile, Trackdir td)
 {
 	return IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, td) &&
 			IsPbsSignal(GetSignalType(tile, TrackdirToTrack(td)));
@@ -472,14 +472,14 @@ static inline bool HasPbsSignalOnTrackdir(TileIndex tile, Trackdir td)
  * @param tile the tile to check
  * @param td the trackdir to check
  */
-static inline bool HasOnewaySignalBlockingTrackdir(TileIndex tile, Trackdir td)
+static inline bool HasOnewaySignalBlockingTrackdir(Tile tile, Trackdir td)
 {
 	return IsTileType(tile, MP_RAILWAY) && HasSignalOnTrackdir(tile, ReverseTrackdir(td)) &&
 			!HasSignalOnTrackdir(tile, td) && IsOnewaySignal(tile, TrackdirToTrack(td));
 }
 
 
-RailType GetTileRailType(TileIndex tile);
+RailType GetTileRailType(Tile tile);
 
 /** The ground 'under' the rail */
 enum RailGroundType {
@@ -500,49 +500,49 @@ enum RailGroundType {
 	RAIL_GROUND_HALF_SNOW    = 14, ///< Snow only on higher part of slope (steep or one corner raised)
 };
 
-static inline void SetRailGroundType(TileIndex t, RailGroundType rgt)
+static inline void SetRailGroundType(Tile t, RailGroundType rgt)
 {
-	SB(_m[t].m4, 0, 4, rgt);
+	SB(t.m4(), 0, 4, rgt);
 }
 
-static inline RailGroundType GetRailGroundType(TileIndex t)
+static inline RailGroundType GetRailGroundType(Tile t)
 {
-	return (RailGroundType)GB(_m[t].m4, 0, 4);
+	return (RailGroundType)GB(t.m4(), 0, 4);
 }
 
-static inline bool IsSnowRailGround(TileIndex t)
+static inline bool IsSnowRailGround(Tile t)
 {
 	return GetRailGroundType(t) == RAIL_GROUND_ICE_DESERT;
 }
 
 
-static inline void MakeRailNormal(TileIndex t, Owner o, TrackBits b, RailType r)
+static inline void MakeRailNormal(Tile t, Owner o, TrackBits b, RailType r)
 {
 	SetTileType(t, MP_RAILWAY);
 	SetTileOwner(t, o);
 	SetDockingTile(t, false);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = RAIL_TILE_NORMAL << 6 | b;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
-	_me[t].m8 = r;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = RAIL_TILE_NORMAL << 6 | b;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
+	t.m8() = r;
 }
 
 
-static inline void MakeRailDepot(TileIndex t, Owner o, DepotID did, DiagDirection d, RailType r)
+static inline void MakeRailDepot(Tile t, Owner o, DepotID did, DiagDirection d, RailType r)
 {
 	SetTileType(t, MP_RAILWAY);
 	SetTileOwner(t, o);
 	SetDockingTile(t, false);
-	_m[t].m2 = did;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = RAIL_TILE_DEPOT << 6 | d;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
-	_me[t].m8 = r;
+	t.m2() = did;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = RAIL_TILE_DEPOT << 6 | d;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
+	t.m8() = r;
 }
 
 #endif /* RAIL_MAP_H */

--- a/src/road_map.cpp
+++ b/src/road_map.cpp
@@ -30,7 +30,7 @@
  * @param straight_tunnel_bridge_entrance whether to return straight road bits for tunnels/bridges.
  * @return the road bits of the given tile
  */
-RoadBits GetAnyRoadBits(TileIndex tile, RoadTramType rtt, bool straight_tunnel_bridge_entrance)
+RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge_entrance)
 {
 	if (!MayHaveRoad(tile) || !HasTileRoadType(tile, rtt)) return ROAD_NONE;
 

--- a/src/road_map.h
+++ b/src/road_map.h
@@ -30,7 +30,7 @@ enum RoadTileType {
  * @param t Tile to query.
  * @return true if tile can be queried about road/tram types.
  */
-static inline bool MayHaveRoad(TileIndex t)
+static inline bool MayHaveRoad(Tile t)
 {
 	switch (GetTileType(t)) {
 		case MP_ROAD:
@@ -49,10 +49,10 @@ static inline bool MayHaveRoad(TileIndex t)
  * @pre IsTileType(t, MP_ROAD)
  * @return The road tile type.
  */
-debug_inline static RoadTileType GetRoadTileType(TileIndex t)
+debug_inline static RoadTileType GetRoadTileType(Tile t)
 {
 	assert(IsTileType(t, MP_ROAD));
-	return (RoadTileType)GB(_m[t].m5, 6, 2);
+	return (RoadTileType)GB(t.m5(), 6, 2);
 }
 
 /**
@@ -61,7 +61,7 @@ debug_inline static RoadTileType GetRoadTileType(TileIndex t)
  * @pre IsTileType(t, MP_ROAD)
  * @return True if normal road.
  */
-debug_inline static bool IsNormalRoad(TileIndex t)
+debug_inline static bool IsNormalRoad(Tile t)
 {
 	return GetRoadTileType(t) == ROAD_TILE_NORMAL;
 }
@@ -71,7 +71,7 @@ debug_inline static bool IsNormalRoad(TileIndex t)
  * @param t Tile to query.
  * @return True if normal road tile.
  */
-debug_inline static bool IsNormalRoadTile(TileIndex t)
+debug_inline static bool IsNormalRoadTile(Tile t)
 {
 	return IsTileType(t, MP_ROAD) && IsNormalRoad(t);
 }
@@ -82,7 +82,7 @@ debug_inline static bool IsNormalRoadTile(TileIndex t)
  * @pre IsTileType(t, MP_ROAD)
  * @return True if level crossing.
  */
-static inline bool IsLevelCrossing(TileIndex t)
+static inline bool IsLevelCrossing(Tile t)
 {
 	return GetRoadTileType(t) == ROAD_TILE_CROSSING;
 }
@@ -92,7 +92,7 @@ static inline bool IsLevelCrossing(TileIndex t)
  * @param t Tile to query.
  * @return True if level crossing tile.
  */
-static inline bool IsLevelCrossingTile(TileIndex t)
+static inline bool IsLevelCrossingTile(Tile t)
 {
 	return IsTileType(t, MP_ROAD) && IsLevelCrossing(t);
 }
@@ -103,7 +103,7 @@ static inline bool IsLevelCrossingTile(TileIndex t)
  * @pre IsTileType(t, MP_ROAD)
  * @return True if road depot.
  */
-debug_inline static bool IsRoadDepot(TileIndex t)
+debug_inline static bool IsRoadDepot(Tile t)
 {
 	return GetRoadTileType(t) == ROAD_TILE_DEPOT;
 }
@@ -113,7 +113,7 @@ debug_inline static bool IsRoadDepot(TileIndex t)
  * @param t Tile to query.
  * @return True if road depot tile.
  */
-debug_inline static bool IsRoadDepotTile(TileIndex t)
+debug_inline static bool IsRoadDepotTile(Tile t)
 {
 	return IsTileType(t, MP_ROAD) && IsRoadDepot(t);
 }
@@ -125,11 +125,11 @@ debug_inline static bool IsRoadDepotTile(TileIndex t)
  * @pre IsNormalRoad(t)
  * @return The present road bits for the road type.
  */
-static inline RoadBits GetRoadBits(TileIndex t, RoadTramType rtt)
+static inline RoadBits GetRoadBits(Tile t, RoadTramType rtt)
 {
 	assert(IsNormalRoad(t));
-	if (rtt == RTT_TRAM) return (RoadBits)GB(_m[t].m3, 0, 4);
-	return (RoadBits)GB(_m[t].m5, 0, 4);
+	if (rtt == RTT_TRAM) return (RoadBits)GB(t.m3(), 0, 4);
+	return (RoadBits)GB(t.m5(), 0, 4);
 }
 
 /**
@@ -138,7 +138,7 @@ static inline RoadBits GetRoadBits(TileIndex t, RoadTramType rtt)
  * @param tile The tile from which we want to get the RoadBits
  * @return all set RoadBits of the tile
  */
-static inline RoadBits GetAllRoadBits(TileIndex tile)
+static inline RoadBits GetAllRoadBits(Tile tile)
 {
 	return GetRoadBits(tile, RTT_ROAD) | GetRoadBits(tile, RTT_TRAM);
 }
@@ -150,29 +150,29 @@ static inline RoadBits GetAllRoadBits(TileIndex tile)
  * @param rt Road type.
  * @pre IsNormalRoad(t)
  */
-static inline void SetRoadBits(TileIndex t, RoadBits r, RoadTramType rtt)
+static inline void SetRoadBits(Tile t, RoadBits r, RoadTramType rtt)
 {
 	assert(IsNormalRoad(t)); // XXX incomplete
 	if (rtt == RTT_TRAM) {
-		SB(_m[t].m3, 0, 4, r);
+		SB(t.m3(), 0, 4, r);
 	} else {
-		SB(_m[t].m5, 0, 4, r);
+		SB(t.m5(), 0, 4, r);
 	}
 }
 
-static inline RoadType GetRoadTypeRoad(TileIndex t)
+static inline RoadType GetRoadTypeRoad(Tile t)
 {
 	assert(MayHaveRoad(t));
-	return (RoadType)GB(_m[t].m4, 0, 6);
+	return (RoadType)GB(t.m4(), 0, 6);
 }
 
-static inline RoadType GetRoadTypeTram(TileIndex t)
+static inline RoadType GetRoadTypeTram(Tile t)
 {
 	assert(MayHaveRoad(t));
-	return (RoadType)GB(_me[t].m8, 6, 6);
+	return (RoadType)GB(t.m8(), 6, 6);
 }
 
-static inline RoadType GetRoadType(TileIndex t, RoadTramType rtt)
+static inline RoadType GetRoadType(Tile t, RoadTramType rtt)
 {
 	return (rtt == RTT_TRAM) ? GetRoadTypeTram(t) : GetRoadTypeRoad(t);
 }
@@ -182,7 +182,7 @@ static inline RoadType GetRoadType(TileIndex t, RoadTramType rtt)
  * @param t The tile to query.
  * @return Present road types.
  */
-static inline RoadTypes GetPresentRoadTypes(TileIndex t)
+static inline RoadTypes GetPresentRoadTypes(Tile t)
 {
 	RoadTypes result = ROADTYPES_NONE;
 	if (MayHaveRoad(t)) {
@@ -192,12 +192,12 @@ static inline RoadTypes GetPresentRoadTypes(TileIndex t)
 	return result;
 }
 
-static inline bool HasRoadTypeRoad(TileIndex t)
+static inline bool HasRoadTypeRoad(Tile t)
 {
 	return GetRoadTypeRoad(t) != INVALID_ROADTYPE;
 }
 
-static inline bool HasRoadTypeTram(TileIndex t)
+static inline bool HasRoadTypeTram(Tile t)
 {
 	return GetRoadTypeTram(t) != INVALID_ROADTYPE;
 }
@@ -208,7 +208,7 @@ static inline bool HasRoadTypeTram(TileIndex t)
  * @param tram True to check tram, false to check road.
  * @return True if the tile has the specified road type.
  */
-static inline bool HasTileRoadType(TileIndex t, RoadTramType rtt)
+static inline bool HasTileRoadType(Tile t, RoadTramType rtt)
 {
 	return GetRoadType(t, rtt) != INVALID_ROADTYPE;
 }
@@ -219,7 +219,7 @@ static inline bool HasTileRoadType(TileIndex t, RoadTramType rtt)
  * @param rts Allowed road types.
  * @return True if the tile has one of the specified road types.
  */
-static inline bool HasTileAnyRoadType(TileIndex t, RoadTypes rts)
+static inline bool HasTileAnyRoadType(Tile t, RoadTypes rts)
 {
 	if (!MayHaveRoad(t)) return false;
 	return (GetPresentRoadTypes(t) & rts);
@@ -231,14 +231,14 @@ static inline bool HasTileAnyRoadType(TileIndex t, RoadTypes rts)
  * @param rtt RoadTramType.
  * @return Owner of the given road type.
  */
-static inline Owner GetRoadOwner(TileIndex t, RoadTramType rtt)
+static inline Owner GetRoadOwner(Tile t, RoadTramType rtt)
 {
 	assert(MayHaveRoad(t));
-	if (rtt == RTT_ROAD) return (Owner)GB(IsNormalRoadTile(t) ? _m[t].m1 : _me[t].m7, 0, 5);
+	if (rtt == RTT_ROAD) return (Owner)GB(IsNormalRoadTile(t) ? t.m1() : t.m7(), 0, 5);
 
 	/* Trams don't need OWNER_TOWN, and remapping OWNER_NONE
 	 * to OWNER_TOWN makes it use one bit less */
-	Owner o = (Owner)GB(_m[t].m3, 4, 4);
+	Owner o = (Owner)GB(t.m3(), 4, 4);
 	return o == OWNER_TOWN ? OWNER_NONE : o;
 }
 
@@ -248,12 +248,12 @@ static inline Owner GetRoadOwner(TileIndex t, RoadTramType rtt)
  * @param rtt RoadTramType.
  * @param o  New owner of the given road type.
  */
-static inline void SetRoadOwner(TileIndex t, RoadTramType rtt, Owner o)
+static inline void SetRoadOwner(Tile t, RoadTramType rtt, Owner o)
 {
 	if (rtt == RTT_ROAD) {
-		SB(IsNormalRoadTile(t) ? _m[t].m1 : _me[t].m7, 0, 5, o);
+		SB(IsNormalRoadTile(t) ? t.m1() : t.m7(), 0, 5, o);
 	} else {
-		SB(_m[t].m3, 4, 4, o == OWNER_NONE ? OWNER_TOWN : o);
+		SB(t.m3(), 4, 4, o == OWNER_NONE ? OWNER_TOWN : o);
 	}
 }
 
@@ -265,7 +265,7 @@ static inline void SetRoadOwner(TileIndex t, RoadTramType rtt, Owner o)
  * @pre HasTileRoadType(t, rt)
  * @return True if the road type is owned by the given owner.
  */
-static inline bool IsRoadOwner(TileIndex t, RoadTramType rtt, Owner o)
+static inline bool IsRoadOwner(Tile t, RoadTramType rtt, Owner o)
 {
 	assert(HasTileRoadType(t, rtt));
 	return (GetRoadOwner(t, rtt) == o);
@@ -277,7 +277,7 @@ static inline bool IsRoadOwner(TileIndex t, RoadTramType rtt, Owner o)
  * @pre IsTileType(t, MP_ROAD)
  * @return true iff tile has road and the road is owned by a town
  */
-static inline bool HasTownOwnedRoad(TileIndex t)
+static inline bool HasTownOwnedRoad(Tile t)
 {
 	return HasTileRoadType(t, RTT_ROAD) && IsRoadOwner(t, RTT_ROAD, OWNER_TOWN);
 }
@@ -298,10 +298,10 @@ static inline bool IsValidDisallowedRoadDirections(DisallowedRoadDirections drt)
  * @param t the tile to get the directions from
  * @return the disallowed directions
  */
-static inline DisallowedRoadDirections GetDisallowedRoadDirections(TileIndex t)
+static inline DisallowedRoadDirections GetDisallowedRoadDirections(Tile t)
 {
 	assert(IsNormalRoad(t));
-	return (DisallowedRoadDirections)GB(_m[t].m5, 4, 2);
+	return (DisallowedRoadDirections)GB(t.m5(), 4, 2);
 }
 
 /**
@@ -309,11 +309,11 @@ static inline DisallowedRoadDirections GetDisallowedRoadDirections(TileIndex t)
  * @param t   the tile to set the directions for
  * @param drd the disallowed directions
  */
-static inline void SetDisallowedRoadDirections(TileIndex t, DisallowedRoadDirections drd)
+static inline void SetDisallowedRoadDirections(Tile t, DisallowedRoadDirections drd)
 {
 	assert(IsNormalRoad(t));
 	assert(drd < DRD_END);
-	SB(_m[t].m5, 4, 2, drd);
+	SB(t.m5(), 4, 2, drd);
 }
 
 /**
@@ -322,10 +322,10 @@ static inline void SetDisallowedRoadDirections(TileIndex t, DisallowedRoadDirect
  * @pre IsLevelCrossing(t)
  * @return The axis of the road.
  */
-static inline Axis GetCrossingRoadAxis(TileIndex t)
+static inline Axis GetCrossingRoadAxis(Tile t)
 {
 	assert(IsLevelCrossing(t));
-	return (Axis)GB(_m[t].m5, 0, 1);
+	return (Axis)GB(t.m5(), 0, 1);
 }
 
 /**
@@ -334,7 +334,7 @@ static inline Axis GetCrossingRoadAxis(TileIndex t)
  * @pre IsLevelCrossing(t)
  * @return The axis of the rail.
  */
-static inline Axis GetCrossingRailAxis(TileIndex t)
+static inline Axis GetCrossingRailAxis(Tile t)
 {
 	assert(IsLevelCrossing(t));
 	return OtherAxis((Axis)GetCrossingRoadAxis(t));
@@ -345,7 +345,7 @@ static inline Axis GetCrossingRailAxis(TileIndex t)
  * @param tile The tile to query.
  * @return The present road bits.
  */
-static inline RoadBits GetCrossingRoadBits(TileIndex tile)
+static inline RoadBits GetCrossingRoadBits(Tile tile)
 {
 	return GetCrossingRoadAxis(tile) == AXIS_X ? ROAD_X : ROAD_Y;
 }
@@ -355,7 +355,7 @@ static inline RoadBits GetCrossingRoadBits(TileIndex tile)
  * @param tile The tile to query.
  * @return The rail track.
  */
-static inline Track GetCrossingRailTrack(TileIndex tile)
+static inline Track GetCrossingRailTrack(Tile tile)
 {
 	return AxisToTrack(GetCrossingRailAxis(tile));
 }
@@ -365,7 +365,7 @@ static inline Track GetCrossingRailTrack(TileIndex tile)
  * @param tile The tile to query.
  * @return The rail track bits.
  */
-static inline TrackBits GetCrossingRailBits(TileIndex tile)
+static inline TrackBits GetCrossingRailBits(Tile tile)
 {
 	return AxisToTrackBits(GetCrossingRailAxis(tile));
 }
@@ -377,10 +377,10 @@ static inline TrackBits GetCrossingRailBits(TileIndex tile)
  * @return reservation state
  * @pre IsLevelCrossingTile(t)
  */
-static inline bool HasCrossingReservation(TileIndex t)
+static inline bool HasCrossingReservation(Tile t)
 {
 	assert(IsLevelCrossingTile(t));
-	return HasBit(_m[t].m5, 4);
+	return HasBit(t.m5(), 4);
 }
 
 /**
@@ -390,10 +390,10 @@ static inline bool HasCrossingReservation(TileIndex t)
  * @param b the reservation state
  * @pre IsLevelCrossingTile(t)
  */
-static inline void SetCrossingReservation(TileIndex t, bool b)
+static inline void SetCrossingReservation(Tile t, bool b)
 {
 	assert(IsLevelCrossingTile(t));
-	SB(_m[t].m5, 4, 1, b ? 1 : 0);
+	SB(t.m5(), 4, 1, b ? 1 : 0);
 }
 
 /**
@@ -402,7 +402,7 @@ static inline void SetCrossingReservation(TileIndex t, bool b)
  * @pre IsLevelCrossingTile(t)
  * @return reserved track bits
  */
-static inline TrackBits GetCrossingReservationTrackBits(TileIndex t)
+static inline TrackBits GetCrossingReservationTrackBits(Tile t)
 {
 	return HasCrossingReservation(t) ? GetCrossingRailBits(t) : TRACK_BIT_NONE;
 }
@@ -413,10 +413,10 @@ static inline TrackBits GetCrossingReservationTrackBits(TileIndex t)
  * @pre IsLevelCrossing(t)
  * @return True if the level crossing is barred.
  */
-static inline bool IsCrossingBarred(TileIndex t)
+static inline bool IsCrossingBarred(Tile t)
 {
 	assert(IsLevelCrossing(t));
-	return HasBit(_m[t].m5, 5);
+	return HasBit(t.m5(), 5);
 }
 
 /**
@@ -425,17 +425,17 @@ static inline bool IsCrossingBarred(TileIndex t)
  * @param barred True if the crossing should be barred, false otherwise.
  * @pre IsLevelCrossing(t)
  */
-static inline void SetCrossingBarred(TileIndex t, bool barred)
+static inline void SetCrossingBarred(Tile t, bool barred)
 {
 	assert(IsLevelCrossing(t));
-	SB(_m[t].m5, 5, 1, barred ? 1 : 0);
+	SB(t.m5(), 5, 1, barred ? 1 : 0);
 }
 
 /**
  * Unbar a level crossing.
  * @param t The tile to change.
  */
-static inline void UnbarCrossing(TileIndex t)
+static inline void UnbarCrossing(Tile t)
 {
 	SetCrossingBarred(t, false);
 }
@@ -444,7 +444,7 @@ static inline void UnbarCrossing(TileIndex t)
  * Bar a level crossing.
  * @param t The tile to change.
  */
-static inline void BarCrossing(TileIndex t)
+static inline void BarCrossing(Tile t)
 {
 	SetCrossingBarred(t, true);
 }
@@ -456,9 +456,9 @@ static inline void BarCrossing(TileIndex t)
  * @param t The tile to query.
  * @return True if the tile has snow/desert.
  */
-static inline bool IsOnSnow(TileIndex t)
+static inline bool IsOnSnow(Tile t)
 {
-	return HasBit(_me[t].m7, 5);
+	return HasBit(t.m7(), 5);
 }
 
 /** Toggle the snow/desert state of a road tile. */
@@ -467,9 +467,9 @@ static inline bool IsOnSnow(TileIndex t)
  * Toggle the snow/desert state of a road tile.
  * @param t The tile to change.
  */
-static inline void ToggleSnow(TileIndex t)
+static inline void ToggleSnow(Tile t)
 {
-	ToggleBit(_me[t].m7, 5);
+	ToggleBit(t.m7(), 5);
 }
 
 
@@ -490,9 +490,9 @@ enum Roadside {
  * @param tile The tile to query.
  * @return The road decoration of the tile.
  */
-static inline Roadside GetRoadside(TileIndex tile)
+static inline Roadside GetRoadside(Tile tile)
 {
-	return (Roadside)GB(_me[tile].m6, 3, 3);
+	return (Roadside)GB(tile.m6(), 3, 3);
 }
 
 /**
@@ -500,9 +500,9 @@ static inline Roadside GetRoadside(TileIndex tile)
  * @param tile The tile to change.
  * @param s    The new road decoration of the tile.
  */
-static inline void SetRoadside(TileIndex tile, Roadside s)
+static inline void SetRoadside(Tile tile, Roadside s)
 {
-	SB(_me[tile].m6, 3, 3, s);
+	SB(tile.m6(), 3, 3, s);
 }
 
 /**
@@ -510,7 +510,7 @@ static inline void SetRoadside(TileIndex tile, Roadside s)
  * @param t The tile to check.
  * @return True if the tile has road works in progress.
  */
-static inline bool HasRoadWorks(TileIndex t)
+static inline bool HasRoadWorks(Tile t)
 {
 	return GetRoadside(t) >= ROADSIDE_GRASS_ROAD_WORKS;
 }
@@ -520,11 +520,11 @@ static inline bool HasRoadWorks(TileIndex t)
  * @param t The tile to modify.
  * @return True if the road works are in the last stage.
  */
-static inline bool IncreaseRoadWorksCounter(TileIndex t)
+static inline bool IncreaseRoadWorksCounter(Tile t)
 {
-	AB(_me[t].m7, 0, 4, 1);
+	AB(t.m7(), 0, 4, 1);
 
-	return GB(_me[t].m7, 0, 4) == 15;
+	return GB(t.m7(), 0, 4) == 15;
 }
 
 /**
@@ -532,7 +532,7 @@ static inline bool IncreaseRoadWorksCounter(TileIndex t)
  * @param t The tile to start the work on.
  * @pre !HasRoadWorks(t)
  */
-static inline void StartRoadWorks(TileIndex t)
+static inline void StartRoadWorks(Tile t)
 {
 	assert(!HasRoadWorks(t));
 	/* Remove any trees or lamps in case or roadwork */
@@ -548,12 +548,12 @@ static inline void StartRoadWorks(TileIndex t)
  * @param t Tile to stop the road works on.
  * @pre HasRoadWorks(t)
  */
-static inline void TerminateRoadWorks(TileIndex t)
+static inline void TerminateRoadWorks(Tile t)
 {
 	assert(HasRoadWorks(t));
 	SetRoadside(t, (Roadside)(GetRoadside(t) - ROADSIDE_GRASS_ROAD_WORKS + ROADSIDE_GRASS));
 	/* Stop the counter */
-	SB(_me[t].m7, 0, 4, 0);
+	SB(t.m7(), 0, 4, 0);
 }
 
 
@@ -562,25 +562,25 @@ static inline void TerminateRoadWorks(TileIndex t)
  * @param t The tile to query.
  * @return Diagonal direction of the depot exit.
  */
-static inline DiagDirection GetRoadDepotDirection(TileIndex t)
+static inline DiagDirection GetRoadDepotDirection(Tile t)
 {
 	assert(IsRoadDepot(t));
-	return (DiagDirection)GB(_m[t].m5, 0, 2);
+	return (DiagDirection)GB(t.m5(), 0, 2);
 }
 
 
-RoadBits GetAnyRoadBits(TileIndex tile, RoadTramType rtt, bool straight_tunnel_bridge_entrance = false);
+RoadBits GetAnyRoadBits(Tile tile, RoadTramType rtt, bool straight_tunnel_bridge_entrance = false);
 
 /**
  * Set the road road type of a tile.
  * @param t The tile to change.
  * @param rt The road type to set.
  */
-static inline void SetRoadTypeRoad(TileIndex t, RoadType rt)
+static inline void SetRoadTypeRoad(Tile t, RoadType rt)
 {
 	assert(MayHaveRoad(t));
 	assert(rt == INVALID_ROADTYPE || RoadTypeIsRoad(rt));
-	SB(_m[t].m4, 0, 6, rt);
+	SB(t.m4(), 0, 6, rt);
 }
 
 /**
@@ -588,11 +588,11 @@ static inline void SetRoadTypeRoad(TileIndex t, RoadType rt)
  * @param t The tile to change.
  * @param rt The road type to set.
  */
-static inline void SetRoadTypeTram(TileIndex t, RoadType rt)
+static inline void SetRoadTypeTram(Tile t, RoadType rt)
 {
 	assert(MayHaveRoad(t));
 	assert(rt == INVALID_ROADTYPE || RoadTypeIsTram(rt));
-	SB(_me[t].m8, 6, 6, rt);
+	SB(t.m8(), 6, 6, rt);
 }
 
 /**
@@ -601,7 +601,7 @@ static inline void SetRoadTypeTram(TileIndex t, RoadType rt)
  * @param rtt Set road or tram type.
  * @param rt The road type to set.
  */
-static inline void SetRoadType(TileIndex t, RoadTramType rtt, RoadType rt)
+static inline void SetRoadType(Tile t, RoadTramType rtt, RoadType rt)
 {
 	if (rtt == RTT_TRAM) {
 		SetRoadTypeTram(t, rt);
@@ -616,7 +616,7 @@ static inline void SetRoadType(TileIndex t, RoadTramType rtt, RoadType rt)
  * @param road_rt The road roadtype to set for the tile.
  * @param tram_rt The tram roadtype to set for the tile.
  */
-static inline void SetRoadTypes(TileIndex t, RoadType road_rt, RoadType tram_rt)
+static inline void SetRoadTypes(Tile t, RoadType road_rt, RoadType tram_rt)
 {
 	SetRoadTypeRoad(t, road_rt);
 	SetRoadTypeTram(t, tram_rt);
@@ -632,15 +632,15 @@ static inline void SetRoadTypes(TileIndex t, RoadType road_rt, RoadType tram_rt)
  * @param road    New owner of road.
  * @param tram    New owner of tram tracks.
  */
-static inline void MakeRoadNormal(TileIndex t, RoadBits bits, RoadType road_rt, RoadType tram_rt, TownID town, Owner road, Owner tram)
+static inline void MakeRoadNormal(Tile t, RoadBits bits, RoadType road_rt, RoadType tram_rt, TownID town, Owner road, Owner tram)
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, road);
-	_m[t].m2 = town;
-	_m[t].m3 = (tram_rt != INVALID_ROADTYPE ? bits : 0);
-	_m[t].m5 = (road_rt != INVALID_ROADTYPE ? bits : 0) | ROAD_TILE_NORMAL << 6;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = town;
+	t.m3() = (tram_rt != INVALID_ROADTYPE ? bits : 0);
+	t.m5() = (road_rt != INVALID_ROADTYPE ? bits : 0) | ROAD_TILE_NORMAL << 6;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 	SetRoadTypes(t, road_rt, tram_rt);
 	SetRoadOwner(t, RTT_TRAM, tram);
 }
@@ -657,17 +657,17 @@ static inline void MakeRoadNormal(TileIndex t, RoadBits bits, RoadType road_rt, 
  * @param tram_rt The tram roadtype to set for the tile.
  * @param town    Town ID if the road is a town-owned road.
  */
-static inline void MakeRoadCrossing(TileIndex t, Owner road, Owner tram, Owner rail, Axis roaddir, RailType rat, RoadType road_rt, RoadType tram_rt, uint town)
+static inline void MakeRoadCrossing(Tile t, Owner road, Owner tram, Owner rail, Axis roaddir, RailType rat, RoadType road_rt, RoadType tram_rt, uint town)
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, rail);
-	_m[t].m2 = town;
-	_m[t].m3 = 0;
-	_m[t].m4 = INVALID_ROADTYPE;
-	_m[t].m5 = ROAD_TILE_CROSSING << 6 | roaddir;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = road;
-	_me[t].m8 = INVALID_ROADTYPE << 6 | rat;
+	t.m2() = town;
+	t.m3() = 0;
+	t.m4() = INVALID_ROADTYPE;
+	t.m5() = ROAD_TILE_CROSSING << 6 | roaddir;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = road;
+	t.m8() = INVALID_ROADTYPE << 6 | rat;
 	SetRoadTypes(t, road_rt, tram_rt);
 	SetRoadOwner(t, RTT_TRAM, tram);
 }
@@ -680,17 +680,17 @@ static inline void MakeRoadCrossing(TileIndex t, Owner road, Owner tram, Owner r
  * @param dir   Direction of the depot exit.*
  * @param rt    Road type of the depot.
  */
-static inline void MakeRoadDepot(TileIndex t, Owner owner, DepotID did, DiagDirection dir, RoadType rt)
+static inline void MakeRoadDepot(Tile t, Owner owner, DepotID did, DiagDirection dir, RoadType rt)
 {
 	SetTileType(t, MP_ROAD);
 	SetTileOwner(t, owner);
-	_m[t].m2 = did;
-	_m[t].m3 = 0;
-	_m[t].m4 = INVALID_ROADTYPE;
-	_m[t].m5 = ROAD_TILE_DEPOT << 6 | dir;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = owner;
-	_me[t].m8 = INVALID_ROADTYPE << 6;
+	t.m2() = did;
+	t.m3() = 0;
+	t.m4() = INVALID_ROADTYPE;
+	t.m5() = ROAD_TILE_DEPOT << 6 | dir;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = owner;
+	t.m8() = INVALID_ROADTYPE << 6;
 	SetRoadType(t, GetRoadTramType(rt), rt);
 	SetRoadOwner(t, RTT_TRAM, owner);
 }

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -150,7 +150,7 @@ void SetWaterClassDependingOnSurroundings(TileIndex t, bool include_invalid_wate
 
 static void ConvertTownOwner()
 {
-	for (TileIndex tile = 0; tile != Map::Size(); tile++) {
+	for (auto tile : Map::Iterate()) {
 		switch (GetTileType(tile)) {
 			case MP_ROAD:
 				if (GB(_m[tile].m5, 4, 2) == ROAD_TILE_CROSSING && HasBit(_m[tile].m3, 7)) {
@@ -566,8 +566,6 @@ bool AfterLoadGame()
 {
 	SetSignalHandlers();
 
-	TileIndex map_size = Map::Size();
-
 	extern TileIndex _cur_tileloop_tile; // From landscape.cpp.
 	/* The LFSR used in RunTileLoop iteration cannot have a zeroed state, make it non-zeroed. */
 	if (_cur_tileloop_tile == 0) _cur_tileloop_tile = 1;
@@ -614,7 +612,7 @@ bool AfterLoadGame()
 		for (Station *st : Station::Iterate()) {
 			st->train_station.w = st->train_station.h = 0;
 		}
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsTileType(t, MP_STATION)) continue;
 			if (_m[t].m5 > 7) continue; // is it a rail station tile?
 			Station *st = Station::Get(_m[t].m2);
@@ -631,7 +629,7 @@ bool AfterLoadGame()
 		_settings_game.construction.map_height_limit = 15;
 
 		/* In old savegame versions, the heightlevel was coded in bits 0..3 of the type field */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			_m[t].height = GB(_m[t].type, 0, 4);
 			SB(_m[t].type, 0, 2, GB(_me[t].m6, 0, 2));
 			SB(_me[t].m6, 0, 2, 0);
@@ -658,7 +656,7 @@ bool AfterLoadGame()
 	 * (4.3) version, so I just check when versions are older, and then
 	 * walk through the whole map.. */
 	if (IsSavegameVersionBefore(SLV_4, 3)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_WATER) && GetTileOwner(t) >= MAX_COMPANIES) {
 				SetTileOwner(t, OWNER_WATER);
 			}
@@ -840,7 +838,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_72)) {
 		/* Locks in very old savegames had OWNER_WATER as owner */
-		for (TileIndex t = 0; t < Map::Size(); t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				default: break;
 
@@ -894,7 +892,7 @@ bool AfterLoadGame()
 		}
 	}
 
-	for (TileIndex t = 0; t < map_size; t++) {
+	for (auto t : Map::Iterate()) {
 		switch (GetTileType(t)) {
 			case MP_STATION: {
 				BaseStation *bst = BaseStation::GetByTile(t);
@@ -964,7 +962,7 @@ bool AfterLoadGame()
 	 *  to use m2 (16bit big), so we need to clean m2, and that is where this is
 	 *  all about ;) */
 	if (IsSavegameVersionBefore(SLV_6, 1)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_HOUSE:
 					_m[t].m4 = _m[t].m2;
@@ -1019,7 +1017,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_48)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_RAILWAY:
 					if (IsPlainRail(t)) {
@@ -1049,7 +1047,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_61)) {
 		/* Added the RoadType */
 		bool old_bridge = IsSavegameVersionBefore(SLV_42);
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_ROAD:
 					SB(_m[t].m5, 6, 2, GB(_m[t].m5, 4, 2));
@@ -1089,7 +1087,7 @@ bool AfterLoadGame()
 		bool fix_roadtypes = !IsSavegameVersionBefore(SLV_61);
 		bool old_bridge = IsSavegameVersionBefore(SLV_42);
 
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_ROAD:
 					if (fix_roadtypes) SB(_me[t].m7, 6, 2, (RoadTypes)GB(_me[t].m7, 5, 3));
@@ -1154,7 +1152,7 @@ bool AfterLoadGame()
 
 	/* Railtype moved from m3 to m8 in version SLV_EXTEND_RAILTYPES. */
 	if (IsSavegameVersionBefore(SLV_EXTEND_RAILTYPES)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_RAILWAY:
 					SetRailType(t, (RailType)GB(_m[t].m3, 0, 4));
@@ -1185,7 +1183,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_42)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (MayHaveBridgeAbove(t)) ClearBridgeMiddle(t);
 			if (IsBridgeTile(t)) {
 				if (HasBit(_m[t].m5, 6)) { // middle part
@@ -1267,7 +1265,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_ROAD_TYPES)) {
 		/* Add road subtypes */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			bool has_road = false;
 			switch (GetTileType(t)) {
 				case MP_ROAD:
@@ -1306,7 +1304,7 @@ bool AfterLoadGame()
 		}
 
 		/* .. so we convert the entire map from normal to elrail (so maintain "fairness") */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_RAILWAY:
 					SetRailType(t, UpdateRailType(GetRailType(t), min_rail));
@@ -1358,7 +1356,7 @@ bool AfterLoadGame()
 	/* From version 15, we moved a semaphore bit from bit 2 to bit 3 in m4, making
 	 *  room for PBS. Now in version 21 move it back :P. */
 	if (IsSavegameVersionBefore(SLV_21) && !IsSavegameVersionBefore(SLV_15)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_RAILWAY:
 					if (HasSignals(t)) {
@@ -1438,7 +1436,7 @@ bool AfterLoadGame()
 	 *  To give this prettiness to old savegames, we remove all farmfields and
 	 *  plant new ones. */
 	if (IsSavegameVersionBefore(SLV_32)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_CLEAR) && IsClearGround(t, CLEAR_FIELDS)) {
 				/* remove fields */
 				MakeClear(t, CLEAR_GRASS, 3);
@@ -1475,7 +1473,7 @@ bool AfterLoadGame()
 	/* From version 53, the map array was changed for house tiles to allow
 	 * space for newhouses grf features. A new byte, m7, was also added. */
 	if (IsSavegameVersionBefore(SLV_53)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_HOUSE)) {
 				if (GB(_m[t].m3, 6, 2) != TOWN_HOUSE_COMPLETED) {
 					/* Move the construction stage from m3[7..6] to m5[5..4].
@@ -1512,7 +1510,7 @@ bool AfterLoadGame()
 	UpdateHousesAndTowns();
 
 	if (IsSavegameVersionBefore(SLV_43)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_INDUSTRY)) {
 				switch (GetIndustryGfx(t)) {
 					case GFX_POWERPLANT_SPARKS:
@@ -1572,7 +1570,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_49)) for (Company *c : Company::Iterate()) c->face = ConvertFromOldCompanyManagerFace(c->face);
 
 	if (IsSavegameVersionBefore(SLV_52)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_OBJECT) && _m[t].m5 == OBJECT_STATUE) {
 				_m[t].m2 = CalcClosestTownFromTile(t)->index;
 			}
@@ -1630,7 +1628,7 @@ bool AfterLoadGame()
 	if (IsSavegameVersionBefore(SLV_64)) {
 		/* Since now we allow different signal types and variants on a single tile.
 		 * Move signal states to m4 to make room and clone the signal type/variant. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_RAILWAY) && HasSignals(t)) {
 				/* move signal states */
 				SetSignalStates(t, GB(_m[t].m2, 4, 4));
@@ -1658,7 +1656,7 @@ bool AfterLoadGame()
 	/* From version 82, old style canals (above sealevel (0), WATER owner) are no longer supported.
 	    Replace the owner for those by OWNER_NONE. */
 	if (IsSavegameVersionBefore(SLV_82)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_WATER) &&
 					GetWaterTileType(t) == WATER_TILE_CLEAR &&
 					GetTileOwner(t) == OWNER_WATER &&
@@ -1675,7 +1673,7 @@ bool AfterLoadGame()
 	 * making floods using the removal of ship depots.
 	 */
 	if (IsSavegameVersionBefore(SLV_83)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsShipDepotTile(t)) {
 				_m[t].m4 = (TileHeight(t) == 0) ? OWNER_WATER : OWNER_NONE;
 			}
@@ -1709,7 +1707,7 @@ bool AfterLoadGame()
 	 * land used to have zero density, now they have full density. Therefore,
 	 * make all grassy/rough land trees have a density of 3. */
 	if (IsSavegameVersionBefore(SLV_81)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (GetTileType(t) == MP_TREES) {
 				TreeGround groundType = (TreeGround)GB(_m[t].m2, 4, 2);
 				if (groundType != TREE_GROUND_SNOW_DESERT) SB(_m[t].m2, 6, 2, 3);
@@ -1767,7 +1765,7 @@ bool AfterLoadGame()
 
 	/* The water class was moved/unified. */
 	if (IsSavegameVersionBefore(SLV_146)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_STATION:
 					switch (GetStationType(t)) {
@@ -1801,7 +1799,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_86)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			/* Move river flag and update canals to use water class */
 			if (IsTileType(t, MP_WATER)) {
 				if (GetWaterClass(t) != WATER_CLASS_RIVER) {
@@ -1823,7 +1821,7 @@ bool AfterLoadGame()
 		/* Update locks, depots, docks and buoys to have a water class based
 		 * on its neighbouring tiles. Done after river and canal updates to
 		 * ensure neighbours are correct. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsTileFlat(t)) continue;
 
 			if (IsTileType(t, MP_WATER) && IsLock(t)) SetWaterClassDependingOnSurroundings(t, false);
@@ -1832,7 +1830,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_87)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			/* skip oil rigs at borders! */
 			if ((IsTileType(t, MP_WATER) || IsBuoyTile(t)) &&
 					(TileX(t) == 0 || TileY(t) == 0 || TileX(t) == Map::MaxX() - 1 || TileY(t) == Map::MaxY() - 1)) {
@@ -1899,7 +1897,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_91)) {
 		/* Increase HouseAnimationFrame from 5 to 7 bits */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_HOUSE) && GetHouseType(t) >= NEW_HOUSE_OFFSET) {
 				SB(_me[t].m6, 2, 6, GB(_me[t].m6, 3, 5));
 				SB(_m[t].m3, 5, 1, 0);
@@ -1920,7 +1918,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_99)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			/* Set newly introduced WaterClass of industry tiles */
 			if (IsTileType(t, MP_STATION) && IsOilRig(t)) {
 				SetWaterClassDependingOnSurroundings(t, true);
@@ -1944,7 +1942,7 @@ bool AfterLoadGame()
 	 * format here, as an old layout wouldn't work properly anyway. To be safe, we
 	 * clear any possible PBS reservations as well. */
 	if (IsSavegameVersionBefore(SLV_100)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_RAILWAY:
 					if (HasSignals(t)) {
@@ -2027,7 +2025,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_112)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			/* Check for HQ bit being set, instead of using map accessor,
 			 * since we've already changed it code-wise */
 			if (IsTileType(t, MP_OBJECT) && HasBit(_m[t].m5, 7)) {
@@ -2039,7 +2037,7 @@ bool AfterLoadGame()
 		}
 	}
 	if (IsSavegameVersionBefore(SLV_144)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsTileType(t, MP_OBJECT)) continue;
 
 			/* Reordering/generalisation of the object bits. */
@@ -2055,7 +2053,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_147) && Object::GetNumItems() == 0) {
 		/* Make real objects for object tiles. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsTileType(t, MP_OBJECT)) continue;
 
 			if (Town::GetNumItems() == 0) {
@@ -2322,7 +2320,7 @@ bool AfterLoadGame()
 	/* The bits for the tree ground and tree density have
 	 * been swapped (m2 bits 7..6 and 5..4. */
 	if (IsSavegameVersionBefore(SLV_135)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_CLEAR)) {
 				if (GetRawClearGround(t) == CLEAR_SNOW) {
 					SetClearGroundDensity(t, CLEAR_GRASS, GetClearDensity(t));
@@ -2367,7 +2365,7 @@ bool AfterLoadGame()
 			{119, 15}, // 14 unused tiles (radar)
 			{140,  4}, // APT_GRASS_FENCE_NE_FLAG_2
 		};
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsAirportTile(t)) {
 				StationGfx old_gfx = GetStationGfx(t);
 				byte offset = 0;
@@ -2397,7 +2395,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_141)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			/* Reset tropic zone for VOID tiles, they shall not have any. */
 			if (IsTileType(t, MP_VOID)) SetTropicZone(t, TROPICZONE_NORMAL);
 		}
@@ -2438,7 +2436,7 @@ bool AfterLoadGame()
 
 	/* Move the animation frame to the same location (m7) for all objects. */
 	if (IsSavegameVersionBefore(SLV_147)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			switch (GetTileType(t)) {
 				case MP_HOUSE:
 					if (GetHouseType(t) >= NEW_HOUSE_OFFSET) {
@@ -2477,7 +2475,7 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_149)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsTileType(t, MP_STATION)) continue;
 			if (!IsBuoy(t) && !IsOilRig(t) && !(IsDock(t) && IsTileFlat(t))) {
 				SetWaterClass(t, WATER_CLASS_INVALID);
@@ -2770,7 +2768,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_164) && !IsSavegameVersionBefore(SLV_32)) {
 		/* We store 4 fences in the field tiles instead of only SE and SW. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsTileType(t, MP_CLEAR) && !IsTileType(t, MP_TREES)) continue;
 			if (IsTileType(t, MP_CLEAR) && IsClearGround(t, CLEAR_FIELDS)) continue;
 			uint fence = GB(_m[t].m4, 5, 3);
@@ -2819,7 +2817,7 @@ bool AfterLoadGame()
 
 	/* The road owner of standard road stops was not properly accounted for. */
 	if (IsSavegameVersionBefore(SLV_172)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (!IsStandardRoadStopTile(t)) continue;
 			Owner o = GetTileOwner(t);
 			SetRoadOwner(t, RTT_ROAD, o);
@@ -2860,7 +2858,7 @@ bool AfterLoadGame()
 
 		/* Blocked tiles could be reserved due to a bug, which causes
 		 * other places to assert upon e.g. station reconstruction. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (HasStationTileRail(t) && IsStationTileBlocked(t)) {
 				SetRailStationReservation(t, false);
 			}
@@ -2880,7 +2878,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_186)) {
 		/* Move ObjectType from map to pool */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_OBJECT)) {
 				Object *o = Object::Get(_m[t].m2);
 				o->type = _m[t].m5;
@@ -3079,14 +3077,14 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_TREES_WATER_CLASS)) {
 		/* Update water class for trees. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_TREES)) SetWaterClass(t, GetTreeGround(t) == TREE_GROUND_SHORE ? WATER_CLASS_SEA : WATER_CLASS_INVALID);
 		}
 	}
 
 	/* Update structures for multitile docks */
 	if (IsSavegameVersionBefore(SLV_MULTITILE_DOCKS)) {
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			/* Clear docking tile flag from relevant tiles as it
 			 * was not previously cleared. */
 			if (IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE)) {
@@ -3108,7 +3106,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBeforeOrAt(SLV_ENDING_YEAR)) {
 		/* Reset roadtype/streetcartype info for non-road bridges. */
-		for (TileIndex t = 0; t < map_size; t++) {
+		for (auto t : Map::Iterate()) {
 			if (IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) != TRANSPORT_ROAD) {
 				SetRoadTypes(t, INVALID_ROADTYPE, INVALID_ROADTYPE);
 			}
@@ -3191,7 +3189,7 @@ bool AfterLoadGame()
 
 		if (IsSavegameVersionBeforeOrAt(SLV_MULTITRACK_LEVEL_CROSSINGS)) {
 			/* Reset unused tree counters to reduce the savegame size. */
-			for (TileIndex t = 0; t < map_size; t++) {
+			for (auto t : Map::Iterate()) {
 				if (IsTileType(t, MP_TREES)) {
 					SB(_m[t].m2, 0, 4, 0);
 				}
@@ -3199,7 +3197,7 @@ bool AfterLoadGame()
 		}
 
 		/* Refresh all level crossings to bar adjacent crossing tiles, if needed. */
-		for (TileIndex tile = 0; tile < Map::Size(); tile++) {
+		for (auto tile : Map::Iterate()) {
 			if (IsLevelCrossingTile(tile)) UpdateLevelCrossing(tile, false);
 		}
 	}

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -77,7 +77,7 @@ struct MAPTChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].type = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).type() = buf[j];
 		}
 	}
 
@@ -88,7 +88,7 @@ struct MAPTChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].type;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).type();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -104,7 +104,7 @@ struct MAPHChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].height = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).height() = buf[j];
 		}
 	}
 
@@ -115,7 +115,7 @@ struct MAPHChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].height;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).height();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -131,7 +131,7 @@ struct MAPOChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m1 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m1() = buf[j];
 		}
 	}
 
@@ -142,7 +142,7 @@ struct MAPOChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m1;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m1();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -161,7 +161,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 				/* In those versions the m2 was 8 bits */
 				IsSavegameVersionBefore(SLV_5) ? SLE_FILE_U8 | SLE_VAR_U16 : SLE_UINT16
 			);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m2 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m2() = buf[j];
 		}
 	}
 
@@ -172,7 +172,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 
 		SlSetLength(size * sizeof(uint16));
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m2;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m2();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 		}
 	}
@@ -188,7 +188,7 @@ struct M3LOChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m3 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m3() = buf[j];
 		}
 	}
 
@@ -199,7 +199,7 @@ struct M3LOChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m3;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m3();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -215,7 +215,7 @@ struct M3HIChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m4 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m4() = buf[j];
 		}
 	}
 
@@ -226,7 +226,7 @@ struct M3HIChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m4;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m4();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -242,7 +242,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _m[i++].m5 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m5() = buf[j];
 		}
 	}
 
@@ -253,7 +253,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _m[i++].m5;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m5();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -272,16 +272,16 @@ struct MAPEChunkHandler : ChunkHandler {
 				/* 1024, otherwise we overflow on 64x64 maps! */
 				SlCopy(buf.data(), 1024, SLE_UINT8);
 				for (uint j = 0; j != 1024; j++) {
-					_me[i++].m6 = GB(buf[j], 0, 2);
-					_me[i++].m6 = GB(buf[j], 2, 2);
-					_me[i++].m6 = GB(buf[j], 4, 2);
-					_me[i++].m6 = GB(buf[j], 6, 2);
+					Tile(i++).m6() = GB(buf[j], 0, 2);
+					Tile(i++).m6() = GB(buf[j], 2, 2);
+					Tile(i++).m6() = GB(buf[j], 4, 2);
+					Tile(i++).m6() = GB(buf[j], 6, 2);
 				}
 			}
 		} else {
 			for (TileIndex i = 0; i != size;) {
 				SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-				for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _me[i++].m6 = buf[j];
+				for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m6() = buf[j];
 			}
 		}
 	}
@@ -293,7 +293,7 @@ struct MAPEChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _me[i++].m6;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m6();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -309,7 +309,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _me[i++].m7 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m7() = buf[j];
 		}
 	}
 
@@ -320,7 +320,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _me[i++].m7;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m7();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
 		}
 	}
@@ -336,7 +336,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) _me[i++].m8 = buf[j];
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) Tile(i++).m8() = buf[j];
 		}
 	}
 
@@ -347,7 +347,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 
 		SlSetLength(size * sizeof(uint16));
 		for (TileIndex i = 0; i != size;) {
-			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = _me[i++].m8;
+			for (uint j = 0; j != MAP_SL_BUF_SIZE; j++) buf[j] = Tile(i++).m8();
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
 		}
 	}

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -91,9 +91,10 @@ void MoveBuoysToWaypoints()
 		if (train) {
 			/* When we make a rail waypoint of the station, convert the map as well. */
 			for (TileIndex t : train_st) {
-				if (!IsTileType(t, MP_STATION) || GetStationIndex(t) != index) continue;
+				Tile tile(t);
+				if (!IsTileType(tile, MP_STATION) || GetStationIndex(tile) != index) continue;
 
-				SB(_me[t].m6, 3, 3, STATION_WAYPOINT);
+				SB(tile.m6(), 3, 3, STATION_WAYPOINT);
 				wp->rect.BeforeAddTile(t, StationRect::ADD_FORCE);
 			}
 

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -74,10 +74,11 @@ void MoveWaypointsToBaseStations()
 			if (wp.delete_ctr != 0) continue; // The waypoint was deleted
 
 			/* Waypoint indices were not added to the map prior to this. */
-			_m[wp.xy].m2 = (StationID)wp.index;
+			Tile tile = wp.xy;
+			tile.m2() = (StationID)wp.index;
 
-			if (HasBit(_m[wp.xy].m3, 4)) {
-				wp.spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(_m[wp.xy].m4 + 1);
+			if (HasBit(tile.m3(), 4)) {
+				wp.spec = StationClass::Get(STAT_CLASS_WAYP)->GetSpec(tile.m4() + 1);
 			}
 		}
 	} else {
@@ -102,10 +103,10 @@ void MoveWaypointsToBaseStations()
 		TileIndex t = wp.xy;
 		/* Sometimes waypoint (sign) locations became disconnected from their actual location in
 		 * the map array. If this is the case, try to locate the actual location in the map array */
-		if (!IsTileType(t, MP_RAILWAY) || GetRailTileType(t) != 2 /* RAIL_TILE_WAYPOINT */ || _m[t].m2 != wp.index) {
+		if (!IsTileType(t, MP_RAILWAY) || GetRailTileType(t) != 2 /* RAIL_TILE_WAYPOINT */ || Tile(t).m2() != wp.index) {
 			Debug(sl, 0, "Found waypoint tile {} with invalid position", t);
 			for (t = 0; t < Map::Size(); t++) {
-				if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && _m[t].m2 == wp.index) {
+				if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && Tile(t).m2() == wp.index) {
 					Debug(sl, 0, "Found actual waypoint position at {}", t);
 					break;
 				}
@@ -125,19 +126,20 @@ void MoveWaypointsToBaseStations()
 		new_wp->string_id  = STR_SV_STNAME_WAYPOINT;
 
 		/* The tile might've been reserved! */
-		bool reserved = !IsSavegameVersionBefore(SLV_100) && HasBit(_m[t].m5, 4);
+		Tile tile(t);
+		bool reserved = !IsSavegameVersionBefore(SLV_100) && HasBit(tile.m5(), 4);
 
 		/* The tile really has our waypoint, so reassign the map array */
-		MakeRailWaypoint(t, GetTileOwner(t), new_wp->index, (Axis)GB(_m[t].m5, 0, 1), 0, GetRailType(t));
+		MakeRailWaypoint(tile, GetTileOwner(tile), new_wp->index, (Axis)GB(tile.m5(), 0, 1), 0, GetRailType(tile));
 		new_wp->facilities |= FACIL_TRAIN;
-		new_wp->owner = GetTileOwner(t);
+		new_wp->owner = GetTileOwner(tile);
 
-		SetRailStationReservation(t, reserved);
+		SetRailStationReservation(tile, reserved);
 
 		if (wp.spec != nullptr) {
-			SetCustomStationSpecIndex(t, AllocateSpecToStation(wp.spec, new_wp, true));
+			SetCustomStationSpecIndex(tile, AllocateSpecToStation(wp.spec, new_wp, true));
 		}
-		new_wp->rect.BeforeAddTile(t, StationRect::ADD_FORCE);
+		new_wp->rect.BeforeAddTile(tile, StationRect::ADD_FORCE);
 
 		wp.new_index = new_wp->index;
 	}

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -69,7 +69,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		encoded_text = text->GetEncodedText();
 		EnforcePreconditionEncodedText(STORY_PAGE_ELEMENT_INVALID, encoded_text);
 	}
-	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_LOCATION || ::IsValidTile(reference));
+	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_LOCATION || ::IsValidTile((::TileIndex)reference));
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || ScriptGoal::IsValidGoal((ScriptGoal::GoalID)reference));
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, type != SPET_GOAL || !(StoryPage::Get(story_page_id)->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
 
@@ -118,7 +118,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 		encoded_text = text->GetEncodedText();
 		EnforcePreconditionEncodedText(false, encoded_text);
 	}
-	EnforcePrecondition(false, type != ::SPET_LOCATION || ::IsValidTile(reference));
+	EnforcePrecondition(false, type != ::SPET_LOCATION || ::IsValidTile((::TileIndex)reference));
 	EnforcePrecondition(false, type != ::SPET_GOAL || ScriptGoal::IsValidGoal((ScriptGoal::GoalID)reference));
 	EnforcePrecondition(false, type != ::SPET_GOAL || !(p->company == INVALID_COMPANY && Goal::Get(reference)->company != INVALID_COMPANY));
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -78,7 +78,7 @@
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is a hangar.
  */
-bool IsHangar(TileIndex t)
+bool IsHangar(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 
@@ -89,7 +89,7 @@ bool IsHangar(TileIndex t)
 	const AirportSpec *as = st->airport.GetSpec();
 
 	for (uint i = 0; i < as->nof_depots; i++) {
-		if (st->airport.GetHangarTile(i) == t) return true;
+		if (st->airport.GetHangarTile(i) == TileIndex(t)) return true;
 	}
 
 	return false;
@@ -2366,11 +2366,12 @@ CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, byte airport_ty
 		st->rect.BeforeAddRect(tile, w, h, StationRect::ADD_TRY);
 
 		for (AirportTileTableIterator iter(as->table[layout], tile); iter != INVALID_TILE; ++iter) {
-			MakeAirport(iter, st->owner, st->index, iter.GetStationGfx(), WATER_CLASS_INVALID);
-			SetStationTileRandomBits(iter, GB(Random(), 0, 4));
+			Tile t(iter);
+			MakeAirport(t, st->owner, st->index, iter.GetStationGfx(), WATER_CLASS_INVALID);
+			SetStationTileRandomBits(t, GB(Random(), 0, 4));
 			st->airport.Add(iter);
 
-			if (AirportTileSpec::Get(GetTranslatedAirportTileID(iter.GetStationGfx()))->animation.status != ANIM_STATUS_NO_ANIMATION) AddAnimatedTile(iter);
+			if (AirportTileSpec::Get(GetTranslatedAirportTileID(iter.GetStationGfx()))->animation.status != ANIM_STATUS_NO_ANIMATION) AddAnimatedTile(t);
 		}
 
 		/* Only call the animation trigger after all tiles have been built */

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -25,10 +25,10 @@ typedef byte StationGfx; ///< Index of station graphics. @see _station_display_d
  * @pre IsTileType(t, MP_STATION)
  * @return Station ID of the station at \a t
  */
-static inline StationID GetStationIndex(TileIndex t)
+static inline StationID GetStationIndex(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
-	return (StationID)_m[t].m2;
+	return (StationID)t.m2();
 }
 
 
@@ -41,10 +41,10 @@ static const int GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET =  4; ///< The offset for the
  * @pre IsTileType(t, MP_STATION)
  * @return the station type
  */
-static inline StationType GetStationType(TileIndex t)
+static inline StationType GetStationType(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
-	return (StationType)GB(_me[t].m6, 3, 3);
+	return (StationType)GB(t.m6(), 3, 3);
 }
 
 /**
@@ -53,7 +53,7 @@ static inline StationType GetStationType(TileIndex t)
  * @pre GetStationType(t) == STATION_TRUCK || GetStationType(t) == STATION_BUS
  * @return the road stop type
  */
-static inline RoadStopType GetRoadStopType(TileIndex t)
+static inline RoadStopType GetRoadStopType(Tile t)
 {
 	assert(GetStationType(t) == STATION_TRUCK || GetStationType(t) == STATION_BUS);
 	return GetStationType(t) == STATION_TRUCK ? ROADSTOP_TRUCK : ROADSTOP_BUS;
@@ -65,10 +65,10 @@ static inline RoadStopType GetRoadStopType(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return the station graphics
  */
-static inline StationGfx GetStationGfx(TileIndex t)
+static inline StationGfx GetStationGfx(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
-	return _m[t].m5;
+	return t.m5();
 }
 
 /**
@@ -77,10 +77,10 @@ static inline StationGfx GetStationGfx(TileIndex t)
  * @param gfx the new graphics
  * @pre IsTileType(t, MP_STATION)
  */
-static inline void SetStationGfx(TileIndex t, StationGfx gfx)
+static inline void SetStationGfx(Tile t, StationGfx gfx)
 {
 	assert(IsTileType(t, MP_STATION));
-	_m[t].m5 = gfx;
+	t.m5() = gfx;
 }
 
 /**
@@ -89,7 +89,7 @@ static inline void SetStationGfx(TileIndex t, StationGfx gfx)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is a rail station
  */
-static inline bool IsRailStation(TileIndex t)
+static inline bool IsRailStation(Tile t)
 {
 	return GetStationType(t) == STATION_RAIL;
 }
@@ -99,7 +99,7 @@ static inline bool IsRailStation(TileIndex t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail station
  */
-static inline bool IsRailStationTile(TileIndex t)
+static inline bool IsRailStationTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsRailStation(t);
 }
@@ -110,7 +110,7 @@ static inline bool IsRailStationTile(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is a rail waypoint
  */
-static inline bool IsRailWaypoint(TileIndex t)
+static inline bool IsRailWaypoint(Tile t)
 {
 	return GetStationType(t) == STATION_WAYPOINT;
 }
@@ -120,7 +120,7 @@ static inline bool IsRailWaypoint(TileIndex t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is a rail waypoint
  */
-static inline bool IsRailWaypointTile(TileIndex t)
+static inline bool IsRailWaypointTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsRailWaypoint(t);
 }
@@ -132,7 +132,7 @@ static inline bool IsRailWaypointTile(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile has rail
  */
-static inline bool HasStationRail(TileIndex t)
+static inline bool HasStationRail(Tile t)
 {
 	return IsRailStation(t) || IsRailWaypoint(t);
 }
@@ -143,7 +143,7 @@ static inline bool HasStationRail(TileIndex t)
  * @param t the tile to check
  * @return true if and only if the tile is a station tile and has rail
  */
-static inline bool HasStationTileRail(TileIndex t)
+static inline bool HasStationTileRail(Tile t)
 {
 	return IsTileType(t, MP_STATION) && HasStationRail(t);
 }
@@ -154,7 +154,7 @@ static inline bool HasStationTileRail(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return true if and only if the tile is an airport
  */
-static inline bool IsAirport(TileIndex t)
+static inline bool IsAirport(Tile t)
 {
 	return GetStationType(t) == STATION_AIRPORT;
 }
@@ -164,12 +164,12 @@ static inline bool IsAirport(TileIndex t)
  * @param t the tile to get the information from
  * @return true if and only if the tile is an airport
  */
-static inline bool IsAirportTile(TileIndex t)
+static inline bool IsAirportTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsAirport(t);
 }
 
-bool IsHangar(TileIndex t);
+bool IsHangar(Tile t);
 
 /**
  * Is the station at \a t a truck stop?
@@ -177,7 +177,7 @@ bool IsHangar(TileIndex t);
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if station is a truck stop, \c false otherwise
  */
-static inline bool IsTruckStop(TileIndex t)
+static inline bool IsTruckStop(Tile t)
 {
 	return GetStationType(t) == STATION_TRUCK;
 }
@@ -188,7 +188,7 @@ static inline bool IsTruckStop(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if station is a bus stop, \c false otherwise
  */
-static inline bool IsBusStop(TileIndex t)
+static inline bool IsBusStop(Tile t)
 {
 	return GetStationType(t) == STATION_BUS;
 }
@@ -199,7 +199,7 @@ static inline bool IsBusStop(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if station at the tile is a bus top or a truck stop, \c false otherwise
  */
-static inline bool IsRoadStop(TileIndex t)
+static inline bool IsRoadStop(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
 	return IsTruckStop(t) || IsBusStop(t);
@@ -210,7 +210,7 @@ static inline bool IsRoadStop(TileIndex t)
  * @param t Tile to check
  * @return \c true if the tile is a station tile and a road stop
  */
-static inline bool IsRoadStopTile(TileIndex t)
+static inline bool IsRoadStopTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsRoadStop(t);
 }
@@ -220,7 +220,7 @@ static inline bool IsRoadStopTile(TileIndex t)
  * @param t Tile to check
  * @return \c true if the tile is a station tile and a standard road stop
  */
-static inline bool IsStandardRoadStopTile(TileIndex t)
+static inline bool IsStandardRoadStopTile(Tile t)
 {
 	return IsRoadStopTile(t) && GetStationGfx(t) < GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET;
 }
@@ -230,7 +230,7 @@ static inline bool IsStandardRoadStopTile(TileIndex t)
  * @param t Tile to check
  * @return \c true if the tile is a station tile and a drive through road stop
  */
-static inline bool IsDriveThroughStopTile(TileIndex t)
+static inline bool IsDriveThroughStopTile(Tile t)
 {
 	return IsRoadStopTile(t) && GetStationGfx(t) >= GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET;
 }
@@ -243,7 +243,7 @@ StationGfx GetTranslatedAirportTileID(StationGfx gfx);
  * @pre IsAirport(t)
  * @return the station graphics
  */
-static inline StationGfx GetAirportGfx(TileIndex t)
+static inline StationGfx GetAirportGfx(Tile t)
 {
 	assert(IsAirport(t));
 	return GetTranslatedAirportTileID(GetStationGfx(t));
@@ -255,7 +255,7 @@ static inline StationGfx GetAirportGfx(TileIndex t)
  * @pre IsRoadStopTile(t)
  * @return the direction of the entrance
  */
-static inline DiagDirection GetRoadStopDir(TileIndex t)
+static inline DiagDirection GetRoadStopDir(Tile t)
 {
 	StationGfx gfx = GetStationGfx(t);
 	assert(IsRoadStopTile(t));
@@ -272,7 +272,7 @@ static inline DiagDirection GetRoadStopDir(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if the tile is an oilrig tile
  */
-static inline bool IsOilRig(TileIndex t)
+static inline bool IsOilRig(Tile t)
 {
 	return GetStationType(t) == STATION_OILRIG;
 }
@@ -283,7 +283,7 @@ static inline bool IsOilRig(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if the tile is a dock
  */
-static inline bool IsDock(TileIndex t)
+static inline bool IsDock(Tile t)
 {
 	return GetStationType(t) == STATION_DOCK;
 }
@@ -293,7 +293,7 @@ static inline bool IsDock(TileIndex t)
  * @param t Tile to check
  * @return \c true if the tile is a dock
  */
-static inline bool IsDockTile(TileIndex t)
+static inline bool IsDockTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && GetStationType(t) == STATION_DOCK;
 }
@@ -304,7 +304,7 @@ static inline bool IsDockTile(TileIndex t)
  * @pre IsTileType(t, MP_STATION)
  * @return \c true if the tile is a buoy
  */
-static inline bool IsBuoy(TileIndex t)
+static inline bool IsBuoy(Tile t)
 {
 	return GetStationType(t) == STATION_BUOY;
 }
@@ -314,7 +314,7 @@ static inline bool IsBuoy(TileIndex t)
  * @param t Tile to check
  * @return \c true if the tile is a buoy
  */
-static inline bool IsBuoyTile(TileIndex t)
+static inline bool IsBuoyTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsBuoy(t);
 }
@@ -324,7 +324,7 @@ static inline bool IsBuoyTile(TileIndex t)
  * @param t Tile to check
  * @return \c true if the tile is an hangar
  */
-static inline bool IsHangarTile(TileIndex t)
+static inline bool IsHangarTile(Tile t)
 {
 	return IsTileType(t, MP_STATION) && IsHangar(t);
 }
@@ -335,7 +335,7 @@ static inline bool IsHangarTile(TileIndex t)
  * @pre HasStationRail(t)
  * @return The direction of the rails on tile \a t.
  */
-static inline Axis GetRailStationAxis(TileIndex t)
+static inline Axis GetRailStationAxis(Tile t)
 {
 	assert(HasStationRail(t));
 	return HasBit(GetStationGfx(t), 0) ? AXIS_Y : AXIS_X;
@@ -347,7 +347,7 @@ static inline Axis GetRailStationAxis(TileIndex t)
  * @pre HasStationRail(t)
  * @return The rail track of the rails on tile \a t.
  */
-static inline Track GetRailStationTrack(TileIndex t)
+static inline Track GetRailStationTrack(Tile t)
 {
 	return AxisToTrack(GetRailStationAxis(t));
 }
@@ -358,7 +358,7 @@ static inline Track GetRailStationTrack(TileIndex t)
  * @pre HasStationRail(t)
  * @return The trackbits of the rails on tile \a t.
  */
-static inline TrackBits GetRailStationTrackBits(TileIndex t)
+static inline TrackBits GetRailStationTrackBits(Tile t)
 {
 	return AxisToTrackBits(GetRailStationAxis(t));
 }
@@ -376,7 +376,7 @@ static inline TrackBits GetRailStationTrackBits(TileIndex t)
  * @pre IsRailStationTile(station_tile)
  * @return true if the two tiles are compatible
  */
-static inline bool IsCompatibleTrainStationTile(TileIndex test_tile, TileIndex station_tile)
+static inline bool IsCompatibleTrainStationTile(Tile test_tile, Tile station_tile)
 {
 	assert(IsRailStationTile(station_tile));
 	return IsRailStationTile(test_tile) && IsCompatibleRail(GetRailType(test_tile), GetRailType(station_tile)) &&
@@ -391,10 +391,10 @@ static inline bool IsCompatibleTrainStationTile(TileIndex test_tile, TileIndex s
  * @param t the station tile
  * @return reservation state
  */
-static inline bool HasStationReservation(TileIndex t)
+static inline bool HasStationReservation(Tile t)
 {
 	assert(HasStationRail(t));
-	return HasBit(_me[t].m6, 2);
+	return HasBit(t.m6(), 2);
 }
 
 /**
@@ -403,10 +403,10 @@ static inline bool HasStationReservation(TileIndex t)
  * @param t the station tile
  * @param b the reservation state
  */
-static inline void SetRailStationReservation(TileIndex t, bool b)
+static inline void SetRailStationReservation(Tile t, bool b)
 {
 	assert(HasStationRail(t));
-	SB(_me[t].m6, 2, 1, b ? 1 : 0);
+	SB(t.m6(), 2, 1, b ? 1 : 0);
 }
 
 /**
@@ -415,7 +415,7 @@ static inline void SetRailStationReservation(TileIndex t, bool b)
  * @param t the tile
  * @return reserved track bits
  */
-static inline TrackBits GetStationReservationTrackBits(TileIndex t)
+static inline TrackBits GetStationReservationTrackBits(Tile t)
 {
 	return HasStationReservation(t) ? GetRailStationTrackBits(t) : TRACK_BIT_NONE;
 }
@@ -427,7 +427,7 @@ static inline TrackBits GetStationReservationTrackBits(TileIndex t)
  * @pre \a t is the land part of the dock
  * @return The direction of the dock on tile \a t.
  */
-static inline DiagDirection GetDockDirection(TileIndex t)
+static inline DiagDirection GetDockDirection(Tile t)
 {
 	StationGfx gfx = GetStationGfx(t);
 	assert(IsDock(t) && gfx < GFX_DOCK_BASE_WATER_PART);
@@ -441,7 +441,7 @@ static inline DiagDirection GetDockDirection(TileIndex t)
  * @pre IsBuoy(t) || IsOilRig(t) || IsDock(t)
  * @return The offset from this tile that should be used as destination for ships.
  */
-static inline TileIndexDiffC GetDockOffset(TileIndex t)
+static inline TileIndexDiffC GetDockOffset(Tile t)
 {
 	static const TileIndexDiffC buoy_offset = {0, 0};
 	static const TileIndexDiffC oilrig_offset = {2, 0};
@@ -467,10 +467,10 @@ static inline TileIndexDiffC GetDockOffset(TileIndex t)
  * @pre HasStationTileRail(t)
  * @return True if this station is part of a newgrf station.
  */
-static inline bool IsCustomStationSpecIndex(TileIndex t)
+static inline bool IsCustomStationSpecIndex(Tile t)
 {
 	assert(HasStationTileRail(t));
-	return _m[t].m4 != 0;
+	return t.m4() != 0;
 }
 
 /**
@@ -479,10 +479,10 @@ static inline bool IsCustomStationSpecIndex(TileIndex t)
  * @param specindex The new spec.
  * @pre HasStationTileRail(t)
  */
-static inline void SetCustomStationSpecIndex(TileIndex t, byte specindex)
+static inline void SetCustomStationSpecIndex(Tile t, byte specindex)
 {
 	assert(HasStationTileRail(t));
-	_m[t].m4 = specindex;
+	t.m4() = specindex;
 }
 
 /**
@@ -491,10 +491,10 @@ static inline void SetCustomStationSpecIndex(TileIndex t, byte specindex)
  * @pre HasStationTileRail(t)
  * @return The custom station spec of this tile.
  */
-static inline uint GetCustomStationSpecIndex(TileIndex t)
+static inline uint GetCustomStationSpecIndex(Tile t)
 {
 	assert(HasStationTileRail(t));
-	return _m[t].m4;
+	return t.m4();
 }
 
 /**
@@ -503,10 +503,10 @@ static inline uint GetCustomStationSpecIndex(TileIndex t)
  * @pre IsRoadStopTile(t)
  * @return True if this station is part of a newgrf station.
  */
-static inline bool IsCustomRoadStopSpecIndex(TileIndex t)
+static inline bool IsCustomRoadStopSpecIndex(Tile t)
 {
 	assert(IsRoadStopTile(t));
-	return GB(_me[t].m8, 0, 6) != 0;
+	return GB(t.m8(), 0, 6) != 0;
 }
 
 /**
@@ -515,10 +515,10 @@ static inline bool IsCustomRoadStopSpecIndex(TileIndex t)
  * @param specindex The new spec.
  * @pre IsRoadStopTile(t)
  */
-static inline void SetCustomRoadStopSpecIndex(TileIndex t, byte specindex)
+static inline void SetCustomRoadStopSpecIndex(Tile t, byte specindex)
 {
 	assert(IsRoadStopTile(t));
-	SB(_me[t].m8, 0, 6, specindex);
+	SB(t.m8(), 0, 6, specindex);
 }
 
 /**
@@ -527,10 +527,10 @@ static inline void SetCustomRoadStopSpecIndex(TileIndex t, byte specindex)
  * @pre IsRoadStopTile(t)
  * @return The custom station spec of this tile.
  */
-static inline uint GetCustomRoadStopSpecIndex(TileIndex t)
+static inline uint GetCustomRoadStopSpecIndex(Tile t)
 {
 	assert(IsRoadStopTile(t));
-	return GB(_me[t].m8, 0, 6);
+	return GB(t.m8(), 0, 6);
 }
 
 /**
@@ -539,10 +539,10 @@ static inline uint GetCustomRoadStopSpecIndex(TileIndex t)
  * @param random_bits The random bits.
  * @pre IsTileType(t, MP_STATION)
  */
-static inline void SetStationTileRandomBits(TileIndex t, byte random_bits)
+static inline void SetStationTileRandomBits(Tile t, byte random_bits)
 {
 	assert(IsTileType(t, MP_STATION));
-	SB(_m[t].m3, 4, 4, random_bits);
+	SB(t.m3(), 4, 4, random_bits);
 }
 
 /**
@@ -551,10 +551,10 @@ static inline void SetStationTileRandomBits(TileIndex t, byte random_bits)
  * @pre IsTileType(t, MP_STATION)
  * @return The random bits for this station tile.
  */
-static inline byte GetStationTileRandomBits(TileIndex t)
+static inline byte GetStationTileRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_STATION));
-	return GB(_m[t].m3, 4, 4);
+	return GB(t.m3(), 4, 4);
 }
 
 /**
@@ -566,20 +566,20 @@ static inline byte GetStationTileRandomBits(TileIndex t)
  * @param section the StationGfx to be used for this tile
  * @param wc The water class of the station
  */
-static inline void MakeStation(TileIndex t, Owner o, StationID sid, StationType st, byte section, WaterClass wc = WATER_CLASS_INVALID)
+static inline void MakeStation(Tile t, Owner o, StationID sid, StationType st, byte section, WaterClass wc = WATER_CLASS_INVALID)
 {
 	SetTileType(t, MP_STATION);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
 	SetDockingTile(t, false);
-	_m[t].m2 = sid;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = section;
-	SB(_me[t].m6, 2, 1, 0);
-	SB(_me[t].m6, 3, 3, st);
-	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	t.m2() = sid;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = section;
+	SB(t.m6(), 2, 1, 0);
+	SB(t.m6(), 3, 3, st);
+	t.m7() = 0;
+	t.m8() = 0;
 }
 
 /**
@@ -591,7 +591,7 @@ static inline void MakeStation(TileIndex t, Owner o, StationID sid, StationType 
  * @param section the StationGfx to be used for this tile
  * @param rt the railtype of this tile
  */
-static inline void MakeRailStation(TileIndex t, Owner o, StationID sid, Axis a, byte section, RailType rt)
+static inline void MakeRailStation(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
 {
 	MakeStation(t, o, sid, STATION_RAIL, section + a);
 	SetRailType(t, rt);
@@ -607,7 +607,7 @@ static inline void MakeRailStation(TileIndex t, Owner o, StationID sid, Axis a, 
  * @param section the StationGfx to be used for this tile
  * @param rt the railtype of this tile
  */
-static inline void MakeRailWaypoint(TileIndex t, Owner o, StationID sid, Axis a, byte section, RailType rt)
+static inline void MakeRailWaypoint(Tile t, Owner o, StationID sid, Axis a, byte section, RailType rt)
 {
 	MakeStation(t, o, sid, STATION_WAYPOINT, section + a);
 	SetRailType(t, rt);
@@ -624,7 +624,7 @@ static inline void MakeRailWaypoint(TileIndex t, Owner o, StationID sid, Axis a,
  * @param tram_rt the tram roadtype on this tile
  * @param d the direction of the roadstop
  */
-static inline void MakeRoadStop(TileIndex t, Owner o, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, DiagDirection d)
+static inline void MakeRoadStop(Tile t, Owner o, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, DiagDirection d)
 {
 	MakeStation(t, o, sid, (rst == ROADSTOP_BUS ? STATION_BUS : STATION_TRUCK), d);
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -644,7 +644,7 @@ static inline void MakeRoadStop(TileIndex t, Owner o, StationID sid, RoadStopTyp
  * @param tram_rt the tram roadtype on this tile
  * @param a the direction of the roadstop
  */
-static inline void MakeDriveThroughRoadStop(TileIndex t, Owner station, Owner road, Owner tram, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, Axis a)
+static inline void MakeDriveThroughRoadStop(Tile t, Owner station, Owner road, Owner tram, StationID sid, RoadStopType rst, RoadType road_rt, RoadType tram_rt, Axis a)
 {
 	MakeStation(t, station, sid, (rst == ROADSTOP_BUS ? STATION_BUS : STATION_TRUCK), GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET + a);
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -660,7 +660,7 @@ static inline void MakeDriveThroughRoadStop(TileIndex t, Owner station, Owner ro
  * @param section the StationGfx to be used for this tile
  * @param wc the type of water on this tile
  */
-static inline void MakeAirport(TileIndex t, Owner o, StationID sid, byte section, WaterClass wc)
+static inline void MakeAirport(Tile t, Owner o, StationID sid, byte section, WaterClass wc)
 {
 	MakeStation(t, o, sid, STATION_AIRPORT, section, wc);
 }
@@ -671,7 +671,7 @@ static inline void MakeAirport(TileIndex t, Owner o, StationID sid, byte section
  * @param sid the station to which this tile belongs
  * @param wc the type of water on this tile
  */
-static inline void MakeBuoy(TileIndex t, StationID sid, WaterClass wc)
+static inline void MakeBuoy(Tile t, StationID sid, WaterClass wc)
 {
 	/* Make the owner of the buoy tile the same as the current owner of the
 	 * water tile. In this way, we can reset the owner of the water to its
@@ -687,10 +687,10 @@ static inline void MakeBuoy(TileIndex t, StationID sid, WaterClass wc)
  * @param d the direction of the dock
  * @param wc the type of water on this tile
  */
-static inline void MakeDock(TileIndex t, Owner o, StationID sid, DiagDirection d, WaterClass wc)
+static inline void MakeDock(Tile t, Owner o, StationID sid, DiagDirection d, WaterClass wc)
 {
 	MakeStation(t, o, sid, STATION_DOCK, d);
-	MakeStation(t + TileOffsByDiagDir(d), o, sid, STATION_DOCK, GFX_DOCK_BASE_WATER_PART + DiagDirToAxis(d), wc);
+	MakeStation(TileIndex(t) + TileOffsByDiagDir(d), o, sid, STATION_DOCK, GFX_DOCK_BASE_WATER_PART + DiagDirToAxis(d), wc);
 }
 
 /**
@@ -699,7 +699,7 @@ static inline void MakeDock(TileIndex t, Owner o, StationID sid, DiagDirection d
  * @param sid the station to which this tile belongs
  * @param wc the type of water on this tile
  */
-static inline void MakeOilrig(TileIndex t, StationID sid, WaterClass wc)
+static inline void MakeOilrig(Tile t, StationID sid, WaterClass wc)
 {
 	MakeStation(t, OWNER_NONE, sid, STATION_OILRIG, 0, wc);
 }

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -26,10 +26,10 @@
  * @return the height of the tile
  * @pre tile < Map::Size()
  */
-debug_inline static uint TileHeight(TileIndex tile)
+debug_inline static uint TileHeight(Tile tile)
 {
 	assert(tile < Map::Size());
-	return _m[tile].height;
+	return tile.height();
 }
 
 /**
@@ -54,11 +54,11 @@ static inline uint TileHeightOutsideMap(int x, int y)
  * @pre tile < Map::Size()
  * @pre height <= MAX_TILE_HEIGHT
  */
-static inline void SetTileHeight(TileIndex tile, uint height)
+static inline void SetTileHeight(Tile tile, uint height)
 {
 	assert(tile < Map::Size());
 	assert(height <= MAX_TILE_HEIGHT);
-	_m[tile].height = height;
+	tile.height() = height;
 }
 
 /**
@@ -69,7 +69,7 @@ static inline void SetTileHeight(TileIndex tile, uint height)
  * @param tile The tile to get the height
  * @return The height of the tile in pixel
  */
-static inline uint TilePixelHeight(TileIndex tile)
+static inline uint TilePixelHeight(Tile tile)
 {
 	return TileHeight(tile) * TILE_HEIGHT;
 }
@@ -93,10 +93,10 @@ static inline uint TilePixelHeightOutsideMap(int x, int y)
  * @return The tiletype of the tile
  * @pre tile < Map::Size()
  */
-debug_inline static TileType GetTileType(TileIndex tile)
+debug_inline static TileType GetTileType(Tile tile)
 {
 	assert(tile < Map::Size());
-	return (TileType)GB(_m[tile].type, 4, 4);
+	return (TileType)GB(tile.type(), 4, 4);
 }
 
 /**
@@ -106,7 +106,7 @@ debug_inline static TileType GetTileType(TileIndex tile)
  * @return Whether the tile is in the interior of the map
  * @pre tile < Map::Size()
  */
-static inline bool IsInnerTile(TileIndex tile)
+static inline bool IsInnerTile(Tile tile)
 {
 	assert(tile < Map::Size());
 
@@ -128,14 +128,14 @@ static inline bool IsInnerTile(TileIndex tile)
  * @pre tile < Map::Size()
  * @pre type MP_VOID <=> tile is on the south-east or south-west edge.
  */
-static inline void SetTileType(TileIndex tile, TileType type)
+static inline void SetTileType(Tile tile, TileType type)
 {
 	assert(tile < Map::Size());
 	/* VOID tiles (and no others) are exactly allowed at the lower left and right
 	 * edges of the map. If _settings_game.construction.freeform_edges is true,
 	 * the upper edges of the map are also VOID tiles. */
 	assert(IsInnerTile(tile) == (type != MP_VOID));
-	SB(_m[tile].type, 4, 4, type);
+	SB(tile.type(), 4, 4, type);
 }
 
 /**
@@ -147,7 +147,7 @@ static inline void SetTileType(TileIndex tile, TileType type)
  * @param type The type to check against
  * @return true If the type matches against the type of the tile
  */
-debug_inline static bool IsTileType(TileIndex tile, TileType type)
+debug_inline static bool IsTileType(Tile tile, TileType type)
 {
 	return GetTileType(tile) == type;
 }
@@ -158,7 +158,7 @@ debug_inline static bool IsTileType(TileIndex tile, TileType type)
  * @param tile The tile to check
  * @return True if the tile is on the map and not one of MP_VOID.
  */
-static inline bool IsValidTile(TileIndex tile)
+static inline bool IsValidTile(Tile tile)
 {
 	return tile < Map::Size() && !IsTileType(tile, MP_VOID);
 }
@@ -175,13 +175,13 @@ static inline bool IsValidTile(TileIndex tile)
  * @pre IsValidTile(tile)
  * @pre The type of the tile must not be MP_HOUSE and MP_INDUSTRY
  */
-static inline Owner GetTileOwner(TileIndex tile)
+static inline Owner GetTileOwner(Tile tile)
 {
 	assert(IsValidTile(tile));
 	assert(!IsTileType(tile, MP_HOUSE));
 	assert(!IsTileType(tile, MP_INDUSTRY));
 
-	return (Owner)GB(_m[tile].m1, 0, 5);
+	return (Owner)GB(tile.m1(), 0, 5);
 }
 
 /**
@@ -195,13 +195,13 @@ static inline Owner GetTileOwner(TileIndex tile)
  * @pre IsValidTile(tile)
  * @pre The type of the tile must not be MP_HOUSE and MP_INDUSTRY
  */
-static inline void SetTileOwner(TileIndex tile, Owner owner)
+static inline void SetTileOwner(Tile tile, Owner owner)
 {
 	assert(IsValidTile(tile));
 	assert(!IsTileType(tile, MP_HOUSE));
 	assert(!IsTileType(tile, MP_INDUSTRY));
 
-	SB(_m[tile].m1, 0, 5, owner);
+	SB(tile.m1(), 0, 5, owner);
 }
 
 /**
@@ -211,7 +211,7 @@ static inline void SetTileOwner(TileIndex tile, Owner owner)
  * @param owner The owner to check against
  * @return True if a tile belongs the the given owner
  */
-static inline bool IsTileOwner(TileIndex tile, Owner owner)
+static inline bool IsTileOwner(Tile tile, Owner owner)
 {
 	return GetTileOwner(tile) == owner;
 }
@@ -222,11 +222,11 @@ static inline bool IsTileOwner(TileIndex tile, Owner owner)
  * @param type the new type
  * @pre tile < Map::Size()
  */
-static inline void SetTropicZone(TileIndex tile, TropicZone type)
+static inline void SetTropicZone(Tile tile, TropicZone type)
 {
 	assert(tile < Map::Size());
 	assert(!IsTileType(tile, MP_VOID) || type == TROPICZONE_NORMAL);
-	SB(_m[tile].type, 0, 2, type);
+	SB(tile.type(), 0, 2, type);
 }
 
 /**
@@ -235,10 +235,10 @@ static inline void SetTropicZone(TileIndex tile, TropicZone type)
  * @pre tile < Map::Size()
  * @return the zone type
  */
-static inline TropicZone GetTropicZone(TileIndex tile)
+static inline TropicZone GetTropicZone(Tile tile)
 {
 	assert(tile < Map::Size());
-	return (TropicZone)GB(_m[tile].type, 0, 2);
+	return (TropicZone)GB(tile.type(), 0, 2);
 }
 
 /**
@@ -247,10 +247,10 @@ static inline TropicZone GetTropicZone(TileIndex tile)
  * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
  * @return frame number
  */
-static inline byte GetAnimationFrame(TileIndex t)
+static inline byte GetAnimationFrame(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
-	return _me[t].m7;
+	return t.m7();
 }
 
 /**
@@ -259,10 +259,10 @@ static inline byte GetAnimationFrame(TileIndex t)
  * @param frame the new frame number
  * @pre IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION)
  */
-static inline void SetAnimationFrame(TileIndex t, byte frame)
+static inline void SetAnimationFrame(Tile t, byte frame)
 {
 	assert(IsTileType(t, MP_HOUSE) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_INDUSTRY) ||IsTileType(t, MP_STATION));
-	_me[t].m7 = frame;
+	t.m7() = frame;
 }
 
 Slope GetTileSlope(TileIndex tile, int *h = nullptr);

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -19,10 +19,10 @@
  * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
  * @return TownID
  */
-static inline TownID GetTownIndex(TileIndex t)
+static inline TownID GetTownIndex(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
-	return _m[t].m2;
+	return t.m2();
 }
 
 /**
@@ -31,10 +31,10 @@ static inline TownID GetTownIndex(TileIndex t)
  * @param index the index of the town
  * @pre IsTileType(t, MP_HOUSE) or IsTileType(t, MP_ROAD) but not a road depot
  */
-static inline void SetTownIndex(TileIndex t, TownID index)
+static inline void SetTownIndex(Tile t, TownID index)
 {
 	assert(IsTileType(t, MP_HOUSE) || (IsTileType(t, MP_ROAD) && !IsRoadDepot(t)));
-	_m[t].m2 = index;
+	t.m2() = index;
 }
 
 /**
@@ -44,10 +44,10 @@ static inline void SetTownIndex(TileIndex t, TownID index)
  * @pre IsTileType(t, MP_HOUSE)
  * @return house type
  */
-static inline HouseID GetCleanHouseType(TileIndex t)
+static inline HouseID GetCleanHouseType(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return _m[t].m4 | (GB(_m[t].m3, 6, 1) << 8);
+	return t.m4() | (GB(t.m3(), 6, 1) << 8);
 }
 
 /**
@@ -56,7 +56,7 @@ static inline HouseID GetCleanHouseType(TileIndex t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return house type
  */
-static inline HouseID GetHouseType(TileIndex t)
+static inline HouseID GetHouseType(Tile t)
 {
 	return GetTranslatedHouseID(GetCleanHouseType(t));
 }
@@ -67,11 +67,11 @@ static inline HouseID GetHouseType(TileIndex t)
  * @param house_id the new house type
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseType(TileIndex t, HouseID house_id)
+static inline void SetHouseType(Tile t, HouseID house_id)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	_m[t].m4 = GB(house_id, 0, 8);
-	SB(_m[t].m3, 6, 1, GB(house_id, 8, 1));
+	t.m4() = GB(house_id, 0, 8);
+	SB(t.m3(), 6, 1, GB(house_id, 8, 1));
 }
 
 /**
@@ -79,9 +79,9 @@ static inline void SetHouseType(TileIndex t, HouseID house_id)
  * @param t the tile
  * @return has destination
  */
-static inline bool LiftHasDestination(TileIndex t)
+static inline bool LiftHasDestination(Tile t)
 {
-	return HasBit(_me[t].m7, 0);
+	return HasBit(t.m7(), 0);
 }
 
 /**
@@ -90,10 +90,10 @@ static inline bool LiftHasDestination(TileIndex t)
  * @param t the tile
  * @param dest new destination
  */
-static inline void SetLiftDestination(TileIndex t, byte dest)
+static inline void SetLiftDestination(Tile t, byte dest)
 {
-	SetBit(_me[t].m7, 0);
-	SB(_me[t].m7, 1, 3, dest);
+	SetBit(t.m7(), 0);
+	SB(t.m7(), 1, 3, dest);
 }
 
 /**
@@ -101,9 +101,9 @@ static inline void SetLiftDestination(TileIndex t, byte dest)
  * @param t the tile
  * @return destination
  */
-static inline byte GetLiftDestination(TileIndex t)
+static inline byte GetLiftDestination(Tile t)
 {
-	return GB(_me[t].m7, 1, 3);
+	return GB(t.m7(), 1, 3);
 }
 
 /**
@@ -112,9 +112,9 @@ static inline byte GetLiftDestination(TileIndex t)
  * and the destination.
  * @param t the tile
  */
-static inline void HaltLift(TileIndex t)
+static inline void HaltLift(Tile t)
 {
-	SB(_me[t].m7, 0, 4, 0);
+	SB(t.m7(), 0, 4, 0);
 }
 
 /**
@@ -122,9 +122,9 @@ static inline void HaltLift(TileIndex t)
  * @param t the tile
  * @return position, from 0 to 36
  */
-static inline byte GetLiftPosition(TileIndex t)
+static inline byte GetLiftPosition(Tile t)
 {
-	return GB(_me[t].m6, 2, 6);
+	return GB(t.m6(), 2, 6);
 }
 
 /**
@@ -132,9 +132,9 @@ static inline byte GetLiftPosition(TileIndex t)
  * @param t the tile
  * @param pos position, from 0 to 36
  */
-static inline void SetLiftPosition(TileIndex t, byte pos)
+static inline void SetLiftPosition(Tile t, byte pos)
 {
-	SB(_me[t].m6, 2, 6, pos);
+	SB(t.m6(), 2, 6, pos);
 }
 
 /**
@@ -142,10 +142,10 @@ static inline void SetLiftPosition(TileIndex t, byte pos)
  * @param t the tile
  * @return true if it is, false if it is not
  */
-static inline bool IsHouseCompleted(TileIndex t)
+static inline bool IsHouseCompleted(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return HasBit(_m[t].m3, 7);
+	return HasBit(t.m3(), 7);
 }
 
 /**
@@ -153,10 +153,10 @@ static inline bool IsHouseCompleted(TileIndex t)
  * @param t the tile
  * @param status
  */
-static inline void SetHouseCompleted(TileIndex t, bool status)
+static inline void SetHouseCompleted(Tile t, bool status)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	SB(_m[t].m3, 7, 1, !!status);
+	SB(t.m3(), 7, 1, !!status);
 }
 
 /**
@@ -180,10 +180,10 @@ static inline void SetHouseCompleted(TileIndex t, bool status)
  * @pre IsTileType(t, MP_HOUSE)
  * @return the building stage of the house
  */
-static inline byte GetHouseBuildingStage(TileIndex t)
+static inline byte GetHouseBuildingStage(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return IsHouseCompleted(t) ? (byte)TOWN_HOUSE_COMPLETED : GB(_m[t].m5, 3, 2);
+	return IsHouseCompleted(t) ? (byte)TOWN_HOUSE_COMPLETED : GB(t.m5(), 3, 2);
 }
 
 /**
@@ -192,10 +192,10 @@ static inline byte GetHouseBuildingStage(TileIndex t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return the construction stage of the house
  */
-static inline byte GetHouseConstructionTick(TileIndex t)
+static inline byte GetHouseConstructionTick(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return IsHouseCompleted(t) ? 0 : GB(_m[t].m5, 0, 3);
+	return IsHouseCompleted(t) ? 0 : GB(t.m5(), 0, 3);
 }
 
 /**
@@ -205,12 +205,12 @@ static inline byte GetHouseConstructionTick(TileIndex t)
  * @param t the tile of the house to increment the construction stage of
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void IncHouseConstructionTick(TileIndex t)
+static inline void IncHouseConstructionTick(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	AB(_m[t].m5, 0, 5, 1);
+	AB(t.m5(), 0, 5, 1);
 
-	if (GB(_m[t].m5, 3, 2) == TOWN_HOUSE_COMPLETED) {
+	if (GB(t.m5(), 3, 2) == TOWN_HOUSE_COMPLETED) {
 		/* House is now completed.
 		 * Store the year of construction as well, for newgrf house purpose */
 		SetHouseCompleted(t, true);
@@ -223,10 +223,10 @@ static inline void IncHouseConstructionTick(TileIndex t)
  * @param t the tile of this house
  * @pre IsTileType(t, MP_HOUSE) && IsHouseCompleted(t)
  */
-static inline void ResetHouseAge(TileIndex t)
+static inline void ResetHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE) && IsHouseCompleted(t));
-	_m[t].m5 = 0;
+	t.m5() = 0;
 }
 
 /**
@@ -234,10 +234,10 @@ static inline void ResetHouseAge(TileIndex t)
  * @param t the tile of this house
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void IncrementHouseAge(TileIndex t)
+static inline void IncrementHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	if (IsHouseCompleted(t) && _m[t].m5 < 0xFF) _m[t].m5++;
+	if (IsHouseCompleted(t) && t.m5() < 0xFF) t.m5()++;
 }
 
 /**
@@ -246,10 +246,10 @@ static inline void IncrementHouseAge(TileIndex t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return year
  */
-static inline Year GetHouseAge(TileIndex t)
+static inline Year GetHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return IsHouseCompleted(t) ? _m[t].m5 : 0;
+	return IsHouseCompleted(t) ? t.m5() : 0;
 }
 
 /**
@@ -259,10 +259,10 @@ static inline Year GetHouseAge(TileIndex t)
  * @param random the new random bits
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseRandomBits(TileIndex t, byte random)
+static inline void SetHouseRandomBits(Tile t, byte random)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	_m[t].m1 = random;
+	t.m1() = random;
 }
 
 /**
@@ -272,10 +272,10 @@ static inline void SetHouseRandomBits(TileIndex t, byte random)
  * @pre IsTileType(t, MP_HOUSE)
  * @return random bits
  */
-static inline byte GetHouseRandomBits(TileIndex t)
+static inline byte GetHouseRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return _m[t].m1;
+	return t.m1();
 }
 
 /**
@@ -285,10 +285,10 @@ static inline byte GetHouseRandomBits(TileIndex t)
  * @param triggers the activated triggers
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseTriggers(TileIndex t, byte triggers)
+static inline void SetHouseTriggers(Tile t, byte triggers)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	SB(_m[t].m3, 0, 5, triggers);
+	SB(t.m3(), 0, 5, triggers);
 }
 
 /**
@@ -298,10 +298,10 @@ static inline void SetHouseTriggers(TileIndex t, byte triggers)
  * @pre IsTileType(t, MP_HOUSE)
  * @return triggers
  */
-static inline byte GetHouseTriggers(TileIndex t)
+static inline byte GetHouseTriggers(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return GB(_m[t].m3, 0, 5);
+	return GB(t.m3(), 0, 5);
 }
 
 /**
@@ -310,10 +310,10 @@ static inline byte GetHouseTriggers(TileIndex t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return time remaining
  */
-static inline byte GetHouseProcessingTime(TileIndex t)
+static inline byte GetHouseProcessingTime(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	return GB(_me[t].m6, 2, 6);
+	return GB(t.m6(), 2, 6);
 }
 
 /**
@@ -322,10 +322,10 @@ static inline byte GetHouseProcessingTime(TileIndex t)
  * @param time the time to be set
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void SetHouseProcessingTime(TileIndex t, byte time)
+static inline void SetHouseProcessingTime(Tile t, byte time)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	SB(_me[t].m6, 2, 6, time);
+	SB(t.m6(), 2, 6, time);
 }
 
 /**
@@ -333,10 +333,10 @@ static inline void SetHouseProcessingTime(TileIndex t, byte time)
  * @param t the house tile
  * @pre IsTileType(t, MP_HOUSE)
  */
-static inline void DecHouseProcessingTime(TileIndex t)
+static inline void DecHouseProcessingTime(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
-	_me[t].m6 -= 1 << 2;
+	t.m6() -= 1 << 2;
 }
 
 /**
@@ -349,17 +349,17 @@ static inline void DecHouseProcessingTime(TileIndex t)
  * @param random_bits required for newgrf houses
  * @pre IsTileType(t, MP_CLEAR)
  */
-static inline void MakeHouseTile(TileIndex t, TownID tid, byte counter, byte stage, HouseID type, byte random_bits)
+static inline void MakeHouseTile(Tile t, TownID tid, byte counter, byte stage, HouseID type, byte random_bits)
 {
 	assert(IsTileType(t, MP_CLEAR));
 
 	SetTileType(t, MP_HOUSE);
-	_m[t].m1 = random_bits;
-	_m[t].m2 = tid;
-	_m[t].m3 = 0;
+	t.m1() = random_bits;
+	t.m2() = tid;
+	t.m3() = 0;
 	SetHouseType(t, type);
 	SetHouseCompleted(t, stage == TOWN_HOUSE_COMPLETED);
-	_m[t].m5 = IsHouseCompleted(t) ? 0 : (stage << 3 | counter);
+	t.m5() = IsHouseCompleted(t) ? 0 : (stage << 3 | counter);
 	SetAnimationFrame(t, 0);
 	SetHouseProcessingTime(t, HouseSpec::Get(type)->processing_time);
 }

--- a/src/tree_map.h
+++ b/src/tree_map.h
@@ -70,10 +70,10 @@ enum TreeGround {
  * @return The treetype of the given tile with trees
  * @pre Tile t must be of type MP_TREES
  */
-static inline TreeType GetTreeType(TileIndex t)
+static inline TreeType GetTreeType(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
-	return (TreeType)_m[t].m3;
+	return (TreeType)t.m3();
 }
 
 /**
@@ -85,10 +85,10 @@ static inline TreeType GetTreeType(TileIndex t)
  * @return The groundtype of the tile
  * @pre Tile must be of type MP_TREES
  */
-static inline TreeGround GetTreeGround(TileIndex t)
+static inline TreeGround GetTreeGround(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
-	return (TreeGround)GB(_m[t].m2, 6, 3);
+	return (TreeGround)GB(t.m2(), 6, 3);
 }
 
 /**
@@ -110,10 +110,10 @@ static inline TreeGround GetTreeGround(TileIndex t)
  * @pre Tile must be of type MP_TREES
  * @see GetTreeCount
  */
-static inline uint GetTreeDensity(TileIndex t)
+static inline uint GetTreeDensity(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
-	return GB(_m[t].m2, 4, 2);
+	return GB(t.m2(), 4, 2);
 }
 
 /**
@@ -127,11 +127,11 @@ static inline uint GetTreeDensity(TileIndex t)
  * @param d The density to save with
  * @pre Tile must be of type MP_TREES
  */
-static inline void SetTreeGroundDensity(TileIndex t, TreeGround g, uint d)
+static inline void SetTreeGroundDensity(Tile t, TreeGround g, uint d)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
-	SB(_m[t].m2, 4, 2, d);
-	SB(_m[t].m2, 6, 3, g);
+	SB(t.m2(), 4, 2, d);
+	SB(t.m2(), 6, 3, g);
 	SetWaterClass(t, g == TREE_GROUND_SHORE ? WATER_CLASS_SEA : WATER_CLASS_INVALID);
 }
 
@@ -146,10 +146,10 @@ static inline void SetTreeGroundDensity(TileIndex t, TreeGround g, uint d)
  * @return The number of trees (1-4)
  * @pre Tile must be of type MP_TREES
  */
-static inline uint GetTreeCount(TileIndex t)
+static inline uint GetTreeCount(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
-	return GB(_m[t].m5, 6, 2) + 1;
+	return GB(t.m5(), 6, 2) + 1;
 }
 
 /**
@@ -163,10 +163,10 @@ static inline uint GetTreeCount(TileIndex t)
  * @param c The value to add (or reduce) on the tree-count value
  * @pre Tile must be of type MP_TREES
  */
-static inline void AddTreeCount(TileIndex t, int c)
+static inline void AddTreeCount(Tile t, int c)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
-	_m[t].m5 += c << 6;
+	t.m5() += c << 6;
 }
 
 /**
@@ -178,10 +178,10 @@ static inline void AddTreeCount(TileIndex t, int c)
  * @return The tree growth status
  * @pre Tile must be of type MP_TREES
  */
-static inline uint GetTreeGrowth(TileIndex t)
+static inline uint GetTreeGrowth(Tile t)
 {
 	assert(IsTileType(t, MP_TREES));
-	return GB(_m[t].m5, 0, 3);
+	return GB(t.m5(), 0, 3);
 }
 
 /**
@@ -193,10 +193,10 @@ static inline uint GetTreeGrowth(TileIndex t)
  * @param a The value to add on the tree growth status
  * @pre Tile must be of type MP_TREES
  */
-static inline void AddTreeGrowth(TileIndex t, int a)
+static inline void AddTreeGrowth(Tile t, int a)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
-	_m[t].m5 += a;
+	t.m5() += a;
 }
 
 /**
@@ -209,10 +209,10 @@ static inline void AddTreeGrowth(TileIndex t, int a)
  * @param g The new value
  * @pre Tile must be of type MP_TREES
  */
-static inline void SetTreeGrowth(TileIndex t, uint g)
+static inline void SetTreeGrowth(Tile t, uint g)
 {
 	assert(IsTileType(t, MP_TREES)); // XXX incomplete
-	SB(_m[t].m5, 0, 3, g);
+	SB(t.m5(), 0, 3, g);
 }
 
 /**
@@ -227,17 +227,17 @@ static inline void SetTreeGrowth(TileIndex t, uint g)
  * @param ground the ground type
  * @param density the density (not the number of trees)
  */
-static inline void MakeTree(TileIndex t, TreeType type, uint count, uint growth, TreeGround ground, uint density)
+static inline void MakeTree(Tile t, TreeType type, uint count, uint growth, TreeGround ground, uint density)
 {
 	SetTileType(t, MP_TREES);
 	SetTileOwner(t, OWNER_NONE);
 	SetWaterClass(t, ground == TREE_GROUND_SHORE ? WATER_CLASS_SEA : WATER_CLASS_INVALID);
-	_m[t].m2 = ground << 6 | density << 4 | 0;
-	_m[t].m3 = type;
-	_m[t].m4 = 0 << 5 | 0 << 2;
-	_m[t].m5 = count << 6 | growth;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = ground << 6 | density << 4 | 0;
+	t.m3() = type;
+	t.m4() = 0 << 5 | 0 << 2;
+	t.m5() = count << 6 | growth;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 }
 
 #endif /* TREE_MAP_H */

--- a/src/tunnel_map.h
+++ b/src/tunnel_map.h
@@ -20,10 +20,10 @@
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return true if and only if this tile is a tunnel (entrance)
  */
-static inline bool IsTunnel(TileIndex t)
+static inline bool IsTunnel(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
-	return !HasBit(_m[t].m5, 7);
+	return !HasBit(t.m5(), 7);
 }
 
 /**
@@ -31,7 +31,7 @@ static inline bool IsTunnel(TileIndex t)
  * @param t the tile that might be a tunnel
  * @return true if and only if this tile is a tunnel (entrance)
  */
-static inline bool IsTunnelTile(TileIndex t)
+static inline bool IsTunnelTile(Tile t)
 {
 	return IsTileType(t, MP_TUNNELBRIDGE) && IsTunnel(t);
 }
@@ -47,17 +47,17 @@ bool IsTunnelInWayDir(TileIndex tile, int z, DiagDirection dir);
  * @param d the direction facing out of the tunnel
  * @param r the road type used in the tunnel
  */
-static inline void MakeRoadTunnel(TileIndex t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
+static inline void MakeRoadTunnel(Tile t, Owner o, DiagDirection d, RoadType road_rt, RoadType tram_rt)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = TRANSPORT_ROAD << 2 | d;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = TRANSPORT_ROAD << 2 | d;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
+	t.m8() = 0;
 	SetRoadOwner(t, RTT_ROAD, o);
 	if (o != OWNER_TOWN) SetRoadOwner(t, RTT_TRAM, o);
 	SetRoadTypes(t, road_rt, tram_rt);
@@ -70,17 +70,17 @@ static inline void MakeRoadTunnel(TileIndex t, Owner o, DiagDirection d, RoadTyp
  * @param d the direction facing out of the tunnel
  * @param r the rail type used in the tunnel
  */
-static inline void MakeRailTunnel(TileIndex t, Owner o, DiagDirection d, RailType r)
+static inline void MakeRailTunnel(Tile t, Owner o, DiagDirection d, RailType r)
 {
 	SetTileType(t, MP_TUNNELBRIDGE);
 	SetTileOwner(t, o);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = TRANSPORT_RAIL << 2 | d;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
-	_me[t].m8 = 0;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = TRANSPORT_RAIL << 2 | d;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
+	t.m8() = 0;
 	SetRailType(t, r);
 	SetRoadTypes(t, INVALID_ROADTYPE, INVALID_ROADTYPE);
 }

--- a/src/tunnelbridge_map.h
+++ b/src/tunnelbridge_map.h
@@ -23,10 +23,10 @@
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return the above mentioned direction
  */
-static inline DiagDirection GetTunnelBridgeDirection(TileIndex t)
+static inline DiagDirection GetTunnelBridgeDirection(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
-	return (DiagDirection)GB(_m[t].m5, 0, 2);
+	return (DiagDirection)GB(t.m5(), 0, 2);
 }
 
 /**
@@ -36,10 +36,10 @@ static inline DiagDirection GetTunnelBridgeDirection(TileIndex t)
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return the transport type in the tunnel/bridge
  */
-static inline TransportType GetTunnelBridgeTransportType(TileIndex t)
+static inline TransportType GetTunnelBridgeTransportType(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
-	return (TransportType)GB(_m[t].m5, 2, 2);
+	return (TransportType)GB(t.m5(), 2, 2);
 }
 
 /**
@@ -49,10 +49,10 @@ static inline TransportType GetTunnelBridgeTransportType(TileIndex t)
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return true if and only if the tile is in a snowy/desert area
  */
-static inline bool HasTunnelBridgeSnowOrDesert(TileIndex t)
+static inline bool HasTunnelBridgeSnowOrDesert(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
-	return HasBit(_me[t].m7, 5);
+	return HasBit(t.m7(), 5);
 }
 
 /**
@@ -63,10 +63,10 @@ static inline bool HasTunnelBridgeSnowOrDesert(TileIndex t)
  *                       not in snow and not in desert false
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  */
-static inline void SetTunnelBridgeSnowOrDesert(TileIndex t, bool snow_or_desert)
+static inline void SetTunnelBridgeSnowOrDesert(Tile t, bool snow_or_desert)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
-	SB(_me[t].m7, 5, 1, snow_or_desert);
+	SB(t.m7(), 5, 1, snow_or_desert);
 }
 
 /**
@@ -75,7 +75,7 @@ static inline void SetTunnelBridgeSnowOrDesert(TileIndex t, bool snow_or_desert)
  * @pre IsTileType(t, MP_TUNNELBRIDGE)
  * @return other end
  */
-static inline TileIndex GetOtherTunnelBridgeEnd(TileIndex t)
+static inline TileIndex GetOtherTunnelBridgeEnd(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	return IsTunnel(t) ? GetOtherTunnelEnd(t) : GetOtherBridgeEnd(t);
@@ -88,11 +88,11 @@ static inline TileIndex GetOtherTunnelBridgeEnd(TileIndex t)
  * @param t the tile
  * @return reservation state
  */
-static inline bool HasTunnelBridgeReservation(TileIndex t)
+static inline bool HasTunnelBridgeReservation(Tile t)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
-	return HasBit(_m[t].m5, 4);
+	return HasBit(t.m5(), 4);
 }
 
 /**
@@ -101,11 +101,11 @@ static inline bool HasTunnelBridgeReservation(TileIndex t)
  * @param t the tile
  * @param b the reservation state
  */
-static inline void SetTunnelBridgeReservation(TileIndex t, bool b)
+static inline void SetTunnelBridgeReservation(Tile t, bool b)
 {
 	assert(IsTileType(t, MP_TUNNELBRIDGE));
 	assert(GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL);
-	SB(_m[t].m5, 4, 1, b ? 1 : 0);
+	SB(t.m5(), 4, 1, b ? 1 : 0);
 }
 
 /**
@@ -114,7 +114,7 @@ static inline void SetTunnelBridgeReservation(TileIndex t, bool b)
  * @param t the tile
  * @return reserved track bits
  */
-static inline TrackBits GetTunnelBridgeReservationTrackBits(TileIndex t)
+static inline TrackBits GetTunnelBridgeReservationTrackBits(Tile t)
 {
 	return HasTunnelBridgeReservation(t) ? DiagDirToDiagTrackBits(GetTunnelBridgeDirection(t)) : TRACK_BIT_NONE;
 }

--- a/src/void_map.h
+++ b/src/void_map.h
@@ -16,17 +16,17 @@
  * Make a nice void tile ;)
  * @param t the tile to make void
  */
-static inline void MakeVoid(TileIndex t)
+static inline void MakeVoid(Tile t)
 {
 	SetTileType(t, MP_VOID);
 	SetTileHeight(t, 0);
-	_m[t].m1 = 0;
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = 0;
-	_me[t].m6 = 0;
-	_me[t].m7 = 0;
+	t.m1() = 0;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = 0;
+	t.m6() = 0;
+	t.m7() = 0;
 }
 
 #endif /* VOID_MAP_H */

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -158,7 +158,7 @@ CommandCost CmdBuildShipDepot(DoCommandFlag flags, TileIndex tile, Axis axis)
 	return cost;
 }
 
-bool IsPossibleDockingTile(TileIndex t)
+bool IsPossibleDockingTile(Tile t)
 {
 	assert(IsValidTile(t));
 	switch (GetTileType(t)) {

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -78,19 +78,19 @@ enum LockPart {
 	LOCK_PART_UPPER  = 2, ///< Upper part of a lock.
 };
 
-bool IsPossibleDockingTile(TileIndex t);
+bool IsPossibleDockingTile(Tile t);
 
 /**
  * Get the water tile type at a tile.
  * @param t Water tile to query.
  * @return Water tile type at the tile.
  */
-static inline WaterTileType GetWaterTileType(TileIndex t)
+static inline WaterTileType GetWaterTileType(Tile t)
 {
 	assert(IsTileType(t, MP_WATER));
 
-	switch (GB(_m[t].m5, WBL_TYPE_BEGIN, WBL_TYPE_COUNT)) {
-		case WBL_TYPE_NORMAL: return HasBit(_m[t].m5, WBL_COAST_FLAG) ? WATER_TILE_COAST : WATER_TILE_CLEAR;
+	switch (GB(t.m5(), WBL_TYPE_BEGIN, WBL_TYPE_COUNT)) {
+		case WBL_TYPE_NORMAL: return HasBit(t.m5(), WBL_COAST_FLAG) ? WATER_TILE_COAST : WATER_TILE_CLEAR;
 		case WBL_TYPE_LOCK:   return WATER_TILE_LOCK;
 		case WBL_TYPE_DEPOT:  return WATER_TILE_DEPOT;
 		default: NOT_REACHED();
@@ -103,7 +103,7 @@ static inline WaterTileType GetWaterTileType(TileIndex t)
  * @param t Tile to query.
  * @return True if the tiletype has a waterclass.
  */
-static inline bool HasTileWaterClass(TileIndex t)
+static inline bool HasTileWaterClass(Tile t)
 {
 	return IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT) || IsTileType(t, MP_TREES);
 }
@@ -114,10 +114,10 @@ static inline bool HasTileWaterClass(TileIndex t)
  * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
  * @return Water class at the tile.
  */
-static inline WaterClass GetWaterClass(TileIndex t)
+static inline WaterClass GetWaterClass(Tile t)
 {
 	assert(HasTileWaterClass(t));
-	return (WaterClass)GB(_m[t].m1, 5, 2);
+	return (WaterClass)GB(t.m1(), 5, 2);
 }
 
 /**
@@ -126,10 +126,10 @@ static inline WaterClass GetWaterClass(TileIndex t)
  * @param wc New water class.
  * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
  */
-static inline void SetWaterClass(TileIndex t, WaterClass wc)
+static inline void SetWaterClass(Tile t, WaterClass wc)
 {
 	assert(HasTileWaterClass(t));
-	SB(_m[t].m1, 5, 2, wc);
+	SB(t.m1(), 5, 2, wc);
 }
 
 /**
@@ -138,7 +138,7 @@ static inline void SetWaterClass(TileIndex t, WaterClass wc)
  * @pre IsTileType(t, MP_WATER) || IsTileType(t, MP_STATION) || IsTileType(t, MP_INDUSTRY) || IsTileType(t, MP_OBJECT)
  * @return true iff on water
  */
-static inline bool IsTileOnWater(TileIndex t)
+static inline bool IsTileOnWater(Tile t)
 {
 	return (GetWaterClass(t) != WATER_CLASS_INVALID);
 }
@@ -149,7 +149,7 @@ static inline bool IsTileOnWater(TileIndex t)
  * @return \c true if any type of clear water like ocean, river, or canal.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsWater(TileIndex t)
+static inline bool IsWater(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_CLEAR;
 }
@@ -160,7 +160,7 @@ static inline bool IsWater(TileIndex t)
  * @return \c true if it is a sea water tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsSea(TileIndex t)
+static inline bool IsSea(Tile t)
 {
 	return IsWater(t) && GetWaterClass(t) == WATER_CLASS_SEA;
 }
@@ -171,7 +171,7 @@ static inline bool IsSea(TileIndex t)
  * @return \c true if it is a canal tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsCanal(TileIndex t)
+static inline bool IsCanal(Tile t)
 {
 	return IsWater(t) && GetWaterClass(t) == WATER_CLASS_CANAL;
 }
@@ -182,7 +182,7 @@ static inline bool IsCanal(TileIndex t)
  * @return \c true if it is a river water tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsRiver(TileIndex t)
+static inline bool IsRiver(Tile t)
 {
 	return IsWater(t) && GetWaterClass(t) == WATER_CLASS_RIVER;
 }
@@ -192,7 +192,7 @@ static inline bool IsRiver(TileIndex t)
  * @param t Tile to query.
  * @return \c true if it is a plain water tile.
  */
-static inline bool IsWaterTile(TileIndex t)
+static inline bool IsWaterTile(Tile t)
 {
 	return IsTileType(t, MP_WATER) && IsWater(t);
 }
@@ -203,7 +203,7 @@ static inline bool IsWaterTile(TileIndex t)
  * @return \c true if it is a sea water tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsCoast(TileIndex t)
+static inline bool IsCoast(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_COAST;
 }
@@ -213,7 +213,7 @@ static inline bool IsCoast(TileIndex t)
  * @param t Tile to query.
  * @return \c true if it is a coast.
  */
-static inline bool IsCoastTile(TileIndex t)
+static inline bool IsCoastTile(Tile t)
 {
 	return (IsTileType(t, MP_WATER) && IsCoast(t)) || (IsTileType(t, MP_TREES) && GetWaterClass(t) != WATER_CLASS_INVALID);
 }
@@ -224,7 +224,7 @@ static inline bool IsCoastTile(TileIndex t)
  * @return \c true if it is a ship depot tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsShipDepot(TileIndex t)
+static inline bool IsShipDepot(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_DEPOT;
 }
@@ -234,7 +234,7 @@ static inline bool IsShipDepot(TileIndex t)
  * @param t Tile to query.
  * @return \c true if it is a ship depot tile.
  */
-static inline bool IsShipDepotTile(TileIndex t)
+static inline bool IsShipDepotTile(Tile t)
 {
 	return IsTileType(t, MP_WATER) && IsShipDepot(t);
 }
@@ -245,10 +245,10 @@ static inline bool IsShipDepotTile(TileIndex t)
  * @return Axis of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline Axis GetShipDepotAxis(TileIndex t)
+static inline Axis GetShipDepotAxis(Tile t)
 {
 	assert(IsShipDepotTile(t));
-	return (Axis)GB(_m[t].m5, WBL_DEPOT_AXIS, 1);
+	return (Axis)GB(t.m5(), WBL_DEPOT_AXIS, 1);
 }
 
 /**
@@ -257,10 +257,10 @@ static inline Axis GetShipDepotAxis(TileIndex t)
  * @return Part of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline DepotPart GetShipDepotPart(TileIndex t)
+static inline DepotPart GetShipDepotPart(Tile t)
 {
 	assert(IsShipDepotTile(t));
-	return (DepotPart)GB(_m[t].m5, WBL_DEPOT_PART, 1);
+	return (DepotPart)GB(t.m5(), WBL_DEPOT_PART, 1);
 }
 
 /**
@@ -269,7 +269,7 @@ static inline DepotPart GetShipDepotPart(TileIndex t)
  * @return Direction of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline DiagDirection GetShipDepotDirection(TileIndex t)
+static inline DiagDirection GetShipDepotDirection(Tile t)
 {
 	return XYNSToDiagDir(GetShipDepotAxis(t), GetShipDepotPart(t));
 }
@@ -280,9 +280,9 @@ static inline DiagDirection GetShipDepotDirection(TileIndex t)
  * @return Tile containing the other section of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline TileIndex GetOtherShipDepotTile(TileIndex t)
+static inline TileIndex GetOtherShipDepotTile(Tile t)
 {
-	return t + (GetShipDepotPart(t) != DEPOT_PART_NORTH ? -1 : 1) * (GetShipDepotAxis(t) != AXIS_X ? TileDiffXY(0, 1) : TileDiffXY(1, 0));
+	return TileIndex(t) + (GetShipDepotPart(t) != DEPOT_PART_NORTH ? -1 : 1) * (GetShipDepotAxis(t) != AXIS_X ? TileDiffXY(0, 1) : TileDiffXY(1, 0));
 }
 
 /**
@@ -291,12 +291,12 @@ static inline TileIndex GetOtherShipDepotTile(TileIndex t)
  * @return The northern tile of the depot.
  * @pre IsShipDepotTile(t)
  */
-static inline TileIndex GetShipDepotNorthTile(TileIndex t)
+static inline TileIndex GetShipDepotNorthTile(Tile t)
 {
 	assert(IsShipDepot(t));
 	TileIndex tile2 = GetOtherShipDepotTile(t);
 
-	return t < tile2 ? t : tile2;
+	return t < tile2 ? TileIndex(t) : tile2;
 }
 
 /**
@@ -305,7 +305,7 @@ static inline TileIndex GetShipDepotNorthTile(TileIndex t)
  * @return \c true if it is a water lock tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline bool IsLock(TileIndex t)
+static inline bool IsLock(Tile t)
 {
 	return GetWaterTileType(t) == WATER_TILE_LOCK;
 }
@@ -316,10 +316,10 @@ static inline bool IsLock(TileIndex t)
  * @return Direction of the lock.
  * @pre IsTileType(t, MP_WATER) && IsLock(t)
  */
-static inline DiagDirection GetLockDirection(TileIndex t)
+static inline DiagDirection GetLockDirection(Tile t)
 {
 	assert(IsLock(t));
-	return (DiagDirection)GB(_m[t].m5, WBL_LOCK_ORIENT_BEGIN, WBL_LOCK_ORIENT_COUNT);
+	return (DiagDirection)GB(t.m5(), WBL_LOCK_ORIENT_BEGIN, WBL_LOCK_ORIENT_COUNT);
 }
 
 /**
@@ -328,10 +328,10 @@ static inline DiagDirection GetLockDirection(TileIndex t)
  * @return The part.
  * @pre IsTileType(t, MP_WATER) && IsLock(t)
  */
-static inline byte GetLockPart(TileIndex t)
+static inline byte GetLockPart(Tile t)
 {
 	assert(IsLock(t));
-	return GB(_m[t].m5, WBL_LOCK_PART_BEGIN, WBL_LOCK_PART_COUNT);
+	return GB(t.m5(), WBL_LOCK_PART_BEGIN, WBL_LOCK_PART_COUNT);
 }
 
 /**
@@ -340,10 +340,10 @@ static inline byte GetLockPart(TileIndex t)
  * @return Random bits of the tile.
  * @pre IsTileType(t, MP_WATER)
  */
-static inline byte GetWaterTileRandomBits(TileIndex t)
+static inline byte GetWaterTileRandomBits(Tile t)
 {
 	assert(IsTileType(t, MP_WATER));
-	return _m[t].m4;
+	return t.m4();
 }
 
 /**
@@ -352,7 +352,7 @@ static inline byte GetWaterTileRandomBits(TileIndex t)
  * @return true iff the tile has water at the ground.
  * @note Coast tiles are not considered waterish, even if there is water on a halftile.
  */
-static inline bool HasTileWaterGround(TileIndex t)
+static inline bool HasTileWaterGround(Tile t)
 {
 	return HasTileWaterClass(t) && IsTileOnWater(t) && !IsCoastTile(t);
 }
@@ -363,19 +363,19 @@ static inline bool HasTileWaterGround(TileIndex t)
  * @param t the tile
  * @param b the docking tile state
  */
-static inline void SetDockingTile(TileIndex t, bool b)
+static inline void SetDockingTile(Tile t, bool b)
 {
 	assert(IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE));
-	SB(_m[t].m1, 7, 1, b ? 1 : 0);
+	SB(t.m1(), 7, 1, b ? 1 : 0);
 }
 
 /**
  * Checks whether the tile is marked as a dockling tile.
  * @return true iff the tile is marked as a docking tile.
  */
-static inline bool IsDockingTile(TileIndex t)
+static inline bool IsDockingTile(Tile t)
 {
-	return (IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE)) && HasBit(_m[t].m1, 7);
+	return (IsTileType(t, MP_WATER) || IsTileType(t, MP_RAILWAY) || IsTileType(t, MP_STATION) || IsTileType(t, MP_TUNNELBRIDGE)) && HasBit(t.m1(), 7);
 }
 
 
@@ -383,18 +383,18 @@ static inline bool IsDockingTile(TileIndex t)
  * Helper function to make a coast tile.
  * @param t The tile to change into water
  */
-static inline void MakeShore(TileIndex t)
+static inline void MakeShore(Tile t)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, OWNER_WATER);
 	SetWaterClass(t, WATER_CLASS_SEA);
 	SetDockingTile(t, false);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = WBL_TYPE_NORMAL << WBL_TYPE_BEGIN | 1 << WBL_COAST_FLAG;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = WBL_TYPE_NORMAL << WBL_TYPE_BEGIN | 1 << WBL_COAST_FLAG;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 }
 
 /**
@@ -404,25 +404,25 @@ static inline void MakeShore(TileIndex t)
  * @param wc The class of water the tile has to be
  * @param random_bits Eventual random bits to be set for this tile
  */
-static inline void MakeWater(TileIndex t, Owner o, WaterClass wc, uint8 random_bits)
+static inline void MakeWater(Tile t, Owner o, WaterClass wc, uint8 random_bits)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);
 	SetWaterClass(t, wc);
 	SetDockingTile(t, false);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = random_bits;
-	_m[t].m5 = WBL_TYPE_NORMAL << WBL_TYPE_BEGIN;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = random_bits;
+	t.m5() = WBL_TYPE_NORMAL << WBL_TYPE_BEGIN;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 }
 
 /**
  * Make a sea tile.
  * @param t The tile to change into sea
  */
-static inline void MakeSea(TileIndex t)
+static inline void MakeSea(Tile t)
 {
 	MakeWater(t, OWNER_WATER, WATER_CLASS_SEA, 0);
 }
@@ -432,7 +432,7 @@ static inline void MakeSea(TileIndex t)
  * @param t The tile to change into river
  * @param random_bits Random bits to be set for this tile
  */
-static inline void MakeRiver(TileIndex t, uint8 random_bits)
+static inline void MakeRiver(Tile t, uint8 random_bits)
 {
 	MakeWater(t, OWNER_WATER, WATER_CLASS_RIVER, random_bits);
 }
@@ -443,7 +443,7 @@ static inline void MakeRiver(TileIndex t, uint8 random_bits)
  * @param o The owner of the canal
  * @param random_bits Random bits to be set for this tile
  */
-static inline void MakeCanal(TileIndex t, Owner o, uint8 random_bits)
+static inline void MakeCanal(Tile t, Owner o, uint8 random_bits)
 {
 	assert(o != OWNER_WATER);
 	MakeWater(t, o, WATER_CLASS_CANAL, random_bits);
@@ -458,18 +458,18 @@ static inline void MakeCanal(TileIndex t, Owner o, uint8 random_bits)
  * @param a    Axis of the depot.
  * @param original_water_class Original water class.
  */
-static inline void MakeShipDepot(TileIndex t, Owner o, DepotID did, DepotPart part, Axis a, WaterClass original_water_class)
+static inline void MakeShipDepot(Tile t, Owner o, DepotID did, DepotPart part, Axis a, WaterClass original_water_class)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);
 	SetWaterClass(t, original_water_class);
 	SetDockingTile(t, false);
-	_m[t].m2 = did;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = WBL_TYPE_DEPOT << WBL_TYPE_BEGIN | part << WBL_DEPOT_PART | a << WBL_DEPOT_AXIS;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = did;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = WBL_TYPE_DEPOT << WBL_TYPE_BEGIN | part << WBL_DEPOT_PART | a << WBL_DEPOT_AXIS;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 }
 
 /**
@@ -481,18 +481,18 @@ static inline void MakeShipDepot(TileIndex t, Owner o, DepotID did, DepotPart pa
  * @param original_water_class Original water class.
  * @see MakeLock
  */
-static inline void MakeLockTile(TileIndex t, Owner o, LockPart part, DiagDirection dir, WaterClass original_water_class)
+static inline void MakeLockTile(Tile t, Owner o, LockPart part, DiagDirection dir, WaterClass original_water_class)
 {
 	SetTileType(t, MP_WATER);
 	SetTileOwner(t, o);
 	SetWaterClass(t, original_water_class);
 	SetDockingTile(t, false);
-	_m[t].m2 = 0;
-	_m[t].m3 = 0;
-	_m[t].m4 = 0;
-	_m[t].m5 = WBL_TYPE_LOCK << WBL_TYPE_BEGIN | part << WBL_LOCK_PART_BEGIN | dir << WBL_LOCK_ORIENT_BEGIN;
-	SB(_me[t].m6, 2, 4, 0);
-	_me[t].m7 = 0;
+	t.m2() = 0;
+	t.m3() = 0;
+	t.m4() = 0;
+	t.m5() = WBL_TYPE_LOCK << WBL_TYPE_BEGIN | part << WBL_LOCK_PART_BEGIN | dir << WBL_LOCK_ORIENT_BEGIN;
+	SB(t.m6(), 2, 4, 0);
+	t.m7() = 0;
 }
 
 /**
@@ -504,15 +504,17 @@ static inline void MakeLockTile(TileIndex t, Owner o, LockPart part, DiagDirecti
  * @param wc_upper Original water class of the upper part.
  * @param wc_middle Original water class of the middle part.
  */
-static inline void MakeLock(TileIndex t, Owner o, DiagDirection d, WaterClass wc_lower, WaterClass wc_upper, WaterClass wc_middle)
+static inline void MakeLock(Tile t, Owner o, DiagDirection d, WaterClass wc_lower, WaterClass wc_upper, WaterClass wc_middle)
 {
 	TileIndexDiff delta = TileOffsByDiagDir(d);
+	Tile lower_tile = TileIndex(t) - delta;
+	Tile upper_tile = TileIndex(t) + delta;
 
 	/* Keep the current waterclass and owner for the tiles.
 	 * It allows to restore them after the lock is deleted */
 	MakeLockTile(t, o, LOCK_PART_MIDDLE, d, wc_middle);
-	MakeLockTile(t - delta, IsWaterTile(t - delta) ? GetTileOwner(t - delta) : o, LOCK_PART_LOWER, d, wc_lower);
-	MakeLockTile(t + delta, IsWaterTile(t + delta) ? GetTileOwner(t + delta) : o, LOCK_PART_UPPER, d, wc_upper);
+	MakeLockTile(lower_tile, IsWaterTile(lower_tile) ? GetTileOwner(lower_tile) : o, LOCK_PART_LOWER, d, wc_lower);
+	MakeLockTile(upper_tile, IsWaterTile(upper_tile) ? GetTileOwner(upper_tile) : o, LOCK_PART_UPPER, d, wc_upper);
 }
 
 #endif /* WATER_MAP_H */


### PR DESCRIPTION
## Motivation / Problem

Initial trigger was CodeQL complaining about short global variable names `_m` and `_me`. Then realizing that the whole idea of splitting `_m` and `_me` is basically arbitrary for performance reasons, so why would the user need to be aware of that.
Similarly CodeQL complains about functions defined in code blocks, so when I saw the same globals for map size related purposes being used in a similar way, I though about just creating a `Map` structure with all the size related information as well as the tiles, that provides simple access to the different fields of tiles.

With this reordering/refactoring where the different fields of the tiles are going to be stored becomes quite trivial.


## Description

Move map size related accessors to Map, as well abstracting away the Tile and TileExtended structs into Map accessors for the different fields.
Also some minor improvements (first few commits) to the code, so other more approprate functions are used instead of directly accessing the map.

The use/migrate changes have been mostly done by use of bash scripts. In case of conflicts undoing the changes and running the appropriate one(s) of the scripts below could help with conflict solution.
```
for i in `grep '_m\[' -R .|sed s/:.*//|uniq|grep -v map_func.h`; do sed "s/_me\[\([^]]*\)\]\.m\([0-9]\)/Map::m\2(\1)/g" -i $i; sed "s/_m\[\([^]]*\)\]\.m\([0-9]\)/Map::m\2(\1)/g" -i $i; sed "s/_m\[\([^]]*\)\]\.type/Map::type(\1)/g" -i $i; sed "s/_m\[\([^]]*\)\]\.height/Map::height(\1)/g" -i $i; done

for i in `grep ScaleByMapSize -R .|sed s/:.*//`; do sed s/ScaleByMapSize/Map::ScaleBySize/g -i $i; done
for i in `grep MapLog -R .|sed s/:.*//`; do sed s/MapLog/Map::Log/g -i $i; done
for i in `grep MapMax -R .|sed s/:.*//`; do sed s/MapMax/Map::Max/g -i $i; done
for i in `grep MapSize -R .|sed s/:.*//`; do sed 's/ MapSize/ Map::Size/g' -i $i; done
```

## Limitations

Breaks a lot of other patches.
Still no memory safety for the tile arrays; was thinking about using std::vector but decided against it for this PR, but that could be added relatively easily.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
