### PR TITLE
Codechange: use StringBuilder to create town names

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1664,7 +1664,7 @@ static void StationGetSpecialString(StringBuilder &builder, int x)
 
 static void GetSpecialTownNameString(StringBuilder &builder, int ind, uint32 seed)
 {
-	builder.AddViaStreCallback([&](auto buff, auto last) { return GenerateTownNameString(buff, last, ind, seed); });
+	GenerateTownNameString(builder, ind, seed);
 }
 
 static const char * const _silly_company_names[] = {

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -20,7 +20,8 @@
  * extra functions to ease the migration from char buffers to std::string.
  */
 class StringBuilder {
-	char **current; ///< The current location to add strings
+	char **current; ///< The current location to add strings.
+	char *start;   ///< The begin of the string.
 	const char *last; ///< The last element of the buffer.
 
 public:
@@ -36,7 +37,7 @@ public:
 	 * @param start The start location to write to.
 	 * @param last  The last location to write to.
 	 */
-	StringBuilder(char **start, const char *last) : current(start), last(last) {}
+	StringBuilder(char **start, const char *last) : current(start), start(*start), last(last) {}
 
 	/* Required operators for this to be an output_iterator; mimics std::back_insert_iterator, which has no-ops. */
 	StringBuilder &operator++() { return *this; }
@@ -101,6 +102,15 @@ public:
 	}
 
 	/**
+	 * Remove the given amount of characters from the back of the string.
+	 * @param amount The amount of characters to remove.
+	 */
+	void RemoveElementsFromBack(size_t amount)
+	{
+		*this->current = std::max(this->start, *this->current - amount);
+	}
+
+	/**
 	 * Get the pointer to the this->last written element in the buffer.
 	 * This call does '\0' terminate the string, whereas other calls do not
 	 * (necessarily) do this.
@@ -122,19 +132,28 @@ public:
 	}
 
 	/**
-	 * Add a string using the strecpy-esque calling signature.
-	 * @param function The function to pass the current and last location to,
-	 *                 that will then return the new current location.
+	 * Get the current index in the string.
+	 * @return The index.
 	 */
-	void AddViaStreCallback(std::function<char*(char*, const char*)> function)
+	size_t CurrentIndex()
 	{
-		*this->current = function(*this->current, this->last);
+		return *this->current - this->start;
+	}
+
+	/**
+	 * Get the reference to the character at the given index.
+	 * @return The reference to the character.
+	 */
+	char &operator[](size_t index)
+	{
+		return this->start[index];
 	}
 };
 
 void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters *args, uint case_index = 0, bool game_script = false);
 
 /* Do not leak the StringBuilder to everywhere. */
+void GenerateTownNameString(StringBuilder &builder, size_t lang, uint32_t seed);
 void GetTownName(StringBuilder &builder, const struct Town *t);
 void GRFTownNameGenerate(StringBuilder &builder, uint32 grfid, uint16 gen, uint32 seed);
 

--- a/src/townname_func.h
+++ b/src/townname_func.h
@@ -13,7 +13,6 @@
 #include "core/random_func.hpp"
 #include "townname_type.h"
 
-char *GenerateTownNameString(char *buf, const char *last, size_t lang, uint32 seed);
 char *GetTownName(char *buff, const TownNameParams *par, uint32 townnameparts, const char *last);
 char *GetTownName(char *buff, const Town *t, const char *last);
 bool VerifyTownName(uint32 r, const TownNameParams *par, TownNames *town_names = nullptr);


### PR DESCRIPTION
## Motivation / Problem

Another step in the ongoing slow migration to C++ .


## Description

Use the `StringBuilder` instead of the `strecpy`-esque parameters to create the town names.
Not sure this is the way to go, or whether they should just create the town names to their own strings, and then including the strings later.

## Limitations

Changing `StringBuilder` over to actually become a `std::string` is beyond the scope of this, as that requires replacing all the `GetString(buf, <StringID>, last)` calls with the `std::string` returning `GetString` version.
Adds quite a bit of cruft to force the town name building into the `StringBuilder`. Are there any good ideas how to make it better?


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
