### PR TITLE
Codechange: Cache ScriptConfig for the slot in constructor

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -68,7 +68,7 @@ static const NWidgetPart _nested_ai_config_widgets[] = {
 
 /** Window definition for the configure AI window. */
 static WindowDesc _ai_config_desc(
-	WDP_CENTER, "settings_script_config", 0, 0,
+	WDP_CENTER, "settings_ai_config", 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
 	_nested_ai_config_widgets, lengthof(_nested_ai_config_widgets)
@@ -128,7 +128,7 @@ struct AIConfigWindow : public Window {
 	/**
 	 * Can the AI config in the given company slot be edited?
 	 * @param slot The slot to query.
-	 * @return True if and only if the given AI Config slot can e edited.
+	 * @return True if and only if the given AI Config slot can be edited.
 	 */
 	static bool IsEditable(CompanyID slot)
 	{
@@ -194,7 +194,7 @@ struct AIConfigWindow : public Window {
 			case WID_AIC_LIST: { // Select a slot
 				this->selected_slot = (CompanyID)this->vscroll->GetScrolledRowFromWidget(pt.y, this, widget);
 				this->InvalidateData();
-				if (click_count > 1 && this->selected_slot != INVALID_COMPANY) ShowScriptListWindow((CompanyID)this->selected_slot);
+				if (click_count > 1 && this->selected_slot != INVALID_COMPANY) ShowScriptListWindow(this->selected_slot);
 				break;
 			}
 
@@ -217,11 +217,11 @@ struct AIConfigWindow : public Window {
 				break;
 
 			case WID_AIC_CHANGE:  // choose other AI
-				ShowScriptListWindow((CompanyID)this->selected_slot);
+				ShowScriptListWindow(this->selected_slot);
 				break;
 
 			case WID_AIC_CONFIGURE: // change the settings for an AI
-				ShowScriptSettingsWindow((CompanyID)this->selected_slot);
+				ShowScriptSettingsWindow(this->selected_slot);
 				break;
 
 			case WID_AIC_CLOSE:
@@ -270,4 +270,3 @@ void ShowAIConfigWindow()
 	CloseWindowByClass(WC_GAME_OPTIONS);
 	new AIConfigWindow();
 }
-

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -74,11 +74,11 @@ static WindowDesc _gs_config_desc(
 );
 
 /**
- * Window to configure which GSs will start.
+ * Window to configure which GS will start.
  */
 struct GSConfigWindow : public Window {
 	ScriptConfig *gs_config; ///< The configuration we're modifying.
-	int line_height;         ///< Height of a single GS-name line.
+	int line_height;         ///< Height of GS-name line.
 	int clicked_button;      ///< The button we clicked.
 	bool clicked_increase;   ///< Whether we clicked the increase or decrease button.
 	bool clicked_dropdown;   ///< Whether the dropdown is open.
@@ -113,7 +113,7 @@ struct GSConfigWindow : public Window {
 
 	/**
 	 * Rebuilds the list of visible settings. GS settings with the flag
-	 * GSCONFIG_GS_DEVELOPER set will only be visible if the game setting
+	 * SCRIPTCONFIG_DEVELOPER set will only be visible if the game setting
 	 * gui.ai_developer_tools is enabled.
 	 */
 	void RebuildVisibleSettings()
@@ -149,7 +149,7 @@ struct GSConfigWindow : public Window {
 
 	/**
 	 * Can the GS config be edited?
-	 * @return True if the given GS Config slot can be edited, otherwise false.
+	 * @return True if the given GS Config can be edited, otherwise false.
 	 */
 	static bool IsEditable()
 	{
@@ -167,7 +167,7 @@ struct GSConfigWindow : public Window {
 					text = STR_JUST_RAW_STRING;
 				}
 
-				/* There is only one slot, unlike with the GS GUI, so it should never be white */
+				/* There is only one slot, unlike with the AI GUI, so it should never be white */
 				DrawString(r.Shrink(WidgetDimensions::scaled.matrix), text, (IsEditable() ? TC_ORANGE : TC_SILVER));
 				break;
 			}
@@ -242,19 +242,19 @@ struct GSConfigWindow : public Window {
 		if (widget >= WID_GSC_TEXTFILE && widget < WID_GSC_TEXTFILE + TFT_END) {
 			if (this->gs_config == nullptr) return;
 
-			ShowScriptTextfileWindow((TextfileType)(widget - WID_GSC_TEXTFILE), (CompanyID)OWNER_DEITY);
+			ShowScriptTextfileWindow((TextfileType)(widget - WID_GSC_TEXTFILE), OWNER_DEITY);
 			return;
 		}
 
 		switch (widget) {
 			case WID_GSC_GSLIST: {
 				this->InvalidateData();
-				if (click_count > 1 && _game_mode != GM_NORMAL) ShowScriptListWindow((CompanyID)OWNER_DEITY);
+				if (click_count > 1 && _game_mode != GM_NORMAL) ShowScriptListWindow(OWNER_DEITY);
 				break;
 			}
 
 			case WID_GSC_CHANGE:  // choose other Game Script
-				ShowScriptListWindow((CompanyID)OWNER_DEITY);
+				ShowScriptListWindow(OWNER_DEITY);
 				break;
 
 			case WID_GSC_CONTENT_DOWNLOAD:
@@ -403,7 +403,7 @@ struct GSConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GM_NORMAL) || !IsEditable());
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, this->gs_config->GetTextfile(tft, (CompanyID)OWNER_DEITY) == nullptr);
+			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, this->gs_config->GetTextfile(tft, OWNER_DEITY) == nullptr);
 		}
 		this->RebuildVisibleSettings();
 		HideDropDownMenu(this);
@@ -413,9 +413,9 @@ private:
 	bool IsEditableItem(const ScriptConfigItem &config_item) const
 	{
 		return _game_mode == GM_MENU
-		    || _game_mode == GM_EDITOR
-		    || (config_item.flags & SCRIPTCONFIG_INGAME) != 0
-		    || _settings_client.gui.ai_developer_tools;
+				|| _game_mode == GM_EDITOR
+				|| (config_item.flags & SCRIPTCONFIG_INGAME) != 0
+				|| _settings_client.gui.ai_developer_tools;
 	}
 
 	void SetValue(int value)

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -162,8 +162,8 @@ struct GSConfigWindow : public Window {
 			case WID_GSC_GSLIST: {
 				StringID text = STR_AI_CONFIG_NONE;
 
-				if (GameConfig::GetConfig()->GetInfo() != nullptr) {
-					SetDParamStr(0, GameConfig::GetConfig()->GetInfo()->GetName());
+				if (this->gs_config->GetInfo() != nullptr) {
+					SetDParamStr(0, this->gs_config->GetInfo()->GetName());
 					text = STR_JUST_RAW_STRING;
 				}
 
@@ -240,7 +240,7 @@ struct GSConfigWindow : public Window {
 	void OnClick(Point pt, int widget, int click_count) override
 	{
 		if (widget >= WID_GSC_TEXTFILE && widget < WID_GSC_TEXTFILE + TFT_END) {
-			if (GameConfig::GetConfig() == nullptr) return;
+			if (this->gs_config == nullptr) return;
 
 			ShowScriptTextfileWindow((TextfileType)(widget - WID_GSC_TEXTFILE), (CompanyID)OWNER_DEITY);
 			return;
@@ -407,7 +407,7 @@ struct GSConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GM_NORMAL) || !IsEditable());
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, GameConfig::GetConfig()->GetTextfile(tft, (CompanyID)OWNER_DEITY) == nullptr);
+			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, this->gs_config->GetTextfile(tft, (CompanyID)OWNER_DEITY) == nullptr);
 		}
 		this->RebuildVisibleSettings();
 		HideDropDownMenu(this);

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -321,16 +321,12 @@ struct GSConfigWindow : public Window {
 					int new_val = old_val;
 					if (bool_item) {
 						new_val = !new_val;
-					} else if (x >= SETTING_BUTTON_WIDTH / 2) {
-						/* Increase button clicked */
-						new_val += config_item.step_size;
-						if (new_val > config_item.max_value) new_val = config_item.max_value;
-						this->clicked_increase = true;
 					} else {
-						/* Decrease button clicked */
-						new_val -= config_item.step_size;
-						if (new_val < config_item.min_value) new_val = config_item.min_value;
-						this->clicked_increase = false;
+						/* Increase/Decrease button clicked */
+						this->clicked_increase = (x >= SETTING_BUTTON_WIDTH / 2);
+						new_val = this->clicked_increase ?
+								std::min(config_item.max_value, new_val + config_item.step_size) :
+								std::max(config_item.min_value, new_val - config_item.step_size);
 					}
 
 					if (new_val != old_val) {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -39,17 +39,12 @@
 #include "../safeguards.h"
 
 
-static ScriptConfig *GetConfig(CompanyID slot)
-{
-	if (slot == OWNER_DEITY) return GameConfig::GetConfig();
-	return AIConfig::GetConfig(slot);
-}
-
 /**
  * Window that let you choose an available Script.
  */
 struct ScriptListWindow : public Window {
 	const ScriptInfoList *info_list;    ///< The list of Scripts.
+	ScriptConfig *script_config;        ///< The configuration we're modifying.
 	int selected;                       ///< The currently selected Script.
 	CompanyID slot;                     ///< The company we're selecting a new Script for.
 	int line_height;                    ///< Height of a row in the matrix widget.
@@ -65,8 +60,10 @@ struct ScriptListWindow : public Window {
 	{
 		if (slot == OWNER_DEITY) {
 			this->info_list = Game::GetUniqueInfoList();
+			this->script_config = GameConfig::GetConfig();
 		} else {
 			this->info_list = AI::GetUniqueInfoList();
+			this->script_config = AIConfig::GetConfig(slot);
 		}
 
 		this->CreateNestedTree();
@@ -77,8 +74,8 @@ struct ScriptListWindow : public Window {
 
 		/* Try if we can find the currently selected AI */
 		this->selected = -1;
-		if (GetConfig(slot)->HasScript()) {
-			ScriptInfo *info = GetConfig(slot)->GetInfo();
+		if (this->script_config->HasScript()) {
+			ScriptInfo *info = this->script_config->GetInfo();
 			int i = 0;
 			for (const auto &item : *this->info_list) {
 				if (item.second == info) {
@@ -165,11 +162,11 @@ struct ScriptListWindow : public Window {
 	void ChangeScript()
 	{
 		if (this->selected == -1) {
-			GetConfig(slot)->Change(nullptr);
+			this->script_config->Change(nullptr);
 		} else {
 			ScriptInfoList::const_iterator it = this->info_list->begin();
 			for (int i = 0; i < this->selected; i++) it++;
-			GetConfig(slot)->Change((*it).second->GetName(), (*it).second->GetVersion());
+			this->script_config->Change((*it).second->GetName(), (*it).second->GetVersion());
 		}
 		InvalidateWindowData(WC_GAME_OPTIONS, slot == OWNER_DEITY ? WN_GAME_OPTIONS_GS : WN_GAME_OPTIONS_AI);
 		InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
@@ -301,7 +298,11 @@ struct ScriptSettingsWindow : public Window {
 		closing_dropdown(false),
 		timeout(0)
 	{
-		this->script_config = GetConfig(slot);
+		if (slot == OWNER_DEITY) {
+			this->script_config = GameConfig::GetConfig();
+		} else {
+			this->script_config = AIConfig::GetConfig(slot);
+		}
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_SCRS_SCROLLBAR);
@@ -628,10 +629,16 @@ void ShowScriptSettingsWindow(CompanyID slot)
 
 /** Window for displaying the textfile of a AI. */
 struct ScriptTextfileWindow : public TextfileWindow {
-	CompanyID slot; ///< View the textfile of this CompanyID slot.
+	CompanyID slot;              ///< View the textfile of this CompanyID slot.
+	ScriptConfig *script_config; ///< The configuration we selected.
 
 	ScriptTextfileWindow(TextfileType file_type, CompanyID slot) : TextfileWindow(file_type), slot(slot)
 	{
+		if (slot == OWNER_DEITY) {
+			this->script_config = GameConfig::GetConfig();
+		} else {
+			this->script_config = AIConfig::GetConfig(slot);
+		}
 		this->OnInvalidateData();
 	}
 
@@ -639,13 +646,13 @@ struct ScriptTextfileWindow : public TextfileWindow {
 	{
 		if (widget == WID_TF_CAPTION) {
 			SetDParam(0, (slot == OWNER_DEITY) ? STR_CONTENT_TYPE_GAME_SCRIPT : STR_CONTENT_TYPE_AI);
-			SetDParamStr(1, GetConfig(slot)->GetInfo()->GetName());
+			SetDParamStr(1, script_config->GetInfo()->GetName());
 		}
 	}
 
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
-		const char *textfile = GetConfig(slot)->GetTextfile(file_type, slot);
+		const char *textfile = script_config->GetTextfile(file_type, slot);
 		if (textfile == nullptr) {
 			this->Close();
 		} else {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -72,7 +72,7 @@ struct ScriptListWindow : public Window {
 
 		this->vscroll->SetCount((int)this->info_list->size() + 1);
 
-		/* Try if we can find the currently selected AI */
+		/* Try if we can find the currently selected Script */
 		this->selected = -1;
 		if (this->script_config->HasScript()) {
 			ScriptInfo *info = this->script_config->GetInfo();
@@ -223,12 +223,12 @@ struct ScriptListWindow : public Window {
 
 		this->vscroll->SetCount((int)this->info_list->size() + 1);
 
-		/* selected goes from -1 .. length of ai list - 1. */
+		/* selected goes from -1 .. length of info_list - 1. */
 		this->selected = std::min(this->selected, this->vscroll->GetCount() - 2);
 	}
 };
 
-/** Widgets for the AI list window. */
+/** Widgets for the Script list window. */
 static const NWidgetPart _nested_script_list_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
@@ -250,7 +250,7 @@ static const NWidgetPart _nested_script_list_widgets[] = {
 	EndContainer(),
 };
 
-/** Window definition for the ai list window. */
+/** Window definition for the Script list window. */
 static WindowDesc _script_list_desc(
 	WDP_CENTER, "settings_script_list", 200, 234,
 	WC_SCRIPT_LIST, WC_NONE,
@@ -259,7 +259,7 @@ static WindowDesc _script_list_desc(
 );
 
 /**
- * Open the AI list window to chose an AI for the given company slot.
+ * Open the Script list window to chose a Script for the given company slot or game script.
  * @param slot The slot to change the AI of.
  */
 void ShowScriptListWindow(CompanyID slot)
@@ -313,7 +313,7 @@ struct ScriptSettingsWindow : public Window {
 
 	/**
 	 * Rebuilds the list of visible settings. AI settings with the flag
-	 * AICONFIG_AI_DEVELOPER set will only be visible if the game setting
+	 * SCRIPTCONFIG_DEVELOPER set will only be visible if the game setting
 	 * gui.ai_developer_tools is enabled.
 	 */
 	void RebuildVisibleSettings()
@@ -623,7 +623,7 @@ void ShowScriptSettingsWindow(CompanyID slot)
 }
 
 
-/** Window for displaying the textfile of a AI. */
+/** Window for displaying the textfile of a Script. */
 struct ScriptTextfileWindow : public TextfileWindow {
 	CompanyID slot;              ///< View the textfile of this CompanyID slot.
 	ScriptConfig *script_config; ///< The configuration we selected.
@@ -682,7 +682,7 @@ static bool SetScriptButtonColour(NWidgetCore &button, bool dead, bool paused)
 	/* Dead scripts are indicated with red background and
 	 * paused scripts are indicated with yellow background. */
 	Colours colour = dead ? COLOUR_RED :
-		(paused ? COLOUR_YELLOW : COLOUR_GREY);
+			(paused ? COLOUR_YELLOW : COLOUR_GREY);
 	if (button.colour != colour) {
 		button.colour = colour;
 		return true;
@@ -691,18 +691,18 @@ static bool SetScriptButtonColour(NWidgetCore &button, bool dead, bool paused)
 }
 
 /**
- * Window with everything an AI prints via ScriptLog.
+ * Window with everything a Script prints via ScriptLog.
  */
 struct ScriptDebugWindow : public Window {
 	static const uint MAX_BREAK_STR_STRING_LENGTH = 256;   ///< Maximum length of the break string.
 
-	static CompanyID script_debug_company;                 ///< The AI that is (was last) being debugged.
+	static CompanyID script_debug_company;                 ///< The Script that is (was last) being debugged.
 	int redraw_timer;                                      ///< Timer for redrawing the window, otherwise it'll happen every tick.
 	int last_vscroll_pos;                                  ///< Last position of the scrolling.
 	bool autoscroll;                                       ///< Whether automatically scrolling should be enabled or not.
 	bool show_break_box;                                   ///< Whether the break/debug box is visible.
-	static bool break_check_enabled;                       ///< Stop an AI when it prints a matching string
-	static char break_string[MAX_BREAK_STR_STRING_LENGTH]; ///< The string to match to the AI output
+	static bool break_check_enabled;                       ///< Stop a Script when it prints a matching string
+	static char break_string[MAX_BREAK_STR_STRING_LENGTH]; ///< The string to match to the Script output
 	QueryString break_editbox;                             ///< Break editbox
 	static StringFilter break_string_filter;               ///< Log filter for break.
 	static bool case_sensitive_break_check;                ///< Is the matching done case-sensitive
@@ -716,7 +716,7 @@ struct ScriptDebugWindow : public Window {
 	}
 
 	/**
-	 * Check whether the currently selected AI/GS is dead.
+	 * Check whether the currently selected Script is dead.
 	 * @return true if dead.
 	 */
 	bool IsDead() const
@@ -748,7 +748,7 @@ struct ScriptDebugWindow : public Window {
 	 */
 	void SelectValidDebugCompany()
 	{
-		/* Check if the currently selected company is still active. */
+		/* Check if the currently selected Script is still active. */
 		if (this->IsValidDebugCompany(script_debug_company)) return;
 
 		script_debug_company = INVALID_COMPANY;
@@ -936,8 +936,8 @@ struct ScriptDebugWindow : public Window {
 	}
 
 	/**
-	 * Change all settings to select another Script.
-	 * @param show_ai The new AI to show.
+	 * Change log to select another Script.
+	 * @param show_script The new Script to show.
 	 */
 	void ChangeToScript(CompanyID show_script)
 	{
@@ -947,7 +947,7 @@ struct ScriptDebugWindow : public Window {
 
 		this->highlight_row = -1; // The highlight of one Script make little sense for another Script.
 
-		/* Close AI settings window to prevent confusion */
+		/* Close Script settings window to prevent confusion */
 		CloseWindowByClass(WC_SCRIPT_SETTINGS);
 
 		this->InvalidateData(-1);
@@ -1095,7 +1095,7 @@ struct ScriptDebugWindow : public Window {
 		extern CompanyID _local_company;
 		this->SetWidgetDisabledState(WID_SCRD_RELOAD_TOGGLE, script_debug_company == INVALID_COMPANY || script_debug_company == OWNER_DEITY || script_debug_company == _local_company);
 		this->SetWidgetDisabledState(WID_SCRD_CONTINUE_BTN, script_debug_company == INVALID_COMPANY ||
-			(script_debug_company == OWNER_DEITY ? !Game::IsPaused() : !AI::IsPaused(script_debug_company)));
+				(script_debug_company == OWNER_DEITY ? !Game::IsPaused() : !AI::IsPaused(script_debug_company)));
 	}
 
 	void OnResize() override
@@ -1156,7 +1156,7 @@ static Hotkey scriptdebug_hotkeys[] = {
 	Hotkey(WKC_RETURN, "continue", WID_SCRD_CONTINUE_BTN),
 	HOTKEY_LIST_END
 };
-HotkeyList ScriptDebugWindow::hotkeys("aidebug", scriptdebug_hotkeys, ScriptDebugGlobalHotkeys);
+HotkeyList ScriptDebugWindow::hotkeys("scriptdebug", scriptdebug_hotkeys, ScriptDebugGlobalHotkeys);
 
 /** Widgets for the Script debug window. */
 static const NWidgetPart _nested_script_debug_widgets[] = {
@@ -1213,8 +1213,8 @@ static WindowDesc _script_debug_desc(
 );
 
 /**
- * Open the Script debug window and select the given company.
- * @param show_company Display debug information about this AI company.
+ * Open the Script debug window and select the given company or game script.
+ * @param show_company Display debug information about this AI company or game script.
  */
 Window *ShowScriptDebugWindow(CompanyID show_company)
 {
@@ -1238,10 +1238,10 @@ void InitializeScriptGui()
 	ScriptDebugWindow::script_debug_company = INVALID_COMPANY;
 }
 
-/** Open the AI debug window if one of the AI scripts has crashed. */
+/** Open the Script debug window if one of the scripts has crashed. */
 void ShowScriptDebugWindowIfScriptError()
 {
-	/* Network clients can't debug AIs. */
+	/* Network clients can't debug Scripts. */
 	if (_networking && !_network_server) return;
 
 	for (const Company *c : Company::Iterate()) {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -479,16 +479,12 @@ struct ScriptSettingsWindow : public Window {
 					int new_val = old_val;
 					if (bool_item) {
 						new_val = !new_val;
-					} else if (x >= SETTING_BUTTON_WIDTH / 2) {
-						/* Increase button clicked */
-						new_val += config_item.step_size;
-						if (new_val > config_item.max_value) new_val = config_item.max_value;
-						this->clicked_increase = true;
 					} else {
-						/* Decrease button clicked */
-						new_val -= config_item.step_size;
-						if (new_val < config_item.min_value) new_val = config_item.min_value;
-						this->clicked_increase = false;
+						/* Increase/Decrease button clicked */
+						this->clicked_increase = (x >= SETTING_BUTTON_WIDTH / 2);
+						new_val = this->clicked_increase ?
+								std::min(config_item.max_value, new_val + config_item.step_size) :
+								std::max(config_item.min_value, new_val - config_item.step_size);
 					}
 
 					if (new_val != old_val) {

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -777,7 +777,7 @@ struct ScriptDebugWindow : public Window {
 		this->GetWidget<NWidgetStacked>(WID_SCRD_BREAK_STRING_WIDGETS)->SetDisplayedPlane(this->show_break_box ? 0 : SZSP_HORIZONTAL);
 		this->FinishInitNested(number);
 
-		if (!this->show_break_box) break_check_enabled = false;
+		if (!this->show_break_box) this->break_check_enabled = false;
 
 		this->last_vscroll_pos = 0;
 		this->autoscroll = true;
@@ -1074,6 +1074,13 @@ struct ScriptDebugWindow : public Window {
 
 		if (!gui_scope) return;
 
+		this->show_break_box = _settings_client.gui.ai_developer_tools;
+		this->GetWidget<NWidgetStacked>(WID_SCRD_BREAK_STRING_WIDGETS)->SetDisplayedPlane(this->show_break_box ? 0 : SZSP_HORIZONTAL);
+		if (!this->show_break_box) this->break_check_enabled = false;
+		this->SetWidgetDisabledState(WID_SCRD_BREAK_STR_ON_OFF_BTN, !this->show_break_box);
+		this->SetWidgetDisabledState(WID_SCRD_MATCH_CASE_BTN, !this->show_break_box);
+		this->SetWidgetDisabledState(WID_SCRD_BREAK_STR_EDIT_BOX, !this->show_break_box);
+
 		this->SelectValidDebugCompany();
 
 		ScriptLog::LogData *log = script_debug_company != INVALID_COMPANY ? this->GetLogPointer() : nullptr;
@@ -1094,7 +1101,7 @@ struct ScriptDebugWindow : public Window {
 		this->SetWidgetDisabledState(WID_SCRD_SETTINGS, script_debug_company == INVALID_COMPANY);
 		extern CompanyID _local_company;
 		this->SetWidgetDisabledState(WID_SCRD_RELOAD_TOGGLE, script_debug_company == INVALID_COMPANY || script_debug_company == OWNER_DEITY || script_debug_company == _local_company);
-		this->SetWidgetDisabledState(WID_SCRD_CONTINUE_BTN, script_debug_company == INVALID_COMPANY ||
+		this->SetWidgetDisabledState(WID_SCRD_CONTINUE_BTN, !this->show_break_box || script_debug_company == INVALID_COMPANY ||
 				(script_debug_company == OWNER_DEITY ? !Game::IsPaused() : !AI::IsPaused(script_debug_company)));
 	}
 

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -277,6 +277,14 @@ static void SpriteZoomMinChanged(int32 new_value)
 	MarkWholeScreenDirty();
 }
 
+static void InvalidateScriptSettingsWindow(int32 new_value)
+{
+	InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
+	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_AI);
+	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GS);
+	InvalidateWindowClassesData(WC_SCRIPT_DEBUG);
+}
+
 /**
  * Update any possible saveload window and delete any newgrf dialogue as
  * its widget parts might change. Reinit all windows as it allows access to the

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -12,6 +12,7 @@ static void v_PositionStatusbar(int32 new_value);
 static void RedrawSmallmap(int32 new_value);
 static void UpdateLinkgraphColours(int32 new_value);
 static void InvalidateCompanyLiveryWindow(int32 new_value);
+static void InvalidateScriptSettingsWindow(int32 new_value);
 static void InvalidateNewGRFChangeWindows(int32 new_value);
 static void ZoomMinMaxChanged(int32 new_value);
 static void SpriteZoomMinChanged(int32 new_value);
@@ -779,7 +780,7 @@ cat      = SC_EXPERT
 var      = gui.ai_developer_tools
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
-post_cb  = [](auto) { InvalidateWindowClassesData(WC_SCRIPT_SETTINGS); }
+post_cb  = InvalidateScriptSettingsWindow
 cat      = SC_EXPERT
 
 [SDTC_BOOL]


### PR DESCRIPTION
## Motivation / Problem
GSConfigWindow seems to mix usage of this->gs_config and GameConfig::GetConfig(). And ScriptListWindow could also cache ScriptConfig for the slot in constructor instead calling GetConfig() everytime. Then the static function can be removed. https://github.com/OpenTTD/OpenTTD/pull/10458#pullrequestreview-1290199005

While at it, maybe also invalidate debug window (to show/hide break string), but the invalidate code of that window doesn't really do anything in that regard. https://github.com/OpenTTD/OpenTTD/pull/10458#discussion_r1100808654 , https://github.com/OpenTTD/OpenTTD/pull/10458#discussion_r1101349547

Possible programmatic simplification Game and Script OnClick handlers. https://github.com/OpenTTD/OpenTTD/pull/10458#discussion_r1100995974
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
When changing ai_developer_tools, the invalidate call on the Debug Window doesn't really show or hide the break box (to do).
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
