### PR TITLE
Fix #10846: [Squirrel] Ensure sqvector size does not overflow

### DIFF
--- a/src/3rdparty/squirrel/squirrel/squtils.h
+++ b/src/3rdparty/squirrel/squirrel/squtils.h
@@ -2,6 +2,9 @@
 #ifndef _SQUTILS_H_
 #define _SQUTILS_H_
 
+#include "../../fmt/format.h"
+#include "../../../script/script_fatalerror.hpp"
+
 void *sq_vm_malloc(SQUnsignedInteger size);
 void *sq_vm_realloc(void *p,SQUnsignedInteger oldsize,SQUnsignedInteger size);
 void sq_vm_free(void *p,SQUnsignedInteger size);
@@ -102,6 +105,10 @@ private:
 	void _realloc(SQUnsignedInteger newsize)
 	{
 		newsize = (newsize > 0)?newsize:4;
+		if (newsize > SIZE_MAX / sizeof(T)) {
+			std::string msg = fmt::format("cannot resize to {}", newsize);
+			throw Script_FatalError(msg);
+		}
 		_vals = (T*)SQ_REALLOC(_vals, _allocated * sizeof(T), newsize * sizeof(T));
 		_allocated = (size_t)newsize;
 	}


### PR DESCRIPTION
Fixes #10846

## Motivation / Problem
`array(4611686018427387904)` implies allocating 4611686018427387904 * 16 (size of `SQObjectPtr`) and that is 0 in 64bit world.
And as there is no check for overflow we happily allocate 0 bytes of memory and use it like if we allocated the expected number of elements.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
Check for overflow of `newsize * sizeof(T)` when reallocating `sqvector`.
As `sqvector` is deep inside squirrel we don't have access to the VM and the only way to signal the error is throwing an exception. The only catchable exception without adding special handling inside squirrel itself, SQVM catches `...` and rethrows, is `Script_FatalError` so I used it.

Adding overflow check in https://github.com/OpenTTD/OpenTTD/blob/master/src/3rdparty/squirrel/squirrel/sqbaselib.cpp#L217 could work for `array()` but would not protect when resizing the array after its creation, like in
```
local x = array(10);
x.resize(4611686018427387904);
```
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
Squirrel compiler also uses `sqvector` but it only catches `SQChar *`, so throwing something else might be an issue. Anyway compiler is less likely to try to allocate enough to trigger an overflow.
<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
