### PR TITLE
Cleanup: remnants of OTTD_PRINTF, str_fmt and vseprintf

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -385,7 +385,8 @@ DEF_CONSOLE_CMD(ConSave)
 	}
 
 	if (argc == 2) {
-		char *filename = str_fmt("%s.sav", argv[1]);
+		std::string filename = argv[1];
+		filename += ".sav";
 		IConsolePrint(CC_DEFAULT, "Saving map...");
 
 		if (SaveOrLoad(filename, SLO_SAVE, DFT_GAME_FILE, SAVE_DIR) != SL_OK) {
@@ -393,7 +394,6 @@ DEF_CONSOLE_CMD(ConSave)
 		} else {
 			IConsolePrint(CC_INFO, "Map successfully saved to '{}'.", filename);
 		}
-		free(filename);
 		return true;
 	}
 

--- a/src/dedicated.cpp
+++ b/src/dedicated.cpp
@@ -9,6 +9,7 @@
 
 #include "stdafx.h"
 #include "fileio_func.h"
+#include "debug.h"
 #include <string>
 
 std::string _log_file; ///< File to reroute output of a forked OpenTTD to
@@ -19,15 +20,6 @@ std::unique_ptr<FILE, FileDeleter> _log_fd; ///< File to reroute output of a for
 #include <unistd.h>
 
 #include "safeguards.h"
-
-#if defined(SUNOS) && !defined(_LP64) && !defined(_I32LPx)
-/* Solaris has, in certain situation, pid_t defined as long, while in other
- *  cases it has it defined as int... this handles all cases nicely.
- */
-# define PRINTF_PID_T "%ld"
-#else
-# define PRINTF_PID_T "%d"
-#endif
 
 void DedicatedFork()
 {
@@ -59,8 +51,8 @@ void DedicatedFork()
 
 		default:
 			/* We're the parent */
-			printf("Loading dedicated server...\n");
-			printf("  - Forked to background with pid " PRINTF_PID_T "\n", pid);
+			Debug(net, 0, "Loading dedicated server...");
+			Debug(net, 0, "  - Forked to background with pid {}", pid);
 			exit(0);
 	}
 }

--- a/src/music/os2_m.cpp
+++ b/src/music/os2_m.cpp
@@ -12,6 +12,7 @@
 #include "os2_m.h"
 #include "midifile.hpp"
 #include "../base_media_base.h"
+#include "../3rdparty/fmt/format.h"
 
 #define INCL_DOS
 #define INCL_OS2MM
@@ -36,14 +37,9 @@
  * @param cmd The command to send.
  * @return The result of sending it.
  */
-static long CDECL MidiSendCommand(const char *cmd, ...)
+static long CDECL MidiSendCommand(const std::string_view cmd)
 {
-	va_list va;
-	char buf[512];
-	va_start(va, cmd);
-	vseprintf(buf, lastof(buf), cmd, va);
-	va_end(va);
-	return mciSendString(buf, nullptr, 0, nullptr, 0);
+	return mciSendString(cmd.data(), nullptr, 0, nullptr, 0);
 }
 
 /** OS/2's music player's factory. */
@@ -56,7 +52,7 @@ void MusicDriver_OS2::PlaySong(const MusicSongInfo &song)
 	MidiSendCommand("close all");
 	if (filename.empty()) return;
 
