### PR TITLE
Fix: Restore using founder client name as company manager name

### DIFF
--- a/src/command_func.h
+++ b/src/command_func.h
@@ -235,7 +235,7 @@ public:
 	{
 		auto args_tuple = std::forward_as_tuple(args...);
 
-		::NetworkSendCommand(Tcmd, err_message, nullptr, _current_company, EndianBufferWriter<CommandDataBuffer>::FromValue(args_tuple));
+		::NetworkSendCommand(Tcmd, err_message, nullptr, company, EndianBufferWriter<CommandDataBuffer>::FromValue(args_tuple));
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

In previous versions when creating new company in multiplayer founder client name was used as a company manager name. In 13.0 (after #9725 I guess) that no longer works as the network command gets rejected because it's issued as INVALID_COMPANY.

## Description

Looks like wrong company was passed to NetworkSendCommand in SendNet. Afaict in all other cases _current_company happens to be the same as passed company so CMD_RENAME_PRESIDENT was the only one affected.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* **The bug fix is important enough to be backported? (label: 'backport requested')**
* ~~This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)~~
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* ~~This PR affects the GS/AI API? (label 'needs review: Script API')~~
    * ~~ai_changelog.hpp, gs_changelog.hpp need updating.~~
    * ~~The compatibility wrappers (compat_*.nut) need updating.~~
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
    * ~~newgrf_debug_data.h may need updating.~~
    * ~~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~~
