### PR TITLE
Change title screen GUI: Move buttons to bottom edge of screen

### DIFF
--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -31,6 +31,7 @@
 #include "signs_base.h"
 #include "viewport_func.h"
 #include "vehicle_base.h"
+#include "zoom_func.h"
 #include <regex>
 
 #include "widgets/intro_widget.h"
@@ -259,17 +260,74 @@ struct IntroGameAnimator {
 };
 
 
+enum class SelectGameWindowNumber : WindowNumber {
+	StartGame = 0,
+	SetupContent = 1,
+	SetupGame = 2,
+};
+
+Point PositionSelectGameWindow(Window *w)
+{
+	/* State to reposition the side windows above the centre window if they would overlap.
+	 * Doing this depends on the windows being ordered/handled with the centre window first. */
+	static int start_game_window_width = 0;
+	static int start_game_window_top = 0;
+
+	Point p;
+	const int edge_offset = ScaleGUITrad(20);
+	const int width = w->width;
+	const int height = w->height;
+
+	switch (w->window_number) {
+		case static_cast<int>(SelectGameWindowNumber::StartGame):
+			/* Centre part */
+			p.x = (_screen.width - width) / 2;
+			p.y = _screen.height - height - edge_offset;
+			start_game_window_width = width;
+			start_game_window_top = p.y;
+			return p;
+
+		case static_cast<int>(SelectGameWindowNumber::SetupContent):
+			/* Left part */
+			p.x = edge_offset;
+			p.y = _screen.height - height - edge_offset;
+			if (p.x + width > (_screen.width - start_game_window_width) / 2 && start_game_window_top != 0) {
+				p.y = start_game_window_top - height - edge_offset / 2;
+			}
+			return p;
+
+		case static_cast<int>(SelectGameWindowNumber::SetupGame):
+			/* Right part */
+			p.x = _screen.width - width - edge_offset;
+			p.y = _screen.height - height - edge_offset;
+			if (p.x - start_game_window_width < (_screen.width - start_game_window_width) / 2 && start_game_window_top != 0) {
+				p.y = start_game_window_top - height - edge_offset / 2;
+			}
+			return p;
+
+		default:
+			NOT_REACHED();
+	}
+}
+
 struct SelectGameWindow : public Window {
 	std::unique_ptr<IntroGameAnimator> intro_animator;
 
-	SelectGameWindow(WindowDesc *desc) : Window(desc)
+	SelectGameWindow(WindowDesc *desc, SelectGameWindowNumber window_number) : Window(desc)
 	{
 		this->CreateNestedTree();
-		this->FinishInitNested(0);
+		this->FinishInitNested(static_cast<WindowNumber>(window_number));
 		this->OnInvalidateData();
 
+		if (window_number == SelectGameWindowNumber::StartGame) {
 			this->intro_animator.reset(new IntroGameAnimator());
 		}
+	}
+
+	Point OnInitialPosition(int16 sm_width, int16 sm_height, int window_number) override
+	{
+		return PositionSelectGameWindow(this);
+	}
 
 	void OnRealtimeTick(uint delta_ms) override
 	{
@@ -278,27 +336,17 @@ struct SelectGameWindow : public Window {
 		}
 	}
 
-	/**
-	 * Some data on this window has become invalid.
-	 * @param data Information about the changed data.
-	 * @param gui_scope Whether the call is done from GUI scope. You may not do everything when not in GUI scope. See #InvalidateWindowData() for details.
-	 */
-	void OnInvalidateData(int data = 0, bool gui_scope = true) override
-	{
-		if (!gui_scope) return;
-		this->SetWidgetLoweredState(WID_SGI_TEMPERATE_LANDSCAPE, _settings_newgame.game_creation.landscape == LT_TEMPERATE);
-		this->SetWidgetLoweredState(WID_SGI_ARCTIC_LANDSCAPE,    _settings_newgame.game_creation.landscape == LT_ARCTIC);
-		this->SetWidgetLoweredState(WID_SGI_TROPIC_LANDSCAPE,    _settings_newgame.game_creation.landscape == LT_TROPIC);
-		this->SetWidgetLoweredState(WID_SGI_TOYLAND_LANDSCAPE,   _settings_newgame.game_creation.landscape == LT_TOYLAND);
-	}
-
 	void OnInit() override
 	{
-		bool missing_sprites = _missing_extra_graphics > 0 && !IsReleasedVersion();
-		this->GetWidget<NWidgetStacked>(WID_SGI_BASESET_SELECTION)->SetDisplayedPlane(missing_sprites ? 0 : SZSP_NONE);
+		if (this->window_number == 2) {
+			/* Window number 2 is right part, which will have the missing graphics/translations warnings */
 
-		bool missing_lang = _current_language->missing >= _settings_client.gui.missing_strings_threshold && !IsReleasedVersion();
-		this->GetWidget<NWidgetStacked>(WID_SGI_TRANSLATION_SELECTION)->SetDisplayedPlane(missing_lang ? 0 : SZSP_NONE);
+			bool missing_sprites = _missing_extra_graphics > 0 && !IsReleasedVersion();
+			this->GetWidget<NWidgetStacked>(WID_SGI_BASESET_SELECTION)->SetDisplayedPlane(missing_sprites ? 0 : SZSP_NONE);
+
+			bool missing_lang = _current_language->missing >= _settings_client.gui.missing_strings_threshold && !IsReleasedVersion();
+			this->GetWidget<NWidgetStacked>(WID_SGI_TRANSLATION_SELECTION)->SetDisplayedPlane(missing_lang ? 0 : SZSP_NONE);
+		}
 	}
 
 	void DrawWidget(const Rect &r, int widget) const override
@@ -332,16 +380,15 @@ struct SelectGameWindow : public Window {
 		}
 
 		if (str != 0) {
+			constexpr int MAX_LINES = 7;
+
 			int height = GetStringHeight(str, size->width);
-			if (height > 3 * FONT_HEIGHT_NORMAL) {
-				/* Don't let the window become too high. */
-				Dimension textdim = GetStringBoundingBox(str);
-				textdim.height *= 3;
-				textdim.width -= textdim.width / 2;
-				*size = maxdim(*size, textdim);
-			} else {
-				size->height = height + padding.height;
+			/* Don't let the window become too tall - allow up to 7 lines. */
+			while (height > MAX_LINES * FONT_HEIGHT_NORMAL) {
+				size->width = size->width * 7 / 5; // increase width in 40% steps until it fits
+				height = GetStringHeight(str, size->width);
 			}
+				size->height = height + padding.height;
 		}
 	}
 
@@ -396,131 +443,138 @@ struct SelectGameWindow : public Window {
 	}
 };
 
