### PR TITLE
Fix #10222: Adjust line drawing algorithm

### DIFF
--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -109,11 +109,6 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		}
 
 		while (x1 != x2) {
-			if (dash_count < dash) {
-				for (int y = y_low; y != y_high; y += stepy) {
-					if (y >= 0 && y < screen_height) set_pixel(x1, y);
-				}
-			}
 			if (frac_low >= 0) {
 				y_low += stepy;
 				frac_low -= dx;
@@ -122,6 +117,12 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 				y_high += stepy;
 				frac_high -= dx;
 			}
+			if (dash_count < dash) {
+				for (int y = y_low; y != y_high; y += stepy) {
+					if (y >= 0 && y < screen_height) set_pixel(x1, y);
+				}
+			}
+
 			x1++;
 			frac_low += dy;
 			frac_high += dy;
@@ -171,11 +172,6 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		}
 
 		while (y1 != y2) {
-			if (dash_count < dash) {
-				for (int x = x_low; x != x_high; x += stepx) {
-					if (x >= 0 && x < screen_width) set_pixel(x, y1);
-				}
-			}
 			if (frac_low >= 0) {
 				x_low += stepx;
 				frac_low -= dy;
@@ -184,6 +180,12 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 				x_high += stepx;
 				frac_high -= dy;
 			}
+			if (dash_count < dash) {
+				for (int x = x_low; x != x_high; x += stepx) {
+					if (x >= 0 && x < screen_width) set_pixel(x, y1);
+				}
+			}
+
 			y1++;
 			frac_low += dx;
 			frac_high += dx;


### PR DESCRIPTION
This adjusts the line drawing algorithm by setting up a few variables in the loop before the pixel is set, rather than after. This change appears to fix this off-by-one error.

I was testing with a few lines in the console_gui, shown below.

Before change:
![Screenshot_2023-02-17_23-36-38](https://user-images.githubusercontent.com/59292/219833860-0ddbe2f4-7ccd-42eb-b58d-f7302b5ea634.png)

After change:
![Screenshot_2023-02-17_23-40-32](https://user-images.githubusercontent.com/59292/219834608-1170783f-26b9-45d3-92f2-b07c1a908624.png)

Closes #10222