### PR TITLE
Fix #10554: Let Scrollbar::SetPosition clamp instead of assert.

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -795,7 +795,7 @@ public:
 		/* Position scrollbar to selected group */
 		for (uint i = 0; i < this->rows; i++) {
 			if (this->groups[i]->index == sel) {
-				this->vscroll->SetPosition(Clamp(i - this->vscroll->GetCapacity() / 2, 0, std::max(this->vscroll->GetCount() - this->vscroll->GetCapacity(), 0)));
+				this->vscroll->SetPosition(i - this->vscroll->GetCapacity() / 2);
 				break;
 			}
 		}

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -866,9 +866,7 @@ struct ScriptDebugWindow : public Window {
 		}
 		if (this->autoscroll) {
 			int scroll_pos = std::max(0, log->used - this->vscroll->GetCapacity());
-			if (scroll_pos != this->vscroll->GetPosition()) {
-				this->vscroll->SetPosition(scroll_pos);
-
+			if (this->vscroll->SetPosition(scroll_pos)) {
 				/* We need a repaint */
 				this->SetWidgetDirty(WID_SCRD_SCROLLBAR);
 				this->SetWidgetDirty(WID_SCRD_LOG_PANEL);

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -746,10 +746,8 @@ public:
 	 */
 	bool SetPosition(int position)
 	{
-		assert(position >= 0);
-		assert(this->count <= this->cap ? (position == 0) : (position + this->cap <= this->count));
 		uint16 old_pos = this->pos;
-		this->pos = position;
+		this->pos = Clamp(position, 0, std::max(this->count - this->cap, 0));
 		return this->pos != old_pos;
 	}
 
@@ -768,7 +766,7 @@ public:
 			case SS_BIG:   difference *= this->cap; break;
 			default: break;
 		}
-		return this->SetPosition(Clamp(this->pos + difference, 0, std::max(this->count - this->cap, 0)));
+		return this->SetPosition(this->pos + difference);
 	}
 
 	/**


### PR DESCRIPTION
## Motivation / Problem

As per #10554, calling Scrollbar::ScrollTowards() with an out-of-range position calls Scrollbar::SetPosition() with an out-of-range position.

## Description

Instead of requiring all callers to check the scrollbar bounds, this PR 'cheats' by simply clamping the bounds in Scrollbar::SetPosition().

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
