### PR TITLE
Codechange: Add/use industry cargo helpers

### DIFF
--- a/src/economy.cpp
+++ b/src/economy.cpp
@@ -1017,12 +1017,9 @@ static uint DeliverGoodsToIndustry(const Station *st, CargoID cargo_type, uint n
 		Industry *ind = i.industry;
 		if (ind->index == source) continue;
 
-		uint cargo_index;
-		for (cargo_index = 0; cargo_index < lengthof(ind->accepts_cargo); cargo_index++) {
-			if (cargo_type == ind->accepts_cargo[cargo_index]) break;
-		}
+		int cargo_index = ind->GetCargoAcceptedIndex(cargo_type);
 		/* Check if matching cargo has been found */
-		if (cargo_index >= lengthof(ind->accepts_cargo)) continue;
+		if (cargo_index < 0) continue;
 
 		/* Check if industry temporarily refuses acceptance */
 		if (IndustryTemporarilyRefusesCargo(ind, cargo_type)) continue;

--- a/src/industry.h
+++ b/src/industry.h
@@ -131,6 +131,28 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 		return pos - this->accepts_cargo;
 	}
 
+	/** Test if this industry accepts any cargo.
+	 * @return true iff the industry accepts any cargo.
+	 */
+	bool IsCargoAccepted() const { return std::any_of(std::begin(this->accepts_cargo), std::end(this->accepts_cargo), [](const auto &cargo) { return IsValidCargoID(cargo); }); }
+
+	/** Test if this industry produces any cargo.
+	 * @return true iff the industry produces any cargo.
+	 */
+	bool IsCargoProduced() const { return std::any_of(std::begin(this->produced_cargo), std::end(this->produced_cargo), [](const auto &cargo) { return IsValidCargoID(cargo); }); }
+
+	/** Test if this industry accepts a specific cargo.
+	 * @param cargo Cargo type to test.
+	 * @return true iff the industry accepts the given cargo type.
+	 */
+	bool IsCargoAccepted(CargoID cargo) const { return std::any_of(std::begin(this->accepts_cargo), std::end(this->accepts_cargo), [&cargo](const auto &cid) { return cid == cargo; }); }
+
+	/** Test if this industry produces a specific cargo.
+	 * @param cargo Cargo type to test.
+	 * @return true iff the industry produces the given cargo types.
+	 */
+	bool IsCargoProduced(CargoID cargo) const { return std::any_of(std::begin(this->produced_cargo), std::end(this->produced_cargo), [&cargo](const auto &cid) { return cid == cargo; }); }
+
 	/**
 	 * Get the industry of the given tile
 	 * @param tile the tile to get the industry from

--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -460,16 +460,8 @@ static void AddAcceptedCargo_Industry(TileIndex tile, CargoArray &acceptance, Ca
 		/* Maybe set 'always accepted' bit (if it's not set already) */
 		if (HasBit(*always_accepted, a)) continue;
 
-		bool accepts = false;
-		for (uint cargo_index = 0; cargo_index < lengthof(ind->accepts_cargo); cargo_index++) {
-			/* Test whether the industry itself accepts the cargo type */
-			if (ind->accepts_cargo[cargo_index] == a) {
-				accepts = true;
-				break;
-			}
-		}
-
-		if (accepts) continue;
+		/* Test whether the industry itself accepts the cargo type */
+		if (ind->IsCargoAccepted(a)) continue;
 
 		/* If the industry itself doesn't accept this cargo, set 'always accepted' bit */
 		SetBit(*always_accepted, a);
