### PR TITLE
Codechange: use std::string instead of strecat to build hotkey strings

### DIFF
--- a/src/hotkeys.cpp
+++ b/src/hotkeys.cpp
@@ -167,53 +167,41 @@ static void ParseHotkeys(Hotkey *hotkey, const char *value)
  * by a '+'.
  * @param keycode The keycode to convert to a string.
  * @return A string representation of this keycode.
- * @note The return value is a static buffer, stredup the result before calling
- *  this function again.
  */
-static const char *KeycodeToString(uint16 keycode)
+static std::string KeycodeToString(uint16 keycode)
 {
-	static char buf[32];
-	buf[0] = '\0';
-	bool first = true;
+	std::string str;
 	if (keycode & WKC_GLOBAL_HOTKEY) {
-		strecat(buf, "GLOBAL", lastof(buf));
-		first = false;
+		str += "GLOBAL";
 	}
 	if (keycode & WKC_SHIFT) {
-		if (!first) strecat(buf, "+", lastof(buf));
-		strecat(buf, "SHIFT", lastof(buf));
-		first = false;
+		if (!str.empty()) str += "+";
+		str += "SHIFT";
 	}
 	if (keycode & WKC_CTRL) {
-		if (!first) strecat(buf, "+", lastof(buf));
-		strecat(buf, "CTRL", lastof(buf));
-		first = false;
+		if (!str.empty()) str += "+";
+		str += "CTRL";
 	}
 	if (keycode & WKC_ALT) {
-		if (!first) strecat(buf, "+", lastof(buf));
-		strecat(buf, "ALT", lastof(buf));
-		first = false;
+		if (!str.empty()) str += "+";
+		str += "ALT";
 	}
 	if (keycode & WKC_META) {
-		if (!first) strecat(buf, "+", lastof(buf));
-		strecat(buf, "META", lastof(buf));
-		first = false;
+		if (!str.empty()) str += "+";
+		str += "META";
 	}
-	if (!first) strecat(buf, "+", lastof(buf));
+	if (!str.empty()) str += "+";
 	keycode = keycode & ~WKC_SPECIAL_KEYS;
 
 	for (uint i = 0; i < lengthof(_keycode_to_name); i++) {
 		if (_keycode_to_name[i].keycode == keycode) {
-			strecat(buf, _keycode_to_name[i].name, lastof(buf));
-			return buf;
+			str += _keycode_to_name[i].name;
+			return str;
 		}
 	}
 	assert(keycode < 128);
-	char key[2];
-	key[0] = keycode;
-	key[1] = '\0';
-	strecat(buf, key, lastof(buf));
-	return buf;
+	str.push_back(keycode);
+	return str;
 }
 
 /**
@@ -221,19 +209,15 @@ static const char *KeycodeToString(uint16 keycode)
  * keycodes are attached to the hotkey they are split by a comma.
  * @param hotkey The keycodes of this hotkey need to be converted to a string.
  * @return A string representation of all keycodes.
- * @note The return value is a static buffer, stredup the result before calling
- *  this function again.
  */
-const char *SaveKeycodes(const Hotkey *hotkey)
+std::string SaveKeycodes(const Hotkey *hotkey)
 {
-	static char buf[128];
-	buf[0] = '\0';
+	std::string str;
 	for (uint i = 0; i < hotkey->keycodes.size(); i++) {
-		const char *str = KeycodeToString(hotkey->keycodes[i]);
-		if (i > 0) strecat(buf, ",", lastof(buf));
-		strecat(buf, str, lastof(buf));
+		if (i > 0) str += ",";
+		str += KeycodeToString(hotkey->keycodes[i]);
 	}
-	return buf;
+	return str;
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

Mostly triggered because the documentation said to use `stredup` before calling the function again, and then not doing so. Although in that context it was just fine.


## Description

`char buf[xyz]` => `std::string str`
`strecat` => `+=`

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
