### PR TITLE
Codechange: introduce (temporary) string builder and use it for formatting numbers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -424,6 +424,7 @@ add_files(
     stringfilter_type.h
     strings.cpp
     strings_func.h
+    strings_internal.h
     strings_type.h
     subsidy.cpp
     subsidy_base.h

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -1,0 +1,123 @@
+/*
+ * This file is part of OpenTTD.
+ * OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file strings_interal.h Types and functions related to the internal workings of formatting OpenTTD's strings. */
+
+#ifndef STRINGS_INTERNAL_H
+#define STRINGS_INTERNAL_H
+
+/**
+ * Equivalent to the std::back_insert_iterator in function, with some
+ * convenience helpers for string concatenation.
+ *
+ * The formatter is currently backed by an external char buffer, and has some
+ * extra functions to ease the migration from char buffers to std::string.
+ */
+class StringBuilder {
+	char *current; ///< The current location to add strings
+	const char *last; ///< The last element of the buffer.
+
+public:
+	/* Required type for this to be an output_iterator; mimics std::back_insert_iterator. */
+	using value_type = void;
+	using difference_type = void;
+	using iterator_category = std::output_iterator_tag;
+	using pointer = void;
+	using reference = void;
+
+	/**
+	 * Create the builder of an external buffer.
+	 * @param start The start location to write to.
+	 * @param last  The last location to write to.
+	 */
+	StringBuilder(char *start, const char *last) : current(start), last(last) {}
+
+	/* Required operators for this to be an output_iterator; mimics std::back_insert_iterator, which has no-ops. */
+	StringBuilder &operator++() { return *this; }
+	StringBuilder operator++(int) { return *this; }
+	StringBuilder &operator*() { return *this; }
+
+	/**
+	 * Operator to add a character to the end of the buffer. Like the back
+	 * insert iterators this also increases the position of the end of the
+	 * buffer.
+	 * @param value The character to add.
+	 * @return Reference to this inserter.
+	 */
+	StringBuilder &operator=(const char value)
+	{
+		return this->operator+=(value);
+	}
+
+	/**
+	 * Operator to add a character to the end of the buffer.
+	 * @param value The character to add.
+	 * @return Reference to this inserter.
+	 */
+	StringBuilder &operator+=(const char value)
+	{
+		if (this->current != this->last) *this->current++ = value;
+		return *this;
+	}
+
+	/**
+	 * Operator to append the given string to the output buffer.
+	 * @param str The string to add.
+	 * @return Reference to this inserter.
+	 */
+	StringBuilder &operator+=(const char *str)
+	{
+		this->current = strecpy(this->current, str, this->last);
+		return *this;
+	}
+
+	/**
+	 * Operator to append the given string to the output buffer.
+	 * @param str The string to add.
+	 * @return Reference to this inserter.
+	 */
+	StringBuilder &operator+=(const std::string &str)
+	{
+		return this->operator+=(str.c_str());
+	}
+
+	/**
+	 * Encode the given Utf8 character into the output buffer.
+	 * @param c The character to encode.
+	 * @return true iff there was enough space and the character got added.
+	 */
+	bool Utf8Encode(WChar c)
+	{
+		if (this->Remaining() < Utf8CharLen(c)) return false;
+
+		this->current += ::Utf8Encode(this->current, c);
+		return true;
+	}
+
+	/**
+	 * Get the pointer to the this->last written element in the buffer.
+	 * This call does '\0' terminate the string, whereas other calls do not
+	 * (necessarily) do this.
+	 * @return The this->current end of the string.
+	 */
+	char *GetEnd()
+	{
+		*this->current = '\0';
+		return this->current;
+	}
+
+	/**
+	 * Get the remaining number of characters that can be placed.
+	 * @return The number of characters.
+	 */
+	ptrdiff_t Remaining()
+	{
+		return (ptrdiff_t)(this->last - this->current);
+	}
+};
+
+#endif /* STRINGS_INTERNAL_H */


### PR DESCRIPTION
## Motivation / Problem

The strings system uses a (limited) char buffer to write the data strings to. This has to be changed to std::string.


## Description

Introduce a `StringBuilder` that essentially a functional `std::back_insert_iterator<std::string>` with a number of convenience functions for the migration. At some point the `StringBuilder` will have to be replaced by `std::back_insert_iterator<std::string>` or just aliasing it as such.
This is the first step of rewriting the string system, and originally part of #10810 but I'm trying to get it merged in some smaller steps now.


## Limitations

Not the complete migration, but just a step towards moving to std::string.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
