### PR TITLE
Codechange: Use display list instead of exclude list for file window.

### DIFF
--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -800,7 +800,7 @@ public:
 		} else {
 			for (auto &it : this->fios_items) {
 				this->string_filter.ResetState();
-				this->string_filter.AddLine(it.title.c_str());
+				this->string_filter.AddLine(it.title);
 				/* We set the vector to show this fios element as filtered depending on the result of the filter */
 				if (this->string_filter.GetState()) {
 					this->display_list.push_back(&it);


### PR DESCRIPTION
## Motivation / Problem

Iterating the File window, and working out the current item from the row, is complicated by filtering being a separate exclude list.

## Description

Replace the exclude list with a list of displayed items.

This simplifies retrieving the correct data for each row when data is filtered. The background FileList is left intact so that savegame data does not have to be rescanned when the filter is changed, and sorting still remains the task of the background FileList.


<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
