### PR TITLE
Fix: disable hardware acceleration when GPU driver crashed the game last attempt

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -16,7 +16,14 @@
 #include "video/video_driver.hpp"
 #include "string_func.h"
 #include "table/strings.h"
+#include "fileio_func.h"
 #include <sstream>
+
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <unistd.h>
+#endif /* _WIN32 */
 
 #include "safeguards.h"
 
@@ -31,6 +38,8 @@ std::string _ini_musicdriver;        ///< The music driver a stored in the confi
 
 std::string _ini_blitter;            ///< The blitter as stored in the configuration file.
 bool _blitter_autodetected;          ///< Was the blitter autodetected or specified by the user?
+
+static const std::string HWACCELERATION_TEST_FILE = "hwaccel.dat"; ///< Filename to test if we crashed last time we tried to use hardware acceleration.
 
 /**
  * Get a string parameter the list of parameters.
@@ -114,6 +123,27 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 
 				if (type == Driver::DT_VIDEO && !_video_hw_accel && d->UsesHardwareAcceleration()) continue;
 
+				if (type == Driver::DT_VIDEO && _video_hw_accel && d->UsesHardwareAcceleration()) {
+					/* Check if we have already tried this driver in last run.
+					 * If it is here, it most likely means we crashed. So skip
+					 * hardware acceleration. */
+					auto filename = FioFindFullPath(BASE_DIR, HWACCELERATION_TEST_FILE);
+					if (!filename.empty()) {
+						unlink(filename.c_str());
+
+						Debug(driver, 1, "Probing {} driver '{}' skipped due to earlier crash", GetDriverTypeName(type), d->name);
+
+						_video_hw_accel = false;
+						ErrorMessageData msg(STR_VIDEO_DRIVER_ERROR, STR_VIDEO_DRIVER_ERROR_HARDWARE_ACCELERATION_CRASH, true);
+						ScheduleErrorMessage(msg);
+						continue;
+					}
+
+					/* Write empty file to note we are attempting hardware acceleration. */
+					auto f = FioFOpenFile(HWACCELERATION_TEST_FILE, "w", BASE_DIR);
+					FioFCloseFile(f);
+				}
+
 				Driver *oldd = *GetActiveDriver(type);
 				Driver *newd = d->CreateInstance();
 				*GetActiveDriver(type) = newd;
@@ -131,7 +161,7 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 
 				if (type == Driver::DT_VIDEO && _video_hw_accel && d->UsesHardwareAcceleration()) {
 					_video_hw_accel = false;
-					ErrorMessageData msg(STR_VIDEO_DRIVER_ERROR, STR_VIDEO_DRIVER_ERROR_NO_HARDWARE_ACCELERATION);
+					ErrorMessageData msg(STR_VIDEO_DRIVER_ERROR, STR_VIDEO_DRIVER_ERROR_NO_HARDWARE_ACCELERATION, true);
 					ScheduleErrorMessage(msg);
 				}
 			}
@@ -175,6 +205,18 @@ bool DriverFactoryBase::SelectDriverImpl(const std::string &name, Driver::Type t
 		}
 		UserError("No such {} driver: {}\n", GetDriverTypeName(type), dname);
 	}
+}
+
+/**
+ * Mark the current video driver as operational.
+ */
+void DriverFactoryBase::MarkVideoDriverOperational()
+{
+	/* As part of the detection whether the GPU driver crashes the game,
+	 * and as we are operational now, remove the hardware acceleration
+	 * test-file. */
+	auto filename = FioFindFullPath(BASE_DIR, HWACCELERATION_TEST_FILE);
+	if (!filename.empty()) unlink(filename.c_str());
 }
 
 /**

--- a/src/driver.h
+++ b/src/driver.h
@@ -100,6 +100,8 @@ private:
 
 	static bool SelectDriverImpl(const std::string &name, Driver::Type type);
 
+	static void MarkVideoDriverOperational();
+
 protected:
 	DriverFactoryBase(Driver::Type type, int priority, const char *name, const char *description);
 

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -2080,6 +2080,7 @@ STR_CONFIG_ERROR_SPRITECACHE_TOO_BIG                            :{WHITE}Allocati
 # Video initalization errors
 STR_VIDEO_DRIVER_ERROR                                          :{WHITE}Error with video settings...
 STR_VIDEO_DRIVER_ERROR_NO_HARDWARE_ACCELERATION                 :{WHITE}... no compatible GPU found. Hardware acceleration disabled
+STR_VIDEO_DRIVER_ERROR_HARDWARE_ACCELERATION_CRASH              :{WHITE}... GPU driver crashed the game. Hardware acceleration disabled
 
 # Intro window
 STR_INTRO_CAPTION                                               :{WHITE}OpenTTD {REV}

--- a/src/video/video_driver.cpp
+++ b/src/video/video_driver.cpp
@@ -12,6 +12,7 @@
 #include "../network/network.h"
 #include "../blitter/factory.hpp"
 #include "../debug.h"
+#include "../driver.h"
 #include "../fontcache.h"
 #include "../gfx_func.h"
 #include "../gfxinit.h"
@@ -156,6 +157,13 @@ void VideoDriver::Tick()
 		this->Paint();
 
 		this->UnlockVideoBuffer();
+
+		/* Wait till the first successful drawing tick before marking the driver as operational. */
+		static bool first_draw_tick = true;
+		if (first_draw_tick) {
+			first_draw_tick = false;
+			DriverFactoryBase::MarkVideoDriverOperational();
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation / Problem

We have a slow but steady report of "game crashes on startup" over the last few months. All these cases come down to:
- We start the OpenGL driver
- The driver crashes for one reason or the other

This leaves the user confused, and they have to dig through tons of things to find out they have to add `-v win32` to start the game. Only then they can disable hardware acceleration.

I was wondering: can't we detect if we crashed, and on next start, disable hardware acceleration for the user?

Fixes #10463 
Fixes #10394
Fixes #10571

## Description

I build this PR on the assumption that `Start()` causes the driver crash. A few backtraces show this is the case, but a few others we cannot decode; so I am not sure this covers all cases. It might still happen that a crash happens when we actually start drawing for the first time, but we can always extend this code to that later on. For example, by waiting for the first tick to remove the detection file.

Either way, this PR creates a file `hwaccel.dat` when starting with hardware acceleration. As soon as the first drawing tick finishes, we remove it again. If we try to initialize the video driver with acceleration while that file exist, it means we must have crashed last time. We then disable hardware acceleration.

PS: some changes recently caused those video-driver errors to no longer show up, as they weren't marked critical (any more). I fixed that while I was here. No clue what happened exactly; it used to work, it no longer does, it does now again. *shrug*

## Limitations

Ideally, we find out what gets those drivers to crash; but that has turned out to be very difficult, and often just: known driver bug. Some people seem to never update their drivers, other GPUs haven't release a new drivers in months, and just randomly crash.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
