### PR TITLE
Feature: Vanilla processing industries warn when at risk of closure

### DIFF
--- a/src/industry.h
+++ b/src/industry.h
@@ -21,6 +21,8 @@
 typedef Pool<Industry, IndustryID, 64, 64000> IndustryPool;
 extern IndustryPool _industry_pool;
 
+static const uint PROCESSING_INDUSTRY_ABANDONMENT_YEARS = 5; ///< If a secondary industry doesn't produce for this many consecutive years, it may close.
+
 /**
  * Production level maximum, minimum and default values.
  * It is not a value been really used in order to change, but rather an indicator

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2856,7 +2856,7 @@ static void ChangeIndustryProduction(Industry *i, bool monthly)
 	if ((i->ctlflags & INDCTL_NO_PRODUCTION_INCREASE) && (mul > 0 || increment > 0)) return;
 
 	if (!callback_enabled && (indspec->life_type & INDUSTRYLIFE_PROCESSING)) {
-		if ( (byte)(_cur_year - i->last_prod_year) >= 5 && Chance16(1, original_economy ? 2 : 180)) {
+		if ( (byte)(_cur_year - i->last_prod_year) >= PROCESSING_INDUSTRY_ABANDONMENT_YEARS && Chance16(1, original_economy ? 2 : 180)) {
 			closeit = true;
 		}
 	}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -869,8 +869,13 @@ public:
 		bool first = true;
 		bool has_accept = false;
 
+		/* If closure is imminent (already decided, draw a warning. */
 		if (i->prod_level == PRODLEVEL_CLOSURE) {
 			DrawString(ir, STR_INDUSTRY_VIEW_INDUSTRY_ANNOUNCED_CLOSURE);
+			ir.top += FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_wide;
+		} else if (ind->grf_prop.grffile == nullptr && (ind->life_type & INDUSTRYLIFE_PROCESSING) && (_cur_year - i->last_prod_year) >= PROCESSING_INDUSTRY_ABANDONMENT_YEARS) {
+			/* Otherwise, if this is a non-NewGRF processing industry in danger of closing due to lack of production, draw a threat that it might decide to close. */
+			DrawString(ir, STR_INDUSTRY_VIEW_INDUSTRY_THREATENS_CLOSURE);
 			ir.top += FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_wide;
 		}
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3788,7 +3788,7 @@ STR_INDUSTRY_VIEW_TRANSPORTED                                   :{YELLOW}{CARGO_
 STR_INDUSTRY_VIEW_LOCATION_TOOLTIP                              :{BLACK}Centre the main view on industry location. Ctrl+Click opens a new viewport on industry location
 STR_INDUSTRY_VIEW_PRODUCTION_LEVEL                              :{BLACK}Production level: {YELLOW}{COMMA}%
 STR_INDUSTRY_VIEW_INDUSTRY_THREATENS_CLOSURE                    :{YELLOW}This industry may close from lack of supplies!
-STR_INDUSTRY_VIEW_INDUSTRY_ANNOUNCED_CLOSURE                    :{YELLOW}The industry has announced imminent closure!
+STR_INDUSTRY_VIEW_INDUSTRY_ANNOUNCED_CLOSURE                    :{YELLOW}This industry has announced imminent closure!
 
 STR_INDUSTRY_VIEW_REQUIRES_N_CARGO                              :{BLACK}Requires: {YELLOW}{STRING}{RAW_STRING}
 STR_INDUSTRY_VIEW_PRODUCES_N_CARGO                              :{BLACK}Produces: {YELLOW}{STRING}{RAW_STRING}

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3787,6 +3787,7 @@ STR_INDUSTRY_VIEW_PRODUCTION_LAST_MONTH_TITLE                   :{BLACK}Producti
 STR_INDUSTRY_VIEW_TRANSPORTED                                   :{YELLOW}{CARGO_LONG}{RAW_STRING}{BLACK} ({COMMA}% transported)
 STR_INDUSTRY_VIEW_LOCATION_TOOLTIP                              :{BLACK}Centre the main view on industry location. Ctrl+Click opens a new viewport on industry location
 STR_INDUSTRY_VIEW_PRODUCTION_LEVEL                              :{BLACK}Production level: {YELLOW}{COMMA}%
+STR_INDUSTRY_VIEW_INDUSTRY_THREATENS_CLOSURE                    :{YELLOW}This industry may close from lack of supplies!
 STR_INDUSTRY_VIEW_INDUSTRY_ANNOUNCED_CLOSURE                    :{YELLOW}The industry has announced imminent closure!
 
 STR_INDUSTRY_VIEW_REQUIRES_N_CARGO                              :{BLACK}Requires: {YELLOW}{STRING}{RAW_STRING}


### PR DESCRIPTION
## Motivation / Problem

Vanilla industries have a random chance of closing if they have not produced cargo in five years. 

Because it's a random chance, we can't warn the player until the decision has been made, by which point it's too late to do anything.

[This](https://www.tt-forums.net/viewtopic.php?t=86324) [has](https://www.tt-forums.net/viewtopic.php?t=53365) [been](https://www.tt-forums.net/viewtopic.php?t=36087) [a](https://www.tt-forums.net/viewtopic.php?t=56709) [frequent](https://www.tt-forums.net/viewtopic.php?t=73408) [subject](https://www.tt-forums.net/viewtopic.php?t=10382) [of](https://www.tt-forums.net/viewtopic.php?t=35603) [frustration](https://www.tt-forums.net/viewtopic.php?t=36653), [complaints](https://www.tt-forums.net/viewtopic.php?t=89323), [and](https://www.tt-forums.net/viewtopic.php?t=90283) [patches](https://www.tt-forums.net/viewtopic.php?t=46843).

## Description

Add a warning to the industry window if the industry has not received cargo in five years, and is at risk of this random closure.

Also tweak the wording of the existing warning of imminent closure to match.

![warning](https://user-images.githubusercontent.com/55058389/233869902-cb332345-5a31-40b7-8fd8-42ec56ba6e9b.png)

(Left is new, right is existing with the first word changed from `The` to `This`)

## Limitations

- Five years after starting a new game, all the unserviced secondary industries gain this warning all at once. We could spread this out somewhat by randomly offsetting the year of last production (+- 3 years, perhaps?), when generating a map, but maybe that would be more confusing? Thoughts?
- The industry window doesn't consider either of these warning messages when determining its width. Translations might be too wide to fit, unless we set width accordingly.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)