### PR TITLE
Codechange: use string/fmt instead of printf for ShowInfo(F)

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1606,7 +1606,7 @@ DEF_CONSOLE_CMD(ConDebugLevel)
 	if (argc == 1) {
 		IConsolePrint(CC_DEFAULT, "Current debug-level: '{}'", GetDebugString());
 	} else {
-		SetDebugString(argv[1], [](const char *err) { IConsolePrint(CC_ERROR, std::string(err)); });
+		SetDebugString(argv[1], [](const std::string &err) { IConsolePrint(CC_ERROR, err); });
 	}
 
 	return true;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -161,7 +161,7 @@ void DebugPrint(const char *level, const std::string &message)
  * @param s Text describing the wanted debugging levels.
  * @param error_func The function to call if a parse error occurs.
  */
-void SetDebugString(const char *s, void (*error_func)(const char *))
+void SetDebugString(const char *s, void (*error_func)(const std::string &))
 {
 	int v;
 	char *end;
@@ -207,7 +207,7 @@ void SetDebugString(const char *s, void (*error_func)(const char *))
 			new_levels[found->name] = v;
 		} else {
 			std::string error_string = fmt::format("Unknown debug level '{}'", std::string(t, s - t));
-			error_func(error_string.c_str());
+			error_func(error_string);
 			return;
 		}
 	}

--- a/src/debug.h
+++ b/src/debug.h
@@ -57,7 +57,7 @@ extern int _debug_random_level;
 #endif
 
 char *DumpDebugFacilityNames(char *buf, char *last);
-void SetDebugString(const char *s, void (*error_func)(const char *));
+void SetDebugString(const char *s, void (*error_func)(const std::string &));
 const char *GetDebugString();
 
 /* Shorter form for passing filename and linenumber */
@@ -117,8 +117,8 @@ const char *GetDebugString();
 }
 
 
-void ShowInfo(const char *str);
-void CDECL ShowInfoF(const char *str, ...) WARN_FORMAT(1, 2);
+void ShowInfoI(const std::string &str);
+#define ShowInfo(format_string, ...) ShowInfoI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 
 const char *GetLogPrefix();
 

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -128,7 +128,7 @@ void LoadFreeTypeFont(FontSize fs)
 
 	if (_library == nullptr) {
 		if (FT_Init_FreeType(&_library) != FT_Err_Ok) {
-			ShowInfoF("Unable to initialize FreeType, using sprite fonts instead");
+			ShowInfo("Unable to initialize FreeType, using sprite fonts instead");
 			return;
 		}
 
@@ -190,7 +190,7 @@ void LoadFreeTypeFont(FontSize fs)
 
 	FT_Done_Face(face);
 
-	ShowInfoF("Unable to use '%s' for %s font, FreeType reported error 0x%X, using sprite font instead", font_name, FontSizeToName(fs), error);
+	ShowInfo("Unable to use '{}' for {} font, FreeType reported error 0x{:X}, using sprite font instead", font_name, FontSizeToName(fs), error);
 	return;
 
 found_face:

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -152,7 +152,7 @@ void CheckExternalFiles()
 		add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", sounds_set->files->filename, SoundsSet::CheckMD5(sounds_set->files, BASESET_DIR) == MD5File::CR_MISMATCH ? "corrupt" : "missing", sounds_set->files->missing_warning);
 	}
 
-	if (add_pos != error_msg) ShowInfoF("%s", error_msg);
+	if (add_pos != error_msg) ShowInfoI(error_msg);
 }
 
 /** Actually load the sprite tables. */

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -132,5 +132,5 @@ bool IniFile::SaveToDisk(const std::string &filename)
 
 /* virtual */ void IniFile::ReportFileError(const char * const pre, const char * const buffer, const char * const post)
 {
-	ShowInfoF("%s%s%s", pre, buffer, post);
+	ShowInfo("{}{}{}", pre, buffer, post);
 }

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -164,20 +164,6 @@ void CDECL error(const char *s, ...)
 }
 
 /**
- * Shows some information on the console/a popup box depending on the OS.
- * @param str the text to show.
- */
-void CDECL ShowInfoF(const char *str, ...)
-{
-	va_list va;
-	char buf[1024];
-	va_start(va, str);
-	vseprintf(buf, lastof(buf), str, va);
-	va_end(va);
-	ShowInfo(buf);
-}
-
-/**
  * Show the help message when someone passed a wrong parameter.
  */
 static void ShowHelp()
