### PR TITLE
Fix #10493, Fix #8424: Collision sensitivity lowered to correct incorrect crash circumstances.

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -3138,8 +3138,8 @@ static Vehicle *FindTrainCollideEnum(Vehicle *v, void *data)
 	if (hash & ~15) return nullptr;
 
 	/* Slower check using multiplication */
-	int min_diff = (Train::From(v)->gcache.cached_veh_length + 1) / 2 + (tcc->v->gcache.cached_veh_length + 1) / 2 - 1;
-	if (x_diff * x_diff + y_diff * y_diff > min_diff * min_diff) return nullptr;
+	int min_diff = (Train::From(v)->gcache.cached_veh_length + tcc->v->gcache.cached_veh_length) / 2 - 2;
+	if (x_diff * x_diff + y_diff * y_diff >= min_diff * min_diff) return nullptr;
 
 	/* Happens when there is a train under bridge next to bridge head */
 	if (abs(v->z_pos - tcc->v->z_pos) > 5) return nullptr;


### PR DESCRIPTION
Collision sensitivity was lowered in a way that both problematic circumstances appear to be rectified while true collisions still seem to function fully. (An idea of making the trains "park in" a little less also comes to mind, but this patch seems sufficient to resolve the overall issue.)