### PR TITLE
Codechange: use std::string for formatting settings

### DIFF
--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -106,16 +106,13 @@ static auto &GenericSettingTables()
  */
 static void SurveySettingsTable(nlohmann::json &survey, const SettingTable &table, void *object)
 {
-	char buf[512];
 	for (auto &desc : table) {
 		const SettingDesc *sd = GetSettingDesc(desc);
 		/* Skip any old settings we no longer save/load. */
 		if (!SlIsObjectCurrentlyValid(sd->save.version_from, sd->save.version_to)) continue;
 
 		auto name = sd->GetName();
-		sd->FormatValue(buf, lastof(buf), object);
-
-		survey[name] = buf;
+		survey[name] = sd->FormatValue(object);
 	}
 }
 

--- a/src/settings_internal.h
+++ b/src/settings_internal.h
@@ -111,7 +111,7 @@ struct SettingDesc {
 	 * @param last The end of the buffer to format into.
 	 * @param object The object the setting is in.
 	 */
-	virtual void FormatValue(char *buf, const char *last, const void *object) const = 0;
+	virtual std::string FormatValue(const void *object) const = 0;
 
 	/**
 	 * Parse/read the value from the Ini item into the setting associated with this object.
@@ -178,7 +178,7 @@ struct IntSettingDesc : SettingDesc {
 	void MakeValueValidAndWrite(const void *object, int32 value) const;
 
 	virtual size_t ParseValue(const char *str) const;
-	void FormatValue(char *buf, const char *last, const void *object) const override;
+	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	int32 Read(const void *object) const;
@@ -198,7 +198,7 @@ struct BoolSettingDesc : IntSettingDesc {
 
 	bool IsBoolSetting() const override { return true; }
 	size_t ParseValue(const char *str) const override;
-	void FormatValue(char *buf, const char *last, const void *object) const override;
+	std::string FormatValue(const void *object) const override;
 };
 
 /** One of many setting. */
@@ -219,10 +219,10 @@ struct OneOfManySettingDesc : IntSettingDesc {
 	OnConvert *many_cnvt;          ///< callback procedure when loading value mechanism fails
 
 	static size_t ParseSingleValue(const char *str, size_t len, const std::vector<std::string> &many);
-	char *FormatSingleValue(char *buf, const char *last, uint id) const;
+	std::string FormatSingleValue(uint id) const;
 
 	size_t ParseValue(const char *str) const override;
-	void FormatValue(char *buf, const char *last, const void *object) const override;
+	std::string FormatValue(const void *object) const override;
 };
 
 /** Many of many setting. */
@@ -235,7 +235,7 @@ struct ManyOfManySettingDesc : OneOfManySettingDesc {
 			str_val, cat, pre_check, post_callback, many, many_cnvt) {}
 
 	size_t ParseValue(const char *str) const override;
-	void FormatValue(char *buf, const char *last, const void *object) const override;
+	std::string FormatValue(const void *object) const override;
 };
 
 /** String settings. */
@@ -268,7 +268,7 @@ struct StringSettingDesc : SettingDesc {
 	bool IsStringSetting() const override { return true; }
 	void ChangeValue(const void *object, std::string &newval) const;
 
-	void FormatValue(char *buf, const char *last, const void *object) const override;
+	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 	const std::string &Read(const void *object) const;
@@ -285,7 +285,7 @@ struct ListSettingDesc : SettingDesc {
 
 	const char *def;        ///< default value given when none is present
 
-	void FormatValue(char *buf, const char *last, const void *object) const override;
+	std::string FormatValue(const void *object) const override;
 	void ParseValue(const IniItem *item, void *object) const override;
 	bool IsSameValue(const IniItem *item, void *object) const override;
 };
@@ -295,7 +295,7 @@ struct NullSettingDesc : SettingDesc {
 	NullSettingDesc(const SaveLoad &save) :
 		SettingDesc(save, SF_NOT_IN_CONFIG, false) {}
 
-	void FormatValue(char *buf, const char *last, const void *object) const override { NOT_REACHED(); }
+	std::string FormatValue(const void *object) const override { NOT_REACHED(); }
 	void ParseValue(const IniItem *item, void *object) const override { NOT_REACHED(); }
 	bool IsSameValue(const IniItem *item, void *object) const override { NOT_REACHED(); }
 };


### PR DESCRIPTION
## Motivation / Problem

Settings code using `strecpy`.


## Description

Remove functions with `char *buf, const char *last` with variants that just return `std::string` instead.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