-	if (MidiSendCommand("open %s type sequencer alias song", filename.c_str()) != 0) {
+	if (MidiSendCommand(fmt::format("open {} type sequencer alias song", filename)) != 0) {
 		return;
 	}
 

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -28,7 +28,6 @@
 
 #include "table/strings.h"
 
-#include <stdarg.h> /* va_list */
 #include <deque>
 
 #include "../safeguards.h"
@@ -429,9 +428,9 @@ struct NetworkChatWindow : public Window {
 
 				/* Change to the found name. Add ': ' if we are at the start of the line (pretty) */
 				if (pre_buf == tb_buf) {
-					this->message_editbox.text.Print("%s: ", cur_name);
+					this->message_editbox.text.Assign(fmt::format("{}: ", cur_name));
 				} else {
-					this->message_editbox.text.Print("%s %s", pre_buf, cur_name);
+					this->message_editbox.text.Assign(fmt::format("{} {}", pre_buf, cur_name));
 				}
 
 				this->SetDirty();

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -403,7 +403,7 @@ struct NewGRFInspectWindow : Window {
 		offset -= this->vscroll->GetPosition();
 		if (offset < 0 || offset >= this->vscroll->GetCapacity()) return;
 
-		::DrawString(r.Shrink(WidgetDimensions::scaled.frametext).Shrink(0, offset * this->resize.step_height, 0, 0), buf, TC_BLACK);
+		::DrawString(r.Shrink(WidgetDimensions::scaled.frametext).Shrink(0, offset * this->resize.step_height, 0, 0), string, TC_BLACK);
 	}
 
 	/**

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -389,17 +389,10 @@ struct NewGRFInspectWindow : Window {
 	 * Helper function to draw a string (line) in the window.
 	 * @param r      The (screen) rectangle we must draw within
 	 * @param offset The offset (in lines) we want to draw for
-	 * @param format The format string
+	 * @param string The string to draw
 	 */
-	void WARN_FORMAT(4, 5) DrawString(const Rect &r, int offset, const char *format, ...) const
+	void DrawString(const Rect &r, int offset, const std::string &string) const
 	{
-		char buf[1024];
-
-		va_list va;
-		va_start(va, format);
-		vseprintf(buf, lastof(buf), format, va);
-		va_end(va);
-
 		offset -= this->vscroll->GetPosition();
 		if (offset < 0 || offset >= this->vscroll->GetCapacity()) return;
 
@@ -470,9 +463,9 @@ struct NewGRFInspectWindow : Window {
 				if (!avail) continue;
 
 				if (HasVariableParameter(niv->var)) {
-					this->DrawString(r, i++, "  %02x[%02x]: %08x (%s)", niv->var, param, value, niv->name);
+					this->DrawString(r, i++, fmt::format("  {:02x}[{:02x}]: {:08x} ({})", niv->var, param, value, niv->name));
 				} else {
-					this->DrawString(r, i++, "  %02x: %08x (%s)", niv->var, value, niv->name);
+					this->DrawString(r, i++, fmt::format("  {:02x}: {:08x} ({})", niv->var, value, niv->name));
 				}
 			}
 		}
@@ -481,13 +474,13 @@ struct NewGRFInspectWindow : Window {
 		const int32 *psa = nih->GetPSAFirstPosition(index, this->caller_grfid);
 		if (psa_size != 0 && psa != nullptr) {
 			if (nih->PSAWithParameter()) {
-				this->DrawString(r, i++, "Persistent storage [%08X]:", BSWAP32(this->caller_grfid));
+				this->DrawString(r, i++, fmt::format("Persistent storage [{:08X}]:", BSWAP32(this->caller_grfid)));
 			} else {
 				this->DrawString(r, i++, "Persistent storage:");
 			}
 			assert(psa_size % 4 == 0);
 			for (uint j = 0; j < psa_size; j += 4, psa += 4) {
-				this->DrawString(r, i++, "  %i: %i %i %i %i", j, psa[0], psa[1], psa[2], psa[3]);
+				this->DrawString(r, i++, fmt::format("  {}: {} {} {} {}", j, psa[0], psa[1], psa[2], psa[3]));
 			}
 		}
 
@@ -520,7 +513,7 @@ struct NewGRFInspectWindow : Window {
 
 				char buffer[64];
 				GetString(buffer, string, lastof(buffer));
-				this->DrawString(r, i++, "  %02x: %s (%s)", nip->prop, buffer, nip->name);
+				this->DrawString(r, i++, fmt::format("  {:02x}: {} ({})", nip->prop, buffer, nip->name));
 			}
 		}
 
@@ -538,9 +531,9 @@ struct NewGRFInspectWindow : Window {
 					}
 
 					if (!HasBit(value, nic->cb_bit)) continue;
-					this->DrawString(r, i++, "  %03x: %s", nic->cb_id, nic->name);
+					this->DrawString(r, i++, fmt::format("  {:03x}: {}", nic->cb_id, nic->name));
 				} else {
-					this->DrawString(r, i++, "  %03x: %s (unmasked)", nic->cb_id, nic->name);
+					this->DrawString(r, i++, fmt::format("  {:03x}: {} (unmasked)", nic->cb_id, nic->name));
 				}
 			}
 		}

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -111,7 +111,7 @@ uint32 NewGRFProfiler::Finish()
 
 	fputs("Tick,Sprite,Feature,Item,CallbackID,Microseconds,Depth,Result\n", f);
 	for (const Call &c : this->calls) {
-		fprintf(f, OTTD_PRINTF64U ",%u,0x%X,%u,0x%X,%u,%u,%u\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result);
+		fputs(fmt::format("{},{},{:#X},{},{:#X},{},{},{}\n", c.tick, c.root_sprite, c.feat, c.item, (uint)c.cb, c.time, c.subs, c.result).c_str(), f);
 		total_microseconds += c.time;
 	}
 

--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -44,7 +44,7 @@
 #define sprintf   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define snprintf  SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use vseprintf instead. */
+/* Use fmt::format instead. */
 #define vsprintf  SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define vsnprintf SAFEGUARD_DO_NOT_USE_THIS_METHOD
 

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -299,21 +299,6 @@
 #endif
 #define PACK(type_dec) PACK_N(type_dec, 1)
 
-/* MSVCRT of course has to have a different syntax for long long *sigh* */
-#if defined(_MSC_VER)
-#   define OTTD_PRINTF64 "%I64d"
-#   define OTTD_PRINTF64U "%I64u"
-#   define OTTD_PRINTFHEX64 "%I64x"
-#elif defined(__MINGW32__)
-#   define OTTD_PRINTF64 "%I64d"
-#   define OTTD_PRINTF64U "%I64llu"
-#   define OTTD_PRINTFHEX64 "%I64x"
-#else
-#   define OTTD_PRINTF64 "%lld"
-#   define OTTD_PRINTF64U "%llu"
-#   define OTTD_PRINTFHEX64 "%llx"
-#endif
-
 /*
  * When making a (pure) debug build, the compiler will by default disable
  * inlining of functions. This has a detremental effect on the performance of

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -51,23 +51,6 @@
 #undef vsnprintf
 
 /**
- * Safer implementation of vsnprintf; same as vsnprintf except:
- * - last instead of size, i.e. replace sizeof with lastof.
- * - return gives the amount of characters added, not what it would add.
- * @param str    buffer to write to up to last
- * @param last   last character we may write to
- * @param format the formatting (see snprintf)
- * @param ap     the list of arguments for the format
- * @return the number of added characters
- */
-int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap)
-{
-	ptrdiff_t diff = last - str;
-	if (diff < 0) return 0;
-	return std::min(static_cast<int>(diff), vsnprintf(str, diff + 1, format, ap));
-}
-
-/**
  * Appends characters from one string to another.
  *
  * Appends the source string to the destination string with respect of the
@@ -536,10 +519,14 @@ int CDECL vsnprintf(char *str, size_t size, const char *format, va_list ap)
  */
 int CDECL seprintf(char *str, const char *last, const char *format, ...)
 {
+	ptrdiff_t diff = last - str;
+	if (diff < 0) return 0;
+
 	va_list ap;
 
 	va_start(ap, format);
-	int ret = vseprintf(str, last, format, ap);
+	int ret = std::min(static_cast<int>(diff), vsnprintf(str, diff + 1, format, ap));
+
 	va_end(ap);
 	return ret;
 }

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -145,24 +145,6 @@ char *stredup(const char *s, const char *last)
 }
 
 /**
- * Format, "printf", into a newly allocated string.
- * @param str The formatting string.
- * @return The formatted string. You must free this!
- */
-char *CDECL str_fmt(const char *str, ...)
-{
-	char buf[4096];
-	va_list va;
-
-	va_start(va, str);
-	int len = vseprintf(buf, lastof(buf), str, va);
-	va_end(va);
-	char *p = MallocT<char>(len + 1);
-	memcpy(p, buf, len + 1);
-	return p;
-}
-
-/**
  * Format a byte array into a continuous hex string.
  * @param data Array to format
  * @return Converted string.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -38,8 +38,6 @@ char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
 int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4) NOACCESS(2);
 int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0) NOACCESS(2);
 
-char *CDECL str_fmt(const char *str, ...) WARN_FORMAT(1, 2);
-
 std::string FormatArrayAsHex(span<const byte> data);
 
 void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -36,7 +36,6 @@ char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
 char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
 
 int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FORMAT(3, 4) NOACCESS(2);
-int CDECL vseprintf(char *str, const char *last, const char *format, va_list ap) WARN_FORMAT(3, 0) NOACCESS(2);
 
 std::string FormatArrayAsHex(span<const byte> data);
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -38,6 +38,7 @@
 #include "newgrf_engine.h"
 #include "core/backup_type.hpp"
 #include <stack>
+#include <charconv>
 
 #include "table/strings.h"
 #include "table/control_codes.h"
@@ -381,7 +382,7 @@ static char *FormatZerofillNumber(char *buff, int64 number, int64 count, const c
 
 static char *FormatHexNumber(char *buff, uint64 number, const char *last)
 {
-	return buff + seprintf(buff, last, "0x" OTTD_PRINTFHEX64, number);
+	return strecpy(buff, fmt::format("0x{:X}", number).c_str(), last);
 }
 
 /**

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -400,21 +400,9 @@ void Textbuf::Assign(StringID string)
  * Copy a string into the textbuffer.
  * @param text Source.
  */
