### PR TITLE
Codechange: Make GRF temporary engine data a vector.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -347,7 +347,7 @@ struct GRFTempEngineData {
 	}
 };
 
-static GRFTempEngineData *_gted;  ///< Temporary engine data used during NewGRF loading
+static std::vector<GRFTempEngineData> _gted;  ///< Temporary engine data used during NewGRF loading
 
 /**
  * Contains the GRF ID of the owner of a vehicle if it has been reserved.
@@ -667,11 +667,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16 intern
 
 	if (engine_pool_size != Engine::GetPoolSize()) {
 		/* Resize temporary engine data ... */
-		_gted = ReallocT(_gted, Engine::GetPoolSize());
-
-		/* and blank the new block. */
-		size_t len = (Engine::GetPoolSize() - engine_pool_size) * sizeof(*_gted);
-		memset(_gted + engine_pool_size, 0, len);
+		_gted.resize(Engine::GetPoolSize());
 	}
 	if (type == VEH_TRAIN) {
 		_gted[e->index].railtypelabel = GetRailTypeInfo(e->u.rail.railtype)->label;
@@ -8753,7 +8749,7 @@ void ResetNewGRFData()
 	ResetRoadTypes();
 
 	/* Allocate temporary refit/cargo class data */
-	_gted = CallocT<GRFTempEngineData>(Engine::GetPoolSize());
+	_gted.resize(Engine::GetPoolSize());
 
 	/* Fill rail type label temporary data for default trains */
 	for (const Engine *e : Engine::IterateType(VEH_TRAIN)) {
@@ -9928,7 +9924,7 @@ static void AfterLoadGRFs()
 	FinalisePriceBaseMultipliers();
 
 	/* Deallocate temporary loading data */
-	free(_gted);
+	_gted.clear();
 	_grm_sprites.clear();
 }
 


### PR DESCRIPTION
## Motivation / Problem

GRFTemporaryEngineData `_gted` is basically a vector, but done with C-style allocations.

## Description

Just make it a vector.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
