### PR TITLE
Fix #10627: Houses subsitute specs should only be copied on first definition.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2409,6 +2409,9 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 					housespec->random_colour[2] = 0x0C;  // they stand for red, blue, orange and green
 					housespec->random_colour[3] = 0x06;
 
+					/* House flags 40 and 80 are exceptions; these flags are never set automatically. */
+					housespec->building_flags &= ~(BUILDING_IS_CHURCH | BUILDING_IS_STADIUM);
+
 					/* Make sure that the third cargo type is valid in this
 					 * climate. This can cause problems when copying the properties
 					 * of a house that accepts food, where the new house is valid

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2396,25 +2396,26 @@ static ChangeInfoResult TownHouseChangeInfo(uint hid, int numinfo, int prop, Byt
 
 				/* Allocate space for this house. */
 				if (housespec == nullptr) {
+					/* Only the first property 08 setting copies properties; if you later change it, properties will stay. */
 					_cur.grffile->housespec[hid + i] = std::make_unique<HouseSpec>(*HouseSpec::Get(subs_id));
 					housespec = _cur.grffile->housespec[hid + i].get();
-				}
 
-				housespec->enabled = true;
-				housespec->grf_prop.local_id = hid + i;
-				housespec->grf_prop.subst_id = subs_id;
-				housespec->grf_prop.grffile = _cur.grffile;
-				housespec->random_colour[0] = 0x04;  // those 4 random colours are the base colour
-				housespec->random_colour[1] = 0x08;  // for all new houses
-				housespec->random_colour[2] = 0x0C;  // they stand for red, blue, orange and green
-				housespec->random_colour[3] = 0x06;
+					housespec->enabled = true;
+					housespec->grf_prop.local_id = hid + i;
+					housespec->grf_prop.subst_id = subs_id;
+					housespec->grf_prop.grffile = _cur.grffile;
+					housespec->random_colour[0] = 0x04;  // those 4 random colours are the base colour
+					housespec->random_colour[1] = 0x08;  // for all new houses
+					housespec->random_colour[2] = 0x0C;  // they stand for red, blue, orange and green
+					housespec->random_colour[3] = 0x06;
 
-				/* Make sure that the third cargo type is valid in this
-				 * climate. This can cause problems when copying the properties
-				 * of a house that accepts food, where the new house is valid
-				 * in the temperate climate. */
-				if (!CargoSpec::Get(housespec->accepts_cargo[2])->IsValid()) {
-					housespec->cargo_acceptance[2] = 0;
+					/* Make sure that the third cargo type is valid in this
+					 * climate. This can cause problems when copying the properties
+					 * of a house that accepts food, where the new house is valid
+					 * in the temperate climate. */
+					if (!CargoSpec::Get(housespec->accepts_cargo[2])->IsValid()) {
+						housespec->cargo_acceptance[2] = 0;
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
## Motivation / Problem

#10627 broke "ITL Houses 2.1" which redefines a house after having defined it already. Before #10627, this action would copy the substituted house specs again, after #10627 this copy only happened on first definition, but the overrides and checks were still performed, which could fail the second time.

However... this opened a can of worms, as the spec, since at least 2007 and probably earlier, states that only the first definition copies anything:

> Only the first property 08 setting copies properties; if you later change it, properties will stay. 

In addition, another step has been missed, that the church/stadium flags should not be copied.

> House flags 40 and 80 are exceptions; these flags are never set automatically.

So before #10627, substitue specs were always copied despite redefinition, and church/stadium flags were carried over too.

## Description

This PR changes OpenTTD to match the specs, so that only the first definition counts, no further substitute copying occurs, and the church/stadium flags are cleared.

This pattern makes more sense as it matches every other feature.

However this may potentially make some NewGRFs behave differently: potentially they were 'always broken' in this case.

None-the-less this change does fix the error that prevents "ITL Houses 2.1" from loading.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
