### PR TITLE
Fix 64523709: rpm uses different package names than deb.

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -29,7 +29,7 @@ jobs:
         yum install -y \
           fontconfig-devel \
           freetype-devel \
-          libcurl4-openssl-dev \
+          libcurl-devel \
           libicu-devel \
           libpng-devel \
           lzo-devel \

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -131,7 +131,7 @@ bool NetworkHTTPRequest::Receive()
 	for (int count = 0; count < 100; count++) {
 		/* Check if there was activity in the multi-handle. */
 		int numfds;
-		curl_multi_poll(this->multi_handle, NULL, 0, 0, &numfds);
+		curl_multi_wait(this->multi_handle, NULL, 0, 0, &numfds);
 		if (numfds == 0) return false;
 
 		/* Let CURL process the activity. */


### PR DESCRIPTION
## Motivation / Problem

Linux nightly failed.

## Description

CI runs on debian. 
Nightly runs on manylinux2014.

Packages have different names.
libcurl from 2014 only has curl_multi_wait, no curl_multi_poll.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
