### PR TITLE
Fix: NewGRF Profile didn't stop if there were no events yet

### DIFF
--- a/src/newgrf_profiling.cpp
+++ b/src/newgrf_profiling.cpp
@@ -98,6 +98,8 @@ uint32 NewGRFProfiler::Finish()
 
 	if (this->calls.empty()) {
 		IConsolePrint(CC_DEBUG, "Finished profile of NewGRF [{:08X}], no events collected, not writing a file.", BSWAP32(this->grffile->grfid));
+
+		this->Abort();
 		return 0;
 	}
 
@@ -116,7 +118,6 @@ uint32 NewGRFProfiler::Finish()
 	}
 
 	this->Abort();
-
 	return total_microseconds;
 }
 


### PR DESCRIPTION
## Motivation / Problem

While working on the code I noticed that profiling OpenGFX meant that the profile remained active, even after a `stop` or `timeout`. Only with `abort` it actually wanted to stop.

## Description

This meant you could have the following situation:
- You start a profile on a GRF with no events, for N days.
- The days pass, the profile should stop. It doesn't.
- The profile will never stop, even if the GRF start generating events.
- There is no real way to discover this, so .. byebye memory? :)

Fixed it by also terminating the profile for GRFs that didn't receive any events.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
