### PR TITLE
Codechange: use fmt::format to create type prefixed driver names

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -210,13 +210,11 @@ DriverFactoryBase::DriverFactoryBase(Driver::Type type, int priority, const char
 	type(type), priority(priority), name(name), description(description)
 {
 	/* Prefix the name with driver type to make it unique */
-	char buf[32];
-	strecpy(buf, GetDriverTypeName(type), lastof(buf));
-	strecpy(buf + 5, name, lastof(buf));
+	std::string typed_name = fmt::format("{}{}", GetDriverTypeName(type), name);
 
 	Drivers &drivers = GetDrivers();
-	assert(drivers.find(buf) == drivers.end());
-	drivers.insert(Drivers::value_type(buf, this));
+	assert(drivers.find(typed_name) == drivers.end());
+	drivers.insert(Drivers::value_type(typed_name, this));
 }
 
 /**
@@ -225,11 +223,9 @@ DriverFactoryBase::DriverFactoryBase(Driver::Type type, int priority, const char
 DriverFactoryBase::~DriverFactoryBase()
 {
 	/* Prefix the name with driver type to make it unique */
-	char buf[32];
-	strecpy(buf, GetDriverTypeName(type), lastof(buf));
-	strecpy(buf + 5, this->name, lastof(buf));
+	std::string typed_name = fmt::format("{}{}", GetDriverTypeName(type), name);
 
-	Drivers::iterator it = GetDrivers().find(buf);
+	Drivers::iterator it = GetDrivers().find(typed_name);
 	assert(it != GetDrivers().end());
 
 	GetDrivers().erase(it);


### PR DESCRIPTION
## Motivation / Problem

Use of strecpy.


## Description

Use fmt::format.


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
