### PR TITLE
Change: Groups cache vehicle lists

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2163,5 +2163,5 @@ void UpdateAirplanesOnNewStation(const Station *st)
 	}
 
 	/* Heliports don't have a hangar. Invalidate all go to hangar orders from all aircraft. */
-	if (!st->airport.HasHangar()) RemoveOrderFromAllVehicles(OT_GOTO_DEPOT, st->index, true);
+	if (!st->airport.HasHangar()) RemoveOrderFromAllVehicles(OT_GOTO_DEPOT, st->index, st->owner, true);
 }

--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -2144,8 +2144,10 @@ void UpdateAirplanesOnNewStation(const Station *st)
 	const AirportFTAClass *ap = st->airport.GetFTA();
 	Direction rotation = st->airport.tile == INVALID_TILE ? DIR_N : st->airport.rotation;
 
-	for (Aircraft *v : Aircraft::Iterate()) {
-		if (!v->IsNormalAircraft() || v->targetairport != st->index) continue;
+	const VehicleList &vehicle_list = Company::Get(st->owner)->group_all[VEH_AIRCRAFT].vehicle_list;
+	for (const Vehicle *vehicle : vehicle_list) {
+		Aircraft *v = Aircraft::From(Vehicle::Get(vehicle->index));
+		if (v->targetairport != st->index) continue;
 		assert(v->state == FLYING);
 
 		Order *o = &v->current_order;

--- a/src/depot.cpp
+++ b/src/depot.cpp
@@ -38,7 +38,7 @@ Depot::~Depot()
 	OrderBackup::Reset(this->xy, false);
 
 	/* Clear the depot from all order-lists */
-	RemoveOrderFromAllVehicles(OT_GOTO_DEPOT, this->index);
+	RemoveOrderFromAllVehicles(OT_GOTO_DEPOT, this->index, GetTileOwner(this->xy));
 
 	/* Delete the depot-window */
 	CloseWindowById(WC_VEHICLE_DEPOT, this->xy);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -210,9 +210,9 @@ int UpdateCompanyRatingAndValue(Company *c, bool update)
 		bool min_profit_first = true;
 		uint num = 0;
 
-		for (const Vehicle *v : Vehicle::Iterate()) {
-			if (v->owner != owner) continue;
-			if (IsCompanyBuildableVehicleType(v->type) && v->IsPrimaryVehicle()) {
+		for (VehicleType type = VEH_BEGIN; type < VEH_COMPANY_END; type++) {
+			const VehicleList &vehicle_list = c->group_all[type].vehicle_list;
+			for (const Vehicle *v : vehicle_list) {
 				if (v->profit_last_year > 0) num++; // For the vehicle score only count profitable vehicles
 				if (v->age > 730) {
 					/* Find the vehicle with the lowest amount of profit */

--- a/src/elrail.cpp
+++ b/src/elrail.cpp
@@ -625,10 +625,13 @@ void SettingsDisableElrail(int32_t new_value)
 		}
 	}
 
-	/* Fix the total power and acceleration for trains */
-	for (Train *t : Train::Iterate()) {
-		/* power and acceleration is cached only for front engines */
-		if (t->IsFrontEngine()) {
+	for (const Company *c : Company::Iterate()) {
+		/* Fix the total power and acceleration for trains.
+		 * These values are only cached for front engines which
+		 * is what the collection enumerates. */
+		const VehicleList &vehicle_list = c->group_all[VEH_TRAIN].vehicle_list;
+		for (const Vehicle *v : vehicle_list) {
+			Train *t = Train::From(Vehicle::Get(v->index));
 			t->ConsistChanged(CCF_TRACK);
 		}
 	}

--- a/src/group.h
+++ b/src/group.h
@@ -16,6 +16,7 @@
 #include "vehicle_type.h"
 #include "engine_type.h"
 #include "livery.h"
+#include "vehiclelist.h"
 
 typedef Pool<Group, GroupID, 16, 64000> GroupPool;
 extern GroupPool _group_pool; ///< Pool of groups.
@@ -29,6 +30,7 @@ struct GroupStatistics {
 	uint16_t num_vehicle_min_age;             ///< Number of vehicles considered for profit statistics;
 	bool autoreplace_defined;               ///< Are any autoreplace rules set?
 	bool autoreplace_finished;              ///< Have all autoreplacement finished?
+	VehicleList vehicle_list;               ///< List of vehicles
 
 	GroupStatistics();
 	~GroupStatistics();

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -50,6 +50,8 @@ void GroupStatistics::Clear()
 	/* This is also called when NewGRF change. So the number of engines might have changed. Reallocate. */
 	free(this->num_engines);
 	this->num_engines = CallocT<uint16_t>(Engine::GetPoolSize());
+
+	this->vehicle_list.clear();
 }
 
 /**
@@ -146,6 +148,16 @@ void GroupStatistics::Clear()
 		stats_all.profit_last_year_min_age += v->GetDisplayProfitLastYear() * delta;
 		stats.num_vehicle_min_age += delta;
 		stats.profit_last_year_min_age += v->GetDisplayProfitLastYear() * delta;
+	}
+
+	auto it_all = std::find(stats_all.vehicle_list.begin(), stats_all.vehicle_list.end(), v);
+	auto it = std::find(stats.vehicle_list.begin(), stats.vehicle_list.end(), v);
+	if (delta == 1) {
+		if (it_all == stats_all.vehicle_list.end()) stats_all.vehicle_list.push_back(v);
+		if (it == stats.vehicle_list.end()) stats.vehicle_list.push_back(v);
+	} else {
+		if (it_all != stats_all.vehicle_list.end()) stats_all.vehicle_list.erase(it_all);
+		if (it != stats.vehicle_list.end()) stats.vehicle_list.erase(it);
 	}
 }
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -204,23 +204,21 @@ void GroupStatistics::Clear()
  */
 /* static */ void GroupStatistics::UpdateProfits()
 {
-	/* Set up the engine count for all companies */
-	for (Company *c : Company::Iterate()) {
-		for (VehicleType type = VEH_BEGIN; type < VEH_COMPANY_END; type++) {
-			c->group_all[type].ClearProfits();
-			c->group_default[type].ClearProfits();
-		}
-	}
-
-	/* Recalculate */
 	for (Group *g : Group::Iterate()) {
 		g->statistics.ClearProfits();
 	}
 
-	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->IsPrimaryVehicle()) {
-			GroupStatistics::AddProfitLastYear(v);
-			if (v->age > VEHICLE_PROFIT_MIN_AGE) GroupStatistics::VehicleReachedMinAge(v);
+	for (Company *c : Company::Iterate()) {
+		for (VehicleType type = VEH_BEGIN; type < VEH_COMPANY_END; type++) {
+			c->group_all[type].ClearProfits();
+			c->group_default[type].ClearProfits();
+
+			/* Recalculate */
+			const VehicleList &vehicle_list = c->group_all[type].vehicle_list;
+			for (const Vehicle *v : vehicle_list) {
+				GroupStatistics::AddProfitLastYear(v);
+				if (v->age > VEHICLE_PROFIT_MIN_AGE) GroupStatistics::VehicleReachedMinAge(v);
+			}
 		}
 	}
 }

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -293,12 +293,11 @@ static void PropagateChildLivery(const Group *g, bool reset_cache)
 {
 	if (reset_cache) {
 		/* Company colour data is indirectly cached. */
-		for (Vehicle *v : Vehicle::Iterate()) {
-			if (v->group_id == g->index && (!v->IsGroundVehicle() || v->IsFrontEngine())) {
-				for (Vehicle *u = v; u != nullptr; u = u->Next()) {
-					u->colourmap = PAL_NONE;
-					u->InvalidateNewGRFCache();
-				}
+		const VehicleList &vehicle_list = g->statistics.vehicle_list;
+		for (const Vehicle *v : vehicle_list) {
+			for (Vehicle *u = Vehicle::Get(v->index); u != nullptr; u = u->Next()) {
+				u->colourmap = PAL_NONE;
+				u->InvalidateNewGRFCache();
 			}
 		}
 	}

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -645,13 +645,10 @@ CommandCost CmdRemoveAllVehiclesGroup(DoCommandFlag flags, GroupID group_id)
 
 	if (flags & DC_EXEC) {
 		/* Find each Vehicle that belongs to the group old_g and add it to the default group */
-		for (const Vehicle *v : Vehicle::Iterate()) {
-			if (v->IsPrimaryVehicle()) {
-				if (v->group_id != group_id) continue;
-
-				/* Add The Vehicle to the default group */
-				Command<CMD_ADD_VEHICLE_GROUP>::Do(flags, DEFAULT_GROUP, v->index, false, VehicleListIdentifier{});
-			}
+		const VehicleList vehicle_list = g->statistics.vehicle_list;
+		for (const Vehicle *v : vehicle_list) {
+			/* Add The Vehicle to the default group */
+			Command<CMD_ADD_VEHICLE_GROUP>::Do(flags, DEFAULT_GROUP, v->index, false, VehicleListIdentifier{});
 		}
 
 		InvalidateWindowData(GetWindowClassForVehicleType(g->vehicle_type), VehicleListIdentifier(VL_GROUP_LIST, g->vehicle_type, _current_company).Pack());

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -614,16 +614,13 @@ CommandCost CmdAddSharedVehicleGroup(DoCommandFlag flags, GroupID id_g, VehicleT
 	if (!Group::IsValidID(id_g) || !IsCompanyBuildableVehicleType(type)) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
-		/* Find the first front engine which belong to the group id_g
-		 * then add all shared vehicles of this front engine to the group id_g */
-		for (const Vehicle *v : Vehicle::Iterate()) {
-			if (v->type == type && v->IsPrimaryVehicle()) {
-				if (v->group_id != id_g) continue;
-
-				/* For each shared vehicles add it to the group */
-				for (Vehicle *v2 = v->FirstShared(); v2 != nullptr; v2 = v2->NextShared()) {
-					if (v2->group_id != id_g) Command<CMD_ADD_VEHICLE_GROUP>::Do(flags, id_g, v2->index, false, VehicleListIdentifier{});
-				}
+		/* For each vehicle belonging to the group id_g
+		 * add all vehicles sharing orders with it to that group */
+		const VehicleList vehicle_list = Group::Get(id_g)->statistics.vehicle_list;
+		for (const Vehicle *v : vehicle_list) {
+			/* For each shared vehicles add it to the group */
+			for (Vehicle *v2 = v->FirstShared(); v2 != nullptr; v2 = v2->NextShared()) {
+				if (v2->group_id != id_g) Command<CMD_ADD_VEHICLE_GROUP>::Do(flags, id_g, v2->index, false, VehicleListIdentifier{});
 			}
 		}
 

--- a/src/order_func.h
+++ b/src/order_func.h
@@ -15,7 +15,7 @@
 #include "company_type.h"
 
 /* Functions */
-void RemoveOrderFromAllVehicles(OrderType type, DestinationID destination, bool hangar = false);
+void RemoveOrderFromAllVehicles(OrderType type, DestinationID destination, Owner owner, bool hangar = false);
 void InvalidateVehicleOrder(const Vehicle *v, int data);
 void CheckOrders(const Vehicle*);
 void DeleteVehicleOrders(Vehicle *v, bool keep_orderlist = false, bool reset_order_indices = true);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1899,7 +1899,6 @@ bool AfterLoadGame()
 	}
 
 	if (IsSavegameVersionBefore(SLV_62)) {
-		GroupStatistics::UpdateAfterLoad(); // Ensure statistics pool is initialised before trying to delete vehicles
 		/* Remove all trams from savegames without tram support.
 		 * There would be trams without tram track under causing crashes sooner or later. */
 		for (RoadVehicle *v : RoadVehicle::Iterate()) {
@@ -3317,7 +3316,6 @@ void ReloadNewGRFData()
 	ResetVehicleHash();
 	AfterLoadVehicles(false);
 	StartupEngines();
-	GroupStatistics::UpdateAfterLoad();
 	/* update station graphics */
 	AfterLoadStations();
 	/* Update company statistics. */

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -491,6 +491,8 @@ void AfterLoadVehicles(bool part_of_load)
 		v->UpdatePosition();
 		v->UpdateViewport(false);
 	}
+
+	GroupStatistics::UpdateAfterLoad();
 }
 
 bool TrainController(Train *v, Vehicle *nomove, bool reverse = true); // From train_cmd.cpp

--- a/src/script/api/script_group.cpp
+++ b/src/script/api/script_group.cpp
@@ -180,10 +180,8 @@
 
 	Money profit = 0;
 
-	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->group_id != group_id) continue;
-		if (!v->IsPrimaryVehicle()) continue;
-
+	const VehicleList &vehicle_list = ::Group::Get(group_id)->statistics.vehicle_list;
+	for (const Vehicle *v : vehicle_list) {
 		profit += v->GetDisplayProfitThisYear();
 	}
 
@@ -204,10 +202,8 @@
 	uint32_t occupancy = 0;
 	uint32_t vehicle_count = 0;
 
-	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->group_id != group_id) continue;
-		if (!v->IsPrimaryVehicle()) continue;
-
+	const VehicleList &vehicle_list = ::Group::Get(group_id)->statistics.vehicle_list;
+	for (const Vehicle *v : vehicle_list) {
 		occupancy += v->trip_occupancy;
 		vehicle_count++;
 	}

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -143,7 +143,7 @@ Station::~Station()
 	CloseWindowById(WC_STATION_VIEW, index);
 
 	/* Now delete all orders that go to the station */
-	RemoveOrderFromAllVehicles(OT_GOTO_STATION, this->index);
+	RemoveOrderFromAllVehicles(OT_GOTO_STATION, this->index, this->owner);
 
 	/* Remove all news items */
 	DeleteStationNews(this->index);

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -730,8 +730,8 @@ static void ToolbarVehicleClick(Window *w, VehicleType veh)
 {
 	int dis = ~0;
 
-	for (const Vehicle *v : Vehicle::Iterate()) {
-		if (v->type == veh && v->IsPrimaryVehicle()) ClrBit(dis, v->owner);
+	for (const Company *c : Company::Iterate()) {
+		if (!c->group_all[veh].vehicle_list.empty()) ClrBit(dis, c->index);
 	}
 	PopupMainCompanyToolbMenu(w, WID_TN_VEHICLE_START + veh, dis);
 }

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -77,23 +77,27 @@ void CheckTrainsLengths()
 {
 	bool first = true;
 
-	for (const Train *v : Train::Iterate()) {
-		if (v->First() == v && !(v->vehstatus & VS_CRASHED)) {
-			for (const Train *u = v, *w = v->Next(); w != nullptr; u = w, w = w->Next()) {
-				if (u->track != TRACK_BIT_DEPOT) {
-					if ((w->track != TRACK_BIT_DEPOT &&
+	for (const Company *c : Company::Iterate()) {
+		const VehicleList &vehicle_list = c->group_all[VEH_TRAIN].vehicle_list;
+		for (const Vehicle *vehicle : vehicle_list) {
+			const Train *v = Train::From(vehicle);
+			if (v->First() == v && !(v->vehstatus & VS_CRASHED)) {
+				for (const Train *u = v, *w = v->Next(); w != nullptr; u = w, w = w->Next()) {
+					if (u->track != TRACK_BIT_DEPOT) {
+						if ((w->track != TRACK_BIT_DEPOT &&
 							std::max(abs(u->x_pos - w->x_pos), abs(u->y_pos - w->y_pos)) != u->CalcNextVehicleOffset()) ||
-							(w->track == TRACK_BIT_DEPOT && TicksToLeaveDepot(u) <= 0)) {
-						SetDParam(0, v->index);
-						SetDParam(1, v->owner);
-						ShowErrorMessage(STR_BROKEN_VEHICLE_LENGTH, INVALID_STRING_ID, WL_CRITICAL);
+								(w->track == TRACK_BIT_DEPOT && TicksToLeaveDepot(u) <= 0)) {
+							SetDParam(0, v->index);
+							SetDParam(1, v->owner);
+							ShowErrorMessage(STR_BROKEN_VEHICLE_LENGTH, INVALID_STRING_ID, WL_CRITICAL);
 
-						if (!_networking && first) {
-							first = false;
-							Command<CMD_PAUSE>::Post(PM_PAUSED_ERROR, true);
+							if (!_networking && first) {
+								first = false;
+								Command<CMD_PAUSE>::Post(PM_PAUSED_ERROR, true);
+							}
+							/* Break so we warn only once for each train. */
+							break;
 						}
-						/* Break so we warn only once for each train. */
-						break;
 					}
 				}
 			}

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -32,7 +32,9 @@ void CcBuildWagon(Commands, const CommandCost &result, VehicleID new_veh_id, uin
 
 	/* find a locomotive in the depot. */
 	const Vehicle *found = nullptr;
-	for (const Train *t : Train::Iterate()) {
+	const VehicleList &vehicle_list = Company::Get(GetTileOwner(tile))->group_all[VEH_TRAIN].vehicle_list;
+	for (const Vehicle *v : vehicle_list) {
+		const Train *t = Train::From(v);
 		if (t->IsFrontEngine() && t->tile == tile && t->IsStoppedInDepot()) {
 			if (found != nullptr) return; // must be exactly one.
 			found = t;

--- a/src/waypoint.cpp
+++ b/src/waypoint.cpp
@@ -52,6 +52,6 @@ Waypoint::~Waypoint()
 {
 	if (CleaningPool()) return;
 	CloseWindowById(WC_WAYPOINT_VIEW, this->index);
-	RemoveOrderFromAllVehicles(OT_GOTO_WAYPOINT, this->index);
+	RemoveOrderFromAllVehicles(OT_GOTO_WAYPOINT, this->index, this->owner);
 	if (this->sign.kdtree_valid) _viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeWaypoint(this->index));
 }


### PR DESCRIPTION
## Motivation / Problem
AIs creating lists of vehicles will slow down OpenTTD especially with high amount of vehicles in the game.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Create a `vehicle_list` member for `GroupStatistics`. Every group, including the `group_default` and the `group_all`, will keep track of `const Vehicle *`'s as they're added or removed from them.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
This is a work in progress.

1. I'm looking into the rest of OpenTTD code for places where the use of this cache could be beneficial, but...
2. ... `AfterLoad` is the biggest hindrance to this approach. Some of its routines can at times call long established functions that are now being switched away from `VehicleListPool` iteration to the cached group vehicle list version. I am experimenting populating `GroupStatistics`, which is where these lists reside, as early as possible in the `AfterLoadGame` function.

The following have been changed so far:
- Iterate group vehicle lists for `GenerateVehicleSortList`.
- Iterate group vehicle lists for `ScriptVehicleList_Station`, `ScriptVehicleList_Depot`, `ScriptVehicleList_Group` and `ScriptVehicleList_DefaultGroup`.
- Iterate aircraft group list for `UpdateAirplanesOnNewStation`.
- Iterate group vehicle lists for `DisasterTick_Ufo` and `DisasterTick_Big_Ufo`. As a compromise, the result of this change differs from the original. The iteration order changed from lowest to highest vehicle index to lowest to highest company index plus the order at which each vehicle was added to each list regardless of their indexes.
- Iterate group vehicle lists for `UpdateCompanyRatingAndValue`.
- Iterate group vehicle lists for `SettingsDisableElrail`.
- Iterate group vehicle lists for `GetPreviewCompany` and `NewVehicleAvailable`. As a compromise, the result of this change differs from the original. Since the list only contains primary vehicles, free wagons aren't taken into consideration.
- Iterate group vehicle lists for `GroupStatistics::UpdateProfits`.
- Iterate group vehicle list for `PropagateChildLivery`.
- Iterate group vehicle list for `CmdAddSharedVehicleGroup`.
- Iterate group vehicle list for `CmdRemoveAllVehiclesGroup`.
- Iterate group vehicle lists for `WhoCanServiceIndustry`.
- Iterate group vehicle lists for `NetworkPopulateCompanyStats` and `NetworkAutoCleanCompanies`.
- Iterate group vehicle lists for `RemoveOrderFromAllVehicles`. Additionally make the function receive one parameter more with the owner of the destination, to help it perform faster.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
