### PR TITLE
Fix: [CI] no need to build unit-tests for releases

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -124,7 +124,7 @@ jobs:
 
         echo "::group::Build"
         echo "Running on $(nproc) cores"
-        cmake --build . -j $(nproc)
+        cmake --build . -j $(nproc) --target openttd
         echo "::endgroup::"
 
     - name: Create bundles

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -107,7 +107,7 @@ jobs:
 
         echo "::group::Build"
         echo "Running on $(sysctl -n hw.logicalcpu) cores"
-        cmake --build . -j $(sysctl -n hw.logicalcpu)
+        cmake --build . -j $(sysctl -n hw.logicalcpu) --target openttd
         echo "::endgroup::"
 
     - name: Build x64
@@ -130,7 +130,7 @@ jobs:
 
         echo "::group::Build"
         echo "Running on $(sysctl -n hw.logicalcpu) cores"
-        cmake --build . -j $(sysctl -n hw.logicalcpu)
+        cmake --build . -j $(sysctl -n hw.logicalcpu) --target openttd
         echo "::endgroup::"
 
     - name: Create bundles

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -133,7 +133,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Build"
-        cmake --build .
+        cmake --build . --target openttd
         echo "::endgroup::"
       env:
         WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}
@@ -157,7 +157,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Build"
-        cmake --build .
+        cmake --build . --target openttd
         echo "::endgroup::"
       env:
         WINDOWS_CERTIFICATE_COMMON_NAME: ${{ secrets.WINDOWS_CERTIFICATE_COMMON_NAME }}


### PR DESCRIPTION
## Motivation / Problem

Noticed we were building `openttd_test` for our releases. We don't use them.

## Description

And LTO can be darn slow.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
