### PR TITLE
Fix: [Win32] Text line breaking did not properly handle punctuation characters.

### DIFF
--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -341,13 +341,13 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 	}
 
 	/* Gather runs until the line is full. */
-	while (last_run != this->ranges.end() && cur_width < max_width) {
+	while (last_run != this->ranges.end() && cur_width <= max_width) {
 		cur_width += last_run->total_advance;
 		++last_run;
 	}
 
 	/* If the text does not fit into the available width, find a suitable breaking point. */
-	int remaining_offset = (last_run - 1)->len;
+	int remaining_offset = (last_run - 1)->len + 1;
 	int whitespace_count = 0;
 	if (cur_width > max_width) {
 		std::vector<SCRIPT_LOGATTR> log_attribs;
@@ -433,7 +433,7 @@ static std::vector<SCRIPT_ITEM> UniscribeItemizeString(UniscribeParagraphLayoutF
 		cur_pos += run.total_advance;
 	}
 
-	if (remaining_offset + whitespace_count < (last_run - 1)->len) {
+	if (remaining_offset + whitespace_count - 1 < (last_run - 1)->len) {
 		/* We didn't use up all of the last run, store remainder for the next line. */
 		this->cur_range_offset = remaining_offset + whitespace_count - 1;
 		this->cur_range = last_run - 1;


### PR DESCRIPTION
## Motivation / Problem

Uniscribe text line breaking failes on punctuation/symbols:
![image](https://user-images.githubusercontent.com/1447653/236632483-735ec516-ece2-4f5b-9ea3-71b481878258.png)


## Description

This problem did happen when the available width exactly coincides with the end of a run. And as punctuation characters are somewhat script/behaviour-agnostic, they get their on runs inside e.g. numbers, making them a prime target for this bug.

To fix this, apply the line breaking algorithm even if the if the used width is exactly the same as the available width.

Additionally, if a punctuation/symbol was the last element of a run and preceded by whitespace, it could get dropped.


## Limitations

Hopefully none.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
