### PR TITLE
Fix 4dd5f994: hotkey parsing was broken

### DIFF
--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -99,7 +99,7 @@ static uint16 ParseCode(const char *start, const char *end)
 	assert(start <= end);
 	while (start < end && *start == ' ') start++;
 	while (end > start && *end == ' ') end--;
-	std::string_view str{start, (size_t)(start - end)};
+	std::string_view str{start, (size_t)(end - start)};
 	for (uint i = 0; i < lengthof(_keycode_to_name); i++) {
 		if (StrEqualsIgnoreCase(str, _keycode_to_name[i].name)) {
 			return _keycode_to_name[i].keycode;


### PR DESCRIPTION
## Motivation / Problem

I broke hotkey parsing in 4dd5f994, by switching math up.


## Description

Math got switch around.


## Limitations

Doesn't restore anyone's trashed hotkeys for the past few revisions.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
