### PR TITLE
Fix #5713: Use pathfinder to find closest ship depot

### DIFF
--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -110,7 +110,7 @@ struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
 	uint Crash(bool flooded = false) override;
 	TileIndex GetOrderStationLocation(StationID station) override;
 	TileIndex GetCargoTile() const override { return this->First()->tile; }
-	ClosestDepot FindClosestDepot() override;
+	ClosestDepot FindClosestDepot(bool may_reverse = false) override;
 
 	/**
 	 * Check if the aircraft type is a normal flying device; eg

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -394,7 +394,7 @@ CommandCost CmdBuildAircraft(DoCommandFlags flags, TileIndex tile, const Engine 
 }
 
 
-ClosestDepot Aircraft::FindClosestDepot()
+ClosestDepot Aircraft::FindClosestDepot([[maybe_unused]] bool may_reverse)
 {
 	const Station *st = GetTargetAirportIfValid(this);
 	/* If the station is not a valid airport or if it has no hangars */

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1894,10 +1894,11 @@ VehicleOrderID ProcessConditionalOrder(const Order *order, const Vehicle *v)
  * Update the vehicle's destination tile from an order.
  * @param order the order the vehicle currently has
  * @param v the vehicle to update
+ * @param may_reverse Whether the vehicle is allowed to reverse when executing the updated order.
  * @param conditional_depth the depth (amount of steps) to go with conditional orders. This to prevent infinite loops.
  * @param pbs_look_ahead Whether we are forecasting orders for pbs reservations in advance. If true, the order indices must not be modified.
  */
-bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool pbs_look_ahead)
+bool UpdateOrderDest(Vehicle *v, const Order *order, bool may_reverse, int conditional_depth, bool pbs_look_ahead)
 {
 	if (conditional_depth > v->GetNumOrders()) {
 		v->current_order.Free();
@@ -1924,7 +1925,7 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 				if (v->dest_tile == 0 && TimerGameEconomy::date_fract != (v->index % Ticks::DAY_TICKS)) break;
 
 				/* We need to search for the nearest depot (hangar). */
-				ClosestDepot closest_depot = v->FindClosestDepot();
+				ClosestDepot closest_depot = v->FindClosestDepot(may_reverse);
 
 				if (closest_depot.found) {
 					/* PBS reservations cannot reverse */
@@ -2016,7 +2017,7 @@ bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth, bool
 	}
 
 	v->current_order = *order;
-	return UpdateOrderDest(v, order, conditional_depth + 1, pbs_look_ahead);
+	return UpdateOrderDest(v, order, may_reverse, conditional_depth + 1, pbs_look_ahead);
 }
 
 /**
@@ -2114,7 +2115,7 @@ bool ProcessOrders(Vehicle *v)
 			break;
 	}
 
-	return UpdateOrderDest(v, order) && may_reverse;
+	return UpdateOrderDest(v, order, may_reverse) && may_reverse;
 }
 
 /**

--- a/src/order_func.h
+++ b/src/order_func.h
@@ -20,7 +20,7 @@ void InvalidateVehicleOrder(const Vehicle *v, int data);
 void CheckOrders(const Vehicle*);
 void DeleteVehicleOrders(Vehicle *v, bool keep_orderlist = false, bool reset_order_indices = true);
 bool ProcessOrders(Vehicle *v);
-bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth = 0, bool pbs_look_ahead = false);
+bool UpdateOrderDest(Vehicle *v, const Order *order, bool may_reverse = false, int conditional_depth = 0, bool pbs_look_ahead = false);
 VehicleOrderID ProcessConditionalOrder(const Order *order, const Vehicle *v);
 uint GetOrderDistance(VehicleOrderID prev, VehicleOrderID cur, const Vehicle *v, int conditional_depth = 0);
 

--- a/src/pathfinder/water_regions.cpp
+++ b/src/pathfinder/water_regions.cpp
@@ -429,3 +429,24 @@ void PrintWaterRegionDebugInfo(TileIndex tile)
 {
 	GetUpdatedWaterRegion(tile).PrintDebugInfo();
 }
+
+/**
+ * Tests the provided callback function on all tiles of the water patch of the region
+ * and returns the first tile that passes the callback test.
+ * @param callback The test function that will be called for the water patch.
+ * @param water_region_patch Water patch within the water region to test the callback.
+ * @return the first tile which passed the callback test, or INVALID_TILE if the callback failed.
+ */
+TileIndex GetTileInWaterRegionPatch(const WaterRegionPatchDesc &water_region_patch, TestTileIndexCallBack &callback)
+{
+	const WaterRegion region = GetUpdatedWaterRegion(water_region_patch.x, water_region_patch.y);
+
+	/* Check if the region has a tile which passes the callback test. */
+	for (const TileIndex tile : region) {
+		if (region.GetLabel(tile) != water_region_patch.label || !callback(tile)) continue;
+
+		return tile;
+	}
+
+	return INVALID_TILE;
+}

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -62,4 +62,7 @@ void AllocateWaterRegions();
 
 void PrintWaterRegionDebugInfo(TileIndex tile);
 
+using TestTileIndexCallBack = std::function<bool(const TileIndex)>;
+TileIndex GetTileInWaterRegionPatch(const WaterRegionPatchDesc &water_region_patch, TestTileIndexCallBack &callback);
+
 #endif /* WATER_REGIONS_H */

--- a/src/pathfinder/water_regions.h
+++ b/src/pathfinder/water_regions.h
@@ -63,6 +63,7 @@ void AllocateWaterRegions();
 void PrintWaterRegionDebugInfo(TileIndex tile);
 
 using TestTileIndexCallBack = std::function<bool(const TileIndex)>;
-TileIndex GetTileInWaterRegionPatch(const WaterRegionPatchDesc &water_region_patch, TestTileIndexCallBack &callback);
+bool TestTileInWaterRegionPatch(const WaterRegionPatchDesc &water_region_patch, TestTileIndexCallBack &callback);
+TileIndex FindClosestEnteringTile(const std::span<WaterRegionPatchDesc> high_level_path, TestTileIndexCallBack &callback);
 
 #endif /* WATER_REGIONS_H */

--- a/src/pathfinder/yapf/yapf.h
+++ b/src/pathfinder/yapf/yapf.h
@@ -40,9 +40,10 @@ bool YapfShipCheckReverse(const Ship *v, Trackdir *trackdir);
  * @param max_penalty  max distance (in pathfinder penalty) from the current ship position
  *                     (used also as optimization - the pathfinder can stop path finding if max_penalty
  *                     was reached and no depot was seen)
+ * @param may_reverse  whether the ship is allowed to reverse
  * @return             the data about the depot
  */
-FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty);
+FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty, bool may_reverse);
 
 /**
  * Finds the best path for given road vehicle using YAPF.

--- a/src/pathfinder/yapf/yapf.h
+++ b/src/pathfinder/yapf/yapf.h
@@ -35,6 +35,16 @@ Track YapfShipChooseTrack(const Ship *v, TileIndex tile, bool &path_found, ShipP
 bool YapfShipCheckReverse(const Ship *v, Trackdir *trackdir);
 
 /**
+ * Used when user sends ship to the nearest depot or if ship needs servicing using YAPF.
+ * @param v            ship that needs to go to some depot
+ * @param max_penalty  max distance (in pathfinder penalty) from the current ship position
+ *                     (used also as optimization - the pathfinder can stop path finding if max_penalty
+ *                     was reached and no depot was seen)
+ * @return             the data about the depot
+ */
+FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty);
+
+/**
  * Finds the best path for given road vehicle using YAPF.
  * @param v         the RV that needs to find a path
  * @param tile      the tile to find the path from (should be next tile the RV is about to enter)

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -100,9 +100,9 @@ public:
 		return tile == this->dest_tile && ((this->dest_trackdirs & TrackdirToTrackdirBits(trackdir)) != TRACKDIR_BIT_NONE);
 	}
 
-	inline TileIndex GetShipDepotDestination(const WaterRegionPatchDesc &water_region_patch)
+	inline TileIndex GetShipDepotDestination(const std::span<WaterRegionPatchDesc> high_level_path)
 	{
-		return GetTileInWaterRegionPatch(water_region_patch, this->detect_ship_depot);
+		return FindClosestEnteringTile(high_level_path, this->detect_ship_depot);
 	}
 
 	/**
@@ -268,7 +268,7 @@ public:
 
 			/* Return early when only searching for the closest depot tile. */
 			if (find_closest_depot) {
-				tile = is_intermediate_destination ? pf.GetShipDepotDestination(high_level_path.back()) : node->GetTile();
+				tile = is_intermediate_destination ? pf.GetShipDepotDestination(high_level_path) : node->GetTile();
 				return INVALID_TRACKDIR;
 			}
 

