### PR TITLE
Codechange: let GetStringWithArgs use StringBuilder

### DIFF
--- a/src/industry_cmd.cpp
+++ b/src/industry_cmd.cpp
@@ -2431,11 +2431,9 @@ void Industry::RecomputeProductionMultipliers()
 
 void Industry::FillCachedName() const
 {
-	char buf[256];
 	int64 args_array[] = { this->index };
 	StringParameters tmp_params(args_array);
-	char *end = GetStringWithArgs(buf, STR_INDUSTRY_NAME, &tmp_params, lastof(buf));
-	this->cached_name.assign(buf, end);
+	this->cached_name = GetStringWithArgs(STR_INDUSTRY_NAME, &tmp_params);
 }
 
 void ClearAllIndustryCachedNames()

--- a/src/newgrf_townname.cpp
+++ b/src/newgrf_townname.cpp
@@ -16,6 +16,7 @@
 #include "newgrf_townname.h"
 #include "core/alloc_func.hpp"
 #include "string_func.h"
+#include "strings_internal.h"
 
 #include "table/strings.h"
 
@@ -46,7 +47,7 @@ void DelGRFTownName(uint32 grfid)
 	_grf_townnames.erase(std::find_if(std::begin(_grf_townnames), std::end(_grf_townnames), [&grfid](const GRFTownName &t){ return t.grfid == grfid; }));
 }
 
-static char *RandomPart(char *buf, const GRFTownName *t, uint32 seed, byte id, const char *last)
+static void RandomPart(StringBuilder &builder, const GRFTownName *t, uint32 seed, byte id)
 {
 	assert(t != nullptr);
 	for (const auto &partlist : t->partlists[id]) {
@@ -57,25 +58,22 @@ static char *RandomPart(char *buf, const GRFTownName *t, uint32 seed, byte id, c
 			maxprob -= GB(part.prob, 0, 7);
 			if (maxprob > r) continue;
 			if (HasBit(part.prob, 7)) {
-				buf = RandomPart(buf, t, seed, part.id, last);
+				RandomPart(builder, t, seed, part.id);
 			} else {
-				buf = strecat(buf, part.text.c_str(), last);
+				builder += part.text;
 			}
 			break;
 		}
 	}
-	return buf;
 }
 
-char *GRFTownNameGenerate(char *buf, uint32 grfid, uint16 gen, uint32 seed, const char *last)
+void GRFTownNameGenerate(StringBuilder &builder, uint32 grfid, uint16 gen, uint32 seed)
 {
-	strecpy(buf, "", last);
 	const GRFTownName *t = GetGRFTownName(grfid);
 	if (t != nullptr) {
 		assert(gen < t->styles.size());
-		buf = RandomPart(buf, t, seed, t->styles[gen].id, last);
+		RandomPart(builder, t, seed, t->styles[gen].id);
 	}
-	return buf;
 }
 
 

--- a/src/newgrf_townname.h
+++ b/src/newgrf_townname.h
@@ -47,7 +47,6 @@ GRFTownName *AddGRFTownName(uint32 grfid);
 GRFTownName *GetGRFTownName(uint32 grfid);
 void DelGRFTownName(uint32 grfid);
 void CleanUpGRFTownNames();
-char *GRFTownNameGenerate(char *buf, uint32 grfid, uint16 gen, uint32 seed, const char *last);
 uint32 GetGRFTownNameId(uint16 gen);
 uint16 GetGRFTownNameType(uint16 gen);
 StringID GetGRFTownNameName(uint16 gen);

--- a/src/station_cmd.cpp
+++ b/src/station_cmd.cpp
@@ -461,11 +461,9 @@ void UpdateAllStationVirtCoords()
 
 void BaseStation::FillCachedName() const
 {
-	char buf[MAX_LENGTH_STATION_NAME_CHARS * MAX_CHAR_LENGTH];
 	int64 args_array[] = { this->index };
 	StringParameters tmp_params(args_array);
-	char *end = GetStringWithArgs(buf, Waypoint::IsExpected(this) ? STR_WAYPOINT_NAME : STR_STATION_NAME, &tmp_params, lastof(buf));
-	this->cached_name.assign(buf, end);
+	this->cached_name = GetStringWithArgs(Waypoint::IsExpected(this) ? STR_WAYPOINT_NAME : STR_STATION_NAME, &tmp_params);
 }
 
 void ClearAllStationCachedNames()

