### PR TITLE
Change: simplify/unify company mode scope checks

### DIFF
--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -18,6 +18,8 @@
  * This version is not yet released. The following changes are not set in stone yet.
  *
  * API additions:
+ * \li GSCompanyMode::IsValid
+ * \li GSCompanyMode::IsDeity
  * \li GSTown::ROAD_LAYOUT_RANDOM
  * \li GSVehicle::IsPrimaryVehicle
  *

--- a/src/script/api/script_airport.cpp
+++ b/src/script/api/script_airport.cpp
@@ -72,7 +72,7 @@
 
 /* static */ bool ScriptAirport::BuildAirport(TileIndex tile, AirportType type, StationID station_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsValidAirportType(type));
 	EnforcePrecondition(false, station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id));
@@ -82,7 +82,7 @@
 
 /* static */ bool ScriptAirport::RemoveAirport(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile))
 	EnforcePrecondition(false, IsAirportTile(tile) || IsHangarTile(tile));
 
@@ -95,7 +95,7 @@
 	if (!::IsTileType(tile, MP_STATION)) return -1;
 
 	const Station *st = ::Station::GetByTile(tile);
-	if (st->owner != ScriptObject::GetCompany() && ScriptObject::GetCompany() != OWNER_DEITY) return -1;
+	if (st->owner != ScriptObject::GetCompany() && ScriptCompanyMode::IsValid()) return -1;
 	if ((st->facilities & FACIL_AIRPORT) == 0) return -1;
 
 	return st->airport.GetNumHangars();
@@ -108,7 +108,7 @@
 	if (GetNumHangars(tile) < 1) return INVALID_TILE;
 
 	const Station *st = ::Station::GetByTile(tile);
-	if (st->owner != ScriptObject::GetCompany() && ScriptObject::GetCompany() != OWNER_DEITY) return INVALID_TILE;
+	if (st->owner != ScriptObject::GetCompany() && ScriptCompanyMode::IsValid()) return INVALID_TILE;
 	if ((st->facilities & FACIL_AIRPORT) == 0) return INVALID_TILE;
 
 	return st->airport.GetHangarTile(0);

--- a/src/script/api/script_airport.hpp
+++ b/src/script/api/script_airport.hpp
@@ -142,7 +142,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre AirportAvailable(type).
 	 * @pre station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
 	 * @exception ScriptError::ERR_LOCAL_AUTHORITY_REFUSES
@@ -156,7 +156,7 @@ public:
 	 * Removes an airport.
 	 * @param tile Any tile of the airport.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the airport has been/can be removed or not.
 	 */

--- a/src/script/api/script_basestation.cpp
+++ b/src/script/api/script_basestation.cpp
@@ -22,7 +22,7 @@
 /* static */ bool ScriptBaseStation::IsValidBaseStation(StationID station_id)
 {
 	const BaseStation *st = ::BaseStation::GetIfValid(station_id);
-	return st != nullptr && (st->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY || st->owner == OWNER_NONE);
+	return st != nullptr && (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || st->owner == OWNER_NONE);
 }
 
 /* static */ char *ScriptBaseStation::GetName(StationID station_id)
@@ -37,7 +37,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidBaseStation(station_id));
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();

--- a/src/script/api/script_basestation.hpp
+++ b/src/script/api/script_basestation.hpp
@@ -51,7 +51,7 @@ public:
 	 * @param name The new name of the station (can be either a raw string, or a ScriptText object).
 	 * @pre IsValidBaseStation(station_id).
 	 * @pre name != null && len(name) != 0.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if the name was changed.
 	 */

--- a/src/script/api/script_bridge.cpp
+++ b/src/script/api/script_bridge.cpp
@@ -78,7 +78,7 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 	EnforcePrecondition(false, vehicle_type == ScriptVehicle::VT_ROAD || vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_WATER);
 	EnforcePrecondition(false, vehicle_type != ScriptVehicle::VT_RAIL || ScriptRail::IsRailTypeAvailable(ScriptRail::GetCurrentRailType()));
 	EnforcePrecondition(false, vehicle_type != ScriptVehicle::VT_ROAD || ScriptRoad::IsRoadTypeAvailable(ScriptRoad::GetCurrentRoadType()));
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY || vehicle_type == ScriptVehicle::VT_ROAD);
+	EnforcePrecondition(false, ScriptCompanyMode::IsValid() || vehicle_type == ScriptVehicle::VT_ROAD);
 
 	switch (vehicle_type) {
 		case ScriptVehicle::VT_ROAD:
@@ -119,7 +119,7 @@ static void _DoCommandReturnBuildBridge1(class ScriptInstance *instance)
 
 /* static */ bool ScriptBridge::RemoveBridge(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsBridgeTile(tile));
 	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);
 }

--- a/src/script/api/script_bridge.hpp
+++ b/src/script/api/script_bridge.hpp
@@ -137,7 +137,7 @@ public:
 	 * @pre vehicle_type == ScriptVehicle::VT_WATER ||
 	 *   (vehicle_type == ScriptVehicle::VT_ROAD && ScriptRoad::IsRoadTypeAvailable(ScriptRoad::GetCurrentRoadType())) ||
 	 *   (vehicle_type == ScriptVehicle::VT_RAIL && ScriptRail::IsRailTypeAvailable(ScriptRail::GetCurrentRailType())).
-	 * @game @pre Outside CompanyMode: vehicle_type == ScriptVehicle::VT_ROAD.
+	 * @game @pre ScriptCompanyMode::IsValid() || vehicle_type == ScriptVehicle::VT_ROAD.
 	 * @exception ScriptError::ERR_ALREADY_BUILT
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
@@ -146,7 +146,7 @@ public:
 	 * @exception ScriptBridge::ERR_BRIDGE_CANNOT_END_IN_WATER
 	 * @exception ScriptBridge::ERR_BRIDGE_HEADS_NOT_ON_SAME_HEIGHT
 	 * @return Whether the bridge has been/can be build or not.
-	 * @game @note Building a bridge (without CompanyMode) results in a bridge owned by towns.
+	 * @game @note Building a bridge as deity (ScriptCompanyMode::IsDeity()) results in a bridge owned by towns.
 	 * @note No matter if the road pieces were build or not, if building the
 	 *  bridge succeeded, this function returns true.
 	 */
@@ -156,7 +156,7 @@ public:
 	 * Removes a bridge, by executing it on either the start or end tile.
 	 * @param tile An end or start tile of the bridge.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the bridge has been/can be removed or not.
 	 */

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -205,7 +205,7 @@
 
 /* static */ bool ScriptCompany::SetLoanAmount(Money loan)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, loan >= 0);
 	EnforcePrecondition(false, ((int64)loan % GetLoanInterval()) == 0);
 	EnforcePrecondition(false, loan <= GetMaxLoanAmount());
@@ -224,7 +224,7 @@
 
 /* static */ bool ScriptCompany::SetMinimumLoanAmount(Money loan)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, loan >= 0);
 
 	Money over_interval = (int64)loan % GetLoanInterval();
@@ -239,7 +239,7 @@
 
 /* static */ bool ScriptCompany::ChangeBankBalance(CompanyID company, Money delta, ExpensesType expenses_type, TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, expenses_type < (ExpensesType)::EXPENSES_END);
 	EnforcePrecondition(false, (int64)delta >= INT32_MIN);
 	EnforcePrecondition(false, (int64)delta <= INT32_MAX);
@@ -254,7 +254,7 @@
 
 /* static */ bool ScriptCompany::BuildCompanyHQ(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_BUILD_OBJECT>::Do(tile, OBJECT_HQ, 0);

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -192,7 +192,7 @@ public:
 	 * @pre GetLoanInterval() must be a multiplier of 'loan'.
 	 * @pre 'loan' must be below GetMaxLoanAmount().
 	 * @pre 'loan' - GetLoanAmount() + GetBankBalance() must be non-negative.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if the loan could be set to your requested amount.
 	 */
 	static bool SetLoanAmount(Money loan);
@@ -202,7 +202,7 @@ public:
 	 * @param loan The amount to loan (any positive number).
 	 * @pre 'loan' must be non-negative.
 	 * @pre 'loan' must be below GetMaxLoanAmount().
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if we could allocate a minimum of 'loan' loan.
 	 */
 	static bool SetMinimumLoanAmount(Money loan);
@@ -244,7 +244,7 @@ public:
 	 * @param expenses_type The account in the finances window that will register the cost.
 	 * @param tile The tile to show text effect on or ScriptMap::TILE_INVALID
 	 * @return True, if the bank balance was changed.
-	 * @game @pre No ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsDeity().
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre delta >= -2**31
 	 * @pre delta <   2**31
@@ -314,7 +314,7 @@ public:
 	 * Build your company's HQ on the given tile.
 	 * @param tile The tile to build your HQ on, this tile is the most northern tile of your HQ.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
 	 * @return True if the HQ could be build.

--- a/src/script/api/script_companymode.cpp
+++ b/src/script/api/script_companymode.cpp
@@ -26,3 +26,13 @@ ScriptCompanyMode::~ScriptCompanyMode()
 {
 	ScriptObject::SetCompany(this->last_company);
 }
+
+/* static */ bool ScriptCompanyMode::IsValid()
+{
+	return ScriptObject::GetCompany() != OWNER_DEITY;
+}
+
+/* static */ bool ScriptCompanyMode::IsDeity()
+{
+	return ScriptObject::GetCompany() == OWNER_DEITY;
+}

--- a/src/script/api/script_companymode.hpp
+++ b/src/script/api/script_companymode.hpp
@@ -47,6 +47,22 @@ public:
 	 *   in when the instance was created.
 	 */
 	~ScriptCompanyMode();
+
+	/**
+	 * Check whether a company mode is valid. In other words, are commands
+	 * being executed under some company.
+	 * @return true When a company mode is valid.
+	 * @post !ScriptCompanyMode::IsDeity().
+	 */
+	static bool IsValid();
+
+	/**
+	 * Check whether the company mode is not active, i.e. whether we are a deity.
+	 * In other words, are commands are not being executed under some company.
+	 * @return true When we are a deity, i.e. company mode is not active.
+	 * @post !ScriptCompanyMode::IsValid().
+	 */
+	static bool IsDeity();
 };
 
 #endif /* SCRIPT_COMPANYMODE_HPP */

