### PR TITLE
Fix: crash due to incomplete deity/company mode precondition checks

### DIFF
--- a/.github/script-missing-mode-enforcement.py
+++ b/.github/script-missing-mode-enforcement.py
@@ -1,0 +1,71 @@
+"""
+Script to scan the OpenTTD's script API for functions that miss checks for the
+function being called from the right mode (deity or company mode).
+
+When a function calls either ScriptObject::Command or ScriptObject::GetCompany
+then the function is considered dangerous. When one of the mode enforcement
+macros from script_error.hpp, i.e. EnforceDeityMode, EnforceCompanyModeValid or
+EnforceDeityOrCompanyModeValid, are called in the function, then we consider
+that the function has mode enforcement.
+
+Any dangerous function for which no enforcement is found are emitted as errors.
+"""
+
+import glob
+import re
+import sys
+
+
+def check_mode_enforcement(path):
+    errors = []
+    with open(path, "r") as reader:
+        mode_enforcement_found = False
+        dangerous_function = False
+        for line in reader:
+            # Line does not start with a tab and have <word>::<word>. That looks like the begin of a function, so reset the state.
+            if re.match(r"^[^\t].*\w::\w", line):
+                mode_enforcement_found = False
+                dangerous_function = False
+                currentFunction = line
+                continue
+
+            if re.match(
+                r"\t(EnforceDeityMode|EnforceCompanyModeValid|EnforceDeityOrCompanyModeValid|EnforceDeityOrCompanyModeValid_Void)\(",
+                line,
+            ):
+                # Mode enforcement macro found
+                mode_enforcement_found = True
+                continue
+
+            if re.match(r".*(ScriptObject::Command|ScriptObject::GetCompany).*", line):
+                # Dangerous function found
+                dangerous_function = True
+                continue
+
+            # Line with only a closing bracket. That looks like the end of a function, so check for the dangerous function without mode enforcement
+            if re.match(r"^}$", line) and dangerous_function and not mode_enforcement_found:
+                function_name = currentFunction.rstrip("\n").replace("/* static */ ", "")
+                errors.append(f"{path}: {function_name}")
+
+    return errors
+
+
+def main():
+    errors = []
+    for path in sorted(glob.glob("src/script/api/*.cpp")):
+        # Skip a number of files that yield only false positives
+        if path.endswith(("script_object.cpp", "script_companymode.cpp", "script_controller.cpp", "script_game.cpp")):
+            continue
+
+        errors.extend(check_mode_enforcement(path))
+
+    if errors:
+        print("Mode enforcement was expected in the following files/functions:")
+        print("\n".join(errors))
+        sys.exit(1)
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/unused-strings.py
+++ b/.github/unused-strings.py
@@ -210,11 +210,10 @@ def main():
             errors.append(f"ERROR: {string} is (possibly) no longer needed.")
 
     if errors:
-        for error in errors:
-            print(error)
+        print("\n".join(errors))
         sys.exit(1)
