### PR TITLE
Codechange: Use std::any_of()

### DIFF
--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -144,8 +144,7 @@ private:
 			this->indents.push_back(indent);
 			if (g->folded) {
 				/* Test if this group has children at all. If not, the folded flag should be cleared to avoid lingering unfold buttons in the list. */
-				auto child = std::find_if(source.begin(), source.end(), [g](const Group *child){ return child->parent == g->index; });
-				bool has_children = child != source.end();
+				bool has_children = std::any_of(source.begin(), source.end(), [g](const Group *child){ return child->parent == g->index; });
 				Group::Get(g->index)->folded = has_children;
 			} else {
 				AddChildren(source, g->index, indent + 1);


### PR DESCRIPTION
## Motivation / Problem

std::any_of/std::none_of exist and can simplify testing if an element exists (or not) in a container.

## Description

When the result of std::find_if is compared only with end() then '!= end()' is replaced with any_of(), and '== end()' is replaced with none_of().

But we only have one instance, so the original premise of this PR is... oh dear.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
