### PR TITLE
Fix #10665: CheckEngines should ignore wagons

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1246,6 +1246,9 @@ void CheckEngines()
 	for (const Engine *e : Engine::Iterate()) {
 		if (!e->IsEnabled()) continue;
 
+		/* Don't consider train wagons, we need a powered engine available. */
+		if (e->type == VEH_TRAIN && e->u.rail.railveh_type == RAILVEH_WAGON) continue;
+
 		/* We have an available engine... yay! */
 		if ((e->flags & ENGINE_AVAILABLE) != 0 && e->company_avail != 0) return;
 


### PR DESCRIPTION
## Motivation / Problem

This fixes the issue described in #10665: the "No vehicles available yet" warning doesn't pop up if the player starts a game in Toyland between 1925 and 1935.

## Description

`CheckEngines()` in `engine.cpp` fails to distinguish rail wagons from locomotives, so start dates between 1925 and 1935 (after several rail cars are introduced for use in Temperate, but before locomotives are available in Toyland) do not trigger the "no vehicles" warning. The fix explicitly ignores wagons when checking for available engines.

Closes #10665.

## Limitations

None; this is a simple fix for a minor UX issue and shouldn't cause any additional problems.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