-    else:
-        print("OK")
+
+    print("OK")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/script-missing-mode-enforcement.yml
+++ b/.github/workflows/script-missing-mode-enforcement.yml
@@ -1,0 +1,22 @@
+name: Script missing mode enforcement
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  script-missing-mode-enforcement:
+    name: Script missing mode enforcement
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Check for finding script functions that require company/deity mode enforcement/checks
+      run: |
+        set -ex
+        python3 .github/script-missing-mode-enforcement.py

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -91,6 +91,7 @@
 
 /* static */ SQInteger ScriptAirport::GetNumHangars(TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid(-1);
 	if (!::IsValidTile(tile)) return -1;
 	if (!::IsTileType(tile, MP_STATION)) return -1;
 
@@ -103,6 +104,7 @@
 
 /* static */ TileIndex ScriptAirport::GetHangarOfAirport(TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid(INVALID_TILE);
 	if (!::IsValidTile(tile)) return INVALID_TILE;
 	if (!::IsTileType(tile, MP_STATION)) return INVALID_TILE;
 	if (GetNumHangars(tile) < 1) return INVALID_TILE;

--- a/src/script/api/script_basestation.cpp
+++ b/src/script/api/script_basestation.cpp
@@ -21,6 +21,7 @@
 
 /* static */ bool ScriptBaseStation::IsValidBaseStation(StationID station_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const BaseStation *st = ::BaseStation::GetIfValid(station_id);
 	return st != nullptr && (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || st->owner == OWNER_NONE);
 }

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -72,6 +72,7 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 
 /* static */ bool ScriptBridge::BuildBridge(ScriptVehicle::VehicleType vehicle_type, BridgeID bridge_id, TileIndex start, TileIndex end)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, start != end);
 	EnforcePrecondition(false, ::IsValidTile(start) && ::IsValidTile(end));
 	EnforcePrecondition(false, TileX(start) == TileX(end) || TileY(start) == TileY(end));
@@ -95,6 +96,8 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 
 /* static */ bool ScriptBridge::_BuildBridgeRoad1()
 {
+	EnforceDeityOrCompanyModeValid(false);
+
 	/* Build the piece of road on the 'start' side of the bridge */
 	TileIndex end = ScriptObject::GetCallbackVariable(0);
 	TileIndex start = ScriptObject::GetCallbackVariable(1);
@@ -107,6 +110,8 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 
 /* static */ bool ScriptBridge::_BuildBridgeRoad2()
 {
+	EnforceDeityOrCompanyModeValid(false);
+
 	/* Build the piece of road on the 'end' side of the bridge */
 	TileIndex end = ScriptObject::GetCallbackVariable(0);
 	TileIndex start = ScriptObject::GetCallbackVariable(1);

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -47,6 +47,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
@@ -68,6 +69,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
 	EnforcePreconditionEncodedText(false, text);
@@ -94,6 +96,7 @@
 
 /* static */ bool ScriptCompany::SetPresidentGender(Gender gender)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, gender == GENDER_MALE || gender == GENDER_FEMALE);
 	EnforcePrecondition(false, GetPresidentGender(ScriptCompany::COMPANY_SELF) != gender);
 
@@ -269,6 +272,7 @@
 
 /* static */ bool ScriptCompany::SetAutoRenewStatus(bool autorenew)
 {
+	EnforceCompanyModeValid(false);
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew", autorenew ? 1 : 0);
 }
 
@@ -282,7 +286,9 @@
 
 /* static */ bool ScriptCompany::SetAutoRenewMonths(SQInteger months)
 {
+	EnforceCompanyModeValid(false);
 	months = Clamp<SQInteger>(months, INT16_MIN, INT16_MAX);
+
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew_months", months);
 }
 
@@ -296,6 +302,7 @@
 
 /* static */ bool ScriptCompany::SetAutoRenewMoney(Money money)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, money >= 0);
 	EnforcePrecondition(false, (int64)money <= UINT32_MAX);
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew_money", money);
@@ -311,11 +318,13 @@
 
 /* static */ bool ScriptCompany::SetPrimaryLiveryColour(LiveryScheme scheme, Colours colour)
 {
+	EnforceCompanyModeValid(false);
 	return ScriptObject::Command<CMD_SET_COMPANY_COLOUR>::Do((::LiveryScheme)scheme, true, (::Colours)colour);
 }
 
 /* static */ bool ScriptCompany::SetSecondaryLiveryColour(LiveryScheme scheme, Colours colour)
 {
+	EnforceCompanyModeValid(false);
 	return ScriptObject::Command<CMD_SET_COMPANY_COLOUR>::Do((::LiveryScheme)scheme, false, (::Colours)colour);
 }
 

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -138,6 +138,7 @@ public:
 	 * Set the name of your company.
 	 * @param name The new name of the company (can be either a raw string, or a ScriptText object).
 	 * @pre name != null && len(name) != 0.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if the name was changed.
 	 */
@@ -155,6 +156,7 @@ public:
 	 * Set the name of your president.
 	 * @param name The new name of the president (can be either a raw string, or a ScriptText object).
 	 * @pre name != null && len(name) != 0.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if the name was changed.
 	 */
@@ -172,6 +174,7 @@ public:
 	 * Set the gender of the president of your company.
 	 * @param gender The new gender for your president.
 	 * @pre GetPresidentGender(ScriptCompany.COMPANY_SELF) != gender.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if the gender was changed.
 	 * @note When successful a random face will be created.
 	 * @api -game
@@ -333,6 +336,7 @@ public:
 	/**
 	 * Set whether autorenew is enabled for your company.
 	 * @param autorenew The new autorenew status.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if autorenew status has been modified.
 	 * @api -game
 	 */
@@ -350,6 +354,7 @@ public:
 	 * Set the number of months before/after max age to autorenew an engine for your company.
 	 * @param months The new months between autorenew.
 	 *               The value will be clamped to MIN(int16) .. MAX(int16).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if autorenew months has been modified.
 	 * @api -game
 	 */
@@ -366,6 +371,7 @@ public:
 	/**
 	 * Set the minimum money needed to autorenew an engine for your company.
 	 * @param money The new minimum required money for autorenew to work.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if autorenew money has been modified.
 	 * @pre money >= 0
 	 * @pre money <  2**32
@@ -385,6 +391,7 @@ public:
 	 * Set primary colour for your company.
 	 * @param scheme Livery scheme to set.
 	 * @param colour Colour to set.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return False if unable to set primary colour of the livery scheme (e.g. colour in use).
 	 */
 	static bool SetPrimaryLiveryColour(LiveryScheme scheme, Colours colour);
@@ -393,6 +400,7 @@ public:
 	 * Set secondary colour for your company.
 	 * @param scheme Livery scheme to set.
 	 * @param colour Colour to set.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return False if unable to set secondary colour of the livery scheme.
 	 */
 	static bool SetSecondaryLiveryColour(LiveryScheme scheme, Colours colour);

--- a/src/script/api/script_companymode.cpp
+++ b/src/script/api/script_companymode.cpp
@@ -29,7 +29,7 @@ ScriptCompanyMode::~ScriptCompanyMode()
 
 /* static */ bool ScriptCompanyMode::IsValid()
 {
-	return ScriptObject::GetCompany() != OWNER_DEITY;
+	return ::Company::IsValidID(ScriptObject::GetCompany());
 }
 
 /* static */ bool ScriptCompanyMode::IsDeity()

--- a/src/script/api/script_companymode.hpp
+++ b/src/script/api/script_companymode.hpp
@@ -50,7 +50,7 @@ public:
 
 	/**
 	 * Check whether a company mode is valid. In other words, are commands
-	 * being executed under some company.
+	 * being executed under some company and does the company still exist?
 	 * @return true When a company mode is valid.
 	 * @post !ScriptCompanyMode::IsDeity().
 	 */

--- a/src/script/api/script_depotlist.cpp
+++ b/src/script/api/script_depotlist.cpp
@@ -16,6 +16,7 @@
 
 ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	::TileType tile_type;
 	switch (transport_type) {
 		default: return;

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -24,6 +24,7 @@
 
 /* static */ bool ScriptEngine::IsValidEngine(EngineID engine_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Engine *e = ::Engine::GetIfValid(engine_id);
 	if (e == nullptr || !e->IsEnabled()) return false;
 
@@ -35,6 +36,7 @@
 
 /* static */ bool ScriptEngine::IsBuildable(EngineID engine_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Engine *e = ::Engine::GetIfValid(engine_id);
 	return e != nullptr && ::IsEngineBuildable(engine_id, e->type, ScriptObject::GetCompany());
 }

--- a/src/script/api/script_enginelist.cpp
+++ b/src/script/api/script_enginelist.cpp
@@ -15,6 +15,7 @@
 
 ScriptEngineList::ScriptEngineList(ScriptVehicle::VehicleType vehicle_type)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (const Engine *e : Engine::IterateType((::VehicleType)vehicle_type)) {
 		if (ScriptCompanyMode::IsDeity() || HasBit(e->company_avail, ScriptObject::GetCompany())) this->AddItem(e->index);
 	}

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -53,14 +53,14 @@
  * @param returnval The value to return on failure.
  */
 #define EnforceCompanyModeValid(returnval) \
-	EnforcePrecondition(returnval, ScriptCompanyMode::IsValid())
+	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
 
 /**
  * Helper to enforce the precondition that we are in a deity mode.
  * @param returnval The value to return on failure.
  */
 #define EnforceDeityMode(returnval) \
-	EnforcePrecondition(returnval, ScriptCompanyMode::IsDeity())
+	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
 
 /**
  * Class that handles all error related functions.

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -63,6 +63,23 @@
 	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
 
 /**
+ * Helper to enforce the precondition that the company mode is valid or that we are a deity.
+ * @param returnval The value to return on failure.
+ */
+#define EnforceDeityOrCompanyModeValid(returnval) \
+	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsDeity() || ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
+
+/**
+ * Helper to enforce the precondition that the company mode is valid or that we are a deity.
+ */
+#define EnforceDeityOrCompanyModeValid_Void() \
+	if (!(ScriptCompanyMode::IsDeity() || ScriptCompanyMode::IsValid())) { \
+		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY); \
+		return; \
+	}
+
+
+/**
  * Class that handles all error related functions.
  * @api ai game
  */

--- a/src/script/api/script_event_types.cpp
+++ b/src/script/api/script_event_types.cpp
@@ -111,12 +111,14 @@ int32 ScriptEventEnginePreview::GetVehicleType()
 
 bool ScriptEventEnginePreview::AcceptPreview()
 {
+	EnforceCompanyModeValid(false);
 	if (!this->IsEngineValid()) return false;
 	return ScriptObject::Command<CMD_WANT_ENGINE_PREVIEW>::Do(this->engine);
 }
 
 bool ScriptEventCompanyAskMerger::AcceptMerger()
 {
+	EnforceCompanyModeValid(false);
 	return ScriptObject::Command<CMD_BUY_COMPANY>::Do((::CompanyID)this->owner);
 }
 

--- a/src/script/api/script_event_types.hpp
+++ b/src/script/api/script_event_types.hpp
@@ -289,6 +289,7 @@ public:
 
 	/**
 	 * Accept the engine preview.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True when the accepting succeeded.
 	 */
 	bool AcceptPreview();
@@ -410,6 +411,7 @@ public:
 
 	/**
 	 * Take over the company for this merger.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return true if the merger was a success.
 	 */
 	bool AcceptMerger();

--- a/src/script/api/script_game.cpp
+++ b/src/script/api/script_game.cpp
@@ -9,6 +9,7 @@
 
 #include "../../stdafx.h"
 #include "script_game.hpp"
+#include "script_error.hpp"
 #include "../../command_type.h"
 #include "../../settings_type.h"
 #include "../../network/network.h"

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -33,6 +33,7 @@
 
 /* static */ bool ScriptGameSettings::SetValue(const char *setting, SQInteger value)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	if (!IsValid(setting)) return false;
 
 	const SettingDesc *sd = GetSettingFromName(setting);

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -32,6 +32,7 @@
 
 /* static */ ScriptGroup::GroupID ScriptGroup::CreateGroup(ScriptVehicle::VehicleType vehicle_type, GroupID parent_group_id)
 {
+	EnforceCompanyModeValid(GROUP_INVALID);
 	if (!ScriptObject::Command<CMD_CREATE_GROUP>::Do(&ScriptInstance::DoCommandReturnGroupID, (::VehicleType)vehicle_type, parent_group_id)) return GROUP_INVALID;
 
 	/* In case of test-mode, we return GroupID 0 */
@@ -40,6 +41,7 @@
 
 /* static */ bool ScriptGroup::DeleteGroup(GroupID group_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 
 	return ScriptObject::Command<CMD_DELETE_GROUP>::Do(group_id);
@@ -56,6 +58,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
@@ -75,6 +78,7 @@
 
 /* static */ bool ScriptGroup::SetParent(GroupID group_id, GroupID parent_group_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 	EnforcePrecondition(false, IsValidGroup(parent_group_id));
 
@@ -91,6 +95,7 @@
 
 /* static */ bool ScriptGroup::EnableAutoReplaceProtection(GroupID group_id, bool enable)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 
 	return ScriptObject::Command<CMD_SET_GROUP_FLAG>::Do(group_id, GroupFlags::GF_REPLACE_PROTECTION, enable, false);
@@ -105,6 +110,7 @@
 
 /* static */ SQInteger ScriptGroup::GetNumEngines(GroupID group_id, EngineID engine_id)
 {
+	EnforceCompanyModeValid(-1);
 	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
 
 	return GetGroupNumEngines(ScriptObject::GetCompany(), group_id, engine_id);
@@ -112,6 +118,7 @@
 
 /* static */ SQInteger ScriptGroup::GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type)
 {
+	EnforceCompanyModeValid(-1);
 	bool valid_group = IsValidGroup(group_id);
 	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
 	if (!valid_group && (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR)) return -1;
@@ -121,6 +128,7 @@
 
 /* static */ bool ScriptGroup::MoveVehicle(GroupID group_id, VehicleID vehicle_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id) || group_id == GROUP_DEFAULT);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 
@@ -129,6 +137,7 @@
 
 /* static */ bool ScriptGroup::EnableWagonRemoval(bool enable_removal)
 {
+	EnforceCompanyModeValid(false);
 	if (HasWagonRemoval() == enable_removal) return true;
 
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.renew_keep_length", enable_removal ? 1 : 0);
@@ -136,11 +145,13 @@
 
 /* static */ bool ScriptGroup::HasWagonRemoval()
 {
+	EnforceCompanyModeValid(false);
 	return ::Company::Get(ScriptObject::GetCompany())->settings.renew_keep_length;
 }
 
 /* static */ bool ScriptGroup::SetAutoReplace(GroupID group_id, EngineID engine_id_old, EngineID engine_id_new)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL);
 	EnforcePrecondition(false, ScriptEngine::IsBuildable(engine_id_new));
 
@@ -149,6 +160,7 @@
 
 /* static */ EngineID ScriptGroup::GetEngineReplacement(GroupID group_id, EngineID engine_id)
 {
+	EnforceCompanyModeValid(::INVALID_ENGINE);
 	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return ::INVALID_ENGINE;
 
 	return ::EngineReplacementForCompany(Company::Get(ScriptObject::GetCompany()), engine_id, group_id);
@@ -156,6 +168,7 @@
 
 /* static */ bool ScriptGroup::StopAutoReplace(GroupID group_id, EngineID engine_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL);
 
 	return ScriptObject::Command<CMD_SET_AUTOREPLACE>::Do(group_id, engine_id, ::INVALID_ENGINE, false);
@@ -206,6 +219,7 @@
 
 /* static */ bool ScriptGroup::SetPrimaryColour(GroupID group_id, ScriptCompany::Colours colour)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 
 	return ScriptObject::Command<CMD_SET_GROUP_LIVERY>::Do(group_id, true, (::Colours)colour);
@@ -213,6 +227,7 @@
 
 /* static */ bool ScriptGroup::SetSecondaryColour(GroupID group_id, ScriptCompany::Colours colour)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidGroup(group_id));
 
 	return ScriptObject::Command<CMD_SET_GROUP_LIVERY>::Do(group_id, false, (::Colours)colour);

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -25,6 +25,7 @@
 
 /* static */ bool ScriptGroup::IsValidGroup(GroupID group_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Group *g = ::Group::GetIfValid(group_id);
 	return g != nullptr && g->owner == ScriptObject::GetCompany();
 }

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -41,6 +41,7 @@ public:
 	 * Create a new group.
 	 * @param vehicle_type The type of vehicle to create a group for.
 	 * @param parent_group_id The parent group id to create this group under, INVALID_GROUP for top-level.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return The GroupID of the new group, or an invalid GroupID when
 	 *  it failed. Check the return value using IsValidGroup(). In test-mode
 	 *  0 is returned if it was successful; any other value indicates failure.
@@ -52,6 +53,7 @@ public:
 	 *  given group will move to the GROUP_DEFAULT.
 	 * @param group_id The group to delete.
 	 * @pre IsValidGroup(group_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the group was successfully deleted.
 	 */
 	static bool DeleteGroup(GroupID group_id);
@@ -70,6 +72,7 @@ public:
 	 * @param name The name for the group (can be either a raw string, or a ScriptText object).
 	 * @pre IsValidGroup(group_id).
 	 * @pre name != null && len(name) != 0
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if and only if the name was changed.
 	 */
@@ -89,6 +92,7 @@ public:
 	 * @param parent_group_id The parent group to set.
 	 * @pre IsValidGroup(group_id).
 	 * @pre IsValidGroup(parent_group_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the parent group was changed.
 	 */
 	static bool SetParent(GroupID group_id, GroupID parent_group_id);
@@ -107,6 +111,7 @@ public:
 	 * @param group_id The group to change the protection for.
 	 * @param enable True if protection should be enabled.
 	 * @pre IsValidGroup(group_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the protection was successfully changed.
 	 */
 	static bool EnableAutoReplaceProtection(GroupID group_id, bool enable);
@@ -124,6 +129,7 @@ public:
 	 * @param group_id The group to get the number of engines in.
 	 * @param engine_id The engine id to count.
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return The number of engines with id engine_id in the group with id group_id.
 	 */
 	static SQInteger GetNumEngines(GroupID group_id, EngineID engine_id);
@@ -135,6 +141,7 @@ public:
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @pre IsValidGroup(group_id) || vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL ||
 	 *   vehicle_type == ScriptVehicle::VT_WATER || vehicle_type == ScriptVehicle::VT_AIR
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return The total number of vehicles in the group with id group_id and it's sub-groups.
 	 * @note If the group is valid (neither GROUP_ALL nor GROUP_DEFAULT), the value of
 	 *  vehicle_type is retrieved from the group itself and not from the input value.
@@ -148,6 +155,7 @@ public:
 	 * @param vehicle_id The vehicle to move to the group.
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_DEFAULT.
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the vehicle was successfully moved to the group.
 	 * @note A vehicle can be in only one group at the same time. To remove it from
 	 *  a group, move it to another or to GROUP_DEFAULT. Moving the vehicle to the
@@ -161,12 +169,14 @@ public:
 	 *  If enabled, wagons are removed from the end of the vehicle until it
 	 *  fits in the same number of tiles as it did before.
 	 * @param keep_length If true, wagons will be removed if the new engine is longer.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the value was successfully changed.
 	 */
 	static bool EnableWagonRemoval(bool keep_length);
 
 	/**
 	 * Get the current status of wagon removal.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether or not wagon removal is enabled.
 	 */
 	static bool HasWagonRemoval();
@@ -179,6 +189,7 @@ public:
 	 * @param engine_id_new The engine id to replace with.
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL.
 	 * @pre ScriptEngine.IsBuildable(engine_id_new).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and if the replacing was successfully started.
 	 * @note To stop autoreplacing engine_id_old, call StopAutoReplace(group_id, engine_id_old).
 	 */
@@ -189,6 +200,7 @@ public:
 	 * @param group_id The group to get the replacement from.
 	 * @param engine_id The engine that is being replaced.
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return The EngineID that is replacing engine_id or an invalid EngineID
 	 *   in case engine_id is not begin replaced.
 	 */
@@ -199,6 +211,7 @@ public:
 	 * @param group_id The group to stop replacing the engine in.
 	 * @param engine_id The engine id to stop replacing with another engine.
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_DEFAULT || group_id == GROUP_ALL.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and if the replacing was successfully stopped.
 	 */
 	static bool StopAutoReplace(GroupID group_id, EngineID engine_id);
@@ -232,6 +245,7 @@ public:
 	 * @param group_id The group id to set the colour of.
 	 * @param colour Colour to set.
 	 * @pre IsValidGroup(group_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True iff the colour was set successfully.
 	 */
 	static bool SetPrimaryColour(GroupID group_id, ScriptCompany::Colours colour);
@@ -241,6 +255,7 @@ public:
 	 * @param group_id The group id to set the colour of.
 	 * @param colour Colour to set.
 	 * @pre IsValidGroup(group_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True iff the colour was set successfully.
 	 */
 	static bool SetSecondaryColour(GroupID group_id, ScriptCompany::Colours colour);

--- a/src/script/api/script_grouplist.cpp
+++ b/src/script/api/script_grouplist.cpp
@@ -9,12 +9,14 @@
 
 #include "../../stdafx.h"
 #include "script_grouplist.hpp"
+#include "script_error.hpp"
 #include "../../group.h"
 
 #include "../../safeguards.h"
 
 ScriptGroupList::ScriptGroupList()
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (const Group *g : Group::Iterate()) {
 		if (g->owner == ScriptObject::GetCompany()) this->AddItem(g->index);
 	}

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -53,6 +53,7 @@
 {
 	CCountedPtr<Text> counter(text);
 
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidIndustry(industry_id));
 
 	return ScriptObject::Command<CMD_INDUSTRY_SET_TEXT>::Do(industry_id, text != nullptr ? text->GetEncodedText() : std::string{});
@@ -268,6 +269,7 @@
 
 /* static */ bool ScriptIndustry::SetExclusiveSupplier(IndustryID industry_id, ScriptCompany::CompanyID company_id)
 {
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidIndustry(industry_id));
 
 	auto company = ScriptCompany::ResolveCompanyID(company_id);
@@ -287,6 +289,7 @@
 
 /* static */ bool ScriptIndustry::SetExclusiveConsumer(IndustryID industry_id, ScriptCompany::CompanyID company_id)
 {
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidIndustry(industry_id));
 
 	auto company = ScriptCompany::ResolveCompanyID(company_id);

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -85,6 +85,7 @@ public:
 	 * Set the custom text of an industry, shown in the GUI.
 	 * @param industry_id The industry to set the custom text of.
 	 * @param text The text to set it to (can be either a raw string, or a ScriptText object). If null, or an empty string, is passed, the text will be removed.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidIndustry(industry_id).
 	 * @return True if the action succeeded.
 	 * @api -ai
@@ -286,6 +287,7 @@ public:
 	 * @param industry_id The index of the industry.
 	 * @param company_id The company to set (ScriptCompany::COMPANY_INVALID to reset).
 	 * @pre IsValidIndustry(industry_id).
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
@@ -306,6 +308,7 @@ public:
 	 * @param industry_id The index of the industry.
 	 * @param company_id The company to set (ScriptCompany::COMPANY_INVALID to reset).
 	 * @pre IsValidIndustry(industry_id).
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -119,6 +119,7 @@
 
 /* static */ bool ScriptIndustryType::BuildIndustry(IndustryType industry_type, TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, CanBuildIndustry(industry_type));
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
@@ -129,6 +130,7 @@
 
 /* static */ bool ScriptIndustryType::ProspectIndustry(IndustryType industry_type)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, CanProspectIndustry(industry_type));
 
 	uint32 seed = ScriptBase::Rand();

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -24,6 +24,7 @@
 {
 	CCountedPtr<Text> counter(text);
 
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, text != nullptr);
 	const std::string &encoded = text->GetEncodedText();
 	EnforcePreconditionEncodedText(false, encoded);

--- a/src/script/api/script_news.hpp
+++ b/src/script/api/script_news.hpp
@@ -62,6 +62,7 @@ public:
 	 * @pre text != null.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre The \a reference condition must be fulfilled.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 */
 	static bool Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference);
 };

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -253,7 +253,7 @@ std::tuple<bool, bool, bool> ScriptObject::DoCommandPrep()
 
 	bool networking = _networking && !_generating_world;
 
-	if (ScriptCompanyMode::IsValid() && !::Company::IsValidID(ScriptObject::GetCompany())) {
+	if (!ScriptCompanyMode::IsDeity() && !ScriptCompanyMode::IsValid()) {
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY);
 		return { true, estimate_only, networking };
 	}

--- a/src/script/api/script_objecttype.cpp
+++ b/src/script/api/script_objecttype.cpp
@@ -39,6 +39,7 @@
 
 /* static */ bool ScriptObjectType::BuildObject(ObjectType object_type, SQInteger view, TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidObjectType(object_type));
 	EnforcePrecondition(false, view >= 0 && view < GetViews(object_type));
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -381,6 +381,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::SetOrderJumpTo(VehicleID vehicle_id, OrderPosition order_position, OrderPosition jump_to)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, jump_to) && jump_to != ORDER_CURRENT);
@@ -390,6 +391,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::SetOrderCondition(VehicleID vehicle_id, OrderPosition order_position, OrderCondition condition)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, condition >= OC_LOAD_PERCENTAGE && condition <= OC_REMAINING_LIFETIME);
@@ -400,6 +402,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::SetOrderCompareFunction(VehicleID vehicle_id, OrderPosition order_position, CompareFunction compare)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, compare >= CF_EQUALS && compare <= CF_IS_FALSE);
@@ -410,6 +413,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::SetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position, SQInteger value)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, value >= 0 && value < 2048);
@@ -421,6 +425,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::SetStopLocation(VehicleID vehicle_id, OrderPosition order_position, StopLocation stop_location)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, ScriptVehicle::GetVehicleType(vehicle_id) == ScriptVehicle::VT_RAIL);
 	EnforcePrecondition(false, IsGotoStationOrder(vehicle_id, order_position));
