### PR TITLE
Change: Avoid crashing to the side of a train

### DIFF
--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -26,6 +26,7 @@
 #include "effectvehicle_base.h"
 #include "elrail_func.h"
 #include "roadveh.h"
+#include "train.h"
 #include "town.h"
 #include "company_base.h"
 #include "core/random_func.hpp"
@@ -2086,6 +2087,8 @@ static TrackStatus GetTileTrackStatus_Road(TileIndex tile, TransportType mode, u
 					trackdirbits = TrackBitsToTrackdirBits(AxisToTrackBits(axis));
 					if (IsCrossingBarred(tile)) {
 						red_signals = trackdirbits;
+						if (TrainOnCrossing(tile)) break;
+
 						auto mask_red_signal_bits_if_crossing_barred = [&](TileIndex t, TrackdirBits mask) {
 							if (IsLevelCrossingTile(t) && IsCrossingBarred(t)) red_signals &= mask;
 						};

--- a/src/train.h
+++ b/src/train.h
@@ -65,6 +65,8 @@ int GetTrainStopLocation(StationID station_id, TileIndex tile, const Train *v, i
 
 void GetTrainSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs, int &yoffs, EngineImageType image_type);
 
+bool TrainOnCrossing(TileIndex tile);
+
 /** Variables that are cached to improve performance and such */
 struct TrainCache {
 	/* Cached wagon override spritegroup */

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -1658,6 +1658,19 @@ static Vehicle *TrainOnTileEnum(Vehicle *v, void *)
 	return (v->type == VEH_TRAIN) ? v : nullptr;
 }
 
+/**
+ * Check if a level crossing tile has a train on it
+ * @param tile tile to test
+ * @return true if a train is on the crossing
+ * @pre tile is a level crossing
+ */
+bool TrainOnCrossing(TileIndex tile)
+{
+	assert(IsLevelCrossingTile(tile));
+
+	return HasVehicleOnPos(tile, nullptr, &TrainOnTileEnum);
+}
+
 
 /**
  * Checks if a train is approaching a rail-road crossing
@@ -1709,7 +1722,7 @@ static bool TrainApproachingCrossing(TileIndex tile)
 static inline bool CheckLevelCrossing(TileIndex tile)
 {
 	/* reserved || train on crossing || train approaching crossing */
-	return HasCrossingReservation(tile) || HasVehicleOnPos(tile, NULL, &TrainOnTileEnum) || TrainApproachingCrossing(tile);
+	return HasCrossingReservation(tile) || TrainOnCrossing(tile) || TrainApproachingCrossing(tile);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem
savegame: [crashing for no reason.zip](https://github.com/OpenTTD/OpenTTD/files/10785953/crashing.for.no.reason.zip)

https://user-images.githubusercontent.com/43006711/220150153-dbf250ad-417b-4bfb-87ed-2d572a71479a.mp4
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
When a road vehicle is already running on a multi-level crossing, and a train shows up ahead, don't make the road vehicle crash on the side of the train.

https://user-images.githubusercontent.com/43006711/220168356-75151e04-c00e-448a-bab7-f47d7fa707c6.mp4


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
I was unsure if I should also add `TrainApproachingCrossing` check. My testings appear to show slightly worse results. I was also curious about the results without the Teleporting conversion.
```
version                                     crash_count.sav     autosave10.sav      Level Crossing Crash Spam STD, 2010-01-01 (2).sav
openttd 13.0-beta1 (old level crossing)      25->46->79->97      42->82->115->147    121->238->338->442
master                                       38->87->114->138    69->118->161->186   23->24->98->99
master + train on tile || approaching        35->62->92->110     63->103->139->176   3->26->47->50
master + train on tile                       35->73->96->123     49->99->137->170    5->19->34->36
master - tele + train on tile                35->73->96->123     57->98->138->179    10->39->63->66
master - tele                                38->87->114->138    54->99->137->162    42->52->99->99
master - tele + train on tile || approaching 35->62->92->110     45->86->119->147    9->38->75->79
                                             number of crashes accumulated year after year

crash_count.sav                                   -> 15 AIs
autosave10.sav                                    -> 15 AIs
Level Crossing Crash Spam STD, 2010-01-01 (2).sav -> LC-Zorg https://github.com/OpenTTD/OpenTTD/pull/9931#issuecomment-1173211773
```

game script: [Crash Counter.zip](https://github.com/OpenTTD/OpenTTD/files/10786011/Crash.Counter.zip)
3 savegames: [3 savegames.zip](https://github.com/OpenTTD/OpenTTD/files/10786018/3.savegames.zip)
I tested these savegames with no AIs installed.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
