### PR TITLE
Codechange: Use std::copy/fill to reset original specs.

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -76,21 +76,16 @@ IndustryBuildData _industry_builder; ///< In-game manager of industries.
  */
 void ResetIndustries()
 {
-	for (IndustryType i = 0; i < NUM_INDUSTRYTYPES; i++) {
-		/* Reset the spec to default */
-		if (i < lengthof(_origin_industry_specs)) {
-			_industry_specs[i] = _origin_industry_specs[i];
-		} else {
-			_industry_specs[i] = IndustrySpec{};
-		}
+	auto industry_insert = std::copy(std::begin(_origin_industry_specs), std::end(_origin_industry_specs), std::begin(_industry_specs));
+	std::fill(industry_insert, std::end(_industry_specs), IndustrySpec{});
 
+	for (IndustryType i = 0; i < lengthof(_origin_industry_specs); i++) {
 		/* Enable only the current climate industries */
-		_industry_specs[i].enabled = i < NEW_INDUSTRYOFFSET &&
-				HasBit(_origin_industry_specs[i].climate_availability, _settings_game.game_creation.landscape);
+		_industry_specs[i].enabled = HasBit(_industry_specs[i].climate_availability, _settings_game.game_creation.landscape);
 	}
 
-	memset(&_industry_tile_specs, 0, sizeof(_industry_tile_specs));
-	memcpy(&_industry_tile_specs, &_origin_industry_tile_specs, sizeof(_origin_industry_tile_specs));
+	auto industry_tile_insert = std::copy(std::begin(_origin_industry_tile_specs), std::end(_origin_industry_tile_specs), std::begin(_industry_tile_specs));
+	std::fill(industry_tile_insert, std::end(_industry_tile_specs), IndustryTileSpec{});
 
 	/* Reset any overrides that have been set. */
 	_industile_mngr.ResetOverride();

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -181,7 +181,7 @@ void AirportOverrideManager::SetEntitySpec(AirportSpec *as)
 		return;
 	}
 
-	memcpy(AirportSpec::GetWithoutOverride(airport_id), as, sizeof(*as));
+	*AirportSpec::GetWithoutOverride(airport_id) = *as;
 
 	/* Now add the overrides. */
 	for (int i = 0; i < this->max_offset; i++) {

--- a/src/newgrf_airport.cpp
+++ b/src/newgrf_airport.cpp
@@ -152,9 +152,10 @@ bool AirportSpec::IsWithinMapBounds(byte table, TileIndex tile) const
  */
 void AirportSpec::ResetAirports()
 {
-	extern const AirportSpec _origin_airport_specs[];
-	memset(&AirportSpec::specs, 0, sizeof(AirportSpec::specs));
-	memcpy(&AirportSpec::specs, &_origin_airport_specs, sizeof(AirportSpec) * NEW_AIRPORT_OFFSET);
+	extern const AirportSpec _origin_airport_specs[NEW_AIRPORT_OFFSET];
+
+	auto insert = std::copy(std::begin(_origin_airport_specs), std::end(_origin_airport_specs), std::begin(AirportSpec::specs));
+	std::fill(insert, std::end(AirportSpec::specs), AirportSpec{});
 
 	_airport_mngr.ResetOverride();
 }

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -57,8 +57,8 @@ AirportTileOverrideManager _airporttile_mngr(NEW_AIRPORTTILE_OFFSET, NUM_AIRPORT
  */
 void AirportTileSpec::ResetAirportTiles()
 {
-	memset(&AirportTileSpec::tiles, 0, sizeof(AirportTileSpec::tiles));
-	memcpy(&AirportTileSpec::tiles, &_origin_airporttile_specs, sizeof(_origin_airporttile_specs));
+	auto insert = std::copy(std::begin(_origin_airporttile_specs), std::end(_origin_airporttile_specs), std::begin(AirportTileSpec::tiles));
+	std::fill(insert, std::end(AirportTileSpec::tiles), AirportTileSpec{});
 
 	/* Reset any overrides that have been set. */
 	_airporttile_mngr.ResetOverride();

--- a/src/newgrf_airporttiles.cpp
+++ b/src/newgrf_airporttiles.cpp
@@ -73,7 +73,7 @@ void AirportTileOverrideManager::SetEntitySpec(const AirportTileSpec *airpts)
 		return;
 	}
 
-	memcpy(&AirportTileSpec::tiles[airpt_id], airpts, sizeof(*airpts));
+	AirportTileSpec::tiles[airpt_id] = *airpts;
 
 	/* Now add the overrides. */
 	for (int i = 0; i < this->max_offset; i++) {

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -164,7 +164,7 @@ void HouseOverrideManager::SetEntitySpec(const HouseSpec *hs)
 		return;
 	}
 
-	MemCpyT(HouseSpec::Get(house_id), hs);
+	*HouseSpec::Get(house_id) = *hs;
 
 	/* Now add the overrides. */
 	for (int i = 0; i < this->max_offset; i++) {
@@ -273,7 +273,7 @@ void IndustryTileOverrideManager::SetEntitySpec(const IndustryTileSpec *its)
 		return;
 	}
 
-	memcpy(&_industry_tile_specs[indt_id], its, sizeof(*its));
+	_industry_tile_specs[indt_id] = *its;
 
 	/* Now add the overrides. */
 	for (int i = 0; i < this->max_offset; i++) {

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -123,11 +123,11 @@ void ResetObjects()
 	_object_specs.clear();
 
 	/* And add our originals. */
-	_object_specs.resize(lengthof(_original_objects));
+	_object_specs.reserve(lengthof(_original_objects));
 
 	for (uint16 i = 0; i < lengthof(_original_objects); i++) {
-		_object_specs[i] = _original_objects[i];
-		_object_specs[i].grf_prop.local_id = i;
+		ObjectSpec &spec = _object_specs.emplace_back(_original_objects[i]);
+		spec.grf_prop.local_id = i;
 	}
 
 	/* Set class for originals. */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3834,8 +3834,8 @@ HouseSpec _house_specs[NUM_HOUSES];
 
 void ResetHouses()
 {
-	memset(&_house_specs, 0, sizeof(_house_specs));
-	memcpy(&_house_specs, &_original_house_specs, sizeof(_original_house_specs));
+	auto insert = std::copy(std::begin(_original_house_specs), std::end(_original_house_specs), std::begin(_house_specs));
+	std::fill(insert, std::end(_house_specs), HouseSpec{});
 
 	/* Reset any overrides that have been set. */
 	_house_mngr.ResetOverride();


### PR DESCRIPTION
## Motivation / Problem

Original specs are currently reset and copied with memset and memcpy, and Individual NewGRF specs are often copied using memcpy instead of simply assigning them.

## Description

This is changed to use std::fill and std::copy, and assignment is simplified.

This clears up a little bit more C-style memory management.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
