### PR TITLE
Codechange: use std::string for the screenshot name/path

### DIFF
--- a/src/crashlog.cpp
+++ b/src/crashlog.cpp
@@ -417,7 +417,7 @@ bool CrashLog::WriteScreenshot()
 
 	std::string filename = this->CreateFileName("", false);
 	bool res = MakeScreenshot(SC_CRASHLOG, filename);
-	if (res) this->screenshot_filename = _full_screenshot_name;
+	if (res) this->screenshot_filename = _full_screenshot_path;
 	return res;
 }
 

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -34,6 +34,6 @@ bool MakeMinimapWorldScreenshot();
 extern std::string _screenshot_format_name;
 extern uint _num_screenshot_formats;
 extern uint _cur_screenshot_format;
-extern char _full_screenshot_name[MAX_PATH];
+extern std::string _full_screenshot_path;
 
 #endif /* SCREENSHOT_H */


### PR DESCRIPTION
## Motivation / Problem

The screenshot name/path are a C-style string.


## Description

Replace them with `std::string`.
Then use assignment instead of `strecpy`/`strecat`, and `fmt::format` instead of `seprintf`.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
