### PR TITLE
Codechange: Move includes for common STL headers to stdafx.

### DIFF
--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -15,7 +15,6 @@
 #include "../debug.h"
 #include "../string_func.h"
 #include "../rev.h"
-#include <set>
 
 #include "../safeguards.h"
 

--- a/src/blitter/factory.hpp
+++ b/src/blitter/factory.hpp
@@ -13,7 +13,6 @@
 #include "base.hpp"
 #include "../debug.h"
 #include "../string_func.h"
-#include <map>
 
 
 /**

--- a/src/cargomonitor.h
+++ b/src/cargomonitor.h
@@ -15,7 +15,6 @@
 #include "industry.h"
 #include "town.h"
 #include "core/overflowsafe_type.hpp"
-#include <map>
 
 struct Station;
 

--- a/src/cargopacket.h
+++ b/src/cargopacket.h
@@ -18,7 +18,6 @@
 #include "vehicle_type.h"
 #include "core/multimap.hpp"
 #include "saveload/saveload.h"
-#include <list>
 
 /** Unique identifier for a single cargo packet. */
 typedef uint32 CargoPacketID;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -59,8 +59,6 @@
 #include "misc/endian_buffer.hpp"
 #include "string_func.h"
 
-#include <array>
-
 #include "table/strings.h"
 
 #include "safeguards.h"

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -17,7 +17,6 @@
 #include "timer/timer_game_calendar.h"
 #include "settings_type.h"
 #include "group.h"
