### PR TITLE
Change: [Script] Restore support of {RAW_STRING} in ScriptText

### DIFF
--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -12,7 +12,23 @@
 
 #include "../core/smallvec_type.hpp"
 
+struct StringParam {
+	enum ParamType {
+		RAW_STRING,
+		STRING,
+		OTHER
+	};
+
+	ParamType type;
+	uint8 consumes;
+
+	StringParam(ParamType type, uint8 consumes) : type(type), consumes(consumes) {}
+};
+using StringParams = std::vector<StringParam>;
+using StringParamsList = std::vector<StringParams>;
+
 const char *GetGameStringPtr(uint id);
+const StringParams &GetGameStringParams(uint id);
 void RegisterGameTranslation(class Squirrel *engine);
 void ReconsiderGameScriptLanguage();
 
@@ -37,6 +53,7 @@ struct GameStrings {
 	std::vector<LanguageStrings> raw_strings;      ///< The raw strings per language, first must be English/the master language!.
 	std::vector<LanguageStrings> compiled_strings; ///< The compiled strings per language, first must be English/the master language!.
 	StringList string_names;                       ///< The names of the compiled strings.
+	StringParamsList string_params;                ///< The parameters for the strings.
 
 	void Compile();
 

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -90,7 +90,6 @@ public:
 	 */
 	ScriptText(StringID string, ...);
 #endif /* DOXYGEN_API */
-	~ScriptText();
 
 #ifndef DOXYGEN_API
 	/**
@@ -129,8 +128,10 @@ public:
 	virtual const std::string GetEncodedText();
 
 private:
+	using ScriptTextRef = ScriptObjectRef<ScriptText>;
+
 	StringID string;
-	std::variant<SQInteger, std::string, ScriptText *> param[SCRIPT_TEXT_MAX_PARAMETERS];
+	std::variant<SQInteger, std::string, ScriptTextRef> param[SCRIPT_TEXT_MAX_PARAMETERS];
 	int paramc;
 
 	/**

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -13,6 +13,8 @@
 #include "script_object.hpp"
 #include "../../core/alloc_type.hpp"
 
+#include <variant>
+
 /**
  * Internal parent object of all Text-like objects.
  * @api -all
@@ -128,9 +130,7 @@ public:
 
 private:
 	StringID string;
-	char *params[SCRIPT_TEXT_MAX_PARAMETERS];
-	int64 parami[SCRIPT_TEXT_MAX_PARAMETERS];
-	ScriptText *paramt[SCRIPT_TEXT_MAX_PARAMETERS];
+	std::variant<SQInteger, std::string, ScriptText *> param[SCRIPT_TEXT_MAX_PARAMETERS];
 	int paramc;
 
 	/**

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -136,6 +136,22 @@ struct LanguageWriter {
 	virtual void WriteLang(const StringData &data);
 };
 
+struct CmdStruct;
+
+struct CmdPair {
+	const CmdStruct *a;
+	const char *v;
+};
+
+struct ParsedCommandStruct {
+	uint np;
+	CmdPair pairs[32];
+	const CmdStruct *cmd[32]; // ordered by param #
+};
+
+const CmdStruct *TranslateCmdForCompare(const CmdStruct *a);
+void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool warnings);
+
 void CDECL strgen_warning(const char *s, ...) WARN_FORMAT(1, 2);
 void CDECL strgen_error(const char *s, ...) WARN_FORMAT(1, 2);
 void NORETURN CDECL strgen_fatal(const char *s, ...) WARN_FORMAT(1, 2);

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -217,17 +217,6 @@ uint StringData::CountInUse(uint tab) const
 
 static const char *_cur_ident;
 
-struct CmdPair {
-	const CmdStruct *a;
-	const char *v;
-};
-
-struct ParsedCommandStruct {
-	uint np;
-	CmdPair pairs[32];
-	const CmdStruct *cmd[32]; // ordered by param #
-};
-
 /* Used when generating some advanced commands. */
 static ParsedCommandStruct _cur_pcs;
 static int _cur_argidx;
@@ -594,7 +583,7 @@ StringReader::~StringReader()
 	free(file);
 }
 
-static void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool warnings)
+void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool warnings)
 {
 	char param[MAX_COMMAND_PARAM_SIZE];
 	int argno;
@@ -628,7 +617,7 @@ static void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool war
 }
 
 
-static const CmdStruct *TranslateCmdForCompare(const CmdStruct *a)
+const CmdStruct *TranslateCmdForCompare(const CmdStruct *a)
 {
 	if (a == nullptr) return nullptr;
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -926,8 +926,9 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 						sub_args.SetParam(i++, param);
 					} else {
+						s++; // skip the leading \"
 						char *g = stredup(s);
-						g[p - s] = '\0';
+						g[p - s - 1] = '\0'; // skip the trailing \"
 
 						sub_args_need_free[i] = true;
 						sub_args.SetParam(i++, (uint64)(size_t)g);
@@ -1044,7 +1045,6 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				break;
 
 			case SCC_RAW_STRING_POINTER: { // {RAW_STRING}
-				if (game_script) break;
 				const char *raw_string = (const char *)(size_t)args->GetInt64(SCC_RAW_STRING_POINTER);
 				buff = FormatString(buff, raw_string, args, last);
 				break;


### PR DESCRIPTION
## Motivation / Problem
Usage of `{RAW_STRING}` in ScriptText is supported in API side since [the introduction of ScriptText](https://github.com/OpenTTD/OpenTTD/commit/b0ac529a6ff4e087520a14d2a0169f445952e7e0).
But the display of raw strings has been disabled in https://github.com/OpenTTD/OpenTTD/commit/c02aabf1b837ba15ae2e2abc68570f0bf63aa190.

The main reason for disabling it is the absence of validation of parameters when they are passed to OpenTTD.
And in the case of `{RAW_STRING}`, an incorrect parameter might crash OpenTTD.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Ensure the parameters provided by the script matches the parameters expected by the string.
Of course the parameters types are checked, but also the parameters consumption, because any mismatch in consumption will offset the following parameters.
The validation is done during `ScriptText::GetEncodedText()` so it happens just before a string is passed to OpenTTD, allowing scripts to do whatever they want with parameters before they decide to pass the string to OpenTTD.
I also fixed a little mistake present since the introduction, the quotes around encoded raw strings were not removed during decoding.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
