### PR TITLE
Codechange: use std::string instead of char* for original editor strings

### DIFF
--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -971,7 +971,7 @@ struct QueryStringWindow : public Window
 
 		this->editbox.text.UpdateSize();
 
-		if ((flags & QSF_ACCEPT_UNCHANGED) == 0) this->editbox.orig = stredup(this->editbox.text.buf);
+		if ((flags & QSF_ACCEPT_UNCHANGED) == 0) this->editbox.orig = this->editbox.text.buf;
 
 		this->querystrings[WID_QS_TEXT] = &this->editbox;
 		this->editbox.caption = caption;
@@ -1033,7 +1033,7 @@ struct QueryStringWindow : public Window
 
 	void OnOk()
 	{
-		if (this->editbox.orig == nullptr || strcmp(this->editbox.text.buf, this->editbox.orig) != 0) {
+		if (!this->editbox.orig.has_value() || this->editbox.text.buf != this->editbox.orig) {
 			assert(this->parent != nullptr);
 
 			this->parent->OnQueryTextFinished(this->editbox.text.buf);

--- a/src/querystring_gui.h
+++ b/src/querystring_gui.h
@@ -27,7 +27,7 @@ struct QueryString {
 	int ok_button;      ///< Widget button of parent window to simulate when pressing OK in OSK.
 	int cancel_button;  ///< Widget button of parent window to simulate when pressing CANCEL in OSK.
 	Textbuf text;
-	const char *orig;
+	std::optional<std::string> orig;
 	bool handled;
 
 	/**
@@ -35,16 +35,8 @@ struct QueryString {
 	 * @param size Maximum size in bytes.
 	 * @param chars Maximum size in chars.
 	 */
-	QueryString(uint16 size, uint16 chars = UINT16_MAX) : ok_button(ACTION_NOTHING), cancel_button(ACTION_DESELECT), text(size, chars), orig(nullptr)
+	QueryString(uint16 size, uint16 chars = UINT16_MAX) : ok_button(ACTION_NOTHING), cancel_button(ACTION_DESELECT), text(size, chars)
 	{
-	}
-
-	/**
-	 * Make sure everything gets freed.
-	 */
-	~QueryString()
-	{
-		free(this->orig);
 	}
 
 public:


### PR DESCRIPTION
## Motivation / Problem

Manual memory management of original states of edit and OSK windows.


## Description

Replace `char*` + `stredup` +`free` with `std::string`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
