### PR TITLE
Change: Remove limit of objects, stations and roadstops per NewGRF.

### DIFF
--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -22,13 +22,13 @@ extern StationPool _station_pool;
 struct StationSpecList {
 	const StationSpec *spec;
 	uint32 grfid;      ///< GRF ID of this custom station
-	uint8  localidx;   ///< Station ID within GRF of station
+	uint16_t localidx; ///< Station ID within GRF of station
 };
 
 struct RoadStopSpecList {
 	const RoadStopSpec *spec;
 	uint32 grfid;      ///< GRF ID of this custom road stop
-	uint8  localidx;   ///< Station ID within GRF of road stop
+	uint16_t localidx; ///< Station ID within GRF of road stop
 };
 
 struct RoadStopTileData {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5643,10 +5643,10 @@ static void VehicleMapSpriteGroup(ByteReader *buf, byte feature, uint8 idcount)
 
 static void CanalMapSpriteGroup(ByteReader *buf, uint8 idcount)
 {
-	std::vector<CanalFeature> cfs;
+	std::vector<uint16_t> cfs;
 	cfs.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		cfs.push_back((CanalFeature)buf->ReadByte());
+		cfs.push_back(buf->ReadExtendedByte());
 	}
 
 	uint8 cidcount = buf->ReadByte();
@@ -5674,10 +5674,10 @@ static void StationMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> stations;
+	std::vector<uint16_t> stations;
 	stations.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		stations.push_back(buf->ReadByte());
+		stations.push_back(buf->ReadExtendedByte());
 	}
 
 	uint8 cidcount = buf->ReadByte();
@@ -5732,10 +5732,10 @@ static void TownHouseMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> houses;
+	std::vector<uint16_t> houses;
 	houses.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		houses.push_back(buf->ReadByte());
+		houses.push_back(buf->ReadExtendedByte());
 	}
 
 	/* Skip the cargo type section, we only care about the default group */
@@ -5764,10 +5764,10 @@ static void IndustryMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> industries;
+	std::vector<uint16_t> industries;
 	industries.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		industries.push_back(buf->ReadByte());
+		industries.push_back(buf->ReadExtendedByte());
 	}
 
 	/* Skip the cargo type section, we only care about the default group */
@@ -5796,10 +5796,10 @@ static void IndustrytileMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> indtiles;
+	std::vector<uint16_t> indtiles;
 	indtiles.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		indtiles.push_back(buf->ReadByte());
+		indtiles.push_back(buf->ReadExtendedByte());
 	}
 
 	/* Skip the cargo type section, we only care about the default group */
@@ -5823,10 +5823,10 @@ static void IndustrytileMapSpriteGroup(ByteReader *buf, uint8 idcount)
 
 static void CargoMapSpriteGroup(ByteReader *buf, uint8 idcount)
 {
-	std::vector<CargoID> cargoes;
+	std::vector<uint16_t> cargoes;
 	cargoes.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		cargoes.push_back((CargoID)buf->ReadByte());
+		cargoes.push_back(buf->ReadExtendedByte());
 	}
 
 	/* Skip the cargo type section, we only care about the default group */
@@ -5855,10 +5855,10 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> objects;
+	std::vector<uint16_t> objects;
 	objects.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		objects.push_back(buf->ReadByte());
+		objects.push_back(buf->ReadExtendedByte());
 	}
 
 	uint8 cidcount = buf->ReadByte();
@@ -5909,7 +5909,7 @@ static void RailTypeMapSpriteGroup(ByteReader *buf, uint8 idcount)
 	std::vector<uint8> railtypes;
 	railtypes.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		uint8 id = buf->ReadByte();
+		uint16_t id = buf->ReadExtendedByte();
 		railtypes.push_back(id < RAILTYPE_END ? _cur.grffile->railtype_map[id] : INVALID_RAILTYPE);
 	}
 
@@ -5943,7 +5943,7 @@ static void RoadTypeMapSpriteGroup(ByteReader *buf, uint8 idcount, RoadTramType 
 	std::vector<uint8> roadtypes;
 	roadtypes.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		uint8 id = buf->ReadByte();
+		uint16_t id = buf->ReadExtendedByte();
 		roadtypes.push_back(id < ROADTYPE_END ? type_map[id] : INVALID_ROADTYPE);
 	}
 
