### PR TITLE
Expose more functions to game scripts

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2052,7 +2052,7 @@ static void AircraftHandleDestTooFar(Aircraft *v, bool too_far)
 		if (!HasBit(v->flags, VAF_DEST_TOO_FAR)) {
 			SetBit(v->flags, VAF_DEST_TOO_FAR);
 			SetWindowWidgetDirty(WC_VEHICLE_VIEW, v->index, WID_VV_START_STOP);
-			AI::NewEvent(v->owner, new ScriptEventAircraftDestTooFar(v->index));
+			ScriptTrigger::NewEvent<ScriptEventAircraftDestTooFar>(v->owner, v->index);
 			if (v->owner == _local_company) {
 				/* Post a news message. */
 				AddVehicleAdviceNewsItem(AdviceType::AircraftDestinationTooFar, GetEncodedString(STR_NEWS_AIRCRAFT_DEST_TOO_FAR, v->index), v->index);

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -27,8 +27,7 @@
 #include "sound_func.h"
 #include "cheat_type.h"
 #include "company_base.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "company_func.h"
 #include "effectvehicle_func.h"
 #include "station_base.h"
@@ -1345,8 +1344,7 @@ static void CrashAirplane(Aircraft *v)
 		headline = GetEncodedString(STR_NEWS_AIRCRAFT_CRASH, victims, st->index);
 	}
 
-	AI::NewEvent(v->owner, new ScriptEventVehicleCrashed(v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING, victims, v->owner));
-	Game::NewEvent(new ScriptEventVehicleCrashed(v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING, victims, v->owner));
+	ScriptTrigger::NewEvent<ScriptEventVehicleCrashed>(v->owner, v->index, vt, st == nullptr ? ScriptEventVehicleCrashed::CRASH_AIRCRAFT_NO_AIRPORT : ScriptEventVehicleCrashed::CRASH_PLANE_LANDING, victims, v->owner);
 
 	NewsType newstype = NewsType::Accident;
 	if (v->owner != _local_company) {
@@ -1411,8 +1409,7 @@ static void AircraftEntersTerminal(Aircraft *v)
 			v->index,
 			st->index
 		);
-		AI::NewEvent(v->owner, new ScriptEventStationFirstVehicle(st->index, v->index));
-		Game::NewEvent(new ScriptEventStationFirstVehicle(st->index, v->index));
+		ScriptTrigger::NewEvent<ScriptEventStationFirstVehicle>(v->owner, st->index, v->index);
 	}
 
 	v->BeginLoading();

--- a/src/autoreplace_cmd.cpp
+++ b/src/autoreplace_cmd.cpp
@@ -20,7 +20,7 @@
 #include "core/random_func.hpp"
 #include "vehiclelist.h"
 #include "road.h"
-#include "ai/ai.hpp"
+#include "script/script_trigger.hpp"
 #include "news_func.h"
 #include "strings_func.h"
 #include "autoreplace_cmd.h"
@@ -481,7 +481,7 @@ static CommandCost ReplaceFreeUnit(Vehicle **single_unit, DoCommandFlags flags, 
 
 			*single_unit = new_v;
 
-			AI::NewEvent(old_v->owner, new ScriptEventVehicleAutoReplaced(old_v->index, new_v->index));
+			ScriptTrigger::NewEvent<ScriptEventVehicleAutoReplaced>(old_v->owner, old_v->index, new_v->index);
 		}
 
 		/* Sell the old vehicle */
@@ -640,7 +640,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 				/* Success ! */
 				if (flags.Test(DoCommandFlag::Execute) && new_head != old_head) {
 					*chain = new_head;
-					AI::NewEvent(old_head->owner, new ScriptEventVehicleAutoReplaced(old_head->index, new_head->index));
+					ScriptTrigger::NewEvent<ScriptEventVehicleAutoReplaced>(old_head->owner, old_head->index, new_head->index);
 				}
 
 				/* Transfer cargo of old vehicles and sell them */
@@ -709,7 +709,7 @@ static CommandCost ReplaceChain(Vehicle **chain, DoCommandFlags flags, bool wago
 					TransferCargo(old_head, new_head, true);
 					*chain = new_head;
 
-					AI::NewEvent(old_head->owner, new ScriptEventVehicleAutoReplaced(old_head->index, new_head->index));
+					ScriptTrigger::NewEvent<ScriptEventVehicleAutoReplaced>(old_head->owner, old_head->index, new_head->index);
 				}
 
 				/* Sell the old vehicle */

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -19,9 +19,9 @@
 #include "network/network_func.h"
 #include "network/network_base.h"
 #include "network/network_admin.h"
-#include "ai/ai.hpp"
 #include "ai/ai_instance.hpp"
 #include "ai/ai_config.hpp"
+#include "script/script_trigger.hpp"
 #include "company_manager_face.h"
 #include "window_func.h"
 #include "strings_func.h"
@@ -32,7 +32,6 @@
 #include "vehicle_base.h"
 #include "vehicle_func.h"
 #include "smallmap_gui.h"
-#include "game/game.hpp"
 #include "goal_base.h"
 #include "story_base.h"
 #include "company_cmd.h"
@@ -415,8 +414,7 @@ set_name:;
 		c->name_2 = strp;
 
 		MarkWholeScreenDirty();
