### PR TITLE
Codechange: Scrollbar::UpdatePosition() will tell if the position changed.

### DIFF
--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -280,14 +280,9 @@ struct DropdownWindow : Window {
 	IntervalTimer<TimerWindow> scroll_interval = {std::chrono::milliseconds(30), [this](auto) {
 		if (this->scrolling == 0) return;
 
-		int pos = this->vscroll->GetPosition();
+		if (this->vscroll->UpdatePosition(this->scrolling)) this->SetDirty();
 
-		this->vscroll->UpdatePosition(this->scrolling);
 		this->scrolling = 0;
-
-		if (pos != this->vscroll->GetPosition()) {
-			this->SetDirty();
-		}
 	}};
 
 	void OnMouseLoop() override


### PR DESCRIPTION
## Motivation / Problem

In the dropdown interval timer, we check if the scrollbar position changed after calling UpdatePosition().

However UpdatePosition() already returns true if the position changed.

## Description

Use return of UpdatePosition() to mark dropdown dirty when necessary.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
