### PR TITLE
Fix: crash when window can't be placed on low resolution screens.

### DIFF
--- a/src/core/math_func.hpp
+++ b/src/core/math_func.hpp
@@ -84,6 +84,32 @@ static inline T Clamp(const T a, const T min, const T max)
 }
 
 /**
+ * Clamp a value between an interval.
+ *
+ * This function returns a value which is between the given interval of
+ * min and max. If the given value is in this interval the value itself
+ * is returned otherwise the border of the interval is returned, according
+ * which side of the interval was 'left'.
+ *
+ * @note If the min value is greater than the max, return value is the average of the min and max.
+ * @param a The value to clamp/truncate.
+ * @param min The minimum of the interval.
+ * @param max the maximum of the interval.
+ * @returns A value between min and max which is closest to a.
+ */
+template <typename T>
+static inline T SoftClamp(const T a, const T min, const T max)
+{
+	if (min > max) {
+		using U = std::make_unsigned_t<T>;
+		return min - (U(min) - max) / 2;
+	}
+	if (a <= min) return min;
+	if (a >= max) return max;
+	return a;
+}
+
+/**
  * Clamp an integer between an interval.
  *
  * This function returns a value which is between the given interval of

--- a/src/misc_gui.cpp
+++ b/src/misc_gui.cpp
@@ -1140,8 +1140,8 @@ struct QueryWindow : public Window {
 	void FindWindowPlacementAndResize(int def_width, int def_height) override
 	{
 		/* Position query window over the calling window, ensuring it's within screen bounds. */
-		this->left = Clamp(parent->left + (parent->width / 2) - (this->width / 2), 0, _screen.width - this->width);
-		this->top = Clamp(parent->top + (parent->height / 2) - (this->height / 2), 0, _screen.height - this->height);
+		this->left = SoftClamp(parent->left + (parent->width / 2) - (this->width / 2), 0, _screen.width - this->width);
+		this->top = SoftClamp(parent->top + (parent->height / 2) - (this->height / 2), 0, _screen.height - this->height);
 		this->SetDirty();
 	}
 

--- a/src/tests/math_func.cpp
+++ b/src/tests/math_func.cpp
@@ -120,3 +120,13 @@ TEST_CASE("ClampTo")
 	/* max uint64_t gets clamped to max int64_t. */
 	CHECK(std::numeric_limits<int64_t>::max() == ClampTo<int64_t>(std::numeric_limits<uint64_t>::max()));
 }
+
+
+TEST_CASE("SoftClamp")
+{
+	/* Special behaviour of soft clamp returning the average of min/max when min is higher than max. */
+	CHECK(1250 == SoftClamp(0, 1500, 1000));
+	int million = 1000 * 1000;
+	CHECK(1250 * million == SoftClamp(0, 1500 * million, 1000 * million));
+	CHECK(0 == SoftClamp(0, 1500 * million, -1500 * million));
+}


### PR DESCRIPTION
## Motivation / Problem

Fixes #10530
Fixes #8869

When a resolution is too low, windows can't be placed anymore with `Clamp`, causing crashes.

## Description

@JGRennison created a `Softclamp`, which tolerates min > max, which is the actual problem here.

I cherry-picked the related commits, and made some minor changes for it to work for us.

Related commits:
- [cf26d48c9](https://github.com/JGRennison/OpenTTD-patches/commit/cf26d48c9b3f9097bc36509c82cbba9aa5166674) (partially cherry-picked, and fixed SoftClamp to return the midpoint in all cases)
- [36700631](https://github.com/JGRennison/OpenTTD-patches/commit/36700631aa7466e82449ed1597264e3d1f965e72)

## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
