### PR TITLE
Fix missing documentation for scripts

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -41,7 +41,6 @@ INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 2
 ALIASES                =
-TCL_SUBST              =
 OPTIMIZE_OUTPUT_FOR_C  = YES
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
@@ -155,7 +154,6 @@ VERBATIM_HEADERS       = YES
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
-COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -224,7 +222,7 @@ LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
 LATEX_HEADER           =
 LATEX_FOOTER           =

--- a/src/script/api/Doxyfile_AI.in
+++ b/src/script/api/Doxyfile_AI.in
@@ -121,7 +121,6 @@ VERBATIM_HEADERS       = NO
 # configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
-COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output
@@ -151,7 +150,7 @@ LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
 LATEX_HEADER           =
 PDF_HYPERLINKS         = NO

--- a/src/script/api/Doxyfile_GS.in
+++ b/src/script/api/Doxyfile_GS.in
@@ -121,7 +121,6 @@ VERBATIM_HEADERS       = NO
 # configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
-COLS_IN_ALPHA_INDEX    = 5
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output
@@ -151,7 +150,7 @@ LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
 LATEX_HEADER           =
 PDF_HYPERLINKS         = NO

--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -50,7 +50,7 @@ public:
 	 * @param station_id The basestation to set the name of.
 	 * @param name The new name of the station (can be either a raw string, or a ScriptText object).
 	 * @pre IsValidBaseStation(station_id).
-	 * @pre name != nullptr && len(name) != 0.
+	 * @pre name != null && len(name) != 0.
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if the name was changed.

--- a/src/script/api/script_clientlist.hpp
+++ b/src/script/api/script_clientlist.hpp
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file script_clientlist.hpp List all the TODO. */
+/** @file script_clientlist.hpp List all the clients in a game or in a company. */
 
 #ifndef SCRIPT_CLIENTLIST_HPP
 #define SCRIPT_CLIENTLIST_HPP
@@ -32,7 +32,7 @@ public:
 class ScriptClientList_Company : public ScriptList {
 public:
 	/**
-	 * @param company_id The company to list clients for.
+	 * @param company The company to list clients for.
 	 */
 	ScriptClientList_Company(ScriptCompany::CompanyID company);
 };

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -137,7 +137,7 @@ public:
 	/**
 	 * Set the name of your company.
 	 * @param name The new name of the company (can be either a raw string, or a ScriptText object).
-	 * @pre name != nullptr && len(name) != 0.
+	 * @pre name != null && len(name) != 0.
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if the name was changed.
 	 */
@@ -154,7 +154,7 @@ public:
 	/**
 	 * Set the name of your president.
 	 * @param name The new name of the president (can be either a raw string, or a ScriptText object).
-	 * @pre name != nullptr && len(name) != 0.
+	 * @pre name != null && len(name) != 0.
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if the name was changed.
 	 */

--- a/src/script/api/script_event.hpp
+++ b/src/script/api/script_event.hpp
@@ -61,6 +61,7 @@ public:
 
 	/**
 	 * Constructor of ScriptEvent, to get the type of event.
+	 * @param type The type of event to construct.
 	 */
 	ScriptEvent(ScriptEvent::ScriptEventType type) :
 		type(type)

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -892,10 +892,19 @@ public:
 	 */
 	static ScriptEventAdminPort *Convert(ScriptEvent *instance) { return (ScriptEventAdminPort *)instance; }
 
+#ifndef DOXYGEN_API
 	/**
-	 * Get the information that was sent to you back as Squirrel object.
+	 * The GetObject() wrapper from Squirrel.
 	 */
 	SQInteger GetObject(HSQUIRRELVM vm);
+#else
+	/**
+	 * Get the information that was sent to you back as Squirrel object.
+	 * @return The object.
+	 */
+	SQObject GetObject();
+#endif /* DOXYGEN_API */
+
 
 private:
 	std::string json; ///< The JSON string.
@@ -951,16 +960,19 @@ public:
 
 	/**
 	 * Get the class of the window that was clicked.
+	 * @return The clicked window class.
 	 */
 	ScriptWindow::WindowClass GetWindowClass() { return this->window; }
 
 	/**
 	 * Get the number of the window that was clicked.
+	 * @return The clicked identifying number of the widget within the class.
 	 */
 	uint32 GetWindowNumber() { return this->number; }
 
 	/**
 	 * Get the number of the widget that was clicked.
+	 * @return The number of the clicked widget.
 	 */
 	uint8 GetWidgetNumber() { return this->widget; }
 
