### PR TITLE
Fix #10550: Vertically align trains in depot menus

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -534,6 +534,8 @@ static void GetRailIcon(EngineID engine, bool rear_head, int &y, EngineImageType
 
 void DrawTrainEngine(int left, int right, int preferred_x, int y, EngineID engine, PaletteID pal, EngineImageType image_type)
 {
+	y += WidgetDimensions::scaled.bevel.Vertical();
+
 	if (RailVehInfo(engine)->railveh_type == RAILVEH_MULTIHEAD) {
 		int yf = y;
 		int yr = y;

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -108,7 +108,7 @@ void DrawTrainImage(const Train *v, const Rect &r, VehicleID selection, EngineIm
 		AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
 
 		int px = rtl ? max_width + skip : -skip;
-		int y = r.Height() / 2;
+		int y = (r.Height() / 2) + WidgetDimensions::scaled.bevel.Vertical();
 		bool sel_articulated = false;
 		bool dragging = (drag_dest != INVALID_VEHICLE);
 		bool drag_at_end_of_train = (drag_dest == v->index); // Head index is used to mark dragging at end of train.


### PR DESCRIPTION
## Motivation / Problem

Fixes #10550.

Train sprites are not vertically aligned in the depot and build menus, as pictured below.
![image](https://user-images.githubusercontent.com/52927756/224296066-565586f1-5435-4ee6-8e89-1d693037d669.png)

## Description

This change vertically aligns them and especially keeps them off of the top bevel, as pictured below.
![image](https://user-images.githubusercontent.com/52927756/224296378-b9a03c56-c7a7-43cd-b248-104c5a5588d7.png)

## Limitations

There are potentially more locations that require vertical alignment. 
I wasn't able to figure out why trains in particular seem to have this alignment issue, and thus have not solved it at the root cause (if it exists).

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
