### PR TITLE
Feature: opt-in survey when exiting a game

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -76,20 +76,20 @@ jobs:
         - name: Clang
           compiler: clang
           cxxcompiler: clang++
-          libraries: libsdl2-dev
+          libraries: libsdl2-dev nlohmann-json3-dev
         - name: GCC - SDL2
           compiler: gcc
           cxxcompiler: g++
-          libraries: libsdl2-dev
+          libraries: libsdl2-dev nlohmann-json3-dev
         - name: GCC - SDL1.2
           compiler: gcc
           cxxcompiler: g++
-          libraries: libsdl1.2-dev
+          libraries: libsdl1.2-dev nlohmann-json3-dev
         - name: GCC - Dedicated
           compiler: gcc
           cxxcompiler: g++
           extra-cmake-parameters: -DOPTION_DEDICATED=ON -DCMAKE_CXX_FLAGS_INIT="-DRANDOM_DEBUG" -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
-          # Compile without SDL / SDL2, as that should compile fine too.
+          # Compile without SDL / SDL2 / nlohmann-json, as that should compile fine too.
 
     name: Linux (${{ matrix.name }})
 
@@ -197,7 +197,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /usr/local/share/vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified
+        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-1 # Increase the number whenever dependencies are modified
         restore-keys: |
           ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}
 
@@ -208,6 +208,7 @@ jobs:
           liblzma \
           libpng \
           lzo \
+          nlohmann-json \
           zlib \
           # EOF
 
@@ -280,7 +281,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified
+        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-1 # Increase the number whenever dependencies are modified
         restore-keys: |
           ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}
 
@@ -291,6 +292,7 @@ jobs:
           liblzma \
           libpng \
           lzo \
+          nlohmann-json \
           zlib \
           # EOF
 
@@ -377,6 +379,7 @@ jobs:
           mingw-w64-${{ matrix.arch }}-libpng
           mingw-w64-${{ matrix.arch }}-lld
           mingw-w64-${{ matrix.arch }}-ninja
+          mingw-w64-${{ matrix.arch }}-nlohmann-json
 
     - name: Install OpenGFX
       shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,12 @@ jobs:
           liballegro4-dev \
           libcurl4-openssl-dev \
           libfontconfig-dev \
+          libharfbuzz-dev \
           libicu-dev \
           liblzma-dev \
           liblzo2-dev \
           libsdl2-dev \
+          nlohmann-json3-dev \
           zlib1g-dev \
           # EOF
         echo "::endgroup::"

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /vcpkg/installed
-        key: ubuntu-20.04-vcpkg-release-0 # Increase the number whenever dependencies are modified
+        key: ubuntu-20.04-vcpkg-release-1 # Increase the number whenever dependencies are modified
         restore-keys: |
           ubuntu-20.04-vcpkg-release
 
@@ -79,6 +79,7 @@ jobs:
             liblzma \
             libpng \
             lzo \
+            nlohmann-json \
             sdl2 \
             zlib \
             # EOF

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -2,6 +2,11 @@ name: Release (Linux)
 
 on:
   workflow_call:
+    inputs:
+      survey_key:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   linux:
@@ -119,6 +124,7 @@ jobs:
         cmake ${GITHUB_WORKSPACE} \
           -DCMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
           -DOPTION_PACKAGE_DEPENDENCIES=ON \
           # EOF
         echo "::endgroup::"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /usr/local/share/vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-release-0 # Increase the number whenever dependencies are modified
+        key: ${{ steps.key.outputs.image }}-vcpkg-release-1 # Increase the number whenever dependencies are modified
         restore-keys: |
           ${{ steps.key.outputs.image }}-vcpkg-release
           ${{ steps.key.outputs.image }}-vcpkg-x64
@@ -56,6 +56,8 @@ jobs:
           libpng:arm64-osx \
           lzo:x64-osx \
           lzo:arm64-osx \
+          nlohmann-json:x64-osx \
+          nlohmann-json:arm64-osx \
           zlib:x64-osx \
           zlib:arm64-osx \
           # EOF

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -2,6 +2,11 @@ name: Release (MacOS)
 
 on:
   workflow_call:
+    inputs:
+      survey_key:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   macos:
@@ -104,6 +109,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
           # EOF
         echo "::endgroup::"
 
@@ -124,6 +130,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
           -DCPACK_BUNDLE_APPLE_CERT_APP=${{ secrets.APPLE_DEVELOPER_CERTIFICATE_ID }} \
           "-DCPACK_BUNDLE_APPLE_CODESIGN_PARAMETER=--deep -f --options runtime" \
           -DAPPLE_UNIVERSAL_PACKAGE=1 \

--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -11,6 +11,8 @@ on:
         value: ${{ jobs.source.outputs.trigger_type }}
       folder:
         value: ${{ jobs.source.outputs.folder }}
+      survey_key:
+        value: ${{ jobs.source.outputs.survey_key }}
 
 jobs:
   source:
@@ -23,6 +25,7 @@ jobs:
       is_tag: ${{ steps.metadata.outputs.is_tag }}
       trigger_type: ${{ steps.metadata.outputs.trigger_type }}
       folder: ${{ steps.metadata.outputs.folder }}
+      survey_key: ${{ steps.survey_key.outputs.survey_key }}
 
     steps:
     - name: Checkout (Release)
@@ -145,6 +148,19 @@ jobs:
         FOLDER_RELEASES: openttd-releases
         FOLDER_NIGHTLIES: openttd-nightlies
         FOLDER_BRANCHES: openttd-branches
+
+    - name: Generate survey key
+      id: survey_key
+      run: |
+        PAYLOAD='{"version":"${{ steps.metadata.outputs.version }}","type":"${{ vars.SURVEY_TYPE }}"}'
+
+        echo "${{ secrets.SURVEY_SIGNING_KEY }}" > survey_signing_key.pem
+        SIGNATURE=$(echo -n "${PAYLOAD}" | openssl dgst -sha256 -sign survey_signing_key.pem | base64 -w0)
+        rm -f survey_signing_key.pem
+
+        SURVEY_KEY=$(curl -f -s -X POST -d "${PAYLOAD}" -H "Content-Type: application/json" -H "X-Signature: ${SIGNATURE}" https://survey-participate.openttd.org/create-survey-key/${{ vars.SURVEY_TYPE }})
+
+        echo "survey_key=${SURVEY_KEY}" >> $GITHUB_OUTPUT
 
     - name: Remove VCS information
       run: |

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: vcpkg/installed
-        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified
+        key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-1 # Increase the number whenever dependencies are modified
         restore-keys: |
           ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}
 
@@ -64,6 +64,7 @@ jobs:
           liblzma \
           libpng \
           lzo \
+          nlohmann-json \
           zlib \
           # EOF
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -3,6 +3,10 @@ name: Release (Windows)
 on:
   workflow_call:
     inputs:
+      survey_key:
+        required: false
+        type: string
+        default: ""
       is_tag:
         required: true
         type: string
@@ -129,6 +133,7 @@ jobs:
           -DOPTION_USE_NSIS=ON \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
           -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \
           # EOF
         echo "::endgroup::"
@@ -153,6 +158,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_SURVEY_KEY=${{ inputs.survey_key }} \
           -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \
           # EOF
         echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,18 @@ jobs:
     uses: ./.github/workflows/release-linux.yml
     secrets: inherit
 
+    with:
+      survey_key: ${{ needs.source.outputs.survey_key }}
+
   macos:
     name: MacOS
     needs: source
 
     uses: ./.github/workflows/release-macos.yml
     secrets: inherit
+
+    with:
+      survey_key: ${{ needs.source.outputs.survey_key }}
 
   windows:
     name: Windows
@@ -54,6 +60,7 @@ jobs:
 
     with:
       is_tag: ${{ needs.source.outputs.is_tag }}
+      survey_key: ${{ needs.source.outputs.survey_key }}
 
   windows-store:
     name: Windows Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ find_package(ZLIB)
 find_package(LibLZMA)
 find_package(LZO)
 find_package(PNG)
+find_package(nlohmann_json)
 
 if(WIN32 OR EMSCRIPTEN)
     # Windows uses WinHttp for HTTP requests.
@@ -293,6 +294,7 @@ link_package(PNG TARGET PNG::PNG ENCOURAGED)
 link_package(ZLIB TARGET ZLIB::ZLIB ENCOURAGED)
 link_package(LIBLZMA TARGET LibLZMA::LibLZMA ENCOURAGED)
 link_package(LZO)
+link_package(nlohmann_json ENCOURAGED)
 
 if(NOT WIN32 AND NOT EMSCRIPTEN)
     link_package(CURL ENCOURAGED)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -4,6 +4,7 @@
 
 OpenTTD makes use of the following external libraries:
 
+- (encouraged) nlohmann-json: JSON handling
 - (encouraged) zlib: (de)compressing of old (0.3.0-1.0.5) savegames, content downloads,
    heightmaps
 - (encouraged) liblzma: (de)compressing of savegames (1.1.0 and later)
@@ -52,13 +53,14 @@ the `static` versions, and OpenTTD currently needs the following dependencies:
 - liblzma
 - libpng
 - lzo
