### PR TITLE
Codechange: Rely on Scrollbar::SetPosition to clamp.

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -217,7 +217,7 @@ class ReplaceVehicleWindow : public Window {
 		if (this->engines[0].NeedRebuild()) {
 			/* We need to rebuild the left engines list */
 			this->GenerateReplaceVehList(true);
-			this->vscroll[0]->SetCount((uint)this->engines[0].size());
+			this->vscroll[0]->SetCount(this->engines[0].size());
 			if (this->reset_sel_engine && this->sel_engine[0] == INVALID_ENGINE && this->engines[0].size() != 0) {
 				this->sel_engine[0] = this->engines[0][0].engine_id;
 			}
@@ -237,7 +237,7 @@ class ReplaceVehicleWindow : public Window {
 				}
 				/* Regenerate the list on the right. Note: This resets sel_engine[1] to INVALID_ENGINE, if it is no longer available. */
 				this->GenerateReplaceVehList(false);
-				this->vscroll[1]->SetCount((uint)this->engines[1].size());
+				this->vscroll[1]->SetCount(this->engines[1].size());
 				if (this->reset_sel_engine && this->sel_engine[1] != INVALID_ENGINE) {
 					int position = 0;
 					for (const auto &item : this->engines[1]) {

--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -167,7 +167,7 @@ public:
 		this->bridges->NeedResort();
 		this->SortBridgeList();
 
-		this->vscroll->SetCount((uint)bl->size());
+		this->vscroll->SetCount(bl->size());
 	}
 
 	~BuildBridgeWindow()

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1787,7 +1787,7 @@ struct BuildVehicleWindow : Window {
 	void OnPaint() override
 	{
 		this->GenerateBuildList();
-		this->vscroll->SetCount((uint)this->eng_list.size());
+		this->vscroll->SetCount(this->eng_list.size());
 
 		this->SetWidgetsDisabledState(this->sel_engine == INVALID_ENGINE, WID_BV_SHOW_HIDE, WID_BV_BUILD, WIDGET_LIST_END);
 

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -735,7 +735,7 @@ struct DepotWindow : Window {
 				max_width = std::max(max_width, width);
 			}
 			/* Always have 1 empty row, so people can change the setting of the train */
-			this->vscroll->SetCount((uint)this->vehicle_list.size() + (uint)this->wagon_list.size() + 1);
+			this->vscroll->SetCount(this->vehicle_list.size() + this->wagon_list.size() + 1);
 			/* Always make it longer than the longest train, so you can attach vehicles at the end, and also see the next vertical tile separator line */
 			this->hscroll->SetCount(max_width + ScaleSpriteTrad(2 * VEHICLEINFO_FULL_VEHICLE_WIDTH + 1));
 		} else {

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -821,7 +821,7 @@ public:
 
 				_fios_path_changed = true;
 				this->fios_items.BuildFileList(this->abstract_filetype, this->fop);
-				this->vscroll->SetCount((uint)this->fios_items.size());
+				this->vscroll->SetCount(this->fios_items.size());
 				this->selected = nullptr;
 				_load_check_data.Clear();
 

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -127,7 +127,7 @@ struct GSConfigWindow : public Window {
 			}
 		}
 
-		this->vscroll->SetCount((int)this->visible_settings.size());
+		this->vscroll->SetCount(this->visible_settings.size());
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override

--- a/src/graph_gui.cpp
+++ b/src/graph_gui.cpp
@@ -892,7 +892,7 @@ struct PaymentRatesGraphWindow : BaseGraphWindow {
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_CPR_MATRIX_SCROLLBAR);
-		this->vscroll->SetCount(static_cast<int>(_sorted_standard_cargo_specs.size()));
+		this->vscroll->SetCount(_sorted_standard_cargo_specs.size());
 
 		/* Initialise the dataset */
 		this->UpdatePaymentRates();

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -364,7 +364,7 @@ public:
 		this->groups.ForceRebuild();
 		this->groups.NeedResort();
 		this->BuildGroupList(vli.company);
-		this->group_sb->SetCount((uint)this->groups.size());
+		this->group_sb->SetCount(this->groups.size());
 
 		this->GetWidget<NWidgetCore>(WID_GL_CAPTION)->widget_data = STR_VEHICLE_LIST_TRAIN_CAPTION + this->vli.vtype;
 		this->GetWidget<NWidgetCore>(WID_GL_LIST_VEHICLE)->tool_tip = STR_VEHICLE_LIST_TRAIN_LIST_TOOLTIP + this->vli.vtype;
@@ -506,8 +506,8 @@ public:
 
 		this->BuildGroupList(this->owner);
 
-		this->group_sb->SetCount(static_cast<int>(this->groups.size()));
-		this->vscroll->SetCount(static_cast<int>(this->vehgroups.size()));
+		this->group_sb->SetCount(this->groups.size());
+		this->vscroll->SetCount(this->vehgroups.size());
 
 		/* The drop down menu is out, *but* it may not be used, retract it. */
 		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_GL_MANAGE_VEHICLES_DROPDOWN)) {
@@ -1087,7 +1087,7 @@ public:
 				}
 				this->groups.ForceRebuild();
 				this->BuildGroupList(this->owner);
-				this->group_sb->SetCount((uint)this->groups.size());
+				this->group_sb->SetCount(this->groups.size());
 				id_g = find_index(this->groups, g);
 			}
 			this->group_sb->ScrollTowards(id_g);

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -325,7 +325,7 @@ class BuildIndustryWindow : public Window {
 
 		this->UpdateAvailability();
 
-		this->vscroll->SetCount((int)this->list.size());
+		this->vscroll->SetCount(this->list.size());
 	}
 
 	/** Update status of the fund and display-chain widgets. */
@@ -1419,7 +1419,7 @@ protected:
 		IndustryDirectoryWindow::produced_cargo_filter = this->cargo_filter[this->produced_cargo_filter_criteria];
 		this->industries.Sort();
 
-		this->vscroll->SetCount((uint)this->industries.size()); // Update scrollbar as well.
+		this->vscroll->SetCount(this->industries.size()); // Update scrollbar as well.
 
 		this->SetDirty();
 	}