@@ -257,7 +243,7 @@ static void ShowHelp()
 #if !defined(_WIN32)
 	printf("%s\n", buf);
 #else
-	ShowInfo(buf);
+	ShowInfoI(buf);
 #endif
 }
 
@@ -295,7 +281,7 @@ static void WriteSavegameInfo(const char *name)
 #if !defined(_WIN32)
 	printf("%s\n", buf);
 #else
-	ShowInfo(buf);
+	ShowInfoI(buf);
 #endif
 }
 
@@ -310,7 +296,7 @@ static void ParseResolution(Dimension *res, const char *s)
 {
 	const char *t = strchr(s, 'x');
 	if (t == nullptr) {
-		ShowInfoF("Invalid resolution '%s'", s);
+		ShowInfo("Invalid resolution '{}'", s);
 		return;
 	}
 
@@ -581,7 +567,7 @@ int openttd_main(int argc, char *argv[])
 			videodriver = "dedicated";
 			blitter = "null";
 			dedicated = true;
-			SetDebugString("net=4", ShowInfo);
+			SetDebugString("net=4", ShowInfoI);
 			if (mgo.opt != nullptr) {
 				scanner->dedicated_host = ParseFullConnectionString(mgo.opt, scanner->dedicated_port);
 			}
@@ -605,7 +591,7 @@ int openttd_main(int argc, char *argv[])
 #if defined(_WIN32)
 				CreateConsole();
 #endif
-				if (mgo.opt != nullptr) SetDebugString(mgo.opt, ShowInfo);
+				if (mgo.opt != nullptr) SetDebugString(mgo.opt, ShowInfoI);
 				break;
 			}
 		case 'e': _switch_mode = (_switch_mode == SM_LOAD_GAME || _switch_mode == SM_LOAD_SCENARIO ? SM_LOAD_SCENARIO : SM_EDITOR); break;

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -386,7 +386,7 @@ void LoadCoreTextFont(FontSize fs)
 				font_ref.reset((CTFontDescriptorRef)CFArrayGetValueAtIndex(descs.get(), 0));
 				CFRetain(font_ref.get());
 			} else {
-				ShowInfoF("Unable to load file '%s' for %s font, using default OS font selection instead", settings->font.c_str(), FontSizeToName(fs));
+				ShowInfo("Unable to load file '{}' for {} font, using default OS font selection instead", settings->font, FontSizeToName(fs));
 			}
 		}
 	}
@@ -410,7 +410,7 @@ void LoadCoreTextFont(FontSize fs)
 	}
 
 	if (!font_ref) {
-		ShowInfoF("Unable to use '%s' for %s font, using sprite font instead", settings->font.c_str(), FontSizeToName(fs));
+		ShowInfo("Unable to use '{}' for {} font, using sprite font instead", settings->font, FontSizeToName(fs));
 		return;
 	}
 

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -133,7 +133,7 @@ bool FiosIsHiddenFile(const struct dirent *ent)
 	return ent->d_name[0] == '.';
 }
 
-void ShowInfo(const char *str)
+void ShowInfoI(const std::string &str)
 {
 	HAB hab;
 	HMQ hmq;
@@ -143,7 +143,7 @@ void ShowInfo(const char *str)
 	hmq = WinCreateMsgQueue((hab = WinInitialize(0)), 0);
 
 	/* display the box */
-	rc = WinMessageBox(HWND_DESKTOP, HWND_DESKTOP, (const unsigned char *)str, (const unsigned char *)"OpenTTD", 0, MB_OK | MB_MOVEABLE | MB_INFORMATION);
+	rc = WinMessageBox(HWND_DESKTOP, HWND_DESKTOP, (const unsigned char *)str.c_str(), (const unsigned char *)"OpenTTD", 0, MB_OK | MB_MOVEABLE | MB_INFORMATION);
 
 	/* terminate PM env. */
 	WinDestroyMsgQueue(hmq);

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -30,7 +30,7 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 	FT_Error err = FT_Err_Cannot_Open_Resource;
 
 	if (!FcInit()) {
-		ShowInfoF("Unable to load font configuration");
+		ShowInfo("Unable to load font configuration");
 	} else {
 		FcPattern *match;
 		FcPattern *pat;

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -210,9 +210,9 @@ std::string FS2OTTD(const std::string &name)
 
 #endif /* WITH_ICONV */
 
-void ShowInfo(const char *str)
+void ShowInfoI(const std::string &str)
 {
-	fprintf(stderr, "%s\n", str);
+	fprintf(stderr, "%s\n", str.c_str());
 }
 
 #if !defined(__APPLE__)

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -609,7 +609,7 @@ void LoadWin32Font(FontSize fs)
 					logfont.lfWeight = strcasestr(font_name, " bold") != nullptr || strcasestr(font_name, "-bold") != nullptr ? FW_BOLD : FW_NORMAL; // Poor man's way to allow selecting bold fonts.
 				}
 			} else {
-				ShowInfoF("Unable to load file '%s' for %s font, using default windows font selection instead", font_name, FontSizeToName(fs));
+				ShowInfo("Unable to load file '{}' for {} font, using default windows font selection instead", font_name, FontSizeToName(fs));
 			}
 		}
 	}
