### PR TITLE
Codechange: do not declare functions in blocks

### DIFF
--- a/src/ai/ai_instance.cpp
+++ b/src/ai/ai_instance.cpp
@@ -80,7 +80,6 @@ void AIInstance::Died()
 void AIInstance::LoadDummyScript()
 {
 	ScriptAllocatorScope alloc_scope(this->engine);
-	extern void Script_CreateDummy(HSQUIRRELVM vm, StringID string, const char *type);
 	Script_CreateDummy(this->engine->GetVM(), STR_ERROR_AI_NO_AI_FOUND, "AI");
 }
 

--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -35,7 +35,6 @@ void AIScannerInfo::Initialize()
 
 	/* Create the dummy AI */
 	this->main_script = "%_dummy";
-	extern void Script_CreateDummyInfo(HSQUIRRELVM vm, const char *type, const char *dir);
 	Script_CreateDummyInfo(this->engine->GetVM(), "AI", "ai");
 }
 

--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -139,5 +139,6 @@ struct Aircraft FINAL : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 void GetRotorImage(const Aircraft *v, EngineImageType image_type, VehicleSpriteSeq *result);
 
 Station *GetTargetAirportIfValid(const Aircraft *v);
+void HandleMissingAircraftOrders(Aircraft *v);
 
 #endif /* AIRCRAFT_H */

--- a/src/base_media_func.h
+++ b/src/base_media_func.h
@@ -15,6 +15,8 @@
 #include "ini_type.h"
 #include "string_func.h"
 
+extern void CheckExternalFiles();
+
 /**
  * Try to read a single piece of metadata and return false if it doesn't exist.
  * @param name the name of the item to fetch.
@@ -227,8 +229,6 @@ bool BaseMedia<Tbase_set>::AddFile(const std::string &filename, size_t basepath_
 template <class Tbase_set>
 /* static */ bool BaseMedia<Tbase_set>::SetSet(const std::string &name)
 {
-	extern void CheckExternalFiles();
-
 	if (name.empty()) {
 		if (!BaseMedia<Tbase_set>::DetermineBestSet()) return false;
 		CheckExternalFiles();

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -42,6 +42,7 @@
 #include "safeguards.h"
 
 void ClearEnginesHiddenFlagOfCompany(CompanyID cid);
+void UpdateObjectColours(const Company *c);
 
 CompanyID _local_company;   ///< Company controlled by the human player at this client. Can also be #COMPANY_SPECTATOR.
 CompanyID _current_company; ///< Company currently doing an action.
@@ -1029,7 +1030,6 @@ CommandCost CmdSetCompanyColour(DoCommandFlag flags, LiveryScheme scheme, bool p
 			if (v->owner == _current_company) v->InvalidateNewGRFCache();
 		}
 
-		extern void UpdateObjectColours(const Company *c);
 		UpdateObjectColours(c);
 	}
 	return CommandCost();

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1069,6 +1069,9 @@ DEF_CONSOLE_CMD(ConReturn)
  *  default console commands
  ******************************/
 extern bool CloseConsoleLogIfActive();
+extern const std::vector<GRFFile *> &GetAllGRFFiles();
+extern void ConPrintFramerate(); // framerate_gui.cpp
+extern void ShowFramerateWindow();
 
 DEF_CONSOLE_CMD(ConScript)
 {
@@ -2213,7 +2216,6 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		return true;
 	}
 
-	extern const std::vector<GRFFile *> &GetAllGRFFiles();
 	const std::vector<GRFFile *> &files = GetAllGRFFiles();
 
 	/* "list" sub-command */
@@ -2338,8 +2340,6 @@ static void IConsoleDebugLibRegister()
 
 DEF_CONSOLE_CMD(ConFramerate)
 {
-	extern void ConPrintFramerate(); // framerate_gui.cpp
-
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Show frame rate and game speed information.");
 		return true;
@@ -2351,8 +2351,6 @@ DEF_CONSOLE_CMD(ConFramerate)
 
 DEF_CONSOLE_CMD(ConFramerateWindow)
 {
-	extern void ShowFramerateWindow();
-
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Open the frame rate window.");
 		return true;

--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -14,6 +14,8 @@
 #include "mem_func.hpp"
 #include "pool_type.hpp"
 
+extern void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);
+
 /**
  * Helper for defining the method's signature.
  * @param type The return type of the method.
@@ -154,8 +156,6 @@ DEFINE_POOL_METHOD(void *)::GetNew(size_t size)
  */
 DEFINE_POOL_METHOD(void *)::GetNew(size_t size, size_t index)
 {
-	extern void NORETURN SlErrorCorruptFmt(const char *format, ...);
-
 	if (index >= Tmax_size) {
 		SlErrorCorruptFmt("%s index " PRINTF_SIZE " out of range (" PRINTF_SIZE ")", this->name, index, Tmax_size);
 	}

--- a/src/depot_func.h
+++ b/src/depot_func.h
@@ -14,6 +14,7 @@
 #include "slope_func.h"
 
 void ShowDepotWindow(TileIndex tile, VehicleType type);
+void InitDepotWindowBlockSizes();
 
 void DeleteDepotHighlightOfVehicle(const Vehicle *v);
 

--- a/src/error.h
+++ b/src/error.h
@@ -10,6 +10,7 @@
 #ifndef ERROR_H
 #define ERROR_H
 
+#include <list>
 #include "strings_type.h"
 #include "company_type.h"
 #include "core/geometry_type.hpp"
@@ -57,6 +58,10 @@ public:
 	void CopyOutDParams();
 };
 
+/** Define a queue with errors. */
+typedef std::list<ErrorMessageData> ErrorList;
+
+void ScheduleErrorMessage(ErrorList &datas);
 void ScheduleErrorMessage(const ErrorMessageData &data);
 
 void ShowErrorMessage(StringID summary_msg, StringID detailed_msg, WarningLevel wl, int x = 0, int y = 0, const GRFFile *textref_stack_grffile = nullptr, uint textref_stack_size = 0, const uint32 *textref_stack = nullptr);

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -174,10 +174,8 @@ void ErrorMessageData::SetDParamStr(uint n, const std::string &str)
 	this->SetDParamStr(n, str.c_str());
 }
 
-/** Define a queue with errors. */
-typedef std::list<ErrorMessageData> ErrorList;
 /** The actual queue with errors. */
-ErrorList _error_list;
+static ErrorList _error_list;
 /** Whether the window system is initialized or not. */
 bool _window_system_initialized = false;
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -69,6 +69,8 @@ TarFileList _tar_filelist[NUM_SUBDIRS];
 typedef std::map<std::string, std::string> TarLinkList;
 static TarLinkList _tar_linklist[NUM_SUBDIRS]; ///< List of directory links
 
+extern bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb);
+
 /**
  * Checks whether the given search path is a valid search path
  * @param sp the search path to check
@@ -1154,8 +1156,6 @@ static bool MatchesExtension(const char *extension, const char *filename)
  */
 static uint ScanPath(FileScanner *fs, const char *extension, const char *path, size_t basepath_length, bool recursive)
 {
-	extern bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb);
-
 	uint num = 0;
 	struct stat sb;
 	struct dirent *dirent;

