### PR TITLE
Codechange: rework Gamelog changes from union to classes

### DIFF
--- a/src/gamelog.h
+++ b/src/gamelog.h
@@ -52,7 +52,7 @@ private:
 	GamelogActionType action_type;
 	struct LoggedAction *current_action;
 
-	LoggedChange *Change(GamelogChangeType ct);
+	void Change(std::unique_ptr<LoggedChange> &&change);
 
 public:
 	Gamelog();

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -11,60 +11,139 @@
 #define GAMELOG_INTERNAL_H
 
 #include "gamelog.h"
+#include <iterator>
 
-static const uint GAMELOG_REVISION_LENGTH = 15;
+/**
+ * Information about the presence of a Grf at a certain point during gamelog history
+ * Note about missing Grfs:
+ * Changes to missing Grfs are not logged including manual removal of the Grf.
+ * So if the gamelog tells a Grf is missing we do not know whether it was readded or completely removed
+ * at some later point.
+ */
+struct GRFPresence{
+	const GRFConfig *gc;  ///< GRFConfig, if known
+	bool was_missing;     ///< Grf was missing during some gameload in the past
 
-/** Contains information about one logged change */
+	GRFPresence(const GRFConfig *gc) : gc(gc), was_missing(false) {}
+	GRFPresence() = default;
+};
+typedef SmallMap<uint32_t, GRFPresence> GrfIDMapping;
+
 struct LoggedChange {
-	GamelogChangeType ct; ///< Type of change logged in this struct
-	union {
-		struct {
-			byte mode;       ///< new game mode - Editor x Game
-			byte landscape;  ///< landscape (temperate, arctic, ...)
-		} mode;
-		struct {
-			char text[GAMELOG_REVISION_LENGTH]; ///< revision string, _openttd_revision
-			uint32 newgrf;   ///< _openttd_newgrf_version
-			uint16 slver;    ///< _sl_version
-			byte modified;   ///< _openttd_revision_modified
-		} revision;
-		struct {
-			uint32 type;     ///< type of savegame, @see SavegameType
-			uint32 version;  ///< major and minor version OR ttdp version
-		} oldver;
-		GRFIdentifier grfadd;    ///< ID and md5sum of added GRF
-		struct {
-			uint32 grfid;    ///< ID of removed GRF
-		} grfrem;
-		GRFIdentifier grfcompat; ///< ID and new md5sum of changed GRF
-		struct {
-			uint32 grfid;    ///< ID of GRF with changed parameters
-		} grfparam;
-		struct {
-			uint32 grfid;    ///< ID of moved GRF
-			int32 offset;    ///< offset, positive = move down
-		} grfmove;
-		struct {
-			char *name;      ///< name of the setting
-			int32 oldval;    ///< old value
-			int32 newval;    ///< new value
-		} setting;
-		struct {
-			uint64 data;     ///< additional data
-			uint32 grfid;    ///< ID of problematic GRF
-			byte bug;        ///< type of bug, @see enum GRFBugs
-		} grfbug;
-	};
+	LoggedChange(GamelogChangeType type = GLCT_NONE) : ct(type) {}
+	virtual ~LoggedChange() {}
+	virtual void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) = 0;
 
