### PR TITLE
Fix #10467: [YAPF] Trains do not use all available tracks

### DIFF
--- a/src/pathfinder/yapf/yapf_costrail.hpp
+++ b/src/pathfinder/yapf/yapf_costrail.hpp
@@ -156,12 +156,18 @@ public:
 		if (n.m_num_signals_passed >= m_sig_look_ahead_costs.size() / 2) return 0;
 		if (!IsPbsSignal(n.m_last_signal_type)) return 0;
 
+		const Train *v = Yapf().GetVehicle();
+		assert(v != nullptr);
+		assert(v->type == VEH_TRAIN);
+		/* the longer a train waits, the more it will consider longer routes around blocking trains */
+		int impatience = std::max(0, v->wait_counter - DAY_TICKS / 2);
+
 		if (IsRailStationTile(tile) && IsAnyStationTileReserved(tile, trackdir, skipped)) {
-			return Yapf().PfGetSettings().rail_pbs_station_penalty * (skipped + 1);
+			return Yapf().PfGetSettings().rail_pbs_station_penalty * (skipped + 1) + impatience;
 		} else if (TrackOverlapsTracks(GetReservedTrackbits(tile), TrackdirToTrack(trackdir))) {
 			int cost = Yapf().PfGetSettings().rail_pbs_cross_penalty;
 			if (!IsDiagonalTrackdir(trackdir)) cost = (cost * YAPF_TILE_CORNER_LENGTH) / YAPF_TILE_LENGTH;
-			return cost * (skipped + 1);
+			return cost * (skipped + 1) + impatience;
 		}
 		return 0;
 	}


### PR DESCRIPTION
## Motivation / Problem
 
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

See #10467 and #9609

There is an issue in the pathfinder regarding the cost associated with blocking trains. The cost can be so low that trains may not use all the bays in a waiting bay. This happens because the path through an occupied bay can have a lower cost than the path through free bays if the occupying train is short enough and the free bays have higher penalties due to additional corners. This can happen in common designs (see #10467). The end result is that trains will wait before the bays and cause blockages.

#9609 is similar, the train refuses to consider driving through the station as it sees a lower cost path trying to drive through the blocking train and a deadlock arises. 


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I have introduced an 'impatience' factor to the cost of reserved tiles. This factor is proportional to how long the train has been waiting at the signal. The longer it waits, the more it considers further paths around the blocking train. This resolves the deadlock in the first save game of the issue and the deadlock pictured in the second issue.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

- The parameters of the impatience factor may need to be tuned.  
- The cost imposed by the impatience factor is proportional to how many reserved tiles the path crosses through. This doesn't really make sense. If a block section ahead is blocked, a train should not tolerate a longer detour just because the block is occupied by a longer train. However this is a limitation with the original YAPF algorithm and perhaps should be dealt with in a separate issue. (I have a fix for it here: PR #10807)

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
