### PR TITLE
Copy wagon configuration to all trains in shared orders/group.

### DIFF
--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -11,6 +11,7 @@
 #define BASE_CONSIST_H
 
 #include "order_type.h"
+#include "vehicle_type.h"
 #include "date_type.h"
 #include <string>
 
@@ -24,6 +25,8 @@ struct BaseConsist {
 	Date timetable_start;               ///< When the vehicle is supposed to start the timetable.
 
 	uint16 service_interval;            ///< The interval for (automatic) servicing; either in days or %.
+
+	VehicleID copy_wagons_from;         ///< Reference to another train; Used to copy wagons configuration from it.
 
 	VehicleOrderID cur_real_order_index;///< The index to the current real (non-implicit) order
 	VehicleOrderID cur_implicit_order_index;///< The index to the current implicit order

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -346,6 +346,10 @@ enum Commands : uint16 {
 	CMD_UPDATE_LEAGUE_TABLE_ELEMENT_SCORE, ///< update the score of a league table element
 	CMD_REMOVE_LEAGUE_TABLE_ELEMENT,       ///< remove a league table element
 
+	CMD_SCHEDULE_COPY_TRAIN_WAGONS,        ///< Schedule wagon copying
+	CMD_STOP_COPYING_TRAIN_WAGONS,         ///< Stop wagon copying
+	CMD_COPY_TRAIN_WAGONS,                 ///< Copy wagons from another train
+
 	CMD_END,                          ///< Must ALWAYS be on the end of this list!! (period)
 };
 

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -984,6 +984,12 @@ public:
 
 						Command<CMD_REMOVE_ALL_VEHICLES_GROUP>::Post(STR_ERROR_GROUP_CAN_T_REMOVE_ALL_VEHICLES, this->vli.index);
 						break;
+					case ADI_COPY_TRAIN_WAGONS:
+						SetObjectToPlaceWnd(SPR_CURSOR_CLONE_TRAIN, PAL_NONE, HT_VEHICLE, this);
+						break;
+					case ADI_CANCEL_COPY_TRAIN_WAGONS:
+						Command<CMD_STOP_COPYING_TRAIN_WAGONS>::Post(STR_ERROR_CAN_T_STOP_COPYING_TRAIN_WAGONS, this->vli);
+						break;
 					default: NOT_REACHED();
 				}
 				break;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -896,6 +896,8 @@ STR_NEWS_AIRCRAFT_DEST_TOO_FAR                                  :{WHITE}{VEHICLE
 STR_NEWS_ORDER_REFIT_FAILED                                     :{WHITE}{VEHICLE} stopped because an ordered refit failed
 STR_NEWS_VEHICLE_AUTORENEW_FAILED                               :{WHITE}Autorenew failed on {VEHICLE}{}{STRING}
 
+STR_NEWS_VEHICLE_COPY_WAGONS_FAILED                             :{WHITE}Copying wagons failed on {VEHICLE}
+
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE                              :{BIG_FONT}{BLACK}New {STRING} now available!
 STR_NEWS_NEW_VEHICLE_TYPE                                       :{BIG_FONT}{BLACK}{ENGINE}
 STR_NEWS_NEW_VEHICLE_NOW_AVAILABLE_WITH_TYPE                    :{BLACK}New {STRING} now available!  -  {ENGINE}
@@ -3816,6 +3818,8 @@ STR_VEHICLE_LIST_MANAGE_LIST                                    :{BLACK}Manage l
 STR_VEHICLE_LIST_MANAGE_LIST_TOOLTIP                            :{BLACK}Send instructions to all vehicles in this list
 STR_VEHICLE_LIST_REPLACE_VEHICLES                               :Replace vehicles
 STR_VEHICLE_LIST_SEND_FOR_SERVICING                             :Send for Servicing
+STR_VEHICLE_LIST_COPY_TRAIN_WAGONS                              :Copy wagons from
+STR_VEHICLE_LIST_CANCEL_COPYING_TRAIN_WAGONS                    :Stop copying wagons
 STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR                     :{TINY_FONT}{BLACK}Profit this year: {CURRENCY_LONG} (last year: {CURRENCY_LONG})
 STR_VEHICLE_LIST_CARGO                                          :{TINY_FONT}{BLACK}[{CARGO_LIST}]
 STR_VEHICLE_LIST_NAME_AND_CARGO                                 :{TINY_FONT}{BLACK}{STRING1} {STRING1}
@@ -5049,6 +5053,9 @@ STR_ERROR_VEHICLE_IS_DESTROYED                                  :{WHITE}... vehi
 
 STR_ERROR_CAN_T_CLONE_VEHICLE_LIST                              :{WHITE}... not all vehicles are identical
 
+STR_ERROR_CAN_T_COPY_TRAIN_WAGONS                               :{WHITE}Can't copy train wagons
+STR_ERROR_CAN_T_STOP_COPYING_TRAIN_WAGONS                       :{WHITE}Can't copy train wagons
+
 STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL                          :{WHITE}No vehicles will be available at all
 STR_ERROR_NO_VEHICLES_AVAILABLE_AT_ALL_EXPLANATION              :{WHITE}Change your NewGRF configuration
 STR_ERROR_NO_VEHICLES_AVAILABLE_YET                             :{WHITE}No vehicles are available yet
@@ -5609,6 +5616,8 @@ STR_ORANGE_STRING1_WHITE                                        :{ORANGE}{STRING
 STR_ORANGE_STRING1_LTBLUE                                       :{ORANGE}{STRING1}{LTBLUE}
 STR_TINY_BLACK_HEIGHT                                           :{TINY_FONT}{BLACK}{HEIGHT}
 STR_TINY_BLACK_VEHICLE                                          :{TINY_FONT}{BLACK}{VEHICLE}
+STR_VEHICLE_LIST_ITEM_CAPTION                                   :{TINY_FONT}{BLACK}{STRING1}{STRING1}
+STR_VEHICLE_LIST_ITEM_CAPTION_COPY_FROM                         : <- {VEHICLE}
 STR_TINY_RIGHT_ARROW                                            :{TINY_FONT}{RIGHT_ARROW}
 
 STR_BLACK_1                                                     :{BLACK}1

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -678,6 +678,7 @@ public:
 		SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                   SL_MIN_VERSION,  SLV_31),
 		SLE_CONDVAR(Vehicle, service_interval,      SLE_FILE_U32 | SLE_VAR_U16,  SLV_31, SLV_180),
 		SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                 SLV_180, SL_MAX_VERSION),
