### PR TITLE
Codechange: Consistent CompanyMask usage.

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -675,7 +675,7 @@ void StartupOneEngine(Engine *e, Date aging_date, uint32 seed)
 	e->intro_date = ei->base_intro <= ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (Date)GB(r, 0, 9) + ei->base_intro;
 	if (e->intro_date <= _date) {
 		e->age = (aging_date - e->intro_date) >> 5;
-		e->company_avail = (CompanyMask)-1;
+		e->company_avail = MAX_UVALUE(CompanyMask);
 		e->flags |= ENGINE_AVAILABLE;
 	}
 
@@ -804,7 +804,7 @@ static void AcceptEnginePreview(EngineID eid, CompanyID company, int recursion_d
 	Engine *e = Engine::Get(eid);
 
 	e->preview_company = INVALID_COMPANY;
-	e->preview_asked = (CompanyMask)-1;
+	e->preview_asked = MAX_UVALUE(CompanyMask);
 
 	EnableEngineForCompany(eid, company);
 
@@ -899,7 +899,7 @@ void EnginesDailyLoop()
 				e->preview_company = GetPreviewCompany(e);
 
 				if (e->preview_company == INVALID_COMPANY) {
-					e->preview_asked = (CompanyMask)-1;
+					e->preview_asked = MAX_UVALUE(CompanyMask);
 					continue;
 				}
 
@@ -1028,7 +1028,7 @@ static void NewVehicleAvailable(Engine *e)
 	AddRemoveEngineFromAutoreplaceAndBuildWindows(e->type);
 
 	/* Now available for all companies */
-	e->company_avail = (CompanyMask)-1;
+	e->company_avail = MAX_UVALUE(CompanyMask);
 
 	/* Do not introduce new rail wagons */
 	if (IsWagon(index)) return;

--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -444,7 +444,7 @@ void LinkGraphOverlay::SetCargoMask(CargoTypes cargo_mask)
  * Set a new company mask and rebuild the cache.
  * @param company_mask New company mask.
  */
-void LinkGraphOverlay::SetCompanyMask(uint32 company_mask)
+void LinkGraphOverlay::SetCompanyMask(CompanyMask company_mask)
 {
 	this->company_mask = company_mask;
 	this->RebuildCache();
@@ -564,7 +564,7 @@ LinkGraphLegendWindow::LinkGraphLegendWindow(WindowDesc *desc, int window_number
  */
 void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay) {
 	this->overlay = overlay;
-	uint32 companies = this->overlay->GetCompanyMask();
+	CompanyMask companies = this->overlay->GetCompanyMask();
 	for (uint c = 0; c < MAX_COMPANIES; c++) {
 		if (!this->IsWidgetDisabled(WID_LGL_COMPANY_FIRST + c)) {
 			this->SetWidgetLoweredState(WID_LGL_COMPANY_FIRST + c, HasBit(companies, c));

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -56,13 +56,13 @@ public:
 	 * @param company_mask Bitmask of companies to be shown.
 	 * @param scale Desired thickness of lines and size of station dots.
 	 */
-	LinkGraphOverlay(Window *w, uint wid, CargoTypes cargo_mask, uint32 company_mask, uint scale) :
+	LinkGraphOverlay(Window *w, uint wid, CargoTypes cargo_mask, CompanyMask company_mask, uint scale) :
 			window(w), widget_id(wid), cargo_mask(cargo_mask), company_mask(company_mask), scale(scale)
 	{}
 
 	void Draw(const DrawPixelInfo *dpi);
 	void SetCargoMask(CargoTypes cargo_mask);
-	void SetCompanyMask(uint32 company_mask);
+	void SetCompanyMask(CompanyMask company_mask);
 
 	bool ShowTooltip(Point pt, TooltipCloseCondition close_cond);
 
@@ -73,13 +73,13 @@ public:
 	CargoTypes GetCargoMask() { return this->cargo_mask; }
 
 	/** Get a bitmask of the currently shown companies. */
-	uint32 GetCompanyMask() { return this->company_mask; }
+	CompanyMask GetCompanyMask() { return this->company_mask; }
 
 protected:
 	Window *window;                    ///< Window to be drawn into.
 	const uint widget_id;              ///< ID of Widget in Window to be drawn to.
 	CargoTypes cargo_mask;             ///< Bitmask of cargos to be displayed.
-	uint32 company_mask;               ///< Bitmask of companies to be displayed.
+	CompanyMask company_mask;          ///< Bitmask of companies to be displayed.
 	LinkMap cached_links;              ///< Cache for links to reduce recalculation.
 	StationSupplyList cached_stations; ///< Cache for stations to be drawn.
 	uint scale;                        ///< Width of link lines.

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -1120,6 +1120,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_COMPANY_UPDATE(
 {
 	if (this->status < STATUS_ACTIVE) return NETWORK_RECV_STATUS_MALFORMED_PACKET;
 
+	static_assert(sizeof(_network_company_passworded) <= sizeof(uint16));
 	_network_company_passworded = p->Recv_uint16();
 	SetWindowClassesDirty(WC_COMPANY);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -775,6 +775,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendCompanyUpdate()
 {
 	Packet *p = new Packet(PACKET_SERVER_COMPANY_UPDATE);
 
+	static_assert(sizeof(_network_company_passworded) <= sizeof(uint16));
 	p->Send_uint16(_network_company_passworded);
 	this->SendPacket(p);
 	return NETWORK_RECV_STATUS_OKAY;

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -286,7 +286,7 @@ RoadTypes ExistingRoadTypes(CompanyID c)
 		if (!HasBit(e->info.climates, _settings_game.game_creation.landscape)) continue;
 
 		/* Check whether available for all potential companies */
-		if (e->company_avail != (CompanyMask)-1) continue;
+		if (e->company_avail != MAX_UVALUE(CompanyMask)) continue;
 
 		known_roadtypes |= GetRoadTypeInfo(e->u.road.roadtype)->introduces_roadtypes;
 	}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2011,15 +2011,15 @@ bool AfterLoadGame()
 
 		/* More companies ... */
 		for (Company *c : Company::Iterate()) {
-			if (c->bankrupt_asked == 0xFF) c->bankrupt_asked = 0xFFFF;
+			if (c->bankrupt_asked == 0xFF) c->bankrupt_asked = MAX_UVALUE(CompanyMask);
 		}
 
 		for (Engine *e : Engine::Iterate()) {
-			if (e->company_avail == 0xFF) e->company_avail = 0xFFFF;
+			if (e->company_avail == 0xFF) e->company_avail = MAX_UVALUE(CompanyMask);
 		}
 
 		for (Town *t : Town::Iterate()) {
-			if (t->have_ratings == 0xFF) t->have_ratings = 0xFFFF;
+			if (t->have_ratings == 0xFF) t->have_ratings = MAX_UVALUE(CompanyMask);
 			for (uint i = 8; i != MAX_COMPANIES; i++) t->ratings[i] = RATING_INITIAL;
 		}
 	}

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -110,7 +110,7 @@ struct ENGNChunkHandler : ChunkHandler {
 				 * Just cancel any previews. */
 				e->flags &= ~4; // ENGINE_OFFER_WINDOW_OPEN
 				e->preview_company = INVALID_COMPANY;
-				e->preview_asked = (CompanyMask)-1;
+				e->preview_asked = MAX_UVALUE(CompanyMask);
 			}
 		}
 	}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -413,7 +413,7 @@ static bool FixTTOEngines()
 			/* Make sure for example monorail and maglev are available when they should be */
 			if (_date >= e->intro_date && HasBit(e->info.climates, 0)) {
 				e->flags |= ENGINE_AVAILABLE;
-				e->company_avail = (CompanyMask)0xFF;
+				e->company_avail = MAX_UVALUE(CompanyMask);
 				e->age = _date > e->intro_date ? (_date - e->intro_date) / 30 : 0;
 			}
 		} else {
@@ -438,7 +438,7 @@ static bool FixTTOEngines()
 			 * if at least one of them was available. */
 			for (uint j = 0; j < lengthof(tto_to_ttd); j++) {
 				if (tto_to_ttd[j] == i && _old_engines[j].company_avail != 0) {
-					e->company_avail = (CompanyMask)0xFF;
+					e->company_avail = MAX_UVALUE(CompanyMask);
 					e->flags |= ENGINE_AVAILABLE;
 					break;
 				}
@@ -448,7 +448,7 @@ static bool FixTTOEngines()
 		}
 
 		e->preview_company = INVALID_COMPANY;
-		e->preview_asked = (CompanyMask)-1;
+		e->preview_asked = MAX_UVALUE(CompanyMask);
 		e->preview_wait = 0;
 		e->name = std::string{};
 	}

--- a/src/smallmap_gui.cpp
+++ b/src/smallmap_gui.cpp
@@ -1594,7 +1594,7 @@ int SmallMapWindow::GetPositionOnLegend(Point pt)
 	if (!this->refresh.Elapsed(delta_ms)) return;
 
 	if (this->map_type == SMT_LINKSTATS) {
-		uint32 company_mask = this->GetOverlayCompanyMask();
+		CompanyMask company_mask = this->GetOverlayCompanyMask();
 		if (this->overlay->GetCompanyMask() != company_mask) {
 			this->overlay->SetCompanyMask(company_mask);
 		} else {

--- a/src/smallmap_gui.h
+++ b/src/smallmap_gui.h
@@ -151,9 +151,9 @@ protected:
 	 * the _local_company. Spectators get to see all companies' links.
 	 * @return Company mask.
 	 */
-	inline uint32 GetOverlayCompanyMask() const
+	inline CompanyMask GetOverlayCompanyMask() const
 	{
-		return Company::IsValidID(_local_company) ? 1U << _local_company : 0xffffffff;
+		return Company::IsValidID(_local_company) ? 1U << _local_company : MAX_UVALUE(CompanyMask);
 	}
 
 	void RebuildColourIndexIfNecessary();


### PR DESCRIPTION
## Motivation / Problem

1) When setting CompanyMask to 'all companies' a variety of values are set, e.g. `MAX_UVALUE(CompanyMask)`, `(CompanyMask)-1` or simply `0xFFFF`.
2) LinkGraph uses `uint32` for company mask instead of `CompanyMask`.
3) Network protocol assumes CompanyMask to be 16 bits.

## Description

1) Replace all occurrences (that I could find) with `MAX_UVALUE(CompanyMask)`.
2) Change LinkGraph to use `CompanyMask`.
3) Assert that CompanyMask fits into 16 bits.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
