### PR TITLE
Feature: Setting to scale cargo production of towns and industries

### DIFF
--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -24,6 +24,21 @@ enum EconomyType : uint8_t {
 	ET_END = 3,
 };
 
+/**
+ * Minimum allowed value of town_cargo_scale/industry_cargo_scale.
+ * Below 13, callback-based industries would produce less than once per month. We round up to 15% because it's a nicer number.
+ * Towns use the same minimum to match, and because below this small towns often produce no cargo.
+ */
+static const int MIN_CARGO_SCALE = 15;
+/**
+ * Maximum allowed value of town_cargo_scale/industry_cargo_scale.
+ * Above 340, callback-based industries would produce more than once per day, which GRFs do not expect.
+ * Towns use the same maximum to match.
+ */
+static const int MAX_CARGO_SCALE = 300;
+/** Default value of town_cargo_scale/industry_cargo_scale. */
+static const int DEF_CARGO_SCALE = 100;
+
 /** Data of the economy. */
 struct Economy {
 	Money max_loan;                       ///< NOSAVE: Maximum possible loan

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1169,7 +1169,7 @@ static void UpdateIndustryProduction(Industry *i)
 
 	for (auto &p : i->produced) {
 		if (IsValidCargoID(p.cargo)) {
-			p.history[LAST_MONTH].production = 8 * p.rate;
+			p.history[LAST_MONTH].production = ScaleByCargoScale(8 * p.rate, false);
 		}
 	}
 }

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1524,6 +1524,12 @@ STR_CONFIG_SETTING_MINUTES_PER_YEAR_VALUE                       :{NUM}
 ###setting-zero-is-special
 STR_CONFIG_SETTING_MINUTES_PER_YEAR_FROZEN                      :0 (calendar time frozen)
 
+STR_CONFIG_SETTING_TOWN_CARGO_SCALE                             :Scale town cargo production: {STRING2}
+STR_CONFIG_SETTING_TOWN_CARGO_SCALE_HELPTEXT                    :Scale the cargo production of towns by this percentage.
+STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE                         :Scale industry cargo production: {STRING2}
+STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE_HELPTEXT                :Scale the cargo production of industries by this percentage.
+STR_CONFIG_SETTING_CARGO_SCALE_VALUE                            :{NUM}%
+
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE                            :Autorenew vehicle when it gets old: {STRING2}
 STR_CONFIG_SETTING_AUTORENEW_VEHICLE_HELPTEXT                   :When enabled, a vehicle nearing its end of life gets automatically replaced when the renew conditions are fulfilled
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -688,7 +688,13 @@ static void TileLoop_Object(TileIndex tile)
 	/* Top town buildings generate 250, so the top HQ type makes 256. */
 	if (GB(r, 0, 8) < (256 / 4 / (6 - level))) {
 		uint amt = GB(r, 0, 8) / 8 / 4 + 1;
+
+		/* Production is halved during recessions. */
 		if (EconomyIsInRecession()) amt = (amt + 1) >> 1;
+
+		/* Scale by cargo scale setting. */
+		amt = ScaleByCargoScale(amt, true);
+
 		MoveGoodsToStation(CT_PASSENGERS, amt, SourceType::Headquarters, GetTileOwner(tile), stations.GetStations());
 	}
 
