### PR TITLE
Codechange: _t type suffix is reserved by POSIX.

### DIFF
--- a/src/core/enum_type.hpp
+++ b/src/core/enum_type.hpp
@@ -28,14 +28,14 @@
 
 
 /** Operators to allow to work with enum as with type safe bit set in C++ */
-# define DECLARE_ENUM_AS_BIT_SET(mask_t) \
-	inline constexpr mask_t operator | (mask_t m1, mask_t m2) {return (mask_t)((std::underlying_type<mask_t>::type)m1 | (std::underlying_type<mask_t>::type)m2);} \
-	inline constexpr mask_t operator & (mask_t m1, mask_t m2) {return (mask_t)((std::underlying_type<mask_t>::type)m1 & (std::underlying_type<mask_t>::type)m2);} \
-	inline constexpr mask_t operator ^ (mask_t m1, mask_t m2) {return (mask_t)((std::underlying_type<mask_t>::type)m1 ^ (std::underlying_type<mask_t>::type)m2);} \
-	inline constexpr mask_t& operator |= (mask_t& m1, mask_t m2) {m1 = m1 | m2; return m1;} \
-	inline constexpr mask_t& operator &= (mask_t& m1, mask_t m2) {m1 = m1 & m2; return m1;} \
-	inline constexpr mask_t& operator ^= (mask_t& m1, mask_t m2) {m1 = m1 ^ m2; return m1;} \
-	inline constexpr mask_t operator ~(mask_t m) {return (mask_t)(~(std::underlying_type<mask_t>::type)m);}
+#define DECLARE_ENUM_AS_BIT_SET(enum_type) \
+	inline constexpr enum_type operator | (enum_type m1, enum_type m2) {return (enum_type)((std::underlying_type<enum_type>::type)m1 | (std::underlying_type<enum_type>::type)m2);} \
+	inline constexpr enum_type operator & (enum_type m1, enum_type m2) {return (enum_type)((std::underlying_type<enum_type>::type)m1 & (std::underlying_type<enum_type>::type)m2);} \
+	inline constexpr enum_type operator ^ (enum_type m1, enum_type m2) {return (enum_type)((std::underlying_type<enum_type>::type)m1 ^ (std::underlying_type<enum_type>::type)m2);} \
+	inline constexpr enum_type& operator |= (enum_type& m1, enum_type m2) {m1 = m1 | m2; return m1;} \
+	inline constexpr enum_type& operator &= (enum_type& m1, enum_type m2) {m1 = m1 & m2; return m1;} \
+	inline constexpr enum_type& operator ^= (enum_type& m1, enum_type m2) {m1 = m1 ^ m2; return m1;} \
+	inline constexpr enum_type operator ~(enum_type m) {return (enum_type)(~(std::underlying_type<enum_type>::type)m);}
 
 
 #endif /* ENUM_TYPE_HPP */

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -25,7 +25,7 @@ template <typename T> struct ArrayT;
 /** Helper template class that provides C array length and item type */
 template <typename T, size_t N> struct ArrayT<T[N]> {
 	static const size_t length = N;
-	typedef T item_t;
+	using Item = T;
 };
 
 