--- a/src/fios.h
+++ b/src/fios.h
@@ -125,6 +125,9 @@ std::string FiosMakeSavegameName(const char *name);
 
 FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last);
 
+void ScanScenarios();
+const char *FindScenario(const ContentInfo *ci, bool md5sum);
+
 /**
  * A savegame name automatically numbered.
  */

--- a/src/fontcache.cpp
+++ b/src/fontcache.cpp
@@ -121,6 +121,15 @@ void SetFont(FontSize fontsize, const std::string& font, uint size, bool aa)
 	if (_save_config) SaveToConfig();
 }
 
+#ifdef WITH_FREETYPE
+extern void LoadFreeTypeFont(FontSize fs);
+extern void UninitFreeType();
+#elif defined(_WIN32)
+extern void LoadWin32Font(FontSize fs);
+#elif defined(WITH_COCOA)
+extern void LoadCoreTextFont(FontSize fs);
+#endif
+
 /**
  * (Re)initialize the font cache related things, i.e. load the non-sprite fonts.
  * @param monospace Whether to initialise the monospace or regular fonts.
@@ -134,13 +143,10 @@ void InitFontCache(bool monospace)
 		if (fc->HasParent()) delete fc;
 
 #ifdef WITH_FREETYPE
-		extern void LoadFreeTypeFont(FontSize fs);
 		LoadFreeTypeFont(fs);
 #elif defined(_WIN32)
-		extern void LoadWin32Font(FontSize fs);
 		LoadWin32Font(fs);
 #elif defined(WITH_COCOA)
-		extern void LoadCoreTextFont(FontSize fs);
 		LoadCoreTextFont(fs);
 #endif
 	}
@@ -157,7 +163,6 @@ void UninitFontCache()
 	}
 
 #ifdef WITH_FREETYPE
-	extern void UninitFreeType();
 	UninitFreeType();
 #endif /* WITH_FREETYPE */
 }