@@ -434,6 +439,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::SetOrderRefit(VehicleID vehicle_id, OrderPosition order_position, CargoID refit_cargo)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, IsGotoStationOrder(vehicle_id, order_position) || (IsGotoDepotOrder(vehicle_id, order_position) && refit_cargo != CT_AUTO_REFIT));
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(refit_cargo) || refit_cargo == CT_AUTO_REFIT || refit_cargo == CT_NO_REFIT);
@@ -443,6 +449,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::AppendOrder(VehicleID vehicle_id, TileIndex destination, ScriptOrderFlags order_flags)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, AreOrderFlagsValid(destination, order_flags));
 
@@ -451,6 +458,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 /* static */ bool ScriptOrder::AppendConditionalOrder(VehicleID vehicle_id, OrderPosition jump_to)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, jump_to));
 
@@ -462,6 +470,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	/* IsValidVehicleOrder is not good enough because it does not allow appending. */
 	if (order_position == ORDER_CURRENT) order_position = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, order_position >= 0 && order_position <= ::Vehicle::Get(vehicle_id)->GetNumManualOrders());
 	EnforcePrecondition(false, AreOrderFlagsValid(destination, order_flags));
@@ -516,6 +525,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	/* IsValidVehicleOrder is not good enough because it does not allow appending. */
 	if (order_position == ORDER_CURRENT) order_position = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, order_position >= 0 && order_position <= ::Vehicle::Get(vehicle_id)->GetNumManualOrders());
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, jump_to) && jump_to != ORDER_CURRENT);
@@ -531,6 +541,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 {
 	order_position = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 
 	int order_pos = ScriptOrderPositionToRealOrderPosition(vehicle_id, order_position);
@@ -541,6 +552,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 {
 	next_order = ScriptOrder::ResolveOrderPosition(vehicle_id, next_order);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, next_order));
 
 	int order_pos = ScriptOrderPositionToRealOrderPosition(vehicle_id, next_order);
