### PR TITLE
Fix: Var68 for station and roadstop was broken

### DIFF
--- a/src/newgrf_roadstop.cpp
+++ b/src/newgrf_roadstop.cpp
@@ -157,7 +157,7 @@ uint32 RoadStopScopeResolver::GetVariable(byte variable, uint32 parameter, bool 
 
 			if (IsCustomRoadStopSpecIndex(nearby_tile)) {
 				const RoadStopSpecList ssl = BaseStation::GetByTile(nearby_tile)->roadstop_speclist[GetCustomRoadStopSpecIndex(nearby_tile)];
-				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | std::max<uint16_t>(ssl.localidx, 0xFF);
+				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | ClampTo<uint8_t>(ssl.localidx);
 			}
 			return res;
 		}

--- a/src/newgrf_station.cpp
+++ b/src/newgrf_station.cpp
@@ -364,7 +364,7 @@ TownScopeResolver *StationResolverObject::GetTown()
 
 			if (IsCustomStationSpecIndex(nearby_tile)) {
 				const StationSpecList ssl = BaseStation::GetByTile(nearby_tile)->speclist[GetCustomStationSpecIndex(nearby_tile)];
-				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | std::max<uint16_t>(ssl.localidx, 0xFF);
+				res |= 1 << (ssl.grfid != grfid ? 9 : 8) | ClampTo<uint8_t>(ssl.localidx);
 			}
 			return res;
 		}


### PR DESCRIPTION
## Motivation / Problem
 * Var68 for station/roadstop is broken since #10672

## Description
 * Change std::max to std::min

## Limitations
 * Variable 68 needs to be extended to support to 16-bit station ID.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