@@ -5977,10 +5977,10 @@ static void AirportMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> airports;
+	std::vector<uint16_t> airports;
 	airports.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		airports.push_back(buf->ReadByte());
+		airports.push_back(buf->ReadExtendedByte());
 	}
 
 	/* Skip the cargo type section, we only care about the default group */
@@ -6009,10 +6009,10 @@ static void AirportTileMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> airptiles;
+	std::vector<uint16_t> airptiles;
 	airptiles.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		airptiles.push_back(buf->ReadByte());
+		airptiles.push_back(buf->ReadExtendedByte());
 	}
 
 	/* Skip the cargo type section, we only care about the default group */
@@ -6041,10 +6041,10 @@ static void RoadStopMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		return;
 	}
 
-	std::vector<uint8> roadstops;
+	std::vector<uint16_t> roadstops;
 	roadstops.reserve(idcount);
 	for (uint i = 0; i < idcount; i++) {
-		roadstops.push_back(buf->ReadByte());
+		roadstops.push_back(buf->ReadExtendedByte());
 	}
 
 	uint8 cidcount = buf->ReadByte();
@@ -6101,7 +6101,7 @@ static void FeatureMapSpriteGroup(ByteReader *buf)
 	 * B feature       see action 0
 	 * B n-id          bits 0-6: how many IDs this definition applies to
 	 *                 bit 7: if set, this is a wagon override definition (see below)
-	 * B ids           the IDs for which this definition applies
+	 * E ids           the IDs for which this definition applies
 	 * B num-cid       number of cargo IDs (sprite group IDs) in this definition
 	 *                 can be zero, in that case the def-cid is used always
 	 * B cargo-type    type of this cargo type (e.g. mail=2, wood=7, see below)

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -314,7 +314,8 @@ public:
 
 typedef void (*SpecialSpriteHandler)(ByteReader *buf);
 
