### PR TITLE
Fix: [Script] Access to enum/consts defined outside of main.nut

### DIFF
--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -566,6 +566,10 @@ void Squirrel::Initialize()
 
 	sq_pushroottable(this->vm);
 	squirrel_register_global_std(this);
+
+	/* Set consts table as delegate of root table, so consts/enums defined via require() are accessible */
+	sq_pushconsttable(this->vm);
+	sq_setdelegate(this->vm, -2);
 }
 
 class SQFile {
@@ -763,6 +767,12 @@ Squirrel::~Squirrel()
 void Squirrel::Uninitialize()
 {
 	ScriptAllocatorScope alloc_scope(this);
+
+	/* Remove the delegation */
+	sq_pushroottable(this->vm);
+	sq_pushnull(this->vm);
+	sq_setdelegate(this->vm, -2);
+	sq_pop(this->vm, 1);
 
 	/* Clean up the stuff */
 	sq_pop(this->vm, 1);


### PR DESCRIPTION
## Motivation / Problem
OpenTTD extended squirrel with `require()` which allows to use AI/GS libraries and also splitting AI/GS into multiple files.

`require()` is a runtime function, and this detail is important to note.

When squirrel compiles a file, it gathers all enum/const into a table global to the VM, then during bytecode generation if an identifier corresponds to an enum/consts it is directly replaced by the value. Else a variable is assumed and an opcode to resolve the identifier at runtime is emitted.
At runtime when an identifier needs to be resolved, it is checked for in local variables, then in global scope (the root table), and only there.

Now the issue with `require()` and enum/consts is the compiler can't know at compile time which enum/consts will be defined by the "required" file, so when it encounters them it assumes they are variables to be resolved at runtime, but enum/consts are not considered at all at runtime. The result is "the index 'blah' does not exist", and script crashes.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
My solution to this issue is to set consts table as delegate of root table. That way if an enum/const from a "required" file is accessed by "requiring" file, it still won't be found in root table, but the search will fallback to the consts table.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
