### PR TITLE
Add: Some additional debugging information when chunk sizes are not as expected

### DIFF
--- a/src/core/pool_func.hpp
+++ b/src/core/pool_func.hpp
@@ -14,7 +14,7 @@
 #include "mem_func.hpp"
 #include "pool_type.hpp"
 
-extern void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);
+#include "../saveload/saveload_error.hpp" // SlErrorCorruptFmt
 
 /**
  * Helper for defining the method's signature.
@@ -157,13 +157,13 @@ DEFINE_POOL_METHOD(void *)::GetNew(size_t size)
 DEFINE_POOL_METHOD(void *)::GetNew(size_t size, size_t index)
 {
 	if (index >= Tmax_size) {
-		SlErrorCorruptFmt("%s index " PRINTF_SIZE " out of range (" PRINTF_SIZE ")", this->name, index, Tmax_size);
+		SlErrorCorruptFmt("{} index {} out of range ({})", this->name, index, Tmax_size);
 	}
 
 	if (index >= this->size) this->ResizeFor(index);
 
 	if (this->data[index] != nullptr) {
-		SlErrorCorruptFmt("%s index " PRINTF_SIZE " already in use", this->name, index);
+		SlErrorCorruptFmt("{} index {} already in use", this->name, index);
 	}
 
 	return this->AllocateItem(size, index);

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -315,7 +315,7 @@ static void SlNullPointers()
 	_sl_version = SAVEGAME_VERSION;
 
 	for (const ChunkHandler &ch : ChunkHandlers()) {
-		Debug(sl, 3, "Nulling pointers for {:c}{:c}{:c}{:c}", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);
+		Debug(sl, 3, "Nulling pointers for {}", ch.GetName());
 		ch.FixPointers();
 	}
 
@@ -365,27 +365,6 @@ void NORETURN SlError(StringID string, const char *extra_msg)
 void NORETURN SlErrorCorrupt(const char *msg)
 {
 	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, msg);
-}
-
-void NORETURN SlErrorCorruptFmt(const char *format, ...) WARN_FORMAT(1, 2);
-
-/**
- * Issue an SlErrorCorrupt with a format string.
- * @param format format string
- * @param ... arguments to format string
- * @note This function does never return as it throws an exception to
- *       break out of all the saveload code.
- */
-void NORETURN SlErrorCorruptFmt(const char *format, ...)
-{
-	va_list ap;
-	char msg[256];
-
-	va_start(ap, format);
-	vseprintf(msg, lastof(msg), format, ap);
-	va_end(ap);
-
-	SlErrorCorrupt(msg);
 }
 
 
@@ -2242,7 +2221,7 @@ static void SlSaveChunk(const ChunkHandler &ch)
 	if (ch.type == CH_READONLY) return;
 
 	SlWriteUint32(ch.id);
-	Debug(sl, 2, "Saving chunk {:c}{:c}{:c}{:c}", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);
+	Debug(sl, 2, "Saving chunk {}", ch.GetName());
 
 	_sl.block_mode = ch.type;
 	_sl.expect_table_header = (_sl.block_mode == CH_TABLE || _sl.block_mode == CH_SPARSE_TABLE);
@@ -2331,7 +2310,7 @@ static void SlFixPointers()
 	_sl.action = SLA_PTRS;
 
 	for (const ChunkHandler &ch : ChunkHandlers()) {
-		Debug(sl, 3, "Fixing pointers for {:c}{:c}{:c}{:c}", ch.id >> 24, ch.id >> 16, ch.id >> 8, ch.id);
+		Debug(sl, 3, "Fixing pointers for {}", ch.GetName());
 		ch.FixPointers();
 	}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -10,9 +10,9 @@
 #ifndef SAVELOAD_H
 #define SAVELOAD_H
 
+#include "saveload_error.hpp"
 #include "../fileio_type.h"
 #include "../fios.h"
-#include "../strings_type.h"
 #include "../core/span_type.hpp"
 #include <optional>
 #include <string>
@@ -449,6 +449,15 @@ struct ChunkHandler {
 	 * @param len Number of bytes to skip.
 	 */
 	virtual void LoadCheck(size_t len = 0) const;
+
+	std::string GetName() const
+	{
+		return std::string()
+			+ static_cast<char>(this->id >> 24)
+			+ static_cast<char>(this->id >> 16)
+			+ static_cast<char>(this->id >> 8)
+			+ static_cast<char>(this->id);
+	}
 };
 
 /** A reference to ChunkHandler. */
@@ -1164,8 +1173,6 @@ void SlCopy(void *object, size_t length, VarType conv);
 std::vector<SaveLoad> SlTableHeader(const SaveLoadTable &slt);
 std::vector<SaveLoad> SlCompatTableHeader(const SaveLoadTable &slt, const SaveLoadCompatTable &slct);
 void SlObject(void *object, const SaveLoadTable &slt);
-void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
-void NORETURN SlErrorCorrupt(const char *msg);
 
 bool SaveloadCrashWithMissingNewGRFs();
 

--- a/src/saveload/saveload_error.hpp
+++ b/src/saveload/saveload_error.hpp
@@ -1,0 +1,34 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file saveload.h Functions/types related to errors from savegames. */
+
+#ifndef SAVELOAD_ERROR_HPP
+#define SAVELOAD_ERROR_HPP
+
+#include "../3rdparty/fmt/format.h"
+#include "../strings_type.h"
+
+void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
+void NORETURN SlErrorCorrupt(const char *msg);
+
+/**
+ * Issue an SlErrorCorrupt with a format string.
+ * @param format_string The formatting string to tell what to do with the remaining arguments.
+ * @param fmt_args The arguments to be passed to fmt.
+ * @tparam T The type of formatting parameter.
+ * @tparam Args The types of the fmt arguments.
+ * @note This function does never return as it throws an exception to
+ *       break out of all the saveload code.
+ */
+template <typename T, typename ... Args>
+static inline void NORETURN SlErrorCorruptFmt(const T &format, Args&&... fmt_args)
+{
+	SlErrorCorrupt(fmt::format(format, fmt_args...).c_str());
+}
+
+#endif /* SAVELOAD_ERROR_HPP */


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Debugging SL errors is hard when they provide no information except "Invalid chunk size" with no context. Also when that message comes from one of 4 possible locations

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Add some context


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