-	~LoggedChange();
+	GamelogChangeType ct;
+};
+
+struct LoggedChangeMode : LoggedChange {
+	LoggedChangeMode() : LoggedChange(GLCT_MODE) {}
+	LoggedChangeMode(byte mode, byte landscape) :
+		LoggedChange(GLCT_MODE), mode(mode), landscape(landscape) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	byte mode;      ///< new game mode - Editor x Game
+	byte landscape; ///< landscape (temperate, arctic, ...)
+};
+
+struct LoggedChangeRevision : LoggedChange {
+	LoggedChangeRevision() : LoggedChange(GLCT_REVISION) {}
+	LoggedChangeRevision(const std::string &text, uint32_t newgrf, uint16_t slver, byte modified) :
+		LoggedChange(GLCT_REVISION), text(text), newgrf(newgrf), slver(slver), modified(modified) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	std::string text; ///< revision string, _openttd_revision
+	uint32_t newgrf;  ///< _openttd_newgrf_version
+	uint16_t slver;   ///< _sl_version
+	byte modified;    //< _openttd_revision_modified
+};
+
+struct LoggedChangeOldVersion : LoggedChange {
+	LoggedChangeOldVersion() : LoggedChange(GLCT_OLDVER) {}
+	LoggedChangeOldVersion(uint32_t type, uint32_t version) :
+		LoggedChange(GLCT_OLDVER), type(type), version(version) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	uint32_t type;    ///< type of savegame, @see SavegameType
+	uint32_t version; ///< major and minor version OR ttdp version
+};
+
+struct LoggedChangeGRFAdd : LoggedChange, GRFIdentifier {
+	LoggedChangeGRFAdd() : LoggedChange(GLCT_GRFADD) {}
+	LoggedChangeGRFAdd(const GRFIdentifier &ident) :
+		LoggedChange(GLCT_GRFADD), GRFIdentifier(ident) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+};
+
+struct LoggedChangeGRFRemoved : LoggedChange {
+	LoggedChangeGRFRemoved() : LoggedChange(GLCT_GRFREM) {}
+	LoggedChangeGRFRemoved(uint32_t grfid) :
+		LoggedChange(GLCT_GRFREM), grfid(grfid) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	uint32_t grfid; ///< ID of removed GRF
+};
+
+struct LoggedChangeGRFChanged : LoggedChange, GRFIdentifier {
+	LoggedChangeGRFChanged() : LoggedChange(GLCT_GRFCOMPAT) {}
+	LoggedChangeGRFChanged(const GRFIdentifier &ident) :
+		LoggedChange(GLCT_GRFCOMPAT), GRFIdentifier(ident) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+};
+
+struct LoggedChangeGRFParameterChanged : LoggedChange {
+	LoggedChangeGRFParameterChanged() : LoggedChange(GLCT_GRFPARAM) {}
+	LoggedChangeGRFParameterChanged(uint32_t grfid) :
+		LoggedChange(GLCT_GRFPARAM), grfid(grfid) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	uint32_t grfid; ///< ID of GRF with changed parameters
+};
+
+struct LoggedChangeGRFMoved : LoggedChange {
+	LoggedChangeGRFMoved() : LoggedChange(GLCT_GRFMOVE) {}
+	LoggedChangeGRFMoved(uint32_t grfid, int32_t offset) :
+		LoggedChange(GLCT_GRFMOVE), grfid(grfid), offset(offset) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	uint32_t grfid; ///< ID of moved GRF
+	int32_t offset; ///< offset, positive = move down
+};
+
+struct LoggedChangeSettingChanged : LoggedChange {
+	LoggedChangeSettingChanged() : LoggedChange(GLCT_SETTING) {}
+	LoggedChangeSettingChanged(const std::string &name, int32_t oldval, int32_t newval) :
+		LoggedChange(GLCT_SETTING), name(name), oldval(oldval), newval(newval) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	std::string name; ///< name of the setting
+	int32_t oldval;   ///< old value
+	int32_t newval;   ///< new value
+};
+
+struct LoggedChangeGRFBug : LoggedChange {
+	LoggedChangeGRFBug() : LoggedChange(GLCT_GRFBUG) {}
+	LoggedChangeGRFBug(uint64_t data, uint32_t grfid, byte bug) :
+		LoggedChange(GLCT_GRFBUG), data(data), grfid(grfid), bug(bug) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
+
+	uint64_t data;  ///< additional data
+	uint32_t grfid; ///< ID of problematic GRF
+	byte bug;       ///< type of bug, @see enum GRFBugs
+};
+
+struct LoggedChangeEmergencySave : LoggedChange {
+	LoggedChangeEmergencySave() : LoggedChange(GLCT_EMERGENCY) {}
+	void FormatTo(std::back_insert_iterator<std::string> &output_iterator, GrfIDMapping &grf_names, GamelogActionType action_type) override;
 };
 
 
 /** Contains information about one logged action that caused at least one logged change */
 struct LoggedAction {
-	std::vector<LoggedChange> change; ///< First logged change in this action
+	std::vector<std::unique_ptr<LoggedChange>> change; ///< Logged changes in this action
 	GamelogActionType at; ///< Type of action
-	uint64 tick;          ///< Tick when it happened
+	uint64_t tick;        ///< Tick when it happened
 };
 
 struct GamelogInternalData {

--- a/src/saveload/gamelog_sl.cpp
+++ b/src/saveload/gamelog_sl.cpp
@@ -14,6 +14,7 @@
 
 #include "../gamelog_internal.h"
 #include "../fios.h"
+#include "../string_func.h"
 
 #include "../safeguards.h"
 
@@ -21,8 +22,8 @@
 class SlGamelogMode : public DefaultSaveLoadHandler<SlGamelogMode, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, mode.mode,         SLE_UINT8),
