### PR TITLE
Codechange: migrate away from C-style Getstring

### DIFF
--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -356,10 +356,6 @@ CommandCost CheckTileOwnership(TileIndex tile)
  */
 static void GenerateCompanyName(Company *c)
 {
-	/* Reserve space for extra unicode character. We need to do this to be able
-	 * to detect too long company name. */
-	char buffer[(MAX_LENGTH_COMPANY_NAME_CHARS + 1) * MAX_CHAR_LENGTH];
-
 	if (c->name_1 != STR_SV_UNNAMED) return;
 	if (c->last_build_coordinate == 0) return;
 
@@ -367,6 +363,7 @@ static void GenerateCompanyName(Company *c)
 
 	StringID str;
 	uint32 strp;
+	std::string name;
 	if (t->name.empty() && IsInsideMM(t->townnametype, SPECSTR_TOWNNAME_START, SPECSTR_TOWNNAME_LAST + 1)) {
 		str = t->townnametype - SPECSTR_TOWNNAME_START + SPECSTR_COMPANY_NAME_START;
 		strp = t->townnameparts;
@@ -377,8 +374,8 @@ verify_name:;
 			if (cc->name_1 == str && cc->name_2 == strp) goto bad_town_name;
 		}
 
-		GetString(buffer, str, lastof(buffer));
-		if (Utf8StringLength(buffer) >= MAX_LENGTH_COMPANY_NAME_CHARS) goto bad_town_name;
+		name = GetString(str);
+		if (Utf8StringLength(name) >= MAX_LENGTH_COMPANY_NAME_CHARS) goto bad_town_name;
 
 set_name:;
 		c->name_1 = str;
@@ -499,18 +496,15 @@ restart:;
 
 		/* Reserve space for extra unicode character. We need to do this to be able
 		 * to detect too long president name. */
-		char buffer[(MAX_LENGTH_PRESIDENT_NAME_CHARS + 1) * MAX_CHAR_LENGTH];
 		SetDParam(0, c->index);
-		GetString(buffer, STR_PRESIDENT_NAME, lastof(buffer));
-		if (Utf8StringLength(buffer) >= MAX_LENGTH_PRESIDENT_NAME_CHARS) continue;
+		std::string name = GetString(STR_PRESIDENT_NAME);
+		if (Utf8StringLength(name) >= MAX_LENGTH_PRESIDENT_NAME_CHARS) continue;
 
 		for (const Company *cc : Company::Iterate()) {
 			if (c != cc) {
-				/* Reserve extra space so even overlength president names can be compared. */
-				char buffer2[(MAX_LENGTH_PRESIDENT_NAME_CHARS + 1) * MAX_CHAR_LENGTH];
 				SetDParam(0, cc->index);
-				GetString(buffer2, STR_PRESIDENT_NAME, lastof(buffer2));
-				if (strcmp(buffer2, buffer) == 0) goto restart;
+				std::string other_name = GetString(STR_PRESIDENT_NAME);
+				if (name == other_name) goto restart;
 			}
 		}
 		return;

--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -1717,9 +1717,8 @@ DEF_CONSOLE_CMD(ConCompanies)
 
 	for (const Company *c : Company::Iterate()) {
 		/* Grab the company name */
-		char company_name[512];
 		SetDParam(0, c->index);
-		GetString(company_name, STR_COMPANY_NAME, lastof(company_name));
+		std::string company_name = GetString(STR_COMPANY_NAME);
 
 		const char *password_state = "";
 		if (c->is_ai) {
@@ -1728,8 +1727,7 @@ DEF_CONSOLE_CMD(ConCompanies)
 			password_state = _network_company_states[c->index].password.empty() ? "unprotected" : "protected";
 		}
 
-		char colour[512];
-		GetString(colour, STR_COLOUR_DARK_BLUE + _company_colours[c->index], lastof(colour));
+		std::string colour = GetString(STR_COLOUR_DARK_BLUE + _company_colours[c->index]);
 		IConsolePrint(CC_INFO, "#:{}({}) Company Name: '{}'  Year Founded: {}  Money: {}  Loan: {}  Value: {}  (T:{}, R:{}, P:{}, S:{}) {}",
 			c->index + 1, colour, company_name,
 			c->inaugurated_year, (int64)c->money, (int64)c->current_loan, (int64)CalculateCompanyValue(c),

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -682,9 +682,7 @@ int DrawString(int left, int right, int top, std::string_view str, TextColour co
  */
 int DrawString(int left, int right, int top, StringID str, TextColour colour, StringAlignment align, bool underline, FontSize fontsize)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	GetString(buffer, str, lastof(buffer));
-	return DrawString(left, right, top, buffer, colour, align, underline, fontsize);
+	return DrawString(left, right, top, GetString(str), colour, align, underline, fontsize);
 }
 
 /**
@@ -707,9 +705,7 @@ int GetStringHeight(std::string_view str, int maxw, FontSize fontsize)
  */
 int GetStringHeight(StringID str, int maxw)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	GetString(buffer, str, lastof(buffer));
-	return GetStringHeight(buffer, maxw);
+	return GetStringHeight(GetString(str), maxw);
 }
 
 /**
@@ -720,10 +716,7 @@ int GetStringHeight(StringID str, int maxw)
  */
 int GetStringLineCount(StringID str, int maxw)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	GetString(buffer, str, lastof(buffer));
-
-	Layouter layout(buffer, maxw);
+	Layouter layout(GetString(str), maxw);
 	return (uint)layout.size();
 }
 
@@ -831,9 +824,7 @@ int DrawStringMultiLine(int left, int right, int top, int bottom, std::string_vi
  */
 int DrawStringMultiLine(int left, int right, int top, int bottom, StringID str, TextColour colour, StringAlignment align, bool underline, FontSize fontsize)
 {
-	char buffer[DRAW_STRING_BUFFER];
-	GetString(buffer, str, lastof(buffer));
-	return DrawStringMultiLine(left, right, top, bottom, buffer, colour, align, underline, fontsize);
+	return DrawStringMultiLine(left, right, top, bottom, GetString(str), colour, align, underline, fontsize);
 }
 
 /**
@@ -860,10 +851,7 @@ Dimension GetStringBoundingBox(std::string_view str, FontSize start_fontsize)
  */
 Dimension GetStringBoundingBox(StringID strid, FontSize start_fontsize)
 {
-	char buffer[DRAW_STRING_BUFFER];
-
-	GetString(buffer, strid, lastof(buffer));
-	return GetStringBoundingBox(buffer, start_fontsize);
+	return GetStringBoundingBox(GetString(strid), start_fontsize);
 }
 
 /**

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -27,6 +27,7 @@
 #include "company_base.h"
 #include "error.h"
 #include "strings_func.h"
+#include "string_func.h"
 
 #include "table/strings.h"
 
@@ -508,16 +509,12 @@ void ErrorUnknownCallbackResult(uint32 grfid, uint16 cbid, uint16 cb_res)
 	}
 
 	/* debug output */
-	char buffer[512];
-
 	SetDParamStr(0, grfconfig->GetName());
-	GetString(buffer, STR_NEWGRF_BUGGY, lastof(buffer));
-	Debug(grf, 0, "{}", buffer + 3);
+	Debug(grf, 0, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY)));
 
 	SetDParam(1, cbid);
 	SetDParam(2, cb_res);
