### PR TITLE
Codechange: Use std::vector for GRFConfig lists.

### DIFF
--- a/src/fios.h
+++ b/src/fios.h
@@ -47,8 +47,7 @@ struct LoadCheckData {
 
 	Gamelog gamelog; ///< Gamelog actions
 
-	LoadCheckData() : grfconfig(nullptr),
-			grf_compatibility(GLC_NOT_FOUND)
+	LoadCheckData() : grf_compatibility(GLC_NOT_FOUND)
 	{
 	}
 
@@ -67,7 +66,7 @@ struct LoadCheckData {
 	 */
 	bool HasNewGrfs()
 	{
-		return this->checkable && this->error == INVALID_STRING_ID && this->grfconfig != nullptr;
+		return this->checkable && this->error == INVALID_STRING_ID && !this->grfconfig.empty();
 	}
 
 	void Clear();

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -590,7 +590,7 @@ public:
 				if (tr.top > tr.bottom) return;
 
 				/* NewGrf compatibility */
-				SetDParam(0, _load_check_data.grfconfig == nullptr ? STR_NEWGRF_LIST_NONE :
+				SetDParam(0, _load_check_data.grfconfig.empty() ? STR_NEWGRF_LIST_NONE :
 						STR_NEWGRF_LIST_ALL_FOUND + _load_check_data.grf_compatibility);
 				DrawString(tr, STR_SAVELOAD_DETAIL_GRFSTATUS);
 				tr.top += GetCharacterHeight(FS_NORMAL);

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -579,8 +579,8 @@ void Gamelog::GRFAddList(const GRFConfigList &newg)
 {
 	assert(this->action_type == GLAT_START || this->action_type == GLAT_LOAD);
 
-	for (GRFConfig *gc = newg; gc != nullptr; gc = gc->next) {
-		this->GRFAdd(*gc);
+	for (const auto &c : newg) {
+		this->GRFAdd(*c);
 	}
 }
 
@@ -591,8 +591,8 @@ void Gamelog::GRFAddList(const GRFConfigList &newg)
 static std::vector<const GRFConfig *> GenerateGRFList(const GRFConfigList &grfc)
 {
 	std::vector<const GRFConfig *> list;
-	for (const GRFConfig *g = grfc; g != nullptr; g = g->next) {
-		if (IsLoggableGrfConfig(*g)) list.push_back(g);
+	for (const auto &g : grfc) {
+		if (IsLoggableGrfConfig(*g)) list.push_back(g.get());
 	}
 
 	return list;

--- a/src/network/core/network_game_info.cpp
+++ b/src/network/core/network_game_info.cpp
@@ -129,7 +129,7 @@ void CheckGameCompatibility(NetworkGameInfo &ngi)
 	ngi.compatible = ngi.version_compatible;
 
 	/* Check if we have all the GRFs on the client-system too. */
-	for (const GRFConfig *c = ngi.grfconfig; c != nullptr; c = c->next) {
+	for (const auto &c : ngi.grfconfig) {
 		if (c->status == GCS_NOT_FOUND) ngi.compatible = false;
 	}
 }
@@ -148,7 +148,7 @@ void FillStaticNetworkServerGameInfo()
 	_network_game_info.map_height     = Map::SizeY();
 	_network_game_info.landscape      = _settings_game.game_creation.landscape;
 	_network_game_info.dedicated      = _network_dedicated;
-	_network_game_info.grfconfig      = _grfconfig;
+	CopyGRFConfigList(_network_game_info.grfconfig, _grfconfig, false);
 
 	_network_game_info.server_name = _settings_client.network.server_name;
 	_network_game_info.server_revision = GetNetworkRevisionString();
@@ -230,17 +230,11 @@ void SerializeNetworkGameInfo(Packet &p, const NetworkServerGameInfo &info, bool
 		 * the GRFs that are needed, i.e. the ones that the server has
 		 * selected in the NewGRF GUI and not the ones that are used due
 		 * to the fact that they are in [newgrf-static] in openttd.cfg */
-		const GRFConfig *c;
-		uint count = 0;
-
-		/* Count number of GRFs to send information about */
-		for (c = info.grfconfig; c != nullptr; c = c->next) {
-			if (!HasBit(c->flags, GCF_STATIC)) count++;
-		}
+		uint count = std::ranges::count_if(info.grfconfig, [](const auto &c) { return !HasBit(c->flags, GCF_STATIC); });
 		p.Send_uint8 (count); // Send number of GRFs
 
 		/* Send actual GRF Identifications */
-		for (c = info.grfconfig; c != nullptr; c = c->next) {
+		for (const auto &c : info.grfconfig) {
 			if (HasBit(c->flags, GCF_STATIC)) continue;
 
 			SerializeGRFIdentifier(p, c->ident);
@@ -311,7 +305,7 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
 			static_assert(std::numeric_limits<uint8_t>::max() == NETWORK_MAX_GRF_COUNT);
 			uint num_grfs = p.Recv_uint8();
 
-			GRFConfig **dst = &info.grfconfig;
+			GRFConfigList &dst = info.grfconfig;
 			for (uint i = 0; i < num_grfs; i++) {
 				NamedGRFIdentifier grf;
 				switch (newgrf_serialisation) {
@@ -335,13 +329,12 @@ void DeserializeNetworkGameInfo(Packet &p, NetworkGameInfo &info, const GameInfo
 						NOT_REACHED();
 				}
 
-				GRFConfig *c = new GRFConfig();
+				auto c = std::make_unique<GRFConfig>();
 				c->ident = grf.ident;
 				HandleIncomingNetworkGameInfoGRFConfig(*c, grf.name);
 
 				/* Append GRFConfig to the list */
-				*dst = c;
-				dst = &c->next;
+				dst.push_back(std::move(c));
 			}
 			[[fallthrough]];
 		}

--- a/src/network/network_coordinator.cpp
+++ b/src/network/network_coordinator.cpp
@@ -243,17 +243,13 @@ bool ClientNetworkCoordinatorSocketHandler::Receive_GC_LISTING(Packet &p)
 	for (; servers > 0; servers--) {
 		std::string connection_string = p.Recv_string(NETWORK_HOSTNAME_PORT_LENGTH);
 
-		/* Read the NetworkGameInfo from the packet. */
-		NetworkGameInfo ngi = {};
-		DeserializeNetworkGameInfo(p, ngi, &this->newgrf_lookup_table);
-
 		/* Now we know the connection string, we can add it to our list. */
 		NetworkGameList *item = NetworkGameListAddItem(connection_string);
 
 		/* Clear any existing GRFConfig chain. */
 		ClearGRFConfigList(item->info.grfconfig);
-		/* Copy the new NetworkGameInfo info. */
-		item->info = ngi;
+		/* Read the NetworkGameInfo from the packet. */
+		DeserializeNetworkGameInfo(p, item->info, &this->newgrf_lookup_table);
 		/* Check for compatability with the client. */
 		CheckGameCompatibility(item->info);
 		/* Mark server as online. */

--- a/src/network/network_gamelist.cpp
+++ b/src/network/network_gamelist.cpp
@@ -72,8 +72,6 @@ void NetworkGameListRemoveItem(NetworkGameList *remove)
 				prev_item->next = remove->next;
 			}
 
-			/* Remove GRFConfig information */
-			ClearGRFConfigList(remove->info.grfconfig);
 			delete remove;
 
 			NetworkRebuildHostList();
@@ -99,8 +97,6 @@ void NetworkGameListRemoveExpired()
 			item = item->next;
 			*prev_item = item;
 
-			/* Remove GRFConfig information */
-			ClearGRFConfigList(remove->info.grfconfig);
 			delete remove;
 		} else {
 			prev_item = &item->next;
@@ -121,7 +117,7 @@ void NetworkAfterNewGRFScan()
 		/* Reset compatibility state */
 		item->info.compatible = item->info.version_compatible;
 
-		for (GRFConfig *c = item->info.grfconfig; c != nullptr; c = c->next) {
+		for (auto &c : item->info.grfconfig) {
 			assert(HasBit(c->flags, GCF_COPY));
 
 			const GRFConfig *f = FindGRFConfig(c->ident.grfid, FGCM_EXACT, &c->ident.md5sum);

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -585,8 +585,8 @@ public:
 
 		/* 'NewGRF Settings' button invisible if no NewGRF is used */
 		bool changed = false;
-		changed |= this->GetWidget<NWidgetStacked>(WID_NG_NEWGRF_SEL)->SetDisplayedPlane(sel == nullptr || sel->status != NGLS_ONLINE || sel->info.grfconfig == nullptr ? SZSP_NONE : 0);
-		changed |= this->GetWidget<NWidgetStacked>(WID_NG_NEWGRF_MISSING_SEL)->SetDisplayedPlane(sel == nullptr || sel->status != NGLS_ONLINE || sel->info.grfconfig == nullptr || !sel->info.version_compatible || sel->info.compatible ? SZSP_NONE : 0);
+		changed |= this->GetWidget<NWidgetStacked>(WID_NG_NEWGRF_SEL)->SetDisplayedPlane(sel == nullptr || sel->status != NGLS_ONLINE || sel->info.grfconfig.empty() ? SZSP_NONE : 0);
+		changed |= this->GetWidget<NWidgetStacked>(WID_NG_NEWGRF_MISSING_SEL)->SetDisplayedPlane(sel == nullptr || sel->status != NGLS_ONLINE || sel->info.grfconfig.empty() || !sel->info.version_compatible || sel->info.compatible ? SZSP_NONE : 0);
 		if (changed) {
 			this->ReInit();
 			return;

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8764,7 +8764,7 @@ static void ResetNewGRF()
 /** Clear all NewGRF errors */
 static void ResetNewGRFErrors()
 {
-	for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
+	for (const auto &c : _grfconfig) {
 		c->error.reset();
 	}
 }
@@ -10077,7 +10077,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 	 * be reset, the NewGRF would remain disabled even though it should
 	 * have been enabled.
 	 */
-	for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
+	for (const auto &c : _grfconfig) {
 		if (c->status != GCS_NOT_FOUND) c->status = GCS_UNKNOWN;
 	}
 
@@ -10089,7 +10089,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 	for (GrfLoadingStage stage = GLS_LABELSCAN; stage <= GLS_ACTIVATION; stage++) {
 		/* Set activated grfs back to will-be-activated between reservation- and activation-stage.
 		 * This ensures that action7/9 conditions 0x06 - 0x0A work correctly. */
-		for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
+		for (const auto &c : _grfconfig) {
 			if (c->status == GCS_ACTIVATED) c->status = GCS_INITIALISED;
 		}
 
@@ -10108,7 +10108,7 @@ void LoadNewGRF(SpriteID load_index, uint num_baseset)
 		uint num_non_static = 0;
 
 		_cur.stage = stage;
-		for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
+		for (const auto &c : _grfconfig) {
 			if (c->status == GCS_DISABLED || c->status == GCS_NOT_FOUND) continue;
 			if (stage > GLS_INIT && HasBit(c->flags, GCF_INIT_ONLY)) continue;
 

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -193,7 +193,7 @@ inline bool HasGrfMiscBit(GrfMiscBit bit)
 /* Indicates which are the newgrf features currently loaded ingame */
 extern GRFLoadedFeatures _loaded_newgrf_features;
 
-void LoadNewGRFFile(struct GRFConfig &config, GrfLoadingStage stage, Subdirectory subdir, bool temporary);
+void LoadNewGRFFile(GRFConfig &config, GrfLoadingStage stage, Subdirectory subdir, bool temporary);
 void LoadNewGRF(SpriteID load_index, uint num_baseset);
 void ReloadNewGRFData(); // in saveload/afterload.cpp
 void ResetNewGRFData();

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -180,8 +180,6 @@ struct GRFConfig {
 	std::vector<std::optional<GRFParameterInfo>> param_info; ///< NOSAVE: extra information about the parameters
 	std::vector<uint32_t> param; ///< GRF parameters
 
-	struct GRFConfig *next = nullptr; ///< NOSAVE: Next item in the linked list
-
 	bool IsCompatible(uint32_t old_version) const;
 	void SetParams(std::span<const uint32_t> pars);
 	void CopyParams(const GRFConfig &src);
@@ -199,7 +197,7 @@ struct GRFConfig {
 	void FinalizeParameterInfo();
 };
 
-using GRFConfigList = GRFConfig *;
+using GRFConfigList = std::vector<std::unique_ptr<GRFConfig>>;
 
 /** Method to find GRFs using FindGRFConfig */
 enum FindGRFConfigMode : uint8_t {
@@ -231,7 +229,7 @@ const GRFConfig *FindGRFConfig(uint32_t grfid, FindGRFConfigMode mode, const MD5
 GRFConfig *GetGRFConfig(uint32_t grfid, uint32_t mask = 0xFFFFFFFF);
 void CopyGRFConfigList(GRFConfigList &dst, const GRFConfigList &src, bool init_only);
 void AppendStaticGRFConfigs(GRFConfigList &dst);
-void AppendToGRFConfigList(GRFConfigList &dst, GRFConfig *el);
+void AppendToGRFConfigList(GRFConfigList &dst, std::unique_ptr<GRFConfig> &&el);
 void ClearGRFConfigList(GRFConfigList &config);
 void ResetGRFConfig(bool defaults);
 GRFListCompatibility IsGoodGRFConfigList(GRFConfigList &grfconfig);

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -242,7 +242,7 @@ static void WriteSavegameInfo(const std::string &name)
 
 	message += "NewGRFs:\n";
 	if (_load_check_data.HasNewGrfs()) {
-		for (GRFConfig *c = _load_check_data.grfconfig; c != nullptr; c = c->next) {
+		for (const auto &c : _load_check_data.grfconfig) {
 			fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", std::byteswap(c->ident.grfid),
 				FormatArrayAsHex(HasBit(c->flags, GCF_COMPATIBLE) ? c->original_md5sum : c->ident.md5sum), c->filename);
 		}

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -1560,11 +1560,11 @@ static bool LoadTTDPatchExtraChunks(LoadgameState *ls, int)
 					uint32_t grfid = ReadUint32(ls);
 
 					if (ReadByte(ls) == 1) {
-						GRFConfig *c = new GRFConfig("TTDP game, no information");
+						auto c = std::make_unique<GRFConfig>("TTDP game, no information");
 						c->ident.grfid = grfid;
 
-						AppendToGRFConfigList(_grfconfig, c);
 						Debug(oldloader, 3, "TTDPatch game using GRF file with GRFID {:08X}", std::byteswap(c->ident.grfid));
+						AppendToGRFConfigList(_grfconfig, std::move(c));
 					}
 					len -= 5;
 				}

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -307,8 +307,10 @@ static bool MakePNGImage(const char *name, ScreenshotCallback *callb, void *user
 	message.reserve(1024);
 	fmt::format_to(std::back_inserter(message), "Graphics set: {} ({})\n", BaseGraphics::GetUsedSet()->name, BaseGraphics::GetUsedSet()->version);
 	message += "NewGRFs:\n";
-	for (const GRFConfig *c = _game_mode == GM_MENU ? nullptr : _grfconfig; c != nullptr; c = c->next) {
-		fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", std::byteswap(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
+	if (_game_mode != GM_MENU) {
+		for (const auto &c : _grfconfig) {
+			fmt::format_to(std::back_inserter(message), "{:08X} {} {}\n", std::byteswap(c->ident.grfid), FormatArrayAsHex(c->ident.md5sum), c->filename);
+		}
 	}
 	message += "\nCompanies:\n";
 	for (const Company *c : Company::Iterate()) {

--- a/src/script/api/script_newgrf.cpp
+++ b/src/script/api/script_newgrf.cpp
@@ -17,7 +17,7 @@
 
 ScriptNewGRFList::ScriptNewGRFList()
 {
-	for (auto c = _grfconfig; c != nullptr; c = c->next) {
+	for (const auto &c : _grfconfig) {
 		if (!HasBit(c->flags, GCF_STATIC)) {
 			this->AddItem(std::byteswap(c->ident.grfid));
 		}
@@ -28,24 +28,15 @@ ScriptNewGRFList::ScriptNewGRFList()
 {
 	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
 
-	for (auto c = _grfconfig; c != nullptr; c = c->next) {
-		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
-			return true;
-		}
-	}
-
-	return false;
+	return std::ranges::any_of(_grfconfig, [grfid](const auto &c) { return !HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid; });
 }
 
 /* static */ SQInteger ScriptNewGRF::GetVersion(SQInteger grfid)
 {
 	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
 
-	for (auto c = _grfconfig; c != nullptr; c = c->next) {
-		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
-			return c->version;
-		}
-	}
+	auto it = std::ranges::find_if(_grfconfig, [grfid](const auto &c) { return !HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid; });
+	if (it != std::end(_grfconfig)) return (*it)->version;
 
 	return 0;
 }
@@ -54,11 +45,8 @@ ScriptNewGRFList::ScriptNewGRFList()
 {
 	grfid = std::byteswap(GB(grfid, 0, 32)); // Match people's expectations.
 
-	for (auto c = _grfconfig; c != nullptr; c = c->next) {
-		if (!HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid) {
-			return c->GetName();
-		}
-	}
+	auto it = std::ranges::find_if(_grfconfig, [grfid](const auto &c) { return !HasBit(c->flags, GCF_STATIC) && c->ident.grfid == grfid; });
+	if (it != std::end(_grfconfig)) return (*it)->GetName();
 
 	return std::nullopt;
 }

--- a/src/settings_func.h
+++ b/src/settings_func.h
@@ -12,6 +12,7 @@
 
 #include "company_type.h"
 #include "string_type.h"
+#include "newgrf_config.h"
 
 struct IniFile;
 
@@ -27,8 +28,8 @@ void IniLoadWindowSettings(IniFile &ini, const char *grpname, void *desc);
 void IniSaveWindowSettings(IniFile &ini, const char *grpname, void *desc);
 
 StringList GetGRFPresetList();
-struct GRFConfig *LoadGRFPresetFromConfig(const char *config_name);
-void SaveGRFPresetToConfig(const char *config_name, struct GRFConfig *config);
+GRFConfigList LoadGRFPresetFromConfig(const char *config_name);
+void SaveGRFPresetToConfig(const char *config_name, GRFConfigList &config);
 void DeleteGRFPresetFromConfig(const char *config_name);
 
 void SetDefaultCompanySettings(CompanyID cid);

--- a/src/survey.cpp
+++ b/src/survey.cpp
@@ -354,7 +354,7 @@ void SurveyTimers(nlohmann::json &survey)
  */
 void SurveyGrfs(nlohmann::json &survey)
 {
-	for (GRFConfig *c = _grfconfig; c != nullptr; c = c->next) {
+	for (const auto &c : _grfconfig) {
 		auto grfid = fmt::format("{:08x}", std::byteswap(c->ident.grfid));
 		auto &grf = survey[grfid];
 


### PR DESCRIPTION
## Motivation / Problem

GRFConfig lists are stored as C-style linked lists.

~~And often it is difficult to know if a function accepts a pointer to a list (GRFConfig *) or a pointer to an individual config (GRFConfig *).~~

## Description

Instead, use a `std::vector` of `std::unique_ptr`s for `GRFConfigList`.

~~There is still some faffing about with iterators to work out 'index' for GUI purposes, but some manual management is now gone.~~

~~Some conversions from linked-list to std algorithms are missing or not optimal, as it takes some effort to work out what the mix of pointers and pointers to pointers is actually intended to do.~~

~~To do:~~

* [x] ~~Standardize on parameter naming, differentiating between lists and individual configs.~~
* [x] ~~Fix initial loading which still uses new/delete and makes a copy, instead of doing it in-place.~~
* [x] ~~Fix doxygen which probably refers to pointers and heads and tails.~~

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