+		    SLE_VAR(Vehicle, copy_wagons_from,      SLE_UINT32),
 		    SLE_VAR(Vehicle, reliability,           SLE_UINT16),
 		    SLE_VAR(Vehicle, reliability_spd_dec,   SLE_UINT16),
 		    SLE_VAR(Vehicle, breakdown_ctr,         SLE_UINT8),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -57,7 +57,10 @@
 #include "vehicle_cmd.h"
 
 #include "table/strings.h"
-
+#include <string>
+#include <iostream>
+#include <sstream>
+#include "3rdparty/fmt/format.h"
 #include "safeguards.h"
 
 /* Number of bits in the hash to use from each vehicle coord */
@@ -354,6 +357,7 @@ Vehicle::Vehicle(VehicleType type)
 	this->cargo_age_counter  = 1;
 	this->last_station_visited = INVALID_STATION;
 	this->last_loading_station = INVALID_STATION;
+	this->copy_wagons_from   = this->index;
 }
 
 /**
@@ -1053,32 +1057,48 @@ void CallVehicleTicks()
 		int z = v->z_pos;
 
 		const Company *c = Company::Get(_current_company);
-		SubtractMoneyFromCompany(CommandCost(EXPENSES_NEW_VEHICLES, (Money)c->settings.engine_renew_money));
+		SubtractMoneyFromCompany(CommandCost(EXPENSES_NEW_VEHICLES, (Money) c->settings.engine_renew_money));
 		CommandCost res = Command<CMD_AUTOREPLACE_VEHICLE>::Do(DC_EXEC, v->index);
-		SubtractMoneyFromCompany(CommandCost(EXPENSES_NEW_VEHICLES, -(Money)c->settings.engine_renew_money));
+		SubtractMoneyFromCompany(CommandCost(EXPENSES_NEW_VEHICLES, -(Money) c->settings.engine_renew_money));
 
-		if (!IsLocalCompany()) continue;
+		if (IsLocalCompany()) {
+			if (res.Succeeded()) {
+				ShowCostOrIncomeAnimation(x, y, z, res.GetCost());
+			} else {
+				StringID error_message = res.GetErrorMessage();
+				if (error_message != STR_ERROR_AUTOREPLACE_NOTHING_TO_DO && error_message != INVALID_STRING_ID) {
+					if (error_message == STR_ERROR_NOT_ENOUGH_CASH_REQUIRES_CURRENCY)
+						error_message = STR_ERROR_AUTOREPLACE_MONEY_LIMIT;
 
-		if (res.Succeeded()) {
-			ShowCostOrIncomeAnimation(x, y, z, res.GetCost());
-			continue;
+					StringID message;
+					if (error_message == STR_ERROR_TRAIN_TOO_LONG_AFTER_REPLACEMENT) {
+						message = error_message;
+					} else {
+						message = STR_NEWS_VEHICLE_AUTORENEW_FAILED;
+					}
+
+					SetDParam(0, v->index);
+					SetDParam(1, error_message);
+					AddVehicleAdviceNewsItem(message, v->index);
+				}
+			}
 		}
 
-		StringID error_message = res.GetErrorMessage();
-		if (error_message == STR_ERROR_AUTOREPLACE_NOTHING_TO_DO || error_message == INVALID_STRING_ID) continue;
+		/* Copy wagons from another train */
+		if (v->type == VehicleType::VEH_TRAIN && v->copy_wagons_from != v->index) {
+			SubtractMoneyFromCompany(CommandCost(EXPENSES_NEW_VEHICLES, (Money) c->settings.engine_renew_money));
+			CommandCost copy_res = Command<CMD_COPY_TRAIN_WAGONS>::Do(DC_EXEC, v->index);
+			SubtractMoneyFromCompany(CommandCost(EXPENSES_NEW_VEHICLES, -(Money) c->settings.engine_renew_money));
+			if (IsLocalCompany()) {
+				if (copy_res.Succeeded()) {
+					ShowCostOrIncomeAnimation(x, y, z, copy_res.GetCost());
+					continue;
+				}
 
-		if (error_message == STR_ERROR_NOT_ENOUGH_CASH_REQUIRES_CURRENCY) error_message = STR_ERROR_AUTOREPLACE_MONEY_LIMIT;
-
-		StringID message;
-		if (error_message == STR_ERROR_TRAIN_TOO_LONG_AFTER_REPLACEMENT) {
-			message = error_message;
-		} else {
-			message = STR_NEWS_VEHICLE_AUTORENEW_FAILED;
+				SetDParam(0, v->index);
+				AddVehicleAdviceNewsItem(STR_NEWS_VEHICLE_COPY_WAGONS_FAILED, v->index);
+			}
 		}
-
-		SetDParam(0, v->index);
-		SetDParam(1, error_message);
-		AddVehicleAdviceNewsItem(message, v->index);
 	}
 
 	cur_company.Restore();
