### PR TITLE
Change: use precompiled headers to speed up compilation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -88,7 +88,7 @@ jobs:
         - name: GCC - Dedicated
           compiler: gcc
           cxxcompiler: g++
-          extra-cmake-parameters: -DOPTION_DEDICATED=ON -DCMAKE_CXX_FLAGS_INIT="-DRANDOM_DEBUG"
+          extra-cmake-parameters: -DOPTION_DEDICATED=ON -DCMAKE_CXX_FLAGS_INIT="-DRANDOM_DEBUG" -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
           # Compile without SDL / SDL2, as that should compile fine too.
 
     name: Linux (${{ matrix.name }})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT BINARY_NAME)
     set(BINARY_NAME openttd)
@@ -6,6 +6,7 @@ endif()
 
 project(${BINARY_NAME}
     VERSION 14.0
+    LANGUAGES CXX
 )
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
@@ -149,6 +150,8 @@ if(NOT OPTION_DEDICATED)
     endif()
 endif()
 if(APPLE)
+    enable_language(OBJCXX)
+
     find_package(Iconv)
 
     find_library(AUDIOTOOLBOX_LIBRARY AudioToolbox)
@@ -242,6 +245,12 @@ if(MSVC)
     # Add DPI manifest to project; other WIN32 targets get this via ottdres.rc
     target_sources(openttd PRIVATE "${CMAKE_SOURCE_DIR}/os/windows/openttd.manifest")
 endif()
+
+target_precompile_headers(openttd_lib
+    PRIVATE
+    src/stdafx.h
+    src/3rdparty/fmt/format.h
+)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/bin)
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -12,7 +12,6 @@
 
 #include "order_type.h"
 #include "timer/timer_game_calendar.h"
