### PR TITLE
Feature: [GS] GSTile::DemolishTile() can now demolish everything

### DIFF
--- a/src/command_func.h
+++ b/src/command_func.h
@@ -62,6 +62,7 @@ static constexpr inline DoCommandFlag CommandFlagsToDCFlags(CommandFlags cmd_fla
 	if (cmd_flags & CMD_NO_WATER) flags |= DC_NO_WATER;
 	if (cmd_flags & CMD_AUTO) flags |= DC_AUTO;
 	if (cmd_flags & CMD_ALL_TILES) flags |= DC_ALL_TILES;
+	if (cmd_flags & CMD_MAGIC_BULLDOZER) flags |= DC_MAGIC_BULLDOZER;
 	return flags;
 }
 

--- a/src/command_type.h
+++ b/src/command_type.h
@@ -190,6 +190,7 @@ enum Commands : uint16_t {
 	CMD_BUILD_SINGLE_RAIL,            ///< build a single rail track
 	CMD_REMOVE_SINGLE_RAIL,           ///< remove a single rail track
 	CMD_LANDSCAPE_CLEAR,              ///< demolish a tile
+	CMD_LANDSCAPE_MAGIC_CLEAR,        ///< demolish a tile with magic bulldozer behaviour
 	CMD_BUILD_BRIDGE,                 ///< build a bridge
 	CMD_BUILD_RAIL_STATION,           ///< build a rail station
 	CMD_BUILD_TRAIN_DEPOT,            ///< build a train depot
@@ -365,19 +366,20 @@ enum Commands : uint16_t {
  * This enums defines some flags which can be used for the commands.
  */
 enum DoCommandFlag {
-	DC_NONE                  = 0x000, ///< no flag is set
-	DC_EXEC                  = 0x001, ///< execute the given command
-	DC_AUTO                  = 0x002, ///< don't allow building on structures
-	DC_QUERY_COST            = 0x004, ///< query cost only,  don't build.
-	DC_NO_WATER              = 0x008, ///< don't allow building on water
+	DC_NONE                  = 0x0000, ///< no flag is set
+	DC_EXEC                  = 0x0001, ///< execute the given command
+	DC_AUTO                  = 0x0002, ///< don't allow building on structures
+	DC_QUERY_COST            = 0x0004, ///< query cost only,  don't build.
+	DC_NO_WATER              = 0x0008, ///< don't allow building on water
 	// 0x010 is unused
-	DC_NO_TEST_TOWN_RATING   = 0x020, ///< town rating does not disallow you from building
-	DC_BANKRUPT              = 0x040, ///< company bankrupts, skip money check, skip vehicle on tile check in some cases
-	DC_AUTOREPLACE           = 0x080, ///< autoreplace/autorenew is in progress, this shall disable vehicle limits when building, and ignore certain restrictions when undoing things (like vehicle attach callback)
-	DC_NO_CARGO_CAP_CHECK    = 0x100, ///< when autoreplace/autorenew is in progress, this shall prevent truncating the amount of cargo in the vehicle to prevent testing the command to remove cargo
-	DC_ALL_TILES             = 0x200, ///< allow this command also on MP_VOID tiles
-	DC_NO_MODIFY_TOWN_RATING = 0x400, ///< do not change town rating
-	DC_FORCE_CLEAR_TILE      = 0x800, ///< do not only remove the object on the tile, but also clear any water left on it
+	DC_NO_TEST_TOWN_RATING   = 0x0020, ///< town rating does not disallow you from building
+	DC_BANKRUPT              = 0x0040, ///< company bankrupts, skip money check, skip vehicle on tile check in some cases
+	DC_AUTOREPLACE           = 0x0080, ///< autoreplace/autorenew is in progress, this shall disable vehicle limits when building, and ignore certain restrictions when undoing things (like vehicle attach callback)
+	DC_NO_CARGO_CAP_CHECK    = 0x0100, ///< when autoreplace/autorenew is in progress, this shall prevent truncating the amount of cargo in the vehicle to prevent testing the command to remove cargo
+	DC_ALL_TILES             = 0x0200, ///< allow this command also on MP_VOID tiles
+	DC_NO_MODIFY_TOWN_RATING = 0x0400, ///< do not change town rating
+	DC_FORCE_CLEAR_TILE      = 0x0800, ///< do not only remove the object on the tile, but also clear any water left on it
+	DC_MAGIC_BULLDOZER       = 0x1000, ///< invoke magic bulldozer behaviour as a deity
 };
 DECLARE_ENUM_AS_BIT_SET(DoCommandFlag)
 
@@ -387,18 +389,19 @@ DECLARE_ENUM_AS_BIT_SET(DoCommandFlag)
  * This enumeration defines flags for the _command_proc_table.
  */
 enum CommandFlags {
-	CMD_SERVER    = 0x001, ///< the command can only be initiated by the server
-	CMD_SPECTATOR = 0x002, ///< the command may be initiated by a spectator
-	CMD_OFFLINE   = 0x004, ///< the command cannot be executed in a multiplayer game; single-player only
-	CMD_AUTO      = 0x008, ///< set the DC_AUTO flag on this command
-	CMD_ALL_TILES = 0x010, ///< allow this command also on MP_VOID tiles
-	CMD_NO_TEST   = 0x020, ///< the command's output may differ between test and execute due to town rating changes etc.
-	CMD_NO_WATER  = 0x040, ///< set the DC_NO_WATER flag on this command
-	CMD_CLIENT_ID = 0x080, ///< set p2 with the ClientID of the sending client.
-	CMD_DEITY     = 0x100, ///< the command may be executed by COMPANY_DEITY
-	CMD_STR_CTRL  = 0x200, ///< the command's string may contain control strings
-	CMD_NO_EST    = 0x400, ///< the command is never estimated.
-	CMD_LOCATION  = 0x800, ///< the command has implicit location argument.
+	CMD_SERVER           = 0x0001, ///< the command can only be initiated by the server
+	CMD_SPECTATOR        = 0x0002, ///< the command may be initiated by a spectator
+	CMD_OFFLINE          = 0x0004, ///< the command cannot be executed in a multiplayer game; single-player only
+	CMD_AUTO             = 0x0008, ///< set the DC_AUTO flag on this command
+	CMD_ALL_TILES        = 0x0010, ///< allow this command also on MP_VOID tiles
+	CMD_NO_TEST          = 0x0020, ///< the command's output may differ between test and execute due to town rating changes etc.
+	CMD_NO_WATER         = 0x0040, ///< set the DC_NO_WATER flag on this command
+	CMD_CLIENT_ID        = 0x0080, ///< set p2 with the ClientID of the sending client.
+	CMD_DEITY            = 0x0100, ///< the command may be executed by COMPANY_DEITY
+	CMD_STR_CTRL         = 0x0200, ///< the command's string may contain control strings
+	CMD_NO_EST           = 0x0400, ///< the command is never estimated.
+	CMD_LOCATION         = 0x0800, ///< the command has implicit location argument.
+	CMD_MAGIC_BULLDOZER  = 0x1000, ///< set the DC_MAGIC_BULLDOZER flag on this command
 };
 DECLARE_ENUM_AS_BIT_SET(CommandFlags)
 

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -16,7 +16,6 @@
 #include "command_func.h"
 #include "town.h"
 #include "news_func.h"
-#include "cheat_type.h"
 #include "company_base.h"
 #include "genworld.h"
 #include "tree_map.h"
@@ -496,7 +495,7 @@ static CommandCost ClearTile_Industry(TileIndex tile, DoCommandFlag flags)
 	 * (area around OILRIG is water, so water shouldn't flood it
 	 */
 	if ((_current_company != OWNER_WATER && _game_mode != GM_EDITOR &&
-			!_cheats.magic_bulldozer.value) ||
+			!IsMagicBulldozeCommand(flags)) ||
 			((flags & DC_AUTO) != 0) ||
 			(_current_company == OWNER_WATER &&
 				((indspec->behaviour & INDUSTRYBEH_BUILT_ONWATER) ||

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -652,6 +652,8 @@ void ClearSnowLine()
  */
 CommandCost CmdLandscapeClear(DoCommandFlag flags, TileIndex tile)
 {
+	if ((flags & DC_MAGIC_BULLDOZER) != 0 &&_current_company != OWNER_DEITY) return CMD_ERROR;
+
 	CommandCost cost(EXPENSES_CONSTRUCTION);
 	bool do_clear = false;
 	/* Test for stuff which results in water when cleared. Then add the cost to also clear the water. */

--- a/src/landscape_cmd.h
+++ b/src/landscape_cmd.h
@@ -15,7 +15,8 @@
 CommandCost CmdLandscapeClear(DoCommandFlag flags, TileIndex tile);
 std::tuple<CommandCost, Money> CmdClearArea(DoCommandFlag flags, TileIndex tile, TileIndex start_tile, bool diagonal);
 
-DEF_CMD_TRAIT(CMD_LANDSCAPE_CLEAR, CmdLandscapeClear, CMD_DEITY,   CMDT_LANDSCAPE_CONSTRUCTION)
-DEF_CMD_TRAIT(CMD_CLEAR_AREA,      CmdClearArea,      CMD_NO_TEST, CMDT_LANDSCAPE_CONSTRUCTION) // destroying multi-tile houses makes town rating differ between test and execution
+DEF_CMD_TRAIT(CMD_LANDSCAPE_CLEAR,       CmdLandscapeClear, CMD_DEITY,                       CMDT_LANDSCAPE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_LANDSCAPE_MAGIC_CLEAR, CmdLandscapeClear, CMD_DEITY | CMD_MAGIC_BULLDOZER, CMDT_LANDSCAPE_CONSTRUCTION)
+DEF_CMD_TRAIT(CMD_CLEAR_AREA,            CmdClearArea,      CMD_NO_TEST,                     CMDT_LANDSCAPE_CONSTRUCTION) // destroying multi-tile houses makes town rating differ between test and execution
 
 #endif /* LANDSCAPE_CMD_H */

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -20,7 +20,6 @@
 #include "water.h"
 #include "window_func.h"
 #include "company_gui.h"
-#include "cheat_type.h"
 #include "object.h"
 #include "cargopacket.h"
 #include "core/random_func.hpp"
@@ -563,13 +562,13 @@ static CommandCost ClearTile_Object(TileIndex tile, DoCommandFlag flags)
 			/* No further limitations for the editor. */
 		} else if (GetTileOwner(tile) == OWNER_NONE) {
 			/* Owned by nobody and unremovable, so we can only remove it with brute force! */
-			if (!_cheats.magic_bulldozer.value && (spec->flags & OBJECT_FLAG_CANNOT_REMOVE) != 0) return CMD_ERROR;
+			if (!IsMagicBulldozeCommand(flags) && (spec->flags & OBJECT_FLAG_CANNOT_REMOVE) != 0) return CMD_ERROR;
 		} else if (CheckTileOwnership(tile).Failed()) {
 			/* We don't own it!. */
 			return_cmd_error(STR_ERROR_OWNED_BY);
 		} else if ((spec->flags & OBJECT_FLAG_CANNOT_REMOVE) != 0 && (spec->flags & OBJECT_FLAG_AUTOREMOVE) == 0) {
 			/* In the game editor or with cheats we can remove, otherwise we can't. */
-			if (!_cheats.magic_bulldozer.value) {
+			if (!IsMagicBulldozeCommand(flags)) {
 				if (type == OBJECT_HQ) return_cmd_error(STR_ERROR_COMPANY_HEADQUARTERS_IN);
 				return CMD_ERROR;
 			}

--- a/src/road_cmd.cpp
+++ b/src/road_cmd.cpp
@@ -21,7 +21,6 @@
 #include "vehicle_func.h"
 #include "sound_func.h"
 #include "tunnelbridge.h"
-#include "cheat_type.h"
 #include "effectvehicle_func.h"
 #include "effectvehicle_base.h"
 #include "elrail_func.h"
@@ -287,7 +286,7 @@ CommandCost CheckAllowRemoveRoad(TileIndex tile, RoadBits remove, Owner owner, R
 
 	if (!town_check) return CommandCost();
 
-	if (_cheats.magic_bulldozer.value) return CommandCost();
+	if (IsMagicBulldozeCommand(flags)) return CommandCost();
 
 	Town *t = ClosestTownFromTile(tile, UINT_MAX);
 	if (t == nullptr) return CommandCost();

--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -182,6 +182,7 @@ add_files(
     script_list.hpp
     script_log.hpp
     script_log_types.hpp
+    script_magicbulldozermode.hpp
     script_map.hpp
     script_marine.hpp
     script_newgrf.hpp
@@ -254,6 +255,7 @@ add_files(
     script_league.cpp
     script_list.cpp
     script_log.cpp
+    script_magicbulldozermode.cpp
     script_map.cpp
     script_marine.cpp
     script_newgrf.cpp

--- a/src/script/api/game_changelog.hpp
+++ b/src/script/api/game_changelog.hpp
@@ -78,6 +78,7 @@
  * \li GSVehicleList_DefaultGroup
  * \li GSGoal::IsValidGoalDestination
  * \li GSGoal::SetDestination
+ * \li GSMagicBulldozerMode
  *
  * API removals:
  * \li GSError::ERR_PRECONDITION_TOO_MANY_PARAMETERS, that error is never returned anymore.

--- a/src/script/api/script_magicbulldozermode.cpp
+++ b/src/script/api/script_magicbulldozermode.cpp
@@ -1,0 +1,23 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_magicbulldozermode.cpp Implementation of ScriptMagicBulldozerMode. */
+
+#include "../../stdafx.h"
+#include "script_magicbulldozermode.hpp"
+#include "squirrel.h"
+
+ScriptMagicBulldozerMode::ScriptMagicBulldozerMode(bool mode)
+{
+	this->last_bulldozermode = ScriptObject::GetMagicBulldozerMode();
+	ScriptObject::SetMagicBulldozerMode(mode);
+}
+
+ScriptMagicBulldozerMode::~ScriptMagicBulldozerMode()
+{
+	ScriptObject::SetMagicBulldozerMode(this->last_bulldozermode);
+}

--- a/src/script/api/script_magicbulldozermode.hpp
+++ b/src/script/api/script_magicbulldozermode.hpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_magicbulldozermode.hpp Switch on the magic bulldozer. */
+
+#ifndef SCRIPT_MAGICBULLDOZERMODE_HPP
+#define SCRIPT_MAGICBULLDOZERMODE_HPP
+
+#include "script_object.hpp"
+
+/**
+ * Class to switch on the magic bulldozer mode.
+ * If you create an instance of this class, the magic bulldozer mode flag will
+ *  be set to the given value.
+ *  If the flag is set, clear tile commands will have magic bulldozer
+ *  functionality.
+ *  The original value of the flag is stored and recovered from when ever the
+ *  instance is destroyed.
+ * If the flag is set and is not valid during an action, the error
+ *  ERR_PRECONDITION_INVALID_COMPANY will be returned.
+ *  This will happen if the action is not commanded by a deity.
+ * @api game
+ */
+class ScriptMagicBulldozerMode : public ScriptObject {
+private:
+	bool last_bulldozermode; ///< The previous value of the mode flag.
+
+public:
+	/**
+	 * Creating instance of this class switches the value of the magic
+	 *  bulldozer flag used when clearing tiles.
+	 * @param mode Whether or not the magic bulldozer mode is switch on.
+	 * @note When the instance is destroyed, it restores the value of the flag
+	 *  that was current when the instance was created!
+	 */
+	ScriptMagicBulldozerMode(bool mode);
+
+	/**
+	 * Destroying this instance resets the mode flag to that what it was when
+	 *  the instance was created.
+	 */
+	~ScriptMagicBulldozerMode();
+};
+
+#endif /* SCRIPT_MAGICBULLDOZERMODE_HPP */

--- a/src/script/api/script_object.cpp
+++ b/src/script/api/script_object.cpp
@@ -200,6 +200,16 @@ ScriptObject::ActiveInstance::~ActiveInstance()
 	return GetStorage()->allow_do_command;
 }
 
+/* static */ void ScriptObject::SetMagicBulldozerMode(bool mode)
+{
+	GetStorage()->magic_bulldozer_mode = mode;
+}
+
+/* static */ bool ScriptObject::GetMagicBulldozerMode()
+{
+	return GetStorage()->magic_bulldozer_mode;
+}
+
 /* static */ void ScriptObject::SetCompany(CompanyID company)
 {
 	if (GetStorage()->root_company == INVALID_OWNER) GetStorage()->root_company = company;

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -244,6 +244,17 @@ protected:
 	static bool GetAllowDoCommand();
 
 	/**
+	 * Set the value of the magic bulldozer mode flag.
+	 * @param mode The new magic bulldozer mode flag value.
+	 */
+	static void SetMagicBulldozerMode(bool mode);
+
+	/**
+	 * Gets the value of the magic bulldozer mode flag.
+	 */
+	static bool GetMagicBulldozerMode();
+
+	/**
 	 * Set the current company to execute commands for or request
 	 *  information about.
 	 * @param company The new company.

--- a/src/script/api/script_tile.cpp
+++ b/src/script/api/script_tile.cpp
@@ -280,8 +280,12 @@
 {
 	EnforceDeityOrCompanyModeValid(false);
 	EnforcePrecondition(false, ::IsValidTile(tile));
-
-	return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);
+	if (GetMagicBulldozerMode()) {
+		EnforceDeityMode(false);
+		return ScriptObject::Command<CMD_LANDSCAPE_MAGIC_CLEAR>::Do(tile);
+	} else {
+		return ScriptObject::Command<CMD_LANDSCAPE_CLEAR>::Do(tile);
+	}
 }
 
 /* static */ bool ScriptTile::PlantTree(TileIndex tile)

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -41,6 +41,7 @@ private:
 	class ScriptObject *mode_instance; ///< The instance belonging to the current build mode.
 	ScriptAsyncModeProc *async_mode;         ///< The current command async mode we are in.
 	class ScriptObject *async_mode_instance; ///< The instance belonging to the current command async mode.
+	bool magic_bulldozer_mode;       ///< whether or not we are in magic bulldozer mode.
 	CompanyID root_company;          ///< The root company, the company that the script really belongs to.
 	CompanyID company;               ///< The current company.
 
@@ -66,23 +67,24 @@ private:
 
 public:
 	ScriptStorage() :
-		mode              (nullptr),
-		mode_instance     (nullptr),
-		async_mode        (nullptr),
+		mode                (nullptr),
+		mode_instance       (nullptr),
+		async_mode          (nullptr),
 		async_mode_instance (nullptr),
-		root_company      (INVALID_OWNER),
-		company           (INVALID_OWNER),
-		delay             (1),
-		allow_do_command  (true),
+		magic_bulldozer_mode(false),
+		root_company        (INVALID_OWNER),
+		company             (INVALID_OWNER),
+		delay               (1),
+		allow_do_command    (true),
 		/* costs (can't be set) */
-		last_cost         (0),
-		last_error        (STR_NULL),
-		last_command_res  (true),
-		last_cmd          (CMD_END),
+		last_cost           (0),
+		last_error          (STR_NULL),
+		last_command_res    (true),
+		last_cmd            (CMD_END),
 		/* calback_value (can't be set) */
-		road_type         (INVALID_ROADTYPE),
-		rail_type         (INVALID_RAILTYPE),
-		event_data        (nullptr)
+		road_type           (INVALID_ROADTYPE),
+		rail_type           (INVALID_RAILTYPE),
+		event_data          (nullptr)
 	{ }
 
 	~ScriptStorage();

--- a/src/tile_cmd.h
+++ b/src/tile_cmd.h
@@ -10,6 +10,7 @@
 #ifndef TILE_CMD_H
 #define TILE_CMD_H
 
+#include "cheat_type.h"
 #include "command_type.h"
 #include "vehicle_type.h"
 #include "cargo_type.h"
@@ -206,6 +207,11 @@ static inline bool ClickTile(TileIndex tile)
 	ClickTileProc *proc = _tile_type_procs[GetTileType(tile)]->click_tile_proc;
 	if (proc == nullptr) return false;
 	return proc(tile);
+}
+
+static inline bool IsMagicBulldozeCommand(DoCommandFlag flags)
+{
+	return _cheats.magic_bulldozer.value || (flags & DC_MAGIC_BULLDOZER) != 0;
 }
 
 #endif /* TILE_CMD_H */

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -32,7 +32,6 @@
 #include "window_func.h"
 #include "string_func.h"
 #include "newgrf_cargo.h"
-#include "cheat_type.h"
 #include "animated_tile_func.h"
 #include "subsidy_func.h"
 #include "core/pool_func.hpp"
@@ -676,7 +675,7 @@ static CommandCost ClearTile_Town(TileIndex tile, DoCommandFlag flags)
 
 	if (Company::IsValidID(_current_company)) {
 		if (rating > t->ratings[_current_company] && !(flags & DC_NO_TEST_TOWN_RATING) &&
-				!_cheats.magic_bulldozer.value && _settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE) {
+				!IsMagicBulldozeCommand(flags) && _settings_game.difficulty.town_council_tolerance != TOWN_COUNCIL_PERMISSIVE) {
 			SetDParam(0, t->index);
 			return_cmd_error(STR_ERROR_LOCAL_AUTHORITY_REFUSES_TO_ALLOW_THIS);
 		}
@@ -3698,7 +3697,7 @@ void ChangeTownRating(Town *t, int add, int max, DoCommandFlag flags)
 	/* if magic_bulldozer cheat is active, town doesn't penalize for removing stuff */
 	if (t == nullptr || (flags & DC_NO_MODIFY_TOWN_RATING) ||
 			!Company::IsValidID(_current_company) ||
-			(_cheats.magic_bulldozer.value && add < 0)) {
+			(IsMagicBulldozeCommand(flags) && add < 0)) {
 		return;
 	}
 
@@ -3734,7 +3733,7 @@ CommandCost CheckforTownRating(DoCommandFlag flags, Town *t, TownRatingCheckType
 {
 	/* if magic_bulldozer cheat is active, town doesn't restrict your destructive actions */
 	if (t == nullptr || !Company::IsValidID(_current_company) ||
-			_cheats.magic_bulldozer.value || (flags & DC_NO_TEST_TOWN_RATING)) {
+			IsMagicBulldozeCommand(flags) || (flags & DC_NO_TEST_TOWN_RATING)) {
 		return CommandCost();
 	}
 

--- a/src/tunnelbridge_cmd.cpp
+++ b/src/tunnelbridge_cmd.cpp
@@ -29,7 +29,6 @@
 #include "vehicle_func.h"
 #include "sound_func.h"
 #include "tunnelbridge.h"
-#include "cheat_type.h"
 #include "elrail_func.h"
 #include "pbs.h"
 #include "company_base.h"
@@ -794,9 +793,10 @@ CommandCost CmdBuildTunnel(DoCommandFlag flags, TileIndex start_tile, TransportT
 /**
  * Are we allowed to remove the tunnel or bridge at \a tile?
  * @param tile End point of the tunnel or bridge.
+ * @param flags Command flags.
  * @return A succeeded command if the tunnel or bridge may be removed, a failed command otherwise.
  */
-static inline CommandCost CheckAllowRemoveTunnelBridge(TileIndex tile)
+static inline CommandCost CheckAllowRemoveTunnelBridge(TileIndex tile, DoCommandFlag flags)
 {
 	/* Floods can remove anything as well as the scenario editor */
 	if (_current_company == OWNER_WATER || _game_mode == GM_EDITOR) return CommandCost();
@@ -812,7 +812,7 @@ static inline CommandCost CheckAllowRemoveTunnelBridge(TileIndex tile)
 			if (tram_rt != INVALID_ROADTYPE) tram_owner = GetRoadOwner(tile, RTT_TRAM);
 
 			/* We can remove unowned road and if the town allows it */
-			if (road_owner == OWNER_TOWN && _current_company != OWNER_TOWN && !(_settings_game.construction.extra_dynamite || _cheats.magic_bulldozer.value)) {
+			if (road_owner == OWNER_TOWN && _current_company != OWNER_TOWN && !(_settings_game.construction.extra_dynamite || IsMagicBulldozeCommand(flags))) {
 				/* Town does not allow */
 				return CheckTileOwnership(tile);
 			}
@@ -846,7 +846,7 @@ static inline CommandCost CheckAllowRemoveTunnelBridge(TileIndex tile)
  */
 static CommandCost DoClearTunnel(TileIndex tile, DoCommandFlag flags)
 {
-	CommandCost ret = CheckAllowRemoveTunnelBridge(tile);
+	CommandCost ret = CheckAllowRemoveTunnelBridge(tile, flags);
 	if (ret.Failed()) return ret;
 
 	TileIndex endtile = GetOtherTunnelEnd(tile);
@@ -926,7 +926,7 @@ static CommandCost DoClearTunnel(TileIndex tile, DoCommandFlag flags)
  */
 static CommandCost DoClearBridge(TileIndex tile, DoCommandFlag flags)
 {
-	CommandCost ret = CheckAllowRemoveTunnelBridge(tile);
+	CommandCost ret = CheckAllowRemoveTunnelBridge(tile, flags);
 	if (ret.Failed()) return ret;
 
 	TileIndex endtile = GetOtherBridgeEnd(tile);


### PR DESCRIPTION
## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->

See #10383 and #10390

It's not possible for a GS to demolish certain objects such as industries.


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->

I have added a boolean parameter `force` to GSTile::DemolishTile(). When this is set,  all objects on the tile will be destroyed.

To facilitate this, I have added an extra `DoCommandFlag` called `DC_MAGIC_BULLDOZER`. Deities can set this flag in order to have the magic bulldozer functionality apply to `CmdLandscapeClear`.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->

Since scripts can't directly set flags on commands, I had to add another entry in the `Commands` enum pointing to `CmdLandscapeClear` with a new `CMD_MAGIC_BULLDOZER` flag to set the `DC_MAGIC_BULLDOZER`. This is in line with how flags are set on other commands, but this is the first time we have two entries for the same command as far as I can see.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