@@ -3044,4 +3064,23 @@ bool VehiclesHaveSameOrderList(const Vehicle *v1, const Vehicle *v2)
 		o1 = o1->next;
 		o2 = o2->next;
 	}
+}
+
+/**
+ * Sets a target for this vehicle to copy wagons from
+ * @param src - source vehicle to copy wagons from
+ */
+void Vehicle::CopyWagonsFrom(VehicleID src)
+{
+	this->copy_wagons_from = src;
+}
+
+std::string Vehicle::PrintDetails() const
+{
+	std::stringstream ss;
+	ss << "Vehicle";
+	for (Vehicle *v = this->First(); v!= nullptr; v=v->Next() ){
+		ss << fmt::format(" [i{}/e{}/c{}/cs{}]", v->index, v->engine_type, v->cargo_type, v->cargo_subtype);
+	}
+	return ss.str();
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -57,10 +57,7 @@
 #include "vehicle_cmd.h"
 
 #include "table/strings.h"
-#include <string>
-#include <iostream>
-#include <sstream>
-#include "3rdparty/fmt/format.h"
+
 #include "safeguards.h"
 
 /* Number of bits in the hash to use from each vehicle coord */
@@ -3073,14 +3070,4 @@ bool VehiclesHaveSameOrderList(const Vehicle *v1, const Vehicle *v2)
 void Vehicle::CopyWagonsFrom(VehicleID src)
 {
 	this->copy_wagons_from = src;
-}
-
-std::string Vehicle::PrintDetails() const
-{
-	std::stringstream ss;
-	ss << "Vehicle";
-	for (Vehicle *v = this->First(); v!= nullptr; v=v->Next() ){
-		ss << fmt::format(" [i{}/e{}/c{}/cs{}]", v->index, v->engine_type, v->cargo_type, v->cargo_subtype);
-	}
-	return ss.str();
 }

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1069,7 +1069,6 @@ public:
 	uint32 GetDisplayMinPowerToWeight() const;
 
 	void CopyWagonsFrom(VehicleID vid);
-	std::string PrintDetails() const;
 };
 
 /**

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -1067,6 +1067,9 @@ public:
 
 	uint32 GetDisplayMaxWeight() const;
 	uint32 GetDisplayMinPowerToWeight() const;
+
+	void CopyWagonsFrom(VehicleID vid);
+	std::string PrintDetails() const;
 };
 
 /**

--- a/src/vehicle_cmd.h
+++ b/src/vehicle_cmd.h
@@ -27,18 +27,24 @@ CommandCost CmdStartStopVehicle(DoCommandFlag flags, VehicleID veh_id, bool eval
 CommandCost CmdMassStartStopVehicle(DoCommandFlag flags, TileIndex tile, bool do_start, bool vehicle_list_window, const VehicleListIdentifier &vli);
 CommandCost CmdDepotSellAllVehicles(DoCommandFlag flags, TileIndex tile, VehicleType vehicle_type);
 CommandCost CmdDepotMassAutoReplace(DoCommandFlag flags, TileIndex tile, VehicleType vehicle_type);
+CommandCost CmdScheduleCopyTrainWagons(DoCommandFlag flags, VehicleID veh_id, const VehicleListIdentifier &vli);
+CommandCost CmdStopCopyTrainWagons(DoCommandFlag flags, const VehicleListIdentifier &vli);
+CommandCost CmdCopyTrainWagons(DoCommandFlag flags, VehicleID veh_id);
 
-DEF_CMD_TRAIT(CMD_BUILD_VEHICLE,           CmdBuildVehicle,         CMD_CLIENT_ID,                CMDT_VEHICLE_CONSTRUCTION)
-DEF_CMD_TRAIT(CMD_SELL_VEHICLE,            CmdSellVehicle,          CMD_CLIENT_ID | CMD_LOCATION, CMDT_VEHICLE_CONSTRUCTION)
-DEF_CMD_TRAIT(CMD_REFIT_VEHICLE,           CmdRefitVehicle,         CMD_LOCATION,                 CMDT_VEHICLE_CONSTRUCTION)
-DEF_CMD_TRAIT(CMD_SEND_VEHICLE_TO_DEPOT,   CmdSendVehicleToDepot,   0,                            CMDT_VEHICLE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_CHANGE_SERVICE_INT,      CmdChangeServiceInt,     0,                            CMDT_VEHICLE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_RENAME_VEHICLE,          CmdRenameVehicle,        0,                            CMDT_OTHER_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_CLONE_VEHICLE,           CmdCloneVehicle,         CMD_NO_TEST,                  CMDT_VEHICLE_CONSTRUCTION) // NewGRF callbacks influence building and refitting making it impossible to correctly estimate the cost
-DEF_CMD_TRAIT(CMD_START_STOP_VEHICLE,      CmdStartStopVehicle,     CMD_LOCATION,                 CMDT_VEHICLE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_MASS_START_STOP,         CmdMassStartStopVehicle, 0,                            CMDT_VEHICLE_MANAGEMENT)
-DEF_CMD_TRAIT(CMD_DEPOT_SELL_ALL_VEHICLES, CmdDepotSellAllVehicles, 0,                            CMDT_VEHICLE_CONSTRUCTION)
-DEF_CMD_TRAIT(CMD_DEPOT_MASS_AUTOREPLACE,  CmdDepotMassAutoReplace, 0,                            CMDT_VEHICLE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_BUILD_VEHICLE,              CmdBuildVehicle,            CMD_CLIENT_ID,                CMDT_VEHICLE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_SELL_VEHICLE,               CmdSellVehicle,             CMD_CLIENT_ID| CMD_LOCATION,  CMDT_VEHICLE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_REFIT_VEHICLE,              CmdRefitVehicle,            CMD_LOCATION,                 CMDT_VEHICLE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_SEND_VEHICLE_TO_DEPOT,      CmdSendVehicleToDepot,      0,                            CMDT_VEHICLE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_CHANGE_SERVICE_INT,         CmdChangeServiceInt,        0,                            CMDT_VEHICLE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_RENAME_VEHICLE,             CmdRenameVehicle,           0,                            CMDT_OTHER_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_CLONE_VEHICLE,              CmdCloneVehicle,            CMD_NO_TEST,                  CMDT_VEHICLE_CONSTRUCTION) // NewGRF callbacks influence building and refitting making it impossible to correctly estimate the cost
+DEF_CMD_TRAIT(CMD_START_STOP_VEHICLE,         CmdStartStopVehicle,        CMD_LOCATION,                 CMDT_VEHICLE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_MASS_START_STOP,            CmdMassStartStopVehicle,    0,                            CMDT_VEHICLE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_DEPOT_SELL_ALL_VEHICLES,    CmdDepotSellAllVehicles,    0,                            CMDT_VEHICLE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_DEPOT_MASS_AUTOREPLACE,     CmdDepotMassAutoReplace,    0,                            CMDT_VEHICLE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_SCHEDULE_COPY_TRAIN_WAGONS, CmdScheduleCopyTrainWagons, 0,                            CMDT_VEHICLE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_STOP_COPYING_TRAIN_WAGONS,  CmdStopCopyTrainWagons,     0,                            CMDT_VEHICLE_MANAGEMENT)
+DEF_CMD_TRAIT(CMD_COPY_TRAIN_WAGONS,          CmdCopyTrainWagons,         0,                            CMDT_VEHICLE_MANAGEMENT)
 
 void CcBuildPrimaryVehicle(Commands cmd, const CommandCost &result, VehicleID new_veh_id, uint, uint16, CargoArray);
 void CcStartStopVehicle(Commands cmd, const CommandCost &result, VehicleID veh_id, bool);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2896,7 +2896,6 @@ public:
 			SPR_SEND_AIRCRAFT_TODEPOT,
 		};
 		const Vehicle *v = Vehicle::Get(window_number);
-		Debug(misc, 0, "{}", v->PrintDetails());
 		this->GetWidget<NWidgetCore>(WID_VV_GOTO_DEPOT)->widget_data = vehicle_view_goto_depot_sprites[v->type];
 
 		/* Sprites for the 'clone vehicle' button indexed by vehicle type. */

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -19,6 +19,9 @@
 #include "vehiclelist.h"
 #include "window_gui.h"
 #include "widgets/dropdown_type.h"
