### PR TITLE
Codechange: Use std::optional for GRFParameterInfo.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8419,10 +8419,10 @@ static bool HandleParameterInfo(ByteReader *buf)
 		if (id >= _cur.grfconfig->param_info.size()) {
 			_cur.grfconfig->param_info.resize(id + 1);
 		}
-		if (_cur.grfconfig->param_info[id] == nullptr) {
-			_cur.grfconfig->param_info[id] = new GRFParameterInfo(id);
+		if (!_cur.grfconfig->param_info[id].has_value()) {
+			_cur.grfconfig->param_info[id] = GRFParameterInfo(id);
 		}
-		_cur_parameter = _cur.grfconfig->param_info[id];
+		_cur_parameter = &_cur.grfconfig->param_info[id].value();
 		/* Read all parameter-data and process each node. */
 		if (!HandleNodes(buf, _tags_parameters)) return false;
 		type = buf->ReadByte();

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -209,26 +209,6 @@ GRFParameterInfo::GRFParameterInfo(uint nr) :
 {}
 
 /**
- * Create a new GRFParameterInfo object that is a deep copy of an existing
- *   parameter info object.
- * @param info The GRFParameterInfo object to make a copy of.
- */
-GRFParameterInfo::GRFParameterInfo(GRFParameterInfo &info) :
-	name(info.name),
-	desc(info.desc),
-	type(info.type),
-	min_value(info.min_value),
-	max_value(info.max_value),
-	def_value(info.def_value),
-	param_nr(info.param_nr),
-	first_bit(info.first_bit),
-	num_bit(info.num_bit),
-	value_names(info.value_names),
-	complete_labels(info.complete_labels)
-{
-}
-
-/**
  * Get the value of this user-changeable parameter from the given config.
  * @param config The GRFConfig to get the value from.
  * @return The value of this parameter.

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -157,27 +157,27 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	/* Remove the copy assignment, as the default implementation will not do the right thing. */
 	GRFConfig &operator=(GRFConfig &rhs) = delete;
 
-	GRFIdentifier ident;                        ///< grfid and md5sum to uniquely identify newgrfs
-	uint8 original_md5sum[16];                  ///< MD5 checksum of original file if only a 'compatible' file was loaded
-	std::string filename;                       ///< Filename - either with or without full path
-	GRFTextWrapper name;                        ///< NOSAVE: GRF name (Action 0x08)
-	GRFTextWrapper info;                        ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
-	GRFTextWrapper url;                         ///< NOSAVE: URL belonging to this GRF.
-	std::unique_ptr<GRFError> error;            ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
+	GRFIdentifier ident; ///< grfid and md5sum to uniquely identify newgrfs
+	uint8 original_md5sum[16]; ///< MD5 checksum of original file if only a 'compatible' file was loaded
+	std::string filename; ///< Filename - either with or without full path
+	GRFTextWrapper name; ///< NOSAVE: GRF name (Action 0x08)
+	GRFTextWrapper info; ///< NOSAVE: GRF info (author, copyright, ...) (Action 0x08)
+	GRFTextWrapper url; ///< NOSAVE: URL belonging to this GRF.
+	std::unique_ptr<GRFError> error; ///< NOSAVE: Error/Warning during GRF loading (Action 0x0B)
 
-	uint32 version;                             ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
-	uint32 min_loadable_version;                ///< NOSAVE: Minimum compatible version a NewGRF can define
-	uint8 flags;                                ///< NOSAVE: GCF_Flags, bitset
-	GRFStatus status;                           ///< NOSAVE: GRFStatus, enum
-	uint32 grf_bugs;                            ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
-	uint32 param[0x80];                         ///< GRF parameters
-	uint8 num_params;                           ///< Number of used parameters
-	uint8 num_valid_params;                     ///< NOSAVE: Number of valid parameters (action 0x14)
-	uint8 palette;                              ///< GRFPalette, bitset
+	uint32 version; ///< NOSAVE: Version a NewGRF can set so only the newest NewGRF is shown
+	uint32 min_loadable_version; ///< NOSAVE: Minimum compatible version a NewGRF can define
+	uint8 flags; ///< NOSAVE: GCF_Flags, bitset
+	GRFStatus status; ///< NOSAVE: GRFStatus, enum
+	uint32 grf_bugs; ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
+	uint32 param[0x80]; ///< GRF parameters
+	uint8 num_params; ///< Number of used parameters
+	uint8 num_valid_params; ///< NOSAVE: Number of valid parameters (action 0x14)
+	uint8 palette; ///< GRFPalette, bitset
 	std::vector<std::optional<GRFParameterInfo>> param_info; ///< NOSAVE: extra information about the parameters
-	bool has_param_defaults;                    ///< NOSAVE: did this newgrf specify any defaults for it's parameters
+	bool has_param_defaults; ///< NOSAVE: did this newgrf specify any defaults for it's parameters
 
-	struct GRFConfig *next;                     ///< NOSAVE: Next item in the linked list
+	struct GRFConfig *next; ///< NOSAVE: Next item in the linked list
 
 	void CopyParams(const GRFConfig &src);
 

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -153,7 +153,6 @@ struct GRFParameterInfo {
 struct GRFConfig : ZeroedMemoryAllocator {
 	GRFConfig(const std::string &filename = std::string{});
 	GRFConfig(const GRFConfig &config);
-	~GRFConfig();
 
 	/* Remove the copy assignment, as the default implementation will not do the right thing. */
 	GRFConfig &operator=(GRFConfig &rhs) = delete;
@@ -175,7 +174,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	uint8 num_params;                           ///< Number of used parameters
 	uint8 num_valid_params;                     ///< NOSAVE: Number of valid parameters (action 0x14)
 	uint8 palette;                              ///< GRFPalette, bitset
-	std::vector<GRFParameterInfo *> param_info; ///< NOSAVE: extra information about the parameters
+	std::vector<std::optional<GRFParameterInfo>> param_info; ///< NOSAVE: extra information about the parameters
 	bool has_param_defaults;                    ///< NOSAVE: did this newgrf specify any defaults for it's parameters
 
 	struct GRFConfig *next;                     ///< NOSAVE: Next item in the linked list

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -132,7 +132,6 @@ enum GRFParameterType {
 /** Information about one grf parameter. */
 struct GRFParameterInfo {
 	GRFParameterInfo(uint nr);
-	GRFParameterInfo(GRFParameterInfo &info);
 	GRFTextList name;      ///< The name of this parameter
 	GRFTextList desc;      ///< The description of this parameter
 	GRFParameterType type; ///< The type of this parameter

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -187,10 +187,31 @@ struct NewGRFParametersWindow : public Window {
 	 * @param nr The param number that should be changed.
 	 * @return GRFParameterInfo with dummy information about the given parameter.
 	 */
-	static GRFParameterInfo *GetDummyParameterInfo(uint nr)
+	static GRFParameterInfo &GetDummyParameterInfo(uint nr)
 	{
 		dummy_parameter_info.param_nr = nr;
-		return &dummy_parameter_info;
+		return dummy_parameter_info;
+	}
+
+	/**
+	 * Test if GRF Parameter Info exists for a given parameter index.
+	 * @param nr The param number that should be tested.
+	 * @return True iff the parameter info exists.
+	 */
+	bool HasParameterInfo(uint nr) const
+	{
+		return nr < this->grf_config->param_info.size() && this->grf_config->param_info[nr].has_value();
+	}
+
+	/**
+	 * Get GRF Parameter Info exists for a given parameter index.
+	 * If the parameter info does not exist, a dummy parameter-info is returned instead.
+	 * @param nr The param number that should be got.
+	 * @return Reference to the GRFParameterInfo.
+	 */
+	GRFParameterInfo &GetParameterInfo(uint nr) const
+	{
+		return this->HasParameterInfo(nr) ? this->grf_config->param_info[nr].value() : GetDummyParameterInfo(nr);
 	}
 
 	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
@@ -223,9 +244,8 @@ struct NewGRFParametersWindow : public Window {
 			case WID_NP_DESCRIPTION:
 				/* Minimum size of 4 lines. The 500 is the default size of the window. */
 				Dimension suggestion = {500U - WidgetDimensions::scaled.frametext.Horizontal(), (uint)FONT_HEIGHT_NORMAL * 4 + WidgetDimensions::scaled.frametext.Vertical()};
-				for (uint i = 0; i < this->grf_config->param_info.size(); i++) {
-					const GRFParameterInfo *par_info = this->grf_config->param_info[i];
-					if (par_info == nullptr) continue;
+				for (const auto &par_info : this->grf_config->param_info) {
+					if (!par_info.has_value()) continue;
 					const char *desc = GetGRFStringFromGRFText(par_info->desc);
 					if (desc == nullptr) continue;
 					Dimension d = GetStringMultiLineBoundingBox(desc, suggestion);
@@ -249,9 +269,9 @@ struct NewGRFParametersWindow : public Window {
 	void DrawWidget(const Rect &r, int widget) const override
 	{
 		if (widget == WID_NP_DESCRIPTION) {
-			const GRFParameterInfo *par_info = (this->clicked_row < this->grf_config->param_info.size()) ? this->grf_config->param_info[this->clicked_row] : nullptr;
-			if (par_info == nullptr) return;
-			const char *desc = GetGRFStringFromGRFText(par_info->desc);
+			if (!this->HasParameterInfo(this->clicked_row)) return;
+			const GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
+			const char *desc = GetGRFStringFromGRFText(par_info.desc);
 			if (desc == nullptr) return;
 			DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.framerect), desc, TC_BLACK);
 			return;
@@ -267,24 +287,23 @@ struct NewGRFParametersWindow : public Window {
 		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
 		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
 		for (uint i = this->vscroll->GetPosition(); this->vscroll->IsVisible(i) && i < this->vscroll->GetCount(); i++) {
-			GRFParameterInfo *par_info = (i < this->grf_config->param_info.size()) ? this->grf_config->param_info[i] : nullptr;
-			if (par_info == nullptr) par_info = GetDummyParameterInfo(i);
-			uint32 current_value = par_info->GetValue(this->grf_config);
+			GRFParameterInfo &par_info = this->GetParameterInfo(i);
+			uint32 current_value = par_info.GetValue(this->grf_config);
 			bool selected = (i == this->clicked_row);
 
-			if (par_info->type == PTYPE_BOOL) {
+			if (par_info.type == PTYPE_BOOL) {
 				DrawBoolButton(buttons_left, ir.top + button_y_offset, current_value != 0, this->editable);
-				SetDParam(2, par_info->GetValue(this->grf_config) == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
-			} else if (par_info->type == PTYPE_UINT_ENUM) {
-				if (par_info->complete_labels) {
+				SetDParam(2, par_info.GetValue(this->grf_config) == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
+			} else if (par_info.type == PTYPE_UINT_ENUM) {
+				if (par_info.complete_labels) {
 					DrawDropDownButton(buttons_left, ir.top + button_y_offset, COLOUR_YELLOW, this->clicked_row == i && this->clicked_dropdown, this->editable);
 				} else {
-					DrawArrowButtons(buttons_left, ir.top + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, this->editable && current_value > par_info->min_value, this->editable && current_value < par_info->max_value);
+					DrawArrowButtons(buttons_left, ir.top + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, this->editable && current_value > par_info.min_value, this->editable && current_value < par_info.max_value);
 				}
 				SetDParam(2, STR_JUST_INT);
 				SetDParam(3, current_value);
-				auto it = par_info->value_names.find(current_value);
-				if (it != par_info->value_names.end()) {
+				auto it = par_info.value_names.find(current_value);
+				if (it != par_info.value_names.end()) {
 					const char *label = GetGRFStringFromGRFText(it->second);
 					if (label != nullptr) {
 						SetDParam(2, STR_JUST_RAW_STRING);
@@ -293,7 +312,7 @@ struct NewGRFParametersWindow : public Window {
 				}
 			}
 
-			const char *name = GetGRFStringFromGRFText(par_info->name);
+			const char *name = GetGRFStringFromGRFText(par_info.name);
 			if (name != nullptr) {
 				SetDParam(0, STR_JUST_RAW_STRING);
 				SetDParamStr(1, name);
@@ -354,12 +373,11 @@ struct NewGRFParametersWindow : public Window {
 				int x = pt.x - r.left;
 				if (_current_text_dir == TD_RTL) x = r.Width() - 1 - x;
 
-				GRFParameterInfo *par_info = *it;
-				if (par_info == nullptr) par_info = GetDummyParameterInfo(num);
+				GRFParameterInfo &par_info = it->has_value() ? it->value() : GetDummyParameterInfo(num);
 
 				/* One of the arrows is clicked */
-				uint32 old_val = par_info->GetValue(this->grf_config);
-				if (par_info->type != PTYPE_BOOL && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && par_info->complete_labels) {
+				uint32 old_val = par_info.GetValue(this->grf_config);
+				if (par_info.type != PTYPE_BOOL && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && par_info.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
 						HideDropDownMenu(this);
@@ -380,8 +398,8 @@ struct NewGRFParametersWindow : public Window {
 							this->closing_dropdown = false;
 
 							DropDownList list;
-							for (uint32 i = par_info->min_value; i <= par_info->max_value; i++) {
-								list.emplace_back(new DropDownListCharStringItem(GetGRFStringFromGRFText(par_info->value_names.find(i)->second), i, false));
+							for (uint32 i = par_info.min_value; i <= par_info.max_value; i++) {
+								list.emplace_back(new DropDownListCharStringItem(GetGRFStringFromGRFText(par_info.value_names.find(i)->second), i, false));
 							}
 
 							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE);
@@ -389,26 +407,26 @@ struct NewGRFParametersWindow : public Window {
 					}
 				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
 					uint32 val = old_val;
-					if (par_info->type == PTYPE_BOOL) {
+					if (par_info.type == PTYPE_BOOL) {
 						val = !val;
 					} else {
 						if (x >= SETTING_BUTTON_WIDTH / 2) {
 							/* Increase button clicked */
-							if (val < par_info->max_value) val++;
+							if (val < par_info.max_value) val++;
 							this->clicked_increase = true;
 						} else {
 							/* Decrease button clicked */
-							if (val > par_info->min_value) val--;
+							if (val > par_info.min_value) val--;
 							this->clicked_increase = false;
 						}
 					}
 					if (val != old_val) {
-						par_info->SetValue(this->grf_config, val);
+						par_info.SetValue(this->grf_config, val);
 
 						this->clicked_button = num;
 						this->unclick_timeout.Reset();
 					}
-				} else if (par_info->type == PTYPE_UINT_ENUM && !par_info->complete_labels && click_count >= 2) {
+				} else if (par_info.type == PTYPE_UINT_ENUM && !par_info.complete_labels && click_count >= 2) {
 					/* Display a query box so users can enter a custom value. */
 					SetDParam(0, old_val);
 					ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, 10, this, CS_NUMERAL, QSF_NONE);
@@ -434,19 +452,17 @@ struct NewGRFParametersWindow : public Window {
 	{
 		if (StrEmpty(str)) return;
 		int32 value = atoi(str);
-		GRFParameterInfo *par_info = ((uint)this->clicked_row < this->grf_config->param_info.size()) ? this->grf_config->param_info[this->clicked_row] : nullptr;
-		if (par_info == nullptr) par_info = GetDummyParameterInfo(this->clicked_row);
-		uint32 val = Clamp<uint32>(value, par_info->min_value, par_info->max_value);
-		par_info->SetValue(this->grf_config, val);
+		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
+		uint32 val = Clamp<uint32>(value, par_info.min_value, par_info.max_value);
+		par_info.SetValue(this->grf_config, val);
 		this->SetDirty();
 	}
 
 	void OnDropdownSelect(int widget, int index) override
 	{
 		assert(this->clicked_dropdown);
-		GRFParameterInfo *par_info = ((uint)this->clicked_row < this->grf_config->param_info.size()) ? this->grf_config->param_info[this->clicked_row] : nullptr;
-		if (par_info == nullptr) par_info = GetDummyParameterInfo(this->clicked_row);
-		par_info->SetValue(this->grf_config, index);
+		GRFParameterInfo &par_info = this->GetParameterInfo(this->clicked_row);
+		par_info.SetValue(this->grf_config, index);
 		this->SetDirty();
 	}
 


### PR DESCRIPTION
## Motivation / Problem

Manual (C++ style at least) memory management of GRF Parameter Info and nullptr checking.

## Description

Use std::optional in the GRF Parameter Info list. This removes the manual management.

Bulk of the changes in newgrf_gui are where a reference to the resolved GRFParameterInfo is used instead of pointers.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
