### PR TITLE
Fix: Ensure dropdowns are closed when closing focus or parent is closed.

### DIFF
--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -276,7 +276,7 @@ struct GSConfigWindow : public Window {
 				int num = it - this->visible_settings.begin();
 				if (this->clicked_row != num) {
 					this->CloseChildWindows(WC_QUERY_STRING);
-					HideDropDownMenu(this);
+					this->CloseChildWindows(WC_DROPDOWN_MENU);
 					this->clicked_row = num;
 					this->clicked_dropdown = false;
 				}
@@ -292,7 +292,7 @@ struct GSConfigWindow : public Window {
 				if (!bool_item && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && config_item.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
-						HideDropDownMenu(this);
+						this->CloseChildWindows(WC_DROPDOWN_MENU);
 						this->clicked_dropdown = false;
 						this->closing_dropdown = false;
 					} else {
@@ -408,7 +408,7 @@ struct GSConfigWindow : public Window {
 			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, !GameConfig::GetConfig()->GetTextfile(tft, (CompanyID)OWNER_DEITY).has_value());
 		}
 		this->RebuildVisibleSettings();
-		HideDropDownMenu(this);
+		this->CloseChildWindows(WC_DROPDOWN_MENU);
 		this->CloseChildWindows(WC_QUERY_STRING);
 	}
 private:

--- a/src/group_gui.cpp
+++ b/src/group_gui.cpp
@@ -461,7 +461,7 @@ public:
 
 		if (!(IsAllGroupID(this->vli.index) || IsDefaultGroupID(this->vli.index) || Group::IsValidID(this->vli.index))) {
 			this->vli.index = ALL_GROUP;
-			HideDropDownMenu(this);
+			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
 		this->SetDirty();
 	}
@@ -512,7 +512,7 @@ public:
 		/* The drop down menu is out, *but* it may not be used, retract it. */
 		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_GL_MANAGE_VEHICLES_DROPDOWN)) {
 			this->RaiseWidget(WID_GL_MANAGE_VEHICLES_DROPDOWN);
-			HideDropDownMenu(this);
+			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
 
 		/* Disable all lists management button when the list is empty */

--- a/src/newgrf_gui.cpp
+++ b/src/newgrf_gui.cpp
@@ -363,7 +363,7 @@ struct NewGRFParametersWindow : public Window {
 				uint num = it - this->grf_config->param_info.begin();
 				if (this->clicked_row != num) {
 					this->CloseChildWindows(WC_QUERY_STRING);
-					HideDropDownMenu(this);
+					this->CloseChildWindows(WC_DROPDOWN_MENU);
 					this->clicked_row = num;
 					this->clicked_dropdown = false;
 				}
@@ -379,7 +379,7 @@ struct NewGRFParametersWindow : public Window {
 				if (par_info.type != PTYPE_BOOL && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && par_info.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
-						HideDropDownMenu(this);
+						this->CloseChildWindows(WC_DROPDOWN_MENU);
 						this->clicked_dropdown = false;
 						this->closing_dropdown = false;
 					} else {

--- a/src/order_gui.cpp
+++ b/src/order_gui.cpp
@@ -854,7 +854,6 @@ public:
 				if (this->selected_order == -1) break;
 
 				this->CloseChildWindows();
-				HideDropDownMenu(this);
 				this->selected_order = -1;
 				break;
 
@@ -886,7 +885,6 @@ public:
 				if (to == INVALID_VEH_ORDER_ID) {
 					/* Deleting selected order */
 					this->CloseChildWindows();
-					HideDropDownMenu(this);
 					this->selected_order = -1;
 					break;
 				}
@@ -1186,7 +1184,6 @@ public:
 
 				/* This order won't be selected any more, close all child windows and dropdowns */
 				this->CloseChildWindows();
-				HideDropDownMenu(this);
 
 				if (sel == INVALID_VEH_ORDER_ID || this->vehicle->owner != _local_company) {
 					/* Deselect clicked order */

--- a/src/script/script_gui.cpp
+++ b/src/script/script_gui.cpp
@@ -434,7 +434,7 @@ struct ScriptSettingsWindow : public Window {
 				int num = it - this->visible_settings.begin();
 				if (this->clicked_row != num) {
 					this->CloseChildWindows(WC_QUERY_STRING);
-					HideDropDownMenu(this);
+					this->CloseChildWindows(WC_DROPDOWN_MENU);
 					this->clicked_row = num;
 					this->clicked_dropdown = false;
 				}
@@ -450,7 +450,7 @@ struct ScriptSettingsWindow : public Window {
 				if (!bool_item && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && config_item.complete_labels) {
 					if (this->clicked_dropdown) {
 						/* unclick the dropdown */
-						HideDropDownMenu(this);
+						this->CloseChildWindows(WC_DROPDOWN_MENU);
 						this->clicked_dropdown = false;
 						this->closing_dropdown = false;
 					} else {
@@ -560,7 +560,7 @@ struct ScriptSettingsWindow : public Window {
 	void OnInvalidateData(int data = 0, bool gui_scope = true) override
 	{
 		this->RebuildVisibleSettings();
-		HideDropDownMenu(this);
+		this->CloseChildWindows(WC_DROPDOWN_MENU);
 		this->CloseChildWindows(WC_QUERY_STRING);
 	}
 

--- a/src/settings_gui.cpp
+++ b/src/settings_gui.cpp
@@ -2349,7 +2349,7 @@ struct GameSettingsWindow : Window {
 
 			if (this->valuedropdown_entry == pe) {
 				/* unclick the dropdown */
-				HideDropDownMenu(this);
+				this->CloseChildWindows(WC_DROPDOWN_MENU);
 				this->closing_dropdown = false;
 				this->valuedropdown_entry->SetButtons(0);
 				this->valuedropdown_entry = nullptr;

--- a/src/vehicle_gui.cpp
+++ b/src/vehicle_gui.cpp
@@ -1966,7 +1966,7 @@ public:
 		this->SortVehicleList();
 
 		if (this->vehicles.size() == 0 && this->IsWidgetLowered(WID_VL_MANAGE_VEHICLES_DROPDOWN)) {
-			HideDropDownMenu(this);
+			this->CloseChildWindows(WC_DROPDOWN_MENU);
 		}
 
 		/* Hide the widgets that we will not use in this window

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -199,6 +199,11 @@ struct DropdownWindow : Window {
 		}
 	}
 
+	void OnFocusLost() override
+	{
+		this->Close();
+	}
+
 	Point OnInitialPosition(int16 sm_width, int16 sm_height, int window_number) override
 	{
 		return this->position;

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -339,7 +339,7 @@ struct DropdownWindow : Window {
  */
 void ShowDropDownListAt(Window *w, DropDownList &&list, int selected, int button, Rect wi_rect, Colours wi_colour, bool instant_close)
 {
-	CloseWindowById(WC_DROPDOWN_MENU, 0);
+	CloseWindowByClass(WC_DROPDOWN_MENU);
 
 	/* The preferred position is just below the dropdown calling widget */
 	int top = w->top + wi_rect.bottom + 1;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -3483,7 +3483,7 @@ void ChangeVehicleViewports(VehicleID from_index, VehicleID to_index)
  */
 void RelocateAllWindows(int neww, int newh)
 {
-	CloseWindowById(WC_DROPDOWN_MENU, 0);
+	CloseWindowByClass(WC_DROPDOWN_MENU);
 
 	for (Window *w : Window::Iterate()) {
 		int left, top;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -2331,7 +2331,6 @@ static void StartWindowDrag(Window *w)
 	_drag_delta.y = w->top  - _cursor.pos.y;
 
 	BringWindowToFront(w);
-	CloseWindowById(WC_DROPDOWN_MENU, 0);
 }
 
 /**
@@ -2349,7 +2348,6 @@ static void StartWindowSizing(Window *w, bool to_left)
 	_drag_delta.y = _cursor.pos.y;
 
 	BringWindowToFront(w);
-	CloseWindowById(WC_DROPDOWN_MENU, 0);
 }
 
 /**


### PR DESCRIPTION
## Motivation / Problem

In relation to #10904, except this is a generalised fixed rather than fixing up just the known problem spot.

In some cases dropdowns can stay open when they should have been closed.

Dropdowns also poll every mouse-loop to see if their parent window is still alive.

## Description

Instead of leaving this up to calling code, make dropdowns self-close when losing focus, and use the standard window->parent pointer so that child windows are automatically closed, and dropdowns can be closed with the standard methods.

HideDropDownMenu() is still used in one place where the return value is used, however.

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
