### PR TITLE
Codechange: Store ObjectSpecs in std::vector

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9518,6 +9518,8 @@ static void FinaliseObjectsArray()
 			}
 		}
 	}
+
+	ObjectSpec::BindToClasses();
 }
 
 /**

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -12,15 +12,16 @@
 
 #include "strings_type.h"
 
+#include <vector>
+
 /**
  * Struct containing information relating to NewGRF classes for stations and airports.
  */
 template <typename Tspec, typename Tid, Tid Tmax>
 struct NewGRFClass {
 private:
-	uint count;       ///< Number of specs in this class.
-	uint ui_count;    ///< Number of specs in this class potentially available to the user.
-	Tspec **spec;     ///< Array of specifications.
+	uint ui_count;             ///< Number of specs in this class potentially available to the user.
+	std::vector<Tspec *> spec; ///< List of specifications.
 
 	/**
 	 * The actual classes.
@@ -41,7 +42,7 @@ public:
 	void Insert(Tspec *spec);
 
 	/** Get the number of allocated specs within the class. */
-	uint GetSpecCount() const { return this->count; }
+	uint GetSpecCount() const { return static_cast<uint>(this->spec.size()); }
 	/** Get the number of potentially user-available specs within the class. */
 	uint GetUISpecCount() const { return this->ui_count; }
 	int GetUIFromIndex(int index) const;

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -28,11 +28,9 @@ DEFINE_NEWGRF_CLASS_METHOD(void)::ResetClass()
 {
 	this->global_id = 0;
 	this->name      = STR_EMPTY;
-	this->count     = 0;
 	this->ui_count  = 0;
 
-	free(this->spec);
-	this->spec = nullptr;
+	this->spec.clear();
 }
 
 /** Reset the classes, i.e. clear everything. */
@@ -75,12 +73,9 @@ DEFINE_NEWGRF_CLASS_METHOD(Tid)::Allocate(uint32 global_id)
  */
 DEFINE_NEWGRF_CLASS_METHOD(void)::Insert(Tspec *spec)
 {
-	uint i = this->count++;
-	this->spec = ReallocT(this->spec, this->count);
+	this->spec.push_back(spec);
 
-	this->spec[i] = spec;
-
-	if (this->IsUIAvailable(i)) this->ui_count++;
+	if (this->IsUIAvailable(static_cast<uint>(this->spec.size() - 1))) this->ui_count++;
 }
 
 /**
@@ -197,7 +192,8 @@ DEFINE_NEWGRF_CLASS_METHOD(const Tspec *)::GetByGrf(uint32 grfid, byte local_id,
 	uint j;
 
 	for (Tid i = (Tid)0; i < Tmax; i++) {
-		for (j = 0; j < classes[i].count; j++) {
+		uint count = static_cast<uint>(classes[i].spec.size());
+		for (j = 0; j < count; j++) {
 			const Tspec *spec = classes[i].spec[j];
 			if (spec == nullptr) continue;
 			if (spec->grf_prop.grffile->grfid == grfid && spec->grf_prop.local_id == local_id) {

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -312,10 +312,11 @@ void ObjectOverrideManager::SetEntitySpec(ObjectSpec *spec)
 		return;
 	}
 
-	extern ObjectSpec _object_specs[NUM_OBJECTS];
+	extern std::vector<ObjectSpec> _object_specs;
 
 	/* Now that we know we can use the given id, copy the spec to its final destination. */
-	memcpy(&_object_specs[type], spec, sizeof(*spec));
+	if (type >= _object_specs.size()) _object_specs.resize(type + 1);
+	_object_specs[type] = *spec;
 }
 
 /**

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -316,7 +316,6 @@ void ObjectOverrideManager::SetEntitySpec(ObjectSpec *spec)
 
 	/* Now that we know we can use the given id, copy the spec to its final destination. */
 	memcpy(&_object_specs[type], spec, sizeof(*spec));
