### PR TITLE
Fix CodeQL "Commented out code" warnings

### DIFF
--- a/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqcompiler.cpp
@@ -607,7 +607,6 @@ public:
 		switch(_token)
 		{
 		case TK_STRING_LITERAL: {
-				//SQObjectPtr id(SQString::Create(_ss(_vm), _lex._svalue,_lex._longstr.size()-1));
 				_fs->AddInstruction(_OP_LOAD, _fs->PushTarget(), _fs->GetConstant(_fs->CreateString(_lex._svalue,_lex._longstr.size()-1)));
 				Lex();
 			}
@@ -840,7 +839,6 @@ public:
 			unsigned char flags = (hasattrs?NEW_SLOT_ATTRIBUTES_FLAG:0)|(isstatic?NEW_SLOT_STATIC_FLAG:0);
 			SQInteger table = _fs->TopTarget(); //<<BECAUSE OF THIS NO COMMON EMIT FUNC IS POSSIBLE
 			_fs->AddInstruction(_OP_NEWSLOTA, flags, table, key, val);
-			//_fs->PopTarget();
 		}
 		if(separator == ',') //hack recognizes a table from the separator
 			_fs->SetIntructionParam(tpos, 1, nkeys);
@@ -1053,7 +1051,6 @@ public:
 		if(tonextcondjmp != -1)
 			_fs->SetIntructionParam(tonextcondjmp, 1, _fs->GetCurrentPos() - tonextcondjmp);
 		if(_token == TK_DEFAULT) {
-		//	_fs->AddLineInfos(_lex._currentline, _lineinfo);
 			Lex(); Expect(':');
 			SQInteger stacksize = _fs->GetStackSize();
 			_last_stacksize = _fs->GetStackSize();
@@ -1167,11 +1164,6 @@ public:
 		}
 		SQTable *enums = _table(_ss(_vm)->_consts);
 		SQObjectPtr strongid = id;
-		/*SQObjectPtr dummy;
-		if(enums->Get(strongid,dummy)) {
-			dummy.Null(); strongid.Null();
-			Error("enumeration already exists");
-		}*/
 		enums->NewSlot(SQObjectPtr(strongid),SQObjectPtr(table));
 		strongid.Null();
 		Lex();
@@ -1318,7 +1310,6 @@ public:
 		funcstate->AddLineInfos(_lex._prevtoken == '\n'?_lex._lasttokenline:_lex._currentline, _lineinfo, true);
         funcstate->AddInstruction(_OP_RETURN, -1);
 		funcstate->SetStackSize(0);
-		//_fs->->_stacksize = _fs->_stacksize;
 		SQFunctionProto *func = funcstate->BuildProto();
 #ifdef _DEBUG_DUMP
 		funcstate->Dump(func);

--- a/src/3rdparty/squirrel/squirrel/sqlexer.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqlexer.cpp
@@ -177,7 +177,6 @@ SQInteger SQLexer::Lex()
 			else if ( CUR_CHAR == '-' ) { NEXT(); RETURN_TOKEN(TK_NEWSLOT); }
 			else if ( CUR_CHAR == '<' ) { NEXT(); RETURN_TOKEN(TK_SHIFTL); }
 			else if ( CUR_CHAR == '/' ) { NEXT(); RETURN_TOKEN(TK_ATTR_OPEN); }
-			//else if ( CUR_CHAR == '[' ) { NEXT(); ReadMultilineString(); RETURN_TOKEN(TK_STRING_LITERAL); }
 			else { RETURN_TOKEN('<') }
 		case '>':
 			NEXT();

