### PR TITLE
Fix: [Win32] Wrong multi-line text layout due to incorrect whitespace

### DIFF
--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -347,7 +347,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	}
 
 	/* If the text does not fit into the available width, find a suitable breaking point. */
-	int remaing_offset = (last_run - 1)->len;
+	int remaining_offset = (last_run - 1)->len;
 	if (cur_width > max_width) {
 		std::vector<SCRIPT_LOGATTR> log_attribs;
 
@@ -390,9 +390,9 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 			num_chars -= run->len;
 
 			if (num_chars <= 0) {
-				remaing_offset = num_chars + run->len + 1;
+				remaining_offset = num_chars + run->len + 1;
 				last_run = run + 1;
-				assert(remaing_offset - 1 > 0);
+				assert(remaining_offset - 1 > 0);
 				break;
 			}
 		}
@@ -415,8 +415,8 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 		UniscribeRun run = *i_run;
 
 		/* Partial run after line break (either start or end)? Reshape run to get the first/last glyphs right. */
-		if (i_run == last_run - 1 && remaing_offset < (last_run - 1)->len) {
-			run.len = remaing_offset - 1;
+		if (i_run == last_run - 1 && remaining_offset < (last_run - 1)->len) {
+			run.len = remaining_offset - 1;
 
 			if (!UniscribeShapeRun(this->text_buffer, run)) return nullptr;
 		}
@@ -432,9 +432,9 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 		cur_pos += run.total_advance;
 	}
 
-	if (remaing_offset < (last_run - 1)->len) {
+	if (remaining_offset < (last_run - 1)->len) {
 		/* We didn't use up all of the last run, store remainder for the next line. */
-		this->cur_range_offset = remaing_offset - 1;
+		this->cur_range_offset = remaining_offset - 1;
 		this->cur_range = last_run - 1;
 		assert(this->cur_range->len > this->cur_range_offset);
 	} else {


### PR DESCRIPTION
## Motivation / Problem

When line breaking multi-line text on Win32, the line start is incorrectly aligned for RTL text layout, see
![image](https://user-images.githubusercontent.com/1447653/235458847-0e7c294f-ec54-433f-b4ea-ff0702c360ce.png)


## Description / Limitations

The Uniscribe text layout did not properly strip whitespace chars before a line break. On a normal LTR layout, this was not noticeable as it would just (invisibly) overhang the line on the right. On a RTL layout on the other hand the right side is the position anchor and thus the whitespace was visible and messing up the width calculations.

This is fixed by stripping the whitespace properly. The last run on a line is now stopping before any whitespace characters while the next line will only start after the whitespace. With this, no layout artifacts on either side of a line break will be visible.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
