### PR TITLE
Cleanup: Remove obsolete (Make)EnumPropsT.

### DIFF
--- a/src/company_type.h
+++ b/src/company_type.h
@@ -45,9 +45,6 @@ static const uint MAX_COMPANY_SHARE_OWNERS        =  4; ///< The maximum number 
 static const uint MIN_COMPETITORS_INTERVAL = 0;   ///< The minimum interval (in minutes) between competitors.
 static const uint MAX_COMPETITORS_INTERVAL = 500; ///< The maximum interval (in minutes) between competitors.
 
-/** Define basic enum properties */
-template <> struct EnumPropsT<Owner> : MakeEnumPropsT<Owner, byte, OWNER_BEGIN, OWNER_END, INVALID_OWNER> {};
-
 typedef Owner CompanyID;
 
 typedef uint16 CompanyMask;

--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -38,34 +38,4 @@
 	inline constexpr mask_t operator ~(mask_t m) {return (mask_t)(~(std::underlying_type<mask_t>::type)m);}
 
 
-/**
- * Informative template class exposing basic enumeration properties used by several
- *  other templates below. Here we have only forward declaration. For each enum type
- *  we will create specialization derived from MakeEnumPropsT<>.
- *  i.e.:
- *    template <> struct EnumPropsT<Track> : MakeEnumPropsT<Track, byte, TRACK_BEGIN, TRACK_END, INVALID_TRACK> {};
- */
-template <typename Tenum_t> struct EnumPropsT;
-
-/**
- * Helper template class that makes basic properties of given enumeration type visible
- *  from outsize. It is used as base class of several EnumPropsT specializations each
- *  dedicated to one of commonly used enumeration types.
- *  @param Tenum_t enumeration type that you want to describe
- *  @param Tstorage_t what storage type would be sufficient (i.e. byte)
- *  @param Tbegin first valid value from the contiguous range (i.e. TRACK_BEGIN)
- *  @param Tend one past the last valid value from the contiguous range (i.e. TRACK_END)
- *  @param Tinvalid value used as invalid value marker (i.e. INVALID_TRACK)
- *  @param Tnum_bits Number of bits for storing the enum in command parameters
- */
-template <typename Tenum_t, typename Tstorage_t, Tenum_t Tbegin, Tenum_t Tend, Tenum_t Tinvalid, uint Tnum_bits = 8 * sizeof(Tstorage_t)>
-struct MakeEnumPropsT {
-	typedef Tenum_t type;                     ///< enum type (i.e. Trackdir)
-	typedef Tstorage_t storage;               ///< storage type (i.e. byte)
-	static const Tenum_t begin = Tbegin;      ///< lowest valid value (i.e. TRACKDIR_BEGIN)
-	static const Tenum_t end = Tend;          ///< one after the last valid value (i.e. TRACKDIR_END)
-	static const Tenum_t invalid = Tinvalid;  ///< what value is used as invalid value (i.e. INVALID_TRACKDIR)
-	static const uint num_bits = Tnum_bits;   ///< Number of bits for storing the enum in command parameters
-};
-
 #endif /* ENUM_TYPE_HPP */

