### PR TITLE
Change: Split Game options into General, Graphics, and Sound tabs.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -930,6 +930,24 @@ STR_EXTRA_VIEW_MOVE_MAIN_TO_VIEW_TT                             :{BLACK}Copy the
 
 # Game options window
 STR_GAME_OPTIONS_CAPTION                                        :{WHITE}Game Options
+
+STR_GAME_OPTIONS_TAB_GENERAL                                    :General
+STR_GAME_OPTIONS_TAB_GENERAL_TT                                 :{BLACK}Choose general settings
+STR_GAME_OPTIONS_TAB_GRAPHICS                                   :Graphics
+STR_GAME_OPTIONS_TAB_GRAPHICS_TT                                :{BLACK}Choose graphics settings
+STR_GAME_OPTIONS_TAB_SOUND                                      :Sound
+STR_GAME_OPTIONS_TAB_SOUND_TT                                   :{BLACK}Choose sound and music settings
+
+STR_GAME_OPTIONS_VOLUME                                         :Volume
+STR_GAME_OPTIONS_SFX_VOLUME                                     :Sound effects
+STR_GAME_OPTIONS_MUSIC_VOLUME                                   :Music
+
+STR_GAME_OPTIONS_VOLUME_0                                       :0%
+STR_GAME_OPTIONS_VOLUME_25                                      :25%
+STR_GAME_OPTIONS_VOLUME_50                                      :50%
+STR_GAME_OPTIONS_VOLUME_75                                      :75%
+STR_GAME_OPTIONS_VOLUME_100                                     :100%
+
 STR_GAME_OPTIONS_CURRENCY_UNITS_FRAME                           :{BLACK}Currency units
 STR_GAME_OPTIONS_CURRENCY_UNITS_DROPDOWN_TOOLTIP                :{BLACK}Currency units selection
 

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -12,7 +12,10 @@
 
 /** Widgets of the #GameOptionsWindow class. */
 enum GameOptionsWidgets {
-	WID_GO_BACKGROUND,             ///< Background of the window.
+	WID_GO_TAB_GENERAL,            ///< General tab.
+	WID_GO_TAB_GRAPHICS,           ///< Graphics tab.
+	WID_GO_TAB_SOUND,              ///< Sound tab.
+	WID_GO_TAB_SELECTION,          ///< Background of the tab selection.
 	WID_GO_CURRENCY_DROPDOWN,      ///< Currency dropdown.
 	WID_GO_DISTANCE_DROPDOWN,      ///< Measuring unit dropdown.
 	WID_GO_AUTOSAVE_DROPDOWN,      ///< Dropdown to say how often to autosave.
@@ -27,10 +30,12 @@ enum GameOptionsWidgets {
 	WID_GO_BASE_GRF_TEXTFILE,      ///< Open base GRF readme, changelog (+1) or license (+2).
 	WID_GO_BASE_GRF_DESCRIPTION = WID_GO_BASE_GRF_TEXTFILE + TFT_END,     ///< Description of selected base GRF.
 	WID_GO_BASE_SFX_DROPDOWN,      ///< Use to select a base SFX.
+	WID_GO_TEXT_SFX_VOLUME,        ///< Sound effects volume label.
 	WID_GO_BASE_SFX_VOLUME,        ///< Change sound effects volume.
 	WID_GO_BASE_SFX_TEXTFILE,      ///< Open base SFX readme, changelog (+1) or license (+2).
 	WID_GO_BASE_SFX_DESCRIPTION = WID_GO_BASE_SFX_TEXTFILE + TFT_END,     ///< Description of selected base SFX.
 	WID_GO_BASE_MUSIC_DROPDOWN,    ///< Use to select a base music set.
+	WID_GO_TEXT_MUSIC_VOLUME,      ///< Music volume label.
 	WID_GO_BASE_MUSIC_VOLUME,      ///< Change music volume.
 	WID_GO_BASE_MUSIC_JUKEBOX,     ///< Open the jukebox.
 	WID_GO_BASE_MUSIC_STATUS,      ///< Info about corrupted files etc.


### PR DESCRIPTION
## Motivation / Problem

Game Options is very large and has lots of different settings on it.

![image](https://user-images.githubusercontent.com/639850/232852150-bc5c262d-3a94-4a1e-8de0-89dfae82abef.png)

## Description

This change splits the Game Options window into three small tabs, "General", "Base sets" and "Video":

![image](https://user-images.githubusercontent.com/639850/232852379-be7a26aa-32e8-41b1-8f14-c2741ce6fcfd.png)
![image](https://user-images.githubusercontent.com/639850/232852446-a75db013-b2b6-400e-8742-6ebe4bc3db4d.png)
![image](https://user-images.githubusercontent.com/639850/232852482-eb67a8c8-adf2-4c1d-ad42-46d60ceb498e.png)

There isn't really a specific widget that could be used to represent tabs (these came in later games...) so this uses a standard button in a contrasting colour.

"Interface size" is left on the (default) General tab, as in modern terminology it fits more into a "graphics" option than a "video" option, but I don't think a separate Graphics tab is appropriate.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