-		SLE_VAR(LoggedChange, mode.landscape,    SLE_UINT8),
+		SLE_VARNAME(LoggedChangeMode, mode,      "mode.mode",      SLE_UINT8),
+		SLE_VARNAME(LoggedChangeMode, landscape, "mode.landscape", SLE_UINT8),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_mode_sl_compat;
 
@@ -43,11 +44,15 @@ public:
 
 class SlGamelogRevision : public DefaultSaveLoadHandler<SlGamelogRevision, LoggedChange> {
 public:
+	static const size_t GAMELOG_REVISION_LENGTH = 15;
+	static char revision_text[GAMELOG_REVISION_LENGTH];
+
 	inline static const SaveLoad description[] = {
-		SLE_ARR(LoggedChange, revision.text,     SLE_UINT8,  GAMELOG_REVISION_LENGTH),
-		SLE_VAR(LoggedChange, revision.newgrf,   SLE_UINT32),
-		SLE_VAR(LoggedChange, revision.slver,    SLE_UINT16),
-		SLE_VAR(LoggedChange, revision.modified, SLE_UINT8),
+		    SLEG_CONDARR("revision.text", SlGamelogRevision::revision_text,   SLE_UINT8, GAMELOG_REVISION_LENGTH, SL_MIN_VERSION,     SLV_STRING_GAMELOG),
+		SLE_CONDSSTRNAME(LoggedChangeRevision, text,     "revision.text",     SLE_STR,                            SLV_STRING_GAMELOG, SL_MAX_VERSION),
+		     SLE_VARNAME(LoggedChangeRevision, newgrf,   "revision.newgrf",   SLE_UINT32),
+		     SLE_VARNAME(LoggedChangeRevision, slver,    "revision.slver",    SLE_UINT16),
+		     SLE_VARNAME(LoggedChangeRevision, modified, "revision.modified", SLE_UINT8),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_revision_sl_compat;
 
@@ -61,16 +66,23 @@ public:
 	{
 		if (lc->ct != GLCT_REVISION) return;
 		SlObject(lc, this->GetLoadDescription());
+
+		if (IsSavegameVersionBefore(SLV_STRING_GAMELOG)) {
+			StrMakeValidInPlace(SlGamelogRevision::revision_text, lastof(SlGamelogRevision::revision_text));
+			static_cast<LoggedChangeRevision *>(lc)->text = SlGamelogRevision::revision_text;
+		}
 	}
 
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
 };
 
+/* static */ char SlGamelogRevision::revision_text[GAMELOG_REVISION_LENGTH];
+
 class SlGamelogOldver : public DefaultSaveLoadHandler<SlGamelogOldver, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, oldver.type,       SLE_UINT32),
-		SLE_VAR(LoggedChange, oldver.version,    SLE_UINT32),
+		SLE_VARNAME(LoggedChangeOldVersion, type,    "oldver.type",    SLE_UINT32),
+		SLE_VARNAME(LoggedChangeOldVersion, version, "oldver.version", SLE_UINT32),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_oldver_sl_compat;
 
@@ -92,9 +104,9 @@ public:
 class SlGamelogSetting : public DefaultSaveLoadHandler<SlGamelogSetting, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_STR(LoggedChange, setting.name,      SLE_STR,    128),
-		SLE_VAR(LoggedChange, setting.oldval,    SLE_INT32),
-		SLE_VAR(LoggedChange, setting.newval,    SLE_INT32),
+		SLE_SSTRNAME(LoggedChangeSettingChanged, name,   "setting.name",   SLE_STR),
+		 SLE_VARNAME(LoggedChangeSettingChanged, oldval, "setting.oldval", SLE_INT32),
+		 SLE_VARNAME(LoggedChangeSettingChanged, newval, "setting.newval", SLE_INT32),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_setting_sl_compat;
 
