### PR TITLE
Fix: change tick-time to its intended value (27ms instead of 30ms)

### DIFF
--- a/src/date_type.h
+++ b/src/date_type.h
@@ -22,8 +22,8 @@ typedef uint8  Day;   ///< Type for the day of the month, note: 1 based, first d
 /**
  * 1 day is 74 ticks; _date_fract used to be uint16 and incremented by 885. On
  *                    an overflow the new day begun and 65535 / 885 = 74.
- * 1 tick is approximately 30 ms.
- * 1 day is thus about 2 seconds (74 * 30 = 2220) on a machine that can run OpenTTD normally
+ * 1 tick is approximately 27 ms.
+ * 1 day is thus about 2 seconds (74 * 27 = 1998) on a machine that can run OpenTTD normally
  */
 static const int DAY_TICKS         =  74; ///< ticks per day
 static const int DAYS_IN_YEAR      = 365; ///< days per year

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -313,8 +313,12 @@ enum SpriteType : byte {
 	ST_INVALID  = 4,      ///< Pseudosprite or other unusable sprite, used only internally
 };
 
-/** The number of milliseconds per game tick. */
-static const uint MILLISECONDS_PER_TICK = 30;
+/**
+ * The number of milliseconds per game tick.
+ * The value 27 together with a day length of 74 ticks makes one day 1998 milliseconds, almost exactly 2 seconds.
+ * With a 2 second day, one standard month is 1 minute, and one standard year is slightly over 12 minutes.
+ */
+static const uint MILLISECONDS_PER_TICK = 27;
 
 /** Information about the currently used palette. */
 struct Palette {


### PR DESCRIPTION
## Motivation / Problem

According to #10205, TTD ran at 27 milliseconds per tick.

OpenTTD always (since day one) has run on 30ms. But this is giving some troubles now we are splitting up timers. Mainly, the idea of 27ms and 74 ticks in a game-day, is that it makes a game-day very close to 2s.

TrueBrain also indicated he never really understood the 74 ticks a day till he realised 27ms was the intended time-per-tick, instead of the picked 30ms.

This most likely was an oversight of the very first version of OpenTTD, which makes this bug the longest unresolved issue as far :)

Additionally, in order for #10605 to support real-time units, we need to change OpenTTD to match. @TrueBrain asked me to split up that PR into smaller chunks, so here's the first one.

## Description

27 milliseconds per tick together with a day length of 74 ticks makes one day 1,998 milliseconds, almost exactly 2 seconds. With a 2-second day, one standard month is 1 minute and one standard year is slightly over 12 minutes.

This makes in-game units like "game-seconds" possible, as that is simply 37 ticks. This is far easier to understand for a human over the other units, especially if we continue to decouple those clocks.

Closes #10205.

## Limitations

The game runs 13.25% faster. #10605 should partially negate this problem, but it's only available with real-time units.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
