### PR TITLE
Codechange: use std::string to return the debug level information

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -220,22 +220,14 @@ void SetDebugString(const char *s, void (*error_func)(const std::string &))
  * Just return a string with the values of all the debug categories.
  * @return string with debug-levels
  */
-const char *GetDebugString()
+std::string GetDebugString()
 {
-	const DebugLevel *i;
-	static char dbgstr[150];
-	char dbgval[20];
-
-	memset(dbgstr, 0, sizeof(dbgstr));
-	i = debug_level;
-	seprintf(dbgstr, lastof(dbgstr), "%s=%d", i->name, *i->level);
-
-	for (i++; i != endof(debug_level); i++) {
-		seprintf(dbgval, lastof(dbgval), ", %s=%d", i->name, *i->level);
-		strecat(dbgstr, dbgval, lastof(dbgstr));
+	std::string result;
+	for (const DebugLevel *i = debug_level; i != endof(debug_level); ++i) {
+		if (!result.empty()) result += ", ";
+		fmt::format_to(std::back_inserter(result), "{}={}", i->name, *i->level);
 	}
-
-	return dbgstr;
+	return result;
 }
 
 /**

--- a/src/debug.h
+++ b/src/debug.h
@@ -58,7 +58,7 @@ extern int _debug_random_level;
 
 void DumpDebugFacilityNames(std::back_insert_iterator<std::string> &output_iterator);
 void SetDebugString(const char *s, void (*error_func)(const std::string &));
-const char *GetDebugString();
+std::string GetDebugString();
 
 /* Shorter form for passing filename and linenumber */
 #define FILE_LINE __FILE__, __LINE__


### PR DESCRIPTION
## Motivation / Problem

Usage of strecat and seprintf.
Fixes #10903.


## Description

Do not use the static buffer, but std::string for the debug level information.

Currently when built with `RANDOM_DEBUG` it uses 147 characters (excluding '\0'). Without that it's 137. Yes, you can set the debug level to more than 9 in which case it will truncate. However, I do not consider that a serious enough issue to warrant backporting or calling it a fix.

If the "bug" report wouldn't have been there, it would have been very likely that this change would have happened regardless due to the usage of strecat/seprintf.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
