### PR TITLE
Codechange: replace strstr with more appropriate function

### DIFF
--- a/src/openttd.cpp
+++ b/src/openttd.cpp
@@ -383,9 +383,9 @@ void MakeNewgameSettingsLive()
 void OpenBrowser(const char *url)
 {
 	/* Make sure we only accept urls that are sure to open a browser. */
-	if (strstr(url, "http://") != url && strstr(url, "https://") != url) return;
-
-	OSOpenBrowser(url);
+	if (StrStartsWith(url, "http://") || StrStartsWith(url, "https://")) {
+		OSOpenBrowser(url);
+	}
 }
 
 /** Callback structure of statements to be executed after the NewGRF scan. */


### PR DESCRIPTION
## Motivation / Problem

Why search for a string in a string, to check whether the result is the start of the string? When you just mean to ask: does this start with the other string?


## Description

Replace `strstr(string_to_search, prefix) == string_to_search` with `StrStartsWith(string_to_search, prefix)`


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
