### PR TITLE
Fix several cases where global pointer outlives stack reference

### DIFF
--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -15,16 +15,8 @@
  */
 class CrashLog {
 private:
-	/** Pointer to the error message. */
-	static const char *message;
-
-	/** Temporary 'local' location of the buffer. */
-	static char *gamelog_buffer;
-
-	/** Temporary 'local' location of the end of the buffer. */
-	static const char *gamelog_last;
-
-	static void GamelogFillCrashLog(const char *s);
+	/** Error message coming from #error(const char *, ...). */
+	static std::string message;
 protected:
 	/**
 	 * Writes OS' version to the buffer.
@@ -46,7 +38,7 @@ protected:
 	 * Writes actually encountered error to the buffer.
 	 * @param buffer  The begin where to write at.
 	 * @param last    The last position in the buffer to write to.
-	 * @param message Message passed to use for possible errors. Can be nullptr.
+	 * @param message Message passed to use for errors.
 	 * @return the position of the \c '\0' character after the buffer.
 	 */
 	virtual char *LogError(char *buffer, const char *last, const char *message) const = 0;

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -189,7 +189,7 @@ typedef SmallMap<uint32, GRFPresence> GrfIDMapping;
  * Prints active gamelog
  * @param proc the procedure to draw with
  */
-void GamelogPrint(GamelogPrintProc *proc)
+void GamelogPrint(std::function<void(const char*)> proc)
 {
 	char buffer[1024];
 	GrfIDMapping grf_names;
@@ -341,24 +341,13 @@ void GamelogPrint(GamelogPrintProc *proc)
 }
 
 
-static void GamelogPrintConsoleProc(const char *s)
-{
-	IConsolePrint(CC_WARNING, s);
-}
-
 /** Print the gamelog data to the console. */
 void GamelogPrintConsole()
 {
-	GamelogPrint(&GamelogPrintConsoleProc);
+	GamelogPrint([](const char *s) {
+		IConsolePrint(CC_WARNING, s);
+	});
 }
-
-static int _gamelog_print_level = 0; ///< gamelog debug level we need to print stuff
-
-static void GamelogPrintDebugProc(const char *s)
-{
-	Debug(gamelog, _gamelog_print_level, "{}", s);
-}
-
 
 /**
  * Prints gamelog to debug output. Code is executed even when
@@ -368,8 +357,9 @@ static void GamelogPrintDebugProc(const char *s)
  */
 void GamelogPrintDebug(int level)
 {
-	_gamelog_print_level = level;
-	GamelogPrint(&GamelogPrintDebugProc);
+	GamelogPrint([level](const char *s) {
+		Debug(gamelog, level, "{}", s);
+	});
 }
 
 

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -10,6 +10,7 @@
 #ifndef GAMELOG_H
 #define GAMELOG_H
 
+#include <functional>
 #include "newgrf_config.h"
 
 /** The actions we log. */
@@ -32,13 +33,7 @@ void GamelogStopAnyAction();
 void GamelogFree(struct LoggedAction *gamelog_action, uint gamelog_actions);
 void GamelogReset();
 
-/**
- * Callback for printing text.
- * @param s The string to print.
- */
-typedef void GamelogPrintProc(const char *s);
-void GamelogPrint(GamelogPrintProc *proc); // needed for WIN32 crash.log
-
+void GamelogPrint(std::function<void(const char *)> proc);
 void GamelogPrintDebug(int level);
 void GamelogPrintConsole();
 

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -80,7 +80,7 @@ class CrashLogOSX : public CrashLog {
 				" Message: %s\n\n",
 				strsignal(this->signum),
 				this->signum,
-				message == nullptr ? "<none>" : message
+				message
 		);
 	}
 

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -66,7 +66,7 @@ class CrashLogUnix : public CrashLog {
 				" Message: %s\n\n",
 				strsignal(this->signum),
 				this->signum,
-				message == nullptr ? "<none>" : message
+				message
 		);
 	}
 

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -114,7 +114,7 @@ public:
 			" Message:   %s\n\n",
 			(int)ep->ExceptionRecord->ExceptionCode,
 			(size_t)ep->ExceptionRecord->ExceptionAddress,
-			message == nullptr ? "<none>" : message
+			message
 	);
 }
 

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -40,8 +40,8 @@ DECLARE_ENUM_AS_BIT_SET(VehicleEnterTileStatus)
 
 /** Tile information, used while rendering the tile */
 struct TileInfo {
-	uint x;         ///< X position of the tile in unit coordinates
-	uint y;         ///< Y position of the tile in unit coordinates
+	int x;          ///< X position of the tile in unit coordinates
+	int y;          ///< Y position of the tile in unit coordinates
 	Slope tileh;    ///< Slope of the tile
 	TileIndex tile; ///< Tile index
 	int z;          ///< Height


### PR DESCRIPTION
## Motivation / Problem

CodeQL warning about a local variable address stored in non-local memory.


## Description

In crashlog an reference to an error message constructed in `abort()` is passed to a global variable, and then that global is used later on in the logging. However, in the `abort` the stack and heap are (most likely) not yet corrupted, so we can as easily just write that to a `string`. By making the default for the string the fallback in case we are not coming from `abort()`, the different crashlog handlers don't need to have their own code to check for `nullptr`.

The two other globals that get a stack location for gamelog printing can easily be replaced by a lambda with capturing, which also paves the way to not have the debug level global for one of the other gamelog printing routines. And since gamelog printing is not done that often, the performance impact of `std::function` should be negligible.

The global pointer in the viewport code can as easily just be an instance of the structure. That will be a few extra bytes, but removed a layer of indirection and prevents there from ever be a dangling pointer to a location somewhere on the stack. A longer term alternative would be passing a `TileInfo` reference all the way down to the drawing routine. But that is a much bigger refactor which should probably be done eventually, but that is not in the scope of this.
The change to `int` for x and y of `TileInfo` seems safe, as there is no combination of map sizes (when accounting for a minimum of 64 tiles per side) where the `int32` x or y would overflow without overflowing `TileIndex`. Only when one side becomes 32 tiles or less could you overflow x or y before `TileIndex`.
Mostly as overflow of y is dictated by `(SizeX() + SizeY()) * 16` whereas `TileIndex`'s overflow is dictated by `SizeX() * SizeY()`.


## Limitations

None as far as I know.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
