### PR TITLE
Codechange: Use vector for NewGRF spec overrides.

### DIFF
--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -175,7 +175,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 {
 	byte airport_id = this->AddEntityID(as->grf_prop.local_id, as->grf_prop.grffile->grfid, as->grf_prop.subst_id);
 
-	if (airport_id == invalid_ID) {
+	if (airport_id == this->invalid_ID) {
 		grfmsg(1, "Airport.SetEntitySpec: Too many airports allocated. Ignoring.");
 		return;
 	}
@@ -183,15 +183,15 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 	memcpy(AirportSpec::GetWithoutOverride(airport_id), as, sizeof(*as));
 
 	/* Now add the overrides. */
-	for (int i = 0; i < max_offset; i++) {
+	for (int i = 0; i < this->max_offset; i++) {
 		AirportSpec *overridden_as = AirportSpec::GetWithoutOverride(i);
 
-		if (entity_overrides[i] != as->grf_prop.local_id || grfid_overrides[i] != as->grf_prop.grffile->grfid) continue;
+		if (this->entity_overrides[i] != as->grf_prop.local_id || this->grfid_overrides[i] != as->grf_prop.grffile->grfid) continue;
 
 		overridden_as->grf_prop.override = airport_id;
 		overridden_as->enabled = false;
-		entity_overrides[i] = invalid_ID;
-		grfid_overrides[i] = 0;
+		this->entity_overrides[i] = this->invalid_ID;
+		this->grfid_overrides[i] = 0;
 	}
 }
 

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -175,7 +175,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 {
 	byte airport_id = this->AddEntityID(as->grf_prop.local_id, as->grf_prop.grffile->grfid, as->grf_prop.subst_id);
 
-	if (airport_id == this->invalid_ID) {
+	if (airport_id == this->invalid_id) {
 		grfmsg(1, "Airport.SetEntitySpec: Too many airports allocated. Ignoring.");
 		return;
 	}
@@ -190,7 +190,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 
 		overridden_as->grf_prop.override = airport_id;
 		overridden_as->enabled = false;
-		this->entity_overrides[i] = this->invalid_ID;
+		this->entity_overrides[i] = this->invalid_id;
 		this->grfid_overrides[i] = 0;
 	}
 }

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -67,7 +67,7 @@ void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 {
 	StationGfx airpt_id = this->AddEntityID(airpts->grf_prop.local_id, airpts->grf_prop.grffile->grfid, airpts->grf_prop.subst_id);
 
-	if (airpt_id == invalid_ID) {
+	if (airpt_id == this->invalid_ID) {
 		grfmsg(1, "AirportTile.SetEntitySpec: Too many airport tiles allocated. Ignoring.");
 		return;
 	}
@@ -75,15 +75,15 @@ void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 	memcpy(&AirportTileSpec::tiles[airpt_id], airpts, sizeof(*airpts));
 
 	/* Now add the overrides. */
-	for (int i = 0; i < max_offset; i++) {
+	for (int i = 0; i < this->max_offset; i++) {
 		AirportTileSpec *overridden_airpts = &AirportTileSpec::tiles[i];
 
-		if (entity_overrides[i] != airpts->grf_prop.local_id || grfid_overrides[i] != airpts->grf_prop.grffile->grfid) continue;
+		if (this->entity_overrides[i] != airpts->grf_prop.local_id || this->grfid_overrides[i] != airpts->grf_prop.grffile->grfid) continue;
 
 		overridden_airpts->grf_prop.override = airpt_id;
 		overridden_airpts->enabled = false;
-		entity_overrides[i] = invalid_ID;
-		grfid_overrides[i] = 0;
+		this->entity_overrides[i] = this->invalid_ID;
+		this->grfid_overrides[i] = 0;
 	}
 }
 

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -67,7 +67,7 @@ void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 {
 	StationGfx airpt_id = this->AddEntityID(airpts->grf_prop.local_id, airpts->grf_prop.grffile->grfid, airpts->grf_prop.subst_id);
 
-	if (airpt_id == this->invalid_ID) {
+	if (airpt_id == this->invalid_id) {
 		grfmsg(1, "AirportTile.SetEntitySpec: Too many airport tiles allocated. Ignoring.");
 		return;
 	}
@@ -82,7 +82,7 @@ void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 
 		overridden_airpts->grf_prop.override = airpt_id;
 		overridden_airpts->enabled = false;
-		this->entity_overrides[i] = this->invalid_ID;
+		this->entity_overrides[i] = this->invalid_id;
 		this->grfid_overrides[i] = 0;
 	}
 }

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -44,21 +44,10 @@ OverrideManagerBase::OverrideManagerBase(uint16 offset, uint16 maximum, uint16 i
 	max_new_entities = maximum;
 	invalid_ID = invalid;
 
-	mapping_ID = CallocT<EntityIDMapping>(max_new_entities);
-	entity_overrides = MallocT<uint16>(max_offset);
-	for (size_t i = 0; i < max_offset; i++) entity_overrides[i] = invalid;
-	grfid_overrides = CallocT<uint32>(max_offset);
-}
-
-/**
- * Destructor of the generic class.
- * Frees allocated memory of constructor
- */
-OverrideManagerBase::~OverrideManagerBase()
-{
-	free(mapping_ID);
-	free(entity_overrides);
-	free(grfid_overrides);
+	this->mapping_ID.resize(this->max_new_entities);
+	this->entity_overrides.resize(this->max_offset);
+	std::fill(this->entity_overrides.begin(), this->entity_overrides.end(), this->invalid_ID);
+	this->grfid_overrides.resize(this->max_offset);
 }
 
 /**
@@ -81,16 +70,14 @@ void OverrideManagerBase::Add(uint8 local_id, uint32 grfid, uint entity_type)
 /** Resets the mapping, which is used while initializing game */
 void OverrideManagerBase::ResetMapping()
 {
-	memset(mapping_ID, 0, (max_new_entities - 1) * sizeof(EntityIDMapping));
+	std::fill(this->mapping_ID.begin(), this->mapping_ID.end(), EntityIDMapping{});
 }
 
 /** Resets the override, which is used while initializing game */
 void OverrideManagerBase::ResetOverride()
 {
-	for (uint16 i = 0; i < max_offset; i++) {
-		entity_overrides[i] = invalid_ID;
-		grfid_overrides[i] = 0;
-	}
+	std::fill(this->entity_overrides.begin(), this->entity_overrides.end(), this->invalid_ID);
+	std::fill(this->grfid_overrides.begin(), this->grfid_overrides.end(), uint32());
 }
 
 /**

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -191,8 +191,8 @@ struct EntityIDMapping {
 
 class OverrideManagerBase {
 protected:
-	uint16 *entity_overrides;
-	uint32 *grfid_overrides;
+	std::vector<uint16> entity_overrides;
+	std::vector<uint32> grfid_overrides;
 
 	uint16 max_offset;       ///< what is the length of the original entity's array of specs
 	uint16 max_new_entities; ///< what is the amount of entities, old and new summed
@@ -201,10 +201,10 @@ protected:
 	virtual bool CheckValidNewID(uint16 testid) { return true; }
 
 public:
-	EntityIDMapping *mapping_ID; ///< mapping of ids from grf files.  Public out of convenience
+	std::vector<EntityIDMapping> mapping_ID; ///< mapping of ids from grf files.  Public out of convenience
 
 	OverrideManagerBase(uint16 offset, uint16 maximum, uint16 invalid);
-	virtual ~OverrideManagerBase();
+	virtual ~OverrideManagerBase() {}
 
 	void ResetOverride();
 	void ResetMapping();
@@ -267,7 +267,7 @@ public:
 struct AirportTileSpec;
 class AirportTileOverrideManager : public OverrideManagerBase {
 protected:
-	virtual bool CheckValidNewID(uint16 testid) { return testid != 0xFF; }
+	virtual bool CheckValidNewID(uint16 testid) override { return testid != 0xFF; }
 public:
 	AirportTileOverrideManager(uint16 offset, uint16 maximum, uint16 invalid) :
 			OverrideManagerBase(offset, maximum, invalid) {}
@@ -278,7 +278,7 @@ public:
 struct ObjectSpec;
 class ObjectOverrideManager : public OverrideManagerBase {
 protected:
-	virtual bool CheckValidNewID(uint16 testid) { return testid != 0xFF; }
+	virtual bool CheckValidNewID(uint16 testid) override { return testid != 0xFF; }
 public:
 	ObjectOverrideManager(uint16 offset, uint16 maximum, uint16 invalid) :
 			OverrideManagerBase(offset, maximum, invalid) {}

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -216,8 +216,8 @@ public:
 	uint16 GetSubstituteID(uint16 entity_id) const;
 	virtual uint16 GetID(uint8 grf_local_id, uint32 grfid) const;
 
-	inline uint16 GetMaxMapping() const { return max_new_entities; }
-	inline uint16 GetMaxOffset() const { return max_offset; }
+	inline uint16 GetMaxMapping() const { return this->max_new_entities; }
+	inline uint16 GetMaxOffset() const { return this->max_offset; }
 };
 
 

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -194,14 +194,14 @@ protected:
 	std::vector<uint16> entity_overrides;
 	std::vector<uint32> grfid_overrides;
 
-	uint16 max_offset;       ///< what is the length of the original entity's array of specs
-	uint16 max_new_entities; ///< what is the amount of entities, old and new summed
+	uint16 max_offset;   ///< what is the length of the original entity's array of specs
+	uint16 max_entities; ///< what is the amount of entities, old and new summed
 
-	uint16 invalid_ID;       ///< ID used to detected invalid entities;
+	uint16 invalid_id;   ///< ID used to detected invalid entities;
 	virtual bool CheckValidNewID(uint16 testid) { return true; }
 
 public:
-	std::vector<EntityIDMapping> mapping_ID; ///< mapping of ids from grf files.  Public out of convenience
+	std::vector<EntityIDMapping> mappings; ///< mapping of ids from grf files.  Public out of convenience
 
 	OverrideManagerBase(uint16 offset, uint16 maximum, uint16 invalid);
 	virtual ~OverrideManagerBase() {}
@@ -216,7 +216,7 @@ public:
 	uint16 GetSubstituteID(uint16 entity_id) const;
 	virtual uint16 GetID(uint8 grf_local_id, uint32 grfid) const;
 
-	inline uint16 GetMaxMapping() const { return this->max_new_entities; }
+	inline uint16 GetMaxMapping() const { return this->max_entities; }
 	inline uint16 GetMaxOffset() const { return this->max_offset; }
 };
 

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -32,10 +32,10 @@ void NewGRFMappingChunkHandler::Save() const
 	SlTableHeader(_newgrf_mapping_desc);
 
 	for (uint i = 0; i < this->mapping.GetMaxMapping(); i++) {
-		if (this->mapping.mapping_ID[i].grfid == 0 &&
-			this->mapping.mapping_ID[i].entity_id == 0) continue;
+		if (this->mapping.mappings[i].grfid == 0 &&
+			this->mapping.mappings[i].entity_id == 0) continue;
 		SlSetArrayIndex(i);
-		SlObject(&this->mapping.mapping_ID[i], _newgrf_mapping_desc);
+		SlObject(&this->mapping.mappings[i], _newgrf_mapping_desc);
 	}
 }
 
@@ -55,7 +55,7 @@ void NewGRFMappingChunkHandler::Load() const
 	int index;
 	while ((index = SlIterateArray()) != -1) {
 		if ((uint)index >= max_id) SlErrorCorrupt("Too many NewGRF entity mappings");
-		SlObject(&this->mapping.mapping_ID[index], slt);
+		SlObject(&this->mapping.mappings[index], slt);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

NewGRF spec override manager uses C-style memory management.

## Description

Switch to std::vector and std::fill instead.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
