### PR TITLE
Fix 7c6bf97: Don't change date and shift dates in the wrong order

### DIFF
--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -112,12 +112,12 @@ static int32 ClickChangeDateCheat(int32 new_value, int32 change_direction)
 	ConvertDateToYMD(TimerGameCalendar::date, &ymd);
 	Date new_date = ConvertYMDToDate(new_value, ymd.month, ymd.day);
 
-	/* Change the date. */
-	TimerGameCalendar::SetDate(new_date, TimerGameCalendar::date_fract);
-
-	/* Shift cached dates. */
+	/* Shift cached dates before we change the date. */
 	for (auto v : Vehicle::Iterate()) v->ShiftDates(new_date - TimerGameCalendar::date);
 	LinkGraphSchedule::instance.ShiftDates(new_date - TimerGameCalendar::date);
+
+	/* Now it's safe to actually change the date. */
+	TimerGameCalendar::SetDate(new_date, TimerGameCalendar::date_fract);
 
 	EnginesMonthlyLoop();
 	SetWindowDirty(WC_STATUS_BAR, 0);


### PR DESCRIPTION
## Motivation / Problem

As @JGRennison pointed out in https://github.com/OpenTTD/OpenTTD/pull/10699#discussion_r1174944034, I made a boo-boo and broke things.

## Description

Un-break things and make clear in the comments that the order of these actions matters, so I don't do it again. 😛 

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
