### PR TITLE
Fix #10556: Duplication of road infrastructure count updates when building a road stop

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -2058,9 +2058,6 @@ CommandCost CmdBuildRoadStop(DoCommandFlag flags, TileIndex tile, uint8 width, u
 			UpdateCompanyRoadInfrastructure(tram_rt, tram_owner, ROAD_STOP_TRACKBIT_FACTOR);
 			Company::Get(st->owner)->infrastructure.station++;
 
-			UpdateCompanyRoadInfrastructure(road_rt, road_owner, ROAD_STOP_TRACKBIT_FACTOR);
-			UpdateCompanyRoadInfrastructure(tram_rt, tram_owner, ROAD_STOP_TRACKBIT_FACTOR);
-
 			SetCustomRoadStopSpecIndex(cur_tile, specindex);
 			if (roadstopspec != nullptr) {
 				st->SetRoadStopRandomBits(cur_tile, GB(Random(), 0, 8));


### PR DESCRIPTION
## Motivation / Problem

#10556

## Description

Fix #10556, caused by text-editing error.

## Limitations

N/A