### PR TITLE
Change: Include style when getting font name.

### DIFF
--- a/src/fontcache.h
+++ b/src/fontcache.h
@@ -134,7 +134,7 @@ public:
 	 * Get the name of this font.
 	 * @return The name of the font.
 	 */
-	virtual const char *GetFontName() = 0;
+	virtual std::string GetFontName() = 0;
 
 	/**
 	 * Get the font cache of a given font size.

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -42,7 +42,7 @@ public:
 	~FreeTypeFontCache();
 	void ClearFontCache() override;
 	GlyphID MapCharToGlyph(WChar key) override;
-	const char *GetFontName() override { return face->family_name; }
+	std::string GetFontName() override { return face->family_name; }
 	bool IsBuiltInFont() override { return false; }
 	const void *GetOSHandle() override { return &face; }
 };

--- a/src/fontcache/freetypefontcache.cpp
+++ b/src/fontcache/freetypefontcache.cpp
@@ -42,7 +42,7 @@ public:
 	~FreeTypeFontCache();
 	void ClearFontCache() override;
 	GlyphID MapCharToGlyph(WChar key) override;
-	std::string GetFontName() override { return face->family_name; }
+	std::string GetFontName() override { return fmt::format("{}, {}", face->family_name, face->style_name); }
 	bool IsBuiltInFont() override { return false; }
 	const void *GetOSHandle() override { return &face; }
 };

--- a/src/fontcache/spritefontcache.h
+++ b/src/fontcache/spritefontcache.h
@@ -31,7 +31,7 @@ public:
 	virtual bool GetDrawGlyphShadow();
 	virtual GlyphID MapCharToGlyph(WChar key) { assert(IsPrintable(key)); return SPRITE_GLYPH | key; }
 	virtual const void *GetFontTable(uint32 tag, size_t &length) { length = 0; return nullptr; }
-	virtual const char *GetFontName() { return "sprite"; }
+	virtual std::string GetFontName() { return "sprite"; }
 	virtual bool IsBuiltInFont() { return true; }
 };
 

--- a/src/os/macosx/font_osx.h
+++ b/src/os/macosx/font_osx.h
@@ -30,7 +30,7 @@ public:
 
 	void ClearFontCache() override;
 	GlyphID MapCharToGlyph(WChar key) override;
-	const char *GetFontName() override { return font_name.c_str(); }
+	std::string GetFontName() override { return font_name; }
 	bool IsBuiltInFont() override { return false; }
 	const void *GetOSHandle() override { return font.get(); }
 };

--- a/src/os/macosx/string_osx.cpp
+++ b/src/os/macosx/string_osx.cpp
@@ -178,7 +178,7 @@ static CTRunDelegateCallbacks _sprite_font_callback = {
 		if (font == nullptr) {
 			if (!_font_cache[i.second->fc->GetSize()]) {
 				/* Cache font information. */
-				CFAutoRelease<CFStringRef> font_name(CFStringCreateWithCString(kCFAllocatorDefault, i.second->fc->GetFontName(), kCFStringEncodingUTF8));
+				CFAutoRelease<CFStringRef> font_name(CFStringCreateWithCString(kCFAllocatorDefault, i.second->fc->GetFontName().c_str(), kCFStringEncodingUTF8));
 				_font_cache[i.second->fc->GetSize()].reset(CTFontCreateWithName(font_name.get(), i.second->fc->GetFontSize(), nullptr));
 			}
 			font = _font_cache[i.second->fc->GetSize()].get();

--- a/src/os/windows/font_win32.h
+++ b/src/os/windows/font_win32.h
@@ -34,7 +34,7 @@ public:
 	~Win32FontCache();
 	void ClearFontCache() override;
 	GlyphID MapCharToGlyph(WChar key) override;
-	const char *GetFontName() override { return this->fontname.c_str(); }
+	std::string GetFontName() override { return this->fontname; }
 	const void *GetOSHandle() override { return &this->logfont; }
 };
 


### PR DESCRIPTION
## Motivation / Problem

With Freetype, family name and style name are separate members, and our GetFontName() only returns the family name. This means that the `font` console command and the survey data does not show the full detail:

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/b3176f86-a856-47fc-b9c2-657a35476efe)

## Description

This is fixed for Freetype by changing `GetFontName()` to return a std::string, and then including both family name and style name for Freetype.

With Win32 the style does not seem to be separated so it is already included.

I'm unsure how this shows with OSX. 

![image](https://github.com/OpenTTD/OpenTTD/assets/639850/623de372-3dda-40b5-a5d7-fa64e8a0dd55)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
