### PR TITLE
Codechange: replace C-style idioms with C++-style for OS specific file calls

### DIFF
--- a/src/console_cmds.cpp
+++ b/src/console_cmds.cpp
@@ -514,8 +514,6 @@ DEF_CONSOLE_CMD(ConChangeDirectory)
 
 DEF_CONSOLE_CMD(ConPrintWorkingDirectory)
 {
-	const char *path;
-
 	if (argc == 0) {
 		IConsolePrint(CC_HELP, "Print out the current working directory. Usage: 'pwd'.");
 		return true;
@@ -525,8 +523,7 @@ DEF_CONSOLE_CMD(ConPrintWorkingDirectory)
 	_console_file_list.ValidateFileList(true);
 	_console_file_list.InvalidateFileList();
 
-	FiosGetDescText(&path, nullptr);
-	IConsolePrint(CC_DEFAULT, path);
+	IConsolePrint(CC_DEFAULT, FiosGetCurrentPath());
 	return true;
 }
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -68,7 +68,7 @@ TarFileList _tar_filelist[NUM_SUBDIRS];
 typedef std::map<std::string, std::string> TarLinkList;
 static TarLinkList _tar_linklist[NUM_SUBDIRS]; ///< List of directory links
 
-extern bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb);
+extern bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb);
 
 /**
  * Checks whether the given search path is a valid search path

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -39,7 +39,6 @@ extern bool FiosIsRoot(const std::string &path);
 extern bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb);
 extern bool FiosIsHiddenFile(const struct dirent *ent);
 extern void FiosGetDrives(FileList &file_list);
-extern bool FiosGetDiskFreeSpace(const char *path, uint64 *tot);
 
 /* get the name of an oldstyle savegame */
 extern void GetOldSaveGameName(const std::string &file, char *title, const char *last);
@@ -128,16 +127,11 @@ const FiosItem *FileList::FindItem(const std::string_view file)
 }
 
 /**
- * Get descriptive texts. Returns the path and free space
- * left on the device
- * @param path string describing the path
- * @param total_free total free space in megabytes, optional (can be nullptr)
- * @return StringID describing the path (free space or failure)
+ * Get the current path/working directory.
  */
-StringID FiosGetDescText(const char **path, uint64 *total_free)
+std::string FiosGetCurrentPath()
 {
-	*path = _fios_path->c_str();
-	return FiosGetDiskFreeSpace(*path, total_free) ? STR_SAVELOAD_BYTES_FREE : STR_ERROR_UNABLE_TO_READ_DRIVE;
+	return *_fios_path;
 }
 
 /**

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -35,7 +35,7 @@ static std::string *_fios_path = nullptr;
 SortingBits _savegame_sort_order = SORT_BY_DATE | SORT_DESCENDING;
 
 /* OS-specific functions are taken from their respective files (win32/unix/os2 .c) */
-extern bool FiosIsRoot(const char *path);
+extern bool FiosIsRoot(const std::string &path);
 extern bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb);
 extern bool FiosIsHiddenFile(const struct dirent *ent);
 extern void FiosGetDrives(FileList &file_list);
@@ -366,7 +366,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 	assert(_fios_path != nullptr);
 
 	/* A parent directory link exists if we are not in the root directory */
-	if (!FiosIsRoot(_fios_path->c_str())) {
+	if (!FiosIsRoot(*_fios_path)) {
 		fios = &file_list.emplace_back();
 		fios->type = FIOS_TYPE_PARENT;
 		fios->mtime = 0;

--- a/src/fios.cpp
+++ b/src/fios.cpp
@@ -36,7 +36,7 @@ SortingBits _savegame_sort_order = SORT_BY_DATE | SORT_DESCENDING;
 
 /* OS-specific functions are taken from their respective files (win32/unix/os2 .c) */
 extern bool FiosIsRoot(const char *path);
-extern bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb);
+extern bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb);
 extern bool FiosIsHiddenFile(const struct dirent *ent);
 extern void FiosGetDrives(FileList &file_list);
 extern bool FiosGetDiskFreeSpace(const char *path, uint64 *tot);
