### PR TITLE
Change: Use cstdint instead of rolling our own types.

### DIFF
--- a/src/3rdparty/squirrel/include/squirrel.h
+++ b/src/3rdparty/squirrel/include/squirrel.h
@@ -32,9 +32,9 @@
 
 #include "../../../string_type.h"
 
-typedef __int64 SQInteger;
-typedef unsigned __int64 SQUnsignedInteger;
-typedef unsigned __int64 SQHash; /*should be the same size of a pointer*/
+typedef int64_t SQInteger;
+typedef uint64_t SQUnsignedInteger;
+typedef uint64_t SQHash; /*should be the same size of a pointer*/
 typedef int SQInt32;
 
 
@@ -44,7 +44,7 @@ typedef double SQFloat;
 typedef float SQFloat;
 #endif
 
-typedef __int64 SQRawObjectVal; //must be 64bits
+typedef int64_t SQRawObjectVal; //must be 64bits
 #define SQ_OBJECT_RAWINIT() { _unVal.raw = 0; }
 
 typedef void* SQUserPointer;

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -74,7 +74,7 @@ void LinkGraph::Compress()
 				if (edge.capacity < (1 << 16)) {
 					edge.travel_time_sum = edge.travel_time_sum * new_capacity / edge.capacity;
 				} else if (edge.travel_time_sum != 0) {
-					edge.travel_time_sum = std::max(1ULL, edge.travel_time_sum / 2);
+					edge.travel_time_sum = std::max<uint64>(1, edge.travel_time_sum / 2);
 				}
 				edge.capacity = new_capacity;
 				edge.usage /= 2;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -35,7 +35,6 @@
 #	include <unistd.h>
 #	define _DEFAULT_SOURCE
 #	define _GNU_SOURCE
-#	define TROUBLED_INTS
 #endif
 
 #if defined(__HAIKU__) || defined(__CYGWIN__)
@@ -57,46 +56,9 @@
 #	endif
 #endif
 
-/* The conditions for these constants to be available are way too messy; so check them one by one */
-#if !defined(UINT64_MAX)
-#	define UINT64_MAX (18446744073709551615ULL)
-#endif
-#if !defined(INT64_MAX)
-#	define INT64_MAX  (9223372036854775807LL)
-#endif
-#if !defined(INT64_MIN)
-#	define INT64_MIN  (-INT64_MAX - 1)
-#endif
-#if !defined(UINT32_MAX)
-#	define UINT32_MAX (4294967295U)
-#endif
-#if !defined(INT32_MAX)
-#	define INT32_MAX  (2147483647)
-#endif
-#if !defined(INT32_MIN)
-#	define INT32_MIN  (-INT32_MAX - 1)
-#endif
-#if !defined(UINT16_MAX)
-#	define UINT16_MAX (65535U)
-#endif
-#if !defined(INT16_MAX)
-#	define INT16_MAX  (32767)
-#endif
-#if !defined(INT16_MIN)
-#	define INT16_MIN  (-INT16_MAX - 1)
-#endif
-#if !defined(UINT8_MAX)
-#	define UINT8_MAX  (255)
-#endif
-#if !defined(INT8_MAX)
-#	define INT8_MAX   (127)
-#endif
-#if !defined(INT8_MIN)
-#	define INT8_MIN   (-INT8_MAX - 1)
-#endif
-
 #include <algorithm>
 #include <cstdio>
+#include <cstdint>
 #include <cstddef>
 #include <cstring>
 #include <cstdlib>
@@ -104,10 +66,6 @@
 #include <cassert>
 #include <memory>
 #include <string>
-
-#ifndef SIZE_MAX
-#	define SIZE_MAX ((size_t)-1)
-#endif
 
 #if defined(UNIX) || defined(__MINGW32__)
 #	include <sys/types.h>
@@ -343,36 +301,21 @@
 #define debug_inline inline
 #endif
 
-typedef unsigned char byte;
+typedef uint8_t byte;
 
 /* This is already defined in unix, but not in QNX Neutrino (6.x) or Cygwin. */
 #if (!defined(UNIX) && !defined(__HAIKU__)) || defined(__QNXNTO__) || defined(__CYGWIN__)
 	typedef unsigned int uint;
 #endif
 
-#if defined(TROUBLED_INTS)
-	/* Haiku's types for uint32/int32/uint64/int64 are different than what
-	 * they are on other platforms; not in length, but how to print them.
-	 * So make them more like the other platforms, to make printf() etc a
-	 * little bit easier. */
-#	define uint32 uint32_ugly_hack
-#	define int32 int32_ugly_hack
-#	define uint64 uint64_ugly_hack
-#	define int64 int64_ugly_hack
-	typedef unsigned int uint32_ugly_hack;
-	typedef signed int int32_ugly_hack;
-	typedef unsigned __int64 uint64_ugly_hack;
-	typedef signed __int64 int64_ugly_hack;
-#else
-	typedef unsigned char    uint8;
-	typedef   signed char     int8;
-	typedef unsigned short   uint16;
-	typedef   signed short    int16;
-	typedef unsigned int     uint32;
-	typedef   signed int      int32;
-	typedef unsigned __int64 uint64;
-	typedef   signed __int64  int64;
-#endif /* !TROUBLED_INTS */
+typedef uint8_t  uint8;
+typedef  int8_t   int8;
+typedef uint16_t uint16;
+typedef  int16_t  int16;
+typedef uint32_t uint32;
+typedef  int32_t  int32;
+typedef uint64_t uint64;
+typedef  int64_t  int64;
 
 #if !defined(WITH_PERSONAL_DIR)
 #	define PERSONAL_DIR ""


### PR DESCRIPTION
## Motivation / Problem

stdafx.h has some old cruft, one of which is where we define our own sized types and min/max definitions.

## Description

This change uses cstdint instead, and removes some Haiku workarounds that may or may not be needed these days -- they're 14 years old.

This does not change how we use our named types, that would conflict with everything...

## Limitations

There's still loads of cruft in stdafx.h!

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
