### PR TITLE
Change: Make cargo flow legend only show defined cargo.

### DIFF
--- a/src/linkgraph/linkgraph_gui.cpp
+++ b/src/linkgraph/linkgraph_gui.cpp
@@ -474,30 +474,32 @@ NWidgetBase *MakeSaturationLegendLinkGraphGUI(int *biggest_index)
 
 NWidgetBase *MakeCargoesLegendLinkGraphGUI(int *biggest_index)
 {
-	static const uint ENTRIES_PER_ROW = CeilDiv(NUM_CARGO, 5);
-	NWidgetVertical *panel = new NWidgetVertical(NC_EQUALSIZE);
-	NWidgetHorizontal *row = nullptr;
-	for (uint i = 0; i < NUM_CARGO; ++i) {
-		if (i % ENTRIES_PER_ROW == 0) {
-			if (row) panel->Add(row);
-			row = new NWidgetHorizontal(NC_EQUALSIZE);
+	uint num_cargo = static_cast<uint>(_sorted_cargo_specs.size());
+	static const uint ENTRIES_PER_COL = 5;
+	NWidgetHorizontal *panel = new NWidgetHorizontal(NC_EQUALSIZE);
+	NWidgetVertical *col = nullptr;
+
+	for (uint i = 0; i < num_cargo; ++i) {
+		if (i % ENTRIES_PER_COL == 0) {
+			if (col != nullptr) panel->Add(col);
+			col = new NWidgetVertical(NC_EQUALSIZE);
 		}
 		NWidgetBackground * wid = new NWidgetBackground(WWT_PANEL, COLOUR_GREY, i + WID_LGL_CARGO_FIRST);
 		wid->SetMinimalSize(25, 0);
 		wid->SetMinimalTextLines(1, 0, FS_SMALL);
 		wid->SetFill(1, 1);
 		wid->SetResize(0, 0);
-		row->Add(wid);
+		col->Add(wid);
 	}
 	/* Fill up last row */
-	for (uint i = 0; i < 4 - (NUM_CARGO - 1) % 5; ++i) {
+	for (uint i = num_cargo; i < Ceil(num_cargo, ENTRIES_PER_COL); ++i) {
 		NWidgetSpacer *spc = new NWidgetSpacer(25, 0);
 		spc->SetMinimalTextLines(1, 0, FS_SMALL);
 		spc->SetFill(1, 1);
 		spc->SetResize(0, 0);
-		row->Add(spc);
+		col->Add(spc);
 	}
-	panel->Add(row);
+	panel->Add(col);
 	*biggest_index = WID_LGL_CARGO_LAST;
 	return panel;
 }
@@ -553,6 +555,8 @@ void ShowLinkGraphLegend()
 
 LinkGraphLegendWindow::LinkGraphLegendWindow(WindowDesc *desc, int window_number) : Window(desc)
 {
+	this->num_cargo = _sorted_cargo_specs.size();
+
 	this->InitNested(window_number);
 	this->InvalidateData(0);
 	this->SetOverlay(GetMainWindow()->viewport->overlay);
@@ -571,10 +575,8 @@ void LinkGraphLegendWindow::SetOverlay(std::shared_ptr<LinkGraphOverlay> overlay
 		}
 	}
 	CargoTypes cargoes = this->overlay->GetCargoMask();
-	for (uint c = 0; c < NUM_CARGO; c++) {
-		if (!this->IsWidgetDisabled(WID_LGL_CARGO_FIRST + c)) {
-			this->SetWidgetLoweredState(WID_LGL_CARGO_FIRST + c, HasBit(cargoes, c));
-		}
+	for (uint c = 0; c < this->num_cargo; c++) {
+		this->SetWidgetLoweredState(WID_LGL_CARGO_FIRST + c, HasBit(cargoes, _sorted_cargo_specs[c]->Index()));
 	}
 }
 
@@ -597,13 +599,11 @@ void LinkGraphLegendWindow::UpdateWidgetSize(int widget, Dimension *size, const 
 		}
 	}
 	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
-		CargoSpec *cargo = CargoSpec::Get(widget - WID_LGL_CARGO_FIRST);
-		if (cargo->IsValid()) {
-			Dimension dim = GetStringBoundingBox(cargo->abbrev, FS_SMALL);
-			dim.width += padding.width;
-			dim.height += padding.height;
-			*size = maxdim(*size, dim);
-		}
+		const CargoSpec *cargo = _sorted_cargo_specs[widget - WID_LGL_CARGO_FIRST];
+		Dimension dim = GetStringBoundingBox(cargo->abbrev, FS_SMALL);
+		dim.width += padding.width;
+		dim.height += padding.height;
+		*size = maxdim(*size, dim);
 	}
 }
 
@@ -633,8 +633,7 @@ void LinkGraphLegendWindow::DrawWidget(const Rect &r, int widget) const
 		}
 	}
 	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
