### PR TITLE
Fix #10568: "can savegame be loaded check" failed in dedicated server

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -969,37 +969,51 @@ bool SafeLoad(const std::string &filename, SaveLoadOperation fop, DetailedFileTy
 
 	_game_mode = newgm;
 
-	switch (lf == nullptr ? SaveOrLoad(filename, fop, dft, subdir) : LoadWithFilter(lf)) {
-		case SL_OK: return true;
+	SaveOrLoadResult result = (lf == nullptr) ? SaveOrLoad(filename, fop, dft, subdir) : LoadWithFilter(lf);
+	if (result == SL_OK) return true;
 
-		case SL_REINIT:
-			if (_network_dedicated) {
-				/*
-				 * We need to reinit a network map...
-				 * We can't simply load the intro game here as that game has many
-				 * special cases which make clients desync immediately. So we fall
-				 * back to just generating a new game with the current settings.
-				 */
-				Debug(net, 0, "Loading game failed, so a new (random) game will be started");
-				MakeNewGame(false, true);
-				return false;
-			}
-			if (_network_server) {
-				/* We can't load the intro game as server, so disconnect first. */
-				NetworkDisconnect();
-			}
-
-			switch (ogm) {
-				default:
-				case GM_MENU:   LoadIntroGame();      break;
-				case GM_EDITOR: MakeNewEditorWorld(); break;
-			}
-			return false;
-
-		default:
-			_game_mode = ogm;
-			return false;
+	if (_network_dedicated && ogm == GM_MENU) {
+		/*
+		 * If we are a dedicated server *and* we just were in the menu, then we
+		 * are loading the first savegame. If that fails, not starting the
+		 * server is a better reaction than starting the server with a newly
+		 * generated map as it is quite likely to be started from a script.
+		 */
+		Debug(net, 0, "Loading requested map failed; closing server.");
+		_exit_game = true;
+		return false;
 	}
+
+	if (result != SL_REINIT) {
+		_game_mode = ogm;
+		return false;
+	}
+
+	if (_network_dedicated) {
+		/*
+		 * If we are a dedicated server, have already loaded/started a game,
+		 * and then loading the savegame fails in a manner that we need to
+		 * reinitialize everything. We must not fall back into the menu mode
+		 * with the intro game, as that is unjoinable by clients. So there is
+		 * nothing else to do than start a new game, as it might have failed
+		 * trying to reload the originally loaded savegame/scenario.
+		 */
+		Debug(net, 0, "Loading game failed, so a new (random) game will be started");
+		MakeNewGame(false, true);
+		return false;
+	}
+
+	if (_network_server) {
+		/* We can't load the intro game as server, so disconnect first. */
+		NetworkDisconnect();
+	}
+
+	switch (ogm) {
+		default:
+		case GM_MENU:   LoadIntroGame();      break;
+		case GM_EDITOR: MakeNewEditorWorld(); break;
+	}
+	return false;
 }
 
 void SwitchToMode(SwitchMode new_mode)

--- a/src/video/dedicated_v.cpp
+++ b/src/video/dedicated_v.cpp
@@ -251,17 +251,6 @@ void VideoDriver_Dedicated::MainLoop()
 	/* If SwitchMode is SM_LOAD_GAME, it means that the user used the '-g' options */
 	if (_switch_mode != SM_LOAD_GAME) {
 		StartNewGameWithoutGUI(GENERATE_NEW_SEED);
-	} else {
-		/* First we need to test if the savegame can be loaded, else we will end up playing the
-		 *  intro game... */
-		if (SaveOrLoad(_file_to_saveload.name, _file_to_saveload.file_op, _file_to_saveload.detail_ftype, BASE_DIR) == SL_ERROR) {
-			/* Loading failed, pop out.. */
-			Debug(net, 0, "Loading requested map failed; closing server.");
-			return;
-		} else {
-			/* We can load this game, so go ahead */
-			_switch_mode = SM_LOAD_GAME;
-		}
 	}
 
 	this->is_game_threaded = false;


### PR DESCRIPTION
## Motivation / Problem

Fixes #10568.

If savegame has NewGRFs, it complains NewGRFs are not allowed in intro game and returns SL_REINIT.
If loading fails, it usually returns SL_REINIT which doesn't trigger check.
When game mode is changed, so the intro game check is not done... the game will just crash slightly later as the NewGRFs are not loaded at this time. In other words, with the current way NewGRFs are loaded the check always fails but it does not trigger the actual error path that stops the server.


## Description

Move the logic for handling these kinds errors to `SafeLoad`, where the NewGRFs have already been loaded.
Then in case a load error (anything other than `SL_OK`) occurs, and we are coming from the menu state, i.e. it is the first savegame that is loaded, and we are a dedicated server, then we show an error message and close the server.

In the other cases nothing happens, but the indentation has changed. Also, I see no reason why the intro savegame is inherently not multiplayer safe, so I changed the comments to more reflect reality. After all, after the error and without the special case for the dedicated server, the server just disconnects and would load the intro game/menu where you cannot join.


## Limitations

People might complain that the dedicated server doesn't keep running with a broken/corrupt savegame, instead of just creating a new game. Though it is "just" reintroducing functionality that got broken in the past.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
