### PR TITLE
Fix: Specify units for value of share trading age setting

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1809,6 +1809,9 @@ STR_CONFIG_SETTING_ALLOW_SHARES_HELPTEXT                        :When enabled, a
 
 STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES                         :Minimum company age to trade shares: {STRING2}
 STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_HELPTEXT                :Set the minimum age of a company for others to be able to buy and sell shares from them.
+STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_VALUE                   :{COMMA} year{P "" s}
+###setting-zero-is-special
+STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_NO_MIN                  :No minimum
 
 STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE                         :Percentage of leg profit to pay in feeder systems: {STRING2}
 STR_CONFIG_SETTING_FEEDER_PAYMENT_SHARE_HELPTEXT                :Percentage of income given to the intermediate legs in feeder systems, giving more control over the income

--- a/src/table/settings/economy_settings.ini
+++ b/src/table/settings/economy_settings.ini
@@ -185,13 +185,14 @@ post_cb  = [](auto) { InvalidateWindowClassesData(WC_COMPANY); }
 var      = economy.min_years_for_shares
 type     = SLE_UINT8
 from     = SLV_TRADING_AGE
+flags    = SF_GUI_0_IS_SPECIAL
 def      = 6
 min      = 0
 max      = 255
 interval = 1
 str      = STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES
 strhelp  = STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_HELPTEXT
-strval   = STR_JUST_INT
+strval   = STR_CONFIG_SETTING_MIN_YEARS_FOR_SHARES_VALUE
 cat      = SC_EXPERT
 
 [SDT_VAR]


### PR DESCRIPTION
## Motivation / Problem

We don't specify the units for the minimum age to trade shares, nor explain what 0 means.

## Description

Make it better.

#10605 will eventually add unit conversion to support economic periods.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
