### PR TITLE
Change: Simplify advertisement by removing small and medium options

### DIFF
--- a/bin/ai/compat_1.0.nut
+++ b/bin/ai/compat_1.0.nut
@@ -144,3 +144,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.1.nut
+++ b/bin/ai/compat_1.1.nut
@@ -81,3 +81,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.10.nut
+++ b/bin/ai/compat_1.10.nut
@@ -19,3 +19,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.11.nut
+++ b/bin/ai/compat_1.11.nut
@@ -19,3 +19,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.2.nut
+++ b/bin/ai/compat_1.2.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.3.nut
+++ b/bin/ai/compat_1.3.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.4.nut
+++ b/bin/ai/compat_1.4.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.5.nut
+++ b/bin/ai/compat_1.5.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.6.nut
+++ b/bin/ai/compat_1.6.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.7.nut
+++ b/bin/ai/compat_1.7.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.8.nut
+++ b/bin/ai/compat_1.8.nut
@@ -33,3 +33,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_1.9.nut
+++ b/bin/ai/compat_1.9.nut
@@ -19,3 +19,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_12.nut
+++ b/bin/ai/compat_12.nut
@@ -19,3 +19,8 @@ AIRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/ai/compat_13.nut
+++ b/bin/ai/compat_13.nut
@@ -6,3 +6,8 @@
  */
 
 AILog.Info("13 API compatibility in effect.");
+
+/* 14.0 removes small and medium advertise options */
+AITown.TOWN_ACTION_ADVERTISE_SMALL <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_MEDIUM <- AITown.TOWN_ACTION_ADVERTISE
+AITown.TOWN_ACTION_ADVERTISE_LARGE <- AITown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.10.nut
+++ b/bin/game/compat_1.10.nut
@@ -26,3 +26,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.11.nut
+++ b/bin/game/compat_1.11.nut
@@ -19,3 +19,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.2.nut
+++ b/bin/game/compat_1.2.nut
@@ -48,3 +48,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.3.nut
+++ b/bin/game/compat_1.3.nut
@@ -48,3 +48,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.4.nut
+++ b/bin/game/compat_1.4.nut
@@ -40,3 +40,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.5.nut
+++ b/bin/game/compat_1.5.nut
@@ -33,3 +33,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.6.nut
+++ b/bin/game/compat_1.6.nut
@@ -33,3 +33,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.7.nut
+++ b/bin/game/compat_1.7.nut
@@ -33,3 +33,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.8.nut
+++ b/bin/game/compat_1.8.nut
@@ -33,3 +33,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_1.9.nut
+++ b/bin/game/compat_1.9.nut
@@ -26,3 +26,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_12.nut
+++ b/bin/game/compat_12.nut
@@ -19,3 +19,8 @@ GSRoad.HasRoadType <- function(tile, road_type)
 	}
 	return false;
 }
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/bin/game/compat_13.nut
+++ b/bin/game/compat_13.nut
@@ -6,3 +6,8 @@
  */
 
 GSLog.Info("13 API compatibility in effect.");
+
+/* 14.0 removes small and medium advertise options */
+GSTown.TOWN_ACTION_ADVERTISE_SMALL <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_MEDIUM <- GSTown.TOWN_ACTION_ADVERTISE
+GSTown.TOWN_ACTION_ADVERTISE_LARGE <- GSTown.TOWN_ACTION_ADVERTISE

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -3519,20 +3519,16 @@ STR_LOCAL_AUTHORITY_ACTIONS_TOOLTIP                             :{BLACK}List of 
 STR_LOCAL_AUTHORITY_DO_IT_BUTTON                                :{BLACK}Do it
 STR_LOCAL_AUTHORITY_DO_IT_TOOLTIP                               :{BLACK}Carry out the highlighted action in the list above
 