@@ -1001,16 +1013,19 @@ public:
 
 	/**
 	 * Get the unique id of the question.
+	 * @return The unique id.
 	 */
 	uint16 GetUniqueID() { return this->uniqueid; }
 
 	/**
 	 * Get the company that pressed a button.
+	 * @return The company.
 	 */
 	ScriptCompany::CompanyID GetCompany() { return this->company; }
 
 	/**
 	 * Get the button that got pressed.
+	 * @return The button.
 	 */
 	ScriptGoal::QuestionButton GetButton() { return this->button; }
 
@@ -1182,13 +1197,22 @@ public:
 	 */
 	static ScriptEventStoryPageButtonClick *Convert(ScriptEvent *instance) { return (ScriptEventStoryPageButtonClick *)instance; }
 
-	/** Get the CompanyID of the player that selected a tile. */
+	/**
+	 * Get the CompanyID of the player that selected a tile.
+	 * @return The ID of the company.
+	 */
 	ScriptCompany::CompanyID GetCompanyID() { return this->company_id; }
 
-	/** Get the StoryPageID of the storybook page the clicked button is located on. */
+	/**
+	 * Get the StoryPageID of the storybook page the clicked button is located on.
+	 * @return The ID of the page in the story book the click was on.
+	 */
 	StoryPageID GetStoryPageID() { return this->page_id; }
 
-	/** Get the StoryPageElementID of the button element that was clicked. */
+	/**
+	 * Get the StoryPageElementID of the button element that was clicked.
+	 * @return The ID of the element that was clicked.
+	 */
 	StoryPageElementID GetElementID() { return this->element_id; }
 
 private:
@@ -1226,16 +1250,28 @@ public:
 	 */
 	static ScriptEventStoryPageTileSelect *Convert(ScriptEvent *instance) { return (ScriptEventStoryPageTileSelect *)instance; }
 
-	/** Get the CompanyID of the player that selected a tile. */
+	/**
+	 * Get the CompanyID of the player that selected a tile.
+	 * @return The company that selected the tile.
+	 */
 	ScriptCompany::CompanyID GetCompanyID() { return this->company_id; }
 
-	/** Get the StoryPageID of the storybook page the used selection button is located on. */
+	/**
+	 * Get the StoryPageID of the storybook page the used selection button is located on.
+	 * @return The ID of the story page selection was done from.
+	 */
 	StoryPageID GetStoryPageID() { return this->page_id; }
 
-	/** Get the StoryPageElementID of the selection button used to select the tile. */
+	/**
+	 * Get the StoryPageElementID of the selection button used to select the tile.
+	 * @return The ID of the element that was used to select the tile.
+	 */
 	StoryPageElementID GetElementID() { return this->element_id; }
 
-	/** Get the TileIndex of the tile the player selected */
+	/**
+	 * Get the TileIndex of the tile the player selected.
+	 * @return The selected tile.
+	 */
 	TileIndex GetTile() { return this->tile_index; }
 
 private:
@@ -1274,16 +1310,28 @@ public:
 	 */
 	static ScriptEventStoryPageVehicleSelect *Convert(ScriptEvent *instance) { return (ScriptEventStoryPageVehicleSelect *)instance; }
 
-	/** Get the CompanyID of the player that selected a tile. */
+	/**
+	 * Get the CompanyID of the player that selected a tile.
+	 * @return The company's ID.
+	 */
 	ScriptCompany::CompanyID GetCompanyID() { return this->company_id; }
 
-	/** Get the StoryPageID of the storybook page the used selection button is located on. */
+	/**
+	 * Get the StoryPageID of the storybook page the used selection button is located on.
+	 * @return The ID of the storybook page the selected element is on.
+	 */
 	StoryPageID GetStoryPageID() { return this->page_id; }
 
-	/** Get the StoryPageElementID of the selection button used to select the vehicle. */
+	/**
+	 * Get the StoryPageElementID of the selection button used to select the vehicle.
+	 * @return The ID of the selected element of the story page.
+	 */
 	StoryPageElementID GetElementID() { return this->element_id; }
 
