### PR TITLE
Codechange: use string/fmt instead of print for strgen warnings/errors/fatals

### DIFF
--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -26,36 +26,21 @@
 
 #include "../safeguards.h"
 
-void CDECL strgen_warning(const char *s, ...)
+void CDECL StrgenWarningI(const std::string &msg)
 {
-	char buf[1024];
-	va_list va;
-	va_start(va, s);
-	vseprintf(buf, lastof(buf), s, va);
-	va_end(va);
-	Debug(script, 0, "{}:{}: warning: {}", _file, _cur_line, buf);
+	Debug(script, 0, "{}:{}: warning: {}", _file, _cur_line, msg);
 	_warnings++;
 }
 
-void CDECL strgen_error(const char *s, ...)
+void CDECL StrgenErrorI(const std::string &msg)
 {
-	char buf[1024];
-	va_list va;
-	va_start(va, s);
-	vseprintf(buf, lastof(buf), s, va);
-	va_end(va);
-	Debug(script, 0, "{}:{}: error: {}", _file, _cur_line, buf);
+	Debug(script, 0, "{}:{}: error: {}", _file, _cur_line, msg);
 	_errors++;
 }
 
-void NORETURN CDECL strgen_fatal(const char *s, ...)
+void CDECL StrgenFatalI(const std::string &msg)
 {
-	char buf[1024];
-	va_list va;
-	va_start(va, s);
-	vseprintf(buf, lastof(buf), s, va);
-	va_end(va);
-	Debug(script, 0, "{}:{}: FATAL: {}", _file, _cur_line, buf);
+	Debug(script, 0, "{}:{}: FATAL: {}", _file, _cur_line, msg);
 	throw std::exception();
 }
 

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -305,19 +305,16 @@
 #   define OTTD_PRINTF64U "%I64u"
 #   define OTTD_PRINTFHEX64 "%I64x"
 #   define PRINTF_SIZE "%Iu"
-#   define PRINTF_SIZEX "%IX"
 #elif defined(__MINGW32__)
 #   define OTTD_PRINTF64 "%I64d"
 #   define OTTD_PRINTF64U "%I64llu"
 #   define OTTD_PRINTFHEX64 "%I64x"
 #   define PRINTF_SIZE "%Iu"
-#   define PRINTF_SIZEX "%IX"
 #else
 #   define OTTD_PRINTF64 "%lld"
 #   define OTTD_PRINTF64U "%llu"
 #   define OTTD_PRINTFHEX64 "%llx"
 #   define PRINTF_SIZE "%zu"
