### PR TITLE
Change: [Actions] cancel previous run if pushing new PR

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,10 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   emscripten:
     name: Emscripten

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     branches:
     - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -3,6 +3,10 @@ name: Commit checker
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   commit-checker:
     name: Commit checker

--- a/.github/workflows/unused-strings.yml
+++ b/.github/workflows/unused-strings.yml
@@ -3,6 +3,10 @@ name: Unused strings
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   unused-strings:
     name: Unused strings


### PR DESCRIPTION


## Motivation / Problem

Lately we had a few times that people pushed to their PR branch a few times to make small changes. Sadly, this triggers all CIs every time, which takes ~20 minutes. As we are limited in the amount of runners we get assigned to us, this means all other CI, even for other repositories within OpenTTD, are delayed too.

We can avoid this by simply cancelling old runs when a new PR is pushed. There is a downside: sometimes people already push a new commit, but still want to know if the old one passed. That will no longer be possible with this change.

## Description

Use `concurrency` tag, grouped per workflow and ref-number (which contains the PR number for example).
Only cancel when it is not the master branch, as well .. we do want all those to run.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
