### PR TITLE
Fix #10619: Crash loading linkgraph for older savegames.

### DIFF
--- a/src/saveload/linkgraph_sl.cpp
+++ b/src/saveload/linkgraph_sl.cpp
@@ -58,7 +58,7 @@ public:
 			if (IsSavegameVersionBefore(SLV_191)) {
 				/* We used to save the full matrix ... */
 				for (NodeID to = 0; to < max_size; ++to) {
-					SlObject(&_linkgraph->nodes[_linkgraph_from].edges[to], this->GetLoadDescription());
+					SlObject(&edges[to], this->GetLoadDescription());
 				}
 			} else {
 				size_t used_size = IsSavegameVersionBefore(SLV_SAVELOAD_LIST_LENGTH) ? max_size : SlGetStructListLength(UINT16_MAX);


### PR DESCRIPTION
## Motivation / Problem

As per #10619, crash when loading linkgraph.

## Description

Fixed by loading data into temporary edges vector instead of empty _linkgraph edges.

## Limitations

The crash no longer occurs but I don't know if this is actually correct.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
