### PR TITLE
Codechange: Use a shared_ptr for viewport overlay.

### DIFF
--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -562,7 +562,7 @@ LinkGraphLegendWindow::LinkGraphLegendWindow(WindowDesc *desc, int window_number
  * Set the overlay belonging to this menu and import its company/cargo settings.
  * @param overlay New overlay for this menu.
  */
-void LinkGraphLegendWindow::SetOverlay(LinkGraphOverlay *overlay) {
+void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay) {
 	this->overlay = overlay;
 	uint32 companies = this->overlay->GetCompanyMask();
 	for (uint c = 0; c < MAX_COMPANIES; c++) {

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -108,7 +108,7 @@ void ShowLinkGraphLegend();
 struct LinkGraphLegendWindow : Window {
 public:
 	LinkGraphLegendWindow(WindowDesc *desc, int window_number);
-	void SetOverlay(LinkGraphOverlay *overlay);
+	void SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay);
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override;
 	void DrawWidget(const Rect &r, int widget) const override;
@@ -117,7 +117,7 @@ public:
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override;
 
 private:
-	LinkGraphOverlay *overlay;
+	std::shared_ptr<LinkGraphOverlay> overlay;
 
 	void UpdateOverlayCompanies();
 	void UpdateOverlayCargoes();

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -224,7 +224,7 @@ struct MainWindow : Window
 		NWidgetViewport *nvp = this->GetWidget<NWidgetViewport>(WID_M_VIEWPORT);
 		nvp->InitializeViewport(this, TileXY(32, 32), ScaleZoomGUI(ZOOM_LVL_VIEWPORT));
 
-		this->viewport->overlay = new LinkGraphOverlay(this, WID_M_VIEWPORT, 0, 0, 2);
+		this->viewport->overlay = std::make_shared<LinkGraphOverlay>(this, WID_M_VIEWPORT, 0, 0, 2);
 		this->refresh.SetInterval(LINKGRAPH_DELAY);
 	}
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -203,10 +203,7 @@ static Point MapXYZToViewport(const Viewport *vp, int x, int y, int z)
 
 void DeleteWindowViewport(Window *w)
 {
-	if (w->viewport == nullptr) return;
-
-	delete w->viewport->overlay;
-	free(w->viewport);
+	delete w->viewport;
 	w->viewport = nullptr;
 }
 
@@ -227,7 +224,7 @@ void InitializeWindowViewport(Window *w, int x, int y,
 {
 	assert(w->viewport == nullptr);
 
-	ViewportData *vp = CallocT<ViewportData>(1);
+	ViewportData *vp = new ViewportData();
 
 	vp->left = x + w->left;
 	vp->top = y + w->top;

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -31,7 +31,7 @@ struct Viewport {
 	int virtual_height;  ///< height << zoom
 
 	ZoomLevel zoom; ///< The zoom level of the viewport.
-	LinkGraphOverlay *overlay;
+	std::shared_ptr<LinkGraphOverlay> overlay;
 };
 
 /** Location information about a sign as seen on the viewport */


### PR DESCRIPTION
## Motivation / Problem

LinkGraphOverlay instance is shared between Viewport and LinkGraphLegendWindow.

## Description

This minor change gives shared ownership of the LinkGraphOverlay so that manual freeing is not necessary, and switches from CallocC/free of w->viewport to new/delete.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