--- a/src/strings_func.h
+++ b/src/strings_func.h
@@ -172,7 +172,7 @@ extern StringParameters _global_string_params;
 
 char *GetString(char *buffr, StringID string, const char *last);
 std::string GetString(StringID string);
-char *GetStringWithArgs(char *buffr, StringID string, StringParameters *args, const char *last, uint case_index = 0, bool game_script = false);
+std::string GetStringWithArgs(StringID string, StringParameters *args);
 const char *GetStringPtr(StringID string);
 
 uint ConvertKmhishSpeedToDisplaySpeed(uint speed, VehicleType type);

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -10,6 +10,8 @@
 #ifndef STRINGS_INTERNAL_H
 #define STRINGS_INTERNAL_H
 
+#include "strings_func.h"
+
 /**
  * Equivalent to the std::back_insert_iterator in function, with some
  * convenience helpers for string concatenation.
@@ -129,5 +131,11 @@ public:
 		this->current = function(this->current, this->last);
 	}
 };
+
+void GetStringWithArgs(StringBuilder &builder, StringID string, StringParameters *args, uint case_index = 0, bool game_script = false);
+
+/* Do not leak the StringBuilder to everywhere. */
+void GetTownName(StringBuilder &builder, const struct Town *t);
+void GRFTownNameGenerate(StringBuilder &builder, uint32 grfid, uint16 gen, uint32 seed);
 
 #endif /* STRINGS_INTERNAL_H */

--- a/src/townname.cpp
+++ b/src/townname.cpp
@@ -15,6 +15,7 @@
 #include "core/random_func.hpp"
 #include "genworld.h"
 #include "gfx_layout.h"
+#include "strings_internal.h"
 
 #include "table/townname.h"
 
@@ -39,6 +40,24 @@ TownNameParams::TownNameParams(const Town *t) :
 
 
 /**
+ * Fills builder with specified town name.
+ * @param builder       The string builder.
+ * @param par           Town name parameters.
+ * @param townnameparts 'Encoded' town name.
+ */
+static void GetTownName(StringBuilder &builder, const TownNameParams *par, uint32 townnameparts)
+{
+	if (par->grfid == 0) {
+		int64 args_array[1] = { townnameparts };
+		StringParameters tmp_params(args_array);
+		GetStringWithArgs(builder, par->type, &tmp_params);
+		return;
+	}
+
+	GRFTownNameGenerate(builder, par->grfid, par->type, townnameparts);
+}
+
+/**
  * Fills buffer with specified town name
  * @param buff buffer start
  * @param par town name parameters
@@ -48,15 +67,21 @@ TownNameParams::TownNameParams(const Town *t) :
  */
 char *GetTownName(char *buff, const TownNameParams *par, uint32 townnameparts, const char *last)
 {
-	if (par->grfid == 0) {
-		int64 args_array[1] = { townnameparts };
-		StringParameters tmp_params(args_array);
-		return GetStringWithArgs(buff, par->type, &tmp_params, last);
-	}
-
-	return GRFTownNameGenerate(buff, par->grfid, par->type, townnameparts, last);
+	StringBuilder builder(buff, last);
+	GetTownName(builder, par, townnameparts);
+	return builder.GetEnd();
 }
 
+/**
+ * Fills builder with town's name.
+ * @param builder String builder.
+ * @param t       The town to get the name from.
+ */
+void GetTownName(StringBuilder &builder, const Town *t)
+{
+	TownNameParams par(t);
+	GetTownName(builder, &par, t->townnameparts);
+}
 
 /**
  * Fills buffer with town's name
@@ -67,8 +92,9 @@ char *GetTownName(char *buff, const TownNameParams *par, uint32 townnameparts, c
  */
 char *GetTownName(char *buff, const Town *t, const char *last)
 {
-	TownNameParams par(t);
-	return GetTownName(buff, &par, t->townnameparts, last);
+	StringBuilder builder(buff, last);
+	GetTownName(builder, t);
+	return builder.GetEnd();
 }
 
 


### PR DESCRIPTION
## Motivation / Problem

String formatting using a char buffer.


## Description

Convert `GetStringWithArgs` to using the `StringBuilder`.
Some collateral changes in other parts were needed to break dependency cycles, and to prevent going back and forth between builder and `stre` functionality.


## Limitations

None.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
