### PR TITLE
Fix #10222: Line drawing bug, without regression error

### DIFF
--- a/src/blitter/common.hpp
+++ b/src/blitter/common.hpp
@@ -45,7 +45,7 @@ void Blitter::DrawLineGeneric(int x1, int y1, int x2, int y2, int screen_width, 
 		return;
 	}
 
-	int frac_diff = width * std::max(dx, dy);
+	int frac_diff = (width - 1) * std::max(dx, dy);
 	if (width > 1) {
 		/* compute frac_diff = width * sqrt(dx*dx + dy*dy)
 		 * Start interval:


### PR DESCRIPTION
Fix this off-by-one problem in a different way, maintains the correct start and end point as pointed out by @ldpl.

Before:
![220485211-d9432331-9830-466e-ab39-e7c576f687fc](https://user-images.githubusercontent.com/59292/220492847-8eb3b622-11ec-463b-a0fe-a867bdc5e35d.png)


After:
![220485242-43d01868-5b70-48b4-bb70-70f54288ed52](https://user-images.githubusercontent.com/59292/220492873-0555bf7f-01ba-4344-835c-ed5d93b8b2af.png)


Test code:
```
        GfxFillRect(100, 100, 120, 120, PC_GREY);
        GfxDrawLine(120, 120, 100, 100, PC_RED, 1, 0); 
        GfxDrawLine(110, 120, 110, 100, PC_RED, 1, 0);
        GfxDrawLine(120, 110, 100, 110, PC_RED, 1, 0); 
        GfxDrawLine(120, 100, 100, 120, PC_RED, 1, 0);   
    
        GfxDrawLine(10, 10, 60, 10, PC_WHITE, 9, 0);   
        GfxDrawLine(10, 15, 60, 15, PC_WHITE, 8, 0);  
     
        GfxDrawLine(70, 10, 70, 40, PC_WHITE, 9, 0);      
        GfxDrawLine(90, 10, 90, 50, PC_WHITE, 8, 0);    

        GfxDrawLine(10, 30, 40, 60, PC_WHITE, 8, 0);     
        GfxDrawLine(40, 30, 80, 60, PC_WHITE, 8, 0);
```

Closes #10222 