-#   define PRINTF_SIZEX "%zX"
 #endif
 
 /*

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -39,40 +39,25 @@
 # define LINE_NUM_FMT(s) "%s:%d: " s ": %s\n"
 #endif
 
-void CDECL strgen_warning(const char *s, ...)
+void StrgenWarningI(const std::string &msg)
 {
-	char buf[1024];
-	va_list va;
-	va_start(va, s);
-	vseprintf(buf, lastof(buf), s, va);
-	va_end(va);
 	if (_show_todo > 0) {
-		fprintf(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, buf);
+		fprintf(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, msg.c_str());
 	} else {
-		fprintf(stderr, LINE_NUM_FMT("info"), _file, _cur_line, buf);
+		fprintf(stderr, LINE_NUM_FMT("info"), _file, _cur_line, msg.c_str());
 	}
 	_warnings++;
 }
 
-void CDECL strgen_error(const char *s, ...)
+void StrgenErrorI(const std::string &msg)
 {
-	char buf[1024];
-	va_list va;
-	va_start(va, s);
-	vseprintf(buf, lastof(buf), s, va);
-	va_end(va);
-	fprintf(stderr, LINE_NUM_FMT("error"), _file, _cur_line, buf);
+	fprintf(stderr, LINE_NUM_FMT("error"), _file, _cur_line, msg.c_str());
 	_errors++;
 }
 
-void NORETURN CDECL strgen_fatal(const char *s, ...)
+void NORETURN StrgenFatalI(const std::string &msg)
 {
-	char buf[1024];
-	va_list va;
-	va_start(va, s);
-	vseprintf(buf, lastof(buf), s, va);
-	va_end(va);
-	fprintf(stderr, LINE_NUM_FMT("FATAL"), _file, _cur_line, buf);
+	fprintf(stderr, LINE_NUM_FMT("FATAL"), _file, _cur_line, msg.c_str());
 #ifdef _MSC_VER
 	fprintf(stderr, LINE_NUM_FMT("warning"), _file, _cur_line, "language is not compiled");
 #endif

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -11,6 +11,7 @@
 #define STRGEN_H
 
 #include "../language.h"
+#include "../3rdparty/fmt/format.h"
 
 /** Container for the different cases of a string. */
 struct Case {
@@ -152,9 +153,12 @@ struct ParsedCommandStruct {
 const CmdStruct *TranslateCmdForCompare(const CmdStruct *a);
 void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool warnings);
 
-void CDECL strgen_warning(const char *s, ...) WARN_FORMAT(1, 2);
-void CDECL strgen_error(const char *s, ...) WARN_FORMAT(1, 2);
-void NORETURN CDECL strgen_fatal(const char *s, ...) WARN_FORMAT(1, 2);
+void StrgenWarningI(const std::string &msg);
+void StrgenErrorI(const std::string &msg);
+void NORETURN StrgenFatalI(const std::string &msg);
+#define StrgenWarning(format_string, ...) StrgenWarningI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
+#define StrgenError(format_string, ...) StrgenErrorI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
+#define StrgenFatal(format_string, ...) StrgenFatalI(fmt::format(FMT_STRING(format_string), ## __VA_ARGS__))
 char *ParseWord(char **buf);
 
 extern const char *_file;

--- a/src/strgen/strgen_base.cpp
+++ b/src/strgen/strgen_base.cpp
@@ -254,7 +254,7 @@ struct Buffer : std::vector<byte> {
 			this->push_back(0x80 + GB(value,  6, 6));
 			this->push_back(0x80 + GB(value,  0, 6));
 		} else {
-			strgen_warning("Invalid unicode value U+0x%X", value);
+			StrgenWarning("Invalid unicode value U+{:#X}", value);
 		}
 	}
 };
@@ -286,7 +286,7 @@ size_t Utf8Validate(const char *s)
 
 void EmitSingleChar(Buffer *buffer, char *buf, int value)
 {
-	if (*buf != '\0') strgen_warning("Ignoring trailing letters in command");
+	if (*buf != '\0') StrgenWarning("Ignoring trailing letters in command");
 	buffer->AppendUtf8(value);
 }
 
@@ -388,7 +388,7 @@ void EmitPlural(Buffer *buffer, char *buf, int value)
 	if (offset == -1) {
 		/* Use default offset */
 		if (cmd == nullptr || cmd->default_plural_offset < 0) {
-			strgen_fatal("Command '%s' has no (default) plural position", cmd == nullptr ? "<empty>" : cmd->cmd);
+			StrgenFatal("Command '{}' has no (default) plural position", cmd == nullptr ? "<empty>" : cmd->cmd);
 		}
 		offset = cmd->default_plural_offset;
 	}
