### PR TITLE
Change: Allow overbuilding station and waypoint tiles

### DIFF
--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -1261,7 +1261,6 @@ static void RestoreTrainReservation(Train *v)
 static CommandCost CalculateRailStationCost(TileArea tile_area, DoCommandFlag flags, Axis axis, StationID *station, RailType rt, std::vector<Train *> &affected_vehicles, StationClassID spec_class, byte spec_index, byte plat_len, byte numtracks)
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
-	bool success = false;
 	bool length_price_ready = true;
 	byte tracknum = 0;
 	for (TileIndex cur_tile : tile_area) {
@@ -1288,11 +1287,8 @@ static CommandCost CalculateRailStationCost(TileArea tile_area, DoCommandFlag fl
 				cost.AddCost(_price[PR_BUILD_STATION_RAIL_LENGTH]);
 				length_price_ready = false;
 			}
-			success = true;
 		}
 	}
-
-	if (!success) return_cmd_error(STR_ERROR_ALREADY_BUILT);
 
 	return cost;
 }
@@ -1877,7 +1873,6 @@ static CommandCost FindJoiningRoadStop(StationID existing_stop, StationID statio
 static CommandCost CalculateRoadStopCost(TileArea tile_area, DoCommandFlag flags, bool is_drive_through, bool is_truck_stop, Axis axis, DiagDirection ddir, StationID *est, RoadType rt, Money unit_cost)
 {
 	CommandCost cost(EXPENSES_CONSTRUCTION);
-	bool success = false;
 	/* Check every tile in the area. */
 	for (TileIndex cur_tile : tile_area) {
 		uint invalid_dirs = 0;
@@ -1896,15 +1891,8 @@ static CommandCost CalculateRoadStopCost(TileArea tile_area, DoCommandFlag flags
 		if (!is_preexisting_roadstop) {
 			cost.AddCost(ret);
 			cost.AddCost(unit_cost);
-			success = true;
-		} else if (is_preexisting_roadstop && !is_drive_through) {
-			/* Allow rotating non-drive through stops for free */
-			success = true;
 		}
-
 	}
-
-	if (!success) return_cmd_error(STR_ERROR_ALREADY_BUILT);
 
 	return cost;
 }

--- a/src/waypoint_cmd.cpp
+++ b/src/waypoint_cmd.cpp
@@ -195,15 +195,8 @@ CommandCost CmdBuildRailWaypoint(DoCommandFlag flags, TileIndex start_tile, Axis
 
 	/* only AddCost for non-existing waypoints */
 	CommandCost cost(EXPENSES_CONSTRUCTION);
-	bool success = false;
 	for (TileIndex cur_tile : new_location) {
-		if (!IsRailWaypointTile(cur_tile)) {
-			cost.AddCost(_price[PR_BUILD_WAYPOINT_RAIL]);
-			success = true;
-		}
-	}
-	if (!success) {
-		return_cmd_error(STR_ERROR_ALREADY_BUILT);
+		if (!IsRailWaypointTile(cur_tile)) cost.AddCost(_price[PR_BUILD_WAYPOINT_RAIL]);
 	}
 
 	/* Make sure the area below consists of clear tiles. (OR tiles belonging to a certain rail station) */


### PR DESCRIPTION
## Motivation / Problem

#9852 made overbuilding free, but blocked overbuilding without changing any tiles. This is very common when building stations using NewGRF station sets, where platforms can have different canopies, footbridges, etc., so having it blocked is frustrating.

## Description

It doesn't hurt anybody to allow overbuilding, even if graphics are the same, so I just removed the error entirely. Costs are still calculated correctly, which was the point of #9852.

Rotating road stations is still only possible for bay stations, since drive-through stations will throw an error about the underlying road.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
