### PR TITLE
Codechange: use fmt::format_to to populate some messages instead of seprintf

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -243,32 +243,32 @@ static void WriteSavegameInfo(const char *name)
 
 	GamelogInfo(_load_check_data.gamelog_action, _load_check_data.gamelog_actions, &last_ottd_rev, &ever_modified, &removed_newgrfs);
 
-	char buf[8192];
-	char *p = buf;
-	p += seprintf(p, lastof(buf), "Name:         %s\n", name);
-	p += seprintf(p, lastof(buf), "Savegame ver: %d\n", _sl_version);
-	p += seprintf(p, lastof(buf), "NewGRF ver:   0x%08X\n", last_ottd_rev);
-	p += seprintf(p, lastof(buf), "Modified:     %d\n", ever_modified);
+	std::string message;
+	message.reserve(1024);
+	fmt::format_to(std::back_inserter(message), "Name:         {}\n", name);
+	fmt::format_to(std::back_inserter(message), "Savegame ver: {}\n", _sl_version);
+	fmt::format_to(std::back_inserter(message), "NewGRF ver:   0x{:08X}\n", last_ottd_rev);
+	fmt::format_to(std::back_inserter(message), "Modified:     {}\n", ever_modified);
 
 	if (removed_newgrfs) {
-		p += seprintf(p, lastof(buf), "NewGRFs have been removed\n");
+		fmt::format_to(std::back_inserter(message), "NewGRFs have been removed\n");
 	}
 
-	p = strecpy(p, "NewGRFs:\n", lastof(buf));
+	message += "NewGRFs:\n";
 	if (_load_check_data.HasNewGrfs()) {
 		for (GRFConfig *c = _load_check_data.grfconfig; c != nullptr; c = c->next) {
 			char md5sum[33];
 			md5sumToString(md5sum, lastof(md5sum), HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum);
-			p += seprintf(p, lastof(buf), "%08X %s %s\n", c->ident.grfid, md5sum, c->filename);
+			fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", c->ident.grfid, md5sum, c->filename);
 		}
 	}
 
 	/* ShowInfo put output to stderr, but version information should go
 	 * to stdout; this is the only exception */
 #if !defined(_WIN32)
-	printf("%s\n", buf);
+	printf("%s\n", message.c_str());
 #else
-	ShowInfoI(buf);
+	ShowInfoI(message);
 #endif
 }
 


### PR DESCRIPTION
## Motivation / Problem

Changing NewGRF filenames to `std::string` would otherwire require `.c_str()` in these functions.


## Description

As the name says, use `fmt::format_to` to write to a `string` instead of `seprintf` to write to a `char buf[arbitrary-size]`.


## Limitations

Instead of the 8192 bytes absolute maximum, now your local memory is the limit. But it might reallocate during the construction. To prevent most reallocations, reserve 1024 bytes which should be enough for the most common cases.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
