### PR TITLE
Codechange: Rework station distant-join list.

### DIFF
--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -2138,12 +2138,12 @@ static bool AddNearbyStation(TileIndex tile, void *user_data)
 	TileArea *ctx = (TileArea *)user_data;
 
 	/* First check if there were deleted stations here */
-	for (uint i = 0; i < _deleted_stations_nearby.size(); i++) {
-		auto ts = _deleted_stations_nearby.begin() + i;
-		if (ts->tile == tile) {
-			_stations_nearby_list.push_back(_deleted_stations_nearby[i].station);
-			_deleted_stations_nearby.erase(ts);
-			i--;
+	for (auto it = _deleted_stations_nearby.begin(); it != _deleted_stations_nearby.end(); /* nothing */) {
+		if (it->tile == tile) {
+			_stations_nearby_list.push_back(it->station);
+			it = _deleted_stations_nearby.erase(it);
+		} else {
+			++it;
 		}
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Station distant join has a 'phantom' unlisted option to create a new station. This makes list and scrollbar management more complicated, requiring special-casing.

## Description

Instead, begin the nearby stations list with the already existing 'NEW_STATION' value. This reduces the special-casing to just checking this for value on display, and allows use of GetScrolledItemFromWidget().

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
