### PR TITLE
Fix c8299304: retain support ICU < 65

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -790,7 +790,7 @@ int StrNaturalCompare(std::string_view s1, std::string_view s2, bool ignore_garb
 #ifdef WITH_ICU_I18N
 	if (_current_collator) {
 		UErrorCode status = U_ZERO_ERROR;
-		int result = _current_collator->compareUTF8(s1, s2, status);
+		int result = _current_collator->compareUTF8(icu::StringPiece(s1.data(), s1.size()), icu::StringPiece(s2.data(), s2.size()), status);
 		if (U_SUCCESS(status)) return result;
 	}
 #endif /* WITH_ICU_I18N */


### PR DESCRIPTION
## Motivation / Problem

Apparantly our release binaries still use an ancient version of ICU, and building for that fails.


## Description

Instead of `icu::StringPiece` accepting `std::string_view`, extract the `char *` and `len` manually to create a `icu::StringPiece`.


## Limitations

None I can think of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
