### PR TITLE
Fix: survey result on crash only worked on Linux

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -454,6 +454,13 @@ bool CrashLog::WriteScreenshot(char *filename, const char *filename_last) const
 	return res;
 }
 
+void CrashLog::SendSurvey() const
+{
+	if (_game_mode == GM_NORMAL) {
+		_survey.Transmit(NetworkSurveyHandler::Reason::CRASH, true);
+	}
+}
+
 /**
  * Makes the crash log, writes it to a file and then subsequently tries
  * to make a crash dump and crash savegame. It uses DEBUG to write
@@ -512,9 +519,7 @@ bool CrashLog::MakeCrashLog() const
 		printf("Writing crash screenshot failed.\n\n");
 	}
 
-	if (_game_mode == GM_NORMAL) {
-		_survey.Transmit(NetworkSurveyHandler::Reason::CRASH, true);
-	}
+	this->SendSurvey();
 
 	return ret;
 }

--- a/src/crashlog.h
+++ b/src/crashlog.h
@@ -99,6 +99,8 @@ public:
 	bool WriteSavegame(char *filename, const char *filename_last) const;
 	bool WriteScreenshot(char *filename, const char *filename_last) const;
 
+	void SendSurvey() const;
+
 	bool MakeCrashLog() const;
 
 	/**

--- a/src/os/macosx/crashlog_osx.cpp
+++ b/src/os/macosx/crashlog_osx.cpp
@@ -192,6 +192,8 @@ public:
 			ret = false;
 		}
 
+		this->SendSurvey();
+
 		return ret;
 	}
 

--- a/src/os/windows/crashlog_win.cpp
+++ b/src/os/windows/crashlog_win.cpp
@@ -564,6 +564,7 @@ static LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS *ep)
 	log->AppendDecodedStacktrace(buf, lastof(log->crashlog));
 	log->WriteCrashLog(log->crashlog, log->crashlog_filename, lastof(log->crashlog_filename));
 	log->WriteScreenshot(log->screenshot_filename, lastof(log->screenshot_filename));
+	log->SendSurvey();
 
 	/* Close any possible log files */
 	CloseConsoleLogIfActive();


### PR DESCRIPTION
## Motivation / Problem

@rubidium42 noticed the survey results couldn't possibly work on Windows.

## Description

Every OS-specific crashlog handler has their own MakeCrashLog in some form. In result, only Linux was calling the generic one.

So instead, abstract sending the survey results a bit, and call it from everywhere.

PS: actually tested if Windows could send a survey on crash, but it can do that just fine :)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
