### PR TITLE
Add: NewGRF persistent storage for vehicles.

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -421,7 +421,7 @@ uint32_t CommandCost::textref_stack[16];
  */
 void CommandCost::UseTextRefStack(const GRFFile *grffile, uint num_registers)
 {
-	extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
+	extern TemporaryStorageArray _temp_store;
 
 	assert(num_registers < lengthof(textref_stack));
 	this->textref_stack_grffile = grffile;

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -186,7 +186,7 @@ public:
 	 * @param grfid Parameter for the PSA. Only required for items with parameters.
 	 * @return Span of the storage array or an empty span when not present.
 	 */
-	virtual const std::span<int32_t> GetPSA([[maybe_unused]] uint index, [[maybe_unused]] uint32_t grfid) const
+	virtual std::span<const int32_t> GetPSA([[maybe_unused]] uint index, [[maybe_unused]] uint32_t grfid) const
 	{
 		return {};
 	}
@@ -468,9 +468,11 @@ struct NewGRFInspectWindow : Window {
 			} else {
 				this->DrawString(r, i++, "Persistent storage:");
 			}
-			assert(psa.size() % 4 == 0);
-			for (size_t j = 0; j < psa.size(); j += 4) {
-				this->DrawString(r, i++, fmt::format("  {}: {} {} {} {}", j, psa[j], psa[j + 1], psa[j + 2], psa[j + 3]));
+			for (uint index = 0; const int32_t &value : psa) {
+				if (value != 0) {
+					this->DrawString(r, i++, fmt::format("  {:02x}: {:08x} ({})", index, value, value));
+				}
+				++index;
 			}
 		}
 

--- a/src/newgrf_engine.h
+++ b/src/newgrf_engine.h
@@ -41,6 +41,7 @@ struct VehicleScopeResolver : public ScopeResolver {
 	uint32_t GetRandomBits() const override;
 	uint32_t GetVariable(uint8_t variable, [[maybe_unused]] uint32_t parameter, bool &available) const override;
 	uint32_t GetTriggers() const override;
+	void StorePSA(uint pos, int32_t value) override;
 };
 
 /** Resolver for a vehicle (chain) */

--- a/src/newgrf_spritegroup.cpp
+++ b/src/newgrf_spritegroup.cpp
@@ -18,7 +18,7 @@
 SpriteGroupPool _spritegroup_pool("SpriteGroup");
 INSTANTIATE_POOL_METHODS(SpriteGroup)
 
-TemporaryStorageArray<int32_t, 0x110> _temp_store;
+TemporaryStorageArray _temp_store;
 
 
 /**

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -28,7 +28,7 @@
  */
 inline uint32_t GetRegister(uint i)
 {
-	extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
+	extern TemporaryStorageArray _temp_store;
 	return _temp_store.GetValue(i);
 }
 

--- a/src/newgrf_storage.h
+++ b/src/newgrf_storage.h
@@ -60,12 +60,11 @@ private:
 /**
  * Class for persistent storage of data.
  * On #ClearChanges that data is either reverted or saved.
- * @tparam TYPE the type of variable to store.
  * @tparam SIZE the size of the array.
  */
-template <typename TYPE, uint SIZE>
+template <uint SIZE>
 struct PersistentStorageArray : BasePersistentStorageArray {
-	using StorageType = std::array<TYPE, SIZE>;
+	using StorageType = std::array<int32_t, SIZE>;
 
 	StorageType storage{}; ///< Memory for the storage array
 	std::unique_ptr<StorageType> prev_storage{}; ///< Temporary memory to store previous state so it can be reverted, e.g. for command tests.
@@ -105,7 +104,7 @@ struct PersistentStorageArray : BasePersistentStorageArray {
 	 * @param pos the position to get the data from
 	 * @return the data from that position
 	 */
-	TYPE GetValue(uint pos) const
+	int32_t GetValue(uint pos) const
 	{
 		/* Out of the scope of the array */
 		if (pos >= SIZE) return 0;
@@ -126,12 +125,11 @@ struct PersistentStorageArray : BasePersistentStorageArray {
 /**
  * Class for temporary storage of data.
  * On #ClearChanges that data is always zero-ed.
- * @tparam TYPE the type of variable to store.
- * @tparam SIZE the size of the array.
  */
-template <typename TYPE, uint SIZE>
 struct TemporaryStorageArray {
-	using StorageType = std::array<TYPE, SIZE>;
+	static constexpr size_t SIZE = 0x110;
+
+	using StorageType = std::array<int32_t, SIZE>;
 	using StorageInitType = std::array<uint16_t, SIZE>;
 
 	StorageType storage{}; ///< Memory for the storage array
@@ -143,7 +141,7 @@ struct TemporaryStorageArray {
 	 * @param pos   the position to write at
 	 * @param value the value to write
 	 */
-	void StoreValue(uint pos, int32_t value)
+	inline void StoreValue(uint pos, int32_t value)
 	{
 		/* Out of the scope of the array */
 		if (pos >= SIZE) return;
@@ -157,7 +155,7 @@ struct TemporaryStorageArray {
 	 * @param pos the position to get the data from
 	 * @return the data from that position
 	 */
-	TYPE GetValue(uint pos) const
+	inline int32_t GetValue(uint pos) const
 	{
 		/* Out of the scope of the array */
 		if (pos >= SIZE) return 0;
@@ -170,7 +168,7 @@ struct TemporaryStorageArray {
 		return this->storage[pos];
 	}
 
-	void ClearChanges()
+	inline void ClearChanges()
 	{
 		/* Increment init_key to invalidate all storage */
 		this->init_key++;
@@ -184,7 +182,7 @@ struct TemporaryStorageArray {
 
 void AddChangedPersistentStorage(BasePersistentStorageArray *storage);
 
-typedef PersistentStorageArray<int32_t, 16> OldPersistentStorage;
+typedef PersistentStorageArray<16> OldPersistentStorage;
 
 typedef uint32_t PersistentStorageID;
 
@@ -196,7 +194,7 @@ extern PersistentStoragePool _persistent_storage_pool;
 /**
  * Class for pooled persistent storage of data.
  */
-struct PersistentStorage : PersistentStorageArray<int32_t, 256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
+struct PersistentStorage : PersistentStorageArray<256>, PersistentStoragePool::PoolItem<&_persistent_storage_pool> {
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	PersistentStorage(const uint32_t new_grfid, uint8_t feature, TileIndex tile)
 	{

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -797,7 +797,7 @@ void RestoreTextRefStackBackup(struct TextRefStack *backup)
  */
 void StartTextRefStackUsage(const GRFFile *grffile, uint8_t numEntries, const uint32_t *values)
 {
-	extern TemporaryStorageArray<int32_t, 0x110> _temp_store;
+	extern TemporaryStorageArray _temp_store;
 
 	_newgrf_textrefstack.ResetStack(grffile);
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -48,6 +48,7 @@
 #include "../subsidy_base.h"
 #include "../subsidy_func.h"
 #include "../newgrf.h"
+#include "../newgrf_debug.h"
 #include "../newgrf_station.h"
 #include "../engine_func.h"
 #include "../rail_gui.h"
@@ -288,6 +289,11 @@ static void InitializeWindowsAndCaches()
 		for (auto &it : t->psa_list) {
 			it->feature = GSF_FAKE_TOWNS;
 			it->tile = t->xy;
+		}
+	}
+	for (Vehicle *v : Vehicle::Iterate()) {
+		if (v->psa != nullptr) {
+			v->psa->feature = GetGrfSpecFeature(v->type);
 		}
 	}
 	for (RoadVehicle *rv : RoadVehicle::Iterate()) {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2800,16 +2800,7 @@ bool AfterLoadGame()
 			for (Industry *ind : Industry::Iterate()) {
 				assert(ind->psa != nullptr);
 
-				/* Check if the old storage was empty. */
-				bool is_empty = true;
-				for (uint i = 0; i < sizeof(ind->psa->storage); i++) {
-					if (ind->psa->GetValue(i) != 0) {
-						is_empty = false;
-						break;
-					}
-				}
-
-				if (!is_empty) {
+				if (!ind->psa->storage.empty()) {
 					ind->psa->grfid = _industry_mngr.GetGRFID(ind->type);
 				} else {
 					delete ind->psa;
@@ -2823,21 +2814,11 @@ bool AfterLoadGame()
 				if (!(st->facilities & FACIL_AIRPORT)) continue;
 				assert(st->airport.psa != nullptr);
 
-				/* Check if the old storage was empty. */
-				bool is_empty = true;
-				for (uint i = 0; i < sizeof(st->airport.psa->storage); i++) {
-					if (st->airport.psa->GetValue(i) != 0) {
-						is_empty = false;
-						break;
-					}
-				}
-
-				if (!is_empty) {
+				if (!st->airport.psa->storage.empty()) {
 					st->airport.psa->grfid = _airport_mngr.GetGRFID(st->airport.type);
 				} else {
 					delete st->airport.psa;
 					st->airport.psa = nullptr;
-
 				}
 			}
 		}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -395,6 +395,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_PATH_CACHE_FORMAT,                  ///< 346  PR#12345 Vehicle path cache format changed.
 	SLV_ANIMATED_TILE_STATE_IN_MAP,         ///< 347  PR#13082 Animated tile state saved for improved performance.
 	SLV_INCREASE_HOUSE_LIMIT,               ///< 348  PR#12288 Increase house limit to 4096.
+	SLV_VARIABLE_PERSISTENT_STORAGE,        ///< 349  PR#10670 NewGRF persistent storage moved from fixed array to dynamic.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -397,6 +397,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_INCREASE_HOUSE_LIMIT,               ///< 348  PR#12288 Increase house limit to 4096.
 	SLV_VARIABLE_PERSISTENT_STORAGE,        ///< 349  PR#10670 NewGRF persistent storage moved from fixed array to dynamic.
 
+	SLV_VEHICLE_STORAGE,                    ///< 350  PR#10670 Addition of persistent storage for vehicles.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/storage_sl.cpp
+++ b/src/saveload/storage_sl.cpp
@@ -16,11 +16,51 @@
 
 #include "../safeguards.h"
 
+/**
+ * Convert old fixed-sized array of persistent storage.
+ * @param old_storage Span containing range of old persistent storage.
+ * @returns Pointer to pool-allocated PersistentStorage object.
+ */
+PersistentStorage *ConvertOldPersistentStorage(std::span<const int32_t> old_storage)
+{
+	/* Find last non-zero value to truncate the storage. */
+	auto last = std::find_if(std::rbegin(old_storage), std::rend(old_storage), [](uint32_t value) { return value != 0; }).base();
+	if (last == std::begin(old_storage)) return nullptr;
+
+	assert(PersistentStorage::CanAllocateItem());
+	PersistentStorage *ps = new PersistentStorage(0, 0, TileIndex{});
+
+	ps->storage.reserve(std::distance(std::begin(old_storage), last));
+	for (auto it = std::begin(old_storage); it != last; ++it) {
+		ps->storage.push_back(*it);
+	}
+
+	return ps;
+}
+
+class SlPersistentStorage : public VectorSaveLoadHandler<SlPersistentStorage, PersistentStorage, int32_t> {
+public:
+	struct PersistentStorageWrapper {
+		int32_t value;
+	};
+
+	inline static const SaveLoad description[] = {
+		SLE_VAR(PersistentStorageWrapper, value, SLE_INT32),
+	};
+	inline const static SaveLoadCompatTable compat_description = {};
+
+	std::vector<int32_t> &GetVector(PersistentStorage *ps) const override { return ps->storage; }
+};
+
+/** Old persistent storage was a fixed array of up to 256 elements. */
+static std::array<int32_t, 256> _old_persistent_storage;
+
 /** Description of the data to save and load in #PersistentStorage. */
 static const SaveLoad _storage_desc[] = {
 	 SLE_CONDVAR(PersistentStorage, grfid,    SLE_UINT32,                  SLV_6, SL_MAX_VERSION),
-	 SLE_CONDARR(PersistentStorage, storage,  SLE_UINT32,  16,           SLV_161, SLV_EXTEND_PERSISTENT_STORAGE),
-	 SLE_CONDARR(PersistentStorage, storage,  SLE_UINT32, 256,           SLV_EXTEND_PERSISTENT_STORAGE, SL_MAX_VERSION),
+	 SLEG_CONDARR("storage", _old_persistent_storage, SLE_FILE_U32 | SLE_VAR_I32,  16, SLV_161, SLV_EXTEND_PERSISTENT_STORAGE),
+	 SLEG_CONDARR("storage", _old_persistent_storage, SLE_FILE_U32 | SLE_VAR_I32, 256, SLV_EXTEND_PERSISTENT_STORAGE, SLV_VARIABLE_PERSISTENT_STORAGE),
+	SLEG_CONDSTRUCTLIST("storage", SlPersistentStorage, SLV_VARIABLE_PERSISTENT_STORAGE, SL_MAX_VERSION),
 };
 
 /** Persistent storage data. */
@@ -31,12 +71,21 @@ struct PSACChunkHandler : ChunkHandler {
 	{
 		const std::vector<SaveLoad> slt = SlCompatTableHeader(_storage_desc, _storage_sl_compat);
 
+		_old_persistent_storage.fill(0);
 		int index;
 
 		while ((index = SlIterateArray()) != -1) {
 			assert(PersistentStorage::CanAllocateItem());
 			PersistentStorage *ps = new (index) PersistentStorage(0, 0, TileIndex{});
 			SlObject(ps, slt);
+
+			if (IsSavegameVersionBefore(SLV_VARIABLE_PERSISTENT_STORAGE)) {
+				auto last = std::find_if(std::rbegin(_old_persistent_storage), std::rend(_old_persistent_storage), [](uint32_t value) { return value != 0; }).base();
+				ps->storage.reserve(std::distance(std::begin(_old_persistent_storage), last));
+				for (auto it = std::begin(_old_persistent_storage); it != last; ++it) {
+					ps->storage.push_back(*it);
+				}
+			}
 		}
 	}
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -767,6 +767,7 @@ public:
 		SLE_CONDVAR(Vehicle, depot_unbunching_last_departure, SLE_UINT64,        SLV_DEPOT_UNBUNCHING, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, depot_unbunching_next_departure, SLE_UINT64,        SLV_DEPOT_UNBUNCHING, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, round_trip_time,       SLE_INT32,                   SLV_DEPOT_UNBUNCHING, SL_MAX_VERSION),
+		SLE_CONDREF(Vehicle, psa,                   REF_STORAGE,                 SLV_VEHICLE_STORAGE, SL_MAX_VERSION),
 	};
 
 	inline const static SaveLoadCompatTable compat_description = _vehicle_common_sl_compat;

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -84,6 +84,13 @@ class NIHVehicle : public NIHelper {
 		VehicleResolverObject ro(v->engine_type, v, VehicleResolverObject::WO_CACHED);
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
+
+	std::span<const int32_t> GetPSA(uint index, uint32_t) const override
+	{
+		const Vehicle *v = Vehicle::Get(index);
+		if (v->psa == nullptr) return {};
+		return v->psa->storage;
+	}
 };
 
 static const NIFeature _nif_vehicle = {

--- a/src/table/newgrf_debug_data.h
+++ b/src/table/newgrf_debug_data.h
@@ -381,7 +381,7 @@ class NIHIndustry : public NIHelper {
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 
-	const std::span<int32_t> GetPSA(uint index, uint32_t) const override
+	std::span<const int32_t> GetPSA(uint index, uint32_t) const override
 	{
 		const Industry *i = (const Industry *)this->GetInstance(index);
 		if (i->psa == nullptr) return {};
@@ -557,7 +557,7 @@ class NIHAirport : public NIHelper {
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 
-	const std::span<int32_t> GetPSA(uint index, uint32_t) const override
+	std::span<const int32_t> GetPSA(uint index, uint32_t) const override
 	{
 		const Station *st = (const Station *)this->GetInstance(index);
 		if (st->airport.psa == nullptr) return {};
@@ -603,7 +603,7 @@ class NIHTown : public NIHelper {
 		return ro.GetScope(VSG_SCOPE_SELF)->GetVariable(var, param, avail);
 	}
 
-	const std::span<int32_t> GetPSA(uint index, uint32_t grfid) const override
+	std::span<const int32_t> GetPSA(uint index, uint32_t grfid) const override
 	{
 		Town *t = Town::Get(index);
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -901,6 +901,8 @@ Vehicle::~Vehicle()
 	 * it may happen that vehicle chain is deleted when visible */
 	if (!(this->vehstatus & VS_HIDDEN)) this->MarkAllViewportsDirty();
 
+	delete this->psa;
+
 	Vehicle *v = this->Next();
 	this->SetNext(nullptr);
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -367,6 +367,8 @@ public:
 
 	mutable MutableSpriteCache sprite_cache; ///< Cache of sprites and values related to recalculating them, see #MutableSpriteCache
 
+	struct PersistentStorage *psa;      ///< Persistent storage
+
 	/**
 	 * Calculates the weight value that this vehicle will have when fully loaded with its current cargo.
 	 * @return Weight value in tonnes.


### PR DESCRIPTION
## Motivation / Problem

People asked for persistent storage for vehicles. This could e.g. allow complex chain calculations to be performed only during the attach callback.

This bumps the savegame so take a backup...

## Description

This probably implements this, but I'm not able to test it. 

~~It likely bloats things if lots of vehicles use persistent storage, as a store allocates 1KB for the vehicle. If you have 10,000 vehicles (e.g. 1000 * 5 tile trains) that's 10MB without thinking about it.~~

PersistentStorageArray is changed to an std::vector. This allows using only as many storage slots as necessary, so the previous 1KB fixed array (256 x uint32_t) is no longer an issue.

PersistentStorage is only allocated if the vehicle uses it.

~~Two callbacks have write access enabled for PersistentStorage: CBID_VEHICLE_START_STOP_CHECK and CBID_TRAIN_ALLOW_WAGON_ATTACH. This is rudimentary and could be extended.~~

## Limitations

All the vehicle callback stuff is const, so there's a const_cast in there to get rid of that. Nasty.

~~Also PersistentStorage needs NewGRF feature, which isn't the same as vehicle type, so I was lazy there too. This is supposed to be updated on load but I didn't do that. **What does this mean? I don't remember...**~~

~~Also missing NewGRF debug GUI stuff.~~

Desync-inviting.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
