### PR TITLE
Fix #10334: Store separate newgrf-safe version of date_of_last_service.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -339,6 +339,7 @@ CommandCost CmdBuildAircraft(DoCommandFlag flags, TileIndex tile, const Engine *
 		v->SetServiceInterval(Company::Get(_current_company)->settings.vehicle.servint_aircraft);
 
 		v->date_of_last_service = TimerGameCalendar::date;
+		v->date_of_last_service_newgrf = v->date_of_last_service;
 		v->build_year = u->build_year = TimerGameCalendar::year;
 
 		v->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);
@@ -1557,6 +1558,7 @@ static void AircraftEventHandler_AtTerminal(Aircraft *v, const AirportFTAClass *
 			if (v->subtype == AIR_HELICOPTER && apc->num_helipads > 0) {
 				/* an excerpt of ServiceAircraft, without the invisibility stuff */
 				v->date_of_last_service = TimerGameCalendar::date;
+				v->date_of_last_service_newgrf = v->date_of_last_service;
 				v->breakdowns_since_last_service = 0;
 				v->reliability = v->GetEngine()->reliability;
 				SetWindowDirty(WC_VEHICLE_DETAILS, v->index);

--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -397,6 +397,7 @@ void AddArticulatedParts(Vehicle *first)
 		v->y_pos = first->y_pos;
 		v->z_pos = first->z_pos;
 		v->date_of_last_service = first->date_of_last_service;
+		v->date_of_last_service_newgrf = first->date_of_last_service_newgrf;
 		v->build_year = first->build_year;
 		v->vehstatus = first->vehstatus & ~VS_STOPPED;
 

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -596,7 +596,7 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 			}
 
 		case 0x4B: // Long date of last service
-			return v->date_of_last_service;
+			return v->date_of_last_service_newgrf;
 
 		case 0x4C: // Current maximum speed in NewGRF units
 			if (!v->IsPrimaryVehicle()) return 0;
@@ -766,8 +766,8 @@ static uint32 VehicleGetVariable(Vehicle *v, const VehicleScopeResolver *object,
 			}
 			return (variable - 0x80) == 0x10 ? ticks : GB(ticks, 8, 8);
 		}
-		case 0x12: return Clamp(v->date_of_last_service - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 0xFFFF);
-		case 0x13: return GB(Clamp(v->date_of_last_service - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 0xFFFF), 8, 8);
+		case 0x12: return Clamp(v->date_of_last_service_newgrf - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 0xFFFF);
+		case 0x13: return GB(Clamp(v->date_of_last_service_newgrf - DAYS_TILL_ORIGINAL_BASE_YEAR, 0, 0xFFFF), 8, 8);
 		case 0x14: return v->GetServiceInterval();
 		case 0x15: return GB(v->GetServiceInterval(), 8, 8);
 		case 0x16: return v->last_station_visited;

--- a/src/roadveh_cmd.cpp
+++ b/src/roadveh_cmd.cpp
@@ -300,6 +300,7 @@ CommandCost CmdBuildRoadVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 		v->SetServiceInterval(Company::Get(v->owner)->settings.vehicle.servint_roadveh);
 
 		v->date_of_last_service = TimerGameCalendar::date;
+		v->date_of_last_service_newgrf = v->date_of_last_service;
 		v->build_year = TimerGameCalendar::year;
 
 		v->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -1455,6 +1455,7 @@ bool AfterLoadGame()
 
 		for (Vehicle *v : Vehicle::Iterate()) {
 			v->date_of_last_service += DAYS_TILL_ORIGINAL_BASE_YEAR;
+			v->date_of_last_service_newgrf = v->date_of_last_service;
 			v->build_year += ORIGINAL_BASE_YEAR;
 		}
 	}
@@ -3269,6 +3270,13 @@ bool AfterLoadGame()
 		extern TimeoutTimer<TimerGameTick> _new_competitor_timeout;
 		_new_competitor_timeout.storage.elapsed = 0;
 		_new_competitor_timeout.fired = _new_competitor_timeout.period == 0;
