### PR TITLE
RFC: Change: Vehicle service uses reliability threshold, not time interval

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -348,7 +348,6 @@ CommandCost CmdBuildAircraft(DoCommandFlag flags, TileIndex tile, const Engine *
 
 		v->vehicle_flags = 0;
 		if (e->flags & ENGINE_EXCLUSIVE_PREVIEW) SetBit(v->vehicle_flags, VF_BUILT_AS_PROTOTYPE);
-		v->SetServiceIntervalIsPercent(Company::Get(_current_company)->settings.vehicle.servint_ispercent);
 
 		v->InvalidateNewGRFCacheOfChain();
 

--- a/src/base_consist.cpp
+++ b/src/base_consist.cpp
@@ -37,8 +37,5 @@ void BaseConsist::CopyConsistPropertiesFrom(const BaseConsist *src)
 	if (HasBit(src->vehicle_flags, VF_TIMETABLE_STARTED)) SetBit(this->vehicle_flags, VF_TIMETABLE_STARTED);
 	if (HasBit(src->vehicle_flags, VF_AUTOFILL_TIMETABLE)) SetBit(this->vehicle_flags, VF_AUTOFILL_TIMETABLE);
 	if (HasBit(src->vehicle_flags, VF_AUTOFILL_PRES_WAIT_TIME)) SetBit(this->vehicle_flags, VF_AUTOFILL_PRES_WAIT_TIME);
-	if (HasBit(src->vehicle_flags, VF_SERVINT_IS_PERCENT) != HasBit(this->vehicle_flags, VF_SERVINT_IS_PERCENT)) {
-		ToggleBit(this->vehicle_flags, VF_SERVINT_IS_PERCENT);
-	}
 	if (HasBit(src->vehicle_flags, VF_SERVINT_IS_CUSTOM)) SetBit(this->vehicle_flags, VF_SERVINT_IS_CUSTOM);
 }

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -23,7 +23,7 @@ struct BaseConsist {
 	int32 lateness_counter;             ///< How many ticks late (or early if negative) this vehicle is.
 	Date timetable_start;               ///< When the vehicle is supposed to start the timetable.
 
-	uint16 service_interval;            ///< The interval for (automatic) servicing; either in days or %.
+	uint16 service_interval;            ///< Automatically service the vehicle when reliability is below this percentage.
 
 	VehicleOrderID cur_real_order_index;///< The index to the current real (non-implicit) order
 	VehicleOrderID cur_implicit_order_index;///< The index to the current implicit order

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -445,7 +445,6 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 			old_company->settings.vehicle.servint_trains = new_company->settings.vehicle.servint_trains;
 			old_company->settings.vehicle.servint_roadveh = new_company->settings.vehicle.servint_roadveh;
 			old_company->settings.vehicle.servint_ships = new_company->settings.vehicle.servint_ships;
-			old_company->settings.vehicle.servint_ispercent = new_company->settings.vehicle.servint_ispercent;
 		}
 
 		for (Vehicle *v : Vehicle::Iterate()) {
@@ -462,7 +461,7 @@ void ChangeOwnershipOfCompanyItems(Owner old_owner, Owner new_owner)
 					 * However, do not rely on that behaviour.
 					 */
 					int interval = CompanyServiceInterval(new_company, v->type);
-					Command<CMD_CHANGE_SERVICE_INT>::Do(DC_EXEC | DC_BANKRUPT, v->index, interval, false, new_company->settings.vehicle.servint_ispercent);
+					Command<CMD_CHANGE_SERVICE_INT>::Do(DC_EXEC | DC_BANKRUPT, v->index, interval, false);
 				}
 
 				v->owner = new_owner;

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1710,18 +1710,15 @@ STR_CONFIG_SETTING_SCRIPT_MAX_MEMORY                            :Max memory usag
 STR_CONFIG_SETTING_SCRIPT_MAX_MEMORY_HELPTEXT                   :How much memory a single script may consume before it's forcibly terminated. This may need to be increased for large maps.
 STR_CONFIG_SETTING_SCRIPT_MAX_MEMORY_VALUE                      :{COMMA} MiB
 
