### PR TITLE
Fix: Re-opening GRF/script settings windows not closing drop down windows

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -107,6 +107,7 @@ struct GSConfigWindow : public Window {
 
 	void Close() override
 	{
+		HideDropDownMenu(this);
 		CloseWindowByClass(WC_SCRIPT_LIST);
 		this->Window::Close();
 	}

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -180,6 +180,12 @@ struct NewGRFParametersWindow : public Window {
 		this->InvalidateData();
 	}
 
+	void Close() override
+	{
+		HideDropDownMenu(this);
+		this->Window::Close();
+	}
+
 	/**
 	 * Get a dummy parameter-info object with default information.
 	 * @param nr The param number that should be changed.

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -316,6 +316,12 @@ struct ScriptSettingsWindow : public Window {
 		this->RebuildVisibleSettings();
 	}
 
+	void Close() override
+	{
+		HideDropDownMenu(this);
+		this->Window::Close();
+	}
+
 	/**
 	 * Rebuilds the list of visible settings. AI settings with the flag
 	 * AICONFIG_AI_DEVELOPER set will only be visible if the game setting


### PR DESCRIPTION
## Motivation / Problem

Re-opening the NewGRF paramer, AI setting, GS setting and GS config windows did not close their drop down windows, causing an assertion failure on window re-opening or subsequent drop down item selection.

The reproduction process is here: https://github.com/JGRennison/OpenTTD-patches/issues/527, but this is also generalisable to the AI and GS setting, and GS config windows.

Re-opening an identical window of one of the above types whilst such a window has a dropdown list open causes the dropdown window to be implicitly re-parented to the replacement window.
This triggers an assertion failure when the replacement window is in the wrong state to receive a dropdown select (or close) event.

## Description

Ensure that dropdown windows are suitably closed when windows of the aforementioned window types are closed.

## Limitations

N/A

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
