### PR TITLE
Fix 30ae072: when a road type is hidden, towns may not build them even when that flag is set

### DIFF
--- a/src/road.cpp
+++ b/src/road.cpp
@@ -112,14 +112,7 @@ bool HasRoadTypeAvail(const CompanyID company, RoadType roadtype)
 {
 	if (company == OWNER_DEITY || company == OWNER_TOWN || _game_mode == GM_EDITOR || _generating_world) {
 		const RoadTypeInfo *rti = GetRoadTypeInfo(roadtype);
-		if (rti->label == 0) return false;
-
-		/*
-		 * Do not allow building hidden road types, except when a town may build it.
-		 * The GS under deity mode, as well as anybody in the editor builds roads that are
-		 * owned by towns. So if a town may build it, it should be buildable by them too.
-		 */
-		return (rti->flags & ROTFB_HIDDEN) == 0 || (rti->flags & ROTFB_TOWN_BUILD) != 0;
+		return rti->label != 0 && (rti->flags & ROTFB_HIDDEN) == 0;
 	} else {
 		const Company *c = Company::GetIfValid(company);
 		if (c == nullptr) return false;

--- a/src/road.h
+++ b/src/road.h
@@ -40,14 +40,14 @@ enum RoadTypeFlags {
 	ROTF_NO_LEVEL_CROSSING,                                ///< Bit number for disabling level crossing
 	ROTF_NO_HOUSES,                                        ///< Bit number for setting this roadtype as not house friendly
 	ROTF_HIDDEN,                                           ///< Bit number for hidden from construction.
-	ROTF_TOWN_BUILD,                                       ///< Bit number for allowing towns to build this roadtype.
+	ROTF_TOWN_BUILD,                                       ///< Bit number for allowing towns to build this roadtype. Does not override ROTF_HIDDEN.
 
 	ROTFB_NONE = 0,                                        ///< All flags cleared.
 	ROTFB_CATENARY          = 1 << ROTF_CATENARY,          ///< Value for drawing a catenary.
 	ROTFB_NO_LEVEL_CROSSING = 1 << ROTF_NO_LEVEL_CROSSING, ///< Value for disabling a level crossing.
 	ROTFB_NO_HOUSES         = 1 << ROTF_NO_HOUSES,         ///< Value for for setting this roadtype as not house friendly.
 	ROTFB_HIDDEN            = 1 << ROTF_HIDDEN,            ///< Value for hidden from construction.
-	ROTFB_TOWN_BUILD        = 1 << ROTF_TOWN_BUILD,        ///< Value for allowing towns to build this roadtype.
+	ROTFB_TOWN_BUILD        = 1 << ROTF_TOWN_BUILD,        ///< Value for allowing towns to build this roadtype. Does not override ROTFB_HIDDEN.
 };
 DECLARE_ENUM_AS_BIT_SET(RoadTypeFlags)
 


### PR DESCRIPTION
## Motivation / Problem

```
< petern> glx22viaGitHub: Hidden road types should not be buildable by towns either
< petern> I think I had a patch or pr for rhat
```

## Description

Remove logic that hidden roads are buildable by towns and GS, and document this behaviour it with the flags.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
