### PR TITLE
Change: [Actions] also attempt a build without any (encouraged) dependencies

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -94,6 +94,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install dependencies
+      # For the variant without libsdl, we also don't any other libraries.
+      # This way we validate that we can build without any of the (encouraged) dependencies.
+      if: ${{ matrix.libsdl }}
       run: |
         echo "::group::Update apt"
         sudo apt-get update


### PR DESCRIPTION
## Motivation / Problem

We weren't actually testing if you can build OpenTTD without zlib, libpng, ...
Trust but validate.


## Description

Use the "dedicated server" build to also build without all the additional dependencies.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
