### PR TITLE
Fix: Extra viewport cannot be scrolled with right-click-close.

### DIFF
--- a/src/viewport_gui.cpp
+++ b/src/viewport_gui.cpp
@@ -134,6 +134,11 @@ public:
 		this->viewport->dest_scrollpos_y = this->viewport->scrollpos_y;
 	}
 
+	bool OnRightClick(Point pt, int widget) override
+	{
+		return widget == WID_EV_VIEWPORT;
+	}
+
 	void OnMouseWheel(int wheel) override
 	{
 		if (_settings_client.gui.scrollwheel_scrolling != 2) {


### PR DESCRIPTION
## Motivation / Problem

If right-click to close window is enabled, then trying to right-click to drag an extra viewport will just close it instead.

## Description

Fixed by handling OnRightClick() if the right-click happens on the viewport widget.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
