### PR TITLE
Fix: [SDL] unify the way X11 and Wayland handle mouse events

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1880,27 +1880,17 @@ void SetAnimatedMouseCursor(const AnimCursor *table)
 }
 
 /**
- * Update cursor position on mouse movement for relative modes.
+ * Update cursor position based on a relative change.
+ *
  * @param delta_x How much change in the X position.
  * @param delta_y How much change in the Y position.
  */
 void CursorVars::UpdateCursorPositionRelative(int delta_x, int delta_y)
 {
-	if (this->fix_at) {
-		this->delta.x = delta_x;
-		this->delta.y = delta_y;
-	} else {
-		int last_position_x = this->pos.x;
-		int last_position_y = this->pos.y;
+	assert(this->fix_at);
 
-		this->pos.x = Clamp(this->pos.x + delta_x, 0, _cur_resolution.width - 1);
-		this->pos.y = Clamp(this->pos.y + delta_y, 0, _cur_resolution.height - 1);
-
-		this->delta.x = last_position_x - this->pos.x;
-		this->delta.y = last_position_y - this->pos.y;
-
-		this->dirty = true;
-	}
+	this->delta.x = delta_x;
+	this->delta.y = delta_y;
 }
 
 /**

--- a/src/gfx_type.h
+++ b/src/gfx_type.h
@@ -144,11 +144,7 @@ struct CursorVars {
 	bool vehchain;                ///< vehicle chain is dragged
 
 	void UpdateCursorPositionRelative(int delta_x, int delta_y);
-	bool UpdateCursorPosition(int x, int y, bool queued_warp);
-
-private:
-	bool queued_warp;
-	Point last_position;
+	bool UpdateCursorPosition(int x, int y);
 };
 
 /** Data about how and where to blit pixels. */

--- a/src/video/allegro_v.cpp
+++ b/src/video/allegro_v.cpp
@@ -391,7 +391,7 @@ bool VideoDriver_Allegro::PollEvent()
 	}
 
 	/* Mouse movement */
