### PR TITLE
Cleanup: strecat has no uses anymore

### DIFF
--- a/src/safeguards.h
+++ b/src/safeguards.h
@@ -36,7 +36,7 @@
 #define strcpy    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strncpy   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 
-/* Use strecat instead. */
+/* Use std::string concatenation/fmt::format instead. */
 #define strcat    SAFEGUARD_DO_NOT_USE_THIS_METHOD
 #define strncat   SAFEGUARD_DO_NOT_USE_THIS_METHOD
 

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -49,33 +49,6 @@
 #include "safeguards.h"
 #undef vsnprintf
 
-/**
- * Appends characters from one string to another.
- *
- * Appends the source string to the destination string with respect of the
- * terminating null-character and and the last pointer to the last element
- * in the destination buffer. If the last pointer is set to nullptr no
- * boundary check is performed.
- *
- * @note usage: strecat(dst, src, lastof(dst));
- * @note lastof() applies only to fixed size arrays
- *
- * @param dst The buffer containing the target string
- * @param src The buffer containing the string to append
- * @param last The pointer to the last element of the destination buffer
- * @return The pointer to the terminating null-character in the destination buffer
- */
-char *strecat(char *dst, const char *src, const char *last)
-{
-	assert(dst <= last);
-	while (*dst != '\0') {
-		if (dst == last) return dst;
-		dst++;
-	}
-
-	return strecpy(dst, src, last);
-}
-
 
 /**
  * Copies characters from one buffer to another.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -30,7 +30,6 @@
 #include "core/span_type.hpp"
 #include "string_type.h"
 
-char *strecat(char *dst, const char *src, const char *last) NOACCESS(3);
 char *strecpy(char *dst, const char *src, const char *last) NOACCESS(3);
 char *stredup(const char *src, const char *last = nullptr) NOACCESS(2);
 

--- a/src/strings_internal.h
+++ b/src/strings_internal.h
@@ -122,7 +122,7 @@ public:
 	}
 
 	/**
-	 * Add a string using the strecpy/strecat-esque calling signature.
+	 * Add a string using the strecpy-esque calling signature.
 	 * @param function The function to pass the current and last location to,
 	 *                 that will then return the new current location.
 	 */


### PR DESCRIPTION
## Motivation / Problem

`strecat` is not used anymore.


## Description

Remove it.


## Limitations

Down streams might be using it.


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
