### PR TITLE
Codechange: use std::string for text file name resolution

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -285,7 +285,7 @@ struct AIConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_AIC_MOVE_DOWN, this->selected_slot == INVALID_COMPANY || !IsEditable((CompanyID)(this->selected_slot + 1)));
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_AIC_TEXTFILE + tft, this->selected_slot == INVALID_COMPANY || (AIConfig::GetConfig(this->selected_slot)->GetTextfile(tft, this->selected_slot) == nullptr));
+			this->SetWidgetDisabledState(WID_AIC_TEXTFILE + tft, this->selected_slot == INVALID_COMPANY || !AIConfig::GetConfig(this->selected_slot)->GetTextfile(tft, this->selected_slot).has_value());
 		}
 	}
 };

--- a/src/base_media_base.h
+++ b/src/base_media_base.h
@@ -137,17 +137,17 @@ struct BaseSet {
 	/**
 	 * Search a textfile file next to this base media.
 	 * @param type The type of the textfile to search for.
-	 * @return The filename for the textfile, \c nullptr otherwise.
+	 * @return The filename for the textfile.
 	 */
-	const char *GetTextfile(TextfileType type) const
+	std::optional<std::string> GetTextfile(TextfileType type) const
 	{
 		for (uint i = 0; i < NUM_FILES; i++) {
-			const char *textfile = ::GetTextfile(type, BASESET_DIR, this->files[i].filename.c_str());
-			if (textfile != nullptr) {
+			auto textfile = ::GetTextfile(type, BASESET_DIR, this->files[i].filename);
+			if (textfile.has_value()) {
 				return textfile;
 			}
 		}
-		return nullptr;
+		return std::nullopt;
 	}
 };
 

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -405,7 +405,7 @@ struct GSConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GM_NORMAL) || !IsEditable());
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, GameConfig::GetConfig()->GetTextfile(tft, (CompanyID)OWNER_DEITY) == nullptr);
+			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, !GameConfig::GetConfig()->GetTextfile(tft, (CompanyID)OWNER_DEITY).has_value());
 		}
 		this->RebuildVisibleSettings();
 		HideDropDownMenu(this);

--- a/src/network/core/tcp_content.cpp
+++ b/src/network/core/tcp_content.cpp
@@ -49,11 +49,11 @@ bool ContentInfo::IsValid() const
 /**
  * Search a textfile file next to this file in the content list.
  * @param type The type of the textfile to search for.
- * @return The filename for the textfile, \c nullptr otherwise.
+ * @return The filename for the textfile.
  */
-const char *ContentInfo::GetTextfile(TextfileType type) const
+std::optional<std::string> ContentInfo::GetTextfile(TextfileType type) const
 {
-	if (this->state == INVALID) return nullptr;
+	if (this->state == INVALID) return std::nullopt;
 	const char *tmp;
 	switch (this->type) {
 		default: NOT_REACHED();
@@ -88,7 +88,7 @@ const char *ContentInfo::GetTextfile(TextfileType type) const
 			tmp = FindScenario(this, true);
 			break;
 	}
-	if (tmp == nullptr) return nullptr;
+	if (tmp == nullptr) return std::nullopt;
 	return ::GetTextfile(type, GetContentInfoSubDir(this->type), tmp);
 }
 

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -12,6 +12,8 @@
 #ifndef NETWORK_CORE_TCP_CONTENT_TYPE_H
 #define NETWORK_CORE_TCP_CONTENT_TYPE_H
 