-static const NWidgetPart _nested_select_game_widgets[] = {
-	NWidget(WWT_CAPTION, COLOUR_BROWN), SetDataTip(STR_INTRO_CAPTION, STR_NULL),
+
+/* Centre part of intro GUI: New game, Load game, Network game, Scenario editor */
+static const NWidgetPart _layout_intro_gui_centre[] = {
 	NWidget(WWT_PANEL, COLOUR_BROWN),
 	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
 
-	/* 'New Game' and 'Load Game' buttons */
+	/* Major Start Playing! buttons - new single player game and multiplayer */
 	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_GENERATE_GAME), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_NEW_GAME, STR_INTRO_TOOLTIP_NEW_GAME), SetPadding(0, 0, 0, 10), SetFill(1, 0),
+		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_GENERATE_GAME), SetMinimalSize(158, 40),
+							SetDataTip(STR_INTRO_NEW_GAME, STR_INTRO_TOOLTIP_NEW_GAME), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_PLAY_NETWORK), SetMinimalSize(158, 40),
+							SetDataTip(STR_INTRO_MULTIPLAYER, STR_INTRO_TOOLTIP_MULTIPLAYER), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+	EndContainer(),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
+
+	/* Secondary start playing buttons - load single player game and open scenario editor */
+	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_LOAD_GAME), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_LOAD_GAME, STR_INTRO_TOOLTIP_LOAD_GAME), SetPadding(0, 10, 0, 0), SetFill(1, 0),
-	EndContainer(),
-
-	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-
-	/* 'Play Scenario' and 'Play Heightmap' buttons */
-	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_PLAY_SCENARIO), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_PLAY_SCENARIO, STR_INTRO_TOOLTIP_PLAY_SCENARIO), SetPadding(0, 0, 0, 10), SetFill(1, 0),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_PLAY_HEIGHTMAP), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_PLAY_HEIGHTMAP, STR_INTRO_TOOLTIP_PLAY_HEIGHTMAP), SetPadding(0, 10, 0, 0), SetFill(1, 0),
-	EndContainer(),
-
-	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-
-	/* 'Scenario Editor' and 'Multiplayer' buttons */
-	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+							SetDataTip(STR_INTRO_LOAD_GAME, STR_INTRO_TOOLTIP_LOAD_GAME), SetPadding(0, 10, 0, 10), SetFill(1, 0),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_EDIT_SCENARIO), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_SCENARIO_EDITOR, STR_INTRO_TOOLTIP_SCENARIO_EDITOR), SetPadding(0, 0, 0, 10), SetFill(1, 0),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_PLAY_NETWORK), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_MULTIPLAYER, STR_INTRO_TOOLTIP_MULTIPLAYER), SetPadding(0, 10, 0, 0), SetFill(1, 0),
+							SetDataTip(STR_INTRO_SCENARIO_EDITOR, STR_INTRO_TOOLTIP_SCENARIO_EDITOR), SetPadding(0, 10, 0, 10), SetFill(1, 0),
 	EndContainer(),
 