-STR_CONFIG_SETTING_SERVINT_ISPERCENT                            :Service intervals are in percents: {STRING2}
-STR_CONFIG_SETTING_SERVINT_ISPERCENT_HELPTEXT                   :Choose whether servicing of vehicles is triggered by the time passed since last service or by reliability dropping by a certain percentage of the maximum reliability
-
-STR_CONFIG_SETTING_SERVINT_TRAINS                               :Default service interval for trains: {STRING2}
-STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT                      :Set the default service interval for new rail vehicles, if no explicit service interval is set for the vehicle
-STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES                        :Default service interval for road vehicles: {STRING2}
-STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT               :Set the default service interval for new road vehicles, if no explicit service interval is set for the vehicle
-STR_CONFIG_SETTING_SERVINT_AIRCRAFT                             :Default service interval for aircraft: {STRING2}
-STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT                    :Set the default service interval for new aircraft, if no explicit service interval is set for the vehicle
-STR_CONFIG_SETTING_SERVINT_SHIPS                                :Default service interval for ships: {STRING2}
-STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT                       :Set the default service interval for new ships, if no explicit service interval is set for the vehicle
-STR_CONFIG_SETTING_SERVINT_VALUE                                :{COMMA}{NBSP}day{P 0 "" s}/%
+STR_CONFIG_SETTING_SERVINT_TRAINS                               :Default reliability threshold for automatic service of trains: {STRING2}
+STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT                      :Set the default reliability threshold for automatic service of new rail vehicles, if no explicit threshold is set for the vehicle
+STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES                        :Default reliability threshold for automatic service of road vehicles: {STRING2}
+STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT               :Set the reliability threshold for automatic service of new road vehicles, if no explicit threshold is set for the vehicle
+STR_CONFIG_SETTING_SERVINT_AIRCRAFT                             :Default reliability threshold for automatic service of aircraft: {STRING2}
+STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT                    :Set the reliability threshold for automatic service of new aircraft, if no explicit threshold is set for the vehicle
+STR_CONFIG_SETTING_SERVINT_SHIPS                                :Default reliability threshold for automatic service of ships: {STRING2}
+STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT                       :Set the reliability threshold for automatic service of new ships, if no explicit threshold is set for the vehicle
+STR_CONFIG_SETTING_SERVINT_VALUE                                :{NUM}%
 ###setting-zero-is-special
 STR_CONFIG_SETTING_SERVINT_DISABLED                             :Disabled
 
@@ -4254,15 +4251,9 @@ STR_VEHICLE_INFO_CAPACITY_CAPACITY                              :{BLACK}Capacity
 
 STR_VEHICLE_INFO_FEEDER_CARGO_VALUE                             :{BLACK}Transfer Credits: {LTBLUE}{CURRENCY_LONG}
 
-STR_VEHICLE_DETAILS_SERVICING_INTERVAL_DAYS                     :{BLACK}Servicing interval: {LTBLUE}{COMMA}{NBSP}days{BLACK}   Last service: {LTBLUE}{DATE_LONG}
-STR_VEHICLE_DETAILS_SERVICING_INTERVAL_PERCENT                  :{BLACK}Servicing interval: {LTBLUE}{COMMA}%{BLACK}   Last service: {LTBLUE}{DATE_LONG}
-STR_VEHICLE_DETAILS_INCREASE_SERVICING_INTERVAL_TOOLTIP         :{BLACK}Increase servicing interval by 10. Ctrl+Click increases servicing interval by 5
-STR_VEHICLE_DETAILS_DECREASE_SERVICING_INTERVAL_TOOLTIP         :{BLACK}Decrease servicing interval by 10. Ctrl+Click decreases servicing interval by 5
-
-STR_SERVICE_INTERVAL_DROPDOWN_TOOLTIP                           :{BLACK}Change servicing interval type
-STR_VEHICLE_DETAILS_DEFAULT                                     :Default
-STR_VEHICLE_DETAILS_DAYS                                        :Days
-STR_VEHICLE_DETAILS_PERCENT                                     :Percentage
+STR_VEHICLE_DETAILS_SERVICING_THRESHOLD                         :{BLACK}Service when reliability below: {LTBLUE}{NUM}%{BLACK}   Last service: {LTBLUE}{DATE_LONG}
+STR_VEHICLE_DETAILS_INCREASE_SERVICING_THRESHOLD_TOOLTIP        :{BLACK}Increase reliability threshold by 10%. Ctrl+Click increases reliability threshold by 5%
+STR_VEHICLE_DETAILS_DECREASE_SERVICING_THRESHOLD_TOOLTIP        :{BLACK}Decrease reliability threshold by 10%. Ctrl+Click decreases reliability threshold by 5%
 
 ###length VEHICLE_TYPES
 STR_QUERY_RENAME_TRAIN_CAPTION                                  :{WHITE}Name train

--- a/src/order_cmd.cpp
+++ b/src/order_cmd.cpp
@@ -1869,17 +1869,6 @@ void DeleteVehicleOrders(Vehicle *v, bool keep_orderlist, bool reset_order_indic
 }
 
 /**
- * Clamp the service interval to the correct min/max. The actual min/max values
- * depend on whether it's in percent or days.
- * @param interval proposed service interval
- * @return Clamped service interval
- */
-uint16 GetServiceIntervalClamped(uint interval, bool ispercent)
-{
-	return ispercent ? Clamp(interval, MIN_SERVINT_PERCENT, MAX_SERVINT_PERCENT) : Clamp(interval, MIN_SERVINT_DAYS, MAX_SERVINT_DAYS);
-}
-
-/**
  *
  * Check if a vehicle has any valid orders
  *

--- a/src/order_func.h
+++ b/src/order_func.h
@@ -26,11 +26,8 @@ uint GetOrderDistance(const Order *prev, const Order *cur, const Vehicle *v, int
 
 void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int y, bool selected, bool timetable, int left, int middle, int right);
 
-#define MIN_SERVINT_PERCENT  5
-#define MAX_SERVINT_PERCENT 90
-#define MIN_SERVINT_DAYS    30
-#define MAX_SERVINT_DAYS   800
-
-uint16 GetServiceIntervalClamped(uint interval, bool ispercent);
+static const uint8 DEF_SERVINT_PERCENT = 50;
+static const uint8 MIN_SERVINT_PERCENT = 5;
+static const uint8 MAX_SERVINT_PERCENT = 90;
 
 #endif /* ORDER_FUNC_H */

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -310,7 +310,6 @@ CommandCost CmdBuildRoadVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 		v->gcache.cached_veh_length = VEHICLE_LENGTH;
 
 		if (e->flags & ENGINE_EXCLUSIVE_PREVIEW) SetBit(v->vehicle_flags, VF_BUILT_AS_PROTOTYPE);