-void Textbuf::Assign(const char *text)
+void Textbuf::Assign(const std::string_view text)
 {
-	strecpy(this->buf, text, &this->buf[this->max_bytes - 1]);
-	this->UpdateSize();
-}
-
-/**
- * Print a formatted string into the textbuffer.
- */
-void Textbuf::Print(const char *format, ...)
-{
-	va_list va;
-	va_start(va, format);
-	vseprintf(this->buf, &this->buf[this->max_bytes - 1], format, va);
-	va_end(va);
+	strecpy(this->buf, text.data(), &this->buf[this->max_bytes - 1]);
 	this->UpdateSize();
 }
 

--- a/src/textbuf_type.h
+++ b/src/textbuf_type.h
@@ -47,8 +47,7 @@ struct Textbuf {
 	~Textbuf();
 
 	void Assign(StringID string);
-	void Assign(const char *text);
-	void CDECL Print(const char *format, ...) WARN_FORMAT(2, 3);
+	void Assign(const std::string_view text);
 
 	void DeleteAll();
 	bool InsertClipboard();


### PR DESCRIPTION
## Motivation / Problem

Small bits and pieces of OTTD_PRINTF macros with environment specific formatting parameters, str_fmt and vseprintf remaining with single uses.


## Description

Replace them with fmt::format and remove the macros, str_fmt and vseprintf.


## Limitations

Breaks patches that use them.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
