### PR TITLE
Change: [CI] Automatically disable asserts when building a stable release

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -104,6 +104,9 @@ jobs:
 
     - name: Build
       run: |
+        # Automatically disable asserts for stable releases
+        IS_STABLE_TAG=$(if [ "$(cat .ottdrev | cut -f 6 -d$'\t')" = "1" ]; then echo "OFF"; else echo "ON"; fi)
+
         mkdir -p build
         cd build
 
@@ -112,6 +115,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DOPTION_PACKAGE_DEPENDENCIES=ON \
+          -DOPTION_USE_ASSERTS=${IS_STABLE_TAG} \
           # EOF
         echo "::endgroup::"
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -92,6 +92,9 @@ jobs:
 
     - name: Build arm64
       run: |
+        # Automatically disable asserts for stable releases
+        IS_STABLE_TAG=$(if [ "$(cat .ottdrev | cut -f 6 -d$'\t')" = "1" ]; then echo "OFF"; else echo "ON"; fi)
+
         mkdir build-arm64
         cd build-arm64
 
@@ -102,6 +105,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_USE_ASSERTS=${IS_STABLE_TAG} \
           # EOF
         echo "::endgroup::"
 
@@ -112,6 +116,9 @@ jobs:
 
     - name: Build x64
       run: |
+        # Automatically disable asserts for stable releases
+        IS_STABLE_TAG=$(if [ "$(cat .ottdrev | cut -f 6 -d$'\t')" = "1" ]; then echo "OFF"; else echo "ON"; fi)
+
         mkdir build-x64
         cd build-x64
 
@@ -122,6 +129,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DOPTION_USE_ASSERTS=${IS_STABLE_TAG} \
           -DCPACK_BUNDLE_APPLE_CERT_APP=${{ secrets.APPLE_DEVELOPER_CERTIFICATE_ID }} \
           "-DCPACK_BUNDLE_APPLE_CODESIGN_PARAMETER=--deep -f --options runtime" \
           -DAPPLE_UNIVERSAL_PACKAGE=1 \

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -117,6 +117,10 @@ jobs:
       if: inputs.is_tag == 'true'
       shell: bash
       run: |
+        # Automatically disable asserts for stable releases
+        # (Only needed with the installer, as this is only for tags)
+        IS_STABLE_TAG=$(if [ "$(cat .ottdrev | cut -f 6 -d$'\t')" = "1" ]; then echo "OFF"; else echo "ON"; fi)
+
         mkdir build
         cd build
 
@@ -126,6 +130,7 @@ jobs:
           -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static \
           -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" \
           -DOPTION_USE_NSIS=ON \
+          -DOPTION_USE_ASSERTS=${IS_STABLE_TAG} \
           -DHOST_BINARY_DIR=${GITHUB_WORKSPACE}/build-host \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DWINDOWS_CERTIFICATE_COMMON_NAME="${WINDOWS_CERTIFICATE_COMMON_NAME}" \


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

Remembering to turn off asserts for official releases is often a very last minute thing that has been forgotten entirely in the past on several occasions (most recently, 13.0)


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

Use the fact that when we build releases we already have a pre-written .ottdrev available. Parse that and turn off the cmake option as appropriate

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->
Not fully tested:

```
 $ echo -e "foo\tbar\tbaz\tquix\tqneez\t1\tflibble" > .ottdrev
 $ IS_STABLE_TAG=$(if [ "$(cat .ottdrev | cut -f 6 -d$'\t')" = "1" ]; then echo "OFF"; else echo "ON"; fi)
 $ echo $IS_STABLE_TAG
OFF
 $ echo -e "foo\tbar\tbaz\tquix\tqneez\t0\tflibble" > .ottdrev
 $ IS_STABLE_TAG=$(if [ "$(cat .ottdrev | cut -f 6 -d$'\t')" = "1" ]; then echo "OFF"; else echo "ON"; fi)
 $ echo $IS_STABLE_TAG
ON

```

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