-		v->SetServiceIntervalIsPercent(Company::Get(_current_company)->settings.vehicle.servint_ispercent);
 
 		AddArticulatedParts(v);
 		v->InvalidateNewGRFCacheOfChain();

--- a/src/saveload/company_sl.cpp
+++ b/src/saveload/company_sl.cpp
@@ -290,7 +290,7 @@ public:
 		SLE_CONDVAR(CompanyProperties, settings.renew_keep_length,   SLE_BOOL,             SLV_2, SL_MAX_VERSION),
 
 		/* Default vehicle settings */
-		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ispercent,   SLE_BOOL,     SLV_120, SL_MAX_VERSION),
+		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_ispercent,   SLE_BOOL,     SLV_120, SLV_SERVICE_INTERVAL_PERCENT_ONLY),
 		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_trains,    SLE_UINT16,     SLV_120, SL_MAX_VERSION),
 		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_roadveh,   SLE_UINT16,     SLV_120, SL_MAX_VERSION),
 		SLE_CONDVAR(CompanyProperties, settings.vehicle.servint_aircraft,  SLE_UINT16,     SLV_120, SL_MAX_VERSION),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -345,6 +345,8 @@ enum SaveLoadVersion : uint16 {
 	SLV_MULTITRACK_LEVEL_CROSSINGS,         ///< 302  PR#9931 v13.0  Multi-track level crossings.
 	SLV_NEWGRF_ROAD_STOPS,                  ///< 303  PR#10144 NewGRF road stops.
 	SLV_LINKGRAPH_EDGES,                    ///< 304  PR#10314 Explicitly store link graph edges destination, PR#10471 int64 instead of uint64 league rating
+	SLV_SERVICE_INTERVAL_PERCENT_ONLY,      ///< 305  PR#10575 Don't use days for service intervals, only percents.
+
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -355,7 +355,6 @@ void AfterLoadVehicles(bool part_of_load)
 				int interval = CompanyServiceInterval(c, v->type);
 
 				v->SetServiceIntervalIsCustom(v->GetServiceInterval() != interval);
-				v->SetServiceIntervalIsPercent(c->settings.vehicle.servint_ispercent);
 			}
 		}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1722,7 +1722,6 @@ static SettingsContainer &GetSettingsTree()
 			company->Add(new SettingEntry("company.engine_renew"));
 			company->Add(new SettingEntry("company.engine_renew_months"));
 			company->Add(new SettingEntry("company.engine_renew_money"));
-			company->Add(new SettingEntry("vehicle.servint_ispercent"));
 			company->Add(new SettingEntry("vehicle.servint_trains"));
 			company->Add(new SettingEntry("vehicle.servint_roadveh"));
 			company->Add(new SettingEntry("vehicle.servint_ships"));

--- a/src/settings_table.cpp
+++ b/src/settings_table.cpp
@@ -127,58 +127,6 @@ static void UpdateConsists(int32 new_value)
 	InvalidateWindowClassesData(WC_BUILD_VEHICLE, 0);
 }
 
