### PR TITLE
Extend callback 161 (engine name) with value 0x22 for autoreplace context - see #10399

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1038,7 +1038,12 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 		StringID str = hidden ? STR_HIDDEN_ENGINE_NAME : STR_ENGINE_NAME;
 		TextColour tc = (item.engine_id == selected_id) ? TC_WHITE : (TC_NO_SHADE | ((hidden | shaded) ? TC_GREY : TC_BLACK));
 
-		SetDParam(0, PackEngineNameDParam(item.engine_id, EngineNameContext::PurchaseList, item.indent));
+		if (show_count) {
+			/* relies on show_count to find 'Vehicle in use' panel of autoreplace window */
+			SetDParam(0, PackEngineNameDParam(item.engine_id, EngineNameContext::AutoreplaceVehicleInUse, item.indent));
+		} else {
+			SetDParam(0, PackEngineNameDParam(item.engine_id, EngineNameContext::PurchaseList, item.indent));
+		}
 		Rect itr = tr.Indent(indent, rtl);
 		DrawString(itr.left, itr.right, y + normal_text_y_offset, str, tc);
 		int sprite_x = ir.Indent(indent + circle_width + WidgetDimensions::scaled.hsep_normal, rtl).WithWidth(sprite_width, rtl).left + sprite_left;

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -186,10 +186,11 @@ enum EngineFlags {
  * Contexts an engine name can be shown in.
  */
 enum EngineNameContext : uint8 {
-	Generic        = 0x00, ///< No specific context available.
-	VehicleDetails = 0x11, ///< Name is shown in the vehicle details GUI.
-	PurchaseList   = 0x20, ///< Name is shown in the purchase list (including autoreplace window).
-	PreviewNews    = 0x21, ///< Name is shown in exclusive preview or newspaper.
+	Generic                 = 0x00, ///< No specific context available.
+	VehicleDetails          = 0x11, ///< Name is shown in the vehicle details GUI.
+	PurchaseList            = 0x20, ///< Name is shown in the purchase list (including autoreplace window 'Available vehicles' panel).
+	PreviewNews             = 0x21, ///< Name is shown in exclusive preview or newspaper.
+	AutoreplaceVehicleInUse = 0x22, ///< Name is show in the autoreplace window 'Vehicles in use' panel.
 };
 
 /** Combine an engine ID and a name context to an engine name dparam. */


### PR DESCRIPTION
## Motivation / Problem
Per https://github.com/OpenTTD/OpenTTD/pull/10399#issuecomment-1506692279
and the proposal, which Frosch has reviewed, in https://github.com/OpenTTD/OpenTTD/pull/10399#issuecomment-1510459144

## Description
Adds value 0x22, per https://github.com/OpenTTD/OpenTTD/pull/10399#issuecomment-1510459144

## Limitations
Describe here
* Is the problem solved in all scenarios?
** Hopefully
* Is this feature complete? Are there things that could be added in the future?
** N/A
* Are there things that are intentionally left out?
** No 
* Do you know of a bug or corner case that does not work?
** Didn't find any yet.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
    * Yes
* This PR touches english.txt or translations? Check the [guidelines]
    * No
* This PR affects the save game format? (label 'savegame upgrade')
    * No
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * No
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * Yes 
        * newgrf_debug_data.h may need updating.  **TBC**
        * [PR must be added to API tracker] *TBC*(https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
