### PR TITLE
Fix: Rail waypoint selection window not closed when rail toolbar or rail waypoint build windows closed

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -423,6 +423,7 @@ struct BuildRailToolbarWindow : Window {
 	{
 		if (this->IsWidgetLowered(WID_RAT_BUILD_STATION)) SetViewportCatchmentStation(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WC_SCEN_LAND_GEN, 0, false);
+		CloseWindowById(WC_SELECT_STATION, 0);
 		this->Window::Close();
 	}
 
@@ -2020,6 +2021,12 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 
 		this->list.ForceRebuild();
 		this->BuildPickerList();
+	}
+
+	void Close() override
+	{
+		CloseWindowById(WC_SELECT_STATION, 0);
+		this->PickerWindowBase::Close();
 	}
 
 	bool FilterByText(const StationSpec *statspec)


### PR DESCRIPTION
## Motivation / Problem

Rail waypoint selection window left open in the following case:

1. Rail toolbar opened
2. Rail waypoint tool selected
3. Ctrl-click on rail to open waypoint selection window (nearby waypoints)
4. Open road toolbar
5. (Rail waypoint selection window and tile highlight remains open)
6. Select another object to place tool e.g. the bus station tool
7. Tile highlights are stuck with the rail waypoint select window, but a bus station is built on click

## Description

Close select station window when closing rail toolbar or rail waypoint build window (matching rail station build window).

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
