### PR TITLE
Fix #10059: Clamp config item values to int, disallow negative random deviation, and allow values up to 12 digits including '-'

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -21,6 +21,7 @@
 #include "game_config.hpp"
 #include "game_info.hpp"
 #include "../script/script_gui.h"
+#include "../script_config.hpp"
 #include "../table/strings.h"
 
 #include "../safeguards.h"
@@ -340,7 +341,7 @@ struct GSConfigWindow : public Window {
 				} else if (!bool_item && !config_item.complete_labels) {
 					/* Display a query box so users can enter a custom value. */
 					SetDParam(0, old_val);
-					ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, 10, this, CS_NUMERAL, QSF_NONE);
+					ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, INT32_DIGITS_WITH_SIGN_AND_TERMINATION, this, CS_NUMERAL_SIGNED, QSF_NONE);
 				}
 				this->SetDirty();
 				break;

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -254,13 +254,16 @@ public:
 	 *  user will see the corresponding name.
 	 * @param setting_name The name of the setting.
 	 * @param value_names A table that maps values to names. The first
-	 *   character of every identifier is ignored and the rest should
+	 *   character of every identifier is ignored, the second character
+	 *   could be '_' to indicate the value is negative, and the rest should
 	 *   be an integer of the value you define a name for. The value
 	 *   is a short description of that value.
 	 * To define labels for a setting named "competition_level" you could
 	 * for example call it like this:
 	 * AddLabels("competition_level", {_0 = "no competition", _1 = "some competition",
 	 * _2 = "a lot of competition"});
+	 * Another example, for a setting with a negative value:
+	 * AddLabels("amount", {__1 = "less than one", _0 = "none", _1 = "more than one"});
 	 *
 	 * @note This is a function provided by OpenTTD, you don't have to
 	 * include it in your Script but should just call it from GetSettings.

--- a/src/script/api/script_info_docs.hpp
+++ b/src/script/api/script_info_docs.hpp
@@ -218,20 +218,27 @@ public:
 	 *    store the current configuration of Scripts. Required.
 	 *  - description A single line describing the setting. Required.
 	 *  - min_value The minimum value of this setting. Required for integer
-	 *    settings and not allowed for boolean settings.
+	 *    settings and not allowed for boolean settings. The value will be
+	 *    clamped in the range [MIN(int32), MAX(int32)] (inclusive).
 	 *  - max_value The maximum value of this setting. Required for integer
-	 *    settings and not allowed for boolean settings.
+	 *    settings and not allowed for boolean settings. The value will be
+	 *    clamped in the range [MIN(int32), MAX(int32)] (inclusive).
 	 *  - easy_value The default value if the easy difficulty level
-	 *    is selected. Required.
+	 *    is selected. Required. The value will be clamped in the range
+	 *    [MIN(int32), MAX(int32)] (inclusive).
 	 *  - medium_value The default value if the medium difficulty level
-	 *    is selected. Required.
+	 *    is selected. Required. The value will be clamped in the range
+	 *    [MIN(int32), MAX(int32)] (inclusive).
 	 *  - hard_value The default value if the hard difficulty level
-	 *    is selected. Required.
+	 *    is selected. Required. The value will be clamped in the range
+	 *    [MIN(int32), MAX(int32)] (inclusive).
 	 *  - custom_value The default value if the custom difficulty level
-	 *    is selected. Required.
+	 *    is selected. Required. The value will be clamped in the range
+	 *    [MIN(int32), MAX(int32)] (inclusive).
 	 *  - random_deviation If this property has a nonzero value, then the
 	 *    actual value of the setting in game will be randomized in the range
 	 *    [user_configured_value - random_deviation, user_configured_value + random_deviation] (inclusive).
