### PR TITLE
Codechange: Base CargoArray off std::array

### DIFF
--- a/src/articulated_vehicles.cpp
+++ b/src/articulated_vehicles.cpp
@@ -139,7 +139,7 @@ static inline CargoTypes GetAvailableVehicleCargoTypes(EngineID engine, bool inc
  */
 CargoArray GetCapacityOfArticulatedParts(EngineID engine)
 {
-	CargoArray capacity;
+	CargoArray capacity{};
 	const Engine *e = Engine::Get(engine);
 
 	CargoID cargo_type;
@@ -284,7 +284,7 @@ void CheckConsistencyOfArticulatedVehicle(const Vehicle *v)
 
 	CargoTypes real_refit_union = 0;
 	CargoTypes real_refit_intersection = ALL_CARGOTYPES;
-	CargoArray real_default_capacity;
+	CargoArray real_default_capacity{};
 
 	do {
 		CargoTypes refit_mask = GetAvailableVehicleCargoTypes(v->engine_type, true);

--- a/src/cargo_type.h
+++ b/src/cargo_type.h
@@ -79,41 +79,7 @@ typedef uint64 CargoTypes;
 static const CargoTypes ALL_CARGOTYPES = (CargoTypes)UINT64_MAX;
 
 /** Class for storing amounts of cargo */
-struct CargoArray {
-private:
-	uint amount[NUM_CARGO]; ///< Amount of each type of cargo.
-
-public:
-	/** Default constructor. */
-	inline CargoArray()
-	{
-		this->Clear();
-	}
-
-	/** Reset all entries. */
-	inline void Clear()
-	{
-		memset(this->amount, 0, sizeof(this->amount));
-	}
-
-	/**
-	 * Read/write access to an amount of a specific cargo type.
-	 * @param cargo Cargo type to access.
-	 */
-	inline uint &operator[](CargoID cargo)
-	{
-		return this->amount[cargo];
-	}
-
-	/**
-	 * Read-only access to an amount of a specific cargo type.
-	 * @param cargo Cargo type to access.
-	 */
-	inline const uint &operator[](CargoID cargo) const
-	{
-		return this->amount[cargo];
-	}
-
+struct CargoArray : std::array<uint, NUM_CARGO> {
 	/**
 	 * Get the sum of all cargo amounts.
 	 * @return The sum.
@@ -121,24 +87,16 @@ public:
 	template <typename T>
 	inline const T GetSum() const
 	{
-		T ret = 0;
-		for (size_t i = 0; i < lengthof(this->amount); i++) {
-			ret += this->amount[i];
-		}
-		return ret;
+		return std::reduce(this->begin(), this->end(), T{});
 	}
 
 	/**
 	 * Get the amount of cargos that have an amount.
 	 * @return The amount.
 	 */
-	inline byte GetCount() const
+	inline uint GetCount() const
 	{
-		byte count = 0;
-		for (size_t i = 0; i < lengthof(this->amount); i++) {
-			if (this->amount[i] != 0) count++;
-		}
-		return count;
+		return std::count_if(this->begin(), this->end(), [](uint amount) { return amount != 0; });
 	}
 };
 

--- a/src/company_base.h
+++ b/src/company_base.h
@@ -22,7 +22,7 @@
 struct CompanyEconomyEntry {
 	Money income;               ///< The amount of income.
 	Money expenses;             ///< The amount of expenses.
-	CargoArray delivered_cargo; ///< The amount of delivered cargo.
+	CargoArray delivered_cargo{}; ///< The amount of delivered cargo.
 	int32 performance_history;  ///< Company score (scale 0-1000)
 	Money company_value;        ///< The value of the company.
 };

--- a/src/depot_gui.cpp
+++ b/src/depot_gui.cpp
@@ -855,7 +855,7 @@ struct DepotWindow : Window {
 
 		if (v == nullptr || mode != MODE_DRAG_VEHICLE) return false;
 
-		CargoArray capacity, loaded;
+		CargoArray capacity{}, loaded{};
 
 		/* Display info for single (articulated) vehicle, or for whole chain starting with selected vehicle */
 		bool whole_chain = (this->type == VEH_TRAIN && _ctrl_pressed);

--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1588,7 +1588,7 @@ static void LoadUnloadVehicle(Vehicle *front)
 
 	StationIDStack next_station = front->GetNextStoppingStation();
 	bool use_autorefit = front->current_order.IsRefit() && front->current_order.GetRefitCargo() == CT_AUTO_REFIT;
-	CargoArray consist_capleft;
+	CargoArray consist_capleft{};
 	if (_settings_game.order.improved_load && use_autorefit ?
 			front->cargo_payment == nullptr : (front->current_order.GetLoadType() & OLFB_FULL_LOAD) != 0) {
 		ReserveConsist(st, front,

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -167,7 +167,7 @@ public:
 
 		td.grf = nullptr;
 
-		CargoArray acceptance;
+		CargoArray acceptance{};
 		AddAcceptedCargo(tile, acceptance, nullptr);
 		GetTileDesc(tile, &td);
 

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -39,7 +39,7 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 	y += FONT_HEIGHT_NORMAL;
 
 	if (v->HasArticulatedPart()) {
-		CargoArray max_cargo;
+		CargoArray max_cargo{};
 		StringID subtype_text[NUM_CARGO];
 		char capacity[512];
 

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -513,7 +513,7 @@ static void ShowRejectOrAcceptNews(const Station *st, uint num_items, CargoID *c
  */
 CargoArray GetProductionAroundTiles(TileIndex north_tile, int w, int h, int rad)
 {
-	CargoArray produced;
+	CargoArray produced{};
 	std::set<IndustryID> industries;
 	TileArea ta = TileArea(north_tile, w, h).Expand(rad);
 
@@ -552,7 +552,7 @@ CargoArray GetProductionAroundTiles(TileIndex north_tile, int w, int h, int rad)
  */
 CargoArray GetAcceptanceAroundTiles(TileIndex center_tile, int w, int h, int rad, CargoTypes *always_accepted)
 {
-	CargoArray acceptance;
+	CargoArray acceptance{};
 	if (always_accepted != nullptr) *always_accepted = 0;
 
 	TileArea ta = TileArea(center_tile, w, h).Expand(rad);
@@ -574,7 +574,7 @@ CargoArray GetAcceptanceAroundTiles(TileIndex center_tile, int w, int h, int rad
  */
 static CargoArray GetAcceptanceAroundStation(const Station *st, CargoTypes *always_accepted)
 {
-	CargoArray acceptance;
+	CargoArray acceptance{};
 	if (always_accepted != nullptr) *always_accepted = 0;
 
 	BitmapTileIterator it(st->catchment_tiles);
@@ -596,7 +596,7 @@ void UpdateStationAcceptance(Station *st, bool show_msg)
 	CargoTypes old_acc = GetAcceptanceMask(st);
 
 	/* And retrieve the acceptance. */
-	CargoArray acceptance;
+	CargoArray acceptance{};
 	if (!st->rect.IsEmpty()) {
 		acceptance = GetAcceptanceAroundStation(st, &st->always_accepted);
 	}

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -74,6 +74,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <set>
 #include <stdexcept>

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -334,10 +334,7 @@ bool FindSubsidyTownCargoRoute()
 	/* Passenger subsidies are not handled here. */
 	town_cargo_produced[CT_PASSENGERS] = 0;
 
-	uint8 cargo_count = 0;
-	for (CargoID i = 0; i < NUM_CARGO; i++) {
-		if (town_cargo_produced[i] > 0) cargo_count++;
-	}
+	uint8 cargo_count = town_cargo_produced.GetCount();
 
 	/* No cargo produced at all? */
 	if (cargo_count == 0) return false;

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -323,7 +323,7 @@ bool FindSubsidyTownCargoRoute()
 	if (src_town->cache.population < SUBSIDY_CARGO_MIN_POPULATION) return false;
 
 	/* Calculate the produced cargo of houses around town center. */
-	CargoArray town_cargo_produced;
+	CargoArray town_cargo_produced{};
 	TileArea ta = TileArea(src_town->xy, 1, 1).Expand(SUBSIDY_TOWN_CARGO_RADIUS);
 	for (TileIndex tile : ta) {
 		if (IsTileType(tile, MP_HOUSE)) {
@@ -431,7 +431,7 @@ bool FindSubsidyCargoDestination(CargoID cid, SourceType src_type, SourceID src)
 			const Town *dst_town = Town::GetRandom();
 
 			/* Calculate cargo acceptance of houses around town center. */
-			CargoArray town_cargo_accepted;
+			CargoArray town_cargo_accepted{};
 			TileArea ta = TileArea(dst_town->xy, 1, 1).Expand(SUBSIDY_TOWN_CARGO_RADIUS);
 			for (TileIndex tile : ta) {
 				if (IsTileType(tile, MP_HOUSE)) {

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -322,10 +322,8 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 	int num = 0;
 
 	if (det_tab == TDW_TAB_TOTALS) { // Total cargo tab
-		CargoArray act_cargo{};
 		CargoArray max_cargo{};
 		for (const Vehicle *v = Vehicle::Get(veh_id); v != nullptr; v = v->Next()) {
-			act_cargo[v->cargo_type] += v->cargo.StoredCount();
 			max_cargo[v->cargo_type] += v->cargo_cap;
 		}
 

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -329,12 +329,7 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 			max_cargo[v->cargo_type] += v->cargo_cap;
 		}
 
-		/* Set scroll-amount separately from counting, as to not compute num double
-		 * for more carriages of the same type
-		 */
-		for (CargoID i = 0; i < NUM_CARGO; i++) {
-			if (max_cargo[i] > 0) num++; // only count carriages that the train has
-		}
+		num = max_cargo.GetCount();
 		num++; // needs one more because first line is description string
 	} else {
 		for (const Train *v = Train::Get(veh_id); v != nullptr; v = v->GetNextVehicle()) {

--- a/src/train_gui.cpp
+++ b/src/train_gui.cpp
@@ -322,8 +322,8 @@ int GetTrainDetailsWndVScroll(VehicleID veh_id, TrainDetailsWindowTabs det_tab)
 	int num = 0;
 
 	if (det_tab == TDW_TAB_TOTALS) { // Total cargo tab
-		CargoArray act_cargo;
-		CargoArray max_cargo;
+		CargoArray act_cargo{};
+		CargoArray max_cargo{};
 		for (const Vehicle *v = Vehicle::Get(veh_id); v != nullptr; v = v->Next()) {
 			act_cargo[v->cargo_type] += v->cargo.StoredCount();
 			max_cargo[v->cargo_type] += v->cargo_cap;
@@ -435,8 +435,8 @@ void DrawTrainDetails(const Train *v, const Rect &r, int vscroll_pos, uint16 vsc
 		}
 	} else {
 		int y = r.top;
-		CargoArray act_cargo;
-		CargoArray max_cargo;
+		CargoArray act_cargo{};
+		CargoArray max_cargo{};
 		Money feeder_share = 0;
 
 		for (const Vehicle *u = v; u != nullptr; u = u->Next()) {

--- a/src/vehicle_cmd.cpp
+++ b/src/vehicle_cmd.cpp
@@ -145,7 +145,7 @@ std::tuple<CommandCost, VehicleID, uint, uint16, CargoArray> CmdBuildVehicle(DoC
 	VehicleID veh_id = INVALID_VEHICLE;
 	uint refitted_capacity = 0;
 	uint16 refitted_mail_capacity = 0;
-	CargoArray cargo_capacities;
+	CargoArray cargo_capacities{};
 	if (value.Succeeded()) {
 		if (subflags & DC_EXEC) {
 			v->unitnumber = unit_num;
@@ -166,7 +166,6 @@ std::tuple<CommandCost, VehicleID, uint, uint16, CargoArray> CmdBuildVehicle(DoC
 				refitted_mail_capacity = 0;
 			} else {
 				refitted_capacity = e->GetDisplayDefaultCapacity(&refitted_mail_capacity);
-				cargo_capacities.Clear();
 				cargo_capacities[default_cargo] = refitted_capacity;
 				cargo_capacities[CT_MAIL] = refitted_mail_capacity;
 			}
@@ -355,7 +354,7 @@ static std::tuple<CommandCost, uint, uint16, CargoArray> RefitVehicle(Vehicle *v
 	uint total_capacity = 0;
 	uint total_mail_capacity = 0;
 	num_vehicles = num_vehicles == 0 ? UINT8_MAX : num_vehicles;
-	CargoArray cargo_capacities;
+	CargoArray cargo_capacities{};
 
 	VehicleSet vehicles_to_refit;
 	if (!only_this) {

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1375,7 +1375,7 @@ static bool VehicleProfitLastYearSorter(const Vehicle * const &a, const Vehicle 
 static bool VehicleCargoSorter(const Vehicle * const &a, const Vehicle * const &b)
 {
 	const Vehicle *v;
-	CargoArray diff;
+	CargoArray diff{};
 
 	/* Append the cargo of the connected waggons */
 	for (v = a; v != nullptr; v = v->Next()) diff[v->cargo_type] += v->cargo_cap;

--- a/src/vehicle_gui.h
+++ b/src/vehicle_gui.h
@@ -43,7 +43,7 @@ struct TestedEngineDetails {
 	CargoID cargo;        ///< Cargo type
 	uint capacity;        ///< Cargo capacity
 	uint16 mail_capacity; ///< Mail capacity if available
-	CargoArray all_capacities; ///< Capacities for all cargoes
+	CargoArray all_capacities{}; ///< Capacities for all cargoes
 
 	void FillDefaultCapacities(const Engine *e);
 };


### PR DESCRIPTION
## Motivation / Problem

CargoArray has a C array as a member and implements operators to allow access to it. 

It also uses MemSet to initialize itself.

## Description

Remove the array member and base CargoArray off std::array instead. This allows use of std::array's standard operators, and also allows value initialization instead of using MemSet.

The member functions that loop through the array have been replaced with iterator-based code instead.,

Second commit makes use of CargoArray::GetCount() where I could see counting being done.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
