### PR TITLE
Improve ScriptText validation error messages and prevent circular references

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -355,6 +355,20 @@ const StringParams &GetGameStringParams(uint id)
 }
 
 /**
+ * Get the name of a particular game string.
+ * @param id The ID of the game string.
+ * @return The name of the string.
+ */
+const std::string &GetGameStringName(uint id)
+{
+	/* The name for STR_UNDEFINED. */
+	static const std::string undefined = "STR_UNDEFINED";
+
+	if (id >= _current_data->string_names.size()) return undefined;
+	return _current_data->string_names[id];
+}
+
+/**
  * Register the current translation to the Squirrel engine.
  * @param engine The engine to update/
  */

--- a/src/game/game_text.hpp
+++ b/src/game/game_text.hpp
@@ -29,6 +29,7 @@ using StringParamsList = std::vector<StringParams>;
 
 const char *GetGameStringPtr(uint id);
 const StringParams &GetGameStringParams(uint id);
+const std::string &GetGameStringName(uint id);
 void RegisterGameTranslation(class Squirrel *engine);
 void ReconsiderGameScriptLanguage();
 

--- a/src/script/api/script_text.hpp
+++ b/src/script/api/script_text.hpp
@@ -129,6 +129,7 @@ public:
 
 private:
 	using ScriptTextRef = ScriptObjectRef<ScriptText>;
+	using StringIDList = std::vector<StringID>;
 
 	StringID string;
 	std::variant<SQInteger, std::string, ScriptTextRef> param[SCRIPT_TEXT_MAX_PARAMETERS];
@@ -140,9 +141,10 @@ private:
 	 * @param p The current position in the buffer.
 	 * @param lastofp The last position valid in the buffer.
 	 * @param param_count The number of parameters that are in the string.
+	 * @param seen_ids The list of seen StringID.
 	 * @return The new current position in the buffer.
 	 */
-	char *_GetEncodedText(char *p, char *lastofp, int &param_count);
+	char *_GetEncodedText(char *p, char *lastofp, int &param_count, StringIDList &seen_ids);
 
 	/**
 	 * Set a parameter, where the value is the first item on the stack.


### PR DESCRIPTION
Closes #10542
## Motivation / Problem
As mentioned in #10542, ScriptText validation error messages are quite generic.
Also while testing the new messages I had a [silly test idea](https://gist.github.com/glx22/14d3e99050978cde1ddcbab23138b7e5) which triggered a nice infinite recursion.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Give more details in the error message to help script authors.
Introduce a mechanism to prevent circular references in ScriptText.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
