### PR TITLE
Atomic libraries: fix build on riscv64

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -32,7 +32,7 @@ struct QueuedDebugItem {
 	std::string level;   ///< The used debug level.
 	std::string message; ///< The actual formatted message.
 };
-std::atomic<bool> _debug_remote_console; ///< Whether we need to send data to either NetworkAdminConsole or IConsolePrint.
+std::atomic<int> _debug_remote_console; ///< Whether we need to send data to either NetworkAdminConsole or IConsolePrint.
 std::mutex _debug_remote_console_mutex; ///< Mutex to guard the queue of debug messages for either NetworkAdminConsole or IConsolePrint.
 std::vector<QueuedDebugItem> _debug_remote_console_queue; ///< Queue for debug messages to be passed to NetworkAdminConsole or IConsolePrint.
 std::vector<QueuedDebugItem> _debug_remote_console_queue_spare; ///< Spare queue to swap with _debug_remote_console_queue.

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -33,7 +33,7 @@
 #include "safeguards.h"
 
 static std::mutex _sound_perf_lock;
-static std::atomic<bool> _sound_perf_pending;
+static std::atomic<int> _sound_perf_pending;
 static std::vector<TimingMeasurement> _sound_perf_measurements;
 
 /**

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -44,7 +44,7 @@ bool _right_button_down;    ///< Is right mouse button pressed?
 bool _right_button_clicked; ///< Is right mouse button clicked?
 DrawPixelInfo _screen;
 bool _screen_disable_anim = false;   ///< Disable palette animation (important for 32bpp-anim blitter during giant screenshot)
-std::atomic<bool> _exit_game;
+std::atomic<int> _exit_game;
 GameMode _game_mode;
 SwitchMode _switch_mode;  ///< The next mainloop command.
 PauseMode _pause_mode;

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -166,8 +166,8 @@ protected:
 	std::thread thread;               ///< Thread the job is running in or a default-constructed thread if it's running in the main thread.
 	Date join_date;                   ///< Date when the job is to be joined.
 	NodeAnnotationVector nodes;       ///< Extra node data necessary for link graph calculation.
-	std::atomic<bool> job_completed;  ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
-	std::atomic<bool> job_aborted;    ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
+	std::atomic<int> job_completed;  ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
+	std::atomic<int> job_aborted;    ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
 
 	void EraseFlows(NodeID from);
 	void JoinThread();

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -35,13 +35,13 @@ struct MixerChannel {
 	bool is16bit;
 };
 
-static std::atomic<uint8> _active_channels;
+static std::atomic<int> _active_channels;
 static MixerChannel _channels[8];
 static uint32 _play_rate = 11025;
 static uint32 _max_size = UINT_MAX;
 static MxStreamCallback _music_stream = nullptr;
 static std::mutex _music_stream_mutex;
-static std::atomic<uint8> _effect_vol;
+static std::atomic<int> _effect_vol;
 
 /**
  * The theoretical maximum volume for a single sound sample. Multiple sound

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -87,7 +87,7 @@ private:
 
 	std::thread resolve_thread;                         ///< Thread used during resolving.
 	std::atomic<Status> status = Status::Init;          ///< The current status of the connecter.
-	std::atomic<bool> killed = false;                   ///< Whether this connecter is marked as killed.
+	std::atomic<int> killed = false;                   ///< Whether this connecter is marked as killed.
 
 	addrinfo *ai = nullptr;                             ///< getaddrinfo() allocated linked-list of resolved addresses.
 	std::vector<addrinfo *> addresses;                  ///< Addresses we can connect to.

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -53,7 +53,7 @@ enum DisplayOptions {
 
 extern GameMode _game_mode;
 extern SwitchMode _switch_mode;
-extern std::atomic<bool> _exit_game;
+extern std::atomic<int> _exit_game;
 extern bool _save_config;
 
 /** Modes of pausing we've got */


### PR DESCRIPTION
Make sure we don't use std_atomic<bool>, but std_atomic<int> instead. This makes the code compilable on riscv64 without needing to use external latomic library.
The program FTBFS on riscv64 due to missing "latomic" link.
There are two solutions:
1) link latomic where needed (look for CheckAtomic.cmake file)
2) avoid atomic<bool> usage, this can't be optimized correctly by the compiler on all the architectures, while atomic<int> can be done.