@@ -116,8 +128,8 @@ public:
 class SlGamelogGrfadd : public DefaultSaveLoadHandler<SlGamelogGrfadd, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, grfadd.grfid,      SLE_UINT32    ),
-		SLE_ARR(LoggedChange, grfadd.md5sum,     SLE_UINT8,  16),
+		SLE_VARNAME(LoggedChangeGRFAdd, grfid,  "grfadd.grfid",  SLE_UINT32    ),
+		SLE_ARRNAME(LoggedChangeGRFAdd, md5sum, "grfadd.md5sum", SLE_UINT8,  16),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_grfadd_sl_compat;
 
@@ -139,7 +151,7 @@ public:
 class SlGamelogGrfrem : public DefaultSaveLoadHandler<SlGamelogGrfrem, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, grfrem.grfid,      SLE_UINT32),
+		SLE_VARNAME(LoggedChangeGRFRemoved, grfid, "grfrem.grfid", SLE_UINT32),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_grfrem_sl_compat;
 
@@ -161,8 +173,8 @@ public:
 class SlGamelogGrfcompat : public DefaultSaveLoadHandler<SlGamelogGrfcompat, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, grfcompat.grfid,   SLE_UINT32    ),
-		SLE_ARR(LoggedChange, grfcompat.md5sum,  SLE_UINT8,  16),
+		SLE_VARNAME(LoggedChangeGRFChanged, grfid,  "grfcompat.grfid",  SLE_UINT32    ),
+		SLE_ARRNAME(LoggedChangeGRFChanged, md5sum, "grfcompat.md5sum", SLE_UINT8,  16),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_grfcompat_sl_compat;
 
@@ -184,7 +196,7 @@ public:
 class SlGamelogGrfparam : public DefaultSaveLoadHandler<SlGamelogGrfparam, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, grfparam.grfid,    SLE_UINT32),
+		SLE_VARNAME(LoggedChangeGRFParameterChanged, grfid, "grfparam.grfid", SLE_UINT32),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_grfparam_sl_compat;
 
@@ -206,8 +218,8 @@ public:
 class SlGamelogGrfmove : public DefaultSaveLoadHandler<SlGamelogGrfmove, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, grfmove.grfid,     SLE_UINT32),
-		SLE_VAR(LoggedChange, grfmove.offset,    SLE_INT32),
+		SLE_VARNAME(LoggedChangeGRFMoved, grfid,  "grfmove.grfid",  SLE_UINT32),
+		SLE_VARNAME(LoggedChangeGRFMoved, offset, "grfmove.offset", SLE_INT32),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_grfmove_sl_compat;
 
@@ -229,9 +241,9 @@ public:
 class SlGamelogGrfbug : public DefaultSaveLoadHandler<SlGamelogGrfbug, LoggedChange> {
 public:
 	inline static const SaveLoad description[] = {
-		SLE_VAR(LoggedChange, grfbug.data,       SLE_UINT64),
-		SLE_VAR(LoggedChange, grfbug.grfid,      SLE_UINT32),
-		SLE_VAR(LoggedChange, grfbug.bug,        SLE_UINT8),
+		SLE_VARNAME(LoggedChangeGRFBug, data,  "grfbug.data",  SLE_UINT64),
+		SLE_VARNAME(LoggedChangeGRFBug, grfid, "grfbug.grfid", SLE_UINT32),
+		SLE_VARNAME(LoggedChangeGRFBug, bug,   "grfbug.bug",   SLE_UINT8),
 	};
 	inline const static SaveLoadCompatTable compat_description = _gamelog_grfbug_sl_compat;
 
@@ -278,6 +290,27 @@ public:
 	void LoadCheck(LoggedChange *lc) const override { this->Load(lc); }
 };
 
