### PR TITLE
Change: Remember waypoint filter string.

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -2001,9 +2001,9 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 	const StationClass *waypoints;
 	WaypointList list;
 	StringFilter string_filter; ///< Filter for waypoint name
-	QueryString editbox;        ///< Filter editbox
+	static QueryString editbox; ///< Filter editbox
 
-	BuildRailWaypointWindow(WindowDesc *desc, Window *parent) : PickerWindowBase(desc, parent), editbox(FILTER_LENGTH * MAX_CHAR_LENGTH, FILTER_LENGTH)
+	BuildRailWaypointWindow(WindowDesc *desc, Window *parent) : PickerWindowBase(desc, parent)
 	{
 		this->waypoints = StationClass::Get(STAT_CLASS_WAYP);
 
@@ -2016,6 +2016,7 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 
 		this->querystrings[WID_BRW_FILTER] = &this->editbox;
 		this->editbox.cancel_button = QueryString::ACTION_CLEAR;
+		this->string_filter.SetFilterTerm(this->editbox.text.buf);
 
 		this->list.ForceRebuild();
 		this->BuildPickerList();
@@ -2169,6 +2170,8 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 		}
 	}
 };
+
+/* static */ QueryString BuildRailWaypointWindow::editbox(BuildRailWaypointWindow::FILTER_LENGTH * MAX_CHAR_LENGTH, BuildRailWaypointWindow::FILTER_LENGTH);
 
 /** Nested widget definition for the build NewGRF rail waypoint window */
 static const NWidgetPart _nested_build_waypoint_widgets[] = {


### PR DESCRIPTION
## Motivation / Problem

When building waypoints, switching build tools causes the waypoint filter string to be forgotten. As this window disappears when any other tool is selected this makes it a little awkward to use.

## Description

The filter string is now remembered between openings by making it static.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