+	 *    random_deviation sign is ignored and the value is clamped in the range [0, MAX(int32)] (inclusive).
 	 *    Not allowed if the CONFIG_RANDOM flag is set, otherwise optional.
 	 *  - step_size The increase/decrease of the value every time the user
 	 *    clicks one of the up/down arrow buttons. Optional, default is 1.

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -216,7 +216,7 @@ std::string ScriptConfig::SettingsToString() const
 	char *s = string;
 	*s = '\0';
 	for (const auto &item : this->settings) {
-		char no[10];
+		char no[INT32_DIGITS_WITH_SIGN_AND_TERMINATION];
 		seprintf(no, lastof(no), "%d", item.second);
 
 		/* Check if the string would fit in the destination */

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -18,6 +18,9 @@
 #include "../textfile_gui.h"
 #include "script_instance.hpp"
 
+/** Maximum of 10 digits for MIN / MAX_INT32, 1 for the sign and 1 for '\0'. */
+static const int INT32_DIGITS_WITH_SIGN_AND_TERMINATION = 10 + 1 + 1;
+
 /** Bitmask of flags for Script settings. */
 enum ScriptConfigFlags {
 	SCRIPTCONFIG_NONE      = 0x0, ///< No flags set.

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -25,6 +25,7 @@
 #include "script_gui.h"
 #include "script_log.hpp"
 #include "script_scanner.hpp"
+#include "script_config.hpp"
 #include "../ai/ai.hpp"
 #include "../ai/ai_config.hpp"
 #include "../ai/ai_info.hpp"
@@ -497,7 +498,7 @@ struct ScriptSettingsWindow : public Window {
 				} else if (!bool_item && !config_item.complete_labels) {
 					/* Display a query box so users can enter a custom value. */
 					SetDParam(0, old_val);
-					ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, 10, this, CS_NUMERAL, QSF_NONE);
+					ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, INT32_DIGITS_WITH_SIGN_AND_TERMINATION, this, CS_NUMERAL_SIGNED, QSF_NONE);
 				}
 				this->SetDirty();
 				break;

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -252,7 +252,14 @@ SQInteger ScriptInfo::AddLabels(HSQUIRRELVM vm)
 		if (SQ_FAILED(sq_getstring(vm, -1, &label))) return SQ_ERROR;
 		/* Because squirrel doesn't support identifiers starting with a digit,
 		 * we skip the first character. */
-		int key = atoi(key_string + 1);
+		key_string++;
+		int sign = 1;
+		if (*key_string == '_') {
+			/* When the second character is '_', it indicates the value is negative. */
+			sign = -1;
+			key_string++;
+		}
+		int key = atoi(key_string) * sign;
 		StrMakeValidInPlace(const_cast<char *>(label));
 
 		/* !Contains() prevents stredup from leaking. */

--- a/src/script/script_info.cpp
+++ b/src/script/script_info.cpp
@@ -146,42 +146,42 @@ SQInteger ScriptInfo::AddSetting(HSQUIRRELVM vm)
 		} else if (strcmp(key, "min_value") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.min_value = res;
+			config.min_value = ClampToI32(res);
 			items |= 0x004;
 		} else if (strcmp(key, "max_value") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.max_value = res;
+			config.max_value = ClampToI32(res);
 			items |= 0x008;
 		} else if (strcmp(key, "easy_value") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.easy_value = res;
+			config.easy_value = ClampToI32(res);
 			items |= 0x010;
 		} else if (strcmp(key, "medium_value") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.medium_value = res;
+			config.medium_value = ClampToI32(res);
 			items |= 0x020;
 		} else if (strcmp(key, "hard_value") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.hard_value = res;
+			config.hard_value = ClampToI32(res);
 			items |= 0x040;
 		} else if (strcmp(key, "random_deviation") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.random_deviation = res;
+			config.random_deviation = ClampToI32(abs(res));
 			items |= 0x200;
 		} else if (strcmp(key, "custom_value") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.custom_value = res;
+			config.custom_value = ClampToI32(res);
 			items |= 0x080;
 		} else if (strcmp(key, "step_size") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;
-			config.step_size = res;
+			config.step_size = ClampToI32(res);
 		} else if (strcmp(key, "flags") == 0) {
 			SQInteger res;
 			if (SQ_FAILED(sq_getinteger(vm, -1, &res))) return SQ_ERROR;


### PR DESCRIPTION
## Motivation / Problem
We can't input custom negative values via query string on a config item and it can't be more than 10 digits.
Crash report is caused by implicit 64 bit to 32 bit conversions during construction of a script's settings.
We can't create labels for settings with a negative value.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
- Clamp config item values to int32. They're already correctly read as int64 (or SQInteger).
- Disallow negative random_deviation. It would cause weirdness during AddDeviation, because it expects uint. If it is negative, the abs of it is set instead.
- Allow custom values via query string to be negative and up to 12 digits, to allow for a large enough number, like -2 147 483 648.
- Also allow saving to the savegame and openttd.cfg numbers these large.
- AddLabels now checks the second character of key_string identifiers. If it finds a '_', then the integer that comes after becomes negative, allowing adding labels to negative values of a setting.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I suppose none.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
