### PR TITLE
Codechange: use std::string for parameters in the dbg_helpers

### DIFF
--- a/src/misc/array.hpp
+++ b/src/misc/array.hpp
@@ -108,9 +108,7 @@ public:
 		dmp.WriteValue("num_items", num_items);
 		for (uint i = 0; i < num_items; i++) {
 			const T &item = (*this)[i];
-			char name[32];
-			seprintf(name, lastof(name), "item[%d]", i);
-			dmp.WriteStructT(name, &item);
+			dmp.WriteStructT(fmt::format("item[{}]", i), &item);
 		}
 	}
 };

--- a/src/misc/dbg_helpers.cpp
+++ b/src/misc/dbg_helpers.cpp
@@ -112,30 +112,30 @@ void DumpTarget::WriteIndent()
 }
 
 /** Write 'name = value' with indent and new-line. */
-void DumpTarget::WriteValue(const char *name, int value)
+void DumpTarget::WriteValue(const std::string &name, int value)
 {
 	WriteIndent();
-	m_out += std::string(name) + " = " + std::to_string(value) + "\n";
+	m_out += name + " = " + std::to_string(value) + "\n";
 }
 
 /** Write 'name = value' with indent and new-line. */
-void DumpTarget::WriteValue(const char *name, const char *value_str)
+void DumpTarget::WriteValue(const std::string &name, const std::string &value_str)
 {
 	WriteIndent();
-	m_out += std::string(name) + " = " + value_str + "\n";
+	m_out += name + " = " + value_str + "\n";
 }
 
 /** Write name & TileIndex to the output. */
-void DumpTarget::WriteTile(const char *name, TileIndex tile)
+void DumpTarget::WriteTile(const std::string &name, TileIndex tile)
 {
 	WriteIndent();
-	m_out += std::string(name) + " = " + TileStr(tile) + "\n";
+	m_out += name + " = " + TileStr(tile) + "\n";
 }
 
 /**
  * Open new structure (one level deeper than the current one) 'name = {\<LF\>'.
  */
-void DumpTarget::BeginStruct(size_t type_id, const char *name, const void *ptr)
+void DumpTarget::BeginStruct(size_t type_id, const std::string &name, const void *ptr)
 {
 	/* make composite name */
 	std::string cur_name = GetCurrentStructName();
@@ -152,7 +152,7 @@ void DumpTarget::BeginStruct(size_t type_id, const char *name, const void *ptr)
 	m_known_names.insert(KNOWN_NAMES::value_type(KnownStructKey(type_id, ptr), cur_name));
 
 	WriteIndent();
-	m_out += std::string(name) + " = {\n";
+	m_out += name + " = {\n";
 	m_indent++;
 }
 

--- a/src/misc/dbg_helpers.h
+++ b/src/misc/dbg_helpers.h
@@ -130,21 +130,21 @@ struct DumpTarget {
 
 	void WriteIndent();
 
-	void WriteValue(const char *name, int value);
-	void WriteValue(const char *name, const char *value_str);
-	void WriteTile(const char *name, TileIndex t);
+	void WriteValue(const std::string &name, int value);
+	void WriteValue(const std::string &name, const std::string &value_str);
+	void WriteTile(const std::string &name, TileIndex t);
 
 	/** Dump given enum value (as a number and as named value) */
-	template <typename E> void WriteEnumT(const char *name, E e)
+	template <typename E> void WriteEnumT(const std::string &name, E e)
 	{
-		WriteValue(name, ValueStr(e).c_str());
+		WriteValue(name, ValueStr(e));
 	}
 
-	void BeginStruct(size_t type_id, const char *name, const void *ptr);
+	void BeginStruct(size_t type_id, const std::string &name, const void *ptr);
 	void EndStruct();
 
 	/** Dump nested object (or only its name if this instance is already known). */
-	template <typename S> void WriteStructT(const char *name, const S *s)
+	template <typename S> void WriteStructT(const std::string &name, const S *s)
 	{
 		static size_t type_id = ++LastTypeId();
 
@@ -157,7 +157,7 @@ struct DumpTarget {
 		if (FindKnownName(type_id, s, known_as)) {
 			/* We already know this one, no need to dump it. */
 			std::string known_as_str = std::string("known_as.") + name;
-			WriteValue(name, known_as_str.c_str());
+			WriteValue(name, known_as_str);
 		} else {
 			/* Still unknown, dump it */
 			BeginStruct(type_id, name, s);


### PR DESCRIPTION
## Motivation / Problem

misc/array.hpp uses `seprintf`, and dbg_helpers converts a lot to `std::string` anyway. So, why not make the parameters of dbg_helpers `const std::string &` and not require `seprintf` or `.c_str()`.


## Description

Replace `const char *` with `const std::string &` and replace calls to the constructor of `std::string` where that's not needed anymore.
Replace `seprintf` with `fmt::format`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
