### PR TITLE
Codechange: Use SQInteger for generic numbers in script API

### DIFF
--- a/src/script/api/script_admin.cpp
+++ b/src/script/api/script_admin.cpp
@@ -28,9 +28,7 @@
 			SQInteger res;
 			sq_getinteger(vm, index, &res);
 
-			char buf[10];
-			seprintf(buf, lastof(buf), "%d", (int32)res);
-			data = buf;
+			data = fmt::format("{}", res);
 			return true;
 		}
 
@@ -44,7 +42,7 @@
 				return false;
 			}
 
-			data = std::string("\"") + buf + "\"";
+			data = fmt::format("\"{}\"", buf);
 			return true;
 		}
 

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -158,7 +158,7 @@
 
 /* static */ uint16 ScriptAirport::GetMaintenanceCostFactor(AirportType type)
 {
-	if (!IsAirportInformationAvailable(type)) return INVALID_TOWN;
+	if (!IsAirportInformationAvailable(type)) return 0;
 
 	return AirportSpec::Get(type)->maintenance_cost;
 }

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -49,21 +49,21 @@
 	return ::IsTileType(tile, MP_STATION) && ::IsAirport(tile);
 }
 
-/* static */ int32 ScriptAirport::GetAirportWidth(AirportType type)
+/* static */ SQInteger ScriptAirport::GetAirportWidth(AirportType type)
 {
 	if (!IsAirportInformationAvailable(type)) return -1;
 
 	return ::AirportSpec::Get(type)->size_x;
 }
 
-/* static */ int32 ScriptAirport::GetAirportHeight(AirportType type)
+/* static */ SQInteger ScriptAirport::GetAirportHeight(AirportType type)
 {
 	if (!IsAirportInformationAvailable(type)) return -1;
 
 	return ::AirportSpec::Get(type)->size_y;
 }
 
-/* static */ int32 ScriptAirport::GetAirportCoverageRadius(AirportType type)
+/* static */ SQInteger ScriptAirport::GetAirportCoverageRadius(AirportType type)
 {
 	if (!IsAirportInformationAvailable(type)) return -1;
 
@@ -89,7 +89,7 @@
 	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);
 }
 
-/* static */ int32 ScriptAirport::GetNumHangars(TileIndex tile)
+/* static */ SQInteger ScriptAirport::GetNumHangars(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return -1;
 	if (!::IsTileType(tile, MP_STATION)) return -1;
@@ -126,7 +126,7 @@
 }
 
 
-/* static */ int ScriptAirport::GetNoiseLevelIncrease(TileIndex tile, AirportType type)
+/* static */ SQInteger ScriptAirport::GetNoiseLevelIncrease(TileIndex tile, AirportType type)
 {
 	if (!::IsValidTile(tile)) return -1;
 	if (!IsAirportInformationAvailable(type)) return -1;
@@ -156,7 +156,7 @@
 	return AirportGetNearestTown(as, AirportTileTableIterator(as->table[0], tile), dist)->index;
 }
 
-/* static */ uint16 ScriptAirport::GetMaintenanceCostFactor(AirportType type)
+/* static */ SQInteger ScriptAirport::GetMaintenanceCostFactor(AirportType type)
 {
 	if (!IsAirportInformationAvailable(type)) return 0;
 

--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -96,7 +96,7 @@ public:
 	 * @pre IsAirportInformationAvailable(type).
 	 * @return The width in tiles.
 	 */
-	static int32 GetAirportWidth(AirportType type);
+	static SQInteger GetAirportWidth(AirportType type);
 
 	/**
 	 * Get the height of this type of airport.
@@ -104,7 +104,7 @@ public:
 	 * @pre IsAirportInformationAvailable(type).
 	 * @return The height in tiles.
 	 */
-	static int32 GetAirportHeight(AirportType type);
+	static SQInteger GetAirportHeight(AirportType type);
 
 	/**
 	 * Get the coverage radius of this type of airport.
@@ -112,7 +112,7 @@ public:
 	 * @pre IsAirportInformationAvailable(type).
 	 * @return The radius in tiles.
 	 */
-	static int32 GetAirportCoverageRadius(AirportType type);
+	static SQInteger GetAirportCoverageRadius(AirportType type);
 
 	/**
 	 * Get the number of hangars of the airport.
@@ -120,7 +120,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @return The number of hangars of the airport.
 	 */
-	static int32 GetNumHangars(TileIndex tile);
+	static SQInteger GetNumHangars(TileIndex tile);
 
 	/**
 	 * Get the first hangar tile of the airport.
@@ -180,7 +180,7 @@ public:
 	 * @return The amount of noise added to the nearest town.
 	 * @note The noise will be added to the town with TownID GetNearestTown(tile, type).
 	 */
-	static int GetNoiseLevelIncrease(TileIndex tile, AirportType type);
+	static SQInteger GetNoiseLevelIncrease(TileIndex tile, AirportType type);
 
 	/**
 	 * Get the TownID of the town whose local authority will influence
@@ -198,7 +198,7 @@ public:
 	 * @pre IsAirportInformationAvailable(type)
 	 * @return Maintenance cost factor of the airport type.
 	 */
-	static uint16 GetMaintenanceCostFactor(AirportType type);
+	static SQInteger GetMaintenanceCostFactor(AirportType type);
 
 	/**
 	 * Get the monthly maintenance cost of an airport type.

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -132,32 +132,34 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	return GetString(vehicle_type == ScriptVehicle::VT_WATER ? STR_LAI_BRIDGE_DESCRIPTION_AQUEDUCT : ::GetBridgeSpec(bridge_id)->transport_name[vehicle_type]);
 }
 
-/* static */ int32 ScriptBridge::GetMaxSpeed(BridgeID bridge_id)
+/* static */ SQInteger ScriptBridge::GetMaxSpeed(BridgeID bridge_id)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
 	return ::GetBridgeSpec(bridge_id)->speed; // km-ish/h
 }
 
-/* static */ Money ScriptBridge::GetPrice(BridgeID bridge_id, uint length)
+/* static */ Money ScriptBridge::GetPrice(BridgeID bridge_id, SQInteger length)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
+
+	length = Clamp<SQInteger>(length, 0, INT32_MAX);
 
 	return ::CalcBridgeLenCostFactor(length) * _price[PR_BUILD_BRIDGE] * ::GetBridgeSpec(bridge_id)->price >> 8;
 }
 
-/* static */ int32 ScriptBridge::GetMaxLength(BridgeID bridge_id)
+/* static */ SQInteger ScriptBridge::GetMaxLength(BridgeID bridge_id)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
-	return std::min(::GetBridgeSpec(bridge_id)->max_length, _settings_game.construction.max_bridge_length) + 2;
+	return std::min<SQInteger>(::GetBridgeSpec(bridge_id)->max_length, _settings_game.construction.max_bridge_length) + 2;
 }
 
-/* static */ int32 ScriptBridge::GetMinLength(BridgeID bridge_id)
+/* static */ SQInteger ScriptBridge::GetMinLength(BridgeID bridge_id)
 {
 	if (!IsValidBridge(bridge_id)) return -1;
 
-	return ::GetBridgeSpec(bridge_id)->min_length + 2;
+	return static_cast<SQInteger>(::GetBridgeSpec(bridge_id)->min_length) + 2;
 }
 
 /* static */ TileIndex ScriptBridge::GetOtherBridgeEnd(TileIndex tile)

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -80,16 +80,17 @@ public:
 	 *       This is mph / 1.6, which is roughly km/h.
 	 *       To get km/h multiply this number by 1.00584.
 	 */
-	static int32 GetMaxSpeed(BridgeID bridge_id);
+	static SQInteger GetMaxSpeed(BridgeID bridge_id);
 
 	/**
 	 * Get the new cost of a bridge, excluding the road and/or rail.
 	 * @param bridge_id The bridge to get the new cost of.
 	 * @param length The length of the bridge.
+	 *               The value will be clamped to 0 .. MAX(int32).
 	 * @pre IsValidBridge(bridge_id).
 	 * @return The new cost the bridge has.
 	 */
-	static Money GetPrice(BridgeID bridge_id, uint length);
+	static Money GetPrice(BridgeID bridge_id, SQInteger length);
 
 	/**
 	 * Get the maximum length of a bridge.
@@ -97,7 +98,7 @@ public:
 	 * @pre IsValidBridge(bridge_id).
 	 * @returns The maximum length the bridge has.
 	 */
-	static int32 GetMaxLength(BridgeID bridge_id);
+	static SQInteger GetMaxLength(BridgeID bridge_id);
 
 	/**
 	 * Get the minimum length of a bridge.
@@ -105,7 +106,7 @@ public:
 	 * @pre IsValidBridge(bridge_id).
 	 * @returns The minimum length the bridge has.
 	 */
-	static int32 GetMinLength(BridgeID bridge_id);
+	static SQInteger GetMinLength(BridgeID bridge_id);
 
 	/**
 	 * Internal function to help BuildBridge in case of road.

--- a/src/script/api/script_bridgelist.cpp
+++ b/src/script/api/script_bridgelist.cpp
@@ -21,11 +21,11 @@ ScriptBridgeList::ScriptBridgeList()
 	}
 }
 
-ScriptBridgeList_Length::ScriptBridgeList_Length(uint length)
+ScriptBridgeList_Length::ScriptBridgeList_Length(SQInteger length)
 {
 	for (byte j = 0; j < MAX_BRIDGES; j++) {
 		if (ScriptBridge::IsValidBridge(j)) {
-			if (length >= (uint)ScriptBridge::GetMinLength(j) && length <= (uint)ScriptBridge::GetMaxLength(j)) this->AddItem(j);
+			if (length >= ScriptBridge::GetMinLength(j) && length <= ScriptBridge::GetMaxLength(j)) this->AddItem(j);
 		}
 	}
 }

--- a/src/script/api/script_bridgelist.hpp
+++ b/src/script/api/script_bridgelist.hpp
@@ -32,7 +32,7 @@ public:
 	/**
 	 * @param length The length of the bridge you want to build.
 	 */
-	ScriptBridgeList_Length(uint length);
+	ScriptBridgeList_Length(SQInteger length);
 };
 
 #endif /* SCRIPT_BRIDGELIST_HPP */

--- a/src/script/api/script_cargo.cpp
+++ b/src/script/api/script_cargo.cpp
@@ -70,9 +70,12 @@
 	return (ScriptCargo::TownEffect)::CargoSpec::Get(cargo_type)->town_effect;
 }
 
-/* static */ Money ScriptCargo::GetCargoIncome(CargoID cargo_type, uint32 distance, uint32 days_in_transit)
+/* static */ Money ScriptCargo::GetCargoIncome(CargoID cargo_type, SQInteger distance, SQInteger days_in_transit)
 {
 	if (!IsValidCargo(cargo_type)) return -1;
+
+	distance = Clamp<SQInteger>(distance, 0, UINT32_MAX);
+
 	return ::GetTransportedGoodsIncome(1, distance, Clamp(days_in_transit * 2 / 5, 0, 255), cargo_type);
 }
 
@@ -82,8 +85,11 @@
 	return (ScriptCargo::DistributionType)_settings_game.linkgraph.GetDistributionType(cargo_type);
 }
 
-/* static */ int64 ScriptCargo::GetWeight(CargoID cargo_type, uint32 amount)
+/* static */ SQInteger ScriptCargo::GetWeight(CargoID cargo_type, SQInteger amount)
 {
 	if (!IsValidCargo(cargo_type)) return -1;
+
+	amount = Clamp<SQInteger>(amount, 0, UINT32_MAX);
+
 	return ::CargoSpec::Get(cargo_type)->WeightOfNUnits(amount);
 }

--- a/src/script/api/script_cargo.hpp
+++ b/src/script/api/script_cargo.hpp
@@ -142,10 +142,12 @@ public:
 	 * @param cargo_type The cargo to transport.
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @param distance The distance the cargo travels from begin to end.
-	 * @param days_in_transit Amount of (game) days the cargo is in transit. The max value of this variable is 637. Any value higher returns the same as 637 would.
+	 *                 The value will be clamped to 0 .. MAX(uint32).
+	 * @param days_in_transit Amount of (game) days the cargo is in transit.
+	 *                        The max value of this variable is 637. Any value higher returns the same as 637 would.
 	 * @return The amount of money that would be earned by this trip.
 	 */
-	static Money GetCargoIncome(CargoID cargo_type, uint32 distance, uint32 days_in_transit);
+	static Money GetCargoIncome(CargoID cargo_type, SQInteger distance, SQInteger days_in_transit);
 
 	/**
 	 * Get the cargo distribution type for a cargo.
@@ -159,10 +161,11 @@ public:
 	 *   cargo for the specified type.
 	 * @param cargo_type The cargo to check on.
 	 * @param amount The quantity of cargo.
+	 *               The value will be clamped to 0 .. MAX(uint32).
 	 * @pre ScriptCargo::IsValidCargo(cargo_type).
 	 * @return The weight in tonnes for that quantity of cargo.
 	 */
-	static int64 GetWeight(CargoID cargo_type, uint32 amount);
+	static SQInteger GetWeight(CargoID cargo_type, SQInteger amount);
 };
 
 #endif /* SCRIPT_CARGO_HPP */

--- a/src/script/api/script_cargomonitor.cpp
+++ b/src/script/api/script_cargomonitor.cpp
@@ -15,7 +15,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ int32 ScriptCargoMonitor::GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;
@@ -26,7 +26,7 @@
 	return GetDeliveryAmount(monitor, keep_monitoring);
 }
 
-/* static */ int32 ScriptCargoMonitor::GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;
@@ -37,7 +37,7 @@
 	return GetDeliveryAmount(monitor, keep_monitoring);
 }
 
-/* static */ int32 ScriptCargoMonitor::GetTownPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetTownPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;
@@ -48,7 +48,7 @@
 	return GetPickupAmount(monitor, keep_monitoring);
 }
 
-/* static */ int32 ScriptCargoMonitor::GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring)
+/* static */ SQInteger ScriptCargoMonitor::GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring)
 {
 	CompanyID cid = static_cast<CompanyID>(company);
 	if (cid >= MAX_COMPANIES) return -1;

--- a/src/script/api/script_cargomonitor.hpp
+++ b/src/script/api/script_cargomonitor.hpp
@@ -51,7 +51,7 @@ public:
 	 * @return Amount of delivered cargo of the given cargo type to the given town by the given company since the last call, or
 	 * \c -1 if a parameter is out-of-bound.
 	 */
-	static int32 GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring);
+	static SQInteger GetTownDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring);
 
 	/**
 	 * Get the amount of cargo delivered to an industry by a company since the last query, and update the monitoring state.
@@ -62,7 +62,7 @@ public:
 	 * @return Amount of delivered cargo of the given cargo type to the given industry by the given company since the last call, or
 	 * \c -1 if a parameter is out-of-bound.
 	 */
-	static int32 GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring);
+	static SQInteger GetIndustryDeliveryAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring);
 
 	/**
 	 * Get the amount of cargo picked up (and delivered) from a town by a company since the last query, and update the monitoring state.
@@ -74,7 +74,7 @@ public:
 	 * \c -1 if a parameter is out-of-bound.
 	 * @note Amounts of picked-up cargo are added during final delivery of it, to prevent users from getting credit for picking up without delivering it.
 	 */
-	static int32 GetTownPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring);
+	static SQInteger GetTownPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, TownID town_id, bool keep_monitoring);
 
 	/**
 	 * Get the amount of cargo picked up (and delivered) from an industry by a company since the last query, and update the monitoring state.
@@ -86,7 +86,7 @@ public:
 	 * \c -1 if a parameter is out-of-bound.
 	 * @note Amounts of picked-up cargo are added during final delivery of it, to prevent users from getting credit for picking up without delivering it.
 	 */
-	static int32 GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring);
+	static SQInteger GetIndustryPickupAmount(ScriptCompany::CompanyID company, CargoID cargo, IndustryID industry_id, bool keep_monitoring);
 
 	/** Stop monitoring everything. */
 	static void StopAllMonitoring();

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -114,11 +114,12 @@
 	return HasBit(ge, ::GENDER_FEMALE) ? GENDER_FEMALE : GENDER_MALE;
 }
 
-/* static */ Money ScriptCompany::GetQuarterlyIncome(ScriptCompany::CompanyID company, uint32 quarter)
+/* static */ Money ScriptCompany::GetQuarterlyIncome(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
+	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
 		return ::Company::Get(company)->cur_economy.income;
@@ -126,11 +127,12 @@
 	return ::Company::Get(company)->old_economy[quarter - 1].income;
 }
 
-/* static */ Money ScriptCompany::GetQuarterlyExpenses(ScriptCompany::CompanyID company, uint32 quarter)
+/* static */ Money ScriptCompany::GetQuarterlyExpenses(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
+	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
 		return ::Company::Get(company)->cur_economy.expenses;
@@ -138,11 +140,12 @@
 	return ::Company::Get(company)->old_economy[quarter - 1].expenses;
 }
 
-/* static */ int32 ScriptCompany::GetQuarterlyCargoDelivered(ScriptCompany::CompanyID company, uint32 quarter)
+/* static */ SQInteger ScriptCompany::GetQuarterlyCargoDelivered(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
+	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
 		return ::Company::Get(company)->cur_economy.delivered_cargo.GetSum<OverflowSafeInt32>();
@@ -150,21 +153,22 @@
 	return ::Company::Get(company)->old_economy[quarter - 1].delivered_cargo.GetSum<OverflowSafeInt32>();
 }
 
-/* static */ int32 ScriptCompany::GetQuarterlyPerformanceRating(ScriptCompany::CompanyID company, uint32 quarter)
+/* static */ SQInteger ScriptCompany::GetQuarterlyPerformanceRating(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
-	if (quarter == CURRENT_QUARTER) return -1;
+	if (quarter <= CURRENT_QUARTER) return -1;
 
 	return ::Company::Get(company)->old_economy[quarter - 1].performance_history;
 }
 
-/* static */ Money ScriptCompany::GetQuarterlyCompanyValue(ScriptCompany::CompanyID company, uint32 quarter)
+/* static */ Money ScriptCompany::GetQuarterlyCompanyValue(ScriptCompany::CompanyID company, SQInteger quarter)
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return -1;
 	if (quarter > EARLIEST_QUARTER) return -1;
+	if (quarter < CURRENT_QUARTER) return -1;
 
 	if (quarter == CURRENT_QUARTER) {
 		return ::CalculateCompanyValue(::Company::Get(company));
@@ -278,12 +282,13 @@
 	return ::Company::Get(company)->settings.engine_renew;
 }
 
-/* static */ bool ScriptCompany::SetAutoRenewMonths(int16 months)
+/* static */ bool ScriptCompany::SetAutoRenewMonths(SQInteger months)
 {
+	months = Clamp<SQInteger>(months, INT16_MIN, INT16_MAX);
 	return ScriptObject::Command<CMD_CHANGE_COMPANY_SETTING>::Do("company.engine_renew_months", months);
 }
 
