### PR TITLE
Fix: multiplication result converted to larger type

### DIFF
--- a/src/cargopacket.cpp
+++ b/src/cargopacket.cpp
@@ -180,7 +180,7 @@ void CargoList<Tinst, Tcont>::RemoveFromCache(const CargoPacket *cp, uint count)
 {
 	assert(count <= cp->count);
 	this->count                 -= count;
-	this->cargo_days_in_transit -= cp->days_in_transit * count;
+	this->cargo_days_in_transit -= static_cast<uint64_t>(cp->days_in_transit) * count;
 }
 
 /**
@@ -192,7 +192,7 @@ template <class Tinst, class Tcont>
 void CargoList<Tinst, Tcont>::AddToCache(const CargoPacket *cp)
 {
 	this->count                 += cp->count;
-	this->cargo_days_in_transit += cp->days_in_transit * cp->count;
+	this->cargo_days_in_transit += static_cast<uint64_t>(cp->days_in_transit) * cp->count;
 }
 
 /** Invalidates the cached data and rebuilds it. */


### PR DESCRIPTION
## Motivation / Problem

Two 'high severity' code scanning alerts.


## Description

Practically unlikely to happen.
Since uint16 * uint16 get promoted to int, UINT16_MAX * UINT16_MAX becomes some negative number. When casting this to uint64 the sign gets extended and it gets really huge.
Similarly uint * uint16 remains uint and gets stored as uint64, so the modulo 2**32 is taken of the intermediate value and then subtracted from the uint64.

Solution is simple... cast one of the two multiplicants to `uint64_t` before multiplication.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
