### PR TITLE
Codechange: Don't use macros for DAYS_TILL and friends

### DIFF
--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -1866,7 +1866,7 @@ struct CompanyInfrastructureWindow : Window
 		}
 
 		/* Get the date introduced railtypes as well. */
-		this->railtypes = AddDateIntroducedRailTypes(this->railtypes, MAX_DAY);
+		this->railtypes = AddDateIntroducedRailTypes(this->railtypes, MAX_DATE);
 
 		/* Find the used roadtypes. */
 		for (const Engine *e : Engine::IterateType(VEH_ROAD)) {
@@ -1876,7 +1876,7 @@ struct CompanyInfrastructureWindow : Window
 		}
 
 		/* Get the date introduced roadtypes as well. */
-		this->roadtypes = AddDateIntroducedRoadTypes(this->roadtypes, MAX_DAY);
+		this->roadtypes = AddDateIntroducedRoadTypes(this->roadtypes, MAX_DATE);
 		this->roadtypes &= ~_roadtypes_hidden_mask;
 	}
 

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2293,7 +2293,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 				GetString(datestrbuf, STR_JUST_DATE_ISO, lastof(datestrbuf));
 				IConsolePrint(CC_DEBUG, "Profiling will automatically stop on game date {}.", datestrbuf);
 			} else {
-				_newgrf_profile_end_date = MAX_DAY;
+				_newgrf_profile_end_date = MAX_DATE;
 			}
 		} else if (_newgrf_profilers.empty()) {
 			IConsolePrint(CC_ERROR, "No GRFs selected for profiling, did not start.");
@@ -2314,7 +2314,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
 			pr.Abort();
 		}
-		_newgrf_profile_end_date = MAX_DAY;
+		_newgrf_profile_end_date = MAX_DATE;
 		return true;
 	}
 

--- a/src/date_type.h
+++ b/src/date_type.h
@@ -52,31 +52,21 @@ static const TimerGameCalendar::Year ORIGINAL_END_YEAR  = 2051;
 static const TimerGameCalendar::Year ORIGINAL_MAX_YEAR  = 2090;
 
 /**
- * Calculate the number of leap years till a given year.
- *
- * Each passed leap year adds one day to the 'day count'.
- *
- * A special case for the year 0 as no year has been passed,
- * but '(year - 1) / 4' does not yield '-1' to counteract the
- * '+1' at the end of the formula as divisions round to zero.
- *
- * @param year the year to get the leap years till.
- * @return the number of leap years.
- */
-#define LEAP_YEARS_TILL(year) ((year) == 0 ? 0 : ((year) - 1) / 4 - ((year) - 1) / 100 + ((year) - 1) / 400 + 1)
-
-/**
  * Calculate the date of the first day of a given year.
  * @param year the year to get the first day of.
  * @return the date.
  */
-#define DAYS_TILL(year) (DAYS_IN_YEAR * (year) + LEAP_YEARS_TILL(year))
+static inline TimerGameCalendar::Date DateAtStartOfYear(TimerGameCalendar::Year year)
+{
+	uint number_of_leap_years = (year == 0) ? 0 : ((year - 1) / 4 - (year - 1) / 100 + (year - 1) / 400 + 1);
+
+	return (DAYS_IN_YEAR * year) + number_of_leap_years;
+}
 
 /**
- * The offset in days from the 'TimerGameCalendar::date == 0' till
- * 'TimerGameCalendar::ConvertYMDToDate(ORIGINAL_BASE_YEAR, 0, 1)'
+ * The date of the first day of the original base year.
  */
-#define DAYS_TILL_ORIGINAL_BASE_YEAR DAYS_TILL(ORIGINAL_BASE_YEAR)
+static const TimerGameCalendar::Date DAYS_TILL_ORIGINAL_BASE_YEAR = DateAtStartOfYear(ORIGINAL_BASE_YEAR);
 
 /** The absolute minimum & maximum years in OTTD */
 static const TimerGameCalendar::Year MIN_YEAR = 0;
@@ -92,8 +82,8 @@ static const TimerGameCalendar::Year DEF_END_YEAR = ORIGINAL_END_YEAR - 1;
  */
 static const TimerGameCalendar::Year MAX_YEAR  = 5000000;
 
-/** The number of days till the last day */
-#define MAX_DAY (DAYS_TILL(MAX_YEAR + 1) - 1)
+/** The date of the last day of the max year. */
+static const TimerGameCalendar::Date MAX_DATE = DateAtStartOfYear(MAX_YEAR + 1) - 1;
 
 static const TimerGameCalendar::Year INVALID_YEAR = -1; ///< Representation of an invalid year
 static const TimerGameCalendar::Date INVALID_DATE = -1; ///< Representation of an invalid date

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -156,7 +156,7 @@ uint32 NewGRFProfiler::FinishAll()
 		IConsolePrint(CC_DEBUG, "Total NewGRF callback processing: {} microseconds over {} ticks.", total_microseconds, max_ticks);
 	}
 
-	_newgrf_profile_end_date = MAX_DAY;
+	_newgrf_profile_end_date = MAX_DATE;
 
 	return total_microseconds;
 }

--- a/src/rail.cpp
+++ b/src/rail.cpp
@@ -225,7 +225,7 @@ RailTypes AddDateIntroducedRailTypes(RailTypes current, TimerGameCalendar::Date 
 		if (rti->label == 0) continue;
 
 		/* Not date introduced. */
-		if (!IsInsideMM(rti->introduction_date, 0, MAX_DAY)) continue;
+		if (!IsInsideMM(rti->introduction_date, 0, MAX_DATE)) continue;
 
 		/* Not yet introduced at this date. */
 		if (rti->introduction_date > date) continue;
@@ -298,7 +298,7 @@ RailTypes GetRailTypes(bool introduces)
 		}
 	}
 