+	}
+
+	if (IsSavegameVersionBefore(SLV_NEWGRF_LAST_SERVICE)) {
+		/* Fixup service date provided to NewGRF. */
+		for (Vehicle *v : Vehicle::Iterate()) {
+			v->date_of_last_service_newgrf = v->date_of_last_service;
+		}
 	}
 
 	AfterLoadLabelMaps();

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -353,6 +353,8 @@ enum SaveLoadVersion : uint16 {
 	SLV_LINKGRAPH_SECONDS,                  ///< 308  PR#10610 Store linkgraph update intervals in seconds instead of days.
 	SLV_AI_START_DATE,                      ///< 309  PR#10653 Removal of individual AI start dates and added a generic one.
 
+	SLV_NEWGRF_LAST_SERVICE,                ///< 310  PR#10720 Added stable date_of_last_service to avoid NewGRF trouble.
+
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
 

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -677,6 +677,7 @@ public:
 		SLE_CONDVAR(Vehicle, max_age,               SLE_INT32,                   SLV_31, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, date_of_last_service,  SLE_FILE_U16 | SLE_VAR_I32,   SL_MIN_VERSION,  SLV_31),
 		SLE_CONDVAR(Vehicle, date_of_last_service,  SLE_INT32,                   SLV_31, SL_MAX_VERSION),
+		SLE_CONDVAR(Vehicle, date_of_last_service_newgrf, SLE_INT32,             SLV_NEWGRF_LAST_SERVICE, SL_MAX_VERSION),
 		SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                   SL_MIN_VERSION,  SLV_31),
 		SLE_CONDVAR(Vehicle, service_interval,      SLE_FILE_U32 | SLE_VAR_U16,  SLV_31, SLV_180),
 		SLE_CONDVAR(Vehicle, service_interval,      SLE_UINT16,                 SLV_180, SL_MAX_VERSION),

--- a/src/ship_cmd.cpp
+++ b/src/ship_cmd.cpp
@@ -892,6 +892,7 @@ CommandCost CmdBuildShip(DoCommandFlag flags, TileIndex tile, const Engine *e, V
 
 		v->SetServiceInterval(Company::Get(_current_company)->settings.vehicle.servint_ships);
 		v->date_of_last_service = TimerGameCalendar::date;
+		v->date_of_last_service_newgrf = v->date_of_last_service;
 		v->build_year = TimerGameCalendar::year;
 		v->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);
 		v->random_bits = VehicleRandomBits();

--- a/src/train_cmd.cpp
+++ b/src/train_cmd.cpp
@@ -654,6 +654,7 @@ static CommandCost CmdBuildRailWagon(DoCommandFlag flags, TileIndex tile, const 
 		v->railtype = rvi->railtype;
 
 		v->date_of_last_service = TimerGameCalendar::date;
+		v->date_of_last_service_newgrf = v->date_of_last_service;
 		v->build_year = TimerGameCalendar::year;
 		v->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);
 		v->random_bits = VehicleRandomBits();
@@ -719,6 +720,7 @@ static void AddRearEngineToMultiheadedTrain(Train *v)
 	u->railtype = v->railtype;
 	u->engine_type = v->engine_type;
 	u->date_of_last_service = v->date_of_last_service;
+	u->date_of_last_service_newgrf = v->date_of_last_service_newgrf;
 	u->build_year = v->build_year;
 	u->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);
 	u->random_bits = VehicleRandomBits();
@@ -784,6 +786,7 @@ CommandCost CmdBuildRailVehicle(DoCommandFlag flags, TileIndex tile, const Engin
 
 		v->SetServiceInterval(Company::Get(_current_company)->settings.vehicle.servint_trains);
 		v->date_of_last_service = TimerGameCalendar::date;
+		v->date_of_last_service_newgrf = v->date_of_last_service;
 		v->build_year = TimerGameCalendar::year;
 		v->sprite_cache.sprite_seq.Set(SPR_IMG_QUERY);
 		v->random_bits = VehicleRandomBits();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -170,6 +170,7 @@ void VehicleServiceInDepot(Vehicle *v)
 
 	do {
 		v->date_of_last_service = TimerGameCalendar::date;
+		v->date_of_last_service_newgrf = v->date_of_last_service;
 		v->breakdowns_since_last_service = 0;
 		v->reliability = v->GetEngine()->reliability;
 		/* Prevent vehicles from breaking down directly after exiting the depot. */
@@ -775,6 +776,8 @@ uint32 Vehicle::GetGRFID() const
 void Vehicle::ShiftDates(int interval)
 {
 	this->date_of_last_service = std::max(this->date_of_last_service + interval, 0);
+	/* date_of_last_service_newgrf is not update here as it must stay stable
+	 * for vehicles outside of a depot. */
 }
 
 /**

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -291,6 +291,7 @@ public:
 	TimerGameCalendar::Date age;                  ///< Age in days
 	TimerGameCalendar::Date max_age;              ///< Maximum age
 	TimerGameCalendar::Date date_of_last_service; ///< Last date the vehicle had a service at a depot.
+	TimerGameCalendar::Date date_of_last_service_newgrf; ///< Last date the vehicle had a service at a depot.
 	uint16 reliability;                 ///< Reliability.
 	uint16 reliability_spd_dec;         ///< Reliability decrease speed.
 	byte breakdown_ctr;                 ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown


### PR DESCRIPTION
## Motivation / Problem

Using the date cheat modifies the date of last service recorded against a vehicle. NewGRFs may use this variable to determine other properties.

## Description

This PR changes this by storing a copy of date_of_last_service which is not changed when the date cheat is used.

Unfortunately this must also be saved in the savegame and so requires a bump.

## Limitations

* Suspect this is a bit of a brute-force way to do this...
* Not actually tested.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