@@ -621,7 +621,7 @@ void LoadWin32Font(FontSize fs)
 
 	HFONT font = CreateFontIndirect(&logfont);
 	if (font == nullptr) {
-		ShowInfoF("Unable to use '%s' for %s font, Win32 reported error 0x%lX, using sprite font instead", font_name, FontSizeToName(fs), GetLastError());
+		ShowInfo("Unable to use '{}' for {} font, Win32 reported error 0x{:X}, using sprite font instead", font_name, FontSizeToName(fs), GetLastError());
 		return;
 	}
 	DeleteObject(font);

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -318,27 +318,27 @@ static INT_PTR CALLBACK HelpDialogFunc(HWND wnd, UINT msg, WPARAM wParam, LPARAM
 	return FALSE;
 }
 
-void ShowInfo(const char *str)
+void ShowInfoI(const std::string &str)
 {
 	if (_has_console) {
-		fprintf(stderr, "%s\n", str);
+		fprintf(stderr, "%s\n", str.c_str());
 	} else {
 		bool old;
 		ReleaseCapture();
 		_left_button_clicked = _left_button_down = false;
 
 		old = MyShowCursor(true);
-		if (strlen(str) > 2048) {
+		if (str.size() > 2048) {
 			/* The minimum length of the help message is 2048. Other messages sent via
 			 * ShowInfo are much shorter, or so long they need this way of displaying
 			 * them anyway. */
-			_help_msg = str;
+			_help_msg = str.c_str();
 			DialogBox(GetModuleHandle(nullptr), MAKEINTRESOURCE(101), nullptr, HelpDialogFunc);
 		} else {
 			/* We need to put the text in a separate buffer because the default
 			 * buffer in OTTD2FS might not be large enough (512 chars). */
 			wchar_t help_msg_buf[8192];
-			MessageBox(GetActiveWindow(), convert_to_fs(str, help_msg_buf, lengthof(help_msg_buf)), L"OpenTTD", MB_ICONINFORMATION | MB_OK);
+			MessageBox(GetActiveWindow(), convert_to_fs(str.c_str(), help_msg_buf, lengthof(help_msg_buf)), L"OpenTTD", MB_ICONINFORMATION | MB_OK);
 		}
 		MyShowCursor(old);
 	}

--- a/src/osk_gui.cpp
+++ b/src/osk_gui.cpp
@@ -392,11 +392,11 @@ void GetKeyboardLayout()
 	}
 
 	if (has_error) {
-		ShowInfoF("The keyboard layout you selected contains invalid chars. Please check those chars marked with ^.");
-		ShowInfoF("Normal keyboard:  %s", keyboard[0]);
-		ShowInfoF("                  %s", errormark[0]);
-		ShowInfoF("Caps Lock:        %s", keyboard[1]);
-		ShowInfoF("                  %s", errormark[1]);
+		ShowInfo("The keyboard layout you selected contains invalid chars. Please check those chars marked with ^.");
+		ShowInfo("Normal keyboard:  {}", keyboard[0]);
+		ShowInfo("                  {}", errormark[0]);
+		ShowInfo("Caps Lock:        {}", keyboard[1]);
+		ShowInfo("                  {}", errormark[1]);
 	}
 }
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -424,7 +424,7 @@ static void CDECL HandleSavegameLoadCrash(int signum)
 			"Please file a bug report and attach this savegame.\n");
 	}
 
-	ShowInfo(buffer);
+	ShowInfoI(buffer);
 
 	SignalHandlerPointer call = nullptr;
 	switch (signum) {


### PR DESCRIPTION
## Motivation / Problem

Get rid of va_list, C-style strings and friends


## Description

Replace ShowInfo(F) with a variant that uses std::string and fmt over C-style string and vseprintf.


## Limitations

There's still plenty of va_list/C-style strings left, but small steps ;)
Don't know whether OS/2 still compiles.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