-/* static */ int16 ScriptCompany::GetAutoRenewMonths(CompanyID company)
+/* static */ SQInteger ScriptCompany::GetAutoRenewMonths(CompanyID company)
 {
 	company = ResolveCompanyID(company);
 	if (company == COMPANY_INVALID) return 0;

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -263,7 +263,7 @@ public:
 	 * @pre quarter <= EARLIEST_QUARTER.
 	 * @return The gross income of the company in the given quarter.
 	 */
-	static Money GetQuarterlyIncome(CompanyID company, uint32 quarter);
+	static Money GetQuarterlyIncome(CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the expenses of the company in the given quarter.
@@ -276,7 +276,7 @@ public:
 	 * @pre quarter <= EARLIEST_QUARTER.
 	 * @return The expenses of the company in the given quarter.
 	 */
-	static Money GetQuarterlyExpenses(CompanyID company, uint32 quarter);
+	static Money GetQuarterlyExpenses(CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the amount of cargo delivered by the given company in the given quarter.
@@ -286,7 +286,7 @@ public:
 	 * @pre quarter <= EARLIEST_QUARTER.
 	 * @return The amount of cargo delivered by the given company in the given quarter.
 	 */
-	static int32 GetQuarterlyCargoDelivered(CompanyID company, uint32 quarter);
+	static SQInteger GetQuarterlyCargoDelivered(CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the performance rating of the given company in the given quarter.
@@ -298,7 +298,7 @@ public:
 	 * @note The performance rating is calculated after every quarter, so the value for CURRENT_QUARTER is undefined.
 	 * @return The performance rating of the given company in the given quarter.
 	 */
-	static int32 GetQuarterlyPerformanceRating(CompanyID company, uint32 quarter);
+	static SQInteger GetQuarterlyPerformanceRating(CompanyID company, SQInteger quarter);
 
 	/**
 	 * Get the value of the company in the given quarter.
@@ -308,7 +308,7 @@ public:
 	 * @pre quarter <= EARLIEST_QUARTER.
 	 * @return The value of the company in the given quarter.
 	 */
-	static Money GetQuarterlyCompanyValue(CompanyID company, uint32 quarter);
+	static Money GetQuarterlyCompanyValue(CompanyID company, SQInteger quarter);
 
 	/**
 	 * Build your company's HQ on the given tile.
@@ -351,10 +351,11 @@ public:
 	/**
 	 * Set the number of months before/after max age to autorenew an engine for your company.
 	 * @param months The new months between autorenew.
+	 *               The value will be clamped to MIN(int16) .. MAX(int16).
 	 * @return True if autorenew months has been modified.
 	 * @api -game
 	 */
-	static bool SetAutoRenewMonths(int16 months);
+	static bool SetAutoRenewMonths(SQInteger months);
 
 	/**
 	 * Return the number of months before/after max age to autorenew an engine for a company.
@@ -362,7 +363,7 @@ public:
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @return The months before/after max age of engine.
 	 */
-	static int16 GetAutoRenewMonths(CompanyID company);
+	static SQInteger GetAutoRenewMonths(CompanyID company);
 
 	/**
 	 * Set the minimum money needed to autorenew an engine for your company.

--- a/src/script/api/script_companymode.cpp
+++ b/src/script/api/script_companymode.cpp
@@ -13,13 +13,13 @@
 
 #include "../../safeguards.h"
 
-ScriptCompanyMode::ScriptCompanyMode(int company)
+ScriptCompanyMode::ScriptCompanyMode(SQInteger company)
 {
 	if (company < OWNER_BEGIN || company >= MAX_COMPANIES) company = INVALID_COMPANY;
 	if (!::Company::IsValidID(company)) company = INVALID_COMPANY;
 
 	this->last_company = ScriptObject::GetCompany();
-	ScriptObject::SetCompany((CompanyID)company);
+	ScriptObject::SetCompany((::CompanyID)company);
 }
 
 ScriptCompanyMode::~ScriptCompanyMode()

--- a/src/script/api/script_companymode.hpp
+++ b/src/script/api/script_companymode.hpp
@@ -40,7 +40,7 @@ public:
 	 * @note When the instance is destroyed, it restores the company that was
 	 *   current when the instance was created!
 	 */
-	ScriptCompanyMode(int company);
+	ScriptCompanyMode(SQInteger company);
 
 	/**
 	 * Destroying this instance reset the company to that what it was

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -48,6 +48,7 @@ class ScriptController {
 	friend class ScriptInstance;
 
 public:
+#ifndef DOXYGEN_API
 	/**
 	 * Initializer of the ScriptController.
 	 * @param company The company this Script is normally serving.
@@ -59,6 +60,7 @@ public:
 	 */
 	~ScriptController();
 
+#else
 	/**
 	 * This function is called to start your script. Your script starts here. If you
 	 *   return from this function, your script dies, so make sure that doesn't
@@ -67,7 +69,6 @@ public:
 	 */
 	void Start();
 
-#ifdef DOXYGEN_API
 	/**
 	 * Save the state of the script.
 	 *

--- a/src/script/api/script_date.cpp
+++ b/src/script/api/script_date.cpp
@@ -25,7 +25,7 @@
 	return (ScriptDate::Date)_date;
 }
 
-/* static */ int32 ScriptDate::GetYear(ScriptDate::Date date)
+/* static */ SQInteger ScriptDate::GetYear(ScriptDate::Date date)
 {
 	if (date < 0) return DATE_INVALID;
 
@@ -34,7 +34,7 @@
 	return ymd.year;
 }
 
-/* static */ int32 ScriptDate::GetMonth(ScriptDate::Date date)
+/* static */ SQInteger ScriptDate::GetMonth(ScriptDate::Date date)
 {
 	if (date < 0) return DATE_INVALID;
 
@@ -43,7 +43,7 @@
 	return ymd.month + 1;
 }
 
-/* static */ int32 ScriptDate::GetDayOfMonth(ScriptDate::Date date)
+/* static */ SQInteger ScriptDate::GetDayOfMonth(ScriptDate::Date date)
 {
 	if (date < 0) return DATE_INVALID;
 
@@ -52,7 +52,7 @@
 	return ymd.day;
 }
 
-/* static */ ScriptDate::Date ScriptDate::GetDate(int32 year, int32 month, int32 day_of_month)
+/* static */ ScriptDate::Date ScriptDate::GetDate(SQInteger year, SQInteger month, SQInteger day_of_month)
 {
 	if (month < 1 || month > 12) return DATE_INVALID;
 	if (day_of_month < 1 || day_of_month > 31) return DATE_INVALID;
@@ -61,7 +61,7 @@
 	return (ScriptDate::Date)::ConvertYMDToDate(year, month - 1, day_of_month);
 }
 
-/* static */ int32 ScriptDate::GetSystemTime()
+/* static */ SQInteger ScriptDate::GetSystemTime()
 {
 	time_t t;
 	time(&t);

--- a/src/script/api/script_date.hpp
+++ b/src/script/api/script_date.hpp
@@ -55,21 +55,21 @@ public:
 	 * @param date The date to get the year of.
 	 * @return The year.
 	 */
-	static int32 GetYear(Date date);
+	static SQInteger GetYear(Date date);
 
 	/**
 	 * Get the month of the given date.
 	 * @param date The date to get the month of.
 	 * @return The month.
 	 */
-	static int32 GetMonth(Date date);
+	static SQInteger GetMonth(Date date);
 
 	/**
 	 * Get the day (of the month) of the given date.
 	 * @param date The date to get the day of.
 	 * @return The day.
 	 */
-	static int32 GetDayOfMonth(Date date);
+	static SQInteger GetDayOfMonth(Date date);
 
 	/**
 	 * Get the date given a year, month and day of month.
@@ -78,7 +78,7 @@ public:
 	 * @param day_of_month The day of month of the to-be determined date.
 	 * @return The date.
 	 */
-	static Date GetDate(int32 year, int32 month, int32 day_of_month);
+	static Date GetDate(SQInteger year, SQInteger month, SQInteger day_of_month);
 
 	/**
 	 * Get the time of the host system.
@@ -86,7 +86,7 @@ public:
 	 * @api -ai
 	 * @note This uses the clock of the host system, which can skew or be set back. Use with caution.
 	 */
-	static int32 GetSystemTime();
+	static SQInteger GetSystemTime();
 };
 
 #endif /* SCRIPT_DATE_HPP */

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -83,7 +83,7 @@
 }
 
 
-/* static */ int32 ScriptEngine::GetCapacity(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetCapacity(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 
@@ -107,7 +107,7 @@
 	}
 }
 
-/* static */ int32 ScriptEngine::GetReliability(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetReliability(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 	if (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL && IsWagon(engine_id)) return -1;
@@ -115,12 +115,12 @@
 	return ::ToPercent16(::Engine::Get(engine_id)->reliability);
 }
 
-/* static */ int32 ScriptEngine::GetMaxSpeed(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetMaxSpeed(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 
 	const Engine *e = ::Engine::Get(engine_id);
-	int32 max_speed = e->GetDisplayMaxSpeed(); // km-ish/h
+	uint max_speed = e->GetDisplayMaxSpeed(); // km-ish/h
 	if (e->type == VEH_AIRCRAFT) max_speed /= _settings_game.vehicle.plane_speed;
 	return max_speed;
 }
@@ -132,7 +132,7 @@
 	return ::Engine::Get(engine_id)->GetCost();
 }
 
-/* static */ int32 ScriptEngine::GetMaxAge(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetMaxAge(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 	if (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL && IsWagon(engine_id)) return -1;
@@ -147,7 +147,7 @@
 	return ::Engine::Get(engine_id)->GetRunningCost();
 }
 
-/* static */ int32 ScriptEngine::GetPower(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetPower(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL && GetVehicleType(engine_id) != ScriptVehicle::VT_ROAD) return -1;
@@ -156,7 +156,7 @@
 	return ::Engine::Get(engine_id)->GetPower();
 }
 
-/* static */ int32 ScriptEngine::GetWeight(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetWeight(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL && GetVehicleType(engine_id) != ScriptVehicle::VT_ROAD) return -1;
@@ -164,7 +164,7 @@
 	return ::Engine::Get(engine_id)->GetDisplayWeight();
 }
 
-/* static */ int32 ScriptEngine::GetMaxTractiveEffort(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetMaxTractiveEffort(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return -1;
 	if (GetVehicleType(engine_id) != ScriptVehicle::VT_RAIL && GetVehicleType(engine_id) != ScriptVehicle::VT_ROAD) return -1;
@@ -265,17 +265,12 @@
 	return (ScriptAirport::PlaneType)::AircraftVehInfo(engine_id)->subtype;
 }
 
-/* static */ uint ScriptEngine::GetMaximumOrderDistance(EngineID engine_id)
+/* static */ SQInteger ScriptEngine::GetMaximumOrderDistance(EngineID engine_id)
 {
 	if (!IsValidEngine(engine_id)) return 0;
+	if (GetVehicleType(engine_id) != ScriptVehicle::VT_AIR) return 0;
 
-	switch (GetVehicleType(engine_id)) {
-		case ScriptVehicle::VT_AIR:
-			return ::Engine::Get(engine_id)->GetRange() * ::Engine::Get(engine_id)->GetRange();
-
-		default:
-			return 0;
-	}
+	return (SQInteger)::Engine::Get(engine_id)->GetRange() * ::Engine::Get(engine_id)->GetRange();
 }
 
 /* static */ bool ScriptEngine::EnableForCompany(EngineID engine_id, ScriptCompany::CompanyID company)

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -89,7 +89,7 @@ public:
 	 * @pre IsValidEngine(engine_id).
 	 * @return The capacity of the engine.
 	 */
-	static int32 GetCapacity(EngineID engine_id);
+	static SQInteger GetCapacity(EngineID engine_id);
 
 	/**
 	 * Get the reliability of an engine. The value is between 0 and 100, where
@@ -100,7 +100,7 @@ public:
 	 * @pre GetVehicleType(engine_id) != ScriptVehicle::VT_TRAIN || !IsWagon(engine_id).
 	 * @return The reliability the engine has.
 	 */
-	static int32 GetReliability(EngineID engine_id);
+	static SQInteger GetReliability(EngineID engine_id);
 
 	/**
 	 * Get the maximum speed of an engine.
@@ -111,7 +111,7 @@ public:
 	 *       This is mph / 1.6, which is roughly km/h.
 	 *       To get km/h multiply this number by 1.00584.
 	 */
-	static int32 GetMaxSpeed(EngineID engine_id);
+	static SQInteger GetMaxSpeed(EngineID engine_id);
 
 	/**
 	 * Get the new cost of an engine.
@@ -128,7 +128,7 @@ public:
 	 * @returns The maximum age of a new engine in days.
 	 * @note Age is in days; divide by 366 to get per year.
 	 */
-	static int32 GetMaxAge(EngineID engine_id);
+	static SQInteger GetMaxAge(EngineID engine_id);
 
 	/**
 	 * Get the running cost of an engine.
@@ -146,7 +146,7 @@ public:
 	 * @pre (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL || GetVehicleType(engine_id) == ScriptVehicle::VT_ROAD) && !IsWagon(engine_id).
 	 * @return The power of the engine in hp.
 	 */
-	static int32 GetPower(EngineID engine_id);
+	static SQInteger GetPower(EngineID engine_id);
 
 	/**
 	 * Get the weight of an engine.
@@ -155,7 +155,7 @@ public:
 	 * @pre (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL || GetVehicleType(engine_id) == ScriptVehicle::VT_ROAD).
 	 * @return The weight of the engine in metric tons.
 	 */
-	static int32 GetWeight(EngineID engine_id);
+	static SQInteger GetWeight(EngineID engine_id);
 
 	/**
 	 * Get the maximum tractive effort of an engine.
@@ -164,7 +164,7 @@ public:
 	 * @pre (GetVehicleType(engine_id) == ScriptVehicle::VT_RAIL || GetVehicleType(engine_id) == ScriptVehicle::VT_ROAD) && !IsWagon(engine_id).
 	 * @return The maximum tractive effort of the engine in kN.
 	 */
-	static int32 GetMaxTractiveEffort(EngineID engine_id);
+	static SQInteger GetMaxTractiveEffort(EngineID engine_id);
 
 	/**
 	 * Get the date this engine was designed.
@@ -286,7 +286,7 @@ public:
 	 *         not be compared with map distances
 	 * @see ScriptOrder::GetOrderDistance
 	 */
-	static uint GetMaximumOrderDistance(EngineID engine_id);
+	static SQInteger GetMaximumOrderDistance(EngineID engine_id);
 
 	/**
 	 * Allows a company to use an engine before its intro date or after retirement.

--- a/src/script/api/script_gamesettings.cpp
+++ b/src/script/api/script_gamesettings.cpp
@@ -22,7 +22,7 @@
 	return sd != nullptr && sd->IsIntSetting();
 }
 
-/* static */ int32 ScriptGameSettings::GetValue(const char *setting)
+/* static */ SQInteger ScriptGameSettings::GetValue(const char *setting)
 {
 	if (!IsValid(setting)) return -1;
 
@@ -31,7 +31,7 @@
 	return sd->AsIntSetting()->Read(&_settings_game);
 }
 
-/* static */ bool ScriptGameSettings::SetValue(const char *setting, int value)
+/* static */ bool ScriptGameSettings::SetValue(const char *setting, SQInteger value)
 {
 	if (!IsValid(setting)) return false;
 
@@ -39,6 +39,8 @@
 	assert(sd != nullptr);
 
 	if ((sd->flags & SF_NO_NETWORK_SYNC) != 0) return false;
+
+	value = Clamp<SQInteger>(value, INT32_MIN, INT32_MAX);
 
 	return ScriptObject::Command<CMD_CHANGE_SETTING>::Do(sd->GetName(), value);
 }

--- a/src/script/api/script_gamesettings.hpp
+++ b/src/script/api/script_gamesettings.hpp
@@ -57,18 +57,19 @@ public:
 	 * @note Results achieved in the past offer no guarantee for the future.
 	 * @return The value for the setting.
 	 */
-	static int32 GetValue(const char *setting);
+	static SQInteger GetValue(const char *setting);
 
 	/**
 	 * Sets the value of the game setting.
 	 * @param setting The setting to set the value of.
 	 * @param value The value to set the setting to.
+	 *              The value will be clamped to MIN(int32) .. MAX(int32).
 	 * @pre IsValid(setting).
 	 * @return True if the action succeeded.
 	 * @note Results achieved in the past offer no guarantee for the future.
 	 * @api -ai
 	 */
-	static bool SetValue(const char *setting, int value);
+	static bool SetValue(const char *setting, SQInteger value);
 
 	/**
 	 * Checks whether the given vehicle-type is disabled for companies.

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -28,7 +28,7 @@
 	return ::Goal::IsValidID(goal_id);
 }
 
-/* static */ ScriptGoal::GoalID ScriptGoal::New(ScriptCompany::CompanyID company, Text *goal, GoalType type, uint32 destination)
+/* static */ ScriptGoal::GoalID ScriptGoal::New(ScriptCompany::CompanyID company, Text *goal, GoalType type, SQInteger destination)
 {
 	CCountedPtr<Text> counter(goal);
 
@@ -104,7 +104,7 @@
 	return g != nullptr && g->completed;
 }
 
-/* static */ bool ScriptGoal::DoQuestion(uint16 uniqueid, uint32 target, bool is_client, Text *question, QuestionType type, uint32 buttons)
+/* static */ bool ScriptGoal::DoQuestion(SQInteger uniqueid, uint32 target, bool is_client, Text *question, QuestionType type, SQInteger buttons)
 {
 	CCountedPtr<Text> counter(question);
 
@@ -114,13 +114,14 @@
 	EnforcePreconditionEncodedText(false, text);
 	uint min_buttons = (type == QT_QUESTION ? 1 : 0);
 	EnforcePrecondition(false, CountBits(buttons) >= min_buttons && CountBits(buttons) <= 3);
-	EnforcePrecondition(false, buttons < (1 << ::GOAL_QUESTION_BUTTON_COUNT));
+	EnforcePrecondition(false, buttons >= 0 && buttons < (1 << ::GOAL_QUESTION_BUTTON_COUNT));
 	EnforcePrecondition(false, (int)type < ::GQT_END);
+	EnforcePrecondition(false, uniqueid >= 0 && uniqueid <= UINT16_MAX);
 
 	return ScriptObject::Command<CMD_GOAL_QUESTION>::Do(uniqueid, target, is_client, buttons, (::GoalQuestionType)type, text);
 }
 
-/* static */ bool ScriptGoal::Question(uint16 uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, int buttons)
+/* static */ bool ScriptGoal::Question(SQInteger uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, SQInteger buttons)
 {
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 	uint8 c = company;
@@ -129,16 +130,17 @@
 	return DoQuestion(uniqueid, c, false, question, type, buttons);
 }
 
-/* static */ bool ScriptGoal::QuestionClient(uint16 uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, int buttons)
+/* static */ bool ScriptGoal::QuestionClient(SQInteger uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, SQInteger buttons)
 {
 	EnforcePrecondition(false, ScriptGame::IsMultiplayer());
 	EnforcePrecondition(false, ScriptClient::ResolveClientID(client) != ScriptClient::CLIENT_INVALID);
 	return DoQuestion(uniqueid, client, true, question, type, buttons);
 }
 
-/* static */ bool ScriptGoal::CloseQuestion(uint16 uniqueid)
+/* static */ bool ScriptGoal::CloseQuestion(SQInteger uniqueid)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforcePrecondition(false, uniqueid >= 0 && uniqueid <= UINT16_MAX);
 
 	return ScriptObject::Command<CMD_GOAL_QUESTION_ANSWER>::Do(uniqueid, 0);
 }

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -103,7 +103,7 @@ public:
 	 *       \li Global goals can only reference global story pages.
 	 *       \li Company specific goals can reference global story pages and story pages of the same company.
 	 */
-	static GoalID New(ScriptCompany::CompanyID company, Text *goal, GoalType type, uint32 destination);
+	static GoalID New(ScriptCompany::CompanyID company, Text *goal, GoalType type, SQInteger destination);
 
 	/**
 	 * Remove a goal from the list.
@@ -170,10 +170,11 @@ public:
 	 * @pre question != null && len(question) != 0.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
+	 * @pre uniqueid >= 0 && uniqueid <= MAX(uint16)
 	 * @note Replies to the question are given by you via the event ScriptEventGoalQuestionAnswer.
 	 * @note There is no guarantee you ever get a reply on your question.
 	 */
-	static bool Question(uint16 uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, int buttons);
+	static bool Question(SQInteger uniqueid, ScriptCompany::CompanyID company, Text *question, QuestionType type, SQInteger buttons);
 
 	/**
 	 * Ask client a question.
@@ -188,28 +189,30 @@ public:
 	 * @pre question != null && len(question) != 0.
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
+	 * @pre uniqueid >= 0 && uniqueid <= MAX(uint16)
 	 * @note Replies to the question are given by you via the event ScriptEventGoalQuestionAnswer.
 	 * @note There is no guarantee you ever get a reply on your question.
 	 */
-	static bool QuestionClient(uint16 uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, int buttons);
+	static bool QuestionClient(SQInteger uniqueid, ScriptClient::ClientID client, Text *question, QuestionType type, SQInteger buttons);
 
 	/**
 	 * Close the question on all clients.
 	 * @param uniqueid The uniqueid of the question you want to close.
 	 * @return True if the action succeeded.
 	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre uniqueid >= 0 && uniqueid <= MAX(uint16)
 	 * @note If you send a question to a single company, and get a reply for them,
 	 *   the question is already closed on all clients. Only use this function if
 	 *   you want to timeout a question, or if you send the question to all
 	 *   companies, but you are only interested in the reply of the first.
 	 */
-	static bool CloseQuestion(uint16 uniqueid);
+	static bool CloseQuestion(SQInteger uniqueid);
 
 protected:
 	/**
 	 * Does common checks and asks the question.
 	 */
-	static bool DoQuestion(uint16 uniqueid, uint32 target, bool is_client, Text *question, QuestionType type, uint32 buttons);
+	static bool DoQuestion(SQInteger uniqueid, uint32 target, bool is_client, Text *question, QuestionType type, SQInteger buttons);
 };
 
 #endif /* SCRIPT_GOAL_HPP */

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -102,14 +102,14 @@
 	return HasBit(::Group::Get(group_id)->flags, GroupFlags::GF_REPLACE_PROTECTION);
 }
 
-/* static */ int32 ScriptGroup::GetNumEngines(GroupID group_id, EngineID engine_id)
+/* static */ SQInteger ScriptGroup::GetNumEngines(GroupID group_id, EngineID engine_id)
 {
 	if (!IsValidGroup(group_id) && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
 
 	return GetGroupNumEngines(ScriptObject::GetCompany(), group_id, engine_id);
 }
 
-/* static */ int32 ScriptGroup::GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type)
+/* static */ SQInteger ScriptGroup::GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type)
 {
 	bool valid_group = IsValidGroup(group_id);
 	if (!valid_group && group_id != GROUP_DEFAULT && group_id != GROUP_ALL) return -1;
@@ -183,7 +183,7 @@
 	return ::Group::Get(group_id)->statistics.profit_last_year;
 }
 
-/* static */ uint32 ScriptGroup::GetCurrentUsage(GroupID group_id)
+/* static */ SQInteger ScriptGroup::GetCurrentUsage(GroupID group_id)
 {
 	if (!IsValidGroup(group_id)) return -1;
 

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -126,7 +126,7 @@ public:
 	 * @pre IsValidGroup(group_id) || group_id == GROUP_ALL || group_id == GROUP_DEFAULT.
 	 * @return The number of engines with id engine_id in the group with id group_id.
 	 */
-	static int32 GetNumEngines(GroupID group_id, EngineID engine_id);
+	static SQInteger GetNumEngines(GroupID group_id, EngineID engine_id);
 
 	/**
 	 * Get the total number of vehicles in a given group and its sub-groups.
@@ -140,7 +140,7 @@ public:
 	 *  vehicle_type is retrieved from the group itself and not from the input value.
 	 *  But if the group is GROUP_ALL or GROUP_DEFAULT, then vehicle_type must be valid.
 	 */
-	static int32 GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type);
+	static SQInteger GetNumVehicles(GroupID group_id, ScriptVehicle::VehicleType vehicle_type);
 
 	/**
 	 * Move a vehicle to a group.
@@ -225,7 +225,7 @@ public:
 	 * @pre IsValidGroup(group_id).
 	 * @return The current usage of the group.
 	 */
-	static uint32 GetCurrentUsage(GroupID group_id);
+	static SQInteger GetCurrentUsage(GroupID group_id);
 
 	/**
 	 * Set primary colour for a group.

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -25,9 +25,9 @@
 
 #include "../../safeguards.h"
 
-/* static */ int32 ScriptIndustry::GetIndustryCount()
+/* static */ SQInteger ScriptIndustry::GetIndustryCount()
 {
-	return (int32)::Industry::GetNumItems();
+	return ::Industry::GetNumItems();
 }
 
 /* static */ bool ScriptIndustry::IsValidIndustry(IndustryID industry_id)
@@ -75,7 +75,7 @@
 	return CAS_NOT_ACCEPTED;
 }
 
-/* static */ int32 ScriptIndustry::GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -91,7 +91,7 @@
 	return -1;
 }
 
