### PR TITLE
Feature: Add search filter and name text to build waypoint window.

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2695,6 +2695,7 @@ STR_STATION_CLASS_DFLT                                          :Default
 STR_STATION_CLASS_DFLT_STATION                                  :Default station
 STR_STATION_CLASS_DFLT_ROADSTOP                                 :Default road stop
 STR_STATION_CLASS_WAYP                                          :Waypoints
+STR_STATION_CLASS_WAYP_WAYPOINT                                 :Default waypoint
 
 # Signal window
 STR_BUILD_SIGNAL_CAPTION                                        :{WHITE}Signal Selection

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2691,7 +2691,9 @@ STR_STATION_BUILD_DRAG_DROP_TOOLTIP                             :{BLACK}Build a 
 STR_STATION_BUILD_STATION_CLASS_TOOLTIP                         :{BLACK}Select a station class to display
 STR_STATION_BUILD_STATION_TYPE_TOOLTIP                          :{BLACK}Select the station type to build
 
-STR_STATION_CLASS_DFLT                                          :Default station
+STR_STATION_CLASS_DFLT                                          :Default
+STR_STATION_CLASS_DFLT_STATION                                  :Default station
+STR_STATION_CLASS_DFLT_ROADSTOP                                 :Default road stop
 STR_STATION_CLASS_WAYP                                          :Waypoints
 
 # Signal window

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2088,7 +2088,7 @@ static const NWidgetPart _nested_build_waypoint_widgets[] = {
 		NWidget(WWT_DEFSIZEBOX, COLOUR_DARK_GREEN),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_PANEL, COLOUR_DARK_GREEN),
+		NWidget(WWT_PANEL, COLOUR_DARK_GREEN), SetScrollbar(WID_BRW_SCROLL),
 			NWidget(NWID_MATRIX, COLOUR_DARK_GREEN, WID_BRW_WAYPOINT_MATRIX), SetPIP(0, 2, 0),  SetPadding(3), SetScrollbar(WID_BRW_SCROLL),
 				NWidget(WWT_PANEL, COLOUR_DARK_GREEN, WID_BRW_WAYPOINT), SetMinimalSize(66, 60), SetDataTip(0x0, STR_WAYPOINT_GRAPHICS_TOOLTIP), SetScrollbar(WID_BRW_SCROLL), EndContainer(),
 			EndContainer(),

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -1219,7 +1219,7 @@ public:
 					StationClass *stclass = StationClass::Get(station_class);
 					for (uint j = 0; j < stclass->GetSpecCount(); j++) {
 						const StationSpec *statspec = stclass->GetSpec(j);
-						SetDParam(0, (statspec != nullptr && statspec->name != 0) ? statspec->name : STR_STATION_CLASS_DFLT);
+						SetDParam(0, (statspec != nullptr && statspec->name != 0) ? statspec->name : STR_STATION_CLASS_DFLT_STATION);
 						d = maxdim(d, GetStringBoundingBox(str));
 					}
 				}
