### PR TITLE
Allow control dedicated server refresh rate.

### DIFF
--- a/src/video/dedicated_v.h
+++ b/src/video/dedicated_v.h
@@ -28,6 +28,19 @@ public:
 	bool ToggleFullscreen(bool fullscreen) override;
 	const char *GetName() const override { return "dedicated"; }
 	bool HasGUI() const override { return false; }
+
+	std::chrono::steady_clock::duration GetGameInterval() override
+	{
+		/* Infinite speed, as quickly as you can. */
+		if (_game_speed == 0) return std::chrono::microseconds(0);
+
+		long min = MILLISECONDS_PER_TICK * 1000;
+		long ms = 1000000 / _settings_client.gui.refresh_rate;
+		if (ms < min)
+			ms = min;
+
+		return std::chrono::microseconds(ms * 100 / _game_speed);
+	}
 };
 
 /** Factory for the dedicated server video driver. */

--- a/src/video/video_driver.hpp
+++ b/src/video/video_driver.hpp
@@ -307,7 +307,7 @@ protected:
 	 */
 	void SleepTillNextTick();
 
-	std::chrono::steady_clock::duration GetGameInterval()
+	virtual std::chrono::steady_clock::duration GetGameInterval()
 	{
 		/* If we are paused, run on normal speed. */
 		if (_pause_mode) return std::chrono::milliseconds(MILLISECONDS_PER_TICK);


### PR DESCRIPTION
## Motivation / Problem

Dedicated servers on old hardware can not run at full speed 30ms / 33.33 fps. It eats 100% for a process.

For example Raspberry PI 1 B, can run at maximum 0.55x game speed which equivalent of 16 simulation rate fps.

## Description

Limiting simulation fps to 15 keep sever load under 80% and keep game speed constant. Feels better for a client.

Helps a lot on low end hardware.


## Limitations

This is optional feature not affecting current server state. Since refresh_rate set to default value of 60, will change nothing. Dedicated server will be affected only by lowering refresh_rate value.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
