### PR TITLE
Codechange: use RAII to automatically restore _cur_dpi after use

### DIFF
--- a/src/core/backup_type.hpp
+++ b/src/core/backup_type.hpp
@@ -144,4 +144,46 @@ private:
 	const int line;
 };
 
+/**
+ * Class to backup a specific variable and restore it upon destruction of this object to prevent
+ * stack values going out of scope before resetting the global to its original value. Contrary to
+ * #Backup this restores the variable automatically and there is no manual option to restore.
+ */
+template <typename T>
+struct AutoRestoreBackup {
+	/*
+	 * There is explicitly no only original constructor version, as that would make it possible
+	 * for the new value to go out of scope before this object goes out of scope, thus defeating
+	 * the whole goal and reason for existing of this object.
+	 */
+
+	/**
+	 * Backup variable and switch to new value.
+	 * @param original Variable to backup.
+	 * @param new_value New value for variable.
+	 */
+	AutoRestoreBackup(T &original, T new_value) : original(original), original_value(original)
+	{
+		original = new_value;
+	}
+
+	/**
+	 * Restore the variable upon object destruction.
+	 */
+	~AutoRestoreBackup()
+	{
+		this->original = this->original_value;
+	}
+
+private:
+	T &original;
+	T original_value;
+
+	/* Prevent copy, assignment and allocation on stack. */
+	AutoRestoreBackup(const AutoRestoreBackup&) = delete;
+	AutoRestoreBackup& operator=(AutoRestoreBackup&) = delete;
+	static void *operator new(std::size_t) = delete;
+	static void *operator new[](std::size_t) = delete;
+};
+
 #endif /* BACKUP_TYPE_HPP */

--- a/src/dock_gui.cpp
+++ b/src/dock_gui.cpp
@@ -547,15 +547,13 @@ public:
 				Axis axis = widget == WID_BDD_X ? AXIS_X : AXIS_Y;
 
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					int x = (r.Width()  - ScaleSpriteTrad(96)) / 2;
 					int y = (r.Height() - ScaleSpriteTrad(64)) / 2;
 					int x1 = ScaleSpriteTrad(63);
 					int x2 = ScaleSpriteTrad(31);
 					DrawShipDepotSprite(x + (axis == AXIS_X ? x1 : x2), y + ScaleSpriteTrad(17), axis, DEPOT_PART_NORTH);
 					DrawShipDepotSprite(x + (axis == AXIS_X ? x2 : x1), y + ScaleSpriteTrad(33), axis, DEPOT_PART_SOUTH);
-					_cur_dpi = old_dpi;
 				}
 				break;
 			}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -2920,10 +2920,9 @@ struct IndustryCargoesWindow : public Window {
 		if (widget != WID_IC_PANEL) return;
 
 		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
-		DrawPixelInfo tmp_dpi, *old_dpi;
+		DrawPixelInfo tmp_dpi;
 		if (!FillDrawPixelInfo(&tmp_dpi, ir.left, ir.top, ir.Width(), ir.Height())) return;
-		old_dpi = _cur_dpi;
-		_cur_dpi = &tmp_dpi;
+		AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 
 		int left_pos = ir.left;
 		if (this->ind_cargo >= NUM_INDUSTRYTYPES) left_pos += (CargoesField::industry_width + CargoesField::cargo_field_width) / 2;
@@ -2952,8 +2951,6 @@ struct IndustryCargoesWindow : public Window {
 			vpos += row_height;
 			if (vpos >= height) break;
 		}
-
-		_cur_dpi = old_dpi;
 	}
 
 	/**

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -820,8 +820,7 @@ void QueryString::DrawEditBox(const Window *w, int wid) const
 	DrawPixelInfo dpi;
 	if (!FillDrawPixelInfo(&dpi, fr.left, fr.top, fr.Width(), fr.Height())) return;
 
-	DrawPixelInfo *old_dpi = _cur_dpi;
-	_cur_dpi = &dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &dpi);
 
 	/* We will take the current widget length as maximum width, with a small
 	 * space reserved at the end for the caret to show */
@@ -839,8 +838,6 @@ void QueryString::DrawEditBox(const Window *w, int wid) const
 		int caret_width = GetStringBoundingBox("_").width;
 		DrawString(tb->caretxoffs + delta, tb->caretxoffs + delta + caret_width, 0, "_", TC_WHITE);
 	}