-	NWidget(NWID_SPACER), SetMinimalSize(0, 7),
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
 
-	/* Climate selection buttons */
-	NWidget(NWID_HORIZONTAL),
-		NWidget(NWID_SPACER), SetMinimalSize(10, 0), SetFill(1, 0),
-		NWidget(WWT_IMGBTN_2, COLOUR_ORANGE, WID_SGI_TEMPERATE_LANDSCAPE), SetMinimalSize(77, 55),
-							SetDataTip(SPR_SELECT_TEMPERATE, STR_INTRO_TOOLTIP_TEMPERATE),
-		NWidget(NWID_SPACER), SetMinimalSize(3, 0), SetFill(1, 0),
-		NWidget(WWT_IMGBTN_2, COLOUR_ORANGE, WID_SGI_ARCTIC_LANDSCAPE), SetMinimalSize(77, 55),
-							SetDataTip(SPR_SELECT_SUB_ARCTIC, STR_INTRO_TOOLTIP_SUB_ARCTIC_LANDSCAPE),
-		NWidget(NWID_SPACER), SetMinimalSize(3, 0), SetFill(1, 0),
-		NWidget(WWT_IMGBTN_2, COLOUR_ORANGE, WID_SGI_TROPIC_LANDSCAPE), SetMinimalSize(77, 55),
-							SetDataTip(SPR_SELECT_SUB_TROPICAL, STR_INTRO_TOOLTIP_SUB_TROPICAL_LANDSCAPE),
-		NWidget(NWID_SPACER), SetMinimalSize(3, 0), SetFill(1, 0),
-		NWidget(WWT_IMGBTN_2, COLOUR_ORANGE, WID_SGI_TOYLAND_LANDSCAPE), SetMinimalSize(77, 55),
-							SetDataTip(SPR_SELECT_TOYLAND, STR_INTRO_TOOLTIP_TOYLAND_LANDSCAPE),
-		NWidget(NWID_SPACER), SetMinimalSize(10, 0), SetFill(1, 0),
+	/* Game name and revision string */
+	NWidget(WWT_LABEL, COLOUR_WHITE, WID_SGI_GAME_VERSION), SetDataTip(STR_INTRO_CAPTION, STR_NULL), SetFill(1, 0),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
 	EndContainer(),
+};
 
-	NWidget(NWID_SPACER), SetMinimalSize(0, 7),
+static WindowDesc _desc_intro_gui_centre(
+	WDP_MANUAL, nullptr, 0, 0,
+	WC_SELECT_GAME, WC_NONE,
+	0,
+	_layout_intro_gui_centre, lengthof(_layout_intro_gui_centre)
+);
+
+/* Left part of intro GUI: Configuring mods and content */
+static const NWidgetPart _layout_intro_gui_left[] = {
+	NWidget(WWT_PANEL, COLOUR_BROWN),
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+
+	/* Play Scenarios and Heightmaps */
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_PLAY_SCENARIO), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_PLAY_SCENARIO, STR_INTRO_TOOLTIP_PLAY_SCENARIO), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_PLAY_HEIGHTMAP), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_PLAY_HEIGHTMAP, STR_INTRO_TOOLTIP_PLAY_HEIGHTMAP), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+
+	/* Access Content Downloader feature */
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_CONTENT_DOWNLOAD), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_ONLINE_CONTENT, STR_INTRO_TOOLTIP_ONLINE_CONTENT), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+
+	/* Set up NewGRF, AI, and GS */
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_GRF_SETTINGS), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_NEWGRF_SETTINGS, STR_INTRO_TOOLTIP_NEWGRF_SETTINGS), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_AI_SETTINGS), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_AI_SETTINGS, STR_INTRO_TOOLTIP_AI_SETTINGS), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_GS_SETTINGS), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_GAMESCRIPT_SETTINGS, STR_INTRO_TOOLTIP_GAMESCRIPT_SETTINGS), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+	EndContainer(),
+};
+
+static WindowDesc _desc_intro_gui_left(
+	WDP_MANUAL, nullptr, 0, 0,
+	WC_SELECT_GAME, WC_NONE,
+	0,
+	_layout_intro_gui_left, lengthof(_layout_intro_gui_left)
+);
+
+/* Right part of the intro GUI: Game settings and info */
+static const NWidgetPart _layout_intro_gui_right[] = {
+	NWidget(WWT_PANEL, COLOUR_BROWN),
+	NWidget(NWID_SPACER), SetMinimalSize(0, 4),
+
+	/* Missing base graphics and translations warnings */
 	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_SGI_BASESET_SELECTION),
 		NWidget(NWID_VERTICAL),
