### PR TITLE
Codechange: replace some char *buf, const char *last with std::string returning functions

### DIFF
--- a/src/gfxinit.cpp
+++ b/src/gfxinit.cpp
@@ -121,38 +121,29 @@ void CheckExternalFiles()
 
 	Debug(grf, 1, "Using the {} base graphics set", used_set->name);
 
-	static const size_t ERROR_MESSAGE_LENGTH = 256;
-	static const size_t MISSING_FILE_MESSAGE_LENGTH = 128;
-
-	/* Allocate for a message for each missing file and for one error
-	 * message per set.
-	 */
-	char error_msg[MISSING_FILE_MESSAGE_LENGTH * (GraphicsSet::NUM_FILES + SoundsSet::NUM_FILES) + 2 * ERROR_MESSAGE_LENGTH];
-	error_msg[0] = '\0';
-	char *add_pos = error_msg;
-	const char *last = lastof(error_msg);
-
+	std::string error_msg;
+	auto output_iterator = std::back_inserter(error_msg);
 	if (used_set->GetNumInvalid() != 0) {
 		/* Not all files were loaded successfully, see which ones */
-		add_pos += seprintf(add_pos, last, "Trying to load graphics set '%s', but it is incomplete. The game will probably not run correctly until you properly install this set or select another one. See section 4.1 of README.md.\n\nThe following files are corrupted or missing:\n", used_set->name.c_str());
+		fmt::format_to(output_iterator, "Trying to load graphics set '{}', but it is incomplete. The game will probably not run correctly until you properly install this set or select another one. See section 4.1 of README.md.\n\nThe following files are corrupted or missing:\n", used_set->name);
 		for (uint i = 0; i < GraphicsSet::NUM_FILES; i++) {
 			MD5File::ChecksumResult res = GraphicsSet::CheckMD5(&used_set->files[i], BASESET_DIR);
-			if (res != MD5File::CR_MATCH) add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", used_set->files[i].filename.c_str(), res == MD5File::CR_MISMATCH ? "corrupt" : "missing", used_set->files[i].missing_warning.c_str());
+			if (res != MD5File::CR_MATCH) fmt::format_to(output_iterator, "\t{} is {} ({})\n", used_set->files[i].filename, res == MD5File::CR_MISMATCH ? "corrupt" : "missing", used_set->files[i].missing_warning);
 		}
-		add_pos += seprintf(add_pos, last, "\n");
+		fmt::format_to(output_iterator, "\n");
 	}
 
 	const SoundsSet *sounds_set = BaseSounds::GetUsedSet();
 	if (sounds_set->GetNumInvalid() != 0) {
-		add_pos += seprintf(add_pos, last, "Trying to load sound set '%s', but it is incomplete. The game will probably not run correctly until you properly install this set or select another one. See section 4.1 of README.md.\n\nThe following files are corrupted or missing:\n", sounds_set->name.c_str());
+		fmt::format_to(output_iterator, "Trying to load sound set '{}', but it is incomplete. The game will probably not run correctly until you properly install this set or select another one. See section 4.1 of README.md.\n\nThe following files are corrupted or missing:\n", sounds_set->name);
 
 		static_assert(SoundsSet::NUM_FILES == 1);
 		/* No need to loop each file, as long as there is only a single
 		 * sound file. */
-		add_pos += seprintf(add_pos, last, "\t%s is %s (%s)\n", sounds_set->files->filename.c_str(), SoundsSet::CheckMD5(sounds_set->files, BASESET_DIR) == MD5File::CR_MISMATCH ? "corrupt" : "missing", sounds_set->files->missing_warning.c_str());
+		fmt::format_to(output_iterator, "\t{} is {} ({})\n", sounds_set->files->filename, SoundsSet::CheckMD5(sounds_set->files, BASESET_DIR) == MD5File::CR_MISMATCH ? "corrupt" : "missing", sounds_set->files->missing_warning);
 	}
 
-	if (add_pos != error_msg) ShowInfoI(error_msg);
+	if (!error_msg.empty()) ShowInfoI(error_msg);
 }
 
 /** Actually load the sprite tables. */

--- a/src/newgrf_config.cpp
+++ b/src/newgrf_config.cpp
@@ -714,18 +714,14 @@ GRFConfig *GetGRFConfig(uint32 grfid, uint32 mask)
 
 
 /** Build a string containing space separated parameter values, and terminate */
