### PR TITLE
Client id mistype

### DIFF
--- a/cmake/scripts/SquirrelExport.cmake
+++ b/cmake/scripts/SquirrelExport.cmake
@@ -298,7 +298,7 @@ foreach(LINE IN LISTS SOURCE_LINES)
                 string(APPEND SQUIRREL_EXPORT "\n	/* Allow enums to be used as Squirrel parameters */")
                 foreach(ENUM IN LISTS ENUMS)
                     string(APPEND SQUIRREL_EXPORT "\n	template <> inline ${ENUM} GetParam(ForceType<${ENUM}>, HSQUIRRELVM vm, int index, SQAutoFreePointers *ptr) { SQInteger tmp; sq_getinteger(vm, index, &tmp); return (${ENUM})tmp; }")
-                    string(APPEND SQUIRREL_EXPORT "\n	template <> inline int Return<${ENUM}>(HSQUIRRELVM vm, ${ENUM} res) { sq_pushinteger(vm, (int32)res); return 1; }")
+                    string(APPEND SQUIRREL_EXPORT "\n	template <> inline int Return<${ENUM}>(HSQUIRRELVM vm, ${ENUM} res) { sq_pushinteger(vm, res); return 1; }")
                 endforeach()
             endif()
 

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -224,9 +224,11 @@ CommandCost CmdSetGoalCompleted(DoCommandFlag flags, GoalID goal, bool completed
  * @param text Text of the question.
  * @return the cost of this operation or an error
  */
-CommandCost CmdGoalQuestion(DoCommandFlag flags, uint16 uniqueid, uint16 target, bool is_client, uint32 button_mask, GoalQuestionType type, const std::string &text)
+CommandCost CmdGoalQuestion(DoCommandFlag flags, uint16 uniqueid, uint32 target, bool is_client, uint32 button_mask, GoalQuestionType type, const std::string &text)
 {
+	static_assert(sizeof(uint32) >= sizeof(CompanyID));
 	CompanyID company = (CompanyID)target;
+	static_assert(sizeof(uint32) >= sizeof(ClientID));
 	ClientID client = (ClientID)target;
 
 	static_assert(GOAL_QUESTION_BUTTON_COUNT < 29);

--- a/src/goal_cmd.h
+++ b/src/goal_cmd.h
@@ -18,7 +18,7 @@ CommandCost CmdRemoveGoal(DoCommandFlag flags, GoalID goal);
 CommandCost CmdSetGoalText(DoCommandFlag flags, GoalID goal, const std::string &text);
 CommandCost CmdSetGoalProgress(DoCommandFlag flags, GoalID goal, const std::string &text);
 CommandCost CmdSetGoalCompleted(DoCommandFlag flags, GoalID goal, bool completed);
-CommandCost CmdGoalQuestion(DoCommandFlag flags, uint16 uniqueid, uint16 target, bool is_client, uint32 button_mask, GoalQuestionType type, const std::string &text);
+CommandCost CmdGoalQuestion(DoCommandFlag flags, uint16 uniqueid, uint32 target, bool is_client, uint32 button_mask, GoalQuestionType type, const std::string &text);
 CommandCost CmdGoalQuestionAnswer(DoCommandFlag flags, uint16 uniqueid, uint8 button);
 
 DEF_CMD_TRAIT(CMD_CREATE_GOAL,          CmdCreateGoal,         CMD_DEITY | CMD_STR_CTRL, CMDT_OTHER_MANAGEMENT)

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -137,8 +137,6 @@
 {
 	EnforcePrecondition(false, ScriptGame::IsMultiplayer());
 	EnforcePrecondition(false, ScriptClient::ResolveClientID(client) != ScriptClient::CLIENT_INVALID);
-	/* Can only send 16 bits of client_id before proper fix is implemented */
-	EnforcePrecondition(false, client < (1 << 16));
 	return DoQuestion(uniqueid, client, true, question, type, buttons);
 }
 

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -170,7 +170,7 @@ public:
 	 * @pre question != null && len(question) != 0.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
-	 * @note Replies to the question are given by you via the event ScriptEvent_GoalQuestionAnswer.
+	 * @note Replies to the question are given by you via the event ScriptEventGoalQuestionAnswer.
 	 * @note There is no guarantee you ever get a reply on your question.
 	 */
 	static bool Question(uint16 uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, int buttons);
@@ -188,7 +188,7 @@ public:
 	 * @pre question != null && len(question) != 0.
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
-	 * @note Replies to the question are given by you via the event ScriptEvent_GoalQuestionAnswer.
+	 * @note Replies to the question are given by you via the event ScriptEventGoalQuestionAnswer.
 	 * @note There is no guarantee you ever get a reply on your question.
 	 */
 	static bool QuestionClient(uint16 uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, int buttons);


### PR DESCRIPTION
## Motivation / Problem

Samu and dP on chat.
Samu (paraphrased): `ResolveClientID` does not return same value for range `2**31 - 2**32-1` as entered. Such client IDs would be returned as negative numbers.
dP (paraphrased): `QuestionClient` does not work with `ClientID`s in range `2**16 - 2**32-1`.


## Description

For first issue: remove cast to `int32`, just let automatic promotion to `int64` take place so the `uint32` value remains positive

For second issue: remove `EnforcePrecondition` and change `target` from `uint16` to `uint32` in `CmdGoalQuestion`.


## Limitations

None AFAIK.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