-			NWidget(WWT_EMPTY, COLOUR_ORANGE, WID_SGI_BASESET), SetMinimalSize(316, 12), SetFill(1, 0), SetPadding(0, 10, 7, 10),
+			NWidget(WWT_EMPTY, COLOUR_ORANGE, WID_SGI_BASESET), SetMinimalSize(158, 12), SetFill(1, 0), SetPadding(0, 10, 7, 10),
 		EndContainer(),
 	EndContainer(),
 	NWidget(NWID_SELECTION, INVALID_COLOUR, WID_SGI_TRANSLATION_SELECTION),
 		NWidget(NWID_VERTICAL),
-			NWidget(WWT_EMPTY, COLOUR_ORANGE, WID_SGI_TRANSLATION), SetMinimalSize(316, 12), SetFill(1, 0), SetPadding(0, 10, 7, 10),
+			NWidget(WWT_EMPTY, COLOUR_ORANGE, WID_SGI_TRANSLATION), SetMinimalSize(158, 12), SetFill(1, 0), SetPadding(0, 10, 7, 10),
 		EndContainer(),
 	EndContainer(),
 
-	/* 'Game Options' and 'Settings' buttons */
-	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_OPTIONS), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_GAME_OPTIONS, STR_INTRO_TOOLTIP_GAME_OPTIONS), SetPadding(0, 0, 0, 10), SetFill(1, 0),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_SETTINGS_OPTIONS), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_CONFIG_SETTINGS_TREE, STR_INTRO_TOOLTIP_CONFIG_SETTINGS_TREE), SetPadding(0, 10, 0, 0), SetFill(1, 0),
-	EndContainer(),
+	NWidget(NWID_SPACER), SetMinimalSize(0, 4),
 
-	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-
-	/* 'AI Settings' and 'Game Script Settings' buttons */
-	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_AI_SETTINGS), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_AI_SETTINGS, STR_INTRO_TOOLTIP_AI_SETTINGS), SetPadding(0, 0, 0, 10), SetFill(1, 0),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_GS_SETTINGS), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_GAMESCRIPT_SETTINGS, STR_INTRO_TOOLTIP_GAMESCRIPT_SETTINGS), SetPadding(0, 10, 0, 0), SetFill(1, 0),
-	EndContainer(),
-
-	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-
-	/* 'Check Online Content' and 'NewGRF Settings' buttons */
-	NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_CONTENT_DOWNLOAD), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_ONLINE_CONTENT, STR_INTRO_TOOLTIP_ONLINE_CONTENT), SetPadding(0, 0, 0, 10), SetFill(1, 0),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_GRF_SETTINGS), SetMinimalSize(158, 12),
-							SetDataTip(STR_INTRO_NEWGRF_SETTINGS, STR_INTRO_TOOLTIP_NEWGRF_SETTINGS), SetPadding(0, 10, 0, 0), SetFill(1, 0),
-	EndContainer(),
-
-	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-
-	/* 'Highscore Table' button */
-	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_HIGHSCORE), SetMinimalSize(316, 12),
-							SetDataTip(STR_INTRO_HIGHSCORE, STR_INTRO_TOOLTIP_HIGHSCORE), SetPadding(0, 10, 0, 10), SetFill(1, 0),
-	EndContainer(),
-
-	NWidget(NWID_SPACER), SetMinimalSize(0, 6),
-
-	/* 'Exit' button */
-	NWidget(NWID_HORIZONTAL),
-		NWidget(NWID_SPACER), SetFill(1, 0),
-		NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_EXIT), SetMinimalSize(128, 12),
-							SetDataTip(STR_INTRO_QUIT, STR_INTRO_TOOLTIP_QUIT),
-		NWidget(NWID_SPACER), SetFill(1, 0),
-	EndContainer(),
+	/* Game Options and Settings */
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_OPTIONS), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_GAME_OPTIONS, STR_INTRO_TOOLTIP_GAME_OPTIONS), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_SETTINGS_OPTIONS), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_CONFIG_SETTINGS_TREE, STR_INTRO_TOOLTIP_CONFIG_SETTINGS_TREE), SetPadding(0, 10, 0, 10), SetFill(1, 0),
 
 	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
 