-	/** Get the VehicleID of the vehicle the player selected */
+	/**
+	 * Get the VehicleID of the vehicle the player selected.
+	 * @return The ID of the vehicle.
+	 */
 	VehicleID GetVehicleID() { return this->vehicle_id; }
 
 private:

--- a/src/script/api/script_game.hpp
+++ b/src/script/api/script_game.hpp
@@ -53,6 +53,7 @@ public:
 
 	/**
 	 * Get the current landscape.
+	 * @return The type of landscape.
 	 */
 	static LandscapeType GetLandscape();
 

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -97,7 +97,7 @@ public:
 	 * @param destination The destination of the \a type type.
 	 * @return The new GoalID, or GOAL_INVALID if it failed.
 	 * @pre No ScriptCompanyMode may be in scope.
-	 * @pre goal != nullptr && len(goal) != 0.
+	 * @pre goal != null && len(goal) != 0.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre if type is GT_STORY_PAGE, the company of the goal and the company of the story page need to match:
 	 *       \li Global goals can only reference global story pages.
@@ -120,7 +120,7 @@ public:
 	 * @param goal The new goal text (can be either a raw string, or a ScriptText object).
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
-	 * @pre goal != nullptr && len(goal) != 0.
+	 * @pre goal != null && len(goal) != 0.
 	 * @pre IsValidGoal(goal_id).
 	 */
 	static bool SetText(GoalID goal_id, Text *goal);
@@ -131,7 +131,7 @@ public:
 	 * the progress string short.
 	 * @param goal_id The goal to update.
 	 * @param progress The new progress text for the goal (can be either a raw string,
-	 * or a ScriptText object). To clear the progress string you can pass nullptr or an
+	 * or a ScriptText object). To clear the progress string you can pass null or an
 	 * empty string.
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
@@ -167,7 +167,7 @@ public:
 	 * @param buttons Any combinations (at least 1, up to 3) of buttons defined in QuestionButton. Like BUTTON_YES + BUTTON_NO.
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
-	 * @pre question != nullptr && len(question) != 0.
+	 * @pre question != null && len(question) != 0.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
 	 * @note Replies to the question are given by you via the event ScriptEvent_GoalQuestionAnswer.
@@ -185,7 +185,7 @@ public:
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre ScriptGame::IsMultiplayer()
-	 * @pre question != nullptr && len(question) != 0.
+	 * @pre question != null && len(question) != 0.
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
 	 * @note Replies to the question are given by you via the event ScriptEvent_GoalQuestionAnswer.

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -69,7 +69,7 @@ public:
 	 * @param group_id The group to set the name for.
 	 * @param name The name for the group (can be either a raw string, or a ScriptText object).
 	 * @pre IsValidGroup(group_id).
-	 * @pre name != nullptr && len(name) != 0
+	 * @pre name != null && len(name) != 0
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if and only if the name was changed.
 	 */

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -232,6 +232,7 @@ public:
 	 * @param group_id The group id to set the colour of.
 	 * @param colour Colour to set.
 	 * @pre IsValidGroup(group_id).
+	 * @return True iff the colour was set successfully.
 	 */
 	static bool SetPrimaryColour(GroupID group_id, ScriptCompany::Colours colour);
 
@@ -240,6 +241,7 @@ public:
 	 * @param group_id The group id to set the colour of.
 	 * @param colour Colour to set.
 	 * @pre IsValidGroup(group_id).
+	 * @return True iff the colour was set successfully.
 	 */
 	static bool SetSecondaryColour(GroupID group_id, ScriptCompany::Colours colour);
 
@@ -247,6 +249,7 @@ public:
 	 * Get primary colour of a group.
 	 * @param group_id The group id to get the colour of.
 	 * @pre IsValidGroup(group_id).
+	 * @return The primary colour of the group.
 	 */
 	static ScriptCompany::Colours GetPrimaryColour(GroupID group_id);
 
@@ -254,6 +257,7 @@ public:
 	 * Get secondary colour for a group.
 	 * @param group_id The group id to get the colour of.
 	 * @pre IsValidGroup(group_id).
+	 * @return The secondary colour of the group.
 	 */
 	static ScriptCompany::Colours GetSecondaryColour(GroupID group_id);
 };