-#include <string>
 
 /** Various front vehicle properties that are preserved when autoreplacing, using order-backup or switching front engines within a consist. */
 struct BaseConsist {

--- a/src/bitmap_type.h
+++ b/src/bitmap_type.h
@@ -10,7 +10,6 @@
 #ifndef BITMAP_TYPE_HPP
 #define BITMAP_TYPE_HPP
 
-#include <vector>
 
 /** Represents a tile area containing containing individually set tiles.
  * Each tile must be contained within the preallocated area.

--- a/src/cargotype.h
+++ b/src/cargotype.h
@@ -17,7 +17,6 @@
 #include "landscape_type.h"
 #include "core/bitmath_func.hpp"
 #include "core/span_type.hpp"
-#include <vector>
 
 /** Globally unique label of a cargo type. */
 typedef uint32 CargoLabel;

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -13,7 +13,6 @@
 #include "economy_type.h"
 #include "strings_type.h"
 #include "tile_type.h"
-#include <vector>
 
 struct GRFFile;
 

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -17,7 +17,6 @@
 #include "timer/timer_game_calendar.h"
 #include "settings_type.h"
 #include "group.h"
-#include <string>
 #include <array>
 
 /** Statistics about the economy. */

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -23,7 +23,6 @@
 #include "timer/timer.h"
 #include "timer/timer_window.h"
 #include <deque>
-#include <string>
 
 #include "widgets/console_widget.h"
 

--- a/src/core/kdtree.hpp
+++ b/src/core/kdtree.hpp
@@ -11,8 +11,6 @@
 #define KDTREE_HPP
 
 #include "../stdafx.h"
-#include <vector>
-#include <limits>
 
 /**
  * K-dimensional tree, specialised for 2-dimensional space.

--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -10,8 +10,6 @@
 #ifndef MATH_FUNC_HPP
 #define MATH_FUNC_HPP
 
-#include <limits>
-#include <type_traits>
 
 /**
  * Returns the absolute value of (scalar) variable.

--- a/src/core/overflowsafe_type.hpp
+++ b/src/core/overflowsafe_type.hpp
@@ -12,7 +12,6 @@
 
 #include "math_func.hpp"
 
-#include <limits>
 
 #ifdef __has_builtin
 #	if __has_builtin(__builtin_add_overflow) && __has_builtin(__builtin_sub_overflow) && __has_builtin(__builtin_mul_overflow)

--- a/src/core/smallvec_type.hpp
+++ b/src/core/smallvec_type.hpp
@@ -11,7 +11,6 @@
 #define SMALLVEC_TYPE_HPP
 
 #include "mem_func.hpp"
-#include <vector>
 
 /**
  * Helper function to append an item to a vector if it is not already contained

--- a/src/dedicated.cpp
+++ b/src/dedicated.cpp
@@ -10,7 +10,6 @@
 #include "stdafx.h"
 #include "fileio_func.h"
 #include "debug.h"
-#include <string>
 
 std::string _log_file; ///< File to reroute output of a forked OpenTTD to
 std::unique_ptr<FILE, FileDeleter> _log_fd; ///< File to reroute output of a forked OpenTTD to

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -16,7 +16,6 @@
 #include "video/video_driver.hpp"
 #include "string_func.h"
 #include "table/strings.h"
-#include <string>
 #include <sstream>
 
 #include "safeguards.h"

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -12,8 +12,6 @@
 
 #include "core/enum_type.hpp"
 #include "fileio_type.h"
-#include <string>
-#include <vector>
 
 void FioFCloseFile(FILE *f);
 FILE *FioFOpenFile(const std::string &filename, const char *mode, Subdirectory subdir, size_t *filesize = nullptr);

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -20,8 +20,6 @@
 #include "strings_func.h"
 #include "tar_type.h"
 #include <sys/stat.h>
-#include <functional>
-#include <optional>
 #include <charconv>
 
 #ifndef _WIN32

--- a/src/framerate_gui.cpp
+++ b/src/framerate_gui.cpp
@@ -29,7 +29,6 @@
 
 #include <atomic>
 #include <mutex>
-#include <vector>
 
 #include "safeguards.h"
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -22,7 +22,6 @@
 #include "table/strgen_tables.h"
 
 #include <stdarg.h>
-#include <memory>
 
 #include "../safeguards.h"
 

--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -10,7 +10,6 @@
 #ifndef GAMELOG_H
 #define GAMELOG_H
 
-#include <functional>
 #include "newgrf_config.h"
 
 /** The actions we log. */

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -15,11 +15,8 @@
 #include "core/smallmap_type.hpp"
 
 #include <map>
-#include <string>
 #include <stack>
 #include <string_view>
-#include <type_traits>
-#include <vector>
 
 /**
  * Text drawing parameters, which can change while drawing a line, but are kept between multiple parts

--- a/src/group.h
+++ b/src/group.h
@@ -16,7 +16,6 @@
 #include "vehicle_type.h"
 #include "engine_type.h"
 #include "livery.h"
-#include <string>
 
 typedef Pool<Group, GroupID, 16, 64000> GroupPool;
 extern GroupPool _group_pool; ///< Pool of groups.

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -11,7 +11,6 @@
 #define INDUSTRYTYPE_H
 
 #include <array>
-#include <vector>
 #include "map_type.h"
 #include "slope_type.h"
 #include "industry_type.h"

--- a/src/ini_type.h
+++ b/src/ini_type.h
@@ -11,8 +11,6 @@
 #define INI_TYPE_H
 
 #include "fileio_type.h"
-#include <string>
-#include <optional>
 
 /** Types of groups */
 enum IniGroupType {

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -16,7 +16,6 @@
 #include "../window_gui.h"
 #include "linkgraph_base.h"
 #include <map>
-#include <vector>
 
 /**
  * Monthly statistics for a link between two stations.

--- a/src/linkgraph/mcf.h
+++ b/src/linkgraph/mcf.h
@@ -4,7 +4,6 @@
 #define MCF_H
 
 #include "linkgraphjob_base.h"
-#include <vector>
 
 typedef std::vector<Path *> PathVector;
 

--- a/src/linkgraph/refresh.h
+++ b/src/linkgraph/refresh.h
@@ -12,7 +12,6 @@
 
 #include "../cargo_type.h"
 #include "../vehicle_base.h"
-#include <vector>
 #include <map>
 #include <set>
 

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -12,7 +12,6 @@
 
 #include <map>
 #include <stack>
-#include <string>
 
 #include "../direction_type.h"
 #include "../signal_type.h"

--- a/src/misc/endian_buffer.hpp
+++ b/src/misc/endian_buffer.hpp
@@ -10,7 +10,6 @@
 #ifndef ENDIAN_BUFFER_HPP
 #define ENDIAN_BUFFER_HPP
 
-#include <iterator>
 #include <string_view>
 #include "../core/span_type.hpp"
 #include "../core/bitmath_func.hpp"

--- a/src/misc/lrucache.hpp
+++ b/src/misc/lrucache.hpp
@@ -12,9 +12,7 @@
 
 #include <utility>
 #include <list>
-#include <functional>
 #include <unordered_map>
-#include <stdexcept>
 
 /**
  * Size limited cache with a least recently used eviction strategy.

--- a/src/music/midifile.hpp
+++ b/src/music/midifile.hpp
@@ -13,8 +13,6 @@
 #include "../stdafx.h"
 #include "../core/smallvec_type.hpp"
 #include "midi.h"
-#include <vector>
-#include <string>
 
 struct MusicSongInfo;
 

--- a/src/music_gui.cpp
+++ b/src/music_gui.cpp
@@ -8,7 +8,6 @@
 /** @file music_gui.cpp GUI for the music playback. */
 
 #include "stdafx.h"
-#include <vector>
 #include "openttd.h"
 #include "base_media_base.h"
 #include "music/music_driver.hpp"

--- a/src/network/core/address.h
+++ b/src/network/core/address.h
@@ -16,7 +16,6 @@
 #include "../../string_func.h"
 #include "../../core/smallmap_type.hpp"
 
-#include <string>
 
 class NetworkAddress;
 typedef std::vector<NetworkAddress> NetworkAddressList; ///< Type for a list of addresses.

--- a/src/network/core/config.cpp
+++ b/src/network/core/config.cpp
@@ -11,7 +11,6 @@
 
 #include "../../stdafx.h"
 
-#include <cstdlib>
 #include "../../string_func.h"
 
 #include "../../safeguards.h"

--- a/src/network/core/http_curl.cpp
+++ b/src/network/core/http_curl.cpp
@@ -21,7 +21,6 @@
 #include <atomic>
 #include <condition_variable>
 #include <curl/curl.h>
-#include <memory>
 #include <mutex>
 #include <queue>
 

--- a/src/network/core/packet.h
+++ b/src/network/core/packet.h
@@ -16,8 +16,6 @@
 #include "config.h"
 #include "core.h"
 #include "../../string_type.h"
-#include <functional>
-#include <limits>
 
 typedef uint16 PacketSize; ///< Size of the whole packet.
 typedef uint8  PacketType; ///< Identifier for the packet

--- a/src/network/core/tcp_content_type.h
+++ b/src/network/core/tcp_content_type.h
@@ -12,8 +12,6 @@
 #ifndef NETWORK_CORE_TCP_CONTENT_TYPE_H
 #define NETWORK_CORE_TCP_CONTENT_TYPE_H
 
-#include <optional>
-
 /** The values in the enum are important; they are used as database 'keys' */
 enum ContentType {
 	CONTENT_TYPE_BEGIN         = 1, ///< Helper to mark the begin of the types

--- a/src/newgrf_class.h
+++ b/src/newgrf_class.h
@@ -12,7 +12,6 @@
 
 #include "strings_type.h"
 
-#include <vector>
 
 /**
  * Struct containing information relating to NewGRF classes for stations and airports.

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -17,7 +17,6 @@
 #include "fileio_type.h"
 #include "textfile_type.h"
 #include "newgrf_text.h"
-#include <optional>
 
 /** GRF config bit flags */
 enum GCF_Flags {

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -17,9 +17,6 @@
 #include "newgrf_callbacks.h"
 #include "newgrf_spritegroup.h"
 
-#include <vector>
-#include <string>
-#include <memory>
 
 /**
  * Callback profiler for NewGRF development

--- a/src/newgrf_text.h
+++ b/src/newgrf_text.h
@@ -15,8 +15,6 @@
 #include "core/smallvec_type.hpp"
 #include "table/control_codes.h"
 #include <utility>
-#include <vector>
-#include <string>
 
 /** This character, the thorn ('þ'), indicates a unicode string to NFO. */
 static const WChar NFO_UTF8_IDENTIFIER = 0x00DE;

--- a/src/newgrf_townname.h
+++ b/src/newgrf_townname.h
@@ -13,7 +13,6 @@
 #ifndef NEWGRF_TOWNNAME_H
 #define NEWGRF_TOWNNAME_H
 
-#include <vector>
 #include "strings_type.h"
 
 struct NamePart {

--- a/src/os/macosx/font_osx.cpp
+++ b/src/os/macosx/font_osx.cpp
@@ -18,7 +18,6 @@
 #include "../../strings_func.h"
 #include "../../zoom_func.h"
 #include "macos.h"
-#include <cmath>
 
 #include "../../table/control_codes.h"
 

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -15,7 +15,6 @@
 #include "../../fontcache.h"
 #include "../../zoom_func.h"
 #include "macos.h"
-#include <cmath>
 
 #include <CoreFoundation/CoreFoundation.h>
 

--- a/src/os/macosx/string_osx.h
+++ b/src/os/macosx/string_osx.h
@@ -12,7 +12,6 @@
 
 #include "../../gfx_layout.h"
 #include "../../string_base.h"
-#include <vector>
 
 /** String iterator using CoreText as a backend. */
 class OSXStringIterator : public StringIterator {

--- a/src/os/windows/string_uniscribe.cpp
+++ b/src/os/windows/string_uniscribe.cpp
@@ -16,7 +16,6 @@
 #include "../../table/control_codes.h"
 #include "../../zoom_func.h"
 #include "win32.h"
-#include <vector>
 
 #include <windows.h>
 #include <usp10.h>

--- a/src/os/windows/string_uniscribe.h
+++ b/src/os/windows/string_uniscribe.h
@@ -12,7 +12,6 @@
 
 #include "../../gfx_layout.h"
 #include "../../string_base.h"
-#include <vector>
 
 
 void UniscribeResetScriptCache(FontSize size);

--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -10,7 +10,6 @@
 #ifndef YAPF_COSTRAIL_HPP
 #define YAPF_COSTRAIL_HPP
 
-#include <vector>
 
 #include "../../pbs.h"
 

--- a/src/random_access_file_type.h
+++ b/src/random_access_file_type.h
@@ -11,7 +11,6 @@
 #define RANDOM_ACCESS_FILE_TYPE_H
 
 #include "fileio_type.h"
-#include <string>
 
 /**
  * A file from which bytes, words and double words are read in (potentially) a random order.

--- a/src/road.h
+++ b/src/road.h
@@ -19,7 +19,6 @@
 #include "newgrf.h"
 #include "economy_func.h"
 
-#include <vector>
 
 enum RoadTramType : bool {
 	RTT_ROAD,

--- a/src/saveload/engine_sl.cpp
+++ b/src/saveload/engine_sl.cpp
@@ -15,7 +15,6 @@
 #include "saveload_internal.h"
 #include "../engine_base.h"
 #include "../string_func.h"
-#include <vector>
 
 #include "../safeguards.h"
 

--- a/src/saveload/oldloader.cpp
+++ b/src/saveload/oldloader.cpp
@@ -19,7 +19,6 @@
 #include "saveload_internal.h"
 #include "oldloader.h"
 
-#include <exception>
 
 #include "../safeguards.h"
 

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -44,8 +44,6 @@
 #include "../error.h"
 #include <atomic>
 #include <deque>
-#include <vector>
-#include <string>
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>
 #endif

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -14,9 +14,6 @@
 #include "../fileio_type.h"
 #include "../fios.h"
 #include "../core/span_type.hpp"
-#include <optional>
-#include <string>
-#include <vector>
 
 /** SaveLoad versions
  * Previous savegame versions, the trunk revision where they were

--- a/src/script/api/script_admin.hpp
+++ b/src/script/api/script_admin.hpp
@@ -10,7 +10,6 @@
 #ifndef SCRIPT_ADMIN_HPP
 #define SCRIPT_ADMIN_HPP
 
-#include <string>
 #include "script_object.hpp"
 
 /**

--- a/src/script/api/script_priorityqueue.hpp
+++ b/src/script/api/script_priorityqueue.hpp
@@ -13,7 +13,6 @@
 
 #include "script_object.hpp"
 #include <utility>
-#include <vector>
 
 /**
  * Class that creates a queue which keeps its items ordered by an item priority.

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -20,7 +20,6 @@
 #include "script_log_types.hpp"
 
 #include "table/strings.h"
-#include <vector>
 
 /**
  * The callback function for Mode-classes.

--- a/src/script/squirrel_helper_type.hpp
+++ b/src/script/squirrel_helper_type.hpp
@@ -10,7 +10,6 @@
 #ifndef SQUIRREL_HELPER_TYPE_HPP
 #define SQUIRREL_HELPER_TYPE_HPP
 
-#include <vector>
 
 /** Definition of a simple array. */
 template <typename Titem = int32>

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -42,8 +42,6 @@
 #include "gui.h"
 #include "mixer.h"
 
-#include <vector>
-#include <iterator>
 
 #include "safeguards.h"
 #include "video/video_driver.hpp"

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -14,7 +14,6 @@
 #include "viewport_type.h"
 #include "core/pool_type.hpp"
 #include "company_type.h"
-#include <string>
 
 typedef Pool<Sign, SignID, 16, 64000> SignPool;
 extern SignPool _sign_pool;

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -38,7 +38,6 @@
 #include "table/strings.h"
 
 #include <set>
-#include <vector>
 
 #include "safeguards.h"
 

--- a/src/station_gui.h
+++ b/src/station_gui.h
@@ -14,7 +14,6 @@
 #include "tilearea_type.h"
 #include "window_type.h"
 #include "station_type.h"
-#include <functional>
 
 
 /** Types of cargo to display for station coverage. */

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -53,15 +53,28 @@
 #endif
 
 #include <algorithm>
-#include <cstdio>
-#include <cstdint>
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
 #include <cstddef>
+#include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <cstdlib>
-#include <climits>
-#include <cassert>
+#include <cwchar>
+#include <exception>
+#include <functional>
+#include <iterator>
+#include <limits>
 #include <memory>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <vector>
 
 #if defined(UNIX) || defined(__MINGW32__)
 #	include <sys/types.h>

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -17,7 +17,6 @@
 
 #include "strgen.h"
 
-#include <exception>
 
 #if !defined(_WIN32) || defined(__CYGWIN__)
 #include <unistd.h>

--- a/src/string_type.h
+++ b/src/string_type.h
@@ -11,8 +11,6 @@
 #define STRING_TYPE_H
 
 #include "core/enum_type.hpp"
-#include <vector>
-#include <string>
 
 /** A non-breaking space. */
 #define NBSP u8"\u00a0"

--- a/src/tar_type.h
+++ b/src/tar_type.h
@@ -11,7 +11,6 @@
 #define TAR_TYPE_H
 
 #include <map>
-#include <string>
 #include <array>
 
 #include "fileio_type.h"

--- a/src/textfile_gui.h
+++ b/src/textfile_gui.h
@@ -14,7 +14,6 @@
 #include "strings_func.h"
 #include "textfile_type.h"
 #include "window_gui.h"
-#include <optional>
 
 std::optional<std::string> GetTextfile(TextfileType type, Subdirectory dir, const std::string &filename);
 

--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -12,7 +12,6 @@
 
 #include "timer_manager.h"
 
-#include <functional>
 
 /**
  * The base where every other type of timer is derived from.

--- a/src/timetable_gui.cpp
+++ b/src/timetable_gui.cpp
@@ -24,7 +24,6 @@
 #include "settings_type.h"
 #include "timetable_cmd.h"
 #include "timetable.h"
-#include <cstdint>
 
 #include "widgets/timetable_widget.h"
 

--- a/src/townname_type.h
+++ b/src/townname_type.h
@@ -17,7 +17,6 @@
 #include "town_type.h"
 #include "string_type.h"
 #include <set>
-#include <string>
 
 typedef std::set<std::string> TownNames;
 

--- a/src/vehicle_gui_base.h
+++ b/src/vehicle_gui_base.h
@@ -20,7 +20,6 @@
 #include "window_gui.h"
 #include "widgets/dropdown_type.h"
 
-#include <iterator>
 #include <numeric>
 
 typedef GUIList<const Vehicle*, CargoID> GUIVehicleList;

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -21,8 +21,6 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
-#include <vector>
-#include <functional>
 
 extern std::string _ini_videodriver;
 extern std::vector<Dimension> _resolutions;

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -11,8 +11,6 @@
 #define WINDOW_GUI_H
 
 #include <list>
-#include <algorithm>
-#include <functional>
 
 #include "vehiclelist.h"
 #include "vehicle_type.h"


### PR DESCRIPTION
## Motivation / Problem

Compilation is slow; precompiled headers make it faster.


## Description

Enable precompiled headers in cmake for `stdafx.h`, `3rdparty/fmt/format.h` and `table/strings.h`, though that required a bump of minimum cmake version.

```
real    12m2.645s
user    43m25.293s
sys     2m39.714s
```
=>
```
real    9m35.804s
user    33m50.140s
sys     2m19.130s
```


## Limitations

18 years ago it seemed to have caused problems, but compilers have probably improved quite a bit since then.


## Scope questions

Should this PR also include the common STL headers into stdafx.h?
Should stdafx.h (ancient MSVC naming) be renamed to the currently more common pch.h?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
