### PR TITLE
Fix #10395: When loading old saves, don't forcibly bar level crossings

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1985,13 +1985,6 @@ bool AfterLoadGame()
 		}
 	}
 
-	if (IsSavegameVersionBefore(SLV_102)) {
-		for (TileIndex t = 0; t < map_size; t++) {
-			/* Now all crossings should be in correct state */
-			if (IsLevelCrossingTile(t)) UpdateLevelCrossing(t, false);
-		}
-	}
-
 	if (IsSavegameVersionBefore(SLV_103)) {
 		/* Non-town-owned roads now store the closest town */
 		UpdateNearestTownForRoadTiles(false);
@@ -3196,9 +3189,9 @@ bool AfterLoadGame()
 			}
 		}
 
-		/* Refresh all level crossings to bar adjacent crossing tiles. */
+		/* Refresh all level crossings to bar adjacent crossing tiles, if needed. */
 		for (TileIndex tile = 0; tile < Map::Size(); tile++) {
-			if (IsLevelCrossingTile(tile)) UpdateLevelCrossing(tile, false, true);
+			if (IsLevelCrossingTile(tile)) UpdateLevelCrossing(tile, false);
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

The savegame conversion in #9931 iterates through all level crossings and updates them, in case the savegame had only one track of a multi-track crossing barred. I erroneously forced every level crossing tile on the map to be barred instead of checking for a closed tile on the same axis. Reported as #10395.

## Description

Check the crossing for barred tiles instead of forcing all tiles to be barred.

Closes #10395.

To make review a bit easier, the parameter being changed is `force_bar`:
```
/**
 * Update a level crossing to barred or open (crossing may include multiple adjacent tiles).
 * @param tile Tile which causes the update.
 * @param sound Should we play sound?
 * @param force_bar Should we force the crossing to be barred?
 */
void UpdateLevelCrossing(TileIndex tile, bool sound, bool force_bar)
```

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
