### PR TITLE
Cleanup: Remove unnecessary hangar check.

### DIFF
--- a/src/aircraft_cmd.cpp
+++ b/src/aircraft_cmd.cpp
@@ -1587,7 +1587,7 @@ static void AircraftEventHandler_AtTerminal(Aircraft *v, const AirportFTAClass *
 			return;
 		default:  // orders have been deleted (no orders), goto depot and don't bother us
 			v->current_order.Free();
-			go_to_hangar = Station::Get(v->targetairport)->airport.HasHangar();
+			go_to_hangar = true;
 	}
 
 	if (go_to_hangar && Station::Get(v->targetairport)->airport.HasHangar()) {


### PR DESCRIPTION
## Motivation

Cleanup code. Removing a check that doesn't belong to the case and is performed anyway later.
In case of doubt, just read line 1593. The rest of the code right now doesn't use this boolean.