-#include <array>
 
 /** Statistics about the economy. */
 struct CompanyEconomyEntry {

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -16,8 +16,6 @@
 #include "console_func.h"
 #include "settings_type.h"
 
-#include <stdarg.h>
-
 #include "safeguards.h"
 
 static const uint ICON_TOKEN_COUNT = 20;     ///< Maximum number of tokens in one command

--- a/src/console_gui.cpp
+++ b/src/console_gui.cpp
@@ -22,7 +22,6 @@
 #include "video/video_driver.hpp"
 #include "timer/timer.h"
 #include "timer/timer_window.h"
-#include <deque>
 
 #include "widgets/console_widget.h"
 

--- a/src/console_internal.h
+++ b/src/console_internal.h
@@ -11,7 +11,6 @@
 #define CONSOLE_INTERNAL_H
 
 #include "gfx_type.h"
-#include <map>
 
 static const uint ICON_CMDLN_SIZE     = 1024; ///< maximum length of a typed in command
 static const uint ICON_MAX_STREAMSIZE = 2048; ///< maximum length of a totally expanded command

--- a/src/core/multimap.hpp
+++ b/src/core/multimap.hpp
@@ -10,9 +10,6 @@
 #ifndef MULTIMAP_HPP
 #define MULTIMAP_HPP
 
-#include <map>
-#include <list>
-
 template<typename Tkey, typename Tvalue, typename Tcompare>
 class MultiMap;
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -8,7 +8,6 @@
 /** @file debug.cpp Handling of printing debug messages. */
 
 #include "stdafx.h"
-#include <stdarg.h>
 #include "console_func.h"
 #include "debug.h"
 #include "string_func.h"

--- a/src/driver.h
+++ b/src/driver.h
@@ -12,7 +12,6 @@
 
 #include "core/enum_type.hpp"
 #include "string_type.h"
-#include <map>
 
 const char *GetDriverParam(const StringList &parm, const char *name);
 bool GetDriverParamBool(const StringList &parm, const char *name);

--- a/src/error.h
+++ b/src/error.h
@@ -10,7 +10,6 @@
 #ifndef ERROR_H
 #define ERROR_H
 
-#include <list>
 #include "strings_type.h"
 #include "company_type.h"
 #include "command_type.h"

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -27,7 +27,6 @@
 #include "widgets/error_widget.h"
 
 #include "table/strings.h"
-#include <list>
 
 #include "safeguards.h"
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -25,7 +25,6 @@
 #include <pwd.h>
 #endif
 #include <sys/stat.h>
-#include <array>
 #include <sstream>
 
 #include "safeguards.h"

--- a/src/game/game_info.cpp
+++ b/src/game/game_info.cpp
@@ -13,7 +13,6 @@
 #include "game_info.hpp"
 #include "game_scanner.hpp"
 #include "../debug.h"
-#include <set>
 
 #include "../safeguards.h"
 

--- a/src/game/game_text.cpp
+++ b/src/game/game_text.cpp
@@ -21,8 +21,6 @@
 #include "table/strings.h"
 #include "table/strgen_tables.h"
 
-#include <stdarg.h>
-
 #include "../safeguards.h"
 
 void CDECL StrgenWarningI(const std::string &msg)

--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -18,8 +18,6 @@
 #include "timer/timer_game_tick.h"
 #include "rev.h"
 
-#include <stdarg.h>
-
 #include "safeguards.h"
 
 extern const SaveLoadVersion SAVEGAME_VERSION;  ///< current savegame version

--- a/src/gamelog_internal.h
+++ b/src/gamelog_internal.h
@@ -11,7 +11,6 @@
 #define GAMELOG_INTERNAL_H
 
 #include "gamelog.h"
-#include <iterator>
 
 /**
  * Information about the presence of a Grf at a certain point during gamelog history

--- a/src/gfx_layout.h
+++ b/src/gfx_layout.h
@@ -14,7 +14,6 @@
 #include "gfx_func.h"
 #include "core/smallmap_type.hpp"
 
-#include <map>
 #include <stack>
 #include <string_view>
 

--- a/src/gfx_layout_icu.cpp
+++ b/src/gfx_layout_icu.cpp
@@ -24,8 +24,6 @@
 #include <hb.h>
 #include <hb-ft.h>
 
-#include <deque>
-
 #include "safeguards.h"
 
 /** harfbuzz doesn't use floats, so we need a value to scale position with to get sub-pixel precision. */

--- a/src/industrytype.h
+++ b/src/industrytype.h
@@ -10,7 +10,6 @@
 #ifndef INDUSTRYTYPE_H
 #define INDUSTRYTYPE_H
 
-#include <array>
 #include "map_type.h"
 #include "slope_type.h"
 #include "industry_type.h"

--- a/src/landscape.cpp
+++ b/src/landscape.cpp
@@ -36,9 +36,6 @@
 #include "landscape_cmd.h"
 #include "terraform_cmd.h"
 #include "station_func.h"
-#include <array>
-#include <list>
-#include <set>
 
 #include "table/strings.h"
 #include "table/sprites.h"

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -15,7 +15,6 @@
 #include "../widget_type.h"
 #include "../window_gui.h"
 #include "linkgraph_base.h"
-#include <map>
 
 /**
  * Monthly statistics for a link between two stations.

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -12,7 +12,6 @@
 
 #include "../thread.h"
 #include "linkgraph.h"
-#include <list>
 #include <atomic>
 
 class LinkGraphJob;

--- a/src/linkgraph/mcf.cpp
+++ b/src/linkgraph/mcf.cpp
@@ -3,7 +3,6 @@
 #include "../stdafx.h"
 #include "../core/math_func.hpp"
 #include "mcf.h"
-#include <set>
 
 #include "../safeguards.h"
 

--- a/src/linkgraph/refresh.h
+++ b/src/linkgraph/refresh.h
@@ -12,8 +12,6 @@
 
 #include "../cargo_type.h"
 #include "../vehicle_base.h"
-#include <map>
-#include <set>
 
 /**
  * Utility to refresh links a consist will visit.

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -10,7 +10,6 @@
 #ifndef DBG_HELPERS_H
 #define DBG_HELPERS_H
 
-#include <map>
 #include <stack>
 
 #include "../direction_type.h"

--- a/src/misc/lrucache.hpp
+++ b/src/misc/lrucache.hpp
@@ -11,7 +11,6 @@
 #define LRUCACHE_HPP
 
 #include <utility>
-#include <list>
 #include <unordered_map>
 
 /**

--- a/src/music/os2_m.cpp
+++ b/src/music/os2_m.cpp
@@ -18,7 +18,6 @@
 #define INCL_OS2MM
 #define INCL_WIN
 
-#include <stdarg.h>
 #include <os2.h>
 #include <os2me.h>
 

--- a/src/network/core/tcp.h
+++ b/src/network/core/tcp.h
@@ -17,7 +17,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <map>
 #include <thread>
 
 /** The states of sending the packets. */

--- a/src/network/core/tcp_connect.cpp
+++ b/src/network/core/tcp_connect.cpp
@@ -16,8 +16,6 @@
 #include "../network_coordinator.h"
 #include "../network_internal.h"
 
-#include <deque>
-
 #include "../../safeguards.h"
 
 /** List of connections that are currently being created */

--- a/src/network/network_chat_gui.cpp
+++ b/src/network/network_chat_gui.cpp
@@ -28,8 +28,6 @@
 
 #include "table/strings.h"
 
-#include <deque>
-
 #include "../safeguards.h"
 
 /** The draw buffer must be able to contain the chat message, client name and the "[All]" message,

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -51,7 +51,6 @@
 #include "../water_cmd.h"
 #include "../waypoint_cmd.h"
 #include "../script/script_cmd.h"
-#include <array>
 
 #include "../safeguards.h"
 

--- a/src/network/network_coordinator.h
+++ b/src/network/network_coordinator.h
@@ -13,7 +13,6 @@
 #include "core/tcp_coordinator.h"
 #include "network_stun.h"
 #include "network_turn.h"
-#include <map>
 
 /**
  * Game Coordinator communication.

--- a/src/network/network_gui.cpp
+++ b/src/network/network_gui.cpp
@@ -52,8 +52,6 @@
 #	include <emscripten.h>
 #endif
 
-#include <map>
-
 #include "../safeguards.h"
 
 static void ShowNetworkStartServerWindow();

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -9,8 +9,6 @@
 
 #include "stdafx.h"
 
-#include <stdarg.h>
-
 #include "debug.h"
 #include "fileio_func.h"
 #include "engine_func.h"

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -41,7 +41,6 @@
 #include "timer/timer_game_calendar.h"
 #include "string_func.h"
 #include "network/core/config.h"
-#include <map>
 #include "smallmap_gui.h"
 #include "genworld.h"
 #include "error.h"

--- a/src/newgrf_debug_gui.cpp
+++ b/src/newgrf_debug_gui.cpp
@@ -8,7 +8,6 @@
 /** @file newgrf_debug_gui.cpp GUIs for debugging NewGRFs. */
 
 #include "stdafx.h"
-#include <stdarg.h>
 #include "core/backup_type.hpp"
 #include "window_gui.h"
 #include "window_func.h"

--- a/src/newgrf_generic.cpp
+++ b/src/newgrf_generic.cpp
@@ -14,7 +14,6 @@
 #include "core/random_func.hpp"
 #include "newgrf_sound.h"
 #include "water_map.h"
-#include <list>
 
 #include "safeguards.h"
 

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -36,7 +36,6 @@
 
 #include "table/sprites.h"
 
-#include <map>
 #include "safeguards.h"
 
 /**

--- a/src/newgrf_storage.cpp
+++ b/src/newgrf_storage.cpp
@@ -12,7 +12,6 @@
 #include "core/pool_func.hpp"
 #include "core/endian_func.hpp"
 #include "debug.h"
-#include <set>
 
 #include "safeguards.h"
 

--- a/src/newgrf_text.cpp
+++ b/src/newgrf_text.cpp
@@ -17,8 +17,6 @@
 
 #include "stdafx.h"
 
-#include <array>
-
 #include "newgrf.h"
 #include "strings_func.h"
 #include "newgrf_storage.h"
@@ -31,7 +29,6 @@
 #include "core/smallmap_type.hpp"
 #include "language.h"
 #include <sstream>
-#include <map>
 
 #include "table/strings.h"
 #include "table/control_codes.h"

--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -76,7 +76,6 @@
 
 #include "linkgraph/linkgraphschedule.h"
 
-#include <stdarg.h>
 #include <system_error>
 
 #include "safeguards.h"

--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -14,7 +14,6 @@
 #include "../../string_func.h"
 #include "../../fileio_func.h"
 #include <pthread.h>
-#include <array>
 
 #define Rect  OTTDRect
 #define Point OTTDPoint

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -27,7 +27,6 @@
 #include <sys/stat.h>
 #include "../../language.h"
 #include "../../thread.h"
-#include <array>
 
 #include "../../safeguards.h"
 

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -17,7 +17,6 @@
 #include "road.h"
 #include "road_map.h"
 #include "newgrf_engine.h"
-#include <deque>
 
 struct RoadVehicle;
 

--- a/src/saveload/map_sl.cpp
+++ b/src/saveload/map_sl.cpp
@@ -15,7 +15,6 @@
 #include "../map_func.h"
 #include "../core/bitmath_func.hpp"
 #include "../fios.h"
-#include <array>
 
 #include "../safeguards.h"
 

--- a/src/saveload/oldloader_sl.cpp
+++ b/src/saveload/oldloader_sl.cpp
@@ -33,7 +33,6 @@
 #include "../timer/timer_game_calendar.h"
 #include "saveload_internal.h"
 #include "oldloader.h"
-#include <array>
 
 #include "table/strings.h"
 #include "../table/engines.h"

--- a/src/saveload/saveload.cpp
+++ b/src/saveload/saveload.cpp
@@ -43,7 +43,6 @@
 #include "../fios.h"
 #include "../error.h"
 #include <atomic>
-#include <deque>
 #ifdef __EMSCRIPTEN__
 #	include <emscripten.h>
 #endif

--- a/src/saveload/vehicle_sl.cpp
+++ b/src/saveload/vehicle_sl.cpp
@@ -23,8 +23,6 @@
 #include "../company_func.h"
 #include "../disaster_vehicle.h"
 
-#include <map>
-
 #include "../safeguards.h"
 
 /**

--- a/src/script/api/script_controller.hpp
+++ b/src/script/api/script_controller.hpp
@@ -11,7 +11,6 @@
 #define SCRIPT_CONTROLLER_HPP
 
 #include "script_types.hpp"
-#include <map>
 
 /**
  * The Controller, the class each Script should extend. It creates the Script,

--- a/src/script/api/script_error.hpp
+++ b/src/script/api/script_error.hpp
@@ -12,7 +12,6 @@
 
 #include "script_object.hpp"
 #include "script_companymode.hpp"
-#include <map>
 
 /**
  * Helper to write precondition enforcers for the script API in an abbreviated manner.

--- a/src/script/api/script_list.hpp
+++ b/src/script/api/script_list.hpp
@@ -12,8 +12,6 @@
 #define SCRIPT_LIST_HPP
 
 #include "script_object.hpp"
-#include <map>
-#include <set>
 
 class ScriptListSorter;
 

--- a/src/script/api/script_log_types.hpp
+++ b/src/script/api/script_log_types.hpp
@@ -10,8 +10,6 @@
 #ifndef SCRIPT_LOG_TYPES_HPP
 #define SCRIPT_LOG_TYPES_HPP
 
-#include <deque>
-
 namespace ScriptLogTypes {
 	/**
 	 * Log levels; The value is also feed to Debug() lvl.

--- a/src/script/script_config.hpp
+++ b/src/script/script_config.hpp
@@ -10,8 +10,6 @@
 #ifndef SCRIPT_CONFIG_HPP
 #define SCRIPT_CONFIG_HPP
 
-#include <map>
-#include <list>
 #include "../core/smallmap_type.hpp"
 #include "../company_type.h"
 #include "../textfile_gui.h"

--- a/src/script/script_instance.hpp
+++ b/src/script/script_instance.hpp
@@ -11,7 +11,6 @@
 #define SCRIPT_INSTANCE_HPP
 
 #include <variant>
-#include <list>
 #include <squirrel.h>
 #include "script_suspend.hpp"
 #include "script_log_types.hpp"

--- a/src/script/script_scanner.hpp
+++ b/src/script/script_scanner.hpp
@@ -10,7 +10,6 @@
 #ifndef SCRIPT_SCANNER_HPP
 #define SCRIPT_SCANNER_HPP
 
-#include <map>
 #include "../fileio_func.h"
 #include "../string_func.h"
 

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -19,8 +19,6 @@
 #include <../squirrel/sqvm.h>
 #include "../core/alloc_func.hpp"
 
-#include <stdarg.h>
-
 /**
  * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS
  * does not have enough memory the game does not go into unrecoverable error mode and kill the

--- a/src/script/squirrel.cpp
+++ b/src/script/squirrel.cpp
@@ -20,7 +20,6 @@
 #include "../core/alloc_func.hpp"
 
 #include <stdarg.h>
-#include <map>
 
 /**
  * In the memory allocator for Squirrel we want to directly use malloc/realloc, so when the OS

--- a/src/settings_table.h
+++ b/src/settings_table.h
@@ -12,7 +12,6 @@
 #ifndef SETTINGS_TABLE_H
 #define SETTINGS_TABLE_H
 
-#include <array>
 #include "settings_internal.h"
 
 extern SettingTable _company_settings;

--- a/src/ship.h
+++ b/src/ship.h
@@ -10,8 +10,6 @@
 #ifndef SHIP_H
 #define SHIP_H
 
-#include <deque>
-
 #include "vehicle_base.h"
 #include "water_map.h"
 

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -18,8 +18,6 @@
 #include "linkgraph/linkgraph_type.h"
 #include "newgrf_storage.h"
 #include "bitmap_type.h"
-#include <map>
-#include <set>
 
 static const byte INITIAL_STATION_RATING = 175;
 

--- a/src/station_gui.cpp
+++ b/src/station_gui.cpp
@@ -37,8 +37,6 @@
 
 #include "table/strings.h"
 
-#include <set>
-
 #include "safeguards.h"
 
 /**

--- a/src/station_type.h
+++ b/src/station_type.h
@@ -12,7 +12,6 @@
 
 #include "core/smallstack_type.hpp"
 #include "tilearea_type.h"
-#include <set>
 
 typedef uint16 StationID;
 typedef uint16 RoadStopID;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -53,6 +53,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cctype>
 #include <cerrno>
@@ -65,12 +66,16 @@
 #include <cstring>
 #include <cstdlib>
 #include <cwchar>
+#include <deque>
 #include <exception>
 #include <functional>
 #include <iterator>
+#include <list>
 #include <limits>
+#include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <type_traits>

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -17,8 +17,6 @@
 
 #include "table/control_codes.h"
 
-#include <stdarg.h>
-#include <ctype.h> /* required for tolower() */
 #include <sstream>
 #include <iomanip>
 

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -24,7 +24,6 @@
 #ifndef STRING_FUNC_H
 #define STRING_FUNC_H
 
-#include <stdarg.h>
 #include <iosfwd>
 
 #include "core/bitmath_func.hpp"

--- a/src/tar_type.h
+++ b/src/tar_type.h
@@ -10,9 +10,6 @@
 #ifndef TAR_TYPE_H
 #define TAR_TYPE_H
 
-#include <map>
-#include <array>
-
 #include "fileio_type.h"
 
 

--- a/src/terraform_cmd.cpp
+++ b/src/terraform_cmd.cpp
@@ -22,9 +22,6 @@
 
 #include "table/strings.h"
 
-#include <map>
-#include <set>
-
 #include "safeguards.h"
 
 /** Set of tiles. */

--- a/src/tests/landscape_partial_pixel_z.cpp
+++ b/src/tests/landscape_partial_pixel_z.cpp
@@ -13,7 +13,6 @@
 
 #include "../landscape.h"
 #include "../slope_func.h"
-#include <array>
 
 /**
  * Check whether the addition of two slope's GetPartialPixelZ values results in

--- a/src/tests/string_func.cpp
+++ b/src/tests/string_func.cpp
@@ -12,7 +12,6 @@
 #include "../3rdparty/catch2/catch.hpp"
 
 #include "../string_func.h"
-#include <array>
 
 /**** String compare/equals *****/
 

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -8,7 +8,6 @@
 /** @file textbuf.cpp Textbuffer handling. */
 
 #include "stdafx.h"
-#include <stdarg.h>
 
 #include "textbuf_type.h"
 #include "string_func.h"

--- a/src/timer/timer_manager.h
+++ b/src/timer/timer_manager.h
@@ -13,8 +13,6 @@
 
 #include "stdafx.h"
 
-#include <set>
-
 template <typename TTimerType>
 class BaseTimer;
 

--- a/src/town.h
+++ b/src/town.h
@@ -16,7 +16,6 @@
 #include "subsidy_type.h"
 #include "newgrf_storage.h"
 #include "cargotype.h"
-#include <list>
 
 template <typename T>
 struct BuildingCounts {

--- a/src/townname_type.h
+++ b/src/townname_type.h
@@ -16,7 +16,6 @@
 #include "newgrf_townname.h"
 #include "town_type.h"
 #include "string_type.h"
-#include <set>
 
 typedef std::set<std::string> TownNames;
 

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -24,8 +24,6 @@
 #include "network/network.h"
 #include "saveload/saveload.h"
 #include "timer/timer_game_calendar.h"
-#include <list>
-#include <map>
 
 const uint TILE_AXIAL_DISTANCE = 192;  // Logical length of the tile in any DiagDirection used in vehicle movement.
 const uint TILE_CORNER_DISTANCE = 128;  // Logical length of the tile corner crossing in any non-diagonal direction used in vehicle movement.

--- a/src/video/cocoa/cocoa_v.mm
+++ b/src/video/cocoa/cocoa_v.mm
@@ -44,7 +44,6 @@
 
 #import <sys/param.h> /* for MAXPATHLEN */
 #import <sys/time.h> /* gettimeofday */
-#include <array>
 
 /* The 10.12 SDK added new names for some enum constants and
  * deprecated the old ones. As there's no functional change in any

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -34,7 +34,6 @@
 #include "../../window_gui.h"
 #include "../../spritecache.h"
 #include "../../toolbar_gui.h"
-#include <array>
 
 #include "table/sprites.h"
 

--- a/src/video/opengl.cpp
+++ b/src/video/opengl.cpp
@@ -36,7 +36,6 @@
 #include "../debug.h"
 #include "../blitter/factory.hpp"
 #include "../zoom_func.h"
-#include <array>
 #include <numeric>
 
 #include "../table/opengl_shader.h"

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -92,7 +92,6 @@
 #include "viewport_cmd.h"
 
 #include <forward_list>
-#include <map>
 #include <stack>
 
 #include "table/strings.h"

--- a/src/viewport_sprite_sorter_sse4.cpp
+++ b/src/viewport_sprite_sorter_sse4.cpp
@@ -14,7 +14,6 @@
 #include "smmintrin.h"
 #include "viewport_sprite_sorter.h"
 #include <forward_list>
-#include <map>
 #include <stack>
 
 #include "safeguards.h"

--- a/src/widgets/slider_func.h
+++ b/src/widgets/slider_func.h
@@ -13,8 +13,6 @@
 #include "../window_type.h"
 #include "../gfx_func.h"
 
-#include <map>
-
 void DrawSliderWidget(Rect r, int min_value, int max_value, int value, const std::map<int, StringID> &labels);
 bool ClickSliderWidget(Rect r, Point pt, int min_value, int max_value, int &value);
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -8,7 +8,6 @@
 /** @file window.cpp Windowing system, widgets and events */
 
 #include "stdafx.h"
-#include <stdarg.h>
 #include "company_func.h"
 #include "gfx_func.h"
 #include "console_func.h"

--- a/src/window_gui.h
+++ b/src/window_gui.h
@@ -10,8 +10,6 @@
 #ifndef WINDOW_GUI_H
 #define WINDOW_GUI_H
 
-#include <list>
-
 #include "vehiclelist.h"
 #include "vehicle_type.h"
 #include "viewport_type.h"


### PR DESCRIPTION
## Motivation / Problem

Random header dependency issues on different platforms.

## Description

Move all `array`, `deque`, `list`, `map` and `set` header includes to stdafx.h. `vector` was already done.

There are some other includes that aren't so widespread, `stack` and `forward_list`, which are not moved.
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

May slow down compilation time?
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