+#include "command_func.h"
+#include "tilehighlight_func.h"
+#include "vehicle_cmd.h"
 
 #include <iterator>
 #include <numeric>
@@ -104,6 +107,8 @@ struct BaseVehicleListWindow : public Window {
 		ADI_REPLACE,
 		ADI_SERVICE,
 		ADI_DEPOT,
+		ADI_COPY_TRAIN_WAGONS,
+		ADI_CANCEL_COPY_TRAIN_WAGONS,
 		ADI_ADD_SHARED,
 		ADI_REMOVE_ALL,
 	};
@@ -153,6 +158,15 @@ struct BaseVehicleListWindow : public Window {
 			default:
 				NOT_REACHED();
 		}
+	}
+
+	bool OnVehicleSelect(const Vehicle *v) override
+	{
+		if (v->type == VehicleType::VEH_TRAIN) {
+			Command<CMD_SCHEDULE_COPY_TRAIN_WAGONS>::Post(STR_ERROR_CAN_T_COPY_TRAIN_WAGONS, v->index, this->vli);
+			ResetObjectToPlace();
+		}
+		return true;
 	}
 };
 


### PR DESCRIPTION
This is a draft. No code-review required yet. I just wanted to initiate a discussion first.
## Motivation / Problem

We have a great feature called auto-replacement and it works really great  for engines and saves time. But there is a similar process that players have to do manually. It is to update their trains with more/new/other train cars(wagons). It is no fun cause it's a tedious process , it takes time to watch all the trains in a group and plus it messes up with the timetables if played without PAUSE.


