### PR TITLE
Expose more script APIs to GS

### DIFF
--- a/.github/script-missing-mode-enforcement.py
+++ b/.github/script-missing-mode-enforcement.py
@@ -30,7 +30,7 @@ def check_mode_enforcement(path):
                 continue
 
             if re.match(
-                r"\t(EnforceDeityMode|EnforceCompanyModeValid|EnforceDeityOrCompanyModeValid|EnforceDeityOrCompanyModeValid_Void)\(",
+                r"\t(EnforceDeityMode|EnforceCompanyModeValid|EnforceCompanyModeValid_Void|EnforceDeityOrCompanyModeValid|EnforceDeityOrCompanyModeValid_Void)\(",
                 line,
             ):
                 # Mode enforcement macro found

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -45,6 +45,35 @@
  * \li GSCompany::SetAutoRenewMonths
  * \li GSCompany::SetAutoRenewMoney
  * \li GSGameSettings::IsDisabledVehicleType
+ * \li GSGroup::GroupID
+ * \li GSGroup::IsValidGroup
+ * \li GSGroup::CreateGroup
+ * \li GSGroup::DeleteGroup
+ * \li GSGroup::GetVehicleType
+ * \li GSGroup::SetName
+ * \li GSGroup::GetName
+ * \li GSGroup::SetParent
+ * \li GSGroup::GetParent
+ * \li GSGroup::EnableAutoReplaceProtection
+ * \li GSGroup::GetAutoReplaceProtection
+ * \li GSGroup::GetNumEngines
+ * \li GSGroup::GetNumVehicles
+ * \li GSGroup::MoveVehicle
+ * \li GSGroup::EnableWagonRemoval
+ * \li GSGroup::HasWagonRemoval
+ * \li GSGroup::SetAutoReplace
+ * \li GSGroup::GetEngineReplacement
+ * \li GSGroup::StopAutoReplace
+ * \li GSGroup::GetProfitThisYear
+ * \li GSGroup::GetProfitLastYear
+ * \li GSGroup::GetCurrentUsage
+ * \li GSGroup::SetPrimaryColour
+ * \li GSGroup::SetSecondaryColour
+ * \li GSGroup::GetPrimaryColour
+ * \li GSGroup::GetSecondaryColour
+ * \li GSGroupList
+ * \li GSVehicleList_Group
+ * \li GSVehicleList_DefaultGroup
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -44,6 +44,7 @@
  * \li GSCompany::SetAutoRenewStatus
  * \li GSCompany::SetAutoRenewMonths
  * \li GSCompany::SetAutoRenewMoney
+ * \li GSGameSettings::IsDisabledVehicleType
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -22,6 +22,23 @@
  * \li GSCompanyMode::IsDeity
  * \li GSTown::ROAD_LAYOUT_RANDOM
  * \li GSVehicle::IsPrimaryVehicle
+ * \li GSOrder::SetOrderJumpTo
+ * \li GSOrder::SetOrderCondition
+ * \li GSOrder::SetOrderCompareFunction
+ * \li GSOrder::SetOrderCompareValue
+ * \li GSOrder::SetStopLocation
+ * \li GSOrder::SetOrderRefit
+ * \li GSOrder::AppendOrder
+ * \li GSOrder::AppendConditionalOrder
+ * \li GSOrder::InsertOrder
+ * \li GSOrder::InsertConditionalOrder
+ * \li GSOrder::RemoveOrder
+ * \li GSOrder::SetOrderFlags
+ * \li GSOrder::MoveOrder
+ * \li GSOrder::SkipToOrder
+ * \li GSOrder::CopyOrders
+ * \li GSOrder::ShareOrders
+ * \li GSOrder::UnshareOrders
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -39,6 +39,11 @@
  * \li GSOrder::CopyOrders
  * \li GSOrder::ShareOrders
  * \li GSOrder::UnshareOrders
+ * \li GSCompany::IsMine
+ * \li GSCompany::SetPresidentGender
+ * \li GSCompany::SetAutoRenewStatus
+ * \li GSCompany::SetAutoRenewMonths
+ * \li GSCompany::SetAutoRenewMoney
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/script_company.cpp
+++ b/src/script/api/script_company.cpp
@@ -40,6 +40,7 @@
 
 /* static */ bool ScriptCompany::IsMine(ScriptCompany::CompanyID company)
 {
+	EnforceCompanyModeValid(false);
 	return ResolveCompanyID(company) == ResolveCompanyID(COMPANY_SELF);
 }
 