-		AI::BroadcastNewEvent(new ScriptEventCompanyRenamed(c->index, name));
-		Game::NewEvent(new ScriptEventCompanyRenamed(c->index, name));
+		ScriptTrigger::BroadcastNewEvent<ScriptEventCompanyRenamed>(c->index, name);
 
 		if (c->is_ai) {
 			auto cni = std::make_unique<CompanyNewsInformation>(STR_NEWS_COMPANY_LAUNCH_TITLE, c);
@@ -621,8 +619,7 @@ Company *DoStartupNewCompany(bool is_ai, CompanyID company = CompanyID::Invalid(
 
 	if (is_ai && (!_networking || _network_server)) AI::StartNew(c->index);
 
-	AI::BroadcastNewEvent(new ScriptEventCompanyNew(c->index), c->index);
-	Game::NewEvent(new ScriptEventCompanyNew(c->index));
+	ScriptTrigger::BroadcastNewEventExceptForCompany<ScriptEventCompanyNew>(c->index, c->index);
 
 	return c;
 }
@@ -947,8 +944,7 @@ CommandCost CmdCompanyCtrl(DoCommandFlags flags, CompanyCtrlAction cca, CompanyI
 
 			CompanyID c_index = c->index;
 			delete c;
-			AI::BroadcastNewEvent(new ScriptEventCompanyBankrupt(c_index));
-			Game::NewEvent(new ScriptEventCompanyBankrupt(c_index));
+			ScriptTrigger::BroadcastNewEvent<ScriptEventCompanyBankrupt>(c_index);
 			CompanyAdminRemove(c_index, (CompanyRemoveReason)reason);
 
 			if (StoryPage::GetNumItems() == 0 || Goal::GetNumItems() == 0) InvalidateWindowData(WC_MAIN_TOOLBAR, 0);
@@ -1173,8 +1169,7 @@ CommandCost CmdRenameCompany(DoCommandFlags flags, const std::string &text)
 		CompanyAdminUpdate(c);
 
 		std::string new_name = GetString(STR_COMPANY_NAME, c->index);
-		AI::BroadcastNewEvent(new ScriptEventCompanyRenamed(c->index, new_name));
-		Game::NewEvent(new ScriptEventCompanyRenamed(c->index, new_name));
+		ScriptTrigger::BroadcastNewEvent<ScriptEventCompanyRenamed>(c->index, new_name);
 	}
 
 	return CommandCost();
@@ -1227,8 +1222,7 @@ CommandCost CmdRenamePresident(DoCommandFlags flags, const std::string &text)
 		CompanyAdminUpdate(c);
 
 		std::string new_name = GetString(STR_PRESIDENT_NAME, c->index);
-		AI::BroadcastNewEvent(new ScriptEventPresidentRenamed(c->index, new_name));
-		Game::NewEvent(new ScriptEventPresidentRenamed(c->index, new_name));
+		ScriptTrigger::BroadcastNewEvent<ScriptEventPresidentRenamed>(c->index, new_name);
 	}
 
 	return CommandCost();

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -730,7 +730,7 @@ static void HandleBankruptcyTakeover(Company *c)
 
 	c->bankrupt_timeout = TAKE_OVER_TIMEOUT;
 
-	AI::NewEvent(best->index, new ScriptEventCompanyAskMerger(c->index, c->bankrupt_value));
+	ScriptTrigger::NewEvent<ScriptEventCompanyAskMerger>(best->index, best->index, c->index, c->bankrupt_value);
 	if (IsInteractiveCompany(best->index)) {
 		ShowBuyCompanyDialog(c->index, false);
 	}

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -245,7 +245,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 				v->age = CalendarTime::MIN_DATE;
 
 				AddTileNewsItem(GetEncodedString(STR_NEWS_DISASTER_ZEPPELIN, GetStationIndex(v->tile)), NewsType::Accident, v->tile);
-				AI::NewEvent(GetTileOwner(v->tile), new ScriptEventDisasterZeppelinerCrashed(GetStationIndex(v->tile)));
+				ScriptTrigger::NewEvent<ScriptEventDisasterZeppelinerCrashed>(GetTileOwner(v->tile), GetStationIndex(v->tile));
 			}
 		}
 
@@ -263,7 +263,7 @@ static bool DisasterTick_Zeppeliner(DisasterVehicle *v)
 		if (IsValidTile(v->tile) && IsAirportTile(v->tile)) {
 			Station *st = Station::GetByTile(v->tile);
 			st->airport.blocks.Reset(AirportBlock::RunwayIn);
-			AI::NewEvent(GetTileOwner(v->tile), new ScriptEventDisasterZeppelinerCleared(st->index));
+			ScriptTrigger::NewEvent<ScriptEventDisasterZeppelinerCleared>(GetTileOwner(v->tile), st->index);
 		}
 
 		v->UpdatePosition(v->x_pos, v->y_pos, GetAircraftFlightLevel(v));

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -40,8 +40,7 @@
 #include "effectvehicle_func.h"
 #include "roadveh.h"
 #include "train.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "company_base.h"
 #include "core/random_func.hpp"
 #include "core/backup_type.hpp"
@@ -388,8 +387,7 @@ static bool DisasterTick_Ufo(DisasterVehicle *v)
 
 				AddTileNewsItem(GetEncodedString(STR_NEWS_DISASTER_SMALL_UFO), NewsType::Accident, u->tile);
 
-				AI::NewEvent(u->owner, new ScriptEventVehicleCrashed(u->index, u->tile, ScriptEventVehicleCrashed::CRASH_RV_UFO, victims, u->owner));
-				Game::NewEvent(new ScriptEventVehicleCrashed(u->index, u->tile, ScriptEventVehicleCrashed::CRASH_RV_UFO, victims, u->owner));
+				ScriptTrigger::NewEvent<ScriptEventVehicleCrashed>(u->owner, u->index, u->tile, ScriptEventVehicleCrashed::CRASH_RV_UFO, victims, u->owner);
 			}
 		}
 

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -16,7 +16,7 @@
 #include "news_func.h"
 #include "network/network.h"
 #include "network/network_func.h"
-#include "ai/ai.hpp"
+#include "script/script_trigger.hpp"
 #include "aircraft.h"
 #include "train.h"
 #include "newgrf_engine.h"
@@ -45,7 +45,6 @@
 #include "core/container_func.hpp"
 #include "cargo_type.h"
 #include "water.h"
-#include "game/game.hpp"
 #include "cargomonitor.h"
 #include "goal_base.h"
 #include "story_base.h"
@@ -585,8 +584,7 @@ static void CompanyCheckBankrupt(Company *c)
 			auto cni = std::make_unique<CompanyNewsInformation>(STR_NEWS_COMPANY_IN_TROUBLE_TITLE, c);
 			EncodedString headline = GetEncodedString(STR_NEWS_COMPANY_IN_TROUBLE_DESCRIPTION, cni->company_name);
 			AddCompanyNewsItem(std::move(headline), std::move(cni));
-			AI::BroadcastNewEvent(new ScriptEventCompanyInTrouble(c->index));
-			Game::NewEvent(new ScriptEventCompanyInTrouble(c->index));
+			ScriptTrigger::BroadcastNewEvent<ScriptEventCompanyInTrouble>(c->index);
 			break;
 		}
 
@@ -1998,8 +1996,7 @@ static void DoAcquireCompany(Company *c, bool hostile_takeover)
 		? GetEncodedString(STR_NEWS_MERGER_TAKEOVER_TITLE, cni->company_name, cni->other_company_name)
 		: GetEncodedString(STR_NEWS_COMPANY_MERGER_DESCRIPTION, cni->company_name, cni->other_company_name, c->bankrupt_value);
 	AddCompanyNewsItem(std::move(headline), std::move(cni));
-	AI::BroadcastNewEvent(new ScriptEventCompanyMerger(ci, _current_company));
-	Game::NewEvent(new ScriptEventCompanyMerger(ci, _current_company));
+	ScriptTrigger::BroadcastNewEvent<ScriptEventCompanyMerger>(ci, _current_company);
 
 	ChangeOwnershipOfCompanyItems(ci, _current_company);
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -21,6 +21,7 @@
 #include "autoreplace_gui.h"
 #include "string_func.h"
 #include "ai/ai.hpp"
+#include "game/game.hpp"
 #include "core/pool_func.hpp"
 #include "engine_gui.h"
 #include "engine_func.h"
