### PR TITLE
Codechange: Use std::array for GRFConfig parameter arrays.

### DIFF
--- a/src/gamelog.cpp
+++ b/src/gamelog.cpp
@@ -659,7 +659,7 @@ void Gamelog::GRFUpdate(const GRFConfig *oldc, const GRFConfig *newc)
 				this->GRFCompatible(&nl[n]->ident);
 			}
 
-			if (og->num_params != ng->num_params || memcmp(og->param, ng->param, og->num_params * sizeof(og->param[0])) != 0) {
+			if (og->num_params != ng->num_params || og->param == ng->param) {
 				this->GRFParameters(ol[o]->ident.grfid);
 			}
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -8090,7 +8090,7 @@ static bool ChangeGRFNumUsedParams(size_t len, ByteReader *buf)
 		GrfMsg(2, "StaticGRFInfo: expected only 1 byte for 'INFO'->'NPAR' but got {}, ignoring this field", len);
 		buf->Skip(len);
 	} else {
-		_cur.grfconfig->num_valid_params = std::min<byte>(buf->ReadByte(), lengthof(_cur.grfconfig->param));
+		_cur.grfconfig->num_valid_params = std::min(buf->ReadByte(), ClampTo<uint8_t>(_cur.grfconfig->param.size()));
 	}
 	return true;
 }
