### PR TITLE
Fix 13528bfcd0: bank balance command allows int64, GS was limited to int32

### DIFF
--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -241,8 +241,6 @@
 {
 	EnforceDeityMode(false);
 	EnforcePrecondition(false, expenses_type < (ExpensesType)::EXPENSES_END);
-	EnforcePrecondition(false, (int64)delta >= INT32_MIN);
-	EnforcePrecondition(false, (int64)delta <= INT32_MAX);
 	EnforcePrecondition(false, tile == INVALID_TILE || ::IsValidTile(tile));
 
 	company = ResolveCompanyID(company);

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -246,8 +246,6 @@ public:
 	 * @return True, if the bank balance was changed.
 	 * @game @pre ScriptCompanyMode::IsDeity().
 	 * @pre ResolveCompanyID(company) != COMPANY_INVALID.
-	 * @pre delta >= -2**31
-	 * @pre delta <   2**31
 	 * @note You need to create your own news message to inform about costs/gifts that you create using this command.
 	 * @api -ai
 	 */


### PR DESCRIPTION
## Motivation / Problem

With the command refactor, commands with money parameters actually got `Money` instead of `int32`. The GS command to change the bank balance of a company was still limiting to `int32`, even though there is no reason for that anymore.


## Description

Remove preconditons (checks and documentation), thus allowing the full int64 range for changing the bank balance.
No compat scripts should be needed; if a script previously did not clamp to int32, then it would not also work outside the limits of int32. If it did clamp, that value is still valid.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