-/* Check service intervals of vehicles, newvalue is value of % or day based servicing */
-static void UpdateAllServiceInterval(int32 new_value)
-{
-	bool update_vehicles;
-	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
-		vds = &_settings_client.company.vehicle;
-		update_vehicles = false;
-	} else {
-		vds = &Company::Get(_current_company)->settings.vehicle;
-		update_vehicles = true;
-	}
-
-	if (new_value != 0) {
-		vds->servint_trains   = 50;
-		vds->servint_roadveh  = 50;
-		vds->servint_aircraft = 50;
-		vds->servint_ships    = 50;
-	} else {
-		vds->servint_trains   = 150;
-		vds->servint_roadveh  = 150;
-		vds->servint_aircraft = 100;
-		vds->servint_ships    = 360;
-	}
-
-	if (update_vehicles) {
-		const Company *c = Company::Get(_current_company);
-		for (Vehicle *v : Vehicle::Iterate()) {
-			if (v->owner == _current_company && v->IsPrimaryVehicle() && !v->ServiceIntervalIsCustom()) {
-				v->SetServiceInterval(CompanyServiceInterval(c, v->type));
-				v->SetServiceIntervalIsPercent(new_value != 0);
-			}
-		}
-	}
-
-	SetWindowClassesDirty(WC_VEHICLE_DETAILS);
-}
-
-static bool CanUpdateServiceInterval(VehicleType type, int32 &new_value)
-{
-	VehicleDefaultSettings *vds;
-	if (_game_mode == GM_MENU || !Company::IsValidID(_current_company)) {
-		vds = &_settings_client.company.vehicle;
-	} else {
-		vds = &Company::Get(_current_company)->settings.vehicle;
-	}
-
-	/* Test if the interval is valid */
-	int32 interval = GetServiceIntervalClamped(new_value, vds->servint_ispercent);
-	return interval == new_value;
-}
-
 static void UpdateServiceInterval(VehicleType type, int32 new_value)
 {
 	if (_game_mode != GM_MENU && Company::IsValidID(_current_company)) {

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -565,7 +565,7 @@ struct StationSettings {
 
 /** Default settings for vehicles. */
 struct VehicleDefaultSettings {
-	bool   servint_ispercent;                ///< service intervals are in percents
+	bool servint_ispercent;                  ///< Unused value, used to load old savegames.
 	uint16 servint_trains;                   ///< service interval for trains
 	uint16 servint_roadveh;                  ///< service interval for road vehicles
 	uint16 servint_aircraft;                 ///< service interval for aircraft

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -899,7 +899,6 @@ CommandCost CmdBuildShip(DoCommandFlag flags, TileIndex tile, const Engine *e, V
 		v->UpdateCache();
 
 		if (e->flags & ENGINE_EXCLUSIVE_PREVIEW) SetBit(v->vehicle_flags, VF_BUILT_AS_PROTOTYPE);
-		v->SetServiceIntervalIsPercent(Company::Get(_current_company)->settings.vehicle.servint_ispercent);
 
 		v->InvalidateNewGRFCacheOfChain();
 

--- a/src/table/settings/company_settings.ini
+++ b/src/table/settings/company_settings.ini
@@ -8,8 +8,6 @@
 ; company changes them, it changes for all players.
 
 [pre-amble]
-static void UpdateAllServiceInterval(int32 new_value);
-static bool CanUpdateServiceInterval(VehicleType type, int32 &new_value);
 static void UpdateServiceInterval(VehicleType type, int32 new_value);
 
 static const SettingVariant _company_settings_table[] = {
@@ -74,59 +72,52 @@ def      = false
 
 [SDT_BOOL]
 var      = vehicle.servint_ispercent
-def      = false
-str      = STR_CONFIG_SETTING_SERVINT_ISPERCENT
-strhelp  = STR_CONFIG_SETTING_SERVINT_ISPERCENT_HELPTEXT
-post_cb  = UpdateAllServiceInterval
+to       = SLV_SERVICE_INTERVAL_PERCENT_ONLY
 
 [SDT_VAR]
 var      = vehicle.servint_trains
 type     = SLE_UINT16
 flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
-def      = 150
-min      = 5
-max      = 800
+def      = DEF_SERVINT_PERCENT
+min      = MIN_SERVINT_PERCENT
+max      = MAX_SERVINT_PERCENT
 str      = STR_CONFIG_SETTING_SERVINT_TRAINS
 strhelp  = STR_CONFIG_SETTING_SERVINT_TRAINS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_TRAIN, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_TRAIN, new_value); }
 
 [SDT_VAR]
 var      = vehicle.servint_roadveh
 type     = SLE_UINT16
 flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
-def      = 150
-min      = 5
-max      = 800
+def      = DEF_SERVINT_PERCENT
+min      = MIN_SERVINT_PERCENT
+max      = MAX_SERVINT_PERCENT
 str      = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES
 strhelp  = STR_CONFIG_SETTING_SERVINT_ROAD_VEHICLES_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_ROAD, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_ROAD, new_value); }
 
 [SDT_VAR]
 var      = vehicle.servint_ships
 type     = SLE_UINT16
 flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
-def      = 360
-min      = 5
-max      = 800
+def      = DEF_SERVINT_PERCENT
+min      = MIN_SERVINT_PERCENT
+max      = MAX_SERVINT_PERCENT
 str      = STR_CONFIG_SETTING_SERVINT_SHIPS
 strhelp  = STR_CONFIG_SETTING_SERVINT_SHIPS_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_SHIP, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_SHIP, new_value); }
 
 [SDT_VAR]
 var      = vehicle.servint_aircraft
 type     = SLE_UINT16
 flags    = SF_PER_COMPANY | SF_GUI_0_IS_SPECIAL
-def      = 100
-min      = 5
-max      = 800
+def      = DEF_SERVINT_PERCENT
+min      = MIN_SERVINT_PERCENT
+max      = MAX_SERVINT_PERCENT
 str      = STR_CONFIG_SETTING_SERVINT_AIRCRAFT
 strhelp  = STR_CONFIG_SETTING_SERVINT_AIRCRAFT_HELPTEXT
 strval   = STR_CONFIG_SETTING_SERVINT_VALUE
-pre_cb   = [](auto &new_value) { return CanUpdateServiceInterval(VEH_AIRCRAFT, new_value); }
 post_cb  = [](auto new_value) { UpdateServiceInterval(VEH_AIRCRAFT, new_value); }

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -787,7 +787,6 @@ CommandCost CmdBuildRailVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 		v->random_bits = VehicleRandomBits();
 
 		if (e->flags & ENGINE_EXCLUSIVE_PREVIEW) SetBit(v->vehicle_flags, VF_BUILT_AS_PROTOTYPE);
-		v->SetServiceIntervalIsPercent(Company::Get(_current_company)->settings.vehicle.servint_ispercent);
 
 		v->group_id = DEFAULT_GROUP;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -190,11 +190,7 @@ bool Vehicle::NeedsServicing() const
 
 	/* Are we ready for the next service cycle? */
 	const Company *c = Company::Get(this->owner);
