### PR TITLE
Fix: Improve grfmessage for ShipVehicleChangeInfo.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -1621,7 +1621,7 @@ static ChangeInfoResult ShipVehicleChangeInfo(uint engine, int numinfo, int prop
 					ei->cargo_type = ctype;
 				} else {
 					ei->cargo_type = CT_INVALID;
-					grfmsg(2, "RailVehicleChangeInfo: Invalid cargo type %d, using first refittable", ctype);
+					grfmsg(2, "ShipVehicleChangeInfo: Invalid cargo type %d, using first refittable", ctype);
 				}
 				break;
 			}


### PR DESCRIPTION
Improve the grfmsg when trying to assign an invalid cargo type to a ship.