### PR TITLE
Codechange: introduce C++ string accepting case insensitive string comparisons

### DIFF
--- a/src/ai/ai_scanner.cpp
+++ b/src/ai/ai_scanner.cpp
@@ -123,7 +123,7 @@ AIInfo *AIScannerInfo::FindInfo(const char *nameParam, int versionParam, bool fo
 	 *  version which allows loading the requested version */
 	for (const auto &item : this->info_list) {
 		AIInfo *i = static_cast<AIInfo *>(item.second);
-		if (strcasecmp(ai_name, i->GetName()) == 0 && i->CanLoadFromVersion(versionParam) && (version == -1 || i->GetVersion() > version)) {
+		if (StrEqualsIgnoreCase(ai_name, i->GetName()) && i->CanLoadFromVersion(versionParam) && (version == -1 || i->GetVersion() > version)) {
 			version = item.second->GetVersion();
 			info = i;
 		}

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -128,7 +128,7 @@ public:
 		Blitters::iterator it = GetBlitters().begin();
 		for (; it != GetBlitters().end(); it++) {
 			BlitterFactory *b = (*it).second;
-			if (strcasecmp(bname, b->name.c_str()) == 0) {
+			if (StrEqualsIgnoreCase(bname, b->name)) {
 				return b->IsUsable() ? b : nullptr;
 			}
 		}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1868,7 +1868,7 @@ static ContentType StringToContentType(const char *str)
 {
 	static const char * const inv_lookup[] = { "", "base", "newgrf", "ai", "ailib", "scenario", "heightmap" };
 	for (uint i = 1 /* there is no type 0 */; i < lengthof(inv_lookup); i++) {
-		if (strcasecmp(str, inv_lookup[i]) == 0) return (ContentType)i;
+		if (StrEqualsIgnoreCase(str, inv_lookup[i])) return (ContentType)i;
 	}
 	return CONTENT_TYPE_END;
 }
@@ -1926,17 +1926,17 @@ DEF_CONSOLE_CMD(ConContent)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "update") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "update")) {
 		_network_content_client.RequestContentList((argc > 2) ? StringToContentType(argv[2]) : CONTENT_TYPE_END);
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "upgrade") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "upgrade")) {
 		_network_content_client.SelectUpgrade();
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "select") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "select")) {
 		if (argc <= 2) {
 			/* List selected content */
 			IConsolePrint(CC_WHITE, "id, type, state, name");
@@ -1944,7 +1944,7 @@ DEF_CONSOLE_CMD(ConContent)
 				if ((*iter)->state != ContentInfo::SELECTED && (*iter)->state != ContentInfo::AUTOSELECTED) continue;
 				OutputContentState(*iter);
 			}
-		} else if (strcasecmp(argv[2], "all") == 0) {
+		} else if (StrEqualsIgnoreCase(argv[2], "all")) {
 			/* The intention of this function was that you could download
 			 * everything after a filter was applied; but this never really
 			 * took off. Instead, a select few people used this functionality
@@ -1958,12 +1958,12 @@ DEF_CONSOLE_CMD(ConContent)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "unselect") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "unselect")) {
 		if (argc <= 2) {
 			IConsolePrint(CC_ERROR, "You must enter the id.");
 			return false;
 		}
-		if (strcasecmp(argv[2], "all") == 0) {
+		if (StrEqualsIgnoreCase(argv[2], "all")) {
 			_network_content_client.UnselectAll();
 		} else {
 			_network_content_client.Unselect((ContentID)atoi(argv[2]));
@@ -1971,7 +1971,7 @@ DEF_CONSOLE_CMD(ConContent)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "state") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "state")) {
 		IConsolePrint(CC_WHITE, "id, type, state, name");
 		for (ConstContentIterator iter = _network_content_client.Begin(); iter != _network_content_client.End(); iter++) {
 			if (argc > 2 && strcasestr((*iter)->name.c_str(), argv[2]) == nullptr) continue;
@@ -1980,7 +1980,7 @@ DEF_CONSOLE_CMD(ConContent)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "download") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "download")) {
 		uint files;
 		uint bytes;
 		_network_content_client.DownloadSelectedContent(files, bytes);
@@ -2007,7 +2007,7 @@ DEF_CONSOLE_CMD(ConFont)
 
 	FontSize argfs;
 	for (argfs = FS_BEGIN; argfs < FS_END; argfs++) {
-		if (argc > 1 && strcasecmp(argv[1], FontSizeToName(argfs)) == 0) break;
+		if (argc > 1 && StrEqualsIgnoreCase(argv[1], FontSizeToName(argfs))) break;
 	}
 
 	/* First argument must be a FontSize. */
@@ -2021,7 +2021,7 @@ DEF_CONSOLE_CMD(ConFont)
 
 		byte arg_index = 2;
 		/* We may encounter "aa" or "noaa" but it must be the last argument. */
-		if (strcasecmp(argv[arg_index], "aa") == 0 || strcasecmp(argv[arg_index], "noaa") == 0) {
+		if (StrEqualsIgnoreCase(argv[arg_index], "aa") || StrEqualsIgnoreCase(argv[arg_index], "noaa")) {
 			aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
 			if (argc > arg_index) return false;
 		} else {
@@ -2043,7 +2043,7 @@ DEF_CONSOLE_CMD(ConFont)
 
 		if (argc > arg_index) {
 			/* Last argument must be "aa" or "noaa". */
-			if (strcasecmp(argv[arg_index], "aa") != 0 && strcasecmp(argv[arg_index], "noaa") != 0) return false;
+			if (!StrEqualsIgnoreCase(argv[arg_index], "aa") && !StrEqualsIgnoreCase(argv[arg_index], "noaa")) return false;
 			aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
 			if (argc > arg_index) return false;
 		}
@@ -2171,7 +2171,7 @@ DEF_CONSOLE_CMD(ConListDirs)
 
 	std::set<std::string> seen_dirs;
 	for (const SubdirNameMap &sdn : subdir_name_map) {
-		if (strcasecmp(argv[1], sdn.name) != 0)  continue;
+		if (!StrEqualsIgnoreCase(argv[1], sdn.name))  continue;
 		bool found = false;
 		for (Searchpath sp : _valid_searchpaths) {
 			/* Get the directory */
@@ -2256,7 +2256,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	/* "unselect" sub-command */
 	if (strncasecmp(argv[1], "uns", 3) == 0 && argc >= 3) {
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
-			if (strcasecmp(argv[argnum], "all") == 0) {
+			if (StrEqualsIgnoreCase(argv[argnum], "all")) {
 				_newgrf_profilers.clear();
 				break;
 			}
@@ -2501,17 +2501,17 @@ DEF_CONSOLE_CMD(ConDumpInfo)
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "roadtypes") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "roadtypes")) {
 		ConDumpRoadTypes();
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "railtypes") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "railtypes")) {
 		ConDumpRailTypes();
 		return true;
 	}
 
-	if (strcasecmp(argv[1], "cargotypes") == 0) {
+	if (StrEqualsIgnoreCase(argv[1], "cargotypes")) {
 		ConDumpCargoTypes();
 		return true;
 	}

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2022,7 +2022,7 @@ DEF_CONSOLE_CMD(ConFont)
 		byte arg_index = 2;
 		/* We may encounter "aa" or "noaa" but it must be the last argument. */
 		if (StrEqualsIgnoreCase(argv[arg_index], "aa") || StrEqualsIgnoreCase(argv[arg_index], "noaa")) {
-			aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
+			aa = !StrStartsWithIgnoreCase(argv[arg_index++], "no");
 			if (argc > arg_index) return false;
 		} else {
 			/* For <name> we want a string. */
@@ -2044,7 +2044,7 @@ DEF_CONSOLE_CMD(ConFont)
 		if (argc > arg_index) {
 			/* Last argument must be "aa" or "noaa". */
 			if (!StrEqualsIgnoreCase(argv[arg_index], "aa") && !StrEqualsIgnoreCase(argv[arg_index], "noaa")) return false;
-			aa = strncasecmp(argv[arg_index++], "no", 2) != 0;
+			aa = !StrStartsWithIgnoreCase(argv[arg_index++], "no");
 			if (argc > arg_index) return false;
 		}
 
@@ -2220,7 +2220,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	const std::vector<GRFFile *> &files = GetAllGRFFiles();
 
 	/* "list" sub-command */
-	if (argc == 1 || strncasecmp(argv[1], "lis", 3) == 0) {
+	if (argc == 1 || StrStartsWithIgnoreCase(argv[1], "lis")) {
 		IConsolePrint(CC_INFO, "Loaded GRF files:");
 		int i = 1;
 		for (GRFFile *grf : files) {
@@ -2236,7 +2236,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	}
 
 	/* "select" sub-command */
-	if (strncasecmp(argv[1], "sel", 3) == 0 && argc >= 3) {
+	if (StrStartsWithIgnoreCase(argv[1], "sel") && argc >= 3) {
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			int grfnum = atoi(argv[argnum]);
 			if (grfnum < 1 || grfnum > (int)files.size()) { // safe cast, files.size() should not be larger than a few hundred in the most extreme cases
@@ -2254,7 +2254,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	}
 
 	/* "unselect" sub-command */
-	if (strncasecmp(argv[1], "uns", 3) == 0 && argc >= 3) {
+	if (StrStartsWithIgnoreCase(argv[1], "uns") && argc >= 3) {
 		for (size_t argnum = 2; argnum < argc; ++argnum) {
 			if (StrEqualsIgnoreCase(argv[argnum], "all")) {
 				_newgrf_profilers.clear();
@@ -2273,7 +2273,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	}
 
 	/* "start" sub-command */
-	if (strncasecmp(argv[1], "sta", 3) == 0) {
+	if (StrStartsWithIgnoreCase(argv[1], "sta")) {
 		std::string grfids;
 		size_t started = 0;
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
@@ -2309,13 +2309,13 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 	}
 
 	/* "stop" sub-command */
-	if (strncasecmp(argv[1], "sto", 3) == 0) {
+	if (StrStartsWithIgnoreCase(argv[1], "sto")) {
 		NewGRFProfiler::FinishAll();
 		return true;
 	}
 
 	/* "abort" sub-command */
-	if (strncasecmp(argv[1], "abo", 3) == 0) {
+	if (StrStartsWithIgnoreCase(argv[1], "abo")) {
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
 			pr.Abort();
 		}

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -160,7 +160,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 			if (d->type != type) continue;
 
 			/* Check driver name */
-			if (strcasecmp(dname.c_str(), d->name) != 0) continue;
+			if (!StrEqualsIgnoreCase(dname, d->name)) continue;
 
 			/* Found our driver, let's try it */
 			Driver *newd = d->CreateInstance();

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1142,7 +1142,7 @@ static bool MatchesExtension(const char *extension, const char *filename)
 	if (extension == nullptr) return true;
 
 	const char *ext = strrchr(filename, extension[0]);
-	return ext != nullptr && strcasecmp(ext, extension) == 0;
+	return ext != nullptr && StrEqualsIgnoreCase(ext, extension);
 }
 
 /**

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -769,7 +769,7 @@ static bool ChangeWorkingDirectoryToExecutable(const char *exe)
 	bool success = false;
 #ifdef WITH_COCOA
 	char *app_bundle = strchr(tmp, '.');
-	while (app_bundle != nullptr && strncasecmp(app_bundle, ".app", 4) != 0) app_bundle = strchr(&app_bundle[1], '.');
+	while (app_bundle != nullptr && !StrStartsWithIgnoreCase(app_bundle, ".app")) app_bundle = strchr(&app_bundle[1], '.');
 
 	if (app_bundle != nullptr) *app_bundle = '\0';
 #endif /* WITH_COCOA */

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -386,7 +386,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 
 			/* found file must be directory, but not '.' or '..' */
 			if (FiosIsValidFile(_fios_path->c_str(), dirent, &sb) && S_ISDIR(sb.st_mode) &&
-					(!FiosIsHiddenFile(dirent) || strncasecmp(d_name, PERSONAL_DIR, strlen(d_name)) == 0) &&
+					(!FiosIsHiddenFile(dirent) || StrStartsWithIgnoreCase(PERSONAL_DIR, d_name)) &&
 					strcmp(d_name, ".") != 0 && strcmp(d_name, "..") != 0) {
 				fios = &file_list.emplace_back();
 				fios->type = FIOS_TYPE_DIR;

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -216,7 +216,7 @@ static std::string FiosMakeFilename(const std::string *path, const char *name, c
 
 	/* Don't append the extension if it is already there */
 	const char *period = strrchr(name, '.');
-	if (period != nullptr && strcasecmp(period, ext) == 0) ext = "";
+	if (period != nullptr && StrEqualsIgnoreCase(period, ext)) ext = "";
 
 	return buf + PATHSEP + name + ext;
 }
@@ -473,14 +473,14 @@ FiosType FiosGetSavegameListCallback(SaveLoadOperation fop, const std::string &f
 	/* Don't crash if we supply no extension */
 	if (ext == nullptr) return FIOS_TYPE_INVALID;
 
-	if (strcasecmp(ext, ".sav") == 0) {
+	if (StrEqualsIgnoreCase(ext, ".sav")) {
 		GetFileTitle(file, title, last, SAVE_DIR);
 		return FIOS_TYPE_FILE;
 	}
 
 	if (fop == SLO_LOAD) {
-		if (strcasecmp(ext, ".ss1") == 0 || strcasecmp(ext, ".sv1") == 0 ||
-				strcasecmp(ext, ".sv2") == 0) {
+		if (StrEqualsIgnoreCase(ext, ".ss1") || StrEqualsIgnoreCase(ext, ".sv1") ||
+				StrEqualsIgnoreCase(ext, ".sv2")) {
 			if (title != nullptr) GetOldSaveGameName(file, title, last);
 			return FIOS_TYPE_OLDFILE;
 		}
@@ -523,13 +523,13 @@ static FiosType FiosGetScenarioListCallback(SaveLoadOperation fop, const std::st
 	 * .SCN OpenTTD style scenario file
 	 * .SV0 Transport Tycoon Deluxe (Patch) scenario
 	 * .SS0 Transport Tycoon Deluxe preset scenario */
-	if (strcasecmp(ext, ".scn") == 0) {
+	if (StrEqualsIgnoreCase(ext, ".scn")) {
 		GetFileTitle(file, title, last, SCENARIO_DIR);
 		return FIOS_TYPE_SCENARIO;
 	}
 
 	if (fop == SLO_LOAD) {
-		if (strcasecmp(ext, ".sv0") == 0 || strcasecmp(ext, ".ss0") == 0 ) {
+		if (StrEqualsIgnoreCase(ext, ".sv0") || StrEqualsIgnoreCase(ext, ".ss0")) {
 			GetOldSaveGameName(file, title, last);
 			return FIOS_TYPE_OLD_SCENARIO;
 		}
@@ -568,10 +568,10 @@ static FiosType FiosGetHeightmapListCallback(SaveLoadOperation fop, const std::s
 	FiosType type = FIOS_TYPE_INVALID;
 
 #ifdef WITH_PNG
-	if (strcasecmp(ext, ".png") == 0) type = FIOS_TYPE_PNG;
+	if (StrEqualsIgnoreCase(ext, ".png")) type = FIOS_TYPE_PNG;
 #endif /* WITH_PNG */
 
-	if (strcasecmp(ext, ".bmp") == 0) type = FIOS_TYPE_BMP;
+	if (StrEqualsIgnoreCase(ext, ".bmp")) type = FIOS_TYPE_BMP;
 
 	if (type == FIOS_TYPE_INVALID) return FIOS_TYPE_INVALID;
 
@@ -760,7 +760,7 @@ FiosNumberedSaveName::FiosNumberedSaveName(const std::string &prefix) : prefix(p
 
 	/* Callback for FiosFileScanner. */
 	static fios_getlist_callback_proc *proc = [](SaveLoadOperation fop, const std::string &file, const char *ext, char *title, const char *last) {
-		if (strcasecmp(ext, ".sav") == 0 && StrStartsWith(file, _prefix)) return FIOS_TYPE_FILE;
+		if (StrEqualsIgnoreCase(ext, ".sav") && StrStartsWith(file, _prefix)) return FIOS_TYPE_FILE;
 		return FIOS_TYPE_INVALID;
 	};
 

--- a/src/game/game_scanner.cpp
+++ b/src/game/game_scanner.cpp
@@ -62,7 +62,7 @@ GameInfo *GameScannerInfo::FindInfo(const char *nameParam, int versionParam, boo
 	 *  version which allows loading the requested version */
 	for (const auto &item : this->info_list) {
 		GameInfo *i = static_cast<GameInfo *>(item.second);
-		if (strcasecmp(game_name, i->GetName()) == 0 && i->CanLoadFromVersion(versionParam) && (version == -1 || i->GetVersion() > version)) {
+		if (StrEqualsIgnoreCase(game_name, i->GetName()) && i->CanLoadFromVersion(versionParam) && (version == -1 || i->GetVersion() > version)) {
 			version = item.second->GetVersion();
 			info = i;
 		}

--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -99,8 +99,9 @@ static uint16 ParseCode(const char *start, const char *end)
 	assert(start <= end);
 	while (start < end && *start == ' ') start++;
 	while (end > start && *end == ' ') end--;
+	std::string_view str{start, (size_t)(start - end)};
 	for (uint i = 0; i < lengthof(_keycode_to_name); i++) {
-		if (strlen(_keycode_to_name[i].name) == (size_t)(end - start) && strncasecmp(start, _keycode_to_name[i].name, end - start) == 0) {
+		if (StrEqualsIgnoreCase(str, _keycode_to_name[i].name)) {
 			return _keycode_to_name[i].keycode;
 		}
 	}

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -421,7 +421,7 @@ struct NetworkChatWindow : public Window {
 			}
 
 			len = strlen(cur_name);
-			if (tb_len < len && strncasecmp(cur_name, tb_buf, tb_len) == 0) {
+			if (tb_len < len && StrStartsWith(cur_name, tb_buf)) {
 				/* Save the data it was before completion */
 				if (!second_scan) seprintf(_chat_tab_completion_buf, lastof(_chat_tab_completion_buf), "%s", tb->buf);
 				_chat_tab_completion_active = true;

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -630,7 +630,7 @@ bool GRFFileScanner::AddFile(const std::string &filename, size_t basepath_length
 				/* Because there can be multiple grfs with the same name, make sure we checked all grfs with the same name,
 				 *  before inserting the entry. So insert a new grf at the end of all grfs with the same name, instead of
 				 *  just after the first with the same name. Avoids doubles in the list. */
-				if (strcasecmp(c->GetName(), d->GetName()) <= 0) {
+				if (StrCompareIgnoreCase(c->GetName(), d->GetName()) <= 0) {
 					stop = true;
 				} else if (stop) {
 					break;

--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -70,12 +70,12 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 					FcPatternGetString(fs->fonts[i], FC_STYLE, 0, &style) == FcResultMatch) {
 
 					/* The correct style? */
-					if (font_style != nullptr && strcasecmp(font_style, (char *)style) != 0) continue;
+					if (font_style != nullptr && !StrEqualsIgnoreCase(font_style, (char *)style)) continue;
 
 					/* Font config takes the best shot, which, if the family name is spelled
 					 * wrongly a 'random' font, so check whether the family name is the
 					 * same as the supplied name */
-					if (strcasecmp(font_family, (char *)family) == 0) {
+					if (StrEqualsIgnoreCase(font_family, (char *)family)) {
 						err = FT_New_Face(_library, (char *)file, 0, face);
 					}
 				}

--- a/src/os/windows/font_win32.cpp
+++ b/src/os/windows/font_win32.cpp
@@ -134,9 +134,9 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 		err = FT_New_Face(_library, font_path, index, face);
 		if (err != FT_Err_Ok) break;
 
-		if (strncasecmp(font_name, (*face)->family_name, strlen((*face)->family_name)) == 0) break;
+		if (StrStartsWithIgnoreCase(font_name, (*face)->family_name)) break;
 		/* Try english name if font name failed */
-		if (strncasecmp(font_name + strlen(font_name) + 1, (*face)->family_name, strlen((*face)->family_name)) == 0) break;
+		if (StrStartsWithIgnoreCase(font_name + strlen(font_name) + 1, (*face)->family_name)) break;
 		err = FT_Err_Cannot_Open_Resource;
 
 	} while ((FT_Long)++index != (*face)->num_faces);

--- a/src/script/script_scanner.cpp
+++ b/src/script/script_scanner.cpp
@@ -115,7 +115,7 @@ void ScriptScanner::RegisterScript(ScriptInfo *info)
 		/* This script was already registered */
 #ifdef _WIN32
 		/* Windows doesn't care about the case */
-		if (strcasecmp(this->info_list[script_name]->GetMainScript(), info->GetMainScript()) == 0) {
+		if (StrEqualsIgnoreCase(this->info_list[script_name]->GetMainScript(), info->GetMainScript()) == 0) {
 #else
 		if (strcmp(this->info_list[script_name]->GetMainScript(), info->GetMainScript()) == 0) {
 #endif
@@ -231,7 +231,7 @@ static bool IsSameScript(const ContentInfo *ci, bool md5sum, ScriptInfo *info, S
 
 			/* Check the extension. */
 			const char *ext = strrchr(tar.first.c_str(), '.');
-			if (ext == nullptr || strcasecmp(ext, ".nut") != 0) continue;
+			if (ext == nullptr || !StrEqualsIgnoreCase(ext, ".nut")) continue;
 
 			checksum.AddFile(tar.first, 0, tar_filename);
 		}

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -37,10 +37,6 @@
 #	define _GNU_SOURCE
 #endif
 
-#if defined(__HAIKU__) || defined(__CYGWIN__)
-#	include <strings.h> /* strncasecmp */
-#endif
-
 /* It seems that we need to include stdint.h before anything else
  * We need INT64_MAX, which for most systems comes from stdint.h. However, MSVC
  * does not have stdint.h.
@@ -69,11 +65,6 @@
 
 #if defined(UNIX) || defined(__MINGW32__)
 #	include <sys/types.h>
-#endif
-
-#if defined(__OS2__)
-#	include <types.h>
-#	define strcasecmp stricmp
 #endif
 
 /* Stuff for GCC */
@@ -206,9 +197,6 @@
 #			define LZMA_API_STATIC
 #		endif
 #	endif
-
-#	define strcasecmp stricmp
-#	define strncasecmp strnicmp
 
 	/* MSVC doesn't have these :( */
 #	define S_ISDIR(mode) (mode & S_IFDIR)
@@ -409,11 +397,6 @@ void NORETURN AssertFailedError(int line, const char *file, const char *expressi
 #if defined(NDEBUG) && defined(WITH_ASSERT)
 #	undef assert
 #	define assert(expression) if (unlikely(!(expression))) AssertFailedError(__LINE__, __FILE__, #expression);
-#endif
-
-#if defined(OPENBSD)
-	/* OpenBSD uses strcasecmp(3) */
-#	define _stricmp strcasecmp
 #endif
 
 #if defined(MAX_PATH)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -23,26 +23,27 @@
 #include <iomanip>
 
 #ifdef _MSC_VER
-#include <errno.h> // required by vsnprintf implementation for MSVC
+#	include <errno.h> // required by vsnprintf implementation for MSVC
+#	define strncasecmp strnicmp
 #endif
 
 #ifdef _WIN32
-#include "os/windows/win32.h"
+#	include "os/windows/win32.h"
 #endif
 
 #ifdef WITH_UNISCRIBE
-#include "os/windows/string_uniscribe.h"
+#	include "os/windows/string_uniscribe.h"
 #endif
 
 #ifdef WITH_ICU_I18N
 /* Required by strnatcmp. */
-#include <unicode/ustring.h>
-#include "language.h"
-#include "gfx_func.h"
+#	include <unicode/ustring.h>
+#	include "language.h"
+#	include "gfx_func.h"
 #endif /* WITH_ICU_I18N */
 
 #if defined(WITH_COCOA)
-#include "os/macosx/string_osx.h"
+#	include "os/macosx/string_osx.h"
 #endif
 
 /* The function vsnprintf is used internally to perform the required formatting
@@ -356,6 +357,18 @@ bool StrStartsWith(const std::string_view str, const std::string_view prefix)
 }
 
 /**
+ * Check whether the given string starts with the given prefix, ignoring case.
+ * @param str    The string to look at.
+ * @param prefix The prefix to look for.
+ * @return True iff the begin of the string is the same as the prefix, ignoring case.
+ */
+bool StrStartsWithIgnoreCase(std::string_view str, const std::string_view prefix)
+{
+	if (str.size() < prefix.size()) return false;
+	return StrEqualsIgnoreCase(str.substr(0, prefix.size()), prefix);
+}
+
+/**
  * Check whether the given string ends with the given suffix.
  * @param str    The string to look at.
  * @param suffix The suffix to look for.
@@ -395,6 +408,18 @@ struct CaseInsensitiveCharTraits : public std::char_traits<char> {
 
 /** Case insensitive string view. */
 typedef std::basic_string_view<char, CaseInsensitiveCharTraits> CaseInsensitiveStringView;
+
+/**
+ * Check whether the given string ends with the given suffix, ignoring case.
+ * @param str    The string to look at.
+ * @param suffix The suffix to look for.
+ * @return True iff the end of the string is the same as the suffix, ignoring case.
+ */
+bool StrEndsWithIgnoreCase(std::string_view str, const std::string_view suffix)
+{
+	if (str.size() < suffix.size()) return false;
+	return StrEqualsIgnoreCase(str.substr(str.size() - suffix.size()), suffix);
+}
 
 /**
  * Compares two string( view)s, while ignoring the case of the characters.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -48,11 +48,13 @@ void str_strip_colours(char *str);
 bool strtolower(char *str);
 bool strtolower(std::string &str, std::string::size_type offs = 0);
 
-bool StrValid(const char *str, const char *last) NOACCESS(2);
+[[nodiscard]] bool StrValid(const char *str, const char *last) NOACCESS(2);
 void StrTrimInPlace(std::string &str);
 
-bool StrStartsWith(const std::string_view str, const std::string_view prefix);
-bool StrEndsWith(const std::string_view str, const std::string_view suffix);
+[[nodiscard]] bool StrStartsWith(const std::string_view str, const std::string_view prefix);
+[[nodiscard]] bool StrStartsWithIgnoreCase(std::string_view str, const std::string_view prefix);
+[[nodiscard]] bool StrEndsWith(const std::string_view str, const std::string_view suffix);
+[[nodiscard]] bool StrEndsWithIgnoreCase(std::string_view str, const std::string_view suffix);
 
 [[nodiscard]] int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str2);
 [[nodiscard]] bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str2);

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -54,6 +54,9 @@ void StrTrimInPlace(std::string &str);
 bool StrStartsWith(const std::string_view str, const std::string_view prefix);
 bool StrEndsWith(const std::string_view str, const std::string_view suffix);
 
+[[nodiscard]] int StrCompareIgnoreCase(const std::string_view str1, const std::string_view str2);
+[[nodiscard]] bool StrEqualsIgnoreCase(const std::string_view str1, const std::string_view str2);
+
 /**
  * Check if a string buffer is empty.
  *

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_test_files(
     landscape_partial_pixel_z.cpp
     math_func.cpp
+    string_func.cpp
     test_main.cpp
 )

--- a/src/tests/math_func.cpp
+++ b/src/tests/math_func.cpp
@@ -5,7 +5,7 @@
  * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file math_func_test.cpp Test functionality from core/math_func. */
+/** @file math_func.cpp Test functionality from core/math_func. */
 
 #include "../stdafx.h"
 

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -1,0 +1,160 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file string_func.cpp Test functionality from string_func. */
+
+#include "../stdafx.h"
+
+#include "../3rdparty/catch2/catch.hpp"
+
+#include "../string_func.h"
+
+TEST_CASE("StrCompareIgnoreCase - std::string")
+{
+	/* Same string, with different cases. */
+	CHECK(StrCompareIgnoreCase(std::string{""}, std::string{""}) == 0);
+	CHECK(StrCompareIgnoreCase(std::string{"a"}, std::string{"a"}) == 0);
+	CHECK(StrCompareIgnoreCase(std::string{"a"}, std::string{"A"}) == 0);
+	CHECK(StrCompareIgnoreCase(std::string{"A"}, std::string{"a"}) == 0);
+	CHECK(StrCompareIgnoreCase(std::string{"A"}, std::string{"A"}) == 0);
+
+	/* Not the same string. */
+	CHECK(StrCompareIgnoreCase(std::string{""}, std::string{"b"}) < 0);
+	CHECK(StrCompareIgnoreCase(std::string{"a"}, std::string{""}) > 0);
+
+	CHECK(StrCompareIgnoreCase(std::string{"a"}, std::string{"b"}) < 0);
+	CHECK(StrCompareIgnoreCase(std::string{"b"}, std::string{"a"}) > 0);
+	CHECK(StrCompareIgnoreCase(std::string{"a"}, std::string{"B"}) < 0);
+	CHECK(StrCompareIgnoreCase(std::string{"b"}, std::string{"A"}) > 0);
+	CHECK(StrCompareIgnoreCase(std::string{"A"}, std::string{"b"}) < 0);
+	CHECK(StrCompareIgnoreCase(std::string{"B"}, std::string{"a"}) > 0);
+
+	CHECK(StrCompareIgnoreCase(std::string{"a"}, std::string{"aa"}) < 0);
+	CHECK(StrCompareIgnoreCase(std::string{"aa"}, std::string{"a"}) > 0);
+}
+
+TEST_CASE("StrCompareIgnoreCase - char pointer")
+{
+	/* Same string, with different cases. */
+	CHECK(StrCompareIgnoreCase("", "") == 0);
+	CHECK(StrCompareIgnoreCase("a", "a") == 0);
+	CHECK(StrCompareIgnoreCase("a", "A") == 0);
+	CHECK(StrCompareIgnoreCase("A", "a") == 0);
+	CHECK(StrCompareIgnoreCase("A", "A") == 0);
+
+	/* Not the same string. */
+	CHECK(StrCompareIgnoreCase("", "b") < 0);
+	CHECK(StrCompareIgnoreCase("a", "") > 0);
+
+	CHECK(StrCompareIgnoreCase("a", "b") < 0);
+	CHECK(StrCompareIgnoreCase("b", "a") > 0);
+	CHECK(StrCompareIgnoreCase("a", "B") < 0);
+	CHECK(StrCompareIgnoreCase("b", "A") > 0);
+	CHECK(StrCompareIgnoreCase("A", "b") < 0);
+	CHECK(StrCompareIgnoreCase("B", "a") > 0);
+
+	CHECK(StrCompareIgnoreCase("a", "aa") < 0);
+	CHECK(StrCompareIgnoreCase("aa", "a") > 0);
+}
+
+TEST_CASE("StrCompareIgnoreCase - std::string_view")
+{
+	/*
+	 * With std::string_view the only way to access the data is via .data(),
+	 * which does not guarantee the termination that would be required by
+	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
+	 * or strcasecmp would fail if it does not account for the length of the
+	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * string but gets different sections to trigger these corner cases.
+	 */
+	std::string_view base{"aaAbB"};
+
+	/* Same string, with different cases. */
+	CHECK(StrCompareIgnoreCase(base.substr(0, 0), base.substr(1, 0)) == 0); // Different positions
+	CHECK(StrCompareIgnoreCase(base.substr(0, 1), base.substr(1, 1)) == 0); // Different positions
+	CHECK(StrCompareIgnoreCase(base.substr(0, 1), base.substr(2, 1)) == 0);
+	CHECK(StrCompareIgnoreCase(base.substr(2, 1), base.substr(1, 1)) == 0);
+	CHECK(StrCompareIgnoreCase(base.substr(2, 1), base.substr(2, 1)) == 0);
+
+	/* Not the same string. */
+	CHECK(StrCompareIgnoreCase(base.substr(3, 0), base.substr(3, 1)) < 0); // Same position, different lengths
+	CHECK(StrCompareIgnoreCase(base.substr(0, 1), base.substr(0, 0)) > 0); // Same position, different lengths
+
+	CHECK(StrCompareIgnoreCase(base.substr(0, 1), base.substr(3, 1)) < 0);
+	CHECK(StrCompareIgnoreCase(base.substr(3, 1), base.substr(0, 1)) > 0);
+	CHECK(StrCompareIgnoreCase(base.substr(0, 1), base.substr(4, 1)) < 0);
+	CHECK(StrCompareIgnoreCase(base.substr(3, 1), base.substr(2, 1)) > 0);
+	CHECK(StrCompareIgnoreCase(base.substr(2, 1), base.substr(3, 1)) < 0);
+	CHECK(StrCompareIgnoreCase(base.substr(4, 1), base.substr(0, 1)) > 0);
+
+	CHECK(StrCompareIgnoreCase(base.substr(0, 1), base.substr(0, 2)) < 0); // Same position, different lengths
+	CHECK(StrCompareIgnoreCase(base.substr(0, 2), base.substr(0, 1)) > 0); // Same position, different lengths
+}
+
+TEST_CASE("StrEqualsIgnoreCase - std::string")
+{
+	/* Same string, with different cases. */
+	CHECK(StrEqualsIgnoreCase(std::string{""}, std::string{""}));
+	CHECK(StrEqualsIgnoreCase(std::string{"a"}, std::string{"a"}));
+	CHECK(StrEqualsIgnoreCase(std::string{"a"}, std::string{"A"}));
+	CHECK(StrEqualsIgnoreCase(std::string{"A"}, std::string{"a"}));
+	CHECK(StrEqualsIgnoreCase(std::string{"A"}, std::string{"A"}));
+
+	/* Not the same string. */
+	CHECK(!StrEqualsIgnoreCase(std::string{""}, std::string{"b"}));
+	CHECK(!StrEqualsIgnoreCase(std::string{"a"}, std::string{""}));
+	CHECK(!StrEqualsIgnoreCase(std::string{"a"}, std::string{"b"}));
+	CHECK(!StrEqualsIgnoreCase(std::string{"b"}, std::string{"a"}));
+	CHECK(!StrEqualsIgnoreCase(std::string{"a"}, std::string{"aa"}));
+	CHECK(!StrEqualsIgnoreCase(std::string{"aa"}, std::string{"a"}));
+}
+
+TEST_CASE("StrEqualsIgnoreCase - char pointer")
+{
+	/* Same string, with different cases. */
+	CHECK(StrEqualsIgnoreCase("", ""));
+	CHECK(StrEqualsIgnoreCase("a", "a"));
+	CHECK(StrEqualsIgnoreCase("a", "A"));
+	CHECK(StrEqualsIgnoreCase("A", "a"));
+	CHECK(StrEqualsIgnoreCase("A", "A"));
+
+	/* Not the same string. */
+	CHECK(!StrEqualsIgnoreCase("", "b"));
+	CHECK(!StrEqualsIgnoreCase("a", ""));
+	CHECK(!StrEqualsIgnoreCase("a", "b"));
+	CHECK(!StrEqualsIgnoreCase("b", "a"));
+	CHECK(!StrEqualsIgnoreCase("a", "aa"));
+	CHECK(!StrEqualsIgnoreCase("aa", "a"));
+}
+
+TEST_CASE("StrEqualsIgnoreCase - std::string_view")
+{
+	/*
+	 * With std::string_view the only way to access the data is via .data(),
+	 * which does not guarantee the termination that would be required by
+	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
+	 * or strcasecmp would fail if it does not account for the length of the
+	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * string but gets different sections to trigger these corner cases.
+	 */
+	std::string_view base{"aaAb"};
+
+	/* Same string, with different cases. */
+	CHECK(StrEqualsIgnoreCase(base.substr(0, 0), base.substr(1, 0))); // Different positions
+	CHECK(StrEqualsIgnoreCase(base.substr(0, 1), base.substr(1, 1))); // Different positions
+	CHECK(StrEqualsIgnoreCase(base.substr(0, 1), base.substr(2, 1)));
+	CHECK(StrEqualsIgnoreCase(base.substr(2, 1), base.substr(1, 1)));
+	CHECK(StrEqualsIgnoreCase(base.substr(2, 1), base.substr(2, 1)));
+
+	/* Not the same string. */
+	CHECK(!StrEqualsIgnoreCase(base.substr(3, 0), base.substr(3, 1))); // Same position, different lengths
+	CHECK(!StrEqualsIgnoreCase(base.substr(0, 1), base.substr(0, 0)));
+	CHECK(!StrEqualsIgnoreCase(base.substr(0, 1), base.substr(3, 1)));
+	CHECK(!StrEqualsIgnoreCase(base.substr(3, 1), base.substr(0, 1)));
+	CHECK(!StrEqualsIgnoreCase(base.substr(0, 1), base.substr(0, 2))); // Same position, different lengths
+	CHECK(!StrEqualsIgnoreCase(base.substr(0, 2), base.substr(0, 1))); // Same position, different lengths
+}

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -13,6 +13,8 @@
 
 #include "../string_func.h"
 
+/**** String compare/equals *****/
+
 TEST_CASE("StrCompareIgnoreCase - std::string")
 {
 	/* Same string, with different cases. */
@@ -157,4 +159,360 @@ TEST_CASE("StrEqualsIgnoreCase - std::string_view")
 	CHECK(!StrEqualsIgnoreCase(base.substr(3, 1), base.substr(0, 1)));
 	CHECK(!StrEqualsIgnoreCase(base.substr(0, 1), base.substr(0, 2))); // Same position, different lengths
 	CHECK(!StrEqualsIgnoreCase(base.substr(0, 2), base.substr(0, 1))); // Same position, different lengths
+}
+
+/**** String starts with *****/
+
+TEST_CASE("StrStartsWith - std::string")
+{
+	/* Everything starts with an empty prefix. */
+	CHECK(StrStartsWith(std::string{""}, std::string{""}));
+	CHECK(StrStartsWith(std::string{"a"}, std::string{""}));
+
+	/* Equal strings. */
+	CHECK(StrStartsWith(std::string{"a"}, std::string{"a"}));
+	CHECK(StrStartsWith(std::string{"A"}, std::string{"A"}));
+
+	/* Starts with same. */
+	CHECK(StrStartsWith(std::string{"ab"}, std::string{"a"}));
+	CHECK(StrStartsWith(std::string{"Ab"}, std::string{"A"}));
+
+	/* Different cases. */
+	CHECK(!StrStartsWith(std::string{"a"}, std::string{"A"}));
+	CHECK(!StrStartsWith(std::string{"A"}, std::string{"a"}));
+	CHECK(!StrStartsWith(std::string{"ab"}, std::string{"A"}));
+	CHECK(!StrStartsWith(std::string{"Ab"}, std::string{"a"}));
+
+	/* Does not start the same. */
+	CHECK(!StrStartsWith(std::string{""}, std::string{"b"}));
+	CHECK(!StrStartsWith(std::string{"a"}, std::string{"b"}));
+	CHECK(!StrStartsWith(std::string{"b"}, std::string{"a"}));
+	CHECK(!StrStartsWith(std::string{"a"}, std::string{"aa"}));
+}
+
+TEST_CASE("StrStartsWith - char pointer")
+{
+	CHECK(StrStartsWith("", ""));
+	CHECK(StrStartsWith("a", ""));
+
+	/* Equal strings. */
+	CHECK(StrStartsWith("a", "a"));
+	CHECK(StrStartsWith("A", "A"));
+
+	/* Starts with same. */
+	CHECK(StrStartsWith("ab", "a"));
+	CHECK(StrStartsWith("Ab", "A"));
+
+	/* Different cases. */
+	CHECK(!StrStartsWith("a", "A"));
+	CHECK(!StrStartsWith("A", "a"));
+	CHECK(!StrStartsWith("ab", "A"));
+	CHECK(!StrStartsWith("Ab", "a"));
+
+	/* Does not start the same. */
+	CHECK(!StrStartsWith("", "b"));
+	CHECK(!StrStartsWith("a", "b"));
+	CHECK(!StrStartsWith("b", "a"));
+	CHECK(!StrStartsWith("a", "aa"));
+}
+
+TEST_CASE("StrStartsWith - std::string_view")
+{
+	/*
+	 * With std::string_view the only way to access the data is via .data(),
+	 * which does not guarantee the termination that would be required by
+	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
+	 * or strcasecmp would fail if it does not account for the length of the
+	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * string but gets different sections to trigger these corner cases.
+	 */
+	std::string_view base{"aabAb"};
+
+	/* Everything starts with an empty prefix. */
+	CHECK(StrStartsWith(base.substr(0, 0), base.substr(1, 0))); // Different positions
+	CHECK(StrStartsWith(base.substr(0, 1), base.substr(0, 0)));
+
+	/* Equals string. */
+	CHECK(StrStartsWith(base.substr(0, 1), base.substr(1, 1))); // Different positions
+	CHECK(StrStartsWith(base.substr(3, 1), base.substr(3, 1)));
+
+	/* Starts with same. */
+	CHECK(StrStartsWith(base.substr(1, 2), base.substr(0, 1)));
+	CHECK(StrStartsWith(base.substr(3, 2), base.substr(3, 1)));
+
+	/* Different cases. */
+	CHECK(!StrStartsWith(base.substr(0, 1), base.substr(3, 1)));
+	CHECK(!StrStartsWith(base.substr(3, 1), base.substr(0, 1)));
+	CHECK(!StrStartsWith(base.substr(1, 2), base.substr(3, 1)));
+	CHECK(!StrStartsWith(base.substr(3, 2), base.substr(0, 1)));
+
+	/* Does not start the same. */
+	CHECK(!StrStartsWith(base.substr(2, 0), base.substr(2, 1)));
+	CHECK(!StrStartsWith(base.substr(0, 1), base.substr(2, 1)));
+	CHECK(!StrStartsWith(base.substr(2, 1), base.substr(0, 1)));
+	CHECK(!StrStartsWith(base.substr(0, 1), base.substr(0, 2)));
+}
+
+
+TEST_CASE("StrStartsWithIgnoreCase - std::string")
+{
+	/* Everything starts with an empty prefix. */
+	CHECK(StrStartsWithIgnoreCase(std::string{""}, std::string{""}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"a"}, std::string{""}));
+
+	/* Equals string, ignoring case. */
+	CHECK(StrStartsWithIgnoreCase(std::string{"a"}, std::string{"a"}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"a"}, std::string{"A"}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"A"}, std::string{"a"}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"A"}, std::string{"A"}));
+
+	/* Starts with same, ignoring case. */
+	CHECK(StrStartsWithIgnoreCase(std::string{"ab"}, std::string{"a"}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"ab"}, std::string{"A"}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"Ab"}, std::string{"a"}));
+	CHECK(StrStartsWithIgnoreCase(std::string{"Ab"}, std::string{"A"}));
+
+	/* Does not start the same. */
+	CHECK(!StrStartsWithIgnoreCase(std::string{""}, std::string{"b"}));
+	CHECK(!StrStartsWithIgnoreCase(std::string{"a"}, std::string{"b"}));
+	CHECK(!StrStartsWithIgnoreCase(std::string{"b"}, std::string{"a"}));
+	CHECK(!StrStartsWithIgnoreCase(std::string{"a"}, std::string{"aa"}));
+}
+
+TEST_CASE("StrStartsWithIgnoreCase - char pointer")
+{
+	/* Everything starts with an empty prefix. */
+	CHECK(StrStartsWithIgnoreCase("", ""));
+	CHECK(StrStartsWithIgnoreCase("a", ""));
+
+	/* Equals string, ignoring case. */
+	CHECK(StrStartsWithIgnoreCase("a", "a"));
+	CHECK(StrStartsWithIgnoreCase("a", "A"));
+	CHECK(StrStartsWithIgnoreCase("A", "a"));
+	CHECK(StrStartsWithIgnoreCase("A", "A"));
+
+	/* Starts with same, ignoring case. */
+	CHECK(StrStartsWithIgnoreCase("ab", "a"));
+	CHECK(StrStartsWithIgnoreCase("ab", "A"));
+	CHECK(StrStartsWithIgnoreCase("Ab", "a"));
+	CHECK(StrStartsWithIgnoreCase("Ab", "A"));
+
+	/* Does not start the same. */
+	CHECK(!StrStartsWithIgnoreCase("", "b"));
+	CHECK(!StrStartsWithIgnoreCase("a", "b"));
+	CHECK(!StrStartsWithIgnoreCase("b", "a"));
+	CHECK(!StrStartsWithIgnoreCase("a", "aa"));
+}
+
+TEST_CASE("StrStartsWithIgnoreCase - std::string_view")
+{
+	/*
+	 * With std::string_view the only way to access the data is via .data(),
+	 * which does not guarantee the termination that would be required by
+	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
+	 * or strcasecmp would fail if it does not account for the length of the
+	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * string but gets different sections to trigger these corner cases.
+	 */
+	std::string_view base{"aabAb"};
+
+	/* Everything starts with an empty prefix. */
+	CHECK(StrStartsWithIgnoreCase(base.substr(0, 0), base.substr(1, 0))); // Different positions
+	CHECK(StrStartsWithIgnoreCase(base.substr(0, 1), base.substr(0, 0)));
+
+	/* Equals string, ignoring case. */
+	CHECK(StrStartsWithIgnoreCase(base.substr(0, 1), base.substr(1, 1))); // Different positions
+	CHECK(StrStartsWithIgnoreCase(base.substr(0, 1), base.substr(3, 1)));
+	CHECK(StrStartsWithIgnoreCase(base.substr(3, 1), base.substr(0, 1)));
+	CHECK(StrStartsWithIgnoreCase(base.substr(3, 1), base.substr(3, 1)));
+
+	/* Starts with same, ignoring case. */
+	CHECK(StrStartsWithIgnoreCase(base.substr(1, 2), base.substr(0, 1)));
+	CHECK(StrStartsWithIgnoreCase(base.substr(1, 2), base.substr(3, 1)));
+	CHECK(StrStartsWithIgnoreCase(base.substr(3, 2), base.substr(0, 1)));
+	CHECK(StrStartsWithIgnoreCase(base.substr(3, 2), base.substr(3, 1)));
+
+	/* Does not start the same. */
+	CHECK(!StrStartsWithIgnoreCase(base.substr(2, 0), base.substr(2, 1)));
+	CHECK(!StrStartsWithIgnoreCase(base.substr(0, 1), base.substr(2, 1)));
+	CHECK(!StrStartsWithIgnoreCase(base.substr(2, 1), base.substr(0, 1)));
+	CHECK(!StrStartsWithIgnoreCase(base.substr(0, 1), base.substr(0, 2)));
+}
+
+/**** String ends with *****/
+
+TEST_CASE("StrEndsWith - std::string")
+{
+	/* Everything ends with an empty prefix. */
+	CHECK(StrEndsWith(std::string{""}, std::string{""}));
+	CHECK(StrEndsWith(std::string{"a"}, std::string{""}));
+
+	/* Equal strings. */
+	CHECK(StrEndsWith(std::string{"a"}, std::string{"a"}));
+	CHECK(StrEndsWith(std::string{"A"}, std::string{"A"}));
+
+	/* Ends with same. */
+	CHECK(StrEndsWith(std::string{"ba"}, std::string{"a"}));
+	CHECK(StrEndsWith(std::string{"bA"}, std::string{"A"}));
+
+	/* Different cases. */
+	CHECK(!StrEndsWith(std::string{"a"}, std::string{"A"}));
+	CHECK(!StrEndsWith(std::string{"A"}, std::string{"a"}));
+	CHECK(!StrEndsWith(std::string{"ba"}, std::string{"A"}));
+	CHECK(!StrEndsWith(std::string{"bA"}, std::string{"a"}));
+
+	/* Does not end the same. */
+	CHECK(!StrEndsWith(std::string{""}, std::string{"b"}));
+	CHECK(!StrEndsWith(std::string{"a"}, std::string{"b"}));
+	CHECK(!StrEndsWith(std::string{"b"}, std::string{"a"}));
+	CHECK(!StrEndsWith(std::string{"a"}, std::string{"aa"}));
+}
+
+TEST_CASE("StrEndsWith - char pointer")
+{
+	CHECK(StrEndsWith("", ""));
+	CHECK(StrEndsWith("a", ""));
+
+	/* Equal strings. */
+	CHECK(StrEndsWith("a", "a"));
+	CHECK(StrEndsWith("A", "A"));
+
+	/* Ends with same. */
+	CHECK(StrEndsWith("ba", "a"));
+	CHECK(StrEndsWith("bA", "A"));
+
+	/* Different cases. */
+	CHECK(!StrEndsWith("a", "A"));
+	CHECK(!StrEndsWith("A", "a"));
+	CHECK(!StrEndsWith("ba", "A"));
+	CHECK(!StrEndsWith("bA", "a"));
+
+	/* Does not end the same. */
+	CHECK(!StrEndsWith("", "b"));
+	CHECK(!StrEndsWith("a", "b"));
+	CHECK(!StrEndsWith("b", "a"));
+	CHECK(!StrEndsWith("a", "aa"));
+}
+
+TEST_CASE("StrEndsWith - std::string_view")
+{
+	/*
+	 * With std::string_view the only way to access the data is via .data(),
+	 * which does not guarantee the termination that would be required by
+	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
+	 * or strcasecmp would fail if it does not account for the length of the
+	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * string but gets different sections to trigger these corner cases.
+	 */
+	std::string_view base{"aabAba"};
+
+	/* Everything ends with an empty prefix. */
+	CHECK(StrEndsWith(base.substr(0, 0), base.substr(1, 0))); // Different positions
+	CHECK(StrEndsWith(base.substr(0, 1), base.substr(0, 0)));
+
+	/* Equals string. */
+	CHECK(StrEndsWith(base.substr(0, 1), base.substr(1, 1))); // Different positions
+	CHECK(StrEndsWith(base.substr(3, 1), base.substr(3, 1)));
+
+	/* Ends with same. */
+	CHECK(StrEndsWith(base.substr(4, 2), base.substr(0, 1)));
+	CHECK(StrEndsWith(base.substr(2, 2), base.substr(3, 1)));
+
+	/* Different cases. */
+	CHECK(!StrEndsWith(base.substr(0, 1), base.substr(3, 1)));
+	CHECK(!StrEndsWith(base.substr(3, 1), base.substr(0, 1)));
+	CHECK(!StrEndsWith(base.substr(4, 2), base.substr(3, 1)));
+	CHECK(!StrEndsWith(base.substr(2, 2), base.substr(0, 1)));
+
+	/* Does not end the same. */
+	CHECK(!StrEndsWith(base.substr(2, 0), base.substr(2, 1)));
+	CHECK(!StrEndsWith(base.substr(0, 1), base.substr(2, 1)));
+	CHECK(!StrEndsWith(base.substr(2, 1), base.substr(0, 1)));
+	CHECK(!StrEndsWith(base.substr(0, 1), base.substr(0, 2)));
+}
+
+
+TEST_CASE("StrEndsWithIgnoreCase - std::string")
+{
+	/* Everything ends with an empty prefix. */
+	CHECK(StrEndsWithIgnoreCase(std::string{""}, std::string{""}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"a"}, std::string{""}));
+
+	/* Equals string, ignoring case. */
+	CHECK(StrEndsWithIgnoreCase(std::string{"a"}, std::string{"a"}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"a"}, std::string{"A"}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"A"}, std::string{"a"}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"A"}, std::string{"A"}));
+
+	/* Ends with same, ignoring case. */
+	CHECK(StrEndsWithIgnoreCase(std::string{"ba"}, std::string{"a"}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"ba"}, std::string{"A"}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"bA"}, std::string{"a"}));
+	CHECK(StrEndsWithIgnoreCase(std::string{"bA"}, std::string{"A"}));
+
+	/* Does not end the same. */
+	CHECK(!StrEndsWithIgnoreCase(std::string{""}, std::string{"b"}));
+	CHECK(!StrEndsWithIgnoreCase(std::string{"a"}, std::string{"b"}));
+	CHECK(!StrEndsWithIgnoreCase(std::string{"b"}, std::string{"a"}));
+	CHECK(!StrEndsWithIgnoreCase(std::string{"a"}, std::string{"aa"}));
+}
+
+TEST_CASE("StrEndsWithIgnoreCase - char pointer")
+{
+	/* Everything ends with an empty prefix. */
+	CHECK(StrEndsWithIgnoreCase("", ""));
+	CHECK(StrEndsWithIgnoreCase("a", ""));
+
+	/* Equals string, ignoring case. */
+	CHECK(StrEndsWithIgnoreCase("a", "a"));
+	CHECK(StrEndsWithIgnoreCase("a", "A"));
+	CHECK(StrEndsWithIgnoreCase("A", "a"));
+	CHECK(StrEndsWithIgnoreCase("A", "A"));
+
+	/* Ends with same, ignoring case. */
+	CHECK(StrEndsWithIgnoreCase("ba", "a"));
+	CHECK(StrEndsWithIgnoreCase("ba", "A"));
+	CHECK(StrEndsWithIgnoreCase("bA", "a"));
+	CHECK(StrEndsWithIgnoreCase("bA", "A"));
+
+	/* Does not end the same. */
+	CHECK(!StrEndsWithIgnoreCase("", "b"));
+	CHECK(!StrEndsWithIgnoreCase("a", "b"));
+	CHECK(!StrEndsWithIgnoreCase("b", "a"));
+	CHECK(!StrEndsWithIgnoreCase("a", "aa"));
+}
+
+TEST_CASE("StrEndsWithIgnoreCase - std::string_view")
+{
+	/*
+	 * With std::string_view the only way to access the data is via .data(),
+	 * which does not guarantee the termination that would be required by
+	 * things such as stricmp/strcasecmp. So, just passing .data() into stricmp
+	 * or strcasecmp would fail if it does not account for the length of the
+	 * view. Thus, contrary to the string/char* tests, this uses the same base
+	 * string but gets different sections to trigger these corner cases.
+	 */
+	std::string_view base{"aabAba"};
+
+	/* Everything ends with an empty prefix. */
+	CHECK(StrEndsWithIgnoreCase(base.substr(0, 0), base.substr(1, 0))); // Different positions
+	CHECK(StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(0, 0)));
+
+	/* Equals string, ignoring case. */
+	CHECK(StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(1, 1))); // Different positions
+	CHECK(StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(3, 1)));
+	CHECK(StrEndsWithIgnoreCase(base.substr(3, 1), base.substr(0, 1)));
+	CHECK(StrEndsWithIgnoreCase(base.substr(3, 1), base.substr(3, 1)));
+
+	/* Ends with same, ignoring case. */
+	CHECK(StrEndsWithIgnoreCase(base.substr(2, 2), base.substr(0, 1)));
+	CHECK(StrEndsWithIgnoreCase(base.substr(2, 2), base.substr(3, 1)));
+	CHECK(StrEndsWithIgnoreCase(base.substr(4, 2), base.substr(0, 1)));
+	CHECK(StrEndsWithIgnoreCase(base.substr(4, 2), base.substr(3, 1)));
+
+	/* Does not end the same. */
+	CHECK(!StrEndsWithIgnoreCase(base.substr(2, 0), base.substr(2, 1)));
+	CHECK(!StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(2, 1)));
+	CHECK(!StrEndsWithIgnoreCase(base.substr(2, 1), base.substr(0, 1)));
+	CHECK(!StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(0, 2)));
 }


### PR DESCRIPTION
## Motivation / Problem

https://github.com/OpenTTD/OpenTTD/pull/10667#discussion_r1170586829


## Description

Introduce `StrEqualsIgnoreCase`, `StrCompareIgnoreCase`, `StrStartsWithIgnoreCase` and `StrEndsWithIgnoreCase` that accept `std::string_view`, so it can be used with both C-style strings and `std::string`.
Replace instances of `strcasecmp` and `strncasecmp` with one of the new functions.
Add unit tests, due to the peculiarities that can occur when working with `std:string_view` and passing that to C-style functions.

## Limitations

Maybe Haiku, Cygwin or OS/2 failing to build?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
