### PR TITLE
Cleanup: version of strgen/settingsgen was always $Revision$, so remove it

### DIFF
--- a/src/settingsgen/settingsgen.cpp
+++ b/src/settingsgen/settingsgen.cpp
@@ -400,7 +400,6 @@ static bool CompareFiles(const char *n1, const char *n2)
 
 /** Options of settingsgen. */
 static const OptionData _opts[] = {
-	  GETOPT_NOVAL(     'v', "--version"),
 	  GETOPT_NOVAL(     'h', "--help"),
 	GETOPT_GENERAL('h', '?', nullptr, ODF_NO_VALUE),
 	  GETOPT_VALUE(     'o', "--output"),
@@ -455,15 +454,10 @@ int CDECL main(int argc, char *argv[])
 		if (i == -1) break;
 
 		switch (i) {
-			case 'v':
-				fmt::print("$Revision$\n");
-				return 0;
-
 			case 'h':
-				fmt::print("settingsgen - $Revision$\n"
+				fmt::print("settingsgen\n"
 						"Usage: settingsgen [options] ini-file...\n"
 						"with options:\n"
-						"   -v, --version           Print version information and exit\n"
 						"   -h, -?, --help          Print this help message and exit\n"
 						"   -b FILE, --before FILE  Copy FILE before all settings\n"
 						"   -a FILE, --after FILE   Copy FILE after all settings\n"

--- a/src/strgen/strgen.cpp
+++ b/src/strgen/strgen.cpp
@@ -397,7 +397,6 @@ static inline char *replace_pathsep(char *s) { return s; }
 
 /** Options of strgen. */
 static const OptionData _opts[] = {
-	  GETOPT_NOVAL(     'v',  "--version"),
 	GETOPT_GENERAL('C', '\0', "-export-commands", ODF_NO_VALUE),
 	GETOPT_GENERAL('L', '\0', "-export-plurals",  ODF_NO_VALUE),
 	GETOPT_GENERAL('P', '\0', "-export-pragmas",  ODF_NO_VALUE),
@@ -422,10 +421,6 @@ int CDECL main(int argc, char *argv[])
 		if (i == -1) break;
 
 		switch (i) {
-			case 'v':
-				fmt::print("$Revision$\n");
-				return 0;
-
 			case 'C':
 				fmt::print("args\tflags\tcommand\treplacement\n");
 				for (const CmdStruct *cs = _cmd_structs; cs < endof(_cmd_structs); cs++) {
@@ -468,8 +463,7 @@ int CDECL main(int argc, char *argv[])
 
 			case 'h':
 				fmt::print(
-					"strgen - $Revision$\n"
-					" -v | --version    print version information and exit\n"
+					"strgen\n"
 					" -t | --todo       replace any untranslated strings with '<TODO>'\n"
 					" -w | --warning    print a warning for any untranslated strings\n"
 					" -h | -? | --help  print this help message and exit\n"


### PR DESCRIPTION
## Motivation / Problem

A long time ago we used subversion which replaced `$Revision$` with the actual revision. Since git that has changed, so since then it always has been literally `$Revision$`.


## Description

Since adding `rev.cpp` in the build is quite a hassle to get working, with lots of duplicated CMake code and/or updating to way newer versions of CMake, just removing the version seems to be the simplest and most reliable solution.


## Limitations

No external tools can get the version of strgen/settingsgen, but that data has been useless for a very long time.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
