### PR TITLE
Change: More icon space size by interface scaling.

### DIFF
--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -85,7 +85,7 @@ private:
 	TransportType transport_type;
 	byte road_rail_type;
 	GUIBridgeList *bridges;
-	int bridgetext_offset; ///< Horizontal offset of the text describing the bridge properties in #WID_BBS_BRIDGE_LIST relative to the left edge.
+	int icon_width; ///< Scaled width of the the bridge icon sprite.
 	Scrollbar *vscroll;
 
 	/** Sort the bridges by their index */
@@ -159,7 +159,7 @@ public:
 		this->vscroll = this->GetScrollbar(WID_BBS_SCROLLBAR);
 		/* Change the data, or the caption of the gui. Set it to road or rail, accordingly. */
 		this->GetWidget<NWidgetCore>(WID_BBS_CAPTION)->widget_data = (transport_type == TRANSPORT_ROAD) ? STR_SELECT_ROAD_BRIDGE_CAPTION : STR_SELECT_RAIL_BRIDGE_CAPTION;
-		this->FinishInitNested(transport_type); // Initializes 'this->bridgetext_offset'.
+		this->FinishInitNested(transport_type); // Initializes 'this->icon_width'.
 
 		this->parent = FindWindowById(WC_BUILD_TOOLBAR, transport_type);
 		this->bridges->SetListing(this->last_sorting);
@@ -201,15 +201,13 @@ public:
 				Dimension sprite_dim = {0, 0}; // Biggest bridge sprite dimension
 				Dimension text_dim   = {0, 0}; // Biggest text dimension
 				for (const BuildBridgeData &bridge_data : *this->bridges) {
-					sprite_dim = maxdim(sprite_dim, GetSpriteSize(bridge_data.spec->sprite));
+					sprite_dim = maxdim(sprite_dim, GetScaledSpriteSize(bridge_data.spec->sprite));
 					text_dim = maxdim(text_dim, GetStringBoundingBox(GetBridgeSelectString(bridge_data)));
 				}
-				sprite_dim.height++; // Sprite is rendered one pixel down in the matrix field.
-				text_dim.height++; // Allowing the bottom row pixels to be rendered on the edge of the matrix field.
 				resize->height = std::max(sprite_dim.height, text_dim.height) + padding.height; // Max of both sizes + account for matrix edges.
 
-				this->bridgetext_offset = sprite_dim.width + WidgetDimensions::scaled.hsep_normal; // Left edge of text, 1 pixel distance from the sprite.
-				size->width = this->bridgetext_offset + text_dim.width + padding.width;
+				this->icon_width = sprite_dim.width; // Width of bridge icon.
+				size->width = this->icon_width + WidgetDimensions::scaled.hsep_normal + text_dim.width + padding.width;
 				size->height = 4 * resize->height; // Smallest bridge gui is 4 entries high in the matrix.
 				break;
 			}
@@ -235,11 +233,12 @@ public:
 
 			case WID_BBS_BRIDGE_LIST: {
 				Rect tr = r.WithHeight(this->resize.step_height).Shrink(WidgetDimensions::scaled.matrix);
+				bool rtl = _current_text_dir == TD_RTL;
 				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < (int)this->bridges->size(); i++) {
 					const BuildBridgeData &bridge_data = this->bridges->at(i);
 					const BridgeSpec *b = bridge_data.spec;
-					DrawSprite(b->sprite, b->pal, tr.left, tr.bottom - GetSpriteSize(b->sprite).height);
-					DrawStringMultiLine(tr.Indent(this->bridgetext_offset, false), GetBridgeSelectString(bridge_data));
+					DrawSpriteIgnorePadding(b->sprite, b->pal, tr.WithWidth(this->icon_width, rtl), false, SA_HOR_CENTER | SA_BOTTOM);
+					DrawStringMultiLine(tr.Indent(this->icon_width + WidgetDimensions::scaled.hsep_normal, rtl), GetBridgeSelectString(bridge_data));
 					tr = tr.Translate(0, this->resize.step_height);
 				}
 				break;

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1009,7 +1009,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 	Dimension replace_icon = {0, 0};
 	int count_width = 0;
 	if (show_count) {
-		replace_icon = GetSpriteSize(SPR_GROUP_REPLACE_ACTIVE);
+		replace_icon = GetScaledSpriteSize(SPR_GROUP_REPLACE_ACTIVE);
 		SetDParamMaxDigits(0, 3, FS_SMALL);
 		count_width = GetStringBoundingBox(STR_TINY_BLACK_COMA).width;
 	}
@@ -1021,7 +1021,6 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 
 	int normal_text_y_offset = (ir.Height() - FONT_HEIGHT_NORMAL) / 2;
 	int small_text_y_offset  = ir.Height() - FONT_HEIGHT_SMALL;