-	if (this->ServiceIntervalIsPercent() ?
-			(this->reliability >= this->GetEngine()->reliability * (100 - this->GetServiceInterval()) / 100) :
-			(this->date_of_last_service + this->GetServiceInterval() >= _date)) {
-		return false;
-	}
+	if (this->reliability >= this->GetEngine()->reliability * (100 - this->GetServiceInterval()) / 100) return false;
 
 	/* If we're servicing anyway, because we have not disabled servicing when
 	 * there are no breakdowns or we are playing with breakdowns, bail out. */

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -52,7 +52,6 @@ enum VehicleFlags {
 	VF_STOP_LOADING,            ///< Don't load anymore during the next load cycle.
 	VF_PATHFINDER_LOST,         ///< Vehicle's pathfinder is lost.
 	VF_SERVINT_IS_CUSTOM,       ///< Service interval is custom.
-	VF_SERVINT_IS_PERCENT,      ///< Service interval is percent.
 };
 
 /** Bit numbers used to indicate which of the #NewGRFCache values are valid. */
@@ -811,11 +810,7 @@ public:
 
 	inline bool ServiceIntervalIsCustom() const { return HasBit(this->vehicle_flags, VF_SERVINT_IS_CUSTOM); }
 
-	inline bool ServiceIntervalIsPercent() const { return HasBit(this->vehicle_flags, VF_SERVINT_IS_PERCENT); }
-
 	inline void SetServiceIntervalIsCustom(bool on) { SB(this->vehicle_flags, VF_SERVINT_IS_CUSTOM, 1, on); }
-
-	inline void SetServiceIntervalIsPercent(bool on) { SB(this->vehicle_flags, VF_SERVINT_IS_PERCENT, 1, on); }
 
 private:
 	/**

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -903,7 +903,6 @@ std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlag flags, TileInde
 				w_front = w;
 				w->service_interval = v->service_interval;
 				w->SetServiceIntervalIsCustom(v->ServiceIntervalIsCustom());
-				w->SetServiceIntervalIsPercent(v->ServiceIntervalIsPercent());
 			}
 			w_rear = w; // trains needs to know the last car in the train, so they can add more in next loop
 		}
@@ -1093,10 +1092,9 @@ CommandCost CmdRenameVehicle(DoCommandFlag flags, VehicleID veh_id, const std::s
  * @param veh_id vehicle ID that is being service-interval-changed
  * @param serv_int new service interval
  * @param is_custom service interval is custom flag
- * @param is_percent service interval is percentage flag
  * @return the cost of this operation or an error
  */
-CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16 serv_int, bool is_custom, bool is_percent)
+CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16 serv_int, bool is_custom)
 {
 	Vehicle *v = Vehicle::GetIfValid(veh_id);
 	if (v == nullptr || !v->IsPrimaryVehicle()) return CMD_ERROR;
@@ -1105,18 +1103,12 @@ CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16 se
 	if (ret.Failed()) return ret;
 
 	const Company *company = Company::Get(v->owner);
-	is_percent = is_custom ? is_percent : company->settings.vehicle.servint_ispercent;
 
-	if (is_custom) {
-		if (serv_int != GetServiceIntervalClamped(serv_int, is_percent)) return CMD_ERROR;
-	} else {
-		serv_int = CompanyServiceInterval(company, v->type);
-	}
+	if (!is_custom) serv_int = CompanyServiceInterval(company, v->type);
 
 	if (flags & DC_EXEC) {
 		v->SetServiceInterval(serv_int);
 		v->SetServiceIntervalIsCustom(is_custom);
-		v->SetServiceIntervalIsPercent(is_percent);
 		SetWindowDirty(WC_VEHICLE_DETAILS, v->index);
 	}
 

--- a/src/vehicle_cmd.h
+++ b/src/vehicle_cmd.h
@@ -20,7 +20,7 @@ std::tuple<CommandCost, VehicleID, uint, uint16, CargoArray> CmdBuildVehicle(DoC
 CommandCost CmdSellVehicle(DoCommandFlag flags, VehicleID v_id, bool sell_chain, bool backup_order, ClientID client_id);
 std::tuple<CommandCost, uint, uint16, CargoArray> CmdRefitVehicle(DoCommandFlag flags, VehicleID veh_id, CargoID new_cid, byte new_subtype, bool auto_refit, bool only_this, uint8 num_vehicles);
 CommandCost CmdSendVehicleToDepot(DoCommandFlag flags, VehicleID veh_id, DepotCommand depot_cmd, const VehicleListIdentifier &vli);
-CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16 serv_int, bool is_custom, bool is_percent);
+CommandCost CmdChangeServiceInt(DoCommandFlag flags, VehicleID veh_id, uint16 serv_int, bool is_custom);
 CommandCost CmdRenameVehicle(DoCommandFlag flags, VehicleID veh_id, const std::string &text);
 std::tuple<CommandCost, VehicleID> CmdCloneVehicle(DoCommandFlag flags, TileIndex tile, VehicleID veh_id, bool share_orders);
 CommandCost CmdStartStopVehicle(DoCommandFlag flags, VehicleID veh_id, bool evaluate_startstop_cb);

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -2238,12 +2238,10 @@ static const NWidgetPart _nested_nontrain_vehicle_details_widgets[] = {
 	NWidget(WWT_PANEL, COLOUR_GREY, WID_VD_TOP_DETAILS), SetMinimalSize(405, 42), SetResize(1, 0), EndContainer(),
 	NWidget(WWT_PANEL, COLOUR_GREY, WID_VD_MIDDLE_DETAILS), SetMinimalSize(405, 45), SetResize(1, 0), EndContainer(),
 	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_DECREASE_SERVICING_INTERVAL), SetFill(0, 1),
-				SetDataTip(AWV_DECREASE, STR_VEHICLE_DETAILS_DECREASE_SERVICING_INTERVAL_TOOLTIP),
-		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_INCREASE_SERVICING_INTERVAL), SetFill(0, 1),
-				SetDataTip(AWV_INCREASE, STR_VEHICLE_DETAILS_INCREASE_SERVICING_INTERVAL_TOOLTIP),
-		NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_VD_SERVICE_INTERVAL_DROPDOWN), SetFill(0, 1),
-				SetDataTip(STR_EMPTY, STR_SERVICE_INTERVAL_DROPDOWN_TOOLTIP),
+		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_DECREASE_SERVICING_THRESHOLD), SetFill(0, 1),
+				SetDataTip(AWV_DECREASE, STR_VEHICLE_DETAILS_DECREASE_SERVICING_THRESHOLD_TOOLTIP),
+		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_INCREASE_SERVICING_THRESHOLD), SetFill(0, 1),
+				SetDataTip(AWV_INCREASE, STR_VEHICLE_DETAILS_INCREASE_SERVICING_THRESHOLD_TOOLTIP),
 		NWidget(WWT_PANEL, COLOUR_GREY, WID_VD_SERVICING_INTERVAL), SetFill(1, 1), SetResize(1, 0), EndContainer(),
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),
@@ -2264,12 +2262,10 @@ static const NWidgetPart _nested_train_vehicle_details_widgets[] = {
 		NWidget(NWID_VSCROLLBAR, COLOUR_GREY, WID_VD_SCROLLBAR),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_DECREASE_SERVICING_INTERVAL), SetFill(0, 1),
