### PR TITLE
Fix: game scripts must not build with non-existing road types

### DIFF
--- a/src/road.cpp
+++ b/src/road.cpp
@@ -111,7 +111,15 @@ RoadBits CleanUpRoadBits(const TileIndex tile, RoadBits org_rb)
 bool HasRoadTypeAvail(const CompanyID company, RoadType roadtype)
 {
 	if (company == OWNER_DEITY || company == OWNER_TOWN || _game_mode == GM_EDITOR || _generating_world) {
-		return true; // TODO: should there be a proper check?
+		const RoadTypeInfo *rti = GetRoadTypeInfo(roadtype);
+		if (rti->label == 0) return false;
+
+		/*
+		 * Do not allow building hidden road types, except when a town may build it.
+		 * The GS under deity mode, as well as anybody in the editor builds roads that are
+		 * owned by towns. So if a town may build it, it should be buildable by them too.
+		 */
+		return (rti->flags & ROTFB_HIDDEN) == 0 || (rti->flags & ROTFB_TOWN_BUILD) != 0;
 	} else {
 		const Company *c = Company::GetIfValid(company);
 		if (c == nullptr) return false;


### PR DESCRIPTION
## Motivation / Problem

Create a GS that, under deity mode, builds roads with `GSRoad.SetCurrentRoadType(10)`. Start a game without NewGRFs, and the script happily builds the roads. Only caveat is that the player can't do much with the road, as their trucks and busses are not compatible with it, nor can they build junctions on them. The only thing you can do is remove them.


## Description

Implement the to-do in `HasRoadTypeAvail`, so that in for towns, scenario, world generation and game script (as deity) there are some limitations on the roads that may be built. The first and foremost is: if the road type has no label, i.e. is not set, then you cannot build it. Next to this is an extra check that prevents building hidden road types, except when the road type may be built by towns. Which I guess includes game scripts in deity mode, as they build roads as town.


## Limitations

This does not check whether there are/will be any vehicles that will use the road type, e.g. it can still build trams in a game without NewGRFs, nor does it check any date ranges or other introduction criteria for road types, like are done for companies. 
The problem is that the current logic requires companies, due to vehicle introductions that influence the available road types. Which makes it unfit in certain situations, like the GS in early world generation when there are no companies and as such fewer "available" roads. So, that would become quite complicated, while this is already vastly better than no checks at all.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