+static std::unique_ptr<LoggedChange> MakeLoggedChange(GamelogChangeType type)
+{
+	switch (type) {
+		case GLCT_MODE:      return std::make_unique<LoggedChangeMode>();
+		case GLCT_REVISION:  return std::make_unique<LoggedChangeRevision>();
+		case GLCT_OLDVER:    return std::make_unique<LoggedChangeOldVersion>();
+		case GLCT_SETTING:   return std::make_unique<LoggedChangeSettingChanged>();
+		case GLCT_GRFADD:    return std::make_unique<LoggedChangeGRFAdd>();
+		case GLCT_GRFREM:    return std::make_unique<LoggedChangeGRFRemoved>();
+		case GLCT_GRFCOMPAT: return std::make_unique<LoggedChangeGRFChanged>();
+		case GLCT_GRFPARAM:  return std::make_unique<LoggedChangeGRFParameterChanged>();
+		case GLCT_GRFMOVE:   return std::make_unique<LoggedChangeGRFMoved>();
+		case GLCT_GRFBUG:    return std::make_unique<LoggedChangeGRFBug>();
+		case GLCT_EMERGENCY: return std::make_unique<LoggedChangeEmergencySave>();
+		case GLCT_END:
+		case GLCT_NONE:
+		default:
+			SlErrorCorrupt("Invalid gamelog action type");
+	}
+}
+
 class SlGamelogAction : public DefaultSaveLoadHandler<SlGamelogAction, LoggedAction> {
 public:
 	inline static const SaveLoad description[] = {
@@ -301,9 +334,16 @@ public:
 		SlSetStructListLength(la->change.size());
 
 		for (auto &lc : la->change) {
-			assert((uint)lc.ct < GLCT_END);
-			SlObject(&lc, this->GetDescription());
+			assert(lc->ct < GLCT_END);
+			SlObject(lc.get(), this->GetDescription());
 		}
+	}
+
+	void LoadChange(LoggedAction *la, GamelogChangeType type) const
+	{
+		std::unique_ptr<LoggedChange> lc = MakeLoggedChange(type);
+		SlObject(lc.get(), this->GetLoadDescription());
+		la->change.push_back(std::move(lc));
 	}
 
 	void Load(LoggedAction *la) const override
@@ -312,11 +352,7 @@ public:
 			byte type;
 			while ((type = SlReadByte()) != GLCT_NONE) {
 				if (type >= GLCT_END) SlErrorCorrupt("Invalid gamelog change type");
-				GamelogChangeType ct = (GamelogChangeType)type;
-
-				LoggedChange &lc = la->change.emplace_back();
-				lc.ct = ct;
-				SlObject(&lc, this->GetLoadDescription());
+				LoadChange(la, (GamelogChangeType)type);
 			}
 			return;
 		}