--- a/src/pathfinder/yapf/yapf_ship.cpp
+++ b/src/pathfinder/yapf/yapf_ship.cpp
@@ -354,9 +354,10 @@ public:
 	 * Find the best depot for a ship.
 	 * @param v Ship
 	 * @param max_penalty maximum pathfinder cost.
+	 * @param may_reverse whether the ship is allowed to reverse.
 	 * @return FindDepotData with the best depot tile, cost and whether to reverse.
 	 */
-	static inline FindDepotData FindNearestDepot(const Ship *v, int max_penalty)
+	static inline FindDepotData FindNearestDepot(const Ship *v, int max_penalty, bool may_reverse)
 	{
 		FindDepotData depot;
 
@@ -364,7 +365,7 @@ public:
 		ShipPathCache dummy_cache;
 		TileIndex tile = INVALID_TILE;
 		Trackdir best_origin_dir = INVALID_TRACKDIR;
-		const bool search_both_ways = max_penalty == 0;
+		const bool search_both_ways = may_reverse && max_penalty == 0;
 		const Trackdir forward_dir = v->GetVehicleTrackdir();
 		const Trackdir reverse_dir = ReverseTrackdir(forward_dir);
 		const TrackdirBits forward_dirs = TrackdirToTrackdirBits(forward_dir);
@@ -524,7 +525,7 @@ bool YapfShipCheckReverse(const Ship *v, Trackdir *trackdir)
 	return CYapfShip::CheckShipReverse(v, trackdir);
 }
 
-FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty)
+FindDepotData YapfShipFindNearestDepot(const Ship *v, int max_penalty, bool may_reverse)
 {
-	return CYapfShip::FindNearestDepot(v, max_penalty);
+	return CYapfShip::FindNearestDepot(v, max_penalty, may_reverse);
 }