+- nlohmann-json
 - zlib
 
 To install both the x64 (64bit) and x86 (32bit) variants (though only one is necessary), you can use:
 
 ```ps
-.\vcpkg install liblzma:x64-windows-static libpng:x64-windows-static lzo:x64-windows-static zlib:x64-windows-static
-.\vcpkg install liblzma:x86-windows-static libpng:x86-windows-static lzo:x86-windows-static zlib:x86-windows-static
+.\vcpkg install liblzma:x64-windows-static libpng:x64-windows-static lzo:x64-windows-static nlohmann-json:x64-windows-static zlib:x64-windows-static
+.\vcpkg install liblzma:x86-windows-static libpng:x86-windows-static lzo:x86-windows-static nlohmann-json:x86-windows-static zlib:x86-windows-static
 ```
 
 You can open the folder (as a CMake project). CMake will be detected, and you can compile from there.

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -71,6 +71,8 @@ function(set_options)
     if (OPTION_DOCS_ONLY)
         set(OPTION_TOOLS_ONLY ON PARENT_SCOPE)
     endif()
+
+    option(OPTION_SURVEY_KEY "Survey-key to use for the opt-in survey (empty if you have none)" "")
 endfunction()
 
 # Show the values of the generic options.
@@ -84,6 +86,12 @@ function(show_options)
     message(STATUS "Option Use assert - ${OPTION_USE_ASSERTS}")
     message(STATUS "Option Use threads - ${OPTION_USE_THREADS}")
     message(STATUS "Option Use NSIS - ${OPTION_USE_NSIS}")
+
+    if(OPTION_SURVEY_KEY)
+        message(STATUS "Option Survey Key - USED")
+    else()
+        message(STATUS "Option Survey Key - NOT USED")
+    endif()
 endfunction()
 
 # Add the definitions for the options that are selected.
@@ -103,5 +111,9 @@ function(add_definitions_based_on_options)
         add_definitions(-DWITH_ASSERT)
     else()
         add_definitions(-DNDEBUG)
+    endif()
+
+    if(OPTION_SURVEY_KEY)
+        add_definitions(-DSURVEY_KEY="${OPTION_SURVEY_KEY}")
     endif()
 endfunction()

--- a/os/emscripten/Dockerfile
+++ b/os/emscripten/Dockerfile
@@ -2,3 +2,6 @@ FROM emscripten/emsdk:3.1.37
 
 COPY emsdk-liblzma.patch /
 RUN cd /emsdk/upstream/emscripten && patch -p1 < /emsdk-liblzma.patch
+
+COPY emsdk-nlohmann-json.patch /
+RUN cd /emsdk/upstream/emscripten && patch -p1 < /emsdk-nlohmann-json.patch

--- a/os/emscripten/README.md
+++ b/os/emscripten/README.md
@@ -4,10 +4,11 @@ Please use docker with the supplied `Dockerfile` to build for emscripten.
 It takes care of a few things:
 - Use a version of emscripten we know works
 - Patch in LibLZMA support (as this is not supported by upstream)
+- Patch in nlohmann-json support (as this is not supported by upstream)
 
 First, build the docker image by navigating in the folder this `README.md` is in, and executing:
 ```
-  docker build -t emsdk-lzma .
+  docker build -t emsdk-openttd .
 ```
 
 Next, navigate back to the root folder of this project.
@@ -15,15 +16,15 @@ Next, navigate back to the root folder of this project.
 Now we build the host tools first:
 ```
   mkdir build-host
-  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build-host emsdk-lzma cmake .. -DOPTION_TOOLS_ONLY=ON
-  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build-host emsdk-lzma make -j$(nproc) tools
+  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build-host emsdk-openttd cmake .. -DOPTION_TOOLS_ONLY=ON
+  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build-host emsdk-openttd make -j$(nproc) tools
 ```
 
 Finally, we build the actual game:
 ```
   mkdir build
-  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-lzma emcmake cmake .. -DHOST_BINARY_DIR=../build-host -DCMAKE_BUILD_TYPE=Release -DOPTION_USE_ASSERTS=OFF
-  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-lzma emmake make -j$(nproc)
+  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-openttd emcmake cmake .. -DHOST_BINARY_DIR=../build-host -DCMAKE_BUILD_TYPE=Release -DOPTION_USE_ASSERTS=OFF
+  docker run -it --rm -v $(pwd):$(pwd) -u $(id -u):$(id -g) --workdir $(pwd)/build emsdk-openttd emmake make -j$(nproc)
 ```
 
 In the `build` folder you will now see `openttd.html`.

--- a/os/emscripten/cmake/FindLibLZMA.cmake
+++ b/os/emscripten/cmake/FindLibLZMA.cmake
@@ -1,5 +1,5 @@
-# LibLZMA is a recent addition to the emscripten SDK, so it is possible
-# someone hasn't updated their SDK yet. Test out if the SDK supports LibLZMA.
+# LibLZMA is a custom addition to the emscripten SDK, so it is possible
+# someone patched their SDK. Test out if the SDK supports LibLZMA.
 include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_FLAGS "-sUSE_LIBLZMA=1")
 

--- a/os/emscripten/cmake/Findnlohmann_json.cmake
+++ b/os/emscripten/cmake/Findnlohmann_json.cmake
@@ -1,0 +1,20 @@
+# nlohmann-json is a custom addition to the emscripten SDK, so it is possible
+# someone patched their SDK. Test out if the SDK supports nlohmann-json.
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS "-sUSE_NLOHMANN_JSON=1")
+
+check_cxx_source_compiles("
+    #include <nlohmann/json.hpp>
+    int main() { return 0; }"
+    NLOHMANN_JSON_FOUND
+)
+
+if (NLOHMANN_JSON_FOUND)
+        add_library(nlohmann_json INTERFACE IMPORTED)
+        set_target_properties(nlohmann_json PROPERTIES
+                INTERFACE_COMPILE_OPTIONS "-sUSE_NLOHMANN_JSON=1"
+                INTERFACE_LINK_LIBRARIES "-sUSE_NLOHMANN_JSON=1"
+        )
+else()
+        message(WARNING "You are using an emscripten SDK without nlohmann-json support. Please apply 'emsdk-nlohmann_json.patch' to your local emsdk installation.")
+endif()

