### PR TITLE
Feature: Highlight waypoint tiles when building/selecting distant waypoint.

### DIFF
--- a/src/rail_gui.cpp
+++ b/src/rail_gui.cpp
@@ -422,6 +422,7 @@ struct BuildRailToolbarWindow : Window {
 	void Close() override
 	{
 		if (this->IsWidgetLowered(WID_RAT_BUILD_STATION)) SetViewportCatchmentStation(nullptr, true);
+		if (this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT)) SetViewportCatchmentWaypoint(nullptr, true);
 		if (_settings_client.gui.link_terraform_toolbar) CloseWindowById(WC_SCEN_LAND_GEN, 0, false);
 		CloseWindowById(WC_SELECT_STATION, 0);
 		this->Window::Close();
@@ -731,6 +732,7 @@ struct BuildRailToolbarWindow : Window {
 	void OnPlaceObjectAbort() override
 	{
 		if (this->IsWidgetLowered(WID_RAT_BUILD_STATION)) SetViewportCatchmentStation(nullptr, true);
+		if (this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT)) SetViewportCatchmentWaypoint(nullptr, true);
 
 		this->RaiseButtons();
 		this->DisableWidget(WID_RAT_REMOVE);
@@ -755,6 +757,11 @@ struct BuildRailToolbarWindow : Window {
 		/* do not toggle Remove button by Ctrl when placing station */
 		if (!this->IsWidgetLowered(WID_RAT_BUILD_STATION) && !this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT) && RailToolbar_CtrlChanged(this)) return ES_HANDLED;
 		return ES_NOT_HANDLED;
+	}
+
+	void OnRealtimeTick(uint delta_ms) override
+	{
+		if (this->IsWidgetLowered(WID_RAT_BUILD_WAYPOINT)) CheckRedrawWaypointCoverage(this);
 	}
 
 	static HotkeyList hotkeys;
@@ -2175,6 +2182,11 @@ struct BuildRailWaypointWindow : PickerWindowBase {
 			this->string_filter.SetFilterTerm(this->editbox.text.buf);
 			this->InvalidateData();
 		}
+	}
+
+	void OnRealtimeTick(uint delta_ms) override
+	{
+		CheckRedrawWaypointCoverage(this);
 	}
 };
 

--- a/src/station_gui.h
+++ b/src/station_gui.h
@@ -25,6 +25,7 @@ enum StationCoverageType {
 
 int DrawStationCoverageAreaText(int left, int right, int top, StationCoverageType sct, int rad, bool supplies);
 void CheckRedrawStationCoverage(const Window *w);
+void CheckRedrawWaypointCoverage(const Window *w);
 
 using StationPickerCmdProc = std::function<bool(bool test, StationID to_join)>;
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -3513,6 +3513,19 @@ void MarkCatchmentTilesDirty()
 	}
 }
 
