### PR TITLE
Fix: [Script] Incorrect subsidy SourceID value used

### DIFF
--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -80,7 +80,7 @@
 
 /* static */ int32 ScriptSubsidy::GetSourceIndex(SubsidyID subsidy_id)
 {
-	if (!IsValidSubsidy(subsidy_id)) return INVALID_STATION;
+	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
 
 	return ::Subsidy::Get(subsidy_id)->src;
 }
@@ -94,7 +94,7 @@
 
 /* static */ int32 ScriptSubsidy::GetDestinationIndex(SubsidyID subsidy_id)
 {
-	if (!IsValidSubsidy(subsidy_id)) return INVALID_STATION;
+	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
 
 	return ::Subsidy::Get(subsidy_id)->dst;
 }


### PR DESCRIPTION
## Motivation / Problem
ScriptSubsidy::GetSourceIndex and ScriptSubsidy::GetDestinationIndex are both using returning INVALID_STATION when the subsidy isn't valid.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