@@ -697,7 +703,13 @@ static void TileLoop_Object(TileIndex tile)
 	 * equations. */
 	if (GB(r, 8, 8) < (196 / 4 / (6 - level))) {
 		uint amt = GB(r, 8, 8) / 8 / 4 + 1;
+
+		/* Production is halved during recessions. */
 		if (EconomyIsInRecession()) amt = (amt + 1) >> 1;
+
+		/* Scale by cargo scale setting. */
+		amt = ScaleByCargoScale(amt, true);
+
 		MoveGoodsToStation(CT_MAIL, amt, SourceType::Headquarters, GetTileOwner(tile), stations.GetStations());
 	}
 }

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2201,6 +2201,7 @@ static SettingsContainer &GetSettingsTree()
 
 			SettingsPage *towns = environment->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT_TOWNS));
 			{
+				towns->Add(new SettingEntry("economy.town_cargo_scale"));
 				towns->Add(new SettingEntry("economy.town_growth_rate"));
 				towns->Add(new SettingEntry("economy.allow_town_roads"));
 				towns->Add(new SettingEntry("economy.allow_town_level_crossings"));
@@ -2213,6 +2214,7 @@ static SettingsContainer &GetSettingsTree()
 
 			SettingsPage *industries = environment->Add(new SettingsPage(STR_CONFIG_SETTING_ENVIRONMENT_INDUSTRIES));
 			{
+				industries->Add(new SettingEntry("economy.industry_cargo_scale"));
 				industries->Add(new SettingEntry("difficulty.industry_density"));
 				industries->Add(new SettingEntry("construction.raw_industry_construction"));
 				industries->Add(new SettingEntry("construction.industry_platform"));

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -561,6 +561,8 @@ struct EconomySettings {
 	bool   infrastructure_maintenance;       ///< enable monthly maintenance fee for owner infrastructure
 	TimekeepingUnits timekeeping_units;      ///< time units to use for the game economy, either calendar or wallclock
 	uint16_t minutes_per_calendar_year;      ///< minutes per calendar year. Special value 0 means that calendar time is frozen.
+	uint16_t town_cargo_scale;               ///< scale cargo production of towns by this percentage.
+	uint16_t industry_cargo_scale;           ///< scale cargo production of industries by this percentage.
 };
 
 struct LinkGraphSettings {

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -315,3 +315,29 @@ strval   = STR_CONFIG_SETTING_MINUTES_PER_YEAR_VALUE
 pre_cb   = [](auto) { return _game_mode == GM_MENU || _settings_game.economy.timekeeping_units == 1; }
 post_cb  = ChangeMinutesPerYear
 cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.town_cargo_scale
+type     = SLE_UINT16
+flags    = SF_NO_NETWORK
+def      = DEF_CARGO_SCALE
+min      = MIN_CARGO_SCALE
+max      = MAX_CARGO_SCALE
+interval = 1
+str      = STR_CONFIG_SETTING_TOWN_CARGO_SCALE
+strhelp  = STR_CONFIG_SETTING_TOWN_CARGO_SCALE_HELPTEXT
+strval   = STR_CONFIG_SETTING_CARGO_SCALE_VALUE
+cat      = SC_BASIC
+
+[SDT_VAR]
+var      = economy.industry_cargo_scale
+type     = SLE_UINT16
+flags    = SF_NO_NETWORK
+def      = DEF_CARGO_SCALE
+min      = MIN_CARGO_SCALE
+max      = MAX_CARGO_SCALE
+interval = 1
+str      = STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE
+strhelp  = STR_CONFIG_SETTING_INDUSTRY_CARGO_SCALE_HELPTEXT
+strval   = STR_CONFIG_SETTING_CARGO_SCALE_VALUE
+cat      = SC_BASIC


### PR DESCRIPTION
## Motivation / Problem

In #11428 I present my solution to the old daylength patch which is so popular in JGR's Patchpack.

In my conversations with players, daylength actually has two common usecases:
* Slowing down the rate of calendar and technology progression. This is handled by #11428.
* Slowing down the economy, to enable less-dense and less-frequent networks, timetabling, and other "realistic" gameplay styles. This PR is my attempt to meet this need.

Slowing down economy time has several pieces:
* Reducing industry cargo production
* Reducing town cargo production
* Slowing down vehicle running costs when trains are running empty, stabled in yards between runs, etc.
* Slowing station rating loss from infrequent service

All of these are possible with NewGRFs. However, the last two are much easier with the Base Costs GRF and #11346.

Reducing town and industry production would require the player to fork the industry and house sets of their choice and make changes to the source code before recompiling. This is problematic with closed-source GRFs and abandoned GRFs that would need decompiling into uncommented NFO.

I think it's worth offering players this control in OpenTTD itself.

JGRPP has settings that do the same thing although it's applied on top of the daylength speed and the setting value is exponential so I have no idea how to interpret it). But the survey results indicate plenty of players tweaking production to suit their play styles:
* [Industry cargo](https://survey.openttd.org/summaries/2024/wk01#jgrpp-0.56.2-game.settings.economy.industry_cargo_scale_factor)
* [Town cargo](https://survey.openttd.org/summaries/2024/wk01#jgrpp-0.56.2-game.settings.economy.town_cargo_scale_factor)

## Description

Adds two settings to scale the cargo production of:
* Towns (including company HQ)
* Industries

For houses, HQ, and basic industries, this simply scales the cargo by the selected percentage (using random to make up for rounding-to-zero losses).

Industries which use the "every 256 ticks" callback often do their own math with input cargos, and we don't want to break them by changing their output without their knowledge. We handle this by scaling the callback interval instead.

NewGRFs are unaware of the scale. They do not need to know about it, and giving them variables just gives authors footguns. Game Scripts can access settings directly so they don't need API additions.

The lower limit of cargo scaling for both industries and towns is 15%. This is a nicer number than the actual minimum (13%), which is determined by the 256-tick industry production callback. Any slower and the industry would not produce every month, leading to confusing feedback in the UI ("no production last month?"). Towns technically have no lower limit, but 15% is a nice limit where towns still produce any cargo. The actual minimum, 1%, typically has zero production even in large cities, which will confuse cargodist... So we make it 15% to match industries. 🙂 

## Limitations

* Industries which use custom text to describe their cargo needs (FIRS, Industries of the Caribbean, etc) won't be accurate. I welcome ideas from NewGRF authors for how we can help them provide descriptive helptext.
* Industries which produce passengers (Plaza as Industry, Apartment Blocks) are controlled by the Industry setting. Not out of laziness, but because this be argued either way so I chose the option with fewer edge cases. 😃 
* Houses have a cargo production callback called every 256 ticks, but since houses don't have input stockpiles, I don't bother scaling the callback interval and just scale the amount.
* I did consider full economy scaling (including cargo value scaling), but that's more opinionated than letting players control cargo production individually without changing the rest of the economy.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
