### PR TITLE
Add: Ctrl+click Rename on VehicleView to rename the group

### DIFF
--- a/src/group_cmd.h
+++ b/src/group_cmd.h
@@ -43,5 +43,6 @@ DEF_CMD_TRAIT(CMD_SET_GROUP_LIVERY,          CmdSetGroupLivery,         0, CMDT_
 
 void CcCreateGroup(Commands cmd, const CommandCost &result, GroupID new_group, VehicleType vt, GroupID parent_group);
 void CcAddVehicleNewGroup(Commands cmd, const CommandCost &result, GroupID new_group, GroupID, VehicleID veh_id, bool);
+void CcRenameVehicleGroup(Commands cmd, const CommandCost &result, GroupID new_group, GroupID, VehicleID veh_id, bool);
 
 #endif /* GROUP_CMD_H */

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4255,10 +4255,10 @@ STR_VEHICLE_COMMAND_STARTED                                     :{GREEN}Started
 STR_VEHICLE_DETAILS_CAPTION                                     :{WHITE}{VEHICLE} (Details)
 
 ###length VEHICLE_TYPES
-STR_VEHICLE_DETAILS_TRAIN_RENAME                                :{BLACK}Name train
-STR_VEHICLE_DETAILS_ROAD_VEHICLE_RENAME                         :{BLACK}Name road vehicle
-STR_VEHICLE_DETAILS_SHIP_RENAME                                 :{BLACK}Name ship
-STR_VEHICLE_DETAILS_AIRCRAFT_RENAME                             :{BLACK}Name aircraft
+STR_VEHICLE_DETAILS_TRAIN_RENAME                                :{BLACK}Name train. Ctrl+Click names its group
+STR_VEHICLE_DETAILS_ROAD_VEHICLE_RENAME                         :{BLACK}Name road vehicle. Ctrl+Click names its group
+STR_VEHICLE_DETAILS_SHIP_RENAME                                 :{BLACK}Name ship. Ctrl+Click names its group
+STR_VEHICLE_DETAILS_AIRCRAFT_RENAME                             :{BLACK}Name aircraft. Ctrl+Click names its group
 
 STR_VEHICLE_INFO_AGE_RUNNING_COST_YR                            :{BLACK}Age: {LTBLUE}{STRING2}{BLACK}   Running Cost: {LTBLUE}{CURRENCY_LONG}/yr
 STR_VEHICLE_INFO_AGE                                            :{COMMA} year{P "" s} ({COMMA})

--- a/src/network/network_command.cpp
+++ b/src/network/network_command.cpp
@@ -82,7 +82,8 @@ static constexpr auto _callback_tuple = std::make_tuple(
 	&CcBuildIndustry,
 	&CcStartStopVehicle,
 	&CcGame,
-	&CcAddVehicleNewGroup
+	&CcAddVehicleNewGroup,
+	&CcRenameVehicleGroup
 );
 
 #ifdef SILENCE_GCC_FUNCTION_POINTER_CAST


### PR DESCRIPTION
## Motivation / Problem

I like to assign a group to all my vehicles so that they all appear named and can be easily managed in bulks after I create duplicate vehicles. Duplicating specifically-named vehicles copies the name, but then duplicated vehicles cannot be easily renamed at once.

Currently, I have to open the vehicle list window, create a group, move my vehicle into it, for every new line. This is tedious enough that I sometimes give up, but then I cannot tell which vehicle is which in vehicle lists.

## Description

In the vehicle view window, the user can name a specific vehicle using the pencil icon. I have extended its behavior so that shift-clicking renames its group instead. If a vehicle has not group, a new group is automatically created containing the vehicle and vehicles sharing its orders.

This feature makes it trivial to create groups for new bus lines without even having to open the vehicle list window. Since unnamed vehicles inherit the name of their group, ~~shift-clicking~~ ctrl-clicking the pencil icon will still have the effect of renaming the vehicle, which makes this approach intuitive in my opinion.

This feature should not negatively impact anyone’s existing workflow since it can hardly be accidentally triggered, and brings no clutter to the UI except for one longer tooltip.

## Limitations

~~I assumed that when the user creates a group for a vehicle, they always expect vehicles sharing orders to follow.~~ Only the current vehicle is added to the new group.

Clicking Default in the query string window when creating a new group cancels the creation instead of creating a default-named group. I suspect this is a behavior of ShowQueryString.

Cancelling the renaming will still create a group if the vehicle was ungrouped, pretty much like cancelling a group creation leaves a default-named group.

## Checklist for review

Nothing special.