-
-	_cur_dpi = old_dpi;
 }
 
 /**

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include <stdarg.h>
+#include "core/backup_type.hpp"
 #include "window_gui.h"
 #include "window_func.h"
 #include "random_access_file_type.h"
@@ -895,17 +896,13 @@ struct SpriteAlignerWindow : Window {
 
 				DrawPixelInfo new_dpi;
 				if (!FillDrawPixelInfo(&new_dpi, ir.left, ir.top, ir.Width(), ir.Height())) break;
-				DrawPixelInfo *old_dpi = _cur_dpi;
-				_cur_dpi = &new_dpi;
+				AutoRestoreBackup dpi_backup(_cur_dpi, &new_dpi);
 
 				DrawSprite(this->current_sprite, PAL_NONE, x, y, nullptr, ZOOM_LVL_GUI);
 				if (this->crosshair) {
 					GfxDrawLine(x, 0, x, ir.Height() - 1, PC_WHITE, 1, 1);
 					GfxDrawLine(0, y, ir.Width() - 1, y, PC_WHITE, 1, 1);
 				}
-
-				_cur_dpi = old_dpi;
-
 				break;
 			}
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -363,8 +363,7 @@ public:
 				DrawPixelInfo tmp_dpi;
 				/* Set up a clipping area for the preview. */
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					if (spec->grf_prop.grffile == nullptr) {
 						extern const DrawTileSprites _objects[];
 						const DrawTileSprites *dts = &_objects[spec->grf_prop.local_id];
@@ -372,7 +371,6 @@ public:
 					} else {
 						DrawNewObjectTileInGUI(r.Width() / 2 - 1, (r.Height() + matrix_height / 2) / 2 - this->object_margin - ScaleSpriteTrad(TILE_PIXELS), spec, GB(widget, 16, 16));
 					}
-					_cur_dpi = old_dpi;
 				}
 				break;
 			}
@@ -390,8 +388,7 @@ public:
 				DrawPixelInfo tmp_dpi;
 				/* Set up a clipping area for the preview. */
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					if (spec->grf_prop.grffile == nullptr) {
 						extern const DrawTileSprites _objects[];
 						const DrawTileSprites *dts = &_objects[spec->grf_prop.local_id];
@@ -400,7 +397,6 @@ public:
 						DrawNewObjectTileInGUI(r.Width() / 2 - 1, r.Height() - this->object_margin - ScaleSpriteTrad(TILE_PIXELS), spec,
 								std::min<int>(_selected_object_view, spec->views - 1));
 					}
-					_cur_dpi = old_dpi;
 				}
 				break;
 			}

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1255,28 +1255,24 @@ public:
 			case WID_BRAS_PLATFORM_DIR_X:
 				/* Set up a clipping area for the '/' station preview */
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 					int y = (r.Height() + ScaleSpriteTrad(58)) / 2 - ScaleSpriteTrad(31);
 					if (!DrawStationTile(x, y, _cur_railtype, AXIS_X, _railstation.station_class, _railstation.station_type)) {
 						StationPickerDrawSprite(x, y, STATION_RAIL, _cur_railtype, INVALID_ROADTYPE, 2);
 					}
-					_cur_dpi = old_dpi;
 				}
 				break;
 
 			case WID_BRAS_PLATFORM_DIR_Y:
 				/* Set up a clipping area for the '\' station preview */
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 					int y = (r.Height() + ScaleSpriteTrad(58)) / 2 - ScaleSpriteTrad(31);
 					if (!DrawStationTile(x, y, _cur_railtype, AXIS_Y, _railstation.station_class, _railstation.station_type)) {
 						StationPickerDrawSprite(x, y, STATION_RAIL, _cur_railtype, INVALID_ROADTYPE, 3);
 					}
-					_cur_dpi = old_dpi;
 				}
 				break;
 
@@ -1306,14 +1302,12 @@ public:
 
 				/* Set up a clipping area for the station preview. */
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 					int y = (r.Height() + ScaleSpriteTrad(58)) / 2 - ScaleSpriteTrad(31);
 					if (!DrawStationTile(x, y, _cur_railtype, _railstation.orientation, _railstation.station_class, type)) {
 						StationPickerDrawSprite(x, y, STATION_RAIL, _cur_railtype, INVALID_ROADTYPE, 2 + _railstation.orientation);
 					}