@@ -325,9 +361,7 @@ public:
 		la->change.reserve(length);
 
 		for (size_t i = 0; i < length; i++) {
-			LoggedChange &lc = la->change.emplace_back();
-			lc.ct = (GamelogChangeType)SlReadByte();
-			SlObject(&lc, this->GetLoadDescription());
+			LoadChange(la, (GamelogChangeType)SlReadByte());
 		}
 	}
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -610,7 +610,6 @@ enum VarTypes {
 	SLE_VAR_I64   =  7 << 4,
 	SLE_VAR_U64   =  8 << 4,
 	SLE_VAR_NULL  =  9 << 4, ///< useful to write zeros in savegame.
-	SLE_VAR_STRB  = 10 << 4, ///< string (with pre-allocated buffer)
 	SLE_VAR_STR   = 12 << 4, ///< string pointer
 	SLE_VAR_STRQ  = 13 << 4, ///< string pointer enclosed in quotes
 	SLE_VAR_NAME  = 14 << 4, ///< old custom name to be converted to a char pointer
@@ -633,7 +632,6 @@ enum VarTypes {
 	SLE_UINT64       = SLE_FILE_U64 | SLE_VAR_U64,
 	SLE_CHAR         = SLE_FILE_I8  | SLE_VAR_CHAR,
 	SLE_STRINGID     = SLE_FILE_STRINGID | SLE_VAR_U32,
-	SLE_STRINGBUF    = SLE_FILE_STRING   | SLE_VAR_STRB,
 	SLE_STRING       = SLE_FILE_STRING   | SLE_VAR_STR,
 	SLE_STRINGQUOTE  = SLE_FILE_STRING   | SLE_VAR_STRQ,
 	SLE_NAME         = SLE_FILE_STRINGID | SLE_VAR_NAME,
@@ -641,7 +639,6 @@ enum VarTypes {
 	/* Shortcut values */
 	SLE_UINT  = SLE_UINT32,
 	SLE_INT   = SLE_INT32,
-	SLE_STRB  = SLE_STRINGBUF,
 	SLE_STR   = SLE_STRING,
 	SLE_STRQ  = SLE_STRINGQUOTE,
 
@@ -659,7 +656,6 @@ enum SaveLoadType : byte {
 	SL_REF         =  1, ///< Save/load a reference.
 	SL_STRUCT      =  2, ///< Save/load a struct.
 
-	SL_STR         =  3, ///< Save/load a string.
 	SL_STDSTR      =  4, ///< Save/load a \c std::string.
 
 	SL_ARR         =  5, ///< Save/load a fixed-size array of #SL_VAR elements.
@@ -881,15 +877,6 @@ struct SaveLoadCompat {
 #define SLE_ARRNAME(base, variable, name, type, length) SLE_CONDARRNAME(base, variable, name, type, length, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
- * Storage of a string in every savegame version.
- * @param base     Name of the class or struct containing the string.
- * @param variable Name of the variable in the class or struct referenced by \a base.
- * @param type     Storage of the data in memory and in the savegame.
- * @param length   Number of elements in the string (only used for fixed size buffers).
- */
-#define SLE_STR(base, variable, type, length) SLE_CONDSTR(base, variable, type, length, SL_MIN_VERSION, SL_MAX_VERSION)
-
-/**
  * Storage of a \c std::string in every savegame version.
  * @param base     Name of the class or struct containing the string.
  * @param variable Name of the variable in the class or struct referenced by \a base.
@@ -971,17 +958,6 @@ struct SaveLoadCompat {
 #define SLEG_CONDARR(name, variable, type, length, from, to) SLEG_GENERAL(name, SL_ARR, variable, type, length, from, to, 0)
 
 /**
- * Storage of a global string in some savegame versions.
- * @param name     The name of the field.
- * @param variable Name of the global variable.
- * @param type     Storage of the data in memory and in the savegame.
- * @param length   Number of elements in the string (only used for fixed size buffers).
- * @param from     First savegame version that has the string.
- * @param to       Last savegame version that has the string.
- */
-#define SLEG_CONDSTR(name, variable, type, length, from, to) SLEG_GENERAL(name, SL_STR, variable, type, length, from, to, 0)
-
-/**
  * Storage of a global \c std::string in some savegame versions.
  * @param name     The name of the field.
  * @param variable Name of the global variable.
@@ -1052,14 +1028,6 @@ struct SaveLoadCompat {
  * @param type     Storage of the data in memory and in the savegame.
  */
 #define SLEG_ARR(name, variable, type) SLEG_CONDARR(name, variable, type, lengthof(variable), SL_MIN_VERSION, SL_MAX_VERSION)
-
-/**
- * Storage of a global string in every savegame version.
- * @param name     The name of the field.
- * @param variable Name of the global variable.
- * @param type     Storage of the data in memory and in the savegame.
- */
-#define SLEG_STR(name, variable, type) SLEG_CONDSTR(name, variable, type, sizeof(variable), SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
  * Storage of a global \c std::string in every savegame version.

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -354,6 +354,7 @@ enum SaveLoadVersion : uint16 {
 	SLV_EXTEND_ENTITY_MAPPING,              ///< 311  PR#10672 Extend entity mapping range.
 	SLV_DISASTER_VEH_STATE,                 ///< 312  PR#10798 Explicit storage of disaster vehicle state.
 	SLV_SAVEGAME_ID,                        ///< 313  PR#10719 Add an unique ID to every savegame (used to deduplicate surveys).
+	SLV_STRING_GAMELOG,                     ///< 314  PR#10801 Use std::string in gamelog.
 
 	SL_MAX_VERSION,                         ///< Highest possible saveload version
 };
@@ -772,6 +773,18 @@ struct SaveLoadCompat {
 #define SLE_CONDARR(base, variable, type, length, from, to) SLE_GENERAL(SL_ARR, base, variable, type, length, from, to, 0)
 
 /**
+ * Storage of a fixed-size array of #SL_VAR elements in some savegame versions.
+ * @param base     Name of the class or struct containing the array.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ * @param name     Field name for table chunks.
+ * @param type     Storage of the data in memory and in the savegame.
+ * @param length   Number of elements in the array.
+ * @param from     First savegame version that has the array.
+ * @param to       Last savegame version that has the array.
+ */
+#define SLE_CONDARRNAME(base, variable, name, type, length, from, to) SLE_GENERAL_NAME(SL_ARR, name, base, variable, type, length, from, to, 0)
+
+/**
  * Storage of a string in some savegame versions.
  * @param base     Name of the class or struct containing the string.
  * @param variable Name of the variable in the class or struct referenced by \a base.
@@ -791,6 +804,17 @@ struct SaveLoadCompat {
  * @param to       Last savegame version that has the string.
  */
 #define SLE_CONDSSTR(base, variable, type, from, to) SLE_GENERAL(SL_STDSTR, base, variable, type, 0, from, to, 0)
+
+/**
+ * Storage of a \c std::string in some savegame versions.
+ * @param base     Name of the class or struct containing the string.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ * @param name     Field name for table chunks.
+ * @param type     Storage of the data in memory and in the savegame.
+ * @param from     First savegame version that has the string.
+ * @param to       Last savegame version that has the string.
+ */
+#define SLE_CONDSSTRNAME(base, variable, name, type, from, to) SLE_GENERAL_NAME(SL_STDSTR, name, base, variable, type, 0, from, to, 0)
 
 /**
  * Storage of a list of #SL_REF elements in some savegame versions.
@@ -821,6 +845,15 @@ struct SaveLoadCompat {
 #define SLE_VAR(base, variable, type) SLE_CONDVAR(base, variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
+ * Storage of a variable in every version of a savegame.
+ * @param base     Name of the class or struct containing the variable.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ * @param name     Field name for table chunks.
+ * @param type     Storage of the data in memory and in the savegame.
+ */
+#define SLE_VARNAME(base, variable, name, type) SLE_CONDVARNAME(base, variable, name, type, SL_MIN_VERSION, SL_MAX_VERSION)
+
+/**
  * Storage of a reference in every version of a savegame.
  * @param base     Name of the class or struct containing the variable.
  * @param variable Name of the variable in the class or struct referenced by \a base.
@@ -838,6 +871,16 @@ struct SaveLoadCompat {
 #define SLE_ARR(base, variable, type, length) SLE_CONDARR(base, variable, type, length, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
+ * Storage of fixed-size array of #SL_VAR elements in every version of a savegame.
+ * @param base     Name of the class or struct containing the array.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ * @param name     Field name for table chunks.
+ * @param type     Storage of the data in memory and in the savegame.
+ * @param length   Number of elements in the array.
+ */
+#define SLE_ARRNAME(base, variable, name, type, length) SLE_CONDARRNAME(base, variable, name, type, length, SL_MIN_VERSION, SL_MAX_VERSION)
+
+/**
  * Storage of a string in every savegame version.
  * @param base     Name of the class or struct containing the string.
  * @param variable Name of the variable in the class or struct referenced by \a base.
@@ -853,6 +896,15 @@ struct SaveLoadCompat {
  * @param type     Storage of the data in memory and in the savegame.
  */
 #define SLE_SSTR(base, variable, type) SLE_CONDSSTR(base, variable, type, SL_MIN_VERSION, SL_MAX_VERSION)
+
+/**
+ * Storage of a \c std::string in every savegame version.
+ * @param base     Name of the class or struct containing the string.
+ * @param variable Name of the variable in the class or struct referenced by \a base.
+ * @param name     Field name for table chunks.
+ * @param type     Storage of the data in memory and in the savegame.
+ */
+#define SLE_SSTRNAME(base, variable, name, type) SLE_CONDSSTRNAME(base, variable, name, type, SL_MIN_VERSION, SL_MAX_VERSION)
 
 /**
  * Storage of a list of #SL_REF elements in every savegame version.


### PR DESCRIPTION
## Motivation / Problem

Usage of manually managed memory within Gamelog, and the last user of `SLE_STR(`(i.e. non std::string text in the savegame).


## Description

Change the union in gamelog to use a class with a lot of sub classes, like for vehicles, and therefor `std::unique_ptr`s.
Rewrite saveload to use these classes, especially because the element name for the union is not needed anymore. I have chosen to retain the old names in the savegame for compatibility reasons.
Replace `uint8 text` and `char *text` with `std::string`.

## Limitations

Sadly an atomic change as due to the classes the internal names of field change, and it's every inefficient to do the conversion per sub type.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
