### PR TITLE
Fix #10630: Don't allow shifting service date earlier than 0

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -771,7 +771,7 @@ uint32 Vehicle::GetGRFID() const
  */
 void Vehicle::ShiftDates(int interval)
 {
-	this->date_of_last_service += interval;
+	this->date_of_last_service = std::max(this->date_of_last_service + interval, 0);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

As described in #10630, it's possible to use the date cheat to make vehicle's `date_of_last_service` negative.

## Description

Don't allow shifting the date of last service earlier than 0.

Closes #10630.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