@@ -577,6 +589,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 
 	order_position = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, AreOrderFlagsValid(GetOrderDestination(vehicle_id, order_position), order_flags));
 
@@ -634,6 +647,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 	order_position_move   = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position_move);
 	order_position_target = ScriptOrder::ResolveOrderPosition(vehicle_id, order_position_target);
 
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position_move));
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position_target));
 	EnforcePrecondition(false, order_position_move != order_position_target);
@@ -645,6 +659,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 
 /* static */ bool ScriptOrder::CopyOrders(VehicleID vehicle_id, VehicleID main_vehicle_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(main_vehicle_id));
 
@@ -653,6 +668,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 
 /* static */ bool ScriptOrder::ShareOrders(VehicleID vehicle_id, VehicleID main_vehicle_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(main_vehicle_id));
 
@@ -661,6 +677,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 
 /* static */ bool ScriptOrder::UnshareOrders(VehicleID vehicle_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptVehicle::IsPrimaryVehicle(vehicle_id));
 
 	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, 0);

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -356,6 +356,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre IsValidVehicleOrder(vehicle_id, jump_to).
 	 * @pre order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
@@ -369,6 +370,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position).
 	 * @pre condition >= OC_LOAD_PERCENTAGE && condition <= OC_UNCONDITIONALLY.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