-char *GRFBuildParamList(char *dst, const GRFConfig *c, const char *last)
+std::string GRFBuildParamList(const GRFConfig *c)
 {
-	uint i;
-
-	/* Return an empty string if there are no parameters */
-	if (c->num_params == 0) return strecpy(dst, "", last);
-
-	for (i = 0; i < c->num_params; i++) {
-		if (i > 0) dst = strecpy(dst, " ", last);
-		dst += seprintf(dst, last, "%d", c->param[i]);
+	std::string result;
+	for (uint i = 0; i < c->num_params; i++) {
+		if (!result.empty()) result += ' ';
+		result += std::to_string(c->param[i]);
 	}
-	return dst;
+	return result;
 }
 
 /**

--- a/src/newgrf_config.h
+++ b/src/newgrf_config.h
@@ -220,7 +220,7 @@ void ClearGRFConfigList(GRFConfig **config);
 void ResetGRFConfig(bool defaults);
 GRFListCompatibility IsGoodGRFConfigList(GRFConfig *grfconfig);
 bool FillGRFDetails(GRFConfig *config, bool is_static, Subdirectory subdir = NEWGRF_DIR);
-char *GRFBuildParamList(char *dst, const GRFConfig *c, const char *last);
+std::string GRFBuildParamList(const GRFConfig *c);
 
 /* In newgrf_gui.cpp */
 void ShowNewGRFSettings(bool editable, bool show_params, bool exec_changes, GRFConfig **config);

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -112,10 +112,9 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 	/* Show GRF parameter list */
 	if (show_params) {
 		if (c->num_params > 0) {
-			char buff[256];
-			GRFBuildParamList(buff, c, lastof(buff));
+			std::string params = GRFBuildParamList(c);
 			SetDParam(0, STR_JUST_RAW_STRING);
-			SetDParamStr(1, buff);
+			SetDParamStr(1, params);
 		} else {
 			SetDParam(0, STR_NEWGRF_SETTINGS_PARAMETER_NONE);
 		}

--- a/src/roadveh_gui.cpp
+++ b/src/roadveh_gui.cpp
@@ -41,7 +41,6 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 	if (v->HasArticulatedPart()) {
 		CargoArray max_cargo{};
 		StringID subtype_text[NUM_CARGO];
-		char capacity[512];
 
 		memset(subtype_text, 0, sizeof(subtype_text));
 
@@ -53,23 +52,19 @@ void DrawRoadVehDetails(const Vehicle *v, const Rect &r)
 			}
 		}
 
-		GetString(capacity, STR_VEHICLE_DETAILS_TRAIN_ARTICULATED_RV_CAPACITY, lastof(capacity));
+		std::string capacity = GetString(STR_VEHICLE_DETAILS_TRAIN_ARTICULATED_RV_CAPACITY);
 
 		bool first = true;
 		for (CargoID i = 0; i < NUM_CARGO; i++) {
 			if (max_cargo[i] > 0) {
-				char buffer[128];
+				if (!first) capacity += ", ";
 
 				SetDParam(0, i);
 				SetDParam(1, max_cargo[i]);
-				GetString(buffer, STR_JUST_CARGO, lastof(buffer));
-
-				if (!first) strecat(capacity, ", ", lastof(capacity));
-				strecat(capacity, buffer, lastof(capacity));
+				capacity += GetString(STR_JUST_CARGO);
 
 				if (subtype_text[i] != 0) {
-					GetString(buffer, subtype_text[i], lastof(buffer));
-					strecat(capacity, buffer, lastof(capacity));
+					capacity += GetString(subtype_text[i]);
 				}
 
 				first = false;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1134,12 +1134,9 @@ static void GRFSaveConfig(IniFile &ini, const char *grpname, const GRFConfig *li
 	const GRFConfig *c;
 
 	for (c = list; c != nullptr; c = c->next) {
-		char params[512];
-		GRFBuildParamList(params, c, lastof(params));
-
 		std::string key = fmt::format("{:08X}|{}|{}", BSWAP32(c->ident.grfid),
 				FormatArrayAsHex(c->ident.md5sum), c->filename);
-		group->GetItem(key, true)->SetValue(params);
+		group->GetItem(key, true)->SetValue(GRFBuildParamList(c));
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

C-style buffers with `strecpy` and `strecat`.


## Description

Replace with more C++-style constructs.


## Limitations

Not that I'm aware of.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
