### PR TITLE
Codechange: let FormatString use StringBuilder

### DIFF
--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -118,6 +118,16 @@ public:
 	{
 		return (ptrdiff_t)(this->last - this->current);
 	}
+
+	/**
+	 * Add a string using the strecpy/strecat-esque calling signature.
+	 * @param function The function to pass the current and last location to,
+	 *                 that will then return the new current location.
+	 */
+	void AddViaStreCallback(std::function<char*(char*, const char*)> function)
+	{
+		this->current = function(this->current, this->last);
+	}
 };
 
 #endif /* STRINGS_INTERNAL_H */


### PR DESCRIPTION
## Motivation / Problem

The strings system uses a (limited) char buffer to write the data strings to. This has to be changed to std::string.


## Description

Use the `StringBuilder` in `FormatString`, add some migration helpers so `GetStringWithArgs` can still remain as it is.


## Limitations

Depends on #10884 to get merged.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
