### PR TITLE
Fix: deity should see all signs, AIs should not see signs of deity

### DIFF
--- a/src/script/api/script_sign.cpp
+++ b/src/script/api/script_sign.cpp
@@ -22,7 +22,7 @@
 /* static */ bool ScriptSign::IsValidSign(SignID sign_id)
 {
 	const Sign *si = ::Sign::GetIfValid(sign_id);
-	return si != nullptr && (si->owner == ScriptObject::GetCompany() || si->owner == OWNER_DEITY);
+	return si != nullptr && (si->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY);
 }
 
 /* static */ ScriptCompany::CompanyID ScriptSign::GetOwner(SignID sign_id)


### PR DESCRIPTION
## Motivation / Problem

The GS can only see the signs from itself. The AI can see signs from itself and GS.

For depots, station, vehicles it is that the AI can see them of its own, whereas the GS can see them of everybody.

Why this inconsistency? I reckon because a mistake was made when amending the code.


## Description

Let GS see the signs from everybody, and AIs see only their own signs.


## Limitations

Breaks AIs that are written to read the sign of the GS, though I wonder whether that has been done.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
