### PR TITLE
Codechange: use C++ idioms for the clipboard handling

### DIFF
--- a/src/os/macosx/macos.mm
+++ b/src/os/macosx/macos.mm
@@ -183,25 +183,21 @@ const char *GetCurrentLocale(const char *)
 /**
  * Return the contents of the clipboard (COCOA).
  *
- * @param buffer Clipboard content.
- * @param last The pointer to the last element of the destination buffer
- * @return Whether clipboard is empty or not.
+ * @return The (optional) clipboard contents.
  */
-bool GetClipboardContents(char *buffer, const char *last)
+std::optional<std::string> GetClipboardContents()
 {
 	NSPasteboard *pb = [ NSPasteboard generalPasteboard ];
 	NSArray *types = [ NSArray arrayWithObject:NSPasteboardTypeString ];
 	NSString *bestType = [ pb availableTypeFromArray:types ];
 
 	/* Clipboard has no text data available. */
-	if (bestType == nil) return false;
+	if (bestType == nil) return std::nullopt;
 
 	NSString *string = [ pb stringForType:NSPasteboardTypeString ];
-	if (string == nil || [ string length ] == 0) return false;
+	if (string == nil || [ string length ] == 0) return std::nullopt;
 
-	strecpy(buffer, [ string UTF8String ], last);
-
-	return true;
+	return [ string UTF8String ];
 }
 
 /** Set the application's bundle directory.

--- a/src/os/os2/os2.cpp
+++ b/src/os/os2/os2.cpp
@@ -154,27 +154,25 @@ void ShowOSErrorBox(const char *buf, bool system)
 	WinTerminate(hab);
 }
 
-bool GetClipboardContents(char *buffer, const char *last)
+std::optional<std::string> GetClipboardContents()
 {
 /* XXX -- Currently no clipboard support implemented with GCC */
 #ifndef __INNOTEK_LIBC__
 	HAB hab = 0;
 
-	if (WinOpenClipbrd(hab))
-	{
-		const char *text = (const char*)WinQueryClipbrdData(hab, CF_TEXT);
+	if (WinOpenClipbrd(hab)) {
+		const char *text = (const char *)WinQueryClipbrdData(hab, CF_TEXT);
 
-		if (text != nullptr)
-		{
-			strecpy(buffer, text, last);
+		if (text != nullptr) {
+			std::string result = text;
 			WinCloseClipbrd(hab);
-			return true;
+			return result;
 		}
 
 		WinCloseClipbrd(hab);
 	}
 #endif
-	return false;
+	return std::nullopt;
 }
 
 

--- a/src/os/unix/unix.cpp
+++ b/src/os/unix/unix.cpp
@@ -217,22 +217,20 @@ void ShowOSErrorBox(const char *buf, bool system)
 #endif
 
 #ifndef WITH_COCOA
-bool GetClipboardContents(char *buffer, const char *last)
+std::optional<std::string> GetClipboardContents()
 {
 #ifdef WITH_SDL2
-	if (SDL_HasClipboardText() == SDL_FALSE) {
-		return false;
-	}
+	if (SDL_HasClipboardText() == SDL_FALSE) return std::nullopt;
 
 	char *clip = SDL_GetClipboardText();
 	if (clip != nullptr) {
-		strecpy(buffer, clip, last);
+		std::string result = clip;
 		SDL_free(clip);
-		return true;
+		return result;
 	}
 #endif
 
-	return false;
+	return std::nullopt;
 }
 #endif
 

--- a/src/os/windows/win32.cpp
+++ b/src/os/windows/win32.cpp
@@ -433,26 +433,19 @@ void DetermineBasePaths(const char *exe)
 }
 
 
-bool GetClipboardContents(char *buffer, const char *last)
+std::optional<std::string> GetClipboardContents()
 {
-	HGLOBAL cbuf;
-	const char *ptr;
+	if (!IsClipboardFormatAvailable(CF_UNICODETEXT)) return std::nullopt;
 
-	if (IsClipboardFormatAvailable(CF_UNICODETEXT)) {
-		OpenClipboard(nullptr);
-		cbuf = GetClipboardData(CF_UNICODETEXT);
+	OpenClipboard(nullptr);
+	HGLOBAL cbuf = GetClipboardData(CF_UNICODETEXT);
 
-		ptr = (const char*)GlobalLock(cbuf);
-		int out_len = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR)ptr, -1, buffer, (last - buffer) + 1, nullptr, nullptr);
-		GlobalUnlock(cbuf);
-		CloseClipboard();
+	std::string result = FS2OTTD(static_cast<LPCWSTR>(GlobalLock(cbuf)));
+	GlobalUnlock(cbuf);
+	CloseClipboard();
 
-		if (out_len == 0) return false;
-	} else {
-		return false;
-	}
-
-	return true;
+	if (result.empty()) return std::nullopt;
+	return result;
 }
 
 

--- a/src/textbuf.cpp
+++ b/src/textbuf.cpp
@@ -23,11 +23,9 @@
  * Try to retrieve the current clipboard contents.
  *
  * @note OS-specific function.
- * @param buffer Clipboard content.
- * @param last The pointer to the last element of the destination buffer
- * @return True if some text could be retrieved.
+ * @return The (optional) clipboard contents.
  */
-bool GetClipboardContents(char *buffer, const char *last);
+std::optional<std::string> GetClipboardContents();
 
 int _caret_timer;
 
@@ -223,11 +221,10 @@ bool Textbuf::InsertString(const char *str, bool marked, const char *caret, cons
  */
 bool Textbuf::InsertClipboard()
 {
-	char utf8_buf[512];
+	auto contents = GetClipboardContents();
+	if (!contents.has_value()) return false;
 
-	if (!GetClipboardContents(utf8_buf, lastof(utf8_buf))) return false;
-
-	return this->InsertString(utf8_buf, false);
+	return this->InsertString(contents.value().c_str(), false);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

C-style string handling.


## Description

Buffer + bool return value to `std::optional<std::string>`.


## Limitations

Not tested on Apple nor OS/2.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
