### PR TITLE
Fix #10131: actually cancel downloads when pressing cancel 

### DIFF
--- a/src/network/core/http.h
+++ b/src/network/core/http.h
@@ -30,6 +30,15 @@ struct HTTPCallback {
 	 */
 	virtual void OnReceiveData(const char *data, size_t length) = 0;
 
+	/**
+	 * Check if there is a request to cancel the transfer.
+	 *
+	 * @return true iff the connection is cancelled.
+	 * @note Cancellations are never instant, and can take a bit of time to be processed.
+	 * The object needs to remain valid until the OnFailure() callback is called.
+	 */
+	virtual bool IsCancelled() const = 0;
+
 	/** Silentium */
 	virtual ~HTTPCallback() {}
 };

--- a/src/network/core/http.h
+++ b/src/network/core/http.h
@@ -42,9 +42,9 @@ public:
 	 *
 	 * @param uri      the URI to connect to (https://.../..).
 	 * @param callback the callback to send data back on.
-	 * @param data     optionally, the data we want to send. When set, this will be a POST request, otherwise a GET request.
+	 * @param data     the data we want to send. When non-empty, this will be a POST request, otherwise a GET request.
 	 */
-	static void Connect(const std::string &uri, HTTPCallback *callback, const char *data = nullptr);
+	static void Connect(const std::string &uri, HTTPCallback *callback, const std::string data = "");
 
 	/**
 	 * Do the receiving for all HTTP connections.

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -53,26 +53,18 @@ public:
 	 *
 	 * @param uri      the URI to connect to (https://.../..).
 	 * @param callback the callback to send data back on.
-	 * @param data     optionally, the data we want to send. When set, this will be a POST request, otherwise a GET request.
+	 * @param data     the data we want to send. When non-empty, this will be a POST request, otherwise a GET request.
 	 */
-	NetworkHTTPRequest(const std::string &uri, HTTPCallback *callback, const char *data = nullptr) :
+	NetworkHTTPRequest(const std::string &uri, HTTPCallback *callback, const std::string &data) :
 		uri(uri),
 		callback(callback),
 		data(data)
 	{
 	}
 
-	/**
-	 * Destructor of the HTTP request.
-	 */
-	~NetworkHTTPRequest()
-	{
-		free(this->data);
-	}
-
-	std::string uri;        ///< URI to connect to.
-	HTTPCallback *callback; ///< Callback to send data back on.
-	const char *data;       ///< Data to send, if any.
+	const std::string uri;        ///< URI to connect to.
+	HTTPCallback *callback;       ///< Callback to send data back on.
+	const std::string data;       ///< Data to send, if any.
 };
 
 static std::thread _http_thread;
@@ -85,7 +77,7 @@ static std::string _http_ca_file = "";
 static std::string _http_ca_path = "";
 #endif /* UNIX */
 
