### PR TITLE
Change: Truncated music set song names, and music set changing.

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -289,7 +289,7 @@ enum MusicTrackType {
 
 /** Metadata about a music track. */
 struct MusicSongInfo {
-	char songname[32];       ///< name of song displayed in UI
+	std::string songname;    ///< name of song displayed in UI
 	byte tracknr;            ///< track number of song displayed in UI
 	const char *filename;    ///< file on disk containing song (when used in MusicSet class, this pointer is owned by MD5File object for the file)
 	MusicTrackType filetype; ///< decoder required for song file

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -128,7 +128,6 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 		for (uint i = 0; i < lengthof(this->songinfo); i++) {
 			const char *filename = this->files[i].filename;
 			if (names == nullptr || StrEmpty(filename) || this->files[i].check_result == MD5File::CR_NO_FILE) {
-				this->songinfo[i].songname[0] = '\0';
 				continue;
 			}
 
@@ -142,10 +141,9 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 				char *songname = GetMusicCatEntryName(filename, this->songinfo[i].cat_index);
 				if (songname == nullptr) {
 					Debug(grf, 0, "Base music set song missing from CAT file: {}/{}", filename, this->songinfo[i].cat_index);
-					this->songinfo[i].songname[0] = '\0';
 					continue;
 				}
-				strecpy(this->songinfo[i].songname, songname, lastof(this->songinfo[i].songname));
+				this->songinfo[i].songname = songname;
 				free(songname);
 			} else {
 				this->songinfo[i].filetype = MTT_STANDARDMIDI;
@@ -166,7 +164,7 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 
 			if (this->songinfo[i].filetype == MTT_STANDARDMIDI) {
 				if (item != nullptr && item->value.has_value() && !item->value->empty()) {
-					strecpy(this->songinfo[i].songname, item->value->c_str(), lastof(this->songinfo[i].songname));
+					this->songinfo[i].songname = item->value.value();
 				} else {
 					Debug(grf, 0, "Base music set song name missing: {}", filename);
 					return false;

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -178,6 +178,8 @@ void MusicSystem::ChangeMusicSet(const std::string &set_name)
 	this->ChangePlaylist(this->selected_playlist);
 
 	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GAME_OPTIONS, 0, true);
+	InvalidateWindowData(WC_MUSIC_TRACK_SELECTION, 0, 1, true);
+	InvalidateWindowData(WC_MUSIC_WINDOW, 0, 1, true);
 }
 
 /** Enable shuffle mode and restart playback */
@@ -480,7 +482,12 @@ struct MusicTrackSelectionWindow : public Window {
 			this->SetWidgetLoweredState(WID_MTS_ALL + i, i == _settings_client.music.playlist);
 		}
 		this->SetWidgetDisabledState(WID_MTS_CLEAR, _settings_client.music.playlist <= 3);
-		this->SetDirty();
+
+		if (data == 1) {
+			this->ReInit();
+		} else {
+			this->SetDirty();
+		}
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
@@ -764,7 +771,11 @@ struct MusicWindow : public Window {
 
 		UpdateDisabledButtons();
 
-		this->SetDirty();
+		if (data == 1) {
+			this->ReInit();
+		} else {
+			this->SetDirty();
+		}
 	}
 
 	void OnClick(Point pt, int widget, int click_count) override

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -43,7 +43,7 @@ struct MusicSystem {
 		uint set_index;        ///< index of song in set
 
 		PlaylistEntry(const MusicSet *set, uint set_index) : MusicSongInfo(set->songinfo[set_index]), set(set), set_index(set_index) { }
-		bool IsValid() const { return !StrEmpty(this->songname); }
+		bool IsValid() const { return !this->songname.empty(); }
 	};
 	typedef std::vector<PlaylistEntry> Playlist;
 

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -612,9 +612,9 @@ static const NWidgetPart _nested_music_track_selection_widgets[] = {
 		NWidget(NWID_HORIZONTAL), SetPIP(2, 4, 2),
 			/* Left panel. */
 			NWidget(NWID_VERTICAL),
-				NWidget(WWT_LABEL, COLOUR_GREY), SetDataTip(STR_PLAYLIST_TRACK_INDEX, STR_NULL),
-				NWidget(WWT_PANEL, COLOUR_GREY, WID_MTS_LIST_LEFT), SetMinimalSize(180, 194), SetDataTip(0x0, STR_PLAYLIST_TOOLTIP_CLICK_TO_ADD_TRACK), EndContainer(),
-				NWidget(NWID_SPACER), SetMinimalSize(0, 2),
+				NWidget(WWT_LABEL, COLOUR_GREY), SetFill(1, 0), SetDataTip(STR_PLAYLIST_TRACK_INDEX, STR_NULL),
+				NWidget(WWT_PANEL, COLOUR_GREY, WID_MTS_LIST_LEFT), SetFill(1, 1), SetMinimalSize(180, 194), SetDataTip(0x0, STR_PLAYLIST_TOOLTIP_CLICK_TO_ADD_TRACK), EndContainer(),
+				NWidget(NWID_SPACER), SetFill(1, 0), SetMinimalSize(0, 2),
 			EndContainer(),
 			/* Middle buttons. */
 			NWidget(NWID_VERTICAL),
@@ -631,9 +631,9 @@ static const NWidgetPart _nested_music_track_selection_widgets[] = {
 			EndContainer(),
 			/* Right panel. */
 			NWidget(NWID_VERTICAL),
-				NWidget(WWT_LABEL, COLOUR_GREY, WID_MTS_PLAYLIST), SetDataTip(STR_PLAYLIST_PROGRAM, STR_NULL),
-				NWidget(WWT_PANEL, COLOUR_GREY, WID_MTS_LIST_RIGHT), SetMinimalSize(180, 194), SetDataTip(0x0, STR_PLAYLIST_TOOLTIP_CLICK_TO_REMOVE_TRACK), EndContainer(),
-				NWidget(NWID_SPACER), SetMinimalSize(0, 2),
+				NWidget(WWT_LABEL, COLOUR_GREY, WID_MTS_PLAYLIST), SetFill(1, 0), SetDataTip(STR_PLAYLIST_PROGRAM, STR_NULL),
+				NWidget(WWT_PANEL, COLOUR_GREY, WID_MTS_LIST_RIGHT), SetFill(1, 1), SetMinimalSize(180, 194), SetDataTip(0x0, STR_PLAYLIST_TOOLTIP_CLICK_TO_REMOVE_TRACK), EndContainer(),
+				NWidget(NWID_SPACER), SetFill(1, 0), SetMinimalSize(0, 2),
 			EndContainer(),
 		EndContainer(),
 	EndContainer(),

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -147,18 +147,20 @@ void MusicSystem::ChangePlaylist(PlaylistChoices pl)
 {
 	assert(pl < PLCH_MAX && pl >= PLCH_ALLMUSIC);
 
-	this->displayed_playlist = this->standard_playlists[pl];
-	this->active_playlist = this->displayed_playlist;
-	this->selected_playlist = pl;
-	this->playlist_position = 0;
+	if (pl != PLCH_THEMEONLY) _settings_client.music.playlist = pl;
 
-	if (this->selected_playlist != PLCH_THEMEONLY) _settings_client.music.playlist = this->selected_playlist;
+	if (_game_mode != GM_MENU || pl == PLCH_THEMEONLY) {
+		this->displayed_playlist = this->standard_playlists[pl];
+		this->active_playlist = this->displayed_playlist;
+		this->selected_playlist = pl;
+		this->playlist_position = 0;
 
-	if (_settings_client.music.shuffle) {
-		this->Shuffle();
-		/* Shuffle() will also Play() if necessary, only start once */
-	} else if (_settings_client.music.playing) {
-		this->Play();
+		if (_settings_client.music.shuffle) {
+			this->Shuffle();
+			/* Shuffle() will also Play() if necessary, only start once */
+		} else if (_settings_client.music.playing) {
+			this->Play();
+		}
 	}
 
 	InvalidateWindowData(WC_MUSIC_TRACK_SELECTION, 0);


### PR DESCRIPTION
## Motivation / Problem

Music set song names are copied into a fixed 32 character array, and therefore may be truncated, which causes a warning log message.

![image](https://user-images.githubusercontent.com/639850/223670832-8e119af6-d13c-4282-9feb-a1096fc6f440.png)

Additionally changing music set does not update window sizes to fit the changed list (height was the main problem here)

![image](https://user-images.githubusercontent.com/639850/223670706-8ba2c3cf-7004-4f90-9b46-8478c728527b.png)

## Description

This is solved by storing song names in a std::string instead, and reinitializing the jukebox windows when changing music set.

![image](https://user-images.githubusercontent.com/639850/223671041-3ffb9fa4-7021-4b4a-8eeb-94dff2f6a62a.png)
![image](https://user-images.githubusercontent.com/639850/223671183-ca034c21-f6a5-4dec-b435-6e8acd2d81ac.png)

## Limitations

Song names can perhaps now be too long...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