-	ObjectClass::Assign(&_object_specs[type]);
 }
 
 /**

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -90,6 +90,18 @@ uint ObjectSpec::Index() const
 	return this - _object_specs;
 }
 
+/**
+ * Tie all ObjectSpecs to their class.
+ */
+/* static */ void ObjectSpec::BindToClasses()
+{
+	for (auto &spec : _object_specs) {
+		if (spec.IsEnabled() && spec.cls_id != INVALID_OBJECT_CLASS) {
+			ObjectClass::Assign(&spec);
+		}
+	}
+}
+
 /** This function initialize the spec arrays of objects. */
 void ResetObjects()
 {
@@ -104,20 +116,17 @@ void ResetObjects()
 	for (uint16 i = 0; i < lengthof(_original_objects); i++) {
 		_object_specs[i].grf_prop.local_id = i;
 	}
+
+	/* Set class for originals. */
+	_object_specs[OBJECT_LIGHTHOUSE].cls_id = ObjectClass::Allocate('LTHS');
+	_object_specs[OBJECT_TRANSMITTER].cls_id = ObjectClass::Allocate('TRNS');
 }
 
 template <typename Tspec, typename Tid, Tid Tmax>
 /* static */ void NewGRFClass<Tspec, Tid, Tmax>::InsertDefaults()
 {
-	ObjectClassID cls = ObjectClass::Allocate('LTHS');
-	ObjectClass::Get(cls)->name = STR_OBJECT_CLASS_LTHS;
-	_object_specs[OBJECT_LIGHTHOUSE].cls_id = cls;
-	ObjectClass::Assign(&_object_specs[OBJECT_LIGHTHOUSE]);
-
-	cls = ObjectClass::Allocate('TRNS');
-	ObjectClass::Get(cls)->name = STR_OBJECT_CLASS_TRNS;
-	_object_specs[OBJECT_TRANSMITTER].cls_id = cls;
-	ObjectClass::Assign(&_object_specs[OBJECT_TRANSMITTER]);
+	ObjectClass::Get(ObjectClass::Allocate('LTHS'))->name = STR_OBJECT_CLASS_LTHS;
+	ObjectClass::Get(ObjectClass::Allocate('TRNS'))->name = STR_OBJECT_CLASS_TRNS;
 }
 
 template <typename Tspec, typename Tid, Tid Tmax>

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -29,7 +29,12 @@ ObjectOverrideManager _object_mngr(NEW_OBJECT_OFFSET, NUM_OBJECTS, INVALID_OBJEC
 
 extern const ObjectSpec _original_objects[NEW_OBJECT_OFFSET];
 /** All the object specifications. */
-ObjectSpec _object_specs[NUM_OBJECTS];
+std::vector<ObjectSpec> _object_specs;
+
+size_t ObjectSpec::Count()
+{
+	return _object_specs.size();
+}
 
 /**
  * Get the specification associated with a specific ObjectType.
@@ -38,7 +43,11 @@ ObjectSpec _object_specs[NUM_OBJECTS];
  */
 /* static */ const ObjectSpec *ObjectSpec::Get(ObjectType index)
 {
+	/* Empty object if index is out of range -- this might happen if NewGRFs are changed. */
+	static ObjectSpec empty = {};
+
 	assert(index < NUM_OBJECTS);
+	if (index >= _object_specs.size()) return &empty;
 	return &_object_specs[index];
 }
 
@@ -87,7 +96,7 @@ bool ObjectSpec::IsAvailable() const
  */
 uint ObjectSpec::Index() const
 {
-	return this - _object_specs;
+	return this - _object_specs.data();
 }
 
 /**
@@ -106,14 +115,13 @@ uint ObjectSpec::Index() const
 void ResetObjects()
 {
 	/* Clean the pool. */
-	for (uint16 i = 0; i < NUM_OBJECTS; i++) {
-		_object_specs[i] = {};
-	}
+	_object_specs.clear();
 
 	/* And add our originals. */
-	MemCpyT(_object_specs, _original_objects, lengthof(_original_objects));
+	_object_specs.resize(lengthof(_original_objects));
 
 	for (uint16 i = 0; i < lengthof(_original_objects); i++) {
+		_object_specs[i] = _original_objects[i];
 		_object_specs[i].grf_prop.local_id = i;
 	}
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -31,6 +31,11 @@ extern const ObjectSpec _original_objects[NEW_OBJECT_OFFSET];
 /** All the object specifications. */
 std::vector<ObjectSpec> _object_specs;
 
+const std::vector<ObjectSpec> &ObjectSpec::Specs()
+{
+	return _object_specs;
+}
+
 size_t ObjectSpec::Count()
 {
 	return _object_specs.size();

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -99,6 +99,7 @@ struct ObjectSpec {
 	bool IsAvailable() const;
 	uint Index() const;
 
+	static size_t Count();
 	static const ObjectSpec *Get(ObjectType index);
 	static const ObjectSpec *GetByTile(TileIndex tile);
 

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -101,6 +101,8 @@ struct ObjectSpec {
 
 	static const ObjectSpec *Get(ObjectType index);
 	static const ObjectSpec *GetByTile(TileIndex tile);
+
+	static void BindToClasses();
 };
 
 /** Object scope resolver. */

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -99,6 +99,7 @@ struct ObjectSpec {
 	bool IsAvailable() const;
 	uint Index() const;
 
+	static const std::vector<ObjectSpec> &Specs();
 	static size_t Count();
 	static const ObjectSpec *Get(ObjectType index);
 	static const ObjectSpec *GetByTile(TileIndex tile);

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -808,21 +808,20 @@ void GenerateObjects()
 	}
 
 	/* Iterate over all possible object types */
-	for (uint i = 0; i < ObjectSpec::Count(); i++) {
-		const ObjectSpec *spec = ObjectSpec::Get(i);
+	for (const auto &spec : ObjectSpec::Specs()) {
 
 		/* Continue, if the object was never available till now or shall not be placed */
-		if (!spec->WasEverAvailable() || spec->generate_amount == 0) continue;
+		if (!spec.WasEverAvailable() || spec.generate_amount == 0) continue;
 
-		uint16 amount = spec->generate_amount;
+		uint16 amount = spec.generate_amount;
 
 		/* Scale by map size */
-		if ((spec->flags & OBJECT_FLAG_SCALE_BY_WATER) && _settings_game.construction.freeform_edges) {
+		if ((spec.flags & OBJECT_FLAG_SCALE_BY_WATER) && _settings_game.construction.freeform_edges) {
 			/* Scale the amount of lighthouses with the amount of land at the borders.
 			 * The -6 is because the top borders are MP_VOID (-2) and all corners
 			 * are counted twice (-4). */
 			amount = Map::ScaleBySize1D(amount * num_water_tiles) / (2 * Map::MaxY() + 2 * Map::MaxX() - 6);
-		} else if (spec->flags & OBJECT_FLAG_SCALE_BY_WATER) {
+		} else if (spec.flags & OBJECT_FLAG_SCALE_BY_WATER) {
 			amount = Map::ScaleBySize1D(amount);
 		} else {
 			amount = Map::ScaleBySize(amount);
@@ -830,7 +829,7 @@ void GenerateObjects()
 
 		/* Now try to place the requested amount of this object */
 		for (uint j = Map::ScaleBySize(1000); j != 0 && amount != 0 && Object::CanAllocateItem(); j--) {
-			switch (i) {
+			switch (spec.Index()) {
 				case OBJECT_TRANSMITTER:
 					if (TryBuildTransmitter()) amount--;
 					break;
@@ -840,8 +839,8 @@ void GenerateObjects()
 					break;
 
 				default:
-					uint8 view = RandomRange(spec->views);
-					if (CmdBuildObject(DC_EXEC | DC_AUTO | DC_NO_TEST_TOWN_RATING | DC_NO_MODIFY_TOWN_RATING, RandomTile(), i, view).Succeeded()) amount--;
+					uint8 view = RandomRange(spec.views);
+					if (CmdBuildObject(DC_EXEC | DC_AUTO | DC_NO_TEST_TOWN_RATING | DC_NO_MODIFY_TOWN_RATING, RandomTile(), spec.Index(), view).Succeeded()) amount--;
 					break;
 			}
 		}

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -207,7 +207,7 @@ CommandCost CmdBuildObject(DoCommandFlag flags, TileIndex tile, ObjectType type,
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 
-	if (type >= NUM_OBJECTS) return CMD_ERROR;
+	if (type >= ObjectSpec::Count()) return CMD_ERROR;
 	const ObjectSpec *spec = ObjectSpec::Get(type);
 	if (_game_mode == GM_NORMAL && !spec->IsAvailable() && !_generating_world) return CMD_ERROR;
 	if ((_game_mode == GM_EDITOR || _generating_world) && !spec->WasEverAvailable()) return CMD_ERROR;
@@ -388,7 +388,7 @@ CommandCost CmdBuildObjectArea(DoCommandFlag flags, TileIndex tile, TileIndex st
 {
 	if (start_tile >= Map::Size()) return CMD_ERROR;
 
-	if (type >= NUM_OBJECTS) return CMD_ERROR;
+	if (type >= ObjectSpec::Count()) return CMD_ERROR;
 	const ObjectSpec *spec = ObjectSpec::Get(type);
 	if (view >= spec->views) return CMD_ERROR;
 
@@ -792,7 +792,7 @@ static bool TryBuildTransmitter()
 void GenerateObjects()
 {
 	/* Set a guestimate on how much we progress */
-	SetGeneratingWorldProgress(GWP_OBJECT, NUM_OBJECTS);
+	SetGeneratingWorldProgress(GWP_OBJECT, (uint)ObjectSpec::Count());
 
 	/* Determine number of water tiles at map border needed for freeform_edges */
 	uint num_water_tiles = 0;
@@ -808,7 +808,7 @@ void GenerateObjects()
 	}
 
 	/* Iterate over all possible object types */
-	for (uint i = 0; i < NUM_OBJECTS; i++) {
+	for (uint i = 0; i < ObjectSpec::Count(); i++) {
 		const ObjectSpec *spec = ObjectSpec::Get(i);
 
 		/* Continue, if the object was never available till now or shall not be placed */

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -275,11 +275,10 @@ public:
 				uint height[2] = {0, 0}; // The height for the different views; in this case views 1/2 and 4.
 
 				/* Get the height and view information. */
-				for (int i = 0; i < ObjectSpec::Count(); i++) {
-					const ObjectSpec *spec = ObjectSpec::Get(i);
-					if (!spec->IsEverAvailable()) continue;
-					two_wide |= spec->views >= 2;
-					height[spec->views / 4] = std::max<int>(spec->height, height[spec->views / 4]);
+				for (const auto &spec : ObjectSpec::Specs()) {
+					if (!spec.IsEverAvailable()) continue;
+					two_wide |= spec.views >= 2;
+					height[spec.views / 4] = std::max<int>(spec.height, height[spec.views / 4]);
 				}
 
 				/* Determine the pixel heights. */

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -275,11 +275,11 @@ public:
 				uint height[2] = {0, 0}; // The height for the different views; in this case views 1/2 and 4.
 
 				/* Get the height and view information. */
-				for (int i = 0; i < NUM_OBJECTS; i++) {
+				for (int i = 0; i < ObjectSpec::Count(); i++) {
 					const ObjectSpec *spec = ObjectSpec::Get(i);
 					if (!spec->IsEverAvailable()) continue;
 					two_wide |= spec->views >= 2;
-					height[spec->views / 4] = std::max<int>(ObjectSpec::Get(i)->height, height[spec->views / 4]);
+					height[spec->views / 4] = std::max<int>(spec->height, height[spec->views / 4]);
 				}
 
 				/* Determine the pixel heights. */

--- a/src/script/api/script_objecttype.cpp
+++ b/src/script/api/script_objecttype.cpp
@@ -19,7 +19,7 @@
 
 /* static */ bool ScriptObjectType::IsValidObjectType(ObjectType object_type)
 {
-	if (object_type >= NUM_OBJECTS) return false;
+	if (object_type >= ObjectSpec::Count()) return false;
 	return ObjectSpec::Get(object_type)->IsEverAvailable();
 }
 

--- a/src/script/api/script_objecttypelist.cpp
+++ b/src/script/api/script_objecttypelist.cpp
@@ -15,7 +15,7 @@
 
 ScriptObjectTypeList::ScriptObjectTypeList()
 {
-	for (int i = 0; i < NUM_OBJECTS; i++) {
+	for (int i = 0; i < ObjectSpec::Count(); i++) {
 		const ObjectSpec *spec = ObjectSpec::Get(i);
 		if (!spec->IsEverAvailable()) continue;
 		this->AddItem(i);

--- a/src/script/api/script_objecttypelist.cpp
+++ b/src/script/api/script_objecttypelist.cpp
@@ -15,9 +15,8 @@
 
 ScriptObjectTypeList::ScriptObjectTypeList()
 {
-	for (int i = 0; i < ObjectSpec::Count(); i++) {
-		const ObjectSpec *spec = ObjectSpec::Get(i);
-		if (!spec->IsEverAvailable()) continue;
-		this->AddItem(i);
+	for (const auto &spec : ObjectSpec::Specs()) {
+		if (!spec.IsEverAvailable()) continue;
+		this->AddItem(spec.Index());
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

Space for 64000 object types is statically allocated, on the off-chance that 64000 object types will be loaded.

As ObjectSpec is around 64 bytes (down from 72 recently), this is 4MB even if no extra object types are loaded.

Some loops also test all 64000 entries in case an object type is defined.

## Description

This is resolved by storing object types in a vector instead of a fixed-size C-style array.

This requires a minor change to how objectspecs are bound to classes as the vector will be reallocated during load, so they need to be bound after all objectspecs are loaded.

This also fixes an issue where the default objects objects are set in default classes before those default objects are actually initialised.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
