### PR TITLE
Codechange: Use cached name for all station/industry/town name formatting.

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -35,6 +35,7 @@
 #include "game/game_text.hpp"
 #include "network/network_content_gui.h"
 #include "newgrf_engine.h"
+#include "core/backup_type.hpp"
 #include <stack>
 
 #include "table/strings.h"
@@ -1458,9 +1459,8 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 				static bool use_cache = true;
 				if (use_cache) { // Use cached version if first call
-					use_cache = false;
+					AutoRestoreBackup cache_backup(use_cache, false);
 					buff = strecpy(buff, i->GetCachedName(), last);
-					use_cache = true;
 				} else if (_scan_for_gender_data) {
 					/* Gender is defined by the industry type.
 					 * STR_FORMAT_INDUSTRY_NAME may have the town first, so it would result in the gender of the town name */
@@ -1508,9 +1508,8 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 				static bool use_cache = true;
 				if (use_cache) { // Use cached version if first call
-					use_cache = false;
+					AutoRestoreBackup cache_backup(use_cache, false);
 					buff = strecpy(buff, st->GetCachedName(), last);
-					use_cache = true;
 				} else if (!st->name.empty()) {
 					int64 args_array[] = {(int64)(size_t)st->name.c_str()};
 					StringParameters tmp_params(args_array);
@@ -1543,9 +1542,8 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 
 				static bool use_cache = true;
 				if (use_cache) { // Use cached version if first call
-					use_cache = false;
+					AutoRestoreBackup cache_backup(use_cache, false);
 					buff = strecpy(buff, t->GetCachedName(), last);
-					use_cache = true;
 				} else if (!t->name.empty()) {
 					int64 args_array[] = {(int64)(size_t)t->name.c_str()};
 					StringParameters tmp_params(args_array);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1456,7 +1456,12 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				const Industry *i = Industry::GetIfValid(args->GetInt32(SCC_INDUSTRY_NAME));
 				if (i == nullptr) break;
 
-				if (_scan_for_gender_data) {
+				static bool use_cache = true;
+				if (use_cache) { // Use cached version if first call
+					use_cache = false;
+					buff = strecpy(buff, i->GetCachedName(), last);
+					use_cache = true;
+				} else if (_scan_for_gender_data) {
 					/* Gender is defined by the industry type.
 					 * STR_FORMAT_INDUSTRY_NAME may have the town first, so it would result in the gender of the town name */
 					StringParameters tmp_params(nullptr, 0, nullptr);
@@ -1501,7 +1506,12 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 					break;
 				}
 
-				if (!st->name.empty()) {
+				static bool use_cache = true;
+				if (use_cache) { // Use cached version if first call
+					use_cache = false;
+					buff = strecpy(buff, st->GetCachedName(), last);
+					use_cache = true;
+				} else if (!st->name.empty()) {
 					int64 args_array[] = {(int64)(size_t)st->name.c_str()};
 					StringParameters tmp_params(args_array);
 					buff = GetStringWithArgs(buff, STR_JUST_RAW_STRING, &tmp_params, last);
@@ -1531,7 +1541,12 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				const Town *t = Town::GetIfValid(args->GetInt32(SCC_TOWN_NAME));
 				if (t == nullptr) break;
 
-				if (!t->name.empty()) {
+				static bool use_cache = true;
+				if (use_cache) { // Use cached version if first call
+					use_cache = false;
+					buff = strecpy(buff, t->GetCachedName(), last);
+					use_cache = true;
+				} else if (!t->name.empty()) {
 					int64 args_array[] = {(int64)(size_t)t->name.c_str()};
 					StringParameters tmp_params(args_array);
 					buff = GetStringWithArgs(buff, STR_JUST_RAW_STRING, &tmp_params, last);


### PR DESCRIPTION
## Motivation / Problem

#7941 introduced cached names for stations, industries and towns to assist sorting performance, but they're not used elsewhere.

## Description

This change also uses the cached names when formatting regular strings, along with a test to ensure infinite recursion.

## Limitations

Industries does something with genders/cases so this might be wrong here.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
