### PR TITLE
Fix: Engine age is in months, not days

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -611,8 +611,8 @@ void CalcEngineReliability(Engine *e, bool new_month)
 		re = Engine::Get(re->info.variant_id);
 	}
 
-	uint age = re->age;
-	if (new_month && re->index > e->index && age != MAX_DAY) age++; /* parent variant's age has not yet updated. */
+	uint32 age = re->age;
+	if (new_month && re->index > e->index && age != INT32_MAX) age++; /* parent variant's age has not yet updated. */
 
 	/* Check for early retirement */
 	if (e->company_avail != 0 && !_settings_game.vehicle.never_expire_vehicles && e->info.base_life != 0xFF) {
@@ -1094,7 +1094,7 @@ void EnginesMonthlyLoop()
 		bool refresh = false;
 		for (Engine *e : Engine::Iterate()) {
 			/* Age the vehicle */
-			if ((e->flags & ENGINE_AVAILABLE) && e->age != MAX_DAY) {
+			if ((e->flags & ENGINE_AVAILABLE) && e->age != INT32_MAX) {
 				e->age++;
 				CalcEngineReliability(e, true);
 				refresh = true;

--- a/src/engine_base.h
+++ b/src/engine_base.h
@@ -37,7 +37,7 @@ extern EnginePool _engine_pool;
 struct Engine : EnginePool::PoolItem<&_engine_pool> {
 	std::string name;           ///< Custom name of engine.
 	TimerGameCalendar::Date intro_date; ///< Date of introduction of the engine.
-	TimerGameCalendar::Date age;        ///< Age of the engine, in days.
+	int32 age;                  ///< Age of the engine in months.
 	uint16 reliability;         ///< Current reliability of the engine.
 	uint16 reliability_spd_dec; ///< Speed of reliability decay between services (per day).
 	uint16 reliability_start;   ///< Initial reliability of the engine.


### PR DESCRIPTION
## Motivation / Problem

Engine age is in months, but has been incorrectly stored as a Date for a long time.

## Description

Make it a generic int32, the same type as the current Date, but generic.

## Limitations

When calculating engine reliability, we use a uint32 to avoid repeated signed/unsigned comparison issues. This shouldn't be a problem as long as `engine->age` is never less than 0, which should not be possible.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
