### PR TITLE
Add: maximum number of companies allowed to the client list

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2358,7 +2358,8 @@ STR_NETWORK_CLIENT_LIST_NEW_COMPANY                             :(New company)
 STR_NETWORK_CLIENT_LIST_NEW_COMPANY_TOOLTIP                     :{BLACK}Create a new company and join it
 STR_NETWORK_CLIENT_LIST_PLAYER_ICON_SELF_TOOLTIP                :{BLACK}This is you
 STR_NETWORK_CLIENT_LIST_PLAYER_ICON_HOST_TOOLTIP                :{BLACK}This is the host of the game
-STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT                    :{BLACK}{NUM} client{P "" s} / {NUM} compan{P y ies}
+STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT                    :{BLACK}{NUM} client{P "" s} - {NUM}/{NUM} compan{P y ies}
+STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT_TOOLTIP            :{BLACK}The number of currently connected clients, number of companies and maximum number of companies allowed by the server administrator
 
 # Matches ConnectionType
 ###length 5

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1111,6 +1111,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CONFIG_UPDATE(P
 
 	_network_server_max_companies = p->Recv_uint8();
 	_network_server_name = p->Recv_string(NETWORK_NAME_LENGTH);
+	SetWindowClassesDirty(WC_CLIENT_LIST);
 
 	return NETWORK_RECV_STATUS_OKAY;
 }
@@ -1320,10 +1321,19 @@ bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio)
 }
 
 /**
+ * Get the maximum number of companies that are allowed by the server.
+ * @return The number of companies allowed.
+ */
+uint NetworkMaxCompaniesAllowed()
+{
+	return _network_server ? _settings_client.network.max_companies : _network_server_max_companies;
+}
+
+/**
  * Check if max_companies has been reached on the server (local check only).
  * @return true if the max value has been reached or exceeded, false otherwise.
  */
 bool NetworkMaxCompaniesReached()
 {
-	return Company::GetNumItems() >= (_network_server ? _settings_client.network.max_companies : _network_server_max_companies);
+	return Company::GetNumItems() >= NetworkMaxCompaniesAllowed();
 }

--- a/src/network/network_func.h
+++ b/src/network/network_func.h
@@ -59,6 +59,7 @@ void NetworkClientSendRcon(const std::string &password, const std::string &comma
 void NetworkClientSendChat(NetworkAction action, DestType type, int dest, const std::string &msg, int64 data = 0);
 bool NetworkClientPreferTeamChat(const NetworkClientInfo *cio);
 bool NetworkCompanyIsPassworded(CompanyID company_id);
+uint NetworkMaxCompaniesAllowed();
 bool NetworkMaxCompaniesReached();
 void NetworkPrintClients();
 void NetworkHandlePauseChange(PauseMode prev_mode, PauseMode changed_mode);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1352,7 +1352,7 @@ static const NWidgetPart _nested_client_list_widgets[] = {
 		NWidget(NWID_VERTICAL),
 			NWidget(WWT_MATRIX, COLOUR_GREY, WID_CL_MATRIX), SetMinimalSize(180, 0), SetResize(1, 1), SetFill(1, 1), SetMatrixDataTip(1, 0, STR_NULL), SetScrollbar(WID_CL_SCROLLBAR),
 			NWidget(WWT_PANEL, COLOUR_GREY),
-				NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_CLIENT_COMPANY_COUNT), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetPadding(2, 1, 2, 1), SetAlignment(SA_CENTER), SetDataTip(STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT, STR_NULL),
+				NWidget(WWT_TEXT, COLOUR_GREY, WID_CL_CLIENT_COMPANY_COUNT), SetFill(1, 0), SetMinimalTextLines(1, 0), SetResize(1, 0), SetPadding(2, 1, 2, 1), SetAlignment(SA_CENTER), SetDataTip(STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT, STR_NETWORK_CLIENT_LIST_CLIENT_COMPANY_COUNT_TOOLTIP),
 			EndContainer(),
 		EndContainer(),
 		NWidget(NWID_VERTICAL),
@@ -1797,6 +1797,7 @@ public:
 			case WID_CL_CLIENT_COMPANY_COUNT:
 				SetDParam(0, NetworkClientInfo::GetNumItems());
 				SetDParam(1, Company::GetNumItems());
+				SetDParam(2, NetworkMaxCompaniesAllowed());
 				break;
 		}
 	}

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -477,7 +477,11 @@ static bool ReplaceAsteriskWithEmptyPassword(std::string &newval)
 static void UpdateClientConfigValues()
 {
 	NetworkServerUpdateGameInfo();
-	if (_network_server) NetworkServerSendConfigUpdate();
+
+	if (_network_server) {
+		NetworkServerSendConfigUpdate();
+		SetWindowClassesDirty(WC_CLIENT_LIST);
+	}
 }
 
 /* End - Callback Functions */


### PR DESCRIPTION
## Motivation / Problem

See #10054: "I've seen a few new players join and try to create a company, not realizing that the game has reached the maximum amount of companies, e.g #9703, which is easier to see at a glance."

I could not push to that PR, so a new one is needed. Closes #10054.


## Description

This PR adds the maximum number of companies to the current label with "{NUM} clients / {NUM} companies" at the bottom of the client list, changing it to: "{NUM} clients - {NUM}/{NUM} companies" (while accounting for the right plurals).

Since the number of clients allowed in the server is not available at the client, I have not made it consistent "{NUM}/{NUM} clients - {NUM}/{NUM} companies". This also keeps the line slightly narrower.

I became aware that #10054 did not update the UIs properly when changing the maximum, so the appropriate dirtying of the client list window was added. This also solves the issue that the server name does not get properly updated at both the server and client.

![example](https://user-images.githubusercontent.com/13785744/221953927-c677359d-dbf6-41c1-819e-200cd1aa4eee.png)


## Limitations

It does not make it 100% explicit that the server's maximum number of companies is reached, as in: that is not explicitly stated. However, there not being a button to start a new company and the number of companies being the same as the maximum should be enough.
However, I added a tooltip to the label so people can be aware of the meaning of everything.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