@@ -1126,6 +1127,9 @@ static void NewVehicleAvailable(Engine *e)
 
 	/* Only broadcast event if AIs are able to build this vehicle type. */
 	if (!IsVehicleTypeDisabled(e->type, true)) AI::BroadcastNewEvent(new ScriptEventEngineAvailable(index));
+
+	/* Only send the event to Game Script if engine can be built. */
+	if (!IsVehicleTypeDisabled(e->type, false)) Game::NewEvent(new ScriptEventEngineAvailable(index));
 
 	/* Only provide the "New Vehicle available" news paper entry, if engine can be built. */
 	if (!IsVehicleTypeDisabled(e->type, false) && !e->info.extra_flags.Test(ExtraEngineFlag::NoNews)) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -20,8 +20,7 @@
 #include "window_func.h"
 #include "autoreplace_gui.h"
 #include "string_func.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "core/pool_func.hpp"
 #include "engine_gui.h"
 #include "engine_func.h"
@@ -992,7 +991,7 @@ static IntervalTimer<TimerGameCalendar> _calendar_engines_daily({TimerGameCalend
 				 * boost that they wouldn't have gotten against other human companies. The check on
 				 * the line below is just to make AIs not notice that they have a preview if they
 				 * cannot build the vehicle. */
-				if (!IsVehicleTypeDisabled(e->type, true)) AI::NewEvent(e->preview_company, new ScriptEventEnginePreview(i));
+				if (!IsVehicleTypeDisabled(e->type, true)) ScriptTrigger::NewEvent<ScriptEventEnginePreview>(e->preview_company, e->preview_company, i);
 				if (IsInteractiveCompany(e->preview_company)) ShowEnginePreviewWindow(i);
 			}
 		}

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -32,12 +32,11 @@
 #include "animated_tile_func.h"
 #include "effectvehicle_func.h"
 #include "effectvehicle_base.h"
-#include "ai/ai.hpp"
+#include "script/script_trigger.hpp"
 #include "core/pool_func.hpp"
 #include "subsidy_func.h"
 #include "core/backup_type.hpp"
 #include "object_base.h"
-#include "game/game.hpp"
 #include "error.h"
 #include "string_func.h"
 #include "industry_cmd.h"
@@ -514,8 +513,7 @@ static CommandCost ClearTile_Industry(TileIndex tile, DoCommandFlags flags)
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		AI::BroadcastNewEvent(new ScriptEventIndustryClose(i->index));
-		Game::NewEvent(new ScriptEventIndustryClose(i->index));
+		ScriptTrigger::BroadcastNewEvent<ScriptEventIndustryClose>(i->index);
 		delete i;
 	}
 	return CommandCost(EXPENSES_CONSTRUCTION, indspec->GetRemovalCost());
@@ -1727,8 +1725,7 @@ static void AdvertiseIndustryOpening(const Industry *ind)
 		headline = GetEncodedString(ind_spc->new_industry_text, ind_spc->name, ind->town->index);
 	}
 	AddIndustryNewsItem(std::move(headline), NewsType::IndustryOpen, ind->index);
-	AI::BroadcastNewEvent(new ScriptEventIndustryOpen(ind->index));
-	Game::NewEvent(new ScriptEventIndustryOpen(ind->index));
+	ScriptTrigger::BroadcastNewEvent<ScriptEventIndustryOpen>(ind->index);
 }
 
 /**
@@ -2971,8 +2968,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 		/* Compute news category */
 		if (closeit) {
 			nt = NewsType::IndustryClose;
-			AI::BroadcastNewEvent(new ScriptEventIndustryClose(i->index));
-			Game::NewEvent(new ScriptEventIndustryClose(i->index));
+			ScriptTrigger::BroadcastNewEvent<ScriptEventIndustryClose>(i->index);
 		} else {
 			switch (WhoCanServiceIndustry(i)) {
 				case 0: nt = NewsType::IndustryNobody;  break;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -23,8 +23,7 @@
 #include "timer/timer_game_economy.h"
 #include "vehicle_func.h"
 #include "sound_func.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "depot_map.h"
 #include "effectvehicle_func.h"
 #include "roadstop_base.h"
@@ -544,8 +543,7 @@ static void RoadVehCrash(RoadVehicle *v)
 {
 	uint victims = v->Crash();
 
-	AI::NewEvent(v->owner, new ScriptEventVehicleCrashed(v->index, v->tile, ScriptEventVehicleCrashed::CRASH_RV_LEVEL_CROSSING, victims, v->owner));
-	Game::NewEvent(new ScriptEventVehicleCrashed(v->index, v->tile, ScriptEventVehicleCrashed::CRASH_RV_LEVEL_CROSSING, victims, v->owner));
+	ScriptTrigger::NewEvent<ScriptEventVehicleCrashed>(v->owner, v->index, v->tile, ScriptEventVehicleCrashed::CRASH_RV_LEVEL_CROSSING, victims, v->owner);
 
 	EncodedString headline = (victims == 1)
 		? GetEncodedString(STR_NEWS_ROAD_VEHICLE_CRASH_DRIVER)
@@ -694,8 +692,7 @@ static void RoadVehArrivesAt(const RoadVehicle *v, Station *st)
 				v->index,
 				st->index
 			);
-			AI::NewEvent(v->owner, new ScriptEventStationFirstVehicle(st->index, v->index));
-			Game::NewEvent(new ScriptEventStationFirstVehicle(st->index, v->index));
+			ScriptTrigger::NewEvent<ScriptEventStationFirstVehicle>(v->owner, st->index, v->index);
 		}
 	} else {
 		/* Check if station was ever visited before */
@@ -707,8 +704,7 @@ static void RoadVehArrivesAt(const RoadVehicle *v, Station *st)
 				v->index,
 				st->index
 			);