--- a/src/script/api/script_company.hpp
+++ b/src/script/api/script_company.hpp
@@ -129,8 +129,8 @@ public:
 	/**
 	 * Check if a CompanyID is your CompanyID, to ease up checks.
 	 * @param company The company index to check.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if this company is your CompanyID.
-	 * @api -game
 	 */
 	static bool IsMine(CompanyID company);
 
@@ -177,7 +177,6 @@ public:
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if the gender was changed.
 	 * @note When successful a random face will be created.
-	 * @api -game
 	 */
 	static bool SetPresidentGender(Gender gender);
 
@@ -338,7 +337,6 @@ public:
 	 * @param autorenew The new autorenew status.
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if autorenew status has been modified.
-	 * @api -game
 	 */
 	static bool SetAutoRenewStatus(bool autorenew);
 
@@ -356,7 +354,6 @@ public:
 	 *               The value will be clamped to MIN(int16) .. MAX(int16).
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if autorenew months has been modified.
-	 * @api -game
 	 */
 	static bool SetAutoRenewMonths(SQInteger months);
 
@@ -375,7 +372,6 @@ public:
 	 * @return True if autorenew money has been modified.
 	 * @pre money >= 0
 	 * @pre money <  2**32
-	 * @api -game
 	 */
 	static bool SetAutoRenewMoney(Money money);
 

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -56,6 +56,15 @@
 	EnforcePreconditionCustomError(returnval, ScriptCompanyMode::IsValid(), ScriptError::ERR_PRECONDITION_INVALID_COMPANY)
 
 /**
+ * Helper to enforce the precondition that the company mode is valid.
+ */
+#define EnforceCompanyModeValid_Void() \
+	if (!ScriptCompanyMode::IsValid()) { \
+		ScriptObject::SetLastError(ScriptError::ERR_PRECONDITION_INVALID_COMPANY); \
+		return; \
+	}
+
+/**
  * Helper to enforce the precondition that we are in a deity mode.
  * @param returnval The value to return on failure.
  */

--- a/src/script/api/script_gamesettings.hpp
+++ b/src/script/api/script_gamesettings.hpp
@@ -75,7 +75,6 @@ public:
 	 * Checks whether the given vehicle-type is disabled for companies.
 	 * @param vehicle_type The vehicle-type to check.
 	 * @return True if the vehicle-type is disabled.
-	 * @api -game
 	 */
 	static bool IsDisabledVehicleType(ScriptVehicle::VehicleType vehicle_type);
 };