@@ -34,7 +34,7 @@ template <typename T, size_t N> struct ArrayT<T[N]> {
  * or t_unk when index is out of bounds.
  */
 template <typename E, typename T>
-inline typename ArrayT<T>::item_t ItemAtT(E idx, const T &t, typename ArrayT<T>::item_t t_unk)
+inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::Item t_unk)
 {
 	if ((size_t)idx >= ArrayT<T>::length) {
 		return t_unk;
@@ -48,7 +48,7 @@ inline typename ArrayT<T>::item_t ItemAtT(E idx, const T &t, typename ArrayT<T>:
  * or t_unk when index is out of bounds.
  */
 template <typename E, typename T>
-inline typename ArrayT<T>::item_t ItemAtT(E idx, const T &t, typename ArrayT<T>::item_t t_unk, E idx_inv, typename ArrayT<T>::item_t t_inv)
+inline typename ArrayT<T>::Item ItemAtT(E idx, const T &t, typename ArrayT<T>::Item t_unk, E idx_inv, typename ArrayT<T>::Item t_inv)
 {
 	if ((size_t)idx < ArrayT<T>::length) {
 		return t[idx];

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -151,17 +151,17 @@
  */
 
 /** Fixed point type for heights */
-typedef int16 height_t;
+using Height = int16;
 static const int height_decimal_bits = 4;
 
 /** Fixed point array for amplitudes (and percent values) */
-typedef int amplitude_t;
+using Amplitude = int;
 static const int amplitude_decimal_bits = 10;
 
 /** Height map - allocated array of heights (MapSizeX() + 1) x (MapSizeY() + 1) */
 struct HeightMap
 {
-	std::vector<height_t> h; //< array of heights
+	std::vector<Height> h; //< array of heights
 	/* Even though the sizes are always positive, there are many cases where
 	 * X and Y need to be signed integers due to subtractions. */
 	int      dim_x;      //< height map size_x Map::SizeX() + 1
@@ -174,7 +174,7 @@ struct HeightMap
 	 * @param y Y position
 	 * @return height as fixed point number
 	 */
-	inline height_t &height(uint x, uint y)
+	inline Height &height(uint x, uint y)
 	{
 		return h[x + y * dim_x];
 	}
@@ -183,24 +183,24 @@ struct HeightMap
 /** Global height map instance */
 static HeightMap _height_map = { {}, 0, 0, 0 };
 
-/** Conversion: int to height_t */
+/** Conversion: int to Height */
 #define I2H(i) ((i) << height_decimal_bits)
-/** Conversion: height_t to int */
+/** Conversion: Height to int */
 #define H2I(i) ((i) >> height_decimal_bits)
 
-/** Conversion: int to amplitude_t */
+/** Conversion: int to Amplitude */
 #define I2A(i) ((i) << amplitude_decimal_bits)
-/** Conversion: amplitude_t to int */
+/** Conversion: Amplitude to int */
 #define A2I(i) ((i) >> amplitude_decimal_bits)
 
-/** Conversion: amplitude_t to height_t */
+/** Conversion: Amplitude to Height */
 #define A2H(a) ((a) >> (amplitude_decimal_bits - height_decimal_bits))
 
 /** Maximum number of TGP noise frequencies. */
 static const int MAX_TGP_FREQUENCIES = 10;
 
 /** Desired water percentage (100% == 1024) - indexed by _settings_game.difficulty.quantity_sea_lakes */
-static const amplitude_t _water_percent[4] = {70, 170, 270, 420};
+static const Amplitude _water_percent[4] = {70, 170, 270, 420};
 
 /**
  * Gets the maximum allowed height while generating a map based on
@@ -208,7 +208,7 @@ static const amplitude_t _water_percent[4] = {70, 170, 270, 420};
  * @return The maximum height for the map generation.
  * @note Values should never be lower than 3 since the minimum snowline height is 2.
  */
-static height_t TGPGetMaxHeight()
+static Height TGPGetMaxHeight()
 {
 	if (_settings_game.difficulty.terrain_type == CUSTOM_TERRAIN_TYPE_NUMBER_DIFFICULTY) {
 		/* TGP never reaches this height; this means that if a user inputs "2",
@@ -261,10 +261,10 @@ uint GetEstimationTGPMapHeight()
  * @param frequency The frequency to get the amplitudes for
  * @return The amplitudes to apply to the map.
  */
-static amplitude_t GetAmplitude(int frequency)
+static Amplitude GetAmplitude(int frequency)
 {
 	/* Base noise amplitudes (multiplied by 1024) and indexed by "smoothness setting" and log2(frequency). */
-	static const amplitude_t amplitudes[][7] = {
+	static const Amplitude amplitudes[][7] = {
 		/* lowest frequency ...... highest (every corner) */
 		{16000,  5600,  1968,   688,   240,    16,    16}, ///< Very smooth
 		{24000, 12800,  6400,  2700,  1024,   128,    16}, ///< Smooth
@@ -287,14 +287,14 @@ static amplitude_t GetAmplitude(int frequency)
 
 	/* Get the table index, and return that value if possible. */
 	int index = frequency - MAX_TGP_FREQUENCIES + lengthof(amplitudes[smoothness]);
-	amplitude_t amplitude = amplitudes[smoothness][std::max(0, index)];
+	Amplitude amplitude = amplitudes[smoothness][std::max(0, index)];
 	if (index >= 0) return amplitude;
 
 	/* We need to extrapolate the amplitude. */
 	double extrapolation_factor = extrapolation_factors[smoothness];
 	int height_range = I2H(16);
 	do {
-		amplitude = (amplitude_t)(extrapolation_factor * (double)amplitude);
+		amplitude = (Amplitude)(extrapolation_factor * (double)amplitude);
 		height_range <<= 1;
 		index++;
 	} while (index < 0);
@@ -344,7 +344,7 @@ static inline void FreeHeightMap()
  * @param rMax Limit of result
  * @return generated height
  */
-static inline height_t RandomHeight(amplitude_t rMax)
+static inline Height RandomHeight(Amplitude rMax)
 {
 	/* Spread height into range -rMax..+rMax */
 	return A2H(RandomRange(2 * rMax + 1) - rMax);
@@ -366,7 +366,7 @@ static void HeightMapGenerate()
 	bool first = true;
 
 	for (int frequency = start; frequency < MAX_TGP_FREQUENCIES; frequency++) {
-		const amplitude_t amplitude = GetAmplitude(frequency);
+		const Amplitude amplitude = GetAmplitude(frequency);
 
 		/* Ignore zero amplitudes; it means our map isn't height enough for this
 		 * amplitude, so ignore it and continue with the next set of amplitude. */
@@ -378,7 +378,7 @@ static void HeightMapGenerate()
 			/* This is first round, we need to establish base heights with step = size_min */
 			for (int y = 0; y <= _height_map.size_y; y += step) {
 				for (int x = 0; x <= _height_map.size_x; x += step) {
-					height_t height = (amplitude > 0) ? RandomHeight(amplitude) : 0;
+					Height height = (amplitude > 0) ? RandomHeight(amplitude) : 0;
 					_height_map.height(x, y) = height;
 				}
 			}
@@ -390,9 +390,9 @@ static void HeightMapGenerate()
 		 * Interpolate height values at odd x, even y tiles */
 		for (int y = 0; y <= _height_map.size_y; y += 2 * step) {
 			for (int x = 0; x <= _height_map.size_x - 2 * step; x += 2 * step) {
-				height_t h00 = _height_map.height(x + 0 * step, y);
-				height_t h02 = _height_map.height(x + 2 * step, y);
-				height_t h01 = (h00 + h02) / 2;
+				Height h00 = _height_map.height(x + 0 * step, y);
+				Height h02 = _height_map.height(x + 2 * step, y);
+				Height h01 = (h00 + h02) / 2;
 				_height_map.height(x + 1 * step, y) = h01;
 			}
 		}
@@ -400,9 +400,9 @@ static void HeightMapGenerate()
 		/* Interpolate height values at odd y tiles */
 		for (int y = 0; y <= _height_map.size_y - 2 * step; y += 2 * step) {
 			for (int x = 0; x <= _height_map.size_x; x += step) {
-				height_t h00 = _height_map.height(x, y + 0 * step);
-				height_t h20 = _height_map.height(x, y + 2 * step);
-				height_t h10 = (h00 + h20) / 2;
+				Height h00 = _height_map.height(x, y + 0 * step);
+				Height h20 = _height_map.height(x, y + 2 * step);
+				Height h10 = (h00 + h20) / 2;
 				_height_map.height(x, y + 1 * step) = h10;
 			}
 		}
@@ -417,21 +417,21 @@ static void HeightMapGenerate()
 }
 
 /** Returns min, max and average height from height map */
-static void HeightMapGetMinMaxAvg(height_t *min_ptr, height_t *max_ptr, height_t *avg_ptr)
+static void HeightMapGetMinMaxAvg(Height *min_ptr, Height *max_ptr, Height *avg_ptr)
 {
-	height_t h_min, h_max, h_avg;
+	Height h_min, h_max, h_avg;
 	int64 h_accu = 0;
 	h_min = h_max = _height_map.height(0, 0);
 
 	/* Get h_min, h_max and accumulate heights into h_accu */
-	for (const height_t &h : _height_map.h) {
+	for (const Height &h : _height_map.h) {
 		if (h < h_min) h_min = h;
 		if (h > h_max) h_max = h;
 		h_accu += h;
 	}
 
 	/* Get average height */
-	h_avg = (height_t)(h_accu / (_height_map.size_x * _height_map.size_y));
+	h_avg = (Height)(h_accu / (_height_map.size_x * _height_map.size_y));
 
 	/* Return required results */
 	if (min_ptr != nullptr) *min_ptr = h_min;
@@ -440,12 +440,12 @@ static void HeightMapGetMinMaxAvg(height_t *min_ptr, height_t *max_ptr, height_t
 }
 
 /** Dill histogram and return pointer to its base point - to the count of zero heights */
-static int *HeightMapMakeHistogram(height_t h_min, height_t h_max, int *hist_buf)
+static int *HeightMapMakeHistogram(Height h_min, Height h_max, int *hist_buf)
 {
 	int *hist = hist_buf - h_min;
 
 	/* Count the heights and fill the histogram */
-	for (const height_t &h : _height_map.h){
+	for (const Height &h : _height_map.h){
 		assert(h >= h_min);
 		assert(h <= h_max);
 		hist[h]++;
@@ -454,9 +454,9 @@ static int *HeightMapMakeHistogram(height_t h_min, height_t h_max, int *hist_buf
 }
 
 /** Applies sine wave redistribution onto height map */
-static void HeightMapSineTransform(height_t h_min, height_t h_max)
+static void HeightMapSineTransform(Height h_min, Height h_max)
 {
-	for (height_t &h : _height_map.h) {
+	for (Height &h : _height_map.h) {
 		double fheight;
 
 		if (h < h_min) continue;
@@ -522,7 +522,7 @@ static void HeightMapSineTransform(height_t h_min, height_t h_max)
 				break;
 		}
 		/* Transform it back into h_min..h_max space */
-		h = (height_t)(fheight * (h_max - h_min) + h_min);
+		h = (Height)(fheight * (h_max - h_min) + h_min);
 		if (h < 0) h = I2H(0);
 		if (h >= h_max) h = h_max - 1;
 	}
@@ -546,15 +546,15 @@ static void HeightMapSineTransform(height_t h_min, height_t h_max)
  */
 static void HeightMapCurves(uint level)
 {
-	height_t mh = TGPGetMaxHeight() - I2H(1); // height levels above sea level only
+	Height mh = TGPGetMaxHeight() - I2H(1); // height levels above sea level only
 
 	/** Basically scale height X to height Y. Everything in between is interpolated. */
 	struct ControlPoint {
-		height_t x; ///< The height to scale from.
-		height_t y; ///< The height to scale to.
+		Height x; ///< The height to scale from.
+		Height y; ///< The height to scale to.
 	};
 	/* Scaled curve maps; value is in height_ts. */
-#define F(fraction) ((height_t)(fraction * mh))
+#define F(fraction) ((Height)(fraction * mh))
 	const ControlPoint curve_map_1[] = { { F(0.0), F(0.0) },                       { F(0.8), F(0.13) },                       { F(1.0), F(0.4)  } };
 	const ControlPoint curve_map_2[] = { { F(0.0), F(0.0) }, { F(0.53), F(0.13) }, { F(0.8), F(0.27) },                       { F(1.0), F(0.6)  } };
 	const ControlPoint curve_map_3[] = { { F(0.0), F(0.0) }, { F(0.53), F(0.27) }, { F(0.8), F(0.57) },                       { F(1.0), F(0.8)  } };
@@ -573,7 +573,7 @@ static void HeightMapCurves(uint level)
 		{ lengthof(curve_map_4), curve_map_4 },
 	};
 
-	height_t ht[lengthof(curve_maps)];
+	Height ht[lengthof(curve_maps)];
 	MemSetT(ht, 0, lengthof(ht));
 
 	/* Set up a grid to choose curve maps based on location; attempt to get a somewhat square grid */
@@ -634,7 +634,7 @@ static void HeightMapCurves(uint level)
 			corner_bits |= 1 << corner_c;
 			corner_bits |= 1 << corner_d;
 
-			height_t *h = &_height_map.height(x, y);
+			Height *h = &_height_map.height(x, y);
 
 			/* Do not touch sea level */
 			if (*h < I2H(1)) continue;
@@ -664,7 +664,7 @@ static void HeightMapCurves(uint level)
 			}
 
 			/* Apply interpolation of curve map results. */
-			*h = (height_t)((ht[corner_a] * yri + ht[corner_b] * yr) * xri + (ht[corner_c] * yri + ht[corner_d] * yr) * xr);
+			*h = (Height)((ht[corner_a] * yri + ht[corner_b] * yr) * xri + (ht[corner_c] * yri + ht[corner_d] * yr) * xr);
 
 			/* Readd sea level */
 			*h += I2H(1);
@@ -673,9 +673,9 @@ static void HeightMapCurves(uint level)
 }
 
 /** Adjusts heights in height map to contain required amount of water tiles */
-static void HeightMapAdjustWaterLevel(amplitude_t water_percent, height_t h_max_new)
+static void HeightMapAdjustWaterLevel(Amplitude water_percent, Height h_max_new)
 {
-	height_t h_min, h_max, h_avg, h_water_level;
+	Height h_min, h_max, h_avg, h_water_level;
 	int64 water_tiles, desired_water_tiles;
 	int *hist;
 
@@ -701,9 +701,9 @@ static void HeightMapAdjustWaterLevel(amplitude_t water_percent, height_t h_max_
 	 *   values from range: h_water_level..h_max are transformed into 0..h_max_new
 	 *   where h_max_new is depending on terrain type and map size.
 	 */
-	for (height_t &h : _height_map.h) {
+	for (Height &h : _height_map.h) {
 		/* Transform height from range h_water_level..h_max into 0..h_max_new range */
-		h = (height_t)(((int)h_max_new) * (h - h_water_level) / (h_max - h_water_level)) + I2H(1);
+		h = (Height)(((int)h_max_new) * (h - h_water_level) / (h_max - h_water_level)) + I2H(1);
 		/* Make sure all values are in the proper range (0..h_max_new) */
 		if (h < 0) h = I2H(0);
 		if (h >= h_max_new) h = h_max_new - 1;
@@ -799,8 +799,8 @@ static void HeightMapSmoothCoastInDirection(int org_x, int org_y, int dir_x, int
 	int ed; // coast distance from edge
 	int depth;
 
-	height_t h_prev = I2H(1);
-	height_t h;
+	Height h_prev = I2H(1);
+	Height h;
 
 	assert(IsValidXY(org_x, org_y));
 
@@ -849,17 +849,17 @@ static void HeightMapSmoothCoasts(uint8 water_borders)
  * the most it can change is one level. When OTTD can support cliffs, this
  * routine may not be necessary.
  */
-static void HeightMapSmoothSlopes(height_t dh_max)
+static void HeightMapSmoothSlopes(Height dh_max)
 {
 	for (int y = 0; y <= (int)_height_map.size_y; y++) {
 		for (int x = 0; x <= (int)_height_map.size_x; x++) {
-			height_t h_max = std::min(_height_map.height(x > 0 ? x - 1 : x, y), _height_map.height(x, y > 0 ? y - 1 : y)) + dh_max;
+			Height h_max = std::min(_height_map.height(x > 0 ? x - 1 : x, y), _height_map.height(x, y > 0 ? y - 1 : y)) + dh_max;
 			if (_height_map.height(x, y) > h_max) _height_map.height(x, y) = h_max;
 		}
 	}
 	for (int y = _height_map.size_y; y >= 0; y--) {
 		for (int x = _height_map.size_x; x >= 0; x--) {
-			height_t h_max = std::min(_height_map.height(x < _height_map.size_x ? x + 1 : x, y), _height_map.height(x, y < _height_map.size_y ? y + 1 : y)) + dh_max;
+			Height h_max = std::min(_height_map.height(x < _height_map.size_x ? x + 1 : x, y), _height_map.height(x, y < _height_map.size_y ? y + 1 : y)) + dh_max;
 			if (_height_map.height(x, y) > h_max) _height_map.height(x, y) = h_max;
 		}
 	}
@@ -875,9 +875,9 @@ static void HeightMapSmoothSlopes(height_t dh_max)
 static void HeightMapNormalize()
 {
 	int sea_level_setting = _settings_game.difficulty.quantity_sea_lakes;
-	const amplitude_t water_percent = sea_level_setting != (int)CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY ? _water_percent[sea_level_setting] : _settings_game.game_creation.custom_sea_level * 1024 / 100;
-	const height_t h_max_new = TGPGetMaxHeight();
-	const height_t roughness = 7 + 3 * _settings_game.game_creation.tgen_smoothness;
+	const Amplitude water_percent = sea_level_setting != (int)CUSTOM_SEA_LEVEL_NUMBER_DIFFICULTY ? _water_percent[sea_level_setting] : _settings_game.game_creation.custom_sea_level * 1024 / 100;
+	const Height h_max_new = TGPGetMaxHeight();
+	const Height roughness = 7 + 3 * _settings_game.game_creation.tgen_smoothness;
 
 	HeightMapAdjustWaterLevel(water_percent, h_max_new);
 

--- a/src/tgp.cpp
+++ b/src/tgp.cpp
@@ -549,24 +549,24 @@ static void HeightMapCurves(uint level)
 	height_t mh = TGPGetMaxHeight() - I2H(1); // height levels above sea level only
 
 	/** Basically scale height X to height Y. Everything in between is interpolated. */
-	struct control_point_t {
+	struct ControlPoint {
 		height_t x; ///< The height to scale from.
 		height_t y; ///< The height to scale to.
 	};
 	/* Scaled curve maps; value is in height_ts. */
 #define F(fraction) ((height_t)(fraction * mh))
-	const control_point_t curve_map_1[] = { { F(0.0), F(0.0) },                       { F(0.8), F(0.13) },                       { F(1.0), F(0.4)  } };
-	const control_point_t curve_map_2[] = { { F(0.0), F(0.0) }, { F(0.53), F(0.13) }, { F(0.8), F(0.27) },                       { F(1.0), F(0.6)  } };
-	const control_point_t curve_map_3[] = { { F(0.0), F(0.0) }, { F(0.53), F(0.27) }, { F(0.8), F(0.57) },                       { F(1.0), F(0.8)  } };
-	const control_point_t curve_map_4[] = { { F(0.0), F(0.0) }, { F(0.4),  F(0.3)  }, { F(0.7), F(0.8)  }, { F(0.92), F(0.99) }, { F(1.0), F(0.99) } };
+	const ControlPoint curve_map_1[] = { { F(0.0), F(0.0) },                       { F(0.8), F(0.13) },                       { F(1.0), F(0.4)  } };
+	const ControlPoint curve_map_2[] = { { F(0.0), F(0.0) }, { F(0.53), F(0.13) }, { F(0.8), F(0.27) },                       { F(1.0), F(0.6)  } };
+	const ControlPoint curve_map_3[] = { { F(0.0), F(0.0) }, { F(0.53), F(0.27) }, { F(0.8), F(0.57) },                       { F(1.0), F(0.8)  } };
+	const ControlPoint curve_map_4[] = { { F(0.0), F(0.0) }, { F(0.4),  F(0.3)  }, { F(0.7), F(0.8)  }, { F(0.92), F(0.99) }, { F(1.0), F(0.99) } };
 #undef F
 
 	/** Helper structure to index the different curve maps. */
-	struct control_point_list_t {
-		size_t length;               ///< The length of the curve map.
-		const control_point_t *list; ///< The actual curve map.
+	struct ControlPointList {
+		size_t length;            ///< The length of the curve map.
+		const ControlPoint *list; ///< The actual curve map.
 	};
-	const control_point_list_t curve_maps[] = {
+	static const ControlPointList curve_maps[] = {
 		{ lengthof(curve_map_1), curve_map_1 },
 		{ lengthof(curve_map_2), curve_map_2 },
 		{ lengthof(curve_map_3), curve_map_3 },
@@ -647,10 +647,10 @@ static void HeightMapCurves(uint level)
 				if (!HasBit(corner_bits, t)) continue;
 
 				[[maybe_unused]] bool found = false;
-				const control_point_t *cm = curve_maps[t].list;
+				const ControlPoint *cm = curve_maps[t].list;
 				for (uint i = 0; i < curve_maps[t].length - 1; i++) {
-					const control_point_t &p1 = cm[i];
-					const control_point_t &p2 = cm[i + 1];
+					const ControlPoint &p1 = cm[i];
+					const ControlPoint &p2 = cm[i + 1];
 
 					if (*h >= p1.x && *h < p2.x) {
 						ht[t] = p1.y + (*h - p1.x) * (p2.y - p1.y) / (p2.x - p1.x);


### PR DESCRIPTION
## Motivation / Problem

Back in the day a couple of devs (guilty) used a _t suffix as if it generically meant "type". This is probably as bad as naming variables based on the type, and also POSIX reserves _t for system use.

These types were also in snake-case.

## Description

This PR removes the _t and changes to PascalCase.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