--- a/src/script/api/script_depotlist.cpp
+++ b/src/script/api/script_depotlist.cpp
@@ -27,7 +27,7 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 		case ScriptTile::TRANSPORT_AIR: {
 			/* Hangars are not seen as real depots by the depot code. */
 			for (const Station *st : Station::Iterate()) {
-				if (st->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) {
+				if (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) {
 					for (uint i = 0; i < st->airport.GetNumHangars(); i++) {
 						this->AddItem(st->airport.GetHangarTile(i));
 					}
@@ -39,6 +39,6 @@ ScriptDepotList::ScriptDepotList(ScriptTile::TransportType transport_type)
 
 	/* Handle 'standard' depots. */
 	for (const Depot *depot : Depot::Iterate()) {
-		if ((::GetTileOwner(depot->xy) == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && ::IsTileType(depot->xy, tile_type)) this->AddItem(depot->xy);
+		if ((::GetTileOwner(depot->xy) == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && ::IsTileType(depot->xy, tile_type)) this->AddItem(depot->xy);
 	}
 }

--- a/src/script/api/script_engine.cpp
+++ b/src/script/api/script_engine.cpp
@@ -30,7 +30,7 @@
 	/* AIs have only access to engines they can purchase or still have in use.
 	 * Deity has access to all engined that will be or were available ever. */
 	CompanyID company = ScriptObject::GetCompany();
-	return company == OWNER_DEITY || ::IsEngineBuildable(engine_id, e->type, company) || ::Company::Get(company)->group_all[e->type].num_engines[engine_id] > 0;
+	return ScriptCompanyMode::IsDeity() || ::IsEngineBuildable(engine_id, e->type, company) || ::Company::Get(company)->group_all[e->type].num_engines[engine_id] > 0;
 }
 
 /* static */ bool ScriptEngine::IsBuildable(EngineID engine_id)
@@ -277,7 +277,7 @@
 {
 	company = ScriptCompany::ResolveCompanyID(company);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidEngine(engine_id));
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 
@@ -288,7 +288,7 @@
 {
 	company = ScriptCompany::ResolveCompanyID(company);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidEngine(engine_id));
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);
 

--- a/src/script/api/script_engine.hpp
+++ b/src/script/api/script_engine.hpp
@@ -24,7 +24,7 @@ public:
 	/**
 	 * Checks whether the given engine type is valid.
 	 * An engine is valid for a company if it has at least one vehicle of this engine or it's currently buildable.
-	 * @game Outside ScriptCompanyMode scope the function reports all engines valid, which were or will be available at some point.
+	 * @game Outside ScriptCompanyMode scope (ScriptCompanyMode::IsDeity) the function reports all engines valid, which were or will be available at some point.
 	 * @param engine_id The engine to check.
 	 * @return True if and only if the engine type is valid.
 	 */
@@ -32,7 +32,7 @@ public:
 
 	/**
 	 * Checks whether the given engine type is buildable for a company.
-	 * @game Outside ScriptCompanyMode scope the function checks whether the engine is currently buildable by all companies (no exclusive preview).
+	 * @game Outside ScriptCompanyMode scope (ScriptCompanyMode::IsDeity) the function checks whether the engine is currently buildable by all companies (no exclusive preview).
 	 * @param engine_id The engine to check.
 	 * @return True if and only if the engine type is buildable.
 	 */

--- a/src/script/api/script_enginelist.cpp
+++ b/src/script/api/script_enginelist.cpp
@@ -16,6 +16,6 @@
 ScriptEngineList::ScriptEngineList(ScriptVehicle::VehicleType vehicle_type)
 {
 	for (const Engine *e : Engine::IterateType((::VehicleType)vehicle_type)) {
-		if (ScriptObject::GetCompany() == OWNER_DEITY || HasBit(e->company_avail, ScriptObject::GetCompany())) this->AddItem(e->index);
+		if (ScriptCompanyMode::IsDeity() || HasBit(e->company_avail, ScriptObject::GetCompany())) this->AddItem(e->index);
 	}
 }

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -11,6 +11,7 @@
 #define SCRIPT_ERROR_HPP
 
 #include "script_object.hpp"
+#include "script_companymode.hpp"
 #include <map>
 
 /**
@@ -46,6 +47,20 @@
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_FAILED); \
 		return returnval; \
 	}
+
+/**
+ * Helper to enforce the precondition that the company mode is valid.
+ * @param returnval The value to return on failure.
+ */
+#define EnforceCompanyModeValid(returnval) \
+	EnforcePrecondition(returnval, ScriptCompanyMode::IsValid())
+
+/**
+ * Helper to enforce the precondition that we are in a deity mode.
+ * @param returnval The value to return on failure.
+ */
+#define EnforceDeityMode(returnval) \
+	EnforcePrecondition(returnval, ScriptCompanyMode::IsDeity())
 
 /**
  * Class that handles all error related functions.

--- a/src/script/api/script_goal.cpp
+++ b/src/script/api/script_goal.cpp
@@ -32,7 +32,7 @@
 {
 	CCountedPtr<Text> counter(goal);
 
-	EnforcePrecondition(GOAL_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(GOAL_INVALID);
 	EnforcePrecondition(GOAL_INVALID, goal != nullptr);
 	const std::string &text = goal->GetEncodedText();
 	EnforcePreconditionEncodedText(GOAL_INVALID, text);
@@ -58,7 +58,7 @@
 
 /* static */ bool ScriptGoal::Remove(GoalID goal_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidGoal(goal_id));
 
 	return ScriptObject::Command<CMD_REMOVE_GOAL>::Do(goal_id);
@@ -69,7 +69,7 @@
 	CCountedPtr<Text> counter(goal);
 
 	EnforcePrecondition(false, IsValidGoal(goal_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, goal != nullptr);
 	const std::string &text = goal->GetEncodedText();
 	EnforcePreconditionEncodedText(false, text);
@@ -82,7 +82,7 @@
 	CCountedPtr<Text> counter(progress);
 
 	EnforcePrecondition(false, IsValidGoal(goal_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 
 	return ScriptObject::Command<CMD_SET_GOAL_PROGRESS>::Do(goal_id, progress != nullptr ? progress->GetEncodedText() : std::string{});
 }
@@ -90,7 +90,7 @@
 /* static */ bool ScriptGoal::SetCompleted(GoalID goal_id, bool completed)
 {
 	EnforcePrecondition(false, IsValidGoal(goal_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 
 	return ScriptObject::Command<CMD_SET_GOAL_COMPLETED>::Do(goal_id, completed);
 }
@@ -98,7 +98,7 @@
 /* static */ bool ScriptGoal::IsCompleted(GoalID goal_id)
 {
 	EnforcePrecondition(false, IsValidGoal(goal_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 
 	Goal *g = Goal::Get(goal_id);
 	return g != nullptr && g->completed;
@@ -108,7 +108,7 @@
 {
 	CCountedPtr<Text> counter(question);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, question != nullptr);
 	const std::string &text = question->GetEncodedText();
 	EnforcePreconditionEncodedText(false, text);
@@ -139,7 +139,7 @@
 
 /* static */ bool ScriptGoal::CloseQuestion(SQInteger uniqueid)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, uniqueid >= 0 && uniqueid <= UINT16_MAX);
 
 	return ScriptObject::Command<CMD_GOAL_QUESTION_ANSWER>::Do(uniqueid, 0);

--- a/src/script/api/script_goal.hpp
+++ b/src/script/api/script_goal.hpp
@@ -96,7 +96,7 @@ public:
 	 * @param type The type of the goal.
 	 * @param destination The destination of the \a type type.
 	 * @return The new GoalID, or GOAL_INVALID if it failed.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre goal != null && len(goal) != 0.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre if type is GT_STORY_PAGE, the company of the goal and the company of the story page need to match:
@@ -109,7 +109,7 @@ public:
 	 * Remove a goal from the list.
 	 * @param goal_id The goal to remove.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidGoal(goal_id).
 	 */
 	static bool Remove(GoalID goal_id);
@@ -119,7 +119,7 @@ public:
 	 * @param goal_id The goal to update.
 	 * @param goal The new goal text (can be either a raw string, or a ScriptText object).
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre goal != null && len(goal) != 0.
 	 * @pre IsValidGoal(goal_id).
 	 */
@@ -134,7 +134,7 @@ public:
 	 * or a ScriptText object). To clear the progress string you can pass null or an
 	 * empty string.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidGoal(goal_id).
 	 */
 	static bool SetProgress(GoalID goal_id, Text *progress);
@@ -144,7 +144,7 @@ public:
 	 * @param goal_id The goal to update.
 	 * @param complete The new goal completed status.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidGoal(goal_id).
 	 */
 	static bool SetCompleted(GoalID goal_id, bool complete);
@@ -153,7 +153,7 @@ public:
 	 * Checks if a given goal have been marked as completed.
 	 * @param goal_id The goal to check complete status.
 	 * @return True if the goal is completed, otherwise false.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidGoal(goal_id).
 	 */
 	static bool IsCompleted(GoalID goal_id);
@@ -166,7 +166,7 @@ public:
 	 * @param type The type of question that is being asked.
 	 * @param buttons Any combinations (at least 1, up to 3) of buttons defined in QuestionButton. Like BUTTON_YES + BUTTON_NO.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre question != null && len(question) != 0.
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 * @pre CountBits(buttons) >= 1 && CountBits(buttons) <= 3.
@@ -184,7 +184,7 @@ public:
 	 * @param type The type of question that is being asked.
 	 * @param buttons Any combinations (at least 1, up to 3) of buttons defined in QuestionButton. Like BUTTON_YES + BUTTON_NO.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre ScriptGame::IsMultiplayer()
 	 * @pre question != null && len(question) != 0.
 	 * @pre ResolveClientID(client) != CLIENT_INVALID.
@@ -199,7 +199,7 @@ public:
 	 * Close the question on all clients.
 	 * @param uniqueid The uniqueid of the question you want to close.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre uniqueid >= 0 && uniqueid <= MAX(uint16)
 	 * @note If you send a question to a single company, and get a reply for them,
 	 *   the question is already closed on all clients. Only use this function if

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -250,7 +250,7 @@
 
 /* static */ bool ScriptIndustry::SetControlFlags(IndustryID industry_id, SQInteger control_flags)
 {
-	if (ScriptObject::GetCompany() != OWNER_DEITY) return false;
+	EnforceDeityMode(false);
 	if (!IsValidIndustry(industry_id)) return false;
 
 	return ScriptObject::Command<CMD_INDUSTRY_SET_FLAGS>::Do(industry_id, (::IndustryControlFlags)control_flags & ::INDCTL_MASK);

--- a/src/script/api/script_industry.hpp
+++ b/src/script/api/script_industry.hpp
@@ -265,7 +265,7 @@ public:
 	 * @param industry_id The index of the industry.
 	 * @param control_flags New flags as a combination of IndustryControlFlags values.
 	 * @pre IsValidIndustry(industry_id).
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @return True if the action succeeded.
 	 * @api -ai
 	 */

--- a/src/script/api/script_industrytype.cpp
+++ b/src/script/api/script_industrytype.cpp
@@ -96,7 +96,7 @@
 {
 	if (!IsValidIndustryType(industry_type)) return false;
 
-	const bool deity = ScriptObject::GetCompany() == OWNER_DEITY;
+	const bool deity = ScriptCompanyMode::IsDeity();
 	if (::GetIndustryProbabilityCallback(industry_type, deity ? IACT_RANDOMCREATION : IACT_USERCREATION, 1) == 0) return false;
 	if (deity) return true;
 	if (!::GetIndustrySpec(industry_type)->IsRawIndustry()) return true;
@@ -109,7 +109,7 @@
 {
 	if (!IsValidIndustryType(industry_type)) return false;
 
-	const bool deity = ScriptObject::GetCompany() == OWNER_DEITY;
+	const bool deity = ScriptCompanyMode::IsDeity();
 	if (!deity && !::GetIndustrySpec(industry_type)->IsRawIndustry()) return false;
 	if (::GetIndustryProbabilityCallback(industry_type, deity ? IACT_RANDOMCREATION : IACT_USERCREATION, 1) == 0) return false;
 

--- a/src/script/api/script_industrytype.hpp
+++ b/src/script/api/script_industrytype.hpp
@@ -111,9 +111,9 @@ public:
 	 * @pre IsValidIndustryType(industry_type).
 	 * @return True if you can build this type of industry at locations of your choice.
 	 * @ai @note Returns false if you can only prospect this type of industry, or not build it at all.
-	 * @game @note If no valid ScriptCompanyMode active in scope, this method returns false if you can
+	 * @game @note When ScriptCompanyMode::IsDeity, this method returns false if you can
 	 * @game only prospect this type of industry, or not build it at all.
-	 * @game @note If no valid ScriptCompanyMode active in scope, the script can
+	 * @game @note When ScriptCompanyMode::IsDeity, the script can
 	 * @game build as long as the industry type can be built. (a NewGRF can for example
 	 * @game reject construction based on current year)
 	 */
@@ -126,10 +126,10 @@ public:
 	 * @return True if you can prospect this type of industry.
 	 * @ai @note If the setting "Manual primary industry construction method" is set
 	 * @ai to either "None" or "as other industries" this function always returns false.
-	 * @game @note If no valid ScriptCompanyMode is active in scope, and if the setting
+	 * @game @note When ScriptCompanyMode::IsDeity, and if the setting
 	 * @game "Manual primary industry construction method" is set to either "None" or
 	 * @game "as other industries" this function always returns false.
-	 * @game @note If no valid ScriptCompanyMode active in scope, the script can
+	 * @game @note When ScriptCompanyMode::IsDeity, the script can
 	 * @game prospect as long as the industry type can be built. (a NewGRF can for
 	 * @game example reject construction based on current year)
 	 */
@@ -152,7 +152,7 @@ public:
 	 * @return True if no error occurred while trying to prospect.
 	 * @note Even if true is returned there is no guarantee a new industry is build.
 	 * @note If true is returned the money is paid, whether a new industry was build or not.
-	 * @game @note if no valid ScriptCompanyMode exist in scope, prospection will not fail
+	 * @game @note When ScriptCompanyMode::IsDeity, prospection will not fail
 	 * @game due to the general chance that prospection may fail. However prospection can still
 	 * @game fail if OpenTTD is unable to find a suitable location to place the industry.
 	 */

--- a/src/script/api/script_league.cpp
+++ b/src/script/api/script_league.cpp
@@ -30,7 +30,7 @@
 	CCountedPtr<Text> header_counter(header);
 	CCountedPtr<Text> footer_counter(footer);
 
-	EnforcePrecondition(LEAGUE_TABLE_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(LEAGUE_TABLE_INVALID);
 	EnforcePrecondition(LEAGUE_TABLE_INVALID, title != nullptr);
 	const std::string &encoded_title = title->GetEncodedText();
 	EnforcePreconditionEncodedText(LEAGUE_TABLE_INVALID, encoded_title);
@@ -54,7 +54,7 @@
 	CCountedPtr<Text> text_counter(text);
 	CCountedPtr<Text> score_counter(score);
 
-	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(LEAGUE_TABLE_ELEMENT_INVALID);
 
 	EnforcePrecondition(LEAGUE_TABLE_ELEMENT_INVALID, IsValidLeagueTable(table));
 
@@ -82,7 +82,7 @@
 {
 	CCountedPtr<Text> text_counter(text);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidLeagueTableElement(element));
 
 	EnforcePrecondition(false, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
@@ -102,7 +102,7 @@
 {
 	CCountedPtr<Text> score_counter(score);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidLeagueTableElement(element));
 
 	EnforcePrecondition(false, score != nullptr);
@@ -114,7 +114,7 @@
 
 /* static */ bool ScriptLeagueTable::RemoveElement(LeagueTableElementID element)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidLeagueTableElement(element));
 
 	return ScriptObject::Command<CMD_REMOVE_LEAGUE_TABLE_ELEMENT>::Do(element);

--- a/src/script/api/script_league.hpp
+++ b/src/script/api/script_league.hpp
@@ -71,7 +71,7 @@ public:
 	 * @param header The optional header text for the table (null is allowed).
 	 * @param footer The optional footer text for the table (null is allowed).
 	 * @return The new LeagueTableID, or LEAGUE_TABLE_INVALID if it failed.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity.
 	 * @pre title != null && len(title) != 0.
 	 */
 	static LeagueTableID New(Text *title, Text *header, Text *footer);
@@ -86,7 +86,7 @@ public:
 	 * @param link_type Type of the referenced object.
 	 * @param link_target Id of the referenced object.
 	 * @return The new LeagueTableElementID, or LEAGUE_TABLE_ELEMENT_INVALID if it failed.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity.
 	 * @pre IsValidLeagueTable(table).
 	 * @pre text != null && len(text) != 0.
 	 * @pre score != null && len(score) != 0.
@@ -102,7 +102,7 @@ public:
 	 * @param link_type Type of the referenced object.
 	 * @param link_target Id of the referenced object.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity.
 	 * @pre IsValidLeagueTableElement(element).
 	 * @pre text != null && len(text) != 0.
 	 * @pre IsValidLink(Link(link_type, link_target)).
@@ -115,7 +115,7 @@ public:
 	 * @param rating Value that elements are ordered by.
 	 * @param score String representation of the score associated with the element (can be either a raw string, or ScriptText object).
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity.
 	 * @pre IsValidLeagueTableElement(element).
 	 * @pre score != null && len(score) != 0.
 	 */
@@ -126,7 +126,7 @@ public:
 	 * Remove a league table element.
 	 * @param element Id of the element to update
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity.
 	 * @pre IsValidLeagueTableElement(element).
 	 */
 	static bool RemoveElement(LeagueTableElementID element);

--- a/src/script/api/script_marine.cpp
+++ b/src/script/api/script_marine.cpp
@@ -78,7 +78,7 @@
 
 /* static */ bool ScriptMarine::BuildWaterDepot(TileIndex tile, TileIndex front)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(front));
 	EnforcePrecondition(false, (::TileX(front) == ::TileX(tile)) != (::TileY(front) == ::TileY(tile)));
@@ -88,7 +88,7 @@
 
 /* static */ bool ScriptMarine::BuildDock(TileIndex tile, StationID station_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id));
 
@@ -97,7 +97,7 @@
 
 /* static */ bool ScriptMarine::BuildBuoy(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_BUILD_BUOY>::Do(tile);
@@ -105,7 +105,7 @@
 
 /* static */ bool ScriptMarine::BuildLock(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_BUILD_LOCK>::Do(tile);
@@ -113,7 +113,7 @@
 
 /* static */ bool ScriptMarine::BuildCanal(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_BUILD_CANAL>::Do(tile, tile, WATER_CLASS_CANAL, false);
@@ -121,7 +121,7 @@
 
 /* static */ bool ScriptMarine::RemoveWaterDepot(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsWaterDepotTile(tile));
 
@@ -130,7 +130,7 @@
 
 /* static */ bool ScriptMarine::RemoveDock(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsDockTile(tile));
 
@@ -139,7 +139,7 @@
 
 /* static */ bool ScriptMarine::RemoveBuoy(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsBuoyTile(tile));
 
@@ -148,7 +148,7 @@
 
 /* static */ bool ScriptMarine::RemoveLock(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsLockTile(tile));
 
@@ -157,7 +157,7 @@
 
 /* static */ bool ScriptMarine::RemoveCanal(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsCanalTile(tile));
 

--- a/src/script/api/script_marine.hpp
+++ b/src/script/api/script_marine.hpp
@@ -99,7 +99,7 @@ public:
 	 * @param front A tile on the same axis with 'tile' as the depot shall be oriented.
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre ScriptMap::IsValidTile(front).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_SITE_UNSUITABLE
 	 * @exception ScriptMarine::ERR_MARINE_MUST_BE_BUILT_ON_WATER
@@ -115,7 +115,7 @@ public:
 	 * @param station_id The station to join, ScriptStation::STATION_NEW or ScriptStation::STATION_JOIN_ADJACENT.
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_SITE_UNSUITABLE
 	 * @exception ScriptStation::ERR_STATION_TOO_CLOSE_TO_ANOTHER_STATION
@@ -128,7 +128,7 @@ public:
 	 * Builds a buoy on tile.
 	 * @param tile The tile where the buoy will be build.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_SITE_UNSUITABLE
 	 * @exception ScriptStation::ERR_STATION_TOO_MANY_STATIONS
@@ -140,7 +140,7 @@ public:
 	 * Builds a lock on tile.
 	 * @param tile The tile where the lock will be build.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
 	 * @exception ScriptError::ERR_SITE_UNSUITABLE
 	 * @return Whether the lock has been/can be build or not.
@@ -151,7 +151,7 @@ public:
 	 * Builds a canal on tile.
 	 * @param tile The tile where the canal will be build.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
@@ -164,7 +164,7 @@ public:
 	 * Removes a water depot.
 	 * @param tile Any tile of the water depot.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the water depot has been/can be removed or not.
 	 */
@@ -174,7 +174,7 @@ public:
 	 * Removes a dock.
 	 * @param tile Any tile of the dock.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the dock has been/can be removed or not.
 	 */
@@ -184,7 +184,7 @@ public:
 	 * Removes a buoy.
 	 * @param tile Any tile of the buoy.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the buoy has been/can be removed or not.
 	 */
@@ -194,7 +194,7 @@ public:
 	 * Removes a lock.
 	 * @param tile Any tile of the lock.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the lock has been/can be removed or not.
 	 */
@@ -204,7 +204,7 @@ public:
 	 * Removes a canal.
 	 * @param tile Any tile of the canal.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the canal has been/can be removed or not.
 	 */

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -253,7 +253,7 @@ std::tuple<bool, bool, bool> ScriptObject::DoCommandPrep()
 
 	bool networking = _networking && !_generating_world;
 
-	if (ScriptObject::GetCompany() != OWNER_DEITY && !::Company::IsValidID(ScriptObject::GetCompany())) {
+	if (ScriptCompanyMode::IsValid() && !::Company::IsValidID(ScriptObject::GetCompany())) {
 		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY);
 		return { true, estimate_only, networking };
 	}

--- a/src/script/api/script_rail.cpp
+++ b/src/script/api/script_rail.cpp
@@ -71,7 +71,7 @@
 {
 	if ((::RailType)rail_type >= RAILTYPE_END) return false;
 
-	return ScriptObject::GetCompany() == OWNER_DEITY || ::HasRailtypeAvail(ScriptObject::GetCompany(), (::RailType)rail_type);
+	return ScriptCompanyMode::IsDeity() || ::HasRailtypeAvail(ScriptObject::GetCompany(), (::RailType)rail_type);
 }
 
 /* static */ ScriptRail::RailType ScriptRail::GetCurrentRailType()
@@ -111,7 +111,7 @@
 
 /* static */ bool ScriptRail::ConvertRailType(TileIndex start_tile, TileIndex end_tile, ScriptRail::RailType convert_to)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(start_tile));
 	EnforcePrecondition(false, ::IsValidTile(end_tile));
 	EnforcePrecondition(false, IsRailTypeAvailable(convert_to));
@@ -135,7 +135,7 @@
 
 /* static */ bool ScriptRail::BuildRailDepot(TileIndex tile, TileIndex front)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, tile != front);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(front));
@@ -149,7 +149,7 @@
 
 /* static */ bool ScriptRail::BuildRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, direction == RAILTRACK_NW_SE || direction == RAILTRACK_NE_SW);
 	EnforcePrecondition(false, num_platforms > 0 && num_platforms <= 0xFF);
@@ -163,7 +163,7 @@
 
 /* static */ bool ScriptRail::BuildNewGRFRailStation(TileIndex tile, RailTrack direction, SQInteger num_platforms, SQInteger platform_length, StationID station_id, CargoID cargo_id, IndustryType source_industry, IndustryType goal_industry, SQInteger distance, bool source_station)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, direction == RAILTRACK_NW_SE || direction == RAILTRACK_NE_SW);
 	EnforcePrecondition(false, num_platforms > 0 && num_platforms <= 0xFF);
@@ -207,7 +207,7 @@
 
 /* static */ bool ScriptRail::BuildRailWaypoint(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsRailTile(tile));
 	EnforcePrecondition(false, GetRailTracks(tile) == RAILTRACK_NE_SW || GetRailTracks(tile) == RAILTRACK_NW_SE);
@@ -218,7 +218,7 @@
 
 /* static */ bool ScriptRail::RemoveRailWaypointTileRectangle(TileIndex tile, TileIndex tile2, bool keep_rail)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(tile2));
 
@@ -227,7 +227,7 @@
 
 /* static */ bool ScriptRail::RemoveRailStationTileRectangle(TileIndex tile, TileIndex tile2, bool keep_rail)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(tile2));
 
@@ -246,7 +246,7 @@
 
 /* static */ bool ScriptRail::BuildRailTrack(TileIndex tile, RailTrack rail_track)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, rail_track != 0);
 	EnforcePrecondition(false, (rail_track & ~::TRACK_BIT_ALL) == 0);
@@ -258,7 +258,7 @@
 
 /* static */ bool ScriptRail::RemoveRailTrack(TileIndex tile, RailTrack rail_track)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsPlainRailTile(tile) || ::IsLevelCrossingTile(tile));
 	EnforcePrecondition(false, GetRailTracks(tile) & rail_track);
@@ -352,7 +352,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 
 /* static */ bool ScriptRail::BuildRail(TileIndex from, TileIndex tile, TileIndex to)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(from));
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(to));
@@ -370,7 +370,7 @@ static Track SimulateDrag(TileIndex from, TileIndex tile, TileIndex *to)
 
 /* static */ bool ScriptRail::RemoveRail(TileIndex from, TileIndex tile, TileIndex to)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(from));
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(to));
@@ -443,7 +443,7 @@ static bool IsValidSignalType(int signal_type)
 
 /* static */ bool ScriptRail::BuildSignal(TileIndex tile, TileIndex front, SignalType signal)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptMap::DistanceManhattan(tile, front) == 1)
 	EnforcePrecondition(false, ::IsPlainRailTile(tile));
 	EnforcePrecondition(false, ::IsValidSignalType(signal));
