### PR TITLE
Codechange: Clean up scrollbars by adding iteration

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -161,7 +161,7 @@ struct AIConfigWindow : public Window {
 		switch (widget) {
 			case WID_AIC_LIST: {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.matrix);
-				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < MAX_COMPANIES; i++) {
+				for (int i = this->vscroll->GetPosition(); i < this->vscroll->End(); i++) {
 					StringID text;
 
 					if ((_game_mode != GM_NORMAL && i == 0) || (_game_mode == GM_NORMAL && Company::IsValidHumanID(i))) {

--- a/src/airport_gui.cpp
+++ b/src/airport_gui.cpp
@@ -390,12 +390,11 @@ public:
 				Rect row = r.WithHeight(this->line_height).Shrink(WidgetDimensions::scaled.bevel);
 				Rect text = r.WithHeight(this->line_height).Shrink(WidgetDimensions::scaled.matrix);
 				AirportClass *apclass = AirportClass::Get(_selected_airport_class);
-				for (uint i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < apclass->GetSpecCount(); i++) {
-					const AirportSpec *as = apclass->GetSpec(i);
+				for (const auto &as : this->vscroll->Iterate(apclass->Specs())) {
 					if (!as->IsAvailable()) {
 						GfxFillRect(row, PC_BLACK, FILLRECT_CHECKER);
 					}
-					DrawString(text, as->name, ((int)i == _selected_airport_index) ? TC_WHITE : TC_BLACK);
+					DrawString(text, as->name, (as->GetIndex() == _selected_airport_index) ? TC_WHITE : TC_BLACK);
 					row = row.Translate(0, this->line_height);
 					text = text.Translate(0, this->line_height);
 				}

--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -33,7 +33,7 @@
 
 #include "safeguards.h"
 
-void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, uint16 min, uint16 max, EngineID selected_id, bool show_count, GroupID selected_group);
+void DrawEngineList(VehicleType type, const Rect &r, const GUIEngineList &eng_list, const Scrollbar *sb, EngineID selected_id, bool show_count, GroupID selected_group);
 
 static bool EngineNumberSorter(const GUIEngineListItem &a, const GUIEngineListItem &b)
 {
@@ -471,11 +471,9 @@ public:
 			case WID_RV_LEFT_MATRIX:
 			case WID_RV_RIGHT_MATRIX: {
 				int side = (widget == WID_RV_LEFT_MATRIX) ? 0 : 1;
-				EngineID start  = static_cast<EngineID>(this->vscroll[side]->GetPosition()); // what is the offset for the start (scrolling)
-				EngineID end    = static_cast<EngineID>(std::min<size_t>(this->vscroll[side]->GetCapacity() + start, this->engines[side].size()));
 
 				/* Do the actual drawing */
-				DrawEngineList((VehicleType)this->window_number, r, this->engines[side], start, end, this->sel_engine[side], side == 0, this->sel_group);
+				DrawEngineList((VehicleType)this->window_number, r, this->engines[side], this->vscroll[side], this->sel_engine[side], side == 0, this->sel_group);
 				break;
 			}
 		}

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -233,8 +233,7 @@ public:
 
 			case WID_BBS_BRIDGE_LIST: {
 				Rect tr = r.WithHeight(this->resize.step_height).Shrink(WidgetDimensions::scaled.matrix);
-				for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < (int)this->bridges.size(); i++) {
-					const BuildBridgeData &bridge_data = this->bridges.at(i);
+				for (const auto &bridge_data : this->vscroll->Iterate(this->bridges)) {
 					const BridgeSpec *b = bridge_data.spec;
 					DrawSprite(b->sprite, b->pal, tr.left, tr.bottom - GetSpriteSize(b->sprite).height);
 					DrawStringMultiLine(tr.Indent(this->bridgetext_offset, false), GetBridgeSelectString(bridge_data));

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -973,11 +973,9 @@ public:
 				}
 			}
 		} else {
-			uint max = static_cast<uint>(std::min<size_t>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->groups.size()));
-			for (uint i = this->vscroll->GetPosition(); i < max; ++i) {
-				const Group *g = this->groups[i];
+			for (const auto &g : this->vscroll->Iterate(this->groups)) {
 				SetDParam(0, g->index);
-				draw_livery(STR_GROUP_NAME, g->livery, this->sel == g->index, false, this->indents[i] * WidgetDimensions::scaled.hsep_indent);
+				draw_livery(STR_GROUP_NAME, g->livery, this->sel == g->index, false, this->indents[&g - this->groups.data()] * WidgetDimensions::scaled.hsep_indent);
 			}
 		}
 	}

--- a/src/core/pool_type.hpp
+++ b/src/core/pool_type.hpp
@@ -172,11 +172,16 @@ struct Pool : PoolBase {
 	 */
 	template <class T>
 	struct IterateWrapper {
+		using iterator = PoolIterator<T>;
+		using const_iterator = PoolIterator<const T>;
+
 		size_t from;
 		IterateWrapper(size_t from = 0) : from(from) {}
-		PoolIterator<T> begin() { return PoolIterator<T>(this->from); }
-		PoolIterator<T> end() { return PoolIterator<T>(T::Pool::MAX_SIZE); }
-		bool empty() { return this->begin() == this->end(); }
+		iterator begin() { return iterator(this->from); }
+		iterator end() { return iterator(T::Pool::MAX_SIZE); }
+		const_iterator cbegin() const { return const_iterator(this->from); }
+		const_iterator cend() const { return const_iterator(T::Pool::MAX_SIZE); }
+		bool empty() const { return this->cbegin() == this->cend(); }
 	};
 
 	/**
@@ -217,12 +222,17 @@ struct Pool : PoolBase {
 	 */
 	template <class T, class F>
 	struct IterateWrapperFiltered {
+		using iterator = PoolIteratorFiltered<T, F>;
+		using const_iterator = PoolIteratorFiltered<const T, F>;
+
 		size_t from;
 		F filter;
 		IterateWrapperFiltered(size_t from, F filter) : from(from), filter(filter) {}
-		PoolIteratorFiltered<T, F> begin() { return PoolIteratorFiltered<T, F>(this->from, this->filter); }
-		PoolIteratorFiltered<T, F> end() { return PoolIteratorFiltered<T, F>(T::Pool::MAX_SIZE, this->filter); }
-		bool empty() { return this->begin() == this->end(); }
+		iterator begin() { return iterator(this->from, this->filter); }
+		iterator end() { return iterator(T::Pool::MAX_SIZE, this->filter); }
+		const_iterator cbegin() const { return const_iterator(this->from, this->filter); }
+		const_iterator cend() const { return const_iterator(T::Pool::MAX_SIZE, this->filter); }
+		bool empty() const { return this->cbegin() == this->cend(); }
 	};
 
 	/**

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -442,9 +442,8 @@ public:
 				GfxFillRect(br, PC_BLACK);
 
 				Rect tr = r.Shrink(WidgetDimensions::scaled.inset).WithHeight(this->resize.step_height);
-				uint scroll_pos = this->vscroll->GetPosition();
-				for (auto it = this->display_list.begin() + scroll_pos; it != this->display_list.end() && tr.top < br.bottom; ++it) {
-					const FiosItem *item = *it;
+				for (auto &it : this->vscroll->Iterate(this->display_list)) {
+					const FiosItem *item = it;
 
 					if (item == this->selected) {
 						GfxFillRect(br.left, tr.top, br.right, tr.bottom, PC_DARK_BLUE);

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -173,9 +173,6 @@ struct GSConfigWindow : public Window {
 			}
 			case WID_GSC_SETTINGS: {
 				ScriptConfig *config = this->gs_config;
-				VisibleSettingsList::const_iterator it = this->visible_settings.begin();
-				int i = 0;
-				for (; !this->vscroll->IsVisible(i); i++) it++;
 
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 				bool rtl = _current_text_dir == TD_RTL;
@@ -185,10 +182,11 @@ struct GSConfigWindow : public Window {
 				int y = r.top;
 				int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 				int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
-				for (; this->vscroll->IsVisible(i) && it != visible_settings.end(); i++, it++) {
-					const ScriptConfigItem &config_item = **it;
-					int current_value = config->GetSetting((config_item).name);
+				for (const auto &it : this->vscroll->Iterate(this->visible_settings)) {
+					const ScriptConfigItem &config_item = *it;
+					int current_value = config->GetSetting(config_item.name);
 					bool editable = this->IsEditableItem(config_item);
+					int i = &it - this->visible_settings.data(); /* Row number required to determine if clicked on. */
 
 					StringID str;
 					TextColour colour;

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -35,6 +35,19 @@ struct Goal : GoalPool::PoolItem<&_goal_pool> {
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
 	inline ~Goal() { }
+
+	struct OwnerFilter {
+		CompanyID cid;
+
+		bool operator() (size_t index) { return Goal::Get(index)->company == this->cid; }
+	};
+
+	/**
+	 */
+	static Pool::IterateWrapperFiltered<Goal, OwnerFilter> IterateOwner(CompanyID cid, size_t from = 0)
+	{
+		return Pool::IterateWrapperFiltered<Goal, OwnerFilter>(from, OwnerFilter{ cid });
+	}
 };
 
 #endif /* GOAL_BASE_H */

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -948,14 +948,8 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 
 		bool rtl = _current_text_dir == TD_RTL;
 
-		int pos = this->vscroll->GetPosition();
-		int max = pos + this->vscroll->GetCapacity();
-
 		Rect line = r.WithHeight(this->line_height);
-		for (const CargoSpec *cs : _sorted_standard_cargo_specs) {
-			if (pos-- > 0) continue;
-			if (--max < 0) break;
-
+		for (const auto &cs : this->vscroll->Iterate(_sorted_standard_cargo_specs)) {
 			bool lowered = !HasBit(_legend_excluded_cargo, cs->Index());
 
 			/* Redraw frame if lowered */

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -606,17 +606,15 @@ public:
 
 			case WID_GL_LIST_GROUP: {
 				int y1 = r.top;
-				size_t max = std::min<size_t>(this->group_sb->GetPosition() + this->group_sb->GetCapacity(), this->groups.size());
-				for (size_t i = this->group_sb->GetPosition(); i < max; ++i) {
-					const Group *g = this->groups[i];
-
+				for (const auto &g : this->group_sb->Iterate(this->groups)) {
 					assert(g->owner == this->owner);
+					size_t i = &g - this->groups.data(); /* Row number required for indent lookup. */
 
 					DrawGroupInfo(y1, r.left, r.right, g->index, this->indents[i] * WidgetDimensions::scaled.hsep_indent, HasBit(g->flags, GroupFlags::GF_REPLACE_PROTECTION), g->folded || (i + 1 < this->groups.size() && indents[i + 1] > this->indents[i]));
 
 					y1 += this->tiny_step_height;
 				}
-				if ((uint)this->group_sb->GetPosition() + this->group_sb->GetCapacity() > this->groups.size()) {
+				if ((size_t)this->group_sb->End() > this->groups.size()) {
 					DrawGroupInfo(y1, r.left, r.right, NEW_GROUP);
 				}
 				break;
@@ -630,9 +628,8 @@ public:
 				if (this->vli.index != ALL_GROUP && this->grouping == GB_NONE) {
 					/* Mark vehicles which are in sub-groups (only if we are not using shared order coalescing) */
 					Rect mr = r.WithHeight(this->resize.step_height);
-					size_t max = std::min<size_t>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->vehgroups.size());
-					for (size_t i = this->vscroll->GetPosition(); i < max; ++i) {
-						const Vehicle *v = this->vehgroups[i].GetSingleVehicle();
+					for (auto &vehgroup : this->vscroll->Iterate(this->vehgroups)) {
+						const Vehicle *v = vehgroup.GetSingleVehicle();
 						if (v->group_id != this->vli.index) {
 							GfxFillRect(mr.Shrink(WidgetDimensions::scaled.bevel), _colour_gradient[COLOUR_GREY][3], FILLRECT_CHECKER);
 						}

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -516,16 +516,16 @@ public:
 				icon.top    = r.top + (this->resize.step_height - this->legend.height + 1) / 2;
 				icon.bottom = icon.top + this->legend.height - 1;
 
-				for (uint16 i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++) {
-					IndustryType type = this->list[i];
-					bool selected = this->selected_type == type;
-					const IndustrySpec *indsp = GetIndustrySpec(type);
+				for (const auto &indtype : this->vscroll->Iterate(this->list)) {
+					bool selected = this->selected_type == indtype;
+
+					const IndustrySpec *indsp = GetIndustrySpec(indtype);
 
 					/* Draw the name of the industry in white is selected, otherwise, in orange */
 					DrawString(text, indsp->name, selected ? TC_WHITE : TC_ORANGE);
 					GfxFillRect(icon, selected ? PC_WHITE : PC_BLACK);
 					GfxFillRect(icon.Shrink(WidgetDimensions::scaled.bevel), indsp->map_colour);
-					SetDParam(0, Industry::GetIndustryTypeCount(type));
+					SetDParam(0, Industry::GetIndustryTypeCount(indtype));
 					DrawString(text, STR_JUST_COMMA, TC_BLACK, SA_RIGHT, false, FS_SMALL);
 
 					text = text.Translate(0, this->resize.step_height);
@@ -1657,26 +1657,22 @@ public:
 				break;
 
 			case WID_ID_INDUSTRY_LIST: {
-				int n = 0;
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 				if (this->industries.size() == 0) {
 					DrawString(ir, STR_INDUSTRY_DIRECTORY_NONE);
 					break;
 				}
-				TextColour tc;
 				const CargoID acf_cid = this->cargo_filter[this->accepted_cargo_filter_criteria];
-				for (uint i = this->vscroll->GetPosition(); i < this->industries.size(); i++) {
-					tc = TC_FROMSTRING;
+				for (const auto &ind : this->vscroll->Iterate(this->industries)) {
+					TextColour tc = TC_FROMSTRING;
 					if (acf_cid != CF_ANY && acf_cid != CF_NONE) {
-						Industry *ind = const_cast<Industry *>(this->industries[i]);
-						if (IndustryTemporarilyRefusesCargo(ind, acf_cid)) {
+						if (IndustryTemporarilyRefusesCargo(const_cast<Industry *>(ind), acf_cid)) {
 							tc = TC_GREY | TC_FORCED;
 						}
 					}
-					DrawString(ir, this->GetIndustryString(this->industries[i]), tc);
+					DrawString(ir, this->GetIndustryString(ind), tc);
 
 					ir.top += this->resize.step_height;
-					if (++n == this->vscroll->GetCapacity()) break; // max number of industries in 1 window
 				}
 				break;
 			}

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -650,13 +650,7 @@ public:
 		int text_y_offset   = (this->resize.step_height - FONT_HEIGHT_NORMAL) / 2;
 
 		Rect mr = r.WithHeight(this->resize.step_height);
-		auto iter = this->content.begin() + this->vscroll->GetPosition();
-		size_t last = this->vscroll->GetPosition() + this->vscroll->GetCapacity();
-		auto end = (last < this->content.size()) ? this->content.begin() + last : this->content.end();
-
-		for (/**/; iter != end; iter++) {
-			const ContentInfo *ci = *iter;
-
+		for (const auto &ci : this->vscroll->Iterate(this->content)) {
 			if (ci == this->selected) GfxFillRect(mr.Shrink(WidgetDimensions::scaled.bevel), PC_GREY);
 
 			SpriteID sprite;

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -567,10 +567,7 @@ public:
 			case WID_NG_MATRIX: {
 				uint16 y = r.top;
 
-				const int max = std::min(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), (int)this->servers.size());
-
-				for (int i = this->vscroll->GetPosition(); i < max; ++i) {
-					const NetworkGameList *ngl = this->servers[i];
+				for (const auto &ngl : this->vscroll->Iterate(this->servers)) {
 					this->DrawServerLine(ngl, y, ngl == this->server);
 					y += this->resize.step_height;
 				}

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -40,6 +40,8 @@ public:
 
 	void Insert(Tspec *spec);
 
+	/** Get a reference to the specs within this class for iteration. */
+	const std::vector<Tspec *> &Specs() const { return this->spec; }
 	/** Get the number of allocated specs within the class. */
 	uint GetSpecCount() const { return static_cast<uint>(this->spec.size()); }
 	/** Get the number of potentially user-available specs within the class. */

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -921,12 +921,9 @@ struct SpriteAlignerWindow : Window {
 				const NWidgetBase *nwid = this->GetWidget<NWidgetBase>(widget);
 				int step_size = nwid->resize_y;
 
-				std::vector<SpriteID> &list = _newgrf_debug_sprite_picker.sprites;
-				int max = std::min<int>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), (uint)list.size());
-
 				Rect ir = r.Shrink(WidgetDimensions::scaled.matrix);
-				for (int i = this->vscroll->GetPosition(); i < max; i++) {
-					SetDParam(0, list[i]);
+				for (const auto &spriteid : this->vscroll->Iterate(_newgrf_debug_sprite_picker.sprites)) {
+					SetDParam(0, spriteid);
 					DrawString(ir, STR_JUST_COMMA, TC_BLACK, SA_RIGHT | SA_FORCE);
 					ir.top += step_size;
 				}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -286,8 +286,9 @@ struct NewGRFParametersWindow : public Window {
 
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
-		for (uint i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++) {
-			GRFParameterInfo &par_info = this->GetParameterInfo(i);
+		for (const auto &it : this->vscroll->Iterate(this->grf_config->param_info)) {
+			uint i = &it - this->grf_config->param_info.data(); /* Row number required to test selection. */
+			const GRFParameterInfo &par_info = it.has_value() ? it.value() : GetDummyParameterInfo(i);
 			uint32 current_value = par_info.GetValue(this->grf_config);
 			bool selected = (i == this->clicked_row);
 
@@ -906,11 +907,8 @@ struct NewGRFWindow : public Window, NewGRFScanCallback {
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 				uint step_height = this->GetWidget<NWidgetBase>(WID_NS_AVAIL_LIST)->resize_y;
 				int offset_y = (step_height - FONT_HEIGHT_NORMAL) / 2;
-				uint min_index = this->vscroll2->GetPosition();
-				uint max_index = std::min(min_index + this->vscroll2->GetCapacity(), (uint)this->avails.size());
 
-				for (uint i = min_index; i < max_index; i++) {
-					const GRFConfig *c = this->avails[i];
+				for (const auto &c : this->vscroll2->Iterate(this->avails)) {
 					bool h = (c == this->avail_sel);
 					const char *text = c->GetName();
 
@@ -2122,13 +2120,12 @@ struct SavePresetWindow : public Window {
 				uint step_height = this->GetWidget<NWidgetBase>(WID_SVP_PRESET_LIST)->resize_y;
 				int offset_y = (step_height - FONT_HEIGHT_NORMAL) / 2;
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-				uint min_index = this->vscroll->GetPosition();
-				uint max_index = std::min(min_index + this->vscroll->GetCapacity(), (uint)this->presets.size());
 
-				for (uint i = min_index; i < max_index; i++) {
-					if ((int)i == this->selected) GfxFillRect(br.left, tr.top, br.right, tr.top + step_height - 1, PC_DARK_BLUE);
+				for (const auto &preset : this->vscroll->Iterate(this->presets)) {
+					int i = &preset - this->presets.data(); /* Row number required to test selection. */
+					if (i == this->selected) GfxFillRect(br.left, tr.top, br.right, tr.top + step_height - 1, PC_DARK_BLUE);
 
-					const char *text = this->presets[i].c_str();
+					const char *text = preset.c_str();
 					DrawString(tr.left, tr.right, tr.top + offset_y, text, ((int)i == this->selected) ? TC_WHITE : TC_SILVER);
 					tr.top += step_height;
 				}

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -358,9 +358,6 @@ struct ScriptSettingsWindow : public Window {
 		if (widget != WID_SCRS_BACKGROUND) return;
 
 		ScriptConfig *config = this->script_config;
-		VisibleSettingsList::const_iterator it = this->visible_settings.begin();
-		int i = 0;
-		for (; !this->vscroll->IsVisible(i); i++) it++;
 
 		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 		bool rtl = _current_text_dir == TD_RTL;
@@ -370,10 +367,11 @@ struct ScriptSettingsWindow : public Window {
 		int y = r.top;
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
-		for (; this->vscroll->IsVisible(i) && it != visible_settings.end(); i++, it++) {
-			const ScriptConfigItem &config_item = **it;
-			int current_value = config->GetSetting((config_item).name);
+		for (const auto &it : this->vscroll->Iterate(this->visible_settings)) {
+			const ScriptConfigItem &config_item = *it;
+			int current_value = config->GetSetting(config_item.name);
 			bool editable = this->IsEditableItem(config_item);
+			int i = &it - this->visible_settings.data(); /* Row number required to determine if clicked on. */
 
 			StringID str;
 			TextColour colour;
@@ -903,9 +901,7 @@ struct ScriptDebugWindow : public Window {
 
 		Rect br = r.Shrink(WidgetDimensions::scaled.bevel);
 		Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-		for (int i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && (size_t)i < log.size(); i++) {
-			const ScriptLogTypes::LogLine &line = log[i];
-
+		for (const auto &line : this->vscroll->Iterate(log)) {
 			TextColour colour;
 			switch (line.type) {
 				case ScriptLogTypes::LOG_SQ_INFO:  colour = TC_BLACK;  break;
@@ -917,6 +913,7 @@ struct ScriptDebugWindow : public Window {
 			}
 
 			/* Check if the current line should be highlighted */
+			int i = &line - &*log.begin();
 			if (i == this->highlight_row) {
 				GfxFillRect(br.left, tr.top, br.right, tr.top + this->resize.step_height - 1, PC_BLACK);
 				if (colour == TC_BLACK) colour = TC_WHITE; // Make black text readable by inverting it to white.

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -211,10 +211,7 @@ struct SignListWindow : Window, SignList {
 				tr = tr.Indent(this->text_offset, rtl);
 
 				/* At least one sign available. */
-				for (uint16 i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++)
-				{
-					const Sign *si = this->signs[i];
-
+				for (const auto *si : this->vscroll->Iterate(this->signs)) {
 					if (si->owner != OWNER_NONE) DrawCompanyIcon(si->owner, icon_left, tr.top + sprite_offset_y);
 
 					SetDParam(0, si->index);

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -429,7 +429,6 @@ public:
 
 			case WID_STL_LIST: {
 				bool rtl = _current_text_dir == TD_RTL;
-				size_t max = std::min<size_t>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->stations.size());
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 				uint line_height = this->GetWidget<NWidgetBase>(widget)->resize_y;
 				/* Spacing between station name and first rating graph. */
@@ -437,8 +436,7 @@ public:
 				/* Spacing between additional rating graphs. */
 				int rating_spacing = WidgetDimensions::scaled.hsep_normal;
 
-				for (size_t i = this->vscroll->GetPosition(); i < max; ++i) { // do until max number of stations of owner
-					const Station *st = this->stations[i];
+				for (const auto &st : this->vscroll->Iterate(this->stations)) {
 					assert(st->xy != INVALID_TILE);
 
 					/* Do not do the complex check HasStationInUse here, it may be even false
@@ -2287,17 +2285,17 @@ struct SelectStationWindow : Window {
 		if (widget != WID_JS_PANEL) return;
 
 		Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
-		for (uint i = this->vscroll->GetPosition(); i < _stations_nearby_list.size(); ++i, tr.top += this->resize.step_height) {
-			if (_stations_nearby_list[i] == NEW_STATION) {
+		for (const auto &station : this->vscroll->Iterate(_stations_nearby_list)) {
+			if (station == INVALID_STATION) {
 				DrawString(tr, T::EXPECTED_FACIL == FACIL_WAYPOINT ? STR_JOIN_WAYPOINT_CREATE_SPLITTED_WAYPOINT : STR_JOIN_STATION_CREATE_SPLITTED_STATION);
 			} else {
-				const T *st = T::Get(_stations_nearby_list[i]);
+				const T *st = T::Get(station);
 				SetDParam(0, st->index);
 				SetDParam(1, st->facilities);
 				DrawString(tr, T::EXPECTED_FACIL == FACIL_WAYPOINT ? STR_STATION_LIST_WAYPOINT : STR_STATION_LIST_STATION);
 			}
+			tr.top += this->resize.step_height;
 		}
-
 	}
 
 	void OnClick(Point pt, int widget, int click_count) override

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -829,7 +829,6 @@ public:
 				break;
 
 			case WID_TD_LIST: {
-				int n = 0;
 				Rect tr = r.Shrink(WidgetDimensions::scaled.framerect);
 				if (this->towns.size() == 0) { // No towns available.
 					DrawString(tr, STR_TOWN_DIRECTORY_NONE);
@@ -842,8 +841,7 @@ public:
 				int icon_x = tr.WithWidth(icon_size.width, rtl).left;
 				tr = tr.Indent(icon_size.width + WidgetDimensions::scaled.hsep_normal, rtl);
 
-				for (uint i = this->vscroll->GetPosition(); i < this->towns.size(); i++) {
-					const Town *t = this->towns[i];
+				for (const auto &t : this->vscroll->Iterate(this->towns)) {
 					assert(t->xy != INVALID_TILE);
 
 					/* Draw rating icon. */
@@ -861,7 +859,6 @@ public:
 					DrawString(tr.left, tr.right, tr.top + (this->resize.step_height - FONT_HEIGHT_NORMAL) / 2, GetTownString(t));
 
 					tr.top += this->resize.step_height;
-					if (++n == this->vscroll->GetCapacity()) break; // max number of towns in 1 window
 				}
 				break;
 			}

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1660,11 +1660,7 @@ void BaseVehicleListWindow::DrawVehicleListItems(VehicleID selected_vehicle, int
 
 	int vehicle_button_x = rtl ? ir.right - profit.width : ir.left;
 
-	uint max = static_cast<uint>(std::min<size_t>(this->vscroll->GetPosition() + this->vscroll->GetCapacity(), this->vehgroups.size()));
-	for (uint i = this->vscroll->GetPosition(); i < max; ++i) {
-
-		const GUIVehicleGroup &vehgroup = this->vehgroups[i];
-
+	for (const auto &vehgroup : this->vscroll->Iterate(this->vehgroups)) {
 		SetDParam(0, vehgroup.GetDisplayProfitThisYear());
 		SetDParam(1, vehgroup.GetDisplayProfitLastYear());
 		DrawString(tr.left, tr.right, ir.bottom - FONT_HEIGHT_SMALL - WidgetDimensions::scaled.framerect.bottom, STR_VEHICLE_LIST_PROFIT_THIS_YEAR_LAST_YEAR);

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -682,6 +682,12 @@ public:
 	}
 
 	/**
+	 * Get the end of the visible valid elements.
+	 * @return index to the end of the visible valid elements.
+	 */
+	inline int End() const { return std::min<int>(this->GetPosition() + this->GetCapacity(), this->GetCount()); }
+
+	/**
 	 * Checks whether given current item is visible in the list
 	 * @param item to check
 	 * @return true iff the item is visible
@@ -810,6 +816,33 @@ public:
 		typename Tcontainer::iterator it = std::begin(container);
 		std::advance(it, row);
 		return it;
+	}
+
+	/* Scrollbar Iterator wrapper */
+	template <class iterator>
+	class IterateWrapper {
+		iterator b;
+		iterator e;
+	public:
+		IterateWrapper(iterator b, iterator e) : b(b), e(e) {}
+		iterator begin() const { return b; }
+		iterator end() const { return e; }
+	};
+
+	/**
+	 * Create an iterator to iterate through the current visible elements.
+	 * @param c Container to iterate through.
+	 * @return iterator of currently visible elements.
+	 */
+	template <class Tcontainer>
+	inline IterateWrapper<typename Tcontainer::const_iterator> Iterate(const Tcontainer &container) const
+	{
+		// assert(this->GetCount() == container.size()); // Scrollbar and container size must match.
+		auto b = container.cbegin();
+		std::advance(b, this->GetPosition());
+		auto e = b;
+		std::advance(e, std::min<size_t>({(size_t)this->GetCapacity(), (size_t)this->GetCount() - this->GetPosition(), (size_t)std::distance(b, container.cend())}));
+		return IterateWrapper<typename Tcontainer::const_iterator>{b, e};
 	}
 
 	EventState UpdateListPositionOnKeyPress(int &list_position, uint16 keycode) const;

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -216,12 +216,8 @@ struct DropdownWindow : Window {
 		const Rect &r = this->GetWidget<NWidgetBase>(WID_DM_ITEMS)->GetCurrentRect().Shrink(WidgetDimensions::scaled.fullbevel);
 		int y     = _cursor.pos.y - this->top - r.top - WidgetDimensions::scaled.fullbevel.top;
 		int width = r.Width();
-		int pos   = this->vscroll->GetPosition();
 
-		for (const auto &item : this->list) {
-			/* Skip items that are scrolled up */
-			if (--pos >= 0) continue;
-
+		for (const auto &item : this->vscroll->Iterate(this->list)) {
 			int item_height = item->Height(width);
 
 			if (y < item_height) {
@@ -244,12 +240,8 @@ struct DropdownWindow : Window {
 
 		Rect ir = r.Shrink(WidgetDimensions::scaled.fullbevel).Shrink(RectPadding::zero, WidgetDimensions::scaled.fullbevel);
 		int y = ir.top;
-		int pos = this->vscroll->GetPosition();
-		for (const auto &item : this->list) {
+		for (const auto &item : this->vscroll->Iterate(this->list)) {
 			int item_height = item->Height(ir.Width());
-
-			/* Skip items that are scrolled up */
-			if (--pos >= 0) continue;
 
 			if (y + item_height - 1 <= ir.bottom) {
 				bool selected = (this->selected_index == item->result);


### PR DESCRIPTION
## Motivation / Problem

There are about 5 million different way we iterate through visible scrollbar elements. They are mostly very C-style, and often involve casts due to data type conversion issues.

## Description

Implement a range iterator to allow iteration through the visible elements that a scrollbar refers to.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