## Description
I know there is a patch `Template Based Train Replacement`. But I play vanila and don't know the status of that patch, although the idea looks really cool.

How I see my solution? I want it to be simple and interfere with the existing code/logic as little as possible. 
I see it as a button somewhere at the vehicle group window, so player can to click the button and then select some train as a target(similar to clone vehicle). When selected, all vehicles in the group are marked as to be refitted(not really, but it's the closest existing term).

Later on, when a marked vehicle enters a depot, it gets refitted. Which means, it will compare its wagons to the ones of the target and fix the difference. Once done, the vehicle clears its status and doesn't need to do the procedure until again explicitly marked by player.

## Limitations

This functionality is only applicable to trains as I don't know of any other transports with non-engine units.

As I'm very new to OpenTTD, it would be great if I can get help with the following questions. Just keep in mind, I didn't even play any non-default NewGRFs.
1. Is it only trains can have attachable parts like wagons? 
2. Is it possible for a train wagon to be refit-able?
3. What is the relation between cargo_type and cargo_subtype? Should I consider different subtypes as different cargos and replace the wagon if it is a different subtype?
4. Please suggest a good naming for the feature. The problem is that there are already 2 related but different processes: autoreplace and refit. My best candidate is `Copy (wagons|train cars) from`. But I'm open to proposals.
5. Are there any game mechanics (maybe enabled in NewGFRs) that may interfere with my feature?


Thanks

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