-	int replace_icon_y_offset = (ir.Height() - replace_icon.height) / 2;
 
 	int y = ir.top;
 	for (; min < max; min++, y += step_size) {
@@ -1046,7 +1045,9 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		if (show_count) {
 			SetDParam(0, num_engines);
 			DrawString(cr.left, cr.right, y + small_text_y_offset, STR_TINY_BLACK_COMA, TC_FROMSTRING, SA_RIGHT | SA_FORCE);
-			if (EngineHasReplacementForCompany(Company::Get(_local_company), item.engine_id, selected_group)) DrawSprite(SPR_GROUP_REPLACE_ACTIVE, num_engines == 0 ? PALETTE_CRASH : PAL_NONE, rr.left, y + replace_icon_y_offset);
+			if (EngineHasReplacementForCompany(Company::Get(_local_company), item.engine_id, selected_group)) {
+				DrawSpriteIgnorePadding(SPR_GROUP_REPLACE_ACTIVE, num_engines == 0 ? PALETTE_CRASH : PAL_NONE, rr.WithTopAndHeight(y, ir.Height()), false, SA_CENTER);
+			}
 		}
 		if (has_variants) {
 			Rect fr = ir.Indent(indent, rtl).WithWidth(circle_width, rtl);

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1050,7 +1050,7 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		}
 		if (has_variants) {
 			Rect fr = ir.Indent(indent, rtl).WithWidth(circle_width, rtl);
-			DrawSpriteIgnorePadding(is_folded ? SPR_CIRCLE_FOLDED : SPR_CIRCLE_UNFOLDED, PAL_NONE, {fr.left, y, fr.right, y + ir.Height() - 1}, false, SA_CENTER);
+			DrawSpriteIgnorePadding(is_folded ? SPR_CIRCLE_FOLDED : SPR_CIRCLE_UNFOLDED, PAL_NONE, fr.WithTopAndHeight(y, ir.Height()), false, SA_CENTER);
 		}
 		if (indent > 0) {
 			/* Draw tree lines */

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -229,8 +229,8 @@ struct CheatWindow : Window {
 
 	void OnInit() override
 	{
-		this->box = maxdim(GetSpriteSize(SPR_BOX_EMPTY), GetSpriteSize(SPR_BOX_CHECKED));
-		this->icon = GetSpriteSize(SPR_COMPANY_ICON);
+		this->box = maxdim(GetScaledSpriteSize(SPR_BOX_EMPTY), GetScaledSpriteSize(SPR_BOX_CHECKED));
+		this->icon = GetScaledSpriteSize(SPR_COMPANY_ICON);
 	}
 
 	void DrawWidget(const Rect &r, int widget) const override
@@ -241,26 +241,24 @@ struct CheatWindow : Window {
 		int y = ir.top;
 
 		bool rtl = _current_text_dir == TD_RTL;
-		uint box_left    = rtl ? ir.right - this->box.width - WidgetDimensions::scaled.hsep_wide : ir.left + WidgetDimensions::scaled.hsep_wide;
-		uint button_left = rtl ? ir.right - this->box.width - WidgetDimensions::scaled.hsep_wide * 2 - SETTING_BUTTON_WIDTH : ir.left + this->box.width + WidgetDimensions::scaled.hsep_wide * 2;
-		uint text_left   = ir.left + (rtl ? 0 : WidgetDimensions::scaled.hsep_wide * 4 + this->box.width + SETTING_BUTTON_WIDTH);
-		uint text_right  = ir.right - (rtl ? WidgetDimensions::scaled.hsep_wide * 4 + this->box.width + SETTING_BUTTON_WIDTH : 0);
+		Rect box    = ir.Indent(WidgetDimensions::scaled.hsep_wide, rtl).WithWidth(this->box.width, rtl);
+		Rect button = ir.Indent(WidgetDimensions::scaled.hsep_wide * 2 + this->box.width, rtl).WithWidth(SETTING_BUTTON_WIDTH, rtl);
+		Rect text   = ir.Indent(WidgetDimensions::scaled.hsep_wide * 3 + this->box.width + SETTING_BUTTON_WIDTH, rtl);
 
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
-		int box_y_offset = (this->line_height - this->box.height) / 2;
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 		int icon_y_offset = (this->line_height - this->icon.height) / 2;
 
 		for (int i = 0; i != lengthof(_cheats_ui); i++) {
 			const CheatEntry *ce = &_cheats_ui[i];
 
-			DrawSprite((*ce->been_used) ? SPR_BOX_CHECKED : SPR_BOX_EMPTY, PAL_NONE, box_left, y + box_y_offset);
+			DrawSpriteIgnorePadding((*ce->been_used) ? SPR_BOX_CHECKED : SPR_BOX_EMPTY, PAL_NONE, box.WithTopAndHeight(y, this->line_height), false, SA_CENTER);
 
 			switch (ce->type) {
 				case SLE_BOOL: {
 					bool on = (*(bool*)ce->variable);
 
-					DrawBoolButton(button_left, y + button_y_offset, on, true);
+					DrawBoolButton(button.left, y + button_y_offset, on, true);
 					SetDParam(0, on ? STR_CONFIG_SETTING_ON : STR_CONFIG_SETTING_OFF);
 					break;
 				}
@@ -270,7 +268,7 @@ struct CheatWindow : Window {
 					char buf[512];
 
 					/* Draw [<][>] boxes for settings of an integer-type */
-					DrawArrowButtons(button_left, y + button_y_offset, COLOUR_YELLOW, clicked - (i * 2), true, true);
+					DrawArrowButtons(button.left, y + button_y_offset, COLOUR_YELLOW, clicked - (i * 2), true, true);
 
 					switch (ce->str) {
 						/* Display date for change date cheat */
@@ -281,7 +279,7 @@ struct CheatWindow : Window {
 							SetDParam(0, val + 1);
 							GetString(buf, STR_CHEAT_CHANGE_COMPANY, lastof(buf));
 							uint offset = WidgetDimensions::scaled.hsep_indent + GetStringBoundingBox(buf).width;
-							DrawCompanyIcon(_local_company, rtl ? text_right - offset - WidgetDimensions::scaled.hsep_indent : text_left + offset, y + icon_y_offset);
+							DrawCompanyIcon(_local_company, rtl ? text.right - offset - WidgetDimensions::scaled.hsep_indent : text.left + offset, y + icon_y_offset);
 							break;
 						}
 
@@ -291,7 +289,7 @@ struct CheatWindow : Window {
 				}
 			}
 
-			DrawString(text_left, text_right, y + text_y_offset, ce->str);
+			DrawString(text.left, text.right, y + text_y_offset, ce->str);
 
 			y += this->line_height;
 		}

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -247,7 +247,6 @@ struct CheatWindow : Window {
 
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
-		int icon_y_offset = (this->line_height - this->icon.height) / 2;
 
 		for (int i = 0; i != lengthof(_cheats_ui); i++) {
 			const CheatEntry *ce = &_cheats_ui[i];
@@ -279,7 +278,7 @@ struct CheatWindow : Window {
 							SetDParam(0, val + 1);
 							GetString(buf, STR_CHEAT_CHANGE_COMPANY, lastof(buf));
 							uint offset = WidgetDimensions::scaled.hsep_indent + GetStringBoundingBox(buf).width;
-							DrawCompanyIcon(_local_company, rtl ? text.right - offset - WidgetDimensions::scaled.hsep_indent : text.left + offset, y + icon_y_offset);
+							DrawCompanyIcon(_local_company, text.Indent(offset, rtl).WithWidth(this->icon.width, rtl).WithTopAndHeight(y, this->line_height), false);
 							break;
 						}
 

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -140,17 +140,6 @@ TextColour GetDrawStringCompanyColour(CompanyID company)
 }
 
 /**
- * Draw the icon of a company.
- * @param c Company that needs its icon drawn.
- * @param x Horizontal coordinate of the icon.
- * @param y Vertical coordinate of the icon.
- */
-void DrawCompanyIcon(CompanyID c, int x, int y)
-{
-	DrawSprite(SPR_COMPANY_ICON, COMPANY_SPRITE_COLOUR(c), x, y);
-}
-
-/**
  * Checks whether a company manager's face is a valid encoding.
  * Unused bits are not enforced to be 0.
  * @param cmf the fact to check

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -605,14 +605,10 @@ public:
 	void Draw(const Rect &r, bool sel, Colours bg_colour) const override
 	{
 		bool rtl = _current_text_dir == TD_RTL;
-		int icon_y = CenterBounds(r.top, r.bottom, 0);
-		int text_y = CenterBounds(r.top, r.bottom, FONT_HEIGHT_NORMAL);
 		Rect tr = r.Shrink(WidgetDimensions::scaled.dropdowntext);
-		DrawSprite(SPR_VEH_BUS_SIDE_VIEW, PALETTE_RECOLOUR_START + (this->result % COLOUR_END),
-				   rtl ? tr.right - ScaleGUITrad(14) : tr.left + ScaleGUITrad(14),
-				   icon_y);
+		DrawSpriteIgnorePadding(SPR_VEH_BUS_SIDE_VIEW, PALETTE_RECOLOUR_START + (this->result % COLOUR_END), tr.WithWidth(ScaleGUITrad(28), rtl), false, SA_CENTER);
 		tr = tr.Indent(ScaleGUITrad(28) + WidgetDimensions::scaled.hsep_normal, rtl);
-		DrawString(tr.left, tr.right, text_y, this->String(), sel ? TC_WHITE : TC_BLACK);
+		DrawString(tr.WithTopCentre(FONT_HEIGHT_NORMAL), this->String(), sel ? TC_WHITE : TC_BLACK);
 	}
 };
 
@@ -2382,10 +2378,7 @@ struct CompanyWindow : Window
 			}
 
 			case WID_C_DESC_COLOUR_SCHEME_EXAMPLE: {
-				Point offset;
-				Dimension d = GetSpriteSize(SPR_VEH_BUS_SW_VIEW, &offset);
-				d.width -= offset.x;
-				d.height -= offset.y;
+				Dimension d = GetScaledSpriteSize(SPR_VEH_BUS_SW_VIEW);
 				*size = maxdim(*size, d);
 				break;
 			}
@@ -2521,13 +2514,9 @@ struct CompanyWindow : Window
 				DrawStringMultiLine(r.left, r.right, r.top, r.bottom, STR_COMPANY_VIEW_PRESIDENT_MANAGER_TITLE, TC_FROMSTRING, SA_HOR_CENTER);
 				break;
 
-			case WID_C_DESC_COLOUR_SCHEME_EXAMPLE: {
-				Point offset;
-				Dimension d = GetSpriteSize(SPR_VEH_BUS_SW_VIEW, &offset);
-				d.height -= offset.y;
-				DrawSprite(SPR_VEH_BUS_SW_VIEW, COMPANY_SPRITE_COLOUR(c->index), r.left - offset.x, CenterBounds(r.top, r.bottom, d.height) - offset.y);
+			case WID_C_DESC_COLOUR_SCHEME_EXAMPLE:
+				DrawSpriteIgnorePadding(SPR_VEH_BUS_SW_VIEW, COMPANY_SPRITE_COLOUR(c->index), r, false, SA_CENTER);
 				break;
-			}
 
 			case WID_C_DESC_VEHICLE_COUNTS:
 				DrawVehicleCountsWidget(r, c);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -2446,7 +2446,7 @@ struct CompanyWindow : Window
 				break;
 
 			case WID_C_HAS_PASSWORD:
-				*size = maxdim(*size, GetSpriteSize(SPR_LOCK));
+				*size = maxdim(*size, GetScaledSpriteSize(SPR_LOCK));
 				break;
 		}
 	}
@@ -2558,7 +2558,7 @@ struct CompanyWindow : Window
 
 			case WID_C_HAS_PASSWORD:
 				if (_networking && NetworkCompanyIsPassworded(c->index)) {
-					DrawSprite(SPR_LOCK, PAL_NONE, r.left, r.top);
+					DrawSpriteIgnorePadding(SPR_LOCK, PAL_NONE, r, false, SA_CENTER);
 				}
 				break;
 		}

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -797,6 +797,11 @@ public:
 		}
 	}
 
+	void OnInit() override
+	{
+		this->square = GetScaledSpriteSize(SPR_SQUARE);
+	}
+
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
 	{
 		switch (widget) {
@@ -821,7 +826,6 @@ public:
 
 			case WID_SCL_MATRIX: {
 				/* 11 items in the default rail class */
-				this->square = GetSpriteSize(SPR_SQUARE);
 				this->line_height = std::max(this->square.height, (uint)FONT_HEIGHT_NORMAL) + padding.height;
 
 				size->height = 11 * this->line_height;
@@ -838,7 +842,7 @@ public:
 				FALLTHROUGH;
 
 			case WID_SCL_PRI_COL_DROPDOWN: {
-				this->square = GetSpriteSize(SPR_SQUARE);
+				this->square = GetScaledSpriteSize(SPR_SQUARE);
 				int string_padding = this->square.width + WidgetDimensions::scaled.hsep_normal + padding.width;
 				for (const StringID *id = _colour_dropdown; id != endof(_colour_dropdown); id++) {
 					size->width = std::max(size->width, GetStringBoundingBox(*id).width + string_padding);
@@ -926,7 +930,6 @@ public:
 		sec = sec.Indent(this->square.width + WidgetDimensions::scaled.hsep_normal, rtl);
 
 		Rect ir = r.WithHeight(this->resize.step_height).Shrink(WidgetDimensions::scaled.matrix);
-		int square_offs = (ir.Height() - this->square.height) / 2;
 		int text_offs   = (ir.Height() - FONT_HEIGHT_NORMAL) / 2;
 
 		int y = ir.top;
@@ -937,12 +940,12 @@ public:
 			DrawString(sch.left + (rtl ? 0 : indent), sch.right - (rtl ? indent : 0), y + text_offs, str, sel ? TC_WHITE : TC_BLACK);
 
 			/* Text below the first dropdown. */
-			DrawSprite(SPR_SQUARE, GENERAL_SPRITE_COLOUR(liv.colour1), pri_squ.left, y + square_offs);
+			DrawSpriteIgnorePadding(SPR_SQUARE, GENERAL_SPRITE_COLOUR(liv.colour1), pri_squ.WithTopAndHeight(y, ir.Height()), false, SA_CENTER);
 			DrawString(pri.left, pri.right, y + text_offs, (def || HasBit(liv.in_use, 0)) ? STR_COLOUR_DARK_BLUE + liv.colour1 : STR_COLOUR_DEFAULT, sel ? TC_WHITE : TC_GOLD);
 
 			/* Text below the second dropdown. */
 			if (sec.right > sec.left) { // Second dropdown has non-zero size.
-				DrawSprite(SPR_SQUARE, GENERAL_SPRITE_COLOUR(liv.colour2), sec_squ.left, y + square_offs);
+				DrawSpriteIgnorePadding(SPR_SQUARE, GENERAL_SPRITE_COLOUR(liv.colour2), sec_squ.WithTopAndHeight(y, ir.Height()), false, SA_CENTER);
 				DrawString(sec.left, sec.right, y + text_offs, (def || HasBit(liv.in_use, 1)) ? STR_COLOUR_DARK_BLUE + liv.colour2 : STR_COLOUR_DEFAULT, sel ? TC_WHITE : TC_GOLD);
 			}
 

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -52,6 +52,17 @@
 static void DoSelectCompanyManagerFace(Window *parent);
 static void ShowCompanyInfrastructure(CompanyID company);
 
+/**
+ * Draw the icon of a company.
+ * @param c Company that needs its icon drawn.
+ * @param r Rect of the icon.
+ * @param lowered True iff the icon should be displayed as lowered.
+ */
+void DrawCompanyIcon(CompanyID c, const Rect &r, bool lowered)
+{
+	DrawSpriteIgnorePadding(SPR_COMPANY_ICON, COMPANY_SPRITE_COLOUR(c), r, lowered, SA_CENTER);
+}
+
 /** List of revenues. */
 static ExpensesType _expenses_list_revenue[] = {
 	EXPENSES_TRAIN_REVENUE,

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -605,7 +605,7 @@ public:
 
 	uint Height(uint width) const override
 	{
-		return std::max(FONT_HEIGHT_NORMAL, ScaleGUITrad(12) + 2);
+		return std::max(FONT_HEIGHT_NORMAL, ScaleGUITrad(12) + WidgetDimensions::scaled.vsep_normal);
 	}
 
 	bool Selectable() const override

--- a/src/company_gui.h
+++ b/src/company_gui.h
@@ -15,7 +15,7 @@
 #include "gfx_type.h"
 
 TextColour GetDrawStringCompanyColour(CompanyID company);
-void DrawCompanyIcon(CompanyID c, int x, int y);
+void DrawCompanyIcon(CompanyID c, const Rect &r, bool lowered);
 
 void ShowCompanyLiveryWindow(CompanyID company, GroupID group);
 void ShowCompanyStations(CompanyID company);

--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -221,6 +221,16 @@ struct Rect {
 	}
 
 	/**
+	 * Copy Rect and vertically centre.
+	 * @param height height in pixels for new Rect.
+	 * @return the new resized Rect.
+	 */
+	[[nodiscard]] inline Rect WithTopCentre(int height) const
+	{
+		return this->WithTopAndHeight((this->top + this->bottom - height + 1) / 2, height);
+	}
+
+	/**
 	 * Test if a point falls inside this Rect.
 	 * @param pt the point to test.
 	 * @return true iif the point falls inside the Rect.

--- a/src/core/geometry_type.hpp
+++ b/src/core/geometry_type.hpp
@@ -198,8 +198,8 @@ struct Rect {
 
 	/**
 	 * Copy Rect and set its height.
-	 * @param width height in pixels for new Rect.
-	 * @param end   if set, set height at end of Rect, i.e. at bottom.
+	 * @param height height in pixels for new Rect.
+	 * @param end    if set, set height at end of Rect, i.e. at bottom.
 	 * @return the new resized Rect.
 	 */
 	[[nodiscard]] inline Rect WithHeight(int height, bool end = false) const
@@ -207,6 +207,17 @@ struct Rect {
 		return end
 			? Rect {this->left, this->bottom - height + 1, this->right, this->bottom}
 			: Rect {this->left, this->top,                 this->right, this->top + height - 1};
+	}
+
+	/**
+	 * Copy Rect and set its top and height.
+	 * @param top    top position in pixels for the new Rect.
+	 * @param height height in pixels for new Rect.
+	 * @return the new resized Rect.
+	 */
+	[[nodiscard]] inline Rect WithTopAndHeight(int top, int height) const
+	{
+		return Rect {this->left, top, this->right, top + height - 1};
 	}
 
 	/**

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -65,8 +65,8 @@ struct GraphLegendWindow : Window {
 		bool rtl = _current_text_dir == TD_RTL;
 
 		const Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
-		Dimension d = GetSpriteSize(SPR_COMPANY_ICON);
-		DrawCompanyIcon(cid, rtl ? ir.right - d.width : ir.left, CenterBounds(ir.top, ir.bottom, d.height));
+		Dimension d = GetScaledSpriteSize(SPR_COMPANY_ICON);
+		DrawCompanyIcon(cid, ir.WithWidth(d.width, rtl), false);
 
 		const Rect tr = ir.Indent(d.width + WidgetDimensions::scaled.hsep_normal, rtl);
 		SetDParam(0, cid);
@@ -1201,9 +1201,7 @@ struct PerformanceRatingDetailWindow : Window {
 		if (IsInsideMM(widget, WID_PRD_COMPANY_FIRST, WID_PRD_COMPANY_LAST + 1)) {
 			if (this->IsWidgetDisabled(widget)) return;
 			CompanyID cid = (CompanyID)(widget - WID_PRD_COMPANY_FIRST);
-			int offset = (cid == this->company) ? WidgetDimensions::scaled.pressed : 0;
-			Dimension sprite_size = GetSpriteSize(SPR_COMPANY_ICON);
-			DrawCompanyIcon(cid, CenterBounds(r.left, r.right, sprite_size.width) + offset, CenterBounds(r.top, r.bottom, sprite_size.height) + offset);
+			DrawCompanyIcon(cid, r, cid == this->company);
 			return;
 		}
 

--- a/src/league_gui.cpp
+++ b/src/league_gui.cpp
@@ -105,19 +105,18 @@ public:
 		if (widget != WID_PLT_BACKGROUND) return;
 
 		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
-		int icon_y_offset = (this->line_height - this->icon.height) / 2;
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
 
 		bool rtl = _current_text_dir == TD_RTL;
 		Rect ordinal = ir.WithWidth(this->ordinal_width, rtl);
-		uint icon_left = ir.Indent(rtl ? this->text_width : this->ordinal_width, rtl).left;
+		Rect icon    = ir.Indent(this->ordinal_width, rtl).WithWidth(this->icon.width, rtl);
 		Rect text    = ir.WithWidth(this->text_width, !rtl);
 
 		for (uint i = 0; i != this->companies.size(); i++) {
 			const Company *c = this->companies[i];
 			DrawString(ordinal.left, ordinal.right, ir.top + text_y_offset, i + STR_ORDINAL_NUMBER_1ST, i == 0 ? TC_WHITE : TC_YELLOW);
 
-			DrawCompanyIcon(c->index, icon_left, ir.top + icon_y_offset);
+			DrawCompanyIcon(c->index, icon.WithTopAndHeight(ir.top, this->line_height), false);
 
 			SetDParam(0, c->index);
 			SetDParam(1, c->index);
@@ -147,7 +146,7 @@ public:
 			}
 		}
 
-		this->icon = GetSpriteSize(SPR_COMPANY_ICON);
+		this->icon = GetScaledSpriteSize(SPR_COMPANY_ICON);
 		this->line_height = std::max<int>(this->icon.height + WidgetDimensions::scaled.vsep_normal, FONT_HEIGHT_NORMAL);
 
 		for (const Company *c : Company::Iterate()) {
@@ -326,7 +325,6 @@ public:
 			ir.top = DrawStringMultiLine(ir.left, ir.right, ir.top, UINT16_MAX, STR_JUST_RAW_STRING, TC_BLACK) + WidgetDimensions::scaled.vsep_wide;
 		}
 
-		int icon_y_offset = (this->line_height - this->icon_size.height) / 2;
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
 
 		/* Calculate positions.of the columns */
@@ -339,7 +337,7 @@ public:
 
 		for (auto [rank, lte] : this->rows) {
 			DrawString(rank_rect.left, rank_rect.right, ir.top + text_y_offset, rank + STR_ORDINAL_NUMBER_1ST, rank == 0 ? TC_WHITE : TC_YELLOW);
-			if (this->icon_size.width > 0 && lte->company != INVALID_COMPANY) DrawCompanyIcon(lte->company, icon_rect.left, ir.top + icon_y_offset);
+			if (this->icon_size.width > 0 && lte->company != INVALID_COMPANY) DrawCompanyIcon(lte->company, icon_rect.WithTopAndHeight(ir.top, this->line_height), false);
 			SetDParamStr(0, lte->text);
 			DrawString(text_rect.left, text_rect.right, ir.top + text_y_offset, STR_JUST_RAW_STRING, TC_BLACK);
 			SetDParamStr(0, lte->score);
@@ -361,7 +359,7 @@ public:
 		auto lt = LeagueTable::GetIfValid(this->table);
 		if (lt == nullptr) return;
 
-		this->icon_size = GetSpriteSize(SPR_COMPANY_ICON);
+		this->icon_size = GetScaledSpriteSize(SPR_COMPANY_ICON);
 		this->line_height = std::max<int>(this->icon_size.height + WidgetDimensions::scaled.fullbevel.Vertical(), FONT_HEIGHT_NORMAL);
 
 		/* Calculate maximum width of every column */

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -614,8 +614,7 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 	if (IsInsideMM(widget, WID_LGL_COMPANY_FIRST, WID_LGL_COMPANY_LAST + 1)) {
 		if (this->IsWidgetDisabled(widget)) return;
 		CompanyID cid = (CompanyID)(widget - WID_LGL_COMPANY_FIRST);
-		Dimension sprite_size = GetSpriteSize(SPR_COMPANY_ICON);
-		DrawCompanyIcon(cid, CenterBounds(br.left, br.right, sprite_size.width), CenterBounds(br.top, br.bottom, sprite_size.height));
+		DrawCompanyIcon(cid, br, false);
 	}
 	if (IsInsideMM(widget, WID_LGL_SATURATION_FIRST, WID_LGL_SATURATION_LAST + 1)) {
 		uint8 colour = LinkGraphOverlay::LINK_COLOURS[_settings_client.gui.linkgraph_colours][widget - WID_LGL_SATURATION_FIRST];

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -798,7 +798,7 @@ void QueryString::DrawEditBox(const Window *w, int wid) const
 	assert((wi->type & WWT_MASK) == WWT_EDITBOX);
 
 	bool rtl = _current_text_dir == TD_RTL;
-	Dimension sprite_size = GetSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
+	Dimension sprite_size = GetScaledSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
 	int clearbtn_width = sprite_size.width + WidgetDimensions::scaled.imgbtn.Horizontal();
 
 	Rect r = wi->GetCurrentRect();
@@ -806,7 +806,7 @@ void QueryString::DrawEditBox(const Window *w, int wid) const
 	Rect fr = r.Indent(clearbtn_width, !rtl);
 
 	DrawFrameRect(cr, wi->colour, wi->IsLowered() ? FR_LOWERED : FR_NONE);
-	DrawSprite(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT, PAL_NONE, cr.left + WidgetDimensions::scaled.imgbtn.left + (wi->IsLowered() ? 1 : 0), CenterBounds(r.top, r.bottom, sprite_size.height) + (wi->IsLowered() ? 1 : 0));
+	DrawSpriteIgnorePadding(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT, PAL_NONE, cr, wi->IsLowered(), SA_CENTER);
 	if (this->text.bytes == 1) GfxFillRect(cr.Shrink(WidgetDimensions::scaled.bevel), _colour_gradient[wi->colour & 0xF][2], FILLRECT_CHECKER);
 
 	DrawFrameRect(fr, wi->colour, FR_LOWERED | FR_DARKENED);
@@ -850,7 +850,7 @@ Point QueryString::GetCaretPosition(const Window *w, int wid) const
 	assert((wi->type & WWT_MASK) == WWT_EDITBOX);
 
 	bool rtl = _current_text_dir == TD_RTL;
-	Dimension sprite_size = GetSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
+	Dimension sprite_size = GetScaledSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
 	int clearbtn_width = sprite_size.width + WidgetDimensions::scaled.imgbtn.Horizontal();
 
 	Rect r = wi->GetCurrentRect().Indent(clearbtn_width, !rtl).Shrink(WidgetDimensions::scaled.framerect);
@@ -879,7 +879,7 @@ Rect QueryString::GetBoundingRect(const Window *w, int wid, const char *from, co
 	assert((wi->type & WWT_MASK) == WWT_EDITBOX);
 
 	bool rtl = _current_text_dir == TD_RTL;
-	Dimension sprite_size = GetSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
+	Dimension sprite_size = GetScaledSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
 	int clearbtn_width = sprite_size.width + WidgetDimensions::scaled.imgbtn.Horizontal();
 
 	Rect r = wi->GetCurrentRect().Indent(clearbtn_width, !rtl).Shrink(WidgetDimensions::scaled.framerect);
@@ -910,7 +910,7 @@ const char *QueryString::GetCharAtPosition(const Window *w, int wid, const Point
 	assert((wi->type & WWT_MASK) == WWT_EDITBOX);
 
 	bool rtl = _current_text_dir == TD_RTL;
-	Dimension sprite_size = GetSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
+	Dimension sprite_size = GetScaledSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
 	int clearbtn_width = sprite_size.width + WidgetDimensions::scaled.imgbtn.Horizontal();
 
 	Rect r = wi->GetCurrentRect().Indent(clearbtn_width, !rtl).Shrink(WidgetDimensions::scaled.framerect);
@@ -932,7 +932,7 @@ void QueryString::ClickEditBox(Window *w, Point pt, int wid, int click_count, bo
 	assert((wi->type & WWT_MASK) == WWT_EDITBOX);
 
 	bool rtl = _current_text_dir == TD_RTL;
-	Dimension sprite_size = GetSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
+	Dimension sprite_size = GetScaledSpriteSize(rtl ? SPR_IMG_DELETE_RIGHT : SPR_IMG_DELETE_LEFT);
 	int clearbtn_width = sprite_size.width + WidgetDimensions::scaled.imgbtn.Horizontal();
 
 	Rect cr = wi->GetCurrentRect().WithWidth(clearbtn_width, !rtl);

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -581,7 +581,7 @@ public:
 
 	void OnInit() override
 	{
-		this->checkbox_size = maxdim(maxdim(GetSpriteSize(SPR_BOX_EMPTY), GetSpriteSize(SPR_BOX_CHECKED)), GetSpriteSize(SPR_BLOT));
+		this->checkbox_size = maxdim(maxdim(GetScaledSpriteSize(SPR_BOX_EMPTY), GetScaledSpriteSize(SPR_BOX_CHECKED)), GetScaledSpriteSize(SPR_BLOT));
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
@@ -649,7 +649,6 @@ public:
 		Rect type = this->GetWidget<NWidgetBase>(WID_NCL_TYPE)->GetCurrentRect();
 
 		/* Fill the matrix with the information */
-		int sprite_y_offset = (this->resize.step_height - this->checkbox_size.height) / 2;
 		int text_y_offset   = (this->resize.step_height - FONT_HEIGHT_NORMAL) / 2;
 
 		Rect mr = r.WithHeight(this->resize.step_height);
@@ -672,7 +671,7 @@ public:
 				case ContentInfo::DOES_NOT_EXIST: sprite = SPR_BLOT; pal = PALETTE_TO_RED;   break;
 				default: NOT_REACHED();
 			}
-			DrawSprite(sprite, pal, checkbox.left + (sprite == SPR_BLOT ? 3 : 2), mr.top + sprite_y_offset + (sprite == SPR_BLOT ? 0 : 1));
+			DrawSpriteIgnorePadding(sprite, pal, checkbox.WithTopAndHeight(mr.top, this->resize.step_height), false, SA_CENTER);
 
 			StringID str = STR_CONTENT_TYPE_BASE_GRAPHICS + ci->type - CONTENT_TYPE_BASE_GRAPHICS;
 			DrawString(type.left, type.right, mr.top + text_y_offset, str, TC_BLACK, SA_HOR_CENTER);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1300,7 +1300,7 @@ static void ShowNetworkStartServerWindow()
 /* The window below gives information about the connected clients
  * and also makes able to kick them (if server) and stuff like that. */
 
-extern void DrawCompanyIcon(CompanyID cid, int x, int y);
+extern void DrawCompanyIcon(CompanyID c, const Rect &r, bool lowered);
 
 static const NWidgetPart _nested_client_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
@@ -2016,8 +2016,7 @@ public:
 		bool rtl = _current_text_dir == TD_RTL;
 		int text_y_offset = CenterBounds(0, this->line_height, FONT_HEIGHT_NORMAL);
 
-		Dimension d = GetSpriteSize(SPR_COMPANY_ICON);
-		int offset = CenterBounds(0, this->line_height, d.height);
+		Dimension d = GetScaledSpriteSize(SPR_COMPANY_ICON);
 
 		uint line_start = this->vscroll->GetPosition();
 		uint line_end = line_start + this->vscroll->GetCapacity();
@@ -2026,7 +2025,7 @@ public:
 
 		/* Draw the company line (if in range of scrollbar). */
 		if (IsInsideMM(line, line_start, line_end)) {
-			int icon_left = r.WithWidth(d.width, rtl).left;
+			Rect icon = r.WithWidth(d.width, rtl).WithTopAndHeight(y, this->line_height);
 			Rect tr = r.Indent(d.width + WidgetDimensions::scaled.hsep_normal, rtl);
 			int &x = rtl ? tr.left : tr.right;
 
@@ -2037,13 +2036,13 @@ public:
 			}
 
 			if (company_id == COMPANY_SPECTATOR) {
-				DrawSprite(SPR_COMPANY_ICON, PALETTE_TO_GREY, icon_left, y + offset);
+				DrawSpriteIgnorePadding(SPR_COMPANY_ICON, PALETTE_TO_GREY, icon, false, SA_CENTER);
 				DrawString(tr.left, tr.right, y + text_y_offset, STR_NETWORK_CLIENT_LIST_SPECTATORS, TC_SILVER);
 			} else if (company_id == COMPANY_NEW_COMPANY) {
-				DrawSprite(SPR_COMPANY_ICON, PALETTE_TO_GREY, icon_left, y + offset);
+				DrawSpriteIgnorePadding(SPR_COMPANY_ICON, PALETTE_TO_GREY, icon, false, SA_CENTER);
 				DrawString(tr.left, tr.right, y + text_y_offset, STR_NETWORK_CLIENT_LIST_NEW_COMPANY, TC_WHITE);
 			} else {
-				DrawCompanyIcon(company_id, icon_left, y + offset);
+				DrawCompanyIcon(company_id, icon, false);
 
 				SetDParam(0, company_id);
 				SetDParam(1, company_id);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -840,22 +840,17 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 				uint step_height = this->GetWidget<NWidgetBase>(WID_NS_FILE_LIST)->resize_y;
-				Dimension square = GetSpriteSize(SPR_SQUARE);
-				Dimension warning = GetSpriteSize(SPR_WARNING_SIGN);
-				int square_offset_y = (step_height - square.height) / 2;
-				int warning_offset_y = (step_height - warning.height) / 2;
-				int offset_y = (step_height - FONT_HEIGHT_NORMAL) / 2;
+				Dimension square_size = GetScaledSpriteSize(SPR_SQUARE);
+				Dimension warning = GetScaledSpriteSize(SPR_WARNING_SIGN);
 
 				bool rtl = _current_text_dir == TD_RTL;
-				uint text_left    = rtl ? tr.left : tr.left + square.width + 13;
-				uint text_right   = rtl ? tr.right - square.width - 13 : tr.right;
-				uint square_left  = rtl ? tr.right - square.width - 3 : tr.left + 3;
-				uint warning_left = rtl ? tr.right - square.width - warning.width - 8 : tr.left + square.width + 8;
+				Rect square = tr.WithWidth(square_size.width, rtl);
+				Rect text = tr.Indent(square_size.width + WidgetDimensions::scaled.hsep_normal, rtl);
+				int offset_y = (step_height - FONT_HEIGHT_NORMAL) / 2;
 
 				int i = 0;
 				for (const GRFConfig *c = this->actives; c != nullptr; c = c->next, i++) {
 					if (this->vscroll->IsVisible(i)) {
-						const char *text = c->GetName();
 						bool h = (this->active_sel == c);
 						PaletteID pal = this->GetPalette(c);
 
@@ -870,10 +865,10 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 								GfxFillRect(tr.left, top - 1, tr.right, top + 1, PC_GREY);
 							}
 						}
-						DrawSprite(SPR_SQUARE, pal, square_left, tr.top + square_offset_y);
-						if (c->error != nullptr) DrawSprite(SPR_WARNING_SIGN, 0, warning_left, tr.top + warning_offset_y);
-						uint txtoffset = c->error == nullptr ? 0 : warning.width;
-						DrawString(text_left + (rtl ? 0 : txtoffset), text_right - (rtl ? txtoffset : 0), tr.top + offset_y, text, h ? TC_WHITE : TC_ORANGE);
+						DrawSpriteIgnorePadding(SPR_SQUARE, pal, square.WithTopAndHeight(tr.top, step_height), false, SA_CENTER);
+						if (c->error != nullptr) DrawSpriteIgnorePadding(SPR_WARNING_SIGN, 0, text.WithWidth(warning.width, rtl).WithTopAndHeight(tr.top, step_height), false, SA_CENTER);
+						uint txtoffset = c->error == nullptr ? 0 : warning.width + WidgetDimensions::scaled.hsep_normal;
+						DrawString(text.Indent(txtoffset, rtl).WithTopAndHeight(tr.top + offset_y, FONT_HEIGHT_NORMAL), c->GetName(), h ? TC_WHITE : TC_ORANGE);
 						tr.top += step_height;
 					}
 				}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2248,7 +2248,7 @@ DropDownList GetRailTypeDropDownList(bool for_replacement, bool all_option)
 		for (const auto &rt : _sorted_railtypes) {
 			if (!HasBit(used_railtypes, rt)) continue;
 			const RailtypeInfo *rti = GetRailTypeInfo(rt);
-			d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_rail));
+			d = maxdim(d, GetScaledSpriteSize(rti->gui_sprites.build_x_rail));
 		}
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1834,7 +1834,7 @@ DropDownList GetRoadTypeDropDownList(RoadTramTypes rtts, bool for_replacement, b
 		for (const auto &rt : _sorted_roadtypes) {
 			if (!HasBit(used_roadtypes, rt)) continue;
 			const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
-			d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_road));
+			d = maxdim(d, GetScaledSpriteSize(rti->gui_sprites.build_x_road));
 		}
 	}
 
@@ -1883,7 +1883,7 @@ DropDownList GetScenRoadTypeDropDownList(RoadTramTypes rtts)
 	for (const auto &rt : _sorted_roadtypes) {
 		if (!HasBit(used_roadtypes, rt)) continue;
 		const RoadTypeInfo *rti = GetRoadTypeInfo(rt);
-		d = maxdim(d, GetSpriteSize(rti->gui_sprites.build_x_road));
+		d = maxdim(d, GetScaledSpriteSize(rti->gui_sprites.build_x_road));
 	}
 	for (const auto &rt : _sorted_roadtypes) {
 		if (!HasBit(used_roadtypes, rt)) continue;

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -829,8 +829,7 @@ struct ScriptDebugWindow : public Window {
 			/* Draw company icon only for valid AI companies */
 			if (!valid) continue;
 
-			byte offset = (i == script_debug_company) ? 1 : 0;
-			DrawCompanyIcon(i, button->pos_x + button->current_x / 2 - 7 + offset, this->GetWidget<NWidgetBase>(WID_SCRD_COMPANY_BUTTON_START + i)->pos_y + 2 + offset);
+			DrawCompanyIcon(i, button->GetCurrentRect(), i == script_debug_company);
 		}
 
 		/* Set button colour for Game Script. */

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1583,8 +1583,9 @@ uint SettingsPage::Draw(GameSettings *settings_ptr, int left, int right, int y, 
 void SettingsPage::DrawSetting(GameSettings *settings_ptr, int left, int right, int y, bool highlight) const
 {
 	bool rtl = _current_text_dir == TD_RTL;
-	DrawSprite((this->folded ? SPR_CIRCLE_FOLDED : SPR_CIRCLE_UNFOLDED), PAL_NONE, rtl ? right - _circle_size.width : left, y + (SETTING_HEIGHT - _circle_size.height) / 2);
-	DrawString(rtl ? left : left + _circle_size.width + WidgetDimensions::scaled.hsep_normal, rtl ? right - _circle_size.width - WidgetDimensions::scaled.hsep_normal : right, y + (SETTING_HEIGHT - FONT_HEIGHT_NORMAL) / 2, this->title);
+	Rect r = {left, y, right, y + SETTING_HEIGHT - 1};
+	DrawSpriteIgnorePadding((this->folded ? SPR_CIRCLE_FOLDED : SPR_CIRCLE_UNFOLDED), PAL_NONE, r.WithWidth(_circle_size.width, rtl), false, SA_CENTER);
+	DrawString(r.Indent(_circle_size.width + WidgetDimensions::scaled.hsep_normal, rtl).WithTopCentre(FONT_HEIGHT_NORMAL), this->title);
 }
 
 /** Construct settings tree */
@@ -1982,7 +1983,7 @@ struct GameSettingsWindow : Window {
 
 	void OnInit() override
 	{
-		_circle_size = maxdim(GetSpriteSize(SPR_CIRCLE_FOLDED), GetSpriteSize(SPR_CIRCLE_UNFOLDED));
+		_circle_size = maxdim(GetScaledSpriteSize(SPR_CIRCLE_FOLDED), GetScaledSpriteSize(SPR_CIRCLE_UNFOLDED));
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -128,7 +128,7 @@ public:
 
 	DropDownListCompanyItem(int result, bool masked, bool greyed) : DropDownListItem(result, masked), greyed(greyed)
 	{
-		this->icon_size = GetSpriteSize(SPR_COMPANY_ICON);
+		this->icon_size = GetScaledSpriteSize(SPR_COMPANY_ICON);
 		this->lock_size = GetScaledSpriteSize(SPR_LOCK);
 	}
 
@@ -159,10 +159,9 @@ public:
 		if (!Company::IsValidID(company)) return;
 
 		Rect tr = r.Shrink(WidgetDimensions::scaled.dropdowntext, RectPadding::zero);
-		int icon_y = CenterBounds(r.top, r.bottom, icon_size.height);
 		int text_y = CenterBounds(r.top, r.bottom, FONT_HEIGHT_NORMAL);
 
-		DrawCompanyIcon(company, tr.WithWidth(this->icon_size.width, rtl).left, icon_y);
+		DrawCompanyIcon(company, tr.WithWidth(this->icon_size.width, rtl), false);
 		if (NetworkCompanyIsPassworded(company)) {
 			DrawSpriteIgnorePadding(SPR_LOCK, PAL_NONE, tr.WithWidth(this->lock_size.width, !rtl), false, SA_CENTER);
 		}

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -129,7 +129,7 @@ public:
 	DropDownListCompanyItem(int result, bool masked, bool greyed) : DropDownListItem(result, masked), greyed(greyed)
 	{
 		this->icon_size = GetSpriteSize(SPR_COMPANY_ICON);
-		this->lock_size = GetSpriteSize(SPR_LOCK);
+		this->lock_size = GetScaledSpriteSize(SPR_LOCK);
 	}
 
 	bool Selectable() const override
@@ -161,11 +161,10 @@ public:
 		Rect tr = r.Shrink(WidgetDimensions::scaled.dropdowntext, RectPadding::zero);
 		int icon_y = CenterBounds(r.top, r.bottom, icon_size.height);
 		int text_y = CenterBounds(r.top, r.bottom, FONT_HEIGHT_NORMAL);
-		int lock_y = CenterBounds(r.top, r.bottom, lock_size.height);
 
 		DrawCompanyIcon(company, tr.WithWidth(this->icon_size.width, rtl).left, icon_y);
 		if (NetworkCompanyIsPassworded(company)) {
-			DrawSprite(SPR_LOCK, PAL_NONE, tr.WithWidth(this->lock_size.width, !rtl).left, lock_y);
+			DrawSpriteIgnorePadding(SPR_LOCK, PAL_NONE, tr.WithWidth(this->lock_size.width, !rtl), false, SA_CENTER);
 		}
 
 		SetDParam(0, company);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -830,8 +830,8 @@ public:
 
 				/* At least one town available. */
 				bool rtl = _current_text_dir == TD_RTL;
-				Dimension icon_size = GetSpriteSize(SPR_TOWN_RATING_GOOD);
-				int icon_x = tr.WithWidth(icon_size.width, rtl).left;
+				Dimension icon_size = GetScaledSpriteSize(SPR_TOWN_RATING_GOOD);
+				Rect ir = tr.WithWidth(icon_size.width, rtl);
 				tr = tr.Indent(icon_size.width + WidgetDimensions::scaled.hsep_normal, rtl);
 
 				for (uint i = this->vscroll->GetPosition(); i < this->towns.size(); i++) {
@@ -840,12 +840,12 @@ public:
 
 					/* Draw rating icon. */
 					if (_game_mode == GM_EDITOR || !HasBit(t->have_ratings, _local_company)) {
-						DrawSprite(SPR_TOWN_RATING_NA, PAL_NONE, icon_x, tr.top + (this->resize.step_height - icon_size.height) / 2);
+						DrawSpriteIgnorePadding(SPR_TOWN_RATING_NA, PAL_NONE, ir.WithTopAndHeight(tr.top, this->resize.step_height), false, SA_CENTER);
 					} else {
 						SpriteID icon = SPR_TOWN_RATING_APALLING;
 						if (t->ratings[_local_company] > RATING_VERYPOOR) icon = SPR_TOWN_RATING_MEDIOCRE;
 						if (t->ratings[_local_company] > RATING_GOOD)     icon = SPR_TOWN_RATING_GOOD;
-						DrawSprite(icon, PAL_NONE, icon_x, tr.top + (this->resize.step_height - icon_size.height) / 2);
+						DrawSpriteIgnorePadding(icon, PAL_NONE, ir.WithTopAndHeight(tr.top, this->resize.step_height), false, SA_CENTER);
 					}
 
 					SetDParam(0, t->index);
@@ -891,9 +891,9 @@ public:
 					SetDParamMaxDigits(1, 8);
 					d = maxdim(d, GetStringBoundingBox(GetTownString(t)));
 				}
-				Dimension icon_size = GetSpriteSize(SPR_TOWN_RATING_GOOD);
-				d.width += icon_size.width + 2;
-				d.height = std::max(d.height, icon_size.height);
+				Dimension icon_size = GetScaledSpriteSize(SPR_TOWN_RATING_GOOD);
+				d.width += icon_size.width + WidgetDimensions::scaled.hsep_normal;
+				d.height = std::max(d.height, icon_size.height + WidgetDimensions::scaled.vsep_normal);
 				resize->height = d.height;
 				d.height *= 5;
 				d.width += padding.width;

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -122,7 +122,7 @@ public:
 
 	void OnInit() override
 	{
-		this->icon_size      = GetSpriteSize(SPR_COMPANY_ICON);
+		this->icon_size      = GetScaledSpriteSize(SPR_COMPANY_ICON);
 		this->exclusive_size = GetSpriteSize(SPR_EXCLUSIVE_TRANSPORT);
 	}
 
@@ -149,7 +149,6 @@ public:
 		Rect r = this->GetWidget<NWidgetBase>(WID_TA_RATING_INFO)->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect);
 
 		int text_y_offset      = (this->resize.step_height - FONT_HEIGHT_NORMAL) / 2;
-		int icon_y_offset      = (this->resize.step_height - this->icon_size.height) / 2;
 		int exclusive_y_offset = (this->resize.step_height - this->exclusive_size.height) / 2;
 
 		DrawString(r.left, r.right, r.top + text_y_offset, STR_LOCAL_AUTHORITY_COMPANY_RATINGS);
@@ -163,7 +162,7 @@ public:
 		/* Draw list of companies */
 		for (const Company *c : Company::Iterate()) {
 			if ((HasBit(this->town->have_ratings, c->index) || this->town->exclusivity == c->index)) {
-				DrawCompanyIcon(c->index, icon.left, text.top + icon_y_offset);
+				DrawCompanyIcon(c->index, icon.WithTopAndHeight(text.top, this->resize.step_height), false);
 
 				SetDParam(0, c->index);
 				SetDParam(1, c->index);

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -123,7 +123,7 @@ public:
 	void OnInit() override
 	{
 		this->icon_size      = GetScaledSpriteSize(SPR_COMPANY_ICON);
-		this->exclusive_size = GetSpriteSize(SPR_EXCLUSIVE_TRANSPORT);
+		this->exclusive_size = GetScaledSpriteSize(SPR_EXCLUSIVE_TRANSPORT);
 	}
 
 	void OnPaint() override
@@ -149,7 +149,6 @@ public:
 		Rect r = this->GetWidget<NWidgetBase>(WID_TA_RATING_INFO)->GetCurrentRect().Shrink(WidgetDimensions::scaled.framerect);
 
 		int text_y_offset      = (this->resize.step_height - FONT_HEIGHT_NORMAL) / 2;
-		int exclusive_y_offset = (this->resize.step_height - this->exclusive_size.height) / 2;
 
 		DrawString(r.left, r.right, r.top + text_y_offset, STR_LOCAL_AUTHORITY_COMPANY_RATINGS);
 		r.top += this->resize.step_height;
@@ -179,7 +178,7 @@ public:
 
 				SetDParam(2, str);
 				if (this->town->exclusivity == c->index) {
-					DrawSprite(SPR_EXCLUSIVE_TRANSPORT, COMPANY_SPRITE_COLOUR(c->index), exclusive.left, text.top + exclusive_y_offset);
+					DrawSpriteIgnorePadding(SPR_EXCLUSIVE_TRANSPORT, COMPANY_SPRITE_COLOUR(c->index), exclusive.WithTopAndHeight(text.top, this->resize.step_height), false, SA_CENTER);
 				}
 
 				DrawString(text.left, text.right, text.top + text_y_offset, STR_LOCAL_AUTHORITY_COMPANY_RATING);

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -96,6 +96,8 @@ struct BaseVehicleListWindow : public Window {
 	StringID cargo_filter_texts[NUM_CARGO + 4]; ///< Texts for filter_cargo, terminated by INVALID_STRING_ID
 	byte cargo_filter_criteria;                 ///< Selected cargo filter index
 	uint order_arrow_width;                     ///< Width of the arrow in the small order list.
+	Dimension profit_size;                      ///< Dimension of profit icon.
+	Dimension warning_size;                     ///< Dimension of warning icon.
 
 	typedef GUIVehicleGroupList::SortFunction VehicleGroupSortFunction;
 	typedef GUIVehicleList::SortFunction VehicleIndividualSortFunction;

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -73,8 +73,7 @@ StringID DropDownListCharStringItem::String() const
 
 DropDownListIconItem::DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked) : DropDownListParamStringItem(string, result, masked), sprite(sprite), pal(pal)
 {
-	this->dim = GetSpriteSize(sprite);
-	this->sprite_y = dim.height;
+	this->dim = GetScaledSpriteSize(sprite);
 }
 
 uint DropDownListIconItem::Height(uint width) const
@@ -92,7 +91,7 @@ void DropDownListIconItem::Draw(const Rect &r, bool sel, Colours bg_colour) cons
 	bool rtl = _current_text_dir == TD_RTL;
 	Rect ir = r.Shrink(WidgetDimensions::scaled.dropdowntext);
 	Rect tr = ir.Indent(this->dim.width + WidgetDimensions::scaled.hsep_normal, rtl);
-	DrawSprite(this->sprite, this->pal, ir.WithWidth(this->dim.width, rtl).left, CenterBounds(r.top, r.bottom, this->sprite_y));
+	DrawSpriteIgnorePadding(this->sprite, this->pal, ir.WithWidth(this->dim.width, rtl), 0, SA_CENTER);
 	DrawString(tr.left, tr.right, CenterBounds(r.top, r.bottom, FONT_HEIGHT_NORMAL), this->String(), sel ? TC_WHITE : TC_BLACK);
 }
 

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -259,10 +259,10 @@ struct DropdownWindow : Window {
 				bool selected = (this->selected_index == item->result);
 				if (selected) GfxFillRect(ir.left, y, ir.right, y + item_height - 1, PC_BLACK);
 
-				item->Draw({ir.left, y, ir.right, y + item_height - 1}, selected, colour);
+				item->Draw(ir.WithTopAndHeight(y, item_height), selected, colour);
 
 				if (item->masked) {
-					GfxFillRect(ir.left, y, ir.right, y + item_height - 1, _colour_gradient[colour][5], FILLRECT_CHECKER);
+					GfxFillRect(ir.WithTopAndHeight(y, item_height), _colour_gradient[colour][5], FILLRECT_CHECKER);
 				}
 			}
 			y += item_height;

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -83,7 +83,6 @@ class DropDownListIconItem : public DropDownListParamStringItem {
 	SpriteID sprite;
 	PaletteID pal;
 	Dimension dim;
-	uint sprite_y;
 public:
 	DropDownListIconItem(SpriteID sprite, PaletteID pal, StringID string, int result, bool masked);
 


### PR DESCRIPTION
## Motivation / Problem

For consistent interface scaling, scale space for sprites/icons by interface scale instead of sprite size.

This has been done for simple image widgets and many places already.

## Description

This is a continuation of #10114 variable interface scaling changes.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
