### PR TITLE
Add: GSAsyncMode(bool) class to set asynchronous mode of game script commands

### DIFF
--- a/src/script/api/CMakeLists.txt
+++ b/src/script/api/CMakeLists.txt
@@ -146,6 +146,7 @@ add_files(
     script_accounting.hpp
     script_admin.hpp
     script_airport.hpp
+    script_asyncmode.hpp
     script_base.hpp
     script_basestation.hpp
     script_bridge.hpp
@@ -219,6 +220,7 @@ add_files(
     script_accounting.cpp
     script_admin.cpp
     script_airport.cpp
+    script_asyncmode.cpp
     script_base.cpp
     script_basestation.cpp
     script_bridge.cpp

--- a/src/script/api/script_asyncmode.cpp
+++ b/src/script/api/script_asyncmode.cpp
@@ -1,0 +1,61 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_asyncmode.cpp Implementation of ScriptAsyncMode. */
+
+#include "../../stdafx.h"
+#include "script_asyncmode.hpp"
+#include "../script_instance.hpp"
+#include "../script_fatalerror.hpp"
+
+#include "../../safeguards.h"
+
+bool ScriptAsyncMode::AsyncModeProc()
+{
+	/* In async mode we only return 'true', telling the DoCommand it
+	 *  should stop run the command in asynchronous/fire-and-forget mode. */
+	return true;
+}
+
+bool ScriptAsyncMode::NonAsyncModeProc()
+{
+	/* In non-async mode we only return 'false', normal operation. */
+	return false;
+}
+
+ScriptAsyncMode::ScriptAsyncMode(HSQUIRRELVM vm)
+{
+	int nparam = sq_gettop(vm) - 1;
+	if (nparam < 1) {
+		throw sq_throwerror(vm, "You need to pass a boolean to the constructor");
+	}
+
+	SQBool sqasync;
+	if (SQ_FAILED(sq_getbool(vm, 2, &sqasync))) {
+		throw sq_throwerror(vm, "Argument must be a boolean");
+	}
+
+	this->last_mode     = this->GetDoCommandMode();
+	this->last_instance = this->GetDoCommandModeInstance();
+
+	this->SetDoCommandAsyncMode(sqasync ? &ScriptAsyncMode::AsyncModeProc : &ScriptAsyncMode::NonAsyncModeProc, this);
+}
+
+void ScriptAsyncMode::FinalRelease()
+{
+	if (this->GetDoCommandAsyncModeInstance() != this) {
+		/* Ignore this error if the script already died. */
+		if (!ScriptObject::GetActiveInstance()->IsDead()) {
+			throw Script_FatalError("Asyncmode object was removed while it was not the latest *Mode object created.");
+		}
+	}
+}
+
+ScriptAsyncMode::~ScriptAsyncMode()
+{
+	this->SetDoCommandAsyncMode(this->last_mode, this->last_instance);
+}

--- a/src/script/api/script_asyncmode.hpp
+++ b/src/script/api/script_asyncmode.hpp
@@ -1,0 +1,63 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file script_asyncmode.hpp Switch the script instance to Async Mode. */
+
+#ifndef SCRIPT_ASYNCMODE_HPP
+#define SCRIPT_ASYNCMODE_HPP
+
+#include "script_object.hpp"
+
+/**
+ * Class to switch current mode to Async Mode.
+ * If you create an instance of this class, the mode will be switched to
+ *   either Asynchronous or Non-Asynchronous mode.
+ *   The original mode is stored and recovered from when ever the instance is destroyed.
+ * In Asynchronous mode all the commands you execute are queued for later execution. The
+ *   system checks if it would be able to execute your requests, and returns what
+ *   the cost would be. The actual cost and whether the command succeeded when the command
+ *   is eventually executed may differ from what was reported to the script.
+ * @api game
+ */
+class ScriptAsyncMode : public ScriptObject {
+private:
+	ScriptAsyncModeProc *last_mode; ///< The previous mode we were in.
+	ScriptObject *last_instance;    ///< The previous instance of the mode.
+
+protected:
+	static bool AsyncModeProc();
+	static bool NonAsyncModeProc();
+
+public:
+#ifndef DOXYGEN_API
+	/**
+	 * The constructor wrapper from Squirrel.
+	 */
+	ScriptAsyncMode(HSQUIRRELVM vm);
+#else
+	/**
+	 * Creating instance of this class switches the build mode to Asynchronous or Non-Asynchronous (normal).
+	 * @note When the instance is destroyed, it restores the mode that was
+	 *   current when the instance was created!
+	 * @param asynchronous Whether the new mode should be Asynchronous, if true, or Non-Asynchronous, if false.
+	 */
+	ScriptAsyncMode(bool asynchronous);
+#endif /* DOXYGEN_API */
+
+	/**
+	 * Destroying this instance resets the asynchronous mode to the mode it was
+	 *   in when the instance was created.
+	 */
+	~ScriptAsyncMode();
+
+	/**
+	 * @api -all
+	 */
+	virtual void FinalRelease();
+};
+
+#endif /* SCRIPT_ASYNCMODE_HPP */

--- a/src/script/api/script_object.hpp
+++ b/src/script/api/script_object.hpp
@@ -30,6 +30,11 @@
 typedef bool (ScriptModeProc)();
 
 /**
+ * The callback function for Async Mode-classes.
+ */
+typedef bool (ScriptAsyncModeProc)();
+
+/**
  * Uper-parent object of all API classes. You should never use this class in
  *   your script, as it doesn't publish any public functions. It is used
  *   internally to have a common place to handle general things, like internal
@@ -189,6 +194,21 @@ protected:
 	static ScriptObject *GetDoCommandModeInstance();
 
 	/**
+	 * Set the current async mode of your script to this proc.
+	 */
+	static void SetDoCommandAsyncMode(ScriptAsyncModeProc *proc, ScriptObject *instance);
+
+	/**
+	 * Get the current async mode your script is currently under.
+	 */
+	static ScriptModeProc *GetDoCommandAsyncMode();
+
+	/**
+	 * Get the instance of the current async mode your script is currently under.
+	 */
+	static ScriptObject *GetDoCommandAsyncModeInstance();
+
+	/**
 	 * Set the delay of the DoCommand.
 	 */
 	static void SetDoCommandDelay(uint ticks);
@@ -286,8 +306,8 @@ protected:
 
 private:
 	/* Helper functions for DoCommand. */
-	static std::tuple<bool, bool, bool> DoCommandPrep();
-	static bool DoCommandProcessResult(const CommandCost &res, Script_SuspendCallbackProc *callback, bool estimate_only);
+	static std::tuple<bool, bool, bool, bool> DoCommandPrep();
+	static bool DoCommandProcessResult(const CommandCost &res, Script_SuspendCallbackProc *callback, bool estimate_only, bool asynchronous);
 	static CommandCallbackData *GetDoCommandCallback();
 	static Randomizer random_states[OWNER_END]; ///< Random states for each of the scripts (game script uses OWNER_DEITY)
 };
@@ -338,7 +358,7 @@ namespace ScriptObjectInternal {
 template <Commands Tcmd, typename Tret, typename... Targs>
 bool ScriptObject::ScriptDoCommandHelper<Tcmd, Tret(*)(DoCommandFlag, Targs...)>::Execute(Script_SuspendCallbackProc *callback, std::tuple<Targs...> args)
 {
-	auto [err, estimate_only, networking] = ScriptObject::DoCommandPrep();
+	auto [err, estimate_only, asynchronous, networking] = ScriptObject::DoCommandPrep();
 	if (err) return false;
 
 	if ((::GetCommandFlags<Tcmd>() & CMD_STR_CTRL) == 0) {
@@ -363,10 +383,10 @@ bool ScriptObject::ScriptDoCommandHelper<Tcmd, Tret(*)(DoCommandFlag, Targs...)>
 	Tret res = ::Command<Tcmd>::Unsafe((StringID)0, networking ? ScriptObject::GetDoCommandCallback() : nullptr, false, estimate_only, tile, args);
 
 	if constexpr (std::is_same_v<Tret, CommandCost>) {
-		return ScriptObject::DoCommandProcessResult(res, callback, estimate_only);
+		return ScriptObject::DoCommandProcessResult(res, callback, estimate_only, asynchronous);
 	} else {
 		ScriptObject::SetLastCommandResData(EndianBufferWriter<CommandDataBuffer>::FromValue(ScriptObjectInternal::RemoveFirstTupleElement(res)));
-		return ScriptObject::DoCommandProcessResult(std::get<0>(res), callback, estimate_only);
+		return ScriptObject::DoCommandProcessResult(std::get<0>(res), callback, estimate_only, asynchronous);
 	}
 }
 

--- a/src/script/script_storage.hpp
+++ b/src/script/script_storage.hpp
@@ -27,6 +27,11 @@
 typedef bool (ScriptModeProc)();
 
 /**
+ * The callback function for Async Mode-classes.
+ */
+typedef bool (ScriptAsyncModeProc)();
+
+/**
  * The storage for each script. It keeps track of important information.
  */
 class ScriptStorage {
@@ -34,6 +39,8 @@ friend class ScriptObject;
 private:
 	ScriptModeProc *mode;             ///< The current build mode we are int.
 	class ScriptObject *mode_instance; ///< The instance belonging to the current build mode.
+	ScriptAsyncModeProc *async_mode;         ///< The current command async mode we are in.
+	class ScriptObject *async_mode_instance; ///< The instance belonging to the current command async mode.
 	CompanyID root_company;          ///< The root company, the company that the script really belongs to.
 	CompanyID company;               ///< The current company.
 
@@ -61,6 +68,8 @@ public:
 	ScriptStorage() :
 		mode              (nullptr),
 		mode_instance     (nullptr),
+		async_mode        (nullptr),
+		async_mode_instance (nullptr),
 		root_company      (INVALID_OWNER),
 		company           (INVALID_OWNER),
 		delay             (1),


### PR DESCRIPTION
## Motivation / Problem

Currently all GS commands cause the script to be suspended for at least 1 tick, such that it can receive the eventual result of the command as executed on all clients (in single-player, this delay is artificially added).
The vast majority of the time, the result of a command is not used by the GS.
A typical GS spends almost all of its time in a loop issuing commands to set town/industry/etc. text values, or update town growth values, for all towns/industries/etc.
The net effect of this is that GSs are excessively slow to update the game state.

## Description

Add a GSAsyncMode(bool) class to set async mode of game script commands.
The script syntax and mode of operation is broadly equivalent to the GSTestMode class.
In asynchronous mode, don't wait for result of executed command, just fire-and-forget, and return estimated cost/result.
The GS does not lose its time slice when executing a command asynchronously, so charge a nominal opcode fee instead.

## Limitations

Commands issued by the GS are still limited by the network.commands_per_frame setting.
I can create another PR for that if this is merged.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
