### PR TITLE
Fix: no_http_content_downloads and use_relay_service as private settings

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -154,10 +154,11 @@ public:
  * location. These versions assist with situations like that.
  */
 enum IniFileVersion : uint32 {
-	IFV_0,                 ///< 0  All versions prior to introduction.
-	IFV_PRIVATE_SECRETS,   ///< 1  PR#9298  Moving of settings from openttd.cfg to private.cfg / secrets.cfg.
-	IFV_GAME_TYPE,         ///< 2  PR#9515  Convert server_advertise to server_game_type.
-	IFV_LINKGRAPH_SECONDS, ///< 3  PR#10610 Store linkgraph update intervals in seconds instead of days.
+	IFV_0,                                                 ///< 0  All versions prior to introduction.
+	IFV_PRIVATE_SECRETS,                                   ///< 1  PR#9298  Moving of settings from openttd.cfg to private.cfg / secrets.cfg.
+	IFV_GAME_TYPE,                                         ///< 2  PR#9515  Convert server_advertise to server_game_type.
+	IFV_LINKGRAPH_SECONDS,                                 ///< 3  PR#10610 Store linkgraph update intervals in seconds instead of days.
+	IFV_NETWORK_PRIVATE_SETTINGS,                          ///< 4  PR#10762 Move no_http_content_downloads / use_relay_service to private settings.
 
 	IFV_MAX_VERSION,       ///< Highest possible ini-file version.
 };
@@ -1242,6 +1243,31 @@ void LoadFromConfig(bool startup)
 			_settings_newgame.linkgraph.recalc_time     *= SECONDS_PER_DAY;
 		}
 
+		if (generic_version < IFV_NETWORK_PRIVATE_SETTINGS) {
+			IniGroup *network = generic_ini.GetGroup("network", false);
+			if (network != nullptr) {
+				IniItem *no_http_content_downloads = network->GetItem("no_http_content_downloads", false);
+				if (no_http_content_downloads != nullptr) {
+					if (no_http_content_downloads->value == "true") {
+						_settings_client.network.no_http_content_downloads = true;
+					} else if (no_http_content_downloads->value == "false") {
+						_settings_client.network.no_http_content_downloads = false;
+					}
+				}
+
+				IniItem *use_relay_service = network->GetItem("use_relay_service", false);
+				if (use_relay_service != nullptr) {
+					if (use_relay_service->value == "never") {
+						_settings_client.network.use_relay_service = UseRelayService::URS_NEVER;
+					} else if (use_relay_service->value == "ask") {
+						_settings_client.network.use_relay_service = UseRelayService::URS_ASK;
+					} else if (use_relay_service->value == "allow") {
+						_settings_client.network.use_relay_service = UseRelayService::URS_ALLOW;
+					}
+				}
+			}
+		}
+
 		_grfconfig_newgame = GRFLoadConfig(generic_ini, "newgrf", false);
 		_grfconfig_static  = GRFLoadConfig(generic_ini, "newgrf-static", true);
 		AILoadConfig(generic_ini, "ai_players");
@@ -1301,6 +1327,13 @@ void SaveToConfig()
 		IniGroup *network = generic_ini.GetGroup("network", false);
 		if (network != nullptr) {
 			network->RemoveItem("server_advertise");
+		}
+	}
+	if (generic_version < IFV_NETWORK_PRIVATE_SETTINGS) {
+		IniGroup *network = generic_ini.GetGroup("network", false);
+		if (network != nullptr) {
+			network->RemoveItem("no_http_content_downloads");
+			network->RemoveItem("use_relay_service");
 		}
 	}
 

--- a/src/table/settings/network_private_settings.ini
+++ b/src/table/settings/network_private_settings.ini
@@ -7,13 +7,19 @@
 ; Network settings as stored in the private configuration file ("private.cfg").
 
 [pre-amble]
+static constexpr std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
+
 static const SettingVariant _network_private_settings_table[] = {
 [post-amble]
 };
 [templates]
-SDTC_SSTR  =  SDTC_SSTR(              $var, $type, $flags, $def,             $length,                                  $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_BOOL  =  SDTC_BOOL(              $var,        $flags, $def,                              $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_OMANY = SDTC_OMANY(              $var, $type, $flags, $def,             $max, $full,     $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
+SDTC_VAR   =   SDTC_VAR(              $var, $type, $flags, $def,       $min, $max, $interval, $str, $strhelp, $strval, $pre_cb, $post_cb, $from, $to,        $cat, $extra, $startup),
 
 [validation]
+SDTC_OMANY = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
+SDTC_VAR = static_assert($max <= MAX_$type, "Maximum value for $var exceeds storage size");
 
 [defaults]
 flags    = SF_NONE
@@ -66,3 +72,22 @@ length   = 0
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = """"
 cat      = SC_EXPERT
+
+[SDTC_BOOL]
+var      = network.no_http_content_downloads
+flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = false
+cat      = SC_EXPERT
+
+[SDTC_OMANY]
+var      = network.use_relay_service
+type     = SLE_UINT8
+flags    = SF_GUI_DROPDOWN | SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
+def      = URS_ASK
+min      = URS_NO
+max      = URS_ALLOW
+full     = _use_relay_service
+str      = STR_CONFIG_SETTING_USE_RELAY_SERVICE
+strhelp  = STR_CONFIG_SETTING_USE_RELAY_SERVICE_HELPTEXT
+strval   = STR_CONFIG_SETTING_USE_RELAY_SERVICE_NEVER
+cat      = SC_BASIC

--- a/src/table/settings/network_settings.ini
+++ b/src/table/settings/network_settings.ini
@@ -10,7 +10,6 @@
 static void UpdateClientConfigValues();
 
 static constexpr std::initializer_list<const char*> _server_game_type{"local", "public", "invite-only"};
-static constexpr std::initializer_list<const char*> _use_relay_service{"never", "ask", "allow"};
 
 static const SettingVariant _network_settings_table[] = {
 [post-amble]
@@ -246,22 +245,3 @@ var      = network.reload_cfg
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_NETWORK_ONLY
 def      = false
 cat      = SC_EXPERT
-
-[SDTC_BOOL]
-var      = network.no_http_content_downloads
-flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = false
-cat      = SC_EXPERT
-
-[SDTC_OMANY]
-var      = network.use_relay_service
-type     = SLE_UINT8
-flags    = SF_GUI_DROPDOWN | SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
-def      = URS_ASK
-min      = URS_NO
-max      = URS_ALLOW
-full     = _use_relay_service
-str      = STR_CONFIG_SETTING_USE_RELAY_SERVICE
-strhelp  = STR_CONFIG_SETTING_USE_RELAY_SERVICE_HELPTEXT
-strval   = STR_CONFIG_SETTING_USE_RELAY_SERVICE_NEVER
-cat      = SC_BASIC


### PR DESCRIPTION
## Motivation / Problem

While working on the automated opt-in survey, I noticed two settings which I believe should be kept private, and not send in the survey. Additionally, we also don't want them when people send in crash reports.

## Description

So, I moved both settings to the "private.cfg" we have for information like this.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