--- a/src/direction_type.h
+++ b/src/direction_type.h
@@ -38,10 +38,6 @@ enum Direction : byte {
 /** Allow incrementing of Direction variables */
 DECLARE_POSTFIX_INCREMENT(Direction)
 
-/** Define basic enum properties */
-template <> struct EnumPropsT<Direction> : MakeEnumPropsT<Direction, byte, DIR_BEGIN, DIR_END, INVALID_DIR, 3> {};
-
-
 /**
  * Enumeration for the difference between two directions.
  *
@@ -87,10 +83,6 @@ enum DiagDirection : byte {
 /** Allow incrementing of DiagDirection variables */
 DECLARE_POSTFIX_INCREMENT(DiagDirection)
 
-/** Define basic enum properties */
-template <> struct EnumPropsT<DiagDirection> : MakeEnumPropsT<DiagDirection, byte, DIAGDIR_BEGIN, DIAGDIR_END, INVALID_DIAGDIR, 2> {};
-
-
 /**
  * Enumeration for the difference between to DiagDirection.
  *
@@ -128,7 +120,5 @@ enum Axis : byte {
 	AXIS_END,            ///< Used for iterations
 	INVALID_AXIS = 0xFF, ///< Flag for an invalid Axis
 };
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<Axis> : MakeEnumPropsT<Axis, byte, AXIS_X, AXIS_END, INVALID_AXIS, 1> {};
 
 #endif /* DIRECTION_TYPE_H */

--- a/src/economy_type.h
+++ b/src/economy_type.h
@@ -172,9 +172,6 @@ enum ExpensesType : byte {
 	INVALID_EXPENSES      = 0xFF, ///< Invalid expense type.
 };
 
-/** Define basic enum properties for ExpensesType */
-template <> struct EnumPropsT<ExpensesType> : MakeEnumPropsT<ExpensesType, byte, EXPENSES_CONSTRUCTION, EXPENSES_END, INVALID_EXPENSES, 8> {};
-
 /**
  * Categories of a price bases.
  */

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -251,7 +251,6 @@ enum Colours : byte {
 	COLOUR_END,
 	INVALID_COLOUR = 0xFF,
 };
-template <> struct EnumPropsT<Colours> : MakeEnumPropsT<Colours, byte, COLOUR_BEGIN, COLOUR_END, INVALID_COLOUR, 8> {};
 
 /** Colour of the strings, see _string_colourmap in table/string_colours.h or docs/ottd-colourtext-palette.png */
 enum TextColour {

--- a/src/linkgraph/linkgraph_type.h
+++ b/src/linkgraph/linkgraph_type.h
@@ -31,11 +31,6 @@ enum DistributionType : byte {
 	DT_END = 3
 };
 
-/* It needs to be 8bits, because we save and load it as such
- * Define basic enum properties
- */
-template <> struct EnumPropsT<DistributionType> : MakeEnumPropsT<DistributionType, byte, DT_BEGIN, DT_END, DT_NUM> {};
-
 /**
  * Special modes for updating links. 'Restricted' means that vehicles with
  * 'no loading' orders are serving the link. If a link is only served by

--- a/src/livery.h
+++ b/src/livery.h
@@ -57,8 +57,6 @@ enum LiveryScheme : byte {
 };
 
 DECLARE_POSTFIX_INCREMENT(LiveryScheme)
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<LiveryScheme> : MakeEnumPropsT<LiveryScheme, byte, LS_BEGIN, LS_END, LS_END, 8> {};
 
 /** List of different livery classes, used only by the livery GUI. */
 enum LiveryClass {

--- a/src/newgrf_roadstop.h
+++ b/src/newgrf_roadstop.h
@@ -161,9 +161,6 @@ struct RoadStopSpec {
 	static const RoadStopSpec *Get(uint16 index);
 };
 
-template <>
-struct EnumPropsT<RoadStopClassID> : MakeEnumPropsT<RoadStopClassID, byte, ROADSTOP_CLASS_BEGIN, ROADSTOP_CLASS_MAX, ROADSTOP_CLASS_MAX, 8> {};
-
 typedef NewGRFClass<RoadStopSpec, RoadStopClassID, ROADSTOP_CLASS_MAX> RoadStopClass;
 
 void DrawRoadStopTile(int x, int y, RoadType roadtype, const RoadStopSpec *spec, StationType type, int view);

--- a/src/newgrf_station.h
+++ b/src/newgrf_station.h
@@ -86,7 +86,6 @@ enum StationClassID : byte {
 	STAT_CLASS_WAYP,         ///< Waypoint class.
 	STAT_CLASS_MAX = 255,    ///< Maximum number of classes.
 };
-template <> struct EnumPropsT<StationClassID> : MakeEnumPropsT<StationClassID, byte, STAT_CLASS_BEGIN, STAT_CLASS_MAX, STAT_CLASS_MAX, 8> {};
 
 /** Allow incrementing of StationClassID variables */
 DECLARE_POSTFIX_INCREMENT(StationClassID)

--- a/src/order_type.h
+++ b/src/order_type.h
@@ -152,7 +152,6 @@ enum ModifyOrderFlags : byte {
 	MOF_COND_DESTINATION,///< Change the destination of a conditional order.
 	MOF_END
 };
-template <> struct EnumPropsT<ModifyOrderFlags> : MakeEnumPropsT<ModifyOrderFlags, byte, MOF_NON_STOP, MOF_END, MOF_END, 4> {};
 
 /**
  * Depot action to switch to when doing a #MOF_DEPOT_ACTION.
@@ -173,8 +172,6 @@ enum ModifyTimetableFlags : byte {
 	MTF_TRAVEL_SPEED, ///< Set max travel speed.
 	MTF_END
 };
-template <> struct EnumPropsT<ModifyTimetableFlags> : MakeEnumPropsT<ModifyTimetableFlags, byte, MTF_WAIT_TIME, MTF_END, MTF_END, 2> {};
-
 
 /** Clone actions. */
 enum CloneOptions : byte {

--- a/src/rail_type.h
+++ b/src/rail_type.h
@@ -36,8 +36,6 @@ enum RailType : byte {
 
 /** Allow incrementing of Track variables */
 DECLARE_POSTFIX_INCREMENT(RailType)
-/** Define basic enum properties */
-template <> struct EnumPropsT<RailType> : MakeEnumPropsT<RailType, byte, RAILTYPE_BEGIN, RAILTYPE_END, INVALID_RAILTYPE, 6> {};
 
 /**
  * The different railtypes we support, but then a bitmask of them.

--- a/src/road_type.h
+++ b/src/road_type.h
@@ -27,7 +27,6 @@ enum RoadType : byte {
 	INVALID_ROADTYPE = 63,   ///< flag for invalid roadtype
 };
 DECLARE_POSTFIX_INCREMENT(RoadType)
-template <> struct EnumPropsT<RoadType> : MakeEnumPropsT<RoadType, byte, ROADTYPE_BEGIN, ROADTYPE_END, INVALID_ROADTYPE, 6> {};
 
 /**
  * The different roadtypes we support, but then a bitmask of them.
@@ -66,7 +65,6 @@ enum RoadBits : byte {
 	ROAD_END  = ROAD_ALL + 1,        ///< Out-of-range roadbits, used for iterations
 };
 DECLARE_ENUM_AS_BIT_SET(RoadBits)
-template <> struct EnumPropsT<RoadBits> : MakeEnumPropsT<RoadBits, byte, ROAD_NONE, ROAD_END, ROAD_NONE, 4> {};
 
 /** Which directions are disallowed ? */
 enum DisallowedRoadDirections : byte {
@@ -77,7 +75,5 @@ enum DisallowedRoadDirections : byte {
 	DRD_END,        ///< Sentinel
 };
 DECLARE_ENUM_AS_BIT_SET(DisallowedRoadDirections)
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<DisallowedRoadDirections> : MakeEnumPropsT<DisallowedRoadDirections, byte, DRD_NONE, DRD_END, DRD_END, 2> {};
 
 #endif /* ROAD_TYPE_H */

--- a/src/signal_type.h
+++ b/src/signal_type.h
@@ -32,9 +32,6 @@ enum SignalType : byte {
 	SIGTYPE_LAST       = SIGTYPE_PBS_ONEWAY,
 	SIGTYPE_LAST_NOPBS = SIGTYPE_COMBO,
 };
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<SignalType> : MakeEnumPropsT<SignalType, byte, SIGTYPE_NORMAL, SIGTYPE_END, SIGTYPE_END, 3> {};
-
 
 /**
  * These are states in which a signal can be. Currently these are only two, so

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -38,9 +38,6 @@ enum StoryPageElementType : byte {
 	INVALID_SPET = 0xFF,
 };
 
-/** Define basic enum properties */
-template <> struct EnumPropsT<StoryPageElementType> : MakeEnumPropsT<StoryPageElementType, byte, SPET_TEXT, SPET_END, INVALID_SPET, 8> {};
-
 /** Flags available for buttons */
 enum StoryPageButtonFlags : byte {
 	SPBF_NONE        = 0,
@@ -109,9 +106,6 @@ enum StoryPageButtonCursor : byte {
 	SPBC_END,
 	INVALID_SPBC = 0xFF
 };
-
-/** Define basic enum properties */
-template <> struct EnumPropsT<StoryPageButtonCursor> : MakeEnumPropsT<StoryPageButtonCursor, byte, SPBC_MOUSE, SPBC_END, INVALID_SPBC, 8> {};
 
 /**
  * Checks if a StoryPageButtonCursor value is valid.

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -24,7 +24,6 @@ enum TownSize : byte {
 
 	TSZ_END,    ///< Number of available town sizes.
 };
-template <> struct EnumPropsT<TownSize> : MakeEnumPropsT<TownSize, byte, TSZ_SMALL, TSZ_END, TSZ_END, 2> {};
 
 enum Ratings {
 	/* These refer to the maximums, so Appalling is -1000 to -400
@@ -88,7 +87,6 @@ enum TownLayout : byte {
 
 	NUM_TLS,             ///< Number of town layouts
 };
-template <> struct EnumPropsT<TownLayout> : MakeEnumPropsT<TownLayout, byte, TL_BEGIN, NUM_TLS, NUM_TLS, 3> {};
 
 /** Town founding setting values. It needs to be 8bits, because we save and load it as such */
 enum TownFounding : byte {

--- a/src/track_type.h
+++ b/src/track_type.h
@@ -30,9 +30,6 @@ enum Track : byte {
 
 /** Allow incrementing of Track variables */
 DECLARE_POSTFIX_INCREMENT(Track)
-/** Define basic enum properties */
-template <> struct EnumPropsT<Track> : MakeEnumPropsT<Track, byte, TRACK_BEGIN, TRACK_END, INVALID_TRACK, 3> {};
-
 
 /** Bitfield corresponding to Track */
 enum TrackBits : byte {
@@ -88,9 +85,6 @@ enum Trackdir : byte {
 	TRACKDIR_END,                   ///< Used for iterations
 	INVALID_TRACKDIR  = 0xFF,       ///< Flag for an invalid trackdir
 };
-
-/** Define basic enum properties */
-template <> struct EnumPropsT<Trackdir> : MakeEnumPropsT<Trackdir, byte, TRACKDIR_BEGIN, TRACKDIR_END, INVALID_TRACKDIR, 4> {};
 
 /**
  * Enumeration of bitmasks for the TrackDirs

--- a/src/transport_type.h
+++ b/src/transport_type.h
@@ -31,7 +31,5 @@ enum TransportType : byte {
 	TRANSPORT_END,   ///< End of iterations.
 	INVALID_TRANSPORT = 0xff, ///< Sentinel for invalid transport types.
 };
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<TransportType> : MakeEnumPropsT<TransportType, byte, TRANSPORT_BEGIN, TRANSPORT_END, INVALID_TRANSPORT, 2> {};
 
 #endif /* TRANSPORT_TYPE_H */

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -35,8 +35,6 @@ enum VehicleType : byte {
 	VEH_INVALID = 0xFF,           ///< Non-existing type of vehicle.
 };
 DECLARE_POSTFIX_INCREMENT(VehicleType)
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<VehicleType> : MakeEnumPropsT<VehicleType, byte, VEH_TRAIN, VEH_END, VEH_INVALID, 3> {};
 
 struct Vehicle;
 struct Train;

--- a/src/water_map.h
+++ b/src/water_map.h
@@ -50,8 +50,6 @@ enum WaterClass : byte {
 	WATER_CLASS_RIVER,   ///< River.
 	WATER_CLASS_INVALID, ///< Used for industry tiles on land (also for oilrig if newgrf says so).
 };
-/** Helper information for extract tool. */
-template <> struct EnumPropsT<WaterClass> : MakeEnumPropsT<WaterClass, byte, WATER_CLASS_SEA, WATER_CLASS_INVALID, WATER_CLASS_INVALID, 2> {};
 
 /**
  * Checks if a water class is valid.


### PR DESCRIPTION
## Motivation / Problem

EnumPropsT/MakeEnumPropsT was used by the command system to help extract p1/p2 parameters, which no longer happens.

## Description

Remove it.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