-					_cur_dpi = old_dpi;
 				}
 				break;
 			}
@@ -1940,12 +1934,10 @@ struct BuildRailDepotWindow : public PickerWindowBase {
 
 		DrawPixelInfo tmp_dpi;
 		if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-			DrawPixelInfo *old_dpi = _cur_dpi;
-			_cur_dpi = &tmp_dpi;
+			AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 			int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 			int y = (r.Height() + ScaleSpriteTrad(48)) / 2 - ScaleSpriteTrad(31);
 			DrawTrainDepotSprite(x, y, widget - WID_BRAD_DEPOT_NE + DIAGDIR_NE, _cur_railtype);
-			_cur_dpi = old_dpi;
 		}
 	}
 
@@ -2052,12 +2044,10 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 
 				DrawPixelInfo tmp_dpi;
 				if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-					DrawPixelInfo *old_dpi = _cur_dpi;
-					_cur_dpi = &tmp_dpi;
+					AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 					int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 					int y = (r.Height() + ScaleSpriteTrad(58)) / 2 - ScaleSpriteTrad(31);
 					DrawWaypointSprite(x, y, type, _cur_railtype);
-					_cur_dpi = old_dpi;
 				}
 
 				if (!IsStationAvailable(statspec)) {

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -984,12 +984,10 @@ struct BuildRoadDepotWindow : public PickerWindowBase {
 
 		DrawPixelInfo tmp_dpi;
 		if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-			DrawPixelInfo *old_dpi = _cur_dpi;
-			_cur_dpi = &tmp_dpi;
+			AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 			int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 			int y = (r.Height() + ScaleSpriteTrad(48)) / 2 - ScaleSpriteTrad(31);
 			DrawRoadDepotSprite(x, y, (DiagDirection)(widget - WID_BROD_DEPOT_NE + DIAGDIR_NE), _cur_roadtype);
-			_cur_dpi = old_dpi;
 		}
 	}
 
@@ -1119,12 +1117,10 @@ struct BuildRoadStationWindow : public PickerWindowBase {
 
 		DrawPixelInfo tmp_dpi;
 		if (FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) {
-			DrawPixelInfo *old_dpi = _cur_dpi;
-			_cur_dpi = &tmp_dpi;
+			AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 			int x = (r.Width()  - ScaleSpriteTrad(64)) / 2 + ScaleSpriteTrad(31);
 			int y = (r.Height() + ScaleSpriteTrad(48)) / 2 - ScaleSpriteTrad(31);
 			StationPickerDrawSprite(x, y, st, INVALID_RAILTYPE, _cur_roadtype, widget - WID_BROS_STATION_NE);
-			_cur_dpi = old_dpi;
 		}
 	}
 

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -8,6 +8,7 @@
 /** @file roadveh_gui.cpp GUI for road vehicles. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "roadveh.h"
 #include "window_gui.h"
 #include "strings_func.h"
@@ -130,13 +131,12 @@ void DrawRoadVehImage(const Vehicle *v, const Rect &r, VehicleID selection, Engi
 	Direction dir = rtl ? DIR_E : DIR_W;
 	const RoadVehicle *u = RoadVehicle::From(v);
 
-	DrawPixelInfo tmp_dpi, *old_dpi;
+	DrawPixelInfo tmp_dpi;
 	int max_width = r.Width();
 
 	if (!FillDrawPixelInfo(&tmp_dpi, r.left, r.top, r.Width(), r.Height())) return;
 
-	old_dpi = _cur_dpi;
-	_cur_dpi = &tmp_dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 
 	int px = rtl ? max_width + skip : -skip;
 	int y = r.Height() / 2;
@@ -154,8 +154,6 @@ void DrawRoadVehImage(const Vehicle *v, const Rect &r, VehicleID selection, Engi
 
 		px += rtl ? -width : width;
 	}
-
-	_cur_dpi = old_dpi;
 
 	if (v->index == selection) {
 		int height = ScaleSpriteTrad(12);

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -8,6 +8,7 @@
 /** @file screenshot.cpp The creation of screenshots! */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "fileio_func.h"
 #include "viewport_func.h"
 #include "gfx_func.h"