--- a/os/emscripten/emsdk-nlohmann-json.patch
+++ b/os/emscripten/emsdk-nlohmann-json.patch
@@ -1,0 +1,93 @@
+From 0edcedbea375e59f41df10acaee0c483d245751f Mon Sep 17 00:00:00 2001
+From: Patric Stout <truebrain@openttd.org>
+Date: Tue, 2 May 2023 21:48:08 +0200
+Subject: [PATCH] Add nlohmmann-json port
+
+---
+ src/settings.js              |  4 ++++
+ tools/ports/nlohmann_json.py | 46 ++++++++++++++++++++++++++++++++++++
+ tools/settings.py            |  1 +
+ 3 files changed, 51 insertions(+)
+ create mode 100644 tools/ports/nlohmann_json.py
+
+diff --git a/src/settings.js b/src/settings.js
+index f93140d..39f4366 100644
+--- a/src/settings.js
++++ b/src/settings.js
+@@ -1483,6 +1483,10 @@ var USE_MPG123 = false;
+ // [compile+link]
+ var USE_FREETYPE = false;
+
++// 1 = use nlohmann-json from emscripten-ports
++// [compile+link]
++var USE_NLOHMANN_JSON = false;
++
+ // Specify the SDL_mixer version that is being linked against.
+ // Doesn't *have* to match USE_SDL, but a good idea.
+ // [compile+link]
+diff --git a/tools/ports/nlohmann_json.py b/tools/ports/nlohmann_json.py
+new file mode 100644
+index 0000000..9e44297
+--- /dev/null
++++ b/tools/ports/nlohmann_json.py
+@@ -0,0 +1,46 @@
++# Copyright 2023 The Emscripten Authors.  All rights reserved.
++# Emscripten is available under two separate licenses, the MIT license and the
++# University of Illinois/NCSA Open Source License.  Both these licenses can be
++# found in the LICENSE file.
++
++import os
++
++TAG = '3.11.2'
++HASH = '99d9e6d588cabe8913a37437f86acb5d4b8b98bce12423e633c11c13b61e6c7f92ef8f9a4e991baa590329ee2b5c09ca9db9894bee1e54bdd68e8d09d83cc245'
++
++
++def needed(settings):
++  return settings.USE_NLOHMANN_JSON
++
++
++def get(ports, settings, shared):
++  ports.fetch_project('nlohmann_json',
++                      f'https://github.com/nlohmann/json/releases/download/v{TAG}/include.zip',
++                      sha512hash=HASH)
++
++  def create(final):
++    source_path = os.path.join(ports.get_dir(), 'nlohmann_json')
++    source_path_include = os.path.join(source_path, 'include', 'nlohmann')
++    ports.install_header_dir(source_path_include, 'nlohmann')
++
++    # write out a dummy cpp file, to create an empty library
++    # this is needed as emscripten ports expect this, even if it is not used
++    dummy_file = os.path.join(source_path, 'dummy.cpp')
++    shared.safe_ensure_dirs(os.path.dirname(dummy_file))
++    ports.write_file(dummy_file, 'static void dummy() {}')
++
++    ports.build_port(source_path, final, 'nlohmann_json', srcs=['dummy.cpp'])
++
++  return [shared.cache.get_lib('libnlohmann_json.a', create, what='port')]
++
++
++def clear(ports, settings, shared):
++  shared.cache.erase_lib('libnlohmann_json.a')
++
++
++def process_args(ports):
++  return []
++
++
++def show():
++  return 'nlohmann-json'
+diff --git a/tools/settings.py b/tools/settings.py
+index 10d6ca0..8536092 100644
+--- a/tools/settings.py
++++ b/tools/settings.py
+@@ -47,6 +47,7 @@ PORTS_SETTINGS = {
+     'USE_MPG123',
+     'USE_GIFLIB',
+     'USE_FREETYPE',
++    'USE_NLOHMANN_JSON',
+     'SDL2_MIXER_FORMATS',
+     'SDL2_IMAGE_FORMATS',
+     'USE_SQLITE3',
+--
+2.34.1

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -183,7 +183,7 @@ struct AIConfigWindow : public Window {
 
 	void OnClick(Point pt, int widget, int click_count) override
 	{
-		if (widget >= WID_AIC_TEXTFILE && widget < WID_AIC_TEXTFILE + TFT_END) {
+		if (widget >= WID_AIC_TEXTFILE && widget < WID_AIC_TEXTFILE + TFT_CONTENT_END) {
 			if (this->selected_slot == INVALID_COMPANY || AIConfig::GetConfig(this->selected_slot) == nullptr) return;
 
 			ShowScriptTextfileWindow((TextfileType)(widget - WID_AIC_TEXTFILE), this->selected_slot);
@@ -284,7 +284,7 @@ struct AIConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_AIC_MOVE_UP, this->selected_slot == INVALID_COMPANY || !IsEditable((CompanyID)(this->selected_slot - 1)));
 		this->SetWidgetDisabledState(WID_AIC_MOVE_DOWN, this->selected_slot == INVALID_COMPANY || !IsEditable((CompanyID)(this->selected_slot + 1)));
 
-		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
+		for (TextfileType tft = TFT_CONTENT_BEGIN; tft < TFT_CONTENT_END; tft++) {
 			this->SetWidgetDisabledState(WID_AIC_TEXTFILE + tft, this->selected_slot == INVALID_COMPANY || !AIConfig::GetConfig(this->selected_slot)->GetTextfile(tft, this->selected_slot).has_value());
 		}
 	}

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -23,6 +23,7 @@
 #include "screenshot.h"
 #include "gfx_func.h"
 #include "network/network.h"
+#include "network/network_survey.h"
 #include "language.h"
 #include "fontcache.h"
 #include "news_gui.h"
@@ -509,6 +510,10 @@ bool CrashLog::MakeCrashLog() const
 	} else {
 		ret = false;
 		printf("Writing crash screenshot failed.\n\n");
+	}
+
+	if (_game_mode == GM_NORMAL) {
+		_survey.Transmit(NetworkSurveyHandler::Reason::CRASH, true);
 	}
 
 	return ret;

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -240,7 +240,7 @@ struct GSConfigWindow : public Window {
 
 	void OnClick(Point pt, int widget, int click_count) override
 	{
-		if (widget >= WID_GSC_TEXTFILE && widget < WID_GSC_TEXTFILE + TFT_END) {
+		if (widget >= WID_GSC_TEXTFILE && widget < WID_GSC_TEXTFILE + TFT_CONTENT_END) {
 			if (GameConfig::GetConfig() == nullptr) return;
 
 			ShowScriptTextfileWindow((TextfileType)(widget - WID_GSC_TEXTFILE), (CompanyID)OWNER_DEITY);
@@ -404,7 +404,7 @@ struct GSConfigWindow : public Window {
 
 		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GM_NORMAL) || !IsEditable());
 
-		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
+		for (TextfileType tft = TFT_CONTENT_BEGIN; tft < TFT_CONTENT_END; tft++) {
 			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, !GameConfig::GetConfig()->GetTextfile(tft, (CompanyID)OWNER_DEITY).has_value());
 		}
 		this->RebuildVisibleSettings();

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -47,6 +47,7 @@ bool _screen_disable_anim = false;   ///< Disable palette animation (important f
 std::atomic<bool> _exit_game;
 GameMode _game_mode;
 SwitchMode _switch_mode;  ///< The next mainloop command.
+std::chrono::steady_clock::time_point _switch_mode_time; ///< The time when the switch mode was requested.
 PauseMode _pause_mode;
 Palette _cur_palette;
 

--- a/src/intro_gui.cpp
+++ b/src/intro_gui.cpp
@@ -17,6 +17,7 @@
 #include "genworld.h"
 #include "network/network_gui.h"
 #include "network/network_content.h"
+#include "network/network_survey.h"
 #include "landscape_type.h"
 #include "landscape.h"
 #include "strings_func.h"
@@ -504,7 +505,10 @@ void ShowSelectGameWindow()
 
 static void AskExitGameCallback(Window *w, bool confirmed)
 {
-	if (confirmed) _exit_game = true;
+	if (confirmed) {
+		_survey.Transmit(NetworkSurveyHandler::Reason::EXIT, true);
+		_exit_game = true;
+	}
 }
 
 void AskExitGame()

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1041,6 +1041,14 @@ STR_GAME_OPTIONS_GUI_SCALE_3X                                   :3x
 STR_GAME_OPTIONS_GUI_SCALE_4X                                   :4x
 STR_GAME_OPTIONS_GUI_SCALE_5X                                   :5x
 
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY_FRAME                       :{BLACK}Automated survey
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY                             :{BLACK}Participate in automated survey
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY_TOOLTIP                     :{BLACK}When enabled, OpenTTD will transmit a survey when leaving a game
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY_LINK                        :{BLACK}About survey and privacy
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY_LINK_TOOLTIP                :{BLACK}This opens a browser with more information about the automated survey
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY_PREVIEW                     :{BLACK}Preview survey result
+STR_GAME_OPTIONS_PARTICIPATE_SURVEY_PREVIEW_TOOLTIP             :{BLACK}Show the survey result of the current running game
+
 STR_GAME_OPTIONS_GRAPHICS                                       :{BLACK}Graphics
 
 STR_GAME_OPTIONS_REFRESH_RATE                                   :{BLACK}Display refresh rate
@@ -2401,6 +2409,13 @@ STR_NETWORK_ASK_RELAY_TEXT                                      :{YELLOW}Failed 
 STR_NETWORK_ASK_RELAY_NO                                        :{BLACK}No
 STR_NETWORK_ASK_RELAY_YES_ONCE                                  :{BLACK}Yes, this once
 STR_NETWORK_ASK_RELAY_YES_ALWAYS                                :{BLACK}Yes, don't ask again
+
+STR_NETWORK_ASK_SURVEY_CAPTION                                  :Participate in automated survey?
+STR_NETWORK_ASK_SURVEY_TEXT                                     :Would you like to participate in the automated survey?{}OpenTTD will transmit a survey when leaving a game.{}You can change this at any time under "Game Options".
+STR_NETWORK_ASK_SURVEY_PREVIEW                                  :Preview survey result
+STR_NETWORK_ASK_SURVEY_LINK                                     :About survey and privacy
+STR_NETWORK_ASK_SURVEY_NO                                       :No
+STR_NETWORK_ASK_SURVEY_YES                                      :Yes
 
 STR_NETWORK_SPECTATORS                                          :Spectators
 
@@ -4654,10 +4669,11 @@ STR_TEXTFILE_WRAP_TEXT_TOOLTIP                                  :{BLACK}Wrap the
 STR_TEXTFILE_VIEW_README                                        :{BLACK}View readme
 STR_TEXTFILE_VIEW_CHANGELOG                                     :{BLACK}Changelog
 STR_TEXTFILE_VIEW_LICENCE                                       :{BLACK}Licence
-###length 3
+###length 4
 STR_TEXTFILE_README_CAPTION                                     :{WHITE}{STRING} readme of {RAW_STRING}
 STR_TEXTFILE_CHANGELOG_CAPTION                                  :{WHITE}{STRING} changelog of {RAW_STRING}
 STR_TEXTFILE_LICENCE_CAPTION                                    :{WHITE}{STRING} licence of {RAW_STRING}
+STR_TEXTFILE_SURVEY_RESULT_CAPTION                              :{WHITE}Preview of survey result
 
 
 # Vehicle loading indicators

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -28,6 +28,8 @@ add_files(
     network_server.h
     network_stun.cpp
     network_stun.h
+    network_survey.cpp
+    network_survey.h
     network_turn.cpp
     network_turn.h
     network_type.h

--- a/src/network/core/config.cpp
+++ b/src/network/core/config.cpp
@@ -66,3 +66,13 @@ const char *NetworkContentMirrorUriString()
 {
 	return GetEnv("OTTD_CONTENT_MIRROR_URI", "https://binaries.openttd.org/bananas");
 }
+
+/**
+ * Get the URI string for the survey from the environment variable OTTD_SURVEY_URI,
+ * or when it has not been set a hard coded URI of the production server.
+ * @return The survey's URI string.
+ */
+const char *NetworkSurveyUriString()
+{
+	return GetEnv("OTTD_SURVEY_URI", "https://survey-participate.openttd.org/");
+}

--- a/src/network/core/config.h
+++ b/src/network/core/config.h
@@ -16,6 +16,7 @@ const char *NetworkCoordinatorConnectionString();
 const char *NetworkStunConnectionString();
 const char *NetworkContentServerConnectionString();
 const char *NetworkContentMirrorUriString();
+const char *NetworkSurveyUriString();
 
 static const uint16 NETWORK_COORDINATOR_SERVER_PORT = 3976;           ///< The default port of the Game Coordinator server (TCP)
 static const uint16 NETWORK_STUN_SERVER_PORT        = 3975;           ///< The default port of the STUN server (TCP)
@@ -26,6 +27,8 @@ static const uint16 NETWORK_ADMIN_PORT              = 3977;           ///< The d
 static const uint16 NETWORK_DEFAULT_DEBUGLOG_PORT   = 3982;           ///< The default port debug-log is sent to (TCP)
 
 static const uint16 UDP_MTU                         = 1460;           ///< Number of bytes we can pack in a single UDP packet
+
+static const std::string NETWORK_SURVEY_DETAILS_LINK = "https://survey.openttd.org/participate"; ///< Link with more details & privacy statement of the survey.
 /*
  * Technically a TCP packet could become 64kiB, however the high bit is kept so it becomes possible in the future
  * to go to (significantly) larger packets if needed. This would entail a strategy such as employed for UTF-8.
@@ -46,6 +49,7 @@ static const uint16 COMPAT_MTU                      = 1460;           ///< Numbe
 static const byte NETWORK_GAME_ADMIN_VERSION        =    3;           ///< What version of the admin network do we use?
 static const byte NETWORK_GAME_INFO_VERSION         =    6;           ///< What version of game-info do we use?
 static const byte NETWORK_COORDINATOR_VERSION       =    6;           ///< What version of game-coordinator-protocol do we use?
+static const byte NETWORK_SURVEY_VERSION            =    1;           ///< What version of the survey do we use?
 
 static const uint NETWORK_NAME_LENGTH               =   80;           ///< The maximum length of the server name and map name, in bytes including '\0'
 static const uint NETWORK_COMPANY_NAME_LENGTH       =  128;           ///< The maximum length of the company name, in bytes including '\0'

--- a/src/network/core/http.h
+++ b/src/network/core/http.h
@@ -14,6 +14,8 @@
 
 #include "tcp.h"
 
+constexpr int HTTP_429_TOO_MANY_REQUESTS = 429;
+
 /** Callback for when the HTTP handler has something to tell us. */
 struct HTTPCallback {
 	/**

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -85,6 +85,8 @@ static_assert((int)NETWORK_COMPANY_NAME_LENGTH == MAX_LENGTH_COMPANY_NAME_CHARS 
 /** The amount of clients connected */
 byte _network_clients_connected = 0;
 
+extern std::string GenerateUid(std::string_view subject);
+
 /**
  * Return whether there is any client connected or trying to connect at all.
  * @return whether we have any client activity
@@ -1204,24 +1206,7 @@ void NetworkGameLoop()
 
 static void NetworkGenerateServerId()
 {
-	Md5 checksum;
-	uint8 digest[16];
-	char hex_output[16 * 2 + 1];
-	char coding_string[NETWORK_NAME_LENGTH];
-	int di;
-
-	seprintf(coding_string, lastof(coding_string), "%d%s", (uint)Random(), "OpenTTD Server ID");
-
-	/* Generate the MD5 hash */
-	checksum.Append((const uint8*)coding_string, strlen(coding_string));
-	checksum.Finish(digest);
-
-	for (di = 0; di < 16; ++di) {
-		seprintf(hex_output + di * 2, lastof(hex_output), "%02x", digest[di]);
-	}
-
-	/* _settings_client.network.network_id is our id */
-	_settings_client.network.network_id = hex_output;
+	_settings_client.network.network_id = GenerateUid("OpenTTD Server ID");
 }
 
 class TCPNetworkDebugConnecter : TCPConnecter {

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -790,7 +790,7 @@ public:
 
 	void OnClick(Point pt, int widget, int click_count) override
 	{
-		if (widget >= WID_NCL_TEXTFILE && widget < WID_NCL_TEXTFILE + TFT_END) {
+		if (widget >= WID_NCL_TEXTFILE && widget < WID_NCL_TEXTFILE + TFT_CONTENT_END) {
 			if (this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE) return;
 
 			ShowContentTextfileWindow((TextfileType)(widget - WID_NCL_TEXTFILE), this->selected);
@@ -997,7 +997,7 @@ public:
 		this->SetWidgetDisabledState(WID_NCL_SELECT_ALL, !show_select_all);
 		this->SetWidgetDisabledState(WID_NCL_SELECT_UPDATE, !show_select_upgrade);
 		this->SetWidgetDisabledState(WID_NCL_OPEN_URL, this->selected == nullptr || this->selected->url.empty());
-		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
+		for (TextfileType tft = TFT_CONTENT_BEGIN; tft < TFT_CONTENT_END; tft++) {
 			this->SetWidgetDisabledState(WID_NCL_TEXTFILE + tft, this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE || !this->selected->GetTextfile(tft).has_value());
 		}
 

--- a/src/network/network_gui.h
+++ b/src/network/network_gui.h
@@ -24,7 +24,8 @@ void ShowNetworkGameWindow();
 void ShowClientList();
 void ShowNetworkCompanyPasswordWindow(Window *parent);
 void ShowNetworkAskRelay(const std::string &server_connection_string, const std::string &relay_connection_string, const std::string &token);
-
+void ShowNetworkAskSurvey();
+void ShowSurveyResultTextfileWindow();
 
 /** Company information stored at the client side */
 struct NetworkCompanyInfo : NetworkCompanyStats {

--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -1,0 +1,397 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_survey.cpp Opt-in survey part of the network protocol. */
+
+#include "../stdafx.h"
+#include "network_survey.h"
+#include "settings_table.h"
+#include "network.h"
+#include "../debug.h"
+#include "../rev.h"
+#include "../settings_type.h"
+#include "../timer/timer_game_tick.h"
+
+#include "../currency.h"
+#include "../fontcache.h"
+#include "../language.h"
+
+#include "../ai/ai_info.hpp"
+#include "../game/game.hpp"
+#include "../game/game_info.hpp"
+
+#include "../music/music_driver.hpp"
+#include "../sound/sound_driver.hpp"
+#include "../video/video_driver.hpp"
+
+#include "../base_media_base.h"
+#include "../blitter/factory.hpp"
+
+#ifdef WITH_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+#endif /* WITH_NLOHMANN_JSON */
+
+#include "../safeguards.h"
+
+extern std::string _savegame_id;
+
+NetworkSurveyHandler _survey = {};
+
+#ifdef WITH_NLOHMANN_JSON
+
+NLOHMANN_JSON_SERIALIZE_ENUM(NetworkSurveyHandler::Reason, {
+	{NetworkSurveyHandler::Reason::PREVIEW, "preview"},
+	{NetworkSurveyHandler::Reason::LEAVE, "leave"},
+	{NetworkSurveyHandler::Reason::EXIT, "exit"},
+	{NetworkSurveyHandler::Reason::CRASH, "crash"},
+})
+
+NLOHMANN_JSON_SERIALIZE_ENUM(GRFStatus, {
+	{GRFStatus::GCS_UNKNOWN, "unknown"},
+	{GRFStatus::GCS_DISABLED, "disabled"},
+	{GRFStatus::GCS_NOT_FOUND, "not found"},
+	{GRFStatus::GCS_INITIALISED, "initialised"},
+	{GRFStatus::GCS_ACTIVATED, "activated"},
+})
+
+static const std::string _vehicle_type_to_string[] = {
+	"train",
+	"roadveh",
+	"ship",
+	"aircraft",
+};
+
+/* Defined in one of the os/ survey files. */
+extern void SurveyOS(nlohmann::json &json);
+
+/**
+ * List of all the generic setting tables.
+ *
+ * There are a few tables that are special and not processed like the rest:
+ * - _currency_settings
+ * - _misc_settings
+ * - _company_settings
+ * - _win32_settings
+ * As such, they are not part of this list.
+ */
+static auto &GenericSettingTables()
+{
+	static const SettingTable _generic_setting_tables[] = {
+		_difficulty_settings,
+		_economy_settings,
+		_game_settings,
+		_gui_settings,
+		_linkgraph_settings,
+		_locale_settings,
+		_multimedia_settings,
+		_network_settings,
+		_news_display_settings,
+		_pathfinding_settings,
+		_script_settings,
+		_world_settings,
+	};
+	return _generic_setting_tables;
+}
+
+/**
+ * Convert a settings table to JSON.
+ *
+ * @param survey The JSON object.
+ * @param table The settings table to convert.
+ * @param object The object to get the settings from.
+ */
+static void SurveySettingsTable(nlohmann::json &survey, const SettingTable &table, void *object)
+{
+	char buf[512];
+	for (auto &desc : table) {
+		const SettingDesc *sd = GetSettingDesc(desc);
+		/* Skip any old settings we no longer save/load. */
+		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
+
+		auto name = sd->GetName();
+		sd->FormatValue(buf, lastof(buf), object);
+
+		survey[name] = buf;
+	}
+}
+
+/**
+ * Convert settings to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveySettings(nlohmann::json &survey)
+{
+	SurveySettingsTable(survey, _misc_settings, nullptr);
+#if defined(_WIN32) && !defined(DEDICATED)
+	SurveySettingsTable(survey, _win32_settings, nullptr);
+#endif
+	for (auto &table : GenericSettingTables()) {
+		SurveySettingsTable(survey, table, &_settings_game);
+	}
+	SurveySettingsTable(survey, _currency_settings, &_custom_currency);
+	SurveySettingsTable(survey, _company_settings, &_settings_client.company);
+}
+
+/**
+ * Convert generic OpenTTD information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyOpenTTD(nlohmann::json &survey)
+{
+	survey["version"] = std::string(_openttd_revision);
+	survey["newgrf_version"] = _openttd_newgrf_version;
+	survey["build_date"] = std::string(_openttd_build_date);
+	survey["bits"] =
+#ifdef POINTER_IS_64BIT
+			64
+#else
+			32
+#endif
+		;
+	survey["endian"] =
+#if (TTD_ENDIAN == TTD_LITTLE_ENDIAN)
+			"little"
+#else
+			"big"
+#endif
+		;
+	survey["dedicated_build"] =
+#ifdef DEDICATED
+			"yes"
+#else
+			"no"
+#endif
+		;
+}
+
+/**
+ * Convert generic game information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyConfiguration(nlohmann::json &survey)
+{
+	survey["network"] = _networking ? (_network_server ? "server" : "client") : "no";
+	if (_current_language != nullptr) {
+		std::string_view language_basename(_current_language->file);
+		auto e = language_basename.rfind(PATHSEPCHAR);
+		if (e != std::string::npos) {
+			language_basename = language_basename.substr(e + 1);
+		}
+
+		survey["language"]["filename"] = language_basename;
+		survey["language"]["name"] = _current_language->name;
+		survey["language"]["isocode"] = _current_language->isocode;
+	}
+	if (BlitterFactory::GetCurrentBlitter() != nullptr) {
+		survey["blitter"] = BlitterFactory::GetCurrentBlitter()->GetName();
+	}
+	if (MusicDriver::GetInstance() != nullptr) {
+		survey["music_driver"] = MusicDriver::GetInstance()->GetName();
+	}
+	if (SoundDriver::GetInstance() != nullptr) {
+		survey["sound_driver"] = SoundDriver::GetInstance()->GetName();
+	}
+	if (VideoDriver::GetInstance() != nullptr) {
+		survey["video_driver"] = VideoDriver::GetInstance()->GetName();
+		survey["video_info"] = VideoDriver::GetInstance()->GetInfoString();
+	}
+	if (BaseGraphics::GetUsedSet() != nullptr) {
+		survey["graphics_set"] = fmt::format("{}.{}", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
+	}
+	if (BaseMusic::GetUsedSet() != nullptr) {
+		survey["music_set"] = fmt::format("{}.{}", BaseMusic::GetUsedSet()->name, BaseMusic::GetUsedSet()->version);
+	}
+	if (BaseSounds::GetUsedSet() != nullptr) {
+		survey["sound_set"] = fmt::format("{}.{}", BaseSounds::GetUsedSet()->name, BaseSounds::GetUsedSet()->version);
+	}
+}
+
+/**
+ * Convert font information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyFont(nlohmann::json &survey)
+{
+	survey["small"] = FontCache::Get(FS_SMALL)->GetFontName();
+	survey["medium"] = FontCache::Get(FS_NORMAL)->GetFontName();
+	survey["large"] = FontCache::Get(FS_LARGE)->GetFontName();
+	survey["mono"] = FontCache::Get(FS_MONO)->GetFontName();
+}
+
+/**
+ * Convert company information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyCompanies(nlohmann::json &survey)
+{
+	for (const Company *c : Company::Iterate()) {
+		auto &company = survey[std::to_string(c->index)];
+		if (c->ai_info == nullptr) {
+			company["type"] = "human";
+		} else {
+			company["type"] = "ai";
+			company["script"] = fmt::format("{}.{}", c->ai_info->GetName(), c->ai_info->GetVersion());
+		}
+
+		for (VehicleType type = VEH_BEGIN; type < VEH_COMPANY_END; type++) {
+			uint amount = c->group_all[type].num_vehicle;
+			company["vehicles"][_vehicle_type_to_string[type]] = amount;
+		}
+
+		company["infrastructure"]["road"] = c->infrastructure.GetRoadTotal();
+		company["infrastructure"]["tram"] = c->infrastructure.GetTramTotal();
+		company["infrastructure"]["rail"] = c->infrastructure.GetRailTotal();
+		company["infrastructure"]["signal"] = c->infrastructure.signal;
+		company["infrastructure"]["water"] = c->infrastructure.water;
+		company["infrastructure"]["station"] = c->infrastructure.station;
+		company["infrastructure"]["airport"] = c->infrastructure.airport;
+	}
+}
+
+/**
+ * Convert GRF information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyGrfs(nlohmann::json &survey)
+{
+	for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
+		auto grfid = fmt::format("{:08x}", BSWAP32(c->ident.grfid));
+		auto &grf = survey[grfid];
+
+		grf["md5sum"] = MD5SumToString(c->ident.md5sum);
+		grf["status"] = c->status;
+
+		if ((c->palette & GRFP_GRF_MASK) == GRFP_GRF_UNSET) grf["palette"] = "unset";
+		if ((c->palette & GRFP_GRF_MASK) == GRFP_GRF_DOS) grf["palette"] = "dos";
+		if ((c->palette & GRFP_GRF_MASK) == GRFP_GRF_WINDOWS) grf["palette"] = "windows";
+		if ((c->palette & GRFP_GRF_MASK) == GRFP_GRF_ANY) grf["palette"] = "any";
+
+		if ((c->palette & GRFP_BLT_MASK) == GRFP_BLT_UNSET) grf["blitter"] = "unset";
+		if ((c->palette & GRFP_BLT_MASK) == GRFP_BLT_32BPP) grf["blitter"] = "32bpp";
+
+		grf["is_static"] = HasBit(c->flags, GCF_STATIC);
+
+		std::vector<uint32> parameters;
+		for (int i = 0; i < c->num_params; i++) {
+			parameters.push_back(c->param[i]);
+		}
+		grf["parameters"] = parameters;
+	}
+}
+
+/**
+ * Convert game-script information to JSON.
+ *
+ * @param survey The JSON object.
+ */
+static void SurveyGameScript(nlohmann::json &survey)
+{
+	if (Game::GetInfo() == nullptr) return;
+
+	survey = fmt::format("{}.{}", Game::GetInfo()->GetName(), Game::GetInfo()->GetVersion());
+}
+
+#endif /* WITH_NLOHMANN_JSON */
+
+/**
+ * Create the payload for the survey.
+ *
+ * @param reason The reason for sending the survey.
+ * @param for_preview Whether the payload is meant for preview. This indents the result, and filters out the id/key.
+ * @return std::string The JSON payload as string for the survey.
+ */
+std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
+{
+#ifndef WITH_NLOHMANN_JSON
+	return "";
+#else
+	nlohmann::json survey;
+
+	survey["schema"] = NETWORK_SURVEY_VERSION;
+	survey["reason"] = reason;
+	survey["id"] = _savegame_id;
+
+#ifdef SURVEY_KEY
+	/* We censor the key to avoid people trying to be "clever" and use it to send their own surveys. */
+	survey["key"] = for_preview ? "(redacted)" : SURVEY_KEY;
+#else
+	survey["key"] = "";
+#endif
+
+	{
+		auto &info = survey["info"];
+		SurveyOS(info["os"]);
+		info["os"]["hardware_concurrency"] = std::thread::hardware_concurrency();
+
+		SurveyOpenTTD(info["openttd"]);
+		SurveyConfiguration(info["configuration"]);
+		SurveyFont(info["font"]);
+	}
+
+	{
+		auto &game = survey["game"];
+		game["ticks"] = TimerGameTick::counter;
+		game["time"] = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - _switch_mode_time).count();
+		SurveyCompanies(game["companies"]);
+		SurveySettings(game["settings"]);
+		SurveyGrfs(game["grfs"]);
+		SurveyGameScript(game["game_script"]);
+	}
+
+	/* For preview, we indent with 4 whitespaces to make things more readable. */
+	int indent = for_preview ? 4 : -1;
+	return survey.dump(indent);
+#endif /* WITH_NLOHMANN_JSON */
+}
+
+/**
+ * Transmit the survey.
+ *
+ * @param reason The reason for sending the survey.
+ * @param blocking Whether to block until the survey is sent.
+ */
+void NetworkSurveyHandler::Transmit(Reason reason, bool blocking)
+{
+	if constexpr (!NetworkSurveyHandler::IsSurveyPossible()) {
+		Debug(net, 4, "Survey: not possible to send survey; most likely due to missing JSON library at compile-time");
+		return;
+	}
+
+	if (_settings_client.network.participate_survey != PS_YES) {
+		Debug(net, 5, "Survey: user is not participating in survey; skipping survey");
+		return;
+	}
+
+	Debug(net, 1, "Survey: sending survey results");
+	NetworkHTTPSocketHandler::Connect(NetworkSurveyUriString(), this, this->CreatePayload(reason));
+
+	if (blocking) {
+		std::unique_lock<std::mutex> lock(this->mutex);
+		/* Block no longer than 2 seconds. If we failed to send the survey in that time, so be it. */
+		this->loaded.wait_for(lock, std::chrono::seconds(2));
+	}
+}
+
+void NetworkSurveyHandler::OnFailure()
+{
+	Debug(net, 1, "Survey: failed to send survey results");
+	this->loaded.notify_all();
+}
+
+void NetworkSurveyHandler::OnReceiveData(const char *data, size_t length)
+{
+	if (data == nullptr) {
+		Debug(net, 1, "Survey: survey results sent");
+		this->loaded.notify_all();
+	}
+}

--- a/src/network/network_survey.h
+++ b/src/network/network_survey.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file network_survey.h Part of the network protocol handling opt-in survey. */
+
+#ifndef NETWORK_SURVEY_H
+#define NETWORK_SURVEY_H
+
+#include <condition_variable>
+#include <mutex>
+#include "core/http.h"
+
+/**
+ * Socket handler for the survey connection
+ */
+class NetworkSurveyHandler : public HTTPCallback {
+protected:
+	void OnFailure() override;
+	void OnReceiveData(const char *data, size_t length) override;
+	bool IsCancelled() const override { return false; }
+
+public:
+	enum class Reason {
+		PREVIEW, ///< User is previewing the survey result.
+		LEAVE, ///< User is leaving the game (but not exiting the application).
+		EXIT, ///< User is exiting the application.
+		CRASH, ///< Game crashed.
+	};
+
+	void Transmit(Reason reason, bool blocking = false);
+	std::string CreatePayload(Reason reason, bool for_preview = false);
+
+	constexpr static bool IsSurveyPossible()
+	{
+#ifndef WITH_NLOHMANN_JSON
+		/* Without JSON library, we cannot send a payload; so we disable the survey. */
+		return false;
+#else
+		return true;
+#endif /* WITH_NLOHMANN_JSON */
+	}
+
+private:
+	std::mutex mutex; ///< Mutex for the condition variable.
+	std::condition_variable loaded; ///< Condition variable to wait for the survey to be sent.
+};
+
+extern NetworkSurveyHandler _survey;
+
+#endif /* NETWORK_SURVEY_H */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -925,7 +925,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 	void OnClick(Point pt, int widget, int click_count) override
 	{
-		if (widget >= WID_NS_NEWGRF_TEXTFILE && widget < WID_NS_NEWGRF_TEXTFILE + TFT_END) {
+		if (widget >= WID_NS_NEWGRF_TEXTFILE && widget < WID_NS_NEWGRF_TEXTFILE + TFT_CONTENT_END) {
 			if (this->active_sel == nullptr && this->avail_sel == nullptr) return;
 
 			ShowNewGRFTextfileWindow((TextfileType)(widget - WID_NS_NEWGRF_TEXTFILE), this->active_sel != nullptr ? this->active_sel : this->avail_sel);
@@ -1286,7 +1286,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 		);
 
 		const GRFConfig *selected_config = (this->avail_sel == nullptr) ? this->active_sel : this->avail_sel;
-		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
+		for (TextfileType tft = TFT_CONTENT_BEGIN; tft < TFT_CONTENT_END; tft++) {
 			this->SetWidgetDisabledState(WID_NS_NEWGRF_TEXTFILE + tft, selected_config == nullptr || !selected_config->GetTextfile(tft).has_value());
 		}
 		this->SetWidgetDisabledState(WID_NS_OPEN_URL, selected_config == nullptr || StrEmpty(selected_config->GetURL()));

--- a/src/openttd.h
+++ b/src/openttd.h
@@ -11,6 +11,7 @@
 #define OPENTTD_H
 
 #include <atomic>
+#include <chrono>
 #include "core/enum_type.hpp"
 
 /** Mode which defines the state of the game. */
@@ -53,6 +54,7 @@ enum DisplayOptions {
 
 extern GameMode _game_mode;
 extern SwitchMode _switch_mode;
+extern std::chrono::steady_clock::time_point _switch_mode_time;
 extern std::atomic<bool> _exit_game;
 extern bool _save_config;
 
@@ -86,6 +88,7 @@ void HandleExitGameRequest();
 void SwitchToMode(SwitchMode new_mode);
 
 bool RequestNewGRFScan(struct NewGRFScanCallback *callback = nullptr);
+void GenerateSavegameId();
 
 void OpenBrowser(const char *url);
 void ChangeAutosaveFrequency(bool reset);

--- a/src/os/macosx/CMakeLists.txt
+++ b/src/os/macosx/CMakeLists.txt
@@ -7,6 +7,7 @@ add_files(
     osx_stdafx.h
     string_osx.cpp
     string_osx.h
+    survey_osx.cpp
     CONDITION APPLE
 )
 

--- a/src/os/macosx/macos.h
+++ b/src/os/macosx/macos.h
@@ -38,6 +38,8 @@ bool IsMonospaceFont(CFStringRef name);
 
 void MacOSSetThreadName(const char *name);
 
+uint64 MacOSGetPhysicalMemory();
+
 
 /** Deleter that calls CFRelease rather than deleting the pointer. */
 template <typename T> struct CFDeleter {

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -272,3 +272,8 @@ void MacOSSetThreadName(const char *name)
 		[ cur performSelector:@selector(setName:) withObject:[ NSString stringWithUTF8String:name ] ];
 	}
 }
+
+uint64 MacOSGetPhysicalMemory()
+{
+	return [ [ NSProcessInfo processInfo ] physicalMemory ];
+}

--- a/src/os/macosx/survey_osx.cpp
+++ b/src/os/macosx/survey_osx.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file survey_osx.cpp OSX implementation of OS-specific survey information. */
+
+#ifdef WITH_NLOHMANN_JSON
+
+#include "../../stdafx.h"
+
+#include "../../3rdparty/fmt/format.h"
+#include "macos.h"
+
+#include <mach-o/arch.h>
+#include <nlohmann/json.hpp>
+
+#include "../../safeguards.h"
+
+void SurveyOS(nlohmann::json &json)
+{
+	int ver_maj, ver_min, ver_bug;
+	GetMacOSVersion(&ver_maj, &ver_min, &ver_bug);
+
+	const NXArchInfo *arch = NXGetLocalArchInfo();
+
+	json["os"] = "MacOS";
+	json["release"] = fmt::format("{}.{}.{}", ver_maj, ver_min, ver_bug);
+	json["machine"] = arch != nullptr ? arch->description : "unknown";
+	json["min_ver"] = MAC_OS_X_VERSION_MIN_REQUIRED;
+	json["max_ver"] = MAC_OS_X_VERSION_MAX_ALLOWED;
+
+	json["memory"] = MacOSGetPhysicalMemory();
+}
+
+#endif /* WITH_NLOHMANN_JSON */

--- a/src/os/unix/CMakeLists.txt
+++ b/src/os/unix/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_files(
     crashlog_unix.cpp
+    survey_unix.cpp
     CONDITION UNIX AND NOT APPLE AND NOT OPTION_OS2
 )
 

--- a/src/os/unix/survey_unix.cpp
+++ b/src/os/unix/survey_unix.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file survey_unix.cpp Unix implementation of OS-specific survey information. */
+
+#ifdef WITH_NLOHMANN_JSON
+
+#include "../../stdafx.h"
+
+#include <nlohmann/json.hpp>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include "../../safeguards.h"
+
+void SurveyOS(nlohmann::json &json)
+{
+	struct utsname name;
+	if (uname(&name) < 0) {
+		json["os"] = "Unix";
+		return;
+	}
+
+	json["os"] = name.sysname;
+	json["release"] = name.release;
+	json["machine"] = name.machine;
+	json["version"] = name.version;
+
+	long pages = sysconf(_SC_PHYS_PAGES);
+	long page_size = sysconf(_SC_PAGE_SIZE);
+	json["memory"] = pages * page_size;
+}
+
+#endif /* WITH_NLOHMANN_JSON */

--- a/src/os/windows/CMakeLists.txt
+++ b/src/os/windows/CMakeLists.txt
@@ -4,6 +4,7 @@ add_files(
     font_win32.h
     string_uniscribe.cpp
     string_uniscribe.h
+    survey_win.cpp
     win32.cpp
     win32.h
     CONDITION WIN32

--- a/src/os/windows/survey_win.cpp
+++ b/src/os/windows/survey_win.cpp
@@ -1,0 +1,37 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file survey_win.cpp Windows implementation of OS-specific survey information. */
+
+#ifdef WITH_NLOHMANN_JSON
+
+#include "../../stdafx.h"
+
+#include "../../3rdparty/fmt/format.h"
+
+#include <nlohmann/json.hpp>
+#include <windows.h>
+
+#include "../../safeguards.h"
+
+void SurveyOS(nlohmann::json &json)
+{
+	_OSVERSIONINFOA os;
+	os.dwOSVersionInfoSize = sizeof(os);
+	GetVersionExA(&os);
+
+	json["os"] = "Windows";
+	json["release"] = fmt::format("{}.{}.{} ({})", os.dwMajorVersion, os.dwMinorVersion, os.dwBuildNumber, os.szCSDVersion);
+
+	MEMORYSTATUSEX status;
+	status.dwLength = sizeof(status);
+	GlobalMemoryStatusEx(&status);
+
+	json["memory"] = status.ullTotalPhys;
+}
+
+#endif /* WITH_NLOHMANN_JSON */

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -3224,6 +3224,10 @@ bool AfterLoadGame()
 		for (Station *st : Station::Iterate()) UpdateStationAcceptance(st, false);
 	}
 
+	if (IsSavegameVersionBefore(SLV_SAVEGAME_ID)) {
+		GenerateSavegameId();
+	}
+
 	if (IsSavegameVersionBefore(SLV_AI_START_DATE)) {
 		/* For older savegames, we don't now the actual interval; so set it to the newgame value. */
 		_settings_game.difficulty.competitors_interval = _settings_newgame.difficulty.competitors_interval;

--- a/src/saveload/misc_sl.cpp
+++ b/src/saveload/misc_sl.cpp
@@ -29,6 +29,7 @@
 extern TileIndex _cur_tileloop_tile;
 extern uint16 _disaster_delay;
 extern byte _trees_tick_ctr;
+extern std::string _savegame_id;
 
 /* Keep track of current game position */
 int _saved_scrollpos_x;
@@ -87,6 +88,7 @@ static const SaveLoad _date_desc[] = {
 	    SLEG_VAR("company_tick_counter", _cur_company_tick_index, SLE_FILE_U8  | SLE_VAR_U32),
 	    SLEG_VAR("trees_tick_counter",     _trees_tick_ctr,         SLE_UINT8),
 	SLEG_CONDVAR("pause_mode",             _pause_mode,             SLE_UINT8,                   SLV_4, SL_MAX_VERSION),
+	SLEG_CONDSSTR("id",                    _savegame_id,            SLE_STR,                     SLV_SAVEGAME_ID, SL_MAX_VERSION),
 	/* For older savegames, we load the current value as the "period"; afterload will set the "fired" and "elapsed". */
 	SLEG_CONDVAR("next_competitor_start",        _new_competitor_timeout.period,          SLE_FILE_U16 | SLE_VAR_U32,  SL_MIN_VERSION, SLV_109),
 	SLEG_CONDVAR("next_competitor_start",        _new_competitor_timeout.period,          SLE_UINT32,                  SLV_109, SLV_AI_START_DATE),

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -353,6 +353,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_EXTEND_VEHICLE_RANDOM,              ///< 310  PR#10701 Extend vehicle random bits.
 	SLV_EXTEND_ENTITY_MAPPING,              ///< 311  PR#10672 Extend entity mapping range.
 	SLV_DISASTER_VEH_STATE,                 ///< 312  PR#10798 Explicit storage of disaster vehicle state.
+	SLV_SAVEGAME_ID,                        ///< 313  PR#10719 Add an unique ID to every savegame (used to deduplicate surveys).
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -63,11 +63,18 @@ enum IndustryDensity {
 	ID_END,       ///< Number of industry density settings.
 };
 
-/** Possible values for "userelayservice" setting. */
+/** Possible values for "use_relay_service" setting. */
 enum UseRelayService {
 	URS_NEVER = 0,
 	URS_ASK,
 	URS_ALLOW,
+};
+
+/** Possible values for "participate_survey" setting. */
+enum ParticipateSurvey {
+	PS_ASK = 0,
+	PS_NO,
+	PS_YES,
 };
 
 /** Settings related to the difficulty of the game */
@@ -306,7 +313,8 @@ struct NetworkSettings {
 	bool        reload_cfg;                               ///< reload the config file before restarting
 	std::string last_joined;                              ///< Last joined server
 	bool        no_http_content_downloads;                ///< do not do content downloads over HTTP
-	UseRelayService use_relay_service;                        ///< Use relay service?
+	UseRelayService use_relay_service;                    ///< Use relay service?
+	ParticipateSurvey participate_survey;                 ///< Participate in the automated survey
 };
 
 /** Settings related to the creation of games. */

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -8,6 +8,7 @@
 
 [pre-amble]
 static constexpr std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
+static constexpr std::initializer_list<const char*> _participate_survey{"ask", "no", "yes"};
 
 static const SettingVariant _network_private_settings_table[] = {
 [post-amble]
@@ -16,6 +17,7 @@ static const SettingVariant _network_private_settings_table[] = {
 SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
 SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
@@ -90,3 +92,12 @@ str      = STR_CONFIG_SETTING_USE_RELAY_SERVICE
 strhelp  = STR_CONFIG_SETTING_USE_RELAY_SERVICE_HELPTEXT
 strval   = STR_CONFIG_SETTING_USE_RELAY_SERVICE_NEVER
 cat      = SC_BASIC
+
+[SDTC_OMANY]
+var      = network.participate_survey
+type     = SLE_UINT8
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = PS_ASK
+min      = PS_ASK
+max      = PS_YES
+full     = _participate_survey

--- a/src/textfile_gui.cpp
+++ b/src/textfile_gui.cpp
@@ -366,8 +366,21 @@ static void Xunzip(byte **bufp, size_t *sizep)
 	if (StrStartsWith(sv_buf, u8"\ufeff")) sv_buf.remove_prefix(3);
 
 	/* Replace any invalid characters with a question-mark. This copies the buf in the process. */
-	this->text = StrMakeValid(sv_buf, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE | SVS_REPLACE_TAB_CR_NL_WITH_SPACE);
+	this->LoadText(sv_buf);
 	free(buf);
+}
+
+/**
+ * Load a text into the textfile viewer.
+ *
+ * This will split the text into newlines and stores it for fast drawing.
+ *
+ * @param buf The text to load.
+ */
+void TextfileWindow::LoadText(std::string_view buf)
+{
+	this->text = StrMakeValid(buf, SVS_REPLACE_WITH_QUESTION_MARK | SVS_ALLOW_NEWLINE | SVS_REPLACE_TAB_CR_NL_WITH_SPACE);
+	this->lines.clear();
 
 	/* Split the string on newlines. */
 	std::string_view p(this->text);
@@ -406,7 +419,7 @@ std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, cons
 		"changelog",
 		"license",
 	};
-	static_assert(lengthof(prefixes) == TFT_END);
+	static_assert(lengthof(prefixes) == TFT_CONTENT_END);
 
 	std::string_view prefix = prefixes[type];
 

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -42,6 +42,9 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 
 	virtual void LoadTextfile(const std::string &textfile, Subdirectory dir);
 
+protected:
+	void LoadText(std::string_view buf);
+
 private:
 	struct Line {
 		int top;               ///< Top scroll position.

--- a/src/textfile_type.h
+++ b/src/textfile_type.h
@@ -12,13 +12,15 @@
 
 /** Additional text files accompanying Tar archives */
 enum TextfileType {
-	TFT_BEGIN,
+	TFT_CONTENT_BEGIN,
 
-	TFT_README = TFT_BEGIN, ///< NewGRF readme
-	TFT_CHANGELOG,          ///< NewGRF changelog
-	TFT_LICENSE,            ///< NewGRF license
+	TFT_README = TFT_CONTENT_BEGIN, ///< Content readme
+	TFT_CHANGELOG,                  ///< Content changelog
+	TFT_LICENSE,                    ///< Content license
 
-	TFT_END,
+	TFT_CONTENT_END, // This marker is used to generate the above three buttons in sequence by various of places in the code.
+
+	TFT_SURVEY_RESULT = TFT_CONTENT_END, ///< Survey result (preview)
 };
 DECLARE_POSTFIX_INCREMENT(TextfileType)
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1172,7 +1172,7 @@ NWidgetCore::NWidgetCore(WidgetType tp, Colours colour, uint fill_x, uint fill_y
 	this->widget_data = widget_data;
 	this->tool_tip = tool_tip;
 	this->scrollbar_index = -1;
-	this->text_colour = TC_BLACK;
+	this->text_colour = tp == WWT_CAPTION ? TC_WHITE : TC_BLACK;
 	this->text_size = FS_NORMAL;
 	this->align = SA_CENTER;
 }

--- a/src/widgets/ai_widget.h
+++ b/src/widgets/ai_widget.h
@@ -29,7 +29,7 @@ enum AIConfigWidgets {
 	WID_AIC_CONFIGURE,        ///< Change AI settings button.
 	WID_AIC_CLOSE,            ///< Close window button.
 	WID_AIC_TEXTFILE,         ///< Open AI readme, changelog (+1) or license (+2).
-	WID_AIC_CONTENT_DOWNLOAD = WID_AIC_TEXTFILE + TFT_END, ///< Download content button.
+	WID_AIC_CONTENT_DOWNLOAD = WID_AIC_TEXTFILE + TFT_CONTENT_END, ///< Download content button.
 };
 
 #endif /* WIDGETS_AI_WIDGET_H */

--- a/src/widgets/game_widget.h
+++ b/src/widgets/game_widget.h
@@ -20,7 +20,7 @@ enum GSConfigWidgets {
 	WID_GSC_SCROLLBAR,        ///< Scrollbar to scroll through the selected AIs.
 	WID_GSC_CHANGE,           ///< Select another Game Script button.
 	WID_GSC_TEXTFILE,         ///< Open GS readme, changelog (+1) or license (+2).
-	WID_GSC_CONTENT_DOWNLOAD = WID_GSC_TEXTFILE + TFT_END, ///< Download content button.
+	WID_GSC_CONTENT_DOWNLOAD = WID_GSC_TEXTFILE + TFT_CONTENT_END, ///< Download content button.
 	WID_GSC_ACCEPT,           ///< Accept ("Close") button
 	WID_GSC_RESET,            ///< Reset button.
 };

--- a/src/widgets/network_content_widget.h
+++ b/src/widgets/network_content_widget.h
@@ -36,7 +36,7 @@ enum NetworkContentListWidgets {
 	WID_NCL_DETAILS,        ///< Panel with content details.
 	WID_NCL_TEXTFILE,       ///< Open readme, changelog (+1) or license (+2) of a file in the content window.
 
-	WID_NCL_SELECT_ALL = WID_NCL_TEXTFILE + TFT_END, ///< 'Select all' button.
+	WID_NCL_SELECT_ALL = WID_NCL_TEXTFILE + TFT_CONTENT_END, ///< 'Select all' button.
 	WID_NCL_SELECT_UPDATE,  ///< 'Select updates' button.
 	WID_NCL_UNSELECT,       ///< 'Unselect all' button.
 	WID_NCL_OPEN_URL,       ///< 'Open url' button.

--- a/src/widgets/network_widget.h
+++ b/src/widgets/network_widget.h
@@ -119,4 +119,14 @@ enum NetworkAskRelayWidgets {
 	WID_NAR_YES_ALWAYS, ///< "Yes, always" button.
 };
 
+/** Widgets of the #NetworkAskSurveyWindow class. */
+enum NetworkAskSurveyWidgets {
+	WID_NAS_CAPTION,    ///< Caption of the window.
+	WID_NAS_TEXT,       ///< Text in the window.
+	WID_NAS_PREVIEW,    ///< "Preview" button.
+	WID_NAS_LINK,       ///< "Details & Privacy" button.
+	WID_NAS_NO,         ///< "No" button.
+	WID_NAS_YES,        ///< "Yes" button.
+};
+
 #endif /* WIDGETS_NETWORK_WIDGET_H */

--- a/src/widgets/newgrf_widget.h
+++ b/src/widgets/newgrf_widget.h
@@ -47,7 +47,7 @@ enum NewGRFStateWidgets {
 	WID_NS_NEWGRF_INFO,       ///< Panel for Info on selected NewGRF.
 	WID_NS_OPEN_URL,          ///< Open URL of NewGRF.
 	WID_NS_NEWGRF_TEXTFILE,   ///< Open NewGRF readme, changelog (+1) or license (+2).
-	WID_NS_SET_PARAMETERS = WID_NS_NEWGRF_TEXTFILE + TFT_END,   ///< Open Parameters Window for selected NewGRF for editing parameters.
+	WID_NS_SET_PARAMETERS = WID_NS_NEWGRF_TEXTFILE + TFT_CONTENT_END,   ///< Open Parameters Window for selected NewGRF for editing parameters.
 	WID_NS_VIEW_PARAMETERS,   ///< Open Parameters Window for selected NewGRF for viewing parameters.
 	WID_NS_TOGGLE_PALETTE,    ///< Toggle Palette of selected, active NewGRF.
 	WID_NS_APPLY_CHANGES,     ///< Apply changes to NewGRF config.

--- a/src/widgets/settings_widget.h
+++ b/src/widgets/settings_widget.h
@@ -28,23 +28,27 @@ enum GameOptionsWidgets {
 	WID_GO_BASE_GRF_DROPDOWN,      ///< Use to select a base GRF.
 	WID_GO_BASE_GRF_STATUS,        ///< Info about missing files etc.
 	WID_GO_BASE_GRF_TEXTFILE,      ///< Open base GRF readme, changelog (+1) or license (+2).
-	WID_GO_BASE_GRF_DESCRIPTION = WID_GO_BASE_GRF_TEXTFILE + TFT_END,     ///< Description of selected base GRF.
+	WID_GO_BASE_GRF_DESCRIPTION = WID_GO_BASE_GRF_TEXTFILE + TFT_CONTENT_END,     ///< Description of selected base GRF.
 	WID_GO_BASE_SFX_DROPDOWN,      ///< Use to select a base SFX.
 	WID_GO_TEXT_SFX_VOLUME,        ///< Sound effects volume label.
 	WID_GO_BASE_SFX_VOLUME,        ///< Change sound effects volume.
 	WID_GO_BASE_SFX_TEXTFILE,      ///< Open base SFX readme, changelog (+1) or license (+2).
-	WID_GO_BASE_SFX_DESCRIPTION = WID_GO_BASE_SFX_TEXTFILE + TFT_END,     ///< Description of selected base SFX.
+	WID_GO_BASE_SFX_DESCRIPTION = WID_GO_BASE_SFX_TEXTFILE + TFT_CONTENT_END,     ///< Description of selected base SFX.
 	WID_GO_BASE_MUSIC_DROPDOWN,    ///< Use to select a base music set.
 	WID_GO_TEXT_MUSIC_VOLUME,      ///< Music volume label.
 	WID_GO_BASE_MUSIC_VOLUME,      ///< Change music volume.
 	WID_GO_BASE_MUSIC_JUKEBOX,     ///< Open the jukebox.
 	WID_GO_BASE_MUSIC_STATUS,      ///< Info about corrupted files etc.
 	WID_GO_BASE_MUSIC_TEXTFILE,    ///< Open base music readme, changelog (+1) or license (+2).
-	WID_GO_BASE_MUSIC_DESCRIPTION = WID_GO_BASE_MUSIC_TEXTFILE + TFT_END, ///< Description of selected base music set.
+	WID_GO_BASE_MUSIC_DESCRIPTION = WID_GO_BASE_MUSIC_TEXTFILE + TFT_CONTENT_END, ///< Description of selected base music set.
 	WID_GO_VIDEO_ACCEL_BUTTON,     ///< Toggle for video acceleration.
 	WID_GO_VIDEO_VSYNC_BUTTON,     ///< Toggle for video vsync.
 	WID_GO_REFRESH_RATE_DROPDOWN,  ///< Dropdown for all available refresh rates.
 	WID_GO_VIDEO_DRIVER_INFO,      ///< Label showing details about the current video driver.
+	WID_GO_SURVEY_SEL,             ///< Selection to hide survey if no JSON library is compiled in.
+	WID_GO_SURVEY_PARTICIPATE_BUTTON, ///< Toggle for participating in the automated survey.
+	WID_GO_SURVEY_LINK_BUTTON,     ///< Button to open browser to go to the survey website.
+	WID_GO_SURVEY_PREVIEW_BUTTON,  ///< Button to open a preview window with the survey results
 };
 
 /** Widgets of the #GameSettingsWindow class. */

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -484,6 +484,12 @@ enum WindowClass {
 	WC_NETWORK_ASK_RELAY,
 
 	/**
+	 * Network ask survey window; %Window numbers:
+	 *  - 0 - #NetworkAskSurveyWidgets
+	 */
+	WC_NETWORK_ASK_SURVEY,
+
+	/**
 	 * Chatbox; %Window numbers:
 	 *   - #DestType = #NetWorkChatWidgets
 	 */


### PR DESCRIPTION
Binaries for testing available here:
https://www.openttd.org/downloads/openttd-branches/pr10719/latest

## Motivation / Problem

As mentioned in #10632 we would like to add an opt-in survey system to OpenTTD, for us to see how the game is being used.

There are many ways to play OpenTTD. There are tons of settings, you can load extensions, from AIs to NewGRFs. They all modify how the game plays.

From a developer perspective, we don't actually know what settings are heavily used, and which are never used. As such, we often find ourself in a discussion about whether something is actually useful. The people we talk most about, are not our average user; as it goes, the most vocal people are not the commoner, but more likely the niche. And although we like to promote as many playstyles as possible, it is easy to focus on those vocal people, instead of the 90%.

From a AI / NewGRF perspective, we don't actually know how many people play a game with my extension. And as such it is difficult to judge what is actually "popular", and what extensions are never really used. This means it is tricky on BaNaNaS to suggest any content.

For both there is a simple solution we have been putting off for a long time now: automated surveys. (one could also call it telemetry, but survey sounds a bit more like what our intent is).

First of all, of course survey will always be opt-in. But to gain a better understanding how OpenTTD is being used, we are considering adding survey.

There are a few groundrules:

- No personal data or data to track a specific user with.
- The user has to be able to validate the information that is being sent.
- Minimize the moments we send survey results.

## Description

On first start-up, the game will ask if you want to participate in our automated survey. You have to opt-in, and can easily opt-out (via the Options) at any time.

When opt-in, whenever you exit a game, a JSON blob will be send to the survey server hosted by OpenTTD. This JSON blob contains information that gives a global picture of the game just played:
- What settings were used
- How many humans vs AIs
- How long the game has been played
- Basic information about the OS / CPU

All this information is kept very generic, so there is no chance we send private information to our survey server. Nothing in the JSON blob could identify you as a person; it mostly tells about the game played. At any time you can see what the JSON blob includes, by pressing the "Preview Survey Results" button in-game.

The HTML part that belongs to this PR can be found here: https://github.com/OpenTTD/survey-web/pull/1

![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/a2cfbdaf-5171-4be8-9d30-d170ae4560f7)
![image](https://github.com/OpenTTD/OpenTTD/assets/1663690/64c1fad4-acf9-4bff-8c0f-285bf1b5088b)
![image](https://user-images.githubusercontent.com/1663690/236220808-790aaac3-3130-4a1b-b1fd-506c440b77b2.png)

## Work in progress

Currently the JSON is collected, but that is it. This means there are a few things left to do:

- [x] Add the opt-in question on first start.
- [x] Allow an easy way to opt-out again (via Options?).
- [x] Link to the privacy statement or something, explaining what is in the JSON blob, and what we do with the information.
- [x] Add JSON library to Emscripten.
- [x] Generate SavegameID when loading a scenario.
- [x] Add more randomness for the SavegameID, by doing a sleep and using the clocks nanoseconds; that should be rather random.
- [x] Generate secrets per release in the CI. (a secret will be a JWT token signed by the survey server, which includes things like what OpenTTD version etc)
- [x] Implement backend: collector (the part that receives the surveys and stores it in a bucket)
- [ ] ~Implement backend: analyzer (the part that looks at all the surveys and takes conclusions based on it)~ (postponed till we have more data)
- [ ] ~Implement backend: compactor (the part that takes the surveys of a period, and compresses them (to save on disk-space)~

## Limitations

If you don't have nlohmann-json available during compile-time, you get from cmake an ENCOURAGE warning, but otherwise it compiles just fine. Additionally, in-game there is no mention of a survey in those cases (as you can't participate anyway).

Emscripten can't make HTTPS connections (yet), so it doesn't participate in survey.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