@@ -2625,20 +2617,10 @@ static void CanCargoServiceIndustry(CargoID cargo, Industry *ind, bool *c_accept
 	if (!IsValidCargoID(cargo)) return;
 
 	/* Check for acceptance of cargo */
-	for (byte j = 0; j < lengthof(ind->accepts_cargo); j++) {
-		if (cargo == ind->accepts_cargo[j] && !IndustryTemporarilyRefusesCargo(ind, cargo)) {
-			*c_accepts = true;
-			break;
-		}
-	}
+	if (ind->IsCargoAccepted(cargo) && !IndustryTemporarilyRefusesCargo(ind, cargo)) *c_accepts = true;
 
 	/* Check for produced cargo */
-	for (byte j = 0; j < lengthof(ind->produced_cargo); j++) {
-		if (cargo == ind->produced_cargo[j]) {
-			*c_produces = true;
-			break;
-		}
-	}
+	if (ind->IsCargoProduced(cargo)) *c_produces = true;
 }
 
 /**

--- a/src/industry_gui.cpp
+++ b/src/industry_gui.cpp
@@ -1243,14 +1243,11 @@ static bool CDECL CargoFilter(const Industry * const *industry, const std::pair<
 			break;
 
 		case CF_NONE:
-			accepted_cargo_matches = std::all_of(std::begin((*industry)->accepts_cargo), std::end((*industry)->accepts_cargo), [](CargoID cargo) {
-				return !IsValidCargoID(cargo);
-			});
+			accepted_cargo_matches = !(*industry)->IsCargoAccepted();
 			break;
 
 		default:
-			const auto &ac = (*industry)->accepts_cargo;
-			accepted_cargo_matches = std::find(std::begin(ac), std::end(ac), accepted_cargo) != std::end(ac);
+			accepted_cargo_matches = (*industry)->IsCargoAccepted(accepted_cargo);
 			break;
 	}
 
@@ -1262,14 +1259,11 @@ static bool CDECL CargoFilter(const Industry * const *industry, const std::pair<
 			break;
 
 		case CF_NONE:
-			produced_cargo_matches = std::all_of(std::begin((*industry)->produced_cargo), std::end((*industry)->produced_cargo), [](CargoID cargo) {
-				return !IsValidCargoID(cargo);
-			});
+			produced_cargo_matches = !(*industry)->IsCargoProduced();
 			break;
 
 		default:
-			const auto &pc = (*industry)->produced_cargo;
-			produced_cargo_matches = std::find(std::begin(pc), std::end(pc), produced_cargo) != std::end(pc);
+			produced_cargo_matches = (*industry)->IsCargoProduced(produced_cargo);
 			break;
 	}
 

--- a/src/newgrf_industries.cpp
+++ b/src/newgrf_industries.cpp
@@ -680,7 +680,7 @@ void IndustryProductionCallback(Industry *ind, int reason)
  */
 bool IndustryTemporarilyRefusesCargo(Industry *ind, CargoID cargo_type)
 {
-	assert(std::find(ind->accepts_cargo, endof(ind->accepts_cargo), cargo_type) != endof(ind->accepts_cargo));
+	assert(ind->IsCargoAccepted(cargo_type));
 
 	const IndustrySpec *indspec = GetIndustrySpec(ind->type);
 	if (HasBit(indspec->callback_mask, CBM_IND_REFUSE_CARGO)) {

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -67,14 +67,10 @@
 
 	Industry *i = ::Industry::Get(industry_id);
 
-	for (byte j = 0; j < lengthof(i->accepts_cargo); j++) {
-		if (i->accepts_cargo[j] == cargo_id) {
-			if (IndustryTemporarilyRefusesCargo(i, cargo_id)) return CAS_TEMP_REFUSED;
-			return CAS_ACCEPTED;
-		}
-	}
+	if (!i->IsCargoAccepted(cargo_id)) return CAS_NOT_ACCEPTED;
+	if (IndustryTemporarilyRefusesCargo(i, cargo_id)) return CAS_TEMP_REFUSED;
 
-	return CAS_NOT_ACCEPTED;
+	return CAS_ACCEPTED;
 }
 
 /* static */ SQInteger ScriptIndustry::GetStockpiledCargo(IndustryID industry_id, CargoID cargo_id)

--- a/src/script/api/script_industry.cpp
+++ b/src/script/api/script_industry.cpp
@@ -82,15 +82,12 @@
 	if (!IsValidIndustry(industry_id)) return -1;
 	if (!ScriptCargo::IsValidCargo(cargo_id)) return -1;
 
-	Industry *ind = ::Industry::Get(industry_id);
-	for (uint i = 0; i < lengthof(ind->accepts_cargo); i++) {
-		CargoID cid = ind->accepts_cargo[i];
-		if (cid == cargo_id) {
-			return ind->incoming_cargo_waiting[i];
-		}
-	}
+	Industry *i = ::Industry::Get(industry_id);
 
-	return -1;
+	int j = i->GetCargoAcceptedIndex(cargo_id);
+	if (j < 0) return -1;
+
+	return i->incoming_cargo_waiting[j];
 }
 
 /* static */ SQInteger ScriptIndustry::GetLastMonthProduction(IndustryID industry_id, CargoID cargo_id)
@@ -100,11 +97,10 @@
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	for (byte j = 0; j < lengthof(i->produced_cargo); j++) {
-		if (i->produced_cargo[j] == cargo_id) return i->last_month_production[j];
-	}
+	int j = i->GetCargoProducedIndex(cargo_id);
+	if (j < 0) return -1;
 
-	return -1;
+	return i->last_month_production[j];
 }
 
 /* static */ SQInteger ScriptIndustry::GetLastMonthTransported(IndustryID industry_id, CargoID cargo_id)
@@ -114,11 +110,10 @@
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	for (byte j = 0; j < lengthof(i->produced_cargo); j++) {
-		if (i->produced_cargo[j] == cargo_id) return i->last_month_transported[j];
-	}
+	int j = i->GetCargoProducedIndex(cargo_id);
+	if (j < 0) return -1;
 
-	return -1;
+	return i->last_month_transported[j];
 }
 
 /* static */ SQInteger ScriptIndustry::GetLastMonthTransportedPercentage(IndustryID industry_id, CargoID cargo_id)