-	GetString(buffer, STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT, lastof(buffer));
-	Debug(grf, 0, "{}", buffer + 3);
+	Debug(grf, 0, "{}", StrMakeValid(GetString(STR_NEWGRF_BUGGY_UNKNOWN_CALLBACK_RESULT)));
 }
 
 /**

--- a/src/news_gui.cpp
+++ b/src/news_gui.cpp
@@ -1099,37 +1099,13 @@ void ShowLastNewsMessage()
  */
 static void DrawNewsString(uint left, uint right, int y, TextColour colour, const NewsItem *ni)
 {
-	char buffer[512], buffer2[512];
-	StringID str;
-
 	CopyInDParam(0, ni->params, lengthof(ni->params));
-	str = ni->string_id;
 
-	GetString(buffer, str, lastof(buffer));
-	/* Copy the just gotten string to another buffer to remove any formatting
-	 * from it such as big fonts, etc. */
-	const char *ptr = buffer;
-	char *dest = buffer2;
-	WChar c_last = '\0';
-	for (;;) {
-		WChar c = Utf8Consume(&ptr);
-		if (c == 0) break;
-		/* Make a space from a newline, but ignore multiple newlines */
-		if (c == '\n' && c_last != '\n') {
-			dest[0] = ' ';
-			dest++;
-		} else if (c == '\r') {
-			dest[0] = dest[1] = dest[2] = dest[3] = ' ';
-			dest += 4;
-		} else if (IsPrintable(c)) {
-			dest += Utf8Encode(dest, c);
-		}
-		c_last = c;
-	}
+	/* Get the string, replaces newlines with spaces and remove control codes from the string. */
+	std::string message = StrMakeValid(GetString(ni->string_id), SVS_REPLACE_TAB_CR_NL_WITH_SPACE);
 
-	*dest = '\0';
 	/* Truncate and show string; postfixed by '...' if necessary */
-	DrawString(left, right, y, buffer2, colour);
+	DrawString(left, right, y, message, colour);
 }
 
 struct MessageHistoryWindow : Window {

--- a/src/script/api/script_text.cpp
+++ b/src/script/api/script_text.cpp
@@ -250,8 +250,6 @@ const std::string Text::GetDecodedText()
 {
 	const std::string &encoded_text = this->GetEncodedText();
 
-	static char buf[1024];
 	::SetDParamStr(0, encoded_text);
-	::GetString(buf, STR_JUST_RAW_STRING, lastof(buf));
-	return buf;
+	return ::GetString(STR_JUST_RAW_STRING);
 }

--- a/src/statusbar_gui.cpp
+++ b/src/statusbar_gui.cpp
@@ -40,39 +40,18 @@
 static bool DrawScrollingStatusText(const NewsItem *ni, int scroll_pos, int left, int right, int top, int bottom)
 {
 	CopyInDParam(0, ni->params, lengthof(ni->params));
-	StringID str = ni->string_id;
 
-	char buf[512];
-	GetString(buf, str, lastof(buf));
-	const char *s = buf;
-
-	char buffer[256];
-	char *d = buffer;
-	const char *last = lastof(buffer);
-
-	for (;;) {
-		WChar c = Utf8Consume(&s);
-		if (c == 0) {
-			break;
-		} else if (c == '\n') {
-			if (d + 4 >= last) break;
-			d[0] = d[1] = d[2] = d[3] = ' ';
-			d += 4;
-		} else if (IsPrintable(c)) {
-			if (d + Utf8CharLen(c) >= last) break;
-			d += Utf8Encode(d, c);
-		}
-	}
-	*d = '\0';
+	/* Replace newlines and the likes with spaces. */
+	std::string message = StrMakeValid(GetString(ni->string_id), SVS_REPLACE_TAB_CR_NL_WITH_SPACE);
 
 	DrawPixelInfo tmp_dpi;
 	if (!FillDrawPixelInfo(&tmp_dpi, left, top, right - left, bottom)) return true;
 
-	int width = GetStringBoundingBox(buffer).width;
+	int width = GetStringBoundingBox(message).width;
 	int pos = (_current_text_dir == TD_RTL) ? (scroll_pos - width) : (right - scroll_pos - left);
 
 	AutoRestoreBackup dpi_backup(_cur_dpi, &tmp_dpi);
-	DrawString(pos, INT16_MAX, 0, buffer, TC_LIGHT_BLUE, SA_LEFT | SA_FORCE);
+	DrawString(pos, INT16_MAX, 0, message, TC_LIGHT_BLUE, SA_LEFT | SA_FORCE);
 
 	return (_current_text_dir == TD_RTL) ? (pos < right - left) : (pos + width > 0);
 }

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -155,8 +155,8 @@ void CopyOutDParam(uint64 *dst, int offs, int num)
  */
 void CopyOutDParam(uint64 *dst, const char **strings, StringID string, int num)
 {
-	char buf[DRAW_STRING_BUFFER];
-	GetString(buf, string, lastof(buf));
+	/* Just get the string to extract the type information. */
+	GetString(string);
 
 	MemCpyT(dst, _global_string_params.GetPointerToOffset(0), num);
 	for (int i = 0; i < num; i++) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -315,15 +315,11 @@ void ShowNewGrfVehicleError(EngineID engine, StringID part1, StringID part2, GRF
 	}
 
 	/* debug output */
-	char buffer[512];
-
 	SetDParamStr(0, grfconfig->GetName());
-	GetString(buffer, part1, lastof(buffer));
-	Debug(grf, 0, "{}", buffer + 3);
+	Debug(grf, 0, "{}", StrMakeValid(GetString(part1)));
 
 	SetDParam(1, engine);
-	GetString(buffer, part2, lastof(buffer));
-	Debug(grf, 0, "{}", buffer + 3);
+	Debug(grf, 0, "{}", StrMakeValid(GetString(part2)));
 }
 
 /**

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1449,17 +1449,15 @@ void ViewportSign::UpdatePosition(int center, int top, StringID str, StringID st
 
 	this->top = top;
 
-	char buffer[DRAW_STRING_BUFFER];
-
-	GetString(buffer, str, lastof(buffer));
-	this->width_normal = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(buffer).width, 2) + WidgetDimensions::scaled.fullbevel.right;
+	std::string name = GetString(str);
+	this->width_normal = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(name).width, 2) + WidgetDimensions::scaled.fullbevel.right;
 	this->center = center;
 
 	/* zoomed out version */
 	if (str_small != STR_NULL) {
-		GetString(buffer, str_small, lastof(buffer));
+		name = GetString(str_small);
 	}
-	this->width_small = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(buffer, FS_SMALL).width, 2) + WidgetDimensions::scaled.fullbevel.right;
+	this->width_small = WidgetDimensions::scaled.fullbevel.left + Align(GetStringBoundingBox(name, FS_SMALL).width, 2) + WidgetDimensions::scaled.fullbevel.right;
 
 	this->MarkDirty();
 }


### PR DESCRIPTION
## Motivation / Problem

Migration to more C++-style strings.


## Description

Replace `GetString(buffer, str, lastof(buffer))` with something like `std::string message = GetString(str)`.

In some cases, where there is filtering happening on the string afterwards to remove/replace certain characters, just pass it through `StrMakeValid` to remove these characters (color/font size) or replace (\r \n to space). This currently happened only for the first character at the front, but now it will remove any color/font encoding character.


## Limitations

There is more to be changed, but lets keep it in reviewable portions.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