@@ -1323,7 +1323,7 @@ public:
 	{
 		if (widget == WID_BRAS_SHOW_NEWST_TYPE) {
 			const StationSpec *statspec = StationClass::Get(_railstation.station_class)->GetSpec(_railstation.station_type);
-			SetDParam(0, (statspec != nullptr && statspec->name != 0) ? statspec->name : STR_STATION_CLASS_DFLT);
+			SetDParam(0, (statspec != nullptr && statspec->name != 0) ? statspec->name : STR_STATION_CLASS_DFLT_STATION);
 		}
 	}
 

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2090,7 +2090,7 @@ static const NWidgetPart _nested_build_waypoint_widgets[] = {
 	NWidget(NWID_HORIZONTAL),
 		NWidget(WWT_PANEL, COLOUR_DARK_GREEN), SetScrollbar(WID_BRW_SCROLL),
 			NWidget(NWID_MATRIX, COLOUR_DARK_GREEN, WID_BRW_WAYPOINT_MATRIX), SetPIP(0, 2, 0),  SetPadding(3), SetScrollbar(WID_BRW_SCROLL),
-				NWidget(WWT_PANEL, COLOUR_DARK_GREEN, WID_BRW_WAYPOINT), SetMinimalSize(66, 60), SetDataTip(0x0, STR_WAYPOINT_GRAPHICS_TOOLTIP), SetScrollbar(WID_BRW_SCROLL), EndContainer(),
+				NWidget(WWT_PANEL, COLOUR_DARK_GREEN, WID_BRW_WAYPOINT), SetDataTip(0x0, STR_WAYPOINT_GRAPHICS_TOOLTIP), SetScrollbar(WID_BRW_SCROLL), EndContainer(),
 			EndContainer(),
 		EndContainer(),
 		NWidget(NWID_VERTICAL),

--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2022,9 +2022,9 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 	{
 		switch (widget) {
 			case WID_BRW_WAYPOINT_MATRIX:
-				/* Three blobs high and wide. */
+				/* Two blobs high and three wide. */
 				size->width  += resize->width  * 2;
-				size->height += resize->height * 2;
+				size->height += resize->height * 1;
 
 				/* Resizing in X direction only at blob size, but at pixel level in Y. */
 				resize->height = 1;

--- a/src/road_gui.cpp
+++ b/src/road_gui.cpp
@@ -1375,7 +1375,7 @@ public:
 					RoadStopClass *rs_class = RoadStopClass::Get(roadstop_class);
 					for (uint j = 0; j < rs_class->GetSpecCount(); j++) {
 						const RoadStopSpec *roadstopspec = rs_class->GetSpec(j);
-						SetDParam(0, (roadstopspec != nullptr && roadstopspec->name != 0) ? roadstopspec->name : STR_STATION_CLASS_DFLT);
+						SetDParam(0, (roadstopspec != nullptr && roadstopspec->name != 0) ? roadstopspec->name : STR_STATION_CLASS_DFLT_ROADSTOP);
 						d = maxdim(d, GetStringBoundingBox(str));
 					}
 				}
@@ -1497,7 +1497,7 @@ public:
 	void SetStringParameters(int widget) const override {
 		if (widget == WID_BROS_SHOW_NEWST_TYPE) {
 			const RoadStopSpec *roadstopspec = RoadStopClass::Get(_roadstop_gui_settings.roadstop_class)->GetSpec(_roadstop_gui_settings.roadstop_type);
-			SetDParam(0, (roadstopspec != nullptr && roadstopspec->name != 0) ? roadstopspec->name : STR_STATION_CLASS_DFLT);
+			SetDParam(0, (roadstopspec != nullptr && roadstopspec->name != 0) ? roadstopspec->name : STR_STATION_CLASS_DFLT_ROADSTOP);
 		}
 	}
 

--- a/src/widgets/rail_widget.h
+++ b/src/widgets/rail_widget.h
@@ -117,9 +117,11 @@ enum BuildRailDepotWidgets {
 
 /** Widgets of the #BuildRailWaypointWindow class. */
 enum BuildRailWaypointWidgets {
+	WID_BRW_FILTER,          ///< Text filter.
 	WID_BRW_WAYPOINT_MATRIX, ///< Matrix with waypoints.
 	WID_BRW_WAYPOINT,        ///< A single waypoint.
 	WID_BRW_SCROLL,          ///< Scrollbar for the matrix.
+	WID_BRW_NAME,            ///< Name of selected waypoint.
 };
 
 #endif /* WIDGETS_RAIL_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

With a few NewGRFs loaded, the waypoint list is unwieldy. And waypoint name is only shown Lard Area Information.

## Description

Add a text filter to filter by waypoint and NewGRF name.

![image](https://user-images.githubusercontent.com/639850/236709382-386696cb-6174-41fc-ac54-a971cabef6b8.png)

<s>This is a quick & dirty, e.g. it misuses STR_COLOUR_DEFAULT :-)</s>

Oh, and yes, the matrix item background is changed to grey to match some other windows...

## Limitations

Invalid selection isn't really handled properly yet, as previously it there was always at least 1 buildable waypoint.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
