### PR TITLE
Fix #10574: Force town-buildable roads to be not hidden.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -4516,6 +4516,7 @@ static ChangeInfoResult RoadTypeChangeInfo(uint id, int numinfo, int prop, ByteR
 
 			case 0x10: // Road Type flags
 				rti->flags = (RoadTypeFlags)buf->ReadByte();
+				if (HasBit(rti->flags, ROTF_TOWN_BUILD)) ClrBit(rti->flags, ROTF_HIDDEN);
 				break;
 
 			case 0x13: // Construction cost factor


### PR DESCRIPTION
## Motivation / Problem

Some NewGRFs set all town-buildable roads as hidden, which is not the intention of the hidden flag.

Since the hidden flag was enforced, these NewGRFs can no longer be used in the game. As per #10574, map generation fails, and if loading a savegame, towns will not be able to grow.

## Description

This is resolved by forcing town-buildable roads to be not hidden.

## Limitations

This is just a suggestion of how to work around this issue without reverting the changes which enforce the check.

An alternative is to test if there are no town-buildable roads and then force a non-hidden road to be town-buildable, but that would probably cause different problems.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