-	if (_cursor.UpdateCursorPosition(mouse_x, mouse_y, false)) {
+	if (_cursor.UpdateCursorPosition(mouse_x, mouse_y)) {
 		position_mouse(_cursor.pos.x, _cursor.pos.y);
 	}
 	if (_cursor.delta.x != 0 || _cursor.delta.y) mouse_action = true;

--- a/src/video/cocoa/cocoa_wnd.mm
+++ b/src/video/cocoa/cocoa_wnd.mm
@@ -658,7 +658,7 @@ void CocoaDialog(const char *title, const char *message, const char *buttonLabel
 		_cursor.UpdateCursorPositionRelative(event.deltaX * self.getContentsScale, event.deltaY * self.getContentsScale);
 	} else {
 		NSPoint pt = [ self mousePositionFromEvent:event ];
-		_cursor.UpdateCursorPosition(pt.x, pt.y, false);
+		_cursor.UpdateCursorPosition(pt.x, pt.y);
 	}
 
 	HandleMouseEvents();

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -371,12 +371,25 @@ bool VideoDriver_SDL_Base::PollEvent()
 	if (!SDL_PollEvent(&ev)) return false;
 
 	switch (ev.type) {
-		case SDL_MOUSEMOTION:
-			if (_cursor.UpdateCursorPosition(ev.motion.x, ev.motion.y, true)) {
+		case SDL_MOUSEMOTION: {
+			int32_t x = ev.motion.x;
+			int32_t y = ev.motion.y;
+
+			if (_cursor.fix_at) {
+				/* Get all queued mouse events now in case we have to warp the cursor. In the
+				 * end, we only care about the current mouse position and not bygone events. */
+				while (SDL_PeepEvents(&ev, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION)) {
+					x = ev.motion.x;
+					y = ev.motion.y;
+				}
+			}
+
+			if (_cursor.UpdateCursorPosition(x, y, false)) {
 				SDL_WarpMouseInWindow(this->sdl_window, _cursor.pos.x, _cursor.pos.y);
 			}
 			HandleMouseEvents();
 			break;
+		}
 
 		case SDL_MOUSEWHEEL:
 			if (ev.wheel.y > 0) {
@@ -478,10 +491,8 @@ bool VideoDriver_SDL_Base::PollEvent()
 			} else if (ev.window.event == SDL_WINDOWEVENT_ENTER) {
 				// mouse entered the window, enable cursor
 				_cursor.in_window = true;
-#ifdef __EMSCRIPTEN__
 				/* Ensure pointer lock will not occur. */
 				SDL_SetRelativeMouseMode(SDL_FALSE);
-#endif
 			} else if (ev.window.event == SDL_WINDOWEVENT_LEAVE) {
 				// mouse left the window, undraw cursor
 				UndrawMouseCursor();
@@ -500,9 +511,6 @@ static const char *InitializeSDL()
 	 * UpdateWindowSurface() to update the window's texture instead of
 	 * its surface. */
 	SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "0");
-#ifndef __EMSCRIPTEN__
-	SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
-#endif
 
 	/* Check if the video-driver is already initialized. */
 	if (SDL_WasInit(SDL_INIT_VIDEO) != 0) return nullptr;

--- a/src/video/sdl2_v.cpp
+++ b/src/video/sdl2_v.cpp
@@ -384,7 +384,7 @@ bool VideoDriver_SDL_Base::PollEvent()
 				}
 			}
 
-			if (_cursor.UpdateCursorPosition(x, y, false)) {
+			if (_cursor.UpdateCursorPosition(x, y)) {
 				SDL_WarpMouseInWindow(this->sdl_window, _cursor.pos.x, _cursor.pos.y);
 			}
 			HandleMouseEvents();

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -478,12 +478,25 @@ bool VideoDriver_SDL::PollEvent()
 	if (!SDL_PollEvent(&ev)) return false;
 
 	switch (ev.type) {
-		case SDL_MOUSEMOTION:
-			if (_cursor.UpdateCursorPosition(ev.motion.x, ev.motion.y, true)) {
+		case SDL_MOUSEMOTION: {
+			int32_t x = ev.motion.x;
+			int32_t y = ev.motion.y;
+
+			if (_cursor.fix_at) {
+				/* Get all queued mouse events now in case we have to warp the cursor. In the
+				 * end, we only care about the current mouse position and not bygone events. */
+				while (SDL_PeepEvents(&ev, 1, SDL_GETEVENT, SDL_MOUSEMOTION)) {
+					x = ev.motion.x;
+					y = ev.motion.y;
+				}
+			}
+
+			if (_cursor.UpdateCursorPosition(x, y, false)) {
 				SDL_WarpMouse(_cursor.pos.x, _cursor.pos.y);
 			}
 			HandleMouseEvents();
 			break;
+		}
 
 		case SDL_MOUSEBUTTONDOWN:
 			if (_rightclick_emulate && SDL_GetModState() & KMOD_CTRL) {

--- a/src/video/sdl_v.cpp
+++ b/src/video/sdl_v.cpp
@@ -491,7 +491,7 @@ bool VideoDriver_SDL::PollEvent()
 				}
 			}
 
-			if (_cursor.UpdateCursorPosition(x, y, false)) {
+			if (_cursor.UpdateCursorPosition(x, y)) {
 				SDL_WarpMouse(_cursor.pos.x, _cursor.pos.y);
 			}
 			HandleMouseEvents();

--- a/src/video/win32_v.cpp
+++ b/src/video/win32_v.cpp
@@ -490,7 +490,7 @@ LRESULT CALLBACK WndProcGdi(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 				}
 			}
 
-			if (_cursor.UpdateCursorPosition(x, y, false)) {
+			if (_cursor.UpdateCursorPosition(x, y)) {
 				POINT pt;
 				pt.x = _cursor.pos.x;
 				pt.y = _cursor.pos.y;


### PR DESCRIPTION
## Motivation / Problem

#10140 mentions issues with Wayland and SDL, where mouse movement stutters. This made me look into the mouse movement handling, and it has grown a bit weird over the years.


## Description

Basically, we drop RelativeMode completely, and use the same trick as used by the Windows driver: read all motion events till the last one, and use that as value.

As SDL was the last one using RelativeMode, this means we can clean up all the special code for this. Additionally, `UpdateCursorPositionRelative` exists which is only called by MacOS and always when `fix_at`. So simplified that code while at it.

This still leaves the problem that `SDL_WarpMouseInWindow` doesn't always work on all systems (like WSLg or Remote Desktop); this PR doesn't addresses this, but hopefully also doesn't make it worse.

As final thought, this also unifies Emscripten back with the rest of the SDL users.


## Limitations

This needs testing by native Linux users, both X11 and Wayland.

- [x] Tested on Emscripten
- [x] Tested on X11 via WSLg
- [x] Tested on Wayland via WSLg
- [x] Tested on X11 natively
- [x] Tested on Wayland natively

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
