### PR TITLE
Fix #10289: Don't silently fail when setting timetable start dates

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -5110,6 +5110,7 @@ STR_ERROR_NO_BUOY                                               :{WHITE}There is
 STR_ERROR_CAN_T_TIMETABLE_VEHICLE                               :{WHITE}Can't timetable vehicle...
 STR_ERROR_TIMETABLE_ONLY_WAIT_AT_STATIONS                       :{WHITE}Vehicles can only wait at stations
 STR_ERROR_TIMETABLE_NOT_STOPPING_HERE                           :{WHITE}This vehicle is not stopping at this station
+STR_ERROR_TIMETABLE_INCOMPLETE                                  :{WHITE}... timetable is incomplete
 
 # Sign related errors
 STR_ERROR_TOO_MANY_SIGNS                                        :{WHITE}... too many signs

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -306,7 +306,7 @@ CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool tim
 	if (start_date < 0 || start_date > MAX_DAY) return CMD_ERROR;
 	if (start_date - _date > MAX_TIMETABLE_START_YEARS * DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (_date - start_date > DAYS_IN_LEAP_YEAR) return CMD_ERROR;
-	if (timetable_all && !v->orders->IsCompleteTimetable()) return CMD_ERROR;
+	if (timetable_all && !v->orders->IsCompleteTimetable()) return CommandCost(STR_ERROR_TIMETABLE_INCOMPLETE);
 	if (timetable_all && start_date + total_duration / DAY_TICKS > MAX_DAY) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -572,7 +572,7 @@ struct TimetableWindow : Window {
 			}
 
 			case WID_VT_START_DATE: // Change the date that the timetable starts.
-				ShowSetDateWindow(this, v->index, _date, _cur_year, _cur_year + MAX_TIMETABLE_START_YEARS, ChangeTimetableStartCallback, reinterpret_cast<void *>(static_cast<uintptr_t>(v->orders->IsCompleteTimetable() && _ctrl_pressed)));
+				ShowSetDateWindow(this, v->index, _date, _cur_year, _cur_year + MAX_TIMETABLE_START_YEARS, ChangeTimetableStartCallback, reinterpret_cast<void *>(static_cast<uintptr_t>(_ctrl_pressed)));
 				break;
 
 			case WID_VT_CHANGE_TIME: { // "Wait For" button.


### PR DESCRIPTION
## Motivation / Problem

Copied from #10289:

### Expected result

When setting timetable start dates for multiple vehicle with shared orders, Ctrl+clicking the Start Date button spaces out vehicles along the route. 

If the entire route is not timetabled, we don’t know the full duration and therefore can’t space our vehicles evenly. 

In this case I would expect it to either spread out vehicles using the known incomplete total, or throw an error message to the player. 

### Actual result

The command fails silently and only sets the start date of the selected vehicle, leading to misunderstandings like #8054. 

@nchappe explains in #8054:
> In the code the exact condition to set the timetable start date for all the vehicles with the same shared orders when the set start date button is pressed is v->orders->IsCompleteTimetable() && _ctrl_pressed, which means that if some orders are not explicitly timetabled, Ctrl+Click silently falls back to setting the timetable start date of a single vehicle, with no user feedback.
This is explained in the relevant tooltip ("Ctrl+Click distributes all vehicles sharing this order evenly from the given date based on their relative order, if the order is completely timetabled"), but I still find it a bit counter-intuitive, and I suspect this is the root of this issue.

### Steps to reproduce

1. Create more than one vehicle with shared orders
2. Timetable most but not all of their orders
3. Ctrl+click Start Date to space them out over the route
4. Notice that only the selected vehicle gets its start date changed

## Description

Throw an error instead of silently failing.

The `CmdSetTimetableStart()` command is already supposed to throw an error if the timetable is not complete, but the check is being performed in the GUI click handler before calling the command, which incorrectly passes the `timetable_all` parameter as false.

I've removed the incorrectly-placed check and added a descriptive error to tell the player why it's not working.

Closes #10289.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
