### PR TITLE
Reset late counter for the entire group.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4529,7 +4529,7 @@ STR_TIMETABLE_CLEAR_SPEED                                       :{BLACK}Clear Sp
 STR_TIMETABLE_CLEAR_SPEED_TOOLTIP                               :{BLACK}Clear the maximum travel speed of the highlighted order. Ctrl+Click clears the speed for all orders
 
 STR_TIMETABLE_RESET_LATENESS                                    :{BLACK}Reset Late Counter
-STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reset the lateness counter, so the vehicle will be on time
+STR_TIMETABLE_RESET_LATENESS_TOOLTIP                            :{BLACK}Reset the lateness counter, so the vehicle will be on time. Ctrl+Click will reset the entire group so the latest vehicle will be on time and all others will be early
 
 STR_TIMETABLE_AUTOFILL                                          :{BLACK}Autofill
 STR_TIMETABLE_AUTOFILL_TOOLTIP                                  :{BLACK}Fill the timetable automatically with the values from the next journey. Ctrl+Click to try to keep waiting times

--- a/src/timetable_cmd.h
+++ b/src/timetable_cmd.h
@@ -14,7 +14,7 @@
 
 CommandCost CmdChangeTimetable(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, ModifyTimetableFlags mtf, uint16 data);
 CommandCost CmdBulkChangeTimetable(DoCommandFlag flags, VehicleID veh, ModifyTimetableFlags mtf, uint16 data);
-CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh);
+CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh, bool apply_to_group);
 CommandCost CmdAutofillTimetable(DoCommandFlag flags, VehicleID veh, bool autofill, bool preserve_wait_time);
 CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, Date start_date);
 

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -600,7 +600,7 @@ struct TimetableWindow : Window {
 			}
 
 			case WID_VT_RESET_LATENESS: // Reset the vehicle's late counter.
-				Command<CMD_SET_VEHICLE_ON_TIME>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, v->index);
+				Command<CMD_SET_VEHICLE_ON_TIME>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, v->index, _ctrl_pressed);
 				break;
 
 			case WID_VT_AUTOFILL: { // Autofill the timetable.


### PR DESCRIPTION
When Ctrl+click `Reset late counter`, it will find the most late vehicle among those sharing orders. And change late counter for all vehicles in the group so every vehicle is either on time or early. This way vehicles remain the relative position on the route, but no more late.

## Motivation / Problem

Setup: A player has a group of vehicles with perfectly adjusted timetable. All the vehicles are evenly spread out on the route. 
Then due to external reason(congestion, whatever) some of the vehicles become late. 

What can be done now? It needs to find the most late vehicle and reset its start date to the expected arrival to the first order. It will work, but has two complications:
 - All vehicles loose their schedule until they get to the first order.
 - It needs to manually go to each vehicle's timetable to find the latest one. Otherwise if you reset the start date on non-latest vehicle, the latest will remain late on the next round too.
 - You don't see the effect until all vehicles complete the current order round.

The process is very tedious.

## Description

This feature allows to reset the late counter for the entire group. But it will also retain the relative position on the route. 

How is it done?

When a player Ctrl+clicks on `Reset late counter`, the game will find the most late vehicle and adjust every vehicle in the group so that the most late becomes on time and others are ahead of time depending on their previous late counter.


## Limitations

This feature works in all scenarios AFAIK


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