-	if (introduces) return AddDateIntroducedRailTypes(rts, MAX_DAY);
+	if (introduces) return AddDateIntroducedRailTypes(rts, MAX_DATE);
 	return rts;
 }
 

--- a/src/road.cpp
+++ b/src/road.cpp
@@ -163,7 +163,7 @@ RoadTypes AddDateIntroducedRoadTypes(RoadTypes current, TimerGameCalendar::Date 
 		if (rti->label == 0) continue;
 
 		/* Not date introduced. */
-		if (!IsInsideMM(rti->introduction_date, 0, MAX_DAY)) continue;
+		if (!IsInsideMM(rti->introduction_date, 0, MAX_DATE)) continue;
 
 		/* Not yet introduced at this date. */
 		if (rti->introduction_date > date) continue;
@@ -231,7 +231,7 @@ RoadTypes GetRoadTypes(bool introduces)
 		}
 	}
 
-	if (introduces) return AddDateIntroducedRoadTypes(rts, MAX_DAY);
+	if (introduces) return AddDateIntroducedRoadTypes(rts, MAX_DATE);
 	return rts;
 }
 
@@ -292,7 +292,7 @@ RoadTypes ExistingRoadTypes(CompanyID c)
 	}
 
 	/* Get the date introduced roadtypes as well. */
-	known_roadtypes = AddDateIntroducedRoadTypes(known_roadtypes, MAX_DAY);
+	known_roadtypes = AddDateIntroducedRoadTypes(known_roadtypes, MAX_DATE);
 
 	return known_roadtypes;
 }

--- a/src/table/object_land.h
+++ b/src/table/object_land.h
@@ -121,7 +121,7 @@ static const DrawTileSprites _object_hq[] = {
 
 #undef TILE_SPRITE_LINE
 
-#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) { GRFFilePropsBase<2>(), {0, 0, 0, 0}, INVALID_OBJECT_CLASS, name, climate, size, build_cost_multiplier, clear_cost_multiplier, 0, MAX_DAY + 1, flags, 0, height, 1, gen_amount }
+#define M(name, size, build_cost_multiplier, clear_cost_multiplier, height, climate, gen_amount, flags) { GRFFilePropsBase<2>(), {0, 0, 0, 0}, INVALID_OBJECT_CLASS, name, climate, size, build_cost_multiplier, clear_cost_multiplier, 0, MAX_DATE + 1, flags, 0, height, 1, gen_amount }
 
 /* Climates
  * T = Temperate

--- a/src/timer/timer_game_calendar.cpp
+++ b/src/timer/timer_game_calendar.cpp
@@ -131,7 +131,7 @@ static const uint16 _accum_days_for_month[] = {
 	/* Account for the missing of the 29th of February in non-leap years */
 	if (!TimerGameCalendar::IsLeapYear(year) && days >= ACCUM_MAR) days--;
 
-	return DAYS_TILL(year) + days;
+	return DateAtStartOfYear(year) + days;
 }
 
 /**

--- a/src/timetable_cmd.cpp
+++ b/src/timetable_cmd.cpp
@@ -303,11 +303,11 @@ CommandCost CmdSetTimetableStart(DoCommandFlag flags, VehicleID veh_id, bool tim
 	int total_duration = v->orders->GetTimetableTotalDuration();
 
 	/* Don't let a timetable start more than 15 years into the future or 1 year in the past. */
-	if (start_date < 0 || start_date > MAX_DAY) return CMD_ERROR;
+	if (start_date < 0 || start_date > MAX_DATE) return CMD_ERROR;
 	if (start_date - TimerGameCalendar::date > MAX_TIMETABLE_START_YEARS * DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (TimerGameCalendar::date - start_date > DAYS_IN_LEAP_YEAR) return CMD_ERROR;
 	if (timetable_all && !v->orders->IsCompleteTimetable()) return CommandCost(STR_ERROR_TIMETABLE_INCOMPLETE);
-	if (timetable_all && start_date + total_duration / DAY_TICKS > MAX_DAY) return CMD_ERROR;
+	if (timetable_all && start_date + total_duration / DAY_TICKS > MAX_DATE) return CMD_ERROR;
 
 	if (flags & DC_EXEC) {
 		std::vector<Vehicle *> vehs;

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -873,7 +873,7 @@ RoadType GetTownRoadType(const Town *t)
 		if (!HasBit(rti->flags, ROTF_TOWN_BUILD)) continue;
 
 		/* Not yet introduced at this date. */
-		if (IsInsideMM(rti->introduction_date, 0, MAX_DAY) && rti->introduction_date > TimerGameCalendar::date) continue;
+		if (IsInsideMM(rti->introduction_date, 0, MAX_DATE) && rti->introduction_date > TimerGameCalendar::date) continue;
 
 		if (best != nullptr) {
 			if ((rti->max_speed == 0 ? assume_max_speed : rti->max_speed) < (best->max_speed == 0 ? assume_max_speed : best->max_speed)) continue;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1370,7 +1370,7 @@ bool Vehicle::HandleBreakdown()
  */
 void AgeVehicle(Vehicle *v)
 {
-	if (v->age < MAX_DAY) {
+	if (v->age < MAX_DATE) {
 		v->age++;
 		if (v->IsPrimaryVehicle() && v->age == VEHICLE_PROFIT_MIN_AGE + 1) GroupStatistics::VehicleReachedMinAge(v);
 	}


### PR DESCRIPTION
## Motivation / Problem

We use macros for date lookups. 

I needed to change this for my ongoing work with time, but it's no longer necessary. Might as well clean it up, though.

## Description

- Convert the macros in `date_type.h` into inline functions.

## Limitations

- I have not measured performance changes.
- There might be better ways to do this.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