@@ -382,6 +384,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position).
 	 * @pre compare >= CF_EQUALS && compare <= CF_IS_FALSE.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
@@ -395,6 +398,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position).
 	 * @pre value >= 0 && value < 2048.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
@@ -409,6 +413,7 @@ public:
 	 * @pre ScriptVehicle::GetVehicleType(vehicle_id) == ScriptVehicle::VT_RAIL.
 	 * @pre IsGotoStationOrder(vehicle_id, order_position).
 	 * @pre stop_location >= STOPLOCATION_NEAR && stop_location <= STOPLOCATION_FAR
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
@@ -422,6 +427,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre IsGotoStationOrder(vehicle_id, order_position) || (IsGotoDepotOrder(vehicle_id, order_position) && refit_cargo != CT_AUTO_REFIT).
 	 * @pre ScriptCargo::IsValidCargo(refit_cargo) || refit_cargo == CT_AUTO_REFIT || refit_cargo == CT_NO_REFIT
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
@@ -434,6 +440,7 @@ public:
 	 * @param order_flags The flags given to the order.
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
 	 * @pre AreOrderFlagsValid(destination, order_flags).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_FAR_AWAY_FROM_PREVIOUS_DESTINATION
@@ -448,6 +455,7 @@ public:
 	 * @param jump_to The OrderPosition to jump to if the condition is true.
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
 	 * @pre IsValidVehicleOrder(vehicle_id, jump_to).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @return True if and only if the order was appended.