-###length 8
-STR_LOCAL_AUTHORITY_ACTION_SMALL_ADVERTISING_CAMPAIGN           :Small advertising campaign
-STR_LOCAL_AUTHORITY_ACTION_MEDIUM_ADVERTISING_CAMPAIGN          :Medium advertising campaign
-STR_LOCAL_AUTHORITY_ACTION_LARGE_ADVERTISING_CAMPAIGN           :Large advertising campaign
+###length 6
+STR_LOCAL_AUTHORITY_ACTION_ADVERTISING_CAMPAIGN                 :Advertising campaign
 STR_LOCAL_AUTHORITY_ACTION_ROAD_RECONSTRUCTION                  :Fund local road reconstruction
 STR_LOCAL_AUTHORITY_ACTION_STATUE_OF_COMPANY                    :Build statue of company owner
 STR_LOCAL_AUTHORITY_ACTION_NEW_BUILDINGS                        :Fund new buildings
 STR_LOCAL_AUTHORITY_ACTION_EXCLUSIVE_TRANSPORT                  :Buy exclusive transport rights
 STR_LOCAL_AUTHORITY_ACTION_BRIBE                                :Bribe the local authority
 
-###length 8
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_SMALL_ADVERTISING            :{PUSH_COLOUR}{YELLOW}Initiate a small local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a small radius around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_MEDIUM_ADVERTISING           :{PUSH_COLOUR}{YELLOW}Initiate a medium local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a medium radius around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
-STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_LARGE_ADVERTISING            :{PUSH_COLOUR}{YELLOW}Initiate a large local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating in a large radius around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
+###length 6
+STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ADVERTISING            :{PUSH_COLOUR}{YELLOW}Initiate a local advertising campaign, to attract more passengers and cargo to your transport services.{}Provides a temporary boost to station rating around the town centre.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ROAD_RECONSTRUCTION          :{PUSH_COLOUR}{YELLOW}Fund the reconstruction of the urban road network.{}Causes considerable disruption to road traffic for up to 6 months.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_STATUE_OF_COMPANY            :{PUSH_COLOUR}{YELLOW}Build a statue in honour of your company.{}Provides a permanent boost to station rating in this town.{}{POP_COLOUR}Cost: {CURRENCY_LONG}
 STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_NEW_BUILDINGS                :{PUSH_COLOUR}{YELLOW}Fund the construction of new buildings in the town.{}Provides a temporary boost to town growth in this town.{}{POP_COLOUR}Cost: {CURRENCY_LONG}

--- a/src/script/api/script_town.hpp
+++ b/src/script/api/script_town.hpp
@@ -27,50 +27,36 @@ public:
 		/* Note: these values represent part of the in-game order of the _town_action_proc array */
 
 		/**
-		 * The cargo ratings temporary gains 25% of rating (in
-		 * absolute percentage, so 10% becomes 35%, with a max of 99%)
-		 * for all stations within 10 tiles.
-		 */
-		TOWN_ACTION_ADVERTISE_SMALL  = 0,
-
-		/**
-		 * The cargo ratings temporary gains 44% of rating (in
-		 * absolute percentage, so 10% becomes 54%, with a max of 99%)
-		 * for all stations within 15 tiles.
-		 */
-		TOWN_ACTION_ADVERTISE_MEDIUM = 1,
-
-		/**
 		 * The cargo ratings temporary gains 63% of rating (in
 		 * absolute percentage, so 10% becomes 73%, with a max of 99%)
 		 * for all stations within 20 tiles.
 		 */
-		TOWN_ACTION_ADVERTISE_LARGE  = 2,
+		TOWN_ACTION_ADVERTISE        = 0,
 
 		/**
 		 * Rebuild the roads of this town for 6 months.
 		 */
-		TOWN_ACTION_ROAD_REBUILD     = 3,
+		TOWN_ACTION_ROAD_REBUILD     = 1,
 
 		/**
 		 * Build a statue in this town.
 		 */
-		TOWN_ACTION_BUILD_STATUE     = 4,
+		TOWN_ACTION_BUILD_STATUE     = 2,
 
 		/**
 		 * Fund the creation of extra buildings for 3 months.
 		 */
-		TOWN_ACTION_FUND_BUILDINGS   = 5,
+		TOWN_ACTION_FUND_BUILDINGS   = 3,
 
 		/**
 		 * Buy exclusive rights for this town for 12 months.
 		 */
-		TOWN_ACTION_BUY_RIGHTS       = 6,
+		TOWN_ACTION_BUY_RIGHTS       = 4,
 
 		/**
 		 * Bribe the town in order to get a higher rating.
 		 */
