### PR TITLE
Fix #10255: Reduce basic thickness of linkgraph GUI lines

### DIFF
--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -224,7 +224,7 @@ struct MainWindow : Window
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_M_VIEWPORT);
 		nvp->InitializeViewport(this, TileXY(32, 32), ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
 
-		this->viewport->overlay = new LinkGraphOverlay(this, WID_M_VIEWPORT, 0, 0, 3);
+		this->viewport->overlay = new LinkGraphOverlay(this, WID_M_VIEWPORT, 0, 0, 2);
 		this->refresh.SetInterval(LINKGRAPH_DELAY);
 	}
 


### PR DESCRIPTION
From 3px to 2px (multiplied by UI scale).

## Motivation / Problem

See #10255. #10064 changed the thickness of linkgraph GUI ("Cargo Flow Legend") lines from 3px to (3 * UI scaling) px. This seems to be too thick at higher scaling.

## Description

Per @PeterN's suggestion, changed the thickness from (3 * UI scaling) px to (2 & UI scaling) px.

Closes #10255.

## Limitations

Maybe those who are using it with 1x scaling could find the lines too thin now. I had suggested a setting (there is a similar setting for the thickness of graph lines already), but of course implementing new settings is not really nice.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
