### PR TITLE
Fix: Network server highlight invisible with RTL layout.

### DIFF
--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -398,9 +398,8 @@ protected:
 
 		/* show highlighted item with a different colour */
 		if (highlight) {
-			Rect r = {name.left, y, info.right, y + (int)this->resize.step_height - 1};
-			Rect ir = r.Shrink(WidgetDimensions::scaled.bevel);
-			GfxFillRect(ir.left, ir.top, ir.right, ir.bottom, PC_GREY);
+			Rect r = {std::min(name.left, info.left), y, std::max(name.right, info.right), y + (int)this->resize.step_height - 1};
+			GfxFillRect(r.Shrink(WidgetDimensions::scaled.bevel), PC_GREY);
 		}
 
 		/* offsets to vertically centre text and icons */


### PR DESCRIPTION
## Motivation / Problem

Server list highlight does not work when using an RTL language.

![image](https://user-images.githubusercontent.com/639850/223555558-a69a4c36-f5b4-4750-ace6-6343ca3f4759.png)

## Description

Existing code assumed that `name` and `info` widgets are in a certain order.
This is fixed by using the min/max of .left and .right of both widgets instead.

![image](https://user-images.githubusercontent.com/639850/223555702-8a0360e7-ef80-4b32-8f10-899fa21b0e2d.png)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
