### PR TITLE
Fix 5e14a20: [GS] Save league table title into string

### DIFF
--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -31,12 +31,13 @@
 	CCountedPtr<Text> footer_counter(footer);
 
 	EnforcePrecondition(LEAGUE_TABLE_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
-	EnforcePrecondition(LEAGUE_TABLE_INVALID, title != nullptr);
-	const char *encoded_title = title->GetEncodedText();
-	EnforcePreconditionEncodedText(LEAGUE_TABLE_INVALID, encoded_title);
 
 	auto encoded_header = (header != nullptr ? std::string{ header->GetEncodedText() } : std::string{});
 	auto encoded_footer = (footer != nullptr ? std::string{ footer->GetEncodedText() } : std::string{});
+
+	EnforcePrecondition(LEAGUE_TABLE_INVALID, title != nullptr);
+	const char *encoded_title = title->GetEncodedText();
+	EnforcePreconditionEncodedText(LEAGUE_TABLE_INVALID, encoded_title);
 
 	if (!ScriptObject::Command<CMD_CREATE_LEAGUE_TABLE>::Do(&ScriptInstance::DoCommandReturnLeagueTableID, encoded_title, encoded_header, encoded_footer)) return LEAGUE_TABLE_INVALID;
 


### PR DESCRIPTION
## Motivation / Problem
![Unnamed, 1955-06-17](https://user-images.githubusercontent.com/43006711/218814346-936a3353-b324-4cca-b42a-7543617a20ad.png)

GetEncodedText is changing the title to the last non-null text param. In the example screenshot, it's the footer.
<!--
![Unnamed, 1955-06-17](https://user-images.githubusercontent.com/43006711/218814346-936a3353-b324-4cca-b42a-7543617a20ad.png)

Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Move title handling two lines lower as header and footer are stored in strings anyway
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