@@ -464,6 +472,7 @@ public:
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id)
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre AreOrderFlagsValid(destination, order_flags).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_FAR_AWAY_FROM_PREVIOUS_DESTINATION
@@ -480,6 +489,7 @@ public:
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre IsValidVehicleOrder(vehicle_id, jump_to).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @return True if and only if the order was inserted.
@@ -492,6 +502,7 @@ public:
 	 * @param vehicle_id The vehicle to remove the order from.
 	 * @param order_position The order to remove from the order list.
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only if the order was removed.
 	 * @api -game
@@ -512,6 +523,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position).
 	 * @pre AreOrderFlagsValid(GetOrderDestination(vehicle_id, order_position), order_flags).
 	 * @pre (order_flags & OF_GOTO_NEAREST_DEPOT) == (GetOrderFlags(vehicle_id, order_position) & OF_GOTO_NEAREST_DEPOT).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only if the order was changed.
 	 * @api -game
@@ -526,6 +538,7 @@ public:
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position_move).
 	 * @pre IsValidVehicleOrder(vehicle_id, order_position_target).
 	 * @pre order_position_move != order_position_target.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only if the order was moved.
 	 * @note If the order is moved to a lower place (e.g. from 7 to 2)
@@ -541,6 +554,7 @@ public:
 	 * @param vehicle_id The vehicle that should skip some orders.
 	 * @param next_order The order the vehicle should skip to.
 	 * @pre IsValidVehicleOrder(vehicle_id, next_order).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only the current order was changed.
 	 * @api -game
