### PR TITLE
Change: [CI] Use a custom name for matrix runs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -69,24 +69,29 @@ jobs:
         echo "::endgroup::"
 
   linux:
-    name: Linux
-
     strategy:
       fail-fast: false
       matrix:
         include:
-        - compiler: clang
+        - name: Clang
+          compiler: clang
           cxxcompiler: clang++
-          libsdl: libsdl2-dev
-        - compiler: gcc
+          libraries: libsdl2-dev
+        - name: GCC - SDL2
+          compiler: gcc
           cxxcompiler: g++
-          libsdl: libsdl2-dev
-        - compiler: gcc
+          libraries: libsdl2-dev
+        - name: GCC - SDL1.2
+          compiler: gcc
           cxxcompiler: g++
-          libsdl: libsdl1.2-dev
-        - compiler: gcc
+          libraries: libsdl1.2-dev
+        - name: GCC - Dedicated
+          compiler: gcc
           cxxcompiler: g++
           extra-cmake-parameters: -DOPTION_DEDICATED=ON -DCMAKE_CXX_FLAGS_INIT="-DRANDOM_DEBUG"
+          # Compile without SDL / SDL2, as that should compile fine too.
+
+    name: Linux (${{ matrix.name }})
 
     runs-on: ubuntu-20.04
     env:
@@ -111,7 +116,7 @@ jobs:
           libicu-dev \
           liblzma-dev \
           liblzo2-dev \
-          ${{ matrix.libsdl }} \
+          ${{ matrix.libraries }} \
           zlib1g-dev \
           # EOF
         echo "::endgroup::"
@@ -156,14 +161,14 @@ jobs:
         ctest -j $(nproc) --timeout 120
 
   macos:
-    name: Mac OS
-
     strategy:
       fail-fast: false
       matrix:
         include:
         - arch: x64
           full_arch: x86_64
+
+    name: Mac OS (${{ matrix.arch }})
 
     runs-on: macos-latest
     env:
@@ -247,13 +252,13 @@ jobs:
         ctest -j $(sysctl -n hw.logicalcpu) --timeout 120
 
   windows:
-    name: Windows
-
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, windows-2019]
         arch: [x86, x64]
+
+    name: Windows (${{ matrix.os }} / ${{ matrix.arch }})
 
     runs-on: ${{ matrix.os }}
 
@@ -338,8 +343,6 @@ jobs:
 
 
   msys2:
-    name: msys2
-
     strategy:
       fail-fast: false
       matrix:
@@ -348,6 +351,8 @@ jobs:
             arch: x86_64
           - msystem: MINGW32
             arch: i686
+
+    name: MinGW (${{ matrix.arch }})
 
     runs-on: windows-latest
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -9,8 +9,6 @@ on:
 
 jobs:
   windows:
-    name: Windows
-
     strategy:
       fail-fast: false
       matrix:
@@ -21,6 +19,8 @@ jobs:
           host: x64
         - arch: arm64
           host: x64_arm64
+
+    name: Windows (${{ matrix.arch }}})
 
     runs-on: windows-latest
 


### PR DESCRIPTION
## Motivation / Problem

By default, GitHub adds all arguments of the matrix between (). This is fine sometimes, but in other times it becomes a very lengthy line.

## Description

With this commit, we decide what is between those (), making it a lot more readable.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