--- a/src/script/api/script_industrytype.hpp
+++ b/src/script/api/script_industrytype.hpp
@@ -184,7 +184,7 @@ public:
 
 	/**
 	 * Get a specific industry-type from a grf.
-	 * @param grf_id The ID of the NewGRF.
+	 * @param grfid The ID of the NewGRF.
 	 * @param grf_local_id The ID of the industry, local to the NewGRF.
 	 * @pre 0x00 <= grf_local_id < NUM_INDUSTRYTYPES_PER_GRF.
 	 * @return the industry-type ID, local to the current game (this diverges from the grf_local_id).

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -72,7 +72,7 @@ public:
 	 * @param footer The optional footer text for the table (null is allowed).
 	 * @return The new LeagueTableID, or LEAGUE_TABLE_INVALID if it failed.
 	 * @pre No ScriptCompanyMode may be in scope.
-	 * @pre title != nullptr && len(title) != 0.
+	 * @pre title != null && len(title) != 0.
 	 */
 	static LeagueTableID New(Text *title, Text *header, Text *footer);
 
@@ -88,8 +88,8 @@ public:
 	 * @return The new LeagueTableElementID, or LEAGUE_TABLE_ELEMENT_INVALID if it failed.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre IsValidLeagueTable(table).
-	 * @pre text != nullptr && len(text) != 0.
-	 * @pre score != nullptr && len(score) != 0.
+	 * @pre text != null && len(text) != 0.
+	 * @pre score != null && len(score) != 0.
 	 * @pre IsValidLink(Link(link_type, link_target)).
 	 */
 	static LeagueTableElementID NewElement(LeagueTableID table, int64 rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, LinkTargetID link_target);
@@ -104,7 +104,7 @@ public:
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre IsValidLeagueTableElement(element).
-	 * @pre text != nullptr && len(text) != 0.
+	 * @pre text != null && len(text) != 0.
 	 * @pre IsValidLink(Link(link_type, link_target)).
 	 */
 	static bool UpdateElementData(LeagueTableElementID element, ScriptCompany::CompanyID company, Text *text, LinkType link_type, LinkTargetID link_target);
@@ -117,7 +117,7 @@ public:
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre IsValidLeagueTableElement(element).
-	 * @pre score != nullptr && len(score) != 0.
+	 * @pre score != null && len(score) != 0.
 	 */
 	static bool UpdateElementScore(LeagueTableElementID element, int64 rating, Text *score);
 

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -68,6 +68,8 @@ public:
 	/**
 	 * Create a new league table.
 	 * @param title League table title (can be either a raw string, or ScriptText object).
+	 * @param header The optional header text for the table (null is allowed).
+	 * @param footer The optional footer text for the table (null is allowed).
 	 * @return The new LeagueTableID, or LEAGUE_TABLE_INVALID if it failed.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre title != nullptr && len(title) != 0.

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -196,7 +196,7 @@ public:
 	/**
 	 * Remove everything that is in the given list from this list (same item index that is).
 	 * @param list the list of items to remove.
-	 * @pre list != nullptr
+	 * @pre list != null
 	 */
 	void RemoveList(ScriptList *list);
 
@@ -240,7 +240,7 @@ public:
 	/**
 	 * Keeps everything that is in the given list from this list (same item index that is).
 	 * @param list the list of items to keep.
-	 * @pre list != nullptr
+	 * @pre list != null
 	 */
 	void KeepList(ScriptList *list);
 

--- a/src/script/api/script_newgrf.hpp
+++ b/src/script/api/script_newgrf.hpp
@@ -48,7 +48,7 @@ public:
 	 * Get the name of a loaded NewGRF.
 	 * @param grfid The NewGRF to query.
 	 * @pre ScriptNewGRF::IsLoaded(grfid).
-	 * @return The name of the NewGRF or nullptr if no name is defined.
+	 * @return The name of the NewGRF or null if no name is defined.
 	 */
 	static char *GetName(uint32 grfid);
 };

--- a/src/script/api/script_news.hpp
+++ b/src/script/api/script_news.hpp
@@ -59,7 +59,7 @@ public:
 	 *  - For #NR_TOWN this parameter should be a valid townID (ScriptTown::IsValidTown).
 	 * @return True if the action succeeded.
 	 * @pre type must be #NT_ECONOMY, #NT_SUBSIDIES, or #NT_GENERAL.
