### PR TITLE
Hide map size related information in Map class

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -529,12 +529,12 @@ void SetAircraftPosition(Aircraft *v, int x, int y, int z)
 
 	Aircraft *u = v->Next();
 
-	int safe_x = Clamp(x, 0, MapMaxX() * TILE_SIZE);
-	int safe_y = Clamp(y - 1, 0, MapMaxY() * TILE_SIZE);
+	int safe_x = Clamp(x, 0, Map::MaxX() * TILE_SIZE);
+	int safe_y = Clamp(y - 1, 0, Map::MaxY() * TILE_SIZE);
 	u->x_pos = x;
 	u->y_pos = y - ((v->z_pos - GetSlopePixelZ(safe_x, safe_y)) >> 3);
 
-	safe_y = Clamp(u->y_pos, 0, MapMaxY() * TILE_SIZE);
+	safe_y = Clamp(u->y_pos, 0, Map::MaxY() * TILE_SIZE);
 	u->z_pos = GetSlopePixelZ(safe_x, safe_y);
 	u->sprite_cache.sprite_seq.CopyWithoutPalette(v->sprite_cache.sprite_seq); // the shadow is never coloured
 
@@ -696,8 +696,8 @@ static int UpdateAircraftSpeed(Aircraft *v, uint speed_limit = SPEED_LIMIT_NONE,
  */
 int GetTileHeightBelowAircraft(const Vehicle *v)
 {
-	int safe_x = Clamp(v->x_pos, 0, MapMaxX() * TILE_SIZE);
-	int safe_y = Clamp(v->y_pos, 0, MapMaxY() * TILE_SIZE);
+	int safe_x = Clamp(v->x_pos, 0, Map::MaxX() * TILE_SIZE);
+	int safe_y = Clamp(v->y_pos, 0, Map::MaxY() * TILE_SIZE);
 	return TileHeight(TileVirtXY(safe_x, safe_y)) * TILE_HEIGHT;
 }
 
@@ -1164,7 +1164,7 @@ static bool HandleCrashedAircraft(Aircraft *v)
 
 	/* make aircraft crash down to the ground */
 	if (v->crashed_counter < 500 && st == nullptr && ((v->crashed_counter % 3) == 0) ) {
-		int z = GetSlopePixelZ(Clamp(v->x_pos, 0, MapMaxX() * TILE_SIZE), Clamp(v->y_pos, 0, MapMaxY() * TILE_SIZE));
+		int z = GetSlopePixelZ(Clamp(v->x_pos, 0, Map::MaxX() * TILE_SIZE), Clamp(v->y_pos, 0, Map::MaxY() * TILE_SIZE));
 		v->z_pos -= 1;
 		if (v->z_pos == z) {
 			v->crashed_counter = 500;

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -133,7 +133,7 @@ static int32 ClickChangeMaxHlCheat(int32 p1, int32 p2)
 
 	/* Check if at least one mountain on the map is higher than the new value.
 	 * If yes, disallow the change. */
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if ((int32)TileHeight(t) > p1) {
 			ShowErrorMessage(STR_CONFIG_SETTING_TOO_HIGH_MOUNTAIN, INVALID_STRING_ID, WL_ERROR);
 			/* Return old, unchanged value */

--- a/src/clear_cmd.cpp
+++ b/src/clear_cmd.cpp
@@ -316,8 +316,8 @@ void GenerateClearTile()
 	TileIndex tile;
 
 	/* add rough tiles */
-	i = ScaleByMapSize(GB(Random(), 0, 10) + 0x400);
-	gi = ScaleByMapSize(GB(Random(), 0, 7) + 0x80);
+	i = Map::ScaleBySize(GB(Random(), 0, 10) + 0x400);
+	gi = Map::ScaleBySize(GB(Random(), 0, 7) + 0x80);
 
 	SetGeneratingWorldProgress(GWP_ROUGH_ROCKY, gi + i);
 	do {

--- a/src/command_func.h
+++ b/src/command_func.h
@@ -152,7 +152,7 @@ public:
 		if constexpr (std::is_same_v<TileIndex, std::tuple_element_t<0, std::tuple<Targs...>>>) {
 			/* Do not even think about executing out-of-bounds tile-commands. */
 			TileIndex tile = std::get<0>(std::make_tuple(args...));
-			if (tile != 0 && (tile >= MapSize() || (!IsValidTile(tile) && (flags & DC_ALL_TILES) == 0))) return MakeResult(CMD_ERROR);
+			if (tile != 0 && (tile >= Map::Size() || (!IsValidTile(tile) && (flags & DC_ALL_TILES) == 0))) return MakeResult(CMD_ERROR);
 		}
 
 		RecursiveCommandCounter counter{};
@@ -225,7 +225,7 @@ public:
 		if constexpr (std::is_same_v<TileIndex, std::tuple_element_t<0, decltype(args)>>) {
 			/* Do not even think about executing out-of-bounds tile-commands. */
 			TileIndex tile = std::get<0>(args);
-			if (tile != 0 && (tile >= MapSize() || (!IsValidTile(tile) && (GetCommandFlags<Tcmd>() & CMD_ALL_TILES) == 0))) return false;
+			if (tile != 0 && (tile >= Map::Size() || (!IsValidTile(tile) && (GetCommandFlags<Tcmd>() & CMD_ALL_TILES) == 0))) return false;
 		}
 
 		return InternalPost(err_message, callback, my_cmd, true, location, std::move(args));
@@ -306,7 +306,7 @@ protected:
 	static bool InternalPost(StringID err_message, Tcallback *callback, bool my_cmd, bool network_command, TileIndex tile, std::tuple<Targs...> args)
 	{
 		/* Do not even think about executing out-of-bounds tile-commands. */
-		if (tile != 0 && (tile >= MapSize() || (!IsValidTile(tile) && (GetCommandFlags<Tcmd>() & CMD_ALL_TILES) == 0))) return false;
+		if (tile != 0 && (tile >= Map::Size() || (!IsValidTile(tile) && (GetCommandFlags<Tcmd>() & CMD_ALL_TILES) == 0))) return false;
 
 		auto [err, estimate_only, only_sending] = InternalPostBefore(Tcmd, GetCommandFlags<Tcmd>(), tile, err_message, network_command);
 		if (err) return false;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -344,7 +344,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 		case 1: {
 			uint32 result;
 			if (GetArgumentInteger(&result, argv[arg_index])) {
-				if (result >= MapSize()) {
+				if (result >= Map::Size()) {
 					IConsolePrint(CC_ERROR, "Tile does not exist.");
 					return true;
 				}
@@ -357,7 +357,7 @@ DEF_CONSOLE_CMD(ConScrollToTile)
 		case 2: {
 			uint32 x, y;
 			if (GetArgumentInteger(&x, argv[arg_index]) && GetArgumentInteger(&y, argv[arg_index + 1])) {
-				if (x >= MapSizeX() || y >= MapSizeY()) {
+				if (x >= Map::SizeX() || y >= Map::SizeY()) {
 					IConsolePrint(CC_ERROR, "Tile does not exist.");
 					return true;
 				}
@@ -1143,8 +1143,8 @@ DEF_CONSOLE_CMD(ConRestart)
 	}
 
 	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
-	_settings_game.game_creation.map_x = MapLogX();
-	_settings_game.game_creation.map_y = MapLogY();
+	_settings_game.game_creation.map_x = Map::LogX();
+	_settings_game.game_creation.map_y = Map::LogY();
 	_switch_mode = SM_RESTARTGAME;
 	return true;
 }
@@ -1160,8 +1160,8 @@ DEF_CONSOLE_CMD(ConReload)
 	}
 
 	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
-	_settings_game.game_creation.map_x = MapLogX();
-	_settings_game.game_creation.map_y = MapLogY();
+	_settings_game.game_creation.map_x = Map::LogX();
+	_settings_game.game_creation.map_y = Map::LogY();
 	_switch_mode = SM_RELOADGAME;
 	return true;
 }

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1144,7 +1144,7 @@ DEF_CONSOLE_CMD(ConRestart)
 
 	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
 	_settings_game.game_creation.map_x = MapLogX();
-	_settings_game.game_creation.map_y = FindFirstBit(MapSizeY());
+	_settings_game.game_creation.map_y = MapLogY();
 	_switch_mode = SM_RESTARTGAME;
 	return true;
 }
@@ -1161,7 +1161,7 @@ DEF_CONSOLE_CMD(ConReload)
 
 	/* Don't copy the _newgame pointers to the real pointers, so call SwitchToMode directly */
 	_settings_game.game_creation.map_x = MapLogX();
-	_settings_game.game_creation.map_y = FindFirstBit(MapSizeY());
+	_settings_game.game_creation.map_y = MapLogY();
 	_switch_mode = SM_RELOADGAME;
 	return true;
 }

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -413,9 +413,9 @@ bool CrashLog::WriteCrashLog(const char *buffer, char *filename, const char *fil
  */
 bool CrashLog::WriteSavegame(char *filename, const char *filename_last) const
 {
-	/* If the map array doesn't exist, saving will fail too. If the map got
+	/* If the map doesn't exist, saving will fail too. If the map got
 	 * initialised, there is a big chance the rest is initialised too. */
-	if (_m == nullptr) return false;
+	if (!Map::IsInitialized()) return false;
 
 	try {
 		GamelogEmergency();

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -191,12 +191,12 @@ void DisasterVehicle::UpdatePosition(int x, int y, int z)
 
 	DisasterVehicle *u = this->Next();
 	if (u != nullptr) {
-		int safe_x = Clamp(x, 0, MapMaxX() * TILE_SIZE);
-		int safe_y = Clamp(y - 1, 0, MapMaxY() * TILE_SIZE);
+		int safe_x = Clamp(x, 0, Map::MaxX() * TILE_SIZE);
+		int safe_y = Clamp(y - 1, 0, Map::MaxY() * TILE_SIZE);
 
 		u->x_pos = x;
 		u->y_pos = y - 1 - (std::max(z - GetSlopePixelZ(safe_x, safe_y), 0) >> 3);
-		safe_y = Clamp(u->y_pos, 0, MapMaxY() * TILE_SIZE);
+		safe_y = Clamp(u->y_pos, 0, Map::MaxY() * TILE_SIZE);
 		u->z_pos = GetSlopePixelZ(safe_x, safe_y);
 		u->direction = this->direction;
 
@@ -250,7 +250,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 			}
 		}
 
-		if (v->y_pos >= (int)((MapSizeY() + 9) * TILE_SIZE - 1)) {
+		if (v->y_pos >= (int)((Map::SizeY() + 9) * TILE_SIZE - 1)) {
 			delete v;
 			return false;
 		}
@@ -400,7 +400,7 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 
 static void DestructIndustry(Industry *i)
 {
-	for (TileIndex tile = 0; tile != MapSize(); tile++) {
+	for (TileIndex tile = 0; tile != Map::Size(); tile++) {
 		if (i->TileBelongsToIndustry(tile)) {
 			ResetIndustryConstructionStage(tile);
 			MarkTileDirtyByTile(tile);
@@ -429,7 +429,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16 image_override, boo
 	GetNewVehiclePosResult gp = GetNewVehiclePos(v);
 	v->UpdatePosition(gp.x, gp.y, GetAircraftFlightLevel(v));
 
-	if ((leave_at_top && gp.x < (-10 * (int)TILE_SIZE)) || (!leave_at_top && gp.x > (int)(MapSizeX() * TILE_SIZE + 9 * TILE_SIZE) - 1)) {
+	if ((leave_at_top && gp.x < (-10 * (int)TILE_SIZE)) || (!leave_at_top && gp.x > (int)(Map::SizeX() * TILE_SIZE + 9 * TILE_SIZE) - 1)) {
 		delete v;
 		return false;
 	}
@@ -465,7 +465,7 @@ static bool DisasterTick_Aircraft(DisasterVehicle *v, uint16 image_override, boo
 		int x = v->x_pos + ((leave_at_top ? -15 : 15) * TILE_SIZE);
 		int y = v->y_pos;
 
-		if ((uint)x > MapMaxX() * TILE_SIZE - 1) return true;
+		if ((uint)x > Map::MaxX() * TILE_SIZE - 1) return true;
 
 		TileIndex tile = TileVirtXY(x, y);
 		if (!IsTileType(tile, MP_INDUSTRY)) return true;
@@ -623,7 +623,7 @@ static bool DisasterTick_Big_Ufo_Destroyer(DisasterVehicle *v)
 	GetNewVehiclePosResult gp = GetNewVehiclePos(v);
 	v->UpdatePosition(gp.x, gp.y, GetAircraftFlightLevel(v));
 
-	if (gp.x > (int)(MapSizeX() * TILE_SIZE + 9 * TILE_SIZE) - 1) {
+	if (gp.x > (int)(Map::SizeX() * TILE_SIZE + 9 * TILE_SIZE) - 1) {
 		delete v;
 		return false;
 	}
@@ -751,7 +751,7 @@ static void Disaster_Small_Ufo_Init()
 
 	int x = TileX(Random()) * TILE_SIZE + TILE_SIZE / 2;
 	DisasterVehicle *v = new DisasterVehicle(x, 0, DIR_SE, ST_SMALL_UFO);
-	v->dest_tile = TileXY(MapSizeX() / 2, MapSizeY() / 2);
+	v->dest_tile = TileXY(Map::SizeX() / 2, Map::SizeY() / 2);
 
 	/* Allocate shadow */
 	DisasterVehicle *u = new DisasterVehicle(x, 0, DIR_SE, ST_SMALL_UFO_SHADOW);
@@ -776,7 +776,7 @@ static void Disaster_Airplane_Init()
 	if (found == nullptr) return;
 
 	/* Start from the bottom (south side) of the map */
-	int x = (MapSizeX() + 9) * TILE_SIZE - 1;
+	int x = (Map::SizeX() + 9) * TILE_SIZE - 1;
 	int y = TileY(found->location.tile) * TILE_SIZE + 37;
 
 	DisasterVehicle *v = new DisasterVehicle(x, y, DIR_NE, ST_AIRPLANE);
@@ -820,10 +820,10 @@ static void Disaster_Big_Ufo_Init()
 	if (!Vehicle::CanAllocateItem(2)) return;
 
 	int x = TileX(Random()) * TILE_SIZE + TILE_SIZE / 2;
-	int y = MapMaxX() * TILE_SIZE - 1;
+	int y = Map::MaxX() * TILE_SIZE - 1;
 
 	DisasterVehicle *v = new DisasterVehicle(x, y, DIR_NW, ST_BIG_UFO);
-	v->dest_tile = TileXY(MapSizeX() / 2, MapSizeY() / 2);
+	v->dest_tile = TileXY(Map::SizeX() / 2, Map::SizeY() / 2);
 
 	/* Allocate shadow */
 	DisasterVehicle *u = new DisasterVehicle(x, y, DIR_NW, ST_BIG_UFO_SHADOW);
@@ -841,7 +841,7 @@ static void Disaster_Submarine_Init(DisasterSubType subtype)
 	int x = TileX(r) * TILE_SIZE + TILE_SIZE / 2;
 
 	if (HasBit(r, 31)) {
-		y = MapMaxY() * TILE_SIZE - TILE_SIZE / 2 - 1;
+		y = Map::MaxY() * TILE_SIZE - TILE_SIZE / 2 - 1;
 		dir = DIR_NW;
 	} else {
 		y = TILE_SIZE / 2;

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -491,7 +491,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 		TileIndex tile = 0;
 		do {
 			ChangeTileOwner(tile, old_owner, new_owner);
-		} while (++tile != MapSize());
+		} while (++tile != Map::Size());
 
 		if (new_owner != INVALID_OWNER) {
 			/* Update all signals because there can be new segment that was owned by two companies
@@ -510,7 +510,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 				} else if (IsLevelCrossingTile(tile) && IsTileOwner(tile, new_owner)) {
 					UpdateLevelCrossing(tile);
 				}
-			} while (++tile != MapSize());
+			} while (++tile != Map::Size());
 		}
 
 		/* update signals in buffer */
@@ -903,7 +903,7 @@ void SetPriceBaseMultiplier(Price price, int factor)
  */
 void StartupIndustryDailyChanges(bool init_counter)
 {
-	uint map_size = MapLogX() + MapLogY();
+	uint map_size = Map::LogX() + Map::LogY();
 	/* After getting map size, it needs to be scaled appropriately and divided by 31,
 	 * which stands for the days in a month.
 	 * Using just 31 will make it so that a monthly reset (based on the real number of days of that month)

--- a/src/effectvehicle.cpp
+++ b/src/effectvehicle.cpp
@@ -621,8 +621,8 @@ EffectVehicle *CreateEffectVehicle(int x, int y, int z, EffectVehicleType type)
  */
 EffectVehicle *CreateEffectVehicleAbove(int x, int y, int z, EffectVehicleType type)
 {
-	int safe_x = Clamp(x, 0, MapMaxX() * TILE_SIZE);
-	int safe_y = Clamp(y, 0, MapMaxY() * TILE_SIZE);
+	int safe_x = Clamp(x, 0, Map::MaxX() * TILE_SIZE);
+	int safe_y = Clamp(y, 0, Map::MaxY() * TILE_SIZE);
 	return CreateEffectVehicle(x, y, GetSlopePixelZ(safe_x, safe_y) + z, type);
 }
 

--- a/src/genworld.cpp
+++ b/src/genworld.cpp
@@ -110,8 +110,8 @@ static void _GenerateWorld()
 
 			/* Make sure the tiles at the north border are void tiles if needed. */
 			if (_settings_game.construction.freeform_edges) {
-				for (uint x = 0; x < MapSizeX(); x++) MakeVoid(TileXY(x, 0));
-				for (uint y = 0; y < MapSizeY(); y++) MakeVoid(TileXY(0, y));
+				for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, 0));
+				for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(0, y));
 			}
 
 			/* Make the map the height of the setting */
@@ -322,7 +322,7 @@ void GenerateWorld(GenWorldMode mode, uint size_x, uint size_y, bool reset_setti
 	ShowGenerateWorldProgress();
 
 	/* Centre the view on the map */
-	ScrollMainWindowToTile(TileXY(MapSizeX() / 2, MapSizeY() / 2), true);
+	ScrollMainWindowToTile(TileXY(Map::SizeX() / 2, Map::SizeY() / 2), true);
 
 	_GenerateWorld();
 }

--- a/src/heightmap.cpp
+++ b/src/heightmap.cpp
@@ -341,12 +341,12 @@ static void GrayscaleToMapHeights(uint img_width, uint img_height, byte *map)
 	switch (_settings_game.game_creation.heightmap_rotation) {
 		default: NOT_REACHED();
 		case HM_COUNTER_CLOCKWISE:
-			width   = MapSizeX();
-			height  = MapSizeY();
+			width   = Map::SizeX();
+			height  = Map::SizeY();
 			break;
 		case HM_CLOCKWISE:
-			width   = MapSizeY();
-			height  = MapSizeX();
+			width   = Map::SizeY();
+			height  = Map::SizeX();
 			break;
 	}
 
@@ -361,8 +361,8 @@ static void GrayscaleToMapHeights(uint img_width, uint img_height, byte *map)
 	}
 
 	if (_settings_game.construction.freeform_edges) {
-		for (uint x = 0; x < MapSizeX(); x++) MakeVoid(TileXY(x, 0));
-		for (uint y = 0; y < MapSizeY(); y++) MakeVoid(TileXY(0, y));
+		for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, 0));
+		for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(0, y));
 	}
 
 	/* Form the landscape */
@@ -426,8 +426,8 @@ void FixSlopes()
 	byte current_tile;
 
 	/* Adjust height difference to maximum one horizontal/vertical change. */
-	width   = MapSizeX();
-	height  = MapSizeY();
+	width   = Map::SizeX();
+	height  = Map::SizeY();
 
 	/* Top and left edge */
 	for (row = 0; (uint)row < height; row++) {
@@ -544,8 +544,8 @@ void LoadHeightmap(DetailedFileType dft, const char *filename)
 void FlatEmptyWorld(byte tile_height)
 {
 	int edge_distance = _settings_game.construction.freeform_edges ? 0 : 2;
-	for (uint row = edge_distance; row < MapSizeY() - edge_distance; row++) {
-		for (uint col = edge_distance; col < MapSizeX() - edge_distance; col++) {
+	for (uint row = edge_distance; row < Map::SizeY() - edge_distance; row++) {
+		for (uint col = edge_distance; col < Map::SizeX() - edge_distance; col++) {
 			SetTileHeight(TileXY(col, row), tile_height);
 		}
 	}

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1044,7 +1044,7 @@ static void PlantFarmField(TileIndex tile, IndustryID industry)
 	/* check the amount of bad tiles */
 	int count = 0;
 	for (TileIndex cur_tile : ta) {
-		assert(cur_tile < MapSize());
+		assert(cur_tile < Map::Size());
 		count += IsSuitableForFarmField(cur_tile, false);
 	}
 	if (count * 2 < ta.w * ta.h) return;
@@ -1056,7 +1056,7 @@ static void PlantFarmField(TileIndex tile, IndustryID industry)
 
 	/* make field */
 	for (TileIndex cur_tile : ta) {
-		assert(cur_tile < MapSize());
+		assert(cur_tile < Map::Size());
 		if (IsSuitableForFarmField(cur_tile, true)) {
 			MakeField(cur_tile, field_type, industry);
 			SetClearCounter(cur_tile, counter);
@@ -1253,8 +1253,8 @@ static bool CheckScaledDistanceFromEdge(TileIndex tile, uint maxdist)
 	uint maxdist_x = maxdist;
 	uint maxdist_y = maxdist;
 
-	if (MapSizeX() > 256) maxdist_x *= MapSizeX() / 256;
-	if (MapSizeY() > 256) maxdist_y *= MapSizeY() / 256;
+	if (Map::SizeX() > 256) maxdist_x *= Map::SizeX() / 256;
+	if (Map::SizeY() > 256) maxdist_y *= Map::SizeY() / 256;
 
 	if (DistanceFromEdgeDir(tile, DIAGDIR_NE) < maxdist_x) return true;
 	if (DistanceFromEdgeDir(tile, DIAGDIR_NW) < maxdist_y) return true;
@@ -1604,7 +1604,7 @@ static bool CheckIfCanLevelIndustryPlatform(TileIndex tile, DoCommandFlag flags,
 	TileArea ta(tile + TileDiffXY(-_settings_game.construction.industry_platform, -_settings_game.construction.industry_platform),
 			max_x + 2 + 2 * _settings_game.construction.industry_platform, max_y + 2 + 2 * _settings_game.construction.industry_platform);
 
-	if (TileX(ta.tile) + ta.w >= MapMaxX() || TileY(ta.tile) + ta.h >= MapMaxY()) return false;
+	if (TileX(ta.tile) + ta.w >= Map::MaxX() || TileY(ta.tile) + ta.h >= Map::MaxY()) return false;
 
 	/* _current_company is OWNER_NONE for randomly generated industries and in editor, or the company who funded or prospected the industry.
 	 * Perform terraforming as OWNER_TOWN to disable autoslope and town ratings. */
@@ -2190,7 +2190,7 @@ static uint32 GetScaledIndustryGenerationProbability(IndustryType it, bool *forc
 		chance *= 16; // to increase precision
 		/* We want industries appearing at coast to appear less often on bigger maps, as length of coast increases slower than map area.
 		 * For simplicity we scale in both cases, though scaling the probabilities of all industries has no effect. */
-		chance = (ind_spc->check_proc == CHECK_REFINERY || ind_spc->check_proc == CHECK_OIL_RIG) ? ScaleByMapSize1D(chance) : ScaleByMapSize(chance);
+		chance = (ind_spc->check_proc == CHECK_REFINERY || ind_spc->check_proc == CHECK_OIL_RIG) ? Map::ScaleBySize1D(chance) : Map::ScaleBySize(chance);
 
 		*force_at_least_one = (chance > 0) && !(ind_spc->behaviour & INDUSTRYBEH_NOBUILT_MAPCREATION) && (_game_mode != GM_EDITOR);
 		return chance;
@@ -2245,7 +2245,7 @@ static uint GetNumberOfIndustries()
 
 	if (difficulty == ID_CUSTOM) return std::min<uint>(IndustryPool::MAX_SIZE, _settings_game.game_creation.custom_industry_number);
 
-	return std::min<uint>(IndustryPool::MAX_SIZE, ScaleByMapSize(numof_industry_table[difficulty]));
+	return std::min<uint>(IndustryPool::MAX_SIZE, Map::ScaleBySize(numof_industry_table[difficulty]));
 }
 
 /**
@@ -2321,9 +2321,9 @@ void IndustryBuildData::MonthlyLoop()
 
 	/* To prevent running out of unused industries for the player to connect,
 	 * add a fraction of new industries each month, but only if the manager can keep up. */
-	uint max_behind = 1 + std::min(99u, ScaleByMapSize(3)); // At most 2 industries for small maps, and 100 at the biggest map (about 6 months industry build attempts).
+	uint max_behind = 1 + std::min(99u, Map::ScaleBySize(3)); // At most 2 industries for small maps, and 100 at the biggest map (about 6 months industry build attempts).
 	if (GetCurrentTotalNumberOfIndustries() + max_behind >= (this->wanted_inds >> 16)) {
-		this->wanted_inds += ScaleByMapSize(NEWINDS_PER_MONTH);
+		this->wanted_inds += Map::ScaleBySize(NEWINDS_PER_MONTH);
 	}
 }
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -1010,7 +1010,7 @@ static void SetupFarmFieldFence(TileIndex tile, int size, byte type, DiagDirecti
 	TileIndexDiff diff = (DiagDirToAxis(side) == AXIS_Y ? TileDiffXY(1, 0) : TileDiffXY(0, 1));
 
 	do {
-		tile = TILE_MASK(tile);
+		tile = Map::WrapToMap(tile);
 
 		if (IsTileType(tile, MP_CLEAR) && IsClearGround(tile, CLEAR_FIELDS)) {
 			byte or_ = type;

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -614,7 +614,7 @@ public:
 		for (Industry *industry : Industry::Iterate()) delete industry;
 
 		/* Clear farmland. */
-		for (TileIndex tile = 0; tile < MapSize(); tile++) {
+		for (TileIndex tile = 0; tile < Map::Size(); tile++) {
 			if (IsTileType(tile, MP_CLEAR) && GetRawClearGround(tile) == CLEAR_FIELDS) {
 				MakeClear(tile, CLEAR_GRASS, 3);
 			}

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -1536,7 +1536,7 @@ static uint CalculateCoverageLine(uint coverage, uint edge_multiplier)
 	}
 
 	/* The amount of land we have is the map size minus the first (sea) layer. */
-	uint land_tiles = MapSizeX() * MapSizeY() - histogram[0];
+	uint land_tiles = MapSize() - histogram[0];
 	int best_score = land_tiles;
 
 	/* Our goal is the coverage amount of the land-mass. */

--- a/src/linkgraph/demands.cpp
+++ b/src/linkgraph/demands.cpp
@@ -256,7 +256,7 @@ void DemandCalculator::CalcDemand(LinkGraphJob &job, Tscaler scaler)
  * @param job Job to calculate the demands for.
  */
 DemandCalculator::DemandCalculator(LinkGraphJob &job) :
-	max_distance(DistanceMaxPlusManhattan(TileXY(0,0), TileXY(MapMaxX(), MapMaxY())))
+	max_distance(DistanceMaxPlusManhattan(TileXY(0,0), TileXY(Map::MaxX(), Map::MaxY())))
 {
 	const LinkGraphSettings &settings = job.Settings();
 	CargoID cargo = job.Cargo();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -36,7 +36,7 @@ TileExtended *_me = nullptr; ///< Extended Tiles of the map
  * @param size_x the width of the map along the NE/SW edge
  * @param size_y the 'height' of the map along the SE/NW edge
  */
-void AllocateMap(uint size_x, uint size_y)
+/* static */ void Map::Allocate(uint size_x, uint size_y)
 {
 	/* Make sure that the map size is within the limits and that
 	 * size of both axes is a power of 2. */

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -20,12 +20,12 @@
 extern "C" _CRTIMP void __cdecl _assert(void *, void *, unsigned);
 #endif
 
-uint _map_log_x;     ///< 2^_map_log_x == _map_size_x
-uint _map_log_y;     ///< 2^_map_log_y == _map_size_y
-uint _map_size_x;    ///< Size of the map along the X
-uint _map_size_y;    ///< Size of the map along the Y
-uint _map_size;      ///< The number of tiles on the map
-uint _map_tile_mask; ///< _map_size - 1 (to mask the mapsize)
+/* static */ uint Map::log_x;     ///< 2^_map_log_x == _map_size_x
+/* static */ uint Map::log_y;     ///< 2^_map_log_y == _map_size_y
+/* static */ uint Map::size_x;    ///< Size of the map along the X
+/* static */ uint Map::size_y;    ///< Size of the map along the Y
+/* static */ uint Map::size;      ///< The number of tiles on the map
+/* static */ uint Map::tile_mask; ///< _map_size - 1 (to mask the mapsize)
 
 Tile *_m = nullptr;          ///< Tiles of the map
 TileExtended *_me = nullptr; ///< Extended Tiles of the map
@@ -49,18 +49,18 @@ TileExtended *_me = nullptr; ///< Extended Tiles of the map
 
 	Debug(map, 1, "Allocating map of size {}x{}", size_x, size_y);
 
-	_map_log_x = FindFirstBit(size_x);
-	_map_log_y = FindFirstBit(size_y);
-	_map_size_x = size_x;
-	_map_size_y = size_y;
-	_map_size = size_x * size_y;
-	_map_tile_mask = _map_size - 1;
+	Map::log_x = FindFirstBit(size_x);
+	Map::log_y = FindFirstBit(size_y);
+	Map::size_x = size_x;
+	Map::size_y = size_y;
+	Map::size = size_x * size_y;
+	Map::tile_mask = Map::size - 1;
 
 	free(_m);
 	free(_me);
 
-	_m = CallocT<Tile>(_map_size);
-	_me = CallocT<TileExtended>(_map_size);
+	_m = CallocT<Tile>(Map::size);
+	_me = CallocT<TileExtended>(Map::size);
 }
 
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -92,7 +92,7 @@ TileIndex TileAdd(TileIndex tile, TileIndexDiff add,
 #endif
 	}
 
-	assert(TileXY(x, y) == TILE_MASK(tile + add));
+	assert(TileXY(x, y) == Map::WrapToMap(tile + add));
 
 	return TileXY(x, y);
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -73,14 +73,14 @@ TileIndex TileAdd(TileIndex tile, TileIndexDiff add,
 	uint x;
 	uint y;
 
-	dx = add & MapMaxX();
-	if (dx >= (int)MapSizeX() / 2) dx -= MapSizeX();
-	dy = (add - dx) / (int)MapSizeX();
+	dx = add & Map::MaxX();
+	if (dx >= (int)Map::SizeX() / 2) dx -= Map::SizeX();
+	dy = (add - dx) / (int)Map::SizeX();
 
 	x = TileX(tile) + dx;
 	y = TileY(tile) + dy;
 
-	if (x >= MapSizeX() || y >= MapSizeY()) {
+	if (x >= Map::SizeX() || y >= Map::SizeY()) {
 		char buf[512];
 
 		seprintf(buf, lastof(buf), "TILE_ADD(%s) when adding 0x%.4X and 0x%.4X failed",
@@ -120,7 +120,7 @@ TileIndex TileAddWrap(TileIndex tile, int addx, int addy)
 	if ((x == 0 || y == 0) && _settings_game.construction.freeform_edges) return INVALID_TILE;
 
 	/* Are we about to wrap? */
-	if (x >= MapMaxX() || y >= MapMaxY()) return INVALID_TILE;
+	if (x >= Map::MaxX() || y >= Map::MaxY()) return INVALID_TILE;
 
 	return TileXY(x, y);
 }
@@ -218,8 +218,8 @@ uint DistanceFromEdge(TileIndex tile)
 {
 	const uint xl = TileX(tile);
 	const uint yl = TileY(tile);
-	const uint xh = MapSizeX() - 1 - xl;
-	const uint yh = MapSizeY() - 1 - yl;
+	const uint xh = Map::SizeX() - 1 - xl;
+	const uint yh = Map::SizeY() - 1 - yl;
 	const uint minl = std::min(xl, yl);
 	const uint minh = std::min(xh, yh);
 	return std::min(minl, minh);
@@ -236,8 +236,8 @@ uint DistanceFromEdgeDir(TileIndex tile, DiagDirection dir)
 	switch (dir) {
 		case DIAGDIR_NE: return             TileX(tile) - (_settings_game.construction.freeform_edges ? 1 : 0);
 		case DIAGDIR_NW: return             TileY(tile) - (_settings_game.construction.freeform_edges ? 1 : 0);
-		case DIAGDIR_SW: return MapMaxX() - TileX(tile) - 1;
-		case DIAGDIR_SE: return MapMaxY() - TileY(tile) - 1;
+		case DIAGDIR_SW: return Map::MaxX() - TileX(tile) - 1;
+		case DIAGDIR_SE: return Map::MaxY() - TileY(tile) - 1;
 		default: NOT_REACHED();
 	}
 }
@@ -307,7 +307,7 @@ bool CircularTileSearch(TileIndex *tile, uint radius, uint w, uint h, TestTileOn
 		for (DiagDirection dir = DIAGDIR_BEGIN; dir < DIAGDIR_END; dir++) {
 			/* Is the tile within the map? */
 			for (uint j = extent[dir] + n * 2 + 1; j != 0; j--) {
-				if (x < MapSizeX() && y < MapSizeY()) {
+				if (x < Map::SizeX() && y < Map::SizeY()) {
 					TileIndex t = TileXY(x, y);
 					/* Is the callback successful? */
 					if (proc(t, user_data)) {
@@ -346,8 +346,8 @@ uint GetClosestWaterDistance(TileIndex tile, bool water)
 	int x = TileX(tile);
 	int y = TileY(tile);
 
-	uint max_x = MapMaxX();
-	uint max_y = MapMaxY();
+	uint max_x = Map::MaxX();
+	uint max_y = Map::MaxY();
 	uint min_xy = _settings_game.construction.freeform_edges ? 1 : 0;
 
 	/* go in a 'spiral' with increasing manhattan distance in each iteration */
@@ -378,7 +378,7 @@ uint GetClosestWaterDistance(TileIndex tile, bool water)
 
 	if (!water) {
 		/* no land found - is this a water-only map? */
-		for (TileIndex t = 0; t < MapSize(); t++) {
+		for (TileIndex t = 0; t < Map::Size(); t++) {
 			if (!IsTileType(t, MP_VOID) && !IsTileType(t, MP_WATER)) return 0x1FF;
 		}
 	}

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -41,105 +41,120 @@ extern Tile *_m;
  */
 extern TileExtended *_me;
 
-void AllocateMap(uint size_x, uint size_y);
-
 /**
- * Logarithm of the map size along the X side.
- * @note try to avoid using this one
- * @return 2^"return value" == MapSizeX()
+ * Size related data of the map.
  */
-static inline uint MapLogX()
-{
-	extern uint _map_log_x;
-	return _map_log_x;
-}
+struct Map {
+	static void Allocate(uint size_x, uint size_y);
 
-/**
- * Logarithm of the map size along the y side.
- * @note try to avoid using this one
- * @return 2^"return value" == MapSizeY()
- */
-static inline uint MapLogY()
-{
-	extern uint _map_log_y;
-	return _map_log_y;
-}
+	/**
+	 * Logarithm of the map size along the X side.
+	 * @note try to avoid using this one
+	 * @return 2^"return value" == Map::SizeX()
+	 */
+	static inline uint LogX()
+	{
+		extern uint _map_log_x;
+		return _map_log_x;
+	}
 
-/**
- * Get the size of the map along the X
- * @return the number of tiles along the X of the map
- */
-static inline uint MapSizeX()
-{
-	extern uint _map_size_x;
-	return _map_size_x;
-}
+	/**
+	 * Logarithm of the map size along the y side.
+	 * @note try to avoid using this one
+	 * @return 2^"return value" == Map::SizeY()
+	 */
+	static inline uint LogY()
+	{
+		extern uint _map_log_y;
+		return _map_log_y;
+	}
 
-/**
- * Get the size of the map along the Y
- * @return the number of tiles along the Y of the map
- */
-static inline uint MapSizeY()
-{
-	extern uint _map_size_y;
-	return _map_size_y;
-}
+	/**
+	 * Get the size of the map along the X
+	 * @return the number of tiles along the X of the map
+	 */
+	static inline uint SizeX()
+	{
+		extern uint _map_size_x;
+		return _map_size_x;
+	}
 
-/**
- * Get the size of the map
- * @return the number of tiles of the map
- */
-static inline uint MapSize()
-{
-	extern uint _map_size;
-	return _map_size;
-}
+	/**
+	 * Get the size of the map along the Y
+	 * @return the number of tiles along the Y of the map
+	 */
+	static inline uint SizeY()
+	{
+		extern uint _map_size_y;
+		return _map_size_y;
+	}
 
-/**
- * Gets the maximum X coordinate within the map, including MP_VOID
- * @return the maximum X coordinate
- */
-static inline uint MapMaxX()
-{
-	return MapSizeX() - 1;
-}
+	/**
+	 * Get the size of the map
+	 * @return the number of tiles of the map
+	 */
+	static inline uint Size()
+	{
+		extern uint _map_size;
+		return _map_size;
+	}
 
-/**
- * Gets the maximum Y coordinate within the map, including MP_VOID
- * @return the maximum Y coordinate
- */
-static inline uint MapMaxY()
-{
-	return MapSizeY() - 1;
-}
+	/**
+	 * Gets the maximum X coordinate within the map, including MP_VOID
+	 * @return the maximum X coordinate
+	 */
+	static inline uint MaxX()
+	{
+		return Map::SizeX() - 1;
+	}
 
-/**
- * Scales the given value by the map size, where the given value is
- * for a 256 by 256 map.
- * @param n the value to scale
- * @return the scaled size
- */
-static inline uint ScaleByMapSize(uint n)
-{
-	/* Subtract 12 from shift in order to prevent integer overflow
-	 * for large values of n. It's safe since the min mapsize is 64x64. */
-	return CeilDiv(n << (MapLogX() + MapLogY() - 12), 1 << 4);
-}
+	/**
+	 * Gets the maximum Y coordinate within the map, including MP_VOID
+	 * @return the maximum Y coordinate
+	 */
+	static inline uint MaxY()
+	{
+		return Map::SizeY() - 1;
+	}
 
+	/**
+	 * Scales the given value by the map size, where the given value is
+	 * for a 256 by 256 map.
+	 * @param n the value to scale
+	 * @return the scaled size
+	 */
+	static inline uint ScaleBySize(uint n)
+	{
+		/* Subtract 12 from shift in order to prevent integer overflow
+		 * for large values of n. It's safe since the min mapsize is 64x64. */
+		return CeilDiv(n << (Map::LogX() + Map::LogY() - 12), 1 << 4);
+	}
 
-/**
- * Scales the given value by the maps circumference, where the given
- * value is for a 256 by 256 map
- * @param n the value to scale
- * @return the scaled size
- */
-static inline uint ScaleByMapSize1D(uint n)
-{
-	/* Normal circumference for the X+Y is 256+256 = 1<<9
-	 * Note, not actually taking the full circumference into account,
-	 * just half of it. */
-	return CeilDiv((n << MapLogX()) + (n << MapLogY()), 1 << 9);
-}
+	/**
+	 * Scales the given value by the maps circumference, where the given
+	 * value is for a 256 by 256 map
+	 * @param n the value to scale
+	 * @return the scaled size
+	 */
+	static inline uint ScaleBySize1D(uint n)
+	{
+		/* Normal circumference for the X+Y is 256+256 = 1<<9
+		 * Note, not actually taking the full circumference into account,
+		 * just half of it. */
+		return CeilDiv((n << Map::LogX()) + (n << Map::LogY()), 1 << 9);
+	}
+};
+
+static inline void AllocateMap(uint size_x, uint size_y) { Map::Allocate(size_x, size_y); }
+static inline uint MapLogX() { return Map::LogX(); }
+static inline uint MapLogY() { return Map::LogY(); }
+static inline uint MapSizeX() { return Map::SizeX(); }
+static inline uint MapSizeY() { return Map::SizeY(); }
+static inline uint MapSize() { return Map::Size(); }
+static inline uint MapMaxX() { return Map::MaxX(); }
+static inline uint MapMaxY() { return Map::MaxY(); }
+static inline uint ScaleByMapSize(uint n) { return Map::ScaleBySize(n); }
+static inline uint ScaleByMapSize1D(uint n) { return Map::ScaleBySize1D(n); }
 
 /**
  * An offset value between two tiles.

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -35,6 +35,15 @@ extern TileExtended *_me;
  * Size related data of the map.
  */
 struct Map {
+private:
+	static uint log_x;     ///< 2^_map_log_x == _map_size_x
+	static uint log_y;     ///< 2^_map_log_y == _map_size_y
+	static uint size_x;    ///< Size of the map along the X
+	static uint size_y;    ///< Size of the map along the Y
+	static uint size;      ///< The number of tiles on the map
+	static uint tile_mask; ///< _map_size - 1 (to mask the mapsize)
+
+public:
 	static void Allocate(uint size_x, uint size_y);
 
 	/**
@@ -44,8 +53,7 @@ struct Map {
 	 */
 	static inline uint LogX()
 	{
-		extern uint _map_log_x;
-		return _map_log_x;
+		return Map::log_x;
 	}
 
 	/**
@@ -55,8 +63,7 @@ struct Map {
 	 */
 	static inline uint LogY()
 	{
-		extern uint _map_log_y;
-		return _map_log_y;
+		return Map::log_y;
 	}
 
 	/**
@@ -65,8 +72,7 @@ struct Map {
 	 */
 	static inline uint SizeX()
 	{
-		extern uint _map_size_x;
-		return _map_size_x;
+		return Map::size_x;
 	}
 
 	/**
@@ -75,8 +81,7 @@ struct Map {
 	 */
 	static inline uint SizeY()
 	{
-		extern uint _map_size_y;
-		return _map_size_y;
+		return Map::size_y;
 	}
 
 	/**
@@ -85,8 +90,7 @@ struct Map {
 	 */
 	static inline uint Size()
 	{
-		extern uint _map_size;
-		return _map_size;
+		return Map::size;
 	}
 
 	/**
@@ -115,8 +119,7 @@ struct Map {
 	 */
 	static inline TileIndex WrapToMap(uint tile)
 	{
-		extern uint _map_tile_mask;
-		return tile & _map_tile_mask;
+		return tile & Map::tile_mask;
 	}
 
 	/**
@@ -145,9 +148,17 @@ struct Map {
 		 * just half of it. */
 		return CeilDiv((n << Map::LogX()) + (n << Map::LogY()), 1 << 9);
 	}
-};
 
-static inline void AllocateMap(uint size_x, uint size_y) { Map::Allocate(size_x, size_y); }
+	/**
+	 * Check whether the map has been initialized, as to not try to save the map
+	 * during crashlog when the map is not there yet.
+	 * @return true when the map has been allocated/initialized.
+	 */
+	static bool IsInitialized()
+	{
+		return _m != nullptr;
+	}
+};
 
 /**
  * An offset value between two tiles.

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -15,16 +15,6 @@
 #include "map_type.h"
 #include "direction_func.h"
 
-extern uint _map_tile_mask;
-
-/**
- * 'Wraps' the given tile to it is within the map. It does
- * this by masking the 'high' bits of.
- * @param x the tile to 'wrap'
- */
-
-#define TILE_MASK(x) ((x) & _map_tile_mask)
-
 /**
  * Pointer to the tile-array.
  *
@@ -115,6 +105,18 @@ struct Map {
 	static inline uint MaxY()
 	{
 		return Map::SizeY() - 1;
+	}
+
+
+	/**
+	 * 'Wraps' the given "tile" so it is within the map.
+	 * It does this by masking the 'high' bits of.
+	 * @param tile the tile to 'wrap'
+	 */
+	static inline TileIndex WrapToMap(uint tile)
+	{
+		extern uint _map_tile_mask;
+		return tile & _map_tile_mask;
 	}
 
 	/**
@@ -429,7 +431,7 @@ bool CircularTileSearch(TileIndex *tile, uint radius, uint w, uint h, TestTileOn
  */
 static inline TileIndex RandomTileSeed(uint32 r)
 {
-	return TILE_MASK(r);
+	return Map::WrapToMap(r);
 }
 
 /**

--- a/src/map_func.h
+++ b/src/map_func.h
@@ -146,15 +146,6 @@ struct Map {
 };
 
 static inline void AllocateMap(uint size_x, uint size_y) { Map::Allocate(size_x, size_y); }
-static inline uint MapLogX() { return Map::LogX(); }
-static inline uint MapLogY() { return Map::LogY(); }
-static inline uint MapSizeX() { return Map::SizeX(); }
-static inline uint MapSizeY() { return Map::SizeY(); }
-static inline uint MapSize() { return Map::Size(); }
-static inline uint MapMaxX() { return Map::MaxX(); }
-static inline uint MapMaxY() { return Map::MaxY(); }
-static inline uint ScaleByMapSize(uint n) { return Map::ScaleBySize(n); }
-static inline uint ScaleByMapSize1D(uint n) { return Map::ScaleBySize1D(n); }
 
 /**
  * An offset value between two tiles.
@@ -177,7 +168,7 @@ typedef int32 TileIndexDiff;
  */
 static inline TileIndex TileXY(uint x, uint y)
 {
-	return (y << MapLogX()) + x;
+	return (y << Map::LogX()) + x;
 }
 
 /**
@@ -197,7 +188,7 @@ static inline TileIndexDiff TileDiffXY(int x, int y)
 	 * 0 << shift isn't optimized to 0 properly.
 	 * Typically x and y are constants, and then this doesn't result
 	 * in any actual multiplication in the assembly code.. */
-	return (y * MapSizeX()) + x;
+	return (y * Map::SizeX()) + x;
 }
 
 /**
@@ -208,7 +199,7 @@ static inline TileIndexDiff TileDiffXY(int x, int y)
  */
 static inline TileIndex TileVirtXY(uint x, uint y)
 {
-	return (y >> 4 << MapLogX()) + (x >> 4);
+	return (y >> 4 << Map::LogX()) + (x >> 4);
 }
 
 
@@ -219,7 +210,7 @@ static inline TileIndex TileVirtXY(uint x, uint y)
  */
 static inline uint TileX(TileIndex tile)
 {
-	return tile.value & MapMaxX();
+	return tile.value & Map::MaxX();
 }
 
 /**
@@ -229,7 +220,7 @@ static inline uint TileX(TileIndex tile)
  */
 static inline uint TileY(TileIndex tile)
 {
-	return tile.value >> MapLogX();
+	return tile.value >> Map::LogX();
 }
 
 /**
@@ -244,7 +235,7 @@ static inline uint TileY(TileIndex tile)
  */
 static inline TileIndexDiff ToTileIndexDiff(TileIndexDiffC tidc)
 {
-	return (tidc.y << MapLogX()) + tidc.x;
+	return (tidc.y << Map::LogX()) + tidc.x;
 }
 
 
@@ -317,7 +308,7 @@ static inline TileIndex AddTileIndexDiffCWrap(TileIndex tile, TileIndexDiffC dif
 	int x = TileX(tile) + diff.x;
 	int y = TileY(tile) + diff.y;
 	/* Negative value will become big positive value after cast */
-	if ((uint)x >= MapSizeX() || (uint)y >= MapSizeY()) return INVALID_TILE;
+	if ((uint)x >= Map::SizeX() || (uint)y >= Map::SizeY()) return INVALID_TILE;
 	return TileXY(x, y);
 }
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -61,7 +61,7 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 	 * related to the new game we're about to start/load. */
 	UnInitWindowSystem();
 
-	AllocateMap(size_x, size_y);
+	Map::Allocate(size_x, size_y);
 
 	_pause_mode = PM_UNPAUSED;
 	_game_speed = 100;

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -126,8 +126,8 @@ void FillStaticNetworkServerGameInfo()
 	_network_game_info.start_date     = ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1);
 	_network_game_info.clients_max    = _settings_client.network.max_clients;
 	_network_game_info.companies_max  = _settings_client.network.max_companies;
-	_network_game_info.map_width      = MapSizeX();
-	_network_game_info.map_height     = MapSizeY();
+	_network_game_info.map_width      = Map::SizeX();
+	_network_game_info.map_height     = Map::SizeY();
 	_network_game_info.landscape      = _settings_game.game_creation.landscape;
 	_network_game_info.dedicated      = _network_dedicated;
 	_network_game_info.grfconfig      = _grfconfig;

--- a/src/network/network_admin.cpp
+++ b/src/network/network_admin.cpp
@@ -178,8 +178,8 @@ NetworkRecvStatus ServerNetworkAdminSocketHandler::SendWelcome()
 	p->Send_uint32(_settings_game.game_creation.generation_seed);
 	p->Send_uint8 (_settings_game.game_creation.landscape);
 	p->Send_uint32(ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1));
-	p->Send_uint16(MapSizeX());
-	p->Send_uint16(MapSizeY());
+	p->Send_uint16(Map::SizeX());
+	p->Send_uint16(Map::SizeY());
 
 	this->SendPacket(p);
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -7076,8 +7076,8 @@ static uint32 GetPatchVariable(uint8 param)
 		 */
 		case 0x13: {
 			byte map_bits = 0;
-			byte log_X = MapLogX() - 6; // subtraction is required to make the minimal size (64) zero based
-			byte log_Y = MapLogY() - 6;
+			byte log_X = Map::LogX() - 6; // subtraction is required to make the minimal size (64) zero based
+			byte log_Y = Map::LogY() - 6;
 			byte max_edge = std::max(log_X, log_Y);
 
 			if (log_X == log_Y) { // we have a squared map, since both edges are identical

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -143,8 +143,8 @@ bool AirportSpec::IsWithinMapBounds(byte table, TileIndex tile) const
 	byte h = this->size_y;
 	if (this->rotation[table] == DIR_E || this->rotation[table] == DIR_W) Swap(w, h);
 
-	return TileX(tile) + w < MapSizeX() &&
-		TileY(tile) + h < MapSizeY();
+	return TileX(tile) + w < Map::SizeX() &&
+		TileY(tile) + h < Map::SizeY();
 }
 
 /**

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -433,7 +433,7 @@ TileIndex GetNearbyTile(byte parameter, TileIndex tile, bool signed_offsets, Axi
 	if (axis == AXIS_Y) Swap(x, y);
 
 	/* Make sure we never roam outside of the map, better wrap in that case */
-	return TILE_MASK(tile + TileDiffXY(x, y));
+	return Map::WrapToMap(tile + TileDiffXY(x, y));
 }
 
 /**

--- a/src/newgrf_house.cpp
+++ b/src/newgrf_house.cpp
@@ -346,7 +346,7 @@ static uint32 GetDistanceFromNearbyHouse(uint8 parameter, TileIndex tile, HouseI
 			/* Extract tile offset. */
 			int8 x_offs = GB(GetRegister(0x100), 0, 8);
 			int8 y_offs = GB(GetRegister(0x100), 8, 8);
-			TileIndex testtile = TILE_MASK(this->tile + TileDiffXY(x_offs, y_offs));
+			TileIndex testtile = Map::WrapToMap(this->tile + TileDiffXY(x_offs, y_offs));
 
 			StationFinder stations(TileArea(testtile, 1, 1));
 			const StationList *sl = stations.GetStations();

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -386,7 +386,7 @@ CommandCost CmdBuildObject(DoCommandFlag flags, TileIndex tile, ObjectType type,
  */
 CommandCost CmdBuildObjectArea(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, ObjectType type, uint8 view, bool diagonal)
 {
-	if (start_tile >= MapSize()) return CMD_ERROR;
+	if (start_tile >= Map::Size()) return CMD_ERROR;
 
 	if (type >= NUM_OBJECTS) return CMD_ERROR;
 	const ObjectSpec *spec = ObjectSpec::Get(type);
@@ -735,8 +735,8 @@ static bool HasTransmitter(TileIndex tile, void *user)
  */
 static bool TryBuildLightHouse()
 {
-	uint maxx = MapMaxX();
-	uint maxy = MapMaxY();
+	uint maxx = Map::MaxX();
+	uint maxy = Map::MaxY();
 	uint r = Random();
 
 	/* Scatter the lighthouses more evenly around the perimeter */
@@ -762,7 +762,7 @@ static bool TryBuildLightHouse()
 		int h;
 		if (IsTileType(tile, MP_CLEAR) && IsTileFlat(tile, &h) && h <= 2 && !IsBridgeAbove(tile)) {
 			BuildObject(OBJECT_LIGHTHOUSE, tile);
-			assert(tile < MapSize());
+			assert(tile < Map::Size());
 			return true;
 		}
 		tile += TileOffsByDiagDir(dir);
@@ -797,13 +797,13 @@ void GenerateObjects()
 	/* Determine number of water tiles at map border needed for freeform_edges */
 	uint num_water_tiles = 0;
 	if (_settings_game.construction.freeform_edges) {
-		for (uint x = 0; x < MapMaxX(); x++) {
+		for (uint x = 0; x < Map::MaxX(); x++) {
 			if (IsTileType(TileXY(x, 1), MP_WATER)) num_water_tiles++;
-			if (IsTileType(TileXY(x, MapMaxY() - 1), MP_WATER)) num_water_tiles++;
+			if (IsTileType(TileXY(x, Map::MaxY() - 1), MP_WATER)) num_water_tiles++;
 		}
-		for (uint y = 1; y < MapMaxY() - 1; y++) {
+		for (uint y = 1; y < Map::MaxY() - 1; y++) {
 			if (IsTileType(TileXY(1, y), MP_WATER)) num_water_tiles++;
-			if (IsTileType(TileXY(MapMaxX() - 1, y), MP_WATER)) num_water_tiles++;
+			if (IsTileType(TileXY(Map::MaxX() - 1, y), MP_WATER)) num_water_tiles++;
 		}
 	}
 
@@ -821,15 +821,15 @@ void GenerateObjects()
 			/* Scale the amount of lighthouses with the amount of land at the borders.
 			 * The -6 is because the top borders are MP_VOID (-2) and all corners
 			 * are counted twice (-4). */
-			amount = ScaleByMapSize1D(amount * num_water_tiles) / (2 * MapMaxY() + 2 * MapMaxX() - 6);
+			amount = Map::ScaleBySize1D(amount * num_water_tiles) / (2 * Map::MaxY() + 2 * Map::MaxX() - 6);
 		} else if (spec->flags & OBJECT_FLAG_SCALE_BY_WATER) {
-			amount = ScaleByMapSize1D(amount);
+			amount = Map::ScaleBySize1D(amount);
 		} else {
-			amount = ScaleByMapSize(amount);
+			amount = Map::ScaleBySize(amount);
 		}
 
 		/* Now try to place the requested amount of this object */
-		for (uint j = ScaleByMapSize(1000); j != 0 && amount != 0 && Object::CanAllocateItem(); j--) {
+		for (uint j = Map::ScaleBySize(1000); j != 0 && amount != 0 && Object::CanAllocateItem(); j--) {
 			switch (i) {
 				case OBJECT_TRANSMITTER:
 					if (TryBuildTransmitter()) amount--;

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -575,8 +575,8 @@ public:
 				if (!_settings_game.construction.freeform_edges) {
 					/* When end_tile is MP_VOID, the error tile will not be visible to the
 						* user. This happens when terraforming at the southern border. */
-					if (TileX(end_tile) == MapMaxX()) end_tile += TileDiffXY(-1, 0);
-					if (TileY(end_tile) == MapMaxY()) end_tile += TileDiffXY(0, -1);
+					if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
+					if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 				}
 				const ObjectSpec *spec = ObjectClass::Get(_selected_object_class)->GetSpec(_selected_object_index);
 				Command<CMD_BUILD_OBJECT_AREA>::Post(STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER,

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -883,7 +883,7 @@ static CommandCost CmdRailTrackHelper(DoCommandFlag flags, TileIndex tile, TileI
 	CommandCost total_cost(EXPENSES_CONSTRUCTION);
 
 	if ((!remove && !ValParamRailtype(railtype)) || !ValParamTrackOrientation(track)) return CMD_ERROR;
-	if (end_tile >= MapSize() || tile >= MapSize()) return CMD_ERROR;
+	if (end_tile >= Map::Size() || tile >= Map::Size()) return CMD_ERROR;
 
 	Trackdir trackdir = TrackToTrackdir(track);
 
@@ -1244,7 +1244,7 @@ static CommandCost CmdSignalTrackHelper(DoCommandFlag flags, TileIndex tile, Til
 {
 	CommandCost total_cost(EXPENSES_CONSTRUCTION);
 
-	if (end_tile >= MapSize() || !ValParamTrackOrientation(track)) return CMD_ERROR;
+	if (end_tile >= Map::Size() || !ValParamTrackOrientation(track)) return CMD_ERROR;
 	if (signal_density == 0 || signal_density > 20) return CMD_ERROR;
 	if (!remove && (sigtype > SIGTYPE_LAST || sigvar > SIG_SEMAPHORE)) return CMD_ERROR;
 
@@ -1540,7 +1540,7 @@ CommandCost CmdConvertRail(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 	TileIndex area_end = tile;
 
 	if (!ValParamRailtype(totype)) return CMD_ERROR;
-	if (area_start >= MapSize()) return CMD_ERROR;
+	if (area_start >= Map::Size()) return CMD_ERROR;
 
 	TrainList affected_trains;
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2156,7 +2156,7 @@ static void SetDefaultRailGui()
 			/* Find the most used rail type */
 			uint count[RAILTYPE_END];
 			memset(count, 0, sizeof(count));
-			for (TileIndex t = 0; t < MapSize(); t++) {
+			for (TileIndex t = 0; t < Map::Size(); t++) {
 				if (IsTileType(t, MP_RAILWAY) || IsLevelCrossingTile(t) || HasStationTileRail(t) ||
 						(IsTileType(t, MP_TUNNELBRIDGE) && GetTunnelBridgeTransportType(t) == TRANSPORT_RAIL)) {
 					count[GetRailType(t)]++;

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -979,7 +979,7 @@ static bool CanConnectToRoad(TileIndex tile, RoadType rt, DiagDirection dir)
  */
 CommandCost CmdBuildLongRoad(DoCommandFlag flags, TileIndex end_tile, TileIndex start_tile, RoadType rt, Axis axis, DisallowedRoadDirections drd, bool start_half, bool end_half, bool is_ai)
 {
-	if (start_tile >= MapSize()) return CMD_ERROR;
+	if (start_tile >= Map::Size()) return CMD_ERROR;
 
 	if (!ValParamRoadType(rt) || !IsValidAxis(axis) || !IsValidDisallowedRoadDirections(drd)) return CMD_ERROR;
 
@@ -1077,7 +1077,7 @@ std::tuple<CommandCost, Money> CmdRemoveLongRoad(DoCommandFlag flags, TileIndex 
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 
-	if (start_tile >= MapSize()) return { CMD_ERROR, 0 };
+	if (start_tile >= Map::Size()) return { CMD_ERROR, 0 };
 	if (!ValParamRoadType(rt) || !IsValidAxis(axis)) return { CMD_ERROR, 0 };
 
 	/* Only drag in X or Y direction dictated by the direction variable */
@@ -1725,7 +1725,7 @@ static void DrawTile_Road(TileInfo *ti)
 				uint adjacent_diagdirs = 0;
 				for (DiagDirection dir : { dir1, dir2 }) {
 					const TileIndex t = TileAddByDiagDir(ti->tile, dir);
-					if (t < MapSize() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == road_axis) {
+					if (t < Map::Size() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == road_axis) {
 						SetBit(adjacent_diagdirs, dir);
 					}
 				}
@@ -1873,7 +1873,7 @@ void UpdateNearestTownForRoadTiles(bool invalidate)
 {
 	assert(!invalidate || _generating_world);
 
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if (IsTileType(t, MP_ROAD) && !IsRoadDepot(t) && !HasTownOwnedRoad(t)) {
 			TownID tid = INVALID_TOWN;
 			if (!invalidate) {
@@ -2391,7 +2391,7 @@ CommandCost CmdConvertRoad(DoCommandFlag flags, TileIndex tile, TileIndex area_s
 	TileIndex area_end = tile;
 
 	if (!ValParamRoadType(to_type)) return CMD_ERROR;
-	if (area_start >= MapSize()) return CMD_ERROR;
+	if (area_start >= Map::Size()) return CMD_ERROR;
 
 	RoadVehicleList affected_rvs;
 	RoadTramType rtt = GetRoadTramType(to_type);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -93,7 +93,7 @@ void SetWaterClassDependingOnSurroundings(TileIndex t, bool include_invalid_wate
 	/* Mark tile dirty in all cases */
 	MarkTileDirtyByTile(t);
 
-	if (TileX(t) == 0 || TileY(t) == 0 || TileX(t) == MapMaxX() - 1 || TileY(t) == MapMaxY() - 1) {
+	if (TileX(t) == 0 || TileY(t) == 0 || TileX(t) == Map::MaxX() - 1 || TileY(t) == Map::MaxY() - 1) {
 		/* tiles at map borders are always WATER_CLASS_SEA */
 		SetWaterClass(t, WATER_CLASS_SEA);
 		return;
@@ -150,7 +150,7 @@ void SetWaterClassDependingOnSurroundings(TileIndex t, bool include_invalid_wate
 
 static void ConvertTownOwner()
 {
-	for (TileIndex tile = 0; tile != MapSize(); tile++) {
+	for (TileIndex tile = 0; tile != Map::Size(); tile++) {
 		switch (GetTileType(tile)) {
 			case MP_ROAD:
 				if (GB(_m[tile].m5, 4, 2) == ROAD_TILE_CROSSING && HasBit(_m[tile].m3, 7)) {
@@ -203,8 +203,8 @@ static void UpdateCurrencies()
  */
 static void UpdateVoidTiles()
 {
-	for (uint x = 0; x < MapSizeX(); x++) MakeVoid(TileXY(x, MapMaxY()));
-	for (uint y = 0; y < MapSizeY(); y++) MakeVoid(TileXY(MapMaxX(), y));
+	for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, Map::MaxY()));
+	for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(Map::MaxX(), y));
 }
 
 static inline RailType UpdateRailType(RailType rt, RailType min)
@@ -564,7 +564,7 @@ bool AfterLoadGame()
 {
 	SetSignalHandlers();
 
-	TileIndex map_size = MapSize();
+	TileIndex map_size = Map::Size();
 
 	extern TileIndex _cur_tileloop_tile; // From landscape.cpp.
 	/* The LFSR used in RunTileLoop iteration cannot have a zeroed state, make it non-zeroed. */
@@ -838,7 +838,7 @@ bool AfterLoadGame()
 
 	if (IsSavegameVersionBefore(SLV_72)) {
 		/* Locks in very old savegames had OWNER_WATER as owner */
-		for (TileIndex t = 0; t < MapSize(); t++) {
+		for (TileIndex t = 0; t < Map::Size(); t++) {
 			switch (GetTileType(t)) {
 				default: break;
 
@@ -1833,7 +1833,7 @@ bool AfterLoadGame()
 		for (TileIndex t = 0; t < map_size; t++) {
 			/* skip oil rigs at borders! */
 			if ((IsTileType(t, MP_WATER) || IsBuoyTile(t)) &&
-					(TileX(t) == 0 || TileY(t) == 0 || TileX(t) == MapMaxX() - 1 || TileY(t) == MapMaxY() - 1)) {
+					(TileX(t) == 0 || TileY(t) == 0 || TileX(t) == Map::MaxX() - 1 || TileY(t) == Map::MaxY() - 1)) {
 				/* Some version 86 savegames have wrong water class at map borders (under buoy, or after removing buoy).
 				 * This conversion has to be done before buoys with invalid owner are removed. */
 				SetWaterClass(t, WATER_CLASS_SEA);
@@ -3197,7 +3197,7 @@ bool AfterLoadGame()
 		}
 
 		/* Refresh all level crossings to bar adjacent crossing tiles. */
-		for (TileIndex tile = 0; tile < MapSize(); tile++) {
+		for (TileIndex tile = 0; tile < Map::Size(); tile++) {
 			if (IsLevelCrossingTile(tile)) UpdateLevelCrossing(tile, false, true);
 		}
 	}

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -106,7 +106,7 @@ void AfterLoadCompanyStats()
 	}
 
 	Company *c;
-	for (TileIndex tile = 0; tile < MapSize(); tile++) {
+	for (TileIndex tile = 0; tile < Map::Size(); tile++) {
 		switch (GetTileType(tile)) {
 			case MP_RAILWAY:
 				c = Company::GetIfValid(GetTileOwner(tile));

--- a/src/saveload/labelmaps_sl.cpp
+++ b/src/saveload/labelmaps_sl.cpp
@@ -52,7 +52,7 @@ void AfterLoadLabelMaps()
 			railtype_conversion_map.push_back(r);
 		}
 
-		for (TileIndex t = 0; t < MapSize(); t++) {
+		for (TileIndex t = 0; t < Map::Size(); t++) {
 			switch (GetTileType(t)) {
 				case MP_RAILWAY:
 					SetRailType(t, railtype_conversion_map[GetRailType(t)]);

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -34,8 +34,8 @@ struct MAPSChunkHandler : ChunkHandler {
 	{
 		SlTableHeader(_map_desc);
 
-		_map_dim_x = MapSizeX();
-		_map_dim_y = MapSizeY();
+		_map_dim_x = Map::SizeX();
+		_map_dim_y = Map::SizeY();
 
 		SlSetArrayIndex(0);
 		SlGlobList(_map_desc);
@@ -73,7 +73,7 @@ struct MAPTChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -84,7 +84,7 @@ struct MAPTChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -100,7 +100,7 @@ struct MAPHChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -111,7 +111,7 @@ struct MAPHChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -127,7 +127,7 @@ struct MAPOChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -138,7 +138,7 @@ struct MAPOChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -154,7 +154,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<uint16, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE,
@@ -168,7 +168,7 @@ struct MAP2ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<uint16, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size * sizeof(uint16));
 		for (TileIndex i = 0; i != size;) {
@@ -184,7 +184,7 @@ struct M3LOChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -195,7 +195,7 @@ struct M3LOChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -211,7 +211,7 @@ struct M3HIChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -222,7 +222,7 @@ struct M3HIChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -238,7 +238,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -249,7 +249,7 @@ struct MAP5ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -265,7 +265,7 @@ struct MAPEChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		if (IsSavegameVersionBefore(SLV_42)) {
 			for (TileIndex i = 0; i != size;) {
@@ -289,7 +289,7 @@ struct MAPEChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -305,7 +305,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT8);
@@ -316,7 +316,7 @@ struct MAP7ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<byte, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size);
 		for (TileIndex i = 0; i != size;) {
@@ -332,7 +332,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 	void Load() const override
 	{
 		std::array<uint16, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		for (TileIndex i = 0; i != size;) {
 			SlCopy(buf.data(), MAP_SL_BUF_SIZE, SLE_UINT16);
@@ -343,7 +343,7 @@ struct MAP8ChunkHandler : ChunkHandler {
 	void Save() const override
 	{
 		std::array<uint16, MAP_SL_BUF_SIZE> buf;
-		TileIndex size = MapSize();
+		TileIndex size = Map::Size();
 
 		SlSetLength(size * sizeof(uint16));
 		for (TileIndex i = 0; i != size;) {

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -49,7 +49,7 @@ struct MAPSChunkHandler : ChunkHandler {
 		SlGlobList(slt);
 		if (!IsSavegameVersionBefore(SLV_RIFF_TO_ARRAY) && SlIterateArray() != -1) SlErrorCorrupt("Too many MAPS entries");
 
-		AllocateMap(_map_dim_x, _map_dim_y);
+		Map::Allocate(_map_dim_x, _map_dim_y);
 	}
 
 	void LoadCheck(size_t) const override

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1465,7 +1465,7 @@ static bool LoadOldGameDifficulty(LoadgameState *ls, int num)
 static bool LoadOldMapPart1(LoadgameState *ls, int num)
 {
 	if (_savegame_type == SGT_TTO) {
-		AllocateMap(OLD_MAP_SIZE, OLD_MAP_SIZE);
+		Map::Allocate(OLD_MAP_SIZE, OLD_MAP_SIZE);
 	}
 
 	for (uint i = 0; i < OLD_MAP_SIZE; i++) {

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -47,9 +47,7 @@ void FixOldMapArray()
 {
 	/* TTO/TTD/TTDP savegames could have buoys at tile 0
 	 * (without assigned station struct) */
-	MemSetT(&_m[0], 0);
-	SetTileType(0, MP_WATER);
-	SetTileOwner(0, OWNER_WATER);
+	MakeSea(0);
 }
 
 static void FixTTDMapArray()
@@ -1467,8 +1465,7 @@ static bool LoadOldGameDifficulty(LoadgameState *ls, int num)
 static bool LoadOldMapPart1(LoadgameState *ls, int num)
 {
 	if (_savegame_type == SGT_TTO) {
-		MemSetT(_m, 0, OLD_MAP_SIZE);
-		MemSetT(_me, 0, OLD_MAP_SIZE);
+		AllocateMap(OLD_MAP_SIZE, OLD_MAP_SIZE);
 	}
 
 	for (uint i = 0; i < OLD_MAP_SIZE; i++) {

--- a/src/saveload/town_sl.cpp
+++ b/src/saveload/town_sl.cpp
@@ -38,7 +38,7 @@ void RebuildTownCaches()
 		town->cache.num_houses = 0;
 	}
 
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if (!IsTileType(t, MP_HOUSE)) continue;
 
 		HouseID house_id = GetHouseType(t);
@@ -66,7 +66,7 @@ void RebuildTownCaches()
  */
 void UpdateHousesAndTowns()
 {
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if (!IsTileType(t, MP_HOUSE)) continue;
 
 		HouseID house_id = GetCleanHouseType(t);
@@ -79,7 +79,7 @@ void UpdateHousesAndTowns()
 	}
 
 	/* Check for cases when a NewGRF has set a wrong house substitute type. */
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if (!IsTileType(t, MP_HOUSE)) continue;
 
 		HouseID house_type = GetCleanHouseType(t);

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -104,14 +104,14 @@ void MoveWaypointsToBaseStations()
 		 * the map array. If this is the case, try to locate the actual location in the map array */
 		if (!IsTileType(t, MP_RAILWAY) || GetRailTileType(t) != 2 /* RAIL_TILE_WAYPOINT */ || _m[t].m2 != wp.index) {
 			Debug(sl, 0, "Found waypoint tile {} with invalid position", t);
-			for (t = 0; t < MapSize(); t++) {
+			for (t = 0; t < Map::Size(); t++) {
 				if (IsTileType(t, MP_RAILWAY) && GetRailTileType(t) == 2 /* RAIL_TILE_WAYPOINT */ && _m[t].m2 == wp.index) {
 					Debug(sl, 0, "Found actual waypoint position at {}", t);
 					break;
 				}
 			}
 		}
-		if (t == MapSize()) {
+		if (t == Map::Size()) {
 			SlErrorCorrupt("Waypoint with invalid tile");
 		}
 

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -753,7 +753,7 @@ void SetupScreenshotViewport(ScreenshotType t, Viewport *vp, uint32 width, uint3
 			vp->zoom = ZOOM_LVL_WORLD_SCREENSHOT;
 
 			TileIndex north_tile = _settings_game.construction.freeform_edges ? TileXY(1, 1) : TileXY(0, 0);
-			TileIndex south_tile = MapSize() - 1;
+			TileIndex south_tile = Map::Size() - 1;
 
 			/* We need to account for a hill or high building at tile 0,0. */
 			int extra_height_top = TilePixelHeight(north_tile) + 150;
@@ -829,8 +829,8 @@ static void HeightmapCallback(void *userdata, void *buffer, uint y, uint pitch, 
 {
 	byte *buf = (byte *)buffer;
 	while (n > 0) {
-		TileIndex ti = TileXY(MapMaxX(), y);
-		for (uint x = MapMaxX(); true; x--) {
+		TileIndex ti = TileXY(Map::MaxX(), y);
+		for (uint x = Map::MaxX(); true; x--) {
 			*buf = 256 * TileHeight(ti) / (1 + _heightmap_highest_peak);
 			buf++;
 			if (x == 0) break;
@@ -856,13 +856,13 @@ bool MakeHeightmapScreenshot(const char *filename)
 	}
 
 	_heightmap_highest_peak = 0;
-	for (TileIndex tile = 0; tile < MapSize(); tile++) {
+	for (TileIndex tile = 0; tile < Map::Size(); tile++) {
 		uint h = TileHeight(tile);
 		_heightmap_highest_peak = std::max(h, _heightmap_highest_peak);
 	}
 
 	const ScreenshotFormat *sf = _screenshot_formats + _cur_screenshot_format;
-	return sf->proc(filename, HeightmapCallback, nullptr, MapSizeX(), MapSizeY(), 8, palette);
+	return sf->proc(filename, HeightmapCallback, nullptr, Map::SizeX(), Map::SizeY(), 8, palette);
 }
 
 static ScreenshotType _confirmed_screenshot_type; ///< Screenshot type the current query is about to confirm.
@@ -889,8 +889,8 @@ void MakeScreenshotWithConfirm(ScreenshotType t)
 	SetupScreenshotViewport(t, &vp);
 
 	bool heightmap_or_minimap = t == SC_HEIGHTMAP || t == SC_MINIMAP;
-	uint64_t width = (heightmap_or_minimap ? MapSizeX() : vp.width);
-	uint64_t height = (heightmap_or_minimap ? MapSizeY() : vp.height);
+	uint64_t width = (heightmap_or_minimap ? Map::SizeX() : vp.width);
+	uint64_t height = (heightmap_or_minimap ? Map::SizeY() : vp.height);
 
 	if (width * height > 8192 * 8192) {
 		/* Ask for confirmation */
@@ -1010,7 +1010,7 @@ static void MinimapScreenCallback(void *userdata, void *buf, uint y, uint pitch,
 	uint num = (pitch * n);
 	for (uint i = 0; i < num; i++) {
 		uint row = y + (int)(i / pitch);
-		uint col = (MapSizeX() - 1) - (i % pitch);
+		uint col = (Map::SizeX() - 1) - (i % pitch);
 
 		TileIndex tile = TileXY(col, row);
 		byte val = GetSmallMapOwnerPixels(tile, GetTileType(tile), IncludeHeightmap::Never) & 0xFF;
@@ -1031,5 +1031,5 @@ static void MinimapScreenCallback(void *userdata, void *buf, uint y, uint pitch,
 bool MakeMinimapWorldScreenshot()
 {
 	const ScreenshotFormat *sf = _screenshot_formats + _cur_screenshot_format;
-	return sf->proc(MakeScreenshotName(SCREENSHOT_NAME, sf->extension), MinimapScreenCallback, nullptr, MapSizeX(), MapSizeY(), 32, _cur_palette.palette);
+	return sf->proc(MakeScreenshotName(SCREENSHOT_NAME, sf->extension), MinimapScreenCallback, nullptr, Map::SizeX(), Map::SizeY(), 32, _cur_palette.palette);
 }

--- a/src/script/api/script_map.cpp
+++ b/src/script/api/script_map.cpp
@@ -20,17 +20,17 @@
 
 /* static */ TileIndex ScriptMap::GetMapSize()
 {
-	return ::MapSize();
+	return ::Map::Size();
 }
 
 /* static */ uint32 ScriptMap::GetMapSizeX()
 {
-	return ::MapSizeX();
+	return ::Map::SizeX();
 }
 
 /* static */ uint32 ScriptMap::GetMapSizeY()
 {
-	return ::MapSizeY();
+	return ::Map::SizeY();
 }
 
 /* static */ int32 ScriptMap::GetTileX(TileIndex t)

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -348,7 +348,7 @@ bool ScriptObject::ScriptDoCommandHelper<Tcmd, Tret(*)(DoCommandFlag, Targs...)>
 	}
 
 	/* Do not even think about executing out-of-bounds tile-commands. */
-	if (tile != 0 && (tile >= MapSize() || (!IsValidTile(tile) && (GetCommandFlags<Tcmd>() & CMD_ALL_TILES) == 0))) return false;
+	if (tile != 0 && (tile >= Map::Size() || (!IsValidTile(tile) && (GetCommandFlags<Tcmd>() & CMD_ALL_TILES) == 0))) return false;
 
 	/* Only set ClientID parameters when the command does not come from the network. */
 	if constexpr ((::GetCommandFlags<Tcmd>() & CMD_CLIENT_ID) != 0) ScriptObjectInternal::SetClientIds(args, std::index_sequence_for<Targs...>{});

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -276,11 +276,11 @@
 
 	if (tile - from == 1) {
 		if (to - tile == 1) return (GetRailTracks(tile) & RAILTRACK_NE_SW) != 0;
-		if (to - tile == ::MapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NE_SE) != 0;
-	} else if (tile - from == ::MapSizeX()) {
+		if (to - tile == ScriptMap::GetMapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NE_SE) != 0;
+	} else if (tile - from == ScriptMap::GetMapSizeX()) {
 		if (tile - to == 1) return (GetRailTracks(tile) & RAILTRACK_NW_NE) != 0;
 		if (to - tile == 1) return (GetRailTracks(tile) & RAILTRACK_NW_SW) != 0;
-		if (to - tile == ::MapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NW_SE) != 0;
+		if (to - tile == ScriptMap::GetMapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NW_SE) != 0;
 	} else {
 		return (GetRailTracks(tile) & RAILTRACK_SW_SE) != 0;
 	}
@@ -301,7 +301,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
 	} else if (::TileX(from) == ::TileX(*to)) {
 		track = TRACK_Y;
-		*to -= ::MapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
+		*to -= ScriptMap::GetMapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
 	} else if (::TileY(from) < ::TileY(tile)) {
 		if (::TileX(*to) < ::TileX(tile)) {
 			track = TRACK_UPPER;
@@ -311,7 +311,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		if (diag_offset != 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
 		} else {
-			*to -= ::MapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
+			*to -= ScriptMap::GetMapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
 		}
 	} else if (::TileY(from) > ::TileY(tile)) {
 		if (::TileX(*to) < ::TileX(tile)) {
@@ -322,7 +322,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		if (diag_offset != 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
 		} else {
-			*to -= ::MapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
+			*to -= ScriptMap::GetMapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
 		}
 	} else if (::TileX(from) < ::TileX(tile)) {
 		if (::TileY(*to) < ::TileY(tile)) {
@@ -333,7 +333,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		if (diag_offset == 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
 		} else {
-			*to -= ::MapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
+			*to -= ScriptMap::GetMapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
 		}
 	} else if (::TileX(from) > ::TileX(tile)) {
 		if (::TileY(*to) < ::TileY(tile)) {
@@ -344,7 +344,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 		if (diag_offset == 0) {
 			*to -= Clamp((int)::TileX(*to) - (int)::TileX(tile), -1, 1);
 		} else {
-			*to -= ::MapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
+			*to -= ScriptMap::GetMapSizeX() * Clamp((int)::TileY(*to) - (int)::TileY(tile), -1, 1);
 		}
 	}
 	return track;

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -253,7 +253,7 @@
 /* static */ bool ScriptTile::RaiseTile(TileIndex tile, int32 slope)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
-	EnforcePrecondition(false, tile < ::MapSize());
+	EnforcePrecondition(false, tile < ScriptMap::GetMapSize());
 
 	return ScriptObject::Command<CMD_TERRAFORM_LAND>::Do(tile, (::Slope)slope, true);
 }
@@ -261,7 +261,7 @@
 /* static */ bool ScriptTile::LowerTile(TileIndex tile, int32 slope)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
-	EnforcePrecondition(false, tile < ::MapSize());
+	EnforcePrecondition(false, tile < ScriptMap::GetMapSize());
 
 	return ScriptObject::Command<CMD_TERRAFORM_LAND>::Do(tile, (::Slope)slope, false);
 }
@@ -269,8 +269,8 @@
 /* static */ bool ScriptTile::LevelTiles(TileIndex start_tile, TileIndex end_tile)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
-	EnforcePrecondition(false, start_tile < ::MapSize());
-	EnforcePrecondition(false, end_tile < ::MapSize());
+	EnforcePrecondition(false, start_tile < ScriptMap::GetMapSize());
+	EnforcePrecondition(false, end_tile < ScriptMap::GetMapSize());
 
 	return ScriptObject::Command<CMD_LEVEL_LAND>::Do(end_tile, start_tile, false, LM_LEVEL);
 }

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -61,9 +61,9 @@ static void FillIndustryCatchment(const Industry *i, int radius, BitmapTileArea 
 		int tx = TileX(cur_tile);
 		int ty = TileY(cur_tile);
 		for (int y = -radius; y <= radius; y++) {
-			if (ty + y < 0 || ty + y > (int)MapMaxY()) continue;
+			if (ty + y < 0 || ty + y > (int)Map::MaxY()) continue;
 			for (int x = -radius; x <= radius; x++) {
-				if (tx + x < 0 || tx + x > (int)MapMaxX()) continue;
+				if (tx + x < 0 || tx + x > (int)Map::MaxX()) continue;
 				TileIndex tile = TileXY(tx + x, ty + y);
 				if (!IsValidTile(tile)) continue;
 				if (::IsTileType(tile, MP_INDUSTRY) && ::GetIndustryIndex(tile) == i->index) continue;

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -12,6 +12,7 @@
 #include "script_cargo.hpp"
 #include "script_gamesettings.hpp"
 #include "script_group.hpp"
+#include "script_map.hpp"
 #include "../script_instance.hpp"
 #include "../../string_func.h"
 #include "../../strings_func.h"
@@ -256,8 +257,8 @@
 
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 	if (v->type == VEH_AIRCRAFT) {
-		uint x = Clamp(v->x_pos / TILE_SIZE, 0, ::MapSizeX() - 2);
-		uint y = Clamp(v->y_pos / TILE_SIZE, 0, ::MapSizeY() - 2);
+		uint x = Clamp(v->x_pos / TILE_SIZE, 0, ScriptMap::GetMapSizeX() - 2);
+		uint y = Clamp(v->y_pos / TILE_SIZE, 0, ScriptMap::GetMapSizeY() - 2);
 		return ::TileXY(x, y);
 	}
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -360,26 +360,26 @@ static bool CheckFreeformEdges(int32 &new_value)
 			}
 		}
 	} else {
-		for (uint i = 0; i < MapMaxX(); i++) {
+		for (uint i = 0; i < Map::MaxX(); i++) {
 			if (TileHeight(TileXY(i, 1)) != 0) {
 				ShowErrorMessage(STR_CONFIG_SETTING_EDGES_NOT_WATER, INVALID_STRING_ID, WL_ERROR);
 				return false;
 			}
 		}
-		for (uint i = 1; i < MapMaxX(); i++) {
-			if (!IsTileType(TileXY(i, MapMaxY() - 1), MP_WATER) || TileHeight(TileXY(1, MapMaxY())) != 0) {
+		for (uint i = 1; i < Map::MaxX(); i++) {
+			if (!IsTileType(TileXY(i, Map::MaxY() - 1), MP_WATER) || TileHeight(TileXY(1, Map::MaxY())) != 0) {
 				ShowErrorMessage(STR_CONFIG_SETTING_EDGES_NOT_WATER, INVALID_STRING_ID, WL_ERROR);
 				return false;
 			}
 		}
-		for (uint i = 0; i < MapMaxY(); i++) {
+		for (uint i = 0; i < Map::MaxY(); i++) {
 			if (TileHeight(TileXY(1, i)) != 0) {
 				ShowErrorMessage(STR_CONFIG_SETTING_EDGES_NOT_WATER, INVALID_STRING_ID, WL_ERROR);
 				return false;
 			}
 		}
-		for (uint i = 1; i < MapMaxY(); i++) {
-			if (!IsTileType(TileXY(MapMaxX() - 1, i), MP_WATER) || TileHeight(TileXY(MapMaxX(), i)) != 0) {
+		for (uint i = 1; i < Map::MaxY(); i++) {
+			if (!IsTileType(TileXY(Map::MaxX() - 1, i), MP_WATER) || TileHeight(TileXY(Map::MaxX(), i)) != 0) {
 				ShowErrorMessage(STR_CONFIG_SETTING_EDGES_NOT_WATER, INVALID_STRING_ID, WL_ERROR);
 				return false;
 			}
@@ -393,15 +393,15 @@ static void UpdateFreeformEdges(int32 new_value)
 	if (_game_mode == GM_MENU) return;
 
 	if (new_value != 0) {
-		for (uint x = 0; x < MapSizeX(); x++) MakeVoid(TileXY(x, 0));
-		for (uint y = 0; y < MapSizeY(); y++) MakeVoid(TileXY(0, y));
+		for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, 0));
+		for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(0, y));
 	} else {
 		/* Make tiles at the border water again. */
-		for (uint i = 0; i < MapMaxX(); i++) {
+		for (uint i = 0; i < Map::MaxX(); i++) {
 			SetTileHeight(TileXY(i, 0), 0);
 			SetTileType(TileXY(i, 0), MP_WATER);
 		}
-		for (uint i = 0; i < MapMaxY(); i++) {
+		for (uint i = 0; i < Map::MaxY(); i++) {
 			SetTileHeight(TileXY(0, i), 0);
 			SetTileType(TileXY(0, i), MP_WATER);
 		}
@@ -432,7 +432,7 @@ static bool CheckMaxHeightLevel(int32 &new_value)
 
 	/* Check if at least one mountain on the map is higher than the new value.
 	 * If yes, disallow the change. */
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if ((int32)TileHeight(t) > new_value) {
 			ShowErrorMessage(STR_CONFIG_SETTING_TOO_HIGH_MOUNTAIN, INVALID_STRING_ID, WL_ERROR);
 			/* Return old, unchanged value */

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -844,7 +844,7 @@ void SmallMapWindow::DrawSmallMapColumn(void *dst, uint xc, uint yc, int pitch, 
 
 	do {
 		/* Check if the tile (xc,yc) is within the map range */
-		if (xc >= MapMaxX() || yc >= MapMaxY()) continue;
+		if (xc >= Map::MaxX() || yc >= Map::MaxY()) continue;
 
 		/* Check if the dst pointer points to a pixel inside the screen buffer */
 		if (dst < _screen.dst_ptr) continue;
@@ -1629,16 +1629,16 @@ void SmallMapWindow::SetNewScroll(int sx, int sy, int sub)
 		sx = -hv.x;
 		sub = 0;
 	}
-	if (sx > (int)(MapMaxX() * TILE_SIZE) - hv.x) {
-		sx = MapMaxX() * TILE_SIZE - hv.x;
+	if (sx > (int)(Map::MaxX() * TILE_SIZE) - hv.x) {
+		sx = Map::MaxX() * TILE_SIZE - hv.x;
 		sub = 0;
 	}
 	if (sy < -hv.y) {
 		sy = -hv.y;
 		sub = 0;
 	}
-	if (sy > (int)(MapMaxY() * TILE_SIZE) - hv.y) {
-		sy = MapMaxY() * TILE_SIZE - hv.y;
+	if (sy > (int)(Map::MaxY() * TILE_SIZE) - hv.y) {
+		sy = Map::MaxY() * TILE_SIZE - hv.y;
 		sub = 0;
 	}
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -268,8 +268,8 @@ static void SndPlayScreenCoordFx(SoundID sound, int left, int right, int top, in
 void SndPlayTileFx(SoundID sound, TileIndex tile)
 {
 	/* emits sound from center of the tile */
-	int x = std::min(MapMaxX() - 1, TileX(tile)) * TILE_SIZE + TILE_SIZE / 2;
-	int y = std::min(MapMaxY() - 1, TileY(tile)) * TILE_SIZE - TILE_SIZE / 2;
+	int x = std::min(Map::MaxX() - 1, TileX(tile)) * TILE_SIZE + TILE_SIZE / 2;
+	int y = std::min(Map::MaxY() - 1, TileY(tile)) * TILE_SIZE - TILE_SIZE / 2;
 	int z = (y < 0 ? 0 : GetSlopePixelZ(x, y));
 	Point pt = RemapCoords(x, y, z);
 	y += 2 * TILE_SIZE;

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -346,8 +346,8 @@ Rect Station::GetCatchmentRect() const
 	Rect ret = {
 		std::max<int>(this->rect.left   - catchment_radius, 0),
 		std::max<int>(this->rect.top    - catchment_radius, 0),
-		std::min<int>(this->rect.right  + catchment_radius, MapMaxX()),
-		std::min<int>(this->rect.bottom + catchment_radius, MapMaxY())
+		std::min<int>(this->rect.right  + catchment_radius, Map::MaxX()),
+		std::min<int>(this->rect.bottom + catchment_radius, Map::MaxY())
 	};
 
 	return ret;

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1657,7 +1657,7 @@ CommandCost RemoveFromRailBaseStation(TileArea ta, std::vector<T *> &affected_st
 CommandCost CmdRemoveFromRailStation(DoCommandFlag flags, TileIndex start, TileIndex end, bool keep_rail)
 {
 	if (end == 0) end = start;
-	if (start >= MapSize() || end >= MapSize()) return CMD_ERROR;
+	if (start >= Map::Size() || end >= Map::Size()) return CMD_ERROR;
 
 	TileArea ta(start, end);
 	std::vector<Station *> affected_stations;
@@ -1690,7 +1690,7 @@ CommandCost CmdRemoveFromRailStation(DoCommandFlag flags, TileIndex start, TileI
 CommandCost CmdRemoveFromRailWaypoint(DoCommandFlag flags, TileIndex start, TileIndex end, bool keep_rail)
 {
 	if (end == 0) end = start;
-	if (start >= MapSize() || end >= MapSize()) return CMD_ERROR;
+	if (start >= Map::Size() || end >= Map::Size()) return CMD_ERROR;
 
 	TileArea ta(start, end);
 	std::vector<Waypoint *> affected_stations;
@@ -4071,10 +4071,10 @@ void UpdateStationDockingTiles(Station *st)
 
 	/* Expand the area by a tile on each side while
 	 * making sure that we remain inside the map. */
-	int x2 = std::min<int>(x + area->w + 1, MapSizeX());
+	int x2 = std::min<int>(x + area->w + 1, Map::SizeX());
 	int x1 = std::max<int>(x - 1, 0);
 
-	int y2 = std::min<int>(y + area->h + 1, MapSizeY());
+	int y2 = std::min<int>(y + area->h + 1, Map::SizeY());
 	int y1 = std::max<int>(y - 1, 0);
 
 	TileArea ta(TileXY(x1, y1), TileXY(x2 - 1, y2 - 1));

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -56,7 +56,7 @@ int DrawStationCoverageAreaText(int left, int right, int top, StationCoverageTyp
 {
 	TileIndex tile = TileVirtXY(_thd.pos.x, _thd.pos.y);
 	CargoTypes cargo_mask = 0;
-	if (_thd.drawstyle == HT_RECT && tile < MapSize()) {
+	if (_thd.drawstyle == HT_RECT && tile < Map::Size()) {
 		CargoArray cargoes;
 		if (supplies) {
 			cargoes = GetProductionAroundTiles(tile, _thd.size.x / TILE_SIZE, _thd.size.y / TILE_SIZE, rad);
@@ -99,7 +99,7 @@ static void FindStationsAroundSelection()
 	uint y = TileY(location.tile);
 
 	int max_c = 1;
-	TileArea ta(TileXY(std::max<int>(0, x - max_c), std::max<int>(0, y - max_c)), TileXY(std::min<int>(MapMaxX(), x + location.w + max_c), std::min<int>(MapMaxY(), y + location.h + max_c)));
+	TileArea ta(TileXY(std::max<int>(0, x - max_c), std::max<int>(0, y - max_c)), TileXY(std::min<int>(Map::MaxX(), x + location.w + max_c), std::min<int>(Map::MaxY(), y + location.h + max_c)));
 
 	Station *adjacent = nullptr;
 
@@ -2187,7 +2187,7 @@ static const T *FindStationsNearby(TileArea ta, bool distant_join)
 
 	/* Check the inside, to return, if we sit on another station */
 	for (TileIndex t : ta) {
-		if (t < MapSize() && IsTileType(t, MP_STATION) && T::IsValidID(GetStationIndex(t))) return T::GetByTile(t);
+		if (t < Map::Size() && IsTileType(t, MP_STATION) && T::IsValidID(GetStationIndex(t))) return T::GetByTile(t);
 	}
 
 	/* Look for deleted stations */

--- a/src/station_kdtree.h
+++ b/src/station_kdtree.h
@@ -30,9 +30,9 @@ void ForAllStationsRadius(TileIndex center, uint radius, Func func)
 {
 	uint16 x1, y1, x2, y2;
 	x1 = (uint16)std::max<int>(0, TileX(center) - radius);
-	x2 = (uint16)std::min<int>(TileX(center) + radius + 1, MapSizeX());
+	x2 = (uint16)std::min<int>(TileX(center) + radius + 1, Map::SizeX());
 	y1 = (uint16)std::max<int>(0, TileY(center) - radius);
-	y2 = (uint16)std::min<int>(TileY(center) + radius + 1, MapSizeY());
+	y2 = (uint16)std::min<int>(TileY(center) + radius + 1, Map::SizeY());
 
 	_station_kdtree.FindContained(x1, y1, x2, y2, [&](StationID id) {
 		func(Station::Get(id));

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -84,7 +84,7 @@ static void TerraformAddDirtyTile(TerraformerState *ts, TileIndex tile)
  */
 static void TerraformAddDirtyTileAround(TerraformerState *ts, TileIndex tile)
 {
-	/* Make sure all tiles passed to TerraformAddDirtyTile are within [0, MapSize()] */
+	/* Make sure all tiles passed to TerraformAddDirtyTile are within [0, Map::Size()] */
 	if (TileY(tile) >= 1) TerraformAddDirtyTile(ts, tile + TileDiffXY( 0, -1));
 	if (TileY(tile) >= 1 && TileX(tile) >= 1) TerraformAddDirtyTile(ts, tile + TileDiffXY(-1, -1));
 	if (TileX(tile) >= 1) TerraformAddDirtyTile(ts, tile + TileDiffXY(-1,  0));
@@ -101,7 +101,7 @@ static void TerraformAddDirtyTileAround(TerraformerState *ts, TileIndex tile)
  */
 static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *ts, TileIndex tile, int height)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 
 	/* Check range of destination height */
 	if (height < 0) return { CommandCost(STR_ERROR_ALREADY_AT_SEA_LEVEL), INVALID_TILE };
@@ -117,7 +117,7 @@ static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *
 	/* Check "too close to edge of map". Only possible when freeform-edges is off. */
 	uint x = TileX(tile);
 	uint y = TileY(tile);
-	if (!_settings_game.construction.freeform_edges && ((x <= 1) || (y <= 1) || (x >= MapMaxX() - 1) || (y >= MapMaxY() - 1))) {
+	if (!_settings_game.construction.freeform_edges && ((x <= 1) || (y <= 1) || (x >= Map::MaxX() - 1) || (y >= Map::MaxY() - 1))) {
 		/*
 		 * Determine a sensible error tile
 		 */
@@ -152,10 +152,10 @@ static std::tuple<CommandCost, TileIndex> TerraformTileHeight(TerraformerState *
 		for (ttm = _terraform_tilepos; ttm != endof(_terraform_tilepos); ttm++) {
 			tile += ToTileIndexDiff(*ttm);
 
-			if (tile >= MapSize()) continue;
+			if (tile >= Map::Size()) continue;
 			/* Make sure we don't wrap around the map */
-			if (Delta(TileX(orig_tile), TileX(tile)) == MapSizeX() - 1) continue;
-			if (Delta(TileY(orig_tile), TileY(tile)) == MapSizeY() - 1) continue;
+			if (Delta(TileX(orig_tile), TileX(tile)) == Map::SizeX() - 1) continue;
+			if (Delta(TileY(orig_tile), TileY(tile)) == Map::SizeY() - 1) continue;
 
 			/* Get TileHeight of neighboured tile as of current terraform progress */
 			int r = TerraformGetHeightOfTile(ts, tile);
@@ -190,21 +190,21 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlag flags, 
 	TerraformerState ts;
 
 	/* Compute the costs and the terraforming result in a model of the landscape */
-	if ((slope & SLOPE_W) != 0 && tile + TileDiffXY(1, 0) < MapSize()) {
+	if ((slope & SLOPE_W) != 0 && tile + TileDiffXY(1, 0) < Map::Size()) {
 		TileIndex t = tile + TileDiffXY(1, 0);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
 		total_cost.AddCost(cost);
 	}
 
-	if ((slope & SLOPE_S) != 0 && tile + TileDiffXY(1, 1) < MapSize()) {
+	if ((slope & SLOPE_S) != 0 && tile + TileDiffXY(1, 1) < Map::Size()) {
 		TileIndex t = tile + TileDiffXY(1, 1);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
 		total_cost.AddCost(cost);
 	}
 
-	if ((slope & SLOPE_E) != 0 && tile + TileDiffXY(0, 1) < MapSize()) {
+	if ((slope & SLOPE_E) != 0 && tile + TileDiffXY(0, 1) < Map::Size()) {
 		TileIndex t = tile + TileDiffXY(0, 1);
 		auto [cost, err_tile] = TerraformTileHeight(&ts, t, TileHeight(t) + direction);
 		if (cost.Failed()) return { cost, 0, err_tile };
@@ -225,7 +225,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlag flags, 
 		for (TileIndexSet::const_iterator it = ts.dirty_tiles.begin(); it != ts.dirty_tiles.end(); it++) {
 			TileIndex t = *it;
 
-			assert(t < MapSize());
+			assert(t < Map::Size());
 			/* MP_VOID tiles can be terraformed but as tunnels and bridges
 			 * cannot go under / over these tiles they don't need checking. */
 			if (IsTileType(t, MP_VOID)) continue;
@@ -334,7 +334,7 @@ std::tuple<CommandCost, Money, TileIndex> CmdTerraformLand(DoCommandFlag flags, 
  */
 std::tuple<CommandCost, Money, TileIndex> CmdLevelLand(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, bool diagonal, LevelMode lm)
 {
-	if (start_tile >= MapSize()) return { CMD_ERROR, 0, INVALID_TILE };
+	if (start_tile >= Map::Size()) return { CMD_ERROR, 0, INVALID_TILE };
 
 	/* remember level height */
 	uint oldh = TileHeight(start_tile);

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -113,8 +113,8 @@ bool GUIPlaceProcDragXY(ViewportDragDropSelectionProcess proc, TileIndex start_t
 	if (!_settings_game.construction.freeform_edges) {
 		/* When end_tile is MP_VOID, the error tile will not be visible to the
 		 * user. This happens when terraforming at the southern border. */
-		if (TileX(end_tile) == MapMaxX()) end_tile += TileDiffXY(-1, 0);
-		if (TileY(end_tile) == MapMaxY()) end_tile += TileDiffXY(0, -1);
+		if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
+		if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 	}
 
 	switch (proc) {
@@ -280,8 +280,8 @@ struct TerraformToolbarWindow : Window {
 					if (!_settings_game.construction.freeform_edges) {
 						/* When end_tile is MP_VOID, the error tile will not be visible to the
 							* user. This happens when terraforming at the southern border. */
-						if (TileX(end_tile) == MapMaxX()) end_tile += TileDiffXY(-1, 0);
-						if (TileY(end_tile) == MapMaxY()) end_tile += TileDiffXY(0, -1);
+						if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
+						if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 					}
 					Command<CMD_BUILD_OBJECT_AREA>::Post(STR_ERROR_CAN_T_PURCHASE_THIS_LAND, CcPlaySound_CONSTRUCTION_RAIL,
 						end_tile, start_tile, OBJECT_OWNED_LAND, 0, (_ctrl_pressed ? true : false));

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -164,9 +164,9 @@ struct HeightMap
 	std::vector<height_t> h; //< array of heights
 	/* Even though the sizes are always positive, there are many cases where
 	 * X and Y need to be signed integers due to subtractions. */
-	int      dim_x;      //< height map size_x MapSizeX() + 1
-	int      size_x;     //< MapSizeX()
-	int      size_y;     //< MapSizeY()
+	int      dim_x;      //< height map size_x Map::SizeX() + 1
+	int      size_x;     //< Map::SizeX()
+	int      size_y;     //< Map::SizeY()
 
 	/**
 	 * Height map accessor
@@ -220,7 +220,7 @@ static height_t TGPGetMaxHeight()
 	/**
 	 * Desired maximum height - indexed by:
 	 *  - _settings_game.difficulty.terrain_type
-	 *  - min(MapLogX(), MapLogY()) - MIN_MAP_SIZE_BITS
+	 *  - min(Map::LogX(), Map::LogY()) - MIN_MAP_SIZE_BITS
 	 *
 	 * It is indexed by map size as well as terrain type since the map size limits the height of
 	 * a usable mountain. For example, on a 64x64 map a 24 high single peak mountain (as if you
@@ -236,7 +236,7 @@ static height_t TGPGetMaxHeight()
 		{  12,  19,  25,  31,  67,  75,  87 }, ///< Alpinist
 	};
 
-	int map_size_bucket = std::min(MapLogX(), MapLogY()) - MIN_MAP_SIZE_BITS;
+	int map_size_bucket = std::min(Map::LogX(), Map::LogY()) - MIN_MAP_SIZE_BITS;
 	int max_height_from_table = max_height[_settings_game.difficulty.terrain_type][map_size_bucket];
 
 	/* If there is a manual map height limit, clamp to it. */
@@ -322,8 +322,8 @@ static inline bool AllocHeightMap()
 {
 	assert(_height_map.h.empty());
 
-	_height_map.size_x = MapSizeX();
-	_height_map.size_y = MapSizeY();
+	_height_map.size_x = Map::SizeX();
+	_height_map.size_y = Map::SizeY();
 
 	/* Allocate memory block for height map row pointers */
 	size_t total_size = static_cast<size_t>(_height_map.size_x + 1) * (_height_map.size_y + 1);
@@ -362,7 +362,7 @@ static void HeightMapGenerate()
 	/* Trying to apply noise to uninitialized height map */
 	assert(!_height_map.h.empty());
 
-	int start = std::max(MAX_TGP_FREQUENCIES - (int)std::min(MapLogX(), MapLogY()), 0);
+	int start = std::max(MAX_TGP_FREQUENCIES - (int)std::min(Map::LogX(), Map::LogY()), 0);
 	bool first = true;
 
 	for (int frequency = start; frequency < MAX_TGP_FREQUENCIES; frequency++) {
@@ -1004,8 +1004,8 @@ void GenerateTerrainPerlin()
 
 	/* First make sure the tiles at the north border are void tiles if needed. */
 	if (_settings_game.construction.freeform_edges) {
-		for (uint x = 0; x < MapSizeX(); x++) MakeVoid(TileXY(x, 0));
-		for (uint y = 0; y < MapSizeY(); y++) MakeVoid(TileXY(0, y));
+		for (uint x = 0; x < Map::SizeX(); x++) MakeVoid(TileXY(x, 0));
+		for (uint y = 0; y < Map::SizeY(); y++) MakeVoid(TileXY(0, y));
 	}
 
 	int max_height = H2I(TGPGetMaxHeight());

--- a/src/tile_map.cpp
+++ b/src/tile_map.cpp
@@ -60,8 +60,8 @@ Slope GetTileSlope(TileIndex tile, int *h)
 {
 	uint x1 = TileX(tile);
 	uint y1 = TileY(tile);
-	uint x2 = std::min(x1 + 1, MapMaxX());
-	uint y2 = std::min(y1 + 1, MapMaxY());
+	uint x2 = std::min(x1 + 1, Map::MaxX());
+	uint y2 = std::min(y1 + 1, Map::MaxY());
 
 	int hnorth = TileHeight(tile);           // Height of the North corner.
 	int hwest  = TileHeight(TileXY(x2, y1)); // Height of the West corner.
@@ -101,8 +101,8 @@ bool IsTileFlat(TileIndex tile, int *h)
 {
 	uint x1 = TileX(tile);
 	uint y1 = TileY(tile);
-	uint x2 = std::min(x1 + 1, MapMaxX());
-	uint y2 = std::min(y1 + 1, MapMaxY());
+	uint x2 = std::min(x1 + 1, Map::MaxX());
+	uint y2 = std::min(y1 + 1, Map::MaxY());
 
 	uint z = TileHeight(tile);
 	if (TileHeight(TileXY(x2, y1)) != z) return false;
@@ -122,8 +122,8 @@ int GetTileZ(TileIndex tile)
 {
 	uint x1 = TileX(tile);
 	uint y1 = TileY(tile);
-	uint x2 = std::min(x1 + 1, MapMaxX());
-	uint y2 = std::min(y1 + 1, MapMaxY());
+	uint x2 = std::min(x1 + 1, Map::MaxX());
+	uint y2 = std::min(y1 + 1, Map::MaxY());
 
 	return std::min({
 		TileHeight(tile),           // N corner
@@ -142,8 +142,8 @@ int GetTileMaxZ(TileIndex t)
 {
 	uint x1 = TileX(t);
 	uint y1 = TileY(t);
-	uint x2 = std::min(x1 + 1, MapMaxX());
-	uint y2 = std::min(y1 + 1, MapMaxY());
+	uint x2 = std::min(x1 + 1, Map::MaxX());
+	uint y2 = std::min(y1 + 1, Map::MaxY());
 
 	return std::max({
 		TileHeight(t),              // N corner

--- a/src/tile_map.h
+++ b/src/tile_map.h
@@ -24,11 +24,11 @@
  *
  * @param tile The tile to get the height from
  * @return the height of the tile
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  */
 static inline uint TileHeight(TileIndex tile)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 	return _m[tile].height;
 }
 
@@ -41,7 +41,7 @@ static inline uint TileHeight(TileIndex tile)
  */
 static inline uint TileHeightOutsideMap(int x, int y)
 {
-	return TileHeight(TileXY(Clamp(x, 0, MapMaxX()), Clamp(y, 0, MapMaxY())));
+	return TileHeight(TileXY(Clamp(x, 0, Map::MaxX()), Clamp(y, 0, Map::MaxY())));
 }
 
 /**
@@ -51,12 +51,12 @@ static inline uint TileHeightOutsideMap(int x, int y)
  *
  * @param tile The tile to change the height
  * @param height The new height value of the tile
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  * @pre height <= MAX_TILE_HEIGHT
  */
 static inline void SetTileHeight(TileIndex tile, uint height)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 	assert(height <= MAX_TILE_HEIGHT);
 	_m[tile].height = height;
 }
@@ -91,11 +91,11 @@ static inline uint TilePixelHeightOutsideMap(int x, int y)
  *
  * @param tile The tile to get the TileType
  * @return The tiletype of the tile
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  */
 static inline TileType GetTileType(TileIndex tile)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 	return (TileType)GB(_m[tile].type, 4, 4);
 }
 
@@ -104,16 +104,16 @@ static inline TileType GetTileType(TileIndex tile)
  *
  * @param tile The tile to check
  * @return Whether the tile is in the interior of the map
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  */
 static inline bool IsInnerTile(TileIndex tile)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 
 	uint x = TileX(tile);
 	uint y = TileY(tile);
 
-	return x < MapMaxX() && y < MapMaxY() && ((x > 0 && y > 0) || !_settings_game.construction.freeform_edges);
+	return x < Map::MaxX() && y < Map::MaxY() && ((x > 0 && y > 0) || !_settings_game.construction.freeform_edges);
 }
 
 /**
@@ -125,12 +125,12 @@ static inline bool IsInnerTile(TileIndex tile)
  *
  * @param tile The tile to save the new type
  * @param type The type to save
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  * @pre type MP_VOID <=> tile is on the south-east or south-west edge.
  */
 static inline void SetTileType(TileIndex tile, TileType type)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 	/* VOID tiles (and no others) are exactly allowed at the lower left and right
 	 * edges of the map. If _settings_game.construction.freeform_edges is true,
 	 * the upper edges of the map are also VOID tiles. */
@@ -160,7 +160,7 @@ static inline bool IsTileType(TileIndex tile, TileType type)
  */
 static inline bool IsValidTile(TileIndex tile)
 {
-	return tile < MapSize() && !IsTileType(tile, MP_VOID);
+	return tile < Map::Size() && !IsTileType(tile, MP_VOID);
 }
 
 /**
@@ -220,11 +220,11 @@ static inline bool IsTileOwner(TileIndex tile, Owner owner)
  * Set the tropic zone
  * @param tile the tile to set the zone of
  * @param type the new type
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  */
 static inline void SetTropicZone(TileIndex tile, TropicZone type)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 	assert(!IsTileType(tile, MP_VOID) || type == TROPICZONE_NORMAL);
 	SB(_m[tile].type, 0, 2, type);
 }
@@ -232,12 +232,12 @@ static inline void SetTropicZone(TileIndex tile, TropicZone type)
 /**
  * Get the tropic zone
  * @param tile the tile to get the zone of
- * @pre tile < MapSize()
+ * @pre tile < Map::Size()
  * @return the zone type
  */
 static inline TropicZone GetTropicZone(TileIndex tile)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 	return (TropicZone)GB(_m[tile].type, 0, 2);
 }
 

--- a/src/tilearea.cpp
+++ b/src/tilearea.cpp
@@ -20,8 +20,8 @@
  */
 OrthogonalTileArea::OrthogonalTileArea(TileIndex start, TileIndex end)
 {
-	assert(start < MapSize());
-	assert(end < MapSize());
+	assert(start < Map::Size());
+	assert(end < Map::Size());
 
 	uint sx = TileX(start);
 	uint sy = TileY(start);
@@ -127,8 +127,8 @@ OrthogonalTileArea &OrthogonalTileArea::Expand(int rad)
 
 	int sx = std::max<int>(x - rad, 0);
 	int sy = std::max<int>(y - rad, 0);
-	int ex = std::min<int>(x + this->w + rad, MapSizeX());
-	int ey = std::min<int>(y + this->h + rad, MapSizeY());
+	int ex = std::min<int>(x + this->w + rad, Map::SizeX());
+	int ey = std::min<int>(y + this->h + rad, Map::SizeY());
 
 	this->tile = TileXY(sx, sy);
 	this->w    = ex - sx;
@@ -141,9 +141,9 @@ OrthogonalTileArea &OrthogonalTileArea::Expand(int rad)
  */
 void OrthogonalTileArea::ClampToMap()
 {
-	assert(this->tile < MapSize());
-	this->w = std::min<int>(this->w, MapSizeX() - TileX(this->tile));
-	this->h = std::min<int>(this->h, MapSizeY() - TileY(this->tile));
+	assert(this->tile < Map::Size());
+	this->w = std::min<int>(this->w, Map::SizeX() - TileX(this->tile));
+	this->h = std::min<int>(this->h, Map::SizeY() - TileY(this->tile));
 }
 
 /**
@@ -171,8 +171,8 @@ OrthogonalTileIterator OrthogonalTileArea::end() const
  */
 DiagonalTileArea::DiagonalTileArea(TileIndex start, TileIndex end) : tile(start)
 {
-	assert(start < MapSize());
-	assert(end < MapSize());
+	assert(start < Map::Size());
+	assert(end < Map::Size());
 
 	/* Unfortunately we can't find a new base and make all a and b positive because
 	 * the new base might be a "flattened" corner where there actually is no single
@@ -274,8 +274,8 @@ TileIterator &DiagonalTileIterator::operator++()
 		uint x = this->base_x + (this->a_cur - this->b_cur) / 2;
 		uint y = this->base_y + (this->b_cur + this->a_cur) / 2;
 		/* Prevent wrapping around the map's borders. */
-		this->tile = x >= MapSizeX() || y >= MapSizeY() ? INVALID_TILE : TileXY(x, y);
-	} while (this->tile > MapSize() && this->b_max != this->b_cur);
+		this->tile = x >= Map::SizeX() || y >= Map::SizeY() ? INVALID_TILE : TileXY(x, y);
+	} while (this->tile > Map::Size() && this->b_max != this->b_cur);
 
 	if (this->b_max == this->b_cur) this->tile = INVALID_TILE;
 	return *this;

--- a/src/tilematrix_type.hpp
+++ b/src/tilematrix_type.hpp
@@ -101,8 +101,8 @@ public:
 		tile_x -= std::min(extend * N, tile_x);
 		tile_y -= std::min(extend * N, tile_y);
 
-		w += std::min(extend * N, MapSizeX() - tile_x - w);
-		h += std::min(extend * N, MapSizeY() - tile_y - h);
+		w += std::min(extend * N, Map::SizeX() - tile_x - w);
+		h += std::min(extend * N, Map::SizeY() - tile_y - h);
 
 		return TileArea(TileXY(tile_x, tile_y), w, h);
 	}

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -121,7 +121,7 @@ Town::~Town()
 #endif /* WITH_ASSERT */
 
 	/* Check no tile is related to us. */
-	for (TileIndex tile = 0; tile < MapSize(); ++tile) {
+	for (TileIndex tile = 0; tile < Map::Size(); ++tile) {
 		switch (GetTileType(tile)) {
 			case MP_HOUSE:
 				assert(GetTownIndex(tile) != this->index);
@@ -974,7 +974,7 @@ static bool IsRoadAllowedHere(Town *t, TileIndex tile, DiagDirection dir)
 
 static bool TerraformTownTile(TileIndex tile, Slope edges, bool dir)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 
 	CommandCost r = std::get<0>(Command<CMD_TERRAFORM_LAND>::Do(DC_AUTO | DC_NO_WATER, tile, edges, dir));
 	if (r.Failed() || r.GetCost() >= (_price[PR_TERRAFORM] + 2) * 8) return false;
@@ -984,7 +984,7 @@ static bool TerraformTownTile(TileIndex tile, Slope edges, bool dir)
 
 static void LevelTownLand(TileIndex tile)
 {
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 
 	/* Don't terraform if land is plain or if there's a house there. */
 	if (IsTileType(tile, MP_HOUSE)) return;
@@ -1384,7 +1384,7 @@ static void GrowTownInTile(TileIndex *tile_ptr, RoadBits cur_rb, DiagDirection t
 	RoadBits rcmd = ROAD_NONE;  // RoadBits for the road construction command
 	TileIndex tile = *tile_ptr; // The main tile on which we base our growth
 
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 
 	if (cur_rb == ROAD_NONE) {
 		/* Tile has no road. First reset the status counter
@@ -1632,7 +1632,7 @@ static bool GrowTownAtRoad(Town *t, TileIndex tile)
 	 */
 	DiagDirection target_dir = DIAGDIR_END; // The direction in which we want to extend the town
 
-	assert(tile < MapSize());
+	assert(tile < Map::Size());
 
 	/* Number of times to search.
 	 * Better roads, 2X2 and 3X3 grid grow quite fast so we give
@@ -2231,7 +2231,7 @@ bool GenerateTowns(TownLayout layout)
 {
 	uint current_number = 0;
 	uint difficulty = (_game_mode != GM_EDITOR) ? _settings_game.difficulty.number_towns : 0;
-	uint total = (difficulty == (uint)CUSTOM_TOWN_NUMBER_DIFFICULTY) ? _settings_game.game_creation.custom_town_number : ScaleByMapSize(_num_initial_towns[difficulty] + (Random() & 7));
+	uint total = (difficulty == (uint)CUSTOM_TOWN_NUMBER_DIFFICULTY) ? _settings_game.game_creation.custom_town_number : Map::ScaleBySize(_num_initial_towns[difficulty] + (Random() & 7));
 	total = std::min<uint>(TownPool::MAX_SIZE, total);
 	uint32 townnameparts;
 	TownNames town_names;
@@ -2991,7 +2991,7 @@ CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id)
 	 * these do not directly have an owner so we need to check adjacent
 	 * tiles. This won't work correctly in the same loop if the adjacent
 	 * tile was already deleted earlier in the loop. */
-	for (TileIndex current_tile = 0; current_tile < MapSize(); ++current_tile) {
+	for (TileIndex current_tile = 0; current_tile < Map::Size(); ++current_tile) {
 		if (IsTileType(current_tile, MP_TUNNELBRIDGE) && TestTownOwnsBridge(current_tile, t)) {
 			CommandCost ret = Command<CMD_LANDSCAPE_CLEAR>::Do(flags, current_tile);
 			if (ret.Failed()) return ret;
@@ -2999,7 +2999,7 @@ CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id)
 	}
 
 	/* Check all remaining tiles for town ownership. */
-	for (TileIndex current_tile = 0; current_tile < MapSize(); ++current_tile) {
+	for (TileIndex current_tile = 0; current_tile < Map::Size(); ++current_tile) {
 		bool try_clear = false;
 		switch (GetTileType(current_tile)) {
 			case MP_ROAD:
@@ -3758,7 +3758,7 @@ void TownsMonthlyLoop()
 void TownsYearlyLoop()
 {
 	/* Increment house ages */
-	for (TileIndex t = 0; t < MapSize(); t++) {
+	for (TileIndex t = 0; t < Map::Size(); t++) {
 		if (!IsTileType(t, MP_HOUSE)) continue;
 		IncrementHouseAge(t);
 	}

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1753,7 +1753,7 @@ void UpdateLevelCrossing(TileIndex tile, bool sound, bool force_bar)
 
 	/* Check if an adjacent crossing is barred. */
 	for (DiagDirection dir : { dir1, dir2 }) {
-		for (TileIndex t = tile; !forced_state && t < MapSize() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == axis; t = TileAddByDiagDir(t, dir)) {
+		for (TileIndex t = tile; !forced_state && t < Map::Size() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == axis; t = TileAddByDiagDir(t, dir)) {
 			forced_state |= CheckLevelCrossing(t);
 		}
 	}
@@ -1762,7 +1762,7 @@ void UpdateLevelCrossing(TileIndex tile, bool sound, bool force_bar)
 	 * we need to update those tiles. We start with the tile itself, then look along the road axis. */
 	UpdateLevelCrossingTile(tile, sound, forced_state);
 	for (DiagDirection dir : { dir1, dir2 }) {
-		for (TileIndex t = TileAddByDiagDir(tile, dir); t < MapSize() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == axis; t = TileAddByDiagDir(t, dir)) {
+		for (TileIndex t = TileAddByDiagDir(tile, dir); t < Map::Size() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == axis; t = TileAddByDiagDir(t, dir)) {
 			UpdateLevelCrossingTile(t, sound, forced_state);
 		}
 	}
@@ -1778,7 +1778,7 @@ void MarkDirtyAdjacentLevelCrossingTiles(TileIndex tile, Axis road_axis)
 	const DiagDirection dir2 = ReverseDiagDir(dir1);
 	for (DiagDirection dir : { dir1, dir2 }) {
 		const TileIndex t = TileAddByDiagDir(tile, dir);
-		if (t < MapSize() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == road_axis) {
+		if (t < Map::Size() && IsLevelCrossingTile(t) && GetCrossingRoadAxis(t) == road_axis) {
 			MarkTileDirtyByTile(t);
 		}
 	}

--- a/src/tree_cmd.cpp
+++ b/src/tree_cmd.cpp
@@ -250,7 +250,7 @@ void PlaceTreesRandomly()
 {
 	int i, j, ht;
 
-	i = ScaleByMapSize(DEFAULT_TREE_STEPS);
+	i = Map::ScaleBySize(DEFAULT_TREE_STEPS);
 	if (_game_mode == GM_EDITOR) i /= EDITOR_TREE_DIV;
 	do {
 		uint32 r = Random();
@@ -278,7 +278,7 @@ void PlaceTreesRandomly()
 
 	/* place extra trees at rainforest area */
 	if (_settings_game.game_creation.landscape == LT_TROPIC) {
-		i = ScaleByMapSize(DEFAULT_RAINFOREST_TREE_STEPS);
+		i = Map::ScaleBySize(DEFAULT_RAINFOREST_TREE_STEPS);
 		if (_game_mode == GM_EDITOR) i /= EDITOR_TREE_DIV;
 
 		do {
@@ -365,10 +365,10 @@ void GenerateTrees()
 		default: NOT_REACHED();
 	}
 
-	total = ScaleByMapSize(DEFAULT_TREE_STEPS);
-	if (_settings_game.game_creation.landscape == LT_TROPIC) total += ScaleByMapSize(DEFAULT_RAINFOREST_TREE_STEPS);
+	total = Map::ScaleBySize(DEFAULT_TREE_STEPS);
+	if (_settings_game.game_creation.landscape == LT_TROPIC) total += Map::ScaleBySize(DEFAULT_RAINFOREST_TREE_STEPS);
 	total *= i;
-	uint num_groups = (_settings_game.game_creation.landscape != LT_TOYLAND) ? ScaleByMapSize(GB(Random(), 0, 5) + 25) : 0;
+	uint num_groups = (_settings_game.game_creation.landscape != LT_TOYLAND) ? Map::ScaleBySize(GB(Random(), 0, 5) + 25) : 0;
 	total += num_groups * DEFAULT_TREE_STEPS;
 	SetGeneratingWorldProgress(GWP_TREE, total);
 
@@ -393,7 +393,7 @@ CommandCost CmdPlantTree(DoCommandFlag flags, TileIndex tile, TileIndex start_ti
 	StringID msg = INVALID_STRING_ID;
 	CommandCost cost(EXPENSES_OTHER);
 
-	if (start_tile >= MapSize()) return CMD_ERROR;
+	if (start_tile >= Map::Size()) return CMD_ERROR;
 	/* Check the tree type within the current climate */
 	if (tree_to_plant != TREE_INVALID && !IsInsideBS(tree_to_plant, _tree_base_by_landscape[_settings_game.game_creation.landscape], _tree_count_by_landscape[_settings_game.game_creation.landscape])) return CMD_ERROR;
 
@@ -827,7 +827,7 @@ bool DecrementTreeCounter()
 
 	/* byte underflow */
 	byte old_trees_tick_ctr = _trees_tick_ctr;
-	_trees_tick_ctr -= ScaleByMapSize(1);
+	_trees_tick_ctr -= Map::ScaleBySize(1);
 	return old_trees_tick_ctr <= _trees_tick_ctr;
 }
 
@@ -843,12 +843,12 @@ void OnTick_Trees()
 	/* Skip some tree ticks for map sizes below 256 * 256. 64 * 64 is 16 times smaller, so
 	 * this is the maximum number of ticks that are skipped. Number of ticks to skip is
 	 * inversely proportional to map size, so that is handled to create a mask. */
-	int skip = ScaleByMapSize(16);
+	int skip = Map::ScaleBySize(16);
 	if (skip < 16 && (_tick_counter & (16 / skip - 1)) != 0) return;
 
 	/* place a tree at a random rainforest spot */
 	if (_settings_game.game_creation.landscape == LT_TROPIC) {
-		for (uint c = ScaleByMapSize(1); c > 0; c--) {
+		for (uint c = Map::ScaleBySize(1); c > 0; c--) {
 			if ((r = Random(), tile = RandomTileSeed(r), GetTropicZone(tile) == TROPICZONE_RAINFOREST) &&
 				CanPlantTreesOnTile(tile, false) &&
 				(tree = GetRandomTreeType(tile, GB(r, 24, 8))) != TREE_INVALID) {

--- a/src/tunnel_map.cpp
+++ b/src/tunnel_map.cpp
@@ -67,6 +67,6 @@ bool IsTunnelInWayDir(TileIndex tile, int z, DiagDirection dir)
  */
 bool IsTunnelInWay(TileIndex tile, int z)
 {
-	return IsTunnelInWayDir(tile, z, (TileX(tile) > (MapMaxX() / 2)) ? DIAGDIR_NE : DIAGDIR_SW) ||
-			IsTunnelInWayDir(tile, z, (TileY(tile) > (MapMaxY() / 2)) ? DIAGDIR_NW : DIAGDIR_SE);
+	return IsTunnelInWayDir(tile, z, (TileX(tile) > (Map::MaxX() / 2)) ? DIAGDIR_NE : DIAGDIR_SW) ||
+			IsTunnelInWayDir(tile, z, (TileY(tile) > (Map::MaxY() / 2)) ? DIAGDIR_NW : DIAGDIR_SE);
 }

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -673,9 +673,9 @@ CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportT
 	TileIndexDiff delta = TileOffsByDiagDir(direction);
 	DiagDirection tunnel_in_way_dir;
 	if (DiagDirToAxis(direction) == AXIS_Y) {
-		tunnel_in_way_dir = (TileX(start_tile) < (MapMaxX() / 2)) ? DIAGDIR_SW : DIAGDIR_NE;
+		tunnel_in_way_dir = (TileX(start_tile) < (Map::MaxX() / 2)) ? DIAGDIR_SW : DIAGDIR_NE;
 	} else {
-		tunnel_in_way_dir = (TileY(start_tile) < (MapMaxX() / 2)) ? DIAGDIR_SE : DIAGDIR_NW;
+		tunnel_in_way_dir = (TileY(start_tile) < (Map::MaxX() / 2)) ? DIAGDIR_SE : DIAGDIR_NW;
 	}
 
 	TileIndex end_tile = start_tile;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1224,8 +1224,8 @@ static void ViewportAddLandscape()
 			tile_info.x = tilecoord.x * TILE_SIZE; // FIXME tile_info should use signed integers
 			tile_info.y = tilecoord.y * TILE_SIZE;
 
-			if (IsInsideBS(tilecoord.x, 0, MapSizeX()) && IsInsideBS(tilecoord.y, 0, MapSizeY())) {
-				/* This includes the south border at MapMaxX / MapMaxY. When terraforming we still draw tile selections there. */
+			if (IsInsideBS(tilecoord.x, 0, Map::SizeX()) && IsInsideBS(tilecoord.y, 0, Map::SizeY())) {
+				/* This includes the south border at Map::MaxX / Map::MaxY. When terraforming we still draw tile selections there. */
 				tile_info.tile = TileXY(tilecoord.x, tilecoord.y);
 				tile_type = GetTileType(tile_info.tile);
 			} else {
@@ -1892,7 +1892,7 @@ void UpdateViewportPosition(Window *w)
 		bool update_overlay = false;
 		if (delta_x != 0 || delta_y != 0) {
 			if (_settings_client.gui.smooth_scroll) {
-				int max_scroll = ScaleByMapSize1D(512 * ZOOM_LVL_BASE);
+				int max_scroll = Map::ScaleBySize1D(512 * ZOOM_LVL_BASE);
 				/* Not at our desired position yet... */
 				w->viewport->scrollpos_x += Clamp(DivAwayFromZero(delta_x, 4), -max_scroll, max_scroll);
 				w->viewport->scrollpos_y += Clamp(DivAwayFromZero(delta_y, 4), -max_scroll, max_scroll);
@@ -2034,11 +2034,11 @@ static void SetSelectionTilesDirty()
 		assert(x_size >= 0);
 		assert(y_size >= 0);
 
-		int x_end = Clamp(x_start + x_size, 0, MapSizeX() * TILE_SIZE - TILE_SIZE);
-		int y_end = Clamp(y_start + y_size, 0, MapSizeY() * TILE_SIZE - TILE_SIZE);
+		int x_end = Clamp(x_start + x_size, 0, Map::SizeX() * TILE_SIZE - TILE_SIZE);
+		int y_end = Clamp(y_start + y_size, 0, Map::SizeY() * TILE_SIZE - TILE_SIZE);
 
-		x_start = Clamp(x_start, 0, MapSizeX() * TILE_SIZE - TILE_SIZE);
-		y_start = Clamp(y_start, 0, MapSizeY() * TILE_SIZE - TILE_SIZE);
+		x_start = Clamp(x_start, 0, Map::SizeX() * TILE_SIZE - TILE_SIZE);
+		y_start = Clamp(y_start, 0, Map::SizeY() * TILE_SIZE - TILE_SIZE);
 
 		/* make sure everything is multiple of TILE_SIZE */
 		assert((x_end | y_end | x_start | y_start) % TILE_SIZE == 0);
@@ -2114,7 +2114,7 @@ static void SetSelectionTilesDirty()
 				uint x = (_thd.pos.x + (a + b) / 2) / TILE_SIZE;
 				uint y = (_thd.pos.y + (a - b) / 2) / TILE_SIZE;
 
-				if (x < MapMaxX() && y < MapMaxY()) {
+				if (x < Map::MaxX() && y < Map::MaxY()) {
 					MarkTileDirtyByTile(TileXY(x, y));
 				}
 			}
@@ -2411,8 +2411,8 @@ bool ScrollWindowTo(int x, int y, int z, Window *w, bool instant)
 {
 	/* The slope cannot be acquired outside of the map, so make sure we are always within the map. */
 	if (z == -1) {
-		if ( x >= 0 && x <= (int)MapSizeX() * (int)TILE_SIZE - 1
-				&& y >= 0 && y <= (int)MapSizeY() * (int)TILE_SIZE - 1) {
+		if ( x >= 0 && x <= (int)Map::SizeX() * (int)TILE_SIZE - 1
+				&& y >= 0 && y <= (int)Map::SizeY() * (int)TILE_SIZE - 1) {
 			z = GetSlopePixelZ(x, y);
 		} else {
 			z = TileHeightOutsideMap(x / (int)TILE_SIZE, y / (int)TILE_SIZE);
@@ -2981,9 +2981,9 @@ static void CalcRaildirsDrawstyle(int x, int y, int method)
 					/* Make sure we do not overflow the map! */
 					CheckUnderflow(x, y, 1);
 					CheckUnderflow(y, x, 1);
-					CheckOverflow(x, y, (MapMaxX() - 1) * TILE_SIZE, 1);
-					CheckOverflow(y, x, (MapMaxY() - 1) * TILE_SIZE, 1);
-					assert(x >= 0 && y >= 0 && x <= (int)(MapMaxX() * TILE_SIZE) && y <= (int)(MapMaxY() * TILE_SIZE));
+					CheckOverflow(x, y, (Map::MaxX() - 1) * TILE_SIZE, 1);
+					CheckOverflow(y, x, (Map::MaxY() - 1) * TILE_SIZE, 1);
+					assert(x >= 0 && y >= 0 && x <= (int)(Map::MaxX() * TILE_SIZE) && y <= (int)(Map::MaxY() * TILE_SIZE));
 				}
 				break;
 
@@ -3016,9 +3016,9 @@ static void CalcRaildirsDrawstyle(int x, int y, int method)
 					/* Make sure we do not overflow the map! */
 					CheckUnderflow(x, y, -1);
 					CheckUnderflow(y, x, -1);
-					CheckOverflow(x, y, (MapMaxX() - 1) * TILE_SIZE, -1);
-					CheckOverflow(y, x, (MapMaxY() - 1) * TILE_SIZE, -1);
-					assert(x >= 0 && y >= 0 && x <= (int)(MapMaxX() * TILE_SIZE) && y <= (int)(MapMaxY() * TILE_SIZE));
+					CheckOverflow(x, y, (Map::MaxX() - 1) * TILE_SIZE, -1);
+					CheckOverflow(y, x, (Map::MaxY() - 1) * TILE_SIZE, -1);
+					assert(x >= 0 && y >= 0 && x <= (int)(Map::MaxX() * TILE_SIZE) && y <= (int)(Map::MaxY() * TILE_SIZE));
 				}
 				break;
 
@@ -3440,7 +3440,7 @@ Point GetViewportStationMiddle(const Viewport *vp, const Station *st)
 {
 	int x = TileX(st->xy) * TILE_SIZE;
 	int y = TileY(st->xy) * TILE_SIZE;
-	int z = GetSlopePixelZ(Clamp(x, 0, MapSizeX() * TILE_SIZE - 1), Clamp(y, 0, MapSizeY() * TILE_SIZE - 1));
+	int z = GetSlopePixelZ(Clamp(x, 0, Map::SizeX() * TILE_SIZE - 1), Clamp(y, 0, Map::SizeY() * TILE_SIZE - 1));
 
 	Point p = RemapCoords(x, y, z);
 	p.x = UnScaleByZoom(p.x - vp->virtual_left, vp->zoom) + vp->left;

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -450,7 +450,7 @@ void MakeRiverAndModifyDesertZoneAround(TileIndex tile) {
  */
 CommandCost CmdBuildCanal(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, WaterClass wc, bool diagonal)
 {
-	if (start_tile >= MapSize() || !IsValidWaterClass(wc)) return CMD_ERROR;
+	if (start_tile >= Map::Size() || !IsValidWaterClass(wc)) return CMD_ERROR;
 
 	/* Outside of the editor you can only build canals, not oceans */
 	if (wc != WATER_CLASS_CANAL && _game_mode != GM_EDITOR) return CMD_ERROR;
@@ -528,8 +528,8 @@ static CommandCost ClearTile_Water(TileIndex tile, DoCommandFlag flags)
 
 			Money base_cost = IsCanal(tile) ? _price[PR_CLEAR_CANAL] : _price[PR_CLEAR_WATER];
 			/* Make sure freeform edges are allowed or it's not an edge tile. */
-			if (!_settings_game.construction.freeform_edges && (!IsInsideMM(TileX(tile), 1, MapMaxX() - 1) ||
-					!IsInsideMM(TileY(tile), 1, MapMaxY() - 1))) {
+			if (!_settings_game.construction.freeform_edges && (!IsInsideMM(TileX(tile), 1, Map::MaxX() - 1) ||
+					!IsInsideMM(TileY(tile), 1, Map::MaxY() - 1))) {
 				return_cmd_error(STR_ERROR_TOO_CLOSE_TO_EDGE_OF_MAP);
 			}
 
@@ -1257,7 +1257,7 @@ void ConvertGroundTilesIntoWaterTiles()
 {
 	int z;
 
-	for (TileIndex tile = 0; tile < MapSize(); ++tile) {
+	for (TileIndex tile = 0; tile < Map::Size(); ++tile) {
 		Slope slope = GetTileSlope(tile, &z);
 		if (IsTileType(tile, MP_CLEAR) && z == 0) {
 			/* Make both water for tiles at level 0


### PR DESCRIPTION
## Motivation / Problem

Quite a few `_map...` globals that could easily be hidden and made inaccessible inside a class. Also removes the need for using `extern _map...` in functions, and makes it harder to access them in an unwanted manner.
I had included this in #10380, but after some talking to others another more future proof idea has emerged that has to be implemented. However, these changes are separate from that so can also be merged separately.
 

## Description

Move the `Map*` functions into a new class `Map` that also contains their cached values, and only set them upon a call to `Map::Allocate` (previously `AllocateMap`). It does not mess with `Tile` and `TileExtended`; that is part of #10380.


## Limitations

Potentially some conflict in patches, but in almost each conflict changing `Map` to `Map::` will solve the issue.


## Checklist for review

Maybe enable "ignore whitespace changes" for reviewing map_func.h, as most of that is just changing indentation.

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
