### PR TITLE
Feature: Setting to disallow level crossings with competitors

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1426,6 +1426,9 @@ STR_CONFIG_SETTING_PLANE_CRASHES_NONE                           :None*
 STR_CONFIG_SETTING_PLANE_CRASHES_REDUCED                        :Reduced
 STR_CONFIG_SETTING_PLANE_CRASHES_NORMAL                         :Normal
 
+STR_CONFIG_SETTING_CROSSING_WITH_COMPETITOR                     :Allow level crossings with roads or rails owned by competitors: {STRING2}
+STR_CONFIG_SETTING_CROSSING_WITH_COMPETITOR_HELPTEXT            :Allow construction of level crossings on roads or rails owned by competitors
+
 STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD                            :Allow drive-through road stops on roads owned by towns: {STRING2}
 STR_CONFIG_SETTING_STOP_ON_TOWN_ROAD_HELPTEXT                   :Allow construction of drive-through road stops on roads owned by towns
 STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD                      :Allow drive-through road stops on roads owned by competitors: {STRING2}

--- a/src/rail_cmd.cpp
+++ b/src/rail_cmd.cpp
@@ -507,6 +507,11 @@ CommandCost CmdBuildSingleRail(DoCommandFlag flags, TileIndex tile, RailType rai
 			/* Level crossings may only be built on these slopes */
 			if (!HasBit(VALID_LEVEL_CROSSING_SLOPES, tileh)) return_cmd_error(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 
+			if (!_settings_game.construction.crossing_with_competitor && _current_company != OWNER_DEITY) {
+				CommandCost ret = CheckTileOwnership(tile);
+				if (ret.Failed()) return ret;
+			}
+
 			CommandCost ret = EnsureNoVehicleOnGround(tile);
 			if (ret.Failed()) return ret;
 

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -737,6 +737,11 @@ CommandCost CmdBuildRoad(DoCommandFlag flags, TileIndex tile, RoadBits pieces, R
 				return_cmd_error(STR_ERROR_LAND_SLOPED_IN_WRONG_DIRECTION);
 			}
 
+			if (!_settings_game.construction.crossing_with_competitor && company != OWNER_TOWN && company != OWNER_DEITY) {
+				CommandCost ret = CheckTileOwnership(tile);
+				if (ret.Failed()) return ret;
+			}
+
 			if (GetRailTileType(tile) != RAIL_TILE_NORMAL) goto do_clear;
 
 			if (RoadNoLevelCrossing(rt)) {

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -1932,6 +1932,7 @@ static SettingsContainer &GetSettingsTree()
 			limitations->Add(new SettingEntry("station.distant_join_stations"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_town_road"));
 			limitations->Add(new SettingEntry("construction.road_stop_on_competitor_road"));
+			limitations->Add(new SettingEntry("construction.crossing_with_competitor"));
 			limitations->Add(new SettingEntry("vehicle.disable_elrails"));
 		}
 

--- a/src/settings_type.h
+++ b/src/settings_type.h
@@ -368,6 +368,7 @@ struct ConstructionSettings {
 	bool   extra_dynamite;                   ///< extra dynamite
 	bool   road_stop_on_town_road;           ///< allow building of drive-through road stops on town owned roads
 	bool   road_stop_on_competitor_road;     ///< allow building of drive-through road stops on roads owned by competitors
+	bool   crossing_with_competitor;         ///< allow building of level crossings with competitor roads or rails
 	uint8_t  raw_industry_construction;        ///< type of (raw) industry construction (none, "normal", prospecting)
 	uint8_t  industry_platform;                ///< the amount of flat land around an industry
 	bool   freeform_edges;                   ///< allow terraforming the tiles at the map edges

--- a/src/table/settings/world_settings.ini
+++ b/src/table/settings/world_settings.ini
@@ -523,6 +523,13 @@ str      = STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD
 strhelp  = STR_CONFIG_SETTING_STOP_ON_COMPETITOR_ROAD_HELPTEXT
 cat      = SC_BASIC
 
+[SDT_BOOL]
+var      = construction.crossing_with_competitor
+def      = true
+str      = STR_CONFIG_SETTING_CROSSING_WITH_COMPETITOR
+strhelp  = STR_CONFIG_SETTING_CROSSING_WITH_COMPETITOR_HELPTEXT
+cat      = SC_BASIC
+
 [SDT_VAR]
 var      = construction.raw_industry_construction
 type     = SLE_UINT8


### PR DESCRIPTION
## Motivation / Problem

See https://github.com/OpenTTD/OpenTTD/issues/10311

Players can construct level crossings with other player's roads/rails and cause collisions.

## Description

I added a setting which prevents players from constructing level crossings on other player's (or AI's) roads/rails.

It doesn't affect infrastructure constructed by towns or scripts.

Closes #10311 (edit 2TT)

## Limitations

Perhaps we should think more about the implications of preventing towns from constructing level crossings.

On one hand, collisions can still occur. On the other, it would be a bit cheesy to block towns from growing with just one rail.
Also, it's harder to grief with the roads towns build.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