--- a/src/network/network_content_gui.cpp
+++ b/src/network/network_content_gui.cpp
@@ -423,7 +423,7 @@ class NetworkContentListWindow : public Window, ContentCallback {
 		this->content.RebuildDone();
 		this->SortContentList();
 
-		this->vscroll->SetCount((int)this->content.size()); // Update the scrollbar
+		this->vscroll->SetCount(this->content.size()); // Update the scrollbar
 		this->ScrollToSelected();
 	}
 

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -279,7 +279,7 @@ protected:
 
 		this->servers.shrink_to_fit();
 		this->servers.RebuildDone();
-		this->vscroll->SetCount((int)this->servers.size());
+		this->vscroll->SetCount(this->servers.size());
 
 		/* Sort the list of network games as requested. */
 		this->servers.Sort();

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -1055,7 +1055,7 @@ struct SpriteAlignerWindow : Window {
 		if (data == 1) {
 			/* Sprite picker finished */
 			this->RaiseWidget(WID_SA_PICKER);
-			this->vscroll->SetCount((uint)_newgrf_debug_sprite_picker.sprites.size());
+			this->vscroll->SetCount(_newgrf_debug_sprite_picker.sprites.size());
 		}
 	}
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -1490,7 +1490,7 @@ private:
 			}
 		}
 
