### PR TITLE
Fix #10823, Fix #10811: Order list has end marker row.

### DIFF
--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -562,7 +562,8 @@ private:
 	{
 		int sel = this->vscroll->GetScrolledRowFromWidget(y, this, WID_O_ORDER_LIST, WidgetDimensions::scaled.framerect.top);
 		if (sel == INT_MAX) return INVALID_VEH_ORDER_ID;
-		assert(IsInsideBS(sel, 0, vehicle->GetNumOrders()));
+		/* One past the orders is the 'End of Orders' line. */
+		assert(IsInsideBS(sel, 0, vehicle->GetNumOrders() + 1));
 		return sel;
 	}
 


### PR DESCRIPTION
## Motivation / Problem

As per #10823, clicking on the 'end of orders' line asserts.

## Description

Fix the assertion to take account of the marker line.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
