### PR TITLE
Codechange: Pass more std::string to StringFilter::AddLine()

### DIFF
--- a/src/industry.h
+++ b/src/industry.h
@@ -184,10 +184,10 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 		memset(&counts, 0, sizeof(counts));
 	}
 
-	inline const char *GetCachedName() const
+	inline const std::string &GetCachedName() const
 	{
 		if (this->cached_name.empty()) this->FillCachedName();
-		return this->cached_name.c_str();
+		return this->cached_name;
 	}
 
 private:

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -467,9 +467,9 @@ class NetworkContentListWindow : public Window, ContentCallback {
 	static bool CDECL TagNameFilter(const ContentInfo * const *a, ContentListFilterData &filter)
 	{
 		filter.string_filter.ResetState();
-		for (auto &tag : (*a)->tags) filter.string_filter.AddLine(tag.c_str());
+		for (auto &tag : (*a)->tags) filter.string_filter.AddLine(tag);
 
-		filter.string_filter.AddLine((*a)->name.c_str());
+		filter.string_filter.AddLine((*a)->name);
 		return filter.string_filter.GetState();
 	}
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -379,7 +379,7 @@ protected:
 		assert((*item) != nullptr);
 
 		sf.ResetState();
-		sf.AddLine((*item)->info.server_name.c_str());
+		sf.AddLine((*item)->info.server_name);
 		return sf.GetState();
 	}
 

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -142,11 +142,9 @@ public:
 	static bool CDECL TagNameFilter(ObjectClassID const *oc, StringFilter &filter)
 	{
 		ObjectClass *objclass = ObjectClass::Get(*oc);
-		char buffer[DRAW_STRING_BUFFER];
-		GetString(buffer, objclass->name, lastof(buffer));
 
 		filter.ResetState();
-		filter.AddLine(buffer);
+		filter.AddLine(GetString(objclass->name));
 		return filter.GetState();
 	}
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1046,11 +1046,8 @@ public:
 	/** Filter station classes by class name. */
 	static bool CDECL TagNameFilter(StationClassID const * sc, StringFilter &filter)
 	{
-		char buffer[DRAW_STRING_BUFFER];
-		GetString(buffer, StationClass::Get(*sc)->name, lastof(buffer));
-
 		filter.ResetState();
-		filter.AddLine(buffer);
+		filter.AddLine(GetString(StationClass::Get(*sc)->name));
 		return filter.GetState();
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1249,11 +1249,8 @@ public:
 	/** Filter classes by class name. */
 	static bool CDECL TagNameFilter(RoadStopClassID const *sc, StringFilter &filter)
 	{
-		char buffer[DRAW_STRING_BUFFER];
-		GetString(buffer, RoadStopClass::Get(*sc)->name, lastof(buffer));
-
 		filter.ResetState();
-		filter.AddLine(buffer);
+		filter.AddLine(GetString(RoadStopClass::Get(*sc)->name));
 		return filter.GetState();
 	}
 

--- a/src/stringfilter.cpp
+++ b/src/stringfilter.cpp
@@ -125,9 +125,20 @@ void StringFilter::AddLine(const char *str)
  *
  * @param str Another line from the item.
  */
+void StringFilter::AddLine(const std::string &str)
+{
+	AddLine(str.c_str());
+}
+
+/**
+ * Pass another text line from the current item to the filter.
+ *
+ * You can call this multiple times for a single item, if the filter shall apply to multiple things.
+ * Before processing the next item you have to call ResetState().
+ *
+ * @param str Another line from the item.
+ */
 void StringFilter::AddLine(StringID str)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	GetString(buffer, str, lastof(buffer));
-	AddLine(buffer);
+	AddLine(GetString(str));
 }

--- a/src/stringfilter_type.h
+++ b/src/stringfilter_type.h
@@ -60,6 +60,7 @@ public:
 
 	void ResetState();
 	void AddLine(const char *str);
+	void AddLine(const std::string &str);
 	void AddLine(StringID str);
 
 	/**

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1458,7 +1458,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				static bool use_cache = true;
 				if (use_cache) { // Use cached version if first call
 					AutoRestoreBackup cache_backup(use_cache, false);
-					buff = strecpy(buff, i->GetCachedName(), last);
+					buff = strecpy(buff, i->GetCachedName().c_str(), last);
 				} else if (_scan_for_gender_data) {
 					/* Gender is defined by the industry type.
 					 * STR_FORMAT_INDUSTRY_NAME may have the town first, so it would result in the gender of the town name */
@@ -1541,7 +1541,7 @@ static char *FormatString(char *buff, const char *str_arg, StringParameters *arg
 				static bool use_cache = true;
 				if (use_cache) { // Use cached version if first call
 					AutoRestoreBackup cache_backup(use_cache, false);
-					buff = strecpy(buff, t->GetCachedName(), last);
+					buff = strecpy(buff, t->GetCachedName().c_str(), last);
 				} else if (!t->name.empty()) {
 					int64 args_array[] = {(int64)(size_t)t->name.c_str()};
 					StringParameters tmp_params(args_array);

--- a/src/town.h
+++ b/src/town.h
@@ -125,11 +125,11 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 
 	void UpdateVirtCoord();
 
-	inline const char *GetCachedName() const
+	inline const std::string &GetCachedName() const
 	{
-		if (!this->name.empty()) return this->name.c_str();
+		if (!this->name.empty()) return this->name;
 		if (this->cached_name.empty()) this->FillCachedName();
-		return this->cached_name.c_str();
+		return this->cached_name;
 	}
 
 	static inline Town *GetByTile(TileIndex tile)


### PR DESCRIPTION
## Motivation / Problem

In https://github.com/OpenTTD/OpenTTD/pull/10519#discussion_r1181112446 @rubidium42 suggested changing some `.c_str()` conversions to just passing std::strings, now that we have a suitable `StringFilter::AddLine()` which accepts them.

## Description

Convert all the easy C-strings to std::string.

Does not depend on #10519.

## Limitations

I'm not sure the two conversions from `inline const char *GetCachedName() const` to `inline const std::string &GetCachedName() const` is correct, because my understanding of `*` vs `&` is...limited. 🙂 

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