-/* static */ int32 ScriptIndustry::GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -105,7 +105,7 @@
 	return -1;
 }
 
-/* static */ int32 ScriptIndustry::GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -119,7 +119,7 @@
 	return -1;
 }
 
-/* static */ int32 ScriptIndustry::GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id)
+/* static */ SQInteger ScriptIndustry::GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -140,22 +140,22 @@
 	return ::Industry::Get(industry_id)->location.tile;
 }
 
-/* static */ int32 ScriptIndustry::GetAmountOfStationsAround(IndustryID industry_id)
+/* static */ SQInteger ScriptIndustry::GetAmountOfStationsAround(IndustryID industry_id)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 
 	Industry *ind = ::Industry::Get(industry_id);
-	return (int32)ind->stations_near.size();
+	return ind->stations_near.size();
 }
 
-/* static */ int32 ScriptIndustry::GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile)
+/* static */ SQInteger ScriptIndustry::GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 
 	return ScriptMap::DistanceManhattan(tile, GetLocation(industry_id));
 }
 
-/* static */ int32 ScriptIndustry::GetDistanceSquareToTile(IndustryID industry_id, TileIndex tile)
+/* static */ SQInteger ScriptIndustry::GetDistanceSquareToTile(IndustryID industry_id, TileIndex tile)
 {
 	if (!IsValidIndustry(industry_id)) return -1;
 
@@ -220,14 +220,14 @@
 	return ::Industry::Get(industry_id)->type;
 }
 
-int32 ScriptIndustry::GetLastProductionYear(IndustryID industry_id)
+/* static */ SQInteger ScriptIndustry::GetLastProductionYear(IndustryID industry_id)
 {
 	Industry *i = Industry::GetIfValid(industry_id);
 	if (i == nullptr) return 0;
 	return i->last_prod_year;
 }
 
-ScriptDate::Date ScriptIndustry::GetCargoLastAcceptedDate(IndustryID industry_id, CargoID cargo_type)
+/* static */ ScriptDate::Date ScriptIndustry::GetCargoLastAcceptedDate(IndustryID industry_id, CargoID cargo_type)
 {
 	Industry *i = Industry::GetIfValid(industry_id);
 	if (i == nullptr) return ScriptDate::DATE_INVALID;
@@ -241,14 +241,14 @@ ScriptDate::Date ScriptIndustry::GetCargoLastAcceptedDate(IndustryID industry_id
 	}
 }
 
-uint32 ScriptIndustry::GetControlFlags(IndustryID industry_id)
+/* static */ SQInteger ScriptIndustry::GetControlFlags(IndustryID industry_id)
 {
 	Industry *i = Industry::GetIfValid(industry_id);
 	if (i == nullptr) return 0;
 	return i->ctlflags;
 }
 
-bool ScriptIndustry::SetControlFlags(IndustryID industry_id, uint32 control_flags)
+/* static */ bool ScriptIndustry::SetControlFlags(IndustryID industry_id, SQInteger control_flags)
 {
 	if (ScriptObject::GetCompany() != OWNER_DEITY) return false;
 	if (!IsValidIndustry(industry_id)) return false;

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -54,7 +54,7 @@ public:
 	 * @return The number of industries.
 	 * @note The maximum valid IndustryID can be higher than the value returned.
 	 */
-	static int32 GetIndustryCount();
+	static SQInteger GetIndustryCount();
 
 	/**
 	 * Checks whether the given industry index is valid.
@@ -109,7 +109,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The amount of cargo that is waiting for processing.
 	 */
-	static int32 GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id);
 
 	/**
 	 * Get the total last month's production of the given cargo at an industry.
@@ -119,7 +119,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The last month's production of the given cargo for this industry.
 	 */
-	static int32 GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id);
 
 	/**
 	 * Get the total amount of cargo transported from an industry last month.
@@ -129,7 +129,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The amount of given cargo transported from this industry last month.
 	 */
-	static int32 GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id);
 
 	/**
 	 * Get the percentage of cargo transported from an industry last month.
@@ -139,7 +139,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The percentage of given cargo transported from this industry last month.
 	 */
-	static int32 GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id);
+	static SQInteger GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id);
 
 	/**
 	 * Gets the location of the industry.
@@ -157,7 +157,7 @@ public:
 	 * @pre IsValidIndustry(industry_id).
 	 * @return The number of stations around an industry.
 	 */
-	static int32 GetAmountOfStationsAround(IndustryID industry_id);
+	static SQInteger GetAmountOfStationsAround(IndustryID industry_id);
 
 	/**
 	 * Get the manhattan distance from the tile to the ScriptIndustry::GetLocation()
@@ -168,7 +168,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @return The distance between industry and tile.
 	 */
-	static int32 GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile);
+	static SQInteger GetDistanceManhattanToTile(IndustryID industry_id, TileIndex tile);
 
 	/**
 	 * Get the square distance from the tile to the ScriptIndustry::GetLocation()
@@ -179,7 +179,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @return The distance between industry and tile.
 	 */
-	static int32 GetDistanceSquareToTile(IndustryID industry_id, TileIndex tile);
+	static SQInteger GetDistanceSquareToTile(IndustryID industry_id, TileIndex tile);
 
 	/**
 	 * Is this industry built on water.
@@ -238,7 +238,7 @@ public:
 	 * @return Year the industry last had production, 0 if error.
 	 * @api -ai
 	 */
-	static int32 GetLastProductionYear(IndustryID industry_id);
+	static SQInteger GetLastProductionYear(IndustryID industry_id);
 
 	/**
 	 * Get the last date this industry accepted any cargo delivery.
@@ -258,7 +258,7 @@ public:
 	 * @return Bit flags of the IndustryControlFlags enumeration.
 	 * @api -ai
 	 */
-	static uint32 GetControlFlags(IndustryID industry_id);
+	static SQInteger GetControlFlags(IndustryID industry_id);
 
 	/**
 	 * Change the control flags for an industry.
@@ -269,7 +269,7 @@ public:
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
-	static bool SetControlFlags(IndustryID industry_id, uint32 control_flags);
+	static bool SetControlFlags(IndustryID industry_id, SQInteger control_flags);
 
 	/**
 	 * Find out which company currently has the exclusive rights to deliver cargo to the industry.

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -156,10 +156,10 @@
 	return (::GetIndustrySpec(industry_type)->behaviour & INDUSTRYBEH_AI_AIRSHIP_ROUTES) != 0;
 }
 
-/* static */ IndustryType ScriptIndustryType::ResolveNewGRFID(uint32 grfid, uint16 grf_local_id)
+/* static */ IndustryType ScriptIndustryType::ResolveNewGRFID(SQInteger grfid, SQInteger grf_local_id)
 {
 	EnforcePrecondition(INVALID_INDUSTRYTYPE, IsInsideBS(grf_local_id, 0x00, NUM_INDUSTRYTYPES_PER_GRF));
 
-	grfid = BSWAP32(grfid); // Match people's expectations.
+	grfid = BSWAP32(GB(grfid, 0, 32)); // Match people's expectations.
 	return _industry_mngr.GetID(grf_local_id, grfid);
 }

--- a/src/script/api/script_industrytype.hpp
+++ b/src/script/api/script_industrytype.hpp
@@ -189,7 +189,7 @@ public:
 	 * @pre 0x00 <= grf_local_id < NUM_INDUSTRYTYPES_PER_GRF.
 	 * @return the industry-type ID, local to the current game (this diverges from the grf_local_id).
 	 */
-	static IndustryType ResolveNewGRFID(uint32 grfid, uint16 grf_local_id);
+	static IndustryType ResolveNewGRFID(SQInteger grfid, SQInteger grf_local_id);
 };
 
 #endif /* SCRIPT_INDUSTRYTYPE_HPP */

--- a/src/script/api/script_infrastructure.cpp
+++ b/src/script/api/script_infrastructure.cpp
@@ -18,7 +18,7 @@
 #include "../../safeguards.h"
 
 
-/* static */ uint32 ScriptInfrastructure::GetRailPieceCount(ScriptCompany::CompanyID company, ScriptRail::RailType railtype)
+/* static */ SQInteger ScriptInfrastructure::GetRailPieceCount(ScriptCompany::CompanyID company, ScriptRail::RailType railtype)
 {
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || (::RailType)railtype >= RAILTYPE_END) return 0;
@@ -26,7 +26,7 @@
 	return ::Company::Get((::CompanyID)company)->infrastructure.rail[railtype];
 }
 
-/* static */ uint32 ScriptInfrastructure::GetRoadPieceCount(ScriptCompany::CompanyID company, ScriptRoad::RoadType roadtype)
+/* static */ SQInteger ScriptInfrastructure::GetRoadPieceCount(ScriptCompany::CompanyID company, ScriptRoad::RoadType roadtype)
 {
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID || (::RoadType)roadtype >= ROADTYPE_END) return 0;
@@ -34,7 +34,7 @@
 	return ::Company::Get((::CompanyID)company)->infrastructure.road[roadtype];
 }
 