@@ -617,7 +618,7 @@ static void CurrentScreenCallback(void *userdata, void *buf, uint y, uint pitch,
 static void LargeWorldCallback(void *userdata, void *buf, uint y, uint pitch, uint n)
 {
 	Viewport *vp = (Viewport *)userdata;
-	DrawPixelInfo dpi, *old_dpi;
+	DrawPixelInfo dpi;
 	int wx, left;
 
 	/* We are no longer rendering to the screen */
@@ -630,8 +631,7 @@ static void LargeWorldCallback(void *userdata, void *buf, uint y, uint pitch, ui
 	_screen.pitch = pitch;
 	_screen_disable_anim = true;
 
-	old_dpi = _cur_dpi;
-	_cur_dpi = &dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &dpi);
 
 	dpi.dst_ptr = buf;
 	dpi.height = n;
@@ -654,8 +654,6 @@ static void LargeWorldCallback(void *userdata, void *buf, uint y, uint pitch, ui
 			ScaleByZoom((y + n) - vp->top, vp->zoom) + vp->virtual_top
 		);
 	}
-
-	_cur_dpi = old_dpi;
 
 	/* Switch back to rendering to the screen */
 	_screen = old_screen;

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -8,6 +8,7 @@
 /** @file smallmap_gui.cpp GUI that shows a small map of the world with metadata like owner or height. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "clear_map.h"
 #include "industry.h"
 #include "station_map.h"
@@ -973,10 +974,7 @@ void SmallMapWindow::DrawMapIndicators() const
 void SmallMapWindow::DrawSmallMap(DrawPixelInfo *dpi) const
 {
 	Blitter *blitter = BlitterFactory::GetCurrentBlitter();
-	DrawPixelInfo *old_dpi;
-
-	old_dpi = _cur_dpi;
-	_cur_dpi = dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, dpi);
 
 	/* Clear it */
 	GfxFillRect(dpi->left, dpi->top, dpi->left + dpi->width - 1, dpi->top + dpi->height - 1, PC_BLACK);
@@ -1027,8 +1025,6 @@ void SmallMapWindow::DrawSmallMap(DrawPixelInfo *dpi) const
 
 	/* Draw map indicators */
 	this->DrawMapIndicators();
-
-	_cur_dpi = old_dpi;
 }
 
 /**

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -8,6 +8,7 @@
 /** @file statusbar_gui.cpp The GUI for the bottom status bar. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "date_func.h"
 #include "gfx_func.h"
 #include "news_func.h"
@@ -68,10 +69,8 @@ static bool DrawScrollingStatusText(const NewsItem *ni, int scroll_pos, int left
 	int width = GetStringBoundingBox(buffer).width;
 	int pos = (_current_text_dir == TD_RTL) ? (scroll_pos - width) : (right - scroll_pos - left);
 
-	DrawPixelInfo *old_dpi = _cur_dpi;
-	_cur_dpi = &tmp_dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 	DrawString(pos, INT16_MAX, 0, buffer, TC_LIGHT_BLUE, SA_LEFT | SA_FORCE);
-	_cur_dpi = old_dpi;
 
 	return (_current_text_dir == TD_RTL) ? (pos < right - left) : (pos + width > 0);
 }

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -698,8 +698,7 @@ public:
 		DrawPixelInfo tmp_dpi;
 		if (!FillDrawPixelInfo(&tmp_dpi, fr.left, fr.top, fr.Width(), fr.Height())) return;
 
-		DrawPixelInfo *old_dpi = _cur_dpi;
-		_cur_dpi = &tmp_dpi;
+		AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 
 		/* Draw content (now coordinates given to Draw** are local to the new clipping region). */
 		fr = fr.Translate(-fr.left, -fr.top);
@@ -758,9 +757,6 @@ public:
 				default: NOT_REACHED();
 			}
 		}
-
-		/* Restore clipping region. */
-		_cur_dpi = old_dpi;
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -8,6 +8,7 @@
 /** @file textfile_gui.cpp Implementation of textfile window. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "fileio_func.h"
 #include "fontcache.h"
 #include "gfx_type.h"
@@ -152,8 +153,7 @@ void TextfileWindow::SetupScrollbars(bool force_reflow)
 
 	DrawPixelInfo new_dpi;
 	if (!FillDrawPixelInfo(&new_dpi, fr.left, fr.top, fr.Width(), fr.Height())) return;
-	DrawPixelInfo *old_dpi = _cur_dpi;
-	_cur_dpi = &new_dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &new_dpi);
 
 	/* Draw content (now coordinates given to DrawString* are local to the new clipping region). */
 	fr = fr.Translate(-fr.left, -fr.top);
