### PR TITLE
Cleanup: Fix and add comments to date cheat callback

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -98,22 +98,27 @@ extern void EnginesMonthlyLoop();
 
 /**
  * Handle changing of the current year.
- * @param new_value Unused.
+ * @param new_value The chosen year to change to.
  * @param change_direction +1 (increase) or -1 (decrease).
  * @return New year.
  */
 static int32 ClickChangeDateCheat(int32 new_value, int32 change_direction)
 {
-	YearMonthDay ymd;
-	ConvertDateToYMD(_date, &ymd);
-
+	/* Don't allow changing to an invalid year, or the current year. */
 	new_value = Clamp(new_value, MIN_YEAR, MAX_YEAR);
 	if (new_value == _cur_year) return _cur_year;
 
+	YearMonthDay ymd;
+	ConvertDateToYMD(_date, &ymd);
 	Date new_date = ConvertYMDToDate(new_value, ymd.month, ymd.day);
+
+	/* Change the date. */
+	SetDate(new_date, _date_fract);
+
+	/* Shift cached dates. */
 	for (auto v : Vehicle::Iterate()) v->ShiftDates(new_date - _date);
 	LinkGraphSchedule::instance.ShiftDates(new_date - _date);
-	SetDate(new_date, _date_fract);
+
 	EnginesMonthlyLoop();
 	SetWindowDirty(WC_STATUS_BAR, 0);
 	InvalidateWindowClassesData(WC_BUILD_STATION, 0);


### PR DESCRIPTION
## Motivation / Problem

My ongoing rework of #10605 touches the date cheat callback, and I did some cleanup.

## Description

Put the cleanup work in its own PR to make later reviews easier.

- Fix the doxygen header which incorrectly describes a parameter as unused
- Move some lines for better organization and add comments

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
