### PR TITLE
Fix: GRF Parameters not displayed due to scope issue.

### DIFF
--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -110,8 +110,9 @@ static void ShowNewGRFInfo(const GRFConfig *c, const Rect &r, bool show_params)
 
 	/* Show GRF parameter list */
 	if (show_params) {
+		std::string params;
 		if (c->num_params > 0) {
-			std::string params = GRFBuildParamList(c);
+			params = GRFBuildParamList(c);
 			SetDParam(0, STR_JUST_RAW_STRING);
 			SetDParamStr(1, params);
 		} else {


### PR DESCRIPTION
## Motivation / Problem

GRF Parameters are not displayed correctly in the NewGRF settings window.

SetDParamStr() is called with `params` but that goes out of scopes before the text is actually drawn.

## Description

Move params so it is still in scope when the text is actually drawn.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
