### PR TITLE
Codechange: use more C++ constructs in strgen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (EMSCRIPTEN)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 
 # Use GNUInstallDirs to allow customisation
 # but set our own default data and bin dir

--- a/src/3rdparty/fmt/core.h
+++ b/src/3rdparty/fmt/core.h
@@ -1666,8 +1666,7 @@ constexpr auto encode_types() -> unsigned long long {
 
 template <typename Context, typename T>
 FMT_CONSTEXPR FMT_INLINE auto make_value(T&& val) -> value<Context> {
-  auto&& arg = arg_mapper<Context>().map(FMT_FORWARD(val));
-  using arg_type = remove_cvref_t<decltype(arg)>;
+  using arg_type = remove_cvref_t<decltype(arg_mapper<Context>().map(val))>;
 
   constexpr bool formattable_char =
       !std::is_same<arg_type, unformattable_char>::value;
@@ -1686,7 +1685,7 @@ FMT_CONSTEXPR FMT_INLINE auto make_value(T&& val) -> value<Context> {
       formattable,
       "Cannot format an argument. To make type T formattable provide a "
       "formatter<T> specialization: https://fmt.dev/latest/api.html#udt");
-  return {arg};
+  return {arg_mapper<Context>().map(val)};
 }
 
 template <typename Context, typename T>

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -158,7 +158,7 @@ struct StringNameWriter : HeaderWriter {
 	{
 	}
 
-	void WriteStringID(const char *name, int stringid)
+	void WriteStringID(const std::string &name, int stringid)
 	{
 		if (stringid == (int)this->strings.size()) this->strings.emplace_back(name);
 	}
@@ -271,7 +271,7 @@ static void ExtractStringParams(const StringData &data, StringParamsList &params
 		if (ls != nullptr) {
 			StringParams &param = params.emplace_back();
 			ParsedCommandStruct pcs;
-			ExtractCommandString(&pcs, ls->english, false);
+			ExtractCommandString(&pcs, ls->english.c_str(), false);
 
 			for (const CmdStruct *cs : pcs.cmd) {
 				if (cs == nullptr) break;

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -266,7 +266,7 @@ static StringParam::ParamType GetParamType(const CmdStruct *cs)
 static void ExtractStringParams(const StringData &data, StringParamsList &params)
 {
 	for (size_t i = 0; i < data.max_strings; i++) {
-		const LangString *ls = data.strings[i];
+		const LangString *ls = data.strings[i].get();
 
 		if (ls != nullptr) {
 			StringParams &param = params.emplace_back();

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -270,10 +270,9 @@ static void ExtractStringParams(const StringData &data, StringParamsList &params
 
 		if (ls != nullptr) {
 			StringParams &param = params.emplace_back();
-			ParsedCommandStruct pcs;
-			ExtractCommandString(&pcs, ls->english.c_str(), false);
+			ParsedCommandStruct pcs = ExtractCommandString(ls->english.c_str(), false);
 
-			for (const CmdStruct *cs : pcs.cmd) {
+			for (const CmdStruct *cs : pcs.consuming_commands) {
 				if (cs == nullptr) break;
 				param.emplace_back(GetParamType(cs), cs->consumes);
 			}

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -236,7 +236,7 @@ struct HeaderFileWriter : HeaderWriter, FileWriter {
 		this->output_stream << "#define TABLE_STRINGS_H\n";
 	}
 
-	void WriteStringID(const char *name, int stringid)
+	void WriteStringID(const std::string &name, int stringid)
 	{
 		if (prev + 1 != stringid) this->output_stream << "\n";
 		fmt::print(this->output_stream, "static const StringID {} = 0x{:X};\n", name, stringid);

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -137,18 +137,17 @@ struct LanguageWriter {
 struct CmdStruct;
 
 struct CmdPair {
-	const CmdStruct *a;
-	const char *v;
+	const CmdStruct *cmd;
+	std::string param;
 };
 
 struct ParsedCommandStruct {
-	uint np;
-	CmdPair pairs[32];
-	const CmdStruct *cmd[32]; // ordered by param #
+	std::vector<CmdPair> non_consuming_commands;
+	std::array<const CmdStruct*, 32> consuming_commands{ nullptr }; // ordered by param #
 };
 
 const CmdStruct *TranslateCmdForCompare(const CmdStruct *a);
-void ExtractCommandString(ParsedCommandStruct *p, const char *s, bool warnings);
+ParsedCommandStruct ExtractCommandString(const char *s, bool warnings);
 
 void StrgenWarningI(const std::string &msg);
 void StrgenErrorI(const std::string &msg);

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -15,12 +15,10 @@
 
 /** Container for the different cases of a string. */
 struct Case {
-	int caseidx;  ///< The index of the case.
-	char *string; ///< The translation of the case.
-	Case *next;   ///< The next, chained, case.
+	int caseidx;        ///< The index of the case.
+	std::string string; ///< The translation of the case.
 
-	Case(int caseidx, const char *string, Case *next);
-	~Case();
+	Case(int caseidx, const std::string &string);
 };
 
 /** Information about a single string. */
@@ -31,7 +29,7 @@ struct LangString {
 	size_t hash_next;      ///< Next hash entry.
 	size_t index;          ///< The index in the language file.
 	int line;              ///< Line of string in source-file.
-	Case *translated_case; ///< Cases of the translation.
+	std::vector<Case> translated_cases; ///< Cases of the translation.
 
 	LangString(const char *name, const char *english, size_t index, int line);
 	~LangString();

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -23,16 +23,15 @@ struct Case {
 
 /** Information about a single string. */
 struct LangString {
-	char *name;            ///< Name of the string.
-	char *english;         ///< English text.
-	char *translated;      ///< Translated text.
-	size_t hash_next;      ///< Next hash entry.
-	size_t index;          ///< The index in the language file.
-	int line;              ///< Line of string in source-file.
+	std::string name;       ///< Name of the string.
+	std::string english;    ///< English text.
+	std::string translated; ///< Translated text.
+	size_t hash_next;       ///< Next hash entry.
+	size_t index;           ///< The index in the language file.
+	int line;               ///< Line of string in source-file.
 	std::vector<Case> translated_cases; ///< Cases of the translation.
 
-	LangString(const char *name, const char *english, size_t index, int line);
-	~LangString();
+	LangString(const std::string &name, const std::string &english, size_t index, int line);
 	void FreeTranslation();
 };
 
@@ -93,7 +92,7 @@ struct HeaderWriter {
 	 * @param name     The name of the string.
 	 * @param stringid The ID of the string.
 	 */
-	virtual void WriteStringID(const char *name, int stringid) = 0;
+	virtual void WriteStringID(const std::string &name, int stringid) = 0;
 
 	/**
 	 * Finalise writing the file.


### PR DESCRIPTION
## Motivation / Problem

Long term goal to go towards more C++-ish code, though primarily getting rid of stredup/calloc.


## Description

Use `std::filesystem::path` and friends over `stredup` C-strings.
Use `std::string` over `stredup` C-strings.
Use `std::vector` over `CallocT`-ed arrays and linked lists.
Use `std::array` where applicable.
Use streams over file handled for file access.
Replace custom hashing lookup with `std::unordered_map`.
Fix a memory leak (CmdPair.v would be `stredup`-ed, but never `free`d).


## Limitations

Requires a newer MacOS deployment target due to amongst others `std::filesystem::path`. 


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