--- a/src/3rdparty/squirrel/squirrel/sqstate.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqstate.cpp
@@ -453,7 +453,7 @@ void RefTable::Resize(SQUnsignedInteger size)
 	[[maybe_unused]] SQUnsignedInteger nfound = 0;
 	for(SQUnsignedInteger n = 0; n < oldnumofslots; n++) {
 		if(type(t->obj) != OT_NULL) {
-			//add back;
+			//add back
 			assert(t->refs != 0);
 			RefNode *nn = Add(::HashObj(t->obj)&(_numofslots-1),t->obj);
 			nn->refs = t->refs;

--- a/src/3rdparty/squirrel/squirrel/sqvm.cpp
+++ b/src/3rdparty/squirrel/squirrel/sqvm.cpp
@@ -140,7 +140,6 @@ void SQVM::Finalize()
 SQVM::~SQVM()
 {
 	Finalize();
-	//sq_free(_callsstack,_alloccallsstacksize*sizeof(CallInfo));
 	REMOVE_FROM_CHAIN(&_ss(this)->_gc_chain,this);
 }
 
@@ -712,7 +711,6 @@ bool SQVM::Execute(SQObjectPtr &closure, SQInteger target, SQInteger nargs, SQIn
 				return false;
 			}
 			if (_funcproto(_closure(temp_reg)->_function)->_bgenerator) {
-				//SQFunctionProto *f = _funcproto(_closure(temp_reg)->_function);
 				SQGenerator *gen = SQGenerator::Create(_ss(this), _closure(temp_reg));
 				_GUARD(gen->Yield(this));
 				Return(1, ci->_target, temp_reg);
@@ -747,8 +745,10 @@ exception_restore:
 			if (ShouldSuspend()) { _suspended = SQTrue; _suspended_traps = traps; return true; }
 
 			const SQInstruction &_i_ = *ci->_ip++;
-			//dumpstack(_stackbase);
-			//printf("%s %d %d %d %d\n",g_InstrDesc[_i_.op].name,arg0,arg1,arg2,arg3);
+#ifdef _DEBUG_DUMP
+			dumpstack(_stackbase);
+			printf("%s %d %d %d %d\n",g_InstrDesc[_i_.op].name,arg0,arg1,arg2,arg3);
+#endif
 			switch(_i_.op)
 			{
 			case _OP_LINE:
@@ -1053,7 +1053,9 @@ common_call:
 exception_trap:
 	{
 		SQObjectPtr currerror = _lasterror;
-//		dumpstack(_stackbase);
+#ifdef _DEBUG_DUMP
+		dumpstack(_stackbase);
+#endif
 		SQInteger n = 0;
 		SQInteger last_top = _top;
 		if(ci) {

--- a/src/3rdparty/squirrel/squirrel/sqvm.h
+++ b/src/3rdparty/squirrel/squirrel/sqvm.h
@@ -36,7 +36,6 @@ struct SQVM : public CHAINABLE_OBJ
 	};
 
 	struct CallInfo{
-		//CallInfo() { _generator._type = OT_NULL;}
 		SQInstruction *_ip;
 		SQObjectPtr *_literals;
 		SQObjectPtr _closure;

--- a/src/blitter/40bpp_anim.hpp
+++ b/src/blitter/40bpp_anim.hpp
@@ -18,7 +18,6 @@
 class Blitter_40bppAnim : public Blitter_32bppOptimized {
 public:
 
-	// void *MoveTo(void *video, int x, int y) override;
 	void SetPixel(void *video, int x, int y, uint8 colour) override;
 	void DrawRect(void *video, int width, int height, uint8 colour) override;
 	void DrawLine(void *video, int x, int y, int x2, int y2, int screen_width, int screen_height, uint8 colour, int width, int dash) override;

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -234,7 +234,9 @@ static int GetPCPElevation(TileIndex tile, DiagDirection PCPpos)
 
 	int z = GetSlopePixelZ(TileX(tile) * TILE_SIZE + std::min<int8>(x_pcp_offsets[PCPpos], TILE_SIZE - 1),
 	                       TileY(tile) * TILE_SIZE + std::min<int8>(y_pcp_offsets[PCPpos], TILE_SIZE - 1));
-	return (z + 2) & ~3; // this means z = (z + TILE_HEIGHT / 4) / (TILE_HEIGHT / 2) * (TILE_HEIGHT / 2);
+	/* Round the Z to the nearest half tile height. */
+	static const uint HALF_TILE_HEIGHT = TILE_HEIGHT / 2;
+	return (z + HALF_TILE_HEIGHT / 2) / HALF_TILE_HEIGHT * HALF_TILE_HEIGHT;
 }
 
 /**

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -295,7 +295,7 @@ bool FiosFileScanner::AddFile(const std::string &filename, size_t basepath_lengt
 	std::string ext = filename.substr(sep);
 
 	char fios_title[64];
-	fios_title[0] = '\0'; // reset the title;
+	fios_title[0] = '\0'; // reset the title
 
 	FiosType type = this->callback_proc(this->fop, filename, ext.c_str(), fios_title, lastof(fios_title));
 	if (type == FIOS_TYPE_INVALID) return false;

--- a/src/misc/countedptr.hpp
+++ b/src/misc/countedptr.hpp
@@ -125,12 +125,6 @@ public:
 		return m_pT == nullptr;
 	}
 
-	/** another way how to test for nullptr value */
-	//inline bool operator == (const CCountedPtr &sp) const {return m_pT == sp.m_pT;}
-
-	/** yet another way how to test for nullptr value */
-	//inline bool operator != (const CCountedPtr &sp) const {return m_pT != sp.m_pT;}
-
 	/** assign pointer w/o incrementing ref count */
 	inline void Attach(Tcls *pT)
 	{

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -197,7 +197,7 @@ protected:
 	uint16 max_offset;   ///< what is the length of the original entity's array of specs
 	uint16 max_entities; ///< what is the amount of entities, old and new summed
 
-	uint16 invalid_id;   ///< ID used to detected invalid entities;
+	uint16 invalid_id;   ///< ID used to detected invalid entities
 	virtual bool CheckValidNewID(uint16 testid) { return true; }
 
 public:

--- a/src/pathfinder/follow_track.hpp
+++ b/src/pathfinder/follow_track.hpp
@@ -371,7 +371,7 @@ protected:
 			/* entered railway station
 			 * get platform length */
 			uint length = BaseStation::GetByTile(m_new_tile)->GetPlatformLength(m_new_tile, TrackdirToExitdir(m_old_td));
-			/* how big step we must do to get to the last platform tile; */
+			/* how big step we must do to get to the last platform tile? */
 			m_tiles_skipped = length - 1;
 			/* move to the platform end */
 			TileIndexDiff diff = TileOffsByDiagDir(m_exitdir);

--- a/src/pathfinder/npf/aystar.h
+++ b/src/pathfinder/npf/aystar.h
@@ -20,8 +20,6 @@
 #include "../../tile_type.h"
 #include "../../track_type.h"
 
-//#define AYSTAR_DEBUG
-
 /** Return status of #AyStar methods. */
 enum AystarStatus {
 	AYSTAR_FOUND_END_NODE, ///< An end node was found.

--- a/src/pathfinder/npf/npf.cpp
+++ b/src/pathfinder/npf/npf.cpp
@@ -314,7 +314,6 @@ static Vehicle *CountShipProc(Vehicle *v, void *data)
 
 static int32 NPFWaterPathCost(AyStar *as, AyStarNode *current, OpenListNode *parent)
 {
-	/* TileIndex tile = current->tile; */
 	int32 cost = 0;
 	Trackdir trackdir = current->direction;
 
@@ -1114,7 +1113,6 @@ void InitializeNPF()
 	}
 	_npf_aystar.loops_per_tick = 0;
 	_npf_aystar.max_path_cost = 0;
-	//_npf_aystar.max_search_nodes = 0;
 	/* We will limit the number of nodes for now, until we have a better
 	 * solution to really fix performance */
 	_npf_aystar.max_search_nodes = _settings_game.pf.npf.npf_max_search_nodes;

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -1067,7 +1067,7 @@ static inline bool SlIsObjectCurrentlyValid(SaveLoadVersion version_from, SaveLo
  */
 static inline VarType GetVarMemType(VarType type)
 {
-	return type & 0xF0; // GB(type, 4, 4) << 4;
+	return GB(type, 4, 4) << 4;
 }
 
 /**
@@ -1078,7 +1078,7 @@ static inline VarType GetVarMemType(VarType type)
  */
 static inline VarType GetVarFileType(VarType type)
 {
-	return type & 0xF; // GB(type, 0, 4);
+	return GB(type, 0, 4);
 }
 
 /**

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -618,7 +618,6 @@ size_t Utf8Decode(WChar *c, const char *s)
 		}
 	}
 
-	/* Debug(misc, 1, "[utf8] invalid UTF-8 sequence"); */
 	*c = '?';
 	return 1;
 }
@@ -654,7 +653,6 @@ inline size_t Utf8Encode(T buf, WChar c)
 		return 4;
 	}
 
-	/* Debug(misc, 1, "[utf8] can't UTF-8 encode value 0x{:X}", c); */
 	*buf = '?';
 	return 1;
 }

--- a/src/video/opengl.h
+++ b/src/video/opengl.h
@@ -48,16 +48,16 @@ private:
 
 	GLuint remap_program;    ///< Shader program for blending and rendering a RGBA + remap texture.
 	GLint  remap_sprite_loc; ///< Uniform location for sprite parameters.
-	GLint  remap_screen_loc; ///< Uniform location for screen size;
-	GLint  remap_zoom_loc;   ///< Uniform location for sprite zoom;
-	GLint  remap_rgb_loc;    ///< Uniform location for RGB mode flag;
+	GLint  remap_screen_loc; ///< Uniform location for screen size.
+	GLint  remap_zoom_loc;   ///< Uniform location for sprite zoom.
+	GLint  remap_rgb_loc;    ///< Uniform location for RGB mode flag.
 
 	GLuint sprite_program;    ///< Shader program for blending and rendering a sprite to the video buffer.
 	GLint  sprite_sprite_loc; ///< Uniform location for sprite parameters.
-	GLint  sprite_screen_loc; ///< Uniform location for screen size;
-	GLint  sprite_zoom_loc;   ///< Uniform location for sprite zoom;
-	GLint  sprite_rgb_loc;    ///< Uniform location for RGB mode flag;
-	GLint  sprite_crash_loc;  ///< Uniform location for crash remap mode flag;
+	GLint  sprite_screen_loc; ///< Uniform location for screen size.
+	GLint  sprite_zoom_loc;   ///< Uniform location for sprite zoom.
+	GLint  sprite_rgb_loc;    ///< Uniform location for RGB mode flag.
+	GLint  sprite_crash_loc;  ///< Uniform location for crash remap mode flag.
 
 	LRUCache<SpriteID, Sprite> cursor_cache;   ///< Cache of encoded cursor sprites.
 	PaletteID last_sprite_pal = (PaletteID)-1; ///< Last uploaded remap palette.

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -262,8 +262,8 @@ void InitializeWindowViewport(Window *w, int x, int y,
 	vp->overlay = nullptr;
 
 	w->viewport = vp;
-	vp->virtual_left = 0; // pt.x;
-	vp->virtual_top = 0;  // pt.y;
+	vp->virtual_left = 0;
+	vp->virtual_top = 0;
 }
 
 static Point _vp_move_offs;


### PR DESCRIPTION
## Motivation / Problem

CodeQL complaining about commented out code.


## Description

Either remove the code, remove a semi-colon from the comment to make it not look like code, or use the commented code instead of the handcrafted code. In the latter cases minimal optimisation (-O1) already yields the same machine code (clang, gcc & MSVC).


## Limitations

Potential tiny increase in runtime of debug builds due to hand crafted optimization not taking place when optimizations are disabled.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