@@ -473,7 +473,7 @@ static bool IsValidSignalType(int signal_type)
 
 /* static */ bool ScriptRail::RemoveSignal(TileIndex tile, TileIndex front)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ScriptMap::DistanceManhattan(tile, front) == 1)
 	EnforcePrecondition(false, GetSignalType(tile, front) != SIGNALTYPE_NONE);
 

--- a/src/script/api/script_rail.hpp
+++ b/src/script/api/script_rail.hpp
@@ -201,7 +201,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(start_tile).
 	 * @pre ScriptMap::IsValidTile(end_tile).
 	 * @pre IsRailTypeAvailable(convert_to).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether at least some rail has been converted successfully.
 	 */
@@ -231,7 +231,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(front).
 	 * @pre 'tile' is not equal to 'front', but in a straight line of it.
 	 * @pre IsRailTypeAvailable(GetCurrentRailType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @return Whether the rail depot has been/can be build or not.
@@ -251,7 +251,7 @@ public:
 	 * @pre num_platforms > 0 && num_platforms <= 255.
 	 * @pre platform_length > 0 && platform_length <= 255.
 	 * @pre station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
@@ -288,7 +288,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo_type)
 	 * @pre source_industry == ScriptIndustryType::INDUSTRYTYPE_UNKNOWN || source_industry == ScriptIndustryType::INDUSTRYTYPE_TOWN || ScriptIndustryType::IsValidIndustryType(source_industry).
 	 * @pre goal_industry == ScriptIndustryType::INDUSTRYTYPE_UNKNOWN || goal_industry == ScriptIndustryType::INDUSTRYTYPE_TOWN || ScriptIndustryType::IsValidIndustryType(goal_industry).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