--- a/src/framerate_type.h
+++ b/src/framerate_type.h
@@ -121,5 +121,6 @@ public:
 };
 
 void ShowFramerateWindow();
+void ProcessPendingPerformanceMeasurements();
 
 #endif /* FRAMERATE_TYPE_H */

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -71,6 +71,7 @@ struct CargoSuffix {
 	char text[512];             ///< Cargo suffix text.
 };
 
+extern void GenerateIndustries();
 static void ShowIndustryCargoesWindow(IndustryType id);
 
 /**
@@ -598,7 +599,6 @@ public:
 		if (Town::GetNumItems() == 0) {
 			ShowErrorMessage(STR_ERROR_CAN_T_GENERATE_INDUSTRIES, STR_ERROR_MUST_FOUND_TOWN_FIRST, WL_INFO);
 		} else {
-			extern void GenerateIndustries();
 			Backup<bool> old_generating_world(_generating_world, true, FILE_LINE);
 			BasePersistentStorageArray::SwitchMode(PSM_ENTER_GAMELOOP);
 			GenerateIndustries();

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -85,7 +85,6 @@ const char *ContentInfo::GetTextfile(TextfileType type) const
 			break;
 		case CONTENT_TYPE_SCENARIO:
 		case CONTENT_TYPE_HEIGHTMAP:
-			extern const char *FindScenario(const ContentInfo *ci, bool md5sum);
 			tmp = FindScenario(this, true);
 			break;
 	}

--- a/src/network/core/tcp_game.cpp
+++ b/src/network/core/tcp_game.cpp
@@ -42,7 +42,6 @@ NetworkRecvStatus NetworkGameSocketHandler::CloseConnection(bool error)
 {
 	/* Clients drop back to the main menu */
 	if (!_network_server && _networking) {
-		extern void ClientNetworkEmergencySave(); // from network_client.cpp
 		ClientNetworkEmergencySave();
 		_switch_mode = SM_MENU;
 		_networking = false;

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -85,9 +85,6 @@ static_assert((int)NETWORK_COMPANY_NAME_LENGTH == MAX_LENGTH_COMPANY_NAME_CHARS 
 /** The amount of clients connected */
 byte _network_clients_connected = 0;
 
-/* Some externs / forwards */
-extern void StateGameLoop();
-
 /**
  * Return whether there is any client connected or trying to connect at all.
  * @return whether we have any client activity

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -264,7 +264,6 @@ void ClientNetworkGameSocketHandler::ClientError(NetworkRecvStatus res)
 
 	NetworkExecuteLocalCommandQueue();
 
-	extern void StateGameLoop();
 	StateGameLoop();
 
 	/* Check if we are in sync! */

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -21,6 +21,7 @@
 #include "../querystring_gui.h"
 #include "../core/geometry_func.hpp"
 #include "../textfile_gui.h"
+#include "../fios.h"
 #include "network_content_gui.h"
 
 
@@ -263,7 +264,6 @@ public:
 
 				case CONTENT_TYPE_SCENARIO:
 				case CONTENT_TYPE_HEIGHTMAP:
-					extern void ScanScenarios();
 					ScanScenarios();
 					InvalidateWindowData(WC_SAVELOAD, 0, 0);
 					break;
@@ -344,8 +344,6 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	/** Search external websites for content */
 	void OpenExternalSearch()
 	{
-		extern void OpenBrowser(const char *url);
-
 		char url[1024];
 		const char *last = lastof(url);
 
@@ -854,7 +852,6 @@ public:
 
 			case WID_NCL_OPEN_URL:
 				if (this->selected != nullptr) {
-					extern void OpenBrowser(const char *url);
 					OpenBrowser(this->selected->url.c_str());
 				}
 				break;

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -85,6 +85,7 @@ uint NetworkServerKickOrBanIP(ClientID client_id, bool ban, const std::string &r
 uint NetworkServerKickOrBanIP(const std::string &ip, bool ban, const std::string &reason);
 
 void NetworkInitChatMessage();
+void NetworkReInitChatBoxSize();
 void CDECL NetworkAddChatMessage(TextColour colour, uint duration, const std::string &message);
 void NetworkUndrawChatMessage();
 void NetworkChatMessageLoop();

--- a/src/network/network_internal.h
+++ b/src/network/network_internal.h
@@ -138,4 +138,6 @@ std::string_view ParseCompanyFromConnectionString(const std::string &connection_
 NetworkAddress ParseConnectionString(const std::string &connection_string, uint16 default_port);
 std::string NormalizeConnectionString(const std::string &connection_string, uint16 default_port);
 
+void ClientNetworkEmergencySave();
+
 #endif /* NETWORK_INTERNAL_H */

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -23,6 +23,7 @@
 
 #include "safeguards.h"
 
+extern uint32 GetRelativePosition(TileIndex tile, TileIndex ind_tile);
 
 AirportTileSpec AirportTileSpec::tiles[NUM_AIRPORTTILES];
 
@@ -161,8 +162,6 @@ static uint32 GetAirportTileIDAtOffset(TileIndex tile, const Station *st, uint32
 /* virtual */ uint32 AirportTileScopeResolver::GetVariable(byte variable, uint32 parameter, bool *available) const
 {
 	assert(this->st != nullptr);
-
-	extern uint32 GetRelativePosition(TileIndex tile, TileIndex ind_tile);
 
 	switch (variable) {
 		/* Terrain type */

--- a/src/newgrf_airporttiles.h
+++ b/src/newgrf_airporttiles.h
@@ -82,7 +82,6 @@ private:
 	friend void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts);
 };
 
-StationGfx GetTranslatedAirportTileID(StationGfx gfx);
 void AnimateAirportTile(TileIndex tile);
 void AirportTileAnimationTrigger(Station *st, TileIndex tile, AirpAnimationTrigger trigger, CargoID cargo_type = CT_INVALID);
 void AirportAnimationTrigger(Station *st, AirpAnimationTrigger trigger, CargoID cargo_type = CT_INVALID);

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -121,4 +121,6 @@ void CommitVehicleListOrderChanges();
 
 EngineID GetNewEngineID(const GRFFile *file, VehicleType type, uint16 internal_id);
 
+void FillNewGRFVehicleCache(const Vehicle *v);
+
 #endif /* NEWGRF_ENGINE_H */

--- a/src/newgrf_generic.h
+++ b/src/newgrf_generic.h
@@ -48,6 +48,7 @@ void ResetGenericCallbacks();
 void AddGenericCallback(uint8 feature, const GRFFile *file, const SpriteGroup *group);
 
 uint16 GetAiPurchaseCallbackResult(uint8 feature, CargoID cargo_type, uint8 default_selection, IndustryType src_industry, IndustryType dst_industry, uint8 distance, AIConstructionEvent event, uint8 count, uint8 station_size, const GRFFile **file);
+void AmbientSoundEffectCallback(TileIndex tile);
 
 /** Play an ambient sound effect for an empty tile. */
 static inline void AmbientSoundEffect(TileIndex tile)
@@ -55,7 +56,6 @@ static inline void AmbientSoundEffect(TileIndex tile)
 	/* Only run callback if enabled. */
 	if (!HasGrfMiscBit(GMB_AMBIENT_SOUND_CALLBACK)) return;
 
-	extern void AmbientSoundEffectCallback(TileIndex tile);
 	AmbientSoundEffectCallback(tile);
 }
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -950,7 +950,6 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 			case WID_NS_OPEN_URL: {
 				const GRFConfig *c = (this->avail_sel == nullptr) ? this->active_sel : this->avail_sel;
 
-				extern void OpenBrowser(const char *url);
 				OpenBrowser(c->GetURL());
 				break;
 			}

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -89,7 +89,10 @@ void ResetMusic();
 void CallWindowGameTickEvent();
 bool HandleBootstrap();
 
+extern void AfterLoadCompanyStats();
 extern Company *DoStartupNewCompany(bool is_ai, CompanyID company = INVALID_COMPANY);
+extern void OSOpenBrowser(const char *url);
+extern void RebuildTownCaches();
 extern void ShowOSErrorBox(const char *buf, bool system);
 extern std::string _config_file;
 
@@ -402,7 +405,6 @@ void OpenBrowser(const char *url)
 	/* Make sure we only accept urls that are sure to open a browser. */
 	if (strstr(url, "http://") != url && strstr(url, "https://") != url) return;
 
-	extern void OSOpenBrowser(const char *url);
 	OSOpenBrowser(url);
 }
 
@@ -1161,7 +1163,6 @@ static void CheckCaches()
 		old_town_caches.push_back(t->cache);
 	}
 
-	extern void RebuildTownCaches();
 	RebuildTownCaches();
 	RebuildSubsidisedSourceAndDestinationCache();
 
@@ -1177,7 +1178,6 @@ static void CheckCaches()
 	std::vector<CompanyInfrastructure> old_infrastructure;
 	for (const Company *c : Company::Iterate()) old_infrastructure.push_back(c->infrastructure);
 
-	extern void AfterLoadCompanyStats();
 	AfterLoadCompanyStats();
 
 	i = 0;
@@ -1198,7 +1198,6 @@ static void CheckCaches()
 	}
 
 	for (Vehicle *v : Vehicle::Iterate()) {
-		extern void FillNewGRFVehicleCache(const Vehicle *v);
 		if (v != v->First() || v->vehstatus & VS_CRASHED || !v->IsPrimaryVehicle()) continue;
 
 		uint length = 0;

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -79,10 +79,13 @@ void AskExitGame();
 void AskExitToGameMenu();
 
 int openttd_main(int argc, char *argv[]);
+void StateGameLoop();
 void HandleExitGameRequest();
 
 void SwitchToMode(SwitchMode new_mode);
 
 bool RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
+
+void OpenBrowser(const char *url);
 
 #endif /* OPENTTD_H */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1996,7 +1996,6 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 						Aircraft *a = Aircraft::From(v);
 						if (a->state == FLYING && a->targetairport != closestDepot.destination) {
 							/* The aircraft is now heading for a different hangar than the next in the orders */
-							extern void AircraftNextAirportPos_and_Order(Aircraft *a);
 							AircraftNextAirportPos_and_Order(a);
 						}
 					}
@@ -2138,7 +2137,6 @@ bool ProcessOrders(Vehicle *v)
 	if (order == nullptr || (v->type == VEH_AIRCRAFT && !CheckForValidOrders(v))) {
 		if (v->type == VEH_AIRCRAFT) {
 			/* Aircraft do something vastly different here, so handle separately */
-			extern void HandleMissingAircraftOrders(Aircraft *v);
 			HandleMissingAircraftOrders(Aircraft::From(v));
 			return false;
 		}

--- a/src/roadveh_cmd.h
+++ b/src/roadveh_cmd.h
@@ -15,6 +15,8 @@
 #include "vehicle_type.h"
 
 bool RoadVehLeaveDepot(RoadVehicle *v, bool first);
+bool IndividualRoadVehicleController(RoadVehicle *v, const RoadVehicle *prev);
+bool RoadVehiclesAreBuilt();
 
 CommandCost CmdBuildRoadVehicle(DoCommandFlag flags, TileIndex tile, const Engine *e, Vehicle **v);
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2941,7 +2941,6 @@ bool AfterLoadGame()
 				RoadVehicle *u = v;
 				RoadVehicle *prev = nullptr;
 				for (uint sf : skip_frames) {
-					extern bool IndividualRoadVehicleController(RoadVehicle *v, const RoadVehicle *prev);
 					if (sf >= cur_skip) IndividualRoadVehicleController(u, prev);
 
 					prev = u;

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -367,6 +367,8 @@ void NORETURN SlErrorCorrupt(const char *msg)
 	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, msg);
 }
 
+void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);
+
 /**
  * Issue an SlErrorCorrupt with a format string.
  * @param format format string

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -1134,7 +1134,6 @@ std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLo
 void SlObject(void *object, const SaveLoadTable &slt);
 void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
 void NORETURN SlErrorCorrupt(const char *msg);
-void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);
 
 bool SaveloadCrashWithMissingNewGRFs();
 

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -128,9 +128,6 @@
 
 /* static */ int ScriptAirport::GetNoiseLevelIncrease(TileIndex tile, AirportType type)
 {
-	extern Town *AirportGetNearestTown(const AirportSpec *as, const TileIterator &it, uint &mindist);
-	extern uint8 GetAirportNoiseLevelForDistance(const AirportSpec *as, uint distance);
-
 	if (!::IsValidTile(tile)) return -1;
 	if (!IsAirportInformationAvailable(type)) return -1;
 
@@ -149,8 +146,6 @@
 
 /* static */ TownID ScriptAirport::GetNearestTown(TileIndex tile, AirportType type)
 {
-	extern Town *AirportGetNearestTown(const AirportSpec *as, const TileIterator &it, uint &mindist);
-
 	if (!::IsValidTile(tile)) return INVALID_TOWN;
 	if (!IsAirportInformationAvailable(type)) return INVALID_TOWN;
 

--- a/src/script/script_info.hpp
+++ b/src/script/script_info.hpp
@@ -164,4 +164,7 @@ private:
 	class ScriptScanner *scanner; ///< ScriptScanner object that was used to scan this script info.
 };
 
+void Script_CreateDummyInfo(HSQUIRRELVM vm, const char *type, const char *dir);
+void Script_CreateDummy(HSQUIRRELVM vm, StringID string, const char *type);
+
 #endif /* SCRIPT_INFO_HPP */

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -12,6 +12,7 @@
 #include "../saveload/saveload.h"
 
 #include "../script/squirrel_class.hpp"
+#include "../script/squirrel_std.hpp"
 
 #include "script_fatalerror.hpp"
 #include "script_storage.hpp"
@@ -110,7 +111,6 @@ void ScriptInstance::Initialize(const char *main_script, const char *instance_na
 
 void ScriptInstance::RegisterAPI()
 {
-	extern void squirrel_register_std(Squirrel *engine);
 	squirrel_register_std(this->engine);
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -58,7 +58,6 @@ std::string _config_file; ///< Configuration file of OpenTTD.
 std::string _private_file; ///< Private configuration file of OpenTTD.
 std::string _secrets_file; ///< Secrets configuration file of OpenTTD.
 
-typedef std::list<ErrorMessageData> ErrorList;
 static ErrorList _settings_error_list; ///< Errors while loading minimal settings.
 
 /**
@@ -1250,7 +1249,6 @@ void LoadFromConfig(bool startup)
 		DebugReconsiderSendRemoteMessages();
 
 		/* Display scheduled errors */
-		extern void ScheduleErrorMessage(ErrorList &datas);
 		ScheduleErrorMessage(_settings_error_list);
 		if (FindWindowById(WC_ERRMSG, 0) == nullptr) ShowFirstError();
 	}

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -42,7 +42,9 @@
 #include "ship.h"
 #include "smallmap_gui.h"
 #include "roadveh.h"
+#include "roadveh_cmd.h"
 #include "vehicle_func.h"
+#include "viewport_func.h"
 #include "void_map.h"
 
 #include "table/strings.h"
@@ -258,7 +260,6 @@ static void TownFoundingChanged(int32 new_value)
 
 static void ZoomMinMaxChanged(int32 new_value)
 {
-	extern void ConstrainAllViewportsZoom();
 	ConstrainAllViewportsZoom();
 	GfxClearSpriteCache();
 	if (_settings_client.gui.zoom_min > _gui_zoom) {
@@ -323,7 +324,6 @@ static void MaxNoAIsChange(int32 new_value)
  */
 static bool CheckRoadSide(int32 &new_value)
 {
-	extern bool RoadVehiclesAreBuilt();
 	return _game_mode == GM_MENU || !RoadVehiclesAreBuilt();
 }
 

--- a/src/station_cmd.h
+++ b/src/station_cmd.h
@@ -15,6 +15,9 @@
 
 enum StationClassID : byte;
 
+extern Town *AirportGetNearestTown(const struct AirportSpec *as, const TileIterator &it, uint &mindist);
+extern uint8 GetAirportNoiseLevelForDistance(const struct AirportSpec *as, uint distance);
+
 CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, byte airport_type, byte layout, StationID station_to_join, bool allow_adjacent);
 CommandCost CmdBuildDock(DoCommandFlag flags, TileIndex tile, StationID station_to_join, bool adjacent);
 CommandCost CmdBuildRailStation(DoCommandFlag flags, TileIndex tile_org, RailType rt, Axis axis, byte numtracks, byte plat_len, StationClassID spec_class, byte spec_index, StationID station_to_join, bool adjacent);

--- a/src/station_map.h
+++ b/src/station_map.h
@@ -235,6 +235,8 @@ static inline bool IsDriveThroughStopTile(TileIndex t)
 	return IsRoadStopTile(t) && GetStationGfx(t) >= GFX_TRUCK_BUS_DRIVETHROUGH_OFFSET;
 }
 
+StationGfx GetTranslatedAirportTileID(StationGfx gfx);
+
 /**
  * Get the station graphics of this airport tile
  * @param t the tile to query
@@ -244,7 +246,6 @@ static inline bool IsDriveThroughStopTile(TileIndex t)
 static inline StationGfx GetAirportGfx(TileIndex t)
 {
 	assert(IsAirport(t));
-	extern StationGfx GetTranslatedAirportTileID(StationGfx gfx);
 	return GetTranslatedAirportTileID(GetStationGfx(t));
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -871,7 +871,6 @@ void Vehicle::PreDestructor()
 	DeleteVehicleOrders(this);
 	DeleteDepotHighlightOfVehicle(this);
 
-	extern void StopGlobalFollowVehicle(const Vehicle *v);
 	StopGlobalFollowVehicle(this);
 
 	ReleaseDisastersTargetingVehicle(this->index);
@@ -2449,7 +2448,6 @@ CommandCost Vehicle::SendToDepot(DoCommandFlag flags, DepotCommand command)
 			Aircraft *a = Aircraft::From(this);
 			if (a->state == FLYING && a->targetairport != closestDepot.destination) {
 				/* The aircraft is now heading for a different hangar than the next in the orders */
-				extern void AircraftNextAirportPos_and_Order(Aircraft *a);
 				AircraftNextAirportPos_and_Order(a);
 			}
 		}

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -112,6 +112,7 @@ bool VehicleClicked(const GUIVehicleGroup &vehgroup);
 void StartStopVehicle(const Vehicle *v, bool texteffect);
 
 Vehicle *CheckClickOnVehicle(const struct Viewport *vp, int x, int y);
+void StopGlobalFollowVehicle(const Vehicle *v);
 
 void DrawVehicleImage(const Vehicle *v, const Rect &r, VehicleID selection, EngineImageType image_type, int skip);
 void SetMouseCursorVehicle(const Vehicle *v, EngineImageType image_type);

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -31,6 +31,7 @@ bool MarkAllViewportsDirty(int left, int top, int right, int bottom);
 
 bool DoZoomInOutWindow(ZoomStateChange how, Window *w);
 void ZoomInOrOutToCursorWindow(bool in, Window * w);
+void ConstrainAllViewportsZoom();
 Point GetTileZoomCenterWindow(bool in, Window * w);
 void FixTitleGameZoom(int zoom_adjust = 0);
 void HandleZoomMessage(Window *w, const Viewport *vp, byte widget_zoom_in, byte widget_zoom_out);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -18,6 +18,7 @@
 #include "blitter/factory.hpp"
 #include "zoom_func.h"
 #include "vehicle_base.h"
+#include "depot_func.h"
 #include "window_func.h"
 #include "tilehighlight_func.h"
 #include "network/network.h"
@@ -3090,7 +3091,6 @@ void UpdateWindows()
 	PerformanceMeasurer framerate(PFE_DRAWING);
 	PerformanceAccumulator::Reset(PFE_DRAWWORLD);
 
-	extern void ProcessPendingPerformanceMeasurements();
 	ProcessPendingPerformanceMeasurements();
 
 	CallWindowRealtimeTickEvent(delta_ms);
@@ -3386,7 +3386,6 @@ void ReInitAllWindows(bool zoom_changed)
 	NWidgetLeaf::InvalidateDimensionCache(); // Reset cached sizes of several widgets.
 	NWidgetScrollbar::InvalidateDimensionCache();
 
-	extern void InitDepotWindowBlockSizes();
 	InitDepotWindowBlockSizes();
 
 	/* When _gui_zoom has changed, we need to resize toolbar and statusbar first,
@@ -3398,7 +3397,6 @@ void ReInitAllWindows(bool zoom_changed)
 		ReInitWindow(w, zoom_changed);
 	}
 
-	void NetworkReInitChatBoxSize();
 	NetworkReInitChatBoxSize();
 
 	/* Make sure essential parts of all windows are visible */


### PR DESCRIPTION
## Motivation / Problem

CodeQL alerting about functions being declared in blocks. Specifically that even if you declare them in a block, they will become available globally.


## Description

Either remove it because it was already declared outside the block, move it to the "global" scope of the cpp file or add the function to a reasonably appropriate header file.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
