### PR TITLE
Fix #10660: Sprite Font scale affected by viewport zoom level limits.

### DIFF
--- a/src/fontcache/spritefontcache.cpp
+++ b/src/fontcache/spritefontcache.cpp
@@ -22,6 +22,16 @@
 static const int ASCII_LETTERSTART = 32; ///< First printable ASCII letter.
 
 /**
+ * Scale traditional pixel dimensions to font zoom level, for drawing sprite fonts.
+ * @param value Pixel amount at #ZOOM_LVL_BASE (traditional "normal" interface size).
+ * @return Pixel amount at _font_zoom (current interface size).
+ */
+static int ScaleFontTrad(int value)
+{
+	return UnScaleByZoom(value * ZOOM_LVL_BASE, _font_zoom);
+}
+
+/**
  * Create a new sprite font cache.
  * @param fs The font size to create the cache for.
  */
@@ -29,7 +39,7 @@ SpriteFontCache::SpriteFontCache(FontSize fs) : FontCache(fs), glyph_to_spriteid
 {
 	this->InitializeUnicodeGlyphMap();
 	this->height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
-	this->ascender = (this->height - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
+	this->ascender = (this->height - ScaleFontTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
 }
 
 /**
@@ -106,7 +116,7 @@ void SpriteFontCache::ClearFontCache()
 {
 	Layouter::ResetFontCache(this->fs);
 	this->height = ScaleGUITrad(FontCache::GetDefaultFontHeight(this->fs));
-	this->ascender = (this->height - ScaleSpriteTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
+	this->ascender = (this->height - ScaleFontTrad(FontCache::GetDefaultFontHeight(this->fs))) / 2;
 }
 
 const Sprite *SpriteFontCache::GetGlyph(GlyphID key)
@@ -120,7 +130,7 @@ uint SpriteFontCache::GetGlyphWidth(GlyphID key)
 {
 	SpriteID sprite = this->GetUnicodeGlyph(key);
 	if (sprite == 0) sprite = this->GetUnicodeGlyph('?');
-	return SpriteExists(sprite) ? GetSprite(sprite, SpriteType::Font)->width + ScaleSpriteTrad(this->fs != FS_NORMAL ? 1 : 0) : 0;
+	return SpriteExists(sprite) ? GetSprite(sprite, SpriteType::Font)->width + ScaleFontTrad(this->fs != FS_NORMAL ? 1 : 0) : 0;
 }
 
 bool SpriteFontCache::GetDrawGlyphShadow()

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -61,9 +61,10 @@ static void GfxMainBlitter(const Sprite *sprite, int x, int y, BlitterMode mode,
 
 static ReusableBuffer<uint8> _cursor_backup;
 
-ZoomLevel _gui_zoom = ZOOM_LVL_OUT_4X;     ///< GUI Zoom level
-int _gui_scale      = MIN_INTERFACE_SCALE; ///< GUI scale, 100 is 100%.
-int _gui_scale_cfg;                        ///< GUI scale in config.
+ZoomLevel _gui_zoom  = ZOOM_LVL_OUT_4X;     ///< GUI Zoom level
+ZoomLevel _font_zoom = _gui_zoom;           ///< Sprite font Zoom level (not clamped)
+int _gui_scale       = MIN_INTERFACE_SCALE; ///< GUI scale, 100 is 100%.
+int _gui_scale_cfg;                         ///< GUI scale in config.
 
 /**
  * The rect for repaint.
@@ -2049,6 +2050,8 @@ void UpdateGUIZoom()
 	}
 
 	int8 new_zoom = ScaleGUITrad(1) <= 1 ? ZOOM_LVL_OUT_4X : ScaleGUITrad(1) >= 4 ? ZOOM_LVL_MIN : ZOOM_LVL_OUT_2X;
+	/* Font glyphs should not be clamped to min/max zoom. */
+	_font_zoom = static_cast<ZoomLevel>(new_zoom);
 	/* Ensure the gui_zoom is clamped between min/max. */
 	new_zoom = Clamp(new_zoom, _settings_client.gui.zoom_min, _settings_client.gui.zoom_max);
 	_gui_zoom = static_cast<ZoomLevel>(new_zoom);
@@ -2062,16 +2065,19 @@ void UpdateGUIZoom()
  */
 bool AdjustGUIZoom(bool automatic)
 {
-	ZoomLevel old_zoom = _gui_zoom;
+	ZoomLevel old_gui_zoom = _gui_zoom;
+	ZoomLevel old_font_zoom = _font_zoom;
 	int old_scale = _gui_scale;
 	UpdateGUIZoom();
 	if (old_scale == _gui_scale) return false;
 
 	/* Reload sprites if sprite zoom level has changed. */
-	if (old_zoom != _gui_zoom) {
+	if (old_gui_zoom != _gui_zoom) {
 		GfxClearSpriteCache();
 		VideoDriver::GetInstance()->ClearSystemSprites();
 		UpdateCursorSize();
+	} else if (old_font_zoom != _font_zoom) {
+		GfxClearFontSpriteCache();
 	}
 
 	ClearFontCache();
@@ -2080,7 +2086,7 @@ bool AdjustGUIZoom(bool automatic)
 
 	/* Adjust all window sizes to match the new zoom level, so that they don't appear
 	   to move around when the application is moved to a screen with different DPI. */
-	auto zoom_shift = old_zoom - _gui_zoom;
+	auto zoom_shift = old_gui_zoom - _gui_zoom;
 	for (Window *w : Window::Iterate()) {
 		if (automatic) {
 			w->left   = (w->left   * _gui_scale) / old_scale;

--- a/src/spritecache.cpp
+++ b/src/spritecache.cpp
@@ -519,14 +519,14 @@ static void *ReadSprite(const SpriteCache *sc, SpriteID id, SpriteType sprite_ty
 		return (void*)GetRawSprite(SPR_IMG_QUERY, SpriteType::Normal, allocator, encoder);
 	}
 
-	if (sprite->type == SpriteType::Font && ZOOM_LVL_GUI != ZOOM_LVL_NORMAL) {
+	if (sprite->type == SpriteType::Font && _font_zoom != ZOOM_LVL_NORMAL) {
 		/* Make ZOOM_LVL_NORMAL be ZOOM_LVL_GUI */
-		sprite[ZOOM_LVL_NORMAL].width  = sprite[ZOOM_LVL_GUI].width;
-		sprite[ZOOM_LVL_NORMAL].height = sprite[ZOOM_LVL_GUI].height;
-		sprite[ZOOM_LVL_NORMAL].x_offs = sprite[ZOOM_LVL_GUI].x_offs;
-		sprite[ZOOM_LVL_NORMAL].y_offs = sprite[ZOOM_LVL_GUI].y_offs;
-		sprite[ZOOM_LVL_NORMAL].data   = sprite[ZOOM_LVL_GUI].data;
-		sprite[ZOOM_LVL_NORMAL].colours = sprite[ZOOM_LVL_GUI].colours;
+		sprite[ZOOM_LVL_NORMAL].width  = sprite[_font_zoom].width;
+		sprite[ZOOM_LVL_NORMAL].height = sprite[_font_zoom].height;
+		sprite[ZOOM_LVL_NORMAL].x_offs = sprite[_font_zoom].x_offs;
+		sprite[ZOOM_LVL_NORMAL].y_offs = sprite[_font_zoom].y_offs;
+		sprite[ZOOM_LVL_NORMAL].data   = sprite[_font_zoom].data;
+		sprite[ZOOM_LVL_NORMAL].colours = sprite[_font_zoom].colours;
 	}
 
 	return encoder->Encode(sprite, allocator);
@@ -1046,6 +1046,19 @@ void GfxClearSpriteCache()
 	}
 
 	VideoDriver::GetInstance()->ClearSystemSprites();
+}
+
+/**
+ * Remove all encoded font sprites from the sprite cache without
+ * discarding sprite location information.
+ */
+void GfxClearFontSpriteCache()
+{
+	/* Clear sprite ptr for all cached font items */
+	for (uint i = 0; i != _spritecache_items; i++) {
+		SpriteCache *sc = GetSpriteCache(i);
+		if (sc->type == SpriteType::Font && sc->ptr != nullptr) DeleteEntryFromSpriteCache(i);
+	}
 }
 
 /* static */ ReusableBuffer<SpriteLoader::CommonPixel> SpriteLoader::Sprite::buffer[ZOOM_LVL_COUNT];

--- a/src/spritecache.h
+++ b/src/spritecache.h
@@ -58,6 +58,7 @@ static inline const byte *GetNonSprite(SpriteID sprite, SpriteType type)
 
 void GfxInitSpriteMem();
 void GfxClearSpriteCache();
+void GfxClearFontSpriteCache();
 void IncreaseSpriteLRU();
 
 SpriteFile &OpenCachedSpriteFile(const std::string &filename, Subdirectory subdir, bool palette_remap);

--- a/src/spriteloader/grf.cpp
+++ b/src/spriteloader/grf.cpp
@@ -282,11 +282,12 @@ uint8 LoadSpriteV2(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_p
 		if (sprite_type != SpriteType::MapGen) {
 			if (zoom < lengthof(zoom_lvl_map)) {
 				is_wanted_zoom_lvl = true;
-				if (_settings_client.gui.sprite_zoom_min >= ZOOM_LVL_OUT_2X &&
+				ZoomLevel zoom_min = sprite_type == SpriteType::Font ? ZOOM_LVL_NORMAL : _settings_client.gui.sprite_zoom_min;
+				if (zoom_min >= ZOOM_LVL_OUT_2X &&
 						HasBit(control_flags, load_32bpp ? SCCF_ALLOW_ZOOM_MIN_2X_32BPP : SCCF_ALLOW_ZOOM_MIN_2X_PAL) && zoom_lvl_map[zoom] < ZOOM_LVL_OUT_2X) {
 					is_wanted_zoom_lvl = false;
 				}
-				if (_settings_client.gui.sprite_zoom_min >= ZOOM_LVL_OUT_4X &&
+				if (zoom_min >= ZOOM_LVL_OUT_4X &&
 						HasBit(control_flags, load_32bpp ? SCCF_ALLOW_ZOOM_MIN_1X_32BPP : SCCF_ALLOW_ZOOM_MIN_1X_PAL) && zoom_lvl_map[zoom] < ZOOM_LVL_OUT_4X) {
 					is_wanted_zoom_lvl = false;
 				}

--- a/src/zoom_type.h
+++ b/src/zoom_type.h
@@ -52,6 +52,7 @@ extern int _gui_scale;
 extern int _gui_scale_cfg;
 
 extern ZoomLevel _gui_zoom;
+extern ZoomLevel _font_zoom;
 #define ZOOM_LVL_GUI (_gui_zoom)
 
 static const int MIN_INTERFACE_SCALE = 100;


### PR DESCRIPTION
## Motivation / Problem

The maximum viewport zoom level setting inadvertently affects the scaled sprite font, since with variable interface scaling all the font_zoom related variables were merged with gui_zoom.

This issue does not affect scaleable fonts, only the built-in sprite font.

![image](https://user-images.githubusercontent.com/639850/232340525-12e0321c-867c-4ca2-bd2e-be424766305f.png)

## Description

Add separate _font_zoom which is only used to scale the sprite font. This is not clamped to the viewport zoom level limits, so always follows interface scale.

![image](https://user-images.githubusercontent.com/639850/232340533-f451e48a-aa53-4889-8366-044dca528399.png)

## Limitations

Non-font sprites are still limited to the viewport zoom level, even when shown in a GUI. This is because there's currently no differentiation between viewport sprites and gui sprites, and also some sprites are used in both locations.

Could possibly be done but I think it's separate to this.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