-			AI::NewEvent(v->owner, new ScriptEventStationFirstVehicle(st->index, v->index));
-			Game::NewEvent(new ScriptEventStationFirstVehicle(st->index, v->index));
+			ScriptTrigger::NewEvent<ScriptEventStationFirstVehicle>(v->owner, st->index, v->index);
 		}
 	}
 }

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -20,6 +20,7 @@ add_files(
     script_scanner.hpp
     script_storage.hpp
     script_suspend.hpp
+    script_trigger.hpp
     squirrel.cpp
     squirrel.hpp
     squirrel_class.hpp

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -37,6 +37,7 @@
  * \li GSEventAircraftDestTooFar
  * \li GSEventVehicleAutoReplaced
  * \li GSEventCompanyAskMerger
+ * \li GSEventEnginePreview
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -28,6 +28,14 @@
  * \li GSCargo::CC_POTABLE
  * \li GSCargo::CC_NON_POTABLE
  * \li GSGroup::GetOwner
+ * \li GSEventVehicleLost
+ * \li GSEventVehicleWaitingInDepot
+ * \li GSEventVehicleUnprofitable
+ * \li GSEventEngineAvailable
+ * \li GSEventDisasterZeppelinerCrashed
+ * \li GSEventDisasterZeppelinerCleared
+ * \li GSEventAircraftDestTooFar
+ * \li GSEventVehicleAutoReplaced
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -36,6 +36,7 @@
  * \li GSEventDisasterZeppelinerCleared
  * \li GSEventAircraftDestTooFar
  * \li GSEventVehicleAutoReplaced
+ * \li GSEventCompanyAskMerger
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -27,6 +27,7 @@
  * \li GSCargo::CC_NON_POURABLE
  * \li GSCargo::CC_POTABLE
  * \li GSCargo::CC_NON_POTABLE
+ * \li GSGroup::GetOwner
  *
  * Other changes:
  * \li GSBridge::GetBridgeID renamed to GSBridge::GetBridgeType

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -106,6 +106,7 @@ int32_t ScriptEventEnginePreview::GetVehicleType()
 bool ScriptEventEnginePreview::AcceptPreview()
 {
 	EnforceCompanyModeValid(false);
+	EnforcePrecondition(false, ScriptObject::GetCompany() == ScriptCompany::FromScriptCompanyID(this->owner));
 	if (!this->IsEngineValid()) return false;
 	return ScriptObject::Command<CMD_WANT_ENGINE_PREVIEW>::Do(this->engine);
 }

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -113,6 +113,7 @@ bool ScriptEventEnginePreview::AcceptPreview()
 bool ScriptEventCompanyAskMerger::AcceptMerger()
 {
 	EnforceCompanyModeValid(false);
+	EnforcePrecondition(false, ScriptObject::GetCompany() == ScriptCompany::FromScriptCompanyID(this->buyer));
 	return ScriptObject::Command<CMD_BUY_COMPANY>::Do(ScriptCompany::FromScriptCompanyID(this->owner), false);
 }
 

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -439,17 +439,19 @@ private:
 
 /**
  * Event Company Ask Merger, indicating a company can be bought (cheaply) by you.
- * @api ai
+ * @api ai game
  */
 class ScriptEventCompanyAskMerger : public ScriptEvent {
 public:
 #ifndef DOXYGEN_API
 	/**
+	 * @param buyer The company that can buy.
 	 * @param owner The company that can be bought.
 	 * @param value The value/costs of buying the company.
 	 */
-	ScriptEventCompanyAskMerger(Owner owner, Money value) :
+	ScriptEventCompanyAskMerger(Owner buyer, Owner owner, Money value) :
 		ScriptEvent(ET_COMPANY_ASK_MERGER),
+		buyer(ScriptCompany::ToScriptCompanyID(buyer)),
 		owner(ScriptCompany::ToScriptCompanyID(owner)),
 		value(value)
 	{}
@@ -461,6 +463,14 @@ public:
 	 * @return The converted instance.
 	 */
 	static ScriptEventCompanyAskMerger *Convert(ScriptEvent *instance) { return (ScriptEventCompanyAskMerger *)instance; }
+
+	/**
+	 * Get the CompanyID of the company that can purchase the other.
+	 * @return The CompanyID of the company that can purchase.
+	 * @note If the company is bought this will become invalid.
+	 * @api -ai
+	 */
+	ScriptCompany::CompanyID GetBuyerID() { return this->buyer; }
 
 	/**
 	 * Get the CompanyID of the company that can be bought.
@@ -483,8 +493,9 @@ public:
 	bool AcceptMerger();
 
 private:
+	ScriptCompany::CompanyID buyer; ///< The company that is buying.
 	ScriptCompany::CompanyID owner; ///< The company that is in trouble.
-	Money value;                ///< The value of the company, i.e. the amount you would pay.
+	Money value;                ///< The value of the company in trouble, i.e. the amount the buyer would pay.
 };
 
 /**

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -568,7 +568,7 @@ private:
 
 /**
  * Event Vehicle Lost, indicating a vehicle can't find its way to its destination.
- * @api ai
+ * @api ai game
  */
 class ScriptEventVehicleLost : public ScriptEvent {
 public:
@@ -601,7 +601,7 @@ private:
 
 /**
  * Event VehicleWaitingInDepot, indicating a vehicle has arrived a depot and is now waiting there.
- * @api ai
+ * @api ai game
  */
 class ScriptEventVehicleWaitingInDepot : public ScriptEvent {
 public:
@@ -634,7 +634,7 @@ private:
 
 /**
  * Event Vehicle Unprofitable, indicating a vehicle lost money last year.
- * @api ai
+ * @api ai game
  */
 class ScriptEventVehicleUnprofitable : public ScriptEvent {
 public:
@@ -733,7 +733,7 @@ private:
 
 /**
  * Event Engine Available, indicating a new engine is available.
- * @api ai
+ * @api ai game
  */
 class ScriptEventEngineAvailable : public ScriptEvent {
 public:
@@ -808,7 +808,7 @@ private:
 
 /**
  * Event Disaster Zeppeliner Crashed, indicating a zeppeliner has crashed on an airport and is blocking the runway.
- * @api ai
+ * @api ai game
  */
 class ScriptEventDisasterZeppelinerCrashed : public ScriptEvent {
 public:
@@ -841,7 +841,7 @@ private:
 
 /**
  * Event Disaster Zeppeliner Cleared, indicating a previously crashed zeppeliner has been removed, and the airport is operating again.
- * @api ai
+ * @api ai game
  */
 class ScriptEventDisasterZeppelinerCleared : public ScriptEvent {
 public:
@@ -909,7 +909,7 @@ private:
  * Event AircraftDestTooFar, indicating the next destination of an aircraft is too far away.
  * This event can be triggered when the current order of an aircraft changes, usually either when
  * loading is done or when switched manually.
- * @api ai
+ * @api ai game
  */
 class ScriptEventAircraftDestTooFar : public ScriptEvent {
 public:
@@ -1177,7 +1177,7 @@ public:
 
 /**
  * Event VehicleAutoReplaced, indicating a vehicle has been auto replaced.
- * @api ai
+ * @api ai game
  */
 class ScriptEventVehicleAutoReplaced : public ScriptEvent {
 public:

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -238,16 +238,18 @@ private:
  * Event Engine Preview, indicating a manufacturer offer you to test a new engine.
  *  You can get the same information about the offered engine as a real user
  *  would see in the offer window. And you can also accept the offer.
- * @api ai
+ * @api ai game
  */
 class ScriptEventEnginePreview : public ScriptEvent {
 public:
 #ifndef DOXYGEN_API
 	/**
+	 * @param owner The company being offered the test engine.
 	 * @param engine The engine offered to test.
 	 */
-	ScriptEventEnginePreview(EngineID engine) :
+	ScriptEventEnginePreview(Owner owner, EngineID engine) :
 		ScriptEvent(ET_ENGINE_PREVIEW),
+		owner(ScriptCompany::ToScriptCompanyID(owner)),
 		engine(engine)
 	{}
 #endif /* DOXYGEN_API */
@@ -258,6 +260,13 @@ public:
 	 * @return The converted instance.
 	 */
 	static ScriptEventEnginePreview *Convert(ScriptEvent *instance) { return (ScriptEventEnginePreview *)instance; }
+
+	/**
+	 * Get the company being offered the test engine.
+	 * @return The company being offered to test the engine.
+	 * @api -ai
+	 */
+	ScriptCompany::CompanyID GetCompanyID() { return this->owner; }
 
 	/**
 	 * Get the name of the offered engine.
@@ -319,6 +328,7 @@ public:
 	bool AcceptPreview();
 
 private:
+	ScriptCompany::CompanyID owner; ///< The company the engine preview is for.
 	EngineID engine; ///< The engine the preview is for.
 
 	/**

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -31,6 +31,13 @@
 	return g != nullptr && g->owner == ScriptObject::GetCompany();
 }
 
+/* static */ ScriptCompany::CompanyID ScriptGroup::GetOwner(GroupID group_id)
+{
+	if (!IsValidGroup(group_id)) return ScriptCompany::COMPANY_INVALID;
+
+	return ScriptCompany::ToScriptCompanyID(::Group::Get(group_id)->owner);
+}
+
 /* static */ GroupID ScriptGroup::CreateGroup(ScriptVehicle::VehicleType vehicle_type, GroupID parent_group_id)
 {
 	EnforceCompanyModeValid(GROUP_INVALID);

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -28,7 +28,7 @@
 {
 	EnforceDeityOrCompanyModeValid(false);
 	const Group *g = ::Group::GetIfValid(group_id);
-	return g != nullptr && g->owner == ScriptObject::GetCompany();
+	return g != nullptr && (g->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity());
 }
 
 /* static */ ScriptCompany::CompanyID ScriptGroup::GetOwner(GroupID group_id)
@@ -117,23 +117,29 @@
 
 /* static */ SQInteger ScriptGroup::GetNumEngines(GroupID group_id, EngineID engine_id)
 {
-	EnforceCompanyModeValid(-1);
+	if (group_id == GROUP_DEFAULT || group_id == GROUP_ALL) EnforceCompanyModeValid(-1);
+	EnforceDeityOrCompanyModeValid(-1);
 	if (!ScriptEngine::IsValidEngine(engine_id)) return -1;
 	bool valid_group = IsValidGroup(group_id);
 	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
 	if (valid_group && ScriptEngine::GetVehicleType(engine_id) != GetVehicleType(group_id)) return -1;
 
-	return GetGroupNumEngines(ScriptObject::GetCompany(), group_id, engine_id);
+	::CompanyID company = (valid_group && ScriptCompanyMode::IsDeity()) ? ::Group::Get(group_id)->owner : ScriptObject::GetCompany();
+
+	return GetGroupNumEngines(company, group_id, engine_id);
 }
 
 /* static */ SQInteger ScriptGroup::GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type)
 {
-	EnforceCompanyModeValid(-1);
+	if (group_id == GROUP_DEFAULT || group_id == GROUP_ALL) EnforceCompanyModeValid(-1);
+	EnforceDeityOrCompanyModeValid(-1);
 	bool valid_group = IsValidGroup(group_id);
 	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
 	if (!valid_group && (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR)) return -1;
 
-	return GetGroupNumVehicle(ScriptObject::GetCompany(), group_id, valid_group ? ::Group::Get(group_id)->vehicle_type : (::VehicleType)vehicle_type);
+	::CompanyID company = (valid_group && ScriptCompanyMode::IsDeity()) ? ::Group::Get(group_id)->owner : ScriptObject::GetCompany();
+
+	return GetGroupNumVehicle(company, group_id, valid_group ? ::Group::Get(group_id)->vehicle_type : (::VehicleType)vehicle_type);
 }
 
 /* static */ bool ScriptGroup::MoveVehicle(GroupID group_id, VehicleID vehicle_id)
@@ -170,10 +176,14 @@
 
 /* static */ EngineID ScriptGroup::GetEngineReplacement(GroupID group_id, EngineID engine_id)
 {
-	EnforceCompanyModeValid(::EngineID::Invalid());
-	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return ::EngineID::Invalid();
+	if (group_id == GROUP_DEFAULT || group_id == GROUP_ALL) EnforceCompanyModeValid(::EngineID::Invalid());
+	EnforceDeityOrCompanyModeValid(::EngineID::Invalid());
+	bool valid_group = IsValidGroup(group_id);
+	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return ::EngineID::Invalid();
 
-	return ::EngineReplacementForCompany(Company::Get(ScriptObject::GetCompany()), engine_id, group_id);
+	::CompanyID company = (valid_group && ScriptCompanyMode::IsDeity()) ? ::Group::Get(group_id)->owner : ScriptObject::GetCompany();
+
+	return ::EngineReplacementForCompany(Company::Get(company), engine_id, group_id);
 }
 
 /* static */ bool ScriptGroup::StopAutoReplace(GroupID group_id, EngineID engine_id)

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -32,6 +32,15 @@ public:
 	static bool IsValidGroup(GroupID group_id);
 
 	/**
+	 * Get the owner of a group.
+	 * @param group_id The group to get the owner of.
+	 * @pre IsValidGroup(group_id).
+	 * @return The owner the group has.
+	 * @api -ai
+	 */
+	static ScriptCompany::CompanyID GetOwner(GroupID group_id);
+
+	/**
 	 * Create a new group.
 	 * @param vehicle_type The type of vehicle to create a group for.
 	 * @param parent_group_id The parent group id to create this group under, INVALID_GROUP for top-level.

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -134,7 +134,7 @@ public:
 	 * @pre ScriptEngine::IsValidEngine(engine_id).
 	 * @pre (IsValidGroup(group_id) && ScriptEngine::GetVehicleType(engine_id) == GetVehicleType(group_id)) ||
 	     group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
-	 * @game @pre ScriptCompanyMode::IsValid().
+	 * @game @pre ScriptCompanyMode::IsValid() when group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @return The number of engines with id engine_id in the group with id group_id.
 	 */
 	static SQInteger GetNumEngines(GroupID group_id, EngineID engine_id);
@@ -146,7 +146,7 @@ public:
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @pre IsValidGroup(group_id) || vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL ||
 	 *   vehicle_type == ScriptVehicle::VT_WATER || vehicle_type == ScriptVehicle::VT_AIR
-	 * @game @pre ScriptCompanyMode::IsValid().
+	 * @game @pre ScriptCompanyMode::IsValid() when group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @return The total number of vehicles in the group with id group_id and it's sub-groups.
 	 * @note If the group is valid (neither GROUP_ALL nor GROUP_DEFAULT), the value of
 	 *  vehicle_type is retrieved from the group itself and not from the input value.
@@ -194,7 +194,7 @@ public:
 	 * @param engine_id_new The engine id to replace with.
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL.
 	 * @pre ScriptEngine.IsBuildable(engine_id_new).
-	 * @game @pre ScriptCompanyMode::IsValid().
+	 * @game @pre ScriptCompanyMode::IsValid() when group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @return True if and if the replacing was successfully started.
 	 * @note To stop autoreplacing engine_id_old, call StopAutoReplace(group_id, engine_id_old).
 	 */

--- a/src/script/api/script_grouplist.cpp
+++ b/src/script/api/script_grouplist.cpp
@@ -16,9 +16,12 @@
 
 ScriptGroupList::ScriptGroupList(HSQUIRRELVM vm)
 {
-	EnforceCompanyModeValid_Void();
+	EnforceDeityOrCompanyModeValid_Void();
+
+	bool is_deity = ScriptCompanyMode::IsDeity();
 	::CompanyID owner = ScriptObject::GetCompany();
+
 	ScriptList::FillList<Group>(vm, this,
-		[owner](const Group *g) { return g->owner == owner; }
+		[owner, is_deity](const Group *g) { return g->owner == owner || is_deity; }
 	);
 }

--- a/src/script/api/script_grouplist.hpp
+++ b/src/script/api/script_grouplist.hpp
@@ -21,9 +21,6 @@
 class ScriptGroupList : public ScriptList {
 public:
 #ifdef DOXYGEN_API
-	/**
-	 * @game @pre ScriptCompanyMode::IsValid().
-	 */
 	ScriptGroupList();
 
 	/**

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -106,26 +106,28 @@ ScriptVehicleList_SharedOrders::ScriptVehicleList_SharedOrders(VehicleID vehicle
 
 ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 {
-	EnforceCompanyModeValid_Void();
+	EnforceDeityOrCompanyModeValid_Void();
 	if (!ScriptGroup::IsValidGroup(group_id)) return;
 
+	bool is_deity = ScriptCompanyMode::IsDeity();
 	::CompanyID owner = ScriptObject::GetCompany();
 
 	ScriptList::FillList<Vehicle>(this,
-		[owner](const Vehicle *v) { return v->owner == owner && v->IsPrimaryVehicle(); },
+		[owner, is_deity](const Vehicle *v) { return (v->owner == owner || is_deity) && v->IsPrimaryVehicle(); },
 		[group_id](const Vehicle *v) { return v->group_id == group_id; }
 	);
 }
 
 ScriptVehicleList_DefaultGroup::ScriptVehicleList_DefaultGroup(ScriptVehicle::VehicleType vehicle_type)
 {
-	EnforceCompanyModeValid_Void();
+	EnforceDeityOrCompanyModeValid_Void();
 	if (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR) return;
 
+	bool is_deity = ScriptCompanyMode::IsDeity();
 	::CompanyID owner = ScriptObject::GetCompany();
 
 	ScriptList::FillList<Vehicle>(this,
-		[owner](const Vehicle *v) { return v->owner == owner && v->IsPrimaryVehicle(); },
+		[owner, is_deity](const Vehicle *v) { return (v->owner == owner || is_deity) && v->IsPrimaryVehicle(); },
 		[vehicle_type](const Vehicle *v) { return v->type == (::VehicleType)vehicle_type && v->group_id == ScriptGroup::GROUP_DEFAULT; }
 	);
 }

--- a/src/script/api/script_vehiclelist.hpp
+++ b/src/script/api/script_vehiclelist.hpp
@@ -104,7 +104,6 @@ class ScriptVehicleList_Group : public ScriptList {
 public:
 	/**
 	 * @param group_id The ID of the group the vehicles are in.
-	 * @game @pre ScriptCompanyMode::IsValid().
 	 */
 	ScriptVehicleList_Group(GroupID group_id);
 };
@@ -118,7 +117,6 @@ class ScriptVehicleList_DefaultGroup : public ScriptList {
 public:
 	/**
 	 * @param vehicle_type The VehicleType to get the list of vehicles for.
-	 * @game @pre ScriptCompanyMode::IsValid().
 	 */
 	ScriptVehicleList_DefaultGroup(ScriptVehicle::VehicleType vehicle_type);
 };

--- a/src/script/script_trigger.hpp
+++ b/src/script/script_trigger.hpp
@@ -1,0 +1,51 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /** @file script_trigger.hpp Functionality to trigger events in AI and game scripts. */
+
+#ifndef SCRIPT_TRIGGER_HPP
+#define SCRIPT_TRIGGER_HPP
+
+#include "../ai/ai.hpp"
+#include "../game/game.hpp"
+
+/**
+ * Main Script class. Contains functions needed to handle Script Events.
+ */
+class ScriptTrigger {
+public:
+	/**
+	 * Queue two new events, one for an AI, the other for the Game Script.
+	 * @param company The company receiving the event.
+	 */
+	template <class ScriptEventType, typename ... Args>
+	static void NewEvent(CompanyID company, Args ... args) {
+		AI::NewEvent(company, new ScriptEventType(args...));
+		Game::NewEvent(new ScriptEventType(args...));
+	}
+
+	/**
+	 * Broadcast a new event to all active AIs, and to the Game Script.
+	 */
+	template <class ScriptEventType, typename ... Args>
+	static void BroadcastNewEvent(Args ... args) {
+		AI::BroadcastNewEvent(new ScriptEventType(args...));
+		Game::NewEvent(new ScriptEventType(args...));
+	}
+
+	/**
+	 * Broadcast a new event to all active AIs, and to the Game Script, except to one AI.
+	 * @param skip_company The company to skip broadcasting for.
+	 */
+	template <class ScriptEventType, typename ... Args>
+	static void BroadcastNewEventExceptForCompany(CompanyID skip_company, Args ... args) {
+		AI::BroadcastNewEvent(new ScriptEventType(args...), skip_company);
+		Game::NewEvent(new ScriptEventType(args...));
+	}
+};
+
+#endif /* SCRIPT_TRIGGER_HPP */

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -26,8 +26,7 @@
 #include "timer/timer_game_economy.h"
 #include "vehicle_func.h"
 #include "sound_func.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "engine_base.h"
 #include "company_base.h"
 #include "tunnelbridge_map.h"
@@ -477,8 +476,7 @@ static void ShipArrivesAt(const Vehicle *v, Station *st)
 			v->index,
 			st->index
 		);
-		AI::NewEvent(v->owner, new ScriptEventStationFirstVehicle(st->index, v->index));
-		Game::NewEvent(new ScriptEventStationFirstVehicle(st->index, v->index));
+		ScriptTrigger::NewEvent<ScriptEventStationFirstVehicle>(v->owner, st->index, v->index);
 	}
 }
 

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -12,7 +12,7 @@
 #include "industry.h"
 #include "town.h"
 #include "news_func.h"
-#include "ai/ai.hpp"
+#include "script/script_trigger.hpp"
 #include "station_base.h"
 #include "strings_func.h"
 #include "window_func.h"
@@ -21,7 +21,6 @@
 #include "core/pool_func.hpp"
 #include "core/random_func.hpp"
 #include "core/container_func.hpp"
-#include "game/game.hpp"
 #include "command_func.h"
 #include "string_func.h"
 #include "tile_cmd.h"
@@ -79,8 +78,7 @@ void Subsidy::AwardTo(CompanyID company)
 	const CargoSpec *cs = CargoSpec::Get(this->cargo_type);
 	EncodedString headline = GetEncodedString(STR_NEWS_SERVICE_SUBSIDY_AWARDED_HALF + _settings_game.difficulty.subsidy_multiplier, std::move(company_name), cs->name, this->src.GetFormat(), this->src.id, this->dst.GetFormat(), this->dst.id, _settings_game.difficulty.subsidy_duration);
 	AddNewsItem(std::move(headline), NewsType::Subsidies, NewsStyle::Normal, {}, this->src.GetNewsReference(), this->dst.GetNewsReference());
-	AI::BroadcastNewEvent(new ScriptEventSubsidyAwarded(this->index));
-	Game::NewEvent(new ScriptEventSubsidyAwarded(this->index));
+	ScriptTrigger::BroadcastNewEvent<ScriptEventSubsidyAwarded>(this->index);
 
 	InvalidateWindowData(WC_SUBSIDIES_LIST, 0);
 }
@@ -179,8 +177,7 @@ void CreateSubsidy(CargoType cargo_type, Source src, Source dst)
 	AddNewsItem(std::move(headline), NewsType::Subsidies, NewsStyle::Normal, {}, s->src.GetNewsReference(), s->dst.GetNewsReference());
 	SetPartOfSubsidyFlag(s->src, PartOfSubsidy::Source);
 	SetPartOfSubsidyFlag(s->dst, PartOfSubsidy::Destination);
-	AI::BroadcastNewEvent(new ScriptEventSubsidyOffer(s->index));
-	Game::NewEvent(new ScriptEventSubsidyOffer(s->index));
+	ScriptTrigger::BroadcastNewEvent<ScriptEventSubsidyOffer>(s->index);
 
 	InvalidateWindowData(WC_SUBSIDIES_LIST, 0);
 }
@@ -432,16 +429,14 @@ static IntervalTimer<TimerGameEconomy> _economy_subsidies_monthly({TimerGameEcon
 				const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
 				EncodedString headline = GetEncodedString(STR_NEWS_OFFER_OF_SUBSIDY_EXPIRED, cs->name, s->src.GetFormat(), s->src.id, s->dst.GetFormat(), s->dst.id);
 				AddNewsItem(std::move(headline), NewsType::Subsidies, NewsStyle::Normal, {}, s->src.GetNewsReference(), s->dst.GetNewsReference());
-				AI::BroadcastNewEvent(new ScriptEventSubsidyOfferExpired(s->index));
-				Game::NewEvent(new ScriptEventSubsidyOfferExpired(s->index));
+				ScriptTrigger::BroadcastNewEvent<ScriptEventSubsidyOfferExpired>(s->index);
 			} else {
 				if (s->awarded == _local_company) {
 					const CargoSpec *cs = CargoSpec::Get(s->cargo_type);
 					EncodedString headline = GetEncodedString(STR_NEWS_SUBSIDY_WITHDRAWN_SERVICE, cs->name, s->src.GetFormat(), s->src.id, s->dst.GetFormat(), s->dst.id);
 					AddNewsItem(std::move(headline), NewsType::Subsidies, NewsStyle::Normal, {}, s->src.GetNewsReference(), s->dst.GetNewsReference());
 				}
-				AI::BroadcastNewEvent(new ScriptEventSubsidyExpired(s->index));
-				Game::NewEvent(new ScriptEventSubsidyExpired(s->index));
+				ScriptTrigger::BroadcastNewEvent<ScriptEventSubsidyExpired>(s->index);
 			}
 			delete s;
 			modified = true;

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -46,8 +46,7 @@
 #include "depot_base.h"
 #include "object_map.h"
 #include "object_base.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "town_cmd.h"
 #include "landscape_cmd.h"
 #include "road_cmd.h"
@@ -2237,8 +2236,7 @@ std::tuple<CommandCost, Money, TownID> CmdFoundTown(DoCommandFlags flags, TileIn
 				std::string company_name = GetString(STR_COMPANY_NAME, _current_company);
 				AddTileNewsItem(GetEncodedString(STR_NEWS_NEW_TOWN, company_name, t->index), NewsType::IndustryOpen, tile);
 			}
-			AI::BroadcastNewEvent(new ScriptEventTownFounded(t->index));
-			Game::NewEvent(new ScriptEventTownFounded(t->index));
+			ScriptTrigger::BroadcastNewEvent<ScriptEventTownFounded>(t->index);
 		}
 	}
 	return { cost, 0, new_town };
@@ -3409,8 +3407,7 @@ static CommandCost TownActionRoadRebuild(Town *t, DoCommandFlags flags)
 		AddNewsItem(
 			GetEncodedString(TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_ROAD_REBUILDING_MINUTES : STR_NEWS_ROAD_REBUILDING_MONTHS, t->index, company_name),
 			NewsType::General, NewsStyle::Normal, {}, t->index);
-		AI::BroadcastNewEvent(new ScriptEventRoadReconstruction(_current_company, t->index));
-		Game::NewEvent(new ScriptEventRoadReconstruction(_current_company, t->index));
+		ScriptTrigger::BroadcastNewEvent<ScriptEventRoadReconstruction>(_current_company, t->index);
 	}
 	return CommandCost();
 }
@@ -3562,8 +3559,7 @@ static CommandCost TownActionBuyRights(Town *t, DoCommandFlags flags)
 		EncodedString message = GetEncodedString(TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_EXCLUSIVE_RIGHTS_DESCRIPTION_MINUTES : STR_NEWS_EXCLUSIVE_RIGHTS_DESCRIPTION_MONTHS, t->index, cni->company_name);
 		AddNewsItem(std::move(message),
 			NewsType::General, NewsStyle::Company, {}, t->index, {}, std::move(cni));
-		AI::BroadcastNewEvent(new ScriptEventExclusiveTransportRights(_current_company, t->index));
-		Game::NewEvent(new ScriptEventExclusiveTransportRights(_current_company, t->index));
+		ScriptTrigger::BroadcastNewEvent<ScriptEventExclusiveTransportRights>(_current_company, t->index);
 	}
 	return CommandCost();
 }

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -21,8 +21,7 @@
 #include "viewport_func.h"
 #include "vehicle_func.h"
 #include "sound_func.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "newgrf_station.h"
 #include "effectvehicle_func.h"
 #include "network/network.h"
@@ -3014,8 +3013,7 @@ static void TrainEnterStation(Train *v, StationID station)
 			v->index,
 			st->index
 		);
