### PR TITLE
Fix: Violation of strict weak ordering in TownRatingSorter and GenericEngineValueVsRunningCostSorter

### DIFF
--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -300,7 +300,7 @@ static bool EnginePowerVsRunningCostSorter(const GUIEngineListItem &a, const GUI
 	 * since we want consistent sorting.
 	 * Also if both have no power then sort with reverse of running cost to simulate
 	 * previous sorting behaviour for wagons. */
-	if (v_a == 0 && v_b == 0) return !EngineRunningCostSorter(a, b);
+	if (v_a == 0 && v_b == 0) return EngineRunningCostSorter(b, a);
 	if (v_a == v_b)  return EngineNumberSorter(a, b);
 	return _engine_sort_direction != (v_a < v_b);
 }

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -777,7 +777,7 @@ private:
 
 		/* Sort unrated towns always on ascending town name. */
 		if (before) return TownDirectoryWindow::TownNameSorter(a, b);
-		return !TownDirectoryWindow::TownNameSorter(a, b);
+		return TownDirectoryWindow::TownNameSorter(b, a);
 	}
 
 public:


### PR DESCRIPTION
## Motivation / Problem

Violation of strict weak ordering in TownRatingSorter if two unrated town names compare equal in TownNameSorter.
Violation of strict weak ordering in GenericEngineValueVsRunningCostSorter if an engine is compared with itself.

Platforms which rely on std::sort comparators obeying the strict weak ordering restrictions (i.e. MacOS) may misbehave and/or crash if this is not followed. In particular a < b and b < a may not both be true.

Crash report identifying issue: https://www.tt-forums.net/viewtopic.php?p=1260523#p1260523

## Description

Don't use !comparator(a, b) to reverse order, because this incorrectly handles the equal case, use comparator(b, a).

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
