### PR TITLE
Allow dedicated server to use threaded saves.

### DIFF
--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -112,7 +112,6 @@ struct PacketWriter : SaveFilter {
 		 * we need to handle the save finish as well as the
 		 * next connection might just be requesting a map. */
 		WaitTillSaved();
-		ProcessAsyncSaveFinish();
 	}
 
 	/**
@@ -548,6 +547,7 @@ NetworkRecvStatus ServerNetworkGameSocketHandler::SendMap()
 	}
 
 	if (this->status == STATUS_AUTHORIZED) {
+		WaitTillSaved();
 		this->savegame = new PacketWriter(this);
 
 		/* Now send the _frame_counter and how many packets are coming */

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -3280,7 +3280,7 @@ SaveOrLoadResult SaveOrLoad(const std::string &filename, SaveLoadOperation fop, 
 
 		if (fop == SLO_SAVE) { // SAVE game
 			Debug(desync, 1, "save: {:08x}; {:02x}; {}", TimerGameCalendar::date, TimerGameCalendar::date_fract, filename);
-			if (_network_server || !_settings_client.gui.threaded_saves) threaded = false;
+			if (!_settings_client.gui.threaded_saves) threaded = false;
 
 			return DoSave(new FileWriter(fh), threaded);
 		}


### PR DESCRIPTION
## Motivation / Problem

Dedicated server on old hardware freeze on autosave for a few seconds.

For example Rasbeery PI 1 B, lags for 6 seconds saving 1024x2048 map. Using threaded saves it lags for 1 second and drop simulation rate to 0.2x game speed for 5 seconds. Maximum game speed is 0.55x for 100% CPU load on that hardware.



## Description

Allow dedicated server to use threaded saves. Helps a lot on low end hardware.


## Limitations

This restriction first appear in commit a51cfd58b8b61cbe2aba3b7c2c56f903ac39594b ./saveload.c

Not clear if author precautious or server has multirhread related issue saving files in background.

I've tested this patch for a day or two on my server - no problems.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