+	/* High score table */
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_HIGHSCORE), SetMinimalSize(158, 12),
+						SetDataTip(STR_INTRO_HIGHSCORE, STR_INTRO_TOOLTIP_HIGHSCORE), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
+
+	/* Exit button */
+	NWidget(WWT_PUSHTXTBTN, COLOUR_ORANGE, WID_SGI_EXIT), SetMinimalSize(128, 12),
+						SetDataTip(STR_INTRO_QUIT, STR_INTRO_TOOLTIP_QUIT), SetPadding(0, 10, 0, 10), SetFill(1, 0),
+
+	NWidget(NWID_SPACER), SetMinimalSize(0, 8),
 	EndContainer(),
 };
 
-static WindowDesc _select_game_desc(
-	WDP_CENTER, nullptr, 0, 0,
+static WindowDesc _desc_intro_gui_right(
+	WDP_MANUAL, nullptr, 0, 0,
 	WC_SELECT_GAME, WC_NONE,
 	0,
-	_nested_select_game_widgets, lengthof(_nested_select_game_widgets)
+	_layout_intro_gui_right, lengthof(_layout_intro_gui_right)
 );
+
 
 void ShowSelectGameWindow()
 {
-	new SelectGameWindow(&_select_game_desc);
+	new SelectGameWindow(&_desc_intro_gui_centre, SelectGameWindowNumber::StartGame);
+	new SelectGameWindow(&_desc_intro_gui_left, SelectGameWindowNumber::SetupContent);
+	new SelectGameWindow(&_desc_intro_gui_right, SelectGameWindowNumber::SetupGame);
 }
 
 static void AskExitGameCallback(Window *w, bool confirmed)

--- a/src/widgets/intro_widget.h
+++ b/src/widgets/intro_widget.h
@@ -12,6 +12,7 @@
 
 /** Widgets of the #SelectGameWindow class. */
 enum SelectGameIntroWidgets {
+	WID_SGI_GAME_VERSION,          ///< Game name and version label.
 	WID_SGI_GENERATE_GAME,         ///< Generate game button.
 	WID_SGI_LOAD_GAME,             ///< Load game button.
 	WID_SGI_PLAY_SCENARIO,         ///< Play scenario button.

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3502,6 +3502,13 @@ void RelocateAllWindows(int neww, int newh)
 				left = PositionMainToolbar(w); // changes toolbar orientation
 				break;
 
+			case WC_SELECT_GAME: {
+				Point p = PositionSelectGameWindow(w);
+				left = p.x;
+				top = p.y;
+				break;
+			}
+
 			case WC_NEWS_WINDOW:
 				top = newh - w->height;
 				left = PositionNewsMessage(w);

--- a/src/window_func.h
+++ b/src/window_func.h
@@ -24,6 +24,7 @@ int PositionMainToolbar(Window *w);
 int PositionStatusbar(Window *w);
 int PositionNewsMessage(Window *w);
 int PositionNetworkChatWindow(Window *w);
+Point PositionSelectGameWindow(Window *w);
 
 int GetMainViewTop();
 int GetMainViewBottom();


### PR DESCRIPTION
## Motivation / Problem

The title screen GUI has several oddities and wants more and more buttons, but doesn't afford structuring them well.

Allow the title screen game to be more prominent, by freeing the centre part of the viewport.

The prominence of the climate selection buttons in the title screen menu is often questioned.


## Description

![image](https://user-images.githubusercontent.com/1062071/232606751-6fdc8764-b79d-4b67-a13b-da078587ebc0.png)

Split the main menu into three sub-windows, positioned along the bottom edge of the screen.
- The middle window has four buttons with the theme, *Start playing*. Starting and loading single player games, joining multi player games, and accessing the scenario editor.
- The left hand window gives access to user generated content: Starting games from scenarios and height maps (those should maybe be moved into the New Game window), accessing the content downloader, and configuring NewGRF, AI, and GS.
- The right hand window offers setting up the game and getting information. This is also where a "Help" button (#7786) would go.


## Limitations

Does not look good in 640x480, the windows starts overlapping. Can we change the minimum resolution to 800x600?

Some of the strings might need a review, maybe they can be improved for the new layout.

Wishlist items: Adding snazzy graphical icons to the buttons, and maybe a bigger and fancier game logo at the top of the screen.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
