### PR TITLE
Codechange: use default dtor instead of empty

### DIFF
--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -29,7 +29,7 @@ struct BaseConsist {
 
 	uint16 vehicle_flags;               ///< Used for gradual loading and other miscellaneous things (@see VehicleFlags enum)
 
-	virtual ~BaseConsist() {}
+	virtual ~BaseConsist() = default;
 
 	void CopyConsistPropertiesFrom(const BaseConsist *src);
 };

--- a/src/blitter/32bpp_sse2.hpp
+++ b/src/blitter/32bpp_sse2.hpp
@@ -29,7 +29,7 @@
 /** Base methods for 32bpp SSE blitters. */
 class Blitter_32bppSSE_Base {
 public:
-	virtual ~Blitter_32bppSSE_Base() {}
+	virtual ~Blitter_32bppSSE_Base() = default;
 
 	struct MapValue {
 		uint8 m;

--- a/src/blitter/base.hpp
+++ b/src/blitter/base.hpp
@@ -208,7 +208,7 @@ public:
 	 */
 	virtual void PostResize() { };
 
-	virtual ~Blitter() { }
+	virtual ~Blitter() = default;
 
 	template <typename SetPixelT> void DrawLineGeneric(int x, int y, int x2, int y2, int screen_width, int screen_height, int width, int dash, SetPixelT set_pixel);
 };

--- a/src/core/alloc_type.hpp
+++ b/src/core/alloc_type.hpp
@@ -86,7 +86,7 @@ class ZeroedMemoryAllocator
 {
 public:
 	ZeroedMemoryAllocator() {}
-	virtual ~ZeroedMemoryAllocator() {}
+	virtual ~ZeroedMemoryAllocator() = default;
 
 	/**
 	 * Memory allocator for a single class instance.

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -81,7 +81,7 @@ protected:
 
 public:
 	/** Stub destructor to silence some compilers. */
-	virtual ~CrashLog() {}
+	virtual ~CrashLog() = default;
 
 	char *FillCrashLog(char *buffer, const char *last) const;
 	bool WriteCrashLog(const char *buffer, char *filename, const char *filename_last) const;

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -44,7 +44,7 @@ struct DisasterVehicle FINAL : public SpecializedVehicle<DisasterVehicle, VEH_DI
 	DisasterVehicle() : SpecializedVehicleBase() {}
 	DisasterVehicle(int x, int y, Direction direction, DisasterSubType subtype, VehicleID big_ufo_destroyer_target = VEH_INVALID);
 	/** We want to 'destruct' the right class. */
-	virtual ~DisasterVehicle() {}
+	virtual ~DisasterVehicle() = default;
 
 	void UpdatePosition(int x, int y, int z);
 	void UpdateDeltaXY();

--- a/src/driver.h
+++ b/src/driver.h
@@ -33,7 +33,7 @@ public:
 	 */
 	virtual void Stop() = 0;
 
-	virtual ~Driver() { }
+	virtual ~Driver() = default;
 
 	/** The type of driver */
 	enum Type {

--- a/src/effectvehicle_base.h
+++ b/src/effectvehicle_base.h
@@ -28,7 +28,7 @@ struct EffectVehicle FINAL : public SpecializedVehicle<EffectVehicle, VEH_EFFECT
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	EffectVehicle() : SpecializedVehicleBase() {}
 	/** We want to 'destruct' the right class. */
-	virtual ~EffectVehicle() {}
+	virtual ~EffectVehicle() = default;
 
 	void UpdateDeltaXY();
 	bool Tick();

--- a/src/fileio_func.h
+++ b/src/fileio_func.h
@@ -39,7 +39,7 @@ protected:
 	Subdirectory subdir; ///< The current sub directory we are searching through
 public:
 	/** Destruct the proper one... */
-	virtual ~FileScanner() {}
+	virtual ~FileScanner() = default;
 
 	uint Scan(const char *extension, Subdirectory sd, bool tars = true, bool recursive = true);
 	uint Scan(const char *extension, const char *directory, bool recursive = true);

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -89,12 +89,12 @@ typedef SmallMap<int, Font *> FontMap;
  */
 class ParagraphLayouter {
 public:
-	virtual ~ParagraphLayouter() {}
+	virtual ~ParagraphLayouter() = default;
 
 	/** Visual run contains data about the bit of text with the same font. */
 	class VisualRun {
 	public:
-		virtual ~VisualRun() {}
+		virtual ~VisualRun() = default;
 		virtual const Font *GetFont() const = 0;
 		virtual int GetGlyphCount() const = 0;
 		virtual const GlyphID *GetGlyphs() const = 0;
@@ -106,7 +106,7 @@ public:
 	/** A single line worth of VisualRuns. */
 	class Line {
 	public:
-		virtual ~Line() {}
+		virtual ~Line() = default;
 		virtual int GetLeading() const = 0;
 		virtual int GetWidth() const = 0;
 		virtual int CountRuns() const = 0;

--- a/src/linkgraph/demands.h
+++ b/src/linkgraph/demands.h
@@ -37,7 +37,7 @@ public:
 	/**
 	 * Virtual destructor has to be defined because of virtual Run().
 	 */
-	virtual ~DemandHandler() {}
+	virtual ~DemandHandler() = default;
 };
 
 #endif /* DEMANDS_H */

--- a/src/linkgraph/flowmapper.h
+++ b/src/linkgraph/flowmapper.h
@@ -30,10 +30,6 @@ public:
 	FlowMapper(bool scale) : scale(scale) {}
 	virtual void Run(LinkGraphJob &job) const;
 
-	/**
-	 * Virtual destructor has to be defined because of virtual Run().
-	 */
-	virtual ~FlowMapper() {}
 private:
 
 	/**

--- a/src/linkgraph/init.h
+++ b/src/linkgraph/init.h
@@ -17,11 +17,6 @@ public:
 	 * @param job Job to be initialized.
 	 */
 	virtual void Run(LinkGraphJob &job) const { job.Init(); }
-
-	/**
-	 * Virtual destructor has to be defined because of virtual Run().
-	 */
-	virtual ~InitHandler() {}
 };
 
 #endif /* INIT_H */

--- a/src/linkgraph/linkgraphschedule.h
+++ b/src/linkgraph/linkgraphschedule.h
@@ -23,7 +23,7 @@ public:
 	/**
 	 * Destroy the handler. Must be given due to virtual Run.
 	 */
-	virtual ~ComponentHandler() {}
+	virtual ~ComponentHandler() = default;
 
 	/**
 	 * Run the handler. A link graph handler must not read or write any data

--- a/src/linkgraph/mcf.h
+++ b/src/linkgraph/mcf.h
@@ -81,11 +81,6 @@ public:
 	 * @param graph Component to be calculated.
 	 */
 	virtual void Run(LinkGraphJob &job) const { Tpass pass(job); }
-
-	/**
-	 * Destructor. Has to be given because of virtual Run().
-	 */
-	virtual ~MCFHandler() {}
 };
 
 #endif /* MCF_H */

--- a/src/network/core/core.h
+++ b/src/network/core/core.h
@@ -48,7 +48,7 @@ public:
 	NetworkSocketHandler() { this->has_quit = false; }
 
 	/** Close the socket when destructing the socket handler */
-	virtual ~NetworkSocketHandler() {}
+	virtual ~NetworkSocketHandler() = default;
 
 	/**
 	 * Mark the connection as closed.

--- a/src/network/core/http.h
+++ b/src/network/core/http.h
@@ -40,7 +40,7 @@ struct HTTPCallback {
 	virtual bool IsCancelled() const = 0;
 
 	/** Silentium */
-	virtual ~HTTPCallback() {}
+	virtual ~HTTPCallback() = default;
 };
 
 /** Base socket handler for HTTP traffic. */

--- a/src/network/core/tcp_game.h
+++ b/src/network/core/tcp_game.h
@@ -518,7 +518,7 @@ public:
 	 * @param status The reason the connection got closed.
 	 */
 	virtual NetworkRecvStatus CloseConnection(NetworkRecvStatus status) = 0;
-	virtual ~NetworkGameSocketHandler() {}
+	virtual ~NetworkGameSocketHandler() = default;
 
 	/**
 	 * Sets the client info for this socket handler.

--- a/src/network/network_content.h
+++ b/src/network/network_content.h
@@ -57,7 +57,7 @@ struct ContentCallback {
 	virtual void OnDownloadComplete(ContentID cid) {}
 
 	/** Silentium */
-	virtual ~ContentCallback() {}
+	virtual ~ContentCallback() = default;
 };
 
 /**

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -1442,7 +1442,7 @@ public:
 		this->height = d.height + WidgetDimensions::scaled.framerect.Vertical();
 		this->width = d.width + WidgetDimensions::scaled.framerect.Horizontal();
 	}
-	virtual ~ButtonCommon() {}
+	virtual ~ButtonCommon() = default;
 
 	/**
 	 * OnClick handler for when the button is pressed.

--- a/src/network/network_udp.cpp
+++ b/src/network/network_udp.cpp
@@ -70,7 +70,7 @@ public:
 	 * @param addresses The addresses to bind on.
 	 */
 	ServerNetworkUDPSocketHandler(NetworkAddressList *addresses) : NetworkUDPSocketHandler(addresses) {}
-	virtual ~ServerNetworkUDPSocketHandler() {}
+	virtual ~ServerNetworkUDPSocketHandler() = default;
 };
 
 void ServerNetworkUDPSocketHandler::Receive_CLIENT_FIND_SERVER(Packet *p, NetworkAddress *client_addr)