@@ -554,6 +568,7 @@ public:
 	 * @param main_vehicle_id The vehicle to copy the orders from.
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
 	 * @pre ScriptVehicle::IsPrimaryVehicle(main_vehicle_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @exception ScriptOrder::ERR_ORDER_AIRCRAFT_NOT_ENOUGH_RANGE
@@ -569,6 +584,7 @@ public:
 	 * @param main_vehicle_id The vehicle to share the orders with.
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
 	 * @pre ScriptVehicle::IsPrimaryVehicle(main_vehicle_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_AIRCRAFT_NOT_ENOUGH_RANGE
 	 * @return True if and only if the sharing succeeded.
@@ -581,6 +597,7 @@ public:
 	 * After unsharing orders, the orders list of the vehicle is empty.
 	 * @param vehicle_id The vehicle to remove from the shared order list.
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the unsharing succeeded.
 	 * @api -game
 	 */

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -69,6 +69,7 @@
 
 /* static */ bool ScriptRail::IsRailTypeAvailable(RailType rail_type)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	if ((::RailType)rail_type >= RAILTYPE_END) return false;
 
 	return ScriptCompanyMode::IsDeity() || ::HasRailtypeAvail(ScriptObject::GetCompany(), (::RailType)rail_type);

--- a/src/script/api/script_railtypelist.cpp
+++ b/src/script/api/script_railtypelist.cpp
@@ -9,13 +9,14 @@
 
 #include "../../stdafx.h"
 #include "script_railtypelist.hpp"
-#include "script_companymode.hpp"
+#include "script_error.hpp"
 #include "../../rail.h"
 
 #include "../../safeguards.h"
 
 ScriptRailTypeList::ScriptRailTypeList()
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (RailType rt = RAILTYPE_BEGIN; rt != RAILTYPE_END; rt++) {
 		if (ScriptCompanyMode::IsDeity() || ::HasRailtypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
 	}

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -67,6 +67,7 @@
 
 /* static */ bool ScriptRoad::IsRoadTypeAvailable(RoadType road_type)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	return (::RoadType)road_type < ROADTYPE_END && ::HasRoadTypeAvail(ScriptObject::GetCompany(), (::RoadType)road_type);
 }
 
@@ -489,6 +490,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::_BuildRoadInternal(TileIndex start, TileIndex end, bool one_way, bool full)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, start != end);
 	EnforcePrecondition(false, ::IsValidTile(start));
 	EnforcePrecondition(false, ::IsValidTile(end));

--- a/src/script/api/script_roadtypelist.cpp
+++ b/src/script/api/script_roadtypelist.cpp
@@ -15,6 +15,7 @@
 
 ScriptRoadTypeList::ScriptRoadTypeList(ScriptRoad::RoadTramTypes rtts)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (RoadType rt = ROADTYPE_BEGIN; rt != ROADTYPE_END; rt++) {
 		if (!HasBit(rtts, GetRoadTramType(rt))) continue;
 		if (ScriptCompanyMode::IsDeity() || ::HasRoadTypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);

--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -21,6 +21,7 @@
 
 /* static */ bool ScriptSign::IsValidSign(SignID sign_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Sign *si = ::Sign::GetIfValid(sign_id);
 	return si != nullptr && (si->owner == ScriptObject::GetCompany() || si->owner == OWNER_DEITY);
 }
@@ -36,6 +37,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidSign(sign_id));
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();
@@ -63,6 +65,7 @@
 
 /* static */ bool ScriptSign::RemoveSign(SignID sign_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidSign(sign_id));
 	return ScriptObject::Command<CMD_RENAME_SIGN>::Do(sign_id, "");
 }
@@ -71,6 +74,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceDeityOrCompanyModeValid(INVALID_SIGN);
 	EnforcePrecondition(INVALID_SIGN, ::IsValidTile(location));
 	EnforcePrecondition(INVALID_SIGN, name != nullptr);
 	const std::string &text = name->GetDecodedText();

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -21,6 +21,7 @@
 
 /* static */ bool ScriptStation::IsValidStation(StationID station_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Station *st = ::Station::GetIfValid(station_id);
 	return st != nullptr && (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || st->owner == OWNER_NONE);
 }

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -238,6 +238,7 @@ template<bool Tfrom, bool Tvia>
 
 /* static */ bool ScriptStation::OpenCloseAirport(StationID station_id)
 {
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidStation(station_id));
 	EnforcePrecondition(false, HasStationType(station_id, STATION_AIRPORT));
 

--- a/src/script/api/script_station.hpp
+++ b/src/script/api/script_station.hpp
@@ -287,6 +287,7 @@ public:
 	/**
 	 * Toggle the open/closed state of an airport.
 	 * @param station_id The airport to modify.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @pre IsValidStation(station_id).
 	 * @pre HasStationType(station_id, STATION_AIRPORT).
 	 * @return True if the state was toggled successfully.

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -18,6 +18,7 @@
 
 ScriptStationList::ScriptStationList(ScriptStation::StationType station_type)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (Station *st : Station::Iterate()) {
 		if ((st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (st->facilities & station_type) != 0) this->AddItem(st->index);
 	}

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -33,6 +33,7 @@
 
 /* static */ bool ScriptSubsidy::Create(CargoID cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id)
 {
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, from_type == SPT_INDUSTRY || from_type == SPT_TOWN);
 	EnforcePrecondition(false, to_type == SPT_INDUSTRY || to_type == SPT_TOWN);