--- a/src/script/api/script_group.hpp
+++ b/src/script/api/script_group.hpp
@@ -15,7 +15,7 @@
 
 /**
  * Class that handles all group related functions.
- * @api ai
+ * @api ai game
  */
 class ScriptGroup : public ScriptObject {
 public:

--- a/src/script/api/script_grouplist.cpp
+++ b/src/script/api/script_grouplist.cpp
@@ -16,7 +16,7 @@
 
 ScriptGroupList::ScriptGroupList()
 {
-	EnforceDeityOrCompanyModeValid_Void();
+	EnforceCompanyModeValid_Void();
 	for (const Group *g : Group::Iterate()) {
 		if (g->owner == ScriptObject::GetCompany()) this->AddItem(g->index);
 	}

--- a/src/script/api/script_grouplist.hpp
+++ b/src/script/api/script_grouplist.hpp
@@ -15,11 +15,14 @@
 /**
  * Creates a list of groups of which you are the owner.
  * @note Neither ScriptGroup::GROUP_ALL nor ScriptGroup::GROUP_DEFAULT is in this list.
- * @api ai
+ * @api ai game
  * @ingroup ScriptList
  */
 class ScriptGroupList : public ScriptList {
 public:
+	/**
+	 * @game @pre ScriptCompanyMode::IsValid().
+	 */
 	ScriptGroupList();
 };
 

--- a/src/script/api/script_order.hpp
+++ b/src/script/api/script_order.hpp
@@ -358,7 +358,6 @@ public:
 	 * @pre order_position != ORDER_CURRENT && IsConditionalOrder(vehicle_id, order_position).
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
-	 * @api -game
 	 */
 	static bool SetOrderJumpTo(VehicleID vehicle_id, OrderPosition order_position, OrderPosition jump_to);
 
@@ -372,7 +371,6 @@ public:
 	 * @pre condition >= OC_LOAD_PERCENTAGE && condition <= OC_UNCONDITIONALLY.
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
-	 * @api -game
 	 */
 	static bool SetOrderCondition(VehicleID vehicle_id, OrderPosition order_position, OrderCondition condition);
 
@@ -386,7 +384,6 @@ public:
 	 * @pre compare >= CF_EQUALS && compare <= CF_IS_FALSE.
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
-	 * @api -game
 	 */
 	static bool SetOrderCompareFunction(VehicleID vehicle_id, OrderPosition order_position, CompareFunction compare);
 
@@ -400,7 +397,6 @@ public:
 	 * @pre value >= 0 && value < 2048.
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
-	 * @api -game
 	 */
 	static bool SetOrderCompareValue(VehicleID vehicle_id, OrderPosition order_position, SQInteger value);
 
@@ -415,7 +411,6 @@ public:
 	 * @pre stop_location >= STOPLOCATION_NEAR && stop_location <= STOPLOCATION_FAR
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
-	 * @api -game
 	 */
 	static bool SetStopLocation(VehicleID vehicle_id, OrderPosition order_position, StopLocation stop_location);
 
@@ -429,7 +424,6 @@ public:
 	 * @pre ScriptCargo::IsValidCargo(refit_cargo) || refit_cargo == CT_AUTO_REFIT || refit_cargo == CT_NO_REFIT
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return Whether the order has been/can be changed.
-	 * @api -game
 	 */
 	static bool SetOrderRefit(VehicleID vehicle_id, OrderPosition order_position, CargoID refit_cargo);
 
@@ -445,7 +439,6 @@ public:
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_FAR_AWAY_FROM_PREVIOUS_DESTINATION
 	 * @return True if and only if the order was appended.
-	 * @api -game
 	 */
 	static bool AppendOrder(VehicleID vehicle_id, TileIndex destination, ScriptOrderFlags order_flags);
 
@@ -459,7 +452,6 @@ public:
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @return True if and only if the order was appended.
-	 * @api -game
 	 */
 	static bool AppendConditionalOrder(VehicleID vehicle_id, OrderPosition jump_to);
 
@@ -477,7 +469,6 @@ public:
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_FAR_AWAY_FROM_PREVIOUS_DESTINATION
 	 * @return True if and only if the order was inserted.
-	 * @api -game
 	 */
 	static bool InsertOrder(VehicleID vehicle_id, OrderPosition order_position, TileIndex destination, ScriptOrderFlags order_flags);
 
@@ -493,7 +484,6 @@ public:
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @return True if and only if the order was inserted.
-	 * @api -game
 	 */
 	static bool InsertConditionalOrder(VehicleID vehicle_id, OrderPosition order_position, OrderPosition jump_to);
 
@@ -505,7 +495,6 @@ public:
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only if the order was removed.
-	 * @api -game
 	 */
 	static bool RemoveOrder(VehicleID vehicle_id, OrderPosition order_position);
 
@@ -526,7 +515,6 @@ public:
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only if the order was changed.
-	 * @api -game
 	 */
 	static bool SetOrderFlags(VehicleID vehicle_id, OrderPosition order_position, ScriptOrderFlags order_flags);
 
@@ -545,7 +533,6 @@ public:
 	 *  the target order is moved upwards (e.g. 3). If the order is moved
 	 *  to a higher place (e.g. from 7 to 9) the target will be moved
 	 *  downwards (e.g. 8).
-	 * @api -game
 	 */
 	static bool MoveOrder(VehicleID vehicle_id, OrderPosition order_position_move, OrderPosition order_position_target);
 
@@ -557,7 +544,6 @@ public:
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @return True if and only the current order was changed.
-	 * @api -game
 	 */
 	static bool SkipToOrder(VehicleID vehicle_id, OrderPosition next_order);
 
@@ -573,7 +559,6 @@ public:
 	 * @exception ScriptOrder::ERR_ORDER_TOO_MANY
 	 * @exception ScriptOrder::ERR_ORDER_AIRCRAFT_NOT_ENOUGH_RANGE
 	 * @return True if and only if the copying succeeded.
-	 * @api -game
 	 */
 	static bool CopyOrders(VehicleID vehicle_id, VehicleID main_vehicle_id);
 
@@ -588,7 +573,6 @@ public:
 	 * @exception ScriptError::ERR_OWNED_BY_ANOTHER_COMPANY
 	 * @exception ScriptOrder::ERR_ORDER_AIRCRAFT_NOT_ENOUGH_RANGE
 	 * @return True if and only if the sharing succeeded.
-	 * @api -game
 	 */
 	static bool ShareOrders(VehicleID vehicle_id, VehicleID main_vehicle_id);
 
@@ -599,7 +583,6 @@ public:
 	 * @pre ScriptVehicle::IsPrimaryVehicle(vehicle_id).
 	 * @game @pre ScriptCompanyMode::IsValid().
 	 * @return True if and only if the unsharing succeeded.
-	 * @api -game
 	 */
 	static bool UnshareOrders(VehicleID vehicle_id);
 

--- a/src/script/api/script_vehiclelist.cpp
+++ b/src/script/api/script_vehiclelist.cpp
@@ -103,7 +103,7 @@ ScriptVehicleList_SharedOrders::ScriptVehicleList_SharedOrders(VehicleID vehicle
 
 ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 {
-	EnforceDeityOrCompanyModeValid_Void();
+	EnforceCompanyModeValid_Void();
 	if (!ScriptGroup::IsValidGroup((ScriptGroup::GroupID)group_id)) return;
 
 	for (const Vehicle *v : Vehicle::Iterate()) {
@@ -115,7 +115,7 @@ ScriptVehicleList_Group::ScriptVehicleList_Group(GroupID group_id)
 
 ScriptVehicleList_DefaultGroup::ScriptVehicleList_DefaultGroup(ScriptVehicle::VehicleType vehicle_type)
 {
-	EnforceDeityOrCompanyModeValid_Void();
+	EnforceCompanyModeValid_Void();
 	if (vehicle_type < ScriptVehicle::VT_RAIL || vehicle_type > ScriptVehicle::VT_AIR) return;
 
 	for (const Vehicle *v : Vehicle::Iterate()) {

--- a/src/script/api/script_vehiclelist.hpp
+++ b/src/script/api/script_vehiclelist.hpp
@@ -69,26 +69,28 @@ public:
 
 /**
  * Creates a list of vehicles that are in a group.
- * @api ai
+ * @api ai game
  * @ingroup ScriptList
  */
 class ScriptVehicleList_Group : public ScriptList {
 public:
 	/**
 	 * @param group_id The ID of the group the vehicles are in.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 */
 	ScriptVehicleList_Group(GroupID group_id);
 };
 
 /**
  * Creates a list of vehicles that are in the default group.
- * @api ai
+ * @api ai game
  * @ingroup ScriptList
  */
 class ScriptVehicleList_DefaultGroup : public ScriptList {
 public:
 	/**
 	 * @param vehicle_type The VehicleType to get the list of vehicles for.
+	 * @game @pre ScriptCompanyMode::IsValid().
 	 */
 	ScriptVehicleList_DefaultGroup(ScriptVehicle::VehicleType vehicle_type);
 };


### PR DESCRIPTION
## Motivation / Problem

Given most functions are already exposed to GS, such as making vehicles. It does not make much sense to have some arbitrary limitation on what can and cannot be exposed.

This is basically a superset of #10381 and a subset of #10411, where I left out providing vehicle related events to GS, as well as the questions for merger and engine preview. Furthermore I did not add many special cases to the Group related functionality to make some groups work in deity mode and others do not. For groups you always need to be in company mode in this version.

Closes #10381.


## Description

Basically removing all the '@api -game' tags, except for `ScriptInfo::UseAsRandomAI()` as that's the only function I would say has no use for a game script.
Adding the group related lists, but enforcing those to be only used in company mode.


## Limitations

Not all events that can be received by a AI will be received by the game script. I left these out of this PR for two reasons; first I'm not sure whether vehicle related events are that interesting for game scripts, but if the GS does not read the events the number of events might grow significantly. The other reason is that I'm far from sure whether it's wanted for the GS to accept vehicle preview or company mergers. As such that's left out in this PR.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
