### PR TITLE
Change: Move gamelog functions into a gamelog class.

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2116,7 +2116,7 @@ DEF_CONSOLE_CMD(ConListSettings)
 
 DEF_CONSOLE_CMD(ConGamelogPrint)
 {
-	GamelogPrintConsole();
+	_gamelog.PrintConsole();
 	return true;
 }
 

--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -299,7 +299,7 @@ char *CrashLog::LogLibraries(char *buffer, const char *last) const
  */
 char *CrashLog::LogGamelog(char *buffer, const char *last) const
 {
-	GamelogPrint([&buffer, last](const char *s) {
+	_gamelog.Print([&buffer, last](const char *s) {
 		buffer += seprintf(buffer, last, "%s\n", s);
 	});
 	return buffer + seprintf(buffer, last, "\n");
@@ -421,7 +421,7 @@ bool CrashLog::WriteSavegame(char *filename, const char *filename_last) const
 	if (!Map::IsInitialized()) return false;
 
 	try {
-		GamelogEmergency();
+		_gamelog.Emergency();
 
 		this->CreateFileName(filename, filename_last, ".sav");
 

--- a/src/fios.h
+++ b/src/fios.h
@@ -13,6 +13,7 @@
 #include "gfx_type.h"
 #include "company_base.h"
 #include "newgrf_config.h"
+#include "gamelog.h"
 #include "network/core/tcp_content_type.h"
 #include "timer/timer_game_calendar.h"
 
@@ -44,21 +45,11 @@ struct LoadCheckData {
 	GRFConfig *grfconfig;                         ///< NewGrf configuration from save.
 	GRFListCompatibility grf_compatibility;       ///< Summary state of NewGrfs, whether missing files or only compatible found.
 
-	struct LoggedAction *gamelog_action;          ///< Gamelog actions
-	uint gamelog_actions;                         ///< Number of gamelog actions
+	Gamelog gamelog; ///< Gamelog actions
 
 	LoadCheckData() : grfconfig(nullptr),
-			grf_compatibility(GLC_NOT_FOUND), gamelog_action(nullptr), gamelog_actions(0)
+			grf_compatibility(GLC_NOT_FOUND)
 	{
-		this->Clear();
-	}
-
-	/**
-	 * Don't leak memory at program exit
-	 */
-	~LoadCheckData()
-	{
-		this->Clear();
 	}
 
 	/**

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -28,6 +28,7 @@
 #include "gamelog.h"
 #include "stringfilter_type.h"
 #include "misc_cmd.h"
+#include "gamelog_internal.h"
 
 #include "widgets/fios_widget.h"
 
@@ -40,7 +41,6 @@ LoadCheckData _load_check_data;    ///< Data loaded from save during SL_LOAD_CHE
 
 static bool _fios_path_changed;
 static bool _savegame_sort_dirty;
-
 
 /**
  * Reset read data.
@@ -60,9 +60,7 @@ void LoadCheckData::Clear()
 	}
 	companies.clear();
 
-	GamelogFree(this->gamelog_action, this->gamelog_actions);
-	this->gamelog_action = nullptr;
-	this->gamelog_actions = 0;
+	this->gamelog.Reset();
 
 	ClearGRFConfigList(&this->grfconfig);
 }

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -26,36 +26,77 @@ enum GamelogActionType : uint8 {
 	GLAT_NONE  = 0xFF, ///< No logging active; in savegames, end of list
 };
 
-void GamelogStartAction(GamelogActionType at);
-void GamelogStopAction();
-void GamelogStopAnyAction();
+/** Type of logged change */
+enum GamelogChangeType : uint8 {
+	GLCT_MODE,        ///< Scenario editor x Game, different landscape
+	GLCT_REVISION,    ///< Changed game revision string
+	GLCT_OLDVER,      ///< Loaded from savegame without logged data
+	GLCT_SETTING,     ///< Non-networksafe setting value changed
+	GLCT_GRFADD,      ///< Removed GRF
+	GLCT_GRFREM,      ///< Added GRF
+	GLCT_GRFCOMPAT,   ///< Loading compatible GRF
+	GLCT_GRFPARAM,    ///< GRF parameter changed
+	GLCT_GRFMOVE,     ///< GRF order changed
+	GLCT_GRFBUG,      ///< GRF bug triggered
+	GLCT_EMERGENCY,   ///< Emergency savegame
+	GLCT_END,         ///< So we know how many GLCTs are there
+	GLCT_NONE = 0xFF, ///< In savegames, end of list
+};
 
-void GamelogFree(struct LoggedAction *gamelog_action, uint gamelog_actions);
-void GamelogReset();
+struct LoggedChange;
+struct LoggedAction;
+struct GamelogInternalData;
 
-void GamelogPrint(std::function<void(const char *)> proc);
-void GamelogPrintDebug(int level);
-void GamelogPrintConsole();
+class Gamelog {
+private:
+	std::unique_ptr<GamelogInternalData> data;
+	GamelogActionType action_type;
+	struct LoggedAction *current_action;
 
-void GamelogEmergency();
-bool GamelogTestEmergency();
+	LoggedChange *Change(GamelogChangeType ct);
 
-void GamelogRevision();
-void GamelogMode();
-void GamelogOldver();
-void GamelogSetting(const std::string &name, int32 oldval, int32 newval);
+public:
+	Gamelog();
+	~Gamelog();
 
-void GamelogGRFUpdate(const GRFConfig *oldg, const GRFConfig *newg);
-void GamelogGRFAddList(const GRFConfig *newg);
-void GamelogGRFRemove(uint32 grfid);
-void GamelogGRFAdd(const GRFConfig *newg);
-void GamelogGRFCompatible(const GRFIdentifier *newg);
+	void StartAction(GamelogActionType at);
+	void StopAction();
+	void StopAnyAction();
 
-void GamelogTestRevision();
-void GamelogTestMode();
+	void Reset();
 
-bool GamelogGRFBugReverse(uint32 grfid, uint16 internal_id);
+	void Print(std::function<void(const char *)> proc);
+	void PrintDebug(int level);
+	void PrintConsole();
 
-void GamelogInfo(struct LoggedAction *gamelog_action, uint gamelog_actions, uint32 *last_ottd_rev, byte *ever_modified, bool *removed_newgrfs);
+	void Emergency();
+	bool TestEmergency();
+
+	void Revision();
+	void Mode();
+	void Oldver();
+	void Setting(const std::string &name, int32 oldval, int32 newval);
+
+	void GRFUpdate(const GRFConfig *oldg, const GRFConfig *newg);
+	void GRFAddList(const GRFConfig *newg);
+	void GRFRemove(uint32 grfid);
+	void GRFAdd(const GRFConfig *newg);
+	void GRFBug(uint32 grfid, byte bug, uint64 data);
+	bool GRFBugReverse(uint32 grfid, uint16 internal_id);
+	void GRFCompatible(const GRFIdentifier *newg);
+	void GRFMove(uint32 grfid, int32 offset);
+	void GRFParameters(uint32 grfid);
+
+	void TestRevision();
+	void TestMode();
+
+	void Info(uint32 *last_ottd_rev, byte *ever_modified, bool *removed_newgrfs);
+	const GRFIdentifier *GetOverriddenIdentifier(const GRFConfig *c);
+
+	/* Saveload handler for gamelog needs access to internal data. */
+	friend struct GLOGChunkHandler;
+};
+
+extern Gamelog _gamelog;
 
 #endif /* GAMELOG_H */

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -12,24 +12,6 @@
 
 #include "gamelog.h"
 
-/** Type of logged change */
-enum GamelogChangeType : uint8 {
-	GLCT_MODE,        ///< Scenario editor x Game, different landscape
-	GLCT_REVISION,    ///< Changed game revision string
-	GLCT_OLDVER,      ///< Loaded from savegame without logged data
-	GLCT_SETTING,     ///< Non-networksafe setting value changed
-	GLCT_GRFADD,      ///< Removed GRF
-	GLCT_GRFREM,      ///< Added GRF
-	GLCT_GRFCOMPAT,   ///< Loading compatible GRF
-	GLCT_GRFPARAM,    ///< GRF parameter changed
-	GLCT_GRFMOVE,     ///< GRF order changed
-	GLCT_GRFBUG,      ///< GRF bug triggered
-	GLCT_EMERGENCY,   ///< Emergency savegame
-	GLCT_END,         ///< So we know how many GLCTs are there
-	GLCT_NONE = 0xFF, ///< In savegames, end of list
-};
-
-
 static const uint GAMELOG_REVISION_LENGTH = 15;
 
 /** Contains information about one logged change */
@@ -73,18 +55,20 @@ struct LoggedChange {
 			byte bug;        ///< type of bug, @see enum GRFBugs
 		} grfbug;
 	};
+
+	~LoggedChange();
 };
 
 
 /** Contains information about one logged action that caused at least one logged change */
 struct LoggedAction {
-	LoggedChange *change; ///< First logged change in this action
-	uint32 changes;       ///< Number of changes in this action
+	std::vector<LoggedChange> change; ///< First logged change in this action
 	GamelogActionType at; ///< Type of action
 	uint64 tick;          ///< Tick when it happened
 };
 
-extern LoggedAction *_gamelog_action;
-extern uint _gamelog_actions;
+struct GamelogInternalData {
+	std::vector<LoggedAction> action;
+};
 
 #endif /* GAMELOG_INTERNAL_H */

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -122,10 +122,10 @@ void InitializeGame(uint size_x, uint size_y, bool reset_date, bool reset_settin
 
 	ResetObjectToPlace();
 
-	GamelogReset();
-	GamelogStartAction(GLAT_START);
-	GamelogRevision();
-	GamelogMode();
-	GamelogGRFAddList(_grfconfig);
-	GamelogStopAction();
+	_gamelog.Reset();
+	_gamelog.StartAction(GLAT_START);
+	_gamelog.Revision();
+	_gamelog.Mode();
+	_gamelog.GRFAddList(_grfconfig);
+	_gamelog.StopAction();
 }

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1964,11 +1964,11 @@ static void NewGRFConfirmationCallback(Window *w, bool confirmed)
 		CloseWindowByClass(WC_TEXTFILE);
 		NewGRFWindow *nw = dynamic_cast<NewGRFWindow*>(w);
 
-		GamelogStartAction(GLAT_GRF);
-		GamelogGRFUpdate(_grfconfig, nw->actives); // log GRF changes
+		_gamelog.StartAction(GLAT_GRF);
+		_gamelog.GRFUpdate(_grfconfig, nw->actives); // log GRF changes
 		CopyGRFConfigList(nw->orig_list, nw->actives, false);
 		ReloadNewGRFData();
-		GamelogStopAction();
+		_gamelog.StopAction();
 
 		/* Show new, updated list */
 		GRFConfig *c;

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -241,7 +241,7 @@ static void WriteSavegameInfo(const char *name)
 	byte ever_modified = 0;
 	bool removed_newgrfs = false;
 
-	GamelogInfo(_load_check_data.gamelog_action, _load_check_data.gamelog_actions, &last_ottd_rev, &ever_modified, &removed_newgrfs);
+	_gamelog.Info(&last_ottd_rev, &ever_modified, &removed_newgrfs);
 
 	std::string message;
 	message.reserve(1024);
@@ -311,7 +311,7 @@ static void ShutdownGame()
 	Game::Uninitialize(false);
 
 	/* Uninitialize variables that are allocated dynamically */
-	GamelogReset();
+	_gamelog.Reset();
 
 	LinkGraphSchedule::Clear();
 	PoolBase::Clean(PT_ALL);

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -227,7 +227,7 @@ void CDECL HandleCrash(int signum)
 		signal(*i, SIG_DFL);
 	}
 
-	if (GamelogTestEmergency()) {
+	if (_gamelog.TestEmergency()) {
 		ShowMacDialog("A serious fault condition occurred in the game. The game will shut down.",
 				"As you loaded an emergency savegame no crash information will be generated.\n",
 				"Quit");

--- a/src/os/unix/crashlog_unix.cpp
+++ b/src/os/unix/crashlog_unix.cpp
@@ -155,7 +155,7 @@ static void CDECL HandleCrash(int signum)
 		signal(*i, SIG_DFL);
 	}
 
-	if (GamelogTestEmergency()) {
+	if (_gamelog.TestEmergency()) {
 		printf("A serious fault condition occurred in the game. The game will shut down.\n");
 		printf("As you loaded an emergency savegame no crash information will be generated.\n");
 		abort();

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -540,7 +540,7 @@ static LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS *ep)
 		ExitProcess(2);
 	}
 
-	if (GamelogTestEmergency()) {
+	if (_gamelog.TestEmergency()) {
 		static const wchar_t _emergency_crash[] =
 			L"A serious fault condition occurred in the game. The game will shut down.\n"
 			L"As you loaded an emergency savegame no crash information will be generated.\n";

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -348,7 +348,7 @@ void NORETURN SlError(StringID string, const std::string &extra_msg)
 	if (_sl.action == SLA_LOAD || _sl.action == SLA_PTRS) SlNullPointers();
 
 	/* Logging could be active. */
-	GamelogStopAnyAction();
+	_gamelog.StopAnyAction();
 
 	throw std::exception();
 }
@@ -3129,7 +3129,7 @@ static SaveOrLoadResult DoLoad(LoadFilter *reader, bool load_check)
 		 * confuse old games */
 		InitializeGame(256, 256, true, true);
 
-		GamelogReset();
+		_gamelog.Reset();
 
 		if (IsSavegameVersionBefore(SLV_4)) {
 			/*
@@ -3175,16 +3175,16 @@ static SaveOrLoadResult DoLoad(LoadFilter *reader, bool load_check)
 		/* The only part from AfterLoadGame() we need */
 		_load_check_data.grf_compatibility = IsGoodGRFConfigList(_load_check_data.grfconfig);
 	} else {
-		GamelogStartAction(GLAT_LOAD);
+		_gamelog.StartAction(GLAT_LOAD);
 
 		/* After loading fix up savegame for any internal changes that
 		 * might have occurred since then. If it fails, load back the old game. */
 		if (!AfterLoadGame()) {
-			GamelogStopAction();
+			_gamelog.StopAction();
 			return SL_REINIT;
 		}
 
-		GamelogStopAction();
+		_gamelog.StopAction();
 	}
 
 	return SL_OK;
@@ -3237,16 +3237,16 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
 			 * Note: this is done here because AfterLoadGame is also called
 			 * for OTTD savegames which have their own NewGRF logic. */
 			ClearGRFConfigList(&_grfconfig);
-			GamelogReset();
+			_gamelog.Reset();
 			if (!LoadOldSaveGame(filename)) return SL_REINIT;
 			_sl_version = SL_MIN_VERSION;
 			_sl_minor_version = 0;
-			GamelogStartAction(GLAT_LOAD);
+			_gamelog.StartAction(GLAT_LOAD);
 			if (!AfterLoadGame()) {
-				GamelogStopAction();
+				_gamelog.StopAction();
 				return SL_REINIT;
 			}
-			GamelogStopAction();
+			_gamelog.StopAction();
 			return SL_OK;
 		}
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1401,9 +1401,9 @@ void IntSettingDesc::ChangeValue(const void *object, int32 newval) const
 	if (this->post_callback != nullptr) this->post_callback(newval);
 
 	if (this->flags & SF_NO_NETWORK) {
-		GamelogStartAction(GLAT_SETTING);
-		GamelogSetting(this->GetName(), oldval, newval);
-		GamelogStopAction();
+		_gamelog.StartAction(GLAT_SETTING);
+		_gamelog.Setting(this->GetName(), oldval, newval);
+		_gamelog.StopAction();
 	}
 
 	SetWindowClassesDirty(WC_GAME_OPTIONS);

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -337,7 +337,7 @@ void VehicleLengthChanged(const Vehicle *u)
 	const Engine *engine = u->GetEngine();
 	uint32 grfid = engine->grf_prop.grffile->grfid;
 	GRFConfig *grfconfig = GetGRFConfig(grfid);
-	if (GamelogGRFBugReverse(grfid, engine->grf_prop.local_id) || !HasBit(grfconfig->grf_bugs, GBUG_VEH_LENGTH)) {
+	if (_gamelog.GRFBugReverse(grfid, engine->grf_prop.local_id) || !HasBit(grfconfig->grf_bugs, GBUG_VEH_LENGTH)) {
 		ShowNewGrfVehicleError(u->engine_type, STR_NEWGRF_BROKEN, STR_NEWGRF_BROKEN_VEHICLE_LENGTH, GBUG_VEH_LENGTH, true);
 	}
 }


### PR DESCRIPTION
## Motivation / Problem

Gamelog manipulation involves manual memory management and passing counters around.

## Description

I fell into a rabbit hole while replacing malloc/free with vectors and ended up converting the lot to a class with internal data.

Gamelog is now contained and self-managing.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
