### PR TITLE
Fix #10493: Fix with station stop location adjusted.

### DIFF
--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -294,7 +294,7 @@ int GetTrainStopLocation(StationID station_id, TileIndex tile, const Train *v, i
 
 	/* Subtract half the front vehicle length of the train so we get the real
 	 * stop location of the train. */
-	return stop - (v->gcache.cached_veh_length + 1) / 2;
+	return stop - (v->gcache.cached_veh_length) / 2 - 1;
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

Regarding #10493 and #8424, trains overshoot some stopping points by an infinitesimal amount, leading to train crashing in situations where trains should not be crashing.

## Description

Train's stopping location in stations have been put back by a very slight amount.

## Limitations

#8424 is not fixed in this particular commit.

This adjustment of the stop location may theoretically cause issues regarding the collision of the back of the train, but none have been confirmed as of yet.

## Checklist for Review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)