--- a/src/pathfinder/yapf/yapf_ship_regions.cpp
+++ b/src/pathfinder/yapf/yapf_ship_regions.cpp
@@ -155,7 +155,7 @@ public:
 	inline bool PfDetectDestination(Node &n)
 	{
 		if (this->any_ship_depot) {
-			return GetTileInWaterRegionPatch(n.key.water_region_patch, this->detect_ship_depot) != INVALID_TILE;
+			return TestTileInWaterRegionPatch(n.key.water_region_patch, this->detect_ship_depot);
 		}
 
 		return n.key == this->dest;

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -132,7 +132,7 @@ struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
 	uint Crash(bool flooded = false) override;
 	Trackdir GetVehicleTrackdir() const override;
 	TileIndex GetOrderStationLocation(StationID station) override;
-	ClosestDepot FindClosestDepot() override;
+	ClosestDepot FindClosestDepot(bool may_reverse = false) override;
 
 	bool IsBus() const;
 

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -345,7 +345,7 @@ static FindDepotData FindClosestRoadDepot(const RoadVehicle *v, int max_distance
 	return YapfRoadVehicleFindNearestDepot(v, max_distance);
 }
 
-ClosestDepot RoadVehicle::FindClosestDepot()
+ClosestDepot RoadVehicle::FindClosestDepot([[maybe_unused]] bool may_reverse)
 {
 	FindDepotData rfdd = FindClosestRoadDepot(this, 0);
 	if (rfdd.best_length == UINT_MAX) return ClosestDepot();

--- a/src/ship.h
+++ b/src/ship.h
@@ -57,7 +57,7 @@ struct Ship final : public SpecializedVehicle<Ship, VEH_SHIP> {
 	void OnNewEconomyDay() override;
 	Trackdir GetVehicleTrackdir() const override;
 	TileIndex GetOrderStationLocation(StationID station) override;
-	ClosestDepot FindClosestDepot() override;
+	ClosestDepot FindClosestDepot(bool may_reverse = false) override;
 	void UpdateCache();
 	void SetDestTile(TileIndex tile) override;
 };

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -17,7 +17,6 @@
 #include "station_base.h"
 #include "newgrf_engine.h"
 #include "pathfinder/yapf/yapf.h"
-#include "pathfinder/yapf/yapf_ship_regions.h"
 #include "newgrf_sound.h"
 #include "strings_func.h"
 #include "window_func.h"
@@ -38,12 +37,7 @@
 
 #include "table/strings.h"
 
-#include <unordered_set>
-
 #include "safeguards.h"
-
-/** Max distance in tiles (as the crow flies) to search for depots when user clicks "go to depot". */
-constexpr int MAX_SHIP_DEPOT_SEARCH_DISTANCE = 80;
 
 /**
  * Determine the effective #WaterClass for a ship travelling on a tile.
@@ -149,55 +143,13 @@ void Ship::GetImage(Direction direction, EngineImageType image_type, VehicleSpri
 
 static const Depot *FindClosestShipDepot(const Vehicle *v, uint max_distance)
 {
-	const int max_region_distance = (max_distance / WATER_REGION_EDGE_LENGTH) + 1;
+	const TileIndex tile = v->tile;
+	if (IsShipDepotTile(tile) && IsTileOwner(tile, v->owner)) return Depot::GetByTile(tile);
 
-	static std::unordered_set<int> visited_patch_hashes;
-	static std::deque<WaterRegionPatchDesc> patches_to_search;
-	visited_patch_hashes.clear();
-	patches_to_search.clear();
+	FindDepotData sfdd = YapfShipFindNearestDepot(Ship::From(v), max_distance);
 
-	/* Step 1: find a set of reachable Water Region Patches using BFS. */
-	const WaterRegionPatchDesc start_patch = GetWaterRegionPatchInfo(v->tile);
-	patches_to_search.push_back(start_patch);
-	visited_patch_hashes.insert(CalculateWaterRegionPatchHash(start_patch));
-
-	while (!patches_to_search.empty()) {
-		/* Remove first patch from the queue and make it the current patch. */
-		const WaterRegionPatchDesc current_node = patches_to_search.front();
-		patches_to_search.pop_front();
-
-		/* Add neighbours of the current patch to the search queue. */
-		VisitWaterRegionPatchCallback visit_func = [&](const WaterRegionPatchDesc &water_region_patch) {
-			/* Note that we check the max distance per axis, not the total distance. */
-			if (std::abs(water_region_patch.x - start_patch.x) > max_region_distance ||
-					std::abs(water_region_patch.y - start_patch.y) > max_region_distance) return;
-
-			const int hash = CalculateWaterRegionPatchHash(water_region_patch);
-			if (visited_patch_hashes.count(hash) == 0) {
-				visited_patch_hashes.insert(hash);
-				patches_to_search.push_back(water_region_patch);
-			}
-		};
-
-		VisitWaterRegionPatchNeighbours(current_node, visit_func);
-	}
-
-	/* Step 2: Find the closest depot within the reachable Water Region Patches. */
-	const Depot *best_depot = nullptr;
-	uint best_dist_sq = std::numeric_limits<uint>::max();
-	for (const Depot *depot : Depot::Iterate()) {
-		const TileIndex tile = depot->xy;
-		if (IsShipDepotTile(tile) && IsTileOwner(tile, v->owner)) {
-			const uint dist_sq = DistanceSquare(tile, v->tile);
-			if (dist_sq < best_dist_sq && dist_sq <= max_distance * max_distance &&
-					visited_patch_hashes.count(CalculateWaterRegionPatchHash(GetWaterRegionPatchInfo(tile))) > 0) {
-				best_dist_sq = dist_sq;
-				best_depot = depot;
-			}
-		}
-	}
-
-	return best_depot;
+	if (sfdd.tile == INVALID_TILE) return nullptr;
+	return Depot::GetByTile(sfdd.tile);
 }
 
 static void CheckIfShipNeedsService(Vehicle *v)
@@ -208,7 +160,7 @@ static void CheckIfShipNeedsService(Vehicle *v)
 		return;
 	}
 