-/* static */ uint32 ScriptInfrastructure::GetInfrastructurePieceCount(ScriptCompany::CompanyID company, Infrastructure infra_type)
+/* static */ SQInteger ScriptInfrastructure::GetInfrastructurePieceCount(ScriptCompany::CompanyID company, Infrastructure infra_type)
 {
 	company = ScriptCompany::ResolveCompanyID(company);
 	if (company == ScriptCompany::COMPANY_INVALID) return 0;

--- a/src/script/api/script_infrastructure.hpp
+++ b/src/script/api/script_infrastructure.hpp
@@ -35,7 +35,7 @@ public:
 	 * @param railtype Rail type to get the count of.
 	 * @return Count for the rail type.
 	 */
-	static uint32 GetRailPieceCount(ScriptCompany::CompanyID company, ScriptRail::RailType railtype);
+	static SQInteger GetRailPieceCount(ScriptCompany::CompanyID company, ScriptRail::RailType railtype);
 
 	/**
 	 * Return the number of road pieces of a specific road type for a company.
@@ -43,7 +43,7 @@ public:
 	 * @param roadtype Road type to get the count of.
 	 * @return Count for the road type.
 	 */
-	static uint32 GetRoadPieceCount(ScriptCompany::CompanyID company, ScriptRoad::RoadType roadtype);
+	static SQInteger GetRoadPieceCount(ScriptCompany::CompanyID company, ScriptRoad::RoadType roadtype);
 
 	/**
 	 * Return the number of pieces of an infrastructure category for a company.
@@ -52,7 +52,7 @@ public:
 	 * @return Count for the wanted category.
 	 * @note #INFRASTRUCTURE_RAIL and #INFRASTRUCTURE_ROAD return the total count for all rail/road types.
 	 */
-	static uint32 GetInfrastructurePieceCount(ScriptCompany::CompanyID company, Infrastructure infra_type);
+	static SQInteger GetInfrastructurePieceCount(ScriptCompany::CompanyID company, Infrastructure infra_type);
 
 	/**
 	 * Return the monthly maintenance costs of a specific rail type for a company.

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -49,7 +49,7 @@
 	return ::LeagueTableElement::IsValidID(element_id);
 }
 
-/* static */ ScriptLeagueTable::LeagueTableElementID ScriptLeagueTable::NewElement(ScriptLeagueTable::LeagueTableID table, int64 rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, uint32 link_target)
+/* static */ ScriptLeagueTable::LeagueTableElementID ScriptLeagueTable::NewElement(ScriptLeagueTable::LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, LinkTargetID link_target)
 {
 	CCountedPtr<Text> text_counter(text);
 	CCountedPtr<Text> score_counter(score);
@@ -98,7 +98,7 @@
 	return ScriptObject::Command<CMD_UPDATE_LEAGUE_TABLE_ELEMENT_DATA>::Do(element, c, encoded_text, (::LinkType)link_type, (::LinkTargetID)link_target);
 }
 
-/* static */ bool ScriptLeagueTable::UpdateElementScore(LeagueTableElementID element, int64 rating, Text *score)
+/* static */ bool ScriptLeagueTable::UpdateElementScore(LeagueTableElementID element, SQInteger rating, Text *score)
 {
 	CCountedPtr<Text> score_counter(score);
 

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -92,7 +92,7 @@ public:
 	 * @pre score != null && len(score) != 0.
 	 * @pre IsValidLink(Link(link_type, link_target)).
 	 */
-	static LeagueTableElementID NewElement(LeagueTableID table, int64 rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, LinkTargetID link_target);
+	static LeagueTableElementID NewElement(LeagueTableID table, SQInteger rating, ScriptCompany::CompanyID company, Text *text, Text *score, LinkType link_type, LinkTargetID link_target);
 
 	/**
 	 * Update the attributes of a league table element.
@@ -119,7 +119,7 @@ public:
 	 * @pre IsValidLeagueTableElement(element).
 	 * @pre score != null && len(score) != 0.
 	 */
-	static bool UpdateElementScore(LeagueTableElementID element, int64 rating, Text *score);
+	static bool UpdateElementScore(LeagueTableElementID element, SQInteger rating, Text *score);
 
 
 	/**

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -22,7 +22,7 @@ class ScriptListSorter {
 protected:
 	ScriptList *list;       ///< The list that's being sorted.
 	bool has_no_more_items; ///< Whether we have more items to iterate over.
-	int64 item_next;        ///< The next item we will show.
+	SQInteger item_next;    ///< The next item we will show.
 
 public:
 	/**
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Get the first item of the sorter.
 	 */
-	virtual int64 Begin() = 0;
+	virtual SQInteger Begin() = 0;
 
 	/**
 	 * Stop iterating a sorter.
@@ -43,7 +43,7 @@ public:
 	/**
 	 * Get the next item of the sorter.
 	 */
-	virtual int64 Next() = 0;
+	virtual SQInteger Next() = 0;
 
 	/**
 	 * See if the sorter has reached the end.
@@ -56,7 +56,7 @@ public:
 	/**
 	 * Callback from the list if an item gets removed.
 	 */
-	virtual void Remove(int item) = 0;
+	virtual void Remove(SQInteger item) = 0;
 
 	/**
 	 * Attach the sorter to a new list. This assumes the content of the old list has been moved to
@@ -90,7 +90,7 @@ public:
 		this->End();
 	}
 
-	int64 Begin()
+	SQInteger Begin()
 	{
 		if (this->list->buckets.empty()) return 0;
 		this->has_no_more_items = false;
@@ -100,7 +100,7 @@ public:
 		this->bucket_list_iter = this->bucket_list->begin();
 		this->item_next = *this->bucket_list_iter;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
@@ -135,16 +135,16 @@ public:
 		this->item_next = *this->bucket_list_iter;
 	}
 
-	int64 Next()
+	SQInteger Next()
 	{
 		if (this->IsEnd()) return 0;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
 
-	void Remove(int item)
+	void Remove(SQInteger item)
 	{
 		if (this->IsEnd()) return;
 
@@ -179,7 +179,7 @@ public:
 		this->End();
 	}
 
-	int64 Begin()
+	SQInteger Begin()
 	{
 		if (this->list->buckets.empty()) return 0;
 		this->has_no_more_items = false;
@@ -194,7 +194,7 @@ public:
 		--this->bucket_list_iter;
 		this->item_next = *this->bucket_list_iter;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
@@ -232,16 +232,16 @@ public:
 		this->item_next = *this->bucket_list_iter;
 	}
 
-	int64 Next()
+	SQInteger Next()
 	{
 		if (this->IsEnd()) return 0;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
 
-	void Remove(int item)
+	void Remove(SQInteger item)
 	{
 		if (this->IsEnd()) return;
 
@@ -271,7 +271,7 @@ public:
 		this->End();
 	}
 
-	int64 Begin()
+	SQInteger Begin()
 	{
 		if (this->list->items.empty()) return 0;
 		this->has_no_more_items = false;
@@ -279,7 +279,7 @@ public:
 		this->item_iter = this->list->items.begin();
 		this->item_next = (*this->item_iter).first;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
@@ -302,16 +302,16 @@ public:
 		if (this->item_iter != this->list->items.end()) item_next = (*this->item_iter).first;
 	}
 
-	int64 Next()
+	SQInteger Next()
 	{
 		if (this->IsEnd()) return 0;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
 
-	void Remove(int item)
+	void Remove(SQInteger item)
 	{
 		if (this->IsEnd()) return;
 
@@ -344,7 +344,7 @@ public:
 		this->End();
 	}
 
-	int64 Begin()
+	SQInteger Begin()
 	{
 		if (this->list->items.empty()) return 0;
 		this->has_no_more_items = false;
@@ -353,7 +353,7 @@ public:
 		--this->item_iter;
 		this->item_next = (*this->item_iter).first;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
@@ -381,16 +381,16 @@ public:
 		if (this->item_iter != this->list->items.end()) item_next = (*this->item_iter).first;
 	}
 
-	int64 Next()
+	SQInteger Next()
 	{
 		if (this->IsEnd()) return 0;
 
-		int64 item_current = this->item_next;
+		SQInteger item_current = this->item_next;
 		FindNext();
 		return item_current;
 	}
 
-	void Remove(int item)
+	void Remove(SQInteger item)
 	{
 		if (this->IsEnd()) return;
 
@@ -419,7 +419,7 @@ ScriptList::~ScriptList()
 	delete this->sorter;
 }
 
-bool ScriptList::HasItem(int64 item)
+bool ScriptList::HasItem(SQInteger item)
 {
 	return this->items.count(item) == 1;
 }
@@ -433,7 +433,7 @@ void ScriptList::Clear()
 	this->sorter->End();
 }
 
-void ScriptList::AddItem(int64 item, int64 value)
+void ScriptList::AddItem(SQInteger item, SQInteger value)
 {
 	this->modifications++;
 
@@ -443,14 +443,14 @@ void ScriptList::AddItem(int64 item, int64 value)
 	this->buckets[value].insert(item);
 }
 
-void ScriptList::RemoveItem(int64 item)
+void ScriptList::RemoveItem(SQInteger item)
 {
 	this->modifications++;
 
 	ScriptListMap::iterator item_iter = this->items.find(item);
 	if (item_iter == this->items.end()) return;
 
-	int64 value = item_iter->second;
+	SQInteger value = item_iter->second;
 
 	this->sorter->Remove(item);
 	ScriptListBucket::iterator bucket_iter = this->buckets.find(value);
@@ -460,13 +460,13 @@ void ScriptList::RemoveItem(int64 item)
 	this->items.erase(item_iter);
 }
 
-int64 ScriptList::Begin()
+SQInteger ScriptList::Begin()
 {
 	this->initialized = true;
 	return this->sorter->Begin();
 }
 
-int64 ScriptList::Next()
+SQInteger ScriptList::Next()
 {
 	if (!this->initialized) {
 		Debug(script, 0, "Next() is invalid as Begin() is never called");
@@ -489,25 +489,25 @@ bool ScriptList::IsEnd()
 	return this->sorter->IsEnd();
 }
 
-int32 ScriptList::Count()
+SQInteger ScriptList::Count()
 {
-	return (int32)this->items.size();
+	return this->items.size();
 }
 
-int64 ScriptList::GetValue(int64 item)
+SQInteger ScriptList::GetValue(SQInteger item)
 {
 	ScriptListMap::const_iterator item_iter = this->items.find(item);
 	return item_iter == this->items.end() ? 0 : item_iter->second;
 }
 
-bool ScriptList::SetValue(int64 item, int64 value)
+bool ScriptList::SetValue(SQInteger item, SQInteger value)
 {
 	this->modifications++;
 
 	ScriptListMap::iterator item_iter = this->items.find(item);
 	if (item_iter == this->items.end()) return false;
 
-	int64 value_old = item_iter->second;
+	SQInteger value_old = item_iter->second;
 	if (value_old == value) return true;
 
 	this->sorter->Remove(item);
@@ -586,7 +586,7 @@ void ScriptList::SwapList(ScriptList *list)
 	list->sorter->Retarget(list);
 }
 
-void ScriptList::RemoveAboveValue(int64 value)
+void ScriptList::RemoveAboveValue(SQInteger value)
 {
 	this->modifications++;
 
@@ -596,7 +596,7 @@ void ScriptList::RemoveAboveValue(int64 value)
 	}
 }
 
-void ScriptList::RemoveBelowValue(int64 value)
+void ScriptList::RemoveBelowValue(SQInteger value)
 {
 	this->modifications++;
 
@@ -606,7 +606,7 @@ void ScriptList::RemoveBelowValue(int64 value)
 	}
 }
 
-void ScriptList::RemoveBetweenValue(int64 start, int64 end)
+void ScriptList::RemoveBetweenValue(SQInteger start, SQInteger end)
 {
 	this->modifications++;
 
@@ -616,7 +616,7 @@ void ScriptList::RemoveBetweenValue(int64 start, int64 end)
 	}
 }
 
-void ScriptList::RemoveValue(int64 value)
+void ScriptList::RemoveValue(SQInteger value)
 {
 	this->modifications++;
 
@@ -626,7 +626,7 @@ void ScriptList::RemoveValue(int64 value)
 	}
 }
 
-void ScriptList::RemoveTop(int32 count)
+void ScriptList::RemoveTop(SQInteger count)
 {
 	this->modifications++;
 
@@ -663,7 +663,7 @@ void ScriptList::RemoveTop(int32 count)
 	}
 }
 
-void ScriptList::RemoveBottom(int32 count)
+void ScriptList::RemoveBottom(SQInteger count)
 {
 	this->modifications++;
 
@@ -714,7 +714,7 @@ void ScriptList::RemoveList(ScriptList *list)
 	}
 }
 
-void ScriptList::KeepAboveValue(int64 value)
+void ScriptList::KeepAboveValue(SQInteger value)
 {
 	this->modifications++;
 
@@ -724,7 +724,7 @@ void ScriptList::KeepAboveValue(int64 value)
 	}
 }
 
-void ScriptList::KeepBelowValue(int64 value)
+void ScriptList::KeepBelowValue(SQInteger value)
 {
 	this->modifications++;
 
@@ -734,7 +734,7 @@ void ScriptList::KeepBelowValue(int64 value)
 	}
 }
 
-void ScriptList::KeepBetweenValue(int64 start, int64 end)
+void ScriptList::KeepBetweenValue(SQInteger start, SQInteger end)
 {
 	this->modifications++;
 
@@ -744,7 +744,7 @@ void ScriptList::KeepBetweenValue(int64 start, int64 end)
 	}
 }
 
-void ScriptList::KeepValue(int64 value)
+void ScriptList::KeepValue(SQInteger value)
 {
 	this->modifications++;
 
@@ -754,14 +754,14 @@ void ScriptList::KeepValue(int64 value)
 	}
 }
 
-void ScriptList::KeepTop(int32 count)
+void ScriptList::KeepTop(SQInteger count)
 {
 	this->modifications++;
 
 	this->RemoveBottom(this->Count() - count);
 }
 
-void ScriptList::KeepBottom(int32 count)
+void ScriptList::KeepBottom(SQInteger count)
 {
 	this->modifications++;
 

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -42,9 +42,9 @@ private:
 	int modifications;            ///< Number of modification that has been done. To prevent changing data while valuating.
 
 public:
-	typedef std::set<int64> ScriptItemList;                   ///< The list of items inside the bucket
-	typedef std::map<int64, ScriptItemList> ScriptListBucket; ///< The bucket list per value
-	typedef std::map<int64, int64> ScriptListMap;             ///< List per item
+	typedef std::set<SQInteger> ScriptItemList;                   ///< The list of items inside the bucket
+	typedef std::map<SQInteger, ScriptItemList> ScriptListBucket; ///< The bucket list per value
+	typedef std::map<SQInteger, SQInteger> ScriptListMap;         ///< List per item
 
 	ScriptListMap items;           ///< The items in the list
 	ScriptListBucket buckets;      ///< The items in the list, sorted by value
@@ -58,16 +58,16 @@ public:
 	 * @param item the item to add. Should be unique, otherwise it is ignored.
 	 * @param value the value to assign.
 	 */
-	void AddItem(int64 item, int64 value);
+	void AddItem(SQInteger item, SQInteger value);
 #else
-	void AddItem(int64 item, int64 value = 0);
+	void AddItem(SQInteger item, SQInteger value = 0);
 #endif /* DOXYGEN_API */
 
 	/**
 	 * Remove a single item from the list.
 	 * @param item the item to remove. If not existing, it is ignored.
 	 */
-	void RemoveItem(int64 item);
+	void RemoveItem(SQInteger item);
 
 	/**
 	 * Clear the list, making Count() returning 0 and IsEmpty() returning true.
@@ -79,21 +79,21 @@ public:
 	 * @param item the item to check for.
 	 * @return true if the item is in the list.
 	 */
-	bool HasItem(int64 item);
+	bool HasItem(SQInteger item);
 
 	/**
 	 * Go to the beginning of the list and return the item. To get the value use list.GetValue(list.Begin()).
 	 * @return the first item.
 	 * @note returns 0 if beyond end-of-list. Use IsEnd() to check for end-of-list.
 	 */
-	int64 Begin();
+	SQInteger Begin();
 
 	/**
 	 * Go to the next item in the list and return the item. To get the value use list.GetValue(list.Next()).
 	 * @return the next item.
 	 * @note returns 0 if beyond end-of-list. Use IsEnd() to check for end-of-list.
 	 */
-	int64 Next();
+	SQInteger Next();
 
 	/**
 	 * Check if a list is empty.
@@ -112,14 +112,14 @@ public:
 	 * Returns the amount of items in the list.
 	 * @return amount of items in the list.
 	 */
-	int32 Count();
+	SQInteger Count();
 
 	/**
 	 * Get the value that belongs to this item.
 	 * @param item the item to get the value from
 	 * @return the value that belongs to this item.
 	 */
-	int64 GetValue(int64 item);
+	SQInteger GetValue(SQInteger item);
 
 	/**
 	 * Set a value of an item directly.
@@ -129,7 +129,7 @@ public:
 	 * @note Changing values of items while looping through a list might cause
 	 *  entries to be skipped. Be very careful with such operations.
 	 */
-	bool SetValue(int64 item, int64 value);
+	bool SetValue(SQInteger item, SQInteger value);
 
 	/**
 	 * Sort this list by the given sorter and direction.
@@ -160,38 +160,38 @@ public:
 	 * Removes all items with a higher value than 'value'.
 	 * @param value the value above which all items are removed.
 	 */
-	void RemoveAboveValue(int64 value);
+	void RemoveAboveValue(SQInteger value);
 
 	/**
 	 * Removes all items with a lower value than 'value'.
 	 * @param value the value below which all items are removed.
 	 */
-	void RemoveBelowValue(int64 value);
+	void RemoveBelowValue(SQInteger value);
 
 	/**
 	 * Removes all items with a value above start and below end.
 	 * @param start the lower bound of the to be removed values (exclusive).
 	 * @param end   the upper bound of the to be removed values (exclusive).
 	 */
-	void RemoveBetweenValue(int64 start, int64 end);
+	void RemoveBetweenValue(SQInteger start, SQInteger end);
 
 	/**
 	 * Remove all items with this value.
 	 * @param value the value to remove.
 	 */
-	void RemoveValue(int64 value);
+	void RemoveValue(SQInteger value);
 
 	/**
 	 * Remove the first count items.
 	 * @param count the amount of items to remove.
 	 */
-	void RemoveTop(int32 count);
+	void RemoveTop(SQInteger count);
 
 	/**
 	 * Remove the last count items.
 	 * @param count the amount of items to remove.
 	 */
-	void RemoveBottom(int32 count);
+	void RemoveBottom(SQInteger count);
 
 	/**
 	 * Remove everything that is in the given list from this list (same item index that is).
@@ -204,38 +204,38 @@ public:
 	 * Keep all items with a higher value than 'value'.
 	 * @param value the value above which all items are kept.
 	 */
-	void KeepAboveValue(int64 value);
+	void KeepAboveValue(SQInteger value);
 
 	/**
 	 * Keep all items with a lower value than 'value'.
 	 * @param value the value below which all items are kept.
 	 */
-	void KeepBelowValue(int64 value);
+	void KeepBelowValue(SQInteger value);
 
 	/**
 	 * Keep all items with a value above start and below end.
 	 * @param start the lower bound of the to be kept values (exclusive).
 	 * @param end   the upper bound of the to be kept values (exclusive).
 	 */
-	void KeepBetweenValue(int64 start, int64 end);
+	void KeepBetweenValue(SQInteger start, SQInteger end);
 
 	/**
 	 * Keep all items with this value.
 	 * @param value the value to keep.
 	 */
-	void KeepValue(int64 value);
+	void KeepValue(SQInteger value);
 
 	/**
 	 * Keep the first count items, i.e. remove everything except the first count items.
 	 * @param count the amount of items to keep.
 	 */
-	void KeepTop(int32 count);
+	void KeepTop(SQInteger count);
 
 	/**
 	 * Keep the last count items, i.e. remove everything except the last count items.
 	 * @param count the amount of items to keep.
 	 */
-	void KeepBottom(int32 count);
+	void KeepBottom(SQInteger count);
 
 	/**
 	 * Keeps everything that is in the given list from this list (same item index that is).

--- a/src/script/api/script_map.cpp
+++ b/src/script/api/script_map.cpp
@@ -18,57 +18,57 @@
 	return ::IsValidTile(t);
 }
 
-/* static */ TileIndex ScriptMap::GetMapSize()
+/* static */ SQInteger ScriptMap::GetMapSize()
 {
 	return ::Map::Size();
 }
 
-/* static */ uint32 ScriptMap::GetMapSizeX()
+/* static */ SQInteger ScriptMap::GetMapSizeX()
 {
 	return ::Map::SizeX();
 }
 
-/* static */ uint32 ScriptMap::GetMapSizeY()
+/* static */ SQInteger ScriptMap::GetMapSizeY()
 {
 	return ::Map::SizeY();
 }
 
-/* static */ int32 ScriptMap::GetTileX(TileIndex t)
+/* static */ SQInteger ScriptMap::GetTileX(TileIndex t)
 {
 	if (!::IsValidTile(t)) return -1;
 	return ::TileX(t);
 }
 
-/* static */ int32 ScriptMap::GetTileY(TileIndex t)
+/* static */ SQInteger ScriptMap::GetTileY(TileIndex t)
 {
 	if (!::IsValidTile(t)) return -1;
 	return ::TileY(t);
 }
 
-/* static */ TileIndex ScriptMap::GetTileIndex(uint32 x, uint32 y)
+/* static */ TileIndex ScriptMap::GetTileIndex(SQInteger x, SQInteger y)
 {
 	return ::TileXY(x, y);
 }
 
-/* static */ int32 ScriptMap::DistanceManhattan(TileIndex t1, TileIndex t2)
+/* static */ SQInteger ScriptMap::DistanceManhattan(TileIndex t1, TileIndex t2)
 {
 	if (!::IsValidTile(t1) || !::IsValidTile(t2)) return -1;
 	return ::DistanceManhattan(t1, t2);
 }
 
-/* static */ int32 ScriptMap::DistanceMax(TileIndex t1, TileIndex t2)
+/* static */ SQInteger ScriptMap::DistanceMax(TileIndex t1, TileIndex t2)
 {
 	if (!::IsValidTile(t1) || !::IsValidTile(t2)) return -1;
 	return ::DistanceMax(t1, t2);
 }
 
-/* static */ int32 ScriptMap::DistanceSquare(TileIndex t1, TileIndex t2)
+/* static */ SQInteger ScriptMap::DistanceSquare(TileIndex t1, TileIndex t2)
 {
 	if (!::IsValidTile(t1) || !::IsValidTile(t2)) return -1;
 	return ::DistanceSquare(t1, t2);
 }
 
-/* static */ int32 ScriptMap::DistanceFromEdge(TileIndex t)
+/* static */ SQInteger ScriptMap::DistanceFromEdge(TileIndex t)
 {
 	if (!::IsValidTile(t)) return -1;
 	return ::DistanceFromEdge(t);

--- a/src/script/api/script_map.hpp
+++ b/src/script/api/script_map.hpp
@@ -33,21 +33,21 @@ public:
 	 * @return The size of the map in tiles.
 	 * @post Return value is always positive.
 	 */
-	static TileIndex GetMapSize();
+	static SQInteger GetMapSize();
 
 	/**
 	 * Gets the amount of tiles along the SW and NE border.
 	 * @return The length along the SW and NE borders.
 	 * @post Return value is always positive.
 	 */
-	static uint32 GetMapSizeX();
+	static SQInteger GetMapSizeX();
 
 	/**
 	 * Gets the amount of tiles along the SE and NW border.
 	 * @return The length along the SE and NW borders.
 	 * @post Return value is always positive.
 	 */
-	static uint32 GetMapSizeY();
+	static SQInteger GetMapSizeY();
 
 	/**
 	 * Gets the place along the SW/NE border (X-value).
@@ -56,7 +56,7 @@ public:
 	 * @return The X-value.
 	 * @post Return value is always lower than GetMapSizeX().
 	 */
-	static int32 GetTileX(TileIndex tile);
+	static SQInteger GetTileX(TileIndex tile);
 
 	/**
 	 * Gets the place along the SE/NW border (Y-value).
@@ -65,17 +65,18 @@ public:
 	 * @return The Y-value.
 	 * @post Return value is always lower than GetMapSizeY().
 	 */
-	static int32 GetTileY(TileIndex tile);
+	static SQInteger GetTileY(TileIndex tile);
 
 	/**
 	 * Gets the TileIndex given a x,y-coordinate.
 	 * @param x The X coordinate.
 	 * @param y The Y coordinate.
-	 * @pre x < GetMapSizeX().
-	 * @pre y < GetMapSizeY().
 	 * @return The TileIndex for the given (x,y) coordinate.
+	 * @post When 0 <= x && x < GetMapSizeX() && 0 <= y && y < GetMapSizeY(), then a valid tile index is returned.
+	 *       Otherwise it may be invalid, but could be used to calculated neighbouring tiles, e.g. tile + AIMap.GetTileIndex(-1, -1) gets
+	 *       the tile index of the tile to the north. But be aware that even when tile is a valid tile, the result might not be a valid tile.
 	 */
-	static TileIndex GetTileIndex(uint32 x, uint32 y);
+	static TileIndex GetTileIndex(SQInteger x, SQInteger y);
 
 	/**
 	 * Calculates the Manhattan distance; the difference of
@@ -86,7 +87,7 @@ public:
 	 * @pre IsValidTile(tile_to).
 	 * @return The Manhattan distance between the tiles.
 	 */
-	static int32 DistanceManhattan(TileIndex tile_from, TileIndex tile_to);
+	static SQInteger DistanceManhattan(TileIndex tile_from, TileIndex tile_to);
 
 	/**
 	 * Calculates the distance between two tiles via 1D calculation.
@@ -98,7 +99,7 @@ public:
 	 * @pre IsValidTile(tile_to).
 	 * @return The maximum distance between the tiles.
 	 */
-	static int32 DistanceMax(TileIndex tile_from, TileIndex tile_to);
+	static SQInteger DistanceMax(TileIndex tile_from, TileIndex tile_to);
 
 	/**
 	 * The squared distance between the two tiles.
@@ -110,7 +111,7 @@ public:
 	 * @pre IsValidTile(tile_to).
 	 * @return The squared distance between the tiles.
 	 */
-	static int32 DistanceSquare(TileIndex tile_from, TileIndex tile_to);
+	static SQInteger DistanceSquare(TileIndex tile_from, TileIndex tile_to);
 
 	/**
 	 * Calculates the shortest distance to the edge.
@@ -118,7 +119,7 @@ public:
 	 * @pre IsValidTile(tile).
 	 * @return The distances to the closest edge.
 	 */
-	static int32 DistanceFromEdge(TileIndex tile);
+	static SQInteger DistanceFromEdge(TileIndex tile);
 };
 
 #endif /* SCRIPT_MAP_HPP */

--- a/src/script/api/script_newgrf.cpp
+++ b/src/script/api/script_newgrf.cpp
@@ -24,9 +24,9 @@ ScriptNewGRFList::ScriptNewGRFList()
 	}
 }
 
-/* static */ bool ScriptNewGRF::IsLoaded(uint32 grfid)
+/* static */ bool ScriptNewGRF::IsLoaded(SQInteger grfid)
 {
-	grfid = BSWAP32(grfid); // Match people's expectations.
+	grfid = BSWAP32(GB(grfid, 0, 32)); // Match people's expectations.
 
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
@@ -37,9 +37,9 @@ ScriptNewGRFList::ScriptNewGRFList()
 	return false;
 }
 
-/* static */ uint32 ScriptNewGRF::GetVersion(uint32 grfid)
+/* static */ SQInteger ScriptNewGRF::GetVersion(SQInteger grfid)
 {
-	grfid = BSWAP32(grfid); // Match people's expectations.
+	grfid = BSWAP32(GB(grfid, 0, 32)); // Match people's expectations.
 
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
@@ -50,9 +50,9 @@ ScriptNewGRFList::ScriptNewGRFList()
 	return 0;
 }
 
-/* static */ char *ScriptNewGRF::GetName(uint32 grfid)
+/* static */ char *ScriptNewGRF::GetName(SQInteger grfid)
 {
-	grfid = BSWAP32(grfid); // Match people's expectations.
+	grfid = BSWAP32(GB(grfid, 0, 32)); // Match people's expectations.
 
 	for (auto c = _grfconfig; c != nullptr; c = c->next) {
 		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {

--- a/src/script/api/script_newgrf.hpp
+++ b/src/script/api/script_newgrf.hpp
@@ -34,7 +34,7 @@ public:
 	 * @param grfid The grfid to check.
 	 * @return True if and only if a NewGRF with the given grfid is loaded in the game.
 	 */
-	static bool IsLoaded(uint32 grfid);
+	static bool IsLoaded(SQInteger grfid);
 
 	/**
 	 * Get the version of a loaded NewGRF.
@@ -42,7 +42,7 @@ public:
 	 * @pre ScriptNewGRF::IsLoaded(grfid).
 	 * @return Version of the NewGRF or 0 if the NewGRF specifies no version.
 	 */
-	static uint32 GetVersion(uint32 grfid);
+	static SQInteger GetVersion(SQInteger grfid);
 
 	/**
 	 * Get the name of a loaded NewGRF.
@@ -50,7 +50,7 @@ public:
 	 * @pre ScriptNewGRF::IsLoaded(grfid).
 	 * @return The name of the NewGRF or null if no name is defined.
 	 */
-	static char *GetName(uint32 grfid);
+	static char *GetName(SQInteger grfid);
 };
 
 #endif /* SCRIPT_NEWGRF_HPP */

--- a/src/script/api/script_news.cpp
+++ b/src/script/api/script_news.cpp
@@ -20,7 +20,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ bool ScriptNews::Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, uint32 reference)
+/* static */ bool ScriptNews::Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference)
 {
 	CCountedPtr<Text> counter(text);
 

--- a/src/script/api/script_news.hpp
+++ b/src/script/api/script_news.hpp
@@ -63,7 +63,7 @@ public:
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre The \a reference condition must be fulfilled.
 	 */
-	static bool Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, uint32 reference);
+	static bool Create(NewsType type, Text *text, ScriptCompany::CompanyID company, NewsReferenceType ref_type, SQInteger reference);
 };
 
 #endif /* SCRIPT_NEWS_HPP */

--- a/src/script/api/script_objecttype.cpp
+++ b/src/script/api/script_objecttype.cpp
@@ -30,25 +30,26 @@
 	return GetString(ObjectSpec::Get(object_type)->name);
 }
 
-/* static */ uint8 ScriptObjectType::GetViews(ObjectType object_type)
+/* static */ SQInteger ScriptObjectType::GetViews(ObjectType object_type)
 {
 	EnforcePrecondition(0, IsValidObjectType(object_type));
 
 	return ObjectSpec::Get(object_type)->views;
 }
 
