### PR TITLE
Codechange: pass large objects by reference instead of value

### DIFF
--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -115,7 +115,7 @@ private:
 
 public:
 	TCPConnecter() {};
-	TCPConnecter(const std::string &connection_string, uint16 default_port, NetworkAddress bind_address = {}, int family = AF_UNSPEC);
+	TCPConnecter(const std::string &connection_string, uint16 default_port, const NetworkAddress &bind_address = {}, int family = AF_UNSPEC);
 	virtual ~TCPConnecter();
 
 	/**

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -29,7 +29,7 @@ static std::vector<TCPConnecter *> _tcp_connecters;
  * @param default_port If not indicated in connection_string, what port to use.
  * @param bind_address The local bind address to use. Defaults to letting the OS find one.
  */
-TCPConnecter::TCPConnecter(const std::string &connection_string, uint16 default_port, NetworkAddress bind_address, int family) :
+TCPConnecter::TCPConnecter(const std::string &connection_string, uint16 default_port, const NetworkAddress &bind_address, int family) :
 	bind_address(bind_address),
 	family(family)
 {

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -70,7 +70,7 @@ struct IniItem;
 
 /** Properties of config file settings. */
 struct SettingDesc {
-	SettingDesc(SaveLoad save, SettingFlag flags, bool startup) :
+	SettingDesc(const SaveLoad &save, SettingFlag flags, bool startup) :
 		flags(flags), startup(startup), save(save) {}
 	virtual ~SettingDesc() {}
 
@@ -149,7 +149,7 @@ struct IntSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(int32 value);
 
-	IntSettingDesc(SaveLoad save, SettingFlag flags, bool startup, int32 def,
+	IntSettingDesc(const SaveLoad &save, SettingFlag flags, bool startup, int32 def,
 			int32 min, uint32 max, int32 interval, StringID str, StringID str_help, StringID str_val,
 			SettingCategory cat, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, flags, startup), def(def), min(min), max(max), interval(interval),
@@ -191,7 +191,7 @@ private:
 
 /** Boolean setting. */
 struct BoolSettingDesc : IntSettingDesc {
-	BoolSettingDesc(SaveLoad save, SettingFlag flags, bool startup, bool def,
+	BoolSettingDesc(const SaveLoad &save, SettingFlag flags, bool startup, bool def,
 			StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		IntSettingDesc(save, flags, startup, def, 0, 1, 0, str, str_help, str_val, cat,
@@ -207,7 +207,7 @@ struct BoolSettingDesc : IntSettingDesc {
 struct OneOfManySettingDesc : IntSettingDesc {
 	typedef size_t OnConvert(const char *value); ///< callback prototype for conversion error
 
-	OneOfManySettingDesc(SaveLoad save, SettingFlag flags, bool startup, int32 def,
+	OneOfManySettingDesc(const SaveLoad &save, SettingFlag flags, bool startup, int32 def,
 			int32 max, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 			PreChangeCheck pre_check, PostChangeCallback post_callback,
 			std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -231,7 +231,7 @@ struct OneOfManySettingDesc : IntSettingDesc {
 
 /** Many of many setting. */
 struct ManyOfManySettingDesc : OneOfManySettingDesc {
-	ManyOfManySettingDesc(SaveLoad save, SettingFlag flags, bool startup,
+	ManyOfManySettingDesc(const SaveLoad &save, SettingFlag flags, bool startup,
 		int32 def, StringID str, StringID str_help, StringID str_val, SettingCategory cat,
 		PreChangeCheck pre_check, PostChangeCallback post_callback,
 		std::initializer_list<const char *> many, OnConvert *many_cnvt) :
@@ -260,7 +260,7 @@ struct StringSettingDesc : SettingDesc {
 	 */
 	typedef void PostChangeCallback(const std::string &value);
 
-	StringSettingDesc(SaveLoad save, SettingFlag flags, bool startup, const char *def,
+	StringSettingDesc(const SaveLoad &save, SettingFlag flags, bool startup, const char *def,
 			uint32 max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
 			pre_check(pre_check), post_callback(post_callback) {}
@@ -286,7 +286,7 @@ private:
 
 /** List/array settings. */
 struct ListSettingDesc : SettingDesc {
-	ListSettingDesc(SaveLoad save, SettingFlag flags, bool startup, const char *def) :
+	ListSettingDesc(const SaveLoad &save, SettingFlag flags, bool startup, const char *def) :
 		SettingDesc(save, flags, startup), def(def) {}
 	virtual ~ListSettingDesc() {}
 
@@ -299,7 +299,7 @@ struct ListSettingDesc : SettingDesc {
 
 /** Placeholder for settings that have been removed, but might still linger in the savegame. */
 struct NullSettingDesc : SettingDesc {
-	NullSettingDesc(SaveLoad save) :
+	NullSettingDesc(const SaveLoad &save) :
 		SettingDesc(save, SF_NOT_IN_CONFIG, false) {}
 	virtual ~NullSettingDesc() {}
 


### PR DESCRIPTION
## Motivation / Problem

CodeQL having nine notes about passing large objects by value.


## Description

Pass them by const reference instead, especially in the constructors where we are passing the data down to be placed in an instance variable.


## Limitations

None. If it compiles on all platforms.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