-		AI::NewEvent(v->owner, new ScriptEventStationFirstVehicle(st->index, v->index));
-		Game::NewEvent(new ScriptEventStationFirstVehicle(st->index, v->index));
+		ScriptTrigger::NewEvent<ScriptEventStationFirstVehicle>(v->owner, st->index, v->index);
 	}
 
 	v->force_proceed = TFP_NONE;
@@ -3152,8 +3150,7 @@ static uint TrainCrashed(Train *v)
 	/* do not crash train twice */
 	if (!v->vehstatus.Test(VehState::Crashed)) {
 		victims = v->Crash();
-		AI::NewEvent(v->owner, new ScriptEventVehicleCrashed(v->index, v->tile, ScriptEventVehicleCrashed::CRASH_TRAIN, victims, v->owner));
-		Game::NewEvent(new ScriptEventVehicleCrashed(v->index, v->tile, ScriptEventVehicleCrashed::CRASH_TRAIN, victims, v->owner));
+		ScriptTrigger::NewEvent<ScriptEventVehicleCrashed>(v->owner, v->index, v->tile, ScriptEventVehicleCrashed::CRASH_TRAIN, victims, v->owner);
 	}
 
 	/* Try to re-reserve track under already crashed train too.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -29,7 +29,7 @@
 #include "autoreplace_func.h"
 #include "autoreplace_gui.h"
 #include "station_base.h"
-#include "ai/ai.hpp"
+#include "script/script_trigger.hpp"
 #include "depot_func.h"
 #include "network/network.h"
 #include "core/pool_func.hpp"
@@ -812,7 +812,7 @@ void Vehicle::HandlePathfindingResult(bool path_found)
 	this->ResetDepotUnbunching();
 
 	/* Notify user about the event. */
