### PR TITLE
Codechange: Use std:: features for NewGRF town names.

### DIFF
--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -21,15 +21,13 @@
 
 #include "safeguards.h"
 
-static GRFTownName *_grf_townnames = nullptr;
+static std::vector<GRFTownName> _grf_townnames;
 static std::vector<StringID> _grf_townname_names;
 
 GRFTownName *GetGRFTownName(uint32 grfid)
 {
-	GRFTownName *t = _grf_townnames;
-	for (; t != nullptr; t = t->next) {
-		if (t->grfid == grfid) return t;
-	}
+	auto found = std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t){ return t.grfid == grfid; });
+	if (found != std::end(_grf_townnames)) return &*found;
 	return nullptr;
 }
 
@@ -37,53 +35,31 @@ GRFTownName *AddGRFTownName(uint32 grfid)
 {
 	GRFTownName *t = GetGRFTownName(grfid);
 	if (t == nullptr) {
-		t = CallocT<GRFTownName>(1);
+		t = &_grf_townnames.emplace_back();
 		t->grfid = grfid;
-		t->next = _grf_townnames;
-		_grf_townnames = t;
 	}
 	return t;
 }
 
 void DelGRFTownName(uint32 grfid)
 {
-	GRFTownName *t = _grf_townnames;
-	GRFTownName *p = nullptr;
-	for (;t != nullptr; p = t, t = t->next) if (t->grfid == grfid) break;
-	if (t != nullptr) {
-		for (int i = 0; i < 128; i++) {
-			for (int j = 0; j < t->nbparts[i]; j++) {
-				for (int k = 0; k < t->partlist[i][j].partcount; k++) {
-					if (!HasBit(t->partlist[i][j].parts[k].prob, 7)) free(t->partlist[i][j].parts[k].data.text);
-				}
-				free(t->partlist[i][j].parts);
-			}
-			free(t->partlist[i]);
-		}
-		if (p != nullptr) {
-			p->next = t->next;
-		} else {
-			_grf_townnames = t->next;
-		}
-		free(t);
-	}
+	_grf_townnames.erase(std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t){ return t.grfid == grfid; }));
 }
 