The solution 2 avoids usage or external slower libraries and makes the code behave the same way

Example of build failure log:
```
/usr/bin/c++ -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -fdebug-prefix-map=/<<PKGBUILDDIR>>=/usr/src/openttd-13.0-2 -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -g -DNDEBUG -flto=auto -fno-fat-lto-objects -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,-as-needed -rdynamic CMakeFiles/openttd.dir/generated/rev.cpp.o CMakeFiles/openttd.dir/src/script/api/script_accounting.cpp.o CMakeFiles/openttd.dir/src/script/api/script_admin.cpp.o CMakeFiles/openttd.dir/src/script/api/script_airport.cpp.o CMakeFiles/openttd.dir/src/script/api/script_base.cpp.o CMakeFiles/openttd.dir/src/script/api/script_basestation.cpp.o CMakeFiles/openttd.dir/src/script/api/script_bridge.cpp.o CMakeFiles/openttd.dir/src/script/api/script_bridgelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_cargo.cpp.o CMakeFiles/openttd.dir/src/script/api/script_cargolist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_cargomonitor.cpp.o CMakeFiles/openttd.dir/src/script/api/script_client.cpp.o CMakeFiles/openttd.dir/src/script/api/script_clientlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_company.cpp.o CMakeFiles/openttd.dir/src/script/api/script_companymode.cpp.o CMakeFiles/openttd.dir/src/script/api/script_controller.cpp.o CMakeFiles/openttd.dir/src/script/api/script_date.cpp.o CMakeFiles/openttd.dir/src/script/api/script_depotlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_engine.cpp.o CMakeFiles/openttd.dir/src/script/api/script_enginelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_error.cpp.o CMakeFiles/openttd.dir/src/script/api/script_event.cpp.o CMakeFiles/openttd.dir/src/script/api/script_event_types.cpp.o CMakeFiles/openttd.dir/src/script/api/script_execmode.cpp.o CMakeFiles/openttd.dir/src/script/api/script_game.cpp.o CMakeFiles/openttd.dir/src/script/api/script_gamesettings.cpp.o CMakeFiles/openttd.dir/src/script/api/script_goal.cpp.o CMakeFiles/openttd.dir/src/script/api/script_group.cpp.o CMakeFiles/openttd.dir/src/script/api/script_grouplist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_industry.cpp.o CMakeFiles/openttd.dir/src/script/api/script_industrylist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_industrytype.cpp.o CMakeFiles/openttd.dir/src/script/api/script_industrytypelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_infrastructure.cpp.o CMakeFiles/openttd.dir/src/script/api/script_league.cpp.o CMakeFiles/openttd.dir/src/script/api/script_list.cpp.o CMakeFiles/openttd.dir/src/script/api/script_log.cpp.o CMakeFiles/openttd.dir/src/script/api/script_map.cpp.o CMakeFiles/openttd.dir/src/script/api/script_marine.cpp.o CMakeFiles/openttd.dir/src/script/api/script_newgrf.cpp.o CMakeFiles/openttd.dir/src/script/api/script_news.cpp.o CMakeFiles/openttd.dir/src/script/api/script_object.cpp.o CMakeFiles/openttd.dir/src/script/api/script_objecttype.cpp.o CMakeFiles/openttd.dir/src/script/api/script_objecttypelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_order.cpp.o CMakeFiles/openttd.dir/src/script/api/script_priorityqueue.cpp.o CMakeFiles/openttd.dir/src/script/api/script_rail.cpp.o CMakeFiles/openttd.dir/src/script/api/script_railtypelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_road.cpp.o CMakeFiles/openttd.dir/src/script/api/script_roadtypelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_sign.cpp.o CMakeFiles/openttd.dir/src/script/api/script_signlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_station.cpp.o CMakeFiles/openttd.dir/src/script/api/script_stationlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_story_page.cpp.o CMakeFiles/openttd.dir/src/script/api/script_storypagelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_storypageelementlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_subsidy.cpp.o CMakeFiles/openttd.dir/src/script/api/script_subsidylist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_testmode.cpp.o CMakeFiles/openttd.dir/src/script/api/script_text.cpp.o CMakeFiles/openttd.dir/src/script/api/script_tile.cpp.o CMakeFiles/openttd.dir/src/script/api/script_tilelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_town.cpp.o CMakeFiles/openttd.dir/src/script/api/script_townlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_tunnel.cpp.o CMakeFiles/openttd.dir/src/script/api/script_vehicle.cpp.o CMakeFiles/openttd.dir/src/script/api/script_vehiclelist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_viewport.cpp.o CMakeFiles/openttd.dir/src/script/api/script_waypoint.cpp.o CMakeFiles/openttd.dir/src/script/api/script_waypointlist.cpp.o CMakeFiles/openttd.dir/src/script/api/script_window.cpp.o CMakeFiles/openttd.dir/src/script/script_config.cpp.o CMakeFiles/openttd.dir/src/script/script_info.cpp.o CMakeFiles/openttd.dir/src/script/script_info_dummy.cpp.o CMakeFiles/openttd.dir/src/script/script_instance.cpp.o CMakeFiles/openttd.dir/src/script/script_scanner.cpp.o CMakeFiles/openttd.dir/src/script/squirrel.cpp.o CMakeFiles/openttd.dir/src/script/squirrel_std.cpp.o CMakeFiles/openttd.dir/src/strgen/strgen_base.cpp.o CMakeFiles/openttd.dir/src/3rdparty/md5/md5.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/sqstdlib/sqstdaux.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/sqstdlib/sqstdmath.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqapi.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqbaselib.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqclass.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqcompiler.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqdebug.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqfuncstate.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqlexer.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqmem.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqobject.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqstate.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqtable.cpp.o CMakeFiles/openttd.dir/src/3rdparty/squirrel/squirrel/sqvm.cpp.o CMakeFiles/openttd.dir/src/ai/ai_config.cpp.o CMakeFiles/openttd.dir/src/ai/ai_core.cpp.o CMakeFiles/openttd.dir/src/ai/ai_gui.cpp.o CMakeFiles/openttd.dir/src/ai/ai_info.cpp.o CMakeFiles/openttd.dir/src/ai/ai_instance.cpp.o CMakeFiles/openttd.dir/src/ai/ai_scanner.cpp.o CMakeFiles/openttd.dir/src/blitter/32bpp_anim.cpp.o CMakeFiles/openttd.dir/src/blitter/32bpp_base.cpp.o CMakeFiles/openttd.dir/src/blitter/32bpp_optimized.cpp.o CMakeFiles/openttd.dir/src/blitter/32bpp_simple.cpp.o CMakeFiles/openttd.dir/src/blitter/8bpp_base.cpp.o CMakeFiles/openttd.dir/src/blitter/8bpp_optimized.cpp.o CMakeFiles/openttd.dir/src/blitter/8bpp_simple.cpp.o CMakeFiles/openttd.dir/src/blitter/40bpp_anim.cpp.o CMakeFiles/openttd.dir/src/blitter/null.cpp.o CMakeFiles/openttd.dir/src/core/alloc_func.cpp.o CMakeFiles/openttd.dir/src/core/bitmath_func.cpp.o CMakeFiles/openttd.dir/src/core/geometry_func.cpp.o CMakeFiles/openttd.dir/src/core/math_func.cpp.o CMakeFiles/openttd.dir/src/core/pool_func.cpp.o CMakeFiles/openttd.dir/src/core/random_func.cpp.o CMakeFiles/openttd.dir/src/fontcache/freetypefontcache.cpp.o CMakeFiles/openttd.dir/src/fontcache/spritefontcache.cpp.o CMakeFiles/openttd.dir/src/fontcache/truetypefontcache.cpp.o CMakeFiles/openttd.dir/src/game/game_config.cpp.o CMakeFiles/openttd.dir/src/game/game_core.cpp.o CMakeFiles/openttd.dir/src/game/game_gui.cpp.o CMakeFiles/openttd.dir/src/game/game_info.cpp.o CMakeFiles/openttd.dir/src/game/game_instance.cpp.o CMakeFiles/openttd.dir/src/game/game_scanner.cpp.o CMakeFiles/openttd.dir/src/game/game_text.cpp.o CMakeFiles/openttd.dir/src/linkgraph/demands.cpp.o CMakeFiles/openttd.dir/src/linkgraph/flowmapper.cpp.o CMakeFiles/openttd.dir/src/linkgraph/linkgraph.cpp.o CMakeFiles/openttd.dir/src/linkgraph/linkgraph_gui.cpp.o CMakeFiles/openttd.dir/src/linkgraph/linkgraphjob.cpp.o CMakeFiles/openttd.dir/src/linkgraph/linkgraphschedule.cpp.o CMakeFiles/openttd.dir/src/linkgraph/mcf.cpp.o CMakeFiles/openttd.dir/src/linkgraph/refresh.cpp.o CMakeFiles/openttd.dir/src/misc/countedobj.cpp.o CMakeFiles/openttd.dir/src/misc/dbg_helpers.cpp.o CMakeFiles/openttd.dir/src/misc/getoptdata.cpp.o CMakeFiles/openttd.dir/src/music/fluidsynth.cpp.o CMakeFiles/openttd.dir/src/music/extmidi.cpp.o CMakeFiles/openttd.dir/src/music/midifile.cpp.o CMakeFiles/openttd.dir/src/music/null_m.cpp.o CMakeFiles/openttd.dir/src/network/core/address.cpp.o CMakeFiles/openttd.dir/src/network/core/config.cpp.o CMakeFiles/openttd.dir/src/network/core/core.cpp.o CMakeFiles/openttd.dir/src/network/core/game_info.cpp.o CMakeFiles/openttd.dir/src/network/core/host.cpp.o CMakeFiles/openttd.dir/src/network/core/os_abstraction.cpp.o CMakeFiles/openttd.dir/src/network/core/packet.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_admin.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_connect.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_content.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_coordinator.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_game.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_http.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_stun.cpp.o CMakeFiles/openttd.dir/src/network/core/tcp_turn.cpp.o CMakeFiles/openttd.dir/src/network/core/udp.cpp.o CMakeFiles/openttd.dir/src/network/network.cpp.o CMakeFiles/openttd.dir/src/network/network_admin.cpp.o CMakeFiles/openttd.dir/src/network/network_chat_gui.cpp.o CMakeFiles/openttd.dir/src/network/network_client.cpp.o CMakeFiles/openttd.dir/src/network/network_command.cpp.o CMakeFiles/openttd.dir/src/network/network_content.cpp.o CMakeFiles/openttd.dir/src/network/network_content_gui.cpp.o CMakeFiles/openttd.dir/src/network/network_coordinator.cpp.o CMakeFiles/openttd.dir/src/network/network_gamelist.cpp.o CMakeFiles/openttd.dir/src/network/network_gui.cpp.o CMakeFiles/openttd.dir/src/network/network_query.cpp.o CMakeFiles/openttd.dir/src/network/network_server.cpp.o CMakeFiles/openttd.dir/src/network/network_stun.cpp.o CMakeFiles/openttd.dir/src/network/network_turn.cpp.o CMakeFiles/openttd.dir/src/network/network_udp.cpp.o CMakeFiles/openttd.dir/src/os/unix/crashlog_unix.cpp.o CMakeFiles/openttd.dir/src/os/unix/unix.cpp.o CMakeFiles/openttd.dir/src/os/unix/font_unix.cpp.o CMakeFiles/openttd.dir/src/pathfinder/npf/aystar.cpp.o CMakeFiles/openttd.dir/src/pathfinder/npf/npf.cpp.o CMakeFiles/openttd.dir/src/pathfinder/npf/queue.cpp.o CMakeFiles/openttd.dir/src/pathfinder/yapf/yapf_rail.cpp.o CMakeFiles/openttd.dir/src/pathfinder/yapf/yapf_road.cpp.o CMakeFiles/openttd.dir/src/pathfinder/yapf/yapf_ship.cpp.o CMakeFiles/openttd.dir/src/saveload/afterload.cpp.o CMakeFiles/openttd.dir/src/saveload/ai_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/airport_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/animated_tile_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/autoreplace_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/cargomonitor_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/cargopacket_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/cheat_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/company_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/depot_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/economy_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/engine_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/game_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/gamelog_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/goal_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/group_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/industry_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/labelmaps_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/league_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/linkgraph_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/map_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/misc_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/newgrf_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/object_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/oldloader.cpp.o CMakeFiles/openttd.dir/src/saveload/oldloader_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/order_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/saveload.cpp.o CMakeFiles/openttd.dir/src/saveload/settings_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/signs_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/station_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/storage_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/strings_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/story_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/subsidy_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/town_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/vehicle_sl.cpp.o CMakeFiles/openttd.dir/src/saveload/waypoint_sl.cpp.o CMakeFiles/openttd.dir/src/sound/sdl2_s.cpp.o CMakeFiles/openttd.dir/src/sound/null_s.cpp.o CMakeFiles/openttd.dir/src/spriteloader/grf.cpp.o CMakeFiles/openttd.dir/src/spriteloader/sprite_file.cpp.o CMakeFiles/openttd.dir/src/video/opengl.cpp.o CMakeFiles/openttd.dir/src/video/sdl2_v.cpp.o CMakeFiles/openttd.dir/src/video/sdl2_default_v.cpp.o CMakeFiles/openttd.dir/src/video/sdl2_opengl_v.cpp.o CMakeFiles/openttd.dir/src/video/dedicated_v.cpp.o CMakeFiles/openttd.dir/src/video/null_v.cpp.o CMakeFiles/openttd.dir/src/video/video_driver.cpp.o CMakeFiles/openttd.dir/src/widgets/dropdown.cpp.o CMakeFiles/openttd.dir/src/widgets/slider.cpp.o CMakeFiles/openttd.dir/src/aircraft_cmd.cpp.o CMakeFiles/openttd.dir/src/aircraft_gui.cpp.o CMakeFiles/openttd.dir/src/airport.cpp.o CMakeFiles/openttd.dir/src/airport_gui.cpp.o CMakeFiles/openttd.dir/src/animated_tile.cpp.o CMakeFiles/openttd.dir/src/articulated_vehicles.cpp.o CMakeFiles/openttd.dir/src/autoreplace.cpp.o CMakeFiles/openttd.dir/src/autoreplace_cmd.cpp.o CMakeFiles/openttd.dir/src/autoreplace_gui.cpp.o CMakeFiles/openttd.dir/src/base_consist.cpp.o CMakeFiles/openttd.dir/src/bmp.cpp.o CMakeFiles/openttd.dir/src/bootstrap_gui.cpp.o CMakeFiles/openttd.dir/src/bridge_gui.cpp.o CMakeFiles/openttd.dir/src/bridge_map.cpp.o CMakeFiles/openttd.dir/src/build_vehicle_gui.cpp.o CMakeFiles/openttd.dir/src/cargoaction.cpp.o CMakeFiles/openttd.dir/src/cargomonitor.cpp.o CMakeFiles/openttd.dir/src/cargopacket.cpp.o CMakeFiles/openttd.dir/src/cargotype.cpp.o CMakeFiles/openttd.dir/src/cheat.cpp.o CMakeFiles/openttd.dir/src/cheat_gui.cpp.o CMakeFiles/openttd.dir/src/clear_cmd.cpp.o CMakeFiles/openttd.dir/src/command.cpp.o CMakeFiles/openttd.dir/src/company_cmd.cpp.o CMakeFiles/openttd.dir/src/company_gui.cpp.o CMakeFiles/openttd.dir/src/console.cpp.o CMakeFiles/openttd.dir/src/console_cmds.cpp.o CMakeFiles/openttd.dir/src/console_gui.cpp.o CMakeFiles/openttd.dir/src/cpu.cpp.o CMakeFiles/openttd.dir/src/crashlog.cpp.o CMakeFiles/openttd.dir/src/currency.cpp.o CMakeFiles/openttd.dir/src/date.cpp.o CMakeFiles/openttd.dir/src/date_gui.cpp.o CMakeFiles/openttd.dir/src/debug.cpp.o CMakeFiles/openttd.dir/src/dedicated.cpp.o CMakeFiles/openttd.dir/src/depot.cpp.o CMakeFiles/openttd.dir/src/depot_cmd.cpp.o CMakeFiles/openttd.dir/src/depot_gui.cpp.o CMakeFiles/openttd.dir/src/disaster_vehicle.cpp.o CMakeFiles/openttd.dir/src/dock_gui.cpp.o CMakeFiles/openttd.dir/src/driver.cpp.o CMakeFiles/openttd.dir/src/economy.cpp.o CMakeFiles/openttd.dir/src/effectvehicle.cpp.o CMakeFiles/openttd.dir/src/elrail.cpp.o CMakeFiles/openttd.dir/src/engine.cpp.o CMakeFiles/openttd.dir/src/engine_gui.cpp.o CMakeFiles/openttd.dir/src/error_gui.cpp.o CMakeFiles/openttd.dir/src/fileio.cpp.o CMakeFiles/openttd.dir/src/fios.cpp.o CMakeFiles/openttd.dir/src/fios_gui.cpp.o CMakeFiles/openttd.dir/src/fontcache.cpp.o CMakeFiles/openttd.dir/src/framerate_gui.cpp.o CMakeFiles/openttd.dir/src/gamelog.cpp.o CMakeFiles/openttd.dir/src/genworld.cpp.o CMakeFiles/openttd.dir/src/genworld_gui.cpp.o CMakeFiles/openttd.dir/src/gfx.cpp.o CMakeFiles/openttd.dir/src/gfx_layout.cpp.o CMakeFiles/openttd.dir/src/gfxinit.cpp.o CMakeFiles/openttd.dir/src/goal.cpp.o CMakeFiles/openttd.dir/src/goal_gui.cpp.o CMakeFiles/openttd.dir/src/graph_gui.cpp.o CMakeFiles/openttd.dir/src/ground_vehicle.cpp.o CMakeFiles/openttd.dir/src/group_cmd.cpp.o CMakeFiles/openttd.dir/src/group_gui.cpp.o CMakeFiles/openttd.dir/src/heightmap.cpp.o CMakeFiles/openttd.dir/src/highscore.cpp.o CMakeFiles/openttd.dir/src/highscore_gui.cpp.o CMakeFiles/openttd.dir/src/hotkeys.cpp.o CMakeFiles/openttd.dir/src/industry_cmd.cpp.o CMakeFiles/openttd.dir/src/industry_gui.cpp.o CMakeFiles/openttd.dir/src/ini.cpp.o CMakeFiles/openttd.dir/src/ini_load.cpp.o CMakeFiles/openttd.dir/src/intro_gui.cpp.o CMakeFiles/openttd.dir/src/landscape.cpp.o CMakeFiles/openttd.dir/src/league_cmd.cpp.o CMakeFiles/openttd.dir/src/league_gui.cpp.o CMakeFiles/openttd.dir/src/main_gui.cpp.o CMakeFiles/openttd.dir/src/map.cpp.o CMakeFiles/openttd.dir/src/misc.cpp.o CMakeFiles/openttd.dir/src/misc_cmd.cpp.o CMakeFiles/openttd.dir/src/misc_gui.cpp.o CMakeFiles/openttd.dir/src/mixer.cpp.o CMakeFiles/openttd.dir/src/music.cpp.o CMakeFiles/openttd.dir/src/music_gui.cpp.o CMakeFiles/openttd.dir/src/newgrf.cpp.o CMakeFiles/openttd.dir/src/newgrf_airport.cpp.o CMakeFiles/openttd.dir/src/newgrf_airporttiles.cpp.o CMakeFiles/openttd.dir/src/newgrf_canal.cpp.o CMakeFiles/openttd.dir/src/newgrf_cargo.cpp.o CMakeFiles/openttd.dir/src/newgrf_commons.cpp.o CMakeFiles/openttd.dir/src/newgrf_config.cpp.o CMakeFiles/openttd.dir/src/newgrf_debug_gui.cpp.o CMakeFiles/openttd.dir/src/newgrf_engine.cpp.o CMakeFiles/openttd.dir/src/newgrf_generic.cpp.o CMakeFiles/openttd.dir/src/newgrf_gui.cpp.o CMakeFiles/openttd.dir/src/newgrf_house.cpp.o CMakeFiles/openttd.dir/src/newgrf_industries.cpp.o CMakeFiles/openttd.dir/src/newgrf_industrytiles.cpp.o CMakeFiles/openttd.dir/src/newgrf_object.cpp.o CMakeFiles/openttd.dir/src/newgrf_profiling.cpp.o CMakeFiles/openttd.dir/src/newgrf_railtype.cpp.o CMakeFiles/openttd.dir/src/newgrf_roadtype.cpp.o CMakeFiles/openttd.dir/src/newgrf_sound.cpp.o CMakeFiles/openttd.dir/src/newgrf_spritegroup.cpp.o CMakeFiles/openttd.dir/src/newgrf_station.cpp.o CMakeFiles/openttd.dir/src/newgrf_storage.cpp.o CMakeFiles/openttd.dir/src/newgrf_text.cpp.o CMakeFiles/openttd.dir/src/newgrf_town.cpp.o CMakeFiles/openttd.dir/src/newgrf_townname.cpp.o CMakeFiles/openttd.dir/src/news_gui.cpp.o CMakeFiles/openttd.dir/src/object_cmd.cpp.o CMakeFiles/openttd.dir/src/object_gui.cpp.o CMakeFiles/openttd.dir/src/openttd.cpp.o CMakeFiles/openttd.dir/src/order_backup.cpp.o CMakeFiles/openttd.dir/src/order_cmd.cpp.o CMakeFiles/openttd.dir/src/order_gui.cpp.o CMakeFiles/openttd.dir/src/osk_gui.cpp.o CMakeFiles/openttd.dir/src/pbs.cpp.o CMakeFiles/openttd.dir/src/progress.cpp.o CMakeFiles/openttd.dir/src/rail.cpp.o CMakeFiles/openttd.dir/src/rail_cmd.cpp.o CMakeFiles/openttd.dir/src/rail_gui.cpp.o CMakeFiles/openttd.dir/src/random_access_file.cpp.o CMakeFiles/openttd.dir/src/road.cpp.o CMakeFiles/openttd.dir/src/road_cmd.cpp.o CMakeFiles/openttd.dir/src/road_gui.cpp.o CMakeFiles/openttd.dir/src/road_map.cpp.o CMakeFiles/openttd.dir/src/roadstop.cpp.o CMakeFiles/openttd.dir/src/roadveh_cmd.cpp.o CMakeFiles/openttd.dir/src/roadveh_gui.cpp.o CMakeFiles/openttd.dir/src/screenshot_gui.cpp.o CMakeFiles/openttd.dir/src/screenshot.cpp.o CMakeFiles/openttd.dir/src/settings.cpp.o CMakeFiles/openttd.dir/src/settings_gui.cpp.o CMakeFiles/openttd.dir/src/settings_table.cpp.o CMakeFiles/openttd.dir/src/ship_cmd.cpp.o CMakeFiles/openttd.dir/src/ship_gui.cpp.o CMakeFiles/openttd.dir/src/signal.cpp.o CMakeFiles/openttd.dir/src/signs.cpp.o CMakeFiles/openttd.dir/src/signs_cmd.cpp.o CMakeFiles/openttd.dir/src/signs_gui.cpp.o CMakeFiles/openttd.dir/src/smallmap_gui.cpp.o CMakeFiles/openttd.dir/src/sound.cpp.o CMakeFiles/openttd.dir/src/sprite.cpp.o CMakeFiles/openttd.dir/src/spritecache.cpp.o CMakeFiles/openttd.dir/src/station.cpp.o CMakeFiles/openttd.dir/src/station_cmd.cpp.o CMakeFiles/openttd.dir/src/station_gui.cpp.o CMakeFiles/openttd.dir/src/statusbar_gui.cpp.o CMakeFiles/openttd.dir/src/story.cpp.o CMakeFiles/openttd.dir/src/story_gui.cpp.o CMakeFiles/openttd.dir/src/string.cpp.o CMakeFiles/openttd.dir/src/stringfilter.cpp.o CMakeFiles/openttd.dir/src/strings.cpp.o CMakeFiles/openttd.dir/src/subsidy.cpp.o CMakeFiles/openttd.dir/src/subsidy_gui.cpp.o CMakeFiles/openttd.dir/src/terraform_cmd.cpp.o CMakeFiles/openttd.dir/src/terraform_gui.cpp.o CMakeFiles/openttd.dir/src/textbuf.cpp.o CMakeFiles/openttd.dir/src/texteff.cpp.o CMakeFiles/openttd.dir/src/textfile_gui.cpp.o CMakeFiles/openttd.dir/src/tgp.cpp.o CMakeFiles/openttd.dir/src/tile_map.cpp.o CMakeFiles/openttd.dir/src/tilearea.cpp.o CMakeFiles/openttd.dir/src/timetable_cmd.cpp.o CMakeFiles/openttd.dir/src/timetable_gui.cpp.o CMakeFiles/openttd.dir/src/toolbar_gui.cpp.o CMakeFiles/openttd.dir/src/town_cmd.cpp.o CMakeFiles/openttd.dir/src/town_gui.cpp.o CMakeFiles/openttd.dir/src/townname.cpp.o CMakeFiles/openttd.dir/src/train_cmd.cpp.o CMakeFiles/openttd.dir/src/train_gui.cpp.o CMakeFiles/openttd.dir/src/transparency_gui.cpp.o CMakeFiles/openttd.dir/src/tree_cmd.cpp.o CMakeFiles/openttd.dir/src/tree_gui.cpp.o CMakeFiles/openttd.dir/src/tunnel_map.cpp.o CMakeFiles/openttd.dir/src/tunnelbridge_cmd.cpp.o CMakeFiles/openttd.dir/src/vehicle.cpp.o CMakeFiles/openttd.dir/src/vehicle_cmd.cpp.o CMakeFiles/openttd.dir/src/vehicle_gui.cpp.o CMakeFiles/openttd.dir/src/vehiclelist.cpp.o CMakeFiles/openttd.dir/src/viewport.cpp.o CMakeFiles/openttd.dir/src/viewport_gui.cpp.o CMakeFiles/openttd.dir/src/void_cmd.cpp.o CMakeFiles/openttd.dir/src/water_cmd.cpp.o CMakeFiles/openttd.dir/src/waypoint.cpp.o CMakeFiles/openttd.dir/src/waypoint_cmd.cpp.o CMakeFiles/openttd.dir/src/waypoint_gui.cpp.o CMakeFiles/openttd.dir/src/widget.cpp.o CMakeFiles/openttd.dir/src/window.cpp.o -o openttd  /usr/lib/riscv64-linux-gnu/libpng.so /usr/lib/riscv64-linux-gnu/libz.so /usr/lib/riscv64-linux-gnu/liblzma.so /usr/lib/riscv64-linux-gnu/liblzo2.so /usr/lib/riscv64-linux-gnu/liblzo2.so /usr/lib/riscv64-linux-gnu/libfluidsynth.so /usr/lib/riscv64-linux-gnu/libfluidsynth.so /usr/lib/riscv64-linux-gnu/libSDL2.so /usr/lib/riscv64-linux-gnu/libfreetype.so /usr/lib/riscv64-linux-gnu/libfontconfig.so /usr/lib/riscv64-linux-gnu/libicui18n.so /usr/lib/riscv64-linux-gnu/libicuuc.so /usr/lib/riscv64-linux-gnu/libicudata.so 
/usr/bin/ld: /tmp/ccBufhI2.ltrans84.ltrans.o: in function `MxActivateChannel(MixerChannel*)':
/usr/src/openttd-13.0-2/src/mixer.cpp:235: undefined reference to `__atomic_fetch_or_1'
/usr/bin/ld: /tmp/ccBufhI2.ltrans84.ltrans.o: in function `.L0 ':
/usr/include/c++/12/bits/vector.tcc:462: undefined reference to `__atomic_fetch_and_1'
/usr/bin/ld: /tmp/ccBufhI2.ltrans101.ltrans.o: in function `.L0 ':
/usr/src/openttd-13.0-2/src/sound.cpp:128: undefined reference to `__atomic_fetch_or_1'
collect2: error: ld returned 1 exit status
make[4]: *** [CMakeFiles/openttd.dir/build.make:6865: openttd] Error 1
make[4]: Leaving directory '/<<PKGBUILDDIR>>/obj-riscv64-linux-gnu'
make[3]: *** [CMakeFiles/Makefile2:1008: CMakeFiles/openttd.dir/all] Error 2
make[3]: Leaving directory '/<<PKGBUILDDIR>>/obj-riscv64-linux-gnu'
make[2]: *** [Makefile:169: all] Error 2
make[2]: Leaving directory '/<<PKGBUILDDIR>>/obj-riscv64-linux-gnu'
dh_auto_build: error: cd obj-riscv64-linux-gnu && make -j8 "INSTALL=install --strip-program=true" VERBOSE=1 returned exit code 2
make[1]: *** [debian/rules:59: override_dh_auto_build] Error 25
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:9: binary-arch] Error 2
dpkg-buildpackage: error: debian/rules binary-arch subprocess returned exit status 2
```