### PR TITLE
Codechange: rework NewGRFProfiler to use ticks instead of calendar-days

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -2203,8 +2203,8 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		IConsolePrint(CC_HELP, "  Select one or more GRFs for profiling.");
 		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile unselect <grf-num>...':");
 		IConsolePrint(CC_HELP, "  Unselect one or more GRFs from profiling. Use the keyword \"all\" instead of a GRF number to unselect all. Removing an active profiler aborts data collection.");
-		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile start [<num-days>]':");
-		IConsolePrint(CC_HELP, "  Begin profiling all selected GRFs. If a number of days is provided, profiling stops after that many in-game days.");
+		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile start [<num-ticks>]':");
+		IConsolePrint(CC_HELP, "  Begin profiling all selected GRFs. If a number of ticks is provided, profiling stops after that many game ticks. There are 74 ticks in a calendar day.");
 		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile stop':");
 		IConsolePrint(CC_HELP, "  End profiling and write the collected data to CSV files.");
 		IConsolePrint(CC_HELP, "Usage: 'newgrf_profile abort':");
@@ -2284,16 +2284,11 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		}
 		if (started > 0) {
 			IConsolePrint(CC_DEBUG, "Started profiling for GRFID{} {}.", (started > 1) ? "s" : "", grfids);
-			if (argc >= 3) {
-				int days = std::max(atoi(argv[2]), 1);
-				_newgrf_profile_end_date = TimerGameCalendar::date + days;
 
-				char datestrbuf[32]{ 0 };
-				SetDParam(0, _newgrf_profile_end_date);
-				GetString(datestrbuf, STR_JUST_DATE_ISO, lastof(datestrbuf));
-				IConsolePrint(CC_DEBUG, "Profiling will automatically stop on game date {}.", datestrbuf);
-			} else {
-				_newgrf_profile_end_date = MAX_DATE;
+			if (argc >= 3) {
+				uint64 ticks = std::max(atoi(argv[2]), 1);
+				NewGRFProfiler::StartTimer(ticks);
+				IConsolePrint(CC_DEBUG, "Profiling will automatically stop after {} ticks.", ticks);
 			}
 		} else if (_newgrf_profilers.empty()) {
 			IConsolePrint(CC_ERROR, "No GRFs selected for profiling, did not start.");
@@ -2314,7 +2309,7 @@ DEF_CONSOLE_CMD(ConNewGRFProfile)
 		for (NewGRFProfiler &pr : _newgrf_profilers) {
 			pr.Abort();
 		}
-		_newgrf_profile_end_date = MAX_DATE;
+		NewGRFProfiler::AbortTimer();
 		return true;
 	}
 

--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -14,14 +14,12 @@
 #include "spritecache.h"
 #include "walltime_func.h"
 #include "timer/timer.h"
-#include "timer/timer_game_calendar.h"
 #include "timer/timer_game_tick.h"
 
 #include <chrono>
 
 
 std::vector<NewGRFProfiler> _newgrf_profilers;
-TimerGameCalendar::Date _newgrf_profile_end_date;
 
 
 /**
@@ -141,8 +139,10 @@ std::string NewGRFProfiler::GetOutputFilename() const
 	return std::string(filepath);
 }
 
-uint32 NewGRFProfiler::FinishAll()
+/* static */ uint32 NewGRFProfiler::FinishAll()
 {
+	NewGRFProfiler::AbortTimer();
+
 	uint64 max_ticks = 0;
 	uint32 total_microseconds = 0;
 	for (NewGRFProfiler &pr : _newgrf_profilers) {
@@ -156,17 +156,29 @@ uint32 NewGRFProfiler::FinishAll()
 		IConsolePrint(CC_DEBUG, "Total NewGRF callback processing: {} microseconds over {} ticks.", total_microseconds, max_ticks);
 	}
 
-	_newgrf_profile_end_date = MAX_DATE;
-
 	return total_microseconds;
 }
 
 /**
  * Check whether profiling is active and should be finished.
  */
-static IntervalTimer<TimerGameCalendar> _check_profiling_finished({TimerGameCalendar::DAY, TimerGameCalendar::Priority::NONE}, [](auto)
+static TimeoutTimer<TimerGameTick> _profiling_finish_timeout(0, []()
 {
-	if (_newgrf_profilers.empty() || _newgrf_profile_end_date > TimerGameCalendar::date) return;
-
 	NewGRFProfiler::FinishAll();
 });
+
+/**
+ * Start the timeout timer that will finish all profiling sessions.
+ */
+/* static */ void NewGRFProfiler::StartTimer(uint64 ticks)
+{
+	_profiling_finish_timeout.Reset(ticks);
+}
+
+/**
+ * Abort the timeout timer, so the timer callback is never called.
+ */
+/* static */ void NewGRFProfiler::AbortTimer()
+{
+	_profiling_finish_timeout.Abort();
+}

--- a/src/newgrf_profiling.h
+++ b/src/newgrf_profiling.h
@@ -34,6 +34,8 @@ struct NewGRFProfiler {
 	void Abort();
 	std::string GetOutputFilename() const;
 
+	static void StartTimer(uint64 ticks);
+	static void AbortTimer();
 	static uint32 FinishAll();
 
 	/** Measurement of a single sprite group resolution */
@@ -56,6 +58,5 @@ struct NewGRFProfiler {
 };
 
 extern std::vector<NewGRFProfiler> _newgrf_profilers;
-extern TimerGameCalendar::Date _newgrf_profile_end_date;
 
 #endif /* NEWGRF_PROFILING_H */


### PR DESCRIPTION
## Motivation / Problem

We are planning to allow things like freezing the calendar, which makes this variable a bit problemetic. 

## Description

So instead, suggest to the user how many ticks there are in a calendar day, and let them figure out how many ticks they want.

Additionally, use a TimeoutTimer for this, instead of an end-date variable which is checked in an IntervalTimer.

## Limitations

There are a few odd things about the newgrf profiler. For example, when you start it in the middle of a day, and you asked for a single game-day, it would in fact run 1.5 game-days. By using `ticks`, this problem is also resolved. But it is a bit hard to guess the intention behind this functionality .. was it intended to stop on an exact day?

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