@@ -306,7 +306,7 @@ public:
 	 * @pre IsRailTile(tile).
 	 * @pre GetRailTracks(tile) == RAILTRACK_NE_SW || GetRailTracks(tile) == RAILTRACK_NW_SE.
 	 * @pre IsRailTypeAvailable(GetCurrentRailType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
 	 * @return Whether the rail waypoint has been/can be build or not.
 	 */
@@ -319,7 +319,7 @@ public:
 	 * @param keep_rail Whether to keep the rail after removal.
 	 * @pre IsValidTile(tile).
 	 * @pre IsValidTile(tile2).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether at least one tile has been/can be cleared or not.
 	 */
@@ -332,7 +332,7 @@ public:
 	 * @param keep_rail Whether to keep the rail after removal.
 	 * @pre IsValidTile(tile).
 	 * @pre IsValidTile(tile2).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether at least one tile has been/can be cleared or not.
 	 */
@@ -353,7 +353,7 @@ public:
 	 * @param rail_track The RailTrack to build.
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre IsRailTypeAvailable(GetCurrentRailType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
 	 * @exception ScriptRoad::ERR_ROAD_WORKS_IN_PROGRESS
@@ -371,7 +371,7 @@ public:
 	 * @param rail_track The RailTrack to remove.
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre (GetRailTracks(tile) & rail_track) != 0.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether the rail has been/can be removed or not.
 	 * @note You can only remove a single track with this function so do not
@@ -404,7 +404,7 @@ public:
 	 *      (ScriptMap::GetTileX(from) == ScriptMap::GetTileX(tile) && ScriptMap::GetTileX(tile) == ScriptMap::GetTileX(to)) ||
 	 *      (ScriptMap::GetTileY(from) == ScriptMap::GetTileY(tile) && ScriptMap::GetTileY(tile) == ScriptMap::GetTileY(to)).
 	 * @pre IsRailTypeAvailable(GetCurrentRailType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
 	 * @exception ScriptRail::ERR_CROSSING_ON_ONEWAY_ROAD
@@ -427,7 +427,7 @@ public:
 	 *          abs(ScriptMap::GetTileY(to) - ScriptMap::GetTileY(tile))) <= 1) ||
 	 *      (ScriptMap::GetTileX(from) == ScriptMap::GetTileX(tile) && ScriptMap::GetTileX(tile) == ScriptMap::GetTileX(to)) ||
 	 *      (ScriptMap::GetTileY(from) == ScriptMap::GetTileY(tile) && ScriptMap::GetTileY(tile) == ScriptMap::GetTileY(to)).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether the rail has been/can be removed or not.
 	 */
@@ -449,7 +449,7 @@ public:
 	 * @param signal The SignalType to build.
 	 * @pre ScriptMap::DistanceManhattan(tile, front) == 1.
 	 * @pre IsRailTile(tile) && !IsRailStationTile(tile) && !IsRailWaypointTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether the signal has been/can be build or not.
 	 */
@@ -461,7 +461,7 @@ public:
 	 * @param front The tile in front of the signal.
 	 * @pre ScriptMap::DistanceManhattan(tile, front) == 1.
 	 * @pre GetSignalType(tile, front) != SIGNALTYPE_NONE.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRail::ERR_UNSUITABLE_TRACK
 	 * @return Whether the signal has been/can be removed or not.
 	 */

--- a/src/script/api/script_railtypelist.cpp
+++ b/src/script/api/script_railtypelist.cpp
@@ -9,6 +9,7 @@
 
 #include "../../stdafx.h"
 #include "script_railtypelist.hpp"
+#include "script_companymode.hpp"
 #include "../../rail.h"
 
 #include "../../safeguards.h"
@@ -16,6 +17,6 @@
 ScriptRailTypeList::ScriptRailTypeList()
 {
 	for (RailType rt = RAILTYPE_BEGIN; rt != RAILTYPE_END; rt++) {
-		if (ScriptObject::GetCompany() == OWNER_DEITY || ::HasRailtypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
+		if (ScriptCompanyMode::IsDeity() || ::HasRailtypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
 	}
 }

--- a/src/script/api/script_road.cpp
+++ b/src/script/api/script_road.cpp
@@ -125,7 +125,7 @@
 
 /* static */ bool ScriptRoad::ConvertRoadType(TileIndex start_tile, TileIndex end_tile, RoadType road_type)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(start_tile));
 	EnforcePrecondition(false, ::IsValidTile(end_tile));
 	EnforcePrecondition(false, IsRoadTypeAvailable(road_type));
@@ -507,7 +507,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::BuildOneWayRoad(TileIndex start, TileIndex end)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	return _BuildRoadInternal(start, end, true, false);
 }
 
@@ -518,13 +518,13 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::BuildOneWayRoadFull(TileIndex start, TileIndex end)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	return _BuildRoadInternal(start, end, true, true);
 }
 
 /* static */ bool ScriptRoad::BuildRoadDepot(TileIndex tile, TileIndex front)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, tile != front);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(front));
@@ -538,7 +538,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::_BuildRoadStationInternal(TileIndex tile, TileIndex front, RoadVehicleType road_veh_type, bool drive_through, StationID station_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, tile != front);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, ::IsValidTile(front));
@@ -565,7 +565,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::RemoveRoad(TileIndex start, TileIndex end)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, start != end);
 	EnforcePrecondition(false, ::IsValidTile(start));
 	EnforcePrecondition(false, ::IsValidTile(end));
@@ -577,7 +577,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::RemoveRoadFull(TileIndex start, TileIndex end)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, start != end);
 	EnforcePrecondition(false, ::IsValidTile(start));
 	EnforcePrecondition(false, ::IsValidTile(end));
@@ -589,7 +589,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::RemoveRoadDepot(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsTileType(tile, MP_ROAD))
 	EnforcePrecondition(false, GetRoadTileType(tile) == ROAD_TILE_DEPOT);
