### PR TITLE
Codechange: replace C-style strings with C++-style strings in textfile

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -221,9 +221,14 @@ static void StrMakeValidInPlace(T &dst, const char *str, const char *last, Strin
 				str += len;
 				continue;
 			}
-			/* Replace the undesirable character with a question mark */
 			str += len;
-			if ((settings & SVS_REPLACE_WITH_QUESTION_MARK) != 0) *dst++ = '?';
+			if ((settings & SVS_REPLACE_TAB_CR_NL_WITH_SPACE) != 0 && (c == '\r' || c == '\n' || c == '\t')) {
+				/* Replace the tab, carriage return or newline with a space. */
+				*dst++ = ' ';
+			} else if ((settings & SVS_REPLACE_WITH_QUESTION_MARK) != 0) {
+				/* Replace the undesirable character with a question mark */
+				*dst++ = '?';
+			}
 		}
 	}
 
@@ -263,7 +268,7 @@ void StrMakeValidInPlace(char *str, StringValidationSettings settings)
  * @param str The string to validate.
  * @param settings The settings for the string validation.
  */
-std::string StrMakeValid(const std::string &str, StringValidationSettings settings)
+std::string StrMakeValid(std::string_view str, StringValidationSettings settings)
 {
 	auto buf = str.data();
 	auto last = buf + str.size();

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -40,7 +40,7 @@ int CDECL seprintf(char *str, const char *last, const char *format, ...) WARN_FO
 std::string FormatArrayAsHex(span<const byte> data);
 
 void StrMakeValidInPlace(char *str, const char *last, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK) NOACCESS(2);
-[[nodiscard]] std::string StrMakeValid(const std::string &str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
+[[nodiscard]] std::string StrMakeValid(std::string_view str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 void StrMakeValidInPlace(char *str, StringValidationSettings settings = SVS_REPLACE_WITH_QUESTION_MARK);
 
 void str_fix_scc_encoded(char *str, const char *last) NOACCESS(2);

--- a/src/string_type.h
+++ b/src/string_type.h
@@ -47,8 +47,14 @@ static const WChar CHAR_TD_PDF = 0x202C; ///< Restore the text-direction state t
 enum StringValidationSettings {
 	SVS_NONE                       = 0,      ///< Allow nothing and replace nothing.
 	SVS_REPLACE_WITH_QUESTION_MARK = 1 << 0, ///< Replace the unknown/bad bits with question marks.
-	SVS_ALLOW_NEWLINE              = 1 << 1, ///< Allow newlines.
+	SVS_ALLOW_NEWLINE              = 1 << 1, ///< Allow newlines; replaces '\r\n' with '\n' during processing.
 	SVS_ALLOW_CONTROL_CODE         = 1 << 2, ///< Allow the special control codes.
+	/**
+	 * Replace tabs ('\t'), carriage returns ('\r') and newlines ('\n') with spaces.
+	 * When #SVS_ALLOW_NEWLINE is set, a '\n' or '\r\n' combination are not replaced with a space. A lone '\r' is replaced with a space.
+	 * When #SVS_REPLACE_WITH_QUESTION_MARK is set, this replacement runs first.
+	 */
+	SVS_REPLACE_TAB_CR_NL_WITH_SPACE = 1 << 3,
 };
 DECLARE_ENUM_AS_BIT_SET(StringValidationSettings)
 

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -2103,9 +2103,13 @@ bool MissingGlyphSearcher::FindMissingGlyphs()
 	}
 
 	this->Reset();
-	for (const char *text = this->NextString(); text != nullptr; text = this->NextString()) {
+	for (auto text = this->NextString(); text.has_value(); text = this->NextString()) {
+		auto src = text->cbegin();
+
 		FontSize size = this->DefaultSize();
-		for (WChar c = Utf8Consume(&text); c != '\0'; c = Utf8Consume(&text)) {
+		while (src != text->cend()) {
+			WChar c = Utf8Consume(src);
+
 			if (c >= SCC_FIRST_FONT && c <= SCC_LAST_FONT) {
 				size = (FontSize)(c - SCC_FIRST_FONT);
 			} else if (!IsInsideMM(c, SCC_SPRITE_START, SCC_SPRITE_END) && IsPrintable(c) && !IsTextDirectionChar(c) && c != '?' && GetGlyph(size, c) == question_mark[size]) {
@@ -2144,9 +2148,9 @@ class LanguagePackGlyphSearcher : public MissingGlyphSearcher {
 		return FS_NORMAL;
 	}
 
-	const char *NextString() override
+	std::optional<std::string_view> NextString() override
 	{
-		if (this->i >= TEXT_TAB_END) return nullptr;
+		if (this->i >= TEXT_TAB_END) return std::nullopt;
 
 		const char *ret = _langpack.offsets[_langpack.langtab_start[this->i] + this->j];
 

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -261,9 +261,9 @@ public:
 
 	/**
 	 * Get the next string to search through.
-	 * @return The next string or nullptr if there is none.
+	 * @return The next string or nullopt if there is none.
 	 */
-	virtual const char *NextString() = 0;
+	virtual std::optional<std::string_view> NextString() = 0;
 
 	/**
 	 * Get the default (font) size of the string.

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -19,25 +19,14 @@ std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, cons
 
 /** Window for displaying a textfile */
 struct TextfileWindow : public Window, MissingGlyphSearcher {
-	struct Line {
-		int top;          ///< Top scroll position.
-		int bottom;       ///< Bottom scroll position.
-		const char *text; ///< Pointer to text buffer.
-
-		Line(int top, const char *text) : top(top), bottom(top + 1), text(text) {}
-	};
-
 	TextfileType file_type;          ///< Type of textfile to view.
 	Scrollbar *vscroll;              ///< Vertical scrollbar.
 	Scrollbar *hscroll;              ///< Horizontal scrollbar.
-	char *text;                      ///< Lines of text from the NewGRF's textfile.
-	std::vector<Line> lines;         ///< #text, split into lines in a table with lines.
 	uint search_iterator;            ///< Iterator for the font check search.
 
 	uint max_length;                 ///< Maximum length of unwrapped text line.
 
 	TextfileWindow(TextfileType file_type);
-	~TextfileWindow();
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override;
 	void OnClick(Point pt, int widget, int click_count) override;
@@ -47,13 +36,24 @@ struct TextfileWindow : public Window, MissingGlyphSearcher {
 
 	void Reset() override;
 	FontSize DefaultSize() override;
-	const char *NextString() override;
+	std::optional<std::string_view> NextString() override;
 	bool Monospace() override;
 	void SetFontNames(FontCacheSettings *settings, const char *font_name, const void *os_data) override;
 
 	virtual void LoadTextfile(const std::string &textfile, Subdirectory dir);
 
 private:
+	struct Line {
+		int top;               ///< Top scroll position.
+		int bottom;            ///< Bottom scroll position.
+		std::string_view text; ///< Pointer to text buffer.
+
+		Line(int top, std::string_view text) : top(top), bottom(top + 1), text(text) {}
+	};
+
+	std::string text;                ///< Lines of text from the NewGRF's textfile.
+	std::vector<Line> lines;         ///< #text, split into lines in a table with lines.
+
 	uint ReflowContent();
 	uint GetContentHeight();
 	void SetupScrollbars(bool force_reflow);


### PR DESCRIPTION
## Motivation / Problem

For an upcoming PR (survey addition), I want to reuse the textfile GUI. But the content in that PR won't come from a file, but from memory.

Sadly, the current code uses a C-style approach, which made it really tricky to combine these two worlds. So, the easy solution: convert the current code to more C++.


## Description

Exactly what you expect: C-style strings to C++-style strings.

## Limitations

I need to split up this PR before it becomes reviewable.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
