### PR TITLE
Codechange: make StrongTypedef stronger

### DIFF
--- a/src/core/strong_typedef_type.hpp
+++ b/src/core/strong_typedef_type.hpp
@@ -35,14 +35,14 @@ struct StrongTypedef : StrongTypedefBase {
 
 	debug_inline constexpr StrongTypedef(const T &value) : value(value) {}
 
-	debug_inline constexpr Tthis &operator =(const StrongTypedef &rhs) { this->value = rhs.value; return static_cast<Tthis &>(*this); }
-	debug_inline constexpr Tthis &operator =(StrongTypedef &&rhs) { this->value = std::move(rhs.value); return static_cast<Tthis &>(*this); }
+	debug_inline constexpr Tthis &operator =(const Tthis &rhs) { this->value = rhs.value; return static_cast<Tthis &>(*this); }
+	debug_inline constexpr Tthis &operator =(Tthis &&rhs) { this->value = std::move(rhs.value); return static_cast<Tthis &>(*this); }
 	debug_inline constexpr Tthis &operator =(const T &rhs) { this->value = rhs; return static_cast<Tthis &>(*this); }
 
 	explicit constexpr operator T() const { return this->value; }
 
-	constexpr bool operator ==(const StrongTypedef &rhs) const { return this->value == rhs.value; }
-	constexpr bool operator !=(const StrongTypedef &rhs) const { return this->value != rhs.value; }
+	constexpr bool operator ==(const Tthis &rhs) const { return this->value == rhs.value; }
+	constexpr bool operator !=(const Tthis &rhs) const { return this->value != rhs.value; }
 	constexpr bool operator ==(const T &rhs) const { return this->value == rhs; }
 	constexpr bool operator !=(const T &rhs) const { return this->value != rhs; }
 };
@@ -62,8 +62,8 @@ struct StrongIntegralTypedef : StrongTypedef<T, Tthis> {
 
 	debug_inline constexpr StrongIntegralTypedef(const T &value) : StrongTypedef<T, Tthis>(value) {}
 
-	debug_inline constexpr Tthis &operator =(const StrongIntegralTypedef &rhs) { this->value = rhs.value; return static_cast<Tthis &>(*this); }
-	debug_inline constexpr Tthis &operator =(StrongIntegralTypedef &&rhs) { this->value = std::move(rhs.value); return static_cast<Tthis &>(*this); }
+	debug_inline constexpr Tthis &operator =(const Tthis &rhs) { this->value = rhs.value; return static_cast<Tthis &>(*this); }
+	debug_inline constexpr Tthis &operator =(Tthis &&rhs) { this->value = std::move(rhs.value); return static_cast<Tthis &>(*this); }
 	debug_inline constexpr Tthis &operator =(const T &rhs) { this->value = rhs; return static_cast<Tthis &>(*this); }
 
 	constexpr Tthis &operator ++() { this->value++; return static_cast<Tthis &>(*this); }


### PR DESCRIPTION
## Motivation / Problem

A compiler complaining, and then finding out that a `StrongTypedef` will happily compare with another `StrongTypedef` as long as the underlying types are allowed to be compared. Even when it's a completely different `StrongTypedef` instantiation.


## Description

Use Tthis instead of StrongTypedef for ==/=, so it does not compare/assign different strong typedefs except for its own type.


## Limitations

None


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
