### PR TITLE
Codechange: Optimise FormatNumber by removing seprintf calls

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -330,7 +330,7 @@ static char *FormatNumber(char *buff, int64 number, const char *last, const char
 	int thousands_offset = (max_digits - fractional_digits - 1) % 3;
 
 	if (number < 0) {
-		buff += seprintf(buff, last, "-");
+		if (buff != last) *buff++ = '-';
 		number = -number;
 	}
 
@@ -340,7 +340,7 @@ static char *FormatNumber(char *buff, int64 number, const char *last, const char
 		if (i == max_digits - fractional_digits) {
 			const char *decimal_separator = _settings_game.locale.digit_decimal_separator.c_str();
 			if (StrEmpty(decimal_separator)) decimal_separator = _langpack.langpack->digit_decimal_separator;
-			buff += seprintf(buff, last, "%s", decimal_separator);
+			buff = strecpy(buff, decimal_separator, last);
 		}
 
 		uint64 quot = 0;
@@ -349,7 +349,7 @@ static char *FormatNumber(char *buff, int64 number, const char *last, const char
 			num = num % divisor;
 		}
 		if ((tot |= quot) || i >= max_digits - zerofill) {
-			buff += seprintf(buff, last, "%i", (int)quot);
+			if (buff != last) *buff++ = '0' + quot; // quot is a single digit
 			if ((i % 3) == thousands_offset && i < max_digits - 1 - fractional_digits) buff = strecpy(buff, separator, last);
 		}
 


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->
Doing some profiling for some reasons, I noticed that `FormatNumber` appeared in the profile to be taking ~6% of CPU time. This felt excessive, so investigated.
![](https://i.imgur.com/SN7oSUX.png)

Looks like FormatNumber calls `seprintf` an excessive number of times.

## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Initially I played around with using a basic `std::to_string(number)` and reforming the output as needed as what `FormatNumber` does currently seems unnecessarily complicated, but that quickly spiralled out of control into a "rewrite strings api to use std::string" rabbit hole.

Looked at the original function a bit closer and realised that it was calling `seprintf("%d")` for (every) single digit. This felt excessive, and was easily replaced.

With the following command line against a release build:

    ./build/openttd -X -c empty/empty.cfg -x -snull -mnull -vnull:ticks=30000 -g ./media/baseset/opntitle.dat

I get the following perf numbers,  before and after:

           3.58063 +- 0.00196 seconds time elapsed  ( +-  0.05% )
           3.48277 +- 0.00645 seconds time elapsed  ( +-  0.19% )

Similar improvement with wentbourne too

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Technically it's lost a bit of buffer overflow protection due to the removal of the last check from within `seprintf`? I don't think that's a problem in practice though.

There's an additional issue of why the finance window is redrawn quite as often as it is - it appears that this is due to `DrawOverlappedWindow`, but the window itself isn't overlapping anything, so...

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