+#include <optional>
+
 /** The values in the enum are important; they are used as database 'keys' */
 enum ContentType {
 	CONTENT_TYPE_BEGIN         = 1, ///< Helper to mark the begin of the types
@@ -75,7 +77,7 @@ struct ContentInfo {
 
 	bool IsSelected() const;
 	bool IsValid() const;
-	const char *GetTextfile(TextfileType type) const;
+	std::optional<std::string> GetTextfile(TextfileType type) const;
 };
 
 #endif /* NETWORK_CORE_TCP_CONTENT_TYPE_H */

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -43,8 +43,8 @@ struct ContentTextfileWindow : public TextfileWindow {
 
 	ContentTextfileWindow(TextfileType file_type, const ContentInfo *ci) : TextfileWindow(file_type), ci(ci)
 	{
-		const char *textfile = this->ci->GetTextfile(file_type);
-		this->LoadTextfile(textfile, GetContentInfoSubDir(this->ci->type));
+		auto textfile = this->ci->GetTextfile(file_type);
+		this->LoadTextfile(textfile.value(), GetContentInfoSubDir(this->ci->type));
 	}
 
 	StringID GetTypeString() const
@@ -998,7 +998,7 @@ public:
 		this->SetWidgetDisabledState(WID_NCL_SELECT_UPDATE, !show_select_upgrade);
 		this->SetWidgetDisabledState(WID_NCL_OPEN_URL, this->selected == nullptr || this->selected->url.empty());
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_NCL_TEXTFILE + tft, this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE || this->selected->GetTextfile(tft) == nullptr);
+			this->SetWidgetDisabledState(WID_NCL_TEXTFILE + tft, this->selected == nullptr || this->selected->state != ContentInfo::ALREADY_HERE || !this->selected->GetTextfile(tft).has_value());
 		}
 
 		this->GetWidget<NWidgetCore>(WID_NCL_CANCEL)->widget_data = this->filesize_sum == 0 ? STR_AI_SETTINGS_CLOSE : STR_AI_LIST_CANCEL;

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -785,9 +785,9 @@ char *GRFBuildParamList(char *dst, const GRFConfig *c, const char *last)
 /**
  * Search a textfile file next to this NewGRF.
  * @param type The type of the textfile to search for.
- * @return The filename for the textfile, \c nullptr otherwise.
+ * @return The filename for the textfile.
  */
-const char *GRFConfig::GetTextfile(TextfileType type) const
+std::optional<std::string> GRFConfig::GetTextfile(TextfileType type) const
 {
-	return ::GetTextfile(type, NEWGRF_DIR, this->filename.c_str());
+	return ::GetTextfile(type, NEWGRF_DIR, this->filename);
 }

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -17,6 +17,7 @@
 #include "fileio_type.h"
 #include "textfile_type.h"
 #include "newgrf_text.h"
+#include <optional>
 
 /** GRF config bit flags */
 enum GCF_Flags {
@@ -184,7 +185,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 
 	void CopyParams(const GRFConfig &src);
 
-	const char *GetTextfile(TextfileType type) const;
+	std::optional<std::string> GetTextfile(TextfileType type) const;
 	const char *GetName() const;
 	const char *GetDescription() const;
 	const char *GetURL() const;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -545,8 +545,8 @@ struct NewGRFTextfileWindow : public TextfileWindow {
 
 	NewGRFTextfileWindow(TextfileType file_type, const GRFConfig *c) : TextfileWindow(file_type), grf_config(c)
 	{
-		const char *textfile = this->grf_config->GetTextfile(file_type);
-		this->LoadTextfile(textfile, NEWGRF_DIR);
+		auto textfile = this->grf_config->GetTextfile(file_type);
+		this->LoadTextfile(textfile.value(), NEWGRF_DIR);
 	}
 
 	void SetStringParameters(int widget) const override
@@ -1285,7 +1285,7 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 
 		const GRFConfig *selected_config = (this->avail_sel == nullptr) ? this->active_sel : this->avail_sel;
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_NS_NEWGRF_TEXTFILE + tft, selected_config == nullptr || selected_config->GetTextfile(tft) == nullptr);
+			this->SetWidgetDisabledState(WID_NS_NEWGRF_TEXTFILE + tft, selected_config == nullptr || !selected_config->GetTextfile(tft).has_value());
 		}
 		this->SetWidgetDisabledState(WID_NS_OPEN_URL, selected_config == nullptr || StrEmpty(selected_config->GetURL()));
 

--- a/src/script/script_config.cpp
+++ b/src/script/script_config.cpp
@@ -234,9 +234,9 @@ std::string ScriptConfig::SettingsToString() const
 	return string;
 }
 
-const char *ScriptConfig::GetTextfile(TextfileType type, CompanyID slot) const
+std::optional<std::string> ScriptConfig::GetTextfile(TextfileType type, CompanyID slot) const
 {
-	if (slot == INVALID_COMPANY || this->GetInfo() == nullptr) return nullptr;
+	if (slot == INVALID_COMPANY || this->GetInfo() == nullptr) return std::nullopt;
 
 	return ::GetTextfile(type, (slot == OWNER_DEITY) ? GAME_DIR : AI_DIR, this->GetInfo()->GetMainScript());
 }

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -184,9 +184,9 @@ public:
 	 * Search a textfile file next to this script.
 	 * @param type The type of the textfile to search for.
 	 * @param slot #CompanyID to check status of.
-	 * @return The filename for the textfile, \c nullptr otherwise.
+	 * @return The filename for the textfile.
 	 */