@@ -128,11 +123,10 @@
 
 	const Industry *i = ::Industry::Get(industry_id);
 
-	for (byte j = 0; j < lengthof(i->produced_cargo); j++) {
-		if (i->produced_cargo[j] == cargo_id) return ::ToPercent8(i->last_month_pct_transported[j]);
-	}
+	int j = i->GetCargoProducedIndex(cargo_id);
+	if (j < 0) return -1;
 
-	return -1;
+	return ::ToPercent8(i->last_month_pct_transported[j]);
 }
 
 /* static */ TileIndex ScriptIndustry::GetLocation(IndustryID industry_id)

--- a/src/script/api/script_industrylist.cpp
+++ b/src/script/api/script_industrylist.cpp
@@ -23,17 +23,13 @@ ScriptIndustryList::ScriptIndustryList()
 ScriptIndustryList_CargoAccepting::ScriptIndustryList_CargoAccepting(CargoID cargo_id)
 {
 	for (const Industry *i : Industry::Iterate()) {
-		for (byte j = 0; j < lengthof(i->accepts_cargo); j++) {
-			if (i->accepts_cargo[j] == cargo_id) this->AddItem(i->index);
-		}
+		if (i->IsCargoAccepted(cargo_id)) this->AddItem(i->index);
 	}
 }
 
 ScriptIndustryList_CargoProducing::ScriptIndustryList_CargoProducing(CargoID cargo_id)
 {
 	for (const Industry *i : Industry::Iterate()) {
-		for (byte j = 0; j < lengthof(i->produced_cargo); j++) {
-			if (i->produced_cargo[j] == cargo_id) this->AddItem(i->index);
-		}
+		if (i->IsCargoProduced(cargo_id)) this->AddItem(i->index);
 	}
 }

--- a/src/script/api/script_tilelist.cpp
+++ b/src/script/api/script_tilelist.cpp
@@ -83,13 +83,7 @@ ScriptTileList_IndustryAccepting::ScriptTileList_IndustryAccepting(IndustryID in
 	if (i->neutral_station != nullptr && !_settings_game.station.serve_neutral_industries) return;
 
 	/* Check if this industry accepts anything */
-	{
-		bool cargo_accepts = false;
-		for (byte j = 0; j < lengthof(i->accepts_cargo); j++) {
-			if (::IsValidCargoID(i->accepts_cargo[j])) cargo_accepts = true;
-		}
-		if (!cargo_accepts) return;
-	}
+	if (!i->IsCargoAccepted()) return;
 
 	if (!_settings_game.station.modified_catchment) radius = CA_UNMODIFIED;
 
@@ -123,11 +117,7 @@ ScriptTileList_IndustryProducing::ScriptTileList_IndustryProducing(IndustryID in
 	if (i->neutral_station != nullptr && !_settings_game.station.serve_neutral_industries) return;
 
 	/* Check if this industry produces anything */
-	bool cargo_produces = false;
-	for (byte j = 0; j < lengthof(i->produced_cargo); j++) {
-		if (::IsValidCargoID(i->produced_cargo[j])) cargo_produces = true;
-	}
-	if (!cargo_produces) return;
+	if (!i->IsCargoProduced()) return;
 
 	if (!_settings_game.station.modified_catchment) radius = CA_UNMODIFIED;
 

--- a/src/station.cpp
+++ b/src/station.cpp
@@ -405,11 +405,7 @@ void Station::AddIndustryToDeliver(Industry *ind, TileIndex tile)
 	}
 
 	/* Include only industries that can accept cargo */
-	uint cargo_index;
-	for (cargo_index = 0; cargo_index < lengthof(ind->accepts_cargo); cargo_index++) {
-		if (IsValidCargoID(ind->accepts_cargo[cargo_index])) break;
-	}
-	if (cargo_index >= lengthof(ind->accepts_cargo)) return;
+	if (!ind->IsCargoAccepted()) return;
 
 	this->industries_near.insert(IndustryListEntry{distance, ind});
 }

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -452,8 +452,7 @@ bool FindSubsidyCargoDestination(CargoID cid, SourceType src_type, SourceID src)
 			if (dst_ind == nullptr) return false;
 
 			/* The industry must accept the cargo */
-			bool valid = std::find(dst_ind->accepts_cargo, endof(dst_ind->accepts_cargo), cid) != endof(dst_ind->accepts_cargo);
-			if (!valid) return false;
+			if (!dst_ind->IsCargoAccepted(cid)) return false;
 
 			dst = dst_ind->index;
 			break;


### PR DESCRIPTION
## Motivation / Problem

Several bits of code manual loop through industry cargo arrays to do the same thing.

## Description

Add helpers to do the work for us, and to make it simpler to see what the loops are doing.

This is an offshoot of #10853 to simplify review and merging -- IMHO it is useful even alone.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
