### PR TITLE
Fix #10486: [Script] Debug window requires AIs to be started before GS

### DIFF
--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -544,13 +544,15 @@ static inline bool MayHaveBridgeAbove(TileIndex t)
  */
 static void StartScripts()
 {
-	/* Start the GameScript. */
-	Game::StartNew();
+	/* Script debug window requires AIs to be started before trying to start GameScript. */
 
 	/* Start the AIs. */
 	for (const Company *c : Company::Iterate()) {
 		if (Company::IsValidAiID(c->index)) AI::StartNew(c->index, false);
 	}
+
+	/* Start the GameScript. */
+	Game::StartNew();
 
 	ShowScriptDebugWindowIfScriptError();
 }


### PR DESCRIPTION
Fixes #10486

## Motivation / Problem
When loading a savegame, if the GS crashes on start, the debug window is opened and it defaults to the first AI (`is_ai == true`).
But at that point of loading, the AIs are not started yet so no instance => crash.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Start the AIs before GS.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
