### PR TITLE
NewGRF: Fix object and road stop ignore property handlers

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4762,16 +4762,22 @@ static ChangeInfoResult IgnoreRoadStopProperty(uint prop, ByteReader *buf)
 	switch (prop) {
 		case 0x09:
 		case 0x0C:
+		case 0x0F:
+		case 0x11:
 			buf->ReadByte();
 			break;
 
 		case 0x0A:
 		case 0x0B:
+		case 0x0E:
+		case 0x10:
+		case 0x15:
 			buf->ReadWord();
 			break;
 
 		case 0x08:
 		case 0x0D:
+		case 0x12:
 			buf->ReadDWord();
 			break;
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4059,6 +4059,7 @@ static ChangeInfoResult IgnoreObjectProperty(uint prop, ByteReader *buf)
 		case 0x14:
 		case 0x16:
 		case 0x17:
+		case 0x18:
 			buf->ReadByte();
 			break;
 


### PR DESCRIPTION
## Motivation / Problem

Objects: Property 18 not handled
Road stops: Properties 0E - 12 and 15 not handled.

## Description

Add missing property IDs to ignore property handlers.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
