### PR TITLE
Fix: Ensure logo for Windows Store common assets package is named correctly

### DIFF
--- a/os/windows/winstore/generate-assets.ps1
+++ b/os/windows/winstore/generate-assets.ps1
@@ -45,4 +45,4 @@ ResizeImage $logoPath 1240 600 "assets\Wide310x150Logo.png"
 
 # Copy the logo for the store for the common package
 New-Item -Path "." -Name "assets-common" -ItemType "directory" -Force
-Copy-Item "assets\StoreLogo.png" -Destination "assets-common\StoreLogo.png"
+Copy-Item "assets\StoreLogo.png" -Destination "assets-common\StoreLogoCommon.png"


### PR DESCRIPTION
## Motivation / Problem

The scripts that prepare the Windows Store bundle contain a small error that result in rejection from the Store.

## Description

The "common" appx should have a file called StoreLogoCommon.png, to avoid conflicting with StoreLogo.png in the architecture-specific appx. Unfortunately, this error only became apparent when uploading the release to the Store. (I've manually corrected it for the 13.0 Store release.)

It would be worth patching this change into the 13.0 branch if we expect to release any further updates.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