-static char *RandomPart(char *buf, GRFTownName *t, uint32 seed, byte id, const char *last)
+static char *RandomPart(char *buf, const GRFTownName *t, uint32 seed, byte id, const char *last)
 {
 	assert(t != nullptr);
-	for (int i = 0; i < t->nbparts[id]; i++) {
-		byte count = t->partlist[id][i].bitcount;
-		uint16 maxprob = t->partlist[id][i].maxprob;
-		uint32 r = (GB(seed, t->partlist[id][i].bitstart, count) * maxprob) >> count;
-		for (int j = 0; j < t->partlist[id][i].partcount; j++) {
-			byte prob = t->partlist[id][i].parts[j].prob;
-			maxprob -= GB(prob, 0, 7);
+	for (const auto &partlist : t->partlists[id]) {
+		byte count = partlist.bitcount;
+		uint16 maxprob = partlist.maxprob;
+		uint32 r = (GB(seed, partlist.bitstart, count) * maxprob) >> count;
+		for (const auto &part : partlist.parts) {
+			maxprob -= GB(part.prob, 0, 7);
 			if (maxprob > r) continue;
-			if (HasBit(prob, 7)) {
-				buf = RandomPart(buf, t, seed, t->partlist[id][i].parts[j].data.id, last);
+			if (HasBit(part.prob, 7)) {
+				buf = RandomPart(buf, t, seed, part.id, last);
 			} else {
-				buf = strecat(buf, t->partlist[id][i].parts[j].data.text, last);
+				buf = strecat(buf, part.text.c_str(), last);
 			}
 			break;
 		}
@@ -94,12 +70,10 @@ static char *RandomPart(char *buf, GRFTownName *t, uint32 seed, byte id, const c
 char *GRFTownNameGenerate(char *buf, uint32 grfid, uint16 gen, uint32 seed, const char *last)
 {
 	strecpy(buf, "", last);
-	for (GRFTownName *t = _grf_townnames; t != nullptr; t = t->next) {
-		if (t->grfid == grfid) {
-			assert(gen < t->nb_gen);
-			buf = RandomPart(buf, t, seed, t->id[gen], last);
-			break;
-		}
+	const GRFTownName *t = GetGRFTownName(grfid);
+	if (t != nullptr) {
+		assert(gen < t->styles.size());
+		buf = RandomPart(buf, t, seed, t->styles[gen].id, last);
 	}
 	return buf;
 }
@@ -109,8 +83,10 @@ char *GRFTownNameGenerate(char *buf, uint32 grfid, uint16 gen, uint32 seed, cons
 void InitGRFTownGeneratorNames()
 {
 	_grf_townname_names.clear();
-	for (GRFTownName *t = _grf_townnames; t != nullptr; t = t->next) {
-		for (int j = 0; j < t->nb_gen; j++) _grf_townname_names.push_back(t->name[j]);
+	for (const auto &t : _grf_townnames) {
+		for (const auto &style : t.styles) {
+			_grf_townname_names.push_back(style.name);
+		}
 	}
 }
 
@@ -119,31 +95,31 @@ const std::vector<StringID>& GetGRFTownNameList()
 	return _grf_townname_names;
 }
 
-StringID GetGRFTownNameName(uint gen)
+StringID GetGRFTownNameName(uint16 gen)
 {
 	return gen < _grf_townname_names.size() ? _grf_townname_names[gen] : STR_UNDEFINED;
 }
 
 void CleanUpGRFTownNames()
 {
-	while (_grf_townnames != nullptr) DelGRFTownName(_grf_townnames->grfid);
+	_grf_townnames.clear();
 }
 
-uint32 GetGRFTownNameId(int gen)
+uint32 GetGRFTownNameId(uint16 gen)
 {
-	for (GRFTownName *t = _grf_townnames; t != nullptr; t = t->next) {
-		if (gen < t->nb_gen) return t->grfid;
-		gen -= t->nb_gen;
+	for (const auto &t : _grf_townnames) {
+		if (gen < t.styles.size()) return t.grfid;
+		gen -= static_cast<uint16>(t.styles.size());
 	}
 	/* Fallback to no NewGRF */
 	return 0;
 }
 
-uint16 GetGRFTownNameType(int gen)
+uint16 GetGRFTownNameType(uint16 gen)
 {
-	for (GRFTownName *t = _grf_townnames; t != nullptr; t = t->next) {
-		if (gen < t->nb_gen) return gen;
-		gen -= t->nb_gen;
+	for (const auto &t : _grf_townnames) {
+		if (gen < t.styles.size()) return gen;
+		gen -= static_cast<uint16>(t.styles.size());
 	}
 	/* Fallback to english original */
 	return SPECSTR_TOWNNAME_ENGLISH;

--- a/src/newgrf_townname.h
+++ b/src/newgrf_townname.h
@@ -17,29 +17,31 @@
 #include "strings_type.h"
 
 struct NamePart {
-	byte prob;     ///< The relative probability of the following name to appear in the bottom 7 bits.
-	union {
-		char *text;    ///< If probability bit 7 is clear
-		byte id;       ///< If probability bit 7 is set
-	} data;
+	std::string text; ///< If probability bit 7 is clear
+	byte id;          ///< If probability bit 7 is set
+	byte prob;        ///< The relative probability of the following name to appear in the bottom 7 bits.
 };
 
 struct NamePartList {
-	byte partcount;
-	byte bitstart;
-	byte bitcount;
-	uint16 maxprob;
-	NamePart *parts;
+	byte bitstart;  ///< Start of random seed bits to use.
+	byte bitcount;  ///< Number of bits of random seed to use.
+	uint16 maxprob; ///< Total probability of all parts.
+	std::vector<NamePart> parts; ///< List of parts to choose from.
+};
+
+struct TownNameStyle {
+	StringID name; ///< String ID of this town name style.
+	byte id;       ///< Index within partlist for this town name style.
+
+	TownNameStyle(StringID name, byte id) : name(name), id(id) { }
 };
 
 struct GRFTownName {
-	uint32 grfid;
-	byte nb_gen;
-	byte id[128];
-	StringID name[128];
-	byte nbparts[128];
-	NamePartList *partlist[128];
-	GRFTownName *next;
+	static const uint MAX_LISTS = 128; ///< Maximum number of town name lists that can be defined per GRF.
+
+	uint32 grfid;                                   ///< GRF ID of NewGRF.
+	std::vector<TownNameStyle> styles;              ///< Style names defined by the Town Name NewGRF.
+	std::vector<NamePartList> partlists[MAX_LISTS]; ///< Lists of town name parts.
 };
 
 GRFTownName *AddGRFTownName(uint32 grfid);
@@ -47,9 +49,9 @@ GRFTownName *GetGRFTownName(uint32 grfid);
 void DelGRFTownName(uint32 grfid);
 void CleanUpGRFTownNames();
 char *GRFTownNameGenerate(char *buf, uint32 grfid, uint16 gen, uint32 seed, const char *last);
-uint32 GetGRFTownNameId(int gen);
-uint16 GetGRFTownNameType(int gen);
-StringID GetGRFTownNameName(uint gen);
+uint32 GetGRFTownNameId(uint16 gen);
+uint16 GetGRFTownNameType(uint16 gen);
+StringID GetGRFTownNameName(uint16 gen);
 
 const std::vector<StringID>& GetGRFTownNameList();
 


### PR DESCRIPTION
## Motivation / Problem

Loading (and unloading) GRF Town Names requires manual allocation of nested listed and there are multiple levels of array indexing.

I've not tested but it looks like redefinition of a list would leak memory.

## Description

This PR replaces with std::vectors, and the text is stored as a std::string. This removes manual memory (de-)allocation and list counting. The NamePart union (which didn't really serve much purpose due to alignment) is removed as you can't easily put a std::string in a union.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