-	 * @pre text != nullptr.
+	 * @pre text != null.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre The \a reference condition must be fulfilled.
 	 */

--- a/src/script/api/script_objecttype.hpp
+++ b/src/script/api/script_objecttype.hpp
@@ -55,7 +55,7 @@ public:
 
 	/**
 	 * Get a specific object-type from a grf.
-	 * @param grf_id The ID of the NewGRF.
+	 * @param grfid The ID of the NewGRF.
 	 * @param grf_local_id The ID of the object, local to the NewGRF.
 	 * @pre 0x00 <= grf_local_id < NUM_OBJECTS_PER_GRF.
 	 * @return the object-type ID, local to the current game (this diverges from the grf_local_id).

--- a/src/script/api/script_priorityqueue.hpp
+++ b/src/script/api/script_priorityqueue.hpp
@@ -61,6 +61,7 @@ public:
 
 	/**
 	 * Check if an items is already included in the queue.
+	 * @param item The item to check whether it's already in this queue.
 	 * @return true if the items is already in the queue.
 	 * @note Performance is O(n), use only when absolutely required.
 	 */

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -160,7 +160,7 @@ public:
 	/**
 	 * Check if a road vehicle built for a road type can run on another road type.
 	 * @param engine_road_type The road type the road vehicle is built for.
-	 * @param track_road_type The road type you want to check.
+	 * @param road_road_type The road type you want to check.
 	 * @pre ScriptRoad::IsRoadTypeAvailable(engine_road_type).
 	 * @pre ScriptRoad::IsRoadTypeAvailable(road_road_type).
 	 * @return Whether a road vehicle built for 'engine_road_type' can run on 'road_road_type'.
@@ -385,7 +385,6 @@ public:
 	 *  the road is made two-way again. If the road already exists but is
 	 *  one-way in the other direction, it's made a 'no'-way road (it's
 	 *  forbidden to enter the tile from any direction).
-	 * @param start The start tile of the road.
 	 * @param start The start tile of the road.
 	 * @param end The end tile of the road.
 	 * @pre 'start' is not equal to 'end'.

--- a/src/script/api/script_sign.hpp
+++ b/src/script/api/script_sign.hpp
@@ -43,7 +43,7 @@ public:
 	 * @param sign_id The sign to set the name for.
 	 * @param name The name for the sign (can be either a raw string, or a ScriptText object).
 	 * @pre IsValidSign(sign_id).
-	 * @pre name != nullptr && len(name) != 0.
+	 * @pre name != null && len(name) != 0.
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if and only if the name was changed.
 	 */
@@ -79,7 +79,7 @@ public:
 	 * @param location The place to build the sign.
 	 * @param name The text to place on the sign (can be either a raw string, or a ScriptText object).
 	 * @pre ScriptMap::IsValidTile(location).
-	 * @pre name != nullptr && len(name) != 0.
+	 * @pre name != null && len(name) != 0.
 	 * @exception ScriptSign::ERR_SIGN_TOO_MANY_SIGNS
 	 * @return The SignID of the build sign (use IsValidSign() to check for validity).
 	 *   In test-mode it returns 0 if successful, or any other value to indicate

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -315,6 +315,7 @@ public:
 	/**
 	 * Create a reference value for SPET_BUTTON_PUSH element parameters.
 	 * @param colour The colour for the face of the button.
+	 * @param flags The formatting and layout flags for the button.
 	 * @return A reference value usable with the #NewElement and #UpdateElement functions.
 	 */
 	static StoryPageButtonFormatting MakePushButtonReference(StoryPageButtonColour colour, StoryPageButtonFlags flags);
@@ -322,6 +323,7 @@ public:
 	/**
 	 * Create a reference value for SPET_BUTTON_TILE element parameters.
 	 * @param colour The colour for the face of the button.
+	 * @param flags The formatting and layout flags for the button.
 	 * @param cursor The mouse cursor to use when the player clicks the button and the game is ready for the player to select a tile.
 	 * @return A reference value usable with the #NewElement and #UpdateElement functions.
 	 */