-		this->vscroll2->SetCount((uint)this->avails.size()); // Update the scrollbar
+		this->vscroll2->SetCount(this->avails.size()); // Update the scrollbar
 	}
 
 	/**
@@ -2068,7 +2068,7 @@ struct SavePresetWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_SVP_SCROLLBAR);
 		this->FinishInitNested(0);
 
-		this->vscroll->SetCount((uint)this->presets.size());
+		this->vscroll->SetCount(this->presets.size());
 		this->SetFocusedWidget(WID_SVP_EDITBOX);
 		if (initial_text != nullptr) this->presetname_editbox.text.Assign(initial_text);
 	}

--- a/src/object_gui.cpp
+++ b/src/object_gui.cpp
@@ -125,7 +125,7 @@ public:
 
 		ResetObjectToPlace();
 
-		this->vscroll->SetCount((int)this->object_classes.size());
+		this->vscroll->SetCount(this->object_classes.size());
 
 		EnsureSelectedObjectClassIsVisible();
 
@@ -166,7 +166,7 @@ public:
 		this->object_classes.RebuildDone();
 		this->object_classes.Sort();
 
-		this->vscroll->SetCount((uint)this->object_classes.size());
+		this->vscroll->SetCount(this->object_classes.size());
 	}
 
 	/**

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -929,7 +929,7 @@ private:
 			if (station_class == _railstation.station_class) break;
 			pos++;
 		}
-		this->vscroll->SetCount((int)this->station_classes.size());
+		this->vscroll->SetCount(this->station_classes.size());
 		this->vscroll->ScrollTowards(pos);
 	}
 
@@ -1075,7 +1075,7 @@ public:
 			this->station_classes.RebuildDone();
 			this->station_classes.Sort();
 
-			this->vscroll->SetCount((uint)this->station_classes.size());
+			this->vscroll->SetCount(this->station_classes.size());
 		}
 	}
 

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1135,7 +1135,7 @@ private:
 			if (rs_class == _roadstop_gui_settings.roadstop_class) break;
 			pos++;
 		}
-		this->vscrollList->SetCount((int)this->roadstop_classes.size());
+		this->vscrollList->SetCount(this->roadstop_classes.size());
 		this->vscrollList->ScrollTowards(pos);
 	}
 
@@ -1281,7 +1281,7 @@ public:
 			this->roadstop_classes.RebuildDone();
 			this->roadstop_classes.Sort();
 
-			this->vscrollList->SetCount((uint)this->roadstop_classes.size());
+			this->vscrollList->SetCount(this->roadstop_classes.size());
 		}
 	}
 

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -860,11 +860,10 @@ struct ScriptDebugWindow : public Window {
 		/* Detect when the user scrolls the window. Enable autoscroll when the
 		 * bottom-most line becomes visible. */
 		if (this->last_vscroll_pos != this->vscroll->GetPosition()) {
-			this->autoscroll = this->vscroll->GetPosition() >= log.size() - this->vscroll->GetCapacity();
+			this->autoscroll = this->vscroll->GetPosition() + this->vscroll->GetCapacity() >= (int)log.size();
 		}
 		if (this->autoscroll) {
-			int scroll_pos = std::max<int>(0, (int)log.size() - this->vscroll->GetCapacity());
-			if (this->vscroll->SetPosition(scroll_pos)) {
+			if (this->vscroll->SetPosition((int)log.size())) {
 				/* We need a repaint */
 				this->SetWidgetDirty(WID_SCRD_SCROLLBAR);
 				this->SetWidgetDirty(WID_SCRD_LOG_PANEL);

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -77,7 +77,7 @@ struct ScriptListWindow : public Window {
 		this->vscroll = this->GetScrollbar(WID_SCRL_SCROLLBAR);
 		this->FinishInitNested(); // Initializes 'this->line_height' as side effect.
 
-		this->vscroll->SetCount((int)this->info_list->size() + 1);
+		this->vscroll->SetCount(this->info_list->size() + 1);
 
 		/* Try if we can find the currently selected AI */
 		this->selected = -1;
@@ -231,7 +231,7 @@ struct ScriptListWindow : public Window {
 
 		if (!gui_scope) return;
 
-		this->vscroll->SetCount((int)this->info_list->size() + 1);
+		this->vscroll->SetCount(this->info_list->size() + 1);
 
 		/* selected goes from -1 .. length of ai list - 1. */
 		this->selected = std::min(this->selected, this->vscroll->GetCount() - 2);
@@ -332,7 +332,7 @@ struct ScriptSettingsWindow : public Window {
 			}
 		}
 
-		this->vscroll->SetCount((int)this->visible_settings.size());
+		this->vscroll->SetCount(this->visible_settings.size());
 	}
 
 	void SetStringParameters(int widget) const override
@@ -1070,7 +1070,7 @@ struct ScriptDebugWindow : public Window {
 
 		this->SelectValidDebugCompany();
 
-		this->vscroll->SetCount(script_debug_company != INVALID_COMPANY ? (int)this->GetLogData().size() : 0);
+		this->vscroll->SetCount(script_debug_company != INVALID_COMPANY ? this->GetLogData().size() : 0);
 
 		/* Update company buttons */
 		for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {

--- a/src/signs_gui.cpp
+++ b/src/signs_gui.cpp
@@ -308,7 +308,7 @@ struct SignListWindow : Window, SignList {
 	{
 		if (this->signs.NeedRebuild()) {
 			this->BuildSignsList();
-			this->vscroll->SetCount((uint)this->signs.size());
+			this->vscroll->SetCount(this->signs.size());
 			this->SetWidgetDirty(WID_SIL_CAPTION);
 		}
 		this->SortSignsList();

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -252,7 +252,7 @@ protected:
 		this->stations.shrink_to_fit();
 		this->stations.RebuildDone();
 
-		this->vscroll->SetCount((uint)this->stations.size()); // Update the scrollbar
+		this->vscroll->SetCount(this->stations.size()); // Update the scrollbar
 	}
 
 	/** Sort stations by their name */
@@ -2345,7 +2345,7 @@ struct SelectStationWindow : Window {
 	{
 		if (!gui_scope) return;
 		FindStationsNearby<T>(this->area, true);
-		this->vscroll->SetCount((uint)_stations_nearby_list.size() + 1);
+		this->vscroll->SetCount(_stations_nearby_list.size() + 1);
 		this->SetDirty();
 	}
 

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -736,7 +736,7 @@ private:
 
 			this->towns.shrink_to_fit();
 			this->towns.RebuildDone();
-			this->vscroll->SetCount((uint)this->towns.size()); // Update scrollbar as well.
+			this->vscroll->SetCount(this->towns.size()); // Update scrollbar as well.
 		}
 		/* Always sort the towns. */
 		this->towns.Sort();

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -224,7 +224,7 @@ void BaseVehicleListWindow::BuildVehicleList()
 	}
 
 	this->vehgroups.RebuildDone();
-	this->vscroll->SetCount(static_cast<int>(this->vehgroups.size()));
+	this->vscroll->SetCount(this->vehgroups.size());
 }
 
 

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -704,10 +704,11 @@ public:
 	 * Set the distance to scroll when using the buttons or the wheel.
 	 * @param stepsize Scrolling speed.
 	 */
-	void SetStepSize(uint16 stepsize)
+	void SetStepSize(size_t stepsize)
 	{
 		assert(stepsize > 0);
-		this->stepsize = stepsize;
+
+		this->stepsize = ClampTo<uint16_t>(stepsize);
 	}
 
 	/**
@@ -715,12 +716,11 @@ public:
 	 * @param num the number of elements in the list
 	 * @note updates the position if needed
 	 */
-	void SetCount(int num)
+	void SetCount(size_t num)
 	{
-		assert(num >= 0);
 		assert(num <= MAX_UVALUE(uint16));
 
-		this->count = num;
+		this->count = ClampTo<uint16_t>(num);
 		num -= this->cap;
 		if (num < 0) num = 0;
 		if (num < this->pos) this->pos = num;
@@ -731,12 +731,11 @@ public:
 	 * @param capacity the new capacity
 	 * @note updates the position if needed
 	 */
-	void SetCapacity(int capacity)
+	void SetCapacity(size_t capacity)
 	{
-		assert(capacity > 0);
 		assert(capacity <= MAX_UVALUE(uint16));
 
-		this->cap = capacity;
+		this->cap = ClampTo<uint16_t>(capacity);
 		if (this->cap + this->pos > this->count) this->pos = std::max(0, this->count - this->cap);
 	}
 

--- a/src/widget_type.h
+++ b/src/widget_type.h
@@ -721,9 +721,8 @@ public:
 		assert(num <= MAX_UVALUE(uint16));
 
 		this->count = ClampTo<uint16_t>(num);
-		num -= this->cap;
-		if (num < 0) num = 0;
-		if (num < this->pos) this->pos = num;
+		/* Ensure position is within bounds */
+		this->SetPosition(this->pos);
 	}
 
 	/**
@@ -736,7 +735,8 @@ public:
 		assert(capacity <= MAX_UVALUE(uint16));
 
 		this->cap = ClampTo<uint16_t>(capacity);
-		if (this->cap + this->pos > this->count) this->pos = std::max(0, this->count - this->cap);
+		/* Ensure position is within bounds */
+		this->SetPosition(this->pos);
 	}
 
 	void SetCapacityFromWidget(Window *w, int widget, int padding = 0);

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -172,8 +172,8 @@ struct DropdownWindow : Window {
 		}
 
 		/* Capacity is the average number of items visible */
-		this->vscroll->SetCapacity(size.height * (uint16)this->list.size() / list_height);
-		this->vscroll->SetCount((uint16)this->list.size());
+		this->vscroll->SetCapacity(size.height * this->list.size() / list_height);
+		this->vscroll->SetCount(this->list.size());
 
 		this->parent_wnd_class = parent->window_class;
 		this->parent_wnd_num   = parent->window_number;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2379,13 +2379,10 @@ static void HandleScrollbarScrolling(Window *w)
 		return;
 	}
 
-	/* Find the item we want to move to and make sure it's inside bounds. */
-	int pos = std::min(RoundDivSU(std::max(0, i + _scrollbar_start_pos) * sb->GetCount(), _scrollbar_size), std::max(0, sb->GetCount() - sb->GetCapacity()));
-	if (rtl) pos = std::max(0, sb->GetCount() - sb->GetCapacity() - pos);
-	if (pos != sb->GetPosition()) {
-		sb->SetPosition(pos);
-		w->SetDirty();
-	}
+	/* Find the item we want to move to. SetPosition will make sure it's inside bounds. */
+	int pos = RoundDivSU((i + _scrollbar_start_pos) * sb->GetCount(), _scrollbar_size);
+	if (rtl) pos = sb->GetCount() - sb->GetCapacity() - pos;
+	if (sb->SetPosition(pos)) w->SetDirty();
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Manually clamping scrollbar bounds before calling `SetPosition()` is doubling up work that the function already does.

## Description

Remove the clamping and let SetPosition() handle it.
Also uses return value of SetPosition() instead of testing whether the position should be changed.
Also changes the script debug autoscroll condition to  make it clearer, i.e. "last row >= size". Probably separate really but it was right there and kinda related...

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