@@ -381,7 +381,7 @@ static void FiosGetFileList(SaveLoadOperation fop, fios_getlist_callback_proc *c
 			std::string d_name = FS2OTTD(dirent->d_name);
 
 			/* found file must be directory, but not '.' or '..' */
-			if (FiosIsValidFile(_fios_path->c_str(), dirent, &sb) && S_ISDIR(sb.st_mode) &&
+			if (FiosIsValidFile(*_fios_path, dirent, &sb) && S_ISDIR(sb.st_mode) &&
 					(!FiosIsHiddenFile(dirent) || StrStartsWithIgnoreCase(PERSONAL_DIR, d_name)) &&
 					d_name != "." && d_name != "..") {
 				fios = &file_list.emplace_back();

--- a/src/fios.h
+++ b/src/fios.h
@@ -110,7 +110,8 @@ void FiosGetHeightmapList(SaveLoadOperation fop, FileList &file_list);
 
 bool FiosBrowseTo(const FiosItem *item);
 
-StringID FiosGetDescText(const char **path, uint64 *total_free);
+std::string FiosGetCurrentPath();
+std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path);
 bool FiosDelete(const char *name);
 std::string FiosMakeHeightmapName(const char *name);
 std::string FiosMakeSavegameName(const char *name);

--- a/src/fios_gui.cpp
+++ b/src/fios_gui.cpp
@@ -420,19 +420,19 @@ public:
 				break;
 
 			case WID_SL_BACKGROUND: {
-				static const char *path = nullptr;
-				static StringID str = STR_ERROR_UNABLE_TO_READ_DRIVE;
-				static uint64 tot = 0;
+				static std::string path;
+				static std::optional<uint64_t> free_space = std::nullopt;
 
 				if (_fios_path_changed) {
-					str = FiosGetDescText(&path, &tot);
+					path = FiosGetCurrentPath();
+					free_space = FiosGetDiskFreeSpace(path);
 					_fios_path_changed = false;
 				}
 
 				Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
 
-				if (str != STR_ERROR_UNABLE_TO_READ_DRIVE) SetDParam(0, tot);
-				DrawString(ir.left, ir.right, ir.top + FONT_HEIGHT_NORMAL, str);
+				if (free_space.has_value()) SetDParam(0, free_space.value());
+				DrawString(ir.left, ir.right, ir.top + FONT_HEIGHT_NORMAL, free_space.has_value() ? STR_SAVELOAD_BYTES_FREE : STR_ERROR_UNABLE_TO_READ_DRIVE);
 				DrawString(ir.left, ir.right, ir.top, path, TC_BLACK);
 				break;
 			}

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -36,9 +36,9 @@
 #	include <i86.h>
 #endif
 
-bool FiosIsRoot(const char *file)
+bool FiosIsRoot(const std::string &file)
 {
-	return file[3] == '\0';
+	return file.size() == 3; // C:\...
 }
 
 void FiosGetDrives(FileList &file_list)

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -120,12 +120,10 @@ bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
 #endif
 }
 
-bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb)
+bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb)
 {
-	char filename[MAX_PATH];
-
-	snprintf(filename, lengthof(filename), "%s" PATHSEP "%s", path, ent->d_name);
-	return stat(filename, sb) == 0;
+	std::string filename = fmt::format("{}" PATHSEP "{}", path, ent->d_name);
+	return stat(filename.c_str(), sb) == 0;
 }
 
 bool FiosIsHiddenFile(const struct dirent *ent)

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -57,9 +57,9 @@
 
 #include "../../safeguards.h"
 
-bool FiosIsRoot(const char *path)
+bool FiosIsRoot(const std::string &path)
 {
-	return path[1] == '\0';
+	return path == PATHSEP;
 }
 
 void FiosGetDrives(FileList &file_list)

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -67,23 +67,18 @@ void FiosGetDrives(FileList &file_list)
 	return;
 }
 
-bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
+std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path)
 {
-	uint64 free = 0;
-
 #ifdef __APPLE__
 	struct statfs s;
 
-	if (statfs(path, &s) != 0) return false;
-	free = (uint64)s.f_bsize * s.f_bavail;
+	if (statfs(path.c_str(), &s) == 0) return static_cast<uint64_t>(s.f_bsize) * s.f_bavail;
 #elif defined(HAS_STATVFS)
 	struct statvfs s;
 
-	if (statvfs(path, &s) != 0) return false;
-	free = (uint64)s.f_frsize * s.f_bavail;
+	if (statvfs(path.c_str(), &s) == 0) return static_cast<uint64_t>(s.f_frsize) * s.f_bavail;
 #endif
-	if (tot != nullptr) *tot = free;
-	return true;
+	return std::nullopt;
 }
 
 bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb)

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -86,18 +86,13 @@ bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
 	return true;
 }
 
-bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb)
+bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb)
 {
-	char filename[MAX_PATH];
-	int res;
-	assert(path[strlen(path) - 1] == PATHSEPCHAR);
-	if (strlen(path) > 2) assert(path[strlen(path) - 2] != PATHSEPCHAR);
-	res = seprintf(filename, lastof(filename), "%s%s", path, ent->d_name);
+	assert(path.back() == PATHSEPCHAR);
+	if (path.size() > 2) assert(path[path.size() - 2] != PATHSEPCHAR);
+	std::string filename = fmt::format("{}{}", path, ent->d_name);
 
-	/* Could we fully concatenate the path and filename? */
-	if (res >= (int)lengthof(filename) || res < 0) return false;
-
-	return stat(filename, sb) == 0;
+	return stat(filename.c_str(), sb) == 0;
 }
 
 bool FiosIsHiddenFile(const struct dirent *ent)

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -168,9 +168,9 @@ int closedir(DIR *d)
 	return 0;
 }
 
-bool FiosIsRoot(const char *file)
+bool FiosIsRoot(const std::string &file)
 {
-	return file[3] == '\0'; // C:\...
+	return file.size() == 3; // C:\...
 }
 
 void FiosGetDrives(FileList &file_list)

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -213,16 +213,17 @@ bool FiosIsHiddenFile(const struct dirent *ent)
 	return (ent->dir->fd.dwFileAttributes & (FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM)) != 0;
 }
 
-bool FiosGetDiskFreeSpace(const char *path, uint64 *tot)
+std::optional<uint64_t> FiosGetDiskFreeSpace(const std::string &path)
 {
 	UINT sem = SetErrorMode(SEM_FAILCRITICALERRORS);  // disable 'no-disk' message box
 
 	ULARGE_INTEGER bytes_free;
 	bool retval = GetDiskFreeSpaceEx(OTTD2FS(path).c_str(), &bytes_free, nullptr, nullptr);
-	if (retval && tot != nullptr) *tot = bytes_free.QuadPart;
 
 	SetErrorMode(sem); // reset previous setting
-	return retval;
+
+	if (retval) return bytes_free.QuadPart;
+	return std::nullopt;
 }
 
 void CreateConsole()

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -190,7 +190,7 @@ void FiosGetDrives(FileList &file_list)
 	}
 }
 
-bool FiosIsValidFile(const char *path, const struct dirent *ent, struct stat *sb)
+bool FiosIsValidFile(const std::string &path, const struct dirent *ent, struct stat *sb)
 {
 	/* hectonanoseconds between Windows and POSIX epoch */
 	static const int64 posix_epoch_hns = 0x019DB1DED53E8000LL;


### PR DESCRIPTION
## Motivation / Problem

The internal API for the different OSes to implement checking whether a file is a root, a valid file or the free disk space use C-style strings.
Complicated function returning values by reference, instead of just using `std::optional`.


## Description

Replace `const char *` with `const std::string &`.
Split `FiosGetDescText` into `FiosGetCurrentPath` and `FiosGetDiskFreeSpace`.
Let them return values instead of using out parameter references.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