-/* static */ bool ScriptObjectType::BuildObject(ObjectType object_type, uint8 view, TileIndex tile)
+/* static */ bool ScriptObjectType::BuildObject(ObjectType object_type, SQInteger view, TileIndex tile)
 {
 	EnforcePrecondition(false, IsValidObjectType(object_type));
+	EnforcePrecondition(false, view >= 0 && view < GetViews(object_type));
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_BUILD_OBJECT>::Do(tile, object_type, view);
 }
 
-/* static */ ObjectType ScriptObjectType::ResolveNewGRFID(uint32 grfid, uint16 grf_local_id)
+/* static */ ObjectType ScriptObjectType::ResolveNewGRFID(SQInteger grfid, SQInteger grf_local_id)
 {
 	EnforcePrecondition(INVALID_OBJECT_TYPE, IsInsideBS(grf_local_id, 0x00, NUM_OBJECTS_PER_GRF));
 
-	grfid = BSWAP32(grfid); // Match people's expectations.
+	grfid = BSWAP32(GB(grfid, 0, 32)); // Match people's expectations.
 	return _object_mngr.GetID(grf_local_id, grfid);
 }

--- a/src/script/api/script_objecttype.hpp
+++ b/src/script/api/script_objecttype.hpp
@@ -41,7 +41,7 @@ public:
 	 * @pre IsValidObjectType(object_type).
 	 * @return The number of views for an object.
 	 */
-	static uint8 GetViews(ObjectType object_type);
+	static SQInteger GetViews(ObjectType object_type);
 
 	/**
 	 * Build an object of the specified type.
@@ -51,7 +51,7 @@ public:
 	 * @pre IsValidObjectType(object_type).
 	 * @return True if the object was successfully build.
 	 */
-	static bool BuildObject(ObjectType object_type, uint8 view, TileIndex tile);
+	static bool BuildObject(ObjectType object_type, SQInteger view, TileIndex tile);
 
 	/**
 	 * Get a specific object-type from a grf.
@@ -60,7 +60,7 @@ public:
 	 * @pre 0x00 <= grf_local_id < NUM_OBJECTS_PER_GRF.
 	 * @return the object-type ID, local to the current game (this diverges from the grf_local_id).
 	 */
-	static ObjectType ResolveNewGRFID(uint32 grfid, uint16 grf_local_id);
+	static ObjectType ResolveNewGRFID(SQInteger grfid, SQInteger grf_local_id);
 };
 
 #endif /* SCRIPT_OBJECTTYPE_HPP */

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -234,7 +234,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	}
 }
 
-/* static */ int32 ScriptOrder::GetOrderCount(VehicleID vehicle_id)
+/* static */ SQInteger ScriptOrder::GetOrderCount(VehicleID vehicle_id)
 {
 	return ScriptVehicle::IsPrimaryVehicle(vehicle_id) ? ::Vehicle::Get(vehicle_id)->GetNumManualOrders() : -1;
 }
@@ -349,13 +349,13 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	return (CompareFunction)order->GetConditionComparator();
 }
 
-/* static */ int32 ScriptOrder::GetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position)
+/* static */ SQInteger ScriptOrder::GetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position)
 {
 	if (!IsValidVehicleOrder(vehicle_id, order_position)) return -1;
 	if (order_position == ORDER_CURRENT || !IsConditionalOrder(vehicle_id, order_position)) return -1;
 
 	const Order *order = ::ResolveOrder(vehicle_id, order_position);
-	int32 value = order->GetConditionValue();
+	SQInteger value = order->GetConditionValue();
 	if (order->GetConditionVariable() == OCV_MAX_SPEED) value = value * 16 / 10;
 	return value;
 }
@@ -408,7 +408,7 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 	return ScriptObject::Command<CMD_MODIFY_ORDER>::Do(0, vehicle_id, order_pos, MOF_COND_COMPARATOR, compare);
 }
 
-/* static */ bool ScriptOrder::SetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position, int32 value)
+/* static */ bool ScriptOrder::SetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position, SQInteger value)
 {
 	EnforcePrecondition(false, IsValidVehicleOrder(vehicle_id, order_position));
 	EnforcePrecondition(false, order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position));
@@ -666,7 +666,7 @@ static void _DoCommandReturnSetOrderFlags(class ScriptInstance *instance)
 	return ScriptObject::Command<CMD_CLONE_ORDER>::Do(0, CO_UNSHARE, vehicle_id, 0);
 }
 
-/* static */ uint ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)
+/* static */ SQInteger ScriptOrder::GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile)
 {
 	if (vehicle_type == ScriptVehicle::VT_AIR) {
 		if (ScriptTile::IsStationTile(origin_tile)) {

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -250,7 +250,7 @@ public:
 	 * @return The number of orders for the given vehicle or a negative
 	 *   value when the vehicle does not exist.
 	 */
-	static int32 GetOrderCount(VehicleID vehicle_id);
+	static SQInteger GetOrderCount(VehicleID vehicle_id);
 
 	/**
 	 * Gets the destination of the given order for the given vehicle.
@@ -320,7 +320,7 @@ public:
 	 * @pre order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position).
 	 * @return The value to compare against of the order.
 	 */
-	static int32 GetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position);
+	static SQInteger GetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position);
 
 	/**
 	 * Gets the stoplocation of the given order for the given train.
@@ -398,7 +398,7 @@ public:
 	 * @return Whether the order has been/can be changed.
 	 * @api -game
 	 */
-	static bool SetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position, int32 value);
+	static bool SetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position, SQInteger value);
 
 	/**
 	 * Sets the stoplocation of the given order for the given train.
@@ -601,7 +601,7 @@ public:
 	 *         not be compared with map distances
 	 * @see ScriptEngine::GetMaximumOrderDistance and ScriptVehicle::GetMaximumOrderDistance
 	 */
-	static uint GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile);
+	static SQInteger GetOrderDistance(ScriptVehicle::VehicleType vehicle_type, TileIndex origin_tile, TileIndex dest_tile);
 };
 DECLARE_ENUM_AS_BIT_SET(ScriptOrder::ScriptOrderFlags)
 

--- a/src/script/api/script_priorityqueue.cpp
+++ b/src/script/api/script_priorityqueue.cpp
@@ -35,7 +35,7 @@ ScriptPriorityQueue::~ScriptPriorityQueue()
 SQInteger ScriptPriorityQueue::Insert(HSQUIRRELVM vm)
 {
 	HSQOBJECT item;
-	int64 priority;
+	SQInteger priority;
 	sq_resetobject(&item);
 	sq_getstackobj(vm, 2, &item);
 	sq_getinteger(vm, 3, &priority);

--- a/src/script/api/script_priorityqueue.hpp
+++ b/src/script/api/script_priorityqueue.hpp
@@ -21,7 +21,7 @@
  */
 class ScriptPriorityQueue : public ScriptObject {
 public:
-	typedef std::pair<int64, HSQOBJECT> PriorityItem;
+	typedef std::pair<SQInteger, HSQOBJECT> PriorityItem;
 private:
 	struct PriorityComparator {
 		bool operator()(const PriorityItem &lhs, const PriorityItem &rhs) const noexcept
@@ -43,7 +43,7 @@ public:
 	 * @param priority The priority to assign the item.
 	 * @return True if the item was inserted, false if it was already in the queue.
 	 */
-	bool Insert(void *item, int64 priority);
+	bool Insert(void *item, SQInteger priority);
 
 	/**
 	 * Remove and return the item with the lowest priority.

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -147,7 +147,7 @@
 	return ScriptObject::Command<CMD_BUILD_TRAIN_DEPOT>::Do(tile, (::RailType)ScriptObject::GetRailType(), entrance_dir);
 }
 
-/* static */ bool ScriptRail::BuildRailStation(TileIndex tile, RailTrack direction, uint num_platforms, uint platform_length, StationID station_id)
+/* static */ bool ScriptRail::BuildRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, ::IsValidTile(tile));
@@ -161,7 +161,7 @@
 	return ScriptObject::Command<CMD_BUILD_RAIL_STATION>::Do(tile, (::RailType)GetCurrentRailType(), direction == RAILTRACK_NW_SE ? AXIS_Y : AXIS_X, num_platforms, platform_length, STAT_CLASS_DFLT, 0, ScriptStation::IsValidStation(station_id) ? station_id : INVALID_STATION, adjacent);
 }
 
-/* static */ bool ScriptRail::BuildNewGRFRailStation(TileIndex tile, RailTrack direction, uint num_platforms, uint platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, int distance, bool source_station)
+/* static */ bool ScriptRail::BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, ::IsValidTile(tile));
@@ -181,10 +181,10 @@
 		0,
 		source_industry,
 		goal_industry,
-		std::min(255, distance / 2),
+		std::min<SQInteger>(255, distance / 2),
 		AICE_STATION_GET_STATION_ID,
 		source_station ? 0 : 1,
-		std::min(15u, num_platforms) << 4 | std::min(15u, platform_length),
+		std::min<SQInteger>(15u, num_platforms) << 4 | std::min<SQInteger>(15u, platform_length),
 		&file
 	);
 
@@ -504,14 +504,14 @@ static bool IsValidSignalType(int signal_type)
 	}
 }
 
-/* static */ int32 ScriptRail::GetMaxSpeed(RailType railtype)
+/* static */ SQInteger ScriptRail::GetMaxSpeed(RailType railtype)
 {
 	if (!ScriptRail::IsRailTypeAvailable(railtype)) return -1;
 
 	return ::GetRailTypeInfo((::RailType)railtype)->max_speed;
 }
 
-/* static */ uint16 ScriptRail::GetMaintenanceCostFactor(RailType railtype)
+/* static */ SQInteger ScriptRail::GetMaintenanceCostFactor(RailType railtype)
 {
 	if (!ScriptRail::IsRailTypeAvailable(railtype)) return 0;
 

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -276,11 +276,11 @@
 
 	if (tile - from == 1) {
 		if (to - tile == 1) return (GetRailTracks(tile) & RAILTRACK_NE_SW) != 0;
-		if (to - tile == ScriptMap::GetMapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NE_SE) != 0;
-	} else if (tile - from == ScriptMap::GetMapSizeX()) {
+		if (to - tile == (int)ScriptMap::GetMapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NE_SE) != 0;
+	} else if (tile - from == (int)ScriptMap::GetMapSizeX()) {
 		if (tile - to == 1) return (GetRailTracks(tile) & RAILTRACK_NW_NE) != 0;
 		if (to - tile == 1) return (GetRailTracks(tile) & RAILTRACK_NW_SW) != 0;
-		if (to - tile == ScriptMap::GetMapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NW_SE) != 0;
+		if (to - tile == (int)ScriptMap::GetMapSizeX()) return (GetRailTracks(tile) & RAILTRACK_NW_SE) != 0;
 	} else {
 		return (GetRailTracks(tile) & RAILTRACK_SW_SE) != 0;
 	}

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -260,7 +260,7 @@ public:
 	 * @exception ScriptStation::ERR_STATION_TOO_MANY_STATIONS_IN_TOWN
 	 * @return Whether the station has been/can be build or not.
 	 */
-	static bool BuildRailStation(TileIndex tile, RailTrack direction, uint num_platforms, uint platform_length, StationID station_id);
+	static bool BuildRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id);
 
 	/**
 	 * Build a NewGRF rail station. This calls callback 18 to let a NewGRF
@@ -297,7 +297,7 @@ public:
 	 * @exception ScriptStation::ERR_STATION_TOO_MANY_STATIONS_IN_TOWN
 	 * @return Whether the station has been/can be build or not.
 	 */
-	static bool BuildNewGRFRailStation(TileIndex tile, RailTrack direction, uint num_platforms, uint platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, int distance, bool source_station);
+	static bool BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station);
 
 	/**
 	 * Build a rail waypoint.
@@ -486,7 +486,7 @@ public:
 	 *       This is mph / 1.6, which is roughly km/h.
 	 *       To get km/h multiply this number by 1.00584.
 	 */
-	static int32 GetMaxSpeed(RailType railtype);
+	static SQInteger GetMaxSpeed(RailType railtype);
 
 	/**
 	 * Get the maintenance cost factor of a railtype.
@@ -494,7 +494,7 @@ public:
 	 * @pre IsRailTypeAvailable(railtype)
 	 * @return Maintenance cost factor of the railtype.
 	 */
-	static uint16 GetMaintenanceCostFactor(RailType railtype);
+	static SQInteger GetMaintenanceCostFactor(RailType railtype);
 };
 
 #endif /* SCRIPT_RAIL_HPP */

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -452,8 +452,8 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ int32 ScriptRoad::GetNeighbourRoadCount(TileIndex tile)
 {
-	if (!::IsValidTile(tile)) return false;
-	if (!IsRoadTypeAvailable(GetCurrentRoadType())) return false;
+	if (!::IsValidTile(tile)) return -1;
+	if (!IsRoadTypeAvailable(GetCurrentRoadType())) return -1;
 
 	::RoadType rt = (::RoadType)GetCurrentRoadType();
 	int32 neighbour = 0;
@@ -627,7 +627,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ int32 ScriptRoad::GetMaxSpeed(RoadType road_type)
 {
-	if (!ScriptRoad::IsRoadTypeAvailable(road_type)) return 0;
+	if (!ScriptRoad::IsRoadTypeAvailable(road_type)) return -1;
 
 	return GetRoadTypeInfo((::RoadType)road_type)->max_speed;
 }

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -378,7 +378,7 @@ static bool NormaliseTileOffset(int32 *tile)
 		return false;
 }
 
-/* static */ int32 ScriptRoad::CanBuildConnectedRoadParts(ScriptTile::Slope slope_, Array<> existing, TileIndex start_, TileIndex end_)
+/* static */ SQInteger ScriptRoad::CanBuildConnectedRoadParts(ScriptTile::Slope slope_, Array<> existing, TileIndex start_, TileIndex end_)
 {
 	::Slope slope = (::Slope)slope_;
 	int32 start = start_;
@@ -399,7 +399,7 @@ static bool NormaliseTileOffset(int32 *tile)
 	return _settings_game.construction.build_on_slopes ? LookupWithBuildOnSlopes(slope, existing, start, end) : LookupWithoutBuildOnSlopes(slope, existing, start, end);
 }
 
-/* static */ int32 ScriptRoad::CanBuildConnectedRoadPartsHere(TileIndex tile, TileIndex start, TileIndex end)
+/* static */ SQInteger ScriptRoad::CanBuildConnectedRoadPartsHere(TileIndex tile, TileIndex start, TileIndex end)
 {
 	if (!::IsValidTile(tile) || !::IsValidTile(start) || !::IsValidTile(end)) return -1;
 	if (::DistanceManhattan(tile, start) != 1 || ::DistanceManhattan(tile, end) != 1) return -1;
@@ -450,7 +450,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 	}
 }
 
-/* static */ int32 ScriptRoad::GetNeighbourRoadCount(TileIndex tile)
+/* static */ SQInteger ScriptRoad::GetNeighbourRoadCount(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return -1;
 	if (!IsRoadTypeAvailable(GetCurrentRoadType())) return -1;
@@ -625,14 +625,14 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 	return (RoadTramTypes)(1 << ::GetRoadTramType((::RoadType)roadtype));
 }
 
-/* static */ int32 ScriptRoad::GetMaxSpeed(RoadType road_type)
+/* static */ SQInteger ScriptRoad::GetMaxSpeed(RoadType road_type)
 {
 	if (!ScriptRoad::IsRoadTypeAvailable(road_type)) return -1;
 
 	return GetRoadTypeInfo((::RoadType)road_type)->max_speed;
 }
 
-/* static */ uint16 ScriptRoad::GetMaintenanceCostFactor(RoadType roadtype)
+/* static */ SQInteger ScriptRoad::GetMaintenanceCostFactor(RoadType roadtype)
 {
 	if (!ScriptRoad::IsRoadTypeAvailable(roadtype)) return 0;
 

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -246,7 +246,7 @@ public:
 	 *         they are build or 2 when building the first part automatically
 	 *         builds the second part. -1 means the preconditions are not met.
 	 */
-	static int32 CanBuildConnectedRoadParts(ScriptTile::Slope slope, Array<> existing, TileIndex start, TileIndex end);
+	static SQInteger CanBuildConnectedRoadParts(ScriptTile::Slope slope, Array<> existing, TileIndex start, TileIndex end);
 
 	/**
 	 * Lookup function for building road parts independent of whether the
@@ -267,7 +267,7 @@ public:
 	 *         they are build or 2 when building the first part automatically
 	 *         builds the second part. -1 means the preconditions are not met.
 	 */
-	static int32 CanBuildConnectedRoadPartsHere(TileIndex tile, TileIndex start, TileIndex end);
+	static SQInteger CanBuildConnectedRoadPartsHere(TileIndex tile, TileIndex start, TileIndex end);
 
 	/**
 	 * Count how many neighbours are road.
@@ -276,7 +276,7 @@ public:
 	 * @pre IsRoadTypeAvailable(GetCurrentRoadType()).
 	 * @return 0 means no neighbour road; max value is 4.
 	 */
-	static int32 GetNeighbourRoadCount(TileIndex tile);
+	static SQInteger GetNeighbourRoadCount(TileIndex tile);
 
 	/**
 	 * Gets the tile in front of a road depot.
@@ -561,7 +561,7 @@ public:
 	 *       This is mph / 0.8, which is roughly 0.5 km/h.
 	 *       To get km/h multiply this number by 2.01168.
 	 */
-	static int32 GetMaxSpeed(RoadType road_type);
+	static SQInteger GetMaxSpeed(RoadType road_type);
 
 	/**
 	 * Get the maintenance cost factor of a road type.
@@ -569,7 +569,7 @@ public:
 	 * @pre IsRoadTypeAvailable(roadtype)
 	 * @return Maintenance cost factor of the roadtype.
 	 */
-	static uint16 GetMaintenanceCostFactor(RoadType roadtype);
+	static SQInteger GetMaintenanceCostFactor(RoadType roadtype);
 
 private:
 

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -50,7 +50,7 @@ template<bool Tfrom, bool Tvia>
 }
 
 template<bool Tfrom, bool Tvia>
