### PR TITLE
Codechange: Pass bridge type instead of display row to BuildBridge.

### DIFF
--- a/src/bridge_gui.cpp
+++ b/src/bridge_gui.cpp
@@ -106,15 +106,15 @@ private:
 		return a.spec->speed < b.spec->speed;
 	}
 
-	void BuildBridge(uint8 i)
+	void BuildBridge(BridgeType type)
 	{
 		switch (this->transport_type) {
-			case TRANSPORT_RAIL: _last_railbridge_type = this->bridges.at(i).index; break;
-			case TRANSPORT_ROAD: _last_roadbridge_type = this->bridges.at(i).index; break;
+			case TRANSPORT_RAIL: _last_railbridge_type = type; break;
+			case TRANSPORT_ROAD: _last_roadbridge_type = type; break;
 			default: break;
 		}
 		Command<CMD_BUILD_BRIDGE>::Post(STR_ERROR_CAN_T_BUILD_BRIDGE_HERE, CcBuildBridge,
-					this->end_tile, this->start_tile, this->transport_type, this->bridges.at(i).index, this->road_rail_type);
+					this->end_tile, this->start_tile, this->transport_type, type, this->road_rail_type);
 	}
 
 	/** Sort the builable bridges */
@@ -250,7 +250,7 @@ public:
 		const uint8 i = keycode - '1';
 		if (i < 9 && i < this->bridges.size()) {
 			/* Build the requested bridge */
-			this->BuildBridge(i);
+			this->BuildBridge(this->bridges[i].index);
 			this->Close();
 			return ES_HANDLED;
 		}
@@ -264,7 +264,7 @@ public:
 			case WID_BBS_BRIDGE_LIST: {
 				auto it = this->vscroll->GetScrolledItemFromWidget(this->bridges, pt.y, this, WID_BBS_BRIDGE_LIST);
 				if (it != this->bridges.end()) {
-					this->BuildBridge(it - this->bridges.begin());
+					this->BuildBridge(it->index);
 					this->Close();
 				}
 				break;


### PR DESCRIPTION
## Motivation / Problem

When building a bridge, the bridge GUI currently looks up the selected bridge information, and then passes the index of it, so that BuildBridge can look it up again. #10811 made this pretty weird for bridges, as previously the selected row was only range-checked.

## Description

Instead, pass the bridge type (awkwardly called `index` in BuildBridgeData) to the window's BuildBridge function. This avoids calculating indexes and looking up the data.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
