### PR TITLE
Fix #10469, 5e14a20: [Script] League Table rating element is a int64 everywhere else

### DIFF
--- a/src/league_base.h
+++ b/src/league_base.h
@@ -30,7 +30,7 @@ extern LeagueTablePool _league_table_pool;
  **/
 struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_element_pool> {
 	LeagueTableID table;  ///< Id of the table which this element belongs to
-	uint64 rating;        ///< Value that determines ordering of elements in the table (higher=better)
+	int64 rating;         ///< Value that determines ordering of elements in the table (higher=better)
 	CompanyID company;    ///< Company Id to show the color blob for or INVALID_COMPANY
 	std::string text;     ///< Text of the element
 	std::string score;    ///< String representation of the score associated with the element

--- a/src/saveload/league_sl.cpp
+++ b/src/saveload/league_sl.cpp
@@ -16,13 +16,14 @@
 #include "../safeguards.h"
 
 static const SaveLoad _league_table_elements_desc[] = {
-	 SLE_VAR(LeagueTableElement, table,       SLE_UINT8),
-	 SLE_VAR(LeagueTableElement, rating,      SLE_UINT64),
-	 SLE_VAR(LeagueTableElement, company,     SLE_UINT8),
-	SLE_SSTR(LeagueTableElement, text,        SLE_STR | SLF_ALLOW_CONTROL),
-	SLE_SSTR(LeagueTableElement, score,       SLE_STR | SLF_ALLOW_CONTROL),
-	 SLE_VAR(LeagueTableElement, link.type,   SLE_UINT8),
-	 SLE_VAR(LeagueTableElement, link.target, SLE_UINT32),
+	    SLE_VAR(LeagueTableElement, table,       SLE_UINT8),
+	SLE_CONDVAR(LeagueTableElement, rating,      SLE_FILE_U64 | SLE_VAR_I64, SL_MIN_VERSION, SLV_LINKGRAPH_EDGES),
+	SLE_CONDVAR(LeagueTableElement, rating,      SLE_INT64,                  SLV_LINKGRAPH_EDGES, SL_MAX_VERSION),
+	    SLE_VAR(LeagueTableElement, company,     SLE_UINT8),
+	   SLE_SSTR(LeagueTableElement, text,        SLE_STR | SLF_ALLOW_CONTROL),
+	   SLE_SSTR(LeagueTableElement, score,       SLE_STR | SLF_ALLOW_CONTROL),
+	    SLE_VAR(LeagueTableElement, link.type,   SLE_UINT8),
+	    SLE_VAR(LeagueTableElement, link.target, SLE_UINT32),
 };
 
 struct LEAEChunkHandler : ChunkHandler {

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -344,8 +344,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_LAST_LOADING_TICK,                  ///< 301  PR#9693 Store tick of last loading for vehicles.
 	SLV_MULTITRACK_LEVEL_CROSSINGS,         ///< 302  PR#9931 v13.0  Multi-track level crossings.
 	SLV_NEWGRF_ROAD_STOPS,                  ///< 303  PR#10144 NewGRF road stops.
-
-	SLV_LINKGRAPH_EDGES,                    ///< 303  PR#10314 Explicitly store link graph edges destination.
+	SLV_LINKGRAPH_EDGES,                    ///< 304  PR#10314 Explicitly store link graph edges destination, PR#10471 int64 instead of uint64 league rating
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };


### PR DESCRIPTION
## Motivation / Problem
Closes #10469
Rating is a int64 in the Cmd functions, in the script API functions, but not on the league table element struct. Sorting through negative values would cause 0 to be below them.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Turn rating in struct into int64, and add savegame bump and conversion.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Probably will cause issues if the values saved on an old savegame were already above INT64_MAX to begin with, they would turn negative after load, most likely.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