-/* static */ int32 ScriptStation::CountCargoWaiting(StationID station_id,
+/* static */ SQInteger ScriptStation::CountCargoWaiting(StationID station_id,
 		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
 {
 	if (!ScriptStation::IsCargoRequestValid<Tfrom, Tvia>(station_id, from_station_id,
@@ -74,31 +74,31 @@ template<bool Tfrom, bool Tvia>
 	return cargo_count;
 }
 
-/* static */ int32 ScriptStation::GetCargoWaiting(StationID station_id, CargoID cargo_id)
+/* static */ SQInteger ScriptStation::GetCargoWaiting(StationID station_id, CargoID cargo_id)
 {
 	return CountCargoWaiting<false, false>(station_id, STATION_INVALID, STATION_INVALID, cargo_id);
 }
 
-/* static */ int32 ScriptStation::GetCargoWaitingFrom(StationID station_id,
+/* static */ SQInteger ScriptStation::GetCargoWaitingFrom(StationID station_id,
 		StationID from_station_id, CargoID cargo_id)
 {
 	return CountCargoWaiting<true, false>(station_id, from_station_id, STATION_INVALID, cargo_id);
 }
 
-/* static */ int32 ScriptStation::GetCargoWaitingVia(StationID station_id,
+/* static */ SQInteger ScriptStation::GetCargoWaitingVia(StationID station_id,
 		StationID via_station_id, CargoID cargo_id)
 {
 	return CountCargoWaiting<false, true>(station_id, STATION_INVALID, via_station_id, cargo_id);
 }
 
-/* static */ int32 ScriptStation::GetCargoWaitingFromVia(StationID station_id,
+/* static */ SQInteger ScriptStation::GetCargoWaitingFromVia(StationID station_id,
 		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
 {
 	return CountCargoWaiting<true, true>(station_id, from_station_id, via_station_id, cargo_id);
 }
 
 template<bool Tfrom, bool Tvia>
-/* static */ int32 ScriptStation::CountCargoPlanned(StationID station_id,
+/* static */ SQInteger ScriptStation::CountCargoPlanned(StationID station_id,
 		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
 {
 	if (!ScriptStation::IsCargoRequestValid<Tfrom, Tvia>(station_id, from_station_id,
@@ -115,24 +115,24 @@ template<bool Tfrom, bool Tvia>
 	}
 }
 
-/* static */ int32 ScriptStation::GetCargoPlanned(StationID station_id, CargoID cargo_id)
+/* static */ SQInteger ScriptStation::GetCargoPlanned(StationID station_id, CargoID cargo_id)
 {
 	return CountCargoPlanned<false, false>(station_id, STATION_INVALID, STATION_INVALID, cargo_id);
 }
 
-/* static */ int32 ScriptStation::GetCargoPlannedFrom(StationID station_id,
+/* static */ SQInteger ScriptStation::GetCargoPlannedFrom(StationID station_id,
 		StationID from_station_id, CargoID cargo_id)
 {
 	return CountCargoPlanned<true, false>(station_id, from_station_id, STATION_INVALID, cargo_id);
 }
 
-/* static */ int32 ScriptStation::GetCargoPlannedVia(StationID station_id,
+/* static */ SQInteger ScriptStation::GetCargoPlannedVia(StationID station_id,
 		StationID via_station_id, CargoID cargo_id)
 {
 	return CountCargoPlanned<false, true>(station_id, STATION_INVALID, via_station_id, cargo_id);
 }
 
-/* static */ int32 ScriptStation::GetCargoPlannedFromVia(StationID station_id,
+/* static */ SQInteger ScriptStation::GetCargoPlannedFromVia(StationID station_id,
 		StationID from_station_id, StationID via_station_id, CargoID cargo_id)
 {
 	return CountCargoPlanned<true, true>(station_id, from_station_id, via_station_id, cargo_id);
@@ -146,14 +146,14 @@ template<bool Tfrom, bool Tvia>
 	return ::Station::Get(station_id)->goods[cargo_id].HasRating();
 }
 
-/* static */ int32 ScriptStation::GetCargoRating(StationID station_id, CargoID cargo_id)
+/* static */ SQInteger ScriptStation::GetCargoRating(StationID station_id, CargoID cargo_id)
 {
 	if (!ScriptStation::HasCargoRating(station_id, cargo_id)) return -1;
 
 	return ::ToPercent8(::Station::Get(station_id)->goods[cargo_id].rating);
 }
 
-/* static */ int32 ScriptStation::GetCoverageRadius(ScriptStation::StationType station_type)
+/* static */ SQInteger ScriptStation::GetCoverageRadius(ScriptStation::StationType station_type)
 {
 	if (station_type == STATION_AIRPORT) return -1;
 	if (!HasExactlyOneBit(station_type)) return -1;
@@ -169,21 +169,21 @@ template<bool Tfrom, bool Tvia>
 	}
 }
 
-/* static */ int32 ScriptStation::GetStationCoverageRadius(StationID station_id)
+/* static */ SQInteger ScriptStation::GetStationCoverageRadius(StationID station_id)
 {
 	if (!IsValidStation(station_id)) return -1;
 
 	return Station::Get(station_id)->GetCatchmentRadius();
 }
 
-/* static */ int32 ScriptStation::GetDistanceManhattanToTile(StationID station_id, TileIndex tile)
+/* static */ SQInteger ScriptStation::GetDistanceManhattanToTile(StationID station_id, TileIndex tile)
 {
 	if (!IsValidStation(station_id)) return -1;
 
 	return ScriptMap::DistanceManhattan(tile, GetLocation(station_id));
 }
 
-/* static */ int32 ScriptStation::GetDistanceSquareToTile(StationID station_id, TileIndex tile)
+/* static */ SQInteger ScriptStation::GetDistanceSquareToTile(StationID station_id, TileIndex tile)
 {
 	if (!IsValidStation(station_id)) return -1;
 

--- a/src/script/api/script_station.hpp
+++ b/src/script/api/script_station.hpp
@@ -82,7 +82,7 @@ public:
 	 * @pre IsValidCargo(cargo_id).
 	 * @return The amount of units waiting at the station.
 	 */
-	static int32 GetCargoWaiting(StationID station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaiting(StationID station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo with a specific source station there is waiting on a station.
@@ -95,7 +95,7 @@ public:
 	 * @return The amount of units waiting at the station originating from from_station_id.
 	 * @note source station means, the station where cargo was first loaded.
 	 */
-	static int32 GetCargoWaitingFrom(StationID station_id, StationID from_station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaitingFrom(StationID station_id, StationID from_station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo with a specific via-station there is waiting on a station.
@@ -108,7 +108,7 @@ public:
 	 * @return The amount of units waiting at the station with via_station_id as next hop.
 	 * @note if ScriptCargo.GetCargoDistributionType(cargo_id) == ScriptCargo.DT_MANUAL, then all waiting cargo will have STATION_INVALID as next hop.
 	 */
-	static int32 GetCargoWaitingVia(StationID station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaitingVia(StationID station_id, StationID via_station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo with a specific via-station and source station there is waiting on a station.
@@ -123,7 +123,7 @@ public:
 	 * @return The amount of units waiting at the station with from_station_id as source and via_station_id as next hop.
 	 * @note if ScriptCargo.GetCargoDistributionType(cargo_id) == ScriptCargo.DT_MANUAL, then all waiting cargo will have STATION_INVALID as next hop.
 	 */
-	static int32 GetCargoWaitingFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoWaitingFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo was planned to pass (including production and consumption) this station per month.
@@ -133,7 +133,7 @@ public:
 	 * @pre IsValidCargo(cargo_id).
 	 * @return The amount of cargo units planned to pass the station per month.
 	 */
-	static int32 GetCargoPlanned(StationID station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlanned(StationID station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo from the specified origin was planned to pass (including production and consumption) this station per month.
@@ -145,7 +145,7 @@ public:
 	 * @pre IsValidCargo(cargo_id).
 	 * @return The amount of cargo units from the specified origin planned to pass the station per month.
 	 */
-	static int32 GetCargoPlannedFrom(StationID station_id, StationID from_station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlannedFrom(StationID station_id, StationID from_station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo was planned to pass (including production and consumption) this station per month, heading for the specified next hop.
@@ -158,7 +158,7 @@ public:
 	 * @return The amount of cargo units planned to pass the station per month, going via the specified next hop.
 	 * @note Cargo planned to go "via" the same station that's being queried is actually planned to be consumed there.
 	 */
-	static int32 GetCargoPlannedVia(StationID station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlannedVia(StationID station_id, StationID via_station_id, CargoID cargo_id);
 
 	/**
 	 * See how much cargo from the specified origin was planned to pass this station per month,
@@ -175,7 +175,7 @@ public:
 	 * @note Cargo planned to go "via" the same station that's being queried is actually planned to be consumed there.
 	 * @note Cargo planned to pass "from" the same station that's being queried is actually produced there.
 	 */
-	static int32 GetCargoPlannedFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoID cargo_id);
+	static SQInteger GetCargoPlannedFromVia(StationID station_id, StationID from_station_id, StationID via_station_id, CargoID cargo_id);
 
 	/**
 	 * Check whether the given cargo at the given station a rating.
@@ -196,7 +196,7 @@ public:
 	 * @pre HasCargoRating(station_id, cargo_id).
 	 * @return The rating in percent of the cargo on the station.
 	 */
-	static int32 GetCargoRating(StationID station_id, CargoID cargo_id);
+	static SQInteger GetCargoRating(StationID station_id, CargoID cargo_id);
 
 	/**
 	 * Get the coverage radius of this type of station.
@@ -205,7 +205,7 @@ public:
 	 * @return The radius in tiles.
 	 * @note Coverage radius of airports needs to be requested via ScriptAirport::GetAirportCoverageRadius(), as it requires AirportType.
 	 */
-	static int32 GetCoverageRadius(ScriptStation::StationType station_type);
+	static SQInteger GetCoverageRadius(ScriptStation::StationType station_type);
 
 	/**
 	 * Get the coverage radius of this station.
@@ -213,7 +213,7 @@ public:
 	 * @pre IsValidStation(station_id).
 	 * @return The radius in tiles.
 	 */
-	static int32 GetStationCoverageRadius(StationID station_id);
+	static SQInteger GetStationCoverageRadius(StationID station_id);
 
 	/**
 	 * Get the manhattan distance from the tile to the ScriptStation::GetLocation()
@@ -223,7 +223,7 @@ public:
 	 * @pre IsValidStation(station_id).
 	 * @return The distance between station and tile.
 	 */
-	static int32 GetDistanceManhattanToTile(StationID station_id, TileIndex tile);
+	static SQInteger GetDistanceManhattanToTile(StationID station_id, TileIndex tile);
 
 	/**
 	 * Get the square distance from the tile to the ScriptStation::GetLocation()
@@ -233,7 +233,7 @@ public:
 	 * @pre IsValidStation(station_id).
 	 * @return The distance between station and tile.
 	 */
-	static int32 GetDistanceSquareToTile(StationID station_id, TileIndex tile);
+	static SQInteger GetDistanceSquareToTile(StationID station_id, TileIndex tile);
 
 	/**
 	 * Find out if this station is within the rating influence of a town.
@@ -299,11 +299,11 @@ private:
 			StationID via_station_id, CargoID cargo_id);
 
 	template<bool Tfrom, bool Tvia>
-	static int32 CountCargoWaiting(StationID station_id, StationID from_station_id,
+	static SQInteger CountCargoWaiting(StationID station_id, StationID from_station_id,
 			StationID via_station_id, CargoID cargo_id);
 
 	template<bool Tfrom, bool Tvia>
-	static int32 CountCargoPlanned(StationID station_id, StationID from_station_id,
+	static SQInteger CountCargoPlanned(StationID station_id, StationID from_station_id,
 			StationID via_station_id, CargoID cargo_id);
 
 };

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -55,7 +55,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	return (ScriptStoryPage::StoryPageID)0;
 }
 
-/* static */ ScriptStoryPage::StoryPageElementID ScriptStoryPage::NewElement(StoryPageID story_page_id, StoryPageElementType type, uint32 reference, Text *text)
+/* static */ ScriptStoryPage::StoryPageElementID ScriptStoryPage::NewElement(StoryPageID story_page_id, StoryPageElementType type, SQInteger reference, Text *text)
 {
 	CCountedPtr<Text> counter(text);
 
@@ -101,7 +101,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	return (ScriptStoryPage::StoryPageElementID)0;
 }
 
-/* static */ bool ScriptStoryPage::UpdateElement(StoryPageElementID story_page_element_id, uint32 reference, Text *text)
+/* static */ bool ScriptStoryPage::UpdateElement(StoryPageElementID story_page_element_id, SQInteger reference, Text *text)
 {
 	CCountedPtr<Text> counter(text);
 
@@ -143,14 +143,14 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	return ScriptObject::Command<CMD_UPDATE_STORY_PAGE_ELEMENT>::Do(reftile, story_page_element_id, refid, encoded_text);
 }
 
-/* static */ uint32 ScriptStoryPage::GetPageSortValue(StoryPageID story_page_id)
+/* static */ SQInteger ScriptStoryPage::GetPageSortValue(StoryPageID story_page_id)
 {
 	EnforcePrecondition(false, IsValidStoryPage(story_page_id));
 
 	return StoryPage::Get(story_page_id)->sort_value;
 }
 
-/* static */ uint32 ScriptStoryPage::GetPageElementSortValue(StoryPageElementID story_page_element_id)
+/* static */ SQInteger ScriptStoryPage::GetPageElementSortValue(StoryPageElementID story_page_element_id)
 {
 	EnforcePrecondition(false, IsValidStoryPageElement(story_page_element_id));
 

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -207,7 +207,7 @@ public:
 	 * @pre type != SPET_GOAL || ScriptGoal::IsValidGoal(reference).
 	 * @pre if type is SPET_GOAL and story_page is a global page, then referenced goal must be global.
 	 */
-	static StoryPageElementID NewElement(StoryPageID story_page_id, StoryPageElementType type, uint32 reference, Text *text);
+	static StoryPageElementID NewElement(StoryPageID story_page_id, StoryPageElementType type, SQInteger reference, Text *text);
 
 	/**
 	 * Update the content of a page element
@@ -222,7 +222,7 @@ public:
 	 * @pre type != SPET_GOAL || ScriptGoal::IsValidGoal(reference).
 	 * @pre if type is SPET_GOAL and story_page is a global page, then referenced goal must be global.
 	 */
-	static bool UpdateElement(StoryPageElementID story_page_element_id, uint32 reference, Text *text);
+	static bool UpdateElement(StoryPageElementID story_page_element_id, SQInteger reference, Text *text);
 
 	/**
 	 * Get story page sort value. Each page has a sort value that is internally assigned and used
@@ -232,7 +232,7 @@ public:
 	 * @param story_page_id The story page to get the sort value of.
 	 * @return Page sort value.
 	 */
-	static uint32 GetPageSortValue(StoryPageID story_page_id);
+	static SQInteger GetPageSortValue(StoryPageID story_page_id);
 
 	/**
 	 * Get story page element sort value. Each page element has a sort value that is internally
@@ -243,7 +243,7 @@ public:
 	 * @param story_page_element_id The story page element to get the sort value of.
 	 * @return Page element sort value.
 	 */
-	static uint32 GetPageElementSortValue(StoryPageElementID story_page_element_id);
+	static SQInteger GetPageElementSortValue(StoryPageElementID story_page_element_id);
 
 	/**
 	 * Get the company which the page belongs to. If the page is global,

--- a/src/script/api/script_subsidy.cpp
+++ b/src/script/api/script_subsidy.cpp
@@ -31,7 +31,7 @@
 	return ::Subsidy::Get(subsidy_id)->IsAwarded();
 }
 
-/* static */ bool ScriptSubsidy::Create(CargoID cargo_type, SubsidyParticipantType from_type, uint16 from_id, SubsidyParticipantType to_type, uint16 to_id)
+/* static */ bool ScriptSubsidy::Create(CargoID cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id)
 {
 	EnforcePrecondition(false, ScriptCargo::IsValidCargo(cargo_type));
 	EnforcePrecondition(false, from_type == SPT_INDUSTRY || from_type == SPT_TOWN);
@@ -78,7 +78,7 @@
 	return (SubsidyParticipantType)(uint)::Subsidy::Get(subsidy_id)->src_type;
 }
 
-/* static */ int32 ScriptSubsidy::GetSourceIndex(SubsidyID subsidy_id)
+/* static */ SQInteger ScriptSubsidy::GetSourceIndex(SubsidyID subsidy_id)
 {
 	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
 
@@ -92,7 +92,7 @@
 	return (SubsidyParticipantType)(uint)::Subsidy::Get(subsidy_id)->dst_type;
 }
 
-/* static */ int32 ScriptSubsidy::GetDestinationIndex(SubsidyID subsidy_id)
+/* static */ SQInteger ScriptSubsidy::GetDestinationIndex(SubsidyID subsidy_id)
 {
 	if (!IsValidSubsidy(subsidy_id)) return INVALID_SOURCE;
 

--- a/src/script/api/script_subsidy.hpp
+++ b/src/script/api/script_subsidy.hpp
@@ -62,7 +62,7 @@ public:
 	 * @pre (to_type   == SPT_INDUSTRY && ScriptIndustry::IsValidIndustry(to_id))   || (to_type   == SPT_TOWN && ScriptTown::IsValidTown(to_id))
 	 * @api -ai
 	 */
-	static bool Create(CargoID cargo_type, SubsidyParticipantType from_type, uint16 from_id, SubsidyParticipantType to_type, uint16 to_id);
+	static bool Create(CargoID cargo_type, SubsidyParticipantType from_type, SQInteger from_id, SubsidyParticipantType to_type, SQInteger to_id);
 
 	/**
 	 * Get the company index of the company this subsidy is awarded to.
@@ -109,7 +109,7 @@ public:
 	 * @pre IsValidSubsidy(subsidy_id).
 	 * @return One of TownID/IndustryID.
 	 */
-	static int32 GetSourceIndex(SubsidyID subsidy_id);
+	static SQInteger GetSourceIndex(SubsidyID subsidy_id);
 
 	/**
 	 * Returns the type of destination of subsidy.
@@ -127,7 +127,7 @@ public:
 	 * @pre IsValidSubsidy(subsidy_id).
 	 * @return One of TownID/IndustryID.
 	 */
-	static int32 GetDestinationIndex(SubsidyID subsidy_id);
+	static SQInteger GetDestinationIndex(SubsidyID subsidy_id);
 };
 
 #endif /* SCRIPT_SUBSIDY_HPP */

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -44,10 +44,10 @@
 	}
 }
 
-/* static */ bool ScriptTile::IsBuildableRectangle(TileIndex tile, uint width, uint height)
+/* static */ bool ScriptTile::IsBuildableRectangle(TileIndex tile, SQInteger width, SQInteger height)
 {
 	/* Check whether we can extract valid X and Y */
-	if (!::IsValidTile(tile)) return false;
+	if (!::IsValidTile(tile) || width < 0 || height < 0) return false;
 
 	uint tx = ScriptMap::GetTileX(tile);
 	uint ty = ScriptMap::GetTileY(tile);
@@ -180,21 +180,21 @@
 	return (Slope)::ComplementSlope((::Slope)slope);
 }
 
-/* static */ int32 ScriptTile::GetMinHeight(TileIndex tile)
+/* static */ SQInteger ScriptTile::GetMinHeight(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return -1;
 
 	return ::GetTileZ(tile);
 }
 
-/* static */ int32 ScriptTile::GetMaxHeight(TileIndex tile)
+/* static */ SQInteger ScriptTile::GetMaxHeight(TileIndex tile)
 {
 	if (!::IsValidTile(tile)) return -1;
 
 	return ::GetTileMaxZ(tile);
 }
 
-/* static */ int32 ScriptTile::GetCornerHeight(TileIndex tile, Corner corner)
+/* static */ SQInteger ScriptTile::GetCornerHeight(TileIndex tile, Corner corner)
 {
 	if (!::IsValidTile(tile) || !::IsValidCorner((::Corner)corner)) return -1;
 
@@ -224,7 +224,7 @@
 	}
 }
 
-/* static */ int32 ScriptTile::GetCargoAcceptance(TileIndex tile, CargoID cargo_type, int width, int height, int radius)
+/* static */ SQInteger ScriptTile::GetCargoAcceptance(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius)
 {
 	if (!::IsValidTile(tile) || width <= 0 || height <= 0 || radius < 0 || !ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
@@ -232,7 +232,7 @@
 	return acceptance[cargo_type];
 }
 
-/* static */ int32 ScriptTile::GetCargoProduction(TileIndex tile, CargoID cargo_type, int width, int height, int radius)
+/* static */ SQInteger ScriptTile::GetCargoProduction(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius)
 {
 	if (!::IsValidTile(tile) || width <= 0 || height <= 0 || radius < 0 || !ScriptCargo::IsValidCargo(cargo_type)) return -1;
 
@@ -240,17 +240,17 @@
 	return produced[cargo_type];
 }
 
-/* static */ int32 ScriptTile::GetDistanceManhattanToTile(TileIndex tile_from, TileIndex tile_to)
+/* static */ SQInteger ScriptTile::GetDistanceManhattanToTile(TileIndex tile_from, TileIndex tile_to)
 {
 	return ScriptMap::DistanceManhattan(tile_from, tile_to);
 }
 
-/* static */ int32 ScriptTile::GetDistanceSquareToTile(TileIndex tile_from, TileIndex tile_to)
+/* static */ SQInteger ScriptTile::GetDistanceSquareToTile(TileIndex tile_from, TileIndex tile_to)
 {
 	return ScriptMap::DistanceSquare(tile_from, tile_to);
 }
 
-/* static */ bool ScriptTile::RaiseTile(TileIndex tile, int32 slope)
+/* static */ bool ScriptTile::RaiseTile(TileIndex tile, Slope slope)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, tile < ScriptMap::GetMapSize());
@@ -258,7 +258,7 @@
 	return ScriptObject::Command<CMD_TERRAFORM_LAND>::Do(tile, (::Slope)slope, true);
 }
 
-/* static */ bool ScriptTile::LowerTile(TileIndex tile, int32 slope)
+/* static */ bool ScriptTile::LowerTile(TileIndex tile, Slope slope)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, tile < ScriptMap::GetMapSize());
@@ -290,7 +290,7 @@
 	return ScriptObject::Command<CMD_PLANT_TREE>::Do(tile, tile, TREE_INVALID, false);
 }
 
-/* static */ bool ScriptTile::PlantTreeRectangle(TileIndex tile, uint width, uint height)
+/* static */ bool ScriptTile::PlantTreeRectangle(TileIndex tile, SQInteger width, SQInteger height)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, ::IsValidTile(tile));

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -155,9 +155,11 @@ public:
 	 * @param width The width of the rectangle.
 	 * @param height The height of the rectangle.
 	 * @pre ScriptMap::IsValidTile(tile).
+	 * @pre width >= 0.
+	 * @pre height >= 0.
 	 * @return True if it is buildable, false if not.
 	 */
-	static bool IsBuildableRectangle(TileIndex tile, uint width, uint height);
+	static bool IsBuildableRectangle(TileIndex tile, SQInteger width, SQInteger height);
 
 	/**
 	 * Checks whether the given tile is actually a sea tile.
@@ -308,7 +310,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @return The height of the lowest corner of the tile, ranging from 0 to 15.
 	 */
-	static int32 GetMinHeight(TileIndex tile);
+	static SQInteger GetMinHeight(TileIndex tile);
 
 	/**
 	 * Get the maximal height on a tile.
@@ -317,7 +319,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @return The height of the highest corner of the tile, ranging from 0 to 15.
 	 */
-	static int32 GetMaxHeight(TileIndex tile);
+	static SQInteger GetMaxHeight(TileIndex tile);
 
 	/**
 	 * Get the height of a certain corner of a tile.
@@ -327,7 +329,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @return The height of the lowest corner of the tile, ranging from 0 to 15.
 	 */
-	static int32 GetCornerHeight(TileIndex tile, Corner corner);
+	static SQInteger GetCornerHeight(TileIndex tile, Corner corner);
 
 	/**
 	 * Get the owner of the tile.
@@ -372,7 +374,7 @@ public:
 	 * @pre radius >= 0.
 	 * @return Values below 8 mean no acceptance; the more the better.
 	 */
-	static int32 GetCargoAcceptance(TileIndex tile, CargoID cargo_type, int width, int height, int radius);
+	static SQInteger GetCargoAcceptance(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius);
 
 	/**
 	 * Checks how many producers in the radius produces this cargo.
@@ -389,7 +391,7 @@ public:
 	 * @pre radius >= 0.
 	 * @return The number of producers that produce this cargo within radius of the tile.
 	 */
-	static int32 GetCargoProduction(TileIndex tile, CargoID cargo_type, int width, int height, int radius);
+	static SQInteger GetCargoProduction(TileIndex tile, CargoID cargo_type, SQInteger width, SQInteger height, SQInteger radius);
 
 	/**
 	 * Get the manhattan distance from the tile to the tile.
@@ -397,7 +399,7 @@ public:
 	 * @param tile_to The tile to get the distance to.
 	 * @return The distance between the two tiles.
 	 */
-	static int32 GetDistanceManhattanToTile(TileIndex tile_from, TileIndex tile_to);
+	static SQInteger GetDistanceManhattanToTile(TileIndex tile_from, TileIndex tile_to);
 
 	/**
 	 * Get the square distance from the tile to the tile.
@@ -405,7 +407,7 @@ public:
 	 * @param tile_to The tile to get the distance to.
 	 * @return The distance between the two tiles.
 	 */
-	static int32 GetDistanceSquareToTile(TileIndex tile_from, TileIndex tile_to);
+	static SQInteger GetDistanceSquareToTile(TileIndex tile_from, TileIndex tile_to);
 
 	/**
 	 * Raise the given corners of the tile. The corners can be combined,
@@ -422,7 +424,7 @@ public:
 	 * @exception ScriptTile::ERR_TILE_TOO_HIGH
 	 * @return 0 means failed, 1 means success.
 	 */
-	static bool RaiseTile(TileIndex tile, int32 slope);
+	static bool RaiseTile(TileIndex tile, Slope slope);
 
 	/**
 	 * Lower the given corners of the tile. The corners can be combined,
@@ -439,7 +441,7 @@ public:
 	 * @exception ScriptTile::ERR_TILE_TOO_LOW
 	 * @return 0 means failed, 1 means success.
 	 */
-	static bool LowerTile(TileIndex tile, int32 slope);
+	static bool LowerTile(TileIndex tile, Slope slope);
 
 	/**
 	 * Level all tiles in the rectangle between start_tile and end_tile so they
@@ -489,7 +491,7 @@ public:
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @return True if and only if a tree was added on any of the tiles in the rectangle.
 	 */
-	static bool PlantTreeRectangle(TileIndex tile, uint width, uint height);
+	static bool PlantTreeRectangle(TileIndex tile, SQInteger width, SQInteger height);
 
 	/**
 	 * Find out if this tile is within the rating influence of a town.

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -53,7 +53,7 @@ void ScriptTileList::RemoveTile(TileIndex tile)
  * @param radius Catchment radius to test
  * @param bta BitmapTileArea to fill
  */
-static void FillIndustryCatchment(const Industry *i, int radius, BitmapTileArea &bta)
+static void FillIndustryCatchment(const Industry *i, SQInteger radius, BitmapTileArea &bta)
 {
 	for (TileIndex cur_tile : i->location) {
 		if (!::IsTileType(cur_tile, MP_INDUSTRY) || ::GetIndustryIndex(cur_tile) != i->index) continue;
@@ -73,7 +73,7 @@ static void FillIndustryCatchment(const Industry *i, int radius, BitmapTileArea 
 	}
 }
 
-ScriptTileList_IndustryAccepting::ScriptTileList_IndustryAccepting(IndustryID industry_id, int radius)
+ScriptTileList_IndustryAccepting::ScriptTileList_IndustryAccepting(IndustryID industry_id, SQInteger radius)
 {
 	if (!ScriptIndustry::IsValidIndustry(industry_id) || radius <= 0) return;
 
@@ -113,7 +113,7 @@ ScriptTileList_IndustryAccepting::ScriptTileList_IndustryAccepting(IndustryID in
 	}
 }
 
-ScriptTileList_IndustryProducing::ScriptTileList_IndustryProducing(IndustryID industry_id, int radius)
+ScriptTileList_IndustryProducing::ScriptTileList_IndustryProducing(IndustryID industry_id, SQInteger radius)
 {
 	if (!ScriptIndustry::IsValidIndustry(industry_id) || radius <= 0) return;
 

--- a/src/script/api/script_tilelist.hpp
+++ b/src/script/api/script_tilelist.hpp
@@ -68,7 +68,7 @@ public:
 	 * @pre radius > 0.
 	 * @note A station part built on any of the returned tiles will give you coverage.
 	 */
-	ScriptTileList_IndustryAccepting(IndustryID industry_id, int radius);
+	ScriptTileList_IndustryAccepting(IndustryID industry_id, SQInteger radius);
 };
 
 /**
@@ -86,7 +86,7 @@ public:
 	 * @pre radius > 0.
 	 * @note A station part built on any of the returned tiles will give you acceptance.
 	 */
-	ScriptTileList_IndustryProducing(IndustryID industry_id, int radius);
+	ScriptTileList_IndustryProducing(IndustryID industry_id, SQInteger radius);
 };
 
 /**

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -22,9 +22,9 @@
 
 #include "../../safeguards.h"
 
-/* static */ int32 ScriptTown::GetTownCount()
+/* static */ SQInteger ScriptTown::GetTownCount()
 {
-	return (int32)::Town::GetNumItems();
+	return ::Town::GetNumItems();
 }
 
 /* static */ bool ScriptTown::IsValidTown(TownID town_id)
@@ -63,14 +63,14 @@
 	return ScriptObject::Command<CMD_TOWN_SET_TEXT>::Do(town_id, text != nullptr ? text->GetEncodedText() : std::string{});
 }
 
-/* static */ int32 ScriptTown::GetPopulation(TownID town_id)
+/* static */ SQInteger ScriptTown::GetPopulation(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 	const Town *t = ::Town::Get(town_id);
 	return t->cache.population;
 }
 
-/* static */ int32 ScriptTown::GetHouseCount(TownID town_id)
+/* static */ SQInteger ScriptTown::GetHouseCount(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 	const Town *t = ::Town::Get(town_id);
@@ -84,7 +84,7 @@
 	return t->xy;
 }
 
-/* static */ int32 ScriptTown::GetLastMonthProduction(TownID town_id, CargoID cargo_id)
+/* static */ SQInteger ScriptTown::GetLastMonthProduction(TownID town_id, CargoID cargo_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -94,7 +94,7 @@
 	return t->supplied[cargo_id].old_max;
 }
 
-/* static */ int32 ScriptTown::GetLastMonthSupplied(TownID town_id, CargoID cargo_id)
+/* static */ SQInteger ScriptTown::GetLastMonthSupplied(TownID town_id, CargoID cargo_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -104,7 +104,7 @@
 	return t->supplied[cargo_id].old_act;
 }
 
-/* static */ int32 ScriptTown::GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id)
+/* static */ SQInteger ScriptTown::GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
@@ -113,7 +113,7 @@
 	return ::ToPercent8(t->GetPercentTransported(cargo_id));
 }
 
-/* static */ int32 ScriptTown::GetLastMonthReceived(TownID town_id, ScriptCargo::TownEffect towneffect_id)
+/* static */ SQInteger ScriptTown::GetLastMonthReceived(TownID town_id, ScriptCargo::TownEffect towneffect_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 	if (!ScriptCargo::IsValidTownEffect(towneffect_id)) return -1;
@@ -123,18 +123,20 @@
 	return t->received[towneffect_id].old_act;
 }
 
-/* static */ bool ScriptTown::SetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id, uint32 goal)
+/* static */ bool ScriptTown::SetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id, SQInteger goal)
 {
 	EnforcePrecondition(false, IsValidTown(town_id));
 	EnforcePrecondition(false, ScriptCargo::IsValidTownEffect(towneffect_id));
 
+	goal = Clamp<SQInteger>(goal, 0, UINT32_MAX);
+
 	return ScriptObject::Command<CMD_TOWN_CARGO_GOAL>::Do(town_id, (::TownEffect)towneffect_id, goal);
 }
 
-/* static */ uint32 ScriptTown::GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id)
+/* static */ SQInteger ScriptTown::GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id)
 {
-	if (!IsValidTown(town_id)) return UINT32_MAX;
-	if (!ScriptCargo::IsValidTownEffect(towneffect_id)) return UINT32_MAX;
+	if (!IsValidTown(town_id)) return -1;
+	if (!ScriptCargo::IsValidTownEffect(towneffect_id)) return -1;
 
 	const Town *t = ::Town::Get(town_id);
 
@@ -151,7 +153,7 @@
 	}
 }
 
-/* static */ bool ScriptTown::SetGrowthRate(TownID town_id, uint32 days_between_town_growth)
+/* static */ bool ScriptTown::SetGrowthRate(TownID town_id, SQInteger days_between_town_growth)
 {
 	EnforcePrecondition(false, IsValidTown(town_id));
 	uint16 growth_rate;
@@ -167,14 +169,14 @@
 		default:
 			EnforcePrecondition(false, (days_between_town_growth * DAY_TICKS / TOWN_GROWTH_TICKS) <= MAX_TOWN_GROWTH_TICKS);
 			/* Don't use growth_rate 0 as it means GROWTH_NORMAL */
-			growth_rate = std::max(days_between_town_growth * DAY_TICKS, 2u) - 1;
+			growth_rate = std::max<SQInteger>(days_between_town_growth * DAY_TICKS, 2u) - 1;
 			break;
 	}
 
 	return ScriptObject::Command<CMD_TOWN_GROWTH_RATE>::Do(town_id, growth_rate);
 }
 
-/* static */ int32 ScriptTown::GetGrowthRate(TownID town_id)
+/* static */ SQInteger ScriptTown::GetGrowthRate(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 
@@ -185,12 +187,12 @@
 	return RoundDivSU(t->growth_rate + 1, DAY_TICKS);
 }
 
-/* static */ int32 ScriptTown::GetDistanceManhattanToTile(TownID town_id, TileIndex tile)
+/* static */ SQInteger ScriptTown::GetDistanceManhattanToTile(TownID town_id, TileIndex tile)
 {
 	return ScriptMap::DistanceManhattan(tile, GetLocation(town_id));
 }
 
-/* static */ int32 ScriptTown::GetDistanceSquareToTile(TownID town_id, TileIndex tile)
+/* static */ SQInteger ScriptTown::GetDistanceSquareToTile(TownID town_id, TileIndex tile)
 {
 	return ScriptMap::DistanceSquare(tile, GetLocation(town_id));
 }
@@ -218,14 +220,14 @@
 	return ::Town::Get(town_id)->larger_town;
 }
 
-/* static */ int ScriptTown::GetRoadReworkDuration(TownID town_id)
+/* static */ SQInteger ScriptTown::GetRoadReworkDuration(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 
 	return ::Town::Get(town_id)->road_build_months;
 }
 
-/* static */ int ScriptTown::GetFundBuildingsDuration(TownID town_id)
+/* static */ SQInteger ScriptTown::GetFundBuildingsDuration(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 
@@ -240,7 +242,7 @@
 	return (ScriptCompany::CompanyID)(int8)::Town::Get(town_id)->exclusivity;
 }
 
-/* static */ int32 ScriptTown::GetExclusiveRightsDuration(TownID town_id)
+/* static */ SQInteger ScriptTown::GetExclusiveRightsDuration(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 
@@ -264,11 +266,13 @@
 	return ScriptObject::Command<CMD_DO_TOWN_ACTION>::Do(town_id, town_action);
 }
 
-/* static */ bool ScriptTown::ExpandTown(TownID town_id, int houses)
+/* static */ bool ScriptTown::ExpandTown(TownID town_id, SQInteger houses)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	EnforcePrecondition(false, houses > 0);
+
+	houses = std::min<SQInteger>(houses, UINT32_MAX);
 
 	return ScriptObject::Command<CMD_EXPAND_TOWN>::Do(town_id, houses);
 }
@@ -330,7 +334,7 @@
 	}
 }
 
-/* static */ int ScriptTown::GetDetailedRating(TownID town_id, ScriptCompany::CompanyID company_id)
+/* static */ SQInteger ScriptTown::GetDetailedRating(TownID town_id, ScriptCompany::CompanyID company_id)
 {
 	if (!IsValidTown(town_id)) return TOWN_RATING_INVALID;
 	ScriptCompany::CompanyID company = ScriptCompany::ResolveCompanyID(company_id);
@@ -340,7 +344,7 @@
 	return t->ratings[company];
 }
 
-/* static */ bool ScriptTown::ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, int delta)
+/* static */ bool ScriptTown::ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, SQInteger delta)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
 	EnforcePrecondition(false, IsValidTown(town_id));
@@ -354,7 +358,7 @@
 	return ScriptObject::Command<CMD_TOWN_RATING>::Do(town_id, (::CompanyID)company_id, new_rating);
 }
 
-/* static */ int ScriptTown::GetAllowedNoise(TownID town_id)
+/* static */ SQInteger ScriptTown::GetAllowedNoise(TownID town_id)
 {
 	if (!IsValidTown(town_id)) return -1;
 

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -127,7 +127,7 @@ public:
 	 * Gets the number of towns.
 	 * @return The number of towns.
 	 */
-	static int32 GetTownCount();
+	static SQInteger GetTownCount();
 
 	/**
 	 * Checks whether the given town index is valid.
@@ -170,7 +170,7 @@ public:
 	 * @pre IsValidTown(town_id).
 	 * @return The number of inhabitants.
 	 */
-	static int32 GetPopulation(TownID town_id);
+	static SQInteger GetPopulation(TownID town_id);
 
 	/**
 	 * Gets the number of houses in the town.
@@ -178,7 +178,7 @@ public:
 	 * @pre IsValidTown(town_id).
 	 * @return The number of houses.
 	 */
-	static int32 GetHouseCount(TownID town_id);
+	static SQInteger GetHouseCount(TownID town_id);
 
 	/**
 	 * Gets the location of the town.
@@ -196,7 +196,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The last month's production of the given cargo for this town.
 	 */
-	static int32 GetLastMonthProduction(TownID town_id, CargoID cargo_id);
+	static SQInteger GetLastMonthProduction(TownID town_id, CargoID cargo_id);
 
 	/**
 	 * Get the total amount of cargo supplied from a town last month.
@@ -206,7 +206,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The amount of cargo supplied for transport from this town last month.
 	 */
-	static int32 GetLastMonthSupplied(TownID town_id, CargoID cargo_id);
+	static SQInteger GetLastMonthSupplied(TownID town_id, CargoID cargo_id);
 
 	/**
 	 * Get the percentage of transported production of the given cargo at a town.
@@ -216,7 +216,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_id).
 	 * @return The percentage of given cargo transported from this town last month.
 	 */
-	static int32 GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id);
+	static SQInteger GetLastMonthTransportedPercentage(TownID town_id, CargoID cargo_id);
 
 	/**
 	 * Get the total amount of cargo effects received by a town last month.
@@ -226,19 +226,20 @@ public:
 	 * @pre ScriptCargo::IsValidTownEffect(cargo_id).
 	 * @return The amount of cargo received by this town last month for this cargo effect.
 	 */
-	static int32 GetLastMonthReceived(TownID town_id, ScriptCargo::TownEffect towneffect_id);
+	static SQInteger GetLastMonthReceived(TownID town_id, ScriptCargo::TownEffect towneffect_id);
 
 	/**
 	 * Set the goal of a cargo for this town.
 	 * @param town_id The index of the town.
 	 * @param towneffect_id The index of the towneffect.
 	 * @param goal The new goal.
+	 *             The value will be clamped to 0 .. MAX(uint32).
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCargo::IsValidTownEffect(towneffect_id).
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
-	static bool SetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id, uint32 goal);
+	static bool SetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id, SQInteger goal);
 
 	/**
 	 * Get the amount of cargo that needs to be delivered (per TownEffect) for a
@@ -251,7 +252,7 @@ public:
 	 * @note Goals can change over time. For example with a changing snowline, or
 	 *  with a growing town.
 	 */
-	static uint32 GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id);
+	static SQInteger GetCargoGoal(TownID town_id, ScriptCargo::TownEffect towneffect_id);
 
 	/**
 	 * Set the amount of days between town growth.
@@ -265,7 +266,7 @@ public:
 	 * @note When changing the growth rate, the relative progress is preserved and scaled to the new rate.
 	 * @api -ai
 	 */
-	static bool SetGrowthRate(TownID town_id, uint32 days_between_town_growth);
+	static bool SetGrowthRate(TownID town_id, SQInteger days_between_town_growth);
 
 	/**
 	 * Get the amount of days between town growth.
@@ -274,7 +275,7 @@ public:
 	 * @return Amount of days between town growth, or TOWN_GROWTH_NONE.
 	 * @note This function does not indicate when it will grow next. It only tells you the time between growths.
 	 */
-	static int32 GetGrowthRate(TownID town_id);
+	static SQInteger GetGrowthRate(TownID town_id);
 
 	/**
 	 * Get the manhattan distance from the tile to the ScriptTown::GetLocation()
@@ -284,7 +285,7 @@ public:
 	 * @pre IsValidTown(town_id).
 	 * @return The distance between town and tile.
 	 */
-	static int32 GetDistanceManhattanToTile(TownID town_id, TileIndex tile);
+	static SQInteger GetDistanceManhattanToTile(TownID town_id, TileIndex tile);
 
 	/**
 	 * Get the square distance from the tile to the ScriptTown::GetLocation()
@@ -294,7 +295,7 @@ public:
 	 * @pre IsValidTown(town_id).
 	 * @return The distance between town and tile.
 	 */
-	static int32 GetDistanceSquareToTile(TownID town_id, TileIndex tile);
+	static SQInteger GetDistanceSquareToTile(TownID town_id, TileIndex tile);
 
 	/**
 	 * Find out if this tile is within the rating influence of a town.
@@ -331,7 +332,7 @@ public:
 	 * @return The number of months the road reworks are still going to take.
 	 *         The value 0 means that there are currently no road reworks.
 	 */
-	static int GetRoadReworkDuration(TownID town_id);
+	static SQInteger GetRoadReworkDuration(TownID town_id);
 
 	/**
 	 * Find out how long new buildings are still being funded in a town.
@@ -340,7 +341,7 @@ public:
 	 * @return The number of months building construction is still funded.
 	 *         The value 0 means that there is currently no funding.
 	 */
-	static int GetFundBuildingsDuration(TownID town_id);
+	static SQInteger GetFundBuildingsDuration(TownID town_id);
 
 	/**
 	 * Find out which company currently has the exclusive rights of this town.
@@ -361,7 +362,7 @@ public:
 	 *         The value 0 means that there are currently no exclusive rights
 	 *         given out to anyone.
 	 */
-	static int32 GetExclusiveRightsDuration(TownID town_id);
+	static SQInteger GetExclusiveRightsDuration(TownID town_id);
 
 	/**
 	 * Find out if an action can currently be performed on the town.
@@ -388,12 +389,13 @@ public:
 	 * Expand the town.
 	 * @param town_id The town to expand.
 	 * @param houses The amount of houses to grow the town with.
+	 *               The value will be clamped to 0 .. MAX(uint32).
 	 * @pre IsValidTown(town_id).
 	 * @pre houses > 0.
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */
-	static bool ExpandTown(TownID town_id, int houses);
+	static bool ExpandTown(TownID town_id, SQInteger houses);
 
 	/**
 	 * Found a new town.
@@ -433,7 +435,7 @@ public:
 	 * @return The rating as a number between -1000 (worst) and 1000 (best).
 	 * @api -ai
 	 */
-	static int GetDetailedRating(TownID town_id, ScriptCompany::CompanyID company_id);
+	static SQInteger GetDetailedRating(TownID town_id, ScriptCompany::CompanyID company_id);
 
 	/**
 	 * Change the rating of a company within a town.
@@ -446,7 +448,7 @@ public:
 	 * @pre no company mode in scope
 	 * @api -ai
 	 */
-	static bool ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, int delta);
+	static bool ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, SQInteger delta);
 
 	/**
 	 * Get the maximum level of noise that still can be added by airports
@@ -454,7 +456,7 @@ public:
 	 * @param town_id The town to get the allowed noise from.
 	 * @return The noise that still can be added.
 	 */
