### PR TITLE
Codechange: C-style strings + stredup + free -> std::string

### DIFF
--- a/src/fios.h
+++ b/src/fios.h
@@ -32,7 +32,7 @@ typedef SmallMap<uint, CompanyProperties *> CompanyPropertiesMap;
 struct LoadCheckData {
 	bool checkable;     ///< True if the savegame could be checked by SL_LOAD_CHECK. (Old savegames are not checkable.)
 	StringID error;     ///< Error message from loading. INVALID_STRING_ID if no error.
-	char *error_data;   ///< Data to pass to SetDParamStr when displaying #error.
+	std::string error_msg; ///< Data to pass to SetDParamStr when displaying #error.
 
 	uint32 map_size_x, map_size_y;
 	TimerGameCalendar::Date current_date;
@@ -47,7 +47,7 @@ struct LoadCheckData {
 	struct LoggedAction *gamelog_action;          ///< Gamelog actions
 	uint gamelog_actions;                         ///< Number of gamelog actions
 
-	LoadCheckData() : error_data(nullptr), grfconfig(nullptr),
+	LoadCheckData() : grfconfig(nullptr),
 			grf_compatibility(GLC_NOT_FOUND), gamelog_action(nullptr), gamelog_actions(0)
 	{
 		this->Clear();

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -49,8 +49,7 @@ void LoadCheckData::Clear()
 {
 	this->checkable = false;
 	this->error = INVALID_STRING_ID;
-	free(this->error_data);
-	this->error_data = nullptr;
+	this->error_msg.clear();
 
 	this->map_size_x = this->map_size_y = 256; // Default for old savegames which do not store mapsize.
 	this->current_date = 0;
@@ -500,7 +499,7 @@ public:
 			tr.top += FONT_HEIGHT_NORMAL;
 		} else if (_load_check_data.error != INVALID_STRING_ID) {
 			/* Incompatible / broken savegame */
-			SetDParamStr(0, _load_check_data.error_data);
+			SetDParamStr(0, _load_check_data.error_msg);
 			tr.top = DrawStringMultiLine(tr, _load_check_data.error, TC_RED);
 		} else {
 			/* Mapsize */

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -84,8 +84,7 @@ std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlag flags, CompanyID com
 		g->type = type;
 		g->dst = dest;
 		g->company = company;
-		g->text = stredup(text.c_str());
-		g->progress = nullptr;
+		g->text = text;
 		g->completed = false;
 
 		if (g->company == INVALID_COMPANY) {
@@ -143,8 +142,7 @@ CommandCost CmdSetGoalText(DoCommandFlag flags, GoalID goal, const std::string &
 
 	if (flags & DC_EXEC) {
 		Goal *g = Goal::Get(goal);
-		free(g->text);
-		g->text = stredup(text.c_str());
+		g->text = text;
 
 		if (g->company == INVALID_COMPANY) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
@@ -170,12 +168,7 @@ CommandCost CmdSetGoalProgress(DoCommandFlag flags, GoalID goal, const std::stri
 
 	if (flags & DC_EXEC) {
 		Goal *g = Goal::Get(goal);
-		free(g->progress);
-		if (text.empty()) {
-			g->progress = nullptr;
-		} else {
-			g->progress = stredup(text.c_str());
-		}
+		g->progress = text;
 
 		if (g->company == INVALID_COMPANY) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);
@@ -255,7 +248,7 @@ CommandCost CmdGoalQuestion(DoCommandFlag flags, uint16 uniqueid, uint32 target,
 			if (company == INVALID_COMPANY && !Company::IsValidID(_local_company)) return CommandCost();
 			if (company != INVALID_COMPANY && company != _local_company) return CommandCost();
 		}
-		ShowGoalQuestion(uniqueid, type, button_mask, text.c_str());
+		ShowGoalQuestion(uniqueid, type, button_mask, text);
 	}
 
 	return CommandCost();

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -19,12 +19,12 @@ extern GoalPool _goal_pool;
 
 /** Struct about goals, current and completed */
 struct Goal : GoalPool::PoolItem<&_goal_pool> {
-	CompanyID company; ///< Goal is for a specific company; INVALID_COMPANY if it is global
-	GoalType type;     ///< Type of the goal
-	GoalTypeID dst;    ///< Index of type
-	char *text;        ///< Text of the goal.
-	char *progress;    ///< Progress text of the goal.
-	bool completed;    ///< Is the goal completed or not?
+	CompanyID company;    ///< Goal is for a specific company; INVALID_COMPANY if it is global
+	GoalType type;        ///< Type of the goal
+	GoalTypeID dst;       ///< Index of type
+	std::string text;     ///< Text of the goal.
+	std::string progress; ///< Progress text of the goal.
+	bool completed;       ///< Is the goal completed or not?
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
@@ -34,7 +34,7 @@ struct Goal : GoalPool::PoolItem<&_goal_pool> {
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~Goal() { free(this->text); free(this->progress); }
+	inline ~Goal() { }
 };
 
 #endif /* GOAL_BASE_H */

--- a/src/goal_gui.cpp
+++ b/src/goal_gui.cpp
@@ -212,7 +212,7 @@ struct GoalListWindow : public Window {
 						}
 
 						case GC_PROGRESS:
-							if (s->progress != nullptr) {
+							if (!s->progress.empty()) {
 								SetDParamStr(0, s->progress);
 								StringID str = s->completed ? STR_GOALS_PROGRESS_COMPLETE : STR_GOALS_PROGRESS;
 								DrawString(r.WithWidth(progress_col_width, !rtl), str, TC_FROMSTRING, SA_RIGHT | SA_FORCE);
@@ -242,7 +242,7 @@ struct GoalListWindow : public Window {
 		/* Calculate progress column width. */
 		uint max_width = 0;
 		for (const Goal *s : Goal::Iterate()) {
-			if (s->progress != nullptr) {
+			if (!s->progress.empty()) {
 				SetDParamStr(0, s->progress);
 				StringID str = s->completed ? STR_GOALS_PROGRESS_COMPLETE : STR_GOALS_PROGRESS;
 				uint str_width = GetStringBoundingBox(str).width;
@@ -322,14 +322,14 @@ void ShowGoalsList(CompanyID company)
 
 /** Ask a question about a goal. */
 struct GoalQuestionWindow : public Window {
-	char *question;     ///< Question to ask (private copy).
-	int buttons;        ///< Number of valid buttons in #button.
-	int button[3];      ///< Buttons to display.
-	TextColour colour;  ///< Colour of the question text.
+	std::string question; ///< Question to ask (private copy).
+	int buttons;          ///< Number of valid buttons in #button.
+	int button[3];        ///< Buttons to display.
+	TextColour colour;    ///< Colour of the question text.
 
-	GoalQuestionWindow(WindowDesc *desc, WindowNumber window_number, TextColour colour, uint32 button_mask, const char *question) : Window(desc), colour(colour)
+	GoalQuestionWindow(WindowDesc *desc, WindowNumber window_number, TextColour colour, uint32 button_mask, const std::string &question) : Window(desc), colour(colour)
 	{
-		this->question = stredup(question);
+		this->question = question;
 
 		/* Figure out which buttons we have to enable. */
 		int n = 0;
@@ -352,10 +352,6 @@ struct GoalQuestionWindow : public Window {
 		this->FinishInitNested(window_number);
 	}
 
-	~GoalQuestionWindow()
-	{
-		free(this->question);
-	}
 
 	void SetStringParameters(int widget) const override
 	{
@@ -554,7 +550,7 @@ static WindowDesc _goal_question_list_desc[] = {
  * @param button_mask Buttons to display.
  * @param question Question to ask.
  */
-void ShowGoalQuestion(uint16 id, byte type, uint32 button_mask, const char *question)
+void ShowGoalQuestion(uint16 id, byte type, uint32 button_mask, const std::string &question)
 {
 	assert(type < GQT_END);
 	new GoalQuestionWindow(&_goal_question_list_desc[type], id, type == 3 ? TC_WHITE : TC_BLACK, button_mask, question);

--- a/src/gui.h
+++ b/src/gui.h
@@ -49,7 +49,7 @@ void ShowIndustryDirectory();
 void ShowIndustryCargoesWindow();
 void ShowSubsidiesList();
 void ShowGoalsList(CompanyID company);
-void ShowGoalQuestion(uint16 id, byte type, uint32 button_mask, const char *question);
+void ShowGoalQuestion(uint16 id, byte type, uint32 button_mask, const std::string &question);
 void ShowStoryBook(CompanyID company, uint16 page_id = INVALID_STORY_PAGE);
 
 void ShowEstimatedCostOrIncome(Money cost, int x, int y);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -2184,19 +2184,13 @@ static WindowDesc _scan_progress_desc(
 
 /** Window for showing the progress of NewGRF scanning. */
 struct ScanProgressWindow : public Window {
-	char *last_name; ///< The name of the last 'seen' NewGRF.
-	int scanned;     ///< The number of NewGRFs that we have seen.
+	std::string last_name; ///< The name of the last 'seen' NewGRF.
+	int scanned;           ///< The number of NewGRFs that we have seen.
 
 	/** Create the window. */
-	ScanProgressWindow() : Window(&_scan_progress_desc), last_name(nullptr), scanned(0)
+	ScanProgressWindow() : Window(&_scan_progress_desc), scanned(0)
 	{
 		this->InitNested(1);
-	}
-
-	/** Free the last name buffer. */
-	~ScanProgressWindow()
-	{
-		free(last_name);
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
@@ -2241,7 +2235,7 @@ struct ScanProgressWindow : public Window {
 				SetDParam(1, _settings_client.gui.last_newgrf_count);
 				DrawString(r.left, r.right, r.top, STR_NEWGRF_SCAN_STATUS, TC_FROMSTRING, SA_HOR_CENTER);
 
-				DrawString(r.left, r.right, r.top + FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal, this->last_name == nullptr ? "" : this->last_name, TC_BLACK, SA_HOR_CENTER);
+				DrawString(r.left, r.right, r.top + FONT_HEIGHT_NORMAL + WidgetDimensions::scaled.vsep_normal, this->last_name, TC_BLACK, SA_HOR_CENTER);
 				break;
 		}
 	}
@@ -2253,13 +2247,10 @@ struct ScanProgressWindow : public Window {
 	 */
 	void UpdateNewGRFScanStatus(uint num, const char *name)
 	{
-		free(this->last_name);
 		if (name == nullptr) {
-			char buf[256];
-			GetString(buf, STR_NEWGRF_SCAN_ARCHIVES, lastof(buf));
-			this->last_name = stredup(buf);
+			this->last_name = GetString(STR_NEWGRF_SCAN_ARCHIVES);
 		} else {
-			this->last_name = stredup(name);
+			this->last_name = name;
 		}
 		this->scanned = num;
 		if (num > _settings_client.gui.last_newgrf_count) _settings_client.gui.last_newgrf_count = num;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -623,7 +623,7 @@ int openttd_main(int argc, char *argv[])
 				if (_load_check_data.HasErrors()) {
 					InitializeLanguagePacks(); // A language pack is needed for GetString()
 					char buf[256];
-					SetDParamStr(0, _load_check_data.error_data);
+					SetDParamStr(0, _load_check_data.error_msg);
 					GetString(buf, _load_check_data.error, lastof(buf));
 					fprintf(stderr, "%s\n", buf);
 				}

--- a/src/saveload/goal_sl.cpp
+++ b/src/saveload/goal_sl.cpp
@@ -17,12 +17,12 @@
 #include "../safeguards.h"
 
 static const SaveLoad _goals_desc[] = {
-	    SLE_VAR(Goal, company,   SLE_FILE_U16 | SLE_VAR_U8),
-	    SLE_VAR(Goal, type,      SLE_FILE_U16 | SLE_VAR_U8),
-	    SLE_VAR(Goal, dst,       SLE_UINT32),
-	    SLE_STR(Goal, text,      SLE_STR | SLF_ALLOW_CONTROL, 0),
-	SLE_CONDSTR(Goal, progress,  SLE_STR | SLF_ALLOW_CONTROL, 0, SLV_182, SL_MAX_VERSION),
-	SLE_CONDVAR(Goal, completed, SLE_BOOL, SLV_182, SL_MAX_VERSION),
+	     SLE_VAR(Goal, company,   SLE_FILE_U16 | SLE_VAR_U8),
+	     SLE_VAR(Goal, type,      SLE_FILE_U16 | SLE_VAR_U8),
+	     SLE_VAR(Goal, dst,       SLE_UINT32),
+	    SLE_SSTR(Goal, text,      SLE_STR | SLF_ALLOW_CONTROL),
+	SLE_CONDSSTR(Goal, progress,  SLE_STR | SLF_ALLOW_CONTROL, SLV_182, SL_MAX_VERSION),
+	 SLE_CONDVAR(Goal, completed, SLE_BOOL, SLV_182, SL_MAX_VERSION),
 };
 
 struct GOALChunkHandler : ChunkHandler {

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -208,7 +208,7 @@ struct SaveLoadParams {
 	LoadFilter *lf;                      ///< Filter to read the savegame from.
 
 	StringID error_str;                  ///< the translatable error message to show
-	char *extra_msg;                     ///< the error message
+	std::string extra_msg;               ///< the error message
 
 	bool saveinprogress;                 ///< Whether there is currently a save in progress.
 };
@@ -330,17 +330,15 @@ static void SlNullPointers()
  * @note This function does never return as it throws an exception to
  *       break out of all the saveload code.
  */
-void NORETURN SlError(StringID string, const char *extra_msg)
+void NORETURN SlError(StringID string, const std::string &extra_msg)
 {
 	/* Distinguish between loading into _load_check_data vs. normal save/load. */
 	if (_sl.action == SLA_LOAD_CHECK) {
 		_load_check_data.error = string;
-		free(_load_check_data.error_data);
-		_load_check_data.error_data = (extra_msg == nullptr) ? nullptr : stredup(extra_msg);
+		_load_check_data.error_msg = extra_msg;
 	} else {
 		_sl.error_str = string;
-		free(_sl.extra_msg);
-		_sl.extra_msg = (extra_msg == nullptr) ? nullptr : stredup(extra_msg);
+		_sl.extra_msg = extra_msg;
 	}
 
 	/* We have to nullptr all pointers here; we might be in a state where
@@ -362,7 +360,7 @@ void NORETURN SlError(StringID string, const char *extra_msg)
  * @note This function does never return as it throws an exception to
  *       break out of all the saveload code.
  */
-void NORETURN SlErrorCorrupt(const char *msg)
+void NORETURN SlErrorCorrupt(const std::string &msg)
 {
 	SlError(STR_GAME_SAVELOAD_ERROR_BROKEN_SAVEGAME, msg);
 }

--- a/src/saveload/saveload_error.hpp
+++ b/src/saveload/saveload_error.hpp
@@ -13,8 +13,8 @@
 #include "../3rdparty/fmt/format.h"
 #include "../strings_type.h"
 
-void NORETURN SlError(StringID string, const char *extra_msg = nullptr);
-void NORETURN SlErrorCorrupt(const char *msg);
+void NORETURN SlError(StringID string, const std::string &extra_msg = {});
+void NORETURN SlErrorCorrupt(const std::string &msg);
 
 /**
  * Issue an SlErrorCorrupt with a format string.
@@ -28,7 +28,7 @@ void NORETURN SlErrorCorrupt(const char *msg);
 template <typename T, typename ... Args>
 static inline void NORETURN SlErrorCorruptFmt(const T &format, Args&&... fmt_args)
 {
-	SlErrorCorrupt(fmt::format(format, fmt_args...).c_str());
+	SlErrorCorrupt(fmt::format(format, fmt_args...));
 }
 
 #endif /* SAVELOAD_ERROR_HPP */

--- a/src/saveload/story_sl.cpp
+++ b/src/saveload/story_sl.cpp
@@ -35,7 +35,7 @@ static const SaveLoad _story_page_elements_desc[] = {
 	SLE_CONDVAR(StoryPageElement, type,          SLE_FILE_U16 | SLE_VAR_U8,  SL_MIN_VERSION,   SLV_185),
 	SLE_CONDVAR(StoryPageElement, type,          SLE_UINT8,                  SLV_185, SL_MAX_VERSION),
 	    SLE_VAR(StoryPageElement, referenced_id, SLE_UINT32),
-	    SLE_STR(StoryPageElement, text,          SLE_STR | SLF_ALLOW_CONTROL, 0),
+	   SLE_SSTR(StoryPageElement, text,          SLE_STR | SLF_ALLOW_CONTROL),
 };
 
 struct STPEChunkHandler : ChunkHandler {
@@ -77,7 +77,7 @@ static const SaveLoad _story_pages_desc[] = {
 	    SLE_VAR(StoryPage, date,       SLE_UINT32),
 	SLE_CONDVAR(StoryPage, company,    SLE_FILE_U16 | SLE_VAR_U8,  SL_MIN_VERSION,   SLV_185),
 	SLE_CONDVAR(StoryPage, company,    SLE_UINT8,                  SLV_185, SL_MAX_VERSION),
-	    SLE_STR(StoryPage, title,      SLE_STR | SLF_ALLOW_CONTROL, 0),
+	   SLE_SSTR(StoryPage, title,      SLE_STR | SLF_ALLOW_CONTROL),
 };
 
 struct STPAChunkHandler : ChunkHandler {

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -147,7 +147,7 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 	StoryPageElementType type; ///< Type of page element
 
 	uint32 referenced_id;      ///< Id of referenced object (location, goal etc.)
-	char *text;                ///< Static content text of page element
+	std::string text;          ///< Static content text of page element
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
@@ -157,16 +157,16 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~StoryPageElement() { free(this->text); }
+	inline ~StoryPageElement() { }
 };
 
 /** Struct about stories, current and completed */
 struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
-	uint32 sort_value;   ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
+	uint32 sort_value;            ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
 	TimerGameCalendar::Date date; ///< Date when the page was created.
-	CompanyID company;   ///< StoryPage is for a specific company; INVALID_COMPANY if it is global
+	CompanyID company;            ///< StoryPage is for a specific company; INVALID_COMPANY if it is global
 
-	char *title;         ///< Title of story page
+	std::string title;            ///< Title of story page
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
@@ -183,7 +183,6 @@ struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
 				if (spe->page == this->index) delete spe;
 			}
 		}
-		free(this->title);
 	}
 };
 

--- a/src/story_gui.cpp
+++ b/src/story_gui.cpp
@@ -60,7 +60,7 @@ protected:
 	GUIStoryPageList story_pages;      ///< Sorted list of pages.
 	GUIStoryPageElementList story_page_elements; ///< Sorted list of page elements that belong to the current page.
 	StoryPageID selected_page_id;      ///< Pool index of selected page.
-	char selected_generic_title[255];  ///< If the selected page doesn't have a custom title, this buffer is used to store a generic page title.
+	std::string selected_generic_title;  ///< If the selected page doesn't have a custom title, this buffer is used to store a generic page title.
 
 	StoryPageElementID active_button_id; ///< Which button element the player is currently using
 
@@ -188,9 +188,9 @@ protected:
 	{
 		/* Generate generic title if selected page have no custom title. */
 		StoryPage *page = this->GetSelPage();
-		if (page != nullptr && page->title == nullptr) {
+		if (page != nullptr && page->title.empty()) {
 			SetDParam(0, GetSelPageNum() + 1);
-			GetString(selected_generic_title, STR_STORY_BOOK_GENERIC_PAGE_ITEM, lastof(selected_generic_title));
+			selected_generic_title = GetString(STR_STORY_BOOK_GENERIC_PAGE_ITEM);
 		}
 
 		this->story_page_elements.ForceRebuild();
@@ -255,7 +255,7 @@ protected:
 		for (const StoryPage *p : this->story_pages) {
 			bool current_page = p->index == this->selected_page_id;
 			DropDownListStringItem *item = nullptr;
-			if (p->title != nullptr) {
+			if (!p->title.empty()) {
 				item = new DropDownListCharStringItem(p->title, p->index, current_page);
 			} else {
 				/* No custom title => use a generic page title with page number. */
@@ -295,7 +295,7 @@ protected:
 
 		/* Title lines */
 		height += FONT_HEIGHT_NORMAL; // Date always use exactly one line.
-		SetDParamStr(0, page->title != nullptr ? page->title : this->selected_generic_title);
+		SetDParamStr(0, !page->title.empty() ? page->title : this->selected_generic_title);
 		height += GetStringHeight(STR_STORY_BOOK_TITLE, max_width);
 
 		return height;
@@ -616,7 +616,7 @@ public:
 		this->owner = (Owner)this->window_number;
 
 		/* Initialize selected vars. */
-		this->selected_generic_title[0] = '\0';
+		this->selected_generic_title.clear();
 		this->selected_page_id = INVALID_STORY_PAGE;
 
 		this->active_button_id = INVALID_STORY_PAGE_ELEMENT;
@@ -655,7 +655,7 @@ public:
 		switch (widget) {
 			case WID_SB_SEL_PAGE: {
 				StoryPage *page = this->GetSelPage();
-				SetDParamStr(0, page != nullptr && page->title != nullptr ? page->title : this->selected_generic_title);
+				SetDParamStr(0, page != nullptr && !page->title.empty() ? page->title : this->selected_generic_title);
 				break;
 			}
 			case WID_SB_CAPTION:
@@ -713,7 +713,7 @@ public:
 		y_offset += line_height;
 
 		/* Title */
-		SetDParamStr(0, page->title != nullptr ? page->title : this->selected_generic_title);
+		SetDParamStr(0, !page->title.empty() ? page->title : this->selected_generic_title);
 		y_offset = DrawStringMultiLine(0, fr.right, y_offset, fr.bottom, STR_STORY_BOOK_TITLE, TC_BLACK, SA_TOP | SA_HOR_CENTER);
 
 		/* Page elements */
@@ -773,7 +773,7 @@ public:
 				for (size_t i = 0; i < this->story_pages.size(); i++) {
 					const StoryPage *s = this->story_pages[i];
 
-					if (s->title != nullptr) {
+					if (!s->title.empty()) {
 						SetDParamStr(0, s->title);
 					} else {
 						SetDParamStr(0, this->selected_generic_title);
@@ -877,7 +877,7 @@ public:
 
 			/* Was the last page removed? */
 			if (this->story_pages.size() == 0) {
-				this->selected_generic_title[0] = '\0';
+				this->selected_generic_title.clear();
 			}
 
 			/* Verify page selection. */

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2218,8 +2218,8 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 			 * future, so for safety we just Utf8 Encode it into the string,
 			 * which takes exactly three characters, so it replaces the "XXX"
 			 * with the colour marker. */
-			static char *err_str = stredup("XXXThe current font is missing some of the characters used in the texts for this language. Using system fallback font instead.");
-			Utf8Encode(err_str, SCC_YELLOW);
+			static std::string err_str("XXXThe current font is missing some of the characters used in the texts for this language. Using system fallback font instead.");
+			Utf8Encode(err_str.data(), SCC_YELLOW);
 			SetDParamStr(0, err_str);
 			ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_WARNING);
 		}
@@ -2239,8 +2239,8 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 		 * properly we have to set the colour of the string, otherwise we end up with a lot of artifacts.
 		 * The colour 'character' might change in the future, so for safety we just Utf8 Encode it into
 		 * the string, which takes exactly three characters, so it replaces the "XXX" with the colour marker. */
-		static char *err_str = stredup("XXXThe current font is missing some of the characters used in the texts for this language. Read the readme to see how to solve this.");
-		Utf8Encode(err_str, SCC_YELLOW);
+		static std::string err_str("XXXThe current font is missing some of the characters used in the texts for this language. Read the readme to see how to solve this.");
+		Utf8Encode(err_str.data(), SCC_YELLOW);
 		SetDParamStr(0, err_str);
 		ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_WARNING);
 
@@ -2267,8 +2267,8 @@ void CheckForMissingGlyphs(bool base_font, MissingGlyphSearcher *searcher)
 	 * the colour marker.
 	 */
 	if (_current_text_dir != TD_LTR) {
-		static char *err_str = stredup("XXXThis version of OpenTTD does not support right-to-left languages. Recompile with icu enabled.");
-		Utf8Encode(err_str, SCC_YELLOW);
+		static std::string err_str("XXXThis version of OpenTTD does not support right-to-left languages. Recompile with icu enabled.");
+		Utf8Encode(err_str.data(), SCC_YELLOW);
 		SetDParamStr(0, err_str);
 		ShowErrorMessage(STR_JUST_RAW_STRING, INVALID_STRING_ID, WL_ERROR);
 	}


### PR DESCRIPTION
## Motivation / Problem

Lots of manual memory management for strings.


## Description

Replace `char *` with `std::string` and remove need for `stredup` and `free`.


## Limitations

There's still lots of manual memory management, but... small steps.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
