### PR TITLE
Fix d9a04ba446: Ensure all MD5Hash are initialized.

### DIFF
--- a/src/3rdparty/md5/md5.h
+++ b/src/3rdparty/md5/md5.h
@@ -57,20 +57,20 @@
 static const size_t MD5_HASH_BYTES = 16;
 
 /** Container for storing a MD5 hash/checksum/digest. */
-using MD5Hash = std::array<byte, MD5_HASH_BYTES>;
+struct MD5Hash : std::array<byte, MD5_HASH_BYTES> {
+	MD5Hash() : std::array<byte, MD5_HASH_BYTES>{} {}
 
-/**
- * Exclusively-or one hash into another hash.
- * @param lhs The hash to exclusively-or into.
- * @param rhs The hash to exclusively-or with.
- * @return Reference to \c lhs hash.
- */
-inline MD5Hash &operator^=(MD5Hash &lhs, const MD5Hash &rhs)
-{
-	for (size_t i = 0; i < lhs.size(); i++) lhs[i] ^= rhs[i];
-	return lhs;
-}
-
+	/**
+	 * Exclusively-or the given hash into this hash.
+	 * @param other The other hash.
+	 * @return Reference to this hash.
+	 */
+	MD5Hash &operator^=(const MD5Hash &other)
+	{
+		for (size_t i = 0; i < size(); i++) this->operator[](i) ^= other[i];
+		return *this;
+	}
+};
 
 struct Md5 {
 private:


### PR DESCRIPTION
## Motivation / Problem

In some places an MD5Hash is xored with another hash, without ensure the original array is clear. This results in false MD5 mismatches.

## Description

Ensure all MD5Hashes are value initialized. Not all instances need to be initialized as often they are copied or written to, but doing all ensures no surprises.

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