-	static int GetAllowedNoise(TownID town_id);
+	static SQInteger GetAllowedNoise(TownID town_id);
 
 	/**
 	 * Get the road layout for a town.

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -48,7 +48,7 @@
 	return static_cast<ScriptCompany::CompanyID>((int)::Vehicle::Get(vehicle_id)->owner);
 }
 
-/* static */ int32 ScriptVehicle::GetNumWagons(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetNumWagons(VehicleID vehicle_id)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 
@@ -62,7 +62,7 @@
 	return num;
 }
 
-/* static */ int ScriptVehicle::GetLength(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetLength(VehicleID vehicle_id)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 
@@ -97,7 +97,7 @@
 	return _BuildVehicleInternal(depot, engine_id, cargo);
 }
 
-/* static */ int ScriptVehicle::GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo)
 {
 	if (!ScriptEngine::IsBuildable(engine_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -117,7 +117,7 @@
 	return 0;
 }
 
-/* static */ bool ScriptVehicle::_MoveWagonInternal(VehicleID source_vehicle_id, int source_wagon, bool move_attached_wagons, int dest_vehicle_id, int dest_wagon)
+/* static */ bool ScriptVehicle::_MoveWagonInternal(VehicleID source_vehicle_id, SQInteger source_wagon, bool move_attached_wagons, SQInteger dest_vehicle_id, SQInteger dest_wagon)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, IsValidVehicle(source_vehicle_id) && source_wagon < GetNumWagons(source_vehicle_id));
@@ -136,17 +136,17 @@
 	return ScriptObject::Command<CMD_MOVE_RAIL_VEHICLE>::Do(v->index, w == nullptr ? ::INVALID_VEHICLE : w->index, move_attached_wagons);
 }
 
