### PR TITLE
Codechange: Define Date/Year/Month/Day within TimerGameCalendar class

### DIFF
--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -11,7 +11,7 @@
 #define BASE_CONSIST_H
 
 #include "order_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include <string>
 
 /** Various front vehicle properties that are preserved when autoreplacing, using order-backup or switching front engines within a consist. */
@@ -19,9 +19,9 @@ struct BaseConsist {
 	std::string name;                   ///< Name of vehicle
 
 	/* Used for timetabling. */
-	uint32 current_order_time;          ///< How many ticks have passed since this order started.
-	int32 lateness_counter;             ///< How many ticks late (or early if negative) this vehicle is.
-	Date timetable_start;               ///< When the vehicle is supposed to start the timetable.
+	uint32 current_order_time;               ///< How many ticks have passed since this order started.
+	int32 lateness_counter;                  ///< How many ticks late (or early if negative) this vehicle is.
+	TimerGameCalendar::Date timetable_start; ///< When the vehicle is supposed to start the timetable.
 
 	uint16 service_interval;            ///< The interval for (automatic) servicing; either in days or %.
 

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -14,6 +14,7 @@
 #include "command_type.h"
 #include "viewport_type.h"
 #include "station_map.h"
+#include "timer/timer_game_calendar.h"
 
 typedef Pool<BaseStation, StationID, 32, 64000> StationPool;
 extern StationPool _station_pool;
@@ -76,7 +77,7 @@ struct BaseStation : StationPool::PoolItem<&_station_pool> {
 	std::vector<StationSpecList> speclist;           ///< List of rail station specs of this station.
 	std::vector<RoadStopSpecList> roadstop_speclist; ///< List of road stop specs of this station
 
-	Date build_date;                ///< Date of construction
+	TimerGameCalendar::Date build_date; ///< Date of construction
 
 	uint16 random_bits;             ///< Random bits assigned to this station
 	byte waiting_triggers;          ///< Waiting triggers (NewGRF) for this station

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -12,6 +12,7 @@
 
 #include "gfx_type.h"
 #include "tile_cmd.h"
+#include "timer/timer_game_calendar.h"
 
 /**
  * This enum is related to the definition of bridge pieces,
@@ -39,17 +40,17 @@ typedef uint BridgeType; ///< Bridge spec number.
  * Struct containing information about a single bridge type
  */
 struct BridgeSpec {
-	Year avail_year;             ///< the year where it becomes available
-	byte min_length;             ///< the minimum length (not counting start and end tile)
-	uint16 max_length;           ///< the maximum length (not counting start and end tile)
-	uint16 price;                ///< the price multiplier
-	uint16 speed;                ///< maximum travel speed (1 unit = 1/1.6 mph = 1 km-ish/h)
-	SpriteID sprite;             ///< the sprite which is used in the GUI
-	PaletteID pal;               ///< the palette which is used in the GUI
-	StringID material;           ///< the string that contains the bridge description
-	StringID transport_name[2];  ///< description of the bridge, when built for road or rail
-	PalSpriteID **sprite_table;  ///< table of sprites for drawing the bridge
-	byte flags;                  ///< bit 0 set: disable drawing of far pillars.
+	TimerGameCalendar::Year avail_year; ///< the year where it becomes available
+	byte min_length;                    ///< the minimum length (not counting start and end tile)
+	uint16 max_length;                  ///< the maximum length (not counting start and end tile)
+	uint16 price;                       ///< the price multiplier
+	uint16 speed;                       ///< maximum travel speed (1 unit = 1/1.6 mph = 1 km-ish/h)
+	SpriteID sprite;                    ///< the sprite which is used in the GUI
+	PaletteID pal;                      ///< the palette which is used in the GUI
+	StringID material;                  ///< the string that contains the bridge description
+	StringID transport_name[2];         ///< description of the bridge, when built for road or rail
+	PalSpriteID **sprite_table;         ///< table of sprites for drawing the bridge
+	byte flags;                         ///< bit 0 set: disable drawing of far pillars.
 };
 
 extern BridgeSpec _bridge[MAX_BRIDGES];

--- a/src/cheat_gui.cpp
+++ b/src/cheat_gui.cpp
@@ -110,7 +110,7 @@ static int32 ClickChangeDateCheat(int32 new_value, int32 change_direction)
 
 	YearMonthDay ymd;
 	ConvertDateToYMD(TimerGameCalendar::date, &ymd);
-	Date new_date = ConvertYMDToDate(new_value, ymd.month, ymd.day);
+	TimerGameCalendar::Date new_date = ConvertYMDToDate(new_value, ymd.month, ymd.day);
 
 	/* Shift cached dates before we change the date. */
 	for (auto v : Vehicle::Iterate()) v->ShiftDates(new_date - TimerGameCalendar::date);

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -14,6 +14,7 @@
 #include "livery.h"
 #include "autoreplace_type.h"
 #include "tile_type.h"
+#include "timer/timer_game_calendar.h"
 #include "settings_type.h"
 #include "group.h"
 #include <string>
@@ -77,7 +78,7 @@ struct CompanyProperties {
 
 	std::array<Owner, MAX_COMPANY_SHARE_OWNERS> share_owners; ///< Owners of the shares of the company. #INVALID_OWNER if nobody has bought them yet.
 
-	Year inaugurated_year;           ///< Year of starting the company.
+	TimerGameCalendar::Year inaugurated_year; ///< Year of starting the company.
 
 	byte months_of_bankruptcy;       ///< Number of months that the company is unable to pay its debts
 	CompanyMask bankrupt_asked;      ///< which companies were asked about buying it?

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -126,7 +126,7 @@ uint64 GetMaskOfAllowedCurrencies()
 	uint i;
 
 	for (i = 0; i < CURRENCY_END; i++) {
-		Year to_euro = _currency_specs[i].to_euro;
+		TimerGameCalendar::Year to_euro = _currency_specs[i].to_euro;
 
 		if (to_euro != CF_NOEURO && to_euro != CF_ISEURO && TimerGameCalendar::year >= to_euro) continue;
 		if (to_euro == CF_ISEURO && TimerGameCalendar::year < 2000) continue;

--- a/src/currency.h
+++ b/src/currency.h
@@ -10,7 +10,7 @@
 #ifndef CURRENCY_H
 #define CURRENCY_H
 
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "string_func.h"
 #include "strings_type.h"
 
@@ -72,7 +72,7 @@ enum Currencies {
 struct CurrencySpec {
 	uint16 rate;           ///< The conversion rate compared to the base currency.
 	std::string separator; ///< The thousands separator for this currency.
-	Year to_euro;          ///< %Year of switching to the Euro. May also be #CF_NOEURO or #CF_ISEURO.
+	TimerGameCalendar::Year to_euro; ///< Year of switching to the Euro. May also be #CF_NOEURO or #CF_ISEURO.
 	std::string prefix;    ///< Prefix to apply when formatting money in this currency.
 	std::string suffix;    ///< Suffix to apply when formatting money in this currency.
 	/**
@@ -89,7 +89,7 @@ struct CurrencySpec {
 
 	CurrencySpec() = default;
 
-	CurrencySpec(uint16 rate, const char *separator, Year to_euro, const char *prefix, const char *suffix, byte symbol_pos, StringID name) :
+	CurrencySpec(uint16 rate, const char *separator, TimerGameCalendar::Year to_euro, const char *prefix, const char *suffix, byte symbol_pos, StringID name) :
 		rate(rate), separator(separator), to_euro(to_euro), prefix(prefix), suffix(suffix), symbol_pos(symbol_pos), name(name)
 	{
 	}

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -69,14 +69,14 @@ static const uint16 _accum_days_for_month[] = {
  * @param date the date to convert from
  * @param ymd  the year, month and day to write to
  */
-void ConvertDateToYMD(Date date, YearMonthDay *ymd)
+void ConvertDateToYMD(TimerGameCalendar::Date date, YearMonthDay *ymd)
 {
 	/* Year determination in multiple steps to account for leap
 	 * years. First do the large steps, then the smaller ones.
 	 */
 
 	/* There are 97 leap years in 400 years */
-	Year yr = 400 * (date / (DAYS_IN_YEAR * 400 + 97));
+	TimerGameCalendar::Year yr = 400 * (date / (DAYS_IN_YEAR * 400 + 97));
 	int rem = date % (DAYS_IN_YEAR * 400 + 97);
 	uint16 x;
 
@@ -124,7 +124,7 @@ void ConvertDateToYMD(Date date, YearMonthDay *ymd)
  * @param month is a number between 0..11
  * @param day   is a number between 1..31
  */
-Date ConvertYMDToDate(Year year, Month month, Day day)
+TimerGameCalendar::Date ConvertYMDToDate(TimerGameCalendar::Year year, TimerGameCalendar::Month month, TimerGameCalendar::Day day)
 {
 	/* Day-offset in a leap year */
 	int days = _accum_days_for_month[month] + day - 1;

--- a/src/date_func.h
+++ b/src/date_func.h
@@ -12,15 +12,15 @@
 
 #include "date_type.h"
 
-void ConvertDateToYMD(Date date, YearMonthDay *ymd);
-Date ConvertYMDToDate(Year year, Month month, Day day);
+void ConvertDateToYMD(TimerGameCalendar::Date date, YearMonthDay *ymd);
+TimerGameCalendar::Date ConvertYMDToDate(TimerGameCalendar::Year year, TimerGameCalendar::Month month, TimerGameCalendar::Day day);
 
 /**
  * Checks whether the given year is a leap year or not.
  * @param yr The year to check.
  * @return True if \c yr is a leap year, otherwise false.
  */
-static inline bool IsLeapYear(Year yr)
+static inline bool IsLeapYear(TimerGameCalendar::Year yr)
 {
 	return yr % 4 == 0 && (yr % 100 != 0 || yr % 400 == 0);
 }

--- a/src/date_gui.cpp
+++ b/src/date_gui.cpp
@@ -27,8 +27,8 @@ struct SetDateWindow : Window {
 	SetDateCallback *callback; ///< Callback to call when a date has been selected
 	void *callback_data;       ///< Callback data pointer.
 	YearMonthDay date; ///< The currently selected date
-	Year min_year;     ///< The minimum year in the year dropdown
-	Year max_year;     ///< The maximum year (inclusive) in the year dropdown
+	TimerGameCalendar::Year min_year; ///< The minimum year in the year dropdown
+	TimerGameCalendar::Year max_year; ///< The maximum year (inclusive) in the year dropdown
 
 	/**
 	 * Create the new 'set date' window
@@ -40,7 +40,7 @@ struct SetDateWindow : Window {
 	 * @param max_year the maximum year (inclusive) to show in the year dropdown
 	 * @param callback the callback to call once a date has been selected
 	 */
-	SetDateWindow(WindowDesc *desc, WindowNumber window_number, Window *parent, Date initial_date, Year min_year, Year max_year, SetDateCallback *callback, void *callback_data) :
+	SetDateWindow(WindowDesc *desc, WindowNumber window_number, Window *parent, TimerGameCalendar::Date initial_date, TimerGameCalendar::Year min_year, TimerGameCalendar::Year max_year, SetDateCallback *callback, void *callback_data) :
 			Window(desc),
 			callback(callback),
 			callback_data(callback_data),
@@ -89,7 +89,7 @@ struct SetDateWindow : Window {
 				break;
 
 			case WID_SD_YEAR:
-				for (Year i = this->min_year; i <= this->max_year; i++) {
+				for (TimerGameCalendar::Year i = this->min_year; i <= this->max_year; i++) {
 					DropDownListParamStringItem *item = new DropDownListParamStringItem(STR_JUST_INT, i, false);
 					item->SetParam(0, i);
 					list.emplace_back(item);
@@ -214,7 +214,7 @@ static WindowDesc _set_date_desc(
  * @param callback the callback to call once a date has been selected
  * @param callback_data extra callback data
  */
-void ShowSetDateWindow(Window *parent, int window_number, Date initial_date, Year min_year, Year max_year, SetDateCallback *callback, void *callback_data)
+void ShowSetDateWindow(Window *parent, int window_number, TimerGameCalendar::Date initial_date, TimerGameCalendar::Year min_year, TimerGameCalendar::Year max_year, SetDateCallback *callback, void *callback_data)
 {
 	CloseWindowByClass(WC_SET_DATE);
 	new SetDateWindow(&_set_date_desc, window_number, parent, initial_date, min_year, max_year, callback, callback_data);

--- a/src/date_gui.h
+++ b/src/date_gui.h
@@ -10,7 +10,7 @@
 #ifndef DATE_GUI_H
 #define DATE_GUI_H
 
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "window_type.h"
 
 /**
@@ -18,8 +18,8 @@
  * @param w the window that sends the callback
  * @param date the date that has been chosen
  */
-typedef void SetDateCallback(const Window *w, Date date, void *data);
+typedef void SetDateCallback(const Window *w, TimerGameCalendar::Date date, void *data);
 
-void ShowSetDateWindow(Window *parent, int window_number, Date initial_date, Year min_year, Year max_year, SetDateCallback *callback, void *callback_data);
+void ShowSetDateWindow(Window *parent, int window_number, TimerGameCalendar::Date initial_date, TimerGameCalendar::Year min_year, TimerGameCalendar::Year max_year, SetDateCallback *callback, void *callback_data);
 
 #endif /* DATE_GUI_H */

--- a/src/date_type.h
+++ b/src/date_type.h
@@ -10,14 +10,10 @@
 #ifndef DATE_TYPE_H
 #define DATE_TYPE_H
 
+#include "timer/timer_game_calendar.h"
 
-typedef int32  Date;      ///< The type to store our dates in
-typedef uint16 DateFract; ///< The fraction of a date we're in, i.e. the number of ticks since the last date changeover
 typedef int32  Ticks;     ///< The type to store ticks in
 
-typedef int32  Year;  ///< Type for the year, note: 0 based, i.e. starts at the year 0.
-typedef uint8  Month; ///< Type for the month, note: 0 based, i.e. 0 = January, 11 = December.
-typedef uint8  Day;   ///< Type for the day of the month, note: 1 based, first day of a month is 1.
 
 /**
  * 1 day is 74 ticks; TimerGameCalendar::date_fract used to be uint16 and incremented by 885. On
@@ -49,11 +45,11 @@ static const int INDUSTRY_CUT_TREE_TICKS  = INDUSTRY_PRODUCE_TICKS * 2; ///< cyc
  */
 
 /** The minimum starting year/base year of the original TTD */
-static const Year ORIGINAL_BASE_YEAR = 1920;
+static const TimerGameCalendar::Year ORIGINAL_BASE_YEAR = 1920;
 /** The original ending year */
-static const Year ORIGINAL_END_YEAR  = 2051;
+static const TimerGameCalendar::Year ORIGINAL_END_YEAR  = 2051;
 /** The maximum year of the original TTD */
-static const Year ORIGINAL_MAX_YEAR  = 2090;
+static const TimerGameCalendar::Year ORIGINAL_MAX_YEAR  = 2090;
 
 /**
  * Calculate the number of leap years till a given year.
@@ -83,18 +79,18 @@ static const Year ORIGINAL_MAX_YEAR  = 2090;
 #define DAYS_TILL_ORIGINAL_BASE_YEAR DAYS_TILL(ORIGINAL_BASE_YEAR)
 
 /** The absolute minimum & maximum years in OTTD */
-static const Year MIN_YEAR = 0;
+static const TimerGameCalendar::Year MIN_YEAR = 0;
 
 /** The default starting year */
-static const Year DEF_START_YEAR = 1950;
+static const TimerGameCalendar::Year DEF_START_YEAR = 1950;
 /** The default scoring end year */
-static const Year DEF_END_YEAR = ORIGINAL_END_YEAR - 1;
+static const TimerGameCalendar::Year DEF_END_YEAR = ORIGINAL_END_YEAR - 1;
 
 /**
  * MAX_YEAR, nicely rounded value of the number of years that can
  * be encoded in a single 32 bits date, about 2^31 / 366 years.
  */
-static const Year MAX_YEAR  = 5000000;
+static const TimerGameCalendar::Year MAX_YEAR  = 5000000;
 
 /** The number of days till the last day */
 #define MAX_DAY (DAYS_TILL(MAX_YEAR + 1) - 1)
@@ -104,13 +100,13 @@ static const Year MAX_YEAR  = 5000000;
  * @see ConvertDateToYMD(), ConvertYMDToDate()
  */
 struct YearMonthDay {
-	Year  year;   ///< Year (0...)
-	Month month;  ///< Month (0..11)
-	Day   day;    ///< Day (1..31)
+	TimerGameCalendar::Year  year;   ///< Year (0...)
+	TimerGameCalendar::Month month;  ///< Month (0..11)
+	TimerGameCalendar::Day   day;    ///< Day (1..31)
 };
 
-static const Year  INVALID_YEAR  = -1; ///< Representation of an invalid year
-static const Date  INVALID_DATE  = -1; ///< Representation of an invalid date
+static const TimerGameCalendar::Year INVALID_YEAR = -1; ///< Representation of an invalid year
+static const TimerGameCalendar::Date INVALID_DATE = -1; ///< Representation of an invalid date
 static const Ticks INVALID_TICKS = -1; ///< Representation of an invalid number of ticks
 
 #endif /* DATE_TYPE_H */

--- a/src/depot_base.h
+++ b/src/depot_base.h
@@ -12,6 +12,7 @@
 
 #include "depot_map.h"
 #include "core/pool_type.hpp"
+#include "timer/timer_game_calendar.h"
 
 typedef Pool<Depot, DepotID, 64, 64000> DepotPool;
 extern DepotPool _depot_pool;
@@ -21,8 +22,8 @@ struct Depot : DepotPool::PoolItem<&_depot_pool> {
 	std::string name;
 
 	TileIndex xy;
-	uint16 town_cn;    ///< The N-1th depot for this town (consecutive number)
-	Date build_date;   ///< Date of construction
+	uint16 town_cn; ///< The N-1th depot for this town (consecutive number)
+	TimerGameCalendar::Date build_date; ///< Date of construction
 
 	Depot(TileIndex xy = INVALID_TILE) : xy(xy) {}
 	~Depot();

--- a/src/disaster_vehicle.cpp
+++ b/src/disaster_vehicle.cpp
@@ -900,9 +900,9 @@ static void Disaster_CoalMine_Init()
 }
 
 struct Disaster {
-	DisasterInitProc *init_proc; ///< The init function for this disaster.
-	Year min_year;               ///< The first year this disaster will occur.
-	Year max_year;               ///< The last year this disaster will occur.
+	DisasterInitProc *init_proc;      ///< The init function for this disaster.
+	TimerGameCalendar::Year min_year; ///< The first year this disaster will occur.
+	TimerGameCalendar::Year max_year; ///< The last year this disaster will occur.
 };
 
 static const Disaster _disasters[] = {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -47,7 +47,7 @@ EngineOverrideManager _engine_mngr;
  * Year that engine aging stops. Engines will not reduce in reliability
  * and no more engines will be introduced
  */
-static Year _year_engine_aging_stops;
+static TimerGameCalendar::Year _year_engine_aging_stops;
 
 /** Number of engines of each vehicle type in original engine data */
 const uint8 _engine_counts[4] = {
@@ -436,7 +436,7 @@ uint Engine::GetDisplayMaxTractiveEffort() const
  * Returns the vehicle's (not model's!) life length in days.
  * @return the life length
  */
-Date Engine::GetLifeLengthInDays() const
+TimerGameCalendar::Date Engine::GetLifeLengthInDays() const
 {
 	/* Assume leap years; this gives the player a bit more than the given amount of years, but never less. */
 	return (this->info.lifelength + _settings_game.vehicle.extend_vehicle_life) * DAYS_IN_LEAP_YEAR;
@@ -652,7 +652,7 @@ void SetYearEngineAgingStops()
  * @param aging_date The date used for age calculations.
  * @param seed Random seed.
  */
-void StartupOneEngine(Engine *e, Date aging_date, uint32 seed)
+void StartupOneEngine(Engine *e, TimerGameCalendar::Date aging_date, uint32 seed)
 {
 	const EngineInfo *ei = &e->info;
 
@@ -674,7 +674,7 @@ void StartupOneEngine(Engine *e, Date aging_date, uint32 seed)
 	/* Don't randomise the start-date in the first two years after gamestart to ensure availability
 	 * of engines in early starting games.
 	 * Note: TTDP uses fixed 1922 */
-	e->intro_date = ei->base_intro <= ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (Date)GB(r, 0, 9) + ei->base_intro;
+	e->intro_date = ei->base_intro <= ConvertYMDToDate(_settings_game.game_creation.starting_year + 2, 0, 1) ? ei->base_intro : (TimerGameCalendar::Date)GB(r, 0, 9) + ei->base_intro;
 	if (e->intro_date <= TimerGameCalendar::date) {
 		e->age = (aging_date - e->intro_date) >> 5;
 		e->company_avail = MAX_UVALUE(CompanyMask);
@@ -721,7 +721,7 @@ void StartupOneEngine(Engine *e, Date aging_date, uint32 seed)
 void StartupEngines()
 {
 	/* Aging of vehicles stops, so account for that when starting late */
-	const Date aging_date = std::min(TimerGameCalendar::date, ConvertYMDToDate(_year_engine_aging_stops, 0, 1));
+	const TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date, ConvertYMDToDate(_year_engine_aging_stops, 0, 1));
 	uint32 seed = Random();
 
 	for (Engine *e : Engine::Iterate()) {
@@ -1241,7 +1241,7 @@ bool IsEngineRefittable(EngineID engine)
  */
 void CheckEngines()
 {
-	Date min_date = INT32_MAX;
+	TimerGameCalendar::Date min_date = INT32_MAX;
 
 	for (const Engine *e : Engine::Iterate()) {
 		if (!e->IsEnabled()) continue;

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -14,6 +14,7 @@
 #include "vehicle_type.h"
 #include "core/pool_type.hpp"
 #include "newgrf_commons.h"
+#include "timer/timer_game_calendar.h"
 
 struct WagonOverride {
 	std::vector<EngineID> engines;
@@ -35,8 +36,8 @@ extern EnginePool _engine_pool;
 
 struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	std::string name;           ///< Custom name of engine.
-	Date intro_date;            ///< Date of introduction of the engine.
-	Date age;
+	TimerGameCalendar::Date intro_date; ///< Date of introduction of the engine.
+	TimerGameCalendar::Date age;        ///< Age of the engine, in days.
 	uint16 reliability;         ///< Current reliability of the engine.
 	uint16 reliability_spd_dec; ///< Speed of reliability decay between services (per day).
 	uint16 reliability_start;   ///< Initial reliability of the engine.
@@ -123,7 +124,7 @@ struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	uint GetPower() const;
 	uint GetDisplayWeight() const;
 	uint GetDisplayMaxTractiveEffort() const;
-	Date GetLifeLengthInDays() const;
+	TimerGameCalendar::Date GetLifeLengthInDays() const;
 	uint16 GetRange() const;
 	StringID GetAircraftTypeText() const;
 

--- a/src/engine_func.h
+++ b/src/engine_func.h
@@ -13,6 +13,7 @@
 #include "engine_type.h"
 #include "vehicle_type.h"
 #include "company_type.h"
+#include "timer/timer_game_calendar.h"
 
 void SetupEngines();
 void StartupEngines();
@@ -26,7 +27,7 @@ bool IsEngineBuildable(EngineID engine, VehicleType type, CompanyID company);
 bool IsEngineRefittable(EngineID engine);
 void SetYearEngineAgingStops();
 void CalcEngineReliability(Engine *e, bool new_month);
-void StartupOneEngine(Engine *e, Date aging_date, uint32 seed);
+void StartupOneEngine(Engine *e, TimerGameCalendar::Date aging_date, uint32 seed);
 
 uint GetTotalCapacityOfArticulatedParts(EngineID engine);
 

--- a/src/engine_type.h
+++ b/src/engine_type.h
@@ -14,7 +14,7 @@
 #include "rail_type.h"
 #include "road_type.h"
 #include "cargo_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "sound_type.h"
 #include "strings_type.h"
 
@@ -141,9 +141,9 @@ DECLARE_ENUM_AS_BIT_SET(ExtraEngineFlags);
  *  @see table/engines.h
  */
 struct EngineInfo {
-	Date base_intro;    ///< Basic date of engine introduction (without random parts).
-	Year lifelength;    ///< Lifetime of a single vehicle
-	Year base_life;     ///< Basic duration of engine availability (without random parts). \c 0xFF means infinite life.
+	TimerGameCalendar::Date base_intro;    ///< Basic date of engine introduction (without random parts).
+	TimerGameCalendar::Year lifelength;    ///< Lifetime of a single vehicle
+	TimerGameCalendar::Year base_life;     ///< Basic duration of engine availability (without random parts). \c 0xFF means infinite life.
 	byte decay_speed;
 	byte load_amount;
 	byte climates;      ///< Climates supported by the engine.

--- a/src/fios.h
+++ b/src/fios.h
@@ -14,6 +14,7 @@
 #include "company_base.h"
 #include "newgrf_config.h"
 #include "network/core/tcp_content_type.h"
+#include "timer/timer_game_calendar.h"
 
 
 /** Special values for save-load window for the data parameter of #InvalidateWindowData. */
@@ -34,7 +35,7 @@ struct LoadCheckData {
 	char *error_data;   ///< Data to pass to SetDParamStr when displaying #error.
 
 	uint32 map_size_x, map_size_y;
-	Date current_date;
+	TimerGameCalendar::Date current_date;
 
 	GameSettings settings;
 

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -185,7 +185,7 @@ protected:
 	byte num_vert_lines;
 
 	/* The starting month and year that values are plotted against. */
-	byte month;
+	TimerGameCalendar::Month month;
 	TimerGameCalendar::Year year;
 
 	bool draw_dates = true; ///< Should we draw months and years on the time axis?
@@ -385,7 +385,7 @@ protected:
 		if (this->draw_dates) {
 			x = r.left;
 			y = r.bottom + ScaleGUITrad(2);
-			byte month = this->month;
+			TimerGameCalendar::Month month = this->month;
 			TimerGameCalendar::Year year = this->year;
 			for (int i = 0; i < this->num_on_x_axis; i++) {
 				SetDParam(0, month + STR_MONTH_ABBREV_JAN);
@@ -502,7 +502,7 @@ public:
 
 		/* Draw x-axis labels and markings for graphs based on financial quarters and years.  */
 		if (this->draw_dates) {
-			byte month = this->month;
+			TimerGameCalendar::Month month = this->month;
 			TimerGameCalendar::Year year = this->year;
 			for (int i = 0; i < this->num_on_x_axis; i++) {
 				SetDParam(0, month + STR_MONTH_ABBREV_JAN);

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -16,6 +16,7 @@
 #include "cargotype.h"
 #include "strings_func.h"
 #include "window_func.h"
+#include "date_type.h"
 #include "timer/timer_game_calendar.h"
 #include "gfx_func.h"
 #include "core/geometry_func.hpp"
@@ -185,7 +186,7 @@ protected:
 
 	/* The starting month and year that values are plotted against. */
 	byte month;
-	Year year;
+	TimerGameCalendar::Year year;
 
 	bool draw_dates = true; ///< Should we draw months and years on the time axis?
 
@@ -385,7 +386,7 @@ protected:
 			x = r.left;
 			y = r.bottom + ScaleGUITrad(2);
 			byte month = this->month;
-			Year year  = this->year;
+			TimerGameCalendar::Year year = this->year;
 			for (int i = 0; i < this->num_on_x_axis; i++) {
 				SetDParam(0, month + STR_MONTH_ABBREV_JAN);
 				SetDParam(1, year);
@@ -502,7 +503,7 @@ public:
 		/* Draw x-axis labels and markings for graphs based on financial quarters and years.  */
 		if (this->draw_dates) {
 			byte month = this->month;
-			Year year  = this->year;
+			TimerGameCalendar::Year year = this->year;
 			for (int i = 0; i < this->num_on_x_axis; i++) {
 				SetDParam(0, month + STR_MONTH_ABBREV_JAN);
 				SetDParam(1, year);

--- a/src/house.h
+++ b/src/house.h
@@ -11,7 +11,7 @@
 #define HOUSE_H
 
 #include "cargo_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "house_type.h"
 #include "newgrf_animation_type.h"
 #include "newgrf_commons.h"
@@ -97,8 +97,8 @@ DECLARE_ENUM_AS_BIT_SET(HouseExtraFlags)
 
 struct HouseSpec {
 	/* Standard properties */
-	Year min_year;                            ///< introduction year of the house
-	Year max_year;                            ///< last year it can be built
+	TimerGameCalendar::Year min_year;         ///< introduction year of the house
+	TimerGameCalendar::Year max_year;         ///< last year it can be built
 	byte population;                          ///< population (Zero on other tiles in multi tile house.)
 	byte removal_cost;                        ///< cost multiplier for removing it
 	StringID building_name;                   ///< building name

--- a/src/industry.h
+++ b/src/industry.h
@@ -16,12 +16,13 @@
 #include "industrytype.h"
 #include "tilearea_type.h"
 #include "station_base.h"
+#include "timer/timer_game_calendar.h"
 
 
 typedef Pool<Industry, IndustryID, 64, 64000> IndustryPool;
 extern IndustryPool _industry_pool;
 
-static const Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS = 5; ///< If a processing industry doesn't produce for this many consecutive years, it may close.
+static const TimerGameCalendar::Year PROCESSING_INDUSTRY_ABANDONMENT_YEARS = 5; ///< If a processing industry doesn't produce for this many consecutive years, it may close.
 
 /**
  * Production level maximum, minimum and default values.
@@ -78,7 +79,7 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	IndustryType type;             ///< type of industry.
 	Owner owner;                   ///< owner of the industry.  Which SHOULD always be (imho) OWNER_NONE
 	byte random_colour;            ///< randomized colour of the industry, for display purpose
-	Year last_prod_year;           ///< last year of production
+	TimerGameCalendar::Year last_prod_year; ///< last year of production
 	byte was_cargo_delivered;      ///< flag that indicate this has been the closest industry chosen for cargo delivery by a station. see DeliverGoodsToIndustry
 	IndustryControlFlags ctlflags; ///< flags overriding standard behaviours
 
@@ -87,9 +88,9 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the industry
 
 	Owner founder;                 ///< Founder of the industry
-	Date construction_date;        ///< Date of the construction of the industry
+	TimerGameCalendar::Date construction_date; ///< Date of the construction of the industry
 	uint8 construction_type;       ///< Way the industry was constructed (@see IndustryConstructionType)
-	Date last_cargo_accepted_at[INDUSTRY_NUM_INPUTS]; ///< Last day each cargo type was accepted by this industry
+	TimerGameCalendar::Date last_cargo_accepted_at[INDUSTRY_NUM_INPUTS]; ///< Last day each cargo type was accepted by this industry
 	byte selected_layout;          ///< Which tile layout was used when creating the industry
 	Owner exclusive_supplier;      ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
 	Owner exclusive_consumer;      ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)

--- a/src/linkgraph/linkgraph.cpp
+++ b/src/linkgraph/linkgraph.cpp
@@ -89,8 +89,8 @@ void LinkGraph::Compress()
  */
 void LinkGraph::Merge(LinkGraph *other)
 {
-	Date age = TimerGameCalendar::date - this->last_compression + 1;
-	Date other_age = TimerGameCalendar::date - other->last_compression + 1;
+	TimerGameCalendar::Date age = TimerGameCalendar::date - this->last_compression + 1;
+	TimerGameCalendar::Date other_age = TimerGameCalendar::date - other->last_compression + 1;
 	NodeID first = this->Size();
 	for (NodeID node1 = 0; node1 < other->Size(); ++node1) {
 		Station *st = Station::Get(other->nodes[node1].station);

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -14,6 +14,7 @@
 #include "../core/smallmap_type.hpp"
 #include "../station_base.h"
 #include "../cargotype.h"
+#include "../date_type.h"
 #include "../timer/timer_game_calendar.h"
 #include "../saveload/saveload.h"
 #include "linkgraph_type.h"
@@ -44,8 +45,8 @@ public:
 		uint capacity;                 ///< Capacity of the link.
 		uint usage;                    ///< Usage of the link.
 		uint64 travel_time_sum;        ///< Sum of the travel times of the link, in ticks.
-		Date last_unrestricted_update; ///< When the unrestricted part of the link was last updated.
-		Date last_restricted_update;   ///< When the restricted part of the link was last updated.
+		TimerGameCalendar::Date last_unrestricted_update; ///< When the unrestricted part of the link was last updated.
+		TimerGameCalendar::Date last_restricted_update;   ///< When the restricted part of the link was last updated.
 		NodeID dest_node;              ///< Destination of the edge.
 
 		BaseEdge(NodeID dest_node = INVALID_NODE);
@@ -60,7 +61,7 @@ public:
 		 * Get the date of the last update to any part of the edge's capacity.
 		 * @return Last update.
 		 */
-		Date LastUpdate() const { return std::max(this->last_unrestricted_update, this->last_restricted_update); }
+		TimerGameCalendar::Date LastUpdate() const { return std::max(this->last_unrestricted_update, this->last_restricted_update); }
 
 		void Update(uint capacity, uint usage, uint32 time, EdgeUpdateMode mode);
 		void Restrict() { this->last_unrestricted_update = INVALID_DATE; }
@@ -93,7 +94,7 @@ public:
 		uint demand;             ///< Acceptance at the station.
 		StationID station;       ///< Station ID.
 		TileIndex xy;            ///< Location of the station referred to by the node.
-		Date last_update;        ///< When the supply was last updated.
+		TimerGameCalendar::Date last_update;        ///< When the supply was last updated.
 
 		std::vector<BaseEdge> edges; ///< Sorted list of outgoing edges from this node.
 
@@ -234,7 +235,7 @@ public:
 	 * Get date of last compression.
 	 * @return Date of last compression.
 	 */
-	inline Date LastCompression() const { return this->last_compression; }
+	inline TimerGameCalendar::Date LastCompression() const { return this->last_compression; }
 
 	/**
 	 * Get the cargo ID this component's link graph refers to.
@@ -263,7 +264,7 @@ protected:
 	friend class LinkGraphJob;
 
 	CargoID cargo;         ///< Cargo of this component's link graph.
-	Date last_compression; ///< Last time the capacities and supplies were compressed.
+	TimerGameCalendar::Date last_compression; ///< Last time the capacities and supplies were compressed.
 	NodeVector nodes;      ///< Nodes in the component.
 };
 

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -161,13 +161,13 @@ private:
 	friend class LinkGraphSchedule;
 
 protected:
-	const LinkGraph link_graph;       ///< Link graph to by analyzed. Is copied when job is started and mustn't be modified later.
-	const LinkGraphSettings settings; ///< Copy of _settings_game.linkgraph at spawn time.
-	std::thread thread;               ///< Thread the job is running in or a default-constructed thread if it's running in the main thread.
-	Date join_date;                   ///< Date when the job is to be joined.
-	NodeAnnotationVector nodes;       ///< Extra node data necessary for link graph calculation.
-	std::atomic<bool> job_completed;  ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
-	std::atomic<bool> job_aborted;    ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
+	const LinkGraph link_graph;        ///< Link graph to by analyzed. Is copied when job is started and mustn't be modified later.
+	const LinkGraphSettings settings;  ///< Copy of _settings_game.linkgraph at spawn time.
+	std::thread thread;                ///< Thread the job is running in or a default-constructed thread if it's running in the main thread.
+	TimerGameCalendar::Date join_date; ///< Date when the job is to be joined.
+	NodeAnnotationVector nodes;        ///< Extra node data necessary for link graph calculation.
+	std::atomic<bool> job_completed;   ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
+	std::atomic<bool> job_aborted;     ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
 
 	void EraseFlows(NodeID from);
 	void JoinThread();
@@ -218,7 +218,7 @@ public:
 	 * Get the date when the job should be finished.
 	 * @return Join date.
 	 */
-	inline Date JoinDate() const { return join_date; }
+	inline TimerGameCalendar::Date JoinDate() const { return join_date; }
 
 	/**
 	 * Change the join date on date cheating.
@@ -255,7 +255,7 @@ public:
 	 * Get the date when the underlying link graph was last compressed.
 	 * @return Compression date.
 	 */
-	inline Date LastCompression() const { return this->link_graph.LastCompression(); }
+	inline TimerGameCalendar::Date LastCompression() const { return this->link_graph.LastCompression(); }
 
 	/**
 	 * Get the ID of the underlying link graph.

--- a/src/linkgraph/linkgraphschedule.cpp
+++ b/src/linkgraph/linkgraphschedule.cpp
@@ -205,7 +205,7 @@ void AfterLoad_LinkGraphPauseControl()
 void OnTick_LinkGraph()
 {
 	if (TimerGameCalendar::date_fract != LinkGraphSchedule::SPAWN_JOIN_TICK) return;
-	Date offset = TimerGameCalendar::date % (_settings_game.linkgraph.recalc_interval / SECONDS_PER_DAY);
+	TimerGameCalendar::Date offset = TimerGameCalendar::date % (_settings_game.linkgraph.recalc_interval / SECONDS_PER_DAY);
 	if (offset == 0) {
 		LinkGraphSchedule::instance.SpawnNext();
 	} else if (offset == (_settings_game.linkgraph.recalc_interval / SECONDS_PER_DAY) / 2) {

--- a/src/network/core/game_info.cpp
+++ b/src/network/core/game_info.cpp
@@ -256,7 +256,7 @@ void SerializeNetworkGameInfo(Packet *p, const NetworkServerGameInfo *info, bool
  */
 void DeserializeNetworkGameInfo(Packet *p, NetworkGameInfo *info, const GameInfoNewGRFLookupTable *newgrf_lookup_table)
 {
-	static const Date MAX_DATE = ConvertYMDToDate(MAX_YEAR, 11, 31); // December is month 11
+	static const TimerGameCalendar::Date MAX_DATE = ConvertYMDToDate(MAX_YEAR, 11, 31); // December is month 11
 
 	byte game_info_version = p->Recv_uint8();
 	NewGRFSerializationType newgrf_serialisation = NST_GRFID_MD5;

--- a/src/network/core/game_info.h
+++ b/src/network/core/game_info.h
@@ -15,7 +15,7 @@
 #include "config.h"
 #include "core.h"
 #include "../../newgrf_config.h"
-#include "../../date_type.h"
+#include "../../timer/timer_game_calendar.h"
 
 #include <unordered_map>
 
@@ -92,8 +92,8 @@ enum NewGRFSerializationType {
  */
 struct NetworkServerGameInfo {
 	GRFConfig *grfconfig;        ///< List of NewGRF files used
-	Date start_date;             ///< When the game started
-	Date game_date;              ///< Current date
+	TimerGameCalendar::Date start_date; ///< When the game started
+	TimerGameCalendar::Date game_date;  ///< Current date
 	uint16 map_width;            ///< Map width
 	uint16 map_height;           ///< Map height
 	std::string server_name;     ///< Server name

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -1040,7 +1040,7 @@ void NetworkGameLoop()
 		/* Log the sync state to check for in-syncedness of replays. */
 		if (TimerGameCalendar::date_fract == 0) {
 			/* We don't want to log multiple times if paused. */
-			static Date last_log;
+			static TimerGameCalendar::Date last_log;
 			if (last_log != TimerGameCalendar::date) {
 				Debug(desync, 1, "sync: {:08x}; {:02x}; {:08x}; {:08x}", TimerGameCalendar::date, TimerGameCalendar::date_fract, _random.state[0], _random.state[1]);
 				last_log = TimerGameCalendar::date;

--- a/src/network/network_base.h
+++ b/src/network/network_base.h
@@ -15,6 +15,7 @@
 #include "../core/pool_type.hpp"
 #include "../company_type.h"
 #include "../date_type.h"
+#include "../timer/timer_game_calendar.h"
 
 /** Type for the pool with client information. */
 typedef Pool<NetworkClientInfo, ClientIndex, 8, MAX_CLIENT_SLOTS, PT_NCLIENT> NetworkClientInfoPool;
@@ -25,7 +26,7 @@ struct NetworkClientInfo : NetworkClientInfoPool::PoolItem<&_networkclientinfo_p
 	ClientID client_id;      ///< Client identifier (same as ClientState->client_id)
 	std::string client_name; ///< Name of the client
 	CompanyID client_playas; ///< As which company is this client playing (CompanyID)
-	Date join_date;          ///< Gamedate the client has joined
+	TimerGameCalendar::Date join_date; ///< Gamedate the client has joined
 
 	/**
 	 * Create a new client.

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -11,7 +11,7 @@
 #define NETWORK_GUI_H
 
 #include "../company_type.h"
-#include "../date_type.h"
+#include "../timer/timer_game_calendar.h"
 #include "../economy_type.h"
 #include "../window_type.h"
 #include "network_type.h"
@@ -29,7 +29,7 @@ void ShowNetworkAskRelay(const std::string &server_connection_string, const std:
 /** Company information stored at the client side */
 struct NetworkCompanyInfo : NetworkCompanyStats {
 	std::string company_name; ///< Company name
-	Year inaugurated_year;    ///< What year the company started in
+	TimerGameCalendar::Year inaugurated_year; ///< What year the company started in
 	Money company_value;      ///< The company value
 	Money money;              ///< The amount of money the company has
 	Money income;             ///< How much did the company earn last year

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -39,6 +39,7 @@
 #include "strings_func.h"
 #include "date_func.h"
 #include "timer/timer_game_tick.h"
+#include "timer/timer_game_calendar.h"
 #include "string_func.h"
 #include "network/core/config.h"
 #include <map>
@@ -2755,7 +2756,7 @@ static ChangeInfoResult GlobalVarChangeInfo(uint gvid, int numinfo, int prop, By
 
 			case 0x0F: { //  Euro introduction dates
 				uint curidx = GetNewgrfCurrencyIdConverted(gvid + i);
-				Year year_euro = buf->ReadWord();
+				TimerGameCalendar::Year year_euro = buf->ReadWord();
 
 				if (curidx < CURRENCY_END) {
 					_currency_specs[curidx].to_euro = year_euro;
@@ -6509,7 +6510,7 @@ bool GetGlobalVariable(byte param, uint32 *value, const GRFFile *grffile)
 		case 0x02: { // detailed date information: month of year (bit 0-7), day of month (bit 8-12), leap year (bit 15), day of year (bit 16-24)
 			YearMonthDay ymd;
 			ConvertDateToYMD(TimerGameCalendar::date, &ymd);
-			Date start_of_year = ConvertYMDToDate(ymd.year, 0, 1);
+			TimerGameCalendar::Date start_of_year = ConvertYMDToDate(ymd.year, 0, 1);
 			*value = ymd.month | (ymd.day - 1) << 8 | (IsLeapYear(ymd.year) ? 1 << 15 : 0) | (TimerGameCalendar::date - start_of_year) << 16;
 			return true;
 		}
@@ -9239,7 +9240,7 @@ static bool IsHouseSpecValid(HouseSpec *hs, const HouseSpec *next1, const HouseS
  */
 static void EnsureEarlyHouse(HouseZones bitmask)
 {
-	Year min_year = MAX_YEAR;
+	TimerGameCalendar::Year min_year = MAX_YEAR;
 
 	for (int i = 0; i < NUM_HOUSES; i++) {
 		HouseSpec *hs = HouseSpec::Get(i);
@@ -9940,9 +9941,9 @@ void LoadNewGRF(uint load_index, uint num_baseset)
 	 * so all NewGRFs are loaded equally. For this we use the
 	 * start date of the game and we set the counters, etc. to
 	 * 0 so they're the same too. */
-	Date date            = TimerGameCalendar::date;
-	Year year            = TimerGameCalendar::year;
-	DateFract date_fract = TimerGameCalendar::date_fract;
+	TimerGameCalendar::Date date            = TimerGameCalendar::date;
+	TimerGameCalendar::Year year            = TimerGameCalendar::year;
+	TimerGameCalendar::DateFract date_fract = TimerGameCalendar::date_fract;
 	uint64 tick_counter  = TimerGameTick::counter;
 	byte display_opt     = _display_opt;
 

--- a/src/newgrf_airport.h
+++ b/src/newgrf_airport.h
@@ -12,6 +12,7 @@
 
 #include "airport.h"
 #include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "newgrf_class.h"
 #include "newgrf_commons.h"
 #include "tilearea_type.h"
@@ -106,8 +107,8 @@ struct AirportSpec {
 	byte size_y;                           ///< size of airport in y direction
 	byte noise_level;                      ///< noise that this airport generates
 	byte catchment;                        ///< catchment area of this airport
-	Year min_year;                         ///< first year the airport is available
-	Year max_year;                         ///< last year the airport is available
+	TimerGameCalendar::Year min_year;      ///< first year the airport is available
+	TimerGameCalendar::Year max_year;      ///< last year the airport is available
 	StringID name;                         ///< name of this airport
 	TTDPAirportType ttd_airport_type;      ///< ttdpatch airport type (Small/Large/Helipad/Oilrig)
 	AirportClassID cls_id;                 ///< the class to which this airport type belongs

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -19,6 +19,7 @@
 #include "error.h"
 #include "strings_func.h"
 #include "core/random_func.hpp"
+#include "timer/timer_game_calendar.h"
 
 #include "table/strings.h"
 
@@ -403,7 +404,7 @@ static uint32 GetCountAndDistanceOfClosestInstance(byte param_setID, byte layout
 		case 0xB0: return Clamp(this->industry->construction_date - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 65535); // Date when built since 1920 (in days)
 		case 0xB3: return this->industry->construction_type; // Construction type
 		case 0xB4: {
-			Date *latest = std::max_element(this->industry->last_cargo_accepted_at, endof(this->industry->last_cargo_accepted_at));
+			TimerGameCalendar::Date *latest = std::max_element(this->industry->last_cargo_accepted_at, endof(this->industry->last_cargo_accepted_at));
 			return Clamp((*latest) - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 65535); // Date last cargo accepted since 1920 (in days)
 		}
 	}

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -14,7 +14,7 @@
 #include "newgrf_spritegroup.h"
 #include "newgrf_town.h"
 #include "economy_func.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "object_type.h"
 #include "newgrf_animation_type.h"
 #include "newgrf_class.h"
@@ -68,8 +68,8 @@ struct ObjectSpec {
 	uint8 size;                   ///< The size of this objects; low nibble for X, high nibble for Y.
 	uint8 build_cost_multiplier;  ///< Build cost multiplier per tile.
 	uint8 clear_cost_multiplier;  ///< Clear cost multiplier per tile.
-	Date introduction_date;       ///< From when can this object be built.
-	Date end_of_life_date;        ///< When can't this object be built anymore.
+	TimerGameCalendar::Date introduction_date; ///< From when can this object be built.
+	TimerGameCalendar::Date end_of_life_date;  ///< When can't this object be built anymore.
 	ObjectFlags flags;            ///< Flags/settings related to the object.
 	uint16 callback_mask;         ///< Bitmask of requested/allowed callbacks.
 	uint8 height;                 ///< The height of this structure, in heightlevels; max MAX_TILE_HEIGHT.

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -21,7 +21,7 @@
 
 
 std::vector<NewGRFProfiler> _newgrf_profilers;
-Date _newgrf_profile_end_date;
+TimerGameCalendar::Date _newgrf_profile_end_date;
 
 
 /**

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -12,6 +12,7 @@
 
 #include "stdafx.h"
 #include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "newgrf.h"
 #include "newgrf_callbacks.h"
 #include "newgrf_spritegroup.h"
@@ -58,6 +59,6 @@ struct NewGRFProfiler {
 };
 
 extern std::vector<NewGRFProfiler> _newgrf_profilers;
-extern Date _newgrf_profile_end_date;
+extern TimerGameCalendar::Date _newgrf_profile_end_date;
 
 #endif /* NEWGRF_PROFILING_H */

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -11,7 +11,7 @@
 #define NEWS_TYPE_H
 
 #include "core/enum_type.hpp"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "strings_type.h"
 #include "sound_type.h"
 
@@ -124,17 +124,17 @@ struct NewsAllocatedData {
 
 /** Information about a single item of news. */
 struct NewsItem {
-	NewsItem *prev;              ///< Previous news item
-	NewsItem *next;              ///< Next news item
-	StringID string_id;          ///< Message text
-	Date date;                   ///< Date of the news
-	NewsType type;               ///< Type of the news
-	NewsFlag flags;              ///< NewsFlags bits @see NewsFlag
+	NewsItem *prev;               ///< Previous news item
+	NewsItem *next;               ///< Next news item
+	StringID string_id;           ///< Message text
+	TimerGameCalendar::Date date; ///< Date of the news
+	NewsType type;                ///< Type of the news
+	NewsFlag flags;               ///< NewsFlags bits @see NewsFlag
 
-	NewsReferenceType reftype1;  ///< Type of ref1
-	NewsReferenceType reftype2;  ///< Type of ref2
-	uint32 ref1;                 ///< Reference 1 to some object: Used for a possible viewport, scrolling after clicking on the news, and for deleting the news when the object is deleted.
-	uint32 ref2;                 ///< Reference 2 to some object: Used for scrolling after clicking on the news, and for deleting the news when the object is deleted.
+	NewsReferenceType reftype1;   ///< Type of ref1
+	NewsReferenceType reftype2;   ///< Type of ref2
+	uint32 ref1;                  ///< Reference 1 to some object: Used for a possible viewport, scrolling after clicking on the news, and for deleting the news when the object is deleted.
+	uint32 ref2;                  ///< Reference 2 to some object: Used for scrolling after clicking on the news, and for deleting the news when the object is deleted.
 
 	std::unique_ptr<const NewsAllocatedData> data; ///< Custom data for the news item that will be deallocated (deleted) when the news item has reached its end.
 

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -14,7 +14,7 @@
 #include "object_type.h"
 #include "tilearea_type.h"
 #include "town_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 
 typedef Pool<Object, ObjectID, 64, 0xFF0000> ObjectPool;
 extern ObjectPool _object_pool;
@@ -24,7 +24,7 @@ struct Object : ObjectPool::PoolItem<&_object_pool> {
 	ObjectType type;    ///< Type of the object
 	Town *town;         ///< Town the object is built in
 	TileArea location;  ///< Location of the object
-	Date build_date;    ///< Date of construction
+	TimerGameCalendar::Date build_date; ///< Date of construction
 	byte colour;        ///< Colour of the object, for display purpose
 	byte view;          ///< The view setting for this object
 

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -102,7 +102,7 @@ bool _request_newgrf_scan = false;
 NewGRFScanCallback *_request_newgrf_scan_callback = nullptr;
 
 /** Available settings for autosave intervals. */
-static const Month _autosave_months[] = {
+static const TimerGameCalendar::Month _autosave_months[] = {
 	 0, ///< never
 	 1, ///< every month
 	 3, ///< every 3 months
@@ -406,7 +406,7 @@ void OpenBrowser(const char *url)
 
 /** Callback structure of statements to be executed after the NewGRF scan. */
 struct AfterNewGRFScan : NewGRFScanCallback {
-	Year startyear = INVALID_YEAR;              ///< The start year.
+	TimerGameCalendar::Year startyear = INVALID_YEAR; ///< The start year.
 	uint32 generation_seed = GENERATE_NEW_SEED; ///< Seed for the new game.
 	std::string dedicated_host;                 ///< Hostname for the dedicated server.
 	uint16 dedicated_port = 0;                  ///< Port for the dedicated server.

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -215,7 +215,7 @@ bool ValParamRailtype(const RailType rail)
  * @return The rail types that should be available when date
  *         introduced rail types are taken into account as well.
  */
-RailTypes AddDateIntroducedRailTypes(RailTypes current, Date date)
+RailTypes AddDateIntroducedRailTypes(RailTypes current, TimerGameCalendar::Date date)
 {
 	RailTypes rts = current;
 

--- a/src/rail.h
+++ b/src/rail.h
@@ -18,6 +18,7 @@
 #include "slope_type.h"
 #include "strings_type.h"
 #include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "signal_type.h"
 #include "settings_type.h"
 
@@ -249,7 +250,7 @@ public:
 	 * The introduction at this date is furthermore limited by the
 	 * #introduction_required_railtypes.
 	 */
-	Date introduction_date;
+	TimerGameCalendar::Date introduction_date;
 
 	/**
 	 * Bitmask of railtypes that are required for this railtype to be introduced
@@ -450,7 +451,7 @@ bool HasRailtypeAvail(const CompanyID company, const RailType railtype);
 bool HasAnyRailtypesAvail(const CompanyID company);
 bool ValParamRailtype(const RailType rail);
 
-RailTypes AddDateIntroducedRailTypes(RailTypes current, Date date);
+RailTypes AddDateIntroducedRailTypes(RailTypes current, TimerGameCalendar::Date date);
 
 RailTypes GetCompanyRailtypes(CompanyID company, bool introduces = true);
 RailTypes GetRailTypes(bool introduces);

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -153,7 +153,7 @@ bool ValParamRoadType(RoadType roadtype)
  * @return The road types that should be available when date
  *         introduced road types are taken into account as well.
  */
-RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, Date date)
+RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, TimerGameCalendar::Date date)
 {
 	RoadTypes rts = current;
 

--- a/src/road.h
+++ b/src/road.h
@@ -14,7 +14,7 @@
 #include "gfx_type.h"
 #include "core/bitmath_func.hpp"
 #include "strings_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "core/enum_type.hpp"
 #include "newgrf.h"
 #include "economy_func.h"
@@ -161,7 +161,7 @@ public:
 	 * The introduction at this date is furthermore limited by the
 	 * #introduction_required_types.
 	 */
-	Date introduction_date;
+	TimerGameCalendar::Date introduction_date;
 
 	/**
 	 * Bitmask of roadtypes that are required for this roadtype to be introduced

--- a/src/road_func.h
+++ b/src/road_func.h
@@ -151,7 +151,7 @@ bool HasRoadTypeAvail(CompanyID company, RoadType roadtype);
 bool ValParamRoadType(RoadType roadtype);
 RoadTypes GetCompanyRoadTypes(CompanyID company, bool introduces = true);
 RoadTypes GetRoadTypes(bool introduces);
-RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, Date date);
+RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, TimerGameCalendar::Date date);
 
 void UpdateLevelCrossing(TileIndex tile, bool sound = true, bool force_bar = false);
 void MarkDirtyAdjacentLevelCrossingTiles(TileIndex tile, Axis road_axis);

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -30,6 +30,7 @@
 #include "../core/smallvec_type.hpp"
 #include "../timer/timer.h"
 #include "../timer/timer_game_tick.h"
+#include "../timer/timer_game_calendar.h"
 #include "saveload_internal.h"
 #include "oldloader.h"
 #include <array>
@@ -399,7 +400,7 @@ static bool FixTTOEngines()
 		for (uint i = 0; i < lengthof(_orig_aircraft_vehicle_info); i++, j++) new (GetTempDataEngine(j)) Engine(VEH_AIRCRAFT, i);
 	}
 
-	Date aging_date = std::min(TimerGameCalendar::date + DAYS_TILL_ORIGINAL_BASE_YEAR, ConvertYMDToDate(2050, 0, 1));
+	TimerGameCalendar::Date aging_date = std::min(TimerGameCalendar::date + DAYS_TILL_ORIGINAL_BASE_YEAR, ConvertYMDToDate(2050, 0, 1));
 
 	for (EngineID i = 0; i < 256; i++) {
 		int oi = ttd_to_tto[i];

--- a/src/saveload/station_sl.cpp
+++ b/src/saveload/station_sl.cpp
@@ -18,6 +18,7 @@
 #include "../vehicle_base.h"
 #include "../newgrf_station.h"
 #include "../newgrf_roadstop.h"
+#include "../timer/timer_game_calendar.h"
 
 #include "table/strings.h"
 
@@ -67,7 +68,7 @@ void MoveBuoysToWaypoints()
 		Town *town         = st->town;
 		StringID string_id = st->string_id;
 		std::string name   = st->name;
-		Date build_date    = st->build_date;
+		TimerGameCalendar::Date build_date = st->build_date;
 		/* TTDPatch could use "buoys with rail station" for rail waypoints */
 		bool train         = st->train_station.tile != INVALID_TILE;
 		TileArea train_st  = st->train_station;

--- a/src/saveload/waypoint_sl.cpp
+++ b/src/saveload/waypoint_sl.cpp
@@ -14,6 +14,7 @@
 #include "../vehicle_base.h"
 #include "../town.h"
 #include "../newgrf.h"
+#include "../timer/timer_game_calendar.h"
 
 #include "table/strings.h"
 
@@ -31,7 +32,7 @@ struct OldWaypoint {
 	StringID string_id;
 	std::string name;
 	uint8 delete_ctr;
-	Date build_date;
+	TimerGameCalendar::Date build_date;
 	uint8 localidx;
 	uint32 grfid;
 	const StationSpec *spec;

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -20,6 +20,7 @@
 #include "../../station_base.h"
 #include "../../newgrf_industries.h"
 #include "../../industry_cmd.h"
+#include "../../timer/timer_game_calendar.h"
 #include "table/strings.h"
 #include <numeric>
 
@@ -234,7 +235,7 @@
 	if (i == nullptr) return ScriptDate::DATE_INVALID;
 
 	if (cargo_type == CT_INVALID) {
-		return (ScriptDate::Date)std::accumulate(std::begin(i->last_cargo_accepted_at), std::end(i->last_cargo_accepted_at), 0, [](Date a, Date b) { return std::max(a, b); });
+		return (ScriptDate::Date)std::accumulate(std::begin(i->last_cargo_accepted_at), std::end(i->last_cargo_accepted_at), 0, [](TimerGameCalendar::Date a, TimerGameCalendar::Date b) { return std::max(a, b); });
 	} else {
 		int index = i->GetCargoAcceptedIndex(cargo_type);
 		if (index < 0) return ScriptDate::DATE_INVALID;

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -11,6 +11,7 @@
 #define SETTINGS_TYPE_H
 
 #include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "economy_type.h"
 #include "town_type.h"
 #include "transport_type.h"
@@ -152,13 +153,13 @@ struct GUISettings {
 	SignalGUISettings signal_gui_mode;       ///< select which signal types are shown in the signal GUI
 	SignalCycleSettings cycle_signal_types;  ///< Which signal types to cycle with the build signal tool.
 	SignalType default_signal_type;          ///< The default signal type, which is set automatically by the last signal used. Not available in Settings.
-	Year   coloured_news_year;               ///< when does newspaper become coloured?
+	TimerGameCalendar::Year coloured_news_year; ///< when does newspaper become coloured?
 	bool   timetable_in_ticks;               ///< whether to show the timetable in ticks rather than days
 	bool   quick_goto;                       ///< Allow quick access to 'goto button' in vehicle orders window
 	bool   auto_euro;                        ///< automatically switch to euro in 2002
 	byte   drag_signals_density;             ///< many signals density
 	bool   drag_signals_fixed_distance;      ///< keep fixed distance between signals when dragging
-	Year   semaphore_build_before;           ///< build semaphore signals automatically before this year
+	TimerGameCalendar::Year semaphore_build_before; ///< build semaphore signals automatically before this year
 	byte   news_message_timeout;             ///< how much longer than the news message "age" should we keep the message in the history
 	bool   show_track_reservation;           ///< highlight reserved tracks.
 	byte   station_numtracks;                ///< the number of platforms to default on for rail stations
@@ -301,7 +302,7 @@ struct NetworkSettings {
 	uint8       autoclean_novehicles;                     ///< remove companies with no vehicles after this many months
 	uint8       max_companies;                            ///< maximum amount of companies
 	uint8       max_clients;                              ///< maximum amount of clients
-	Year        restart_game_year;                        ///< year the server restarts
+	TimerGameCalendar::Year restart_game_year;            ///< year the server restarts
 	uint8       min_active_clients;                       ///< minimum amount of active clients to unpause the game
 	bool        reload_cfg;                               ///< reload the config file before restarting
 	std::string last_joined;                              ///< Last joined server
@@ -312,8 +313,8 @@ struct NetworkSettings {
 /** Settings related to the creation of games. */
 struct GameCreationSettings {
 	uint32 generation_seed;                  ///< noise seed for world generation
-	Year   starting_year;                    ///< starting date
-	Year   ending_year;                      ///< scoring end date
+	TimerGameCalendar::Year starting_year;   ///< starting date
+	TimerGameCalendar::Year ending_year;     ///< scoring end date
 	uint8  map_x;                            ///< X size of map
 	uint8  map_y;                            ///< Y size of map
 	byte   land_generator;                   ///< the landscape generator

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -345,7 +345,7 @@ CommandCost CmdSetStoryPageTitle(DoCommandFlag flags, StoryPageID page_id, const
  * @param date date
  * @return the cost of this operation or an error
  */
-CommandCost CmdSetStoryPageDate(DoCommandFlag flags, StoryPageID page_id, Date date)
+CommandCost CmdSetStoryPageDate(DoCommandFlag flags, StoryPageID page_id, TimerGameCalendar::Date date)
 {
 	if (_current_company != OWNER_DEITY) return CMD_ERROR;
 	if (!StoryPage::IsValidID(page_id)) return CMD_ERROR;

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -12,7 +12,7 @@
 
 #include "company_type.h"
 #include "story_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "gfx_type.h"
 #include "vehicle_type.h"
 #include "core/pool_type.hpp"
@@ -163,7 +163,7 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 /** Struct about stories, current and completed */
 struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
 	uint32 sort_value;   ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
-	Date date;           ///< Date when the page was created.
+	TimerGameCalendar::Date date; ///< Date when the page was created.
 	CompanyID company;   ///< StoryPage is for a specific company; INVALID_COMPANY if it is global
 
 	char *title;         ///< Title of story page

--- a/src/story_cmd.h
+++ b/src/story_cmd.h
@@ -20,7 +20,7 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlag flags, Com
 std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandFlag flags, TileIndex tile, StoryPageID page_id, StoryPageElementType type, uint32 reference, const std::string &text);
 CommandCost CmdUpdateStoryPageElement(DoCommandFlag flags, TileIndex tile, StoryPageElementID page_element_id, uint32 reference, const std::string &text);
 CommandCost CmdSetStoryPageTitle(DoCommandFlag flags, StoryPageID page_id, const std::string &text);
-CommandCost CmdSetStoryPageDate(DoCommandFlag flags, StoryPageID page_id, Date date);
+CommandCost CmdSetStoryPageDate(DoCommandFlag flags, StoryPageID page_id, TimerGameCalendar::Date date);
 CommandCost CmdShowStoryPage(DoCommandFlag flags, StoryPageID page_id);
 CommandCost CmdRemoveStoryPage(DoCommandFlag flags, StoryPageID page_id);
 CommandCost CmdRemoveStoryPageElement(DoCommandFlag flags, StoryPageElementID page_element_id);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -23,6 +23,7 @@
 #include "rev.h"
 #include "core/endian_func.hpp"
 #include "date_func.h"
+#include "timer/timer_game_calendar.h"
 #include "vehicle_base.h"
 #include "engine_base.h"
 #include "language.h"
@@ -423,7 +424,7 @@ static char *FormatBytes(char *buff, int64 number, const char *last)
 	return buff;
 }
 
-static char *FormatYmdString(char *buff, Date date, const char *last, uint case_index)
+static char *FormatYmdString(char *buff, TimerGameCalendar::Date date, const char *last, uint case_index)
 {
 	YearMonthDay ymd;
 	ConvertDateToYMD(date, &ymd);
@@ -433,7 +434,7 @@ static char *FormatYmdString(char *buff, Date date, const char *last, uint case_
 	return FormatString(buff, GetStringPtr(STR_FORMAT_DATE_LONG), &tmp_params, last, case_index);
 }
 
-static char *FormatMonthAndYear(char *buff, Date date, const char *last, uint case_index)
+static char *FormatMonthAndYear(char *buff, TimerGameCalendar::Date date, const char *last, uint case_index)
 {
 	YearMonthDay ymd;
 	ConvertDateToYMD(date, &ymd);
@@ -443,7 +444,7 @@ static char *FormatMonthAndYear(char *buff, Date date, const char *last, uint ca
 	return FormatString(buff, GetStringPtr(STR_FORMAT_DATE_SHORT), &tmp_params, last, case_index);
 }
 
-static char *FormatTinyOrISODate(char *buff, Date date, StringID str, const char *last)
+static char *FormatTinyOrISODate(char *buff, TimerGameCalendar::Date date, StringID str, const char *last)
 {
 	YearMonthDay ymd;
 	ConvertDateToYMD(date, &ymd);

--- a/src/table/airport_defaults.h
+++ b/src/table/airport_defaults.h
@@ -10,6 +10,8 @@
 #ifndef AIRPORT_DEFAULTS_H
 #define AIRPORT_DEFAULTS_H
 
+#include "date_type.h"
+
 /**
  * Definition of an airport tiles layout.
  * @param x offset x of this tile

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -15,6 +15,7 @@
 #include "cargo_type.h"
 #include "track_type.h"
 #include "tile_map.h"
+#include "timer/timer_game_calendar.h"
 
 /** The returned bits of VehicleEnterTile. */
 enum VehicleEnterTileStatus {
@@ -52,7 +53,7 @@ struct TileDesc {
 	StringID str;               ///< Description of the tile
 	Owner owner[4];             ///< Name of the owner(s)
 	StringID owner_type[4];     ///< Type of each owner
-	Date build_date;            ///< Date of construction of tile contents
+	TimerGameCalendar::Date build_date; ///< Date of construction of tile contents
 	StringID station_class;     ///< Class of station
 	StringID station_name;      ///< Type of station within the class
 	StringID airport_class;     ///< Name of the airport class

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -20,17 +20,17 @@
 
 #include "safeguards.h"
 
-Year TimerGameCalendar::year = {};
-Month TimerGameCalendar::month = {};
-Date TimerGameCalendar::date = {};
-DateFract TimerGameCalendar::date_fract = {};
+TimerGameCalendar::Year TimerGameCalendar::year = {};
+TimerGameCalendar::Month TimerGameCalendar::month = {};
+TimerGameCalendar::Date TimerGameCalendar::date = {};
+TimerGameCalendar::DateFract TimerGameCalendar::date_fract = {};
 
 /**
  * Set the date.
  * @param date  New date
  * @param fract The number of ticks that have passed on this date.
  */
-/* static */ void TimerGameCalendar::SetDate(Date date, DateFract fract)
+/* static */ void TimerGameCalendar::SetDate(TimerGameCalendar::Date date, TimerGameCalendar::DateFract fract)
 {
 	assert(fract < DAY_TICKS);
 

--- a/src/timer/timer_game_calendar.h
+++ b/src/timer/timer_game_calendar.h
@@ -10,7 +10,7 @@
 #ifndef TIMER_GAME_CALENDAR_H
 #define TIMER_GAME_CALENDAR_H
 
-#include "../date_type.h"
+#include "stdafx.h"
 
 /**
  * Timer that is increased every 27ms, and counts towards ticks / days / months / years.
@@ -75,7 +75,14 @@ public:
 	struct TStorage {
 	};
 
-	static void SetDate(Date date, DateFract fract);
+	using Date = int32; ///< The type to store our dates in
+	using DateFract = uint16; ///< The fraction of a date we're in, i.e. the number of ticks since the last date changeover
+
+	using Year = int32; ///< Type for the year, note: 0 based, i.e. starts at the year 0.
+	using Month = uint8; ///< Type for the month, note: 0 based, i.e. 0 = January, 11 = December.
+	using Day = uint8; ///< Type for the day of the month, note: 1 based, first day of a month is 1.
+
+	static void SetDate(TimerGameCalendar::Date date, TimerGameCalendar::DateFract fract);
 
 	static Year year; ///< Current year, starting at 0.
 	static Month month; ///< Current month (0..11).

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -292,7 +292,7 @@ static bool VehicleTimetableSorter(Vehicle * const &a, Vehicle * const &b)
  * @param start_date The timetable start date.
  * @return The error or cost of the operation.
  */
-CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, Date start_date)
+CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, TimerGameCalendar::Date start_date)
 {
 	Vehicle *v = Vehicle::GetIfValid(veh_id);
 	if (v == nullptr || !v->IsPrimaryVehicle() || v->orders == nullptr) return CMD_ERROR;

--- a/src/timetable_cmd.h
+++ b/src/timetable_cmd.h
@@ -11,12 +11,13 @@
 #define TIMETABLE_CMD_H
 
 #include "command_type.h"
+#include "timer/timer_game_calendar.h"
 
 CommandCost CmdChangeTimetable(DoCommandFlag flags, VehicleID veh, VehicleOrderID order_number, ModifyTimetableFlags mtf, uint16 data);
 CommandCost CmdBulkChangeTimetable(DoCommandFlag flags, VehicleID veh, ModifyTimetableFlags mtf, uint16 data);
 CommandCost CmdSetVehicleOnTime(DoCommandFlag flags, VehicleID veh, bool apply_to_group);
 CommandCost CmdAutofillTimetable(DoCommandFlag flags, VehicleID veh, bool autofill, bool preserve_wait_time);
-CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, Date start_date);
+CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool timetable_all, TimerGameCalendar::Date start_date);
 
 DEF_CMD_TRAIT(CMD_CHANGE_TIMETABLE,      CmdChangeTimetable,     0, CMDT_ROUTE_MANAGEMENT)
 DEF_CMD_TRAIT(CMD_BULK_CHANGE_TIMETABLE, CmdBulkChangeTimetable, 0, CMDT_ROUTE_MANAGEMENT)

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -143,7 +143,7 @@ static void FillTimetableArrivalDepartureTable(const Vehicle *v, VehicleOrderID 
  * @param w the window related to the setting of the date
  * @param date the actually chosen date
  */
-static void ChangeTimetableStartCallback(const Window *w, Date date, void *data)
+static void ChangeTimetableStartCallback(const Window *w, TimerGameCalendar::Date date, void *data)
 {
 	Command<CMD_SET_TIMETABLE_START>::Post(STR_ERROR_CAN_T_TIMETABLE_VEHICLE, (VehicleID)w->window_number, reinterpret_cast<std::uintptr_t>(data) != 0, date);
 }

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -18,6 +18,7 @@
 #include "road.h"
 #include "road_gui.h"
 #include "date_func.h"
+#include "timer/timer_game_calendar.h"
 #include "vehicle_func.h"
 #include "sound_func.h"
 #include "terraform_gui.h"
@@ -1144,10 +1145,10 @@ void ToggleDirtyBlocks()
  * Set the starting year for a scenario.
  * @param year New starting year.
  */
-void SetStartingYear(Year year)
+void SetStartingYear(TimerGameCalendar::Year year)
 {
 	_settings_game.game_creation.starting_year = Clamp(year, MIN_YEAR, MAX_YEAR);
-	Date new_date = ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1);
+	TimerGameCalendar::Date new_date = ConvertYMDToDate(_settings_game.game_creation.starting_year, 0, 1);
 	/* If you open a savegame as scenario there may already be link graphs.*/
 	LinkGraphSchedule::instance.ShiftDates(new_date - TimerGameCalendar::date);
 	TimerGameCalendar::SetDate(new_date, 0);

--- a/src/town.h
+++ b/src/town.h
@@ -11,6 +11,7 @@
 #define TOWN_H
 
 #include "viewport_type.h"
+#include "date_type.h"
 #include "town_map.h"
 #include "subsidy_type.h"
 #include "newgrf_storage.h"

--- a/src/town_map.h
+++ b/src/town_map.h
@@ -12,6 +12,7 @@
 
 #include "road_map.h"
 #include "house.h"
+#include "timer/timer_game_calendar.h"
 
 /**
  * Get the index of which town this house/street is attached to.
@@ -246,7 +247,7 @@ static inline void IncrementHouseAge(Tile t)
  * @pre IsTileType(t, MP_HOUSE)
  * @return year
  */
-static inline Year GetHouseAge(Tile t)
+static inline TimerGameCalendar::Year GetHouseAge(Tile t)
 {
 	assert(IsTileType(t, MP_HOUSE));
 	return IsHouseCompleted(t) ? t.m5() : 0;

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -23,6 +23,7 @@
 #include "base_consist.h"
 #include "network/network.h"
 #include "saveload/saveload.h"
+#include "timer/timer_game_calendar.h"
 #include <list>
 #include <map>
 
@@ -286,10 +287,10 @@ public:
 	SpriteID colourmap;                 ///< NOSAVE: cached colour mapping
 
 	/* Related to age and service time */
-	Year build_year;                    ///< Year the vehicle has been built.
-	Date age;                           ///< Age in days
-	Date max_age;                       ///< Maximum age
-	Date date_of_last_service;          ///< Last date the vehicle had a service at a depot.
+	TimerGameCalendar::Year build_year;           ///< Year the vehicle has been built.
+	TimerGameCalendar::Date age;                  ///< Age in days
+	TimerGameCalendar::Date max_age;              ///< Maximum age
+	TimerGameCalendar::Date date_of_last_service; ///< Last date the vehicle had a service at a depot.
 	uint16 reliability;                 ///< Reliability.
 	uint16 reliability_spd_dec;         ///< Reliability decrease speed.
 	byte breakdown_ctr;                 ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown

--- a/src/vehicle_func.h
+++ b/src/vehicle_func.h
@@ -11,6 +11,7 @@
 #define VEHICLE_FUNC_H
 
 #include "gfx_type.h"
+#include "date_type.h"
 #include "direction_type.h"
 #include "command_type.h"
 #include "vehicle_type.h"

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -407,7 +407,7 @@ void DepotSortList(VehicleList *list)
 }
 
 /** draw the vehicle profit button in the vehicle list window. */
-static void DrawVehicleProfitButton(Date age, Money display_profit_last_year, uint num_vehicles, int x, int y)
+static void DrawVehicleProfitButton(TimerGameCalendar::Date age, Money display_profit_last_year, uint num_vehicles, int x, int y)
 {
 	SpriteID spr;
 

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -12,7 +12,7 @@
 
 #include "core/smallvec_type.hpp"
 #include "cargo_type.h"
-#include "date_type.h"
+#include "timer/timer_game_calendar.h"
 #include "economy_type.h"
 #include "sortlist_type.h"
 #include "vehicle_base.h"
@@ -57,7 +57,7 @@ struct GUIVehicleGroup {
 		});
 	}
 
-	Date GetOldestVehicleAge() const
+	TimerGameCalendar::Date GetOldestVehicleAge() const
 	{
 		const Vehicle *oldest = *std::max_element(this->vehicles_begin, this->vehicles_end, [](const Vehicle *v_a, const Vehicle *v_b) {
 			return v_a->age < v_b->age;


### PR DESCRIPTION
## Motivation / Problem

 #10700 splits time into two sets of variables. It would be awfully convenient if they were different data types so the compiler could catch mistakes.

## Description

- Move the definitions for these data types to within the TimerGameCalendar class
- Replace all references to the old data types with the new types, including two in `script_industry.cpp`
- Also includes a sneaky commit to change some Months in `graph_gui.cpp` from byte to the correct type 😉 

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