-		TOWN_ACTION_BRIBE            = 7,
+		TOWN_ACTION_BRIBE            = 5,
 	};
 
 	/**

--- a/src/town.h
+++ b/src/town.h
@@ -204,18 +204,15 @@ void ResetHouses();
 enum TownActions {
 	TACT_NONE             = 0x00, ///< Empty action set.
 
-	TACT_ADVERTISE_SMALL  = 0x01, ///< Small advertising campaign.
-	TACT_ADVERTISE_MEDIUM = 0x02, ///< Medium advertising campaign.
-	TACT_ADVERTISE_LARGE  = 0x04, ///< Large advertising campaign.
-	TACT_ROAD_REBUILD     = 0x08, ///< Rebuild the roads.
-	TACT_BUILD_STATUE     = 0x10, ///< Build a statue.
-	TACT_FUND_BUILDINGS   = 0x20, ///< Fund new buildings.
-	TACT_BUY_RIGHTS       = 0x40, ///< Buy exclusive transport rights.
-	TACT_BRIBE            = 0x80, ///< Try to bribe the council.
+	TACT_ADVERTISE        = 0x01, ///< Large advertising campaign.
+	TACT_ROAD_REBUILD     = 0x02, ///< Rebuild the roads.
+	TACT_BUILD_STATUE     = 0x04, ///< Build a statue.
+	TACT_FUND_BUILDINGS   = 0x08, ///< Fund new buildings.
+	TACT_BUY_RIGHTS       = 0x10, ///< Buy exclusive transport rights.
+	TACT_BRIBE            = 0x20, ///< Try to bribe the council.
 
-	TACT_COUNT            = 8,    ///< Number of available town actions.
+	TACT_COUNT            = 6,    ///< Number of available town actions.
 
-	TACT_ADVERTISE        = TACT_ADVERTISE_SMALL | TACT_ADVERTISE_MEDIUM | TACT_ADVERTISE_LARGE, ///< All possible advertising actions.
 	TACT_CONSTRUCTION     = TACT_ROAD_REBUILD | TACT_BUILD_STATUE | TACT_FUND_BUILDINGS,         ///< All possible construction actions.
 	TACT_FUNDS            = TACT_BUY_RIGHTS | TACT_BRIBE,                                        ///< All possible funding actions.
 	TACT_ALL              = TACT_ADVERTISE | TACT_CONSTRUCTION | TACT_FUNDS,                     ///< All possible actions.

--- a/src/town_cmd.cpp
+++ b/src/town_cmd.cpp
@@ -3076,26 +3076,10 @@ CommandCost CmdDeleteTown(DoCommandFlag flags, TownID town_id)
  * @see TownActions
  */
 const byte _town_action_costs[TACT_COUNT] = {
-	2, 4, 9, 35, 48, 53, 117, 175
+	9, 35, 48, 53, 117, 175
 };
 
-static CommandCost TownActionAdvertiseSmall(Town *t, DoCommandFlag flags)
-{
-	if (flags & DC_EXEC) {
-		ModifyStationRatingAround(t->xy, _current_company, 0x40, 10);
-	}
-	return CommandCost();
-}
-
-static CommandCost TownActionAdvertiseMedium(Town *t, DoCommandFlag flags)
-{
-	if (flags & DC_EXEC) {
-		ModifyStationRatingAround(t->xy, _current_company, 0x70, 15);
-	}
-	return CommandCost();
-}
-
-static CommandCost TownActionAdvertiseLarge(Town *t, DoCommandFlag flags)
+static CommandCost TownActionAdvertise(Town *t, DoCommandFlag flags)
 {
 	if (flags & DC_EXEC) {
 		ModifyStationRatingAround(t->xy, _current_company, 0xA0, 20);
@@ -3300,10 +3284,8 @@ static CommandCost TownActionBribe(Town *t, DoCommandFlag flags)
 }
 
 typedef CommandCost TownActionProc(Town *t, DoCommandFlag flags);
-static TownActionProc * const _town_action_proc[] = {
-	TownActionAdvertiseSmall,
-	TownActionAdvertiseMedium,
-	TownActionAdvertiseLarge,
+static TownActionProc * const _town_action_proc[TACT_COUNT] = {
+	TownActionAdvertise,
 	TownActionRoadRebuild,
 	TownActionBuildStatue,
 	TownActionFundBuildings,

--- a/src/town_gui.cpp
+++ b/src/town_gui.cpp
@@ -216,7 +216,7 @@ public:
 			if (HasBit(this->available_actions, i)) action_colour = TC_ORANGE;
 			if (this->sel_index == i) action_colour = TC_WHITE;
 
-			DrawString(r, STR_LOCAL_AUTHORITY_ACTION_SMALL_ADVERTISING_CAMPAIGN + i, action_colour);
+			DrawString(r, STR_LOCAL_AUTHORITY_ACTION_ADVERTISING_CAMPAIGN + i, action_colour);
 			r.top += FONT_HEIGHT_NORMAL;
 		}
 	}
@@ -236,7 +236,7 @@ public:
 
 					SetDParam(0, action_cost);
 					DrawStringMultiLine(r.Shrink(WidgetDimensions::scaled.framerect),
-						STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_SMALL_ADVERTISING + this->sel_index,
+						STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ADVERTISING + this->sel_index,
 						affordable ? TC_YELLOW : TC_RED);
 				}
 				break;