-				SetDataTip(AWV_DECREASE, STR_VEHICLE_DETAILS_DECREASE_SERVICING_INTERVAL_TOOLTIP),
-		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_INCREASE_SERVICING_INTERVAL), SetFill(0, 1),
-				SetDataTip(AWV_INCREASE, STR_VEHICLE_DETAILS_INCREASE_SERVICING_INTERVAL_TOOLTIP),
-		NWidget(WWT_DROPDOWN, COLOUR_GREY, WID_VD_SERVICE_INTERVAL_DROPDOWN), SetFill(0, 1),
-				SetDataTip(STR_EMPTY, STR_SERVICE_INTERVAL_DROPDOWN_TOOLTIP),
+		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_DECREASE_SERVICING_THRESHOLD), SetFill(0, 1),
+				SetDataTip(AWV_DECREASE, STR_VEHICLE_DETAILS_DECREASE_SERVICING_THRESHOLD_TOOLTIP),
+		NWidget(WWT_PUSHARROWBTN, COLOUR_GREY, WID_VD_INCREASE_SERVICING_THRESHOLD), SetFill(0, 1),
+				SetDataTip(AWV_INCREASE, STR_VEHICLE_DETAILS_INCREASE_SERVICING_THRESHOLD_TOOLTIP),
 		NWidget(WWT_PANEL, COLOUR_GREY, WID_VD_SERVICING_INTERVAL), SetFill(1, 1), SetResize(1, 0), EndContainer(),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),
@@ -2291,13 +2287,6 @@ extern void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uin
 extern void DrawRoadVehDetails(const Vehicle *v, const Rect &r);
 extern void DrawShipDetails(const Vehicle *v, const Rect &r);
 extern void DrawAircraftDetails(const Aircraft *v, const Rect &r);
-
-static StringID _service_interval_dropdown[] = {
-	STR_VEHICLE_DETAILS_DEFAULT,
-	STR_VEHICLE_DETAILS_DAYS,
-	STR_VEHICLE_DETAILS_PERCENT,
-	INVALID_STRING_ID,
-};
 
 /** Class for managing the vehicle details window. */
 struct VehicleDetailsWindow : Window {
@@ -2412,23 +2401,10 @@ struct VehicleDetailsWindow : Window {
 				size->height = 4 * resize->height;
 				break;
 
-			case WID_VD_SERVICE_INTERVAL_DROPDOWN: {
-				StringID *strs = _service_interval_dropdown;
-				while (*strs != INVALID_STRING_ID) {
-					*size = maxdim(*size, GetStringBoundingBox(*strs++));
-				}
-				size->width += padding.width;
-				size->height = FONT_HEIGHT_NORMAL + padding.height;
-				break;
-			}
-
 			case WID_VD_SERVICING_INTERVAL:
-				SetDParamMaxValue(0, MAX_SERVINT_DAYS); // Roughly the maximum interval
+				SetDParamMaxValue(0, MAX_SERVINT_PERCENT); // Roughly the maximum interval
 				SetDParamMaxValue(1, MAX_YEAR * DAYS_IN_YEAR); // Roughly the maximum year
-				size->width = std::max(
-					GetStringBoundingBox(STR_VEHICLE_DETAILS_SERVICING_INTERVAL_PERCENT).width,
-					GetStringBoundingBox(STR_VEHICLE_DETAILS_SERVICING_INTERVAL_DAYS).width
-				) + padding.width;
+				size->width = GetStringBoundingBox(STR_VEHICLE_DETAILS_SERVICING_THRESHOLD).width + padding.width;
 				size->height = FONT_HEIGHT_NORMAL + padding.height;
 				break;
 		}
@@ -2567,8 +2543,7 @@ struct VehicleDetailsWindow : Window {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 				SetDParam(0, v->GetServiceInterval());
 				SetDParam(1, v->date_of_last_service);
-				DrawString(tr.left, tr.right, CenterBounds(r.top, r.bottom, FONT_HEIGHT_NORMAL),
-						v->ServiceIntervalIsPercent() ? STR_VEHICLE_DETAILS_SERVICING_INTERVAL_PERCENT : STR_VEHICLE_DETAILS_SERVICING_INTERVAL_DAYS);
+				DrawString(tr.left, tr.right, CenterBounds(r.top, r.bottom, FONT_HEIGHT_NORMAL), STR_VEHICLE_DETAILS_SERVICING_THRESHOLD);
 				break;
 			}
 		}