-	AI::NewEvent(this->owner, new ScriptEventVehicleLost(this->index));
+	ScriptTrigger::NewEvent<ScriptEventVehicleLost>(this->owner, this->index);
 	if (_settings_client.gui.lost_vehicle_warn && this->owner == _local_company) {
 		AddVehicleAdviceNewsItem(AdviceType::VehicleLost, GetEncodedString(STR_NEWS_VEHICLE_IS_LOST, this->index), this->index);
 	}
@@ -1657,7 +1657,7 @@ void VehicleEnterDepot(Vehicle *v)
 			if (v->owner == _local_company) {
 				AddVehicleAdviceNewsItem(AdviceType::VehicleWaiting, GetEncodedString(STR_NEWS_TRAIN_IS_WAITING + v->type, v->index), v->index);
 			}
-			AI::NewEvent(v->owner, new ScriptEventVehicleWaitingInDepot(v->index));
+			ScriptTrigger::NewEvent<ScriptEventVehicleWaitingInDepot>(v->owner, v->index);
 		}
 
 		/* If we've entered our unbunching depot, record the round trip duration. */
@@ -3020,7 +3020,7 @@ static IntervalTimer<TimerGameEconomy> _economy_vehicles_yearly({TimerGameEconom
 						GetEncodedString(TimerGameEconomy::UsingWallclockUnits() ? STR_NEWS_VEHICLE_UNPROFITABLE_PERIOD : STR_NEWS_VEHICLE_UNPROFITABLE_YEAR, v->index, profit),
 						v->index);
 				}
