### PR TITLE
Codechange: use std::string for base media filename/warning storage

### DIFF
--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -31,9 +31,9 @@ struct MD5File {
 		CR_NO_FILE,  ///< The file did not exist
 	};
 
-	const char *filename;        ///< filename
+	std::string filename;        ///< filename
 	uint8 hash[16];              ///< md5 sum of the file
-	const char *missing_warning; ///< warning when this file is missing
+	std::string missing_warning; ///< warning when this file is missing
 	ChecksumResult check_result; ///< cached result of md5 check
 
 	ChecksumResult CheckMD5(Subdirectory subdir, size_t max_size) const;
@@ -73,11 +73,6 @@ struct BaseSet {
 	/** Free everything we allocated */
 	~BaseSet()
 	{
-		for (uint i = 0; i < NUM_FILES; i++) {
-			free(this->files[i].filename);
-			free(this->files[i].missing_warning);
-		}
-
 		delete this->next;
 	}
 
@@ -100,7 +95,7 @@ struct BaseSet {
 		return Tnum_files - this->valid_files;
 	}
 
-	bool FillSetDetails(IniFile *ini, const char *path, const char *full_filename, bool allow_empty_filename = true);
+	bool FillSetDetails(IniFile *ini, const std::string &path, const std::string &full_filename, bool allow_empty_filename = true);
 
 	/**
 	 * Get the description for the given ISO code.
@@ -147,7 +142,7 @@ struct BaseSet {
 	const char *GetTextfile(TextfileType type) const
 	{
 		for (uint i = 0; i < NUM_FILES; i++) {
-			const char *textfile = ::GetTextfile(type, BASESET_DIR, this->files[i].filename);
+			const char *textfile = ::GetTextfile(type, BASESET_DIR, this->files[i].filename.c_str());
 			if (textfile != nullptr) {
 				return textfile;
 			}
@@ -249,7 +244,7 @@ struct GraphicsSet : BaseSet<GraphicsSet, MAX_GFT, true> {
 	PaletteType palette;       ///< Palette of this graphics set
 	BlitterType blitter;       ///< Blitter of this graphics set
 
-	bool FillSetDetails(struct IniFile *ini, const char *path, const char *full_filename);
+	bool FillSetDetails(struct IniFile *ini, const std::string &path, const std::string &full_filename);
 
 	static MD5File::ChecksumResult CheckMD5(const MD5File *file, Subdirectory subdir);
 };
@@ -279,8 +274,8 @@ static const uint NUM_SONGS_AVAILABLE = 1 + NUM_SONG_CLASSES * NUM_SONGS_CLASS;
 static const uint NUM_SONGS_PLAYLIST  = 32;
 
 /* Functions to read DOS music CAT files, similar to but not quite the same as sound effect CAT files */
-char *GetMusicCatEntryName(const char *filename, size_t entrynum);
-byte *GetMusicCatEntryData(const char *filename, size_t entrynum, size_t &entrylen);
+char *GetMusicCatEntryName(const std::string &filename, size_t entrynum);
+byte *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen);
 
 enum MusicTrackType {
 	MTT_STANDARDMIDI, ///< Standard MIDI file
@@ -291,7 +286,7 @@ enum MusicTrackType {
 struct MusicSongInfo {
 	std::string songname;    ///< name of song displayed in UI
 	byte tracknr;            ///< track number of song displayed in UI
-	const char *filename;    ///< file on disk containing song (when used in MusicSet class, this pointer is owned by MD5File object for the file)
+	std::string filename;    ///< file on disk containing song (when used in MusicSet class)
 	MusicTrackType filetype; ///< decoder required for song file
 	int cat_index;           ///< entry index in CAT file, for filetype==MTT_MPSMIDI
 	bool loop;               ///< song should play in a tight loop if possible, never ending
@@ -306,7 +301,7 @@ struct MusicSet : BaseSet<MusicSet, NUM_SONGS_AVAILABLE, false> {
 	/** Number of valid songs in set. */
 	byte num_available;
 
-	bool FillSetDetails(struct IniFile *ini, const char *path, const char *full_filename);
+	bool FillSetDetails(struct IniFile *ini, const std::string &path, const std::string &full_filename);
 };
 
 /** All data/functions related with replacing the base music */

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -140,7 +140,7 @@ void FioFCloseFile(FILE *f)
  * @param filename Filename to look for.
  * @return String containing the path if the path was found, else an empty string.
  */
-std::string FioFindFullPath(Subdirectory subdir, const char *filename)
+std::string FioFindFullPath(Subdirectory subdir, const std::string &filename)
 {
 	assert(subdir < NUM_SUBDIRS);
 

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -18,7 +18,7 @@
 void FioFCloseFile(FILE *f);
 FILE *FioFOpenFile(const std::string &filename, const char *mode, Subdirectory subdir, size_t *filesize = nullptr);
 bool FioCheckFileExists(const std::string &filename, Subdirectory subdir);
-std::string FioFindFullPath(Subdirectory subdir, const char *filename);
+std::string FioFindFullPath(Subdirectory subdir, const std::string &filename);
 std::string FioGetDirectory(Searchpath sp, Subdirectory subdir);
 std::string FioFindDirectory(Subdirectory subdir);
 void FioCreateDirectory(const std::string &name);

--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -42,7 +42,7 @@ static const SpriteID * const _landscape_spriteindexes[] = {
  * @param needs_palette_remap Whether the colours in the GRF file need a palette remap.
  * @return The number of loaded sprites.
  */
-static uint LoadGrfFile(const char *filename, uint load_index, bool needs_palette_remap)
+static uint LoadGrfFile(const std::string &filename, uint load_index, bool needs_palette_remap)
 {
 	uint load_index_org = load_index;
 	uint sprite_id = 0;
@@ -52,7 +52,7 @@ static uint LoadGrfFile(const char *filename, uint load_index, bool needs_palett
 	Debug(sprite, 2, "Reading grf-file '{}'", filename);
 
 	byte container_ver = file.GetContainerVersion();
-	if (container_ver == 0) usererror("Base grf '%s' is corrupt", filename);
+	if (container_ver == 0) usererror("Base grf '%s' is corrupt", filename.c_str());
 	ReadGRFSpriteOffsets(file);
 	if (container_ver >= 2) {
 		/* Read compression. */
@@ -79,7 +79,7 @@ static uint LoadGrfFile(const char *filename, uint load_index, bool needs_palett
  * @param needs_palette_remap Whether the colours in the GRF file need a palette remap.
  * @return The number of loaded sprites.
  */
-static void LoadGrfFileIndexed(const char *filename, const SpriteID *index_tbl, bool needs_palette_remap)
+static void LoadGrfFileIndexed(const std::string &filename, const SpriteID *index_tbl, bool needs_palette_remap)
 {
 	uint start;
 	uint sprite_id = 0;
@@ -89,7 +89,7 @@ static void LoadGrfFileIndexed(const char *filename, const SpriteID *index_tbl, 
 	Debug(sprite, 2, "Reading indexed grf-file '{}'", filename);
 
 	byte container_ver = file.GetContainerVersion();
-	if (container_ver == 0) usererror("Base grf '%s' is corrupt", filename);
+	if (container_ver == 0) usererror("Base grf '%s' is corrupt", filename.c_str());
 	ReadGRFSpriteOffsets(file);
 	if (container_ver >= 2) {
 		/* Read compression. */
@@ -137,7 +137,7 @@ void CheckExternalFiles()
 		add_pos += seprintf(add_pos, last, "Trying to load graphics set '%s', but it is incomplete. The game will probably not run correctly until you properly install this set or select another one. See section 4.1 of README.md.\n\nThe following files are corrupted or missing:\n", used_set->name.c_str());
 		for (uint i = 0; i < GraphicsSet::NUM_FILES; i++) {
 			MD5File::ChecksumResult res = GraphicsSet::CheckMD5(&used_set->files[i], BASESET_DIR);
-			if (res != MD5File::CR_MATCH) add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", used_set->files[i].filename, res == MD5File::CR_MISMATCH ? "corrupt" : "missing", used_set->files[i].missing_warning);
+			if (res != MD5File::CR_MATCH) add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", used_set->files[i].filename.c_str(), res == MD5File::CR_MISMATCH ? "corrupt" : "missing", used_set->files[i].missing_warning.c_str());
 		}
 		add_pos += seprintf(add_pos, last, "\n");
 	}
@@ -149,7 +149,7 @@ void CheckExternalFiles()
 		static_assert(SoundsSet::NUM_FILES == 1);
 		/* No need to loop each file, as long as there is only a single
 		 * sound file. */
-		add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", sounds_set->files->filename, SoundsSet::CheckMD5(sounds_set->files, BASESET_DIR) == MD5File::CR_MISMATCH ? "corrupt" : "missing", sounds_set->files->missing_warning);
+		add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", sounds_set->files->filename.c_str(), SoundsSet::CheckMD5(sounds_set->files, BASESET_DIR) == MD5File::CR_MISMATCH ? "corrupt" : "missing", sounds_set->files->missing_warning.c_str());
 	}
 
 	if (add_pos != error_msg) ShowInfoF("%s", error_msg);
@@ -201,7 +201,7 @@ static void LoadSpriteTables()
 	ClrBit(master->flags, GCF_INIT_ONLY);
 
 	/* Baseset extra graphics */
-	GRFConfig *extra = new GRFConfig(used_set->files[GFT_EXTRA].filename);
+	GRFConfig *extra = new GRFConfig(used_set->files[GFT_EXTRA].filename.c_str());
 
 	/* We know the palette of the base set, so if the base NewGRF is not
 	 * setting one, use the palette of the base set and not the global
@@ -355,7 +355,7 @@ void GfxLoadSprites()
 	UpdateCursorSize();
 }
 
-bool GraphicsSet::FillSetDetails(IniFile *ini, const char *path, const char *full_filename)
+bool GraphicsSet::FillSetDetails(IniFile *ini, const std::string &path, const std::string &full_filename)
 {
 	bool ret = this->BaseSet<GraphicsSet, MAX_GFT, true>::FillSetDetails(ini, path, full_filename, false);
 	if (ret) {

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -25,7 +25,7 @@
  * @return Pointer to string, caller is responsible for freeing memory,
  *         nullptr if entrynum does not exist.
  */
-char *GetMusicCatEntryName(const char *filename, size_t entrynum)
+char *GetMusicCatEntryName(const std::string &filename, size_t entrynum)
 {
 	if (!FioCheckFileExists(filename, BASESET_DIR)) return nullptr;
 
@@ -52,7 +52,7 @@ char *GetMusicCatEntryName(const char *filename, size_t entrynum)
  * @return Pointer to buffer with data read, caller is responsible for freeind memory,
  *         nullptr if entrynum does not exist.
  */
-byte *GetMusicCatEntryData(const char *filename, size_t entrynum, size_t &entrylen)
+byte *GetMusicCatEntryData(const std::string &filename, size_t entrynum, size_t &entrylen)
 {
 	entrylen = 0;
 	if (!FioCheckFileExists(filename, BASESET_DIR)) return nullptr;
@@ -116,7 +116,7 @@ template <class Tbase_set>
 	return BaseMedia<Tbase_set>::used_set != nullptr;
 }
 
-bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_filename)
+bool MusicSet::FillSetDetails(IniFile *ini, const std::string &path, const std::string &full_filename)
 {
 	bool ret = this->BaseSet<MusicSet, NUM_SONGS_AVAILABLE, false>::FillSetDetails(ini, path, full_filename);
 	if (ret) {
@@ -126,8 +126,8 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 		IniGroup *timingtrim = ini->GetGroup("timingtrim");
 		uint tracknr = 1;
 		for (uint i = 0; i < lengthof(this->songinfo); i++) {
-			const char *filename = this->files[i].filename;
-			if (names == nullptr || StrEmpty(filename) || this->files[i].check_result == MD5File::CR_NO_FILE) {
+			const std::string &filename = this->files[i].filename;
+			if (filename.empty() || this->files[i].check_result == MD5File::CR_NO_FILE) {
 				continue;
 			}
 
@@ -149,7 +149,7 @@ bool MusicSet::FillSetDetails(IniFile *ini, const char *path, const char *full_f
 				this->songinfo[i].filetype = MTT_STANDARDMIDI;
 			}
 
-			const char *trimmed_filename = filename;
+			const char *trimmed_filename = filename.c_str();
 			/* As we possibly add a path to the filename and we compare
 			 * on the filename with the path as in the .obm, we need to
 			 * keep stripping path elements until we find a match. */

--- a/src/music/midifile.cpp
+++ b/src/music/midifile.cpp
@@ -849,7 +849,7 @@ bool MidiFile::LoadSong(const MusicSongInfo &song)
 {
 	switch (song.filetype) {
 		case MTT_STANDARDMIDI:
-			return this->LoadFile(song.filename);
+			return this->LoadFile(song.filename.c_str());
 		case MTT_MPSMIDI:
 		{
 			size_t songdatalen = 0;
@@ -1060,9 +1060,9 @@ std::string MidiFile::GetSMFFile(const MusicSongInfo &song)
 
 	char basename[MAX_PATH];
 	{
-		const char *fnstart = strrchr(song.filename, PATHSEPCHAR);
+		const char *fnstart = strrchr(song.filename.c_str(), PATHSEPCHAR);
 		if (fnstart == nullptr) {
-			fnstart = song.filename;
+			fnstart = song.filename.c_str();
 		} else {
 			fnstart++;
 		}

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -23,7 +23,7 @@
 
 static SoundEntry _original_sounds[ORIGINAL_SAMPLE_COUNT];
 
-static void OpenBankFile(const char *filename)
+static void OpenBankFile(const std::string &filename)
 {
 	/**
 	 * The sound file for the original sounds, i.e. those not defined/overridden by a NewGRF.
@@ -34,7 +34,7 @@ static void OpenBankFile(const char *filename)
 	memset(_original_sounds, 0, sizeof(_original_sounds));
 
 	/* If there is no sound file (nosound set), don't load anything */
-	if (filename == nullptr) return;
+	if (filename.empty()) return;
 
 	original_sound_file.reset(new RandomAccessFile(filename, BASESET_DIR));
 	size_t pos = original_sound_file->GetPos();


### PR DESCRIPTION
## Motivation / Problem

Get rid of stredup/str_fmt/free for base media data.


## Description

Replace `char *` with `std::string` and propogate where appropriate.


## Limitations

The linked list of base sets should probably be changed to a vector, so there is no destructor needed anymore.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
