### PR TITLE
Codechange: Pass reference instead of pointer to GUI*Lists.

### DIFF
--- a/src/autoreplace_gui.cpp
+++ b/src/autoreplace_gui.cpp
@@ -195,10 +195,10 @@ class ReplaceVehicleWindow : public Window {
 
 		this->sel_engine[side] = selected_engine; // update which engine we selected (the same or none, if it's not in the list anymore)
 		if (draw_left) {
-			EngList_Sort(&list, &EngineNumberSorter);
+			EngList_Sort(list, &EngineNumberSorter);
 		} else {
 			_engine_sort_direction = this->descending_sort_order;
-			EngList_Sort(&list, _engine_sort_functions[this->window_number][this->sort_criteria]);
+			EngList_Sort(list, _engine_sort_functions[this->window_number][this->sort_criteria]);
 		}
 
 		this->engines[side].clear();

--- a/src/build_vehicle_gui.cpp
+++ b/src/build_vehicle_gui.cpp
@@ -1430,14 +1430,14 @@ struct BuildVehicleWindow : Window {
 
 		/* make engines first, and then wagons, sorted by selected sort_criteria */
 		_engine_sort_direction = false;
-		EngList_Sort(&list, TrainEnginesThenWagonsSorter);
+		EngList_Sort(list, TrainEnginesThenWagonsSorter);
 
 		/* and then sort engines */
 		_engine_sort_direction = this->descending_sort_order;
-		EngList_SortPartial(&list, _engine_sort_functions[0][this->sort_criteria], 0, num_engines);
+		EngList_SortPartial(list, _engine_sort_functions[0][this->sort_criteria], 0, num_engines);
 
 		/* and finally sort wagons */
-		EngList_SortPartial(&list, _engine_sort_functions[0][this->sort_criteria], num_engines, list.size() - num_engines);
+		EngList_SortPartial(list, _engine_sort_functions[0][this->sort_criteria], num_engines, list.size() - num_engines);
 	}
 
 	/* Figure out what road vehicle EngineIDs to put in the list */
@@ -1561,7 +1561,7 @@ struct BuildVehicleWindow : Window {
 		}
 
 		_engine_sort_direction = this->descending_sort_order;
-		EngList_Sort(&this->eng_list, _engine_sort_functions[this->vehicle_type][this->sort_criteria]);
+		EngList_Sort(this->eng_list, _engine_sort_functions[this->vehicle_type][this->sort_criteria]);
 
 		this->eng_list.swap(list);
 		AddChildren(list, INVALID_ENGINE, 0);

--- a/src/company_gui.cpp
+++ b/src/company_gui.cpp
@@ -690,9 +690,9 @@ private:
 		ShowDropDownList(this, std::move(list), sel, widget);
 	}
 
-	void AddChildren(GUIGroupList *source, GroupID parent, int indent)
+	void AddChildren(GUIGroupList &source, GroupID parent, int indent)
 	{
-		for (const Group *g : *source) {
+		for (const Group *g : source) {
 			if (g->parent != parent) continue;
 			this->groups.push_back(g);
 			this->indents.push_back(indent);
@@ -740,7 +740,7 @@ private:
 				return r < 0;
 			});
 
-			AddChildren(&list, INVALID_GROUP, 0);
+			AddChildren(list, INVALID_GROUP, 0);
 		}
 
 		this->groups.shrink_to_fit();

--- a/src/engine_gui.cpp
+++ b/src/engine_gui.cpp
@@ -324,10 +324,10 @@ void DrawVehicleEngine(int left, int right, int preferred_x, int y, EngineID eng
  * @param el list to be sorted
  * @param compare function for evaluation of the quicksort
  */
-void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare)
+void EngList_Sort(GUIEngineList &el, EngList_SortTypeFunction compare)
 {
-	if (el->size() < 2) return;
-	std::sort(el->begin(), el->end(), compare);
+	if (el.size() < 2) return;
+	std::sort(el.begin(), el.end(), compare);
 }
 
 /**
@@ -337,11 +337,11 @@ void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare)
  * @param begin start of sorting
  * @param num_items count of items to be sorted
  */
-void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, size_t begin, size_t num_items)
+void EngList_SortPartial(GUIEngineList &el, EngList_SortTypeFunction compare, size_t begin, size_t num_items)
 {
 	if (num_items < 2) return;
-	assert(begin < el->size());
-	assert(begin + num_items <= el->size());
-	std::sort(el->begin() + begin, el->begin() + begin + num_items, compare);
+	assert(begin < el.size());
+	assert(begin + num_items <= el.size());
+	std::sort(el.begin() + begin, el.begin() + begin + num_items, compare);
 }
 

--- a/src/engine_gui.h
+++ b/src/engine_gui.h
@@ -31,8 +31,8 @@ struct GUIEngineListItem {
 typedef GUIList<GUIEngineListItem, CargoID> GUIEngineList;
 
 typedef bool EngList_SortTypeFunction(const GUIEngineListItem&, const GUIEngineListItem&); ///< argument type for #EngList_Sort.
-void EngList_Sort(GUIEngineList *el, EngList_SortTypeFunction compare);
-void EngList_SortPartial(GUIEngineList *el, EngList_SortTypeFunction compare, size_t begin, size_t num_items);
+void EngList_Sort(GUIEngineList &el, EngList_SortTypeFunction compare);
+void EngList_SortPartial(GUIEngineList &el, EngList_SortTypeFunction compare, size_t begin, size_t num_items);
 
 StringID GetEngineCategoryName(EngineID engine);
 StringID GetEngineInfoString(EngineID engine);

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -136,16 +136,16 @@ private:
 
 	Dimension column_size[VGC_END]; ///< Size of the columns in the group list.
 
-	void AddChildren(GUIGroupList *source, GroupID parent, int indent)
+	void AddChildren(GUIGroupList &source, GroupID parent, int indent)
 	{
-		for (const Group *g : *source) {
+		for (const Group *g : source) {
 			if (g->parent != parent) continue;
 			this->groups.push_back(g);
 			this->indents.push_back(indent);
 			if (g->folded) {
 				/* Test if this group has children at all. If not, the folded flag should be cleared to avoid lingering unfold buttons in the list. */
-				auto child = std::find_if(source->begin(), source->end(), [g](const Group *child){ return child->parent == g->index; });
-				bool has_children = child != source->end();
+				auto child = std::find_if(source.begin(), source.end(), [g](const Group *child){ return child->parent == g->index; });
+				bool has_children = child != source.end();
 				Group::Get(g->index)->folded = has_children;
 			} else {
 				AddChildren(source, g->index, indent + 1);
@@ -196,7 +196,7 @@ private:
 			return r < 0;
 		});
 
-		AddChildren(&list, INVALID_GROUP, 0);
+		AddChildren(list, INVALID_GROUP, 0);
 
 		this->groups.shrink_to_fit();
 		this->groups.RebuildDone();


### PR DESCRIPTION
## Motivation / Problem

Pointer-avoidance. It could be null!

## Description

Pointers are avoided.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