@@ -330,6 +332,7 @@ public:
 	/**
 	 * Create a reference value for SPET_BUTTON_VEHICLE element parameters.
 	 * @param colour  The colour for the face of the button.
+	 * @param flags The formatting and layout flags for the button.
 	 * @param cursor  The mouse cursor to use when the player clicks the button and the game is ready for the player to select a vehicle.
 	 * @param vehtype The type of vehicle that will be selectable, or \c VT_INVALID to allow all types.
 	 * @return A reference value usable with the #NewElement and #UpdateElement functions.

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -202,7 +202,7 @@ public:
 	 * @return The new StoryPageElementID, or STORY_PAGE_ELEMENT_INVALID if it failed.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre IsValidStoryPage(story_page).
-	 * @pre (type != SPET_TEXT && type != SPET_LOCATION) || (text != nullptr && len(text) != 0).
+	 * @pre (type != SPET_TEXT && type != SPET_LOCATION) || (text != null && len(text) != 0).
 	 * @pre type != SPET_LOCATION || ScriptMap::IsValidTile(reference).
 	 * @pre type != SPET_GOAL || ScriptGoal::IsValidGoal(reference).
 	 * @pre if type is SPET_GOAL and story_page is a global page, then referenced goal must be global.
@@ -217,7 +217,7 @@ public:
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
 	 * @pre IsValidStoryPage(story_page).
-	 * @pre (type != SPET_TEXT && type != SPET_LOCATION) || (text != nullptr && len(text) != 0).
+	 * @pre (type != SPET_TEXT && type != SPET_LOCATION) || (text != null && len(text) != 0).
 	 * @pre type != SPET_LOCATION || ScriptMap::IsValidTile(reference).
 	 * @pre type != SPET_GOAL || ScriptGoal::IsValidGoal(reference).
 	 * @pre if type is SPET_GOAL and story_page is a global page, then referenced goal must be global.

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -400,7 +400,7 @@ public:
 	 * @param size The town size of the new town.
 	 * @param city True if the new town should be a city.
 	 * @param layout The town layout of the new town.
-	 * @param name The name of the new town. Pass nullptr to use a random town name.
+	 * @param name The name of the new town. Pass null to use a random town name.
 	 * @game @pre no company mode in scope || ScriptSettings.GetValue("economy.found_town") != 0.
 	 * @ai @pre ScriptSettings.GetValue("economy.found_town") != 0.
 	 * @game @pre no company mode in scope || size != TOWN_SIZE_LARGE.

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -113,7 +113,7 @@ public:
 	 * @param vehicle_id The vehicle to set the name for.
 	 * @param name The name for the vehicle (can be either a raw string, or a ScriptText object).
 	 * @pre IsValidVehicle(vehicle_id).
-	 * @pre name != nullptr && len(name) != 0.
+	 * @pre name != null && len(name) != 0.
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if and only if the name was changed.

--- a/src/script/api/script_viewport.hpp
+++ b/src/script/api/script_viewport.hpp
@@ -35,6 +35,7 @@ public:
 	 * @param tile The tile to put in the center of the screen.
 	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
 	 * @pre ScriptMap::IsValidTile(tile)
+	 * @return True iff the command was executed successfully.
 	 */
 	static bool ScrollEveryoneTo(TileIndex tile);
 
@@ -46,6 +47,7 @@ public:
 	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
 	 * @pre ScriptMap::IsValidTile(tile)
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID
+	 * @return True iff the command was executed successfully.
 	 */
 	static bool ScrollCompanyClientsTo(ScriptCompany::CompanyID company, TileIndex tile);
 
@@ -58,6 +60,7 @@ public:
 	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
 	 * @pre ScriptMap::IsValidTile(tile)
 	 * @pre ResolveClientID(client) != CLIENT_INVALID
+	 * @return True iff the command was executed successfully.
 	 */
 	static bool ScrollClientTo(ScriptClient::ClientID client, TileIndex tile);
 };


### PR DESCRIPTION
## Motivation / Problem

Working on #10412 I noticed Doxygen complaining about missing/wrong tags and obsolete configuration. While doing it I noticed that `nullptr` was used in the API documentation, but Squirrel has no `nullptr` only `null`.


## Description

Remove or update obsolete configurations.
Add/modify/remove tags to the scripts' documentation where missing.
Replace `nullptr` with `null` where used in the API documenation for scripts. 


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
