### PR TITLE
Codechange: Sprite mapping for objects doesn't involve cargo types.

### DIFF
--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5883,7 +5883,7 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 				continue;
 			}
 
-			spec->grf_prop.spritegroup[1] = _cur.spritegroups[groupid];
+			spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] = _cur.spritegroups[groupid];
 		}
 	}
 
@@ -5903,9 +5903,9 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 			continue;
 		}
 
-		spec->grf_prop.spritegroup[0] = _cur.spritegroups[groupid];
-		spec->grf_prop.grffile        = _cur.grffile;
-		spec->grf_prop.local_id       = object;
+		spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_DEFAULT] = _cur.spritegroups[groupid];
+		spec->grf_prop.grffile = _cur.grffile;
+		spec->grf_prop.local_id = object;
 	}
 }
 

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -5504,15 +5504,6 @@ static void NewSpriteGroup(ByteReader *buf)
 
 static CargoID TranslateCargo(uint8 feature, uint8 ctype)
 {
-	if (feature == GSF_OBJECTS) {
-		switch (ctype) {
-			case 0:    return 0;
-			case 0xFF: return CT_PURCHASE_OBJECT;
-			default:
-				GrfMsg(1, "TranslateCargo: Invalid cargo bitnum {} for objects, skipping.", ctype);
-				return CT_INVALID;
-		}
-	}
 	/* Special cargo types for purchase list and stations */
 	if ((feature == GSF_STATIONS || feature == GSF_ROADSTOPS) && ctype == 0xFE) return CT_DEFAULT_NA;
 	if (ctype == 0xFF) return CT_PURCHASE;
@@ -5878,8 +5869,11 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 		uint16 groupid = buf->ReadWord();
 		if (!IsValidGroupID(groupid, "ObjectMapSpriteGroup")) continue;
 
-		ctype = TranslateCargo(GSF_OBJECTS, ctype);
-		if (!IsValidCargoID(ctype)) continue;
+		/* The only valid option here is purchase list sprite groups. */
+		if (ctype != 0xFF) {
+			GrfMsg(1, "ObjectMapSpriteGroup: Invalid cargo bitnum {} for objects, skipping.", ctype);
+			continue;
+		}
 
 		for (auto &object : objects) {
 			ObjectSpec *spec = object >= _cur.grffile->objectspec.size() ? nullptr : _cur.grffile->objectspec[object].get();
@@ -5889,7 +5883,7 @@ static void ObjectMapSpriteGroup(ByteReader *buf, uint8 idcount)
 				continue;
 			}
 
-			spec->grf_prop.spritegroup[ctype] = _cur.spritegroups[groupid];
+			spec->grf_prop.spritegroup[1] = _cur.spritegroups[groupid];
 		}
 	}
 

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -378,8 +378,8 @@ ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, 
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
 	this->town_scope = nullptr;
-	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[1] != nullptr) ?
-			spec->grf_prop.spritegroup[1] : spec->grf_prop.spritegroup[0];
+	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] != nullptr) ?
+			spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_PURCHASE] : spec->grf_prop.spritegroup[OBJECT_SPRITE_GROUP_DEFAULT];
 }
 
 ObjectResolverObject::~ObjectResolverObject()

--- a/src/newgrf_object.cpp
+++ b/src/newgrf_object.cpp
@@ -378,8 +378,8 @@ ObjectResolverObject::ObjectResolverObject(const ObjectSpec *spec, Object *obj, 
 	: ResolverObject(spec->grf_prop.grffile, callback, param1, param2), object_scope(*this, obj, spec, tile, view)
 {
 	this->town_scope = nullptr;
-	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[CT_PURCHASE_OBJECT] != nullptr) ?
-			spec->grf_prop.spritegroup[CT_PURCHASE_OBJECT] : spec->grf_prop.spritegroup[0];
+	this->root_spritegroup = (obj == nullptr && spec->grf_prop.spritegroup[1] != nullptr) ?
+			spec->grf_prop.spritegroup[1] : spec->grf_prop.spritegroup[0];
 }
 
 ObjectResolverObject::~ObjectResolverObject()

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -166,6 +166,9 @@ private:
 /** Struct containing information relating to object classes. */
 typedef NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX> ObjectClass;
 
+static const size_t OBJECT_SPRITE_GROUP_DEFAULT = 0;
+static const size_t OBJECT_SPRITE_GROUP_PURCHASE = 1;
+
 uint16 GetObjectCallback(CallbackID callback, uint32 param1, uint32 param2, const ObjectSpec *spec, Object *o, TileIndex tile, uint8 view = 0);
 
 void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec);

--- a/src/newgrf_object.h
+++ b/src/newgrf_object.h
@@ -166,9 +166,6 @@ private:
 /** Struct containing information relating to object classes. */
 typedef NewGRFClass<ObjectSpec, ObjectClassID, OBJECT_CLASS_MAX> ObjectClass;
 
-/** Mapping of purchase for objects. */
-static const CargoID CT_PURCHASE_OBJECT = 1;
-
 uint16 GetObjectCallback(CallbackID callback, uint32 param1, uint32 param2, const ObjectSpec *spec, Object *o, TileIndex tile, uint8 view = 0);
 
 void DrawNewObjectTile(TileInfo *ti, const ObjectSpec *spec);


### PR DESCRIPTION
## Motivation / Problem

Objects have a default sprite group and an optional purchase list sprite group. There is no need to pretend that one of these is a cargo ID.

## Description

Remove TranslateCargo call from ObjectMapSpriteGroup and check for the valid value directly.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
