### PR TITLE
Fix 3719f60: Crash when copying non-station orders

### DIFF
--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1577,8 +1577,9 @@ CommandCost CmdCloneOrder(DoCommandFlag flags, CloneOptions action, VehicleID ve
 			/* Trucks can't copy all the orders from busses (and visa versa),
 			 * and neither can helicopters and aircraft. */
 			for (const Order *order : src->Orders()) {
+				if (!OrderGoesToStation(dst, order)) continue;
 				Station *st = Station::Get(order->GetDestination());
-				if (OrderGoesToStation(dst, order) && !CanVehicleUseStation(dst, st)) {
+				if (!CanVehicleUseStation(dst, st)) {
 					return CommandCost(STR_ERROR_CAN_T_COPY_SHARE_ORDER, GetVehicleCannotUseStationReason(dst, st));
 				}
 			}


### PR DESCRIPTION
## Motivation / Problem

- Make a vehicle
- Add non-station order (i.e. depot)
- Make another vehicle and copy (not share) orders from the first one
- Game crashes / asserts

## Description

Introduced #10494, it tries to Get station by id before checking that order even leads to a station. So check before accessing it.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