@@ -2586,14 +2561,9 @@ struct VehicleDetailsWindow : Window {
 
 		/* Disable service-scroller when interval is set to disabled */
 		this->SetWidgetsDisabledState(!IsVehicleServiceIntervalEnabled(v->type, v->owner),
-			WID_VD_INCREASE_SERVICING_INTERVAL,
-			WID_VD_DECREASE_SERVICING_INTERVAL,
+			WID_VD_INCREASE_SERVICING_THRESHOLD,
+			WID_VD_DECREASE_SERVICING_THRESHOLD,
 			WIDGET_LIST_END);
-
-		StringID str = v->ServiceIntervalIsCustom() ?
-			(v->ServiceIntervalIsPercent() ? STR_VEHICLE_DETAILS_PERCENT : STR_VEHICLE_DETAILS_DAYS) :
-			STR_VEHICLE_DETAILS_DEFAULT;
-		this->GetWidget<NWidgetCore>(WID_VD_SERVICE_INTERVAL_DROPDOWN)->widget_data = str;
 
 		this->DrawWidgets();
 	}
@@ -2601,22 +2571,16 @@ struct VehicleDetailsWindow : Window {
 	void OnClick(Point pt, int widget, int click_count) override
 	{
 		switch (widget) {
-			case WID_VD_INCREASE_SERVICING_INTERVAL:   // increase int
-			case WID_VD_DECREASE_SERVICING_INTERVAL: { // decrease int
+			case WID_VD_INCREASE_SERVICING_THRESHOLD:   // increase int
+			case WID_VD_DECREASE_SERVICING_THRESHOLD: { // decrease int
 				int mod = _ctrl_pressed ? 5 : 10;
 				const Vehicle *v = Vehicle::Get(this->window_number);
 
-				mod = (widget == WID_VD_DECREASE_SERVICING_INTERVAL) ? -mod : mod;
-				mod = GetServiceIntervalClamped(mod + v->GetServiceInterval(), v->ServiceIntervalIsPercent());
+				mod = (widget == WID_VD_DECREASE_SERVICING_THRESHOLD) ? -mod : mod;
+				mod = Clamp(mod + v->GetServiceInterval(), MIN_SERVINT_PERCENT, MAX_SERVINT_PERCENT);
 				if (mod == v->GetServiceInterval()) return;
 
-				Command<CMD_CHANGE_SERVICE_INT>::Post(STR_ERROR_CAN_T_CHANGE_SERVICING, v->index, mod, true, v->ServiceIntervalIsPercent());
-				break;
-			}
-
-			case WID_VD_SERVICE_INTERVAL_DROPDOWN: {
-				const Vehicle *v = Vehicle::Get(this->window_number);
-				ShowDropDownMenu(this, _service_interval_dropdown, v->ServiceIntervalIsCustom() ? (v->ServiceIntervalIsPercent() ? 2 : 1) : 0, widget, 0, 0);
+				Command<CMD_CHANGE_SERVICE_INT>::Post(STR_ERROR_CAN_T_CHANGE_SERVICING, v->index, mod, true);
 				break;
 			}
 
@@ -2635,20 +2599,6 @@ struct VehicleDetailsWindow : Window {
 				this->tab = (TrainDetailsWindowTabs)(widget - WID_VD_DETAILS_CARGO_CARRIED);
 				this->SetDirty();
 				break;
-		}
-	}
-
-	void OnDropdownSelect(int widget, int index) override
-	{
-		switch (widget) {
-			case WID_VD_SERVICE_INTERVAL_DROPDOWN: {
-				const Vehicle *v = Vehicle::Get(this->window_number);
-				bool iscustom = index != 0;
-				bool ispercent = iscustom ? (index == 2) : Company::Get(v->owner)->settings.vehicle.servint_ispercent;
-				uint16 interval = GetServiceIntervalClamped(v->GetServiceInterval(), ispercent);
-				Command<CMD_CHANGE_SERVICE_INT>::Post(STR_ERROR_CAN_T_CHANGE_SERVICING, v->index, interval, iscustom, ispercent);
-				break;
-			}
 		}
 	}
 

--- a/src/widgets/vehicle_widget.h
+++ b/src/widgets/vehicle_widget.h
@@ -45,19 +45,18 @@ enum VehicleRefitWidgets {
 
 /** Widgets of the #VehicleDetailsWindow class. */
 enum VehicleDetailsWidgets {
-	WID_VD_CAPTION,                     ///< Caption of window.
-	WID_VD_TOP_DETAILS,                 ///< Panel with generic details.
-	WID_VD_INCREASE_SERVICING_INTERVAL, ///< Increase the servicing interval.
-	WID_VD_DECREASE_SERVICING_INTERVAL, ///< Decrease the servicing interval.
-	WID_VD_SERVICE_INTERVAL_DROPDOWN,   ///< Dropdown to select default/days/percent service interval.
-	WID_VD_SERVICING_INTERVAL,          ///< Information about the servicing interval.
-	WID_VD_MIDDLE_DETAILS,              ///< Details for non-trains.
-	WID_VD_MATRIX,                      ///< List of details for trains.
-	WID_VD_SCROLLBAR,                   ///< Scrollbar for train details.
-	WID_VD_DETAILS_CARGO_CARRIED,       ///< Show carried cargo per part of the train.
-	WID_VD_DETAILS_TRAIN_VEHICLES,      ///< Show all parts of the train with their description.
-	WID_VD_DETAILS_CAPACITY_OF_EACH,    ///< Show the capacity of all train parts.
-	WID_VD_DETAILS_TOTAL_CARGO,         ///< Show the capacity and carried cargo amounts aggregated per cargo of the train.
+	WID_VD_CAPTION,                      ///< Caption of window.
+	WID_VD_TOP_DETAILS,                  ///< Panel with generic details.
+	WID_VD_INCREASE_SERVICING_THRESHOLD, ///< Increase the servicing interval.
+	WID_VD_DECREASE_SERVICING_THRESHOLD, ///< Decrease the servicing interval.
+	WID_VD_SERVICING_INTERVAL,           ///< Information about the servicing interval.
+	WID_VD_MIDDLE_DETAILS,               ///< Details for non-trains.
+	WID_VD_MATRIX,                       ///< List of details for trains.
+	WID_VD_SCROLLBAR,                    ///< Scrollbar for train details.
+	WID_VD_DETAILS_CARGO_CARRIED,        ///< Show carried cargo per part of the train.
+	WID_VD_DETAILS_TRAIN_VEHICLES,       ///< Show all parts of the train with their description.
+	WID_VD_DETAILS_CAPACITY_OF_EACH,     ///< Show the capacity of all train parts.
+	WID_VD_DETAILS_TOTAL_CARGO,          ///< Show the capacity and carried cargo amounts aggregated per cargo of the train.
 };
 
 /** Widgets of the #VehicleListWindow class. */


### PR DESCRIPTION
## Motivation

My ongoing rework of NotDayLength (#10322) to offer both in-game dates and real-world time units means I have to rework service intervals.

## Problem

Currently, we offer two ways of setting service intervals in the vehicle information window and the settings menu (which sets default values):

- Service the vehicle every N days
- Service the vehicle if its reliability drops below N percent

This is in addition to vehicle orders, which offer a range of fine-grained ways to control vehicle service:
- Go to nearest depot order
- Go to a specific depot order
- Go to a specific depot order, but only if needed
- Conditional order: Reliability
- Conditional order: Maximum reliability
- Conditional order: Remaining lifetime
- Conditional order: Requires service

I cannot see a valid usecase for setting vehicle intervals in days. Either you've matched dates with the timetable and want the vehicle to service at a specific segment of the route (and should use orders instead) or you want the vehicle to service often enough to maintain good reliability (and should use the reliability percent mode instead). Or you want to roleplay maintenance schedules, maybe? (but that should be done with orders). I welcome explanation of other usecases I may have overlooked. 🙂 

You may ask: What's wrong with keeping it the way it is?

The dual-unit system currently employed is, in my opinion, a dumpster fire in both user interface and the code. Specifying the units as "N days/%" is confusing to the player. You don't know which is being used and they scale in opposite directions — a higher percentage has similar results to fewer days. If you change the "Service intervals are in percents" setting, all your chosen defaults get reset to hard-coded defaults which vary by type of vehicle.

Behind the scenes, in addition to these hardcoded defaults we have several custom clamping functions to ensure that these settings stay within proper bounds for whatever mode they're operating in. Fine now, but a pain to extend.

And guess who needs to extend them? NotDayLength would require a third unit option, real-world seconds. This needs new defaults, new clamping bounds, and a third unit in the user interface (I'd have to rewrite it to show only one unit at a time, because "N seconds/days/%" is absolutely unacceptable). I can make these changes, but would really prefer not to make a bad design even worse.

## Description

This PR removes the concept of setting time-based service intervals, leaving only the percent-based reliability threshold.

I realize that there are some corner cases where this might change how players' savegames operate. I think the safest way to handle this is to disable breakdowns if any vehicles have custom service intervals.

The PR is a draft because if we move forward with this route, I'd want to rename the remaining "service intervals" references (including possibly the vehicle property itself) to "reliability threshold" to better describe how it's used.

(I'm fully aware that I'm probably not removing the vehicle properties or the game setting properly, but that's a bridge to cross after "can we remove a feature." 😛 )

## Limitations

![Workflow](https://imgs.xkcd.com/comics/workflow.png)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