-static const uint NUM_STATIONS_PER_GRF = 255; ///< Number of StationSpecs per NewGRF; limited to 255 to allow extending Action3 with an extended byte later on.
+/** The maximum amount of stations a single GRF is allowed to add */
+static const uint NUM_STATIONS_PER_GRF = UINT16_MAX - 1;
 
 /** Temporary engine data used when loading only */
 struct GRFTempEngineData {
@@ -1989,7 +1990,7 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 			}
 
 			case 0x0A: { // Copy sprite layout
-				byte srcid = buf->ReadByte();
+				uint16_t srcid = buf->ReadExtendedByte();
 				const StationSpec *srcstatspec = srcid >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[srcid].get();
 
 				if (srcstatspec == nullptr) {
@@ -2043,7 +2044,7 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 				break;
 
 			case 0x0F: { // Copy custom layout
-				byte srcid = buf->ReadByte();
+				uint16_t srcid = buf->ReadExtendedByte();
 				const StationSpec *srcstatspec = srcid >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[srcid].get();
 
 				if (srcstatspec == nullptr) {

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2096,6 +2096,8 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 				statspec->animation.triggers = buf->ReadWord();
 				break;
 
+			/* 0x19 road routing (not implemented) */
+
 			case 0x1A: { // Advanced sprite layout
 				uint16 tiles = buf->ReadExtendedByte();
 				statspec->renderdata.clear(); // delete earlier loaded stuff
@@ -2115,6 +2117,13 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 				}
 				break;
 			}
+
+			case 0x1B: // Minimum bridge height (not implemented)
+				buf->ReadWord();
+				buf->ReadWord();
+				buf->ReadWord();
+				buf->ReadWord();
+				break;
 
 			default:
 				ret = CIR_UNKNOWN;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5693,7 +5693,7 @@ static void StationMapSpriteGroup(ByteReader *buf, uint8 idcount)
 			StationSpec *statspec = station >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[station].get();
 
 			if (statspec == nullptr) {
-				GrfMsg(1, "StationMapSpriteGroup: Station with ID 0x{:02X} does not exist, skipping", station);
+				GrfMsg(1, "StationMapSpriteGroup: Station {} undefined, skipping", station);
 				continue;
 			}
 
@@ -5708,12 +5708,12 @@ static void StationMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		StationSpec *statspec = station >= _cur.grffile->stations.size() ? nullptr : _cur.grffile->stations[station].get();
 
 		if (statspec == nullptr) {
-			GrfMsg(1, "StationMapSpriteGroup: Station with ID 0x{:02X} does not exist, skipping", station);
+			GrfMsg(1, "StationMapSpriteGroup: Station {} undefined, skipping", station);
 			continue;
 		}
 
 		if (statspec->grf_prop.grffile != nullptr) {
-			GrfMsg(1, "StationMapSpriteGroup: Station with ID 0x{:02X} mapped multiple times, skipping", station);
+			GrfMsg(1, "StationMapSpriteGroup: Station {} mapped multiple times, skipping", station);
 			continue;
 		}
 
@@ -5874,7 +5874,7 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 			ObjectSpec *spec = object >= _cur.grffile->objectspec.size() ? nullptr : _cur.grffile->objectspec[object].get();
 
 			if (spec == nullptr) {
-				GrfMsg(1, "ObjectMapSpriteGroup: Object with ID 0x{:02X} undefined, skipping", object);
+				GrfMsg(1, "ObjectMapSpriteGroup: Object {} undefined, skipping", object);
 				continue;
 			}
 
@@ -5889,12 +5889,12 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		ObjectSpec *spec = object >= _cur.grffile->objectspec.size() ? nullptr : _cur.grffile->objectspec[object].get();
 
 		if (spec == nullptr) {
-			GrfMsg(1, "ObjectMapSpriteGroup: Object with ID 0x{:02X} undefined, skipping", object);
+			GrfMsg(1, "ObjectMapSpriteGroup: Object {} undefined, skipping", object);
 			continue;
 		}
 
 		if (spec->grf_prop.grffile != nullptr) {
-			GrfMsg(1, "ObjectMapSpriteGroup: Object with ID 0x{:02X} mapped multiple times, skipping", object);
+			GrfMsg(1, "ObjectMapSpriteGroup: Object {} mapped multiple times, skipping", object);
 			continue;
 		}
 
@@ -6060,7 +6060,7 @@ static void RoadStopMapSpriteGroup(ByteReader *buf, uint8 idcount)
 			RoadStopSpec *roadstopspec = roadstop >= _cur.grffile->roadstops.size() ? nullptr : _cur.grffile->roadstops[roadstop].get();
 
 			if (roadstopspec == nullptr) {
-				GrfMsg(1, "RoadStopMapSpriteGroup: Road stop with ID 0x{:02X} does not exist, skipping", roadstop);
+				GrfMsg(1, "RoadStopMapSpriteGroup: Road stop {} undefined, skipping", roadstop);
 				continue;
 			}
 
@@ -6075,12 +6075,12 @@ static void RoadStopMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		RoadStopSpec *roadstopspec = roadstop >= _cur.grffile->roadstops.size() ? nullptr : _cur.grffile->roadstops[roadstop].get();
 
 		if (roadstopspec == nullptr) {
-			GrfMsg(1, "RoadStopMapSpriteGroup: Road stop with ID 0x{:02X} does not exist, skipping.", roadstop);
+			GrfMsg(1, "RoadStopMapSpriteGroup: Road stop {} undefined, skipping.", roadstop);
 			continue;
 		}
 
 		if (roadstopspec->grf_prop.grffile != nullptr) {
-			GrfMsg(1, "RoadStopMapSpriteGroup: Road stop with ID 0x{:02X} mapped multiple times, skipping", roadstop);
+			GrfMsg(1, "RoadStopMapSpriteGroup: Road stop {} mapped multiple times, skipping", roadstop);
 			continue;
 		}
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -2125,6 +2125,14 @@ static ChangeInfoResult StationChangeInfo(uint stid, int numinfo, int prop, Byte
 				buf->ReadWord();
 				break;
 
+			case 0x1C: // Station Name
+				AddStringForMapping(buf->ReadWord(), &statspec->name);
+				break;
+
+			case 0x1D: // Station Class name
+				AddStringForMapping(buf->ReadWord(), &StationClass::Get(statspec->cls_id)->name);
+				break;
+
 			default:
 				ret = CIR_UNKNOWN;
 				break;

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -61,7 +61,7 @@ public:
 	static Tid GetUIClass(uint index);
 	static NewGRFClass *Get(Tid cls_id);
 
-	static const Tspec *GetByGrf(uint32 grfid, byte local_id, int *index);
+	static const Tspec *GetByGrf(uint32 grfid, uint16_t local_id, int *index);
 };
 
 #endif /* NEWGRF_CLASS_H */

--- a/src/newgrf_class_func.h
+++ b/src/newgrf_class_func.h
@@ -187,7 +187,7 @@ DEFINE_NEWGRF_CLASS_METHOD(int)::GetUIFromIndex(int index) const
  * @param index    Pointer to return the index of the spec in its class. If nullptr then not used.
  * @return The spec.
  */
-DEFINE_NEWGRF_CLASS_METHOD(const Tspec *)::GetByGrf(uint32 grfid, byte local_id, int *index)
+DEFINE_NEWGRF_CLASS_METHOD(const Tspec *)::GetByGrf(uint32 grfid, uint16_t local_id, int *index)
 {
 	uint j;
 
@@ -222,4 +222,4 @@ DEFINE_NEWGRF_CLASS_METHOD(const Tspec *)::GetByGrf(uint32 grfid, byte local_id,
 	template const Tspec *name::GetSpec(uint index) const; \
 	template int name::GetUIFromIndex(int index) const; \
 	template int name::GetIndexFromUI(int ui_index) const; \
-	template const Tspec *name::GetByGrf(uint32 grfid, byte localidx, int *index);
+	template const Tspec *name::GetByGrf(uint32 grfid, uint16_t local_id, int *index);

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -58,7 +58,7 @@ OverrideManagerBase::OverrideManagerBase(uint16 offset, uint16 maximum, uint16 i
  * @param grfid  ID of the grf file
  * @param entity_type original entity type
  */
-void OverrideManagerBase::Add(uint8 local_id, uint32 grfid, uint entity_type)
+void OverrideManagerBase::Add(uint16_t local_id, uint32 grfid, uint entity_type)
 {
 	assert(entity_type < this->max_offset);
 	/* An override can be set only once */
@@ -86,7 +86,7 @@ void OverrideManagerBase::ResetOverride()
  * @param grfid ID of the grf file
  * @return the ID of the candidate, of the Invalid flag item ID
  */
-uint16 OverrideManagerBase::GetID(uint8 grf_local_id, uint32 grfid) const
+uint16 OverrideManagerBase::GetID(uint16_t grf_local_id, uint32 grfid) const
 {
 	for (uint16 id = 0; id < this->max_entities; id++) {
 		const EntityIDMapping *map = &this->mappings[id];
@@ -105,7 +105,7 @@ uint16 OverrideManagerBase::GetID(uint8 grf_local_id, uint32 grfid) const
  * @param substitute_id is the original entity from which data is copied for the new one
  * @return the proper usable slot id, or invalid marker if none is found
  */
-uint16 OverrideManagerBase::AddEntityID(byte grf_local_id, uint32 grfid, byte substitute_id)
+uint16 OverrideManagerBase::AddEntityID(uint16_t grf_local_id, uint32 grfid, uint16_t substitute_id)
 {
 	uint16 id = this->GetID(grf_local_id, grfid);
 
@@ -184,7 +184,7 @@ void HouseOverrideManager::SetEntitySpec(const HouseSpec *hs)
  * @param grfid ID of the grf file
  * @return the ID of the candidate, of the Invalid flag item ID
  */
-uint16 IndustryOverrideManager::GetID(uint8 grf_local_id, uint32 grfid) const
+uint16 IndustryOverrideManager::GetID(uint16_t grf_local_id, uint32 grfid) const
 {
 	uint16 id = OverrideManagerBase::GetID(grf_local_id, grfid);
 	if (id != this->invalid_id) return id;
@@ -204,7 +204,7 @@ uint16 IndustryOverrideManager::GetID(uint8 grf_local_id, uint32 grfid) const
  * @param substitute_id industry from which data has been copied
  * @return a free entity id (slotid) if ever one has been found, or Invalid_ID marker otherwise
  */
-uint16 IndustryOverrideManager::AddEntityID(byte grf_local_id, uint32 grfid, byte substitute_id)
+uint16 IndustryOverrideManager::AddEntityID(uint16_t grf_local_id, uint32 grfid, uint16 substitute_id)
 {
 	/* This entity hasn't been defined before, so give it an ID now. */
 	for (uint16 id = 0; id < this->max_entities; id++) {

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -185,8 +185,8 @@ private:
  */
 struct EntityIDMapping {
 	uint32 grfid;          ///< The GRF ID of the file the entity belongs to
-	uint8  entity_id;      ///< The entity ID within the GRF file
-	uint8  substitute_id;  ///< The (original) entity ID to use if this GRF is not available
+	uint16_t entity_id; ///< The entity ID within the GRF file
+	uint16_t substitute_id; ///< The (original) entity ID to use if this GRF is not available
 };
 
 class OverrideManagerBase {
@@ -209,12 +209,12 @@ public:
 	void ResetOverride();
 	void ResetMapping();
 
-	void Add(uint8 local_id, uint32 grfid, uint entity_type);
-	virtual uint16 AddEntityID(byte grf_local_id, uint32 grfid, byte substitute_id);
+	void Add(uint16_t local_id, uint32 grfid, uint entity_type);
+	virtual uint16 AddEntityID(uint16_t grf_local_id, uint32 grfid, uint16_t substitute_id);
 
 	uint32 GetGRFID(uint16 entity_id) const;
 	uint16 GetSubstituteID(uint16 entity_id) const;
-	virtual uint16 GetID(uint8 grf_local_id, uint32 grfid) const;
+	virtual uint16 GetID(uint16_t grf_local_id, uint32 grfid) const;
 
 	inline uint16 GetMaxMapping() const { return this->max_entities; }
 	inline uint16 GetMaxOffset() const { return this->max_offset; }
@@ -237,8 +237,8 @@ public:
 	IndustryOverrideManager(uint16 offset, uint16 maximum, uint16 invalid) :
 			OverrideManagerBase(offset, maximum, invalid) {}
 
-	uint16 AddEntityID(byte grf_local_id, uint32 grfid, byte substitute_id) override;
-	uint16 GetID(uint8 grf_local_id, uint32 grfid) const override;
+	uint16 AddEntityID(uint16_t grf_local_id, uint32 grfid, uint16_t substitute_id) override;
+	uint16 GetID(uint16_t grf_local_id, uint32 grfid) const override;
 
 	void SetEntitySpec(IndustrySpec *inds);
 };

--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -157,7 +157,7 @@ uint32 RoadStopScopeResolver::GetVariable(byte variable, uint32 parameter, bool 
 
 			if (IsCustomRoadStopSpecIndex(nearby_tile)) {
 				const RoadStopSpecList ssl = BaseStation::GetByTile(nearby_tile)->roadstop_speclist[GetCustomRoadStopSpecIndex(nearby_tile)];
-				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | ssl.localidx;
+				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | std::max<uint16_t>(ssl.localidx, 0xFF);
 			}
 			return res;
 		}

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -20,7 +20,7 @@
 #include "road.h"
 
 /** The maximum amount of roadstops a single GRF is allowed to add */
-static const int NUM_ROADSTOPS_PER_GRF = 255;
+static const int NUM_ROADSTOPS_PER_GRF = UINT16_MAX - 1;
 
 enum RoadStopClassID : byte {
 	ROADSTOP_CLASS_BEGIN = 0,    ///< The lowest valid value

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -364,7 +364,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 
 			if (IsCustomStationSpecIndex(nearby_tile)) {
 				const StationSpecList ssl = BaseStation::GetByTile(nearby_tile)->speclist[GetCustomStationSpecIndex(nearby_tile)];
-				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | ssl.localidx;
+				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | std::max<uint16_t>(ssl.localidx, 0xFF);
 			}
 			return res;
 		}

--- a/src/object_type.h
+++ b/src/object_type.h
@@ -19,10 +19,9 @@ static const ObjectType OBJECT_STATUE       =   2;    ///< Statue in towns
 static const ObjectType OBJECT_OWNED_LAND   =   3;    ///< Owned land 'flag'
 static const ObjectType OBJECT_HQ           =   4;    ///< HeadQuarter of a player
 
-static const ObjectType NUM_OBJECTS_PER_GRF = 255;    ///< Number of supported objects per NewGRF; limited to 255 to allow extending Action3 with an extended byte later on.
-
 static const ObjectType NEW_OBJECT_OFFSET   =   5;    ///< Offset for new objects
 static const ObjectType NUM_OBJECTS         = 64000;  ///< Number of supported objects overall
+static const ObjectType NUM_OBJECTS_PER_GRF = NUM_OBJECTS; ///< Number of supported objects per NewGRF
 static const ObjectType INVALID_OBJECT_TYPE = 0xFFFF; ///< An invalid object
 
 /** Unique identifier for an object. */

--- a/src/saveload/newgrf_sl.cpp
+++ b/src/saveload/newgrf_sl.cpp
@@ -20,8 +20,10 @@
 /** Save and load the mapping between a spec and the NewGRF it came from. */
 static const SaveLoad _newgrf_mapping_desc[] = {
 	SLE_VAR(EntityIDMapping, grfid,         SLE_UINT32),
-	SLE_VAR(EntityIDMapping, entity_id,     SLE_UINT8),
-	SLE_VAR(EntityIDMapping, substitute_id, SLE_UINT8),
+	SLE_CONDVAR(EntityIDMapping, entity_id,     SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION,            SLV_EXTEND_ENTITY_MAPPING),
+	SLE_CONDVAR(EntityIDMapping, entity_id,     SLE_UINT16,                SLV_EXTEND_ENTITY_MAPPING, SL_MAX_VERSION),
+	SLE_CONDVAR(EntityIDMapping, substitute_id, SLE_FILE_U8 | SLE_VAR_U16, SL_MIN_VERSION,            SLV_EXTEND_ENTITY_MAPPING),
+	SLE_CONDVAR(EntityIDMapping, substitute_id, SLE_UINT16,                SLV_EXTEND_ENTITY_MAPPING, SL_MAX_VERSION),
 };
 
 /**

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -354,6 +354,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_AI_START_DATE,                      ///< 309  PR#10653 Removal of individual AI start dates and added a generic one.
 
 	SLV_EXTEND_VEHICLE_RANDOM,              ///< 310  PR#10701 Extend vehicle random bits.
+	SLV_EXTEND_ENTITY_MAPPING,              ///< 311  PR#10672 Extend entity mapping range.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -205,8 +205,9 @@ static void SwapPackets(GoodsEntry *ge)
 class SlStationSpecList : public DefaultSaveLoadHandler<SlStationSpecList, BaseStation> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_CONDVAR(StationSpecList, grfid,    SLE_UINT32, SLV_27, SL_MAX_VERSION),
-		SLE_CONDVAR(StationSpecList, localidx, SLE_UINT8,  SLV_27, SL_MAX_VERSION),
+		SLE_CONDVAR(StationSpecList, grfid,    SLE_UINT32,                SLV_27,                    SL_MAX_VERSION),
+		SLE_CONDVAR(StationSpecList, localidx, SLE_FILE_U8 | SLE_VAR_U16, SLV_27,                    SLV_EXTEND_ENTITY_MAPPING),
+		SLE_CONDVAR(StationSpecList, localidx, SLE_UINT16,                SLV_EXTEND_ENTITY_MAPPING, SL_MAX_VERSION),
 	};
 	inline const static SaveLoadCompatTable compat_description = _station_spec_list_sl_compat;
 
@@ -236,8 +237,9 @@ uint8 SlStationSpecList::last_num_specs;
 class SlRoadStopSpecList : public DefaultSaveLoadHandler<SlRoadStopSpecList, BaseStation> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(RoadStopSpecList, grfid,    SLE_UINT32),
-		SLE_VAR(RoadStopSpecList, localidx, SLE_UINT8),
+		    SLE_VAR(RoadStopSpecList, grfid,    SLE_UINT32),
+		SLE_CONDVAR(RoadStopSpecList, localidx, SLE_FILE_U8 | SLE_VAR_U16, SLV_27,                    SLV_EXTEND_ENTITY_MAPPING),
+		SLE_CONDVAR(RoadStopSpecList, localidx, SLE_UINT16,                SLV_EXTEND_ENTITY_MAPPING, SL_MAX_VERSION),
 	};
 	inline const static SaveLoadCompatTable compat_description = _station_road_stop_spec_list_sl_compat;
 


### PR DESCRIPTION
## Motivation / Problem

255 objects, stations and roadstops per NewGRF.

## Description

64000+ objects, stations and roadstops per NewGRF.

Only specs for 255 different items can be defined in one action 0, but I doubt increasing this batching feature matters much.

Action 00 IDs are already an extended byte.
Action 03 IDs are now an extended byte for objects.

For stations, Action 04 only supports 256 IDs, so two additional Action 00 properties have been added to set name and class name, the same way as is already done for road stops.

Saveload is bumped so that 16 bit IDs can be stored.

## Limitations

Untested beyond starting and loading an existing object NewGRF.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