-/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const char *data)
+/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const std::string data)
 {
 #if defined(UNIX)
 	if (_http_ca_file.empty() && _http_ca_path.empty()) {
@@ -154,9 +146,9 @@ void HttpThread()
 		curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
 
 		/* Prepare POST body and URI. */
-		if (request->data != nullptr) {
+		if (!request->data.empty()) {
 			curl_easy_setopt(curl, CURLOPT_POST, 1L);
-			curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request->data);
+			curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request->data.c_str());
 		}
 		curl_easy_setopt(curl, CURLOPT_URL, request->uri.c_str());
 

--- a/src/network/core/http_none.cpp
+++ b/src/network/core/http_none.cpp
@@ -18,7 +18,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const char *data)
+/* static */ void NetworkHTTPSocketHandler::Connect(const std::string &uri, HTTPCallback *callback, const std::string data)
 {
 	/* No valid HTTP backend was compiled in, so we fail all HTTP requests. */
 	callback->OnFailure();

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -337,25 +337,14 @@ void ClientNetworkContentSocketHandler::DownloadSelectedContent(uint &files, uin
  */
 void ClientNetworkContentSocketHandler::DownloadSelectedContentHTTP(const ContentIDList &content)
 {
-	uint count = (uint)content.size();
-
-	/* Allocate memory for the whole request.
-	 * Requests are "id\nid\n..." (as strings), so assume the maximum ID,
-	 * which is uint32 so 10 characters long. Then the newlines and
-	 * multiply that all with the count and then add the '\0'. */
-	uint bytes = (10 + 1) * count + 1;
-	char *content_request = MallocT<char>(bytes);
-	const char *lastof = content_request + bytes - 1;
-
-	char *p = content_request;
+	std::string content_request;
 	for (const ContentID &id : content) {
-		p += seprintf(p, lastof, "%d\n", id);
+		content_request += std::to_string(id) + "\n";
 	}
 
 	this->http_response_index = -1;
 
 	NetworkHTTPSocketHandler::Connect(NetworkContentMirrorUriString(), this, content_request);
-	/* NetworkHTTPContentConnecter takes over freeing of content_request! */
 }
 
 /**

--- a/src/network/network_content.cpp
+++ b/src/network/network_content.cpp
@@ -586,9 +586,7 @@ void ClientNetworkContentSocketHandler::OnFailure()
 	this->http_response_index = -2;
 
 	if (this->curFile != nullptr) {
-		/* Revert the download progress when we are going for the old system. */
-		long size = ftell(this->curFile);
-		if (size > 0) this->OnDownloadProgress(this->curInfo, (int)-size);
+		this->OnDownloadProgress(this->curInfo, -1);
 
 		fclose(this->curFile);
 		this->curFile = nullptr;

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -76,6 +76,7 @@ protected:
 	FILE *curFile;        ///< Currently downloaded file
 	ContentInfo *curInfo; ///< Information about the currently downloaded file
 	bool isConnecting;    ///< Whether we're connecting
+	bool isCancelled;     ///< Whether the download has been cancelled
 	std::chrono::steady_clock::time_point lastActivity;  ///< The last time there was network activity
 
 	friend class NetworkContentConnecter;
@@ -94,6 +95,7 @@ protected:
 
 	void OnFailure() override;
 	void OnReceiveData(const char *data, size_t length) override;
+	bool IsCancelled() const override;
 
 	bool BeforeDownload();
 	void AfterDownload();

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -100,7 +100,7 @@ static WindowDesc _network_content_download_status_window_desc(
 );
 
 BaseNetworkContentDownloadStatusWindow::BaseNetworkContentDownloadStatusWindow(WindowDesc *desc) :
-		Window(desc), cur_id(UINT32_MAX)
+		Window(desc), downloaded_bytes(0), downloaded_files(0), cur_id(UINT32_MAX)
 {
 	_network_content_client.AddCallback(this);
 	_network_content_client.DownloadSelectedContent(this->total_files, this->total_bytes);
@@ -174,7 +174,13 @@ void BaseNetworkContentDownloadStatusWindow::OnDownloadProgress(const ContentInf
 		this->downloaded_files++;
 	}
 
-	this->downloaded_bytes += bytes;
+	/* A negative value means we are resetting; for example, when retrying or using a fallback. */
+	if (bytes < 0) {
+		this->downloaded_bytes = 0;
+	} else {
+		this->downloaded_bytes += bytes;
+	}
+
 	this->SetDirty();
 }
 


### PR DESCRIPTION
## Motivation / Problem

Pressing cancel didn't actually cancel, but kept downloading in the background. Which gave hilarious results if you try to download another file, as then the filepointers got mixed up, and the whole world got disappointed in you.

## Description

Introduced a "IsCancelled" state, to notify the backends they need to terminate as soon as they can. This to avoid sending pointers back and forth .. the backend now polls the callback object for its state. Not the best solution, but the current state of code is .. well, there are weird things in there.

While at it, found (and solved) various of other bugs. If requested, I have no problem making them into separate PRs. But in short:

- Finally did the much requested change to use `std::string` instead of some custom malloc/free for the content-body
- Download progress was not always starting at zero. While at it, also initialize it as zero. Not really important, but looks much cleaner.

I refrained from making any other changes / fixes .. this code kinda needs a redo anyway, but also on a fundamental level: the download list is fetched in full, every time. This is a long list by now, and is very slow. Ideally, we approach this smarter, either by categories, backend-searching, etc. So I didn't want to spend too much time on this code, and just fixed the problems I spotted.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
