### PR TITLE
Fix 646a7e62: recalc_time was not scaled properly

### DIFF
--- a/src/linkgraph/flowmapper.cpp
+++ b/src/linkgraph/flowmapper.cpp
@@ -50,7 +50,7 @@ void FlowMapper::Run(LinkGraphJob &job) const
 			/* Scale by time the graph has been running without being compressed. Add 1 to avoid
 			 * division by 0 if spawn date == last compression date. This matches
 			 * LinkGraph::Monthly(). */
-			uint runtime = job.JoinDate() - job.Settings().recalc_time - job.LastCompression() + 1;
+			uint runtime = job.JoinDate() - job.Settings().recalc_time / SECONDS_PER_DAY - job.LastCompression() + 1;
 			for (auto &it : flows) {
 				it.second.ScaleToMonthly(runtime);
 			}


### PR DESCRIPTION
## Motivation / Problem

Fixes #10870.

## Description

In 646a7e62 the `recalc_time` got scaled up by `SECONDS_PER_DAY`, but it was not scaled down on all usages. Now it is.

The not-scaling properly caused "runtime" to underflow or, if you are lucky, hit an assert in ScaleToMonthly when it hits zero. But mostly underflow.

## Limitations


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
