### PR TITLE
Codechange: Simplify some CodeQL-flagged trivial switches

### DIFF
--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -328,12 +328,9 @@ void GamelogPrint(std::function<void(const char*)> proc)
 				case GLCT_GRFBUG: {
 					/* A specific bug in a NewGRF, that could cause wide spread problems, has been noted during the execution of the game. */
 					GrfIDMapping::Pair *gm = grf_names.Find(lc->grfrem.grfid);
-					switch (lc->grfbug.bug) {
-						default: NOT_REACHED();
-						case GBUG_VEH_LENGTH:
-							buf += seprintf(buf, lastof(buffer), "Rail vehicle changes length outside a depot: GRF ID %08X, internal ID 0x%X", BSWAP32(lc->grfbug.grfid), (uint)lc->grfbug.data);
-							break;
-					}
+					assert (lc->grfbug.bug == GBUG_VEH_LENGTH);
+
+					buf += seprintf(buf, lastof(buffer), "Rail vehicle changes length outside a depot: GRF ID %08X, internal ID 0x%X", BSWAP32(lc->grfbug.grfid), (uint)lc->grfbug.data);
 					buf = PrintGrfInfo(buf, lastof(buffer), lc->grfbug.grfid, nullptr, gm != grf_names.End() ? gm->second.gc : nullptr);
 					if (gm == grf_names.End()) buf += seprintf(buf, lastof(buffer), ". Gamelog inconsistency: GrfID was never added!");
 					break;

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -360,12 +360,9 @@ public:
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
 		if (!gui_scope) return;
-		switch (data) {
-			case 1:
-				/* ReInit, "debug" sprite might have changed */
-				this->ReInit();
-				break;
-		}
+
+		/* ReInit, "debug" sprite might have changed */
+		if (data == 1) this->ReInit();
 	}
 };
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -565,20 +565,17 @@ public:
 	{
 		if (pt.x == -1) return;
 
-		switch (select_proc) {
-			default: NOT_REACHED();
-			case DDSP_BUILD_OBJECT:
-				if (!_settings_game.construction.freeform_edges) {
-					/* When end_tile is MP_VOID, the error tile will not be visible to the
-						* user. This happens when terraforming at the southern border. */
-					if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
-					if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
-				}
-				const ObjectSpec *spec = ObjectClass::Get(_selected_object_class)->GetSpec(_selected_object_index);
-				Command<CMD_BUILD_OBJECT_AREA>::Post(STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER,
-					end_tile, start_tile, spec->Index(), _selected_object_view, (_ctrl_pressed ? true : false));
-				break;
+		assert(select_proc == DDSP_BUILD_OBJECT);
+
+		if (!_settings_game.construction.freeform_edges) {
+			/* When end_tile is MP_VOID, the error tile will not be visible to the
+			 * user. This happens when terraforming at the southern border. */
+			if (TileX(end_tile) == Map::MaxX()) end_tile += TileDiffXY(-1, 0);
+			if (TileY(end_tile) == Map::MaxY()) end_tile += TileDiffXY(0, -1);
 		}
+		const ObjectSpec *spec = ObjectClass::Get(_selected_object_class)->GetSpec(_selected_object_index);
+		Command<CMD_BUILD_OBJECT_AREA>::Post(STR_ERROR_CAN_T_BUILD_OBJECT, CcPlaySound_CONSTRUCTION_OTHER,
+			end_tile, start_tile, spec->Index(), _selected_object_view, (_ctrl_pressed ? true : false));
 	}
 
 	void OnPlaceObjectAbort() override

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -552,9 +552,7 @@ static CallBackFunction ToolbarSubsidiesClick(Window *w)
  */
 static CallBackFunction MenuClickSubsidies(int index)
 {
-	switch (index) {
-		case 0: ShowSubsidiesList(); break;
-	}
+	ShowSubsidiesList();
 	return CBF_NONE;
 }
 

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -955,14 +955,10 @@ bool OpenGLBackend::Resize(int w, int h, bool force)
 
 	_glActiveTexture(GL_TEXTURE0);
 	_glBindTexture(GL_TEXTURE_2D, this->vid_texture);
-	switch (bpp) {
-		case 8:
-			_glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
-			break;
-
-		default:
-			_glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
-			break;
+	if (bpp == 8) {
+		_glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
+	} else {
+		_glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
 	}
 	_glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
@@ -1224,14 +1220,10 @@ void OpenGLBackend::ReleaseVideoBuffer(const Rect &update_rect)
 		_glActiveTexture(GL_TEXTURE0);
 		_glBindTexture(GL_TEXTURE_2D, this->vid_texture);
 		_glPixelStorei(GL_UNPACK_ROW_LENGTH, _screen.pitch);
-		switch (BlitterFactory::GetCurrentBlitter()->GetScreenDepth()) {
-			case 8:
-				_glTexSubImage2D(GL_TEXTURE_2D, 0, update_rect.left, update_rect.top, update_rect.right - update_rect.left, update_rect.bottom - update_rect.top, GL_RED, GL_UNSIGNED_BYTE, (GLvoid *)(size_t)(update_rect.top * _screen.pitch + update_rect.left));
-				break;
-
-			default:
-				_glTexSubImage2D(GL_TEXTURE_2D, 0, update_rect.left, update_rect.top, update_rect.right - update_rect.left, update_rect.bottom - update_rect.top, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, (GLvoid *)(size_t)(update_rect.top * _screen.pitch * 4 + update_rect.left * 4));
-				break;
+		if (BlitterFactory::GetCurrentBlitter()->GetScreenDepth() == 8) {
+			_glTexSubImage2D(GL_TEXTURE_2D, 0, update_rect.left, update_rect.top, update_rect.right - update_rect.left, update_rect.bottom - update_rect.top, GL_RED, GL_UNSIGNED_BYTE, (GLvoid*)(size_t)(update_rect.top * _screen.pitch + update_rect.left));
+		} else {
+			_glTexSubImage2D(GL_TEXTURE_2D, 0, update_rect.left, update_rect.top, update_rect.right - update_rect.left, update_rect.bottom - update_rect.top, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, (GLvoid*)(size_t)(update_rect.top * _screen.pitch * 4 + update_rect.left * 4));
 		}
 
 #ifndef NO_GL_BUFFER_SYNC


### PR DESCRIPTION
## Motivation / Problem

Today on Discord we discussed CodeQL warnings triggered in #10519 which I proposed to dismiss in #10537.

@frosch123 wrote:
> turning that into an "if" does not make the code better
> and whoever adds a new widget next, will have to readd the switch
> warnings are a suggestion, but depending on context you do not have to follow them
...
> codeql does the checks based on the knowledge it has. all/most widget methods get a "widget" id passed, because we do not do proper oo-gui stuff
> as a result all widget-handlers have a switch-case, because the cases are usually not related (and would be separate methods in any modern gui framework)
> code should reflect intention. it does not make sense to work around warnings, just because the code-checker does not know the intention of the code

@LordAro wrote:
> i agree, disable the trivial switch check rather than anything else
> possibly with a cursory review of them to fix any "genuine" issues

I took that cursory review. This PR aims to fix what I'd consider potentially "genuine" issues.

## Description

Simplify some switches which don't seem like they would need expanding in the future:

- Two switches which use a `NOT_REACHED()` instead of an `assert()`
- One switch in MenuClickSubsidies() which is documented as unused
- Two switches in OpenGL which just need an if/else
- One switch in an OnInvalidateData() which only has one case. Using an `if` for this is done elsewhere, such as in `SpriteAlignerWindow`.

I would hope that with these resolved, we could merge #10537, clearing the way for #10519 to be merged without warnings. 🙂 

## Limitations

Trivial switches for widgets and hotkeys are left alone so they can be easily added to later.

Trivial switches for vehicle types are left alone because it's a multi-nested can of worms that I don't want to open right now. 😛 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
