### PR TITLE
Fix #10600: 'Replace Vehicles' shows numbers >999

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1026,7 +1026,15 @@ void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_li
 	int count_width = 0;
 	if (show_count) {
 		replace_icon = GetSpriteSize(SPR_GROUP_REPLACE_ACTIVE);
-		SetDParamMaxDigits(0, 3, FS_SMALL);
+
+		uint biggest_num_engines = 0;
+		for (auto i = min; i < max; i++) {
+			const auto &item = eng_list[i];
+			const uint num_engines = GetGroupNumEngines(_local_company, selected_group, item.engine_id);
+			biggest_num_engines = std::max(biggest_num_engines, num_engines);
+		}
+
+		SetDParam(0, biggest_num_engines);
 		count_width = GetStringBoundingBox(STR_JUST_COMMA, FS_SMALL).width;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Fixes the digit display issue in the 'Replace Vehicles' window.
Closes #10600 

## Description

Up to 6 digits can now be displayed in the 'Replace Vehicles' window.

## Limitations

Does not allow more than 6 digits.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