--- a/src/script/api/script_subsidy.hpp
+++ b/src/script/api/script_subsidy.hpp
@@ -55,6 +55,7 @@ public:
 	 * @param to_type The type of the subsidy on the 'to' side.
 	 * @param to_id The ID of the 'to' side.
 	 * @return True if the action succeeded.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre ScriptCargo::IsValidCargo(cargo_type)
 	 * @pre from_type == SPT_INDUSTRY || from_type == SPT_TOWN.
 	 * @pre to_type   == SPT_INDUSTRY || to_type   == SPT_TOWN.

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -25,6 +25,7 @@
 
 /* static */ bool ScriptTile::IsBuildable(TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	if (!::IsValidTile(tile)) return false;
 
 	switch (::GetTileType(tile)) {
@@ -277,6 +278,7 @@
 
 /* static */ bool ScriptTile::DemolishTile(TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -281,6 +281,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptCompanyMode::IsDeity() || _settings_game.economy.found_town != TF_FORBIDDEN);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, size == TOWN_SIZE_SMALL || size == TOWN_SIZE_MEDIUM || size == TOWN_SIZE_LARGE)

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -44,6 +44,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	std::string text;
 	if (name != nullptr) {
@@ -58,6 +59,7 @@
 {
 	CCountedPtr<Text> counter(text);
 
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 
 	return ScriptObject::Command<CMD_TOWN_SET_TEXT>::Do(town_id, text != nullptr ? text->GetEncodedText() : std::string{});
@@ -125,6 +127,7 @@
 
 /* static */ bool ScriptTown::SetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id, SQInteger goal)
 {
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	EnforcePrecondition(false, ScriptCargo::IsValidTownEffect(towneffect_id));
 
@@ -155,6 +158,7 @@
 
 /* static */ bool ScriptTown::SetGrowthRate(TownID town_id, SQInteger days_between_town_growth)
 {
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	uint16 growth_rate;
 	switch (days_between_town_growth) {

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -149,6 +149,7 @@ public:
 	 * @param town_id The town to rename
 	 * @param name The new name of the town. If null, or an empty string, is passed, the town name will be reset to the default name.
 	 * @pre IsValidTown(town_id).
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
@@ -159,6 +160,7 @@ public:
 	 * @param town_id The town to set the custom text of.
 	 * @param text The text to set it to (can be either a raw string, or a ScriptText object). If null, or an empty string, is passed, the text will be removed.
 	 * @pre IsValidTown(town_id).
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
@@ -236,6 +238,7 @@ public:
 	 *             The value will be clamped to 0 .. MAX(uint32).
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidTownEffect(towneffect_id).
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
@@ -392,6 +395,7 @@ public:
 	 *               The value will be clamped to 0 .. MAX(uint32).
 	 * @pre IsValidTown(town_id).
 	 * @pre houses > 0.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */

--- a/src/script/api/script_tunnel.cpp
+++ b/src/script/api/script_tunnel.cpp
@@ -82,6 +82,7 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 
 /* static */ bool ScriptTunnel::BuildTunnel(ScriptVehicle::VehicleType vehicle_type, TileIndex start)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(start));
 	EnforcePrecondition(false, vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_ROAD);
 	EnforcePrecondition(false, vehicle_type != ScriptVehicle::VT_RAIL || ScriptRail::IsRailTypeAvailable(ScriptRail::GetCurrentRailType()));
@@ -99,6 +100,8 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 
 /* static */ bool ScriptTunnel::_BuildTunnelRoad1()
 {
+	EnforceDeityOrCompanyModeValid(false);
+
 	/* Build the piece of road on the 'start' side of the tunnel */
 	TileIndex end = ScriptObject::GetCallbackVariable(0);
 	TileIndex start = ScriptTunnel::GetOtherTunnelEnd(end);
@@ -111,6 +114,8 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 
 /* static */ bool ScriptTunnel::_BuildTunnelRoad2()
 {
+	EnforceDeityOrCompanyModeValid(false);
+
 	/* Build the piece of road on the 'end' side of the tunnel */
 	TileIndex end = ScriptObject::GetCallbackVariable(0);
 	TileIndex start = ScriptTunnel::GetOtherTunnelEnd(end);

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -30,6 +30,7 @@
 
 /* static */ bool ScriptVehicle::IsValidVehicle(VehicleID vehicle_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Vehicle *v = ::Vehicle::GetIfValid(vehicle_id);
 	return v != nullptr && (v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()));
 }

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -20,6 +20,7 @@
 
 ScriptVehicleList::ScriptVehicleList()
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (const Vehicle *v : Vehicle::Iterate()) {
 		if ((v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()))) this->AddItem(v->index);
 	}
@@ -27,6 +28,7 @@ ScriptVehicleList::ScriptVehicleList()
 
 ScriptVehicleList_Station::ScriptVehicleList_Station(StationID station_id)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	if (!ScriptBaseStation::IsValidBaseStation(station_id)) return;
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
@@ -43,6 +45,7 @@ ScriptVehicleList_Station::ScriptVehicleList_Station(StationID station_id)
 
 ScriptVehicleList_Depot::ScriptVehicleList_Depot(TileIndex tile)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	if (!ScriptMap::IsValidTile(tile)) return;
 
 	DestinationID dest;
@@ -100,6 +103,7 @@ ScriptVehicleList_SharedOrders::ScriptVehicleList_SharedOrders(VehicleID vehicle
 
 ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	if (!ScriptGroup::IsValidGroup((ScriptGroup::GroupID)group_id)) return;
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
@@ -111,6 +115,7 @@ ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 
 ScriptVehicleList_DefaultGroup::ScriptVehicleList_DefaultGroup(ScriptVehicle::VehicleType vehicle_type)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	if (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR) return;
 
 	for (const Vehicle *v : Vehicle::Iterate()) {

--- a/src/script/api/script_waypoint.cpp
+++ b/src/script/api/script_waypoint.cpp
@@ -17,6 +17,7 @@
 
 /* static */ bool ScriptWaypoint::IsValidWaypoint(StationID waypoint_id)
 {
+	EnforceDeityOrCompanyModeValid(false);
 	const Waypoint *wp = ::Waypoint::GetIfValid(waypoint_id);
 	return wp != nullptr && (wp->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || wp->owner == OWNER_NONE);
 }

--- a/src/script/api/script_waypointlist.cpp
+++ b/src/script/api/script_waypointlist.cpp
@@ -17,6 +17,7 @@
 
 ScriptWaypointList::ScriptWaypointList(ScriptWaypoint::WaypointType waypoint_type)
 {
+	EnforceDeityOrCompanyModeValid_Void();
 	for (const Waypoint *wp : Waypoint::Iterate()) {
 		if ((wp->facilities & waypoint_type) &&
 				(wp->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || wp->owner == OWNER_NONE)) this->AddItem(wp->index);


### PR DESCRIPTION
## Motivation / Problem

Inconsistent/missing checks for being in deity/company mode. For example, for setting the industry text there is no explicit check for it being called from deity mode. If called from company mode the call will eventually fail in the command processing, instead of earlier.

Furthermore there is a potential crash to desktop when the company mode becomes invalid.


## Description

The crashes to desktop are due to the company of the CompanyMode becoming invalid after a merge or bankruptcy, and then the removed company is still being used in getters and commands. This causes dereferences of nullptr.
This is solved by checking in `ScriptCompanyMode::IsValid` for the company of the company mode still being a valid company.

All cases where `ScriptObject::GetCompany` is used, including all commands, are suspect for this potential issue of using an invalid company. So, add a precondition check for either the right company mode or deity mode being active to all those functions.

Furthermore a script has been made that finds such cases, and this is integrated in a workflow that checks for this during builds on github.

Finally the last error for all these precondition checks is changed to `ERR_PRECONDITION_INVALID_COMPANY` instead of the less specific `ERR_PRECONDITION_INVALID`.


## Limitations

None as far as I know.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