-	const char *GetTextfile(TextfileType type, CompanyID slot) const;
+	std::optional<std::string> GetTextfile(TextfileType type, CompanyID slot) const;
 
 	void SetToLoadData(ScriptInstance::ScriptData *data);
 	ScriptInstance::ScriptData *GetToLoadData();

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -643,11 +643,11 @@ struct ScriptTextfileWindow : public TextfileWindow {
 
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
-		const char *textfile = GetConfig(slot)->GetTextfile(file_type, slot);
-		if (textfile == nullptr) {
+		auto textfile = GetConfig(slot)->GetTextfile(file_type, slot);
+		if (!textfile.has_value()) {
 			this->Close();
 		} else {
-			this->LoadTextfile(textfile, (slot == OWNER_DEITY) ? GAME_DIR : AI_DIR);
+			this->LoadTextfile(textfile.value(), (slot == OWNER_DEITY) ? GAME_DIR : AI_DIR);
 		}
 	}
 };

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -101,8 +101,8 @@ struct BaseSetTextfileWindow : public TextfileWindow {
 
 	BaseSetTextfileWindow(TextfileType file_type, const TBaseSet* baseset, StringID content_type) : TextfileWindow(file_type), baseset(baseset), content_type(content_type)
 	{
-		const char *textfile = this->baseset->GetTextfile(file_type);
-		this->LoadTextfile(textfile, BASESET_DIR);
+		auto textfile = this->baseset->GetTextfile(file_type);
+		this->LoadTextfile(textfile.value(), BASESET_DIR);
 	}
 
 	void SetStringParameters(int widget) const override
@@ -704,9 +704,9 @@ struct GameOptionsWindow : Window {
 		this->GetWidget<NWidgetCore>(WID_GO_BASE_GRF_STATUS)->SetDataTip(missing_files ? STR_EMPTY : STR_GAME_OPTIONS_BASE_GRF_STATUS, STR_NULL);
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_GO_BASE_GRF_TEXTFILE + tft, BaseGraphics::GetUsedSet() == nullptr || BaseGraphics::GetUsedSet()->GetTextfile(tft) == nullptr);
-			this->SetWidgetDisabledState(WID_GO_BASE_SFX_TEXTFILE + tft, BaseSounds::GetUsedSet() == nullptr || BaseSounds::GetUsedSet()->GetTextfile(tft) == nullptr);
-			this->SetWidgetDisabledState(WID_GO_BASE_MUSIC_TEXTFILE + tft, BaseMusic::GetUsedSet() == nullptr || BaseMusic::GetUsedSet()->GetTextfile(tft) == nullptr);
+			this->SetWidgetDisabledState(WID_GO_BASE_GRF_TEXTFILE + tft, BaseGraphics::GetUsedSet() == nullptr || !BaseGraphics::GetUsedSet()->GetTextfile(tft).has_value());
+			this->SetWidgetDisabledState(WID_GO_BASE_SFX_TEXTFILE + tft, BaseSounds::GetUsedSet() == nullptr || !BaseSounds::GetUsedSet()->GetTextfile(tft).has_value());
+			this->SetWidgetDisabledState(WID_GO_BASE_MUSIC_TEXTFILE + tft, BaseMusic::GetUsedSet() == nullptr || !BaseMusic::GetUsedSet()->GetTextfile(tft).has_value());
 		}
 
 		missing_files = BaseMusic::GetUsedSet()->GetNumInvalid() == 0;

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -14,8 +14,9 @@
 #include "strings_func.h"
 #include "textfile_type.h"
 #include "window_gui.h"
+#include <optional>
 
-const char *GetTextfile(TextfileType type, Subdirectory dir, const char *filename);
+std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, const std::string &filename);
 
 /** Window for displaying a textfile */
 struct TextfileWindow : public Window, MissingGlyphSearcher {
@@ -51,7 +52,7 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 	bool Monospace() override;
 	void SetFontNames(FontCacheSettings *settings, const char *font_name, const void *os_data) override;
 
-	virtual void LoadTextfile(const char *textfile, Subdirectory dir);
+	virtual void LoadTextfile(const std::string &textfile, Subdirectory dir);
 
 private:
 	uint ReflowContent();


### PR DESCRIPTION
## Motivation / Problem

C-style strings getting used in `GetTextfile`, requiring the addition of `.c_str()` when changing other parts to C++ style strings.


## Description

Use `std::string`, `std::string_view` and `fmt::format` over `char *`, `strrchr` and `seprintf`, as well as the removal of a few `.c_str()`s.

## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