-/* static */ bool ScriptVehicle::MoveWagon(VehicleID source_vehicle_id, int source_wagon, int dest_vehicle_id, int dest_wagon)
+/* static */ bool ScriptVehicle::MoveWagon(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon)
 {
 	return _MoveWagonInternal(source_vehicle_id, source_wagon, false, dest_vehicle_id, dest_wagon);
 }
 
-/* static */ bool ScriptVehicle::MoveWagonChain(VehicleID source_vehicle_id, int source_wagon, int dest_vehicle_id, int dest_wagon)
+/* static */ bool ScriptVehicle::MoveWagonChain(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon)
 {
 	return _MoveWagonInternal(source_vehicle_id, source_wagon, true, dest_vehicle_id, dest_wagon);
 }
 
-/* static */ int ScriptVehicle::GetRefitCapacity(VehicleID vehicle_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetRefitCapacity(VehicleID vehicle_id, CargoID cargo)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -173,7 +173,7 @@
 	return ScriptObject::Command<CMD_SELL_VEHICLE>::Do(vehicle_id, v->type == VEH_TRAIN, false, INVALID_CLIENT_ID);
 }
 
-/* static */ bool ScriptVehicle::_SellWagonInternal(VehicleID vehicle_id, int wagon, bool sell_attached_wagons)
+/* static */ bool ScriptVehicle::_SellWagonInternal(VehicleID vehicle_id, SQInteger wagon, bool sell_attached_wagons)
 {
 	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
 	EnforcePrecondition(false, IsValidVehicle(vehicle_id) && wagon < GetNumWagons(vehicle_id));
@@ -185,12 +185,12 @@
 	return ScriptObject::Command<CMD_SELL_VEHICLE>::Do(v->index, sell_attached_wagons, false, INVALID_CLIENT_ID);
 }
 
-/* static */ bool ScriptVehicle::SellWagon(VehicleID vehicle_id, int wagon)
+/* static */ bool ScriptVehicle::SellWagon(VehicleID vehicle_id, SQInteger wagon)
 {
 	return _SellWagonInternal(vehicle_id, wagon, false);
 }
 
-/* static */ bool ScriptVehicle::SellWagonChain(VehicleID vehicle_id, int wagon)
+/* static */ bool ScriptVehicle::SellWagonChain(VehicleID vehicle_id, SQInteger wagon)
 {
 	return _SellWagonInternal(vehicle_id, wagon, true);
 }
@@ -279,7 +279,7 @@
 	return ::Vehicle::Get(vehicle_id)->engine_type;
 }
 
-/* static */ EngineID ScriptVehicle::GetWagonEngineType(VehicleID vehicle_id, int wagon)
+/* static */ EngineID ScriptVehicle::GetWagonEngineType(VehicleID vehicle_id, SQInteger wagon)
 {
 	if (!IsValidVehicle(vehicle_id)) return INVALID_ENGINE;
 	if (wagon >= GetNumWagons(vehicle_id)) return INVALID_ENGINE;
@@ -291,7 +291,7 @@
 	return v->engine_type;
 }
 
-/* static */ int32 ScriptVehicle::GetUnitNumber(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetUnitNumber(VehicleID vehicle_id)
 {
 	if (!IsPrimaryVehicle(vehicle_id)) return -1;
 
@@ -306,14 +306,14 @@
 	return GetString(STR_VEHICLE_NAME);
 }
 
-/* static */ int32 ScriptVehicle::GetAge(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetAge(VehicleID vehicle_id)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 
 	return ::Vehicle::Get(vehicle_id)->age;
 }
 
-/* static */ int32 ScriptVehicle::GetWagonAge(VehicleID vehicle_id, int wagon)
+/* static */ SQInteger ScriptVehicle::GetWagonAge(VehicleID vehicle_id, SQInteger wagon)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (wagon >= GetNumWagons(vehicle_id)) return -1;
@@ -325,21 +325,21 @@
 	return v->age;
 }
 
-/* static */ int32 ScriptVehicle::GetMaxAge(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetMaxAge(VehicleID vehicle_id)
 {
 	if (!IsPrimaryVehicle(vehicle_id)) return -1;
 
 	return ::Vehicle::Get(vehicle_id)->max_age;
 }
 
-/* static */ int32 ScriptVehicle::GetAgeLeft(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetAgeLeft(VehicleID vehicle_id)
 {
 	if (!IsPrimaryVehicle(vehicle_id)) return -1;
 
 	return ::Vehicle::Get(vehicle_id)->max_age - ::Vehicle::Get(vehicle_id)->age;
 }
 
-/* static */ int32 ScriptVehicle::GetCurrentSpeed(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetCurrentSpeed(VehicleID vehicle_id)
 {
 	if (!IsPrimaryVehicle(vehicle_id)) return -1;
 
@@ -411,7 +411,7 @@
 	return (ScriptRoad::RoadType)(int)(::RoadVehicle::Get(vehicle_id))->roadtype;
 }
 
-/* static */ int32 ScriptVehicle::GetCapacity(VehicleID vehicle_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetCapacity(VehicleID vehicle_id, CargoID cargo)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -424,7 +424,7 @@
 	return amount;
 }
 
-/* static */ int32 ScriptVehicle::GetCargoLoad(VehicleID vehicle_id, CargoID cargo)
+/* static */ SQInteger ScriptVehicle::GetCargoLoad(VehicleID vehicle_id, CargoID cargo)
 {
 	if (!IsValidVehicle(vehicle_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo)) return -1;
@@ -465,7 +465,7 @@
 	return v->orders != nullptr && v->orders->GetNumVehicles() > 1;
 }
 
-/* static */ int ScriptVehicle::GetReliability(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetReliability(VehicleID vehicle_id)
 {
 	if (!IsPrimaryVehicle(vehicle_id)) return -1;
 
@@ -473,16 +473,11 @@
 	return ::ToPercent16(v->reliability);
 }
 
-/* static */ uint ScriptVehicle::GetMaximumOrderDistance(VehicleID vehicle_id)
+/* static */ SQInteger ScriptVehicle::GetMaximumOrderDistance(VehicleID vehicle_id)
 {
 	if (!IsPrimaryVehicle(vehicle_id)) return 0;
 
 	const ::Vehicle *v = ::Vehicle::Get(vehicle_id);
-	switch (v->type) {
-		case VEH_AIRCRAFT:
-			return ::Aircraft::From(v)->acache.cached_max_range_sqr;
-
-		default:
-			return 0;
-	}
+	if (v->type != VEH_AIRCRAFT) return 0;
+	return ::Aircraft::From(v)->acache.cached_max_range_sqr;
 }

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -117,7 +117,7 @@ public:
 	 * @pre IsValidVehicle(vehicle_id).
 	 * @return The number of wagons the vehicle has.
 	 */
-	static int32 GetNumWagons(VehicleID vehicle_id);
+	static SQInteger GetNumWagons(VehicleID vehicle_id);
 
 	/**
 	 * Set the name of a vehicle.
@@ -172,7 +172,7 @@ public:
 	 * @pre wagon < GetNumWagons(vehicle_id).
 	 * @return The engine type the vehicle has.
 	 */
-	static EngineID GetWagonEngineType(VehicleID vehicle_id, int wagon);
+	static EngineID GetWagonEngineType(VehicleID vehicle_id, SQInteger wagon);
 
 	/**
 	 * Get the unitnumber of a vehicle.
@@ -180,7 +180,7 @@ public:
 	 * @pre IsPrimaryVehicle(vehicle_id).
 	 * @return The unitnumber the vehicle has.
 	 */
-	static int32 GetUnitNumber(VehicleID vehicle_id);
+	static SQInteger GetUnitNumber(VehicleID vehicle_id);
 
 	/**
 	 * Get the current age of a vehicle.
@@ -189,7 +189,7 @@ public:
 	 * @return The current age the vehicle has.
 	 * @note The age is in days.
 	 */
-	static int32 GetAge(VehicleID vehicle_id);
+	static SQInteger GetAge(VehicleID vehicle_id);
 
 	/**
 	 * Get the current age of a second (or third, etc.) engine in a train vehicle.
@@ -200,7 +200,7 @@ public:
 	 * @return The current age the vehicle has.
 	 * @note The age is in days.
 	 */
-	static int32 GetWagonAge(VehicleID vehicle_id, int wagon);
+	static SQInteger GetWagonAge(VehicleID vehicle_id, SQInteger wagon);
 
 	/**
 	 * Get the maximum age of a vehicle.
@@ -209,7 +209,7 @@ public:
 	 * @return The maximum age the vehicle has.
 	 * @note The age is in days.
 	 */
-	static int32 GetMaxAge(VehicleID vehicle_id);
+	static SQInteger GetMaxAge(VehicleID vehicle_id);
 
 	/**
 	 * Get the age a vehicle has left (maximum - current).
@@ -218,7 +218,7 @@ public:
 	 * @return The age the vehicle has left.
 	 * @note The age is in days.
 	 */
-	static int32 GetAgeLeft(VehicleID vehicle_id);
+	static SQInteger GetAgeLeft(VehicleID vehicle_id);
 
 	/**
 	 * Get the current speed of a vehicle.
@@ -229,7 +229,7 @@ public:
 	 *       This is mph / 1.6, which is roughly km/h.
 	 *       To get km/h multiply this number by 1.00584.
 	 */
-	static int32 GetCurrentSpeed(VehicleID vehicle_id);
+	static SQInteger GetCurrentSpeed(VehicleID vehicle_id);
 
 	/**
 	 * Get the current state of a vehicle.
@@ -366,7 +366,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @return The capacity the vehicle will have when refited.
 	 */
-	static int GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo);
+	static SQInteger GetBuildWithRefitCapacity(TileIndex depot, EngineID engine_id, CargoID cargo);
 
 	/**
 	 * Clones a vehicle at the given depot, copying or cloning its orders.
@@ -399,7 +399,7 @@ public:
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @return Whether or not moving the wagon succeeded.
 	 */
-	static bool MoveWagon(VehicleID source_vehicle_id, int source_wagon, int dest_vehicle_id, int dest_wagon);
+	static bool MoveWagon(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon);
 
 	/**
 	 * Move a chain of wagons after another wagon.
@@ -415,7 +415,7 @@ public:
 	 * @game @pre Valid ScriptCompanyMode active in scope.
 	 * @return Whether or not moving the wagons succeeded.
 	 */
-	static bool MoveWagonChain(VehicleID source_vehicle_id, int source_wagon, int dest_vehicle_id, int dest_wagon);
+	static bool MoveWagonChain(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon);
 
 	/**
 	 * Gets the capacity of the given vehicle when refitted to the given cargo type.
@@ -427,7 +427,7 @@ public:
 	 * @pre The vehicle must be stopped in the depot.
 	 * @return The capacity the vehicle will have when refited.
 	 */
-	static int GetRefitCapacity(VehicleID vehicle_id, CargoID cargo);
+	static SQInteger GetRefitCapacity(VehicleID vehicle_id, CargoID cargo);
 
 	/**
 	 * Refits a vehicle to the given cargo type.
@@ -471,7 +471,7 @@ public:
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
 	 * @return True if and only if the wagon has been sold.
 	 */
-	static bool SellWagon(VehicleID vehicle_id, int wagon);
+	static bool SellWagon(VehicleID vehicle_id, SQInteger wagon);
 
 	/**
 	 * Sells all wagons from the vehicle starting from a given position.
@@ -486,7 +486,7 @@ public:
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
 	 * @return True if and only if the wagons have been sold.
 	 */
-	static bool SellWagonChain(VehicleID vehicle_id, int wagon);
+	static bool SellWagonChain(VehicleID vehicle_id, SQInteger wagon);
 
 	/**
 	 * Sends the given vehicle to a depot. If the vehicle has already been
@@ -542,7 +542,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @return The maximum amount of the given cargo the vehicle can transport.
 	 */
-	static int32 GetCapacity(VehicleID vehicle_id, CargoID cargo);
+	static SQInteger GetCapacity(VehicleID vehicle_id, CargoID cargo);
 
 	/**
 	 * Get the length of a the total vehicle in 1/16's of a tile.
@@ -551,7 +551,7 @@ public:
 	 * @pre GetVehicleType(vehicle_id) == VT_ROAD || GetVehicleType(vehicle_id) == VT_RAIL.
 	 * @return The length of the engine.
 	 */
-	static int GetLength(VehicleID vehicle_id);
+	static SQInteger GetLength(VehicleID vehicle_id);
 
 	/**
 	 * Get the amount of a specific cargo the given vehicle is transporting.
@@ -561,7 +561,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @return The amount of the given cargo the vehicle is currently transporting.
 	 */
-	static int32 GetCargoLoad(VehicleID vehicle_id, CargoID cargo);
+	static SQInteger GetCargoLoad(VehicleID vehicle_id, CargoID cargo);
 
 	/**
 	 * Get the group of a given vehicle.
@@ -594,7 +594,7 @@ public:
 	 * @pre IsPrimaryVehicle(vehicle_id).
 	 * @return The current reliability (0-100%).
 	 */
-	static int GetReliability(VehicleID vehicle_id);
+	static SQInteger GetReliability(VehicleID vehicle_id);
 
 	/**
 	 * Get the maximum allowed distance between two orders for a vehicle.
@@ -609,7 +609,7 @@ public:
 	 *         not be compared with map distances
 	 * @see ScriptOrder::GetOrderDistance
 	 */
-	static uint GetMaximumOrderDistance(VehicleID vehicle_id);
+	static SQInteger GetMaximumOrderDistance(VehicleID vehicle_id);
 
 private:
 	/**
@@ -620,12 +620,12 @@ private:
 	/**
 	 * Internal function used by SellWagon(Chain).
 	 */
-	static bool _SellWagonInternal(VehicleID vehicle_id, int wagon, bool sell_attached_wagons);
+	static bool _SellWagonInternal(VehicleID vehicle_id, SQInteger wagon, bool sell_attached_wagons);
 
 	/**
 	 * Internal function used by MoveWagon(Chain).
 	 */
-	static bool _MoveWagonInternal(VehicleID source_vehicle_id, int source_wagon, bool move_attached_wagons, int dest_vehicle_id, int dest_wagon);
+	static bool _MoveWagonInternal(VehicleID source_vehicle_id, SQInteger source_wagon, bool move_attached_wagons, SQInteger dest_vehicle_id, SQInteger dest_wagon);
 };
 
 #endif /* SCRIPT_VEHICLE_HPP */

--- a/src/script/api/script_window.cpp
+++ b/src/script/api/script_window.cpp
@@ -15,7 +15,7 @@
 
 #include "../../safeguards.h"
 
-/* static */ void ScriptWindow::Close(WindowClass window, uint32 number)
+/* static */ void ScriptWindow::Close(WindowClass window, SQInteger number)
 {
 	if (ScriptGame::IsMultiplayer()) return;
 
@@ -24,10 +24,12 @@
 		return;
 	}
 
+	number = Clamp<SQInteger>(number, 0, INT32_MAX);
+
 	CloseWindowById((::WindowClass)window, number);
 }
 
-/* static */ bool ScriptWindow::IsOpen(WindowClass window, uint32 number)
+/* static */ bool ScriptWindow::IsOpen(WindowClass window, SQInteger number)
 {
 	if (ScriptGame::IsMultiplayer()) return false;
 
@@ -35,15 +37,19 @@
 		return (FindWindowByClass((::WindowClass)window) != nullptr);
 	}
 
+	number = Clamp<SQInteger>(number, 0, INT32_MAX);
+
 	return FindWindowById((::WindowClass)window, number) != nullptr;
 }
 
-/* static */ void ScriptWindow::Highlight(WindowClass window, uint32 number, uint8 widget, TextColour colour)
+/* static */ void ScriptWindow::Highlight(WindowClass window, SQInteger number, SQInteger widget, TextColour colour)
 {
 	if (ScriptGame::IsMultiplayer()) return;
 	if (number == NUMBER_ALL) return;
 	if (!IsOpen(window, number)) return;
 	if (colour != TC_INVALID && (::TextColour)colour >= ::TC_END) return;
+
+	number = Clamp<SQInteger>(number, 0, INT32_MAX);
 
 	Window *w = FindWindowById((::WindowClass)window, number);
 	assert(w != nullptr);
@@ -53,6 +59,8 @@
 		w->DisableAllWidgetHighlight();
 		return;
 	}
+
+	widget = Clamp<SQInteger>(widget, 0, UINT8_MAX);
 
 	const NWidgetBase *wid = w->GetWidget<NWidgetBase>(widget);
 	if (wid == nullptr) return;

--- a/src/script/api/script_window.hpp.in
+++ b/src/script/api/script_window.hpp.in
@@ -15,7 +15,7 @@
 ${INCLUDES}
 
 /**
- * Class that handles window interaction. A Window in OpenTTD has two imporant
+ * Class that handles window interaction. A Window in OpenTTD has two important
  *  values. The WindowClass, and a Window number. The first indicates roughly
  *  which window it is. WC_TOWN_VIEW for example, is the view of a town.
  * The Window number is a bit more complex, as it depends mostly on the
@@ -67,45 +67,49 @@ public:
 	 * Special number values.
 	 */
 	enum NumberType {
-		NUMBER_ALL = 0xFFFFFFFF, ///< Value to select all windows of a class.
+		NUMBER_ALL = -1, ///< Value to select all windows of a class.
 	};
 
 	/**
 	 * Special widget values.
 	 */
 	enum WidgetType {
-		WIDGET_ALL = 0xFF, ///< Value to select all widgets of a window.
+		WIDGET_ALL = -1, ///< Value to select all widgets of a window.
 	};
 
 	/**
 	 * Close a window.
 	 * @param window The class of the window to close.
 	 * @param number The number of the window to close, or NUMBER_ALL to close all of this class.
+	 *               The value will be clamped to 0 .. MAX(int32) when value is not NUMBER_ALL.
 	 * @pre !ScriptGame::IsMultiplayer().
 	 */
-	static void Close(WindowClass window, uint32 number);
+	static void Close(WindowClass window, SQInteger number);
 
 	/**
 	 * Check if a window is open.
 	 * @param window The class of the window to check for.
 	 * @param number The number of the window to check for, or NUMBER_ALL to check for any in the class.
+	 *               The value will be clamped to 0 .. MAX(int32) when value is not NUMBER_ALL.
 	 * @pre !ScriptGame::IsMultiplayer().
 	 * @return True if the window is open.
 	 */
-	static bool IsOpen(WindowClass window, uint32 number);
+	static bool IsOpen(WindowClass window, SQInteger number);
 
 	/**
 	 * Highlight a widget in a window.
 	 * @param window The class of the window to highlight a widget in.
 	 * @param number The number of the window to highlight a widget in.
+	 *               The value will be clamped to 0 .. MAX(int32) when value is not NUMBER_ALL.
 	 * @param widget The widget in the window to highlight, or WIDGET_ALL (in combination with TC_INVALID) to disable all widget highlighting on this window.
+	 *               The value will be clamped to 0 .. MAX(uint8) when value is not WIDGET_ALL.
 	 * @param colour The colour of the highlight, or TC_INVALID for disabling.
 	 * @pre !ScriptGame::IsMultiplayer().
 	 * @pre number != NUMBER_ALL.
 	 * @pre colour < TC_END || (widget == WIDGET_ALL && colour == TC_INVALID).
 	 * @pre IsOpen(window, number).
 	 */
-	static void Highlight(WindowClass window, uint32 number, uint8 widget, TextColour colour);
+	static void Highlight(WindowClass window, SQInteger number, SQInteger widget, TextColour colour);
 
 	// @enum .*Widgets ../../widgets/*_widget.h@ENUM_WIDGETS@
 	// @endenum


### PR DESCRIPTION
## Motivation / Problem
Squirrel knows only one integer type and it's `SQInteger` (a typedef for `int64`), and all other types are converted to/from SQInteger when calling a script API function with no check on the type range.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Use `SQInteger` instead of `uint16`, `int16`, `uint32`, ..., and clamp the values (if needed) before transferring them to OpenTTD.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Some functions had a unsigned return value, but were returning -1 as error, and I'm not sure how this -1 was actually received on squirrel side. Potentially needs some compatibility handling.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
