### PR TITLE
Revert 92c7551: Line drawing algorithm fix broke other cases

### DIFF
--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -109,6 +109,11 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		}
 
 		while (x1 != x2) {
+			if (dash_count < dash) {
+				for (int y = y_low; y != y_high; y += stepy) {
+					if (y >= 0 && y < screen_height) set_pixel(x1, y);
+				}
+			}
 			if (frac_low >= 0) {
 				y_low += stepy;
 				frac_low -= dx;
@@ -117,12 +122,6 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 				y_high += stepy;
 				frac_high -= dx;
 			}
-			if (dash_count < dash) {
-				for (int y = y_low; y != y_high; y += stepy) {
-					if (y >= 0 && y < screen_height) set_pixel(x1, y);
-				}
-			}
-
 			x1++;
 			frac_low += dy;
 			frac_high += dy;
@@ -172,6 +171,11 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		}
 
 		while (y1 != y2) {
+			if (dash_count < dash) {
+				for (int x = x_low; x != x_high; x += stepx) {
+					if (x >= 0 && x < screen_width) set_pixel(x, y1);
+				}
+			}
 			if (frac_low >= 0) {
 				x_low += stepx;
 				frac_low -= dy;
@@ -180,12 +184,6 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 				x_high += stepx;
 				frac_high -= dy;
 			}
-			if (dash_count < dash) {
-				for (int x = x_low; x != x_high; x += stepx) {
-					if (x >= 0 && x < screen_width) set_pixel(x, y1);
-				}
-			}
-
 			y1++;
 			frac_low += dx;
 			frac_high += dx;


### PR DESCRIPTION
## Motivation / Problem

See the conversation in the comments of #10491. It broke other line drawing cases. Oops.

## Description

Reverts 92c7551, from #10491.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