@@ -251,7 +251,7 @@ public:
 				Dimension d = {0, 0};
 				for (int i = 0; i < TACT_COUNT; i++) {
 					SetDParam(0, _price[PR_TOWN_ACTION] * _town_action_costs[i] >> 8);
-					d = maxdim(d, GetStringMultiLineBoundingBox(STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_SMALL_ADVERTISING + i, *size));
+					d = maxdim(d, GetStringMultiLineBoundingBox(STR_LOCAL_AUTHORITY_ACTION_TOOLTIP_ADVERTISING + i, *size));
 				}
 				d.width += padding.width;
 				d.height += padding.height;
@@ -263,7 +263,7 @@ public:
 				size->height = (TACT_COUNT + 1) * FONT_HEIGHT_NORMAL + padding.height;
 				size->width = GetStringBoundingBox(STR_LOCAL_AUTHORITY_ACTIONS_TITLE).width;
 				for (uint i = 0; i < TACT_COUNT; i++ ) {
-					size->width = std::max(size->width, GetStringBoundingBox(STR_LOCAL_AUTHORITY_ACTION_SMALL_ADVERTISING_CAMPAIGN + i).width);
+					size->width = std::max(size->width, GetStringBoundingBox(STR_LOCAL_AUTHORITY_ACTION_ADVERTISING_CAMPAIGN + i).width);
 				}
 				size->width += padding.width;
 				break;


### PR DESCRIPTION
I got inspired by #10709 /s

## Motivation / Problem

While having a way to spend money to increase ratings isn't bad in general the way it currently works is far from perfect. As it's very unclear what advertisement does and which stations are affected. Also vanilla game lacks a very useful function to set up a continuous advertisement. And improving it is complicated by the fact that there are 3 advertisement options for historical reasons. So, for example, making advertisement range configurable would require 3 settings, showing zone highlight needs 3 colours and so on. And while it can probably be done question is whether it is worth it and what does having 3 options even add to the game. As it currently is you have to plan for future advertisement when you build the station. And smaller advertisement options are cheaper so it encourages players to destroy towns to place stations closer. That's hardly a good thing and even large adv radius is usually too small imo. So I don't see any value in clogging the interface with options that provide questionable incentives.

## Description

This PR removes small and medium advertisement options and renames "large advertisement" to just "advertisement". That hardly affects the gameplay as you can still do advertisement in all the same cases, it just takes more money. And custom patchpacks that provide advertisement automation never even bothered to include small and medium options afaik and I don't remember anyone missing them.

## Limitations

- It totally breaks the game again.
- I forgot to deal with script api so drafting this for now.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* ~~The bug fix is important enough to be backported? (label: 'backport requested')~~
* **This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)**
* ~~This PR affects the save game format? (label 'savegame upgrade')~~
* **This PR affects the GS/AI API? (label 'needs review: Script API')**
    * **ai_changelog.hpp, gs_changelog.hpp need updating.**
    * **The compatibility wrappers (compat_*.nut) need updating.**
* ~~This PR affects the NewGRF API? (label 'needs review: NewGRF')~~
    * ~~newgrf_debug_data.h may need updating.~~
    * ~~[PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)~~
    