-				AI::NewEvent(v->owner, new ScriptEventVehicleUnprofitable(v->index));
+				ScriptTrigger::NewEvent<ScriptEventVehicleUnprofitable>(v->owner, v->index);
 			}
 
 			v->profit_last_year = v->profit_this_year;

--- a/src/water_cmd.cpp
+++ b/src/water_cmd.cpp
@@ -28,8 +28,7 @@
 #include "effectvehicle_func.h"
 #include "tunnelbridge_map.h"
 #include "station_base.h"
-#include "ai/ai.hpp"
-#include "game/game.hpp"
+#include "script/script_trigger.hpp"
 #include "core/random_func.hpp"
 #include "core/backup_type.hpp"
 #include "timer/timer_game_calendar.h"
@@ -1005,8 +1004,7 @@ static void FloodVehicle(Vehicle *v)
 {
 	uint victims = v->Crash(true);
 
-	AI::NewEvent(v->owner, new ScriptEventVehicleCrashed(v->index, v->tile, ScriptEventVehicleCrashed::CRASH_FLOODED, victims, v->owner));
-	Game::NewEvent(new ScriptEventVehicleCrashed(v->index, v->tile, ScriptEventVehicleCrashed::CRASH_FLOODED, victims, v->owner));
+	ScriptTrigger::NewEvent<ScriptEventVehicleCrashed>(v->owner, v->index, v->tile, ScriptEventVehicleCrashed::CRASH_FLOODED, victims, v->owner);
 	AddTileNewsItem(GetEncodedString(STR_NEWS_DISASTER_FLOOD_VEHICLE, victims), NewsType::Accident, v->tile);
 	CreateEffectVehicleRel(v, 4, 4, 8, EV_EXPLOSION_LARGE);
 	if (_settings_client.sound.disaster) SndPlayVehicleFx(SND_12_EXPLOSION, v);


### PR DESCRIPTION
## Motivation / Problem
1. A few functions could work without needing the GS to be in CompanyMode. These have been changed to allow it:
- GSGroup::IsValidGroup
- GSGroup::GetNumEngines
- GSGroup::GetNumVehicles
- GSGroup::GetEngineReplacement
- GSGroupList
- GSVehicleList_Group
- GSVehicleList_DefaultGroup

2. One special method is added and only exposed for Game Scripts to complement for the changes above:
- GSGroup::GetOwner

3. Expose more events to Game Scripts. They and all other events have been templated as requested:
- GSEventEnginePreview
- GSEventCompanyAskMerger
- GSEventVehicleLost
- GSEventVehicleWaitingInDepot
- GSEventVehicleUnprofitable
- GSEventEngineAvailable
- GSEventDisasterZeppelinerCrashed
- GSEventDisasterZeppelinerCleared
- GSEventAircraftDestTooFar
- GSEventVehicleAutoReplaced
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- `ScriptGroup::IsValidGroup`, `ScriptGroupList`, `ScriptVehicleList_Group` and `ScriptVehicleList_DefaultGroup` lets GS to get groups of any company without being in the company.

- `ScriptGroup::GetOwner` didn't exist before. It was added and is only accessible for the GS.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
- `ScriptGroup::GetNumEngines`, `ScriptGroup::GetNumVehicles` and `ScriptGroup::GetEngineReplacement` have extra conditions to make it less restrictive to use when in deity mode. If the group exists and is not `GROUP_DEFAULT` and not `GROUP_ALL`, then the company of that group could be retrieved from the group->owner itself, without the need to be in company scope, but since those functions can also be supplied with `GROUP_DEFAULT` and `GROUP_ALL` as parameters, you need to be in a valid company scope mode for those.

- `ScriptEventEngineAvailable` may happen to not be broadcasted for AIs, only to GS, because a GS can also deal with non-AI companies.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
