### PR TITLE
Change: try to detect the CA file/path for CURL

### DIFF
--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -11,6 +11,7 @@
 
 #include "../../stdafx.h"
 #include "../../debug.h"
+#include "../../fileio_func.h"
 #include "../../rev.h"
 #include "../../thread.h"
 #include "../network_internal.h"
@@ -25,6 +26,24 @@
 #include <queue>
 
 #include "../../safeguards.h"
+
+#if defined(UNIX)
+/** List of certificate bundles, depending on OS. Taken from: https://go.dev/src/crypto/x509/root_linux.go. */
+static auto _certificate_files = {
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+	"/etc/ssl/cert.pem",                                 // Alpine Linux
+};
+/** List of certificate directories, depending on OS. Taken from: https://go.dev/src/crypto/x509/root_linux.go. */
+static auto _certificate_directories = {
+	"/etc/ssl/certs",                                    // SLES10/SLES11, https://golang.org/issue/12139
+	"/etc/pki/tls/certs",                                // Fedora/RHEL
+	"/system/etc/security/cacerts",                      // Android
+};
+#endif /* UNIX */
 
 /** Single HTTP request. */
 class NetworkHTTPRequest {
@@ -61,9 +80,20 @@ static std::atomic<bool> _http_thread_exit = false;
 static std::queue<std::unique_ptr<NetworkHTTPRequest>> _http_requests;
 static std::mutex _http_mutex;
 static std::condition_variable _http_cv;
+#if defined(UNIX)
+static std::string _http_ca_file = "";
+static std::string _http_ca_path = "";
+#endif /* UNIX */
 
 /* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const char *data)
 {
+#if defined(UNIX)
+	if (_http_ca_file.empty() && _http_ca_path.empty()) {
+		callback->OnFailure();
+		return;
+	}
+#endif /* UNIX */
+
 	std::lock_guard<std::mutex> lock(_http_mutex);
 	_http_requests.push(std::make_unique<NetworkHTTPRequest>(uri, callback, data));
 	_http_cv.notify_one();
@@ -105,6 +135,14 @@ void HttpThread()
 		curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent.c_str());
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 		curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+
+		/* Ensure we validate the certificate and hostname of the server. */
+#if defined(UNIX)
+		curl_easy_setopt(curl, CURLOPT_CAINFO, _http_ca_file.empty() ? nullptr : _http_ca_file.c_str());
+		curl_easy_setopt(curl, CURLOPT_CAPATH, _http_ca_path.empty() ? nullptr : _http_ca_path.c_str());
+#endif /* UNIX */
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2);
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, true);
 
 		/* Give the connection about 10 seconds to complete. */
 		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
@@ -158,6 +196,33 @@ void HttpThread()
 void NetworkHTTPInitialize()
 {
 	curl_global_init(CURL_GLOBAL_DEFAULT);
+
+#if defined(UNIX)
+	/* Depending on the Linux distro, certificates can either be in
+	 * a bundle or a folder, in a wide range of different locations.
+	 * Try to find what location is used by this OS. */
+	for (auto &ca_file : _certificate_files) {
+		if (FileExists(ca_file)) {
+			_http_ca_file = ca_file;
+			break;
+		}
+	}
+	if (_http_ca_file.empty()) {
+		for (auto &ca_path : _certificate_directories) {
+			if (FileExists(ca_path)) {
+				_http_ca_path = ca_path;
+				break;
+			}
+		}
+	}
+	Debug(net, 3, "Using certificate file: {}", _http_ca_file.empty() ? "none" : _http_ca_file);
+	Debug(net, 3, "Using certificate path: {}", _http_ca_path.empty() ? "none" : _http_ca_path);
+
+	/* Tell the user why HTTPS will not be working. */
+	if (_http_ca_file.empty() && _http_ca_path.empty()) {
+		Debug(net, 0, "No certificate files or directories found, HTTPS will not work!");
+	}
+#endif /* UNIX */
 
 	_http_thread_exit = false;
 	StartNewThread(&_http_thread, "ottd:http", &HttpThread);


### PR DESCRIPTION
## Motivation / Problem

Linux distros are weird. They all use a different location for their certificates. Some have a pack, others do it in a folder.

So we gave up, and just try to detect the right folder, as done by other software too.

## Description

Walk through a few files / folders, and see which exists. The first to exist, is most likely the valid place to look for a certificate.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