@@ -400,15 +400,15 @@ void EmitPlural(Buffer *buffer, char *buf, int value)
 	}
 
 	if (nw == 0) {
-		strgen_fatal("%s: No plural words", _cur_ident);
+		StrgenFatal("{}: No plural words", _cur_ident);
 	}
 
 	if (expected != nw) {
 		if (_translated) {
-			strgen_fatal("%s: Invalid number of plural forms. Expecting %d, found %d.", _cur_ident,
+			StrgenFatal("{}: Invalid number of plural forms. Expecting {}, found {}.", _cur_ident,
 				expected, nw);
 		} else {
-			if ((_show_todo & 2) != 0) strgen_warning("'%s' is untranslated. Tweaking english string to allow compilation for plural forms", _cur_ident);
+			if ((_show_todo & 2) != 0) StrgenWarning("'{}' is untranslated. Tweaking english string to allow compilation for plural forms", _cur_ident);
 			if (nw > expected) {
 				nw = expected;
 			} else {
@@ -437,7 +437,7 @@ void EmitGender(Buffer *buffer, char *buf, int value)
 
 		/* This is a {G=DER} command */
 		nw = _lang.GetGenderIndex(buf);
-		if (nw >= MAX_NUM_GENDERS) strgen_fatal("G argument '%s' invalid", buf);
+		if (nw >= MAX_NUM_GENDERS) StrgenFatal("G argument '{}' invalid", buf);
 
 		/* now nw contains the gender index */
 		buffer->AppendUtf8(SCC_GENDER_INDEX);
@@ -451,14 +451,14 @@ void EmitGender(Buffer *buffer, char *buf, int value)
 
 		const CmdStruct *cmd = _cur_pcs.cmd[argidx];
 		if (cmd == nullptr || (cmd->flags & C_GENDER) == 0) {
-			strgen_fatal("Command '%s' can't have a gender", cmd == nullptr ? "<empty>" : cmd->cmd);
+			StrgenFatal("Command '{}' can't have a gender", cmd == nullptr ? "<empty>" : cmd->cmd);
 		}
 
 		for (nw = 0; nw < MAX_NUM_GENDERS; nw++) {
 			words[nw] = ParseWord(&buf);
 			if (words[nw] == nullptr) break;
 		}
-		if (nw != _lang.num_genders) strgen_fatal("Bad # of arguments for gender command");
+		if (nw != _lang.num_genders) StrgenFatal("Bad # of arguments for gender command");
 
 		assert(IsInsideBS(cmd->value, SCC_CONTROL_START, UINT8_MAX));
 		buffer->AppendUtf8(SCC_GENDER_LIST);
@@ -484,7 +484,7 @@ static uint ResolveCaseName(const char *str, size_t len)
 	case_str[len] = '\0';
 
 	uint8 case_idx = _lang.GetCaseIndex(case_str);
-	if (case_idx >= MAX_NUM_CASES) strgen_fatal("Invalid case-name '%s'", case_str);
+	if (case_idx >= MAX_NUM_CASES) StrgenFatal("Invalid case-name '{}'", case_str);
 	return case_idx + 1;
 }
 
@@ -509,7 +509,7 @@ static const CmdStruct *ParseCommandString(const char **str, char *param, int *a
 		char *end;
 
 		*argno = strtoul(s, &end, 0);
-		if (*end != ':') strgen_fatal("missing arg #");
+		if (*end != ':') StrgenFatal("missing arg #");
 		s = end + 1;
 	}
 
@@ -521,7 +521,8 @@ static const CmdStruct *ParseCommandString(const char **str, char *param, int *a
 
 	const CmdStruct *cmd = FindCmd(start, s - start - 1);
 	if (cmd == nullptr) {
-		strgen_error("Undefined command '%.*s'", (int)(s - start - 1), start);
+		std::string command(start, s - start - 1);
+		StrgenError("Undefined command '{}'", command);
 		return nullptr;
 	}
 
@@ -529,7 +530,7 @@ static const CmdStruct *ParseCommandString(const char **str, char *param, int *a
 		const char *casep = s;
 
 		if (!(cmd->flags & C_CASE)) {
-			strgen_fatal("Command '%s' can't have a case", cmd->cmd);
+			StrgenFatal("Command '{}' can't have a case", cmd->cmd);
 		}
 
 		do {
@@ -539,7 +540,7 @@ static const CmdStruct *ParseCommandString(const char **str, char *param, int *a
 	}
 
 	if (c == '\0') {
-		strgen_error("Missing } from command '%s'", start);
+		StrgenError("Missing }} from command '{}'", start);
 		return nullptr;
 	}
 
@@ -552,7 +553,7 @@ static const CmdStruct *ParseCommandString(const char **str, char *param, int *a
 			c = *s++;
 			if (c == '}') break;
 			if (c == '\0') {
-				strgen_error("Missing } from command '%s'", start);
+				StrgenError("Missing }} from command '{}'", start);
 				return nullptr;
 			}
 			if (s - start == MAX_COMMAND_PARAM_SIZE) error("param command too long");
@@ -600,16 +601,16 @@ void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool warnings)
 		if (ar == nullptr) break;
 
 		/* Sanity checking */
-		if (argno != -1 && ar->consumes == 0) strgen_fatal("Non consumer param can't have a paramindex");
+		if (argno != -1 && ar->consumes == 0) StrgenFatal("Non consumer param can't have a paramindex");
 
 		if (ar->consumes) {
 			if (argno != -1) argidx = argno;
-			if (argidx < 0 || (uint)argidx >= lengthof(p->cmd)) strgen_fatal("invalid param idx %d", argidx);
-			if (p->cmd[argidx] != nullptr && p->cmd[argidx] != ar) strgen_fatal("duplicate param idx %d", argidx);
+			if (argidx < 0 || (uint)argidx >= lengthof(p->cmd)) StrgenFatal("invalid param idx {}", argidx);
+			if (p->cmd[argidx] != nullptr && p->cmd[argidx] != ar) StrgenFatal("duplicate param idx {}", argidx);
 
 			p->cmd[argidx++] = ar;
 		} else if (!(ar->flags & C_DONTCOUNT)) { // Ignore some of them
-			if (p->np >= lengthof(p->pairs)) strgen_fatal("too many commands in string, max " PRINTF_SIZE, lengthof(p->pairs));
+			if (p->np >= lengthof(p->pairs)) StrgenFatal("too many commands in string, max {}", lengthof(p->pairs));
 			p->pairs[p->np].a = ar;
 			p->pairs[p->np].v = param[0] != '\0' ? stredup(param) : "";
 			p->np++;
@@ -654,7 +655,7 @@ static bool CheckCommandsMatch(char *a, char *b, const char *name)
 
 	/* For each string in templ, see if we find it in lang */
 	if (templ.np != lang.np) {
-		strgen_warning("%s: template string and language string have a different # of commands", name);
+		StrgenWarning("{}: template string and language string have a different # of commands", name);
 		result = false;
 	}
 
@@ -672,7 +673,7 @@ static bool CheckCommandsMatch(char *a, char *b, const char *name)
 		}
 
 		if (!found) {
-			strgen_warning("%s: command '%s' exists in template file but not in language file", name, templ.pairs[i].a->cmd);
+			StrgenWarning("{}: command '{}' exists in template file but not in language file", name, templ.pairs[i].a->cmd);
 			result = false;
 		}
 	}
@@ -681,7 +682,7 @@ static bool CheckCommandsMatch(char *a, char *b, const char *name)
 	 * Check if the non consumer commands match up also. */
 	for (uint i = 0; i < lengthof(templ.cmd); i++) {
 		if (TranslateCmdForCompare(templ.cmd[i]) != lang.cmd[i]) {
-			strgen_warning("%s: Param idx #%d '%s' doesn't match with template command '%s'", name, i,
+			StrgenWarning("{}: Param idx #{} '{}' doesn't match with template command '{}'", name, i,
 				lang.cmd[i]  == nullptr ? "<empty>" : TranslateCmdForCompare(lang.cmd[i])->cmd,
 				templ.cmd[i] == nullptr ? "<empty>" : templ.cmd[i]->cmd);
 			result = false;
@@ -703,7 +704,7 @@ void StringReader::HandleString(char *str)
 
 	char *s = strchr(str, ':');
 	if (s == nullptr) {
-		strgen_error("Line has no ':' delimiter");
+		StrgenError("Line has no ':' delimiter");
 		return;
 	}
 
@@ -718,7 +719,7 @@ void StringReader::HandleString(char *str)
 	const char *tmp;
 	for (tmp = s; *tmp != '\0';) {
 		size_t len = Utf8Validate(tmp);
-		if (len == 0) strgen_fatal("Invalid UTF-8 sequence in '%s'", s);
+		if (len == 0) StrgenFatal("Invalid UTF-8 sequence in '{}'", s);
 
 		WChar c;
 		Utf8Decode(&c, tmp);
@@ -726,7 +727,7 @@ void StringReader::HandleString(char *str)
 				c == 0x200B || // Zero width space
 				(c >= 0xE000 && c <= 0xF8FF) || // Private range
 				(c >= 0xFFF0 && c <= 0xFFFF)) { // Specials range
-			strgen_fatal("Unwanted UTF-8 character U+%04X in sequence '%s'", c, s);
+			StrgenFatal("Unwanted UTF-8 character U+{:04X} in sequence '{}'", (int)c, s);
 		}
 
 		tmp += len;
@@ -742,17 +743,17 @@ void StringReader::HandleString(char *str)
 
 	if (this->master) {
 		if (casep != nullptr) {
-			strgen_error("Cases in the base translation are not supported.");
+			StrgenError("Cases in the base translation are not supported.");
 			return;
 		}
 
 		if (ent != nullptr) {
-			strgen_error("String name '%s' is used multiple times", str);
+			StrgenError("String name '{}' is used multiple times", str);
 			return;
 		}
 
 		if (this->data.strings[this->data.next_string_id] != nullptr) {
-			strgen_error("String ID 0x" PRINTF_SIZEX " for '%s' already in use by '%s'", this->data.next_string_id, str, this->data.strings[this->data.next_string_id]->name);
+			StrgenError("String ID {:#X} for '{}' already in use by '{}'", this->data.next_string_id, str, this->data.strings[this->data.next_string_id]->name);
 			return;
 		}
 
@@ -760,12 +761,12 @@ void StringReader::HandleString(char *str)
 		this->data.Add(str, new LangString(str, s, this->data.next_string_id++, _cur_line));
 	} else {
 		if (ent == nullptr) {
-			strgen_warning("String name '%s' does not exist in master file", str);
+			StrgenWarning("String name '{}' does not exist in master file", str);
 			return;
 		}
 
 		if (ent->translated && casep == nullptr) {
-			strgen_error("String name '%s' is used multiple times", str);
+			StrgenError("String name '{}' is used multiple times", str);
 			return;
 		}
 
@@ -789,10 +790,10 @@ void StringReader::HandlePragma(char *str)
 	if (!memcmp(str, "plural ", 7)) {
 		_lang.plural_form = atoi(str + 7);
 		if (_lang.plural_form >= lengthof(_plural_forms)) {
-			strgen_fatal("Invalid pluralform %d", _lang.plural_form);
+			StrgenFatal("Invalid pluralform {}", _lang.plural_form);
 		}
 	} else {
-		strgen_fatal("unknown pragma '%s'", str);
+		StrgenFatal("unknown pragma '{}'", str);
 	}
 }
 
@@ -829,7 +830,7 @@ void StringReader::ParseFile()
 	}
 
 	if (this->data.next_string_id == this->data.max_strings) {
-		strgen_error("Too many strings, maximum allowed is " PRINTF_SIZE, this->data.max_strings);
+		StrgenError("Too many strings, maximum allowed is {}", this->data.max_strings);
 	}
 }
 
@@ -855,15 +856,15 @@ static int TranslateArgumentIdx(int argidx, int offset)
 	int sum;
 
 	if (argidx < 0 || (uint)argidx >= lengthof(_cur_pcs.cmd)) {
-		strgen_fatal("invalid argidx %d", argidx);
+		StrgenFatal("invalid argidx {}", argidx);
 	}
 	const CmdStruct *cs = _cur_pcs.cmd[argidx];
 	if (cs != nullptr && cs->consumes <= offset) {
-		strgen_fatal("invalid argidx offset %d:%d", argidx, offset);
+		StrgenFatal("invalid argidx offset {}:{}", argidx, offset);
 	}
 
 	if (_cur_pcs.cmd[argidx] == nullptr) {
-		strgen_fatal("no command for this argidx %d", argidx);
+		StrgenFatal("no command for this argidx {}", argidx);
 	}
 
 	for (int i = sum = 0; i < argidx; i++) {
@@ -915,7 +916,7 @@ static void PutCommandString(Buffer *buffer, const char *str)
 			/* Output the one from the master string... it's always accurate. */
 			cs = _cur_pcs.cmd[_cur_argidx++];
 			if (cs == nullptr) {
-				strgen_fatal("%s: No argument exists at position %d", _cur_ident, _cur_argidx - 1);
+				StrgenFatal("{}: No argument exists at position {}", _cur_ident, _cur_argidx - 1);
 			}
 		}
 
@@ -932,7 +933,7 @@ void LanguageWriter::WriteLength(uint length)
 	char buffer[2];
 	int offs = 0;
 	if (length >= 0x4000) {
-		strgen_fatal("string too long");
+		StrgenFatal("string too long");
 	}
 
 	if (length >= 0xC0) {
@@ -987,7 +988,7 @@ void LanguageWriter::WriteLang(const StringData &data)
 			/* Produce a message if a string doesn't have a translation. */
 			if (_show_todo > 0 && ls->translated == nullptr) {
 				if ((_show_todo & 2) != 0) {
-					strgen_warning("'%s' is untranslated", ls->name);
+					StrgenWarning("'{}' is untranslated", ls->name);
 				}
 				if ((_show_todo & 1) != 0) {
 					const char *s = "<TODO> ";


### PR DESCRIPTION
## Motivation / Problem

Get rid of va_list, C-style strings and friends.
Those nasty PRINTF replacement macros.


## Description

Replace ShowInfo(F) with a variant that uses std::string and fmt over C-style string and vseprintf.
Remove PRINTF_SIZEX, as that is not used anymore.


## Limitations

There's still plenty of va_list/C-style strings left, but small steps ;)
Don't know whether OS/2 still compiles.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
