### PR TITLE
Add: New rectangle place method: fixed and limited side lengths.

### DIFF
--- a/src/tilehighlight_func.h
+++ b/src/tilehighlight_func.h
@@ -26,6 +26,8 @@ void VpStartDragging(ViewportDragDropSelectionProcess process);
 void VpStartPlaceSizing(TileIndex tile, ViewportPlaceMethod method, ViewportDragDropSelectionProcess process);
 void VpSetPresizeRange(TileIndex from, TileIndex to);
 void VpSetPlaceSizingLimit(int limit);
+void VpSetPlaceFixedSize(byte fixed_size);
+void VpResetFixedSize();
 
 void UpdateTileSelection();
 

--- a/src/tilehighlight_type.h
+++ b/src/tilehighlight_type.h
@@ -60,6 +60,7 @@ struct TileHighlightData {
 	Point selstart;      ///< The location where the dragging started.
 	Point selend;        ///< The location where the drag currently ends.
 	byte sizelimit;      ///< Whether the selection is limited in length, and what the maximum length is.
+	byte fixed_size;     ///< The fixed length for one of the sides.
 
 	HighLightStyle drawstyle;      ///< Lower bits 0-3 are reserved for detailed highlight information.
 	HighLightStyle next_drawstyle; ///< Queued, but not yet drawn style.

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -86,17 +86,19 @@ static const uint BB_Z_SEPARATOR         = 7; ///< Separates the bridge/tunnel f
 
 /** Viewport place method (type of highlighted area and placed objects) */
 enum ViewportPlaceMethod {
-	VPM_X_OR_Y          =    0, ///< drag in X or Y direction
-	VPM_FIX_X           =    1, ///< drag only in X axis
-	VPM_FIX_Y           =    2, ///< drag only in Y axis
-	VPM_X_AND_Y         =    3, ///< area of land in X and Y directions
-	VPM_X_AND_Y_LIMITED =    4, ///< area of land of limited size
-	VPM_FIX_HORIZONTAL  =    5, ///< drag only in horizontal direction
-	VPM_FIX_VERTICAL    =    6, ///< drag only in vertical direction
-	VPM_X_LIMITED       =    7, ///< Drag only in X axis with limited size
-	VPM_Y_LIMITED       =    8, ///< Drag only in Y axis with limited size
-	VPM_RAILDIRS        = 0x40, ///< all rail directions
-	VPM_SIGNALDIRS      = 0x80, ///< similar to VMP_RAILDIRS, but with different cursor
+	VPM_X_OR_Y            =    0, ///< drag in X or Y direction
+	VPM_FIX_X             =    1, ///< drag only in X axis
+	VPM_FIX_Y             =    2, ///< drag only in Y axis
+	VPM_X_AND_Y           =    3, ///< area of land in X and Y directions
+	VPM_X_AND_Y_LIMITED   =    4, ///< area of land of limited size
+	VPM_FIX_HORIZONTAL    =    5, ///< drag only in horizontal direction
+	VPM_FIX_VERTICAL      =    6, ///< drag only in vertical direction
+	VPM_X_LIMITED         =    7, ///< Drag only in X axis with limited size
+	VPM_Y_LIMITED         =    8, ///< Drag only in Y axis with limited size
+	VPM_LIMITED_Y_FIXED_X =    9, ///< Drag only in Y axis with limited size and a fixed value for x
+	VPM_LIMITED_X_FIXED_Y =   10, ///< Drag only in X axis with limited size and a fixed value for y
+	VPM_RAILDIRS          = 0x40, ///< all rail directions
+	VPM_SIGNALDIRS        = 0x80, ///< similar to VMP_RAILDIRS, but with different cursor
 };
 DECLARE_ENUM_AS_BIT_SET(ViewportPlaceMethod)
 


### PR DESCRIPTION
## Motivation / Problem

This PR is related to #9577 

There is no place method for selecting a rectangle of tiles where one side has a fixed length and the other side has a variable and limited length.

In other words, to make it possible to build 7 ship depots, one next to the other, it should be possible to draw a rectangle with a fixed size of 2 in one side (as ship depots have a length of 2 tiles) and then move the mouse to select the desired tiles (a 2x7 rectangle).
The other side, the one that is not fixed, is limited to the depot spread limit.

This commit adds this new place method.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
