### PR TITLE
Feature: Filter engine build menu by name and NewGRF extra text

### DIFF
--- a/src/widgets/build_vehicle_widget.h
+++ b/src/widgets/build_vehicle_widget.h
@@ -16,6 +16,7 @@ enum BuildVehicleWidgets {
 	WID_BV_SORT_ASCENDING_DESCENDING, ///< Sort direction.
 	WID_BV_SORT_DROPDOWN,             ///< Criteria of sorting dropdown.
 	WID_BV_CARGO_FILTER_DROPDOWN,     ///< Cargo filter dropdown.
+	WID_BV_FILTER,                    ///< Filter by name.
 	WID_BV_SHOW_HIDDEN_ENGINES,       ///< Toggle whether to display the hidden vehicles.
 	WID_BV_LIST,                      ///< List of vehicles.
 	WID_BV_SCROLLBAR,                 ///< Scrollbar of list.


### PR DESCRIPTION
## Motivation / Problem

In #8984, @perezdidac started the work of adding a text filter to the build vehicle menu, but hasn't been touched in 10 months. Let's finish it.

## Description

Implements #8984 with a change to put the editbox below the other lines:

![filter](https://user-images.githubusercontent.com/55058389/221718455-e83dce6f-2490-4ab6-8b8a-e427cc30a042.png)

I added the ability to search NewGRF extra text, which is often used to describe a vehicle's role:

![extra_text](https://user-images.githubusercontent.com/55058389/222837429-d37c0d42-8c73-47dd-bfdd-f53005bc1906.png)

It also works with the vehicle name callback added in #10399 (there's an example trainset in that PR):

![name_callback](https://user-images.githubusercontent.com/55058389/222838238-bfc62b86-1f26-455d-af65-3897f617cb84.png)

If variants are used (unreleased Iron Horse 2 in this screenshot), a subvariant that meets the filter, nested inside a parent does not, will show up underneath its greyed-out parent variant, collapsed by default.

![variants](https://user-images.githubusercontent.com/55058389/221718628-f2fa0eff-0c3e-4417-ad39-93c11b08693f.png)

Closes #8984.

## Limitations

I tried swapping the cargo filter dropdown and the editbox in the GUI, and the cargo filter all by itself looked much more wrong than a full-width textbox (which we have elsewhere in the GUI, including the object menu).

![swapped_lines](https://user-images.githubusercontent.com/55058389/221718615-61c8d8a2-167a-405c-a00c-d79acde0c9ef.png)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
