### PR TITLE
Fix: [ICU] crash when trying to break a non-breaking run

### DIFF
--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -208,7 +208,7 @@ void ICURun::Shape(UChar *buff, size_t buff_length) {
 			x_advance = glyph_pos[i].x_advance / FONT_SCALE;
 		}
 
-		this->glyph_to_char.push_back(glyph_info[i].cluster);
+		this->glyph_to_char.push_back(glyph_info[i].cluster - this->start);
 		this->advance.push_back(x_advance);
 		advance += x_advance;
 	}


### PR DESCRIPTION
## Motivation / Problem

As described in #10790, looking at NewGRF info crashed the game.
Fixes #10790.

## Description

Clusters from harfbuzz are indexed from the start of the buffer, not from the start of the run analyzed. This confuses other parts of the code that do assume they are from the start of the run.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