-		if (this->IsWidgetDisabled(widget)) return;
-		CargoSpec *cargo = CargoSpec::Get(widget - WID_LGL_CARGO_FIRST);
+		const CargoSpec *cargo = _sorted_cargo_specs[widget - WID_LGL_CARGO_FIRST];
 		GfxFillRect(br, cargo->legend_colour);
 		DrawString(br.left, br.right, CenterBounds(br.top, br.bottom, FONT_HEIGHT_SMALL), cargo->abbrev, GetContrastColour(cargo->legend_colour, 73), SA_HOR_CENTER, false, FS_SMALL);
 	}
@@ -655,8 +654,7 @@ bool LinkGraphLegendWindow::OnTooltip(Point pt, int widget, TooltipCloseConditio
 		return true;
 	}
 	if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
-		if (this->IsWidgetDisabled(widget)) return false;
-		CargoSpec *cargo = CargoSpec::Get(widget - WID_LGL_CARGO_FIRST);
+		const CargoSpec *cargo = _sorted_cargo_specs[widget - WID_LGL_CARGO_FIRST];
 		GuiShowTooltips(this, cargo->name, 0, nullptr, close_cond);
 		return true;
 	}
@@ -683,10 +681,9 @@ void LinkGraphLegendWindow::UpdateOverlayCompanies()
 void LinkGraphLegendWindow::UpdateOverlayCargoes()
 {
 	CargoTypes mask = 0;
-	for (uint c = 0; c < NUM_CARGO; c++) {
-		if (this->IsWidgetDisabled(c + WID_LGL_CARGO_FIRST)) continue;
+	for (uint c = 0; c < num_cargo; c++) {
 		if (!this->IsWidgetLowered(c + WID_LGL_CARGO_FIRST)) continue;
-		SetBit(mask, c);
+		SetBit(mask, _sorted_cargo_specs[c]->Index());
 	}
 	this->overlay->SetCargoMask(mask);
 }
@@ -707,13 +704,10 @@ void LinkGraphLegendWindow::OnClick(Point pt, int widget, int click_count)
 		this->UpdateOverlayCompanies();
 		this->SetDirty();
 	} else if (IsInsideMM(widget, WID_LGL_CARGO_FIRST, WID_LGL_CARGO_LAST + 1)) {
-		if (!this->IsWidgetDisabled(widget)) {
-			this->ToggleWidgetLoweredState(widget);
-			this->UpdateOverlayCargoes();
-		}
+		this->ToggleWidgetLoweredState(widget);
+		this->UpdateOverlayCargoes();
 	} else if (widget == WID_LGL_CARGOES_ALL || widget == WID_LGL_CARGOES_NONE) {
-		for (uint c = 0; c < NUM_CARGO; c++) {
-			if (this->IsWidgetDisabled(c + WID_LGL_CARGO_FIRST)) continue;
+		for (uint c = 0; c < this->num_cargo; c++) {
 			this->SetWidgetLoweredState(WID_LGL_CARGO_FIRST + c, widget == WID_LGL_CARGOES_ALL);
 		}
 		this->UpdateOverlayCargoes();
@@ -728,11 +722,13 @@ void LinkGraphLegendWindow::OnClick(Point pt, int widget, int click_count)
  */
 void LinkGraphLegendWindow::OnInvalidateData(int data, bool gui_scope)
 {
+	if (this->num_cargo != _sorted_cargo_specs.size()) {
+		this->Close();
+		return;
+	}
+
 	/* Disable the companies who are not active */
 	for (CompanyID i = COMPANY_FIRST; i < MAX_COMPANIES; i++) {
 		this->SetWidgetDisabledState(i + WID_LGL_COMPANY_FIRST, !Company::IsValidID(i));
-	}
-	for (CargoID i = 0; i < NUM_CARGO; i++) {
-		this->SetWidgetDisabledState(i + WID_LGL_CARGO_FIRST, !CargoSpec::Get(i)->IsValid());
 	}
 }

--- a/src/linkgraph/linkgraph_gui.h
+++ b/src/linkgraph/linkgraph_gui.h
@@ -116,6 +116,7 @@ public:
 
 private:
 	std::shared_ptr<LinkGraphOverlay> overlay;
+	size_t num_cargo;
 
 	void UpdateOverlayCompanies();
 	void UpdateOverlayCargoes();


### PR DESCRIPTION
## Motivation / Problem

Cargo flow legend window has a button for every possible cargo type (64) instead of only the currently defined cargo types. (11 on temperate by default.)

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/fbfa2877-c961-44c7-86ad-a5de5ffc47da)

## Description

Show buttons only for the currently defined cargo types instead, removing the large mostly-empty grid of cargo buttons when not using a complex industry set.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/68e8f069-6ea8-4315-a08c-ff1c445890da)

Caveat: Cargo types are now first drawn down by column instead of across by rows, and in "sort" order instead of index order. This happens to match the cargo legend on the minimap.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