@@ -88,7 +88,7 @@ class ClientNetworkUDPSocketHandler : public NetworkUDPSocketHandler {
 protected:
 	void Receive_SERVER_RESPONSE(Packet *p, NetworkAddress *client_addr) override;
 public:
-	virtual ~ClientNetworkUDPSocketHandler() {}
+	virtual ~ClientNetworkUDPSocketHandler() = default;
 };
 
 void ClientNetworkUDPSocketHandler::Receive_SERVER_RESPONSE(Packet *p, NetworkAddress *client_addr)

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -204,7 +204,7 @@ public:
 	std::vector<EntityIDMapping> mappings; ///< mapping of ids from grf files.  Public out of convenience
 
 	OverrideManagerBase(uint16 offset, uint16 maximum, uint16 invalid);
-	virtual ~OverrideManagerBase() {}
+	virtual ~OverrideManagerBase() = default;
 
 	void ResetOverride();
 	void ResetMapping();

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -212,7 +212,7 @@ extern uint _missing_extra_graphics;  ///< Number of sprites provided by the fal
 /** Callback for NewGRF scanning. */
 struct NewGRFScanCallback {
 	/** Make sure the right destructor gets called. */
-	virtual ~NewGRFScanCallback() {}
+	virtual ~NewGRFScanCallback() = default;
 	/** Called whenever the NewGRF scan completed. */
 	virtual void OnNewGRFsScanned() = 0;
 };

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -116,7 +116,7 @@ struct NIVariable {
 class NIHelper {
 public:
 	/** Silence a warning. */
-	virtual ~NIHelper() {}
+	virtual ~NIHelper() = default;
 
 	/**
 	 * Is the item with the given index inspectable?

--- a/src/newgrf_spritegroup.h
+++ b/src/newgrf_spritegroup.h
@@ -61,7 +61,7 @@ protected:
 	virtual const SpriteGroup *Resolve(ResolverObject &object) const { return this; };
 
 public:
-	virtual ~SpriteGroup() {}
+	virtual ~SpriteGroup() = default;
 
 	uint32 nfo_line;
 	SpriteGroupType type;
@@ -289,7 +289,7 @@ struct ScopeResolver {
 	ResolverObject &ro; ///< Surrounding resolver object.
 
 	ScopeResolver(ResolverObject &ro) : ro(ro) {}
-	virtual ~ScopeResolver() {}
+	virtual ~ScopeResolver() = default;
 
 	virtual uint32 GetRandomBits() const;
 	virtual uint32 GetTriggers() const;
@@ -318,7 +318,7 @@ struct ResolverObject {
 		this->ResetState();
 	}
 
-	virtual ~ResolverObject() {}
+	virtual ~ResolverObject() = default;
 
 	ScopeResolver default_scope; ///< Default implementation of the grf scope.
 

--- a/src/news_type.h
+++ b/src/news_type.h
@@ -118,7 +118,7 @@ struct NewsTypeData {
 
 /** Container for any custom data that must be deleted after the news item has reached end-of-life. */
 struct NewsAllocatedData {
-	virtual ~NewsAllocatedData() {}
+	virtual ~NewsAllocatedData() = default;
 };
 
 

--- a/src/saveload/saveload.h
+++ b/src/saveload/saveload.h
@@ -423,7 +423,7 @@ struct ChunkHandler {
 
 	ChunkHandler(uint32 id, ChunkType type) : id(id), type(type) {}
 
-	virtual ~ChunkHandler() {}
+	virtual ~ChunkHandler() = default;
 
 	/**
 	 * Save the chunk.
@@ -479,7 +479,7 @@ class SaveLoadHandler {
 public:
 	std::optional<std::vector<SaveLoad>> load_description;
 
-	virtual ~SaveLoadHandler() {}
+	virtual ~SaveLoadHandler() = default;
 
 	/**
 	 * Save the object to disk.

--- a/src/script/api/script_list.cpp
+++ b/src/script/api/script_list.cpp
@@ -28,7 +28,7 @@ public:
 	/**
 	 * Virtual dtor, needed to mute warnings.
 	 */
-	virtual ~ScriptListSorter() { }
+	virtual ~ScriptListSorter() = default;
 
 	/**
 	 * Get the first item of the sorter.

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -913,7 +913,7 @@ struct BaseSettingEntry {
 	byte level; ///< Nesting level of this setting entry
 
 	BaseSettingEntry() : flags(0), level(0) {}
-	virtual ~BaseSettingEntry() {}
+	virtual ~BaseSettingEntry() = default;
 
 	virtual void Init(byte level = 0);
 	virtual void FoldAll() {}

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -72,7 +72,7 @@ struct IniItem;
 struct SettingDesc {
 	SettingDesc(const SaveLoad &save, SettingFlag flags, bool startup) :
 		flags(flags), startup(startup), save(save) {}
-	virtual ~SettingDesc() {}
+	virtual ~SettingDesc() = default;
 
 	SettingFlag flags;  ///< Handles how a setting would show up in the GUI (text/currency, etc.).
 	bool startup;       ///< Setting has to be loaded directly at startup?.
@@ -155,7 +155,6 @@ struct IntSettingDesc : SettingDesc {
 		SettingDesc(save, flags, startup), def(def), min(min), max(max), interval(interval),
 			str(str), str_help(str_help), str_val(str_val), cat(cat), pre_check(pre_check),
 			post_callback(post_callback) {}
-	virtual ~IntSettingDesc() {}
 
 	int32 def;              ///< default value given when none is present
 	int32 min;              ///< minimum values
@@ -196,7 +195,6 @@ struct BoolSettingDesc : IntSettingDesc {
 			PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		IntSettingDesc(save, flags, startup, def, 0, 1, 0, str, str_help, str_val, cat,
 			pre_check, post_callback) {}
-	virtual ~BoolSettingDesc() {}
 
 	bool IsBoolSetting() const override { return true; }
 	size_t ParseValue(const char *str) const override;
@@ -217,8 +215,6 @@ struct OneOfManySettingDesc : IntSettingDesc {
 		for (auto one : many) this->many.push_back(one);
 	}
 
-	virtual ~OneOfManySettingDesc() {}
-
 	std::vector<std::string> many; ///< possible values for this type
 	OnConvert *many_cnvt;          ///< callback procedure when loading value mechanism fails
 
@@ -237,7 +233,6 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 		std::initializer_list<const char *> many, OnConvert *many_cnvt) :
 		OneOfManySettingDesc(save, flags, startup, def, (1 << many.size()) - 1, str, str_help,
 			str_val, cat, pre_check, post_callback, many, many_cnvt) {}
-	virtual ~ManyOfManySettingDesc() {}
 
 	size_t ParseValue(const char *str) const override;
 	void FormatValue(char *buf, const char *last, const void *object) const override;
@@ -264,7 +259,6 @@ struct StringSettingDesc : SettingDesc {
 			uint32 max_length, PreChangeCheck pre_check, PostChangeCallback post_callback) :
 		SettingDesc(save, flags, startup), def(def == nullptr ? "" : def), max_length(max_length),
 			pre_check(pre_check), post_callback(post_callback) {}
-	virtual ~StringSettingDesc() {}
 
 	std::string def;                   ///< Default value given when none is present
 	uint32 max_length;                 ///< Maximum length of the string, 0 means no maximum length
@@ -288,7 +282,6 @@ private:
 struct ListSettingDesc : SettingDesc {
 	ListSettingDesc(const SaveLoad &save, SettingFlag flags, bool startup, const char *def) :
 		SettingDesc(save, flags, startup), def(def) {}
-	virtual ~ListSettingDesc() {}
 
 	const char *def;        ///< default value given when none is present
 
@@ -301,7 +294,6 @@ struct ListSettingDesc : SettingDesc {
 struct NullSettingDesc : SettingDesc {
 	NullSettingDesc(const SaveLoad &save) :
 		SettingDesc(save, SF_NOT_IN_CONFIG, false) {}
-	virtual ~NullSettingDesc() {}
 
 	void FormatValue(char *buf, const char *last, const void *object) const override { NOT_REACHED(); }
 	void ParseValue(const IniItem *item, void *object) const override { NOT_REACHED(); }

--- a/src/spriteloader/spriteloader.hpp
+++ b/src/spriteloader/spriteloader.hpp
@@ -77,14 +77,14 @@ public:
 	 */
 	virtual uint8 LoadSprite(SpriteLoader::Sprite *sprite, SpriteFile &file, size_t file_pos, SpriteType sprite_type, bool load_32bpp, byte control_flags) = 0;
 
-	virtual ~SpriteLoader() { }
+	virtual ~SpriteLoader() = default;
 };
 
 /** Interface for something that can encode a sprite. */
 class SpriteEncoder {
 public:
 
-	virtual ~SpriteEncoder() { }
+	virtual ~SpriteEncoder() = default;
 
 	/**
 	 * Can the sprite encoder make use of RGBA sprites?

--- a/src/strgen/strgen.h
+++ b/src/strgen/strgen.h
@@ -104,7 +104,7 @@ struct HeaderWriter {
 	virtual void Finalise(const StringData &data) = 0;
 
 	/** Especially destroy the subclasses. */
-	virtual ~HeaderWriter() {};
+	virtual ~HeaderWriter() = default;
 
 	void WriteHeader(const StringData &data);
 };
@@ -131,7 +131,7 @@ struct LanguageWriter {
 	virtual void Finalise() = 0;
 
 	/** Especially destroy the subclasses. */
-	virtual ~LanguageWriter() {}
+	virtual ~LanguageWriter() = default;
 
 	virtual void WriteLength(uint length);
 	virtual void WriteLang(const StringData &data);

--- a/src/string_base.h
+++ b/src/string_base.h
@@ -28,7 +28,7 @@ public:
 	 */
 	static std::unique_ptr<StringIterator> Create();
 
-	virtual ~StringIterator() {}
+	virtual ~StringIterator() = default;
 
 	/**
 	 * Set a new iteration string. Must also be called if the string contents

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -257,7 +257,7 @@ bool StringIDSorter(const StringID &a, const StringID &b);
 class MissingGlyphSearcher {
 public:
 	/** Make sure everything gets destructed right. */
-	virtual ~MissingGlyphSearcher() {}
+	virtual ~MissingGlyphSearcher() = default;
 
 	/**
 	 * Get the next string to search through.

--- a/src/widgets/dropdown_type.h
+++ b/src/widgets/dropdown_type.h
@@ -25,7 +25,7 @@ public:
 	bool masked; ///< Masked and unselectable item
 
 	DropDownListItem(int result, bool masked) : result(result), masked(masked) {}
-	virtual ~DropDownListItem() {}
+	virtual ~DropDownListItem() = default;
 
 	virtual bool Selectable() const { return false; }
 	virtual uint Height(uint width) const { return FONT_HEIGHT_NORMAL; }


### PR DESCRIPTION
## Motivation / Problem

I was toying around with C++20, and the compiler really really did not like the empty virtual destructor of `SaveLoad`.

## Description

While I could only have fixed the `SaveLoad`, I was like: why not, let's change all empty virtual dtors into `= default`, and let the compiler deal with this crap.

When I spotted it, I also removed empty dtors when the parent already had it defined; no longer any need for all children to define a virtual dtor.

## Limitations

I don't really actually know why C++20 really doesn't like the `SaveLoad` dtor being empty; but it is common practice these days to use `= default` anyway, so I also didn't spend any actual time on finding that out.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