@@ -172,8 +172,6 @@ void TextfileWindow::SetupScrollbars(bool force_reflow)
 			DrawString(-this->hscroll->GetPosition(), fr.right, y_offset, line.text, TC_BLACK, SA_TOP | SA_LEFT, false, FS_MONO);
 		}
 	}
-
-	_cur_dpi = old_dpi;
 }
 
 /* virtual */ void TextfileWindow::OnResize()

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -8,6 +8,7 @@
 /** @file widget.cpp Handling of the default/simple widgets. */
 
 #include "stdafx.h"
+#include "core/backup_type.hpp"
 #include "company_func.h"
 #include "window_gui.h"
 #include "viewport_func.h"
@@ -2009,8 +2010,7 @@ NWidgetCore *NWidgetMatrix::GetWidgetFromPos(int x, int y)
 	bool rtl = _current_text_dir == TD_RTL;
 	DrawPixelInfo tmp_dpi;
 	if (!FillDrawPixelInfo(&tmp_dpi, this->pos_x + (rtl ? this->pip_post : this->pip_pre), this->pos_y + this->pip_pre, this->current_x - this->pip_pre - this->pip_post, this->current_y - this->pip_pre - this->pip_post)) return;
-	DrawPixelInfo *old_dpi = _cur_dpi;
-	_cur_dpi = &tmp_dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 
 	/* Get the appropriate offsets so we can draw the right widgets. */
 	NWidgetCore *child = dynamic_cast<NWidgetCore *>(this->head);
@@ -2043,9 +2043,6 @@ NWidgetCore *NWidgetMatrix::GetWidgetFromPos(int x, int y)
 			child->Draw(w);
 		}
 	}
-
-	/* Restore the clipping area. */
-	_cur_dpi = old_dpi;
 }
 
 /**
@@ -2847,8 +2844,7 @@ void NWidgetLeaf::Draw(const Window *w)
 	new_dpi.left += this->pos_x;
 	new_dpi.top += this->pos_y;
 
-	DrawPixelInfo *old_dpi = _cur_dpi;
-	_cur_dpi = &new_dpi;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &new_dpi);
 
 	Rect r = this->GetCurrentRect();
 
@@ -2962,8 +2958,6 @@ void NWidgetLeaf::Draw(const Window *w)
 	if (this->IsDisabled()) {
 		GfxFillRect(r.Shrink(WidgetDimensions::scaled.bevel), _colour_gradient[this->colour & 0xF][2], FILLRECT_CHECKER);
 	}
-
-	_cur_dpi = old_dpi;
 }
 
 /**

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -980,9 +980,8 @@ static void DrawOverlappedWindow(Window *w, int left, int top, int right, int bo
  */
 void DrawOverlappedWindowForAll(int left, int top, int right, int bottom)
 {
-	DrawPixelInfo *old_dpi = _cur_dpi;
 	DrawPixelInfo bk;
-	_cur_dpi = &bk;
+	AutoRestoreBackup dpi_backup(_cur_dpi, &bk);
 
 	for (Window *w : Window::IterateFromBack()) {
 		if (MayBeShown(w) &&
@@ -994,7 +993,6 @@ void DrawOverlappedWindowForAll(int left, int top, int right, int bottom)
 			DrawOverlappedWindow(w, std::max(left, w->left), std::max(top, w->top), std::min(right, w->left + w->width), std::min(bottom, w->top + w->height));
 		}
 	}
-	_cur_dpi = old_dpi;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

The code is "full" of 
```
DrawPixelInfo *old_pi = _cur_dpi; 
_cur_dpi = &tmp_dpi; 
<code>; 
_cur_dpi = old_dpi;
```
constructs on which CodeQL complains that an address of a stack variable is saved in a global variable. Or rather a local variable's address is stored in non-local memory.


## Description

Introduce a simpler variant of `Backup` that does nothing more than store the old value and restore it when the object goes out of scope, in other words use the RAII paradigm also used for things like `lock_guard`.
Then introduce this in all places where swaps between `old_dpi` and `_cur_dpi` are made.


## Limitations

This introduces one new warning, though solves 23. Technically I would classify that new warning as a non-issue (maybe even a false positive), as the `AutoRestoreBackup` will automatically reset `_cur_dpi` in this context before the reference that has been passed in as new value goes out of scope.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
