### PR TITLE
Add: [Linux] change default scroll mode to non-mouse-lock

### DIFF
--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -1558,7 +1558,7 @@ STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREY_TO_RED                :Grey to red
 STR_CONFIG_SETTING_LINKGRAPH_COLOURS_GREYSCALE                  :Greyscale
 
 STR_CONFIG_SETTING_SCROLLMODE                                   :Viewport scroll behaviour: {STRING2}
-STR_CONFIG_SETTING_SCROLLMODE_HELPTEXT                          :Behaviour when scrolling the map
+STR_CONFIG_SETTING_SCROLLMODE_HELPTEXT                          :Behaviour when scrolling the map. The "mouse position locked" options don't work on all systems, like web-based versions, touchscreens, Linux with Wayland, and others
 ###length 4
 STR_CONFIG_SETTING_SCROLLMODE_DEFAULT                           :Move viewport with RMB, mouse position locked
 STR_CONFIG_SETTING_SCROLLMODE_RMB_LOCKED                        :Move map with RMB, mouse position locked

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -98,7 +98,7 @@ strval   = STR_CONFIG_SETTING_AUTOSCROLL_DISABLED
 cat      = SC_BASIC
 
 [SDTC_VAR]
-ifdef    = __EMSCRIPTEN__
+ifdef    = UNIX
 var      = gui.scroll_mode
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN
@@ -111,7 +111,7 @@ strval   = STR_CONFIG_SETTING_SCROLLMODE_DEFAULT
 cat      = SC_BASIC
 
 [SDTC_VAR]
-ifndef    = __EMSCRIPTEN__
+ifndef    = UNIX
 var      = gui.scroll_mode
 type     = SLE_UINT8
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC | SF_GUI_DROPDOWN


### PR DESCRIPTION
## Motivation / Problem

Not all SDL backends support mouse locking, of "warping". This means users are left confused why the navigation is so shitty, and have to find a certain setting to make it better.

I think it would be better if we guide the user towards this goal.
This most likely is the root cause of #10140, as Wayland doesn't support warping at all.

Fixes #10140.

## Description

Wayland doesn't support mouse warping, X11 only for native systems (so not for remote desktop, WSLg, etc), and emscripten neither without complications. All these cannot offer a mouse-lock.

So the amount of systems that do offer it, are less and less than those that do offer it. Enough reason to flip the switch here.

Initially we tried to detect whether warping was supported, but this turns out to be nearly impossible. Detection for Wayland is simple, but detecting whether the X11 backend actually supports warping ... no. So this solution is simpler.

This will confuse a few players, especially those on X11 and have everything working. But we were enable to find a proper solution that works for all; and we rather have 100% of the players able to play the game, than N% of the players having it the way they are used to.

## Limitations

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
