### PR TITLE
Fix: [Script] Use Money instead of int32 for presenting the value of a company to AIs and show buy company dialog window even when playing in the AI company

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -702,9 +702,9 @@ static void HandleBankruptcyTakeover(Company *c)
 	SetBit(c->bankrupt_asked, best->index);
 
 	c->bankrupt_timeout = TAKE_OVER_TIMEOUT;
-	if (best->is_ai) {
-		AI::NewEvent(best->index, new ScriptEventCompanyAskMerger(c->index, c->bankrupt_value));
-	} else if (IsInteractiveCompany(best->index)) {
+
+	AI::NewEvent(best->index, new ScriptEventCompanyAskMerger(c->index, c->bankrupt_value));
+	if (IsInteractiveCompany(best->index)) {
 		ShowBuyCompanyDialog(c->index);
 	}
 }

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -703,7 +703,7 @@ static void HandleBankruptcyTakeover(Company *c)
 
 	c->bankrupt_timeout = TAKE_OVER_TIMEOUT;
 	if (best->is_ai) {
-		AI::NewEvent(best->index, new ScriptEventCompanyAskMerger(c->index, ClampToI32(c->bankrupt_value)));
+		AI::NewEvent(best->index, new ScriptEventCompanyAskMerger(c->index, c->bankrupt_value));
 	} else if (IsInteractiveCompany(best->index)) {
 		ShowBuyCompanyDialog(c->index);
 	}

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -381,7 +381,7 @@ public:
 	 * @param owner The company that can be bought.
 	 * @param value The value/costs of buying the company.
 	 */
-	ScriptEventCompanyAskMerger(Owner owner, int32 value) :
+	ScriptEventCompanyAskMerger(Owner owner, Money value) :
 		ScriptEvent(ET_COMPANY_ASK_MERGER),
 		owner((ScriptCompany::CompanyID)owner),
 		value(value)
@@ -406,7 +406,7 @@ public:
 	 * Get the value of the new company.
 	 * @return The value of the new company.
 	 */
-	int32 GetValue() { return this->value; }
+	Money GetValue() { return this->value; }
 
 	/**
 	 * Take over the company for this merger.
@@ -416,7 +416,7 @@ public:
 
 private:
 	ScriptCompany::CompanyID owner; ///< The company that is in trouble.
-	int32 value;                ///< The value of the company, i.e. the amount you would pay.
+	Money value;                ///< The value of the company, i.e. the amount you would pay.
 };
 
 /**


### PR DESCRIPTION
## Motivation / Problem
No necessarily this PR, but it seems silly to have an `int32` value instead of a `Money` value. Otherwise the AI will potentially get a lower value presented and accepts it, without knowing how expensive it actually is.

_Originally posted by @rubidium42 in https://github.com/OpenTTD/OpenTTD/pull/10411#discussion_r1101492146_

I have something against this
https://github.com/OpenTTD/OpenTTD/blob/59251d3c6b9bf2a0ae85aefc2c9e9f91a46f3031/src/company_cmd.cpp#L705-L707
The is_ai check is unnecessary. If the company is not AI, AI::NewEvent will deal with it accordingly and won't send the event anyway. And if I'm the local company in the AI company, I'd still like to receive the buyout popup message.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
No longer clamp bankrupt value to int32, and use Money instead.
Show the buy company dialog even when playing in the AI company.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
