### PR TITLE
Fix: Ask FontConfig for the face index when opening fonts.

### DIFF
--- a/src/os/unix/font_unix.cpp
+++ b/src/os/unix/font_unix.cpp
@@ -61,13 +61,15 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 			FcChar8 *family;
 			FcChar8 *style;
 			FcChar8 *file;
+			int32_t index;
 			FcFontSetAdd(fs, match);
 
 			for (i = 0; err != FT_Err_Ok && i < fs->nfont; i++) {
 				/* Try the new filename */
 				if (FcPatternGetString(fs->fonts[i], FC_FILE, 0, &file) == FcResultMatch &&
 					FcPatternGetString(fs->fonts[i], FC_FAMILY, 0, &family) == FcResultMatch &&
-					FcPatternGetString(fs->fonts[i], FC_STYLE, 0, &style) == FcResultMatch) {
+					FcPatternGetString(fs->fonts[i], FC_STYLE, 0, &style) == FcResultMatch &&
+					FcPatternGetInteger(fs->fonts[i], FC_INDEX, 0, &index) == FcResultMatch) {
 
 					/* The correct style? */
 					if (font_style != nullptr && !StrEqualsIgnoreCase(font_style, (char *)style)) continue;
@@ -76,7 +78,7 @@ FT_Error GetFontByFaceName(const char *font_name, FT_Face *face)
 					 * wrongly a 'random' font, so check whether the family name is the
 					 * same as the supplied name */
 					if (StrEqualsIgnoreCase(font_family, (char *)family)) {
-						err = FT_New_Face(_library, (char *)file, 0, face);
+						err = FT_New_Face(_library, (char *)file, index, face);
 					}
 				}
 			}


### PR DESCRIPTION
## Motivation / Problem

Some truetype fonts support different faces/styles but these cannot be selected, as we always use only the first face.

## Description

Ask FontConfig for the face index when opening fonts. This allows selection of the correct face in truetype fonts containing multiple faces.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
