### PR TITLE
Fix #8424: Modified Direction Depot Entry Coordinates to Try to Fix Wrongful Collision

### DIFF
--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -2885,7 +2885,7 @@ static void ChangeTileOwner_Track(TileIndex tile, Owner old_owner, Owner new_own
 }
 
 static const byte _fractcoords_behind[4] = { 0x8F, 0x8, 0x80, 0xF8 };
-static const byte _fractcoords_enter[4] = { 0x8A, 0x48, 0x84, 0xA8 };
+static const byte _fractcoords_enter[4] = { 0x8A, 0x58, 0x85, 0xA8 };
 static const int8 _deltacoord_leaveoffset[8] = {
 	-1,  0,  1,  0, /* x */
 	 0,  1,  0, -1  /* y */


### PR DESCRIPTION
## Motivation / Problem

"#8424: Trains can crash through depots"

## Description

This patch appears to fix the wrongful train crashing, and it changing two directions may be a good sign because it was said the bug was happening in two directions. Counting steps from 5 to 0 also match A to F in number. No process crashing seems to be caused by this, either.

## Limitations

Further testing would be wise.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
