### PR TITLE
WIP: scale out TileLoop, to speed up bigger maps

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -522,4 +522,6 @@ add_files(
     window_type.h
     zoom_func.h
     zoom_type.h
+    worker_thread.cpp
+    worker_thread.h
 )

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -833,7 +833,7 @@ void RunTileLoop()
 	}
 
 	do {
-		int local_count = std::min(count, 256);
+		uint local_count = std::min(count, 1024U);
 		count -= local_count;
 
 		_general_worker_pool.EnqueueJob([](TileIndex tile, uint count) {

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -68,6 +68,7 @@
 #include "industry.h"
 #include "network/network_gui.h"
 #include "misc_cmd.h"
+#include "worker_thread.h"
 
 #include "linkgraph/linkgraphschedule.h"
 
@@ -815,6 +816,8 @@ int openttd_main(int argc, char *argv[])
 
 	/* ScanNewGRFFiles now has control over the scanner. */
 	RequestNewGRFScan(scanner.release());
+
+	_general_worker_pool.Start("ottd:worker", 8);
 
 	VideoDriver::GetInstance()->MainLoop();
 

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -56,6 +56,8 @@
 #include "table/strings.h"
 #include "table/town_land.h"
 
+#include <mutex>
+
 #include "safeguards.h"
 
 /* Initialize the town-pool */
@@ -394,12 +396,16 @@ static bool IsCloseToTown(TileIndex tile, uint dist)
 	return DistanceManhattan(tile, t->xy) < dist;
 }
 
+std::mutex update_lock; ///< Prevent multiple threads to update the coords at the same time.
+
 /**
  * Resize the sign(label) of the town after changes in
  * population (creation or growth or else)
  */
 void Town::UpdateVirtCoord()
 {
+	std::unique_lock<std::mutex> lock(update_lock);
+
 	Point pt = RemapCoords2(TileX(this->xy) * TILE_SIZE, TileY(this->xy) * TILE_SIZE);
 
 	if (this->cache.sign.kdtree_valid) _viewport_sign_kdtree.Remove(ViewportSignKdtreeItem::MakeTown(this->index));

--- a/src/worker_thread.cpp
+++ b/src/worker_thread.cpp
@@ -1,0 +1,90 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file worker_thread.cpp Worker thread pool utility. */
+
+#include "stdafx.h"
+#include "worker_thread.h"
+#include "thread.h"
+
+#include "safeguards.h"
+
+WorkerThreadPool _general_worker_pool;
+
+void WorkerThreadPool::Start(const char *thread_name, uint max_workers)
+{
+	uint cpus = std::thread::hardware_concurrency();
+	if (cpus <= 1) return;
+
+	std::lock_guard<std::mutex> lk(this->lock);
+
+	this->exit = false;
+
+	uint worker_target = std::min<uint>(max_workers, cpus);
+	if (this->workers >= worker_target) return;
+
+	uint new_workers = worker_target - this->workers;
+
+	for (uint i = 0; i < new_workers; i++) {
+		this->workers++;
+		if (!StartNewThread(nullptr, thread_name, &WorkerThreadPool::Run, this)) {
+			this->workers--;
+			return;
+		}
+	}
+}
+
+void WorkerThreadPool::Stop()
+{
+	std::unique_lock<std::mutex> lk(this->lock);
+	this->exit = true;
+	this->empty_cv.notify_all();
+	this->done_cv.wait(lk, [this]() { return this->workers == 0; });
+}
+
+void WorkerThreadPool::EnqueueJob(WorkerJobFunc *func, TileIndex tile, uint count)
+{
+	std::unique_lock<std::mutex> lk(this->lock);
+	if (this->workers == 0) {
+		/* Just execute it here and now */
+		lk.unlock();
+		func(tile, count);
+		return;
+	}
+	this->jobs.push({ func, tile, count });
+	lk.unlock();
+	this->empty_cv.notify_one();
+}
+
+void WorkerThreadPool::WaitTillEmpty()
+{
+    std::unique_lock<std::mutex> lk(this->lock);
+    this->job_cv.wait(lk, [this]() { return this->jobs.empty() && this->jobs_pending == 0; });
+}
+
+void WorkerThreadPool::Run(WorkerThreadPool *pool)
+{
+	std::unique_lock<std::mutex> lk(pool->lock);
+	while (!pool->exit || !pool->jobs.empty()) {
+		if (pool->jobs.empty()) {
+			pool->empty_cv.wait(lk);
+		} else {
+			WorkerJob job = pool->jobs.front();
+			pool->jobs.pop();
+			pool->jobs_pending++;
+			lk.unlock();
+			job.func(job.tile, job.count);
+			lk.lock();
+			pool->jobs_pending--;
+			pool->job_cv.notify_one();
+		}
+	}
+	pool->workers--;
+	if (pool->workers == 0) {
+		pool->done_cv.notify_all();
+	}
+}

--- a/src/worker_thread.h
+++ b/src/worker_thread.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file worker_thread.h Worker thread pool utility. */
+
+#ifndef WORKER_THREAD_H
+#define WORKER_THREAD_H
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#if defined(__MINGW32__)
+#include "3rdparty/mingw-std-threads/mingw.mutex.h"
+#include "3rdparty/mingw-std-threads/mingw.condition_variable.h"
+#endif
+
+#include "tile_type.h"
+
+typedef void WorkerJobFunc(TileIndex, uint);
+
+struct WorkerThreadPool {
+private:
+	struct WorkerJob {
+		WorkerJobFunc *func;
+		TileIndex tile;
+		uint count;
+	};
+
+	uint workers = 0;
+	uint jobs_pending = 0;
+	bool exit = false;
+	std::mutex lock;
+	std::queue<WorkerJob> jobs;
+	std::condition_variable empty_cv;
+	std::condition_variable done_cv;
+	std::condition_variable job_cv;
+
+	static void Run(WorkerThreadPool *pool);
+
+public:
+
+	void Start(const char *thread_name, uint max_workers);
+	void Stop();
+	void EnqueueJob(WorkerJobFunc *func, TileIndex tile, uint count);
+	void WaitTillEmpty();
+
+	~WorkerThreadPool()
+	{
+		this->Stop();
+	}
+};
+
+extern WorkerThreadPool _general_worker_pool;
+
+#endif /* WORKER_THREAD_H */


### PR DESCRIPTION
## Motivation / Problem

I was bored, and wanted to do something fun.

This idea was living in my head for a while now, and when JGRennison showed me he already implemented a worker pool, it just had to be tried.

Mostly I was curious if the TileLoop can be made faster by using a worker-pool. The answer is a very clear and loud: yes.
The next, much harder, assignment will be: make all TileLoops thread-safe. They aren't. So yeah .. that is fun.
But if we go this route, it does speed up the game, for those who have more than 1 core (read: according to Steam survey, 99% of our users), especially on bigger maps.

This was btw the trigger to look into this: Steam says almost nobody has a single-core CPU anymore. So we don't have to worry that much anymore what the performance loss is on those machines; only what the gain is on multi-core CPUs :) Which is a good thing!

## Description

This is a proof-of-concept, to show that something like this will help, but requires some work on the current TileLoop implementations.

On a 4kx4k map the TileLoop goes from 17ms to 3ms on my machine, and a 4kx4k map finally becomes playable (in Debug-mode).
For Release-mode it is from 5ms to 1.5ms.

Currently it queues 1024 tile-updates on a single worker, in an attempt to balance how much we push in a std::queue and how long a worker takes to execute the job. This number is not tuned, but just a number that looked nice.

With this change, it means a TileLoop should only deal with its local Tile, and nothing else. 100% sure this currently isn't always the case, so expect issues when using this.

The main one that kept crashing was the updating of the towns coordinates. But the problem below that is of course that multiple threads updated how big the town is (as that updates the coordinates). So the current fix is .. not a fix, but a workaround.

`worker_thread` is a copy from https://github.com/JGRennison/OpenTTD-patches/blob/b776dcbd173fd09bfa1c9904a0606d4709cdb49b/src/worker_thread.cpp, with small changes (changed the function signature and there is always a worker that will be notified when something got inserted in the queue). Of course this is a dirty solution, and we should go for a more generic approach, but again: proof-of-concept. Tnx JGRennison for the work here :)

Owh, and of course: a picture, or it didn't happen.

Badly tuned batch-size:
![image](https://user-images.githubusercontent.com/1663690/230742347-b5af48e1-fb83-4f54-b2ec-6524b091f07f.png)

Better tuned batch-size:
![image](https://user-images.githubusercontent.com/1663690/230743634-bae5fb4b-a8c7-4ef0-a681-562fb1a8e8e7.png)

Als, as it turns out, release-builds handle a batch of 256 so quickly, that the workers had hardly anything to do. This will be one of the challenges to get such PR just right. As the batch-size will differ per CPU.
- Going too big? There is no scaling out.
- Going too small? The overhead is higher than not threading.
- There is a sweet-spot in between.

## Limitations

SO MANY! Where to begin? Just read the description, okay?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