@@ -8239,7 +8239,7 @@ static bool ChangeGRFParamMask(size_t len, ByteReader *buf)
 		buf->Skip(len);
 	} else {
 		byte param_nr = buf->ReadByte();
-		if (param_nr >= lengthof(_cur.grfconfig->param)) {
+		if (param_nr >= _cur.grfconfig->param.size()) {
 			GrfMsg(2, "StaticGRFInfo: invalid parameter number in 'INFO'->'PARA'->'MASK', param {}, ignoring this field", param_nr);
 			buf->Skip(len - 1);
 		} else {
@@ -8926,13 +8926,8 @@ GRFFile::GRFFile(const GRFConfig *config)
 
 	/* Copy the initial parameter list
 	 * 'Uninitialised' parameters are zeroed as that is their default value when dynamically creating them. */
-	static_assert(lengthof(this->param) == lengthof(config->param) && lengthof(this->param) == 0x80);
-
-	assert(config->num_params <= lengthof(config->param));
+	this->param = config->param;
 	this->param_end = config->num_params;
-	if (this->param_end > 0) {
-		MemCpyT(this->param, config->param, this->param_end);
-	}
 }
 
 GRFFile::~GRFFile()

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -7191,7 +7191,7 @@ static void GRFLoadError(ByteReader *buf)
 	}
 
 	/* Only two parameter numbers can be used in the string. */
-	for (uint i = 0; i < lengthof(error->param_value) && buf->HasData(); i++) {
+	for (uint i = 0; i < error->param_value.size() && buf->HasData(); i++) {
 		uint param_number = buf->ReadByte();
 		error->param_value[i] = _cur.grffile->GetParam(param_number);
 	}

--- a/src/newgrf.h
+++ b/src/newgrf.h
@@ -121,7 +121,7 @@ struct GRFFile : ZeroedMemoryAllocator {
 	std::vector<std::unique_ptr<struct AirportTileSpec>> airtspec;
 	std::vector<std::unique_ptr<struct RoadStopSpec>> roadstops;
 
-	uint32 param[0x80];
+	std::array<uint32_t, 0x80> param;
 	uint param_end;  ///< one more than the highest set parameter
 
 	std::vector<GRFLabel> labels;                   ///< List of labels
@@ -154,9 +154,9 @@ struct GRFFile : ZeroedMemoryAllocator {
 	/** Get GRF Parameter with range checking */
 	uint32 GetParam(uint number) const
 	{
-		/* Note: We implicitly test for number < lengthof(this->param) and return 0 for invalid parameters.
+		/* Note: We implicitly test for number < this->param.size() and return 0 for invalid parameters.
 		 *       In fact this is the more important test, as param is zeroed anyway. */
-		assert(this->param_end <= lengthof(this->param));
+		assert(this->param_end <= this->param.size());
 		return (number < this->param_end) ? this->param[number] : 0;
 	}
 };

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -35,7 +35,7 @@
  * @param filename Set the filename of this GRFConfig to filename.
  */
 GRFConfig::GRFConfig(const std::string &filename) :
-	filename(filename), num_valid_params(lengthof(param))
+	filename(filename), num_valid_params(ClampTo<uint8_t>(GRFConfig::param.size()))
 {
 }
 
@@ -56,13 +56,13 @@ GRFConfig::GRFConfig(const GRFConfig &config) :
 	flags(config.flags & ~(1 << GCF_COPY)),
 	status(config.status),
 	grf_bugs(config.grf_bugs),
+	param(config.param),
 	num_params(config.num_params),
 	num_valid_params(config.num_valid_params),
 	palette(config.palette),
 	param_info(config.param_info),
 	has_param_defaults(config.has_param_defaults)
 {
-	MemCpyT<uint32>(this->param, config.param, lengthof(this->param));
 	if (config.error != nullptr) this->error = std::make_unique<GRFError>(*config.error);
 }
 
@@ -74,7 +74,7 @@ void GRFConfig::CopyParams(const GRFConfig &src)
 {
 	this->num_params = src.num_params;
 	this->num_valid_params = src.num_valid_params;
-	MemCpyT<uint32>(this->param, src.param, lengthof(this->param));
+	this->param = src.param;
 }
 
 /**
@@ -110,7 +110,7 @@ const char *GRFConfig::GetURL() const
 void GRFConfig::SetParameterDefaults()
 {
 	this->num_params = 0;
-	MemSetT<uint32>(this->param, 0, lengthof(this->param));
+	this->param = {};
 
 	if (!this->has_param_defaults) return;
 

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -158,24 +158,8 @@ uint _missing_extra_graphics = 0;
  * @param severity The severity of this error.
  * @param message The actual error-string.
  */
-GRFError::GRFError(StringID severity, StringID message) :
-	message(message),
-	severity(severity),
-	param_value()
+GRFError::GRFError(StringID severity, StringID message) : message(message), severity(severity)
 {
-}
-
-/**
- * Create a new GRFError that is a deep copy of an existing error message.
- * @param error The GRFError object to make a copy of.
- */
-GRFError::GRFError(const GRFError &error) :
-	custom_message(error.custom_message),
-	data(error.data),
-	message(error.message),
-	severity(error.severity)
-{
-	memcpy(this->param_value, error.param_value, sizeof(this->param_value));
 }
 
 /**

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -108,16 +108,12 @@ struct GRFIdentifier {
 /** Information about why GRF had problems during initialisation */
 struct GRFError {
 	GRFError(StringID severity, StringID message = 0);
-	GRFError(const GRFError &error);
-
-	/* Remove the copy assignment, as the default implementation will not do the right thing. */
-	GRFError &operator=(GRFError &rhs) = delete;
 
 	std::string custom_message; ///< Custom message (if present)
 	std::string data;           ///< Additional data for message and custom_message
 	StringID message;           ///< Default message
 	StringID severity;          ///< Info / Warning / Error / Fatal
-	uint32 param_value[2];      ///< Values of GRF parameters to show for message and custom_message
+	std::array<uint32_t, 2> param_value; ///< Values of GRF parameters to show for message and custom_message
 };
 
 /** The possible types of a newgrf parameter. */

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -164,7 +164,7 @@ struct GRFConfig : ZeroedMemoryAllocator {
 	uint8 flags; ///< NOSAVE: GCF_Flags, bitset
 	GRFStatus status; ///< NOSAVE: GRFStatus, enum
 	uint32 grf_bugs; ///< NOSAVE: bugs in this GRF in this run, @see enum GRFBugs
-	uint32 param[0x80]; ///< GRF parameters
+	std::array<uint32_t, 0x80> param; ///< GRF parameters
 	uint8 num_params; ///< Number of used parameters
 	uint8 num_valid_params; ///< NOSAVE: Number of valid parameters (action 0x14)
 	uint8 palette; ///< GRFPalette, bitset

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -169,7 +169,7 @@ struct NewGRFParametersWindow : public Window {
 		clicked_row(UINT_MAX),
 		editable(editable)
 	{
-		this->action14present = (c->num_valid_params != lengthof(c->param) || c->param_info.size() != 0);
+		this->action14present = (c->num_valid_params != c->param.size() || c->param_info.size() != 0);
 
 		this->CreateNestedTree();
 		this->vscroll = this->GetScrollbar(WID_NP_SCROLLBAR);
@@ -225,7 +225,7 @@ struct NewGRFParametersWindow : public Window {
 			}
 
 			case WID_NP_NUMPAR: {
-				SetDParamMaxValue(0, lengthof(this->grf_config->param));
+				SetDParamMaxValue(0, this->grf_config->param.size());
 				Dimension d = GetStringBoundingBox(this->GetWidget<NWidgetCore>(widget)->widget_data);
 				d.width += padding.width;
 				d.height += padding.height;

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -55,7 +55,7 @@ void ShowNewGRFError()
 		SetDParamStr(2, c->error->custom_message);
 		SetDParamStr(3, c->filename);
 		SetDParamStr(4, c->error->data);
-		for (uint i = 0; i < lengthof(c->error->param_value); i++) {
+		for (uint i = 0; i < c->error->param_value.size(); i++) {
 			SetDParam(5 + i, c->error->param_value[i]);
 		}
 		if (c->error->severity == STR_NEWGRF_ERROR_MSG_FATAL) {
@@ -75,7 +75,7 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 		SetDParamStr(0, c->error->custom_message); // is skipped by built-in messages
 		SetDParamStr(1, c->filename);
 		SetDParamStr(2, c->error->data);
-		for (uint i = 0; i < lengthof(c->error->param_value); i++) {
+		for (uint i = 0; i < c->error->param_value.size(); i++) {
 			SetDParam(3 + i, c->error->param_value[i]);
 		}
 		GetString(message, c->error->message != STR_NULL ? c->error->message : STR_JUST_RAW_STRING, lastof(message));

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -227,9 +227,9 @@ static size_t LookupManyOfMany(const std::vector<std::string> &many, const char 
  * @return returns the number of items found, or -1 on an error
  */
 template<typename T>
-static int ParseIntList(const char *p, T *items, int maxitems)
+static int ParseIntList(const char *p, T *items, size_t maxitems)
 {
-	int n = 0; // number of items read so far
+	size_t n = 0; // number of items read so far
 	bool comma = false; // do we accept comma?
 
 	while (*p != '\0') {
@@ -262,7 +262,7 @@ static int ParseIntList(const char *p, T *items, int maxitems)
 	 * We have read comma when (n != 0) and comma is not allowed */
 	if (n != 0 && !comma) return -1;
 
-	return n;
+	return ClampTo<int>(n);
 }
 
 /**
@@ -996,7 +996,7 @@ static GRFConfig *GRFLoadConfig(IniFile &ini, const char *grpname, bool is_stati
 
 		/* Parse parameters */
 		if (item->value.has_value() && !item->value->empty()) {
-			int count = ParseIntList(item->value->c_str(), c->param, lengthof(c->param));
+			int count = ParseIntList(item->value->c_str(), c->param.data(), c->param.size());
 			if (count < 0) {
 				SetDParamStr(0, filename);
 				ShowErrorMessage(STR_CONFIG_ERROR, STR_CONFIG_ERROR_ARRAY, WL_CRITICAL);


### PR DESCRIPTION
## Motivation / Problem

Use of C-style arrays requires liberal use memcpy/memcmp and knowledge of array lengths.

## Description

Use std::array instead. Let the compile handle it.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
