### PR TITLE
Fix: FormatArrayAsHex returns gibberish instead of a hex array

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -135,14 +135,14 @@ char *stredup(const char *s, const char *last)
  */
 std::string FormatArrayAsHex(span<const byte> data)
 {
-	std::ostringstream ss;
-	ss << std::uppercase << std::setfill('0') << std::setw(2) << std::hex;
+	std::string str;
+	str.reserve(data.size() * 2 + 1);
 
 	for (auto b : data) {
-		ss << b;
+		fmt::format_to(std::back_inserter(str), "{:02X}", b);
 	}
 
-	return ss.str();
+	return str;
 }
 
 /**

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -12,6 +12,7 @@
 #include "../3rdparty/catch2/catch.hpp"
 
 #include "../string_func.h"
+#include <array>
 
 /**** String compare/equals *****/
 
@@ -515,4 +516,12 @@ TEST_CASE("StrEndsWithIgnoreCase - std::string_view")
 	CHECK(!StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(2, 1)));
 	CHECK(!StrEndsWithIgnoreCase(base.substr(2, 1), base.substr(0, 1)));
 	CHECK(!StrEndsWithIgnoreCase(base.substr(0, 1), base.substr(0, 2)));
+}
+
+
+TEST_CASE("FormatArrayAsHex")
+{
+	CHECK(FormatArrayAsHex(std::array<byte, 0>{}) == "");
+	CHECK(FormatArrayAsHex(std::array<byte, 1>{0x12}) == "12");
+	CHECK(FormatArrayAsHex(std::array<byte, 4>{0x13, 0x38, 0x42, 0xAF}) == "133842AF");
 }


### PR DESCRIPTION
## Motivation / Problem

Using `FormatArrayAsHex` yields gibberish; not even the first character is correct.

See the following unit-test result: 
```
-------------------------------------------------------------------------------
FormatArrayAsHex
-------------------------------------------------------------------------------
src/tests/string_func.cpp:521
...............................................................................

src/tests/string_func.cpp:524: FAILED:
  CHECK( FormatArrayAsHex(std::array<byte, 1>{0x12}) == "12" )
with expansion:
  "0" == "12"

src/tests/string_func.cpp:525: FAILED:
  CHECK( FormatArrayAsHex(std::array<byte, 4>{0x13, 0x38, 0x42, 0xAF}) == "133842AF" )
with expansion:
  "08B�" == "133842AF"
```

## Description

Use `fmt::format_to`, like in #10729, but as a separate PR so this can be backported.


## Limitations

Due to adding an unit test for `FormatArrayAsHex`, this depends on #10727 but only because that adds the unit test file for "string_func.cpp". When the unit test can be left out.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
