### PR TITLE
Codechange: remove need for stredup/free from GRFConfig/GRFFile

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1900,9 +1900,7 @@ static void OutputContentState(const ContentInfo *const ci)
 	static const char * const states[] = { "Not selected", "Selected", "Dep Selected", "Installed", "Unknown" };
 	static const TextColour state_to_colour[] = { CC_COMMAND, CC_INFO, CC_INFO, CC_WHITE, CC_ERROR };
 
-	char buf[sizeof(ci->md5sum) * 2 + 1];
-	md5sumToString(buf, lastof(buf), ci->md5sum);
-	IConsolePrint(state_to_colour[ci->state], "{}, {}, {}, {}, {:08X}, {}", ci->id, types[ci->type - 1], states[ci->state], ci->name, ci->unique_id, buf);
+	IConsolePrint(state_to_colour[ci->state], "{}, {}, {}, {}, {:08X}, {}", ci->id, types[ci->type - 1], states[ci->state], ci->name, ci->unique_id, MD5SumToString(ci->md5sum));
 }
 
 DEF_CONSOLE_CMD(ConContent)

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -301,8 +301,8 @@ char *CrashLog::LogLibraries(char *buffer, const char *last) const
  */
 char *CrashLog::LogGamelog(char *buffer, const char *last) const
 {
-	_gamelog.Print([&buffer, last](const char *s) {
-		buffer += seprintf(buffer, last, "%s\n", s);
+	_gamelog.Print([&buffer, last](const std::string &s) {
+		buffer += seprintf(buffer, last, "%s\n", s.c_str());
 	});
 	return buffer + seprintf(buffer, last, "\n");
 }

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -125,9 +125,7 @@ template <typename T>
 static void AddGrfInfo(T &outputIterator, uint grfid, const uint8 *md5sum, const GRFConfig *gc)
 {
 	if (md5sum != nullptr) {
-		char txt[40];
-		md5sumToString(txt, lastof(txt), md5sum);
-		fmt::format_to(outputIterator, "GRF ID {:08X}, checksum {}", BSWAP32(grfid), txt);
+		fmt::format_to(outputIterator, "GRF ID {:08X}, checksum {}", BSWAP32(grfid), MD5SumToString(md5sum));
 	} else {
 		fmt::format_to(outputIterator, "GRF ID {:08X}", BSWAP32(grfid));
 	}

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -65,7 +65,7 @@ public:
 
 	void Reset();
 
-	void Print(std::function<void(const char *)> proc);
+	void Print(std::function<void(const std::string &)> proc);
 	void PrintDebug(int level);
 	void PrintConsole();
 

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -71,7 +71,7 @@ const char *ContentInfo::GetTextfile(TextfileType type) const
 			break;
 		case CONTENT_TYPE_NEWGRF: {
 			const GRFConfig *gc = FindGRFConfig(BSWAP32(this->unique_id), FGCM_EXACT, this->md5sum);
-			tmp = gc != nullptr ? gc->filename : nullptr;
+			tmp = gc != nullptr ? gc->filename.c_str() : nullptr;
 			break;
 		}
 		case CONTENT_TYPE_BASE_GRAPHICS:

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -666,9 +666,7 @@ NetworkRecvStatus ClientNetworkGameSocketHandler::Receive_SERVER_CHECK_NEWGRFS(P
 		const GRFConfig *f = FindGRFConfig(c.grfid, FGCM_EXACT, c.md5sum);
 		if (f == nullptr) {
 			/* We do not know this GRF, bail out of initialization */
-			char buf[sizeof(c.md5sum) * 2 + 1];
-			md5sumToString(buf, lastof(buf), c.md5sum);
-			Debug(grf, 0, "NewGRF {:08X} not found; checksum {}", BSWAP32(c.grfid), buf);
+			Debug(grf, 0, "NewGRF {:08X} not found; checksum {}", BSWAP32(c.grfid), MD5SumToString(c.md5sum));
 			ret = NETWORK_RECV_STATUS_NEWGRF_MISMATCH;
 		}
 	}

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -365,9 +365,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 				if (!first) url.push_back(',');
 				first = false;
 
-				char buf[33];
-				md5sumToString(buf, lastof(buf), ci->md5sum);
-				fmt::format_to(std::back_inserter(url), "{:08X}:{}", ci->unique_id, buf);
+				fmt::format_to(std::back_inserter(url), "{:08X}:{}", ci->unique_id, MD5SumToString(ci->md5sum));
 			}
 		} else {
 			url += "do=searchtext&q=";

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -415,10 +415,10 @@ static GRFFile *GetFileByGRFID(uint32 grfid)
  * @param filename The filename to obtain the file for.
  * @return The file.
  */
-static GRFFile *GetFileByFilename(const char *filename)
+static GRFFile *GetFileByFilename(const std::string &filename)
 {
 	for (GRFFile * const file : _grf_files) {
-		if (strcmp(file->filename, filename) == 0) return file;
+		if (file->filename == filename) return file;
 	}
 	return nullptr;
 }
@@ -8883,7 +8883,7 @@ static void InitNewGRFFile(const GRFConfig *config)
  */
 GRFFile::GRFFile(const GRFConfig *config)
 {
-	this->filename = stredup(config->filename);
+	this->filename = config->filename;
 	this->grfid = config->ident.grfid;
 
 	/* Initialise local settings to defaults */
@@ -8923,7 +8923,6 @@ GRFFile::GRFFile(const GRFConfig *config)
 
 GRFFile::~GRFFile()
 {
-	free(this->filename);
 	delete[] this->language_map;
 }
 
@@ -9187,7 +9186,7 @@ static void FinaliseCargoArray()
  * @param filename The filename of the newgrf this house was defined in.
  * @return Whether the given housespec is valid.
  */
-static bool IsHouseSpecValid(HouseSpec *hs, const HouseSpec *next1, const HouseSpec *next2, const HouseSpec *next3, const char *filename)
+static bool IsHouseSpecValid(HouseSpec *hs, const HouseSpec *next1, const HouseSpec *next2, const HouseSpec *next3, const std::string &filename)
 {
 	if (((hs->building_flags & BUILDING_HAS_2_TILES) != 0 &&
 				(next1 == nullptr || !next1->enabled || (next1->building_flags & BUILDING_HAS_1_TILE) != 0)) ||
@@ -9195,7 +9194,7 @@ static bool IsHouseSpecValid(HouseSpec *hs, const HouseSpec *next1, const HouseS
 				(next2 == nullptr || !next2->enabled || (next2->building_flags & BUILDING_HAS_1_TILE) != 0 ||
 				next3 == nullptr || !next3->enabled || (next3->building_flags & BUILDING_HAS_1_TILE) != 0))) {
 		hs->enabled = false;
-		if (filename != nullptr) Debug(grf, 1, "FinaliseHouseArray: {} defines house {} as multitile, but no suitable tiles follow. Disabling house.", filename, hs->grf_prop.local_id);
+		if (!filename.empty()) Debug(grf, 1, "FinaliseHouseArray: {} defines house {} as multitile, but no suitable tiles follow. Disabling house.", filename, hs->grf_prop.local_id);
 		return false;
 	}
 
@@ -9205,13 +9204,13 @@ static bool IsHouseSpecValid(HouseSpec *hs, const HouseSpec *next1, const HouseS
 	if (((hs->building_flags & BUILDING_HAS_2_TILES) != 0 && next1->population != 0) ||
 			((hs->building_flags & BUILDING_HAS_4_TILES) != 0 && (next2->population != 0 || next3->population != 0))) {
 		hs->enabled = false;
-		if (filename != nullptr) Debug(grf, 1, "FinaliseHouseArray: {} defines multitile house {} with non-zero population on additional tiles. Disabling house.", filename, hs->grf_prop.local_id);
+		if (!filename.empty()) Debug(grf, 1, "FinaliseHouseArray: {} defines multitile house {} with non-zero population on additional tiles. Disabling house.", filename, hs->grf_prop.local_id);
 		return false;
 	}
 
 	/* Substitute type is also used for override, and having an override with a different size causes crashes.
 	 * This check should only be done for NewGRF houses because grf_prop.subst_id is not set for original houses.*/
-	if (filename != nullptr && (hs->building_flags & BUILDING_HAS_1_TILE) != (HouseSpec::Get(hs->grf_prop.subst_id)->building_flags & BUILDING_HAS_1_TILE)) {
+	if (!filename.empty() && (hs->building_flags & BUILDING_HAS_1_TILE) != (HouseSpec::Get(hs->grf_prop.subst_id)->building_flags & BUILDING_HAS_1_TILE)) {
 		hs->enabled = false;
 		Debug(grf, 1, "FinaliseHouseArray: {} defines house {} with different house size then it's substitute type. Disabling house.", filename, hs->grf_prop.local_id);
 		return false;
@@ -9220,7 +9219,7 @@ static bool IsHouseSpecValid(HouseSpec *hs, const HouseSpec *next1, const HouseS
 	/* Make sure that additional parts of multitile houses are not available. */
 	if ((hs->building_flags & BUILDING_HAS_1_TILE) == 0 && (hs->building_availability & HZ_ZONALL) != 0 && (hs->building_availability & HZ_CLIMALL) != 0) {
 		hs->enabled = false;
-		if (filename != nullptr) Debug(grf, 1, "FinaliseHouseArray: {} defines house {} without a size but marked it as available. Disabling house.", filename, hs->grf_prop.local_id);
+		if (!filename.empty()) Debug(grf, 1, "FinaliseHouseArray: {} defines house {} without a size but marked it as available. Disabling house.", filename, hs->grf_prop.local_id);
 		return false;
 	}
 
@@ -9298,7 +9297,7 @@ static void FinaliseHouseArray()
 
 		/* We need to check all houses again to we are sure that multitile houses
 		 * did get consecutive IDs and none of the parts are missing. */
-		if (!IsHouseSpecValid(hs, next1, next2, next3, nullptr)) {
+		if (!IsHouseSpecValid(hs, next1, next2, next3, std::string{})) {
 			/* GetHouseNorthPart checks 3 houses that are directly before
 			 * it in the house pool. If any of those houses have multi-tile
 			 * flags set it assumes it's part of a multitile house. Since
@@ -9607,7 +9606,7 @@ static void LoadNewGRFFileFromFile(GRFConfig *config, GrfLoadingStage stage, Spr
  */
 void LoadNewGRFFile(GRFConfig *config, GrfLoadingStage stage, Subdirectory subdir, bool temporary)
 {
-	const char *filename = config->filename;
+	const std::string &filename = config->filename;
 
 	/* A .grf file is activated only if it was active when the game was
 	 * started.  If a game is loaded, only its active .grfs will be

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -105,7 +105,7 @@ struct GRFLabel {
 
 /** Dynamic data of a loaded NewGRF */
 struct GRFFile : ZeroedMemoryAllocator {
-	char *filename;
+	std::string filename;
 	uint32 grfid;
 	byte grf_version;
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -517,14 +517,11 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfig *grfconfig)
 	for (GRFConfig *c = grfconfig; c != nullptr; c = c->next) {
 		const GRFConfig *f = FindGRFConfig(c->ident.grfid, FGCM_EXACT, c->ident.md5sum);
 		if (f == nullptr || HasBit(f->flags, GCF_INVALID)) {
-			char buf[256];
-
 			/* If we have not found the exactly matching GRF try to find one with the
 			 * same grfid, as it most likely is compatible */
 			f = FindGRFConfig(c->ident.grfid, FGCM_COMPATIBLE, nullptr, c->version);
 			if (f != nullptr) {
-				md5sumToString(buf, lastof(buf), c->ident.md5sum);
-				Debug(grf, 1, "NewGRF {:08X} ({}) not found; checksum {}. Compatibility mode on", BSWAP32(c->ident.grfid), c->filename, buf);
+				Debug(grf, 1, "NewGRF {:08X} ({}) not found; checksum {}. Compatibility mode on", BSWAP32(c->ident.grfid), c->filename, MD5SumToString(c->ident.md5sum));
 				if (!HasBit(c->flags, GCF_COMPATIBLE)) {
 					/* Preserve original_md5sum after it has been assigned */
 					SetBit(c->flags, GCF_COMPATIBLE);
@@ -537,8 +534,7 @@ GRFListCompatibility IsGoodGRFConfigList(GRFConfig *grfconfig)
 			}
 
 			/* No compatible grf was found, mark it as disabled */
-			md5sumToString(buf, lastof(buf), c->ident.md5sum);
-			Debug(grf, 0, "NewGRF {:08X} ({}) not found; checksum {}", BSWAP32(c->ident.grfid), c->filename, buf);
+			Debug(grf, 0, "NewGRF {:08X} ({}) not found; checksum {}", BSWAP32(c->ident.grfid), c->filename, MD5SumToString(c->ident.md5sum));
 
 			c->status = GCS_NOT_FOUND;
 			res = GLC_NOT_FOUND;

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -64,7 +64,7 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	MemCpyT<uint8>(this->original_md5sum, config.original_md5sum, lengthof(this->original_md5sum));
 	MemCpyT<uint32>(this->param, config.param, lengthof(this->param));
 	if (config.filename != nullptr) this->filename = stredup(config.filename);
-	if (config.error != nullptr) this->error = new GRFError(*config.error);
+	if (config.error != nullptr) this->error = std::make_unique<GRFError>(*config.error);
 	for (uint i = 0; i < config.param_info.size(); i++) {
 		if (config.param_info[i] == nullptr) {
 			this->param_info.push_back(nullptr);
@@ -80,7 +80,6 @@ GRFConfig::~GRFConfig()
 	/* GCF_COPY as in NOT stredupped/alloced the filename */
 	if (!HasBit(this->flags, GCF_COPY)) {
 		free(this->filename);
-		delete this->error;
 	}
 
 	for (uint i = 0; i < this->param_info.size(); i++) delete this->param_info[i];

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -166,7 +166,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	GRFTextWrapper name;                        ///< NOSAVE: GRF name (Action 0x08)
 	GRFTextWrapper info;                        ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
 	GRFTextWrapper url;                         ///< NOSAVE: URL belonging to this GRF.
-	GRFError *error;                            ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
+	std::unique_ptr<GRFError> error;            ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
 
 	uint32 version;                             ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
 	uint32 min_loadable_version;                ///< NOSAVE: Minimum compatible version a NewGRF can define

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -153,7 +153,7 @@ struct GRFParameterInfo {
 
 /** Information about GRF, used in the game and (part of it) in savegames */
 struct GRFConfig : ZeroedMemoryAllocator {
-	GRFConfig(const char *filename = nullptr);
+	GRFConfig(const std::string &filename = std::string{});
 	GRFConfig(const GRFConfig &config);
 	~GRFConfig();
 
@@ -162,7 +162,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 
 	GRFIdentifier ident;                        ///< grfid and md5sum to uniquely identify newgrfs
 	uint8 original_md5sum[16];                  ///< MD5 checksum of original file if only a 'compatible' file was loaded
-	char *filename;                             ///< Filename - either with or without full path
+	std::string filename;                       ///< Filename - either with or without full path
 	GRFTextWrapper name;                        ///< NOSAVE: GRF name (Action 0x08)
 	GRFTextWrapper info;                        ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
 	GRFTextWrapper url;                         ///< NOSAVE: URL belonging to this GRF.

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -92,9 +92,8 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 	}
 
 	/* Prepare and draw GRF ID */
-	char buff[256];
-	seprintf(buff, lastof(buff), "%08X", BSWAP32(c->ident.grfid));
-	SetDParamStr(0, buff);
+	std::string tmp = fmt::format("{:08X}", BSWAP32(c->ident.grfid));
+	SetDParamStr(0, tmp);
 	tr.top = DrawStringMultiLine(tr, STR_NEWGRF_SETTINGS_GRF_ID);
 
 	if ((_settings_client.gui.newgrf_developer_tools || _settings_client.gui.newgrf_show_old_versions) && c->version != 0) {
@@ -107,13 +106,14 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 	}
 
 	/* Prepare and draw MD5 sum */
-	md5sumToString(buff, lastof(buff), c->ident.md5sum);
-	SetDParamStr(0, buff);
+	tmp = MD5SumToString(c->ident.md5sum);
+	SetDParamStr(0, tmp);
 	tr.top = DrawStringMultiLine(tr, STR_NEWGRF_SETTINGS_MD5SUM);
 
 	/* Show GRF parameter list */
 	if (show_params) {
 		if (c->num_params > 0) {
+			char buff[256];
 			GRFBuildParamList(buff, c, lastof(buff));
 			SetDParam(0, STR_JUST_RAW_STRING);
 			SetDParamStr(1, buff);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -86,7 +86,7 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 	}
 
 	/* Draw filename or not if it is not known (GRF sent over internet) */
-	if (c->filename != nullptr) {
+	if (!c->filename.empty()) {
 		SetDParamStr(0, c->filename);
 		tr.top = DrawStringMultiLine(tr, STR_NEWGRF_SETTINGS_FILENAME);
 	}
@@ -1442,7 +1442,7 @@ private:
 	{
 		filter.ResetState();
 		filter.AddLine((*a)->GetName());
-		filter.AddLine((*a)->filename);
+		filter.AddLine((*a)->filename.c_str());
 		filter.AddLine((*a)->GetDescription());
 		return filter.GetState();;
 	}

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -257,9 +257,8 @@ static void WriteSavegameInfo(const char *name)
 	message += "NewGRFs:\n";
 	if (_load_check_data.HasNewGrfs()) {
 		for (GRFConfig *c = _load_check_data.grfconfig; c != nullptr; c = c->next) {
-			char md5sum[33];
-			md5sumToString(md5sum, lastof(md5sum), HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum);
-			fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", c->ident.grfid, md5sum, c->filename);
+			fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", c->ident.grfid,
+				MD5SumToString(HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum), c->filename);
 		}
 	}
 

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -388,16 +388,12 @@ static void CDECL HandleSavegameLoadCrash(int signum)
 		for (const GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
 			if (HasBit(c->flags, GCF_COMPATIBLE)) {
 				const GRFIdentifier *replaced = _gamelog.GetOverriddenIdentifier(c);
-				char original_md5[40];
-				char replaced_md5[40];
-				md5sumToString(original_md5, lastof(original_md5), c->original_md5sum);
-				md5sumToString(replaced_md5, lastof(replaced_md5), replaced->md5sum);
-				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n", BSWAP32(c->ident.grfid), original_md5, c->filename, replaced_md5);
+				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} (checksum {}) not found.\n  Loaded NewGRF \"{}\" (checksum {}) with same GRF ID instead.\n",
+						BSWAP32(c->ident.grfid), MD5SumToString(c->original_md5sum), c->filename, MD5SumToString(replaced->md5sum));
 			}
 			if (c->status == GCS_NOT_FOUND) {
-				char buf[40];
-				md5sumToString(buf, lastof(buf), c->ident.md5sum);
-				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} ({}) not found; checksum {}.\n", BSWAP32(c->ident.grfid), c->filename, buf);
+				fmt::format_to(std::back_inserter(message), "NewGRF {:08X} ({}) not found; checksum {}.\n",
+						BSWAP32(c->ident.grfid), c->filename, MD5SumToString(c->ident.md5sum));
 			}
 		}
 	} else {

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -320,9 +320,7 @@ static bool MakePNGImage(const char *name, ScreenshotCallback *callb, void *user
 	fmt::format_to(std::back_inserter(message), "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
 	message += "NewGRFs:\n";
 	for (const GRFConfig *c = _game_mode == GM_MENU ? nullptr : _grfconfig; c != nullptr; c = c->next) {
-		char buf[33];
-		md5sumToString(buf, lastof(buf), c->ident.md5sum);
-		fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", BSWAP32(c->ident.grfid), buf, c->filename);
+		fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", BSWAP32(c->ident.grfid), MD5SumToString(c->ident.md5sum), c->filename);
 	}
 	message += "\nCompanies:\n";
 	for (const Company *c : Company::Iterate()) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1133,14 +1133,11 @@ static void GRFSaveConfig(IniFile &ini, const char *grpname, const GRFConfig *li
 	const GRFConfig *c;
 
 	for (c = list; c != nullptr; c = c->next) {
-		/* Hex grfid (4 bytes in nibbles), "|", hex md5sum (16 bytes in nibbles), "|", file system path. */
-		char key[4 * 2 + 1 + 16 * 2 + 1 + MAX_PATH];
 		char params[512];
 		GRFBuildParamList(params, c, lastof(params));
 
-		char *pos = key + seprintf(key, lastof(key), "%08X|", BSWAP32(c->ident.grfid));
-		pos = md5sumToString(pos, lastof(key), c->ident.md5sum);
-		seprintf(pos, lastof(key), "|%s", c->filename);
+		std::string key = fmt::format("{:08X}|{}|{}", BSWAP32(c->ident.grfid),
+				MD5SumToString(c->ident.md5sum), c->filename);
 		group->GetItem(key, true)->SetValue(params);
 	}
 }

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -612,20 +612,12 @@ int CDECL seprintf(char *str, const char *last, const char *format, ...)
 
 /**
  * Convert the md5sum to a hexadecimal string representation
- * @param buf buffer to put the md5sum into
- * @param last last character of buffer (usually lastof(buf))
  * @param md5sum the md5sum itself
- * @return a pointer to the next character after the md5sum
+ * @return the string representation of the md5sum.
  */
-char *md5sumToString(char *buf, const char *last, const uint8 md5sum[16])
+std::string MD5SumToString(const uint8 md5sum[16])
 {
-	char *p = buf;
-
-	for (uint i = 0; i < 16; i++) {
-		p += seprintf(p, last, "%02X", md5sum[i]);
-	}
-
-	return p;
+	return FormatArrayAsHex({md5sum, 16});
 }
 
 

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -86,7 +86,7 @@ static inline size_t ttd_strnlen(const char *str, size_t maxlen)
 	return t - str;
 }
 
-char *md5sumToString(char *buf, const char *last, const uint8 md5sum[16]);
+std::string MD5SumToString(const uint8 md5sum[16]);
 
 bool IsValidChar(WChar key, CharSetFilter afilter);
 


### PR DESCRIPTION
## Motivation / Problem

Some manual filename/error memory management in GRFConfig and GRFFile, and especially the long term vision of replacing C-style constructs with C++ style constructs.


## Description

Replace GRFConfig's error pointer with a `std::unique_ptr`, which contrary to what some comments imply is not copied.
Replace GRFConfig and GRFFile's filename `char *` with `std::string`, and replace `stredup` with assigments. Furthermore replace some `strcmp` with `==` from `std::string`.

Replace the `seprintf` style MD5 checksum printing with `std::string` and using `FormatArrayAsHex`. This is primarily done to ease the migration to C++ style string formatting, which was needed to prevent some additions of `.c_str()` in the PR.


## Limitations

None that I am aware of.
Well, maybe the MD5 checksum should be it's own PR, but then I'm stacking PRs on top of eachother again making my life harder, and all in all this isn't that big I think.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