-	uint max_distance = _settings_game.pf.yapf.maximum_go_to_depot_penalty / YAPF_TILE_LENGTH;
+	uint max_distance = _settings_game.pf.yapf.maximum_go_to_depot_penalty;
 
 	const Depot *depot = FindClosestShipDepot(v, max_distance);
 
@@ -933,7 +885,7 @@ CommandCost CmdBuildShip(DoCommandFlags flags, TileIndex tile, const Engine *e, 
 
 ClosestDepot Ship::FindClosestDepot()
 {
-	const Depot *depot = FindClosestShipDepot(this, MAX_SHIP_DEPOT_SEARCH_DISTANCE);
+	const Depot *depot = FindClosestShipDepot(this, 0);
 	if (depot == nullptr) return ClosestDepot();
 
 	return ClosestDepot(depot->xy, depot->index);

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -141,12 +141,12 @@ void Ship::GetImage(Direction direction, EngineImageType image_type, VehicleSpri
 	result->Set(_ship_sprites[spritenum] + direction);
 }
 
-static const Depot *FindClosestShipDepot(const Vehicle *v, uint max_distance)
+static const Depot *FindClosestShipDepot(const Vehicle *v, uint max_distance, bool may_reverse = false)
 {
 	const TileIndex tile = v->tile;
 	if (IsShipDepotTile(tile) && IsTileOwner(tile, v->owner)) return Depot::GetByTile(tile);
 
-	FindDepotData sfdd = YapfShipFindNearestDepot(Ship::From(v), max_distance);
+	FindDepotData sfdd = YapfShipFindNearestDepot(Ship::From(v), max_distance, may_reverse);
 
 	if (sfdd.tile == INVALID_TILE) return nullptr;
 	return Depot::GetByTile(sfdd.tile);
@@ -883,9 +883,9 @@ CommandCost CmdBuildShip(DoCommandFlags flags, TileIndex tile, const Engine *e, 
 	return CommandCost();
 }
 
-ClosestDepot Ship::FindClosestDepot()
+ClosestDepot Ship::FindClosestDepot(bool may_reverse)
 {
-	const Depot *depot = FindClosestShipDepot(this, 0);
+	const Depot *depot = FindClosestShipDepot(this, 0, may_reverse);
 	if (depot == nullptr) return ClosestDepot();
 
 	return ClosestDepot(depot->xy, depot->index);

--- a/src/train.h
+++ b/src/train.h
@@ -129,7 +129,7 @@ struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
 	uint Crash(bool flooded = false) override;
 	Trackdir GetVehicleTrackdir() const override;
 	TileIndex GetOrderStationLocation(StationID station) override;
-	ClosestDepot FindClosestDepot() override;
+	ClosestDepot FindClosestDepot(bool may_reverse = false) override;
 
 	void ReserveTrackUnderConsist() const;
 

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -2184,7 +2184,7 @@ static FindDepotData FindClosestTrainDepot(Train *v, int max_distance)
 	return YapfTrainFindNearestDepot(v, max_distance);
 }
 
-ClosestDepot Train::FindClosestDepot()
+ClosestDepot Train::FindClosestDepot([[maybe_unused]] bool may_reverse)
 {
 	FindDepotData tfdd = FindClosestTrainDepot(this, 0);
 	if (tfdd.best_length == UINT_MAX) return ClosestDepot();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2594,7 +2594,7 @@ CommandCost Vehicle::SendToDepot(DoCommandFlags flags, DepotCommandFlags command
 		return CommandCost();
 	}
 
-	ClosestDepot closest_depot = this->FindClosestDepot();
+	ClosestDepot closest_depot = this->FindClosestDepot(true);
 	static const StringID no_depot[] = {STR_ERROR_UNABLE_TO_FIND_ROUTE_TO, STR_ERROR_UNABLE_TO_FIND_LOCAL_DEPOT, STR_ERROR_UNABLE_TO_FIND_LOCAL_DEPOT, STR_ERROR_CAN_T_SEND_AIRCRAFT_TO_HANGAR};
 	if (!closest_depot.found) return CommandCost(no_depot[this->type]);
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -768,9 +768,10 @@ public:
 	/**
 	 * Find the closest depot for this vehicle and tell us the location,
 	 * DestinationID and whether we should reverse.
+	 * @param may_reverse Whether the vehicle is allowed to reverse.
 	 * @return A structure with information about the closest depot, if found.
 	 */
-	virtual ClosestDepot FindClosestDepot() { return {}; }
+	virtual ClosestDepot FindClosestDepot([[maybe_unused]] bool may_reverse = false) { return {}; }
 
 	virtual void SetDestTile(TileIndex tile) { this->dest_tile = tile; }
 


### PR DESCRIPTION
## Motivation / Problem
https://github.com/OpenTTD/OpenTTD/issues/8022 - Ships are stuck in a loop due to automatic servicing distance limit triggering it. They can't decide whether to head to ship depot or the dock, which are opposite directions.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
This patch provides the closest reachable ship depot, by utilizing the pathfinder, and removes current masters' method.

I created 3 commits. Commit 1 is the base core of the changes. Commit 2 and 3 are "optional", in the sense that they improve the experience and results, but I recognize they make the code larger or harder to review.

1. ### _Use pathfinder to find closest ship depot_
Yapf searches for a depot by using a breadth-first search approach on both the high-level and low-level pathfinders. The approach I took was to base it as much as I could on the existing `ChooseShipTrack`.

Some changes were made to this function, to adapt for the necessary means to deal with a `max_penalty` path cost and to return the tile of the depot found.

On the high-level part of the pathfinder however, a new method exclusively for searching depots was introduced, `FindShipDepotRegionPath`.

Unlike the original `FindWaterRegionPath`, the depot method has no known destination, so the current ship position is added as the origin, the path is built upside down instead, and the whole of it is reversed then returned to maintain the same behaviour expected for `ChooseShipTrack`, which has been adapted to use spans of the path returned where needed.

Intermediate destinations and automatic servicing required special care of my part. After a lot of experimentation, I decided it was best to simply return no depot found when in this situation even when sometimes there would be no issue with returning the depot. My reasoning for this decision is to prevent exactly what I'm supposed to be solving after all, avoid ships going back and forth undecided whether to service or not. Ships could find themselves outside of an intermediate destination on subsequent automatic service requests and have no ship depot found within the allowed `max_penalty` cost.

2. ### _Find nearest depot to entry edge in intermediate region_
This add-on improves the search of a ship depot when an intermediate region is set. It's not perfect by any means, but it's an attempt to guess which depot is closest to the edge in which the region is entered from. Should there be more than one ship depot in that region, this theoretically helps return the depot which is closest.

3. ### _Ships may reverse on find closest depot order_
This add-on improves the search of a ship depot by letting the pathfinder know whether the ship is allowed to reverse. Ships may be allowed to reverse when manually ordered to find the closest ship depot or executing an updated order to find the closest ship depot after departing from a station.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This was rejected in the past, when ship cache didn't exist and OPF and NPF were still options. But as of today, I think of it as complete and clean enough to warrant a PR again. I've been rebasing it over the years to keep it current.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
