### PR TITLE
Fix: track "memory installed" for surveys less precisely

### DIFF
--- a/src/network/network_survey.cpp
+++ b/src/network/network_survey.cpp
@@ -298,6 +298,33 @@ static void SurveyGameScript(nlohmann::json &survey)
 	survey = fmt::format("{}.{}", Game::GetInfo()->GetName(), Game::GetInfo()->GetVersion());
 }
 
+/**
+ * Change the bytes of memory into a textual version rounded up to the biggest unit.
+ *
+ * For example, 16751108096 would become 16 GiB.
+ *
+ * @param memory The bytes of memory.
+ * @return std::string A textual representation.
+ */
+std::string SurveyMemoryToText(uint64_t memory)
+{
+	memory = memory / 1024; // KiB
+	memory = CeilDiv(memory, 1024); // MiB
+
+	/* Anything above 512 MiB we represent in GiB. */
+	if (memory > 512) {
+		return fmt::format("{} GiB", CeilDiv(memory, 1024));
+	}
+
+	/* Anything above 64 MiB we represent in a multiplier of 128 MiB. */
+	if (memory > 64) {
+		return fmt::format("{} MiB", Ceil(memory, 128));
+	}
+
+	/* Anything else in a multiplier of 4 MiB. */
+	return fmt::format("{} MiB", Ceil(memory, 4));
+}
+
 #endif /* WITH_NLOHMANN_JSON */
 
 /**
@@ -328,8 +355,6 @@ std::string NetworkSurveyHandler::CreatePayload(Reason reason, bool for_preview)
 	{
 		auto &info = survey["info"];
 		SurveyOS(info["os"]);
-		info["os"]["hardware_concurrency"] = std::thread::hardware_concurrency();
-
 		SurveyOpenTTD(info["openttd"]);
 		SurveyConfiguration(info["configuration"]);
 		SurveyFont(info["font"]);

--- a/src/os/macosx/survey_osx.cpp
+++ b/src/os/macosx/survey_osx.cpp
@@ -16,8 +16,11 @@
 
 #include <mach-o/arch.h>
 #include <nlohmann/json.hpp>
+#include <thread>
 
 #include "../../safeguards.h"
+
+extern std::string SurveyMemoryToText(uint64_t memory);
 
 void SurveyOS(nlohmann::json &json)
 {
@@ -32,7 +35,8 @@ void SurveyOS(nlohmann::json &json)
 	json["min_ver"] = MAC_OS_X_VERSION_MIN_REQUIRED;
 	json["max_ver"] = MAC_OS_X_VERSION_MAX_ALLOWED;
 
-	json["memory"] = MacOSGetPhysicalMemory();
+	json["memory"] = SurveyMemoryToText(MacOSGetPhysicalMemory());
+	json["hardware_concurrency"] = std::thread::hardware_concurrency();
 }
 
 #endif /* WITH_NLOHMANN_JSON */

--- a/src/os/unix/survey_unix.cpp
+++ b/src/os/unix/survey_unix.cpp
@@ -13,9 +13,12 @@
 
 #include <nlohmann/json.hpp>
 #include <sys/utsname.h>
+#include <thread>
 #include <unistd.h>
 
 #include "../../safeguards.h"
+
+extern std::string SurveyMemoryToText(uint64_t memory);
 
 void SurveyOS(nlohmann::json &json)
 {
@@ -32,7 +35,8 @@ void SurveyOS(nlohmann::json &json)
 
 	long pages = sysconf(_SC_PHYS_PAGES);
 	long page_size = sysconf(_SC_PAGE_SIZE);
-	json["memory"] = pages * page_size;
+	json["memory"] = SurveyMemoryToText(pages * page_size);
+	json["hardware_concurrency"] = std::thread::hardware_concurrency();
 }
 
 #endif /* WITH_NLOHMANN_JSON */

--- a/src/os/windows/survey_win.cpp
+++ b/src/os/windows/survey_win.cpp
@@ -14,9 +14,12 @@
 #include "../../3rdparty/fmt/format.h"
 
 #include <nlohmann/json.hpp>
+#include <thread>
 #include <windows.h>
 
 #include "../../safeguards.h"
+
+extern std::string SurveyMemoryToText(uint64_t memory);
 
 void SurveyOS(nlohmann::json &json)
 {
@@ -31,7 +34,8 @@ void SurveyOS(nlohmann::json &json)
 	status.dwLength = sizeof(status);
 	GlobalMemoryStatusEx(&status);
 
-	json["memory"] = status.ullTotalPhys;
+	json["memory"] = SurveyMemoryToText(status.ullTotalPhys);
+	json["hardware_concurrency"] = std::thread::hardware_concurrency();
 }
 
 #endif /* WITH_NLOHMANN_JSON */


### PR DESCRIPTION
## Motivation / Problem

It turns out, for Windows and Linux having the exact memory allows for easy tracing of an individual. That is exactly against the idea of the survey. And honestly, we don't need this precision.

## Description

Memory isn't all that precise for Linux and Windows; basically, you see the actual memory minus some value (things like VRAM etc are deduced from it).

To also allow representing things like 512 MiB of RAM, we use a simple algorithm to find what is the most likely nicest way to present the memory.

As bonus, also moved the concurrency to their OS functions; much cleaner code that way (but at the cost of a bit of duplication).

## Limitations



## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
