### PR TITLE
Change: Add Depots and DepotIDs for airports with hangars.

### DIFF
--- a/src/depot_map.h
+++ b/src/depot_map.h
@@ -43,16 +43,21 @@ inline bool IsDepotTile(Tile tile)
 	return IsRailDepotTile(tile) || IsRoadDepotTile(tile) || IsShipDepotTile(tile) || IsHangarTile(tile);
 }
 
+extern DepotID GetHangarIndex(TileIndex t);
+
 /**
  * Get the index of which depot is attached to the tile.
  * @param t the tile
- * @pre IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t)
+ * @pre IsDepotTile(t)
  * @return DepotID
  */
 inline DepotID GetDepotIndex(Tile t)
 {
-	/* Hangars don't have a Depot class, thus store no DepotID. */
-	assert(IsRailDepotTile(t) || IsRoadDepotTile(t) || IsShipDepotTile(t));
+	assert(IsDepotTile(t));
+
+	/* Hangars don't store depot id on m2. */
+	if (IsTileType(t, MP_STATION)) return GetHangarIndex(t);
+
 	return t.m2();
 }
 

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -246,18 +246,14 @@ CommandCost CmdClearOrderBackup(DoCommandFlag flags, TileIndex tile, ClientID us
  * Removes an order from all vehicles. Triggers when, say, a station is removed.
  * @param type The type of the order (OT_GOTO_[STATION|DEPOT|WAYPOINT]).
  * @param destination The destination. Can be a StationID, DepotID or WaypointID.
- * @param hangar Only used for airports in the destination.
- *               When false, remove airport and hangar orders.
- *               When true, remove either airport or hangar order.
  */
-/* static */ void OrderBackup::RemoveOrder(OrderType type, DestinationID destination, bool hangar)
+/* static */ void OrderBackup::RemoveOrder(OrderType type, DestinationID destination)
 {
 	for (OrderBackup *ob : OrderBackup::Iterate()) {
 		for (Order *order = ob->orders; order != nullptr; order = order->next) {
 			OrderType ot = order->GetType();
 			if (ot == OT_GOTO_DEPOT && (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) != 0) continue;
-			if (ot == OT_GOTO_DEPOT && hangar && !IsHangarTile(ob->tile)) continue; // Not an aircraft? Can't have a hangar order.
-			if (ot == OT_IMPLICIT || (IsHangarTile(ob->tile) && ot == OT_GOTO_DEPOT && !hangar)) ot = OT_GOTO_STATION;
+			if (ot == OT_IMPLICIT) ot = OT_GOTO_STATION;
 			if (ot == type && order->GetDestination() == destination) {
 				/* Remove the order backup! If a station/depot gets removed, we can't/shouldn't restore those broken orders. */
 				delete ob;

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -59,7 +59,7 @@ public:
 
 	static void ClearGroup(GroupID group);
 	static void ClearVehicle(const Vehicle *v);
-	static void RemoveOrder(OrderType type, DestinationID destination, bool hangar);
+	static void RemoveOrder(OrderType type, DestinationID destination);
 };
 
 #endif /* ORDER_BACKUP_H */

--- a/src/order_func.h
+++ b/src/order_func.h
@@ -15,7 +15,7 @@
 #include "company_type.h"
 
 /* Functions */
-void RemoveOrderFromAllVehicles(OrderType type, DestinationID destination, bool hangar = false);
+void RemoveOrderFromAllVehicles(OrderType type, DestinationID destination);
 void InvalidateVehicleOrder(const Vehicle *v, int data);
 void CheckOrders(const Vehicle*);
 void DeleteVehicleOrders(Vehicle *v, bool keep_orderlist = false, bool reset_order_indices = true);
@@ -23,6 +23,7 @@ bool ProcessOrders(Vehicle *v);
 bool UpdateOrderDest(Vehicle *v, const Order *order, int conditional_depth = 0, bool pbs_look_ahead = false);
 VehicleOrderID ProcessConditionalOrder(const Order *order, const Vehicle *v);
 uint GetOrderDistance(const Order *prev, const Order *cur, const Vehicle *v, int conditional_depth = 0);
+DestinationID GetTargetDestination(const Order &o, bool is_aircraft);
 
 void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int y, bool selected, bool timetable, int left, int middle, int right);
 

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -34,6 +34,7 @@
 #include "error.h"
 #include "order_cmd.h"
 #include "company_cmd.h"
+#include "depot_base.h"
 
 #include "widgets/order_widget.h"
 
@@ -309,7 +310,7 @@ void DrawOrderString(const Vehicle *v, const Order *order, int order_index, int 
 				/* Going to a specific depot. */
 				SetDParam(0, STR_ORDER_GO_TO_DEPOT_FORMAT);
 				SetDParam(2, v->type);
-				SetDParam(3, order->GetDestination());
+				SetDParam(3, GetTargetDestination(*order, v->type == VEH_AIRCRAFT));
 			}
 
 			if (order->GetDepotOrderType() & ODTFB_SERVICE) {
@@ -384,8 +385,7 @@ static Order GetOrderCmdFromTile(const Vehicle *v, TileIndex tile)
 
 	/* check depot first */
 	if (IsDepotTypeTile(tile, (TransportType)(uint)v->type) && IsTileOwner(tile, _local_company)) {
-		order.MakeGoToDepot(v->type == VEH_AIRCRAFT ? GetStationIndex(tile) : GetDepotIndex(tile),
-				ODTFB_PART_OF_ORDERS,
+		order.MakeGoToDepot(GetDepotIndex(tile), ODTFB_PART_OF_ORDERS,
 				(_settings_client.gui.new_nonstop && v->IsGroundVehicle()) ? ONSF_NO_STOP_AT_INTERMEDIATE_STATIONS : ONSF_STOP_EVERYWHERE);
 
 		if (_ctrl_pressed) {

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2425,28 +2425,6 @@ bool AfterLoadGame()
 		for (Depot *d : Depot::Iterate()) d->build_date = TimerGameCalendar::date;
 	}
 
-	/* In old versions it was possible to remove an airport while a plane was
-	 * taking off or landing. This gives all kind of problems when building
-	 * another airport in the same station so we don't allow that anymore.
-	 * For old savegames with such aircraft we just throw them in the air and
-	 * treat the aircraft like they were flying already. */
-	if (IsSavegameVersionBefore(SLV_146)) {
-		for (Aircraft *v : Aircraft::Iterate()) {
-			if (!v->IsNormalAircraft()) continue;
-			Station *st = GetTargetAirportIfValid(v);
-			if (st == nullptr && v->state != FLYING) {
-				v->state = FLYING;
-				UpdateAircraftCache(v);
-				AircraftNextAirportPos_and_Order(v);
-				/* get aircraft back on running altitude */
-				if ((v->vehstatus & VS_CRASHED) == 0) {
-					GetAircraftFlightLevelBounds(v, &v->z_pos, nullptr);
-					SetAircraftPosition(v, v->x_pos, v->y_pos, GetAircraftFlightLevel(v));
-				}
-			}
-		}
-	}
-
 	/* Move the animation frame to the same location (m7) for all objects. */
 	if (IsSavegameVersionBefore(SLV_147)) {
 		for (auto t : Map::Iterate()) {
@@ -2787,6 +2765,43 @@ bool AfterLoadGame()
 					delete st->airport.psa;
 					st->airport.psa = nullptr;
 
+				}
+			}
+		}
+	}
+
+	if (IsSavegameVersionBefore(SLV_ADD_DEPOTS_TO_HANGARS)) {
+		for (Station *st : Station::Iterate()) {
+			if ((st->facilities & FACIL_AIRPORT) && st->airport.HasHangar()) {
+				/* Add a built-in hangar for some airport types. */
+				assert(Depot::CanAllocateItem());
+				st->airport.AddHangar();
+			} else {
+				/* If airport has no hangar, remove old go to hangar orders
+				 * that could remain from removing an airport with a hangar
+				 * and rebuilding it with an airport with no hangar. */
+				RemoveOrderFromAllVehicles(OT_GOTO_DEPOT, st->index);
+			}
+		}
+	}
+
+	/* In old versions it was possible to remove an airport while a plane was
+	 * taking off or landing. This gives all kind of problems when building
+	 * another airport in the same station so we don't allow that anymore.
+	 * For old savegames with such aircraft we just throw them in the air and
+	 * treat the aircraft like they were flying already. */
+	if (IsSavegameVersionBefore(SLV_146)) {
+		for (Aircraft *v : Aircraft::Iterate()) {
+			if (!v->IsNormalAircraft()) continue;
+			Station *st = GetTargetAirportIfValid(v);
+			if (st == nullptr && v->state != FLYING) {
+				v->state = FLYING;
+				UpdateAircraftCache(v);
+				AircraftNextAirportPos_and_Order(v);
+				/* get aircraft back on running altitude */
+				if ((v->vehstatus & VS_CRASHED) == 0) {
+					GetAircraftFlightLevelBounds(v, &v->z_pos, nullptr);
+					SetAircraftPosition(v, v->x_pos, v->y_pos, GetAircraftFlightLevel(v));
 				}
 			}
 		}

--- a/src/saveload/compat/station_sl_compat.h
+++ b/src/saveload/compat/station_sl_compat.h
@@ -108,6 +108,7 @@ const SaveLoadCompat _station_normal_sl_compat[] = {
 	SLC_VAR("airport.layout"),
 	SLC_VAR("airport.flags"),
 	SLC_VAR("airport.rotation"),
+	SLC_VAR("airport.hangar"),
 	SLC_VAR("storage"),
 	SLC_VAR("airport.psa"),
 	SLC_VAR("indtype"),

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -23,6 +23,7 @@
 #include "../stdafx.h"
 #include "../debug.h"
 #include "../station_base.h"
+#include "../depot_base.h"
 #include "../thread.h"
 #include "../town.h"
 #include "../network/network.h"
@@ -1121,6 +1122,7 @@ static size_t ReferenceToInt(const void *obj, SLRefType rt)
 		case REF_STORAGE:        return ((const PersistentStorage*)obj)->index + 1;
 		case REF_LINK_GRAPH:     return ((const         LinkGraph*)obj)->index + 1;
 		case REF_LINK_GRAPH_JOB: return ((const      LinkGraphJob*)obj)->index + 1;
+		case REF_DEPOT:          return ((const             Depot*)obj)->index + 1;
 		default: NOT_REACHED();
 	}
 }
@@ -1201,6 +1203,10 @@ static void *IntToReference(size_t index, SLRefType rt)
 		case REF_LINK_GRAPH_JOB:
 			if (LinkGraphJob::IsValidID(index)) return LinkGraphJob::Get(index);
 			SlErrorCorrupt("Referencing invalid LinkGraphJob");
+
+		case REF_DEPOT:
+			if (Depot::IsValidID(index)) return Depot::Get(index);
+			SlErrorCorrupt("Referencing invalid Depot");
 
 		default: NOT_REACHED();
 	}

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -385,6 +385,8 @@ enum SaveLoadVersion : uint16_t {
 	SLV_ROAD_WAYPOINTS,                     ///< 338  PR#12572 Road waypoints
 	SLV_ADD_DEPOTS_TO_HANGARS,              ///< 339  PR#10691 Add depots to airports that have a hangar.
 
+	SLV_DEPOTID_IN_HANGAR_ORDERS,           ///< 340  PR#10691 Go to hangar orders store the DepotID instead of StationID.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -383,6 +383,7 @@ enum SaveLoadVersion : uint16_t {
 	SLV_GROUP_NUMBERS,                      ///< 336  PR#12297 Add per-company group numbers.
 	SLV_INCREASE_STATION_TYPE_FIELD_SIZE,   ///< 337  PR#12572 Increase size of StationType field in map array
 	SLV_ROAD_WAYPOINTS,                     ///< 338  PR#12572 Road waypoints
+	SLV_ADD_DEPOTS_TO_HANGARS,              ///< 339  PR#10691 Add depots to airports that have a hangar.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
@@ -598,6 +599,7 @@ enum SLRefType {
 	REF_STORAGE        =  9, ///< Load/save a reference to a persistent storage.
 	REF_LINK_GRAPH     = 10, ///< Load/save a reference to a link graph.
 	REF_LINK_GRAPH_JOB = 11, ///< Load/save a reference to a link graph job.
+	REF_DEPOT          = 12, ///< Load/save a reference to a depot.
 };
 
 /**

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -610,6 +610,7 @@ public:
 		SLE_CONDVAR(Station, airport.layout,             SLE_UINT8,                 SLV_145, SL_MAX_VERSION),
 		    SLE_VAR(Station, airport.flags,              SLE_UINT64),
 		SLE_CONDVAR(Station, airport.rotation,           SLE_UINT8,                 SLV_145, SL_MAX_VERSION),
+		SLE_CONDREF(Station, airport.hangar,             REF_DEPOT,           SLV_ADD_DEPOTS_TO_HANGARS, SL_MAX_VERSION),
 		SLEG_CONDARR("storage", _old_st_persistent_storage.storage,  SLE_UINT32, 16, SLV_145, SLV_161),
 		SLE_CONDREF(Station, airport.psa,                REF_STORAGE,               SLV_161, SL_MAX_VERSION),
 

--- a/src/script/api/script_order.cpp
+++ b/src/script/api/script_order.cpp
@@ -245,18 +245,13 @@ static int ScriptOrderPositionToRealOrderPosition(VehicleID vehicle_id, ScriptOr
 
 	const Order *order = ::ResolveOrder(vehicle_id, order_position);
 	if (order == nullptr || order->GetType() == OT_CONDITIONAL) return INVALID_TILE;
-	const Vehicle *v = ::Vehicle::Get(vehicle_id);
 
 	switch (order->GetType()) {
 		case OT_GOTO_DEPOT: {
 			/* We don't know where the nearest depot is... (yet) */
 			if (order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) return INVALID_TILE;
 
-			if (v->type != VEH_AIRCRAFT) return ::Depot::Get(order->GetDestination())->xy;
-			/* Aircraft's hangars are referenced by StationID, not DepotID */
-			const Station *st = ::Station::Get(order->GetDestination());
-			if (!st->airport.HasHangar()) return INVALID_TILE;
-			return st->airport.GetHangarTile(0);
+			return ::Depot::Get(order->GetDestination())->xy;
 		}
 
 		case OT_GOTO_STATION: {

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -747,8 +747,23 @@ void Airport::AddHangar()
  */
 void Airport::RemoveHangar()
 {
+	RemoveOrderFromAllVehicles(OT_GOTO_DEPOT, this->hangar->index);
+
+	for (Aircraft *a : Aircraft::Iterate()) {
+		if (!a->IsNormalAircraft()) continue;
+		if (!a->current_order.IsType(OT_GOTO_DEPOT)) continue;
+		if (a->current_order.GetDestination() != this->hangar->index) continue;
+		a->current_order.MakeDummy();
+	}
+
 	delete this->hangar;
 	this->hangar = nullptr;
+}
+
+DepotID GetHangarIndex(TileIndex t) {
+	assert(IsAirportTile(t));
+	assert(Station::GetByTile(t)->airport.hangar != nullptr);
+	return Station::GetByTile(t)->airport.hangar->index;
 }
 
 bool StationCompare::operator() (const Station *lhs, const Station *rhs) const

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -26,6 +26,7 @@
 #include "core/random_func.hpp"
 #include "linkgraph/linkgraph.h"
 #include "linkgraph/linkgraphschedule.h"
+#include "depot_base.h"
 
 #include "table/strings.h"
 
@@ -725,6 +726,29 @@ Money AirportMaintenanceCost(Owner owner)
 	}
 	/* 3 bits fraction for the maintenance cost factor. */
 	return total_cost >> 3;
+}
+
+/**
+ * Create a hangar on the airport.
+ */
+void Airport::AddHangar()
+{
+	assert(this->hangar == nullptr);
+	assert(Depot::CanAllocateItem());
+	assert(this->GetNumHangars() > 0);
+	Station *st = Station::GetByTile(this->GetHangarTile(0));
+	this->hangar = new Depot(this->GetHangarTile(0));
+	this->hangar->build_date = st->build_date;
+	this->hangar->town = st->town;
+}
+
+/**
+ * Delete the hangar on the airport.
+ */
+void Airport::RemoveHangar()
+{
+	delete this->hangar;
+	this->hangar = nullptr;
 }
 
 bool StationCompare::operator() (const Station *lhs, const Station *rhs) const

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -18,6 +18,7 @@
 #include "linkgraph/linkgraph_type.h"
 #include "newgrf_storage.h"
 #include "bitmap_type.h"
+#include "depot_type.h"
 
 static const uint8_t INITIAL_STATION_RATING = 175;
 static const uint8_t MAX_STATION_RATING = 255;
@@ -294,6 +295,7 @@ struct Airport : public TileArea {
 	uint8_t type;          ///< Type of this airport, @see AirportTypes
 	uint8_t layout;        ///< Airport layout number.
 	Direction rotation; ///< How this airport is rotated.
+	Depot *hangar;      ///< The corresponding hangar of this airport, if any.
 
 	PersistentStorage *psa; ///< Persistent storage for NewGRF airports.
 
@@ -403,6 +405,9 @@ struct Airport : public TileArea {
 		}
 		return num;
 	}
+
+	void AddHangar();
+	void RemoveHangar();
 
 private:
 	/**

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -67,6 +67,7 @@
 #include "timer/timer_game_tick.h"
 #include "cheat_type.h"
 #include "road_func.h"
+#include "depot_base.h"
 
 #include "widgets/station_widget.h"
 
@@ -2539,6 +2540,8 @@ CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, uint8_t airport
 
 	/* Check if a valid, buildable airport was chosen for construction */
 	const AirportSpec *as = AirportSpec::Get(airport_type);
+
+	if (!as->depots.empty() && !Depot::CanAllocateItem()) return CMD_ERROR;
 	if (!as->IsAvailable() || layout >= as->layouts.size()) return CMD_ERROR;
 	if (!as->IsWithinMapBounds(layout, tile)) return CMD_ERROR;
 
@@ -2632,6 +2635,8 @@ CommandCost CmdBuildAirport(DoCommandFlag flags, TileIndex tile, uint8_t airport
 			AirportTileAnimationTrigger(st, iter, AAT_BUILT);
 		}
 
+		if (!as->depots.empty()) st->airport.AddHangar();
+
 		UpdateAirplanesOnNewStation(st);
 
 		Company::Get(st->owner)->infrastructure.airport++;
@@ -2679,6 +2684,7 @@ static CommandCost RemoveAirport(TileIndex tile, DoCommandFlag flags)
 			OrderBackup::Reset(tile_cur, false);
 			CloseWindowById(WC_VEHICLE_DEPOT, tile_cur);
 		}
+		st->airport.RemoveHangar();
 
 		/* The noise level is the noise from the airport and reduce it to account for the distance to the town center.
 		 * And as for construction, always remove it, even if the setting is not set, in order to avoid the

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1619,7 +1619,7 @@ void VehicleEnterDepot(Vehicle *v)
 		 * Note: The target depot for nearest-/manual-depot-orders is only updated on junctions, but we want to accept every depot. */
 		if ((v->current_order.GetDepotOrderType() & ODTFB_PART_OF_ORDERS) &&
 				real_order != nullptr && !(real_order->GetDepotActionType() & ODATFB_NEAREST_DEPOT) &&
-				(v->type == VEH_AIRCRAFT ? v->current_order.GetDestination() != GetStationIndex(v->tile) : v->dest_tile != v->tile)) {
+				v->current_order.GetDestination() != GetDepotIndex(v->tile)) {
 			/* We are heading for another depot, keep driving. */
 			return;
 		}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -45,6 +45,7 @@
 #include "train_cmd.h"
 #include "hotkeys.h"
 #include "group_cmd.h"
+#include "depot_base.h"
 
 #include "safeguards.h"
 
@@ -3141,7 +3142,7 @@ public:
 
 				case OT_GOTO_DEPOT: {
 					SetDParam(0, v->type);
-					SetDParam(1, v->current_order.GetDestination());
+					SetDParam(1, GetTargetDestination(v->current_order, v->type == VEH_AIRCRAFT));
 					SetDParam(2, PackVelocity(v->GetDisplaySpeed(), v->type));
 					if (v->current_order.GetDestination() == INVALID_DEPOT) {
 						/* This case *only* happens when multiple nearest depot orders


### PR DESCRIPTION
## Motivation / Problem

This PR is related to #9577 

If depots can have more than one tile (as intended with #9577), then the depot window number should be a DepotID (as the TileIndex corresponding to a depot won't be unique anymore).

Then, depot structs for hangars should also be available for consistency and dealing with order backups later and "Go To Hangar" orders. This implies that some old specific code for goto hangar orders will be removed, as some cases will now be dealt with standard cases involving depot construction/demolition and when loading old savegames.

Also, when an airport is removed, their goto depot orders are also removed. This could be a problem, as the immediate removal of these orders is not always desired (rebuilding an airport). In subsequent commits, when a depot is deleted, it will stay for a while as a ghost (to keep orders associated to it) and eventually will be removed forever (behaving in a similar way to station removal).


If modular airports or other changes to airports are made, it is possible that storing a DepotID, as this PR suggests, may be useful.

## Description

- Each airport with at least a hangar tile creates a depot object. The airport stores a pointer to the depot.
- "Go to hangar" orders store the DepotID instead of the StationID.


## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* **This PR affects the save game format? (label 'savegame upgrade')**
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
