### PR TITLE
Codechange: Refactor timetable GUI

### DIFF
--- a/src/timetable.h
+++ b/src/timetable.h
@@ -13,6 +13,8 @@
 #include "date_type.h"
 #include "vehicle_type.h"
 
+static const uint8 MAX_TIMETABLE_START_YEARS = 15; ///< The maximum start date offset, in years.
+
 void ShowTimetableWindow(const Vehicle *v);
 void UpdateVehicleTimetable(Vehicle *v, bool travelling);
 void SetTimetableParams(int param1, int param2, Ticks ticks);

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -14,6 +14,7 @@
 #include "window_func.h"
 #include "vehicle_base.h"
 #include "timetable_cmd.h"
+#include "timetable.h"
 
 #include "table/strings.h"
 
@@ -303,7 +304,7 @@ CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool tim
 
 	/* Don't let a timetable start more than 15 years into the future or 1 year in the past. */
 	if (start_date < 0 || start_date > MAX_DAY) return CMD_ERROR;
-	if (start_date - _date > 15 * DAYS_IN_LEAP_YEAR) return CMD_ERROR;
+	if (start_date - _date > MAX_TIMETABLE_START_YEARS * DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (_date - start_date > DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (timetable_all && !v->orders->IsCompleteTimetable()) return CMD_ERROR;
 	if (timetable_all && start_date + total_duration / DAY_TICKS > MAX_DAY) return CMD_ERROR;


### PR DESCRIPTION
## Motivation / Problem

The timetable GUI needs some love, especially before I extend it in #10605.

## Description

* Replace magic numbers with a constant
* Better tracking of why we opened a query text input
* Un-duplicated text colour and scheduled/expected offsets
* Separated a lengthy DrawWidget() switch into separate helper functions for each widget.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