+static void SetWindowDirtyForViewportCatchment()
+{
+	if (_viewport_highlight_station != nullptr) SetWindowDirty(WC_STATION_VIEW, _viewport_highlight_station->index);
+	if (_viewport_highlight_town != nullptr) SetWindowDirty(WC_TOWN_VIEW, _viewport_highlight_town->index);
+}
+
+static void ClearViewportCatchment()
+{
+	MarkCatchmentTilesDirty();
+	_viewport_highlight_station = nullptr;
+	_viewport_highlight_town = nullptr;
+}
+
 /**
  * Select or deselect station for coverage area highlight.
  * Selecting a station will deselect a town.
@@ -3521,12 +3534,10 @@ void MarkCatchmentTilesDirty()
  */
 void SetViewportCatchmentStation(const Station *st, bool sel)
 {
-	if (_viewport_highlight_station != nullptr) SetWindowDirty(WC_STATION_VIEW, _viewport_highlight_station->index);
-	if (_viewport_highlight_town != nullptr) SetWindowDirty(WC_TOWN_VIEW, _viewport_highlight_town->index);
+	SetWindowDirtyForViewportCatchment();
 	if (sel && _viewport_highlight_station != st) {
-		MarkCatchmentTilesDirty();
+		ClearViewportCatchment();
 		_viewport_highlight_station = st;
-		_viewport_highlight_town = nullptr;
 		MarkCatchmentTilesDirty();
 	} else if (!sel && _viewport_highlight_station == st) {
 		MarkCatchmentTilesDirty();
@@ -3543,10 +3554,9 @@ void SetViewportCatchmentStation(const Station *st, bool sel)
  */
 void SetViewportCatchmentTown(const Town *t, bool sel)
 {
-	if (_viewport_highlight_town != nullptr) SetWindowDirty(WC_TOWN_VIEW, _viewport_highlight_town->index);
-	if (_viewport_highlight_station != nullptr) SetWindowDirty(WC_STATION_VIEW, _viewport_highlight_station->index);
+	SetWindowDirtyForViewportCatchment();
 	if (sel && _viewport_highlight_town != t) {
-		_viewport_highlight_station = nullptr;
+		ClearViewportCatchment();
 		_viewport_highlight_town = t;
 		MarkWholeScreenDirty();
 	} else if (!sel && _viewport_highlight_town == t) {

--- a/src/viewport_func.h
+++ b/src/viewport_func.h
@@ -95,10 +95,27 @@ static inline void MarkTileDirtyByTile(TileIndex tile, int bridge_level_offset =
 Point GetViewportStationMiddle(const Viewport *vp, const Station *st);
 
 struct Station;
+struct Waypoint;
 struct Town;
 
 void SetViewportCatchmentStation(const Station *st, bool sel);
+void SetViewportCatchmentWaypoint(const Waypoint *wp, bool sel);
 void SetViewportCatchmentTown(const Town *t, bool sel);
 void MarkCatchmentTilesDirty();
+
+template<class T>
+void SetViewportCatchmentSpecializedStation(const T *st, bool sel);
+
+template<>
+inline void SetViewportCatchmentSpecializedStation(const Station *st, bool sel)
+{
+	SetViewportCatchmentStation(st, sel);
+}
+
+template<>
+inline void SetViewportCatchmentSpecializedStation(const Waypoint *st, bool sel)
+{
+	SetViewportCatchmentWaypoint(st, sel);
+}
 
 #endif /* VIEWPORT_FUNC_H */

--- a/src/waypoint_gui.cpp
+++ b/src/waypoint_gui.cpp
@@ -79,12 +79,22 @@ public:
 	void Close() override
 	{
 		CloseWindowById(GetWindowClassForVehicleType(this->vt), VehicleListIdentifier(VL_STATION_LIST, this->vt, this->owner, this->window_number).Pack(), false);
+		SetViewportCatchmentWaypoint(Waypoint::Get(this->window_number), false);
 		this->Window::Close();
 	}
 
 	void SetStringParameters(int widget) const override
 	{
 		if (widget == WID_W_CAPTION) SetDParam(0, this->wp->index);
+	}
+
+	void OnPaint() override
+	{
+		extern const Waypoint *_viewport_highlight_waypoint;
+		this->SetWidgetDisabledState(WID_W_CATCHMENT, !this->wp->IsInUse());
+		this->SetWidgetLoweredState(WID_W_CATCHMENT, _viewport_highlight_waypoint == this->wp);
+
+		this->DrawWidgets();
 	}
 
 	void OnClick(Point pt, int widget, int click_count) override
@@ -105,6 +115,10 @@ public:
 
 			case WID_W_SHOW_VEHICLES: // show list of vehicles having this waypoint in their orders
 				ShowVehicleListWindow(this->wp->owner, this->vt, this->wp->index);
+				break;
+
+			case WID_W_CATCHMENT:
+				SetViewportCatchmentWaypoint(Waypoint::Get(this->window_number), !this->IsWidgetLowered(WID_W_CATCHMENT));
 				break;
 		}
 	}
@@ -162,7 +176,7 @@ static const NWidgetPart _nested_waypoint_view_widgets[] = {
 		EndContainer(),
 	EndContainer(),
 	NWidget(NWID_HORIZONTAL),
-		NWidget(WWT_PANEL, COLOUR_GREY), SetFill(1, 1), SetResize(1, 0), EndContainer(),
+		NWidget(WWT_TEXTBTN, COLOUR_GREY, WID_W_CATCHMENT), SetMinimalSize(50, 12), SetResize(1, 0), SetFill(1, 1), SetDataTip(STR_BUTTON_CATCHMENT, STR_TOOLTIP_CATCHMENT),
 		NWidget(WWT_PUSHTXTBTN, COLOUR_GREY, WID_W_SHOW_VEHICLES), SetMinimalSize(15, 12), SetDataTip(STR_SHIP, STR_STATION_VIEW_SCHEDULED_SHIPS_TOOLTIP),
 		NWidget(WWT_RESIZEBOX, COLOUR_GREY),
 	EndContainer(),

--- a/src/widgets/waypoint_widget.h
+++ b/src/widgets/waypoint_widget.h
@@ -17,6 +17,7 @@ enum WaypointWidgets {
 	WID_W_CENTER_VIEW,   ///< Center the main view on this waypoint.
 	WID_W_RENAME,        ///< Rename this waypoint.
 	WID_W_SHOW_VEHICLES, ///< Show the vehicles visiting this waypoint.
+	WID_W_CATCHMENT,     ///< Coverage button.
 };
 
 #endif /* WIDGETS_WAYPOINT_WIDGET_H */


### PR DESCRIPTION
## Motivation / Problem

When distant-joining waypoints it's not obvious from the map which is the correct waypoint, you need to check the signs.

## Description

Similar to rail stations, highlight the waypoint tiles when selecting with distant join, or when adjacent to a waypoint.

Feature backport from JGRPP, with some stuff about road waypoints ripped out, so it's quite a bit different.

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/9c8945dd-a796-4750-a60f-4febed6a0ea4)

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/e2e46d4a-74fd-4c2a-bf76-1c7dd1f61c7a)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