@@ -599,7 +599,7 @@ static bool NeighbourHasReachableRoad(::RoadType rt, TileIndex start_tile, DiagD
 
 /* static */ bool ScriptRoad::RemoveRoadStation(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, IsTileType(tile, MP_STATION));
 	EnforcePrecondition(false, IsRoadStop(tile));

--- a/src/script/api/script_road.hpp
+++ b/src/script/api/script_road.hpp
@@ -141,7 +141,7 @@ public:
 	/**
 	 * Check if a given RoadType is available.
 	 * @param road_type The RoadType to check for.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if this RoadType can be used.
 	 */
 	static bool IsRoadTypeAvailable(RoadType road_type);
@@ -187,7 +187,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(start_tile).
 	 * @pre ScriptMap::IsValidTile(end_tile).
 	 * @pre IsRoadTypeAvailable(road_type).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptRoad::ERR_UNSUITABLE_ROAD
 	 * @return Whether at least some road has been converted successfully.
 	 */
@@ -322,7 +322,7 @@ public:
 	 * @exception ScriptRoad::ERR_ROAD_WORKS_IN_PROGRESS
 	 * @exception ScriptError::ERR_VEHICLE_IN_THE_WAY
 	 * @note Construction will fail if an obstacle is found between the start and end tiles.
-	 * @game @note Building a piece of road (without CompanyMode) results in a piece of road owned by towns.
+	 * @game @note Building a piece of road as deity (ScriptCompanyMode::IsDeity()) results in a piece of road owned by towns.
 	 * @return Whether the road has been/can be build or not.
 	 */
 	static bool BuildRoad(TileIndex start, TileIndex end);
@@ -343,7 +343,7 @@ public:
 	 *  ScriptMap::GetTileX(start) == ScriptMap::GetTileX(end) or
 	 *  ScriptMap::GetTileY(start) == ScriptMap::GetTileY(end).
 	 * @pre GetCurrentRoadType() == ROADTYPE_ROAD.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_ALREADY_BUILT
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
@@ -374,7 +374,7 @@ public:
 	 * @exception ScriptRoad::ERR_ROAD_WORKS_IN_PROGRESS
 	 * @exception ScriptError::ERR_VEHICLE_IN_THE_WAY
 	 * @note Construction will fail if an obstacle is found between the start and end tiles.
-	 * @game @note Building a piece of road (without CompanyMode) results in a piece of road owned by towns.
+	 * @game @note Building a piece of road as deity (ScriptCompanyMode::IsDeity()) results in a piece of road owned by towns.
 	 * @return Whether the road has been/can be build or not.
 	 */
 	static bool BuildRoadFull(TileIndex start, TileIndex end);
@@ -395,7 +395,7 @@ public:
 	 *  ScriptMap::GetTileX(start) == ScriptMap::GetTileX(end) or
 	 *  ScriptMap::GetTileY(start) == ScriptMap::GetTileY(end).
 	 * @pre GetCurrentRoadType() == ROADTYPE_ROAD.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_ALREADY_BUILT
 	 * @exception ScriptError::ERR_LAND_SLOPED_WRONG
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
@@ -415,7 +415,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(front).
 	 * @pre 'tile' is not equal to 'front', but in a straight line of it.
 	 * @pre IsRoadTypeAvailable(GetCurrentRoadType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @return Whether the road depot has been/can be build or not.
@@ -433,7 +433,7 @@ public:
 	 * @pre 'tile' is not equal to 'front', but in a straight line of it.
 	 * @pre station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id).
 	 * @pre GetCurrentRoadType() == ROADTYPE_ROAD.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
@@ -458,7 +458,7 @@ public:
 	 * @pre 'tile' is not equal to 'front', but in a straight line of it.
 	 * @pre station_id == ScriptStation::STATION_NEW || station_id == ScriptStation::STATION_JOIN_ADJACENT || ScriptStation::IsValidStation(station_id).
 	 * @pre IsRoadTypeAvailable(GetCurrentRoadType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_FLAT_LAND_REQUIRED
@@ -483,7 +483,7 @@ public:
 	 *  ScriptMap::GetTileX(start) == ScriptMap::GetTileX(end) or
 	 *  ScriptMap::GetTileY(start) == ScriptMap::GetTileY(end).
 	 * @pre IsRoadTypeAvailable(GetCurrentRoadType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_VEHICLE_IN_THE_WAY
 	 * @exception ScriptRoad::ERR_ROAD_WORKS_IN_PROGRESS
@@ -503,7 +503,7 @@ public:
 	 *  ScriptMap::GetTileX(start) == ScriptMap::GetTileX(end) or
 	 *  ScriptMap::GetTileY(start) == ScriptMap::GetTileY(end).
 	 * @pre IsRoadTypeAvailable(GetCurrentRoadType()).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_VEHICLE_IN_THE_WAY
 	 * @exception ScriptRoad::ERR_ROAD_WORKS_IN_PROGRESS
@@ -516,7 +516,7 @@ public:
 	 * @param tile Place to remove the depot from.
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre Tile is a road depot.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_VEHICLE_IN_THE_WAY
 	 * @return Whether the road depot has been/can be removed or not.
@@ -528,7 +528,7 @@ public:
 	 * @param tile Place to remove the station from.
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre Tile is a road station.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptError::ERR_VEHICLE_IN_THE_WAY
 	 * @return Whether the station has been/can be removed or not.

--- a/src/script/api/script_roadtypelist.cpp
+++ b/src/script/api/script_roadtypelist.cpp
@@ -17,6 +17,6 @@ ScriptRoadTypeList::ScriptRoadTypeList(ScriptRoad::RoadTramTypes rtts)
 {
 	for (RoadType rt = ROADTYPE_BEGIN; rt != ROADTYPE_END; rt++) {
 		if (!HasBit(rtts, GetRoadTramType(rt))) continue;
-		if (ScriptObject::GetCompany() == OWNER_DEITY || ::HasRoadTypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
+		if (ScriptCompanyMode::IsDeity() || ::HasRoadTypeAvail(ScriptObject::GetCompany(), rt)) this->AddItem(rt);
 	}
 }

--- a/src/script/api/script_station.cpp
+++ b/src/script/api/script_station.cpp
@@ -22,7 +22,7 @@
 /* static */ bool ScriptStation::IsValidStation(StationID station_id)
 {
 	const Station *st = ::Station::GetIfValid(station_id);
-	return st != nullptr && (st->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY || st->owner == OWNER_NONE);
+	return st != nullptr && (st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || st->owner == OWNER_NONE);
 }
 
 /* static */ ScriptCompany::CompanyID ScriptStation::GetOwner(StationID station_id)

--- a/src/script/api/script_stationlist.cpp
+++ b/src/script/api/script_stationlist.cpp
@@ -19,7 +19,7 @@
 ScriptStationList::ScriptStationList(ScriptStation::StationType station_type)
 {
 	for (Station *st : Station::Iterate()) {
-		if ((st->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && (st->facilities & station_type) != 0) this->AddItem(st->index);
+		if ((st->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (st->facilities & station_type) != 0) this->AddItem(st->index);
 	}
 }
 

--- a/src/script/api/script_story_page.cpp
+++ b/src/script/api/script_story_page.cpp
@@ -42,7 +42,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 {
 	CCountedPtr<Text> counter(title);
 
-	EnforcePrecondition(STORY_PAGE_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(STORY_PAGE_INVALID);
 	EnforcePrecondition(STORY_PAGE_INVALID, company == ScriptCompany::COMPANY_INVALID || ScriptCompany::ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID);
 
 	uint8 c = company;
@@ -61,7 +61,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 
 	::StoryPageElementType btype = static_cast<::StoryPageElementType>(type);
 
-	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(STORY_PAGE_ELEMENT_INVALID);
 	EnforcePrecondition(STORY_PAGE_ELEMENT_INVALID, IsValidStoryPage(story_page_id));
 	std::string encoded_text;
 	if (StoryPageElementTypeRequiresText(btype)) {
@@ -105,7 +105,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 {
 	CCountedPtr<Text> counter(text);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidStoryPageElement(story_page_element_id));
 
 	StoryPageElement *pe = StoryPageElement::Get(story_page_element_id);
@@ -162,7 +162,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 	CCountedPtr<Text> counter(title);
 
 	EnforcePrecondition(false, IsValidStoryPage(story_page_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 
 	return ScriptObject::Command<CMD_SET_STORY_PAGE_TITLE>::Do(story_page_id, title != nullptr ? title->GetEncodedText() : std::string{});
 }
@@ -180,7 +180,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 /* static */ ScriptDate::Date ScriptStoryPage::GetDate(StoryPageID story_page_id)
 {
 	EnforcePrecondition(ScriptDate::DATE_INVALID, IsValidStoryPage(story_page_id));
-	EnforcePrecondition(ScriptDate::DATE_INVALID, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(ScriptDate::DATE_INVALID);
 
 	return (ScriptDate::Date)StoryPage::Get(story_page_id)->date;
 }
@@ -188,7 +188,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 /* static */ bool ScriptStoryPage::SetDate(StoryPageID story_page_id, ScriptDate::Date date)
 {
 	EnforcePrecondition(false, IsValidStoryPage(story_page_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 
 	return ScriptObject::Command<CMD_SET_STORY_PAGE_DATE>::Do(story_page_id, date);
 }
@@ -197,14 +197,14 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 /* static */ bool ScriptStoryPage::Show(StoryPageID story_page_id)
 {
 	EnforcePrecondition(false, IsValidStoryPage(story_page_id));
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 
 	return ScriptObject::Command<CMD_SHOW_STORY_PAGE>::Do(story_page_id);
 }
 
 /* static */ bool ScriptStoryPage::Remove(StoryPageID story_page_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidStoryPage(story_page_id));
 
 	return ScriptObject::Command<CMD_REMOVE_STORY_PAGE>::Do(story_page_id);
@@ -212,7 +212,7 @@ static inline bool StoryPageElementTypeRequiresText(StoryPageElementType type)
 
 /* static */ bool ScriptStoryPage::RemoveElement(StoryPageElementID story_page_element_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidStoryPageElement(story_page_element_id));
 
 	return ScriptObject::Command<CMD_REMOVE_STORY_PAGE_ELEMENT>::Do(story_page_element_id);

--- a/src/script/api/script_story_page.hpp
+++ b/src/script/api/script_story_page.hpp
@@ -184,7 +184,7 @@ public:
 	 * @param company The company to create the story page for, or ScriptCompany::COMPANY_INVALID for all.
 	 * @param title Page title (can be either a raw string, a ScriptText object, or null).
 	 * @return The new StoryPageID, or STORY_PAGE_INVALID if it failed.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre company == COMPANY_INVALID || ResolveCompanyID(company) != COMPANY_INVALID.
 	 */
 	static StoryPageID New(ScriptCompany::CompanyID company, Text *title);
@@ -200,7 +200,7 @@ public:
 	 *                  use the #BuildPushButtonReference, #BuildTileButtonReference, or #BuildVehicleButtonReference functions to make the values.
 	 * @param text The body text of page elements that allow custom text. (SPET_TEXT and SPET_LOCATION)
 	 * @return The new StoryPageElementID, or STORY_PAGE_ELEMENT_INVALID if it failed.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page).
 	 * @pre (type != SPET_TEXT && type != SPET_LOCATION) || (text != null && len(text) != 0).
 	 * @pre type != SPET_LOCATION || ScriptMap::IsValidTile(reference).
@@ -215,7 +215,7 @@ public:
 	 * @param reference A reference value to the object that is referred to by some page element types. See also NewElement.
 	 * @param text The body text of page elements that allow custom text. See also NewElement.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page).
 	 * @pre (type != SPET_TEXT && type != SPET_LOCATION) || (text != null && len(text) != 0).
 	 * @pre type != SPET_LOCATION || ScriptMap::IsValidTile(reference).
@@ -267,7 +267,7 @@ public:
 	 * @param story_page_id The story page to set the date for.
 	 * @param date Date to display at the top of story page or ScriptDate::DATE_INVALID to disable showing date on this page. (also, @see ScriptDate)
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page_id).
 	 */
 	static bool SetDate(StoryPageID story_page_id, ScriptDate::Date date);
@@ -277,7 +277,7 @@ public:
 	 * @param story_page_id The story page to update.
 	 * @param title Page title (can be either a raw string, a ScriptText object, or null).
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page_id).
 	 */
 	static bool SetTitle(StoryPageID story_page_id, Text *title);
@@ -288,7 +288,7 @@ public:
 	 * companies are affecetd. Otherwise only the clients of the company which the page belongs
 	 * to are affected.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page_id).
 	 */
 	static bool Show(StoryPageID story_page_id);
@@ -298,7 +298,7 @@ public:
 	 * associated with it.
 	 * @param story_page_id The story page to remove.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPage(story_page_id).
 	 */
 	static bool Remove(StoryPageID story_page_id);
@@ -307,7 +307,7 @@ public:
 	 * Removes a story page element.
 	 * @param story_page_element_id The story page element to remove.
 	 * @return True if the action succeeded.
-	 * @pre No ScriptCompanyMode may be in scope.
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre IsValidStoryPageElement(story_page_element_id).
 	 */
 	static bool RemoveElement(StoryPageElementID story_page_element_id);

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -252,7 +252,7 @@
 
 /* static */ bool ScriptTile::RaiseTile(TileIndex tile, Slope slope)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, tile < ScriptMap::GetMapSize());
 
 	return ScriptObject::Command<CMD_TERRAFORM_LAND>::Do(tile, (::Slope)slope, true);
@@ -260,7 +260,7 @@
 
 /* static */ bool ScriptTile::LowerTile(TileIndex tile, Slope slope)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, tile < ScriptMap::GetMapSize());
 
 	return ScriptObject::Command<CMD_TERRAFORM_LAND>::Do(tile, (::Slope)slope, false);
@@ -268,7 +268,7 @@
 
 /* static */ bool ScriptTile::LevelTiles(TileIndex start_tile, TileIndex end_tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, start_tile < ScriptMap::GetMapSize());
 	EnforcePrecondition(false, end_tile < ScriptMap::GetMapSize());
 
@@ -284,7 +284,7 @@
 
 /* static */ bool ScriptTile::PlantTree(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_PLANT_TREE>::Do(tile, tile, TREE_INVALID, false);
@@ -292,7 +292,7 @@
 
 /* static */ bool ScriptTile::PlantTreeRectangle(TileIndex tile, SQInteger width, SQInteger height)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, width >= 1 && width <= 20);
 	EnforcePrecondition(false, height >= 1 && height <= 20);

--- a/src/script/api/script_tile.hpp
+++ b/src/script/api/script_tile.hpp
@@ -418,7 +418,7 @@ public:
 	 * @param tile The tile to raise.
 	 * @param slope Corners to raise (SLOPE_xxx).
 	 * @pre tile < ScriptMap::GetMapSize().
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_TOO_CLOSE_TO_EDGE
 	 * @exception ScriptTile::ERR_TILE_TOO_HIGH
@@ -435,7 +435,7 @@ public:
 	 * @param tile The tile to lower.
 	 * @param slope Corners to lower (SLOPE_xxx).
 	 * @pre tile < ScriptMap::GetMapSize().
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_TOO_CLOSE_TO_EDGE
 	 * @exception ScriptTile::ERR_TILE_TOO_LOW
@@ -451,7 +451,7 @@ public:
 	 * @param end_tile The opposite corner of the rectangle.
 	 * @pre start_tile < ScriptMap::GetMapSize().
 	 * @pre end_tile < ScriptMap::GetMapSize().
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptError::ERR_TOO_CLOSE_TO_EDGE
 	 * @return True if one or more tiles were leveled.
@@ -475,7 +475,7 @@ public:
 	 * Create a random tree on a tile.
 	 * @param tile The tile to build a tree on.
 	 * @pre ScriptMap::IsValidTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if a tree was added on the tile.
 	 */
 	static bool PlantTree(TileIndex tile);
@@ -488,7 +488,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(tile).
 	 * @pre width >= 1 && width <= 20.
 	 * @pre height >= 1 && height <= 20.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if a tree was added on any of the tiles in the rectangle.
 	 */
 	static bool PlantTreeRectangle(TileIndex tile, SQInteger width, SQInteger height);

--- a/src/script/api/script_town.cpp
+++ b/src/script/api/script_town.cpp
@@ -207,7 +207,7 @@
 
 /* static */ bool ScriptTown::HasStatue(TownID town_id)
 {
-	if (ScriptObject::GetCompany() == OWNER_DEITY) return false;
+	EnforceCompanyModeValid(false);
 	if (!IsValidTown(town_id)) return false;
 
 	return ::HasBit(::Town::Get(town_id)->statues, ScriptObject::GetCompany());
@@ -236,7 +236,7 @@
 
 /* static */ ScriptCompany::CompanyID ScriptTown::GetExclusiveRightsCompany(TownID town_id)
 {
-	if (ScriptObject::GetCompany() == OWNER_DEITY) return ScriptCompany::COMPANY_INVALID;
+	EnforceCompanyModeValid(ScriptCompany::COMPANY_INVALID);
 	if (!IsValidTown(town_id)) return ScriptCompany::COMPANY_INVALID;
 
 	return (ScriptCompany::CompanyID)(int8)::Town::Get(town_id)->exclusivity;
@@ -251,7 +251,7 @@
 
 /* static */ bool ScriptTown::IsActionAvailable(TownID town_id, TownAction town_action)
 {
-	if (ScriptObject::GetCompany() == OWNER_DEITY) return false;
+	EnforceCompanyModeValid(false);
 	if (!IsValidTown(town_id)) return false;
 
 	return HasBit(::GetMaskOfTownActions(ScriptObject::GetCompany(), ::Town::Get(town_id)), town_action);
@@ -259,7 +259,7 @@
 
 /* static */ bool ScriptTown::PerformTownAction(TownID town_id, TownAction town_action)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	EnforcePrecondition(false, IsActionAvailable(town_id, town_action));
 
@@ -268,7 +268,7 @@
 
 /* static */ bool ScriptTown::ExpandTown(TownID town_id, SQInteger houses)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	EnforcePrecondition(false, houses > 0);
 
@@ -281,11 +281,11 @@
 {
 	CCountedPtr<Text> counter(name);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY || _settings_game.economy.found_town != TF_FORBIDDEN);
+	EnforcePrecondition(false, ScriptCompanyMode::IsDeity() || _settings_game.economy.found_town != TF_FORBIDDEN);
 	EnforcePrecondition(false, ::IsValidTile(tile));
 	EnforcePrecondition(false, size == TOWN_SIZE_SMALL || size == TOWN_SIZE_MEDIUM || size == TOWN_SIZE_LARGE)
-	EnforcePrecondition(false, size != TOWN_SIZE_LARGE || ScriptObject::GetCompany() == OWNER_DEITY);
-	if (ScriptObject::GetCompany() == OWNER_DEITY || _settings_game.economy.found_town == TF_CUSTOM_LAYOUT) {
+	EnforcePrecondition(false, ScriptCompanyMode::IsDeity() || size != TOWN_SIZE_LARGE);
+	if (ScriptCompanyMode::IsDeity() || _settings_game.economy.found_town == TF_CUSTOM_LAYOUT) {
 		EnforcePrecondition(false, layout >= ROAD_LAYOUT_ORIGINAL && layout <= ROAD_LAYOUT_RANDOM);
 	} else {
 		/* The layout parameter is ignored for AIs when custom layouts is disabled. */
@@ -346,7 +346,7 @@
 
 /* static */ bool ScriptTown::ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, SQInteger delta)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, IsValidTown(town_id));
 	ScriptCompany::CompanyID company = ScriptCompany::ResolveCompanyID(company_id);
 	EnforcePrecondition(false, company != ScriptCompany::COMPANY_INVALID);

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -312,7 +312,7 @@ public:
 	 * Find out if this town has a statue for the current company.
 	 * @param town_id The town to check.
 	 * @pre IsValidTown(town_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if the town has a statue.
 	 */
 	static bool HasStatue(TownID town_id);
@@ -347,7 +347,7 @@ public:
 	 * Find out which company currently has the exclusive rights of this town.
 	 * @param town_id The town to check.
 	 * @pre IsValidTown(town_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return The company that has the exclusive rights. The value
 	 *         ScriptCompany::COMPANY_INVALID means that there are currently no
 	 *         exclusive rights given out to anyone.
@@ -369,7 +369,7 @@ public:
 	 * @param town_id The town to perform the action on.
 	 * @param town_action The action to perform on the town.
 	 * @pre IsValidTown(town_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the action can performed.
 	 */
 	static bool IsActionAvailable(TownID town_id, TownAction town_action);
@@ -380,7 +380,7 @@ public:
 	 * @param town_action The action to perform on the town.
 	 * @pre IsValidTown(town_id).
 	 * @pre IsActionAvailable(town_id, town_action).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if the action succeeded.
 	 */
 	static bool PerformTownAction(TownID town_id, TownAction town_action);
@@ -404,14 +404,14 @@ public:
 	 * @param city True if the new town should be a city.
 	 * @param layout The town layout of the new town.
 	 * @param name The name of the new town. Pass null, or an empty string, to use a random town name.
-	 * @game @pre no company mode in scope || ScriptSettings.GetValue("economy.found_town") != 0.
+	 * @game @pre ScriptCompanyMode::IsDeity() || ScriptSettings.GetValue("economy.found_town") != 0.
 	 * @ai @pre ScriptSettings.GetValue("economy.found_town") != 0.
-	 * @game @pre no company mode in scope || size != TOWN_SIZE_LARGE.
+	 * @game @pre ScriptCompanyMode::IsDeity() || size != TOWN_SIZE_LARGE.
 	 * @ai @pre size != TOWN_SIZE_LARGE.
 	 * @pre size != TOWN_SIZE_INVALID.
 	 * @pre layout != ROAD_LAYOUT_INVALID.
 	 * @return True if the action succeeded.
-	 * @game @note Companies are restricted by the advanced setting that controls if funding towns is allowed or not. If custom road layout is forbidden and there is a company mode in scope, the layout parameter will be ignored.
+	 * @game @note Companies are restricted by the advanced setting that controls if funding towns is allowed or not. If custom road layout is forbidden and there is a company mode in scope (ScriptCompanyMode::IsValid()), the layout parameter will be ignored.
 	 * @ai @note AIs are restricted by the advanced setting that controls if funding towns is allowed or not. If custom road layout is forbidden, the layout parameter will be ignored.
 	 */
 	static bool FoundTown(TileIndex tile, TownSize size, bool city, RoadLayout layout, Text *name);
@@ -445,7 +445,7 @@ public:
 	 * @return True if the rating was changed.
 	 * @pre IsValidTown(town_id).
 	 * @pre ScriptCompany.ResolveCompanyID(company) != ScriptCompany::COMPANY_INVALID.
-	 * @pre no company mode in scope
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @api -ai
 	 */
 	static bool ChangeRating(TownID town_id, ScriptCompany::CompanyID company_id, SQInteger delta);

--- a/src/script/api/script_tunnel.cpp
+++ b/src/script/api/script_tunnel.cpp
@@ -86,7 +86,7 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 	EnforcePrecondition(false, vehicle_type == ScriptVehicle::VT_RAIL || vehicle_type == ScriptVehicle::VT_ROAD);
 	EnforcePrecondition(false, vehicle_type != ScriptVehicle::VT_RAIL || ScriptRail::IsRailTypeAvailable(ScriptRail::GetCurrentRailType()));
 	EnforcePrecondition(false, vehicle_type != ScriptVehicle::VT_ROAD || ScriptRoad::IsRoadTypeAvailable(ScriptRoad::GetCurrentRoadType()));
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY || vehicle_type == ScriptVehicle::VT_ROAD);
+	EnforcePrecondition(false, ScriptCompanyMode::IsValid() || vehicle_type == ScriptVehicle::VT_ROAD);
 
 	if (vehicle_type == ScriptVehicle::VT_RAIL) {
 		/* For rail we do nothing special */
@@ -123,7 +123,7 @@ static void _DoCommandReturnBuildTunnel1(class ScriptInstance *instance)
 
 /* static */ bool ScriptTunnel::RemoveTunnel(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsTunnelTile(tile));
 
 	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);

--- a/src/script/api/script_tunnel.hpp
+++ b/src/script/api/script_tunnel.hpp
@@ -85,7 +85,7 @@ public:
 	 * @pre ScriptMap::IsValidTile(start).
 	 * @pre (vehicle_type == ScriptVehicle::VT_ROAD && ScriptRoad::IsRoadTypeAvailable(ScriptRoad::GetCurrentRoadType())) ||
 	 *      (vehicle_type == ScriptVehicle::VT_RAIL && ScriptRail::IsRailTypeAvailable(ScriptRail::GetCurrentRailType())).
-	 * @game @pre Outside CompanyMode: vehicle_type == ScriptVehicle::VT_ROAD.
+	 * @game @pre ScriptCompanyMode::IsValid() || vehicle_type == ScriptVehicle::VT_ROAD.
 	 * @exception ScriptError::ERR_AREA_NOT_CLEAR
 	 * @exception ScriptTunnel::ERR_TUNNEL_CANNOT_BUILD_ON_WATER
 	 * @exception ScriptTunnel::ERR_TUNNEL_START_SITE_UNSUITABLE
@@ -95,7 +95,7 @@ public:
 	 * @note The slope of a tile can be determined by ScriptTile::GetSlope(TileIndex).
 	 * @note No matter if the road pieces were build or not, if building the
 	 *  tunnel succeeded, this function returns true.
-	 * @game @note Building a bridge (without CompanyMode) results in a bridge owned by towns.
+	 * @game @note Building a tunnel as deity (ScriptCompanyMode::IsDeity()) results in a tunnel owned by towns.
 	 */
 	static bool BuildTunnel(ScriptVehicle::VehicleType vehicle_type, TileIndex start);
 
@@ -103,7 +103,7 @@ public:
 	 * Remove the tunnel whose entrance is located at tile.
 	 * @param tile The tile that is an entrance to a tunnel.
 	 * @pre ScriptMap::IsValidTile(tile) && IsTunnelTile(tile).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return Whether the tunnel has been/can be removed or not.
 	 */

--- a/src/script/api/script_vehicle.cpp
+++ b/src/script/api/script_vehicle.cpp
@@ -31,7 +31,7 @@
 /* static */ bool ScriptVehicle::IsValidVehicle(VehicleID vehicle_id)
 {
 	const Vehicle *v = ::Vehicle::GetIfValid(vehicle_id);
-	return v != nullptr && (v->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()));
+	return v != nullptr && (v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()));
 }
 
 /* static */ bool ScriptVehicle::IsPrimaryVehicle(VehicleID vehicle_id)
@@ -72,7 +72,7 @@
 
 /* static */ VehicleID ScriptVehicle::_BuildVehicleInternal(TileIndex depot, EngineID engine_id, CargoID cargo)
 {
-	EnforcePrecondition(VEHICLE_INVALID, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(VEHICLE_INVALID);
 	EnforcePrecondition(VEHICLE_INVALID, ScriptEngine::IsBuildable(engine_id));
 	EnforcePrecondition(VEHICLE_INVALID, cargo == CT_INVALID || ScriptCargo::IsValidCargo(cargo));
 
@@ -108,7 +108,7 @@
 
 /* static */ VehicleID ScriptVehicle::CloneVehicle(TileIndex depot, VehicleID vehicle_id, bool share_orders)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsPrimaryVehicle(vehicle_id));
 
 	if (!ScriptObject::Command<CMD_CLONE_VEHICLE>::Do(&ScriptInstance::DoCommandReturnVehicleID, depot, vehicle_id, share_orders)) return VEHICLE_INVALID;
@@ -119,7 +119,7 @@
 
 /* static */ bool ScriptVehicle::_MoveWagonInternal(VehicleID source_vehicle_id, SQInteger source_wagon, bool move_attached_wagons, SQInteger dest_vehicle_id, SQInteger dest_wagon)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(source_vehicle_id) && source_wagon < GetNumWagons(source_vehicle_id));
 	EnforcePrecondition(false, dest_vehicle_id == -1 || (IsValidVehicle(dest_vehicle_id) && dest_wagon < GetNumWagons(dest_vehicle_id)));
 	EnforcePrecondition(false, ::Vehicle::Get(source_vehicle_id)->type == VEH_TRAIN);
@@ -157,7 +157,7 @@
 
 /* static */ bool ScriptVehicle::RefitVehicle(VehicleID vehicle_id, CargoID cargo)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(vehicle_id) && ScriptCargo::IsValidCargo(cargo));
 
 	return ScriptObject::Command<CMD_REFIT_VEHICLE>::Do(vehicle_id, cargo, 0, false, false, 0);
@@ -166,7 +166,7 @@
 
 /* static */ bool ScriptVehicle::SellVehicle(VehicleID vehicle_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(vehicle_id));
 
 	const Vehicle *v = ::Vehicle::Get(vehicle_id);
@@ -175,7 +175,7 @@
 
 /* static */ bool ScriptVehicle::_SellWagonInternal(VehicleID vehicle_id, SQInteger wagon, bool sell_attached_wagons)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsValidVehicle(vehicle_id) && wagon < GetNumWagons(vehicle_id));
 	EnforcePrecondition(false, ::Vehicle::Get(vehicle_id)->type == VEH_TRAIN);
 
@@ -197,7 +197,7 @@
 
 /* static */ bool ScriptVehicle::SendVehicleToDepot(VehicleID vehicle_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsPrimaryVehicle(vehicle_id));
 
 	return ScriptObject::Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(vehicle_id, DepotCommand::None, {});
@@ -205,7 +205,7 @@
 
 /* static */ bool ScriptVehicle::SendVehicleToDepotForServicing(VehicleID vehicle_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsPrimaryVehicle(vehicle_id));
 
 	return ScriptObject::Command<CMD_SEND_VEHICLE_TO_DEPOT>::Do(vehicle_id, DepotCommand::Service, {});
@@ -225,7 +225,7 @@
 
 /* static */ bool ScriptVehicle::StartStopVehicle(VehicleID vehicle_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsPrimaryVehicle(vehicle_id));
 
 	return ScriptObject::Command<CMD_START_STOP_VEHICLE>::Do(vehicle_id, false);
@@ -233,7 +233,7 @@
 
 /* static */ bool ScriptVehicle::ReverseVehicle(VehicleID vehicle_id)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, ::Vehicle::Get(vehicle_id)->type == VEH_ROAD || ::Vehicle::Get(vehicle_id)->type == VEH_TRAIN);
 
@@ -248,7 +248,7 @@
 {
 	CCountedPtr<Text> counter(name);
 
-	EnforcePrecondition(false, ScriptObject::GetCompany() != OWNER_DEITY);
+	EnforceCompanyModeValid(false);
 	EnforcePrecondition(false, IsPrimaryVehicle(vehicle_id));
 	EnforcePrecondition(false, name != nullptr);
 	const std::string &text = name->GetDecodedText();

--- a/src/script/api/script_vehicle.hpp
+++ b/src/script/api/script_vehicle.hpp
@@ -125,7 +125,7 @@ public:
 	 * @param name The name for the vehicle (can be either a raw string, or a ScriptText object).
 	 * @pre IsPrimaryVehicle(vehicle_id).
 	 * @pre name != null && len(name) != 0.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_NAME_IS_NOT_UNIQUE
 	 * @return True if and only if the name was changed.
 	 */
@@ -316,7 +316,7 @@ public:
 	 * @pre The tile at depot has a depot that can build the engine and
 	 *   is owned by you.
 	 * @pre ScriptEngine::IsBuildable(engine_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_TOO_MANY
 	 * @exception ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED
 	 * @exception ScriptVehicle::ERR_VEHICLE_WRONG_DEPOT
@@ -342,7 +342,7 @@ public:
 	 *   is owned by you.
 	 * @pre ScriptEngine::IsBuildable(engine_id).
 	 * @pre ScriptCargo::IsValidCargo(cargo).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_TOO_MANY
 	 * @exception ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED
 	 * @exception ScriptVehicle::ERR_VEHICLE_WRONG_DEPOT
@@ -375,7 +375,7 @@ public:
 	 * @param share_orders Should the orders be copied or shared?
 	 * @pre The tile 'depot' has a depot on it, allowing 'vehicle_id'-type vehicles.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_TOO_MANY
 	 * @exception ScriptVehicle::ERR_VEHICLE_BUILD_DISABLED
 	 * @exception ScriptVehicle::ERR_VEHICLE_WRONG_DEPOT
@@ -396,7 +396,7 @@ public:
 	 * @pre dest_vehicle_id == -1 || (IsValidVehicle(dest_vehicle_id) && dest_wagon < GetNumWagons(dest_vehicle_id)).
 	 * @pre GetVehicleType(source_vehicle_id) == VT_RAIL.
 	 * @pre dest_vehicle_id == -1 || GetVehicleType(dest_vehicle_id) == VT_RAIL.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether or not moving the wagon succeeded.
 	 */
 	static bool MoveWagon(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon);
@@ -412,7 +412,7 @@ public:
 	 * @pre dest_vehicle_id == -1 || (IsValidVehicle(dest_vehicle_id) && dest_wagon < GetNumWagons(dest_vehicle_id)).
 	 * @pre GetVehicleType(source_vehicle_id) == VT_RAIL.
 	 * @pre dest_vehicle_id == -1 || GetVehicleType(dest_vehicle_id) == VT_RAIL.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether or not moving the wagons succeeded.
 	 */
 	static bool MoveWagonChain(VehicleID source_vehicle_id, SQInteger source_wagon, SQInteger dest_vehicle_id, SQInteger dest_wagon);
@@ -437,7 +437,7 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(cargo).
 	 * @pre You must own the vehicle.
 	 * @pre The vehicle must be stopped in the depot.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_CANNOT_REFIT
 	 * @exception ScriptVehicle::ERR_VEHICLE_IS_DESTROYED
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
@@ -451,7 +451,7 @@ public:
 	 * @pre IsValidVehicle(vehicle_id).
 	 * @pre You must own the vehicle.
 	 * @pre The vehicle must be stopped in the depot.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_IS_DESTROYED
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
 	 * @return True if and only if the vehicle has been sold.
@@ -466,7 +466,7 @@ public:
 	 * @pre wagon < GetNumWagons(vehicle_id).
 	 * @pre You must own the vehicle.
 	 * @pre The vehicle must be stopped in the depot.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_IS_DESTROYED
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
 	 * @return True if and only if the wagon has been sold.
@@ -481,7 +481,7 @@ public:
 	 * @pre wagon < GetNumWagons(vehicle_id).
 	 * @pre You must own the vehicle.
 	 * @pre The vehicle must be stopped in the depot.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_IS_DESTROYED
 	 * @exception ScriptVehicle::ERR_VEHICLE_NOT_IN_DEPOT
 	 * @return True if and only if the wagons have been sold.
@@ -493,7 +493,7 @@ public:
 	 * sent to a depot it continues with its normal orders instead.
 	 * @param vehicle_id The vehicle to send to a depot.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_CANNOT_SEND_TO_DEPOT
 	 * @return True if the current order was changed.
 	 */
@@ -504,7 +504,7 @@ public:
 	 * already been sent to a depot it continues with its normal orders instead.
 	 * @param vehicle_id The vehicle to send to a depot for servicing.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_CANNOT_SEND_TO_DEPOT
 	 * @return True if the current order was changed.
 	 */
@@ -514,7 +514,7 @@ public:
 	 * Starts or stops the given vehicle depending on the current state.
 	 * @param vehicle_id The vehicle to start/stop.
 	 * @pre IsPrimaryVehicle(vehicle_id).
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptVehicle::ERR_VEHICLE_CANNOT_START_STOP
 	 * @exception (For aircraft only): ScriptVehicle::ERR_VEHICLE_IN_FLIGHT
 	 * @exception (For trains only): ScriptVehicle::ERR_VEHICLE_NO_POWER
@@ -527,7 +527,7 @@ public:
 	 * @param vehicle_id The vehicle to turn.
 	 * @pre IsPrimaryVehicle(vehicle_id).
 	 * @pre GetVehicleType(vehicle_id) == VT_ROAD || GetVehicleType(vehicle_id) == VT_RAIL.
-	 * @game @pre Valid ScriptCompanyMode active in scope.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the vehicle has started to turn.
 	 * @note Vehicles cannot always be reversed. For example busses and trucks need to be running
 	 *  and not be inside a depot.

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -21,7 +21,7 @@
 ScriptVehicleList::ScriptVehicleList()
 {
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if ((v->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()))) this->AddItem(v->index);
+		if ((v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && (v->IsPrimaryVehicle() || (v->type == VEH_TRAIN && ::Train::From(v)->IsFreeWagon()))) this->AddItem(v->index);
 	}
 }
 
@@ -30,7 +30,7 @@ ScriptVehicleList_Station::ScriptVehicleList_Station(StationID station_id)
 	if (!ScriptBaseStation::IsValidBaseStation(station_id)) return;
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if ((v->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && v->IsPrimaryVehicle()) {
+		if ((v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && v->IsPrimaryVehicle()) {
 			for (const Order *order : v->Orders()) {
 				if ((order->IsType(OT_GOTO_STATION) || order->IsType(OT_GOTO_WAYPOINT)) && order->GetDestination() == station_id) {
 					this->AddItem(v->index);
@@ -78,7 +78,7 @@ ScriptVehicleList_Depot::ScriptVehicleList_Depot(TileIndex tile)
 	}
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
-		if ((v->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY) && v->IsPrimaryVehicle() && v->type == type) {
+		if ((v->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity()) && v->IsPrimaryVehicle() && v->type == type) {
 			for (const Order *order : v->Orders()) {
 				if (order->IsType(OT_GOTO_DEPOT) && order->GetDestination() == dest) {
 					this->AddItem(v->index);

--- a/src/script/api/script_viewport.cpp
+++ b/src/script/api/script_viewport.cpp
@@ -28,7 +28,7 @@
 
 /* static */ bool ScriptViewport::ScrollEveryoneTo(TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
 	return ScriptObject::Command<CMD_SCROLL_VIEWPORT>::Do(tile, VST_EVERYONE, 0);
@@ -36,7 +36,7 @@
 
 /* static */ bool ScriptViewport::ScrollCompanyClientsTo(ScriptCompany::CompanyID company, TileIndex tile)
 {
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
 	company = ScriptCompany::ResolveCompanyID(company);
@@ -48,7 +48,7 @@
 /* static */ bool ScriptViewport::ScrollClientTo(ScriptClient::ClientID client, TileIndex tile)
 {
 	EnforcePrecondition(false, ScriptGame::IsMultiplayer());
-	EnforcePrecondition(false, ScriptObject::GetCompany() == OWNER_DEITY);
+	EnforceDeityMode(false);
 	EnforcePrecondition(false, ScriptMap::IsValidTile(tile));
 
 	client = ScriptClient::ResolveClientID(client);

--- a/src/script/api/script_viewport.hpp
+++ b/src/script/api/script_viewport.hpp
@@ -33,7 +33,7 @@ public:
 	 * Scroll the viewport of all players to the given tile,
 	 *  where the tile will be in the center of the screen.
 	 * @param tile The tile to put in the center of the screen.
-	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre ScriptMap::IsValidTile(tile)
 	 * @return True iff the command was executed successfully.
 	 */
@@ -44,7 +44,7 @@ public:
 	 *  where the tile will be in the center of the screen.
 	 * @param company The company which players to scroll the viewport of.
 	 * @param tile The tile to put in the center of the screen.
-	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre ScriptMap::IsValidTile(tile)
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID
 	 * @return True iff the command was executed successfully.
@@ -57,7 +57,7 @@ public:
 	 * @param client The client to scroll the viewport of.
 	 * @param tile The tile to put in the center of the screen.
 	 * @pre ScriptGame::IsMultiplayer()
-	 * @pre ScriptObject::GetCompany() == OWNER_DEITY
+	 * @pre ScriptCompanyMode::IsDeity().
 	 * @pre ScriptMap::IsValidTile(tile)
 	 * @pre ResolveClientID(client) != CLIENT_INVALID
 	 * @return True iff the command was executed successfully.

--- a/src/script/api/script_waypoint.cpp
+++ b/src/script/api/script_waypoint.cpp
@@ -18,7 +18,7 @@
 /* static */ bool ScriptWaypoint::IsValidWaypoint(StationID waypoint_id)
 {
 	const Waypoint *wp = ::Waypoint::GetIfValid(waypoint_id);
-	return wp != nullptr && (wp->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY || wp->owner == OWNER_NONE);
+	return wp != nullptr && (wp->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || wp->owner == OWNER_NONE);
 }
 
 /* static */ StationID ScriptWaypoint::GetWaypointID(TileIndex tile)

--- a/src/script/api/script_waypointlist.cpp
+++ b/src/script/api/script_waypointlist.cpp
@@ -19,7 +19,7 @@ ScriptWaypointList::ScriptWaypointList(ScriptWaypoint::WaypointType waypoint_typ
 {
 	for (const Waypoint *wp : Waypoint::Iterate()) {
 		if ((wp->facilities & waypoint_type) &&
-				(wp->owner == ScriptObject::GetCompany() || ScriptObject::GetCompany() == OWNER_DEITY || wp->owner == OWNER_NONE)) this->AddItem(wp->index);
+				(wp->owner == ScriptObject::GetCompany() || ScriptCompanyMode::IsDeity() || wp->owner == OWNER_NONE)) this->AddItem(wp->index);
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

`GSCompanyMode` is a complicated mechanism, and depending on the scope it could or could not be active. For a script it is essentially unknowable whether you are in a company mode scope or not.

Next to this there are a lot of comparisons of `GSObject::GetCompany()` against `OWNER_DEITY` to determine whether a call is in the company mode or not. That in itself is not a problem, but... a company can go bankrupt and then it is still in a "valid" company scope but the calls will fail in various was, including crashes to desktops. However, `GSObject::GetCompany() != OWNER_DEITY` will not solve the issue on its own, but that needs to be moved to its own function.


## Description

This PR does not prevent or fix the above problem with companies going out of scope, but it lays the foundation for fixing that in #10529. Primarily by moving the trivial changes from that PR into this PR.

The first commit adds `GSCompanyMode::IsValid()` and `GSCompanyMode::IsDeity()`. This `IsValid()` will be changed in #10529 to also perform a check on the validity of the company. In #10529 there is also a check script that gets added to check whether a function checks for the precondition. To make validation with a script easier, separate enforce helper macros `EnforceCompanyModeValid(<retval>)` and `EnforceDeityMode(<retval>)` are added, which also saves on the amount of boiler plate code that needs to be written in many functions.

The second commit replaces:
* `GSObject::GetCompany() != OWNER_DEITY` -> `GSCompanyMode::IsValid()`
* `GSObject::GetCompany() == OWNER_DEITY` -> `GSCompanyMode::IsDeity()`
* `EnforcePrecondition(<retval>, GSObject::GetCompany() != OWNER_DEITY)` -> `EnforceCompanyModeValid(<retval>)`
* `EnforcePrecondition(<retval>, GSObject::GetCompany() == OWNER_DEITY)` -> `EnforceDeityMode(<retval>)`
* Comments mentioning company mode being active or not, now mention `GSCompanyMode::IsValid()` or `GSCompanyMode::IsDeity()` instead.


## Limitations

The crash-to-desktop bug is not fixed yet, that is for #10